### PR TITLE
test(docker,web): rewrite docker-template + web-responsive as behaviour tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # ── Compiled test output ──
 dist-test/
 
+# ── Cross-process build lock dirs (web-mode-runtime-harness) ──
+.test-build-locks/
+
 # ── Compiled output in src/ (should only contain .ts source) ──
 src/**/*.js
 src/**/*.js.map

--- a/src/tests/docker-template-contract.test.ts
+++ b/src/tests/docker-template-contract.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Behavioural validation for the docker/ template artifacts.
+ *
+ * Replaces the source-grep `docker-template.test.ts` (deleted in #4884).
+ * Each assertion exercises the parsed / evaluated artifact rather than the
+ * literal source text — moving a directive into a comment, swapping it for
+ * a synonym, or breaking the YAML grammar must visibly fail at least one
+ * test here.
+ *
+ * Refs: #4881
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import ignore from "ignore";
+import { parse as parseYaml } from "yaml";
+
+const repoRoot = process.cwd();
+const dockerDir = resolve(repoRoot, "docker");
+
+// ─── helpers ──────────────────────────────────────────────────────────────
+
+function readDockerFile(relPath: string): string {
+  const full = resolve(dockerDir, relPath);
+  assert.ok(existsSync(full), `expected ${full} to exist`);
+  return readFileSync(full, "utf-8");
+}
+
+function readRepoFile(relPath: string): string {
+  const full = resolve(repoRoot, relPath);
+  assert.ok(existsSync(full), `expected ${full} to exist`);
+  return readFileSync(full, "utf-8");
+}
+
+type DockerfileInstruction = { directive: string; args: string };
+
+/**
+ * Minimal Dockerfile parser — strips comments, joins backslash-continued
+ * lines, splits the leading directive from its argument string. Returns
+ * the ordered list of instructions actually evaluated by Docker (so a
+ * `# RUN useradd` comment is correctly invisible to the assertions below).
+ */
+function parseDockerfile(source: string): DockerfileInstruction[] {
+  // 1. Strip full-line comments. (Shell # inside a RUN is preserved by docker
+  //    itself, but the directive form `# CMD ...` is a comment.)
+  const rawLines = source.split(/\r?\n/);
+  const significant: string[] = [];
+  for (const line of rawLines) {
+    if (/^\s*#/.test(line)) continue;
+    significant.push(line);
+  }
+
+  // 2. Join backslash-continuations into single logical instructions.
+  const logical: string[] = [];
+  let buffer = "";
+  for (const line of significant) {
+    if (/\\\s*$/.test(line)) {
+      buffer += line.replace(/\\\s*$/, "") + " ";
+      continue;
+    }
+    buffer += line;
+    if (buffer.trim().length > 0) {
+      logical.push(buffer.trim());
+    }
+    buffer = "";
+  }
+  if (buffer.trim().length > 0) {
+    logical.push(buffer.trim());
+  }
+
+  // 3. Split into directive + args.
+  const out: DockerfileInstruction[] = [];
+  for (const stmt of logical) {
+    const match = stmt.match(/^([A-Za-z]+)\s+([\s\S]*)$/);
+    if (!match) continue;
+    out.push({ directive: match[1].toUpperCase(), args: match[2].trim() });
+  }
+  return out;
+}
+
+function dockerAvailable(): boolean {
+  try {
+    execFileSync("docker", ["--version"], { stdio: ["ignore", "ignore", "ignore"] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ─── 1. docker-compose.yaml — minimal sandbox ─────────────────────────────
+
+test("docker-compose.yaml parses as YAML and exposes the gsd service contract", () => {
+  const parsed = parseYaml(readDockerFile("docker-compose.yaml")) as any;
+  const gsd = parsed?.services?.gsd;
+  assert.ok(gsd, "gsd service must be present in docker-compose.yaml");
+
+  // Build context resolves to docker/ ; uses the sandbox Dockerfile.
+  assert.equal(gsd.build?.dockerfile, "Dockerfile.sandbox");
+
+  // Port 3000 must be mapped 1:1 to the host. Compare on parsed form so
+  // string vs sequence ("3000:3000" vs { published: 3000, ... }) both
+  // pass once normalised.
+  const ports: unknown[] = Array.isArray(gsd.ports) ? gsd.ports : [];
+  const has3000 = ports.some((p) => {
+    if (typeof p === "string") return /^3000:3000(\/tcp)?$/.test(p);
+    if (p && typeof p === "object") {
+      const o = p as { published?: number | string; target?: number | string };
+      return Number(o.published) === 3000 && Number(o.target) === 3000;
+    }
+    return false;
+  });
+  assert.ok(has3000, `expected ports to map 3000:3000, got ${JSON.stringify(ports)}`);
+
+  // /workspace mount must be declared as a volume on the gsd service.
+  const volumes: unknown[] = Array.isArray(gsd.volumes) ? gsd.volumes : [];
+  const mountsWorkspace = volumes.some((v) => {
+    if (typeof v === "string") return /:\/workspace(:.*)?$/.test(v);
+    if (v && typeof v === "object") {
+      const o = v as { target?: string };
+      return o.target === "/workspace";
+    }
+    return false;
+  });
+  assert.ok(mountsWorkspace, `expected a /workspace mount, got ${JSON.stringify(volumes)}`);
+
+  // Security contract: no hardcoded user override on the service. The
+  // entrypoint remaps PUID/PGID — a top-level `user:` would defeat that.
+  assert.equal(gsd.user, undefined, "gsd service must not pin a user: directive");
+});
+
+// ─── 2. docker-compose.full.yaml — reference template ─────────────────────
+
+test("docker-compose.full.yaml surfaces healthcheck and PUID/PGID env", () => {
+  const parsed = parseYaml(readDockerFile("docker-compose.full.yaml")) as any;
+  const gsd = parsed?.services?.gsd;
+  assert.ok(gsd, "gsd service must exist");
+
+  // Healthcheck must be a structured directive (not a comment).
+  const healthcheck = gsd.healthcheck;
+  assert.ok(healthcheck, "healthcheck must be defined as YAML, not a comment");
+  assert.deepEqual(healthcheck.test, ["CMD", "gsd", "--version"]);
+  assert.ok(typeof healthcheck.interval === "string" && healthcheck.interval.length > 0);
+
+  // PUID / PGID must surface to the runtime as environment variables
+  // (a comment-only mention would not). Compose accepts environment as
+  // either an object or a "KEY=VALUE" array — handle both.
+  const env = gsd.environment;
+  const hasKey = (key: string): boolean => {
+    if (Array.isArray(env)) return env.some((e) => typeof e === "string" && e.startsWith(`${key}=`));
+    if (env && typeof env === "object") return Object.prototype.hasOwnProperty.call(env, key);
+    return false;
+  };
+  assert.ok(hasKey("PUID"), "PUID must be surfaced as an environment variable");
+  assert.ok(hasKey("PGID"), "PGID must be surfaced as an environment variable");
+});
+
+// ─── 2b. Optional runtime: `docker compose config` ────────────────────────
+
+test("docker compose config validates both compose files", { skip: !dockerAvailable() }, () => {
+  // Both compose files declare `env_file: - .env` (relative to docker/),
+  // which compose insists must exist on disk during `config`. If the
+  // host doesn't already have a real .env (CI, fresh checkouts), seed
+  // an empty placeholder so the schema validator can run, then remove
+  // it. Never clobber a developer's real .env.
+  const sentinelEnv = resolve(dockerDir, ".env");
+  const createdSentinel = !existsSync(sentinelEnv);
+  if (createdSentinel) {
+    writeFileSync(sentinelEnv, "# generated by docker-template-contract test\n", "utf-8");
+  }
+  try {
+    const validate = (rel: string): void => {
+      const file = resolve(dockerDir, rel);
+      // `docker compose -f <compose> config --quiet` resolves variables
+      // and exits 0 only if the file is a valid compose schema. It's
+      // stricter than YAML.parse — catches reserved-word misuse,
+      // missing services, unresolved !include refs, etc.
+      execFileSync("docker", ["compose", "-f", file, "config", "--quiet"], {
+        cwd: dockerDir,
+        stdio: ["ignore", "ignore", "pipe"],
+        env: { ...process.env, COMPOSE_PROJECT_NAME: "gsd-template-contract" },
+      });
+    };
+    validate("docker-compose.yaml");
+    validate("docker-compose.full.yaml");
+  } finally {
+    if (createdSentinel) {
+      try {
+        rmSync(sentinelEnv, { force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+});
+
+// ─── 3. Dockerfile.sandbox — directive structure ──────────────────────────
+
+test("Dockerfile.sandbox directive structure satisfies the runtime contract", () => {
+  const instructions = parseDockerfile(readDockerFile("Dockerfile.sandbox"));
+
+  // FROM: base must be node:24*. (Anchored: a comment mentioning
+  // `node:24` would not appear in the parsed instruction list.)
+  const from = instructions.find((i) => i.directive === "FROM");
+  assert.ok(from, "Dockerfile must have a FROM directive");
+  assert.match(from!.args, /^node:24(\.|-|$)/, `FROM must be node:24*, got: ${from!.args}`);
+
+  // RUN: at least one step must install gsd-pi globally. Match on the
+  // parsed argument string of an actual RUN, not a comment.
+  const installsGsdPi = instructions.some(
+    (i) => i.directive === "RUN" && /\bnpm\s+install\s+(?:[^&|;]*\s)?-g\s[^&|;]*\bgsd-pi\b/.test(i.args),
+  );
+  assert.ok(installsGsdPi, "expected a RUN step that runs `npm install -g gsd-pi`");
+
+  // Non-root contract: image must end as a real non-root user. The legacy
+  // test only asserted `useradd` — that satisfied the directive even if
+  // `USER` was never set. Here we require the actual USER directive.
+  // The current sandbox uses gosu via entrypoint to drop privileges; in
+  // that case the contract is the entrypoint script itself. Accept either
+  // form: a USER directive OR an ENTRYPOINT that hands off to gosu.
+  const hasUserDirective = instructions.some((i) => i.directive === "USER");
+  const hasGosuEntrypoint = instructions.some(
+    (i) => i.directive === "ENTRYPOINT" && /entrypoint\.sh/.test(i.args),
+  );
+  assert.ok(
+    hasUserDirective || hasGosuEntrypoint,
+    "image must drop privileges via USER directive or gosu entrypoint",
+  );
+  if (!hasUserDirective) {
+    // Verify the entrypoint script actually runs gosu (the privilege drop)
+    // — otherwise "gosu entrypoint" is just a name.
+    const entrypointPath = resolve(dockerDir, "entrypoint.sh");
+    assert.ok(existsSync(entrypointPath), "entrypoint.sh must exist when relied on for privilege drop");
+    const entrypoint = readFileSync(entrypointPath, "utf-8");
+    // The entrypoint may use a literal username (`gosu gsd`) or a quoted
+    // variable (`gosu "${GSD_USER}"`). Both are valid privilege drops; only
+    // a missing `exec gosu` is a contract break.
+    assert.match(entrypoint, /\bexec\s+gosu\s+\S+/, "entrypoint.sh must `exec gosu <user> ...`");
+  }
+
+  // EXPOSE 3000 must be a real directive.
+  const exposes3000 = instructions.some(
+    (i) => i.directive === "EXPOSE" && /\b3000\b/.test(i.args),
+  );
+  assert.ok(exposes3000, "Dockerfile.sandbox must EXPOSE 3000");
+});
+
+// ─── 4. .dockerignore — glob behaviour ────────────────────────────────────
+
+test(".dockerignore actually excludes the documented paths", () => {
+  const matcher = ignore().add(readRepoFile(".dockerignore"));
+
+  // Paths that MUST be ignored — exercises the glob, not the literal text.
+  // node_modules/x is matched by the trailing-slash directory rule
+  // `node_modules/`. .env is matched by the literal `.env` line. dist/foo
+  // is matched by `dist/`.
+  const mustIgnore = [
+    "node_modules/some-dep/index.js",
+    "packages/foo/node_modules/dep/x.js",
+    ".env",
+    ".env.local",
+    "dist/index.js",
+    "dist/nested/file.txt",
+  ];
+  for (const p of mustIgnore) {
+    assert.ok(matcher.ignores(p), `expected ${p} to be ignored by .dockerignore`);
+  }
+
+  // Carve-out: .env.example must NOT be ignored (the file is shipped in
+  // the repo intentionally). The current .dockerignore uses `!.env.example`.
+  assert.equal(
+    matcher.ignores(".env.example"),
+    false,
+    ".env.example must remain un-ignored — it is the shipped template",
+  );
+
+  // Sanity: source files that should pass through.
+  assert.equal(matcher.ignores("src/index.ts"), false);
+  assert.equal(matcher.ignores("docker/Dockerfile.sandbox"), false);
+});
+
+// ─── 5. .env.example — dotenv shape ───────────────────────────────────────
+
+test(".env.example declares the required provider keys with empty values", () => {
+  const source = readDockerFile(".env.example");
+
+  // Hand-rolled dotenv parse — match KEY=VALUE on non-comment lines, AND
+  // KEY values reachable only via uncommenting (lines starting with `# `
+  // followed by `KEY=`). The original file ships with provider keys
+  // commented out so users uncomment + fill them in. We need to assert
+  // the SHAPE — that the keys are documented, and that the example value
+  // is empty / placeholder (never a real secret).
+  const lines = source.split(/\r?\n/);
+  type Entry = { commented: boolean; value: string };
+  const entries = new Map<string, Entry>();
+  for (const raw of lines) {
+    const trimmed = raw.replace(/^\s+/, "");
+    const commented = trimmed.startsWith("#");
+    const body = commented ? trimmed.replace(/^#\s?/, "") : trimmed;
+    const m = body.match(/^([A-Z][A-Z0-9_]*)\s*=\s*(.*)$/);
+    if (!m) continue;
+    if (entries.has(m[1])) continue; // first occurrence wins
+    entries.set(m[1], { commented, value: m[2] });
+  }
+
+  for (const required of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]) {
+    const entry = entries.get(required);
+    assert.ok(entry, `${required} must be declared in .env.example (commented or live)`);
+    // Placeholder must be empty OR a documented placeholder pattern (sk-...).
+    // It must NEVER be a real-looking secret — guard against an accidental
+    // real key being committed to the example file.
+    const placeholderOk = entry!.value.length === 0 || /^(sk-[a-z\-]*\.{3}|<.+>|"")$/.test(entry!.value);
+    assert.ok(
+      placeholderOk,
+      `${required} in .env.example must be empty or a placeholder, got: ${JSON.stringify(entry!.value)}`,
+    );
+  }
+});

--- a/src/tests/docker-template-contract.test.ts
+++ b/src/tests/docker-template-contract.test.ts
@@ -85,6 +85,7 @@ function parseDockerfile(source: string): DockerfileInstruction[] {
 function dockerAvailable(): boolean {
   try {
     execFileSync("docker", ["--version"], { stdio: ["ignore", "ignore", "ignore"] });
+    execFileSync("docker", ["compose", "version"], { stdio: ["ignore", "ignore", "ignore"] });
     return true;
   } catch {
     return false;
@@ -130,6 +131,23 @@ test("docker-compose.yaml parses as YAML and exposes the gsd service contract", 
   // Security contract: no hardcoded user override on the service. The
   // entrypoint remaps PUID/PGID — a top-level `user:` would defeat that.
   assert.equal(gsd.user, undefined, "gsd service must not pin a user: directive");
+
+  // Minimal compose must not include runtime healthcheck wiring.
+  assert.equal(gsd.healthcheck, undefined, "minimal compose must not define healthcheck");
+
+  // Minimal compose must not surface UID/GID remap env vars.
+  const env = gsd.environment;
+  const hasEnvKey = (key: string): boolean => {
+    if (Array.isArray(env)) {
+      return env.some((e) => typeof e === "string" && (e === key || e.startsWith(`${key}=`)));
+    }
+    if (env && typeof env === "object") {
+      return Object.prototype.hasOwnProperty.call(env, key);
+    }
+    return false;
+  };
+  assert.equal(hasEnvKey("PUID"), false, "minimal compose must not define PUID");
+  assert.equal(hasEnvKey("PGID"), false, "minimal compose must not define PGID");
 });
 
 // ─── 2. docker-compose.full.yaml — reference template ─────────────────────
@@ -221,7 +239,14 @@ test("Dockerfile.sandbox directive structure satisfies the runtime contract", ()
   // The current sandbox uses gosu via entrypoint to drop privileges; in
   // that case the contract is the entrypoint script itself. Accept either
   // form: a USER directive OR an ENTRYPOINT that hands off to gosu.
-  const hasUserDirective = instructions.some((i) => i.directive === "USER");
+  const hasUserDirective = instructions.some((i) => {
+    if (i.directive !== "USER") return false;
+    const firstToken = i.args.split(/\s+/)[0]?.split(":")[0]?.trim().toLowerCase() ?? "";
+    if (!firstToken) return false;
+    if (firstToken === "root") return false;
+    if (/^\d+$/.test(firstToken) && Number(firstToken) === 0) return false;
+    return true;
+  });
   const hasGosuEntrypoint = instructions.some(
     (i) => i.directive === "ENTRYPOINT" && /entrypoint\.sh/.test(i.args),
   );

--- a/src/tests/integration/web-mode-runtime-harness.ts
+++ b/src/tests/integration/web-mode-runtime-harness.ts
@@ -212,7 +212,9 @@ function withBuildLock(lockName: string, fn: () => void): void {
   }
   const onSigint = () => releaseAndReraise("SIGINT")
   const onSigterm = () => releaseAndReraise("SIGTERM")
+  // allow-coderabbit-theme: process.kill() is only invoked by signal handlers at runtime.
   process.once("SIGINT", onSigint)
+  // allow-coderabbit-theme: process.kill() is only invoked by signal handlers at runtime.
   process.once("SIGTERM", onSigterm)
   try {
     fn()

--- a/src/tests/integration/web-mode-runtime-harness.ts
+++ b/src/tests/integration/web-mode-runtime-harness.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { execFileSync, spawn } from "node:child_process"
-import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 
 import type { Page, Request, Response } from "playwright"
@@ -140,15 +140,78 @@ function runNpmScript(args: string[], label: string): void {
   }
 }
 
+/**
+ * Cross-process build mutex. node:test runs each *.test.ts in its own
+ * worker process, so multiple integration tests calling
+ * `ensureRuntimeArtifacts()` race each other into `npm run build:web-host`
+ * and `npm run build:pi`. Next.js refuses concurrent `next build`
+ * invocations ("Another next build process is already running"), and
+ * concurrent npm workspace builds clobber each other's dist/ output.
+ *
+ * `mkdirSync` is atomic on POSIX (EEXIST when the directory already
+ * exists), so we use it as a sync, cross-process mutex. After acquiring
+ * the lock we re-check the artifact's existsSync — the previous holder
+ * may have just produced it, in which case we no-op and release.
+ */
+function withBuildLock(lockName: string, fn: () => void): void {
+  const lockRoot = join(projectRoot, ".test-build-locks")
+  mkdirSync(lockRoot, { recursive: true })
+  const lockDir = join(lockRoot, lockName)
+  const start = Date.now()
+  const timeoutMs = 10 * 60 * 1000 // builds can be slow on CI
+  while (true) {
+    try {
+      mkdirSync(lockDir)
+      break
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code
+      if (code !== "EEXIST") throw err
+      if (Date.now() - start > timeoutMs) {
+        throw new Error(`Timed out waiting for ${lockName} build lock at ${lockDir}`)
+      }
+      // Sync poll: block this process until the lock holder releases.
+      // Other test files in other processes are doing the same thing.
+      try {
+        execFileSync("sleep", ["1"], { stdio: "ignore" })
+      } catch {
+        // sleep unavailable (Windows); fall back to busy-wait
+        const until = Date.now() + 1000
+        while (Date.now() < until) {
+          /* spin */
+        }
+      }
+    }
+  }
+  try {
+    fn()
+  } finally {
+    try {
+      rmSync(lockDir, { recursive: true, force: true })
+    } catch {
+      // best-effort release
+    }
+  }
+}
+
 export function ensureRuntimeArtifacts(): void {
   if (runtimeArtifactsReady) return
 
   if (!existsSync(builtAgentEntryPath)) {
-    runNpmScript(["run", "build:pi"], "npm run build:pi")
+    withBuildLock("build-pi", () => {
+      // Re-check inside the lock — another process may have built it
+      // while we were waiting.
+      if (!existsSync(builtAgentEntryPath)) {
+        runNpmScript(["run", "build:pi"], "npm run build:pi")
+      }
+    })
   }
 
   if (!existsSync(packagedWebHostPath)) {
-    runNpmScript(["run", "build:web-host"], "npm run build:web-host")
+    withBuildLock("build-web-host", () => {
+      if (!existsSync(packagedWebHostPath)) {
+        runNpmScript(["run", "build:web-host"], "npm run build:web-host")
+      }
+    })
   }
 
   runtimeArtifactsReady = true

--- a/src/tests/integration/web-mode-runtime-harness.ts
+++ b/src/tests/integration/web-mode-runtime-harness.ts
@@ -157,15 +157,37 @@ function withBuildLock(lockName: string, fn: () => void): void {
   const lockRoot = join(projectRoot, ".test-build-locks")
   mkdirSync(lockRoot, { recursive: true })
   const lockDir = join(lockRoot, lockName)
+  const ownerFile = join(lockDir, "owner.json")
   const start = Date.now()
   const timeoutMs = 10 * 60 * 1000 // builds can be slow on CI
+  const staleMs = 2 * 60 * 1000
+
+  const releaseLock = () => {
+    try {
+      rmSync(lockDir, { recursive: true, force: true })
+    } catch {
+      // best-effort release
+    }
+  }
+
   while (true) {
     try {
       mkdirSync(lockDir)
+      writeFileSync(ownerFile, JSON.stringify({ pid: process.pid, createdAt: Date.now() }), "utf-8")
       break
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code
       if (code !== "EEXIST") throw err
+      try {
+        const raw = readFileSync(ownerFile, "utf-8")
+        const owner = JSON.parse(raw) as { createdAt?: number }
+        if (typeof owner.createdAt === "number" && Date.now() - owner.createdAt > staleMs) {
+          rmSync(lockDir, { recursive: true, force: true })
+          continue
+        }
+      } catch {
+        // no owner metadata or unreadable file; keep waiting
+      }
       if (Date.now() - start > timeoutMs) {
         throw new Error(`Timed out waiting for ${lockName} build lock at ${lockDir}`)
       }
@@ -182,14 +204,16 @@ function withBuildLock(lockName: string, fn: () => void): void {
       }
     }
   }
+  const onSigint = () => releaseLock()
+  const onSigterm = () => releaseLock()
+  process.once("SIGINT", onSigint)
+  process.once("SIGTERM", onSigterm)
   try {
     fn()
   } finally {
-    try {
-      rmSync(lockDir, { recursive: true, force: true })
-    } catch {
-      // best-effort release
-    }
+    process.removeListener("SIGINT", onSigint)
+    process.removeListener("SIGTERM", onSigterm)
+    releaseLock()
   }
 }
 

--- a/src/tests/integration/web-mode-runtime-harness.ts
+++ b/src/tests/integration/web-mode-runtime-harness.ts
@@ -204,8 +204,14 @@ function withBuildLock(lockName: string, fn: () => void): void {
       }
     }
   }
-  const onSigint = () => releaseLock()
-  const onSigterm = () => releaseLock()
+  const releaseAndReraise = (signal: "SIGINT" | "SIGTERM") => {
+    releaseLock()
+    process.removeListener("SIGINT", onSigint)
+    process.removeListener("SIGTERM", onSigterm)
+    process.kill(process.pid, signal)
+  }
+  const onSigint = () => releaseAndReraise("SIGINT")
+  const onSigterm = () => releaseAndReraise("SIGTERM")
   process.once("SIGINT", onSigint)
   process.once("SIGTERM", onSigterm)
   try {

--- a/src/tests/integration/web-responsive-contract.test.ts
+++ b/src/tests/integration/web-responsive-contract.test.ts
@@ -102,7 +102,6 @@ async function gotoPackagedHost(
         state: "attached",
         timeout: 30_000,
       })
-      return
     }
 
     // Diagnostic dump — without this, all we see in CI is a generic
@@ -129,6 +128,47 @@ async function gotoPackagedHost(
         `original: ${(error as Error).message}`,
     )
   }
+
+  await unlockOnboardingIfBlocking(page, target)
+}
+
+async function unlockOnboardingIfBlocking(page: Page, target: string): Promise<void> {
+  const gateVisible = await page.locator('[data-testid="onboarding-gate"]').isVisible().catch(() => false)
+  if (!gateVisible) return
+
+  const onboardingState = await page.evaluate(async () => {
+    const res = await fetch("/api/onboarding", { method: "GET" })
+    const payload = await res.json()
+    return payload?.onboarding ?? null
+  })
+
+  const apiKeyProviderId = onboardingState?.required?.providers?.find(
+    (provider: { configured?: boolean; supports?: { apiKey?: boolean }; id?: string }) =>
+      !provider.configured && provider.supports?.apiKey && typeof provider.id === "string",
+  )?.id
+
+  if (!apiKeyProviderId) {
+    throw new Error("onboarding gate is visible but no API-key provider is available to unlock it")
+  }
+
+  const unlock = await page.evaluate(async ({ providerId }) => {
+    const res = await fetch("/api/onboarding", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "save_api_key", providerId, apiKey: "gsd-test-key" }),
+    })
+    const payload = await res.json()
+    return { ok: res.ok, status: res.status, onboarding: payload?.onboarding ?? null, error: payload?.error ?? null }
+  }, { providerId: apiKeyProviderId })
+
+  if (!unlock.ok || unlock.onboarding?.locked) {
+    throw new Error(
+      `failed to unlock onboarding (status=${unlock.status}, provider=${apiKeyProviderId}, locked=${String(unlock.onboarding?.locked)}, error=${unlock.error ?? "none"})`,
+    )
+  }
+
+  await page.goto(target, { waitUntil: "load", timeout: 30_000 })
+  await page.locator('[data-testid="onboarding-gate"]').waitFor({ state: "hidden", timeout: 10_000 })
 }
 
 async function setViewport(page: Page, vp: { width: number; height: number }): Promise<void> {
@@ -141,9 +181,8 @@ async function setViewport(page: Page, vp: { width: number; height: number }): P
 //
 // One subprocess host + one chromium instance shared across all the
 // breakpoint assertions. The harness sanitises the runtime env per
-// launch, and the locked-onboarding state is fine for these tests
-// because the AppShell renders alongside the OnboardingGate (the gate
-// is a sibling overlay, not a wrapping conditional).
+// launch; if onboarding is visible we unlock it through /api/onboarding
+// so overlay pointer interception cannot make this test flaky.
 
 test("responsive contract: web host honours viewport-driven chrome", async (t) => {
   const tempRoot = mkdtempSync(join(tmpdir(), "gsd-web-responsive-contract-"))

--- a/src/tests/integration/web-responsive-contract.test.ts
+++ b/src/tests/integration/web-responsive-contract.test.ts
@@ -86,6 +86,21 @@ async function gotoPackagedHost(
       timeout: 30_000,
     })
   } catch (error) {
+    // Fallback: if the project-selection gate is visible, select the first
+    // discovered project and wait again for the responsive shell controls.
+    const gateVisible = await page.locator('[data-testid="project-selection-gate"]').isVisible().catch(() => false)
+    if (gateVisible) {
+      const firstProjectButton = page.locator('[data-testid="project-selection-gate"] .divide-y > button').first()
+      if (await firstProjectButton.count()) {
+        await firstProjectButton.click()
+        await page.waitForSelector('[data-testid="mobile-nav-toggle"]', {
+          state: "attached",
+          timeout: 30_000,
+        })
+        return
+      }
+    }
+
     // Diagnostic dump — without this, all we see in CI is a generic
     // selector timeout. Surfaces (a) which top-level state the shell
     // settled in, (b) any console errors, (c) a slice of body HTML.

--- a/src/tests/integration/web-responsive-contract.test.ts
+++ b/src/tests/integration/web-responsive-contract.test.ts
@@ -300,7 +300,7 @@ test("responsive contract: web host honours viewport-driven chrome", async (t) =
   await page.waitForFunction(
     () => {
       const el = document.querySelector('[data-testid="mobile-milestone-drawer"]') as HTMLElement | null
-      return Boolean(el) && /-translate-x-full/.test(el!.className)
+      return Boolean(el) && el!.classList.contains("translate-x-full")
     },
     null,
     { timeout: 5_000 },

--- a/src/tests/integration/web-responsive-contract.test.ts
+++ b/src/tests/integration/web-responsive-contract.test.ts
@@ -44,12 +44,19 @@ const DESKTOP = { width: 1440, height: 900 } // xl-band
 
 // ─── helpers ─────────────────────────────────────────────────────────────
 
-async function gotoPackagedHost(page: Page, launch: RuntimeLaunchResult): Promise<void> {
+async function gotoPackagedHost(
+  page: Page,
+  launch: RuntimeLaunchResult,
+  options?: { projectCwd?: string },
+): Promise<void> {
   // The launcher hands an auth token via the fragment so the client
   // bootstrap can read it. Without it the shell renders the
   // "Authentication Required" branch — which is itself responsive but
   // is not what these tests cover.
-  const target = launch.authToken ? `${launch.url}/#token=${launch.authToken}` : launch.url
+  const projectQuery = options?.projectCwd ? `?project=${encodeURIComponent(options.projectCwd)}` : ""
+  const target = launch.authToken
+    ? `${launch.url}/${projectQuery}#token=${launch.authToken}`
+    : `${launch.url}/${projectQuery}`
 
   // Capture browser console + page errors so a failed selector wait
   // can surface why the shell didn't mount instead of just timing out.
@@ -169,7 +176,7 @@ test("responsive contract: web host honours viewport-driven chrome", async (t) =
   context = await browser.newContext({ viewport: MOBILE })
   const page = await context.newPage()
 
-  await gotoPackagedHost(page, launch)
+  await gotoPackagedHost(page, launch, { projectCwd })
 
   // ───────────────────────────────────────────────────────────────────
   // 3. Mobile (≤767px): hamburger visible, bottom bar visible, drawer

--- a/src/tests/integration/web-responsive-contract.test.ts
+++ b/src/tests/integration/web-responsive-contract.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Behavioural responsive-layout contract for the packaged web host.
+ *
+ * Replaces the source-grep `web-responsive.test.ts` (deleted in #4890).
+ * Each assertion drives the rendered DOM at a real viewport via
+ * Playwright — renaming a Tailwind utility but keeping the rendered
+ * outcome unchanged passes; deleting `flex md:hidden` from the
+ * hamburger button (or removing the testid) fails. Goodhart-proof.
+ *
+ * Refs: #4888, #4810
+ *
+ * The test uses the existing web-mode-runtime-harness to launch the
+ * packaged host once, then iterates breakpoints in a single browser
+ * to keep total runtime acceptable for `test:integration`.
+ */
+
+import test from "node:test"
+import assert from "node:assert/strict"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { setTimeout as delay } from "node:timers/promises"
+
+import type { Browser, BrowserContext, Page } from "playwright"
+import { chromium } from "playwright"
+
+import {
+  killProcessOnPort,
+  launchPackagedWebHost,
+  type RuntimeLaunchResult,
+} from "./web-mode-runtime-harness.ts"
+
+const repoRoot = process.cwd()
+
+// ─── viewport breakpoints ────────────────────────────────────────────────
+//
+// Tailwind defaults: sm=640, md=768, lg=1024, xl=1280, 2xl=1536. We pick
+// representative sizes inside each band and assert layout differs in the
+// ways `app-shell.tsx` claims (mobile-only chrome, desktop-only chrome).
+
+const MOBILE = { width: 375, height: 800 } // sm-band
+const TABLET = { width: 900, height: 800 } // md-band (>= md, < lg)
+const DESKTOP = { width: 1440, height: 900 } // xl-band
+
+// ─── helpers ─────────────────────────────────────────────────────────────
+
+async function gotoPackagedHost(page: Page, launch: RuntimeLaunchResult): Promise<void> {
+  // The launcher hands an auth token via the fragment so the client
+  // bootstrap can read it. Without it the shell renders the
+  // "Authentication Required" branch — which is itself responsive but
+  // is not what these tests cover.
+  const target = launch.authToken ? `${launch.url}/#token=${launch.authToken}` : launch.url
+  await page.goto(target, { waitUntil: "domcontentloaded", timeout: 30_000 })
+  // Wait for the lazy-loaded shell to mount. The header testid
+  // `mobile-nav-toggle` exists in the DOM (visible or not) at every
+  // viewport once the shell has hydrated.
+  await page.waitForSelector('[data-testid="mobile-nav-toggle"]', {
+    state: "attached",
+    timeout: 30_000,
+  })
+}
+
+async function setViewport(page: Page, vp: { width: number; height: number }): Promise<void> {
+  await page.setViewportSize(vp)
+  // Allow Tailwind's media-query-driven className flips to settle.
+  await delay(50)
+}
+
+// ─── single-fixture suite ────────────────────────────────────────────────
+//
+// One subprocess host + one chromium instance shared across all the
+// breakpoint assertions. The harness sanitises the runtime env per
+// launch, and the locked-onboarding state is fine for these tests
+// because the AppShell renders alongside the OnboardingGate (the gate
+// is a sibling overlay, not a wrapping conditional).
+
+test("responsive contract: web host honours viewport-driven chrome", async (t) => {
+  const tempRoot = mkdtempSync(join(tmpdir(), "gsd-web-responsive-contract-"))
+  const tempHome = join(tempRoot, "home")
+  let port: number | null = null
+  let browser: Browser | null = null
+  let context: BrowserContext | null = null
+
+  t.after(async () => {
+    if (context) await context.close().catch(() => {})
+    if (browser) await browser.close().catch(() => {})
+    if (port !== null) await killProcessOnPort(port)
+    try {
+      rmSync(tempRoot, { recursive: true, force: true })
+    } catch {
+      // best-effort
+    }
+  })
+
+  // 1. Boot the packaged host. The harness invokes `npm run build:pi`
+  //    and `npm run build:web-host` if their artifacts are missing —
+  //    so this works on a fresh checkout but only pays the build cost
+  //    once per CI run.
+  const launch = await launchPackagedWebHost({
+    launchCwd: repoRoot,
+    tempHome,
+    env: {
+      GSD_WEB_TEST_FAKE_API_KEY_VALIDATION: "1",
+      GSD_WEB_TEST_DISABLE_EXTERNAL_CLI: "1",
+    },
+  })
+  port = launch.port
+  assert.equal(launch.exitCode, 0, `launcher must exit cleanly:\n${launch.stderr}`)
+
+  // 2. Try to launch a real chromium. If the browser isn't installed
+  //    (some minimal CI images), record that explicitly — never silently
+  //    skip. Ship `npx playwright install chromium` as a separate task
+  //    if this appears on a runner; do not paper over it here.
+  try {
+    browser = await chromium.launch({ headless: true })
+  } catch (error) {
+    throw new Error(
+      `Playwright chromium failed to launch — install browsers via 'npx playwright install chromium'. Underlying error: ${(error as Error).message}`,
+    )
+  }
+  context = await browser.newContext({ viewport: MOBILE })
+  const page = await context.newPage()
+
+  await gotoPackagedHost(page, launch)
+
+  // ───────────────────────────────────────────────────────────────────
+  // 3. Mobile (≤767px): hamburger visible, bottom bar visible, drawer
+  //    interaction wires up, milestone toggle present.
+  // ───────────────────────────────────────────────────────────────────
+  await setViewport(page, MOBILE)
+
+  await assert.doesNotReject(
+    page.locator('[data-testid="mobile-nav-toggle"]').waitFor({ state: "visible", timeout: 5_000 }),
+    "mobile-nav-toggle must be visible at mobile viewport",
+  )
+  await assert.doesNotReject(
+    page.locator('[data-testid="mobile-bottom-bar"]').waitFor({ state: "visible", timeout: 5_000 }),
+    "mobile-bottom-bar must be visible at mobile viewport",
+  )
+
+  // Drawer toggle: closed → open → overlay-dismiss → closed.
+  // The drawer element is mounted regardless (it's a transform-based
+  // off-screen panel), so we assert on its className transition rather
+  // than visibility-or-attached.
+  await page.locator('[data-testid="mobile-nav-toggle"]').click()
+  await page.waitForFunction(
+    () => {
+      const el = document.querySelector('[data-testid="mobile-nav-drawer"]') as HTMLElement | null
+      return Boolean(el) && /translate-x-0/.test(el!.className)
+    },
+    null,
+    { timeout: 5_000 },
+  )
+  // Overlay click closes the drawer.
+  await page.locator('[data-testid="mobile-nav-overlay"]').click()
+  await page.waitForFunction(
+    () => {
+      const el = document.querySelector('[data-testid="mobile-nav-drawer"]') as HTMLElement | null
+      return Boolean(el) && /-translate-x-full/.test(el!.className)
+    },
+    null,
+    { timeout: 5_000 },
+  )
+
+  // Milestone drawer parallels the nav drawer.
+  await assert.doesNotReject(
+    page.locator('[data-testid="mobile-milestone-toggle"]').waitFor({ state: "visible", timeout: 5_000 }),
+    "mobile-milestone-toggle must be visible at mobile viewport",
+  )
+
+  // Touch-target minimum: hamburger button must be ≥ 40px square so
+  // the WCAG-recommended 44×44 hit area can be reached without scaling
+  // (Tailwind's h-10 w-10 = 40px; we accept that as the floor).
+  const toggleBox = await page.locator('[data-testid="mobile-nav-toggle"]').boundingBox()
+  assert.ok(toggleBox, "mobile-nav-toggle must have a bounding box")
+  assert.ok(
+    toggleBox!.height >= 40 && toggleBox!.width >= 40,
+    `mobile-nav-toggle must meet the 40px touch-target floor, got ${JSON.stringify(toggleBox)}`,
+  )
+
+  // The branch / project-cwd label uses `hidden sm:inline` — at 375px
+  // it should be hidden (display: none).
+  const cwdDisplay = await page
+    .locator('[data-testid="workspace-project-cwd"]')
+    .first()
+    .evaluate((el) => window.getComputedStyle(el).display)
+  assert.equal(cwdDisplay, "none", `workspace-project-cwd must be hidden on mobile, got display=${cwdDisplay}`)
+
+  // ───────────────────────────────────────────────────────────────────
+  // 4. Desktop (≥1024px): hamburger and bottom bar hidden; cwd visible.
+  // ───────────────────────────────────────────────────────────────────
+  await setViewport(page, DESKTOP)
+
+  const navToggleDisplay = await page
+    .locator('[data-testid="mobile-nav-toggle"]')
+    .evaluate((el) => window.getComputedStyle(el).display)
+  assert.equal(
+    navToggleDisplay,
+    "none",
+    `mobile-nav-toggle must be hidden on desktop, got display=${navToggleDisplay}`,
+  )
+  const bottomBarDisplay = await page
+    .locator('[data-testid="mobile-bottom-bar"]')
+    .evaluate((el) => window.getComputedStyle(el).display)
+  assert.equal(
+    bottomBarDisplay,
+    "none",
+    `mobile-bottom-bar must be hidden on desktop, got display=${bottomBarDisplay}`,
+  )
+
+  const desktopCwdDisplay = await page
+    .locator('[data-testid="workspace-project-cwd"]')
+    .first()
+    .evaluate((el) => window.getComputedStyle(el).display)
+  assert.notEqual(
+    desktopCwdDisplay,
+    "none",
+    "workspace-project-cwd must be visible on desktop",
+  )
+
+  // ───────────────────────────────────────────────────────────────────
+  // 5. Tablet (768–1023px, the md band): mobile chrome already gone,
+  //    desktop chrome already in. Asserts the breakpoint cutover lands
+  //    at md, not at lg.
+  // ───────────────────────────────────────────────────────────────────
+  await setViewport(page, TABLET)
+
+  const tabletNavToggleDisplay = await page
+    .locator('[data-testid="mobile-nav-toggle"]')
+    .evaluate((el) => window.getComputedStyle(el).display)
+  assert.equal(
+    tabletNavToggleDisplay,
+    "none",
+    `mobile-nav-toggle must hide at the md breakpoint, got display=${tabletNavToggleDisplay} at ${TABLET.width}px`,
+  )
+
+  // ───────────────────────────────────────────────────────────────────
+  // 6. Viewport meta — the layout.tsx Viewport export must reach the
+  //    rendered <head> with width=device-width and a maximum-scale.
+  // ───────────────────────────────────────────────────────────────────
+  const viewportMeta = await page
+    .locator('meta[name="viewport"]')
+    .getAttribute("content")
+  assert.ok(viewportMeta, "viewport meta tag must be present in <head>")
+  assert.match(
+    viewportMeta!,
+    /width=device-width/,
+    `viewport meta must declare device-width, got: ${viewportMeta}`,
+  )
+  assert.match(
+    viewportMeta!,
+    /maximum-scale=1/,
+    `viewport meta must pin maximum-scale=1, got: ${viewportMeta}`,
+  )
+})

--- a/src/tests/integration/web-responsive-contract.test.ts
+++ b/src/tests/integration/web-responsive-contract.test.ts
@@ -212,15 +212,31 @@ test("responsive contract: web host honours viewport-driven chrome", async (t) =
     page.locator('[data-testid="mobile-milestone-toggle"]').waitFor({ state: "visible", timeout: 5_000 }),
     "mobile-milestone-toggle must be visible at mobile viewport",
   )
+  await page.locator('[data-testid="mobile-milestone-toggle"]').click()
+  await page.waitForFunction(
+    () => {
+      const el = document.querySelector('[data-testid="mobile-milestone-drawer"]') as HTMLElement | null
+      return Boolean(el) && /translate-x-0/.test(el!.className)
+    },
+    null,
+    { timeout: 5_000 },
+  )
+  await page.locator('[data-testid="mobile-milestone-overlay"]').click()
+  await page.waitForFunction(
+    () => {
+      const el = document.querySelector('[data-testid="mobile-milestone-drawer"]') as HTMLElement | null
+      return Boolean(el) && /-translate-x-full/.test(el!.className)
+    },
+    null,
+    { timeout: 5_000 },
+  )
 
-  // Touch-target minimum: hamburger button must be ≥ 40px square so
-  // the WCAG-recommended 44×44 hit area can be reached without scaling
-  // (Tailwind's h-10 w-10 = 40px; we accept that as the floor).
+  // Touch-target minimum: hamburger button must be ≥ 44px square.
   const toggleBox = await page.locator('[data-testid="mobile-nav-toggle"]').boundingBox()
   assert.ok(toggleBox, "mobile-nav-toggle must have a bounding box")
   assert.ok(
-    toggleBox!.height >= 40 && toggleBox!.width >= 40,
-    `mobile-nav-toggle must meet the 40px touch-target floor, got ${JSON.stringify(toggleBox)}`,
+    toggleBox!.height >= 44 && toggleBox!.width >= 44,
+    `mobile-nav-toggle must meet the 44px touch-target floor, got ${JSON.stringify(toggleBox)}`,
   )
 
   // The branch / project-cwd label uses `hidden sm:inline` — at 375px
@@ -281,7 +297,7 @@ test("responsive contract: web host honours viewport-driven chrome", async (t) =
 
   // ───────────────────────────────────────────────────────────────────
   // 6. Viewport meta — the layout.tsx Viewport export must reach the
-  //    rendered <head> with width=device-width and a maximum-scale.
+  //    rendered <head> with width=device-width.
   // ───────────────────────────────────────────────────────────────────
   const viewportMeta = await page
     .locator('meta[name="viewport"]')
@@ -291,10 +307,5 @@ test("responsive contract: web host honours viewport-driven chrome", async (t) =
     viewportMeta!,
     /width=device-width/,
     `viewport meta must declare device-width, got: ${viewportMeta}`,
-  )
-  assert.match(
-    viewportMeta!,
-    /maximum-scale=1/,
-    `viewport meta must pin maximum-scale=1, got: ${viewportMeta}`,
   )
 })

--- a/src/tests/integration/web-responsive-contract.test.ts
+++ b/src/tests/integration/web-responsive-contract.test.ts
@@ -50,14 +50,59 @@ async function gotoPackagedHost(page: Page, launch: RuntimeLaunchResult): Promis
   // "Authentication Required" branch — which is itself responsive but
   // is not what these tests cover.
   const target = launch.authToken ? `${launch.url}/#token=${launch.authToken}` : launch.url
-  await page.goto(target, { waitUntil: "domcontentloaded", timeout: 30_000 })
+
+  // Capture browser console + page errors so a failed selector wait
+  // can surface why the shell didn't mount instead of just timing out.
+  const consoleEntries: string[] = []
+  page.on("console", (msg) => {
+    consoleEntries.push(`[${msg.type()}] ${msg.text()}`)
+  })
+  const pageErrors: string[] = []
+  page.on("pageerror", (err) => {
+    pageErrors.push(err.stack ?? err.message)
+  })
+
+  // `load` (not `domcontentloaded`) — the shell is loaded via
+  // `next/dynamic({ ssr: false })` so the lazy chunk fetch happens
+  // after the initial HTML; `load` waits for those chunks.
+  await page.goto(target, { waitUntil: "load", timeout: 30_000 })
+
   // Wait for the lazy-loaded shell to mount. The header testid
   // `mobile-nav-toggle` exists in the DOM (visible or not) at every
-  // viewport once the shell has hydrated.
-  await page.waitForSelector('[data-testid="mobile-nav-toggle"]', {
-    state: "attached",
-    timeout: 30_000,
-  })
+  // viewport once the shell has hydrated. AppShell's only early-exit
+  // is the `bootStatus === "unauthenticated"` branch (no testid) —
+  // hitting it means the auth token from the URL fragment didn't
+  // reach `/api/boot`.
+  try {
+    await page.waitForSelector('[data-testid="mobile-nav-toggle"]', {
+      state: "attached",
+      timeout: 30_000,
+    })
+  } catch (error) {
+    // Diagnostic dump — without this, all we see in CI is a generic
+    // selector timeout. Surfaces (a) which top-level state the shell
+    // settled in, (b) any console errors, (c) a slice of body HTML.
+    const diag = await page.evaluate(() => {
+      const body = document.body
+      return {
+        url: window.location.href,
+        hash: window.location.hash,
+        hasOnboardingGate: Boolean(document.querySelector('[data-testid="onboarding-gate"]')),
+        hasAuthRequiredHeading: Array.from(document.querySelectorAll("h1")).some(
+          (h) => h.textContent?.includes("Authentication Required"),
+        ),
+        bodyHtml: body ? body.innerHTML.slice(0, 2_000) : "<no body>",
+      }
+    })
+    throw new Error(
+      `mobile-nav-toggle never attached. url=${diag.url} hash=${JSON.stringify(diag.hash)} ` +
+        `onboardingGate=${diag.hasOnboardingGate} authRequired=${diag.hasAuthRequiredHeading}\n` +
+        `body[0..2000]:\n${diag.bodyHtml}\n` +
+        `pageErrors:\n${pageErrors.join("\n") || "(none)"}\n` +
+        `console:\n${consoleEntries.slice(-50).join("\n") || "(none)"}\n` +
+        `original: ${(error as Error).message}`,
+    )
+  }
 }
 
 async function setViewport(page: Page, vp: { width: number; height: number }): Promise<void> {

--- a/src/tests/integration/web-responsive-contract.test.ts
+++ b/src/tests/integration/web-responsive-contract.test.ts
@@ -16,7 +16,7 @@
 
 import test from "node:test"
 import assert from "node:assert/strict"
-import { mkdtempSync, rmSync } from "node:fs"
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
@@ -122,6 +122,8 @@ async function setViewport(page: Page, vp: { width: number; height: number }): P
 test("responsive contract: web host honours viewport-driven chrome", async (t) => {
   const tempRoot = mkdtempSync(join(tmpdir(), "gsd-web-responsive-contract-"))
   const tempHome = join(tempRoot, "home")
+  const projectCwd = join(tempRoot, "project")
+  mkdirSync(projectCwd, { recursive: true })
   let port: number | null = null
   let browser: Browser | null = null
   let context: BrowserContext | null = null
@@ -147,6 +149,7 @@ test("responsive contract: web host honours viewport-driven chrome", async (t) =
     env: {
       GSD_WEB_TEST_FAKE_API_KEY_VALIDATION: "1",
       GSD_WEB_TEST_DISABLE_EXTERNAL_CLI: "1",
+      GSD_WEB_PROJECT_CWD: projectCwd,
     },
   })
   port = launch.port

--- a/src/tests/integration/web-responsive-contract.test.ts
+++ b/src/tests/integration/web-responsive-contract.test.ts
@@ -16,7 +16,7 @@
 
 import test from "node:test"
 import assert from "node:assert/strict"
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
@@ -131,6 +131,13 @@ test("responsive contract: web host honours viewport-driven chrome", async (t) =
   const tempHome = join(tempRoot, "home")
   const projectCwd = join(tempRoot, "project")
   mkdirSync(projectCwd, { recursive: true })
+  const prefsDir = join(tempHome, ".gsd")
+  mkdirSync(prefsDir, { recursive: true })
+  writeFileSync(
+    join(prefsDir, "web-preferences.json"),
+    JSON.stringify({ devRoot: tempRoot, lastActiveProject: projectCwd }, null, 2),
+    "utf-8",
+  )
   let port: number | null = null
   let browser: Browser | null = null
   let context: BrowserContext | null = null

--- a/src/tests/integration/web-responsive-contract.test.ts
+++ b/src/tests/integration/web-responsive-contract.test.ts
@@ -47,7 +47,7 @@ const DESKTOP = { width: 1440, height: 900 } // xl-band
 async function gotoPackagedHost(
   page: Page,
   launch: RuntimeLaunchResult,
-  options?: { projectCwd?: string },
+  options?: { projectCwd?: string; devRoot?: string },
 ): Promise<void> {
   // The launcher hands an auth token via the fragment so the client
   // bootstrap can read it. Without it the shell renders the
@@ -89,16 +89,20 @@ async function gotoPackagedHost(
     // Fallback: if the project-selection gate is visible, select the first
     // discovered project and wait again for the responsive shell controls.
     const gateVisible = await page.locator('[data-testid="project-selection-gate"]').isVisible().catch(() => false)
-    if (gateVisible) {
-      const firstProjectButton = page.locator('[data-testid="project-selection-gate"] .divide-y > button').first()
-      if (await firstProjectButton.count()) {
-        await firstProjectButton.click()
-        await page.waitForSelector('[data-testid="mobile-nav-toggle"]', {
-          state: "attached",
-          timeout: 30_000,
+    if (gateVisible && options?.projectCwd && options?.devRoot) {
+      await page.evaluate(async ({ projectCwd, devRoot }) => {
+        await fetch("/api/preferences", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ devRoot, lastActiveProject: projectCwd }),
         })
-        return
-      }
+      }, { projectCwd: options.projectCwd, devRoot: options.devRoot })
+      await page.goto(target, { waitUntil: "load", timeout: 30_000 })
+      await page.waitForSelector('[data-testid="mobile-nav-toggle"]', {
+        state: "attached",
+        timeout: 30_000,
+      })
+      return
     }
 
     // Diagnostic dump — without this, all we see in CI is a generic
@@ -198,7 +202,7 @@ test("responsive contract: web host honours viewport-driven chrome", async (t) =
   context = await browser.newContext({ viewport: MOBILE })
   const page = await context.newPage()
 
-  await gotoPackagedHost(page, launch, { projectCwd })
+  await gotoPackagedHost(page, launch, { projectCwd, devRoot: tempRoot })
 
   // ───────────────────────────────────────────────────────────────────
   // 3. Mobile (≤767px): hamburger visible, bottom bar visible, drawer

--- a/src/tests/integration/web-responsive-contract.test.ts
+++ b/src/tests/integration/web-responsive-contract.test.ts
@@ -102,6 +102,7 @@ async function gotoPackagedHost(
         state: "attached",
         timeout: 30_000,
       })
+      return
     }
 
     // Diagnostic dump — without this, all we see in CI is a generic


### PR DESCRIPTION
## Summary

Behavioural replacements for the two source-grep tests deleted in #4884 and #4890.

- `src/tests/docker-template-contract.test.ts` — parses docker-compose.yaml/full.yaml with `yaml`; asserts service shape / port mapping / `/workspace` mount / no `user:` override / healthcheck / PUID/PGID env. Parses Dockerfile.sandbox into directive+args (comments stripped, line-continuations joined) and asserts FROM=node:24*, RUN installs gsd-pi globally, privilege-drop via USER or gosu entrypoint, EXPOSE 3000. Uses `ignore` to evaluate .dockerignore globs against representative paths. Hand-rolled dotenv parse asserts the keys exist with empty/placeholder values. Optional `docker compose config --quiet` runs when docker is on PATH (declared skip if not — never silently).
- `src/tests/integration/web-responsive-contract.test.ts` — drives the packaged web host with Playwright across mobile / tablet / desktop viewports. Asserts on `getComputedStyle().display`, drawer open/close via the overlay, touch-target floor, and the viewport meta tag in `<head>`. One subprocess host + one chromium shared across breakpoints.

Closes #4881
Closes #4888

## Test plan

- [ ] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/docker-template-contract.test.ts` — passes locally (6/6)
- [ ] CI test:integration passes the new web-responsive-contract test
- [ ] Anti-regression spot-check (verified locally): commenting out EXPOSE 3000 in Dockerfile.sandbox fails the docker contract test

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added contract tests validating Docker artifacts, Dockerfile, .dockerignore, and .env.example.
  * Added responsive integration tests verifying mobile, tablet, and desktop UI behaviors and viewport meta.
  * Added integration tests to ensure builds are produced reliably when runs execute concurrently.

* **Chores**
  * Updated ignore list to exclude generated build-lock artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->