### PR TITLE
test(pi-tui): runtime coverage for leak fixes, tool-card cleanup, success notifications

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
@@ -1,0 +1,212 @@
+// Runtime regression tests for the post-compaction tool-card cleanup and the
+// green-bordered success-notification rendering. Replaces the source-grep
+// `src/tests/tui-running-and-success-box.test.ts` that was deleted in #4875
+// (tracked as #4872).
+//
+// The previous tests asserted on identifier presence and method signature
+// shape via regex. A regression that routed `success` notifications through
+// `showStatus` (dim text) by accident would not have failed because the
+// `showSuccess` method would still exist and still match the regex. These
+// tests instead drive the components through the actual scenario and assert
+// on rendered output.
+
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+
+import { Container, Text } from "@gsd/pi-tui";
+import stripAnsi from "strip-ansi";
+
+import { initTheme, theme } from "../theme/theme.js";
+import { DynamicBorder } from "./dynamic-border.js";
+import { ToolExecutionComponent } from "./tool-execution.js";
+
+// Theme is a globalThis-shared singleton that throws if not initialized.
+// Initialize once before any test that exercises themed rendering.
+before(() => {
+	initTheme("dark");
+});
+
+interface MockTui {
+	renderCount: number;
+	requestRender(): void;
+}
+
+function makeMockTUI(): MockTui {
+	return {
+		renderCount: 0,
+		requestRender() {
+			this.renderCount++;
+		},
+	};
+}
+
+// ─── Bug 1: tool cards stuck in "Running" after compaction ──────────────
+
+describe("ToolExecutionComponent post-compaction cleanup", () => {
+	it("renders 'Running' status while the tool call has no result", () => {
+		// Baseline: a freshly-constructed component (mid-stream) must show
+		// the running badge — this is the state we need to flip OUT of when
+		// compaction removes the result message.
+		const ui = makeMockTUI();
+		const c = new ToolExecutionComponent(
+			"read_file",
+			{ path: "/tmp/x.txt" },
+			{},
+			undefined,
+			ui as never,
+		);
+		const rendered = c.render(60).map(stripAnsi).join("\n");
+		assert.ok(
+			rendered.includes("Running"),
+			"freshly constructed component should render 'Running' badge",
+		);
+	});
+
+	it("markHistoricalNoResult flips a stuck tool card OUT of 'Running'", () => {
+		// Real bug: after session-history replay (post-compaction or session
+		// switch), tool calls without matching tool_result messages stay in
+		// isPartial = true forever. markHistoricalNoResult must produce a
+		// rendered output that no longer reads "Running".
+		const ui = makeMockTUI();
+		const c = new ToolExecutionComponent(
+			"read_file",
+			{ path: "/tmp/x.txt" },
+			{},
+			undefined,
+			ui as never,
+		);
+
+		c.markHistoricalNoResult();
+
+		const rendered = c.render(60).map(stripAnsi).join("\n");
+		assert.ok(
+			!rendered.includes("Running"),
+			"after markHistoricalNoResult, the tool card must NOT render 'Running' — got:\n" +
+				rendered,
+		);
+		assert.ok(
+			rendered.includes("Done"),
+			"flipped card should render 'Done' status (no-result success)",
+		);
+	});
+
+	it("markHistoricalNoResult is idempotent when a real result already exists", () => {
+		// Late-arriving stream events must not clobber legitimate results.
+		// We observe the no-clobber via behaviour: a card that completed
+		// with a real result keeps its "Done" badge and content even if
+		// markHistoricalNoResult fires again afterwards.
+		const ui = makeMockTUI();
+		const c = new ToolExecutionComponent(
+			"read_file",
+			{ path: "/tmp/x.txt" },
+			{},
+			undefined,
+			ui as never,
+		);
+
+		// Use the public completion path the runtime calls.
+		c.updateResult(
+			{
+				content: [{ type: "text", text: "real-result-payload" }],
+				isError: false,
+			},
+			false, // isPartial = false → "Done"
+		);
+
+		const before = c.render(60).map(stripAnsi).join("\n");
+		assert.ok(before.includes("Done"), "after complete(), card shows 'Done'");
+
+		c.markHistoricalNoResult(); // must early-return
+		const after = c.render(60).map(stripAnsi).join("\n");
+		assert.equal(
+			after,
+			before,
+			"markHistoricalNoResult must NOT mutate state when a real result is already present",
+		);
+	});
+});
+
+// ─── Bug 2: success notifications render as a green bordered box ────────
+
+describe("Success-notification rendering — DynamicBorder + success theme", () => {
+	// We drive the same component composition that interactive-mode.showSuccess
+	// builds (DynamicBorder + Text + DynamicBorder, all themed with
+	// theme.fg("success", …)) and assert on the rendered output, rather than
+	// trying to instantiate the full InteractiveMode (which requires a real
+	// session, bridge, and TUI runtime).
+	function buildSuccessNotification(message: string): Container {
+		const c = new Container();
+		const successColor = (text: string) => theme.fg("success", text);
+		c.addChild(new DynamicBorder(successColor));
+		c.addChild(new Text(theme.fg("success", message), 1, 0));
+		c.addChild(new DynamicBorder(successColor));
+		return c;
+	}
+
+	it("renders a top and bottom horizontal border framing the message", () => {
+		const c = buildSuccessNotification("Milestone M042 ready.");
+		const lines = c.render(40);
+
+		// First and last lines should be horizontal-rule borders
+		// (DynamicBorder renders a row of "─" characters).
+		const firstStripped = stripAnsi(lines[0]);
+		const lastStripped = stripAnsi(lines[lines.length - 1]);
+
+		assert.ok(
+			firstStripped.includes("─"),
+			`first line should be a border (got: ${JSON.stringify(firstStripped)})`,
+		);
+		assert.ok(
+			lastStripped.includes("─"),
+			`last line should be a border (got: ${JSON.stringify(lastStripped)})`,
+		);
+		assert.ok(
+			lines.length >= 3,
+			`success notification must have at least 3 lines (top border, message, bottom border) — got ${lines.length}`,
+		);
+	});
+
+	it("the message text appears between the two borders", () => {
+		const c = buildSuccessNotification("Milestone M042 ready.");
+		const lines = c.render(40);
+
+		const messageRow = lines.findIndex((l) => stripAnsi(l).includes("Milestone M042 ready."));
+		assert.ok(messageRow > 0, "message must appear after the top border");
+		assert.ok(
+			messageRow < lines.length - 1,
+			"message must appear before the bottom border",
+		);
+	});
+
+	it("borders carry ANSI styling (not plain dim text like showStatus)", () => {
+		// Goodhart-resistant: if a regression routed success through
+		// showStatus, the borders would be missing AND the rendered text
+		// would be plain (or only dim-styled, not success-colored). We
+		// observe the border lines carry ANSI escape codes — the literal
+		// foreground color depends on the theme (which is system-dependent
+		// in CI), so we don't pin a specific code but DO require styling
+		// to be present.
+		const c = buildSuccessNotification("ok");
+		const lines = c.render(40);
+		const top = lines[0];
+		assert.ok(
+			top !== stripAnsi(top),
+			"top border must contain ANSI styling — a plain unstyled border " +
+				"would indicate the rendering bypassed theme.fg('success', ...)",
+		);
+	});
+
+	it("plain Text status (the showStatus path) does NOT produce a bordered box", () => {
+		// Counter-test: this is what the bug looked like — a single dim Text
+		// with no surrounding border. If anyone ever "fixes" the showSuccess
+		// regression by also adding borders to showStatus, this test will
+		// surface the conflation.
+		const plain = new Text(theme.fg("dim", "Milestone M042 ready."), 1, 0);
+		const lines = plain.render(40);
+		const joined = lines.map(stripAnsi).join("\n");
+		assert.ok(
+			!joined.includes("─"),
+			"plain Text (showStatus path) must NOT contain border characters",
+		);
+	});
+});

--- a/packages/pi-tui/src/__tests__/autocomplete.test.ts
+++ b/packages/pi-tui/src/__tests__/autocomplete.test.ts
@@ -28,9 +28,12 @@ describe("CombinedAutocompleteProvider — slash commands", () => {
 		const provider = makeProvider(sampleCommands);
 		const result = provider.getSuggestions(["/se"], 0, 3);
 		assert.ok(result);
-		assert.equal(result!.items.length, 2); // settings, session
+		// /se matches settings and session — name the values, then assert exact
+		// count as the contract for this prefix. Asserting count alone would
+		// pass even if the matches were the wrong commands.
 		assert.ok(result!.items.some((i) => i.value === "settings"));
 		assert.ok(result!.items.some((i) => i.value === "session"));
+		assert.equal(result!.items.length, 2);
 	});
 
 	it("returns null when no commands match", () => {
@@ -43,7 +46,14 @@ describe("CombinedAutocompleteProvider — slash commands", () => {
 		const provider = makeProvider(sampleCommands);
 		const result = provider.getSuggestions(["/mod"], 0, 4);
 		assert.ok(result);
-		assert.equal(result!.items[0]?.description, "Select model");
+		// Verify the matched command is present and every item carries a
+		// description — avoids `[0]` positional coupling that would silently
+		// pass if list ordering changed.
+		assert.ok(result!.items.some((i) => i.value === "model"));
+		assert.ok(
+			result!.items.every((i) => typeof i.description === "string" && i.description.length > 0),
+			"every suggestion must have a non-empty description",
+		);
 	});
 
 	it("does not offer slash command suggestions mid-line", () => {
@@ -95,8 +105,10 @@ describe("CombinedAutocompleteProvider — argument completions", () => {
 		const provider = makeProvider(commands);
 		const result = provider.getSuggestions(["/thinking m"], 0, 11);
 		assert.ok(result);
+		// /thinking m matches only "medium" — verify the expected value is
+		// present (by name, not index) and then assert exact count.
+		assert.ok(result!.items.some((i) => i.value === "medium"));
 		assert.equal(result!.items.length, 1);
-		assert.equal(result!.items[0]?.value, "medium");
 	});
 
 	it("returns null for commands without argument completions", () => {
@@ -122,6 +134,11 @@ describe("CombinedAutocompleteProvider — argument completions", () => {
 		const provider = makeProvider(commands);
 		const result = provider.getSuggestions(["/test "], 0, 6);
 		assert.ok(result);
+		// Empty prefix returns all 3 subcommands — verify each is present
+		// by name. Bare count would pass for any 3-element list.
+		assert.ok(result!.items.some((i) => i.value === "start"));
+		assert.ok(result!.items.some((i) => i.value === "stop"));
+		assert.ok(result!.items.some((i) => i.value === "status"));
 		assert.equal(result!.items.length, 3);
 	});
 });

--- a/packages/pi-tui/src/components/__tests__/leak-fixes-runtime.test.ts
+++ b/packages/pi-tui/src/components/__tests__/leak-fixes-runtime.test.ts
@@ -1,0 +1,219 @@
+// Runtime regression tests for the long-running-session leak fixes.
+//
+// Replaces the source-grep file `src/tests/session-memory-leaks.test.ts`
+// (deleted in #4875, tracked as #4873). The previous tests asserted on
+// identifier presence (`_prevRender`, `_lastMessage`, `MAX_CHAT_COMPONENTS`)
+// in source — a regression that set `MAX_CHAT_COMPONENTS = Number.MAX_SAFE_INTEGER`
+// or replaced `setText` with an inline mutation would still pass.
+//
+// Each test below drives the actual component through a long-running scenario
+// and asserts on observable behaviour.
+
+import { describe, it, mock, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { Container } from "../../tui.js";
+import { Loader } from "../loader.js";
+import { Text } from "../text.js";
+
+interface MockTui {
+	requestRender: ReturnType<typeof mock.fn>;
+}
+
+function makeMockTUI(): MockTui {
+	return { requestRender: mock.fn() };
+}
+
+// ─── Container render-skip ──────────────────────────────────────────────
+
+describe("Container.render skips work when output is unchanged", () => {
+	it("returns the SAME array reference across two renders with no changes", () => {
+		// The container caches `_prevRender` so doRender() can short-circuit
+		// the post-processing (image-line scan, applyLineResets, line diffs).
+		// The contract for the optimization is reference equality of the
+		// returned array — that's what the consumer in tui.ts checks.
+		const c = new Container();
+		c.addChild(new Text("hello", 0, 0));
+
+		const first = c.render(20);
+		const second = c.render(20);
+		assert.strictEqual(
+			second,
+			first,
+			"Container must return the same array reference when content is unchanged " +
+				"(reference equality is the consumer-visible contract for the skip)",
+		);
+	});
+
+	it("returns a DIFFERENT array reference after addChild invalidates the cache", () => {
+		// If a regression caused `_prevRender` to never reset, downstream
+		// rendering would skip post-processing for new components — visible
+		// as missing/stale UI. Behaviourally we observe that adding a child
+		// breaks the reference-equality contract on the next render.
+		const c = new Container();
+		c.addChild(new Text("a", 0, 0));
+		const first = c.render(20);
+		c.addChild(new Text("b", 0, 0));
+		const second = c.render(20);
+		assert.notStrictEqual(
+			second,
+			first,
+			"adding a child must invalidate the cached render reference",
+		);
+	});
+
+	it("returns a different reference after content changes", () => {
+		const t = new Text("hello", 0, 0);
+		const c = new Container();
+		c.addChild(t);
+
+		const first = c.render(20);
+		t.setText("world");
+		const second = c.render(20);
+		assert.notStrictEqual(
+			second,
+			first,
+			"changing a child's text must produce a fresh array (not the cached one)",
+		);
+	});
+});
+
+// ─── Loader frame isolation ─────────────────────────────────────────────
+
+describe("Loader does not mutate Text cache on every spinner tick", () => {
+	let tui: MockTui;
+	let loader: Loader;
+
+	beforeEach(() => {
+		tui = makeMockTUI();
+		mock.timers.enable({ apis: ["setInterval"] });
+	});
+
+	afterEach(() => {
+		try {
+			loader?.stop();
+		} catch {
+			/* best-effort */
+		}
+		mock.timers.reset();
+	});
+
+	it("does not invalidate Text's render cache across N spinner ticks", () => {
+		// Loader extends Text. Text caches its rendered lines keyed by
+		// (text, width). The leak was: the old Loader called setText()
+		// on every 80ms tick, which always cleared the cache, forcing a
+		// re-wrap of the message text.
+		// Behavioural test: render the loader, capture the cached array
+		// reference returned by Text.render, advance many ticks, and
+		// assert the underlying Text cache was NOT invalidated (we observe
+		// this via reference equality of the cached lines slice in the
+		// returned array — the second `result[*]` segment from super.render
+		// stays identity-stable when the cache survives).
+		loader = new Loader(tui as never, (s) => s, (s) => s, "the-message");
+
+		const before = loader.render(40);
+		// Run 50 frame intervals — the spinner should rotate, but the
+		// underlying message text wrapping must not change.
+		mock.timers.tick(80 * 50);
+		const after = loader.render(40);
+
+		// The message portion (everything after the first `""` padding line
+		// and after the spinner glyph + space prefix on the first content
+		// line) must be byte-identical across renders.
+		assert.equal(before.length, after.length, "render shape stable across ticks");
+		// Trailing message lines (index 2 onwards) come straight from Text's
+		// cache without any spinner mutation. They must be reference-equal
+		// substrings — same string contents byte-for-byte.
+		for (let i = 2; i < before.length; i++) {
+			assert.equal(
+				after[i],
+				before[i],
+				`message line ${i} must remain byte-identical across spinner ticks ` +
+					`(cache must not be invalidated by frame rotation)`,
+			);
+		}
+	});
+
+	it("setMessage invalidates Text cache and a new message is reflected", () => {
+		// Quiescence is conditional on the message being unchanged — we
+		// must still see updates when it actually changes. This is the
+		// counter-test that prevents a false-positive "cache always stable"
+		// fix that would freeze the loader text.
+		loader = new Loader(tui as never, (s) => s, (s) => s, "first");
+		const beforeFirstRender = loader.render(40).join("\n");
+		loader.setMessage("second");
+		const afterChange = loader.render(40).join("\n");
+		assert.ok(afterChange.includes("second"), "new message must render");
+		assert.ok(!afterChange.includes("first") || beforeFirstRender !== afterChange,
+			"render output must change when message changes");
+	});
+});
+
+// ─── Text.setText early-return guard ────────────────────────────────────
+
+describe("Text.setText returns early when value is unchanged", () => {
+	it("does not invalidate the cached render when setText receives the same value", () => {
+		// The setText early-return is the runtime guard that keeps the
+		// Loader-and-Text cache stable. We observe it via reference equality
+		// of the rendered output across a setText(SAME) call.
+		const t = new Text("identical", 0, 0);
+		const first = t.render(30);
+		t.setText("identical"); // same value — must NOT clear the cache
+		const second = t.render(30);
+		assert.strictEqual(
+			second,
+			first,
+			"setText with an unchanged value must leave the render cache intact",
+		);
+	});
+
+	it("invalidates cache when the value actually changes", () => {
+		const t = new Text("one", 0, 0);
+		const first = t.render(30);
+		t.setText("two");
+		const second = t.render(30);
+		assert.notStrictEqual(
+			second,
+			first,
+			"setText with a new value must produce a fresh render result",
+		);
+	});
+});
+
+// ─── Heap growth bound (gated on --expose-gc) ───────────────────────────
+
+describe("Long-running render loop does not leak heap (forced-GC bound)", () => {
+	const hasGc = typeof (globalThis as any).gc === "function";
+
+	it(
+		"renders a Container 5000 times with stable heapUsed (within 2x baseline)",
+		{ skip: !hasGc ? "requires --expose-gc to drive deterministic GC between snapshots" : false },
+		() => {
+			// This is the on-the-wire memory-soak test. The naive version
+			// (no forced GC) is flaky because Node's GC is opportunistic;
+			// any background allocation can shift heapUsed past an absolute
+			// bound. We instead force GC between snapshots and assert a
+			// RELATIVE bound: post-iteration heap must be within 2x of the
+			// post-warmup baseline.
+			const gc = (globalThis as any).gc as () => void;
+
+			const c = new Container();
+			const t = new Text("steady-state", 0, 0);
+			c.addChild(t);
+
+			// Warm up so the JIT and any lazy initial allocations settle.
+			for (let i = 0; i < 200; i++) c.render(40);
+			gc();
+			const baseline = process.memoryUsage().heapUsed;
+
+			for (let i = 0; i < 5000; i++) c.render(40);
+			gc();
+			const after = process.memoryUsage().heapUsed;
+
+			assert.ok(
+				after < baseline * 2,
+				`heapUsed must stay within 2x baseline after 5000 renders ` +
+					`(baseline=${baseline}B, after=${after}B, ratio=${(after / baseline).toFixed(2)})`,
+			);
+		},
+	);
+});


### PR DESCRIPTION
## Summary

Three pi-tui test follow-ups in one batch:

- **Closes #4940** — port autocomplete test improvements from closed PR #4937 (overlay-layout already rigorous on main; `input.test.ts` and `markdown-maxlines.test.ts` left untouched per #4878)
- **Closes #4873** — runtime memory-leak coverage for pi-tui long-running sessions (replaces deleted source-grep)
- **Closes #4872** — runtime coverage for post-compaction tool-card cleanup + success-bordered notifications (replaces deleted source-grep)

Each test drives the actual component through the scenario and asserts on observable behaviour (rendered output, reference equality of cached arrays, ANSI styling presence). No source-grep, no identifier-existence assertions.

The memory-soak test uses a forced-GC pattern: skipped when `--expose-gc` is not available, otherwise asserts post-iteration heap stays within 2x of the post-warmup baseline (relative bound, not absolute bytes).

## Test plan

- [x] `node --test dist/__tests__/autocomplete.test.js` (pi-tui) — 21/21 pass
- [x] All pi-tui tests via dist-test harness — 82 pass, 1 skipped (GC-gated)
- [x] All pi-coding-agent interactive tests — 56/56 pass
- [x] GC-gated heap test runs green with --expose-gc

🤖 Generated with [Claude Code](https://claude.com/claude-code)