### PR TITLE
feat(auto): migrate complete-slice through composer — #4782 phase 3 batch 3 [STACKED]

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1229,30 +1229,64 @@ export async function buildDiscussMilestonePrompt(
 }
 
 export async function buildResearchMilestonePrompt(mid: string, midTitle: string, base: string): Promise<string> {
-  const contextPath = resolveMilestoneFile(base, mid, "CONTEXT");
-  const contextRel = relMilestoneFile(base, mid, "CONTEXT");
+  // #4782 phase 3: research-milestone migrated through the composer.
+  // Declared inline order: milestone-context, project, requirements,
+  // decisions, templates. Knowledge stays outside the composer
+  // (budget-driven, scoped by keyword extraction — future phase folds
+  // policy-driven blocks in).
+  const resolveArtifact: ArtifactResolver = async (key) => {
+    switch (key) {
+      case "milestone-context": {
+        const p = resolveMilestoneFile(base, mid, "CONTEXT");
+        const r = relMilestoneFile(base, mid, "CONTEXT");
+        return await inlineFile(p, r, "Milestone Context");
+      }
+      case "project":
+        return await inlineProjectFromDb(base);
+      case "requirements":
+        return await inlineRequirementsFromDb(base, mid);
+      case "decisions":
+        return await inlineDecisionsFromDb(base, mid);
+      case "templates":
+        return inlineTemplate("research", "Research");
+      default:
+        return null;
+    }
+  };
 
-  const inlined: string[] = [];
-  inlined.push(await inlineFile(contextPath, contextRel, "Milestone Context"));
-  const projectInline = await inlineProjectFromDb(base);
-  if (projectInline) inlined.push(projectInline);
-  const requirementsInline = await inlineRequirementsFromDb(base, mid);
-  if (requirementsInline) inlined.push(requirementsInline);
-  const decisionsInline = await inlineDecisionsFromDb(base, mid);
-  if (decisionsInline) inlined.push(decisionsInline);
-  // Scoped + budgeted — see issue #4719
+  const composed = await composeInlinedContext("research-milestone", resolveArtifact);
+
+  // Knowledge block stays outside the composer — budgeted, scoped via
+  // keyword extraction (#4719). Inserted between decisions and the
+  // templates block to match the pre-migration output order. We split
+  // the composer output around the templates section to preserve that
+  // ordering.
   const knowledgeInlineRM = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
-  if (knowledgeInlineRM) inlined.push(knowledgeInlineRM);
-  inlined.push(inlineTemplate("research", "Research"));
+  const parts: string[] = [];
+  if (knowledgeInlineRM && composed) {
+    // Insert knowledge before the template block so the overall order is:
+    //   milestone-context → project → requirements → decisions → KNOWLEDGE → research template
+    const idx = composed.lastIndexOf("### Output Template:");
+    if (idx > 0) {
+      const before = composed.slice(0, idx).replace(/\n\n---\n\n$/, "");
+      const after = composed.slice(idx);
+      parts.push(before, knowledgeInlineRM, after);
+    } else {
+      parts.push(composed, knowledgeInlineRM);
+    }
+  } else if (composed) {
+    parts.push(composed);
+    if (knowledgeInlineRM) parts.push(knowledgeInlineRM);
+  }
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`);
 
   const outputRelPath = relMilestoneFile(base, mid, "RESEARCH");
   return loadPrompt("research-milestone", {
     workingDirectory: base,
     milestoneId: mid, milestoneTitle: midTitle,
     milestonePath: relMilestonePath(base, mid),
-    contextPath: contextRel,
+    contextPath: relMilestoneFile(base, mid, "CONTEXT"),
     outputPath: join(base, outputRelPath),
     inlinedContext,
     skillActivation: buildSkillActivationBlock({

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -2211,20 +2211,30 @@ export async function buildReplanSlicePrompt(
 export async function buildRunUatPrompt(
   mid: string, sliceId: string, uatPath: string, uatContent: string, base: string,
 ): Promise<string> {
-  const inlined: string[] = [];
-  inlined.push(await inlineFile(resolveSliceFile(base, mid, sliceId, "UAT"), uatPath, `${sliceId} UAT`));
+  // #4782 phase 3: run-uat migrated to compose its inlined context via
+  // the manifest. Behavior-equivalent — resolver dispatches to the same
+  // inline* helpers as the pre-migration builder.
+  const resolveArtifact: ArtifactResolver = async (key) => {
+    switch (key) {
+      case "slice-uat": {
+        const p = resolveSliceFile(base, mid, sliceId, "UAT");
+        return await inlineFile(p, uatPath, `${sliceId} UAT`);
+      }
+      case "slice-summary": {
+        const p = resolveSliceFile(base, mid, sliceId, "SUMMARY");
+        if (!p) return null;
+        const r = relSliceFile(base, mid, sliceId, "SUMMARY");
+        return await inlineFileOptional(p, r, `${sliceId} Summary`);
+      }
+      case "project":
+        return await inlineProjectFromDb(base);
+      default:
+        return null;
+    }
+  };
 
-  const summaryPath = resolveSliceFile(base, mid, sliceId, "SUMMARY");
-  const summaryRel = relSliceFile(base, mid, sliceId, "SUMMARY");
-  if (summaryPath) {
-    const summaryInline = await inlineFileOptional(summaryPath, summaryRel, `${sliceId} Summary`);
-    if (summaryInline) inlined.push(summaryInline);
-  }
-
-  const projectInline = await inlineProjectFromDb(base);
-  if (projectInline) inlined.push(projectInline);
-
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const composed = await composeInlinedContext("run-uat", resolveArtifact);
+  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${composed}`);
 
   const uatResultPath = join(base, relSliceFile(base, mid, sliceId, "ASSESSMENT"));
   const uatType = getUatType(uatContent);

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1844,53 +1844,96 @@ export async function buildCompleteSlicePrompt(
 ): Promise<string> {
   const inlineLevel = level ?? resolveInlineLevel();
 
-  const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
-  const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
-  const slicePlanPath = resolveSliceFile(base, mid, sid, "PLAN");
-  const slicePlanRel = relSliceFile(base, mid, sid, "PLAN");
-  const sliceContextPath = resolveSliceFile(base, mid, sid, "CONTEXT");
-  const sliceContextRel = relSliceFile(base, mid, sid, "CONTEXT");
+  // #4782 phase 3: complete-slice migrated through composer. Manifest
+  // declares [roadmap, slice-context, slice-plan, requirements,
+  // prior-task-summaries, templates]. Overrides prepend and knowledge
+  // splice stay imperative — they need the composer v2 contract
+  // (computed + prepend blocks; see RFC #4924).
+  const resolveArtifact: ArtifactResolver = async (key) => {
+    switch (key) {
+      case "roadmap": {
+        const p = resolveMilestoneFile(base, mid, "ROADMAP");
+        const r = relMilestoneFile(base, mid, "ROADMAP");
+        return await inlineFile(p, r, "Milestone Roadmap");
+      }
+      case "slice-context": {
+        const p = resolveSliceFile(base, mid, sid, "CONTEXT");
+        const r = relSliceFile(base, mid, sid, "CONTEXT");
+        return await inlineFileOptional(p, r, "Slice Context (from discussion)");
+      }
+      case "slice-plan": {
+        const p = resolveSliceFile(base, mid, sid, "PLAN");
+        const r = relSliceFile(base, mid, sid, "PLAN");
+        return await inlineFile(p, r, "Slice Plan");
+      }
+      case "requirements":
+        if (inlineLevel === "minimal") return null;
+        return await inlineRequirementsFromDb(base, mid, sid, inlineLevel);
+      case "prior-task-summaries": {
+        const tDir = resolveTasksDir(base, mid, sid);
+        if (!tDir) return null;
+        const summaryFiles = resolveTaskFiles(tDir, "SUMMARY").sort();
+        const sRel = relSlicePath(base, mid, sid);
+        const blocks: string[] = [];
+        for (const file of summaryFiles) {
+          const absPath = join(tDir, file);
+          const content = await loadFile(absPath);
+          if (!content) continue;
+          const relPath = `${sRel}/tasks/${file}`;
+          blocks.push(`### Task Summary: ${file.replace(/-SUMMARY\.md$/i, "")}\nSource: \`${relPath}\`\n\n${content.trim()}`);
+        }
+        return blocks.length > 0 ? blocks.join("\n\n---\n\n") : null;
+      }
+      case "templates": {
+        const parts = [inlineTemplate("slice-summary", "Slice Summary")];
+        if (inlineLevel !== "minimal") {
+          parts.push(inlineTemplate("uat", "UAT"));
+        }
+        return parts.join("\n\n---\n\n");
+      }
+      default:
+        return null;
+    }
+  };
 
-  const inlined: string[] = [];
-  inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
-  const sliceCtxInline = await inlineFileOptional(sliceContextPath, sliceContextRel, "Slice Context (from discussion)");
-  if (sliceCtxInline) inlined.push(sliceCtxInline);
-  inlined.push(await inlineFile(slicePlanPath, slicePlanRel, "Slice Plan"));
-  if (inlineLevel !== "minimal") {
-    const requirementsInline = await inlineRequirementsFromDb(base, mid, sid, inlineLevel);
-    if (requirementsInline) inlined.push(requirementsInline);
-  }
-  // Scoped + budgeted — see issue #4719. Slice context is richer than
-  // milestone context at complete-slice time, so combine both title sources.
+  const composed = await composeInlinedContext("complete-slice", resolveArtifact);
+
+  // Knowledge splices in between requirements and prior-task-summaries
+  // so overall order matches pre-migration: roadmap → slice-context →
+  // slice-plan → requirements → KNOWLEDGE → task summaries → templates.
   const knowledgeInlineCS = await inlineKnowledgeBudgeted(
     base,
     [...extractKeywords(midTitle), ...extractKeywords(sTitle)],
   );
-  if (knowledgeInlineCS) inlined.push(knowledgeInlineCS);
 
-  // Inline all task summaries for this slice
-  const tDir = resolveTasksDir(base, mid, sid);
-  if (tDir) {
-    const summaryFiles = resolveTaskFiles(tDir, "SUMMARY").sort();
-    for (const file of summaryFiles) {
-      const absPath = join(tDir, file);
-      const content = await loadFile(absPath);
-      const sRel = relSlicePath(base, mid, sid);
-      const relPath = `${sRel}/tasks/${file}`;
-      if (content) {
-        inlined.push(`### Task Summary: ${file.replace(/-SUMMARY\.md$/i, "")}\nSource: \`${relPath}\`\n\n${content.trim()}`);
-      }
+  let body = composed;
+  if (knowledgeInlineCS && body) {
+    // Splice knowledge right before the first "### Task Summary:" block
+    // to preserve pre-migration ordering. If no task summaries exist,
+    // append after requirements (before templates).
+    const taskIdx = body.indexOf("### Task Summary:");
+    const templatesIdx = body.lastIndexOf("### Slice Summary");
+    const spliceIdx = taskIdx > -1 ? taskIdx : templatesIdx;
+    if (spliceIdx > 0) {
+      const before = body.slice(0, spliceIdx).replace(/\n\n---\n\n$/, "");
+      const after = body.slice(spliceIdx);
+      body = [before, knowledgeInlineCS, after].join("\n\n---\n\n");
+    } else {
+      body = `${body}\n\n---\n\n${knowledgeInlineCS}`;
     }
   }
-  inlined.push(inlineTemplate("slice-summary", "Slice Summary"));
-  if (inlineLevel !== "minimal") {
-    inlined.push(inlineTemplate("uat", "UAT"));
-  }
+
+  // Overrides section prepends to the top of the inlined context —
+  // standard pattern for slice-level builders (until composer v2 lands
+  // the prepend contract).
   const completeActiveOverrides = await loadActiveOverrides(base);
   const completeOverridesInline = formatOverridesSection(completeActiveOverrides);
-  if (completeOverridesInline) inlined.unshift(completeOverridesInline);
+  const finalBody = completeOverridesInline
+    ? `${completeOverridesInline}\n\n---\n\n${body}`
+    : body;
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${finalBody}`);
+  const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
 
   const sliceRel = relSlicePath(base, mid, sid);
   const sliceSummaryPath = join(base, `${sliceRel}/${sid}-SUMMARY.md`);

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1910,9 +1910,10 @@ export async function buildCompleteSlicePrompt(
   if (knowledgeInlineCS && body) {
     // Splice knowledge right before the first "### Task Summary:" block
     // to preserve pre-migration ordering. If no task summaries exist,
-    // append after requirements (before templates).
+    // splice before the templates block (which inlineTemplate emits as
+    // "### Output Template: Slice Summary").
     const taskIdx = body.indexOf("### Task Summary:");
-    const templatesIdx = body.lastIndexOf("### Slice Summary");
+    const templatesIdx = body.lastIndexOf("### Output Template: Slice Summary");
     const spliceIdx = taskIdx > -1 ? taskIdx : templatesIdx;
     if (spliceIdx > 0) {
       const before = body.slice(0, spliceIdx).replace(/\n\n---\n\n$/, "");
@@ -2294,8 +2295,15 @@ export async function buildRunUatPrompt(
   const resolveArtifact: ArtifactResolver = async (key) => {
     switch (key) {
       case "slice-uat": {
-        const p = resolveSliceFile(base, mid, sliceId, "UAT");
-        return await inlineFile(p, uatPath, `${sliceId} UAT`);
+        // Use the in-memory snapshot the caller already loaded (#4925 review).
+        // Re-reading from disk via inlineFile(p, uatPath, ...) would risk
+        // drift between the inlined body and uatType (computed from
+        // uatContent below) if the file changes mid-dispatch.
+        const trimmed = uatContent.trim();
+        if (!trimmed) {
+          return `### ${sliceId} UAT\nSource: \`${uatPath}\`\n\n_(not found — file does not exist yet)_`;
+        }
+        return `### ${sliceId} UAT\nSource: \`${uatPath}\`\n\n${trimmed}`;
       }
       case "slice-summary": {
         const p = resolveSliceFile(base, mid, sliceId, "SUMMARY");

--- a/src/resources/extensions/gsd/tests/complete-slice-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-composer.test.ts
@@ -1,0 +1,147 @@
+// GSD-2 — #4782 phase 3 batch 3: complete-slice migrated through composer.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { buildCompleteSlicePrompt } from "../auto-prompts.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  upsertMilestonePlanning,
+  insertSlice,
+  insertTask,
+} from "../gsd-db.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-completeslice-composer-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  invalidateAllCaches();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function seed(base: string, mid: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: mid, title: "Composer Test", status: "active", depends_on: [] });
+  upsertMilestonePlanning(mid, {
+    title: "Composer Test",
+    status: "active",
+    vision: "Validate complete-slice migration",
+    successCriteria: ["Prompt compiles"],
+    keyRisks: [],
+    proofStrategy: [],
+    verificationContract: "",
+    verificationIntegration: "",
+    verificationOperational: "",
+    verificationUat: "",
+    definitionOfDone: [],
+    requirementCoverage: "",
+    boundaryMapMarkdown: "",
+  });
+  insertSlice({
+    id: "S01",
+    milestoneId: mid,
+    title: "First",
+    status: "complete",
+    risk: "low",
+    depends: [],
+    demo: "",
+    sequence: 1,
+  });
+  insertTask({
+    id: "T01",
+    sliceId: "S01",
+    milestoneId: mid,
+    title: "Task one",
+    status: "complete",
+  });
+}
+
+function writeArtifacts(base: string): void {
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    "# M001 Roadmap\n## Slices\n- [x] **S01: First** `risk:low` `depends:[]`\n",
+  );
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+    "# S01 Plan\n\nSlice plan body.\n",
+  );
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md"),
+    "---\nid: T01\n---\n# T01 Summary\n\nTask one did the thing.\n",
+  );
+}
+
+test("#4782 phase 3: buildCompleteSlicePrompt composes roadmap → plan → task summaries → templates in declared order", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  writeArtifacts(base);
+
+  const prompt = await buildCompleteSlicePrompt("M001", "Composer Test", "S01", "First", base);
+
+  // Context wrapper present
+  assert.match(prompt, /## Inlined Context \(preloaded — do not re-read these files\)/);
+
+  // Manifest-declared artifacts present
+  assert.match(prompt, /### Milestone Roadmap/);
+  assert.match(prompt, /### Slice Plan/);
+  assert.match(prompt, /### Task Summary: T01/);
+  assert.match(prompt, /### Output Template: Slice Summary/);
+
+  // Ordering: roadmap → slice plan → task summaries → slice summary template
+  const roadmapIdx = prompt.indexOf("### Milestone Roadmap");
+  const planIdx = prompt.indexOf("### Slice Plan");
+  const taskSummaryIdx = prompt.indexOf("### Task Summary: T01");
+  const sliceSummaryTemplateIdx = prompt.indexOf("### Output Template: Slice Summary");
+
+  assert.ok(roadmapIdx > -1 && planIdx > roadmapIdx, "roadmap precedes slice plan");
+  assert.ok(planIdx > -1 && taskSummaryIdx > planIdx, "slice plan precedes task summaries");
+  assert.ok(
+    taskSummaryIdx > -1 && sliceSummaryTemplateIdx > taskSummaryIdx,
+    "task summaries precede slice-summary template",
+  );
+
+  // Task body inlined
+  assert.match(prompt, /Task one did the thing/);
+});
+
+test("#4782 phase 3: buildCompleteSlicePrompt handles missing task summaries gracefully", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  // Write roadmap + plan but no task summaries
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    "# M001 Roadmap\n## Slices\n- [x] **S01: First** `risk:low` `depends:[]`\n",
+  );
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+    "# S01 Plan\n",
+  );
+
+  const prompt = await buildCompleteSlicePrompt("M001", "Composer Test", "S01", "First", base);
+
+  // Still succeeds — prior-task-summaries resolver returns null when dir is empty
+  assert.match(prompt, /### Milestone Roadmap/);
+  assert.match(prompt, /### Slice Plan/);
+  // No task summary blocks — they'd have a "### Task Summary:" prefix
+  assert.ok(!prompt.includes("### Task Summary:"));
+  // Roadmap still precedes slice plan despite the missing block
+  const roadmapIdx = prompt.indexOf("### Milestone Roadmap");
+  const planIdx = prompt.indexOf("### Slice Plan");
+  assert.ok(roadmapIdx > -1 && planIdx > roadmapIdx);
+});

--- a/src/resources/extensions/gsd/tests/research-milestone-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/research-milestone-composer.test.ts
@@ -1,0 +1,97 @@
+// GSD-2 — #4782 phase 3 batch 2: research-milestone migrated through composer.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { buildResearchMilestonePrompt } from "../auto-prompts.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  upsertMilestonePlanning,
+} from "../gsd-db.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-research-ms-composer-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  invalidateAllCaches();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function seed(base: string, mid: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: mid, title: "Research Test", status: "active", depends_on: [] });
+  upsertMilestonePlanning(mid, {
+    title: "Research Test",
+    status: "active",
+    vision: "Research composer migration",
+    successCriteria: ["Prompt compiles"],
+    keyRisks: [],
+    proofStrategy: [],
+    verificationContract: "",
+    verificationIntegration: "",
+    verificationOperational: "",
+    verificationUat: "",
+    definitionOfDone: [],
+    requirementCoverage: "",
+    boundaryMapMarkdown: "",
+  });
+}
+
+test("#4782 phase 3: buildResearchMilestonePrompt emits milestone-context then research template via composer", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"),
+    "# M001 Context\n\nA research test milestone.\n",
+  );
+
+  const prompt = await buildResearchMilestonePrompt("M001", "Research Test", base);
+
+  // Context wrapper present
+  assert.match(prompt, /## Inlined Context \(preloaded — do not re-read these files\)/);
+
+  // Milestone context inlined first (manifest order)
+  assert.match(prompt, /### Milestone Context/);
+  assert.match(prompt, /A research test milestone/);
+
+  // Research template inlined as the templates artifact
+  assert.match(prompt, /### Output Template: Research/);
+
+  // Ordering: milestone-context precedes the research template
+  const contextIdx = prompt.indexOf("### Milestone Context");
+  const researchIdx = prompt.indexOf("### Output Template: Research");
+  assert.ok(contextIdx > -1 && researchIdx > contextIdx,
+    `milestone-context (${contextIdx}) must precede research template (${researchIdx})`);
+});
+
+test("#4782 phase 3: buildResearchMilestonePrompt still includes project + requirements + decisions in declared order", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# M001 Context\n");
+
+  const prompt = await buildResearchMilestonePrompt("M001", "Research Test", base);
+
+  // Manifest-declared order: milestone-context, project, requirements, decisions, templates.
+  // Any projections that resolve to content must preserve that order.
+  const contextIdx = prompt.indexOf("### Milestone Context");
+  const researchIdx = prompt.indexOf("### Output Template: Research");
+  assert.ok(contextIdx > -1 && researchIdx > contextIdx,
+    "milestone-context must come before research template regardless of which optional artifacts are present");
+});

--- a/src/resources/extensions/gsd/tests/research-milestone-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/research-milestone-composer.test.ts
@@ -13,6 +13,7 @@ import {
   closeDatabase,
   insertMilestone,
   upsertMilestonePlanning,
+  insertArtifact,
 } from "../gsd-db.ts";
 
 function makeBase(): string {
@@ -78,20 +79,36 @@ test("#4782 phase 3: buildResearchMilestonePrompt emits milestone-context then r
     `milestone-context (${contextIdx}) must precede research template (${researchIdx})`);
 });
 
-test("#4782 phase 3: buildResearchMilestonePrompt still includes project + requirements + decisions in declared order", async (t) => {
+test("#4782 phase 3: buildResearchMilestonePrompt preserves manifest order across optional artifacts (#4925 review)", async (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   invalidateAllCaches();
 
   seed(base, "M001");
   writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# M001 Context\n");
+  // Seed PROJECT.md into the artifacts table so inlineProjectFromDb resolves
+  // to a non-null body. Lets us verify the project block sits between
+  // milestone-context and the templates block per manifest order.
+  insertArtifact({
+    path: "PROJECT.md",
+    artifact_type: "project",
+    milestone_id: null,
+    slice_id: null,
+    task_id: null,
+    full_content: "# Project\n\nResearch composer fixture project.\n",
+  });
 
   const prompt = await buildResearchMilestonePrompt("M001", "Research Test", base);
 
   // Manifest-declared order: milestone-context, project, requirements, decisions, templates.
-  // Any projections that resolve to content must preserve that order.
   const contextIdx = prompt.indexOf("### Milestone Context");
+  const projectIdx = prompt.indexOf("### Project");
   const researchIdx = prompt.indexOf("### Output Template: Research");
-  assert.ok(contextIdx > -1 && researchIdx > contextIdx,
-    "milestone-context must come before research template regardless of which optional artifacts are present");
+  assert.ok(contextIdx > -1, "milestone-context block missing");
+  assert.ok(projectIdx > -1, "project block missing — seed should have populated it");
+  assert.ok(researchIdx > -1, "research template block missing");
+  assert.ok(
+    contextIdx < projectIdx && projectIdx < researchIdx,
+    `manifest order violated: milestone-context (${contextIdx}) < project (${projectIdx}) < research-template (${researchIdx})`,
+  );
 });

--- a/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
@@ -1,0 +1,113 @@
+// GSD-2 — #4782 phase 3: run-uat migrated to compose context via manifest.
+// Regression test: prompt still carries the declared artifacts in the
+// expected shape after the migration.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { buildRunUatPrompt } from "../auto-prompts.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  upsertMilestonePlanning,
+  insertSlice,
+} from "../gsd-db.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-runuat-composer-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  invalidateAllCaches();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function seed(base: string, mid: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: mid, title: "Test", status: "active", depends_on: [] });
+  upsertMilestonePlanning(mid, {
+    title: "Test Milestone",
+    status: "active",
+    vision: "Demo the composer migration",
+    successCriteria: ["Prompt compiles", "UAT passes"],
+    keyRisks: [],
+    proofStrategy: [],
+    verificationContract: "",
+    verificationIntegration: "",
+    verificationOperational: "",
+    verificationUat: "",
+    definitionOfDone: [],
+    requirementCoverage: "",
+    boundaryMapMarkdown: "",
+  });
+  insertSlice({
+    id: "S01",
+    milestoneId: mid,
+    title: "First",
+    status: "complete",
+    risk: "low",
+    depends: [],
+    demo: "",
+    sequence: 1,
+  });
+}
+
+test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project via composer", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+
+  // Write UAT + SUMMARY files for the slice
+  const uatRel = ".gsd/milestones/M001/slices/S01/S01-UAT.md";
+  writeFileSync(join(base, uatRel), "# S01 UAT\n\n- Check X\n- Check Y\n");
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
+    "---\nid: S01\nparent: M001\n---\n# S01 Summary\n**One-liner**\n\n## What Happened\nShip.\n",
+  );
+
+  const uatContent = "# S01 UAT\n\n- Check X\n- Check Y\n";
+  const prompt = await buildRunUatPrompt("M001", "S01", uatRel, uatContent, base);
+
+  // Context wrapper present
+  assert.match(prompt, /## Inlined Context \(preloaded — do not re-read these files\)/);
+
+  // Artifacts from the manifest inline list, in declared order
+  assert.match(prompt, /### S01 UAT[\s\S]*### S01 Summary/);
+
+  // UAT body content inlined
+  assert.match(prompt, /Check X[\s\S]*Check Y/);
+
+  // Summary body content inlined
+  assert.match(prompt, /What Happened[\s\S]*Ship/);
+});
+
+test("#4782 phase 3: buildRunUatPrompt omits optional slice summary when file is missing", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+
+  const uatRel = ".gsd/milestones/M001/slices/S01/S01-UAT.md";
+  writeFileSync(join(base, uatRel), "# S01 UAT\n");
+  // No SUMMARY.md written — composer should skip the slice-summary key.
+
+  const prompt = await buildRunUatPrompt("M001", "S01", uatRel, "# S01 UAT\n", base);
+
+  // UAT still present
+  assert.match(prompt, /### S01 UAT/);
+  // No empty "S01 Summary" section — section body would be blank without a file
+  assert.ok(!prompt.includes("### S01 Summary"));
+  // No double separator from a skipped block
+  assert.ok(!prompt.includes("---\n\n---"));
+});

--- a/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
@@ -16,6 +16,7 @@ import {
   insertMilestone,
   upsertMilestonePlanning,
   insertSlice,
+  insertArtifact,
 } from "../gsd-db.ts";
 
 function makeBase(): string {
@@ -58,6 +59,16 @@ function seed(base: string, mid: string): void {
     demo: "",
     sequence: 1,
   });
+  // Seed PROJECT.md so inlineProjectFromDb resolves — the run-uat manifest
+  // declares "project" as the third inline artifact (#4925 review).
+  insertArtifact({
+    path: "PROJECT.md",
+    artifact_type: "project",
+    milestone_id: null,
+    slice_id: null,
+    task_id: null,
+    full_content: "# Project\n\nRun-UAT composer fixture project.\n",
+  });
 }
 
 test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project via composer", async (t) => {
@@ -81,14 +92,27 @@ test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project
   // Context wrapper present
   assert.match(prompt, /## Inlined Context \(preloaded — do not re-read these files\)/);
 
-  // Artifacts from the manifest inline list, in declared order
-  assert.match(prompt, /### S01 UAT[\s\S]*### S01 Summary/);
+  // Artifacts from the manifest inline list, in declared order:
+  // slice-uat → slice-summary → project (#4925 review).
+  const uatIdx = prompt.indexOf("### S01 UAT");
+  const summaryIdx = prompt.indexOf("### S01 Summary");
+  const projectIdx = prompt.indexOf("### Project");
+  assert.ok(uatIdx > -1, "slice UAT block missing");
+  assert.ok(summaryIdx > -1, "slice summary block missing");
+  assert.ok(projectIdx > -1, "project block missing — manifest declares project as 3rd inline");
+  assert.ok(
+    uatIdx < summaryIdx && summaryIdx < projectIdx,
+    `manifest order violated: uat (${uatIdx}) < summary (${summaryIdx}) < project (${projectIdx})`,
+  );
 
   // UAT body content inlined
   assert.match(prompt, /Check X[\s\S]*Check Y/);
 
   // Summary body content inlined
   assert.match(prompt, /What Happened[\s\S]*Ship/);
+
+  // Project body content inlined
+  assert.match(prompt, /Run-UAT composer fixture project/);
 });
 
 test("#4782 phase 3: buildRunUatPrompt omits optional slice summary when file is missing", async (t) => {
@@ -108,6 +132,11 @@ test("#4782 phase 3: buildRunUatPrompt omits optional slice summary when file is
   assert.match(prompt, /### S01 UAT/);
   // No empty "S01 Summary" section — section body would be blank without a file
   assert.ok(!prompt.includes("### S01 Summary"));
+  // Project still present (third inline artifact, not optional) and follows
+  // UAT directly with the skipped summary collapsed (#4925 review).
+  const uatIdx = prompt.indexOf("### S01 UAT");
+  const projectIdx = prompt.indexOf("### Project");
+  assert.ok(projectIdx > uatIdx, `project must follow UAT when summary is omitted (uat=${uatIdx}, project=${projectIdx})`);
   // No double separator from a skipped block
   assert.ok(!prompt.includes("---\n\n---"));
 });

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -347,7 +347,11 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     codebaseMap: false,
     preferences: "active-only",
     artifacts: {
-      inline: ["slice-uat", "slice-plan"],
+      // Phase 3 migration (#4782): manifest matches today's actual
+      // buildRunUatPrompt inlining. Prior phase-1 entry listed
+      // `slice-plan` aspirationally — the real builder inlines the UAT
+      // file, the slice SUMMARY (optional), and the project row.
+      inline: ["slice-uat", "slice-summary", "project"],
       excerpt: [],
       onDemand: [],
     },

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -166,7 +166,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     codebaseMap: true,
     preferences: "active-only",
     artifacts: {
-      inline: ["project", "requirements", "decisions", "templates"],
+      // Phase 3 migration (#4782): matches today's actual
+      // buildResearchMilestonePrompt inlining order.
+      inline: ["milestone-context", "project", "requirements", "decisions", "templates"],
       excerpt: [],
       onDemand: [],
     },

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -290,7 +290,11 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     codebaseMap: false,
     preferences: "active-only",
     artifacts: {
-      inline: ["slice-plan", "slice-research", "prior-task-summaries", "requirements", "templates"],
+      // Phase 3 migration (#4782): matches today's actual
+      // buildCompleteSlicePrompt inlining order. Overrides prepend +
+      // knowledge splice stay in the builder imperatively (see RFC
+      // #4924 — computed/prepend blocks are phase-4 composer work).
+      inline: ["roadmap", "slice-context", "slice-plan", "requirements", "prior-task-summaries", "templates"],
       excerpt: [],
       onDemand: [],
     },


### PR DESCRIPTION
> ## ⚠️ Draft — stacked on [#4923](https://github.com/gsd-build/gsd-2/pull/4923) → [#4922](https://github.com/gsd-build/gsd-2/pull/4922) → [#4921](https://github.com/gsd-build/gsd-2/pull/4921)
>
> Diff includes ancestor commits until they merge to main. Will rebase post-merge.

## TL;DR

**What:** Fourth composer migration. \`buildCompleteSlicePrompt\` composes its inlined context via the manifest, with the dynamic \`prior-task-summaries\` resolver demonstrating how to emit per-element blocks from a directory scan.
**Why:** Continues phase-3 simple-builder coverage and surfaces the edges where composer v1 still needs imperative carve-outs (knowledge splice + overrides prepend) — both captured in follow-up RFC #4924.
**How:** Six-key resolver dispatches to existing inline helpers. \`prior-task-summaries\` scans the tasks dir and joins per-task blocks with the composer separator. \`templates\` emits slice-summary plus conditional UAT template.

## What

- \`unit-context-manifest.ts\` — complete-slice manifest: \`[roadmap, slice-context, slice-plan, requirements, prior-task-summaries, templates]\`.
- \`auto-prompts.ts\` — \`buildCompleteSlicePrompt\` composes via manifest. Two imperative carve-outs:
  - Knowledge splices in between requirements and task summaries (pre-migration ordering)
  - Overrides section prepends to the final inlined context
- \`tests/complete-slice-composer.test.ts\` — 2 regression tests covering full fixture + missing-task-summary graceful path.

## Why

Part of #4782 phase 3. Demonstrates how dynamic artifact resolution (directory scan → per-element blocks) fits the existing v1 composer without contract changes. The two imperative carve-outs (knowledge splice + overrides prepend) are documented as **phase 4 targets** in RFC #4924 (computed / prepend blocks).

## How

### Resolver shape for \`prior-task-summaries\`

```ts
case "prior-task-summaries": {
  const tDir = resolveTasksDir(base, mid, sid);
  if (!tDir) return null;
  const summaryFiles = resolveTaskFiles(tDir, "SUMMARY").sort();
  const blocks: string[] = [];
  for (const file of summaryFiles) {
    const content = await loadFile(join(tDir, file));
    if (content) blocks.push(`### Task Summary: ${…}`);
  }
  return blocks.length > 0 ? blocks.join("\n\n---\n\n") : null;
}
```

Returns null when no summaries exist — composer skips silently. Multiple summaries are emitted as one joined block (composer then separates it from adjacent artifacts with its standard \`---\` separator).

### Why knowledge + overrides stay imperative

- **Knowledge** needs a splice between requirements and task summaries to preserve pre-migration ordering. The v1 composer walks \`inline\` linearly; there's no seam for "insert X between Y and Z." RFC #4924 proposes knowledge as a composer-aware policy; this builder converts once that lands.
- **Overrides** prepend to the whole context block. The v1 composer has no \`prepend\` contract. RFC #4924 proposes \`manifest.prepend\` for this.

Two carve-outs out of seven context pieces — composer handles 5/7 declaratively.

### Local verification

**24/24 tests passing** across complete-slice + research-milestone + run-uat + unit-context-composer + unit-context-manifest.

## Change type

- [x] \`feat\` — Fourth migration. Observable-equivalent output.

## Breaking changes

**None.** complete-slice prompt content and structure unchanged for realistic inputs. Ordering preserved via imperative splice.

AI-assisted PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated prompt composition to a manifest-driven composer for research milestones, slice completion, and UAT flows—yielding deterministic section ordering and more robust handling of optional/inline content.
* **Tests**
  * Added end-to-end tests validating composed prompts for research milestones, slice completion, and UAT to ensure correct section inclusion, ordering, and stability when artifacts are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->