### PR TITLE
feat(auto): UnitContextManifest v2 contract — typed computed artifacts (#4924) [STACKED on #4925]

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -10,10 +10,18 @@ import { tmpdir } from "node:os";
 
 import {
   composeInlinedContext,
+  composeUnitContext,
   manifestBudgetChars,
   type ArtifactResolver,
+  type ExcerptResolver,
 } from "../unit-context-composer.ts";
-import type { ArtifactKey } from "../unit-context-manifest.ts";
+import type {
+  ArtifactKey,
+  BaseResolverContext,
+  ComputedArtifactRegistry,
+  UnitContextManifest,
+} from "../unit-context-manifest.ts";
+import { UNIT_MANIFESTS } from "../unit-context-manifest.ts";
 import { buildReassessRoadmapPrompt } from "../auto-prompts.ts";
 import { invalidateAllCaches } from "../cache.ts";
 import {
@@ -172,4 +180,141 @@ test("#4782 phase 2: buildReassessRoadmapPrompt emits composer-shaped context wi
   // Slice context is optional and not present in this fixture — must not
   // leave a stray empty section
   assert.ok(!prompt.includes("Slice Context (from discussion)"));
+});
+
+// ─── v2 surface (#4924) ───────────────────────────────────────────────────
+
+const fakeBase: BaseResolverContext = {
+  unitType: "reassess-roadmap",
+  basePath: "/tmp/fake",
+  milestoneId: "M001",
+  sliceId: "S01",
+};
+
+test("#4924 v2 composer: returns empty sections for unknown unit type", async () => {
+  const out = await composeUnitContext("never-dispatched", { base: fakeBase });
+  assert.deepEqual(out, { prepend: "", inline: "" });
+});
+
+test("#4924 v2 composer: omitting resolveArtifact skips inline keys without erroring", async () => {
+  const out = await composeUnitContext("reassess-roadmap", { base: fakeBase });
+  assert.strictEqual(out.inline, "");
+  assert.strictEqual(out.prepend, "");
+});
+
+test("#4924 v2 composer: walks inline + excerpt + computed sections in declared order", async () => {
+  // Reuse the run-uat manifest shape (small inline, no excerpt/computed) and
+  // synthesise a manifest-shape override via a temporary registration would
+  // require touching production data. Instead, drive the composer through
+  // the existing manifest plus mock resolvers and verify ordering against
+  // the declared sequence.
+  const calls: string[] = [];
+  const resolveArtifact: ArtifactResolver = async (key) => {
+    calls.push(`art:${key}`);
+    return `BODY:${key}`;
+  };
+  const out = await composeUnitContext("run-uat", { base: { ...fakeBase, unitType: "run-uat" }, resolveArtifact });
+  // run-uat manifest inline order: slice-uat, slice-summary, project
+  assert.deepEqual(calls, ["art:slice-uat", "art:slice-summary", "art:project"]);
+  assert.match(out.inline, /BODY:slice-uat\n\n---\n\nBODY:slice-summary\n\n---\n\nBODY:project/);
+});
+
+test("#4924 v2 composer: excerpt section calls resolveExcerpt for declared keys", async () => {
+  // complete-milestone declares slice-summary as excerpt — perfect target.
+  const inlineCalls: ArtifactKey[] = [];
+  const excerptCalls: ArtifactKey[] = [];
+  const resolveArtifact: ArtifactResolver = async (key) => {
+    inlineCalls.push(key);
+    return `INLINE:${key}`;
+  };
+  const resolveExcerpt: ExcerptResolver = async (key) => {
+    excerptCalls.push(key);
+    return `EXCERPT:${key}`;
+  };
+  const out = await composeUnitContext("complete-milestone", {
+    base: { ...fakeBase, unitType: "complete-milestone" },
+    resolveArtifact,
+    resolveExcerpt,
+  });
+  assert.ok(excerptCalls.includes("slice-summary"));
+  // Excerpt body appears in the composed inline section, after inline keys.
+  assert.match(out.inline, /EXCERPT:slice-summary/);
+  // The inline keys come first per the manifest order.
+  const cmManifest = UNIT_MANIFESTS["complete-milestone"];
+  const firstInlineKey = cmManifest.artifacts.inline[0]!;
+  const firstInlineIdx = out.inline.indexOf(`INLINE:${firstInlineKey}`);
+  const excerptIdx = out.inline.indexOf("EXCERPT:slice-summary");
+  assert.ok(firstInlineIdx >= 0 && excerptIdx > firstInlineIdx, "inline body should precede excerpt body");
+});
+
+test("#4924 v2 composer: prepend block is separate from inline section", async () => {
+  // No production manifest declares a prepend block yet (those land with
+  // each batched migration). Drive the composer through a synthetic
+  // manifest by patching UNIT_MANIFESTS just for this test.
+  const original = UNIT_MANIFESTS["run-uat"];
+  type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+  const patched: UnitContextManifest = {
+    ...original,
+    prepend: ["test-banner"] as never[], // computed id not in production registry — typed via cast for the test
+  };
+  (UNIT_MANIFESTS as Mutable<typeof UNIT_MANIFESTS>)["run-uat"] = patched;
+  try {
+    const computed = {
+      "test-banner": {
+        build: async (_inputs: never, base: BaseResolverContext) => `BANNER for ${base.unitType}`,
+        inputs: undefined as never,
+      },
+    } as unknown as ComputedArtifactRegistry;
+    const out = await composeUnitContext("run-uat", {
+      base: { ...fakeBase, unitType: "run-uat" },
+      computed,
+    });
+    assert.strictEqual(out.prepend, "BANNER for run-uat");
+    assert.strictEqual(out.inline, "");
+  } finally {
+    (UNIT_MANIFESTS as Mutable<typeof UNIT_MANIFESTS>)["run-uat"] = original;
+  }
+});
+
+test("#4924 v2 composer: missing computed registry entry is skipped silently", async () => {
+  const original = UNIT_MANIFESTS["run-uat"];
+  type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+  const patched: UnitContextManifest = {
+    ...original,
+    prepend: ["test-banner"] as never[],
+  };
+  (UNIT_MANIFESTS as Mutable<typeof UNIT_MANIFESTS>)["run-uat"] = patched;
+  try {
+    // No `computed` registry supplied — declared id should be skipped, not throw.
+    const out = await composeUnitContext("run-uat", { base: { ...fakeBase, unitType: "run-uat" } });
+    assert.strictEqual(out.prepend, "");
+  } finally {
+    (UNIT_MANIFESTS as Mutable<typeof UNIT_MANIFESTS>)["run-uat"] = original;
+  }
+});
+
+test("#4924 v2 composer: computed builder returning null omits the section (no empty separator)", async () => {
+  const original = UNIT_MANIFESTS["run-uat"];
+  type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+  const patched: UnitContextManifest = {
+    ...original,
+    prepend: ["test-banner-a", "test-banner-b"] as never[],
+  };
+  (UNIT_MANIFESTS as Mutable<typeof UNIT_MANIFESTS>)["run-uat"] = patched;
+  try {
+    const computed = {
+      "test-banner-a": { build: async () => null, inputs: undefined as never },
+      "test-banner-b": { build: async () => "B", inputs: undefined as never },
+    } as unknown as ComputedArtifactRegistry;
+    const out = await composeUnitContext("run-uat", { base: { ...fakeBase, unitType: "run-uat" }, computed });
+    assert.strictEqual(out.prepend, "B");
+    assert.ok(!out.prepend.includes("---"));
+  } finally {
+    (UNIT_MANIFESTS as Mutable<typeof UNIT_MANIFESTS>)["run-uat"] = original;
+  }
+});
+
+test("#4924 v2 composer: backward-compat — composeInlinedContext still works for v1 callers", async () => {
+  const out = await composeInlinedContext("run-uat", async (key) => `BODY:${key}`);
+  assert.match(out, /BODY:slice-uat\n\n---\n\nBODY:slice-summary\n\n---\n\nBODY:project/);
 });

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -318,3 +318,38 @@ test("#4924 v2 composer: backward-compat — composeInlinedContext still works f
   const out = await composeInlinedContext("run-uat", async (key) => `BODY:${key}`);
   assert.match(out, /BODY:slice-uat\n\n---\n\nBODY:slice-summary\n\n---\n\nBODY:project/);
 });
+
+test("#4926 review: computed builders see normalized base.unitType matching the resolved manifest", async () => {
+  // Caller passes one unitType to composeUnitContext but a different (stale)
+  // value in opts.base. Composer must normalize so builders observe the
+  // unitType the manifest was resolved against — preventing manifests and
+  // computed context from drifting.
+  const original = UNIT_MANIFESTS["run-uat"];
+  type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+  const patched: UnitContextManifest = {
+    ...original,
+    prepend: ["test-banner"] as never[],
+  };
+  (UNIT_MANIFESTS as Mutable<typeof UNIT_MANIFESTS>)["run-uat"] = patched;
+  try {
+    let observedUnitType: string | undefined;
+    const computed = {
+      "test-banner": {
+        build: async (_inputs: never, base: BaseResolverContext) => {
+          observedUnitType = base.unitType;
+          return `BANNER for ${base.unitType}`;
+        },
+        inputs: undefined as never,
+      },
+    } as unknown as ComputedArtifactRegistry;
+    const out = await composeUnitContext("run-uat", {
+      // Deliberately mismatched: function arg "run-uat" vs. base.unitType "stale-other-unit".
+      base: { ...fakeBase, unitType: "stale-other-unit" },
+      computed,
+    });
+    assert.strictEqual(observedUnitType, "run-uat", "builder must see the unitType the manifest was resolved against");
+    assert.strictEqual(out.prepend, "BANNER for run-uat");
+  } finally {
+    (UNIT_MANIFESTS as Mutable<typeof UNIT_MANIFESTS>)["run-uat"] = original;
+  }
+});

--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -155,6 +155,38 @@ test("#4782 phase 1: complete-milestone manifest declares slice-summary as excer
   );
 });
 
+// ─── v2 contract invariants (#4924) ──────────────────────────────────────
+
+test("#4924: computed + prepend ids (when declared) are non-empty strings", () => {
+  for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
+    const ids: string[] = [
+      ...((manifest.artifacts as { computed?: readonly string[] }).computed ?? []),
+      ...((manifest as { prepend?: readonly string[] }).prepend ?? []),
+    ];
+    for (const id of ids) {
+      assert.ok(
+        typeof id === "string" && id.length > 0,
+        `manifest "${unitType}" has an empty/invalid computed/prepend id: ${JSON.stringify(id)}`,
+      );
+    }
+  }
+});
+
+test("#4924: no computed id appears in both artifacts.computed AND prepend (mutually exclusive position)", () => {
+  for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
+    const inlineComputed = new Set<string>(
+      ((manifest.artifacts as { computed?: readonly string[] }).computed ?? []),
+    );
+    const clashes = ((manifest as { prepend?: readonly string[] }).prepend ?? [])
+      .filter(id => inlineComputed.has(id));
+    assert.deepEqual(
+      clashes,
+      [],
+      `manifest "${unitType}" places computed id(s) in both prepend and inline-computed: ${clashes.join(", ")}. Pick one position.`,
+    );
+  }
+});
+
 // ─── Budget floor: run-uat + gate-evaluate hit the smallest budget tier ──
 
 test("#4782 phase 2: run-uat and gate-evaluate use the smallest budget tier", () => {

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -14,14 +14,34 @@
 //     "artifact is optional / missing / not applicable to this milestone"
 //     case. The composer never errors on a missing artifact.
 //
-// Scope: phase 2 pilot. The composer currently handles only the `inline`
-// artifact list. Excerpt and on-demand artifact shapes (already used by
-// #4780) will be folded in during phase 3 when the remaining unit types
-// migrate into the composer.
+// Scope: phase 2 pilot shipped `composeInlinedContext` for static-key
+// inlining. Phase 3.5 (#4924) adds the v2 surface — `composeUnitContext`
+// — which also handles excerpts, computed artifacts, and prepended blocks.
+// `composeInlinedContext` stays for backward compatibility with the
+// already-migrated simple builders.
+//
+// ─── Composer boundary invariant (#4924) ─────────────────────────────────
+//
+// The composer is allowed to:
+//   - order named sections per the manifest's declared sequence
+//   - resolve registered artifacts (static / computed / excerpt / on-demand)
+//   - apply typed policies (knowledge / memory / codebase-map / preferences)
+//
+// The composer must NOT grow:
+//   - arbitrary conditionals on unit state
+//   - loops over caller-supplied data
+//   - string templating beyond section composition (join + separator)
+//
+// Logic that needs those belongs in a typed computed-artifact builder
+// owned by the unit, not in the composer. Reviews must enforce this — it
+// is the difference between an orchestrator and a runaway DSL.
 
 import {
   resolveManifest,
   type ArtifactKey,
+  type BaseResolverContext,
+  type ComputedArtifactId,
+  type ComputedArtifactRegistry,
   type UnitContextManifest,
 } from "./unit-context-manifest.js";
 
@@ -70,4 +90,112 @@ export async function composeInlinedContext(
 export function manifestBudgetChars(unitType: string): number | null {
   const manifest = resolveManifest(unitType);
   return manifest ? manifest.maxSystemPromptChars : null;
+}
+
+// ─── v2 surface (#4924) ───────────────────────────────────────────────────
+
+/**
+ * Resolver for excerpt-class artifacts. Returns the compact block body
+ * (per-unit excerpt rendering — e.g. `buildSliceSummaryExcerpt` for the
+ * complete-milestone closer) or `null` to omit. Mirrors `ArtifactResolver`
+ * shape so consumers can reuse the same registry pattern.
+ */
+export type ExcerptResolver = (key: ArtifactKey) => Promise<string | null>;
+
+/**
+ * Inputs to the v2 composer entrypoint. The base context is required;
+ * each resolver/registry is optional and absent ones are treated as
+ * "manifest declares no entries of that class for this unit."
+ */
+export interface ComposeUnitContextOptions {
+  readonly base: BaseResolverContext;
+  readonly resolveArtifact?: ArtifactResolver;
+  readonly resolveExcerpt?: ExcerptResolver;
+  readonly computed?: ComputedArtifactRegistry;
+}
+
+/**
+ * Composer output. Kept structured (rather than a single joined string)
+ * because some builders need to splice the prepend block above their own
+ * preamble while keeping the main context block in its existing position.
+ *
+ * Both fields are joined with the in-tree `\n\n---\n\n` separator. Empty
+ * string means "no content for this section" — callers branch on truthy
+ * to decide whether to render any wrapper headers.
+ */
+export interface ComposedUnitContext {
+  readonly prepend: string;
+  readonly inline: string;
+}
+
+const SECTION_SEPARATOR = "\n\n---\n\n";
+
+/**
+ * Compose all manifest-declared context for a unit type using the v2
+ * surface. Walks `prepend` first (computed-only), then the `inline` list
+ * (static keys via `resolveArtifact`), then `excerpt` (via `resolveExcerpt`),
+ * then `artifacts.computed` (via the typed registry). Order within each
+ * section follows the manifest's declared sequence.
+ *
+ * Unknown unit types return empty strings for both sections — callers can
+ * fall back to existing imperative wiring without a special case.
+ *
+ * Resolver / registry omissions: if the manifest declares an entry but no
+ * resolver / registry entry is provided, the composer skips it silently.
+ * This matches the v1 contract where a null body is a no-op, and lets
+ * partial migrations land without forcing every consumer to register
+ * every artifact class up-front.
+ */
+export async function composeUnitContext(
+  unitType: string,
+  opts: ComposeUnitContextOptions,
+): Promise<ComposedUnitContext> {
+  const manifest: UnitContextManifest | null = resolveManifest(unitType);
+  if (!manifest) return { prepend: "", inline: "" };
+
+  const prependBlocks = await runComputed(manifest.prepend ?? [], opts);
+  const inlineBlocks: string[] = [];
+
+  for (const key of manifest.artifacts.inline) {
+    if (!opts.resolveArtifact) break;
+    const body = await opts.resolveArtifact(key);
+    if (body && body.length > 0) inlineBlocks.push(body);
+  }
+  for (const key of manifest.artifacts.excerpt) {
+    if (!opts.resolveExcerpt) break;
+    const body = await opts.resolveExcerpt(key);
+    if (body && body.length > 0) inlineBlocks.push(body);
+  }
+  inlineBlocks.push(...await runComputed(manifest.artifacts.computed ?? [], opts));
+
+  return {
+    prepend: prependBlocks.join(SECTION_SEPARATOR),
+    inline: inlineBlocks.join(SECTION_SEPARATOR),
+  };
+}
+
+/**
+ * Invoke the registered builder for each declared computed id, in order.
+ * Missing registry entries (manifest declares the id but caller didn't
+ * register it) are skipped silently — see composeUnitContext rationale.
+ */
+async function runComputed(
+  ids: readonly ComputedArtifactId[],
+  opts: ComposeUnitContextOptions,
+): Promise<string[]> {
+  if (ids.length === 0 || !opts.computed) return [];
+  const out: string[] = [];
+  for (const id of ids) {
+    const entry = opts.computed[id];
+    if (!entry) continue;
+    // Each entry is { build, inputs } typed against ComputedArtifactInputs[K].
+    // Cast widens K → ComputedArtifactId for the dispatch; the registry's
+    // per-key types kept the call site honest.
+    const body = await (entry.build as (
+      i: unknown,
+      b: BaseResolverContext,
+    ) => Promise<string | null>)(entry.inputs, opts.base);
+    if (body && body.length > 0) out.push(body);
+  }
+  return out;
 }

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -184,17 +184,22 @@ async function runComputed(
   opts: ComposeUnitContextOptions,
 ): Promise<string[]> {
   if (ids.length === 0 || !opts.computed) return [];
+  // Type safety lives at the registration boundary (caller-supplied
+  // `computed` is typed against ComputedArtifactInputs[K] per id). Inside
+  // the composer we only dispatch — view the registry through a widened
+  // local shape so the loop compiles when the registry is empty (which
+  // it is in the v2-contract foundation PR before any computed ids are
+  // registered, making `keyof ComputedArtifactInputs` resolve to `never`).
+  type AnyEntry = {
+    build: (inputs: unknown, base: BaseResolverContext) => Promise<string | null>;
+    inputs: unknown;
+  };
+  const registry = opts.computed as Record<string, AnyEntry | undefined>;
   const out: string[] = [];
   for (const id of ids) {
-    const entry = opts.computed[id];
+    const entry = registry[id];
     if (!entry) continue;
-    // Each entry is { build, inputs } typed against ComputedArtifactInputs[K].
-    // Cast widens K → ComputedArtifactId for the dispatch; the registry's
-    // per-key types kept the call site honest.
-    const body = await (entry.build as (
-      i: unknown,
-      b: BaseResolverContext,
-    ) => Promise<string | null>)(entry.inputs, opts.base);
+    const body = await entry.build(entry.inputs, opts.base);
     if (body && body.length > 0) out.push(body);
   }
   return out;

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -153,20 +153,32 @@ export async function composeUnitContext(
   const manifest: UnitContextManifest | null = resolveManifest(unitType);
   if (!manifest) return { prepend: "", inline: "" };
 
-  const prependBlocks = await runComputed(manifest.prepend ?? [], opts);
+  // Single-source `unitType`: the manifest is resolved against the
+  // function arg, but computed builders read it from `base.unitType`.
+  // If those ever diverge (caller passes one type to composeUnitContext
+  // but a different one in opts.base), the composer would silently
+  // mix one unit's manifest with another unit's computed context.
+  // Normalize here so the composer dispatches a consistent identity
+  // through to every builder.
+  const normalizedOpts: ComposeUnitContextOptions = {
+    ...opts,
+    base: { ...opts.base, unitType },
+  };
+
+  const prependBlocks = await runComputed(manifest.prepend ?? [], normalizedOpts);
   const inlineBlocks: string[] = [];
 
   for (const key of manifest.artifacts.inline) {
-    if (!opts.resolveArtifact) break;
-    const body = await opts.resolveArtifact(key);
+    if (!normalizedOpts.resolveArtifact) break;
+    const body = await normalizedOpts.resolveArtifact(key);
     if (body && body.length > 0) inlineBlocks.push(body);
   }
   for (const key of manifest.artifacts.excerpt) {
-    if (!opts.resolveExcerpt) break;
-    const body = await opts.resolveExcerpt(key);
+    if (!normalizedOpts.resolveExcerpt) break;
+    const body = await normalizedOpts.resolveExcerpt(key);
     if (body && body.length > 0) inlineBlocks.push(body);
   }
-  inlineBlocks.push(...await runComputed(manifest.artifacts.computed ?? [], opts));
+  inlineBlocks.push(...await runComputed(manifest.artifacts.computed ?? [], normalizedOpts));
 
   return {
     prepend: prependBlocks.join(SECTION_SEPARATOR),

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -90,6 +90,79 @@ export type MemoryPolicy = "none" | "critical-only" | "prompt-relevant";
 /** Preferences block policy. */
 export type PreferencesPolicy = "none" | "active-only" | "full";
 
+// ─── Computed-artifact registry (#4924 v2 contract) ───────────────────────
+
+/**
+ * Typed registry of computed-artifact ids → their per-call input shape.
+ *
+ * **This is the core anti-`extra: Record<string, unknown>` surface.** Each
+ * computed block a unit may emit is registered here with an explicit input
+ * type. Adding a new computed block requires extending this interface — a
+ * deliberate, reviewable change rather than a silent ad-hoc field.
+ *
+ * Consumers extend via module augmentation if a downstream package needs to
+ * register new computed ids (rare in-tree; no public API today). The repo's
+ * own computed blocks are declared inline below.
+ *
+ * Invariant: the value type for each id MUST be a plain serializable shape.
+ * No closures, no class instances, no `any`. If a builder needs framework
+ * state, declare the specific fields it needs — don't smuggle objects.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ComputedArtifactInputs {
+  // Phase 3.5 (v2 contract PR — #4924): no computed ids are registered yet.
+  // Each follow-up batch (slice prompt, replan-slice, gate-evaluate, etc.)
+  // adds the ids it needs as part of its migration commit.
+  //
+  // Example shape an upcoming batch will register:
+  //   "slice-handoff-anchors": { sliceId: string; phase: string };
+  //   "roadmap-excerpt":       { milestoneId: string; aroundSlice: string };
+  //   "graph-subgraph":        { rootArtifact: ArtifactKey };
+  //   "blocker-task-summary":  { sliceId: string };
+  //   "overrides-banner":      { /* basePath via BaseResolverContext */ };
+}
+
+/** Stable string ids for registered computed artifacts. */
+export type ComputedArtifactId = keyof ComputedArtifactInputs & string;
+
+/**
+ * Always-present context the composer hands every computed-artifact builder.
+ * Carries unit-shape fields that don't belong in per-id input types because
+ * every builder needs them (path resolution, dispatch identity).
+ */
+export interface BaseResolverContext {
+  readonly unitType: string;
+  readonly basePath: string;
+  readonly milestoneId?: string;
+  readonly sliceId?: string;
+  readonly taskId?: string;
+}
+
+/**
+ * Builder signature for one computed artifact id. Returns the rendered
+ * block body (joined into the composed prompt at the manifest-declared
+ * position) or `null` to omit the block entirely.
+ */
+export type ComputedArtifactBuilder<K extends ComputedArtifactId> = (
+  inputs: ComputedArtifactInputs[K],
+  base: BaseResolverContext,
+) => Promise<string | null>;
+
+/**
+ * Per-call registry: for each computed id the manifest declares, the
+ * caller supplies the matching builder + the input value for this call.
+ *
+ * Runtime shape: `{ [id]: { build, inputs } }`. Type narrowing per key is
+ * handled inside the composer via the `ComputedArtifactInputs` map — calls
+ * stay type-safe across the registration boundary.
+ */
+export type ComputedArtifactRegistry = {
+  readonly [K in ComputedArtifactId]?: {
+    readonly build: ComputedArtifactBuilder<K>;
+    readonly inputs: ComputedArtifactInputs[K];
+  };
+};
+
 // ─── Manifest ─────────────────────────────────────────────────────────────
 
 export interface UnitContextManifest {
@@ -108,7 +181,21 @@ export interface UnitContextManifest {
     readonly inline: readonly ArtifactKey[];
     readonly excerpt: readonly ArtifactKey[];
     readonly onDemand: readonly ArtifactKey[];
+    /**
+     * Ordered list of computed-block ids emitted in the inline position
+     * (interleaved with `inline` in declared order — see composer for the
+     * exact merge rule). v2 contract addition (#4924). Unknown ids fail
+     * the manifest validator; absent registry entries are skipped silently.
+     */
+    readonly computed?: readonly ComputedArtifactId[];
   };
+  /**
+   * Ordered list of computed-block ids emitted ABOVE the main inlined
+   * context block. Models the existing pattern of overrides / banners
+   * that some builders prepend with `inlined.unshift(...)`. v2 contract
+   * addition (#4924).
+   */
+  readonly prepend?: readonly ComputedArtifactId[];
   /**
    * Nominal upper bound for composer-generated system prompt size, in
    * characters. Phase 2 composer logs telemetry when a unit exceeds its


### PR DESCRIPTION
## TL;DR

Phase 3.5 foundation for #4924. Ships the v2 composer contract — typed `ComputedArtifactInputs` registry, `prepend` blocks, excerpt fold-in, written boundary invariant — without migrating any builder yet. Follow-up PRs migrate the ~10 complex builders in batches against this surface.

**Stacked on #4925** (phase 3 batch 3). Merge order: 4925 → this. Diff against main currently includes batch-3 commits — they drop out automatically once 4925 lands.

## Why

Phase 3 of #4782 closed at 4/16 builder migrations because the v1 composer (single static-key `inline` list) doesn't fit the complex cluster. The RFC #4924 proposed a v2 contract; peer review flagged one issue with the original RFC shape (`UnitResolverContext.extra: Record<string, unknown>` would have become the new imperative splicing layer — see https://github.com/gsd-build/gsd-2/issues/4924#issuecomment-4315672196). This PR ships the revised contract — typed per-id input map, no `extra` escape hatch — and the explicit boundary invariant the composer must respect.

## What changed

### `unit-context-manifest.ts`
- `ComputedArtifactInputs` — typed registry of computed-block ids → input shape. Empty in this PR; each follow-up batch registers the ids its builder needs.
- `BaseResolverContext` — always-present unit-shape fields the composer hands every computed builder.
- `ComputedArtifactBuilder<K>` — typed builder signature.
- `ComputedArtifactRegistry` — per-call `{ build, inputs }` map keyed by id.
- `UnitContextManifest` gains optional `artifacts.computed?` and top-level `prepend?` arrays. Both default to empty — backward-compatible.

### `unit-context-composer.ts`
- **Boundary invariant** codified at the top of the file: composer orders sections, resolves registered artifacts, applies typed policies. Composer must NOT grow conditionals, loops, or string templating beyond section composition. Reviewers enforce.
- `composeUnitContext(unitType, opts)` → `{ prepend, inline }`: walks prepend → static inline → excerpt → computed-inline in declared order. Returns structured result so callers that need to splice prepend above their preamble can do so without re-parsing.
- `ExcerptResolver` type. Folds the existing `artifacts.excerpt` field into the composer (was unused since phase 1).
- v1 `composeInlinedContext` untouched. Already-migrated builders (reassess-roadmap, run-uat, research-milestone, complete-slice, rewrite-docs) keep working unchanged.

### Tests
- 8 new v2 composer tests: unknown unit type, missing resolver, declared-order across all four sections, prepend separation, missing registry skip, null body skip, v1 backward compat.
- 2 new manifest invariants: computed/prepend ids must be non-empty strings; no id may appear in both `artifacts.computed` and `prepend`.
- 28/28 green. `tsc --noEmit` clean.

## Migration roadmap (after this lands)

Per the RFC migration plan, batched as independently revertible PRs:

1. ✅ This PR — v2 contract.
2. `renderSlicePrompt` (plan-slice + refine-slice) — registers slice-handoff-anchor, roadmap-excerpt, knowledge-scoped, graph-subgraph, overrides-banner.
3. `buildResearchSlicePrompt`.
4. `buildExecuteTaskPrompt` + `buildReactiveExecutePrompt`.
5. `buildReplanSlicePrompt` (registers blocker-task-summary).
6. `buildCompleteMilestonePrompt` (folds the #4908 excerpt builder into the v2 surface).
7. `buildValidateMilestonePrompt`.
8. `buildPlanMilestonePrompt` + `buildDiscussMilestonePrompt`.
9. `buildGateEvaluatePrompt` — section-set artifact (separate follow-up PR; this PR doesn't ship section-set yet).

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx tsx --test src/resources/extensions/gsd/tests/unit-context-{manifest,composer}.test.ts` — 28/28 pass
- [x] No production manifest declares `computed` / `prepend` yet — zero behavior change for already-migrated builders
- [x] Pilot builder (`buildReassessRoadmapPrompt`) integration test still passes against the new file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved context composition for generated prompts: preserves intended block ordering, prepends overrides, and omits empty/optional sections to produce cleaner outputs.
  * Manifest-driven artifact resolution enables more predictable inclusion and ordering of roadmap, plan, summaries, templates, and computed sections.

* **Tests**
  * Added extensive tests validating composition ordering, handling of missing summaries, computed/prepend contracts, and backwards-compat behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->