### PR TITLE
fix(headless): wire 'gsd headless doctor' so live-regression + dev-publish pass

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -334,6 +334,30 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     return { exitCode: result.exitCode, interrupted: false }
   }
 
+  // Doctor: read-only health check, no RPC child needed (#4904 live-regression).
+  // The interactive `/gsd doctor` command lives in the GSD extension; this CLI
+  // path lets non-interactive callers (CI, recovery scripts, the live-regression
+  // suite) get the same diagnostic without a TTY.
+  if (options.command === 'doctor') {
+    const wantsJson = options.json || options.commandArgs.includes('--json')
+    const { runGSDDoctor } = await import('./resources/extensions/gsd/doctor.js')
+    const { formatDoctorReport, formatDoctorReportJson } = await import('./resources/extensions/gsd/doctor-format.js')
+    let exitCode = 1
+    try {
+      const report = await runGSDDoctor(process.cwd())
+      const out = wantsJson ? formatDoctorReportJson(report) : formatDoctorReport(report)
+      process.stdout.write(`${out}\n`)
+      exitCode = report.ok ? 0 : 1
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      process.stderr.write(`[headless] doctor failed: ${msg}\n`)
+      exitCode = 1
+    }
+    // Bypass the auto-restart loop in runHeadless — doctor is a one-shot
+    // diagnostic; exit 1 means "issues detected", not "crashed".
+    process.exit(exitCode)
+  }
+
   // Resolve CLI path for the child process
   const cliPath = process.env.GSD_BIN_PATH || process.argv[1]
   if (!cliPath) {

--- a/src/tests/headless-doctor.test.ts
+++ b/src/tests/headless-doctor.test.ts
@@ -1,0 +1,97 @@
+// Project/App Name: gsd-pi · headless doctor wiring (#4929)
+//
+// Regression test for the live-regression assertion added in #4904
+// ("gsd doctor surfaces actionable guidance about the stale lock").
+//
+// Before this fix, the headless dispatcher had no `doctor` case — the
+// only path the live-regression test could reach (`gsd headless doctor`)
+// fell through to RPC dispatch and tried to launch a TUI subprocess.
+// Now the dispatcher invokes runGSDDoctor directly (mirrors the existing
+// `query` shape), and the resulting report from a stale-lock fixture
+// carries the "lock" keyword and stale PID the live-regression
+// assertion checks for.
+//
+// This test exercises the runGSDDoctor + formatDoctorReport pipeline
+// the headless case wires up — covering the behavior end-to-end without
+// having to spawn a child process. The dispatch wiring itself is one
+// branch in headless.ts (verified by `npm run build:core`); the
+// behavior-level guarantee the live-regression test cares about is
+// what's verified here.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { runGSDDoctor } from "../resources/extensions/gsd/doctor.ts";
+import {
+  formatDoctorReport,
+  formatDoctorReportJson,
+} from "../resources/extensions/gsd/doctor-format.ts";
+
+function makeStaleLockFixture(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-headless-doctor-"));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  // PID 99999 is conventional in the live-regression suite for "dead PID
+  // we just verified is not running" — we don't need to verify the dead-PID
+  // capture here, just that the doctor surfaces the stale lock cleanly.
+  writeFileSync(
+    join(base, ".gsd", "auto.lock"),
+    JSON.stringify({
+      pid: 99999,
+      startedAt: new Date().toISOString(),
+      unitType: "execute-task",
+      unitId: "M001/S01/T02",
+      unitStartedAt: new Date().toISOString(),
+      completedUnits: 5,
+    }),
+  );
+  return base;
+}
+
+test("#4929: runGSDDoctor + formatDoctorReport surface 'lock' + stale PID for stale auto.lock", async (t) => {
+  const base = makeStaleLockFixture();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const report = await runGSDDoctor(base);
+  const out = formatDoctorReport(report);
+  const lower = out.toLowerCase();
+
+  assert.ok(
+    lower.includes("lock"),
+    `formatted report must mention "lock" — live-regression #4904 asserts this. Got: ${out.slice(0, 300)}`,
+  );
+  assert.ok(
+    out.includes("99999"),
+    `formatted report must mention the stale PID. Got: ${out.slice(0, 300)}`,
+  );
+  assert.ok(
+    lower.includes("stale") || lower.includes("stale_crash_lock"),
+    `formatted report must include mitigation guidance. Got: ${out.slice(0, 300)}`,
+  );
+  // Doctor should report this as an issue (not "ok") — exit code in the
+  // headless wiring is derived from report.ok.
+  assert.strictEqual(report.ok, false, "stale lock must mark report.ok = false so headless exits 1");
+});
+
+test("#4929: formatDoctorReportJson preserves the stale-lock issue + PID for --json callers", async (t) => {
+  const base = makeStaleLockFixture();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const report = await runGSDDoctor(base);
+  const json = formatDoctorReportJson(report);
+  const parsed = JSON.parse(json);
+
+  assert.strictEqual(parsed.ok, false);
+  const codes = (parsed.issues as Array<{ code: string }>).map(i => i.code);
+  assert.ok(
+    codes.includes("stale_crash_lock"),
+    `JSON output must include stale_crash_lock issue code. Got codes: ${codes.join(", ")}`,
+  );
+  const messages = (parsed.issues as Array<{ message: string }>).map(i => i.message).join("\n");
+  assert.ok(
+    messages.includes("99999"),
+    `JSON output must include the stale PID in some issue message. Got: ${messages.slice(0, 300)}`,
+  );
+});


### PR DESCRIPTION
## TL;DR

The dev-publish gate on main is failing because the live-regression test added in #4904 invokes `gsd doctor` / `gsd doctor --json` / `gsd headless doctor` and asserts the output mentions a stale lock + PID — but none of those command shapes was wired. Every candidate hit the interactive-TTY guard. This PR wires `gsd headless doctor` so the test (and any non-interactive caller) gets a real doctor report.

## Root cause

#4904 ("tighten assertions, delete inlined-source repros") replaced the previous silent-no-op test with one that actually exercises the recovery surface. The test exits successfully if **any** of three command shapes produces output containing "lock":

```
["doctor"], ["doctor", "--json"], ["headless", "doctor"]
```

But:
- `src/cli.ts` has no top-level `doctor` subcommand handler — `gsd doctor` falls through every dispatch branch and lands at the interactive-mode TTY guard at line 808 → exits with "Interactive mode requires a terminal".
- `src/headless.ts` dispatches `query` directly (no RPC child) but no `doctor` case — `gsd headless doctor` would have hit the RPC client path and tried to launch a TUI subprocess.

Net: every candidate exited with the TTY error. Test asserts `output.includes("lock")` against that error string — fails.

## Fix

Add a `doctor` case to `runHeadlessOnce` in `src/headless.ts` that mirrors the existing `query` shape:

- No RPC child (read-only diagnostic)
- Imports `runGSDDoctor` from `src/resources/extensions/gsd/doctor.ts` (already used by `src/web/doctor-service.ts`)
- Formats with `formatDoctorReport` (or `formatDoctorReportJson` when `--json` is passed)
- Writes to stdout
- `process.exit(0|1)` directly to bypass the auto-restart loop — `runHeadless` treats any non-EXIT_SUCCESS/EXIT_BLOCKED exit as a crash and retries up to 3× with 5s/15s backoff. For a one-shot diagnostic where exit 1 means "issues detected" (not "crashed"), that's wrong.

`gsd doctor` (top-level, no `headless` prefix) still hits the TTY guard. The test is satisfied because it iterates and breaks on the first match — `gsd headless doctor` now produces a report containing `stale_crash_lock` + the dead PID.

## Test plan

- [x] `npm run build:core` — clean
- [x] Smoke test against fixture with `.gsd/auto.lock` containing dead PID 99999:
      ```
      GSD_VERSION=2.77.0-dev.x node dist/cli.js headless doctor
      ```
      → "GSD doctor found blocking issues" with `stale_crash_lock` in top issue types and `Stale auto.lock from PID 99999` in priority issues.
      → Single run, no restart loop.
- [ ] Live regression suite passes once published as a dev binary

## Follow-ups (out of scope)

- `gsd doctor` top-level subcommand could shortcut into the same path. Test only requires one of the three to work, so deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `doctor` subcommand that performs read-only system health checks and outputs diagnostics in text or JSON. Exits with code 0 on success or 1 on failure.

* **Tests**
  * Added end-to-end regression tests validating human and JSON doctor outputs, including detection of stale lock situations and cleanup of test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->