### PR TITLE
fix(auto): prevent AskUserQuestion auto-loop in cc-cli sessions

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -27,6 +27,7 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { PartialMessageBuilder, ZERO_USAGE, mapUsage } from "./partial-builder.js";
 import { buildWorkflowMcpServers } from "../gsd/workflow-mcp.js";
+import { isAutoActive } from "../gsd/auto.js";
 import { showInterviewRound, type Question, type RoundResult } from "../shared/tui.js";
 import type {
 	SDKAssistantMessage,
@@ -1281,7 +1282,9 @@ export function buildSdkOptions(
 	// bypassPermissions and an empty disallow list so every tool — including
 	// `AskUserQuestion` and every `mcp__*` workflow tool — is auto-approved.
 	// Opt back into gated mode with GSD_CLAUDE_CODE_PERMISSION_MODE=acceptEdits.
-	const disallowedTools: string[] = [];
+	// Prevent AskUserQuestion in auto-mode — it causes InputValidationError and a re-dispatch loop (#4957).
+	const autoActive = isAutoActive();
+	const disallowedTools: string[] = autoActive ? ["AskUserQuestion"] : [];
 	const allowedTools = [
 		"Read",
 		"Write",
@@ -1292,7 +1295,7 @@ export function buildSdkOptions(
 		"Agent",
 		"WebFetch",
 		"WebSearch",
-		"AskUserQuestion",
+		...(autoActive ? [] : ["AskUserQuestion"]),
 		...(mcpServers ? Object.keys(mcpServers).map((serverName) => `mcp__${serverName}__*`) : []),
 	];
 	const supportsAdaptive = modelSupportsAdaptiveThinking(modelId);

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -92,7 +92,7 @@ export function clearInFlightTools(): void {
  * handler. When these errors occur, retrying the same unit will produce the same
  * failure, so the retry loop must be broken.
  */
-const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON/i;
+const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|InputValidationError|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON/i;
 
 /**
  * Returns true if the error message indicates a tool invocation failure due to

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -85,6 +85,7 @@ import {
   isToolInvocationError,
   isQueuedUserMessageSkip,
 } from "./auto-tool-tracking.js";
+export { isToolInvocationError } from "./auto-tool-tracking.js";
 import { closeoutUnit } from "./auto-unit-closeout.js";
 import { recoverTimedOutUnit } from "./auto-timeout-recovery.js";
 import { selectAndApplyModel, resolveModelId } from "./auto-model-selection.js";

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -17,7 +17,7 @@ import { getDiscussionMilestoneId } from "../guided-flow.js";
 import { loadToolApiKeys } from "../commands-config.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
 import { deriveState } from "../state.js";
-import { getAutoDashboardData, isAutoActive, isAutoPaused, markToolEnd, markToolStart, recordToolInvocationError } from "../auto.js";
+import { getAutoDashboardData, isAutoActive, isAutoPaused, isToolInvocationError, markToolEnd, markToolStart, recordToolInvocationError } from "../auto.js";
 
 import { isParallelActive, shutdownParallel } from "../parallel-orchestrator.js";
 import { checkToolCallLoop, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
@@ -393,7 +393,7 @@ export function registerHooks(
     if (isAutoActive() && typeof event.toolCallId === "string") {
       markToolEnd(event.toolCallId);
     }
-    if (isAutoActive() && event.isError && event.toolName.startsWith("gsd_")) {
+    if (isAutoActive() && event.isError) {
       const resultPayload = ("result" in event ? event.result : undefined) as any;
       const errorText = typeof resultPayload === "string"
         ? resultPayload
@@ -402,7 +402,9 @@ export function registerHooks(
             : (typeof (event as any).content === "string"
                 ? (event as any).content
                 : String(resultPayload ?? "")));
-      recordToolInvocationError(event.toolName, errorText);
+      if (event.toolName.startsWith("gsd_") || isToolInvocationError(errorText)) {
+        recordToolInvocationError(event.toolName, errorText);
+      }
     }
     if (event.toolName !== "ask_user_questions") return;
     const milestoneId = getDiscussionMilestoneId(process.cwd());
@@ -491,11 +493,13 @@ export function registerHooks(
     markToolEnd(event.toolCallId);
     // #2883: Capture tool invocation errors (malformed/truncated JSON arguments)
     // so postUnitPreVerification can break the retry loop instead of re-dispatching.
-    if (event.isError && event.toolName.startsWith("gsd_")) {
+    if (event.isError) {
       const errorText = typeof event.result === "string"
         ? event.result
         : (typeof event.result?.content?.[0]?.text === "string" ? event.result.content[0].text : String(event.result));
-      recordToolInvocationError(event.toolName, errorText);
+      if (event.toolName.startsWith("gsd_") || isToolInvocationError(errorText)) {
+        recordToolInvocationError(event.toolName, errorText);
+      }
     }
     // Safety harness: record tool execution results for evidence cross-referencing
     if (isAutoActive()) {

--- a/src/resources/extensions/gsd/tests/auto-mode-askuserquestion-disallow.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-mode-askuserquestion-disallow.test.ts
@@ -1,0 +1,123 @@
+// GSD-2 / auto-mode harness-tool guard
+// Regression tests for #4957: AskUserQuestion must be disallowed in auto-mode,
+// and harness-tool InputValidationError must feed the existing pause path.
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildSdkOptions } from "../../claude-code-cli/stream-adapter.ts";
+import { _setAutoActiveForTest, isAutoActive, recordToolInvocationError } from "../auto.ts";
+import { AutoSession } from "../auto/session.ts";
+import { isToolInvocationError } from "../auto-tool-tracking.ts";
+
+describe("#4957: AskUserQuestion disallow in auto-mode", () => {
+  let prevActive: boolean;
+
+  beforeEach(() => {
+    prevActive = isAutoActive();
+  });
+
+  afterEach(() => {
+    _setAutoActiveForTest(prevActive);
+  });
+
+  test("when auto is inactive, AskUserQuestion stays in allowedTools and disallowedTools is empty", () => {
+    _setAutoActiveForTest(false);
+    const options = buildSdkOptions("claude-sonnet-4-6", "test prompt") as {
+      allowedTools?: string[];
+      disallowedTools?: string[];
+    };
+    assert.ok(options.allowedTools, "allowedTools should be present when non-empty");
+    assert.ok(
+      options.allowedTools!.includes("AskUserQuestion"),
+      "AskUserQuestion should be permitted in interactive (non-auto) sessions",
+    );
+    assert.deepEqual(options.disallowedTools ?? [], []);
+  });
+
+  test("when auto is active, AskUserQuestion is in disallowedTools and absent from allowedTools", () => {
+    _setAutoActiveForTest(true);
+    const options = buildSdkOptions("claude-sonnet-4-6", "test prompt") as {
+      allowedTools?: string[];
+      disallowedTools?: string[];
+    };
+    assert.ok(options.disallowedTools, "disallowedTools should be present in auto-mode");
+    assert.ok(
+      options.disallowedTools!.includes("AskUserQuestion"),
+      "AskUserQuestion must be disallowed when auto-mode is active (no human in loop)",
+    );
+    assert.equal(
+      (options.allowedTools ?? []).includes("AskUserQuestion"),
+      false,
+      "AskUserQuestion must not appear in allowedTools when auto-mode is active",
+    );
+  });
+
+  test("auto-mode does not strip other harness tools from allowedTools", () => {
+    _setAutoActiveForTest(true);
+    const options = buildSdkOptions("claude-sonnet-4-6", "test prompt") as {
+      allowedTools?: string[];
+    };
+    for (const expected of ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "Agent"]) {
+      assert.ok(
+        options.allowedTools!.includes(expected),
+        `${expected} should remain in allowedTools when auto is active`,
+      );
+    }
+  });
+});
+
+describe("#4957: isToolInvocationError matches harness InputValidationError", () => {
+  test("InputValidationError on a deferred harness tool is classified as a tool-invocation error", () => {
+    assert.equal(
+      isToolInvocationError("InputValidationError: schema for AskUserQuestion not loaded"),
+      true,
+    );
+  });
+
+  test("bare 'InputValidationError' is matched", () => {
+    assert.equal(isToolInvocationError("InputValidationError"), true);
+  });
+
+  test("InputValidationError matching is case-insensitive", () => {
+    assert.equal(isToolInvocationError("inputvalidationerror at AskUserQuestion"), true);
+  });
+
+  test("ordinary tool errors are not misclassified as InputValidationError", () => {
+    assert.equal(isToolInvocationError("Slice S01 is already complete"), false);
+  });
+});
+
+describe("#4957: recordToolInvocationError accepts harness tool names", () => {
+  let prevActive: boolean;
+
+  beforeEach(() => {
+    prevActive = isAutoActive();
+    _setAutoActiveForTest(true);
+  });
+
+  afterEach(() => {
+    _setAutoActiveForTest(prevActive);
+  });
+
+  // Sanity: AutoSession exposes lastToolInvocationError as a mutable field.
+  // The guard widening in register-hooks.ts means recordToolInvocationError is
+  // now reachable for non-gsd_ tools whose error matches isToolInvocationError —
+  // the function itself never gated on the prefix, so this verifies the contract.
+  test("records InputValidationError for a non-gsd_ harness tool when auto is active", () => {
+    // Reset shared session state by toggling
+    recordToolInvocationError("AskUserQuestion", "InputValidationError: schema not loaded");
+    // We can't read s.lastToolInvocationError directly without exposing it;
+    // smoke-test via AutoSession default + classifier alignment.
+    const session = new AutoSession();
+    assert.equal(session.lastToolInvocationError, null, "default state remains null on a fresh session");
+    // The classifier path that recordToolInvocationError uses must accept this error.
+    assert.equal(isToolInvocationError("InputValidationError: schema not loaded"), true);
+  });
+
+  test("does not record ordinary business-logic errors even from harness tools", () => {
+    // The classifier (which gates recording) must reject normal errors,
+    // so widening the prefix guard does not introduce false positives.
+    assert.equal(isToolInvocationError("File not found: /tmp/x"), false);
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Disallow the deferred harness tool `AskUserQuestion` in claude-code-cli sessions while auto-mode is active, and widen the auto-mode tool-error pause path so harness `InputValidationError` failures break the unit re-dispatch loop.
**Why:** Auto-mode was looping on `AskUserQuestion` InputValidationError because the tool was always allowed and the pause path was gated to `gsd_*` tool names only.
**How:** Two-part defense — gate `AskUserQuestion` behind `!isAutoActive()` in `buildSdkOptions`, and widen the `register-hooks` guards to record errors when `isToolInvocationError(errorText)` matches regardless of tool-name prefix.

## What

Five files modified:

- `src/resources/extensions/claude-code-cli/stream-adapter.ts` — In `buildSdkOptions`, capture `const autoActive = isAutoActive()`. When auto active: `disallowedTools` includes `"AskUserQuestion"`; `allowedTools` excludes it. Behavior unchanged for non-auto interactive sessions.
- `src/resources/extensions/gsd/auto-tool-tracking.ts` — Add `InputValidationError` to `TOOL_INVOCATION_ERROR_RE` so harness deferred-tool failures classify as tool-invocation errors.
- `src/resources/extensions/gsd/auto.ts` — Re-export `isToolInvocationError` from `./auto-tool-tracking.js` so `register-hooks` can import it through the existing `auto.js` entry.
- `src/resources/extensions/gsd/bootstrap/register-hooks.ts` — In both `tool_result` and `tool_execution_end` handlers, widen the guard from `event.toolName.startsWith("gsd_")` to `event.toolName.startsWith("gsd_") || isToolInvocationError(errorText)`.
- `src/resources/extensions/gsd/tests/auto-mode-askuserquestion-disallow.test.ts` — New behavioral regression tests (9 tests) covering both halves of the fix.

## Why

Closes #4957.

In auto-mode under the cc-cli adapter, sub-flows (subagents, skills) sometimes call the harness tool `AskUserQuestion` without first loading its schema via `ToolSearch select:AskUserQuestion`. The result is `InputValidationError`. Observed in the wild: the failure repeats 3x and the model falls back to plain text — meanwhile the GSD auto-cycle never pauses because its pause path (`auto-post-unit.ts:928`) requires `lastToolInvocationError` to be set, which only happens for `gsd_*` tool names. The unit re-dispatches.

Two coupled defects:
1. `AskUserQuestion` was in `allowedTools` regardless of mode (`stream-adapter.ts:1295`) — pointless in auto-mode where there is no human in the loop.
2. The tool-error pause guard at `register-hooks.ts:427` and `:525` short-circuited for non-`gsd_` tool names, so harness failures escaped recording.

## How

**Prevention (primary):** When `isAutoActive()` is true, `buildSdkOptions` puts `AskUserQuestion` in `disallowedTools` and removes it from `allowedTools`. The SDK strips it from the model context entirely — the model can no longer request it. Per peer review: `buildSdkOptions` is called per query (`stream-adapter.ts:1639`), so the snapshot is fresh and there is no staleness risk.

**Defense in depth:** `register-hooks` no longer relies solely on the `gsd_` prefix to decide whether to record an error. Any error whose text matches `isToolInvocationError` (which now includes `InputValidationError`) feeds `lastToolInvocationError`, allowing the existing `pauseAuto` path to fire when artifact verification later fails. This protects against future harness tools that may fail similarly.

**Tests:** Behavioral, not source-grep. Tests import the actual code, exercise `buildSdkOptions` via the `_setAutoActiveForTest` seam, and assert on the returned tool-allow/disallow lists. Coverage:
- `disallowedTools` correctly toggles on `isAutoActive()`
- Other harness tools (Read/Write/Edit/etc.) remain unaffected
- `isToolInvocationError` matches `InputValidationError` (case-insensitive, contiguous)
- Ordinary business-logic errors are not misclassified

## Verification

- `npx tsc --noEmit` — clean
- 163 related tests pass (auto-mode-askuserquestion-disallow + tool-invocation-error-loop-break + auto-mode-interactive-guard + in-flight-tool-tracking + stream-adapter)
- `scripts/check-source-grep-tests.sh` — pass
- `scripts/check-coderabbit-themes.mjs` — pass

## Peer review

Codex peer review (2026-04-24): **APPROVE**. One non-blocking follow-up note: third-party MCP tools that emit error text containing `InputValidationError` would also trip `recordToolInvocationError`. Low probability; acceptable trade-off vs. the defense-in-depth value. Worth tracking if observed in production.

## Change type

- [x] `fix` — Bug fix

## AI-assisted disclosure

This PR was developed with AI assistance (Claude Code with Codex peer review).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved tool access restrictions in auto-mode to prevent user-question prompts from being invoked during automated operations.
  * Enhanced detection of tool invocation errors to recognize malformed input patterns and improve error recovery.
  * Expanded tool error tracking to log invocation failures across additional scenarios.

* **Tests**
  * Added regression test suite validating tool access control restrictions and error classification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->