### PR TITLE
ci: codify three recurring CodeRabbit defect classes as lint (#4931)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,15 @@ jobs:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: bash scripts/check-source-grep-tests.sh
 
+      - name: CodeRabbit-theme self-tests
+        run: node --test scripts/__tests__/check-coderabbit-themes.test.mjs
+
+      - name: Reject recurring CodeRabbit themes
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/check-coderabbit-themes.mjs
+
   build:
     timeout-minutes: 15
     needs: detect-changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -319,6 +319,53 @@ assert.match(generated, /export const ROUTES =/);
 
 The reason becomes part of the diff and is visible at review. If you're not sure whether your case qualifies, it doesn't.
 
+### Three recurring defect classes (CodeRabbit themes)
+
+CI enforces three specific patterns that have caused real bugs in merged PRs (see issue #4931). All three are checked by `scripts/check-coderabbit-themes.mjs`.
+
+**1. `Statement#get()` returns `undefined`, not `null`.** better-sqlite3's `Statement#get(…)` returns `undefined` when no row matches. A `!== null` guard passes for `undefined` too (`undefined !== null` is `true`), so the guard is always truthy and downstream property access crashes.
+
+```typescript
+// ❌ WRONG
+const row = stmt.get(id);
+if (row !== null) {
+  use(row.v);  // row is undefined → crash
+}
+
+// ✅ CORRECT
+const row = stmt.get(id);
+if (row != null) { use(row.v); }        // catches both null and undefined
+// or
+if (row === undefined) return null;
+// or
+return row ?? defaultValue;
+```
+
+**2. Attach `once()` listeners BEFORE the triggering syscall.** If the event fires synchronously (fast exit, already-emitted event), a listener attached after the trigger misses it.
+
+```typescript
+// ❌ WRONG — listener can miss sync exit
+proc.kill("SIGINT");
+await new Promise(resolve => proc.once("exit", resolve));
+
+// ✅ CORRECT — listener first, trigger after
+const done = new Promise(resolve => proc.once("exit", resolve));
+proc.kill("SIGINT");
+await done;
+```
+
+**3. `.mjs` importing `.ts` requires `--experimental-strip-types`.** Without the flag (or `--import tsx`, `--loader ts-node`, etc.), Node throws `ERR_UNKNOWN_FILE_EXTENSION`. If your `.mjs` harness imports any `.ts` module, every script that runs it must pass the flag.
+
+```json
+// ❌ WRONG
+"test:tokens": "node --test studio/test/tokens.test.mjs"
+
+// ✅ CORRECT
+"test:tokens": "node --experimental-strip-types --test studio/test/tokens.test.mjs"
+```
+
+**Opt-out marker**: `// allow-coderabbit-theme: <reason>` on the same or preceding line, same convention as `allow-source-grep:`. The reason appears in the diff.
+
 ## Local development
 
 ```bash

--- a/packages/daemon/src/logger.ts
+++ b/packages/daemon/src/logger.ts
@@ -59,10 +59,11 @@ export class Logger {
   /** End the write stream. Resolves when the stream is fully flushed. */
   close(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      this.stream.end(() => {
-        this.stream.once('close', () => resolve());
-      });
+      // Attach listeners BEFORE triggering end() so a synchronous error
+      // from end() or an immediate 'close' cannot slip past the listener.
+      this.stream.once('close', () => resolve());
       this.stream.once('error', reject);
+      this.stream.end();
     });
   }
 

--- a/scripts/__fixtures__/coderabbit-themes/bad-mjs-ts-import.mjs
+++ b/scripts/__fixtures__/coderabbit-themes/bad-mjs-ts-import.mjs
@@ -1,0 +1,4 @@
+// FIXTURE — .mjs harness that imports .ts. Must be paired with an invocation
+// that includes --experimental-strip-types; without the flag, Node throws.
+import { doSomething } from "../../some-module.ts";
+await doSomething();

--- a/scripts/__fixtures__/coderabbit-themes/bad-once-after-trigger.ts
+++ b/scripts/__fixtures__/coderabbit-themes/bad-once-after-trigger.ts
@@ -1,0 +1,21 @@
+// FIXTURE — known-bad once-after-trigger pattern (3 same-receiver cases)
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+
+export async function bad1() {
+  const proc = spawn("sleep", ["0.01"]);
+  proc.kill("SIGINT");
+  await new Promise((resolve) => proc.once("exit", resolve));
+}
+
+export async function bad2() {
+  const em = new EventEmitter();
+  em.emit("ready");
+  em.once("ready", () => console.log("got it"));
+}
+
+export async function bad3() {
+  const em = new EventEmitter();
+  em.emit("data", 42);
+  em.once("data", (d) => console.log(d));
+}

--- a/scripts/__fixtures__/coderabbit-themes/bad-sqlite-null-guard.ts
+++ b/scripts/__fixtures__/coderabbit-themes/bad-sqlite-null-guard.ts
@@ -1,0 +1,24 @@
+// FIXTURE — known-bad sqlite-null-guard pattern
+import Database from "better-sqlite3";
+
+const db = new Database(":memory:");
+const stmt = db.prepare("SELECT v FROM t WHERE k = ?");
+
+export function bad1(k: string) {
+  const row = stmt.get(k);
+  if (row !== null) {
+    return (row as { v: number }).v;
+  }
+  return 0;
+}
+
+export function bad2(k: string) {
+  const row = stmt.get(k);
+  if (row === null) return null;
+  return row;
+}
+
+export function bad3(k: string) {
+  const r = stmt.pluck().get(k);
+  return r !== null ? r : "default";
+}

--- a/scripts/__fixtures__/coderabbit-themes/good-mjs-no-ts-import.mjs
+++ b/scripts/__fixtures__/coderabbit-themes/good-mjs-no-ts-import.mjs
@@ -1,0 +1,3 @@
+// FIXTURE — .mjs harness with no .ts imports (fully ESM-JS).
+import { doSomething } from "../../some-module.mjs";
+await doSomething();

--- a/scripts/__fixtures__/coderabbit-themes/good-once-after-trigger.ts
+++ b/scripts/__fixtures__/coderabbit-themes/good-once-after-trigger.ts
@@ -1,0 +1,25 @@
+// FIXTURE — known-good once-after-trigger (listener before trigger)
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+
+export async function good1() {
+  const proc = spawn("sleep", ["0.01"]);
+  const done = new Promise((resolve) => proc.once("exit", resolve));
+  proc.kill("SIGINT");
+  await done;
+}
+
+export async function good2() {
+  const em = new EventEmitter();
+  em.once("ready", () => console.log("got it"));
+  em.emit("ready");
+}
+
+// Different receivers: otherProc.kill followed by proc.once (not otherProc.once)
+// is fine because the listener is on a distinct emitter.
+export async function good3() {
+  const proc = spawn("sleep", ["0.01"]);
+  const otherProc = spawn("sleep", ["0.01"]);
+  otherProc.kill("SIGINT");
+  proc.once("exit", () => console.log("proc exited"));
+}

--- a/scripts/__fixtures__/coderabbit-themes/good-sqlite-null-guard.ts
+++ b/scripts/__fixtures__/coderabbit-themes/good-sqlite-null-guard.ts
@@ -1,0 +1,37 @@
+// FIXTURE — known-good sqlite guard patterns
+import Database from "better-sqlite3";
+
+const db = new Database(":memory:");
+const stmt = db.prepare("SELECT v FROM t WHERE k = ?");
+
+export function good1(k: string) {
+  const row = stmt.get(k);
+  if (row != null) {
+    return (row as { v: number }).v;
+  }
+  return 0;
+}
+
+export function good2(k: string) {
+  const row = stmt.get(k);
+  if (row === undefined) return null;
+  return row;
+}
+
+export function good3(k: string) {
+  const r = stmt.pluck().get(k);
+  return r ?? "default";
+}
+
+export function good4(k: string) {
+  const row = stmt.get(k);
+  if (row) {
+    return (row as { v: number }).v;
+  }
+}
+
+// Unrelated null guard on a non-Statement-.get value must not trigger.
+export function unrelated(obj: { v: number } | null) {
+  if (obj !== null) return obj.v;
+  return 0;
+}

--- a/scripts/__tests__/check-coderabbit-themes.test.mjs
+++ b/scripts/__tests__/check-coderabbit-themes.test.mjs
@@ -1,0 +1,167 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  checkSqliteNullGuard,
+  checkOnceAfterTrigger,
+  checkMjsTsImport,
+  hasStripTypesFlag,
+} from "../check-coderabbit-themes.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = resolve(HERE, "../__fixtures__/coderabbit-themes");
+
+function readFixture(name) {
+  return readFileSync(join(FIXTURES, name), "utf-8");
+}
+
+// ─── Theme 1: sqlite-null-guard ────────────────────────────────────────────
+
+test("sqlite-null-guard flags !== null after .get()", () => {
+  const src = readFixture("bad-sqlite-null-guard.ts");
+  const offenders = checkSqliteNullGuard("bad.ts", src);
+  assert.ok(offenders.length >= 3, `expected ≥3 offenders, got ${offenders.length}`);
+  for (const o of offenders) {
+    assert.equal(o.rule, "sqlite-null-guard");
+  }
+});
+
+test("sqlite-null-guard does not flag != null, === undefined, ??, or truthy", () => {
+  const src = readFixture("good-sqlite-null-guard.ts");
+  const offenders = checkSqliteNullGuard("good.ts", src);
+  assert.equal(offenders.length, 0, `unexpected offenders: ${JSON.stringify(offenders)}`);
+});
+
+test("sqlite-null-guard ignores non-.get() null checks", () => {
+  const src = `
+    import Database from "better-sqlite3";
+    const obj: { v: number } | null = maybeObj();
+    if (obj !== null) {
+      use(obj.v);
+    }
+  `;
+  const offenders = checkSqliteNullGuard("unrelated.ts", src);
+  assert.equal(offenders.length, 0);
+});
+
+test("sqlite-null-guard skips files without better-sqlite3 import", () => {
+  // This guards against false-flagging Map#get, URLSearchParams#get, etc.
+  const src = `
+    const sortMode = searchParams.get("sortMode");
+    if (sortMode !== null) use(sortMode);
+    const parentId = parentMap.get(entryId);
+    if (parentId === null) return;
+  `;
+  const offenders = checkSqliteNullGuard("route.ts", src);
+  assert.equal(offenders.length, 0, `unexpected offenders: ${JSON.stringify(offenders)}`);
+});
+
+test("sqlite-null-guard honours allow-coderabbit-theme marker", () => {
+  const src = [
+    `import Database from "better-sqlite3";`,
+    `const row = stmt.get(1);`,
+    `// allow-coderabbit-theme: typing quirk, see #9999`,
+    `if (row !== null) { use(row); }`,
+  ].join("\n");
+  const offenders = checkSqliteNullGuard("allowed.ts", src);
+  assert.equal(offenders.length, 0);
+});
+
+// ─── Theme 2: once-after-trigger ───────────────────────────────────────────
+
+test("once-after-trigger flags once() after kill()/emit()/write() on same receiver", () => {
+  const src = readFixture("bad-once-after-trigger.ts");
+  const offenders = checkOnceAfterTrigger("bad.ts", src);
+  assert.ok(offenders.length >= 3, `expected ≥3 offenders, got ${offenders.length}`);
+  for (const o of offenders) assert.equal(o.rule, "once-after-trigger");
+});
+
+test("once-after-trigger does not flag when listener is registered first", () => {
+  const src = readFixture("good-once-after-trigger.ts");
+  const offenders = checkOnceAfterTrigger("good.ts", src);
+  assert.equal(offenders.length, 0, `unexpected offenders: ${JSON.stringify(offenders)}`);
+});
+
+test("once-after-trigger ignores different receivers", () => {
+  const src = `
+    other.kill("SIGINT");
+    proc.once("exit", resolve);
+  `;
+  const offenders = checkOnceAfterTrigger("diff.ts", src);
+  assert.equal(offenders.length, 0);
+});
+
+test("once-after-trigger respects the 6-line lookback window", () => {
+  const lines = [
+    `proc.kill("SIGINT");`,
+    `// line A`,
+    `// line B`,
+    `// line C`,
+    `// line D`,
+    `// line E`,
+    `// line F`,
+    `// line G`,
+    `proc.once("exit", resolve);`,
+  ];
+  const offenders = checkOnceAfterTrigger("far.ts", lines.join("\n"));
+  assert.equal(offenders.length, 0, "trigger should be out-of-window");
+});
+
+// ─── Theme 3: mjs-ts-import ────────────────────────────────────────────────
+
+test("mjs-ts-import flags .mjs importing .ts when invocation lacks --experimental-strip-types", () => {
+  const src = readFixture("bad-mjs-ts-import.mjs");
+  const offenders = checkMjsTsImport(
+    "scripts/__fixtures__/coderabbit-themes/bad-mjs-ts-import.mjs",
+    src,
+    [{ origin: "package.json:scripts.test", command: "node --test bad.mjs" }],
+  );
+  assert.equal(offenders.length, 1);
+  assert.equal(offenders[0].rule, "mjs-ts-import");
+});
+
+test("mjs-ts-import passes when invocation includes --experimental-strip-types", () => {
+  const src = readFixture("bad-mjs-ts-import.mjs");
+  const offenders = checkMjsTsImport(
+    "scripts/__fixtures__/coderabbit-themes/bad-mjs-ts-import.mjs",
+    src,
+    [
+      {
+        origin: "package.json:scripts.test",
+        command: "node --experimental-strip-types --test bad.mjs",
+      },
+    ],
+  );
+  assert.equal(offenders.length, 0);
+});
+
+test("mjs-ts-import does not flag orphan files with no tracked invocation", () => {
+  const src = readFixture("bad-mjs-ts-import.mjs");
+  const offenders = checkMjsTsImport(
+    "scripts/__fixtures__/coderabbit-themes/bad-mjs-ts-import.mjs",
+    src,
+    [],
+  );
+  assert.equal(offenders.length, 0);
+});
+
+test("mjs-ts-import does not flag .mjs without .ts imports", () => {
+  const src = readFixture("good-mjs-no-ts-import.mjs");
+  const offenders = checkMjsTsImport(
+    "scripts/__fixtures__/coderabbit-themes/good-mjs-no-ts-import.mjs",
+    src,
+    [],
+  );
+  assert.equal(offenders.length, 0);
+});
+
+test("hasStripTypesFlag recognizes supported invocations", () => {
+  assert.ok(hasStripTypesFlag("node --experimental-strip-types run.mjs"));
+  assert.ok(hasStripTypesFlag("node --import tsx run.mjs"));
+  assert.ok(hasStripTypesFlag("node --loader tsx run.mjs"));
+  assert.ok(hasStripTypesFlag("node --loader ts-node run.mjs"));
+  assert.ok(hasStripTypesFlag("node --import ts-node/register run.mjs"));
+  assert.ok(!hasStripTypesFlag("node run.mjs"));
+});

--- a/scripts/check-coderabbit-themes.mjs
+++ b/scripts/check-coderabbit-themes.mjs
@@ -1,0 +1,433 @@
+#!/usr/bin/env node
+
+/**
+ * GSD-2 — Lint for three recurring CodeRabbit defect classes.
+ * See issue #4931 for the motivation.
+ *
+ * Checks:
+ *   1. sqlite-null-guard  — `!== null` / `=== null` applied to a variable
+ *                            that was assigned from `.get(…)` on a better-sqlite3
+ *                            Statement. `Statement#get()` returns `undefined`,
+ *                            not `null`, so the guard is a logic bug.
+ *   2. once-after-trigger — `X.once('event', …)` appearing after
+ *                            `X.kill(…)` / `X.send(…)` / `X.write(…)` /
+ *                            `X.emit(…)` / `X.end(…)` in the same block. The
+ *                            listener can miss a synchronous or very-fast
+ *                            event.
+ *   3. mjs-ts-import      — a `.mjs` file that imports a `.ts` module. Every
+ *                            invocation of that mjs must include
+ *                            `--experimental-strip-types` or an equivalent
+ *                            loader, otherwise Node throws
+ *                            ERR_UNKNOWN_FILE_EXTENSION.
+ *
+ * Escape hatch: add `// allow-coderabbit-theme: <reason>` on the offending
+ * line or the line immediately above it. The reason becomes part of the diff
+ * and is visible at review.
+ *
+ * Usage:
+ *   check-coderabbit-themes.mjs                          # CI mode (diff vs base)
+ *   check-coderabbit-themes.mjs --files <path> ...       # explicit files
+ *   check-coderabbit-themes.mjs --all                    # full repo
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, extname, relative, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const ALLOW_MARKER = "allow-coderabbit-theme:";
+
+// ─── Input discovery ───────────────────────────────────────────────────────
+
+function gitDiffNames(base) {
+  try {
+    const out = execFileSync(
+      "git",
+      ["diff", "--name-only", "--diff-filter=AM", base, "HEAD"],
+      { cwd: REPO_ROOT, encoding: "utf-8" },
+    );
+    return out.split("\n").filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function getChangedFiles() {
+  const base =
+    process.env.PR_BASE_SHA ||
+    process.env.PUSH_BEFORE_SHA ||
+    "origin/main";
+  const primary = gitDiffNames(base);
+  if (primary !== null) return primary;
+  const fallback = gitDiffNames("HEAD~1");
+  return fallback ?? [];
+}
+
+const WALK_EXCLUDE = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "dist-test",
+  "__fixtures__",
+]);
+
+// Files whose source contains intentional bad examples inside template
+// literals (e.g. the checker's own test file). Skip these for the --all
+// sweep; diff mode will still scan them if an author modifies them.
+const SWEEP_SKIP_BASENAMES = new Set([
+  "check-coderabbit-themes.test.mjs",
+]);
+
+function walk(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir)) {
+    if (WALK_EXCLUDE.has(entry)) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) walk(full, out);
+    else out.push(relative(REPO_ROOT, full));
+  }
+  return out;
+}
+
+function parseArgs(argv) {
+  const args = { mode: "diff", files: [] };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--all") args.mode = "all";
+    else if (argv[i] === "--files") {
+      args.mode = "files";
+      while (i + 1 < argv.length && !argv[i + 1].startsWith("--")) {
+        args.files.push(argv[++i]);
+      }
+    }
+  }
+  return args;
+}
+
+function hasAllowMarker(lines, lineIdx) {
+  const self = lines[lineIdx] || "";
+  if (self.includes(ALLOW_MARKER)) return true;
+  const prev = lineIdx > 0 ? lines[lineIdx - 1] : "";
+  if (prev.includes(ALLOW_MARKER)) return true;
+  return false;
+}
+
+// ─── Check 1: sqlite-null-guard ────────────────────────────────────────────
+//
+// Strategy: find variable names assigned from `.get(…)` in the file. For
+// each such variable, scan subsequent lines for `<var> !== null` or
+// `<var> === null` and flag them.
+
+const SQLITE_EXT = new Set([".ts", ".tsx", ".mts", ".cts", ".js", ".mjs", ".cjs"]);
+
+function checkSqliteNullGuard(filePath, source) {
+  if (!SQLITE_EXT.has(extname(filePath))) return [];
+  // Scope: only files that import better-sqlite3. JS Map#get, URLSearchParams
+  // #get, and Headers#get all return undefined/null and would false-flag
+  // without this guard.
+  const usesBetterSqlite =
+    /\bfrom\s+['"]better-sqlite3['"]/.test(source) ||
+    /\brequire\s*\(\s*['"]better-sqlite3['"]\s*\)/.test(source);
+  if (!usesBetterSqlite) return [];
+
+  const lines = source.split("\n");
+  const stmtVars = new Map(); // name -> line index of assignment
+  const offenders = [];
+
+  // Capture patterns:
+  //   const <v> = <expr>.get(...)
+  //   const <v> = <expr>.pluck().get(...)
+  //   let/var/const <v> = stmt.get(...)
+  const assignRe = /(?:const|let|var)\s+(\w+)\s*(?::\s*[^=]+)?=\s*[^;]*?\.get\s*\(/;
+  lines.forEach((line, i) => {
+    const m = line.match(assignRe);
+    if (m) stmtVars.set(m[1], i);
+  });
+
+  if (stmtVars.size === 0) return [];
+
+  // Scan every line for `<var> !== null` / `=== null`.
+  // We scan regardless of position to catch usage inside helper functions.
+  const guardRe = (name) =>
+    new RegExp(`\\b${name}\\b\\s*(?:!==|===)\\s*null\\b`);
+
+  lines.forEach((line, i) => {
+    for (const [name] of stmtVars) {
+      if (guardRe(name).test(line)) {
+        if (hasAllowMarker(lines, i)) continue;
+        offenders.push({
+          file: filePath,
+          line: i + 1,
+          rule: "sqlite-null-guard",
+          message: `${name} was assigned from .get() (better-sqlite3 Statement#get returns undefined, not null). Use \`!= null\` / \`== null\` or \`=== undefined\`.`,
+          snippet: line.trim(),
+        });
+      }
+    }
+  });
+
+  return offenders;
+}
+
+// ─── Check 2: once-after-trigger ───────────────────────────────────────────
+//
+// Strategy: scan each file for `<X>.once('event', …)`. If a preceding line
+// (within the same contiguous non-blank block, up to N lines back) contains
+// `<X>.kill(…)` / `.send(…)` / `.write(…)` / `.emit(…)` / `.end(…)` on the
+// same receiver, flag it.
+
+const TRIGGER_METHODS = ["kill", "send", "write", "emit", "end"];
+const EVENT_EXT = new Set([".ts", ".tsx", ".mts", ".cts", ".js", ".mjs", ".cjs"]);
+
+function checkOnceAfterTrigger(filePath, source) {
+  if (!EVENT_EXT.has(extname(filePath))) return [];
+  const lines = source.split("\n");
+  const offenders = [];
+
+  // Find every `<X>.once(...)` occurrence.
+  const onceRe = /(?<!\w)(\w+(?:\??\.\w+)*?)\.once\s*\(\s*['"]/g;
+
+  lines.forEach((line, i) => {
+    onceRe.lastIndex = 0;
+    let m;
+    while ((m = onceRe.exec(line)) !== null) {
+      const receiver = m[1]; // e.g. `proc`, `proc.stdout`, `em`
+      // Look backward up to 6 lines (same block) for a trigger on the same receiver.
+      const lookbackStart = Math.max(0, i - 6);
+      for (let j = lookbackStart; j < i; j++) {
+        const prev = lines[j];
+        if (!prev.trim()) continue;
+        const escReceiver = receiver.replace(/[.?]/g, "\\$&");
+        const triggerRe = new RegExp(
+          `(?<!\\w)${escReceiver}\\.(?:${TRIGGER_METHODS.join("|")})\\s*\\(`,
+        );
+        if (triggerRe.test(prev)) {
+          if (hasAllowMarker(lines, i)) continue;
+          offenders.push({
+            file: filePath,
+            line: i + 1,
+            rule: "once-after-trigger",
+            message: `${receiver}.once(…) is attached after ${receiver}.${TRIGGER_METHODS.join("/")}(…) on line ${j + 1}. Attach the listener first.`,
+            snippet: line.trim(),
+          });
+          break;
+        }
+      }
+    }
+  });
+
+  return offenders;
+}
+
+// ─── Check 3: mjs-ts-import ────────────────────────────────────────────────
+//
+// Strategy: for every *.mjs file with `from "...*.ts"` or `import("...*.ts")`,
+// check that any invocation in package.json "scripts" or in
+// .github/workflows/*.yml targeting that mjs includes
+// `--experimental-strip-types` or `--import tsx` (or similar).
+
+const TS_IMPORT_RE = /(?:from\s+['"]|import\s*\(\s*['"])[^'"]+\.ts['"]/;
+
+function checkMjsTsImport(filePath, source, invocationsOverride) {
+  if (extname(filePath) !== ".mjs") return [];
+  if (!TS_IMPORT_RE.test(source)) return [];
+  const invocations =
+    invocationsOverride !== undefined
+      ? invocationsOverride
+      : findMjsInvocations(filePath);
+  if (invocations.length === 0) {
+    // Orphan: file imports .ts but has no tracked invocation. Not a CURRENT
+    // bug — may be a new file that will be wired up, or invoked from a shell
+    // context we don't see. No offense.
+    return [];
+  }
+  const unsafe = invocations.filter((inv) => !hasStripTypesFlag(inv.command));
+  if (unsafe.length === 0) return [];
+  return unsafe.map((inv) => ({
+    file: filePath,
+    line: 1,
+    rule: "mjs-ts-import",
+    message: `${filePath} imports a .ts module but is invoked by ${inv.origin} without --experimental-strip-types (and without --import tsx/ts-node). Node will throw ERR_UNKNOWN_FILE_EXTENSION.`,
+    snippet: inv.command,
+  }));
+}
+
+function hasStripTypesFlag(cmd) {
+  return (
+    cmd.includes("--experimental-strip-types") ||
+    cmd.includes("--import tsx") ||
+    cmd.includes("--loader tsx") ||
+    cmd.includes("--loader ts-node") ||
+    cmd.includes("--import ts-node")
+  );
+}
+
+let _invocationCache = null;
+function loadInvocationSources() {
+  if (_invocationCache) return _invocationCache;
+  const sources = [];
+  const pkgPath = join(REPO_ROOT, "package.json");
+  if (existsSync(pkgPath)) {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    for (const [name, cmd] of Object.entries(pkg.scripts || {})) {
+      sources.push({ origin: `package.json:scripts.${name}`, command: cmd });
+    }
+  }
+  try {
+    const packagesDir = join(REPO_ROOT, "packages");
+    if (existsSync(packagesDir)) {
+      for (const entry of readdirSync(packagesDir)) {
+        const pkgFile = join(packagesDir, entry, "package.json");
+        if (!existsSync(pkgFile)) continue;
+        const pkg = JSON.parse(readFileSync(pkgFile, "utf-8"));
+        for (const [name, cmd] of Object.entries(pkg.scripts || {})) {
+          sources.push({
+            origin: `packages/${entry}/package.json:scripts.${name}`,
+            command: cmd,
+          });
+        }
+      }
+    }
+  } catch {
+    // If packages/ cannot be read (missing or malformed), skip silently —
+    // .mjs invocations listed there are not discoverable but that's a best-
+    // effort signal, not a correctness requirement.
+  }
+  const wfDir = join(REPO_ROOT, ".github", "workflows");
+  if (existsSync(wfDir)) {
+    for (const entry of readdirSync(wfDir)) {
+      if (!entry.endsWith(".yml") && !entry.endsWith(".yaml")) continue;
+      const content = readFileSync(join(wfDir, entry), "utf-8");
+      for (const line of content.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith("-") || trimmed.startsWith("run:")) {
+          sources.push({
+            origin: `.github/workflows/${entry}`,
+            command: trimmed,
+          });
+        }
+      }
+    }
+  }
+  _invocationCache = sources;
+  return sources;
+}
+
+function globToRegex(glob) {
+  const escaped = glob.replace(/[.+^$|()[\]{}\\]/g, "\\$&");
+  const pattern = escaped
+    .replace(/\*\*/g, "\u0000")
+    .replace(/\*/g, "[^/]*")
+    .replace(/\u0000/g, ".*")
+    .replace(/\?/g, "[^/]");
+  return new RegExp(`^${pattern}$`);
+}
+
+function commandGlobMatches(command, relPath) {
+  // Find glob-like tokens (contain * or **) in the command that look like a
+  // path ending in .mjs or .cjs or .js; return true if any matches relPath.
+  const tokenRe = /(?:^|\s)(?:"([^"]+)"|'([^']+)'|(\S+))/g;
+  let m;
+  while ((m = tokenRe.exec(command)) !== null) {
+    const tok = m[1] || m[2] || m[3];
+    if (!tok) continue;
+    if (!/[*?]/.test(tok)) continue;
+    if (!/\.(mjs|cjs|js)$/.test(tok)) continue;
+    try {
+      if (globToRegex(tok).test(relPath)) return true;
+      // Also try matching without leading path prefix variations
+      const normalized = relPath.split("/").slice(-tok.split("/").length).join("/");
+      if (globToRegex(tok).test(normalized)) return true;
+    } catch {
+      // Invalid glob token — skip.
+    }
+  }
+  return false;
+}
+
+function findMjsInvocations(mjsPath) {
+  const rel = relative(REPO_ROOT, resolve(mjsPath));
+  const base = rel.split("/").pop();
+  const sources = loadInvocationSources();
+  return sources.filter(
+    (s) =>
+      s.command.includes(rel) ||
+      s.command.includes(base) ||
+      commandGlobMatches(s.command, rel),
+  );
+}
+
+// ─── Driver ────────────────────────────────────────────────────────────────
+
+function runChecks(files) {
+  const offenders = [];
+  for (const file of files) {
+    const abs = resolve(REPO_ROOT, file);
+    if (!existsSync(abs)) continue;
+    const st = statSync(abs);
+    if (!st.isFile()) continue;
+    const source = readFileSync(abs, "utf-8");
+    offenders.push(...checkSqliteNullGuard(file, source));
+    offenders.push(...checkOnceAfterTrigger(file, source));
+    offenders.push(...checkMjsTsImport(file, source));
+  }
+  return offenders;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  let files;
+  if (args.mode === "all") {
+    files = walk(REPO_ROOT)
+      .filter((f) => /\.(ts|tsx|mts|cts|js|mjs|cjs)$/.test(f))
+      .filter((f) => !SWEEP_SKIP_BASENAMES.has(f.split("/").pop()));
+  } else if (args.mode === "files") {
+    files = args.files;
+  } else {
+    files = getChangedFiles().filter((f) =>
+      /\.(ts|tsx|mts|cts|js|mjs|cjs)$/.test(f),
+    );
+  }
+
+  if (files.length === 0) {
+    console.log("✓ No eligible files — coderabbit-themes check does not apply");
+    return 0;
+  }
+
+  const offenders = runChecks(files);
+  if (offenders.length === 0) {
+    console.log(
+      `✓ coderabbit-themes check passed (${files.length} file${files.length === 1 ? "" : "s"} scanned)`,
+    );
+    return 0;
+  }
+
+  console.error("──────────────────────────────────────────────────────");
+  console.error("✗ FAILED: coderabbit-themes lint");
+  console.error("──────────────────────────────────────────────────────");
+  for (const o of offenders) {
+    console.error(`\n${o.file}:${o.line}: [${o.rule}]`);
+    console.error(`  ${o.message}`);
+    console.error(`  > ${o.snippet}`);
+  }
+  console.error("");
+  console.error(
+    "Escape hatch: add `// allow-coderabbit-theme: <reason>` on or above the line.",
+  );
+  console.error("");
+  return 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}
+
+// Exports for tests
+export {
+  checkSqliteNullGuard,
+  checkOnceAfterTrigger,
+  checkMjsTsImport,
+  runChecks,
+  hasStripTypesFlag,
+};

--- a/scripts/check-coderabbit-themes.mjs
+++ b/scripts/check-coderabbit-themes.mjs
@@ -229,9 +229,28 @@ function checkOnceAfterTrigger(filePath, source) {
 
 const TS_IMPORT_RE = /(?:from\s+['"]|import\s*\(\s*['"])[^'"]+\.ts['"]/;
 
+function stripCommentsAndStrings(source) {
+  // Remove // line comments, /* */ block comments, and template/quoted
+  // string contents before scanning for actual import statements. This
+  // prevents false positives when doc comments or string fixtures contain
+  // text that looks like a .ts import.
+  let out = source.replace(/\/\*[\s\S]*?\*\//g, "");
+  out = out.replace(/(^|[^:])\/\/.*$/gm, "$1");
+  // Strip string and template-literal bodies (preserve the quote chars so
+  // import statements outside strings remain intact).
+  out = out.replace(/`(?:\\.|\$\{[^}]*\}|[^`\\])*`/g, "``");
+  out = out.replace(/'(?:\\.|[^'\\])*'/g, "''");
+  // Keep real `from "…"` import quotes — use a regex that only collapses
+  // strings NOT immediately following `from ` or `import(` (those are what
+  // we want to scan).
+  out = out.replace(/(?<!from\s|import\s*\(\s*)"(?:\\.|[^"\\])*"/g, '""');
+  return out;
+}
+
 function checkMjsTsImport(filePath, source, invocationsOverride) {
   if (extname(filePath) !== ".mjs") return [];
-  if (!TS_IMPORT_RE.test(source)) return [];
+  const scannable = stripCommentsAndStrings(source);
+  if (!TS_IMPORT_RE.test(scannable)) return [];
   const invocations =
     invocationsOverride !== undefined
       ? invocationsOverride
@@ -360,9 +379,23 @@ function findMjsInvocations(mjsPath) {
 
 // ─── Driver ────────────────────────────────────────────────────────────────
 
+function shouldSkipScannedFile(file) {
+  // The fixtures directory contains intentional bad examples; scanning it
+  // produces known "offenses" by design.
+  if (file.includes("scripts/__fixtures__/coderabbit-themes/")) return true;
+  // The checker's own test file includes bad patterns inside template
+  // literals for verification. stripCommentsAndStrings handles most, but
+  // the template-literal stripper is imperfect — skip explicitly.
+  if (file.endsWith("scripts/__tests__/check-coderabbit-themes.test.mjs")) {
+    return true;
+  }
+  return false;
+}
+
 function runChecks(files) {
   const offenders = [];
   for (const file of files) {
+    if (shouldSkipScannedFile(file)) continue;
     const abs = resolve(REPO_ROOT, file);
     if (!existsSync(abs)) continue;
     const st = statSync(abs);


### PR DESCRIPTION
## Summary

Three defect patterns that repeatedly surfaced in the trek-e 30-PR source-grep eradication batch are now enforced on every PR. Scanner is \`scripts/check-coderabbit-themes.mjs\`; CI wires it into the existing lint job.

1. **sqlite-null-guard** — \`!== null\` / \`=== null\` applied to a variable assigned from \`.get(…)\` in a file that imports \`better-sqlite3\`. Statement#get returns \`undefined\`, not \`null\`, so the guard is always truthy and downstream access crashes.
2. **once-after-trigger** — \`X.once(event, …)\` appearing after \`X.kill/send/write/emit/end(…)\` on the same receiver in the same 6-line block. A synchronous or fast-firing event slips past the listener.
3. **mjs-ts-import** — a \`.mjs\` file importing a \`.ts\` module invoked by a script that does not pass \`--experimental-strip-types\` (or \`--import tsx\` / \`--loader ts-node\`). Node throws \`ERR_UNKNOWN_FILE_EXTENSION\` at run time.

## TDD

- \`scripts/__fixtures__/coderabbit-themes/\` — one bad and one good fixture per theme.
- \`scripts/__tests__/check-coderabbit-themes.test.mjs\` — 14 \`node:test\` cases. Positive detection, negative (false-positive) cases, allow-marker escape hatch, 6-line lookback window, different-receiver case, and the \`better-sqlite3\`-import narrowing.
- CI runs the self-tests unconditionally and the repo scan (PR-only, diff vs base) in the \`lint\` job, same pattern as \`check-source-grep-tests.sh\`.

## Pre-existing bug fixed

\`packages/daemon/src/logger.ts#close\` had \`this.stream.once('error', …)\` attached AFTER \`this.stream.end(…)\`. Reordered so both \`'close'\` and \`'error'\` listeners are registered before \`end()\` is called.

## Scanner narrowing (prevents false positives found during survey)

- \`sqlite-null-guard\` requires \`better-sqlite3\` imported in the file — prevents false-flagging \`Map#get\` / \`URLSearchParams#get\` / \`Headers#get\`.
- \`mjs-ts-import\` has orphan-file tolerance (no tracked invocation = no offense) and basic glob-pattern matching for invocations like \`test/*.test.mjs\`.
- \`--all\` sweep skips \`node_modules\`, \`dist\`, \`dist-test\`, \`__fixtures__\`, and the checker's own test file.

## Escape hatch

\`// allow-coderabbit-theme: <reason>\` on the same or preceding line, mirroring the \`allow-source-grep:\` convention. The reason appears in the diff.

## Test plan

- [x] \`node --test scripts/__tests__/check-coderabbit-themes.test.mjs\` → 14/14 pass
- [x] \`node scripts/check-coderabbit-themes.mjs --all\` → 2101 files scanned, 0 offenses (after fixing logger.ts)
- [ ] CI passes
- [ ] CodeRabbit review addressed

Closes #4931