### PR TITLE
test(auto): #4925 follow-up regressions — KNOWLEDGE splice + UAT drift

### DIFF
--- a/src/resources/extensions/gsd/tests/complete-slice-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-composer.test.ts
@@ -145,3 +145,48 @@ test("#4782 phase 3: buildCompleteSlicePrompt handles missing task summaries gra
   const planIdx = prompt.indexOf("### Slice Plan");
   assert.ok(roadmapIdx > -1 && planIdx > roadmapIdx);
 });
+
+test("#4925 review: KNOWLEDGE splices BEFORE templates when no task summaries exist", async (t) => {
+  // Regression for the bug fixed in fcf3bfbe: the templates fallback was
+  // searching for "### Slice Summary" but inlineTemplate emits
+  // "### Output Template: Slice Summary", so templatesIdx stayed -1 and
+  // knowledge ended up appended after templates instead of before them.
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  // Roadmap + plan only — no T*-SUMMARY.md, so taskIdx must be -1 and the
+  // splice falls through to the templates anchor.
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    "# M001 Roadmap\n## Slices\n- [x] **S01: First** `risk:low` `depends:[]`\n",
+  );
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+    "# S01 Plan\n",
+  );
+  // KNOWLEDGE.md with an H3 section whose header matches the slice title
+  // keyword "first" — queryKnowledge will return the section, so
+  // inlineKnowledgeBudgeted produces a non-null block and the splice
+  // path executes.
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "KNOWLEDGE.md"),
+    "## Topics\n\n### First-slice notes\n\nNotes that should be inlined.\n",
+  );
+
+  const prompt = await buildCompleteSlicePrompt("M001", "Composer Test", "S01", "First", base);
+
+  // Sanity: the splice path actually fired.
+  assert.ok(!prompt.includes("### Task Summary:"), "fixture must have no task summaries to exercise the fallback");
+  const knowledgeIdx = prompt.indexOf("### Project Knowledge (scoped)");
+  const templatesIdx = prompt.indexOf("### Output Template: Slice Summary");
+  assert.ok(knowledgeIdx > -1, "knowledge block missing — fixture failed to populate KNOWLEDGE.md scope");
+  assert.ok(templatesIdx > -1, "templates block missing");
+  // The bug: knowledge appeared AFTER templates. The fix: knowledge before templates.
+  assert.ok(
+    knowledgeIdx < templatesIdx,
+    `knowledge (${knowledgeIdx}) must splice before templates (${templatesIdx}) when no task summaries exist`,
+  );
+});

--- a/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
@@ -78,15 +78,19 @@ test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project
 
   seed(base, "M001");
 
-  // Write UAT + SUMMARY files for the slice
+  // Write UAT + SUMMARY files. Deliberately diverge the on-disk UAT body
+  // from the in-memory uatContent the caller passes — if the resolver
+  // ever re-reads disk (the bug fixed in fcf3bfbe), this test fails
+  // because the prompt would contain "stale on-disk body" instead of
+  // "fresh in-memory snapshot" (#4925 follow-up review).
   const uatRel = ".gsd/milestones/M001/slices/S01/S01-UAT.md";
-  writeFileSync(join(base, uatRel), "# S01 UAT\n\n- Check X\n- Check Y\n");
+  writeFileSync(join(base, uatRel), "# S01 UAT\n\n- stale on-disk body\n");
   writeFileSync(
     join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
     "---\nid: S01\nparent: M001\n---\n# S01 Summary\n**One-liner**\n\n## What Happened\nShip.\n",
   );
 
-  const uatContent = "# S01 UAT\n\n- Check X\n- Check Y\n";
+  const uatContent = "# S01 UAT\n\n- Check X\n- Check Y\n  (fresh in-memory snapshot)\n";
   const prompt = await buildRunUatPrompt("M001", "S01", uatRel, uatContent, base);
 
   // Context wrapper present
@@ -105,8 +109,10 @@ test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project
     `manifest order violated: uat (${uatIdx}) < summary (${summaryIdx}) < project (${projectIdx})`,
   );
 
-  // UAT body content inlined
-  assert.match(prompt, /Check X[\s\S]*Check Y/);
+  // In-memory uatContent inlined — drift assertion: stale disk content
+  // must NOT appear, fresh snapshot MUST appear (#4925 follow-up review).
+  assert.match(prompt, /fresh in-memory snapshot/);
+  assert.ok(!prompt.includes("stale on-disk body"), "resolver re-read disk instead of using uatContent snapshot");
 
   // Summary body content inlined
   assert.match(prompt, /What Happened[\s\S]*Ship/);


### PR DESCRIPTION
## TL;DR

Two regression tests CodeRabbit asked for on #4925 that landed after the merge. Cherry-picked from the orphaned post-merge commits onto a fresh branch off main. Test-only — no production code change.

## Why

#4925 merged at `3336e242` carrying only the original code+test fix (`fcf3bfbe3`). CodeRabbit follow-ups requested:

1. A regression for the KNOWLEDGE-splice template-header bug — exercise the no-task-summaries fallback path so the test actually fails without the fix
2. A drift regression for the UAT in-memory-snapshot fix — diverge on-disk content from `uatContent` so the test fails if the resolver ever re-reads disk

Both were added as `1db1c8ea8` and `961abb274` after the merge. Landing them here so the protection survives.

## What

### `tests/complete-slice-composer.test.ts`
- New test: KNOWLEDGE splices BEFORE templates when no `T*-SUMMARY.md` files exist. Fixture writes `KNOWLEDGE.md` matching the slice keyword and asserts `knowledgeIdx < templatesIdx`. Without the splice fix this would put knowledge after templates.

### `tests/run-uat-composer.test.ts`
- Existing "inlines slice UAT" test: deliberately diverges disk content (`stale on-disk body`) from `uatContent` (`fresh in-memory snapshot`). Asserts only the fresh snapshot appears. Without the in-memory fix this would fail.

## Test plan

- [x] `tsx --test complete-slice-composer.test.ts run-uat-composer.test.ts` — 5/5 pass