### PR TITLE
refactor(gsd): canonicalize quality-gate state and tighten types (#4950)

### DIFF
--- a/src/resources/extensions/gsd/gate-registry.ts
+++ b/src/resources/extensions/gsd/gate-registry.ts
@@ -60,9 +60,9 @@ export const GATE_REGISTRY = {
     id: "Q4",
     scope: "slice",
     ownerTurn: "gate-evaluate",
-    question: "What existing promises does this break?",
+    question: "Which existing requirements (R-IDs) does this slice touch, and which must be re-tested?",
     guidance: [
-      "List which existing requirements (R001, R003, etc.) are touched by this slice.",
+      "List the R-IDs (e.g. R001, R003) touched by this slice; see the milestone requirements artifact at .gsd/milestones/<id>/REQUIREMENTS.md.",
       "Identify what must be re-tested after shipping.",
       "Flag decisions that should be revisited given the new scope.",
       "If no existing requirements are affected, return verdict 'omitted'.",

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -3100,7 +3100,7 @@ function rowToGate(row: Record<string, unknown>): GateRow {
     scope: row["scope"] as GateScope,
     task_id: (row["task_id"] as string) ?? "",
     status: row["status"] as GateStatus,
-    verdict: (row["verdict"] as GateVerdict) || "",
+    verdict: row["status"] === "pending" ? null : (row["verdict"] as GateVerdict),
     rationale: (row["rationale"] as string) || "",
     findings: (row["findings"] as string) || "",
     evaluated_at: (row["evaluated_at"] as string) ?? null,
@@ -3204,7 +3204,7 @@ export function getGateResults(milestoneId: string, sliceId: string, scope?: Gat
 export function markAllGatesOmitted(milestoneId: string, sliceId: string): void {
   if (!currentDb) return;
   currentDb.prepare(
-    `UPDATE quality_gates SET status = 'omitted', verdict = 'omitted', evaluated_at = :now
+    `UPDATE quality_gates SET status = 'complete', verdict = 'omitted', evaluated_at = :now
      WHERE milestone_id = :mid AND slice_id = :sid AND status = 'pending'`,
   ).run({
     ":mid": milestoneId,

--- a/src/resources/extensions/gsd/tests/gate-state-canonicalization.test.ts
+++ b/src/resources/extensions/gsd/tests/gate-state-canonicalization.test.ts
@@ -1,0 +1,102 @@
+// GSD Gate State Canonicalization Tests
+// Regression tests for #4950: canonical omitted state and GateVerdict type narrowing.
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertGateRow,
+  markAllGatesOmitted,
+  getGateResults,
+  getPendingGates,
+  insertMilestone,
+  insertSlice,
+} from "../gsd-db.ts";
+import type { GateVerdict } from "../types.ts";
+
+describe("gate-state canonicalization (#4950)", () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "gate-canon-test-"));
+    dbPath = join(tmpDir, "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+    insertSlice({
+      milestoneId: "M001",
+      id: "S01",
+      title: "Test Slice",
+      status: "pending",
+      risk: "medium",
+      depends: [],
+    });
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("markAllGatesOmitted produces status=complete, verdict=omitted (not status=omitted)", () => {
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q4", scope: "slice" });
+
+    markAllGatesOmitted("M001", "S01");
+
+    const all = getGateResults("M001", "S01");
+    assert.equal(all.length, 2);
+    for (const g of all) {
+      assert.equal(g.status, "complete", `expected status=complete for gate ${g.gate_id}`);
+      assert.equal(g.verdict, "omitted", `expected verdict=omitted for gate ${g.gate_id}`);
+    }
+  });
+
+  test("markAllGatesOmitted leaves no pending gates", () => {
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q4", scope: "slice" });
+
+    markAllGatesOmitted("M001", "S01");
+
+    const pending = getPendingGates("M001", "S01");
+    assert.equal(pending.length, 0);
+  });
+
+  test("pending gate verdict is null, not empty string", () => {
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+
+    const pending = getPendingGates("M001", "S01");
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].verdict, null, "pending gate verdict must be null, not empty string");
+  });
+
+  test("complete gate verdict round-trips as a valid GateVerdict (pass/flag/omitted only)", () => {
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q4", scope: "slice" });
+    markAllGatesOmitted("M001", "S01");
+
+    const results = getGateResults("M001", "S01");
+    const q4 = results.find((g) => g.gate_id === "Q4");
+    assert.ok(q4, "Q4 gate must exist");
+
+    const validVerdicts: GateVerdict[] = ["pass", "flag", "omitted"];
+    assert.ok(
+      q4.verdict !== null && validVerdicts.includes(q4.verdict),
+      `verdict "${q4.verdict}" must be one of: ${validVerdicts.join(", ")}`,
+    );
+  });
+
+  test("empty-string verdict is not reachable after round-trip through DB", () => {
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+    markAllGatesOmitted("M001", "S01");
+
+    const results = getGateResults("M001", "S01");
+    for (const g of results) {
+      assert.notEqual(g.verdict, "", `gate ${g.gate_id} verdict must not be empty string`);
+    }
+  });
+});

--- a/src/resources/extensions/gsd/tests/gate-storage.test.ts
+++ b/src/resources/extensions/gsd/tests/gate-storage.test.ts
@@ -109,7 +109,7 @@ describe("quality_gates CRUD", () => {
     const all = getGateResults("M001", "S01");
     assert.equal(all.length, 3);
     for (const g of all) {
-      assert.equal(g.status, "omitted");
+      assert.equal(g.status, "complete");
       assert.equal(g.verdict, "omitted");
     }
   });

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -695,8 +695,8 @@ export interface CompleteSliceParams {
 
 export type GateId = "Q3" | "Q4" | "Q5" | "Q6" | "Q7" | "Q8" | "MV01" | "MV02" | "MV03" | "MV04";
 export type GateScope = "slice" | "task" | "milestone";
-export type GateStatus = "pending" | "complete" | "omitted";
-export type GateVerdict = "pass" | "flag" | "omitted" | "";
+export type GateStatus = "pending" | "complete";
+export type GateVerdict = "pass" | "flag" | "omitted";
 
 export interface GateRow {
   milestone_id: string;
@@ -705,7 +705,7 @@ export interface GateRow {
   scope: GateScope;
   task_id: string;
   status: GateStatus;
-  verdict: GateVerdict;
+  verdict: GateVerdict | null;
   rationale: string;
   findings: string;
   evaluated_at: string | null;


### PR DESCRIPTION
## TL;DR

**What:** Canonicalize the omitted gate state to `status=complete, verdict=omitted` and remove unreachable types from `GateVerdict`/`GateStatus`.
**Why:** Two representations of "skipped" existed (`status=omitted` vs `status=complete, verdict=omitted`), and `GateVerdict=""` was reachable from `rowToGate` despite not being a valid verdict.
**How:** Minimal SQL and type changes in owned files only; no consumer files touched.

## What

- `gsd-db.ts`: `markAllGatesOmitted` now writes `status='complete', verdict='omitted'` (was `status='omitted'`). `rowToGate` returns `null` for pending-row verdict instead of `""`.
- `types.ts`: `GateStatus` drops `"omitted"`; `GateVerdict` drops `""`; `GateRow.verdict` is now `GateVerdict | null`.
- `gate-registry.ts`: Q4 question tightened to ask for R-IDs explicitly; guidance references `.gsd/milestones/<id>/REQUIREMENTS.md`.
- `tests/gate-state-canonicalization.test.ts`: New regression test file (5 tests).
- `tests/gate-storage.test.ts`: Updated existing assertion to match new canonical `status=complete`.

## Why

Issue #4950 identified three low-severity defects in the quality-gates registry/state: dual omitted representations, an empty-string verdict reachable from `rowToGate`, and ambiguous Q4 question wording.

## How

SQL change in `markAllGatesOmitted` is the single source of the dual-representation bug. Type narrowing in `rowToGate` eliminates the `""` escape hatch. No consumer files were modified — all consumers that render gate verdicts already guard on `g.status === "complete"` before accessing `.verdict`, so `null` on pending rows is safe.

## Change type checklist

- [ ] `feat`
- [ ] `fix`
- [x] `refactor`
- [x] `test`
- [x] `docs`
- [ ] `chore`

## Notes

This is a **partial fix** for #4950. UOK/shutdown/write-gate sister PRs land independently and are NOT covered here.

No consumers filter on `status='omitted'` in source (confirmed via grep). No consumers check `verdict === ""`.

AI-assisted contribution. Code reviewed and verified by the committer.