### PR TITLE
feat(auto): UnitContextManifest tools-policy field — declarative-only (#4934)

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -187,6 +187,61 @@ test("#4924: no computed id appears in both artifacts.computed AND prepend (mutu
   }
 });
 
+// ─── Tools-policy invariants (#4934) ─────────────────────────────────────
+
+test("#4934: every manifest declares a tools policy", () => {
+  for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
+    const policy = (manifest as { tools?: { mode?: string } }).tools;
+    assert.ok(
+      policy && typeof policy.mode === "string",
+      `manifest "${unitType}" is missing a tools policy — required to fail loud rather than default to "all" silently`,
+    );
+  }
+});
+
+test("#4934: tools.mode is one of the four declared policies", () => {
+  const validModes = new Set(["all", "read-only", "planning", "docs"]);
+  for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
+    const mode = (manifest as { tools: { mode: string } }).tools.mode;
+    assert.ok(
+      validModes.has(mode),
+      `manifest "${unitType}" has invalid tools.mode "${mode}" — must be one of ${[...validModes].join(", ")}`,
+    );
+  }
+});
+
+test('#4934: only execute-task and reactive-execute may use tools.mode "all" (full source-tree write access)', () => {
+  const allowedAllUnits = new Set(["execute-task", "reactive-execute"]);
+  for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
+    const mode = (manifest as { tools: { mode: string } }).tools.mode;
+    if (mode === "all") {
+      assert.ok(
+        allowedAllUnits.has(unitType),
+        `manifest "${unitType}" declares tools.mode = "all" but is not on the execute-track. ` +
+        'Only execute-task and reactive-execute should have full source write access; ' +
+        'planning/discuss/research units must use "planning" (or "docs" for rewrite-docs).',
+      );
+    }
+  }
+});
+
+test('#4934: tools.mode "docs" requires a non-empty allowedPathGlobs array', () => {
+  for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
+    const tools = (manifest as { tools: { mode: string; allowedPathGlobs?: readonly string[] } }).tools;
+    if (tools.mode !== "docs") continue;
+    assert.ok(
+      Array.isArray(tools.allowedPathGlobs) && tools.allowedPathGlobs.length > 0,
+      `manifest "${unitType}" has docs policy but no allowedPathGlobs — explicit allow-set is required so the enforcement layer doesn't fall back to a hardcoded default`,
+    );
+    for (const g of tools.allowedPathGlobs!) {
+      assert.ok(
+        typeof g === "string" && g.length > 0,
+        `manifest "${unitType}" has empty/invalid allowedPathGlobs entry: ${JSON.stringify(g)}`,
+      );
+    }
+  }
+});
+
 // ─── Budget floor: run-uat + gate-evaluate hit the smallest budget tier ──
 
 test("#4782 phase 2: run-uat and gate-evaluate use the smallest budget tier", () => {

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -90,6 +90,43 @@ export type MemoryPolicy = "none" | "critical-only" | "prompt-relevant";
 /** Preferences block policy. */
 export type PreferencesPolicy = "none" | "active-only" | "full";
 
+/**
+ * Tool-access policy per unit type (#4934).
+ *
+ * Declarative-only in this PR — runtime enforcement (write-gate.ts predicate
+ * + dispatch-time isolation) lands in follow-up PRs. The shape is the
+ * agreement between manifest authors and enforcement; surfacing it now lets
+ * reviewers ratify per-unit policy intent before any blocking logic ships.
+ *
+ * Modes:
+ *   - "all"        — Read + Edit/Write/MultiEdit/NotebookEdit + Bash + Task.
+ *                    The unit may modify any file in the working tree.
+ *                    Reserved for execute-task / reactive-execute, which run
+ *                    in worktrees today and whose writes are committed.
+ *   - "read-only"  — Read tools only. No file mutation. No shell. No subagent
+ *                    dispatch. Reserved for future units that should be
+ *                    strictly observational (none today).
+ *   - "planning"   — Read tools always; writes restricted to .gsd/** under
+ *                    basePath; Bash limited to a per-unit safe allowlist;
+ *                    Task subagent dispatch denied. Catches the bug class
+ *                    where a discuss-milestone turn modifies user source
+ *                    files (forensics: ~/Github/test-apps/b23, #4934).
+ *   - "docs"       — Read tools always; writes restricted to .gsd/** AND
+ *                    the explicit `allowedPathGlobs` set; Bash safe-allowlist;
+ *                    no subagents. Reserved for rewrite-docs, which legitimately
+ *                    edits project markdown outside .gsd/.
+ *
+ * The allowlist for "docs" is declared per-manifest rather than hardcoded so
+ * projects with non-standard doc layouts can extend it without forking the
+ * enforcement code (open question for the wiring PR — exact representation
+ * may shift). Globs are interpreted relative to the project basePath.
+ */
+export type ToolsPolicy =
+  | { readonly mode: "all" }
+  | { readonly mode: "read-only" }
+  | { readonly mode: "planning" }
+  | { readonly mode: "docs"; readonly allowedPathGlobs: readonly string[] };
+
 // ─── Computed-artifact registry (#4924 v2 contract) ───────────────────────
 
 /**
@@ -176,6 +213,13 @@ export interface UnitContextManifest {
   readonly codebaseMap: boolean;
   /** Preferences block policy. */
   readonly preferences: PreferencesPolicy;
+  /**
+   * Tool-access policy (#4934). Declarative in this PR; runtime enforcement
+   * (path-scoped write blocking + subagent denial + bash allowlist) lands
+   * in follow-ups. Required on every manifest so missing entries fail loud
+   * via the CI invariant test rather than defaulting to "all" silently.
+   */
+  readonly tools: ToolsPolicy;
   /** Artifact handling: inline (full body), excerpt (compact), or on-demand (path only). */
   readonly artifacts: {
     readonly inline: readonly ArtifactKey[];
@@ -218,6 +262,28 @@ const COMMON_BUDGET_LARGE = 1_500_000;  // ~400K tokens
 const COMMON_BUDGET_MEDIUM = 750_000;   // ~200K tokens
 const COMMON_BUDGET_SMALL = 250_000;    // ~65K tokens
 
+// ─── Tool policy constants (#4934) ────────────────────────────────────────
+// Reused across manifests so per-unit assignment stays declarative and the
+// allowed-path set for the docs policy lives in one reviewable place.
+
+const TOOLS_ALL: ToolsPolicy = { mode: "all" };
+const TOOLS_PLANNING: ToolsPolicy = { mode: "planning" };
+const TOOLS_DOCS: ToolsPolicy = {
+  mode: "docs",
+  // Globs are resolved relative to project basePath. The set is intentionally
+  // narrow: top-level docs/, README, CHANGELOG, and any markdown at the
+  // project root. Projects with non-standard layouts (e.g. mintlify-docs/)
+  // will need this list extended in a follow-up; landed conservative now,
+  // expand on demand.
+  allowedPathGlobs: [
+    "docs/**",
+    "README.md",
+    "README.*.md",
+    "CHANGELOG.md",
+    "*.md",
+  ],
+};
+
 /**
  * Canonical unit types handled by auto-mode dispatch. The coverage test
  * enumerates these against `UNIT_MANIFESTS` to catch manifest drift when
@@ -252,6 +318,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    tools: TOOLS_PLANNING,
     artifacts: {
       // Phase 3 migration (#4782): matches today's actual
       // buildResearchMilestonePrompt inlining order.
@@ -267,6 +334,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["project", "requirements", "decisions", "milestone-research", "templates"],
       excerpt: [],
@@ -280,6 +348,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["project", "requirements", "decisions", "milestone-context", "templates"],
       excerpt: [],
@@ -293,6 +362,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: false,
     preferences: "active-only",
+    tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["roadmap", "slice-summary", "slice-uat", "requirements", "decisions", "templates"],
       excerpt: [],
@@ -306,6 +376,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: false,
     preferences: "active-only",
+    tools: TOOLS_PLANNING,
     artifacts: {
       // #4780 landed slice-summary as excerpt for this unit; phase 2 of
       // the architecture will read this manifest as the source of truth
@@ -324,6 +395,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["roadmap", "milestone-research", "dependency-summaries", "templates"],
       excerpt: [],
@@ -337,6 +409,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["roadmap", "slice-research", "dependency-summaries", "requirements", "decisions", "templates"],
       excerpt: [],
@@ -350,6 +423,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["slice-plan", "slice-research", "dependency-summaries", "templates"],
       excerpt: [],
@@ -363,6 +437,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["slice-plan", "slice-research", "dependency-summaries", "prior-task-summaries", "templates"],
       excerpt: [],
@@ -376,6 +451,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: false,
     preferences: "active-only",
+    tools: TOOLS_PLANNING,
     artifacts: {
       // Phase 3 migration (#4782): matches today's actual
       // buildCompleteSlicePrompt inlining order. Overrides prepend +
@@ -393,6 +469,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "critical-only",
     codebaseMap: false,
     preferences: "none",
+    tools: TOOLS_PLANNING,
     artifacts: {
       // Phase 2 pilot (#4782): manifest now matches today's actual
       // buildReassessRoadmapPrompt behavior for equivalence. Phase 3
@@ -411,6 +488,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    tools: TOOLS_ALL,
     artifacts: {
       inline: ["task-plan", "slice-plan", "prior-task-summaries", "templates"],
       excerpt: [],
@@ -424,6 +502,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    tools: TOOLS_ALL,
     artifacts: {
       inline: ["slice-plan", "prior-task-summaries", "templates"],
       excerpt: [],
@@ -439,6 +518,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "critical-only",
     codebaseMap: false,
     preferences: "active-only",
+    tools: TOOLS_PLANNING,
     artifacts: {
       // Phase 3 migration (#4782): manifest matches today's actual
       // buildRunUatPrompt inlining. Prior phase-1 entry listed
@@ -456,6 +536,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "critical-only",
     codebaseMap: false,
     preferences: "active-only",
+    tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["slice-plan", "prior-task-summaries"],
       excerpt: [],
@@ -469,6 +550,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    tools: TOOLS_DOCS,
     artifacts: {
       inline: ["project", "requirements", "decisions", "templates"],
       excerpt: [],


### PR DESCRIPTION
## TL;DR

**What:** Adds a required `tools` policy field to `UnitContextManifest` declaring per-unit tool-access intent (`"all"` / `"read-only"` / `"planning"` / `"docs"`), with each of the 16 unit types assigned. Declarative only — no runtime enforcement here.

**Why:** A `discuss-milestone` LLM turn used the host's `Edit` tool to modify user source files in test app `b23`. The forensics + design are tracked in #4934. Surfacing the policy intent now lets reviewers ratify the shape before the runtime-blocking PRs land.

**How:** Discriminated-union type, four shared constants (`TOOLS_ALL`, `TOOLS_PLANNING`, `TOOLS_DOCS`), per-unit assignment, four CI invariants. No behavior change.

## What

`src/resources/extensions/gsd/unit-context-manifest.ts`
- New `ToolsPolicy` discriminated union:
  ```typescript
  type ToolsPolicy =
    | { readonly mode: "all" }
    | { readonly mode: "read-only" }
    | { readonly mode: "planning" }
    | { readonly mode: "docs"; readonly allowedPathGlobs: readonly string[] };
  ```
- Required `tools: ToolsPolicy` field on `UnitContextManifest` (failing loud beats silent default to `"all"`).
- Three shared constants. The `"docs"` allowed-path glob set (`"docs/**"`, `"README.md"`, `"README.*.md"`, `"CHANGELOG.md"`, `"*.md"`) is intentionally narrow; non-standard layouts will extend it as the wiring PRs surface real cases.

Per-unit assignment:

| Mode | Units |
|---|---|
| `all` | `execute-task`, `reactive-execute` |
| `planning` | `discuss-milestone`, `plan-milestone`, `validate-milestone`, `complete-milestone`, `research-milestone`, `research-slice`, `plan-slice`, `refine-slice`, `replan-slice`, `complete-slice`, `reassess-roadmap`, `run-uat`, `gate-evaluate` |
| `docs` | `rewrite-docs` |
| `read-only` | (none — reserved) |

`src/resources/extensions/gsd/tests/unit-context-manifest.test.ts` — four new invariants:

1. Every manifest declares `tools`
2. `tools.mode` is one of the four valid values
3. Only `execute-task` / `reactive-execute` may use `"all"`
4. `"docs"` requires non-empty `allowedPathGlobs` of non-empty strings

## Why

Background and forensics: #4934. Quick recap: planning units (discuss-milestone, plan-*, research-*, etc.) dispatch in the user's main checkout and have full Edit/Write/Bash tool access. The only existing tool scoping (`guided-flow.ts:582-603`) strips `gsd_*` MCP tools as a grammar-size workaround for xAI/Grok — it does not restrict built-in writes. Result: a discuss-milestone turn can silently edit user source files (reproduced in test app `b23` at `~/Github/test-apps/b23` — `M index.html`, +94/-13 lines of unrequested dark-mode code).

Track-1 plan from #4934:
1. **This PR** — declarative `tools` policy on the manifest
2. Follow-up — extend `src/resources/extensions/gsd/bootstrap/write-gate.ts` with `shouldBlockPlanningUnit(toolName, input, unitType, basePath)`; reads always allowed; Edit/Write denied outside `.gsd/` (or docs paths); Bash switched to per-unit allowlist; Task subagent denied
3. Defense-in-depth — snapshot+diff at `auto-start.ts:651-665` exit path

Track-2 (structural) — RFC to follow once Track-1 lands. Reuses the existing `src/resources/extensions/subagent/isolation.ts` (PR #254, `125be9f94`) to route planning units through git-worktree or FUSE-overlay isolation.

## How

The `ToolsPolicy` shape mirrors the existing `SkillsPolicy` discriminated-union in the same file. Per-unit assignment uses shared constants so all `"planning"` entries point at the same policy object — keeps the docs-allowedPathGlobs in one reviewable place.

The four CI invariants are the contract for follow-up PRs: missing field, invalid mode, accidental `"all"` on a planning unit, or empty `allowedPathGlobs` on `"docs"` all fail loud.

This PR is intentionally tiny (137 lines, no behavior change) so reviewers can focus on policy intent. Runtime enforcement is the next PR.

## Test plan

- [x] `npm run copy-resources` (tsconfig.resources.json strict build) — clean
- [x] `npx tsx --test src/resources/extensions/gsd/tests/unit-context-{manifest,composer}.test.ts` — 33/33 pass
- [x] Per-unit assignments reviewed against the affected-units list in #4934

## Follow-ups

1. Runtime enforcement PR — extend `write-gate.ts` with `shouldBlockPlanningUnit`, wire into `register-hooks.ts:282`
2. Bash allowlist per planning unit (replaces deny-list regex extension — Codex review on #4934 flagged regex as fragile)
3. Subagent dispatch denial — verify `tool_call` hook coverage on Task invocations first
4. Snapshot-and-diff at `auto-start.ts:651-665` exit (Layer 3, detection only)
5. Track-2 RFC — apply existing subagent isolation to planning unit dispatch

Closes phase 1 of #4934. Refs #4924 (composer v2 contract — same manifest file).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a tools access policy system defining tool modes and access levels by unit type.
  * Enforces restricted mode usage and allowlist requirements for specific operation types.

* **Tests**
  * Added unit tests validating tools policy compliance across manifest entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->