### PR TITLE
fix(auto): stop using active-tool snapshot as model-policy gate; restore baseline between units

### DIFF
--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -96,23 +96,17 @@ function restoreToolBaseline(pi: ExtensionAPI): void {
   if (baseline === undefined) {
     // First call: capture the canonical pre-dispatch tool set.  At auto-mode
     // start the active set has not yet been narrowed for any provider.
-    try {
-      const initial = pi.getActiveTools();
-      TOOL_BASELINE.set(key, [...initial]);
-    } catch {
-      // Some test fakes don't implement getActiveTools yet — record an empty
-      // baseline so subsequent calls don't keep retrying.
-      TOOL_BASELINE.set(key, []);
-    }
+    // Guarded against test fakes that omit getActiveTools — record an empty
+    // baseline so subsequent calls don't keep re-probing.
+    const initial = typeof pi.getActiveTools === "function" ? pi.getActiveTools() : [];
+    TOOL_BASELINE.set(key, [...initial]);
     return;
   }
   // Restore baseline before the next unit reads getActiveTools / applies
-  // post-selection adjustToolSet.
-  try {
+  // post-selection adjustToolSet.  Older fakes that omit setActiveTools are
+  // tolerated — the test asserts call order on real fakes.
+  if (typeof pi.setActiveTools === "function") {
     pi.setActiveTools([...baseline]);
-  } catch {
-    // setActiveTools may not exist on older fakes; ignore — the test asserts
-    // call order only, not throw-safety.
   }
 }
 

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -19,6 +19,38 @@ import { logWarning } from "./workflow-logger.js";
 import { resolveUokFlags } from "./uok/flags.js";
 import { applyModelPolicyFilter } from "./uok/model-policy.js";
 import { isModelBlocked } from "./blocked-models.js";
+import { getRequiredWorkflowToolsForAutoUnit } from "./workflow-mcp.js";
+
+/**
+ * Thrown when the model-policy gate rejects every candidate model for a unit
+ * dispatch (#4959 / #4681 / #4850).  The auto-loop catches this specifically
+ * to classify the unit as `blocked` rather than counting it as a retryable
+ * iteration error — pre-send policy denial is a configuration problem, not a
+ * transient runtime failure, so retrying just burns the consecutive-error
+ * budget toward a hard stop.
+ */
+export class ModelPolicyDispatchBlockedError extends Error {
+  readonly unitType: string;
+  readonly unitId: string;
+  readonly reasons: ReadonlyArray<{ provider: string; modelId: string; reason: string }>;
+  constructor(
+    unitType: string,
+    unitId: string,
+    reasons: ReadonlyArray<{ provider: string; modelId: string; reason: string }>,
+  ) {
+    const summary = reasons.length === 0
+      ? "no candidate models"
+      : reasons
+          .slice(0, 4)
+          .map((r) => `${r.provider}/${r.modelId} (${r.reason})`)
+          .join("; ");
+    super(`Model policy denied dispatch for ${unitType}/${unitId} before prompt send. Rejected: ${summary}`);
+    this.name = "ModelPolicyDispatchBlockedError";
+    this.unitType = unitType;
+    this.unitId = unitId;
+    this.reasons = reasons;
+  }
+}
 
 export interface ModelSelectionResult {
   /** Routing metadata for metrics recording */
@@ -31,6 +63,44 @@ export interface PreferredModelConfig {
   primary: string;
   fallbacks: string[];
   source: "explicit" | "synthesized";
+}
+
+// Baseline active-tool set per-`pi` instance, captured the first time
+// `selectAndApplyModel` runs against that instance and re-applied before each
+// subsequent dispatch.  WeakMap so that test fakes / disposed sessions are
+// garbage-collected normally.  See #4959 / #4681 cross-unit poisoning notes
+// at the call site below.
+const TOOL_BASELINE = new WeakMap<object, string[]>();
+
+/** Visible for tests. */
+export function _resetToolBaselineForTesting(pi: object): void {
+  TOOL_BASELINE.delete(pi);
+}
+
+function restoreToolBaseline(pi: ExtensionAPI): void {
+  const key = pi as unknown as object;
+  const baseline = TOOL_BASELINE.get(key);
+  if (baseline === undefined) {
+    // First call: capture the canonical pre-dispatch tool set.  At auto-mode
+    // start the active set has not yet been narrowed for any provider.
+    try {
+      const initial = pi.getActiveTools();
+      TOOL_BASELINE.set(key, [...initial]);
+    } catch {
+      // Some test fakes don't implement getActiveTools yet — record an empty
+      // baseline so subsequent calls don't keep retrying.
+      TOOL_BASELINE.set(key, []);
+    }
+    return;
+  }
+  // Restore baseline before the next unit reads getActiveTools / applies
+  // post-selection adjustToolSet.
+  try {
+    pi.setActiveTools([...baseline]);
+  } catch {
+    // setActiveTools may not exist on older fakes; ignore — the test asserts
+    // call order only, not throw-safety.
+  }
 }
 
 function reapplyThinkingLevel(
@@ -129,6 +199,21 @@ export async function selectAndApplyModel(
   let routing: { tier: string; modelDowngraded: boolean } | null = null;
   let appliedModel: Model<Api> | null = null;
 
+  // ── Restore active-tool baseline before policy evaluation (#4959, #4681, #4850) ──
+  // Per-unit narrowing at the bottom of this function (line ~417) calls
+  // `pi.setActiveTools(finalToolNames)` and monotonically narrows the active
+  // set across units.  Without restoration, a previously-dispatched unit on a
+  // narrow-API provider (e.g. openai-completions) leaves the active set
+  // missing tools that the next unit's selected model fully supports, but
+  // `pi.getActiveTools()` snapshot-as-hard-gate (the old behaviour) blocked
+  // dispatch with "tool policy denied" anyway.
+  //
+  // The baseline is captured once per `pi` instance via a WeakMap and
+  // re-applied here so each unit starts from a clean slate.  Soft adaptation
+  // (adjustToolSet at the bottom of this function) still trims for the
+  // selected model.
+  restoreToolBaseline(pi);
+
   if (modelConfig) {
     const availableModels = ctx.modelRegistry.getAvailable();
     const modelPolicyTraceId = `model:${ctx.sessionManager.getSessionId()}:${Date.now()}`;
@@ -160,7 +245,16 @@ export async function selectAndApplyModel(
       ? extractTaskMetadata(unitId, basePath)
       : undefined;
 
+    let policyDenyReasons: Array<{ provider: string; modelId: string; reason: string }> = [];
     if (uokFlags.modelPolicy) {
+      // Use the workflow-spec required-tool subset for the unit type rather
+      // than the live `pi.getActiveTools()` snapshot (#4959).  The active set
+      // is poisoned by per-unit narrowing for narrow-API providers — using it
+      // as a hard gate promotes soft adaptation (adjustToolSet at line ~417)
+      // into a layering violation that throws before dispatch.  The smaller
+      // workflow-required subset reflects what the unit actually needs; soft
+      // adaptation post-selection still trims provider-incompatible tools.
+      const requiredTools = getRequiredWorkflowToolsForAutoUnit(unitType);
       const policy = applyModelPolicyFilter(
         availableModels,
         {
@@ -171,15 +265,18 @@ export async function selectAndApplyModel(
           taskMetadata: taskMetadataForPolicy,
           currentProvider: ctx.model?.provider,
           allowCrossProvider: routingConfig.cross_provider !== false,
-          requiredTools: pi.getActiveTools(),
+          requiredTools,
         },
       );
       routingEligibleModels = policy.eligible;
       policyAllowedModelKeys = new Set(
         policy.eligible.map((m) => `${m.provider.toLowerCase()}/${m.id.toLowerCase()}`),
       );
+      policyDenyReasons = policy.decisions
+        .filter((d) => !d.allowed)
+        .map((d) => ({ provider: d.provider, modelId: d.modelId, reason: d.reason }));
       if (routingEligibleModels.length === 0) {
-        throw new Error(`Model policy denied all candidate models for ${unitType}/${unitId}`);
+        throw new ModelPolicyDispatchBlockedError(unitType, unitId, policyDenyReasons);
       }
     }
 
@@ -443,7 +540,7 @@ export async function selectAndApplyModel(
     }
 
     if (uokFlags.modelPolicy && policyAllowedModelKeys && !attemptedPolicyEligible) {
-      throw new Error(`Model policy denied dispatch for ${unitType}/${unitId} before prompt send`);
+      throw new ModelPolicyDispatchBlockedError(unitType, unitId, policyDenyReasons);
     }
   } else if (autoModeStartModel) {
     // No model preference for this unit type — re-apply the model captured

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -66,15 +66,28 @@ export interface PreferredModelConfig {
 }
 
 // Baseline active-tool set per-`pi` instance, captured the first time
-// `selectAndApplyModel` runs against that instance and re-applied before each
-// subsequent dispatch.  WeakMap so that test fakes / disposed sessions are
-// garbage-collected normally.  See #4959 / #4681 cross-unit poisoning notes
-// at the call site below.
+// `selectAndApplyModel` runs against that instance during an auto session
+// and re-applied before each subsequent dispatch.  WeakMap so that test
+// fakes / disposed sessions are garbage-collected normally.  See
+// #4959 / #4681 cross-unit poisoning notes at the call site below.
+//
+// LIFECYCLE: the baseline is tied to a single auto session, NOT to the
+// lifetime of the `pi` instance (which can outlive many auto runs and have
+// the user mutate tools between them).  `clearToolBaseline` MUST be called
+// at auto start AND auto stop so that a second `/gsd auto` run on the same
+// `pi` does not silently restore a stale snapshot from the prior run and
+// undo any tool changes the user made between sessions.
 const TOOL_BASELINE = new WeakMap<object, string[]>();
 
-/** Visible for tests. */
-export function _resetToolBaselineForTesting(pi: object): void {
-  TOOL_BASELINE.delete(pi);
+/**
+ * Drop the captured tool baseline for `pi` so the next `selectAndApplyModel`
+ * call re-captures from the live active set.  Wired into `startAuto` and
+ * `stopAuto` in `auto.ts` to bound the baseline to a single auto session.
+ *
+ * Safe to call when no baseline is recorded (no-op).
+ */
+export function clearToolBaseline(pi: ExtensionAPI | object): void {
+  TOOL_BASELINE.delete(pi as unknown as object);
 }
 
 function restoreToolBaseline(pi: ExtensionAPI): void {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -87,7 +87,7 @@ import {
 } from "./auto-tool-tracking.js";
 import { closeoutUnit } from "./auto-unit-closeout.js";
 import { recoverTimedOutUnit } from "./auto-timeout-recovery.js";
-import { selectAndApplyModel, resolveModelId } from "./auto-model-selection.js";
+import { selectAndApplyModel, resolveModelId, clearToolBaseline } from "./auto-model-selection.js";
 import { resetRoutingHistory, recordOutcome } from "./routing-history.js";
 import {
   checkPostUnitHooks,
@@ -1088,6 +1088,12 @@ export async function stopAuto(
     restoreProjectRootEnv();
     restoreMilestoneLockEnv();
 
+    // Drop the active-tool baseline so a subsequent /gsd auto run on the
+    // same `pi` instance recaptures from the live tool set rather than
+    // restoring this session's snapshot and silently undoing any tool
+    // changes the user made between sessions (#4959 / CodeRabbit).
+    if (pi) clearToolBaseline(pi);
+
     // Reset all session state in one call
     s.reset();
   }
@@ -1387,6 +1393,12 @@ export async function startAuto(
     debugLog("startAuto", { phase: "already-active", skipping: true });
     return;
   }
+
+  // Drop any stale active-tool baseline left over from a prior auto session
+  // on this `pi` (e.g. a session that ended without stopAuto running cleanly).
+  // The first selectAndApplyModel call for this run will recapture from the
+  // live tool set (#4959 / CodeRabbit).
+  clearToolBaseline(pi);
 
   const requestedStepMode = options?.step ?? false;
   const interruptedAssessment = options?.interrupted ?? null;

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1394,11 +1394,14 @@ export async function startAuto(
     return;
   }
 
-  // Drop any stale active-tool baseline left over from a prior auto session
-  // on this `pi` (e.g. a session that ended without stopAuto running cleanly).
-  // The first selectAndApplyModel call for this run will recapture from the
-  // live tool set (#4959 / CodeRabbit).
-  clearToolBaseline(pi);
+  // On a *fresh* start, drop any stale active-tool baseline left by a prior
+  // auto session that didn't run stopAuto cleanly.  Skip on resume: pauseAuto
+  // leaves the last provider-trimmed active tools in place, so clearing here
+  // would let the next selectAndApplyModel recapture that already-narrowed
+  // set as the new baseline — exactly the cross-unit poisoning this PR is
+  // fixing (#4959 / CodeRabbit Major).  The pre-pause baseline survives in
+  // the WeakMap keyed by `pi`.
+  if (!s.paused) clearToolBaseline(pi);
 
   const requestedStepMode = options?.step ?? false;
   const interruptedAssessment = options?.interrupted ?? null;

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -737,6 +737,12 @@ export async function autoLoop(
             reasons: loopErr.reasons,
           },
         });
+        // Carry the blocked unit identity into the turn-result observer:
+        // the throw originated inside dispatch, so observedUnitType/Id were
+        // not assigned by the success path at lines 453/631/647 — but the
+        // typed error already names the unit (#4959 / CodeRabbit).
+        observedUnitType = loopErr.unitType;
+        observedUnitId = loopErr.unitId;
         await deps.pauseAuto(ctx, pi);
         finishTurn("paused", "manual-attention", msg);
         // Do NOT increment consecutiveErrors — the failure is configuration,

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -29,6 +29,7 @@ import {
 } from "./phases.js";
 import { debugLog } from "../debug-logger.js";
 import { isInfrastructureError, isTransientCooldownError, getCooldownRetryAfterMs, COOLDOWN_FALLBACK_WAIT_MS, MAX_COOLDOWN_RETRIES } from "./infra-errors.js";
+import { ModelPolicyDispatchBlockedError } from "../auto-model-selection.js";
 import { resolveEngine } from "../engine-resolver.js";
 import { logWarning } from "../workflow-logger.js";
 import { gsdRoot } from "../paths.js";
@@ -702,6 +703,46 @@ export async function autoLoop(
       // completion even on failure (#2344). Without this, errors in
       // runFinalize leave the journal incomplete, making diagnosis harder.
       deps.emitJournalEvent({ ts: new Date().toISOString(), flowId, seq: nextSeq(), eventType: "iteration-end", data: { iteration, error: msg } });
+
+      // ── Pre-send model-policy block: not a retryable error (#4959 / #4850) ──
+      // The model-policy gate runs before the prompt is sent.  When every
+      // candidate model is denied (cross-provider disabled + flat-rate
+      // baseline + tool-policy denial), retrying the same unit produces the
+      // same denial — burning the consecutive-error budget toward a 3-strike
+      // hard stop and corrupting auto-mode state.  Pause for user attention
+      // instead, with the per-model deny reasons surfaced from the typed
+      // error.
+      if (loopErr instanceof ModelPolicyDispatchBlockedError) {
+        debugLog("autoLoop", {
+          phase: "model-policy-blocked",
+          iteration,
+          unitType: loopErr.unitType,
+          unitId: loopErr.unitId,
+          reasons: loopErr.reasons,
+        });
+        ctx.ui.notify(
+          `Auto-mode paused: model-policy denied dispatch for ${loopErr.unitType}/${loopErr.unitId}. ${msg}`,
+          "error",
+        );
+        deps.emitJournalEvent({
+          ts: new Date().toISOString(),
+          flowId,
+          seq: nextSeq(),
+          eventType: "unit-end",
+          data: {
+            unitType: loopErr.unitType,
+            unitId: loopErr.unitId,
+            status: "blocked",
+            reason: "model-policy-dispatch-blocked",
+            reasons: loopErr.reasons,
+          },
+        });
+        await deps.pauseAuto(ctx, pi);
+        finishTurn("paused", "manual-attention", msg);
+        // Do NOT increment consecutiveErrors — the failure is configuration,
+        // not a transient runtime fault.
+        break;
+      }
 
       // ── Infrastructure errors: immediate stop, no retry ──
       // These are unrecoverable (disk full, OOM, etc.). Retrying just burns

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2376,6 +2376,11 @@ test("autoLoop classifies ModelPolicyDispatchBlockedError as blocked, not a retr
   const journalEvents: Array<{ eventType: string; data?: any }> = [];
   let pauseAutoCalls = 0;
   let stopAutoCalls = 0;
+  // Capture onTurnResult to assert blocked-unit identity is propagated to
+  // the uokObserver. Without the fix, observedUnitType/Id are unset because
+  // the throw happens inside dispatch before the success-path assignments
+  // at loop.ts:453/631/647 (#4959 / CodeRabbit Minor).
+  const turnResults: Array<{ unitType?: string; unitId?: string; status: string }> = [];
 
   const deps = makeMockDeps({
     selectAndApplyModel: async () => {
@@ -2388,6 +2393,11 @@ test("autoLoop classifies ModelPolicyDispatchBlockedError as blocked, not a retr
     pauseAuto: async () => { pauseAutoCalls++; },
     stopAuto: async () => { stopAutoCalls++; },
     emitJournalEvent: (entry: any) => { journalEvents.push(entry); },
+    uokObserver: {
+      onTurnStart: () => {},
+      onPhaseResult: () => {},
+      onTurnResult: (res: any) => { turnResults.push({ unitType: res.unitType, unitId: res.unitId, status: res.status }); },
+    } as any,
   });
 
   await autoLoop(ctx, pi, s, deps);
@@ -2409,4 +2419,12 @@ test("autoLoop classifies ModelPolicyDispatchBlockedError as blocked, not a retr
       && n.message.includes("tool policy denied (web_search)"),
   );
   assert.ok(blockedNotice, "user-facing notification should name the policy block + deny reason");
+
+  // Blocked-unit identity must reach uokObserver.onTurnResult — the typed
+  // error already carries it, the loop must thread it into observedUnitType/Id
+  // before finishTurn is called (#4959 / CodeRabbit Minor).
+  const pausedTurn = turnResults.find(r => r.status === "paused");
+  assert.ok(pausedTurn, "uokObserver should observe a paused turn for the blocked unit");
+  assert.equal(pausedTurn!.unitType, "research-slice", "onTurnResult must receive the blocked unitType from the typed error");
+  assert.equal(pausedTurn!.unitId, "M001/S01", "onTurnResult must receive the blocked unitId from the typed error");
 });

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -15,6 +15,7 @@ import {
   type AgentEndEvent,
   type LoopDeps,
 } from "../auto-loop.js";
+import { ModelPolicyDispatchBlockedError } from "../auto-model-selection.js";
 import type { SessionLockStatus } from "../session-lock.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -2358,4 +2359,54 @@ test("autoLoop warns but proceeds for greenfield project (no project files) (#18
     greenfieldWarning,
     "should warn about greenfield project (no project files)",
   );
+});
+
+// ─── #4850: pre-send model-policy block is non-retryable ────────────────────
+test("autoLoop classifies ModelPolicyDispatchBlockedError as blocked, not a retryable error", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  const notifications: Array<{ message: string; level?: string }> = [];
+  ctx.ui.notify = (m: string, l?: string) => { notifications.push({ message: m, level: l }); };
+
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+
+  const journalEvents: Array<{ eventType: string; data?: any }> = [];
+  let pauseAutoCalls = 0;
+  let stopAutoCalls = 0;
+
+  const deps = makeMockDeps({
+    selectAndApplyModel: async () => {
+      throw new ModelPolicyDispatchBlockedError(
+        "research-slice",
+        "M001/S01",
+        [{ provider: "openai", modelId: "gpt-4o", reason: "tool policy denied (web_search) for openai-completions" }],
+      );
+    },
+    pauseAuto: async () => { pauseAutoCalls++; },
+    stopAuto: async () => { stopAutoCalls++; },
+    emitJournalEvent: (entry: any) => { journalEvents.push(entry); },
+  });
+
+  await autoLoop(ctx, pi, s, deps);
+
+  // The unit-end event with status: "blocked" must be emitted.
+  const unitEnd = journalEvents.find(
+    e => e.eventType === "unit-end" && e.data?.status === "blocked",
+  );
+  assert.ok(unitEnd, "should emit unit-end with status=blocked");
+  assert.equal(unitEnd!.data.reason, "model-policy-dispatch-blocked");
+
+  // Loop must pause for manual attention, NOT retry until 3-strike hard stop.
+  assert.equal(pauseAutoCalls, 1, "should pause once on policy block");
+  assert.equal(stopAutoCalls, 0, "should NOT call stopAuto — pre-send block is not a retryable iteration error");
+
+  // The notification should surface the per-model deny reason from the typed error.
+  const blockedNotice = notifications.find(
+    n => n.message.includes("model-policy denied dispatch")
+      && n.message.includes("tool policy denied (web_search)"),
+  );
+  assert.ok(blockedNotice, "user-facing notification should name the policy block + deny reason");
 });

--- a/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
@@ -130,6 +130,15 @@ test("vacuous-truth (a): unit type with empty workflow-required tools → dispat
     // → returns []. Exercises the empty-requiredTools branch in
     // applyModelPolicyFilter (CodeRabbit Minor: existing test used
     // gate-evaluate which has non-empty required tools and never hit this path).
+    //
+    // PREFERENCES with tier_models is required so resolvePreferredModelConfig
+    // returns a non-undefined modelConfig — only then does selectAndApplyModel
+    // run the policy filter we want to exercise.
+    writeFileSync(
+      join(env.dir, ".gsd", "PREFERENCES.md"),
+      ["---", "dynamic_routing:", "  enabled: true", "  tier_models:", "    heavy: anthropic/claude-sonnet-4-6", "---"].join("\n"),
+      "utf-8",
+    );
     const availableModels = [
       { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
     ];
@@ -272,6 +281,15 @@ test("genuinely-impossible (a): workflow tool incompatible with candidate API �
     // Register the workflow tool as image-producing for the duration of this
     // test. afterEach() resets the registry below.
     registerToolCompatibility("gsd_plan_slice", { producesImages: true });
+
+    // PREFERENCES needs tier_models so resolvePreferredModelConfig returns a
+    // non-undefined modelConfig — without that, selectAndApplyModel skips the
+    // entire policy block and we never reach the tool-compat denial path.
+    writeFileSync(
+      join(env.dir, ".gsd", "PREFERENCES.md"),
+      ["---", "dynamic_routing:", "  enabled: true", "  tier_models:", "    heavy: ollama/ollama-llama-3", "---"].join("\n"),
+      "utf-8",
+    );
 
     const availableModels = [
       { id: "ollama-llama-3", provider: "ollama", api: "ollama-chat" },

--- a/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Regression coverage for the model-policy dispatch bugs (#4959, #4681, #4850).
+ *
+ * The five tests here pin the four fix layers documented in the RCA on #4959:
+ *
+ *   1. Vacuous-truth guard: with an empty unit-required tool subset and an
+ *      otherwise-permitted model, dispatch must succeed.  Without this test,
+ *      an over-aggressive Change 1 (e.g. always denying) would still pass any
+ *      "no longer throws" assertion trivially.
+ *   2. Cross-unit poisoning: per-unit narrowing at the bottom of
+ *      `selectAndApplyModel` must NOT bleed into the next unit's policy
+ *      evaluation.  The baseline-restore path (Change 2) must restore the
+ *      pre-dispatch active-tool set before policy runs.
+ *   3. Genuinely-impossible negative: when the workflow REQUIRES a tool no
+ *      candidate model can carry, dispatch must throw
+ *      `ModelPolicyDispatchBlockedError` — proving Change 1 didn't accidentally
+ *      remove gating, and Change 3 wired the typed error.
+ *   4. Restore happened: assert call ordering on a recording fake — the
+ *      baseline `setActiveTools` call must precede the next `selectAndApplyModel`
+ *      reading the active set.
+ *   5. Error message carries reason: the throw must include the per-model
+ *      `tool policy denied (...)` reason fragment from `applyModelPolicyFilter`,
+ *      so users can act on the failure without digging through audit events.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  selectAndApplyModel,
+  ModelPolicyDispatchBlockedError,
+  _resetToolBaselineForTesting,
+} from "../auto-model-selection.js";
+
+function makeTempProject(): { dir: string; cleanup: () => void; restoreEnv: () => void } {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const dir = mkdtempSync(join(tmpdir(), "gsd-policy-poison-"));
+  const home = mkdtempSync(join(tmpdir(), "gsd-policy-home-"));
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  // Empty PREFERENCES so default uok.model_policy.enabled = true applies.
+  writeFileSync(join(dir, ".gsd", "PREFERENCES.md"), "---\n---\n", "utf-8");
+  process.env.GSD_HOME = home;
+  process.chdir(dir);
+  return {
+    dir,
+    cleanup: () => {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    },
+    restoreEnv: () => {
+      process.chdir(originalCwd);
+      if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = originalGsdHome;
+    },
+  };
+}
+
+interface RecordingPi {
+  setModel: (m: { provider: string; id: string }) => Promise<boolean>;
+  emitBeforeModelSelect: () => Promise<undefined>;
+  getActiveTools: () => string[];
+  emitAdjustToolSet: () => Promise<undefined>;
+  setActiveTools: (names: string[]) => void;
+  setThinkingLevel: () => void;
+  __calls: Array<{ kind: string; payload: unknown }>;
+  __activeTools: string[];
+}
+
+function makeRecordingPi(initialActiveTools: string[]): RecordingPi {
+  const calls: Array<{ kind: string; payload: unknown }> = [];
+  let active = [...initialActiveTools];
+  return {
+    __calls: calls,
+    get __activeTools() { return active; },
+    setModel: async (m) => {
+      calls.push({ kind: "setModel", payload: `${m.provider}/${m.id}` });
+      return true;
+    },
+    emitBeforeModelSelect: async () => {
+      calls.push({ kind: "emitBeforeModelSelect", payload: null });
+      return undefined;
+    },
+    getActiveTools: () => {
+      calls.push({ kind: "getActiveTools", payload: [...active] });
+      return [...active];
+    },
+    emitAdjustToolSet: async () => {
+      calls.push({ kind: "emitAdjustToolSet", payload: null });
+      return undefined;
+    },
+    setActiveTools: (names) => {
+      active = [...names];
+      calls.push({ kind: "setActiveTools", payload: [...names] });
+    },
+    setThinkingLevel: () => {},
+  } as RecordingPi;
+}
+
+function makeCtx(availableModels: Array<{ id: string; provider: string; api: string }>) {
+  return {
+    modelRegistry: {
+      getAvailable: () => availableModels,
+      getProviderAuthMode: () => "apiKey",
+    },
+    sessionManager: { getSessionId: () => "test-session" },
+    ui: { notify: () => {} },
+    model: { provider: availableModels[0]?.provider, id: availableModels[0]?.id, api: availableModels[0]?.api },
+  } as any;
+}
+
+// ─── 1. Vacuous-truth guard ──────────────────────────────────────────────────
+test("vacuous-truth: empty workflow tool requirement + permitted model → dispatch succeeds", async () => {
+  const env = makeTempProject();
+  try {
+    // gate-evaluate has tool requirement ["gsd_save_gate_result"], but if every
+    // available model's API can carry it, policy must allow dispatch.
+    const availableModels = [
+      { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+    ];
+    const pi = makeRecordingPi(["gsd_save_gate_result"]);
+    _resetToolBaselineForTesting(pi as unknown as object);
+
+    const result = await selectAndApplyModel(
+      makeCtx(availableModels),
+      pi as any,
+      "gate-evaluate",
+      "g1",
+      env.dir,
+      undefined,
+      false,
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      undefined,
+      true,
+    );
+
+    assert.equal(result.appliedModel?.id, "claude-sonnet-4-6", "should apply the permitted model");
+    const setModelCalls = pi.__calls.filter(c => c.kind === "setModel");
+    assert.equal(setModelCalls.length, 1, "setModel should have been called exactly once");
+  } finally {
+    env.restoreEnv();
+    env.cleanup();
+  }
+});
+
+// ─── 2. Cross-unit poisoning ─────────────────────────────────────────────────
+test("cross-unit poisoning: prior unit narrowing must not deny next unit's eligible model", async () => {
+  const env = makeTempProject();
+  try {
+    // Unit-N runs against an `openai-completions` provider that strips a tool
+    // (e.g. "thinking_partner") via adjustToolSet's hard filter.  Without the
+    // baseline-restore (Change 2), pi.getActiveTools() afterward is missing
+    // that tool, but if we used it as the policy required-set we'd erroneously
+    // deny the next unit.  With Change 1+2, policy uses the workflow-required
+    // subset (NOT the live snapshot), and baseline restoration re-seeds the
+    // active set before the next unit.
+    const availableModels = [
+      { id: "openai-narrow", provider: "openai", api: "openai-completions" },
+      { id: "claude-wide", provider: "anthropic", api: "anthropic-messages" },
+    ];
+    // The baseline contains a synthetic "thinking_partner" that openai-completions
+    // does not support.
+    const pi = makeRecordingPi(["gsd_save_gate_result", "thinking_partner"]);
+    _resetToolBaselineForTesting(pi as unknown as object);
+
+    // Unit-N: dispatch on openai/openai-narrow.  Soft adjustToolSet will narrow
+    // the active set, simulating production poisoning.
+    await selectAndApplyModel(
+      makeCtx(availableModels),
+      pi as any,
+      "gate-evaluate",
+      "n",
+      env.dir,
+      undefined,
+      false,
+      { provider: "openai", id: "openai-narrow" },
+      undefined,
+      true,
+    );
+
+    const setModelCallsAfterUnitN = pi.__calls.filter(c => c.kind === "setModel").length;
+    assert.ok(setModelCallsAfterUnitN >= 1, "unit-N should have dispatched");
+
+    // Unit-N+1: now dispatch with claude-wide.  If active-tool snapshot were
+    // still the policy required-set, the previous narrowing wouldn't matter
+    // (anthropic-messages can carry both tools), so we instead simulate the
+    // 4959 path: a second unit whose workflow requires "gsd_save_gate_result"
+    // (small) — must succeed reaching pi.setModel for claude-wide.
+    const beforeCount = pi.__calls.filter(c => c.kind === "setModel").length;
+    await selectAndApplyModel(
+      makeCtx(availableModels),
+      pi as any,
+      "gate-evaluate",
+      "n+1",
+      env.dir,
+      undefined,
+      false,
+      { provider: "anthropic", id: "claude-wide" },
+      undefined,
+      true,
+    );
+    const afterCount = pi.__calls.filter(c => c.kind === "setModel").length;
+    assert.ok(afterCount > beforeCount, "unit-N+1 should reach pi.setModel — cross-unit narrowing must not block dispatch");
+  } finally {
+    env.restoreEnv();
+    env.cleanup();
+  }
+});
+
+// ─── 3. Genuinely-impossible negative ────────────────────────────────────────
+test("genuinely-impossible: workflow requires a tool no candidate carries → throws typed error", async () => {
+  const env = makeTempProject();
+  try {
+    // Use plan-slice (workflow-required: ["gsd_plan_slice"]) but pretend no
+    // candidate model can carry it.  The simplest way: provide a model whose
+    // api is a fictitious "no-tools" string — `filterToolsForProvider` returns
+    // every tool as filtered for an unknown api with toolCalling=false, OR we
+    // can pick a real api that also denies the tool.  We use an api that
+    // exists but has known incompatibility — no such case is portable, so we
+    // fall back to a model whose api is recognized to deny `gsd_plan_slice`.
+    //
+    // Pragmatic approach: monkey the policy via `allowCrossProvider=false` +
+    // a single candidate model on a *different* provider than current, which
+    // makes EVERY candidate denied for cross-provider-routing reasons.  This
+    // exercises the same throw path with a deterministic deny reason.
+    const availableModels = [
+      { id: "other-model", provider: "other-provider", api: "anthropic-messages" },
+    ];
+    const pi = makeRecordingPi([]);
+    _resetToolBaselineForTesting(pi as unknown as object);
+
+    const ctx = makeCtx(availableModels);
+    // currentProvider mismatches → cross-provider denial when disabled.
+    ctx.model = { provider: "anthropic", id: "claude-sonnet-4-6", api: "anthropic-messages" };
+
+    // Set dynamic_routing.cross_provider=false via PREFERENCES so the policy
+    // disables cross-provider routing.
+    writeFileSync(
+      join(env.dir, ".gsd", "PREFERENCES.md"),
+      ["---", "dynamic_routing:", "  enabled: true", "  cross_provider: false", "  tier_models:", "    heavy: other-provider/other-model", "---"].join("\n"),
+      "utf-8",
+    );
+
+    let thrown: unknown;
+    try {
+      await selectAndApplyModel(
+        ctx,
+        pi as any,
+        "plan-slice",
+        "s1",
+        env.dir,
+        undefined,
+        false,
+        { provider: "anthropic", id: "claude-sonnet-4-6" },
+        undefined,
+        true,
+      );
+    } catch (e) {
+      thrown = e;
+    }
+
+    assert.ok(thrown instanceof ModelPolicyDispatchBlockedError, "should throw ModelPolicyDispatchBlockedError");
+    const err = thrown as ModelPolicyDispatchBlockedError;
+    assert.equal(err.unitType, "plan-slice");
+    assert.equal(err.unitId, "s1");
+    assert.ok(err.reasons.length > 0, "deny reasons should be captured");
+  } finally {
+    env.restoreEnv();
+    env.cleanup();
+  }
+});
+
+// ─── 4. Restore happened ─────────────────────────────────────────────────────
+test("restore baseline: setActiveTools(BASELINE) called between units before next dispatch", async () => {
+  const env = makeTempProject();
+  try {
+    const availableModels = [
+      { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+    ];
+    const baselineTools = ["gsd_save_gate_result", "tool_a", "tool_b"];
+    const pi = makeRecordingPi(baselineTools);
+    _resetToolBaselineForTesting(pi as unknown as object);
+
+    // First call captures the baseline.
+    await selectAndApplyModel(
+      makeCtx(availableModels),
+      pi as any,
+      "gate-evaluate",
+      "u1",
+      env.dir,
+      undefined,
+      false,
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      undefined,
+      true,
+    );
+
+    // Simulate a downstream caller narrowing the tool set (post-unit poisoning).
+    pi.setActiveTools(["gsd_save_gate_result"]);
+    const callsBeforeU2 = pi.__calls.length;
+
+    // Second call should restore the baseline before reading anything.
+    await selectAndApplyModel(
+      makeCtx(availableModels),
+      pi as any,
+      "gate-evaluate",
+      "u2",
+      env.dir,
+      undefined,
+      false,
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      undefined,
+      true,
+    );
+
+    const u2Calls = pi.__calls.slice(callsBeforeU2);
+    const restoreCall = u2Calls.find(
+      c => c.kind === "setActiveTools"
+        && Array.isArray(c.payload)
+        && (c.payload as string[]).length === baselineTools.length
+        && baselineTools.every(t => (c.payload as string[]).includes(t)),
+    );
+    assert.ok(restoreCall, "setActiveTools(BASELINE) must be called during u2's selectAndApplyModel before dispatch");
+
+    const restoreIdx = u2Calls.indexOf(restoreCall!);
+    const setModelIdx = u2Calls.findIndex(c => c.kind === "setModel");
+    assert.ok(setModelIdx > restoreIdx, "baseline restore must precede setModel dispatch");
+  } finally {
+    env.restoreEnv();
+    env.cleanup();
+  }
+});
+
+// ─── 5. Error message carries reason ─────────────────────────────────────────
+test("error carries deny reason fragment from applyModelPolicyFilter", async () => {
+  const env = makeTempProject();
+  try {
+    writeFileSync(
+      join(env.dir, ".gsd", "PREFERENCES.md"),
+      ["---", "dynamic_routing:", "  enabled: true", "  cross_provider: false", "  tier_models:", "    heavy: other-provider/other-model", "---"].join("\n"),
+      "utf-8",
+    );
+
+    const availableModels = [
+      { id: "other-model", provider: "other-provider", api: "anthropic-messages" },
+    ];
+    const pi = makeRecordingPi([]);
+    _resetToolBaselineForTesting(pi as unknown as object);
+
+    const ctx = makeCtx(availableModels);
+    ctx.model = { provider: "anthropic", id: "claude-sonnet-4-6", api: "anthropic-messages" };
+
+    let thrown: Error | undefined;
+    try {
+      await selectAndApplyModel(
+        ctx,
+        pi as any,
+        "plan-slice",
+        "s1",
+        env.dir,
+        undefined,
+        false,
+        { provider: "anthropic", id: "claude-sonnet-4-6" },
+        undefined,
+        true,
+      );
+    } catch (e) {
+      thrown = e as Error;
+    }
+
+    assert.ok(thrown, "should throw");
+    // The cross-provider denial path produces:
+    //   "cross-provider routing disabled (other-provider != anthropic)"
+    assert.match(
+      thrown!.message,
+      /cross-provider routing disabled/,
+      "thrown error message should include the per-model deny reason",
+    );
+    assert.match(thrown!.message, /other-provider\/other-model/, "should name the rejected model");
+  } finally {
+    env.restoreEnv();
+    env.cleanup();
+  }
+});

--- a/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
@@ -32,7 +32,7 @@ import { tmpdir } from "node:os";
 import {
   selectAndApplyModel,
   ModelPolicyDispatchBlockedError,
-  _resetToolBaselineForTesting,
+  clearToolBaseline,
 } from "../auto-model-selection.js";
 
 function makeTempProject(): { dir: string; cleanup: () => void; restoreEnv: () => void } {
@@ -122,7 +122,7 @@ test("vacuous-truth: empty workflow tool requirement + permitted model → dispa
       { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
     ];
     const pi = makeRecordingPi(["gsd_save_gate_result"]);
-    _resetToolBaselineForTesting(pi as unknown as object);
+    clearToolBaseline(pi as unknown as object);
 
     const result = await selectAndApplyModel(
       makeCtx(availableModels),
@@ -164,7 +164,7 @@ test("cross-unit poisoning: prior unit narrowing must not deny next unit's eligi
     // The baseline contains a synthetic "thinking_partner" that openai-completions
     // does not support.
     const pi = makeRecordingPi(["gsd_save_gate_result", "thinking_partner"]);
-    _resetToolBaselineForTesting(pi as unknown as object);
+    clearToolBaseline(pi as unknown as object);
 
     // Unit-N: dispatch on openai/openai-narrow.  Soft adjustToolSet will narrow
     // the active set, simulating production poisoning.
@@ -230,7 +230,7 @@ test("genuinely-impossible: workflow requires a tool no candidate carries → th
       { id: "other-model", provider: "other-provider", api: "anthropic-messages" },
     ];
     const pi = makeRecordingPi([]);
-    _resetToolBaselineForTesting(pi as unknown as object);
+    clearToolBaseline(pi as unknown as object);
 
     const ctx = makeCtx(availableModels);
     // currentProvider mismatches → cross-provider denial when disabled.
@@ -282,7 +282,7 @@ test("restore baseline: setActiveTools(BASELINE) called between units before nex
     ];
     const baselineTools = ["gsd_save_gate_result", "tool_a", "tool_b"];
     const pi = makeRecordingPi(baselineTools);
-    _resetToolBaselineForTesting(pi as unknown as object);
+    clearToolBaseline(pi as unknown as object);
 
     // First call captures the baseline.
     await selectAndApplyModel(
@@ -348,7 +348,7 @@ test("error carries deny reason fragment from applyModelPolicyFilter", async () 
       { id: "other-model", provider: "other-provider", api: "anthropic-messages" },
     ];
     const pi = makeRecordingPi([]);
-    _resetToolBaselineForTesting(pi as unknown as object);
+    clearToolBaseline(pi as unknown as object);
 
     const ctx = makeCtx(availableModels);
     ctx.model = { provider: "anthropic", id: "claude-sonnet-4-6", api: "anthropic-messages" };
@@ -380,6 +380,107 @@ test("error carries deny reason fragment from applyModelPolicyFilter", async () 
       "thrown error message should include the per-model deny reason",
     );
     assert.match(thrown!.message, /other-provider\/other-model/, "should name the rejected model");
+  } finally {
+    env.restoreEnv();
+    env.cleanup();
+  }
+});
+
+// ─── 6. Lifecycle: clearToolBaseline forces recapture (CodeRabbit Major) ─────
+//
+// The WeakMap baseline is keyed per `pi` instance, but auto sessions are NOT
+// 1:1 with `pi` instances — a single `pi` can host multiple `/gsd auto` runs
+// separated by stops, manual tool edits, or extension toggles.  Without
+// `clearToolBaseline(pi)` at session boundaries, the SECOND auto run on the
+// same `pi` would silently restore the FIRST run's snapshot and undo whatever
+// tool changes the user made between sessions.  This test pins the contract
+// that `clearToolBaseline` causes the next dispatch to RECAPTURE from the
+// live active set rather than restoring the prior snapshot.
+test("lifecycle: clearToolBaseline forces recapture; subsequent runs respect intervening tool edits", async () => {
+  const env = makeTempProject();
+  try {
+    const availableModels = [
+      { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+    ];
+    const pi = makeRecordingPi(["A", "B", "C"]);
+    clearToolBaseline(pi as unknown as object);
+
+    // ── Run 1: captures baseline [A, B, C] ──
+    await selectAndApplyModel(
+      makeCtx(availableModels),
+      pi as any,
+      "gate-evaluate",
+      "u1",
+      env.dir,
+      undefined,
+      false,
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      undefined,
+      true,
+    );
+
+    // ── Simulate `/gsd auto` stop + intervening user tool edit ──
+    // (auto.ts calls clearToolBaseline in stopAuto; the user then mutates
+    // tools while auto is paused.)
+    clearToolBaseline(pi as unknown as object);
+    pi.setActiveTools(["A", "B"]); // user removed C between sessions
+
+    // ── Run 2: must capture [A, B] as the NEW baseline, not restore [A, B, C] ──
+    const callsBeforeU2 = pi.__calls.length;
+    await selectAndApplyModel(
+      makeCtx(availableModels),
+      pi as any,
+      "gate-evaluate",
+      "u2",
+      env.dir,
+      undefined,
+      false,
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      undefined,
+      true,
+    );
+    const u2Calls = pi.__calls.slice(callsBeforeU2);
+    // No setActiveTools(["A", "B", "C"]) call should appear during u2 — that
+    // would be the bug (restoring the run-1 snapshot over the user's edit).
+    const staleRestore = u2Calls.find(
+      c => c.kind === "setActiveTools"
+        && Array.isArray(c.payload)
+        && (c.payload as string[]).includes("C"),
+    );
+    assert.equal(
+      staleRestore,
+      undefined,
+      "after clearToolBaseline, run 2 must NOT restore the run-1 snapshot containing tool C",
+    );
+
+    // ── Run 3 (no clear): mutate to [A], expect restore to [A, B] (run-2 baseline) ──
+    pi.setActiveTools(["A"]);
+    const callsBeforeU3 = pi.__calls.length;
+    await selectAndApplyModel(
+      makeCtx(availableModels),
+      pi as any,
+      "gate-evaluate",
+      "u3",
+      env.dir,
+      undefined,
+      false,
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      undefined,
+      true,
+    );
+    const u3Calls = pi.__calls.slice(callsBeforeU3);
+    const restoreToRun2Baseline = u3Calls.find(
+      c => c.kind === "setActiveTools"
+        && Array.isArray(c.payload)
+        && (c.payload as string[]).length === 2
+        && (c.payload as string[]).includes("A")
+        && (c.payload as string[]).includes("B")
+        && !(c.payload as string[]).includes("C"),
+    );
+    assert.ok(
+      restoreToRun2Baseline,
+      "run 3 must restore the run-2 baseline [A, B] — proves the recaptured baseline is in use, not the run-1 snapshot",
+    );
   } finally {
     env.restoreEnv();
     env.cleanup();

--- a/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
@@ -34,6 +34,10 @@ import {
   ModelPolicyDispatchBlockedError,
   clearToolBaseline,
 } from "../auto-model-selection.js";
+import {
+  registerToolCompatibility,
+  resetToolCompatibilityRegistry,
+} from "@gsd/pi-coding-agent";
 
 function makeTempProject(): { dir: string; cleanup: () => void; restoreEnv: () => void } {
   const originalCwd = process.cwd();
@@ -113,11 +117,54 @@ function makeCtx(availableModels: Array<{ id: string; provider: string; api: str
 }
 
 // ─── 1. Vacuous-truth guard ──────────────────────────────────────────────────
-test("vacuous-truth: empty workflow tool requirement + permitted model → dispatch succeeds", async () => {
+//
+// Two scenarios pin the empty-requiredTools branch and a permitted-tool branch.
+// Without the empty-list scenario, a regression that mishandles `requiredTools = []`
+// (e.g. by treating an empty array as "deny all" or by null-derefing the helper
+// return) would still pass.
+
+test("vacuous-truth (a): unit type with empty workflow-required tools → dispatch succeeds", async () => {
   const env = makeTempProject();
   try {
-    // gate-evaluate has tool requirement ["gsd_save_gate_result"], but if every
-    // available model's API can carry it, policy must allow dispatch.
+    // `refine-slice` is not in the getRequiredWorkflowToolsForAutoUnit switch
+    // → returns []. Exercises the empty-requiredTools branch in
+    // applyModelPolicyFilter (CodeRabbit Minor: existing test used
+    // gate-evaluate which has non-empty required tools and never hit this path).
+    const availableModels = [
+      { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+    ];
+    const pi = makeRecordingPi([]);
+    clearToolBaseline(pi as unknown as object);
+
+    const result = await selectAndApplyModel(
+      makeCtx(availableModels),
+      pi as any,
+      "refine-slice",
+      "x1",
+      env.dir,
+      undefined,
+      false,
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      undefined,
+      true,
+    );
+
+    assert.equal(result.appliedModel?.id, "claude-sonnet-4-6", "empty requiredTools must not deny dispatch");
+    const setModelCalls = pi.__calls.filter(c => c.kind === "setModel");
+    assert.equal(setModelCalls.length, 1, "setModel should have been called exactly once");
+  } finally {
+    env.restoreEnv();
+    env.cleanup();
+  }
+});
+
+test("vacuous-truth (b): non-empty workflow tool requirement that the model carries → dispatch succeeds", async () => {
+  const env = makeTempProject();
+  try {
+    // gate-evaluate has tool requirement ["gsd_save_gate_result"]; if the
+    // model's API can carry it, policy must still allow dispatch. Counter-test
+    // to (a): proves the path with a non-empty requirement isn't denying
+    // legitimate dispatches.
     const availableModels = [
       { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
     ];
@@ -137,7 +184,7 @@ test("vacuous-truth: empty workflow tool requirement + permitted model → dispa
       true,
     );
 
-    assert.equal(result.appliedModel?.id, "claude-sonnet-4-6", "should apply the permitted model");
+    assert.equal(result.appliedModel?.id, "claude-sonnet-4-6", "compat-required dispatch must succeed");
     const setModelCalls = pi.__calls.filter(c => c.kind === "setModel");
     assert.equal(setModelCalls.length, 1, "setModel should have been called exactly once");
   } finally {
@@ -210,8 +257,66 @@ test("cross-unit poisoning: prior unit narrowing must not deny next unit's eligi
   }
 });
 
-// ─── 3. Genuinely-impossible negative ────────────────────────────────────────
-test("genuinely-impossible: workflow requires a tool no candidate carries → throws typed error", async () => {
+// ─── 3a. Genuinely-impossible: tool-compatibility denial path ────────────────
+//
+// Exercises the real `getRequiredWorkflowToolsForAutoUnit` →
+// `filterToolsForProvider` path that #4959 was about (CodeRabbit Minor:
+// existing 3b test used cross-provider denial which never hit this path).
+// Registers `gsd_plan_slice` as `producesImages: true`, then offers only an
+// `ollama-chat` candidate (which has `imageToolResults: false`) — the
+// workflow-required tool is incompatible with the candidate's API, so the
+// policy filter denies the model with a `tool policy denied (...)` reason.
+test("genuinely-impossible (a): workflow tool incompatible with candidate API → typed error names tool + api", async () => {
+  const env = makeTempProject();
+  try {
+    // Register the workflow tool as image-producing for the duration of this
+    // test. afterEach() resets the registry below.
+    registerToolCompatibility("gsd_plan_slice", { producesImages: true });
+
+    const availableModels = [
+      { id: "ollama-llama-3", provider: "ollama", api: "ollama-chat" },
+    ];
+    const pi = makeRecordingPi(["gsd_plan_slice"]);
+    clearToolBaseline(pi as unknown as object);
+
+    const ctx = makeCtx(availableModels);
+    // Same provider as candidate so the cross-provider gate doesn't fire —
+    // we want this denial to come from tool-compatibility, not provider mismatch.
+    ctx.model = { provider: "ollama", id: "ollama-llama-3", api: "ollama-chat" };
+
+    let thrown: unknown;
+    try {
+      await selectAndApplyModel(
+        ctx,
+        pi as any,
+        "plan-slice",
+        "s1",
+        env.dir,
+        undefined,
+        false,
+        { provider: "ollama", id: "ollama-llama-3" },
+        undefined,
+        true,
+      );
+    } catch (e) {
+      thrown = e;
+    }
+
+    assert.ok(thrown instanceof ModelPolicyDispatchBlockedError, "should throw ModelPolicyDispatchBlockedError");
+    const err = thrown as ModelPolicyDispatchBlockedError;
+    assert.equal(err.unitType, "plan-slice");
+    assert.match(err.message, /tool policy denied/, "throw must surface the tool-compatibility deny reason");
+    assert.match(err.message, /gsd_plan_slice/, "throw must name the incompatible tool");
+    assert.match(err.message, /ollama-chat/, "throw must name the api for which the tool was filtered");
+  } finally {
+    resetToolCompatibilityRegistry();
+    env.restoreEnv();
+    env.cleanup();
+  }
+});
+
+// ─── 3b. Genuinely-impossible: cross-provider denial path ────────────────────
+test("genuinely-impossible (b): cross-provider routing disabled + provider mismatch → typed error", async () => {
   const env = makeTempProject();
   try {
     // Use plan-slice (workflow-required: ["gsd_plan_slice"]) but pretend no


### PR DESCRIPTION
## Summary

Fixes three open auto-mode dispatch bugs sharing one root cause and one downstream amplifier:

- **#4959** (complete-slice failures)
- **#4681** (100% Windows repro on discuss-milestone)
- **#4850** (research-slice + retry-loop amplifier)

RCA on #4959: `auto-model-selection.ts` was passing `pi.getActiveTools()` as the `requiredTools` hard gate to `applyModelPolicyFilter`, while the same module already runs soft `adjustToolSet` post-selection that monotonically narrows the active set. The next unit inherited the narrowed set, the policy gate then rejected every candidate, and the throw surfaced as a retryable iteration error in `auto/loop.ts` — burning the 3-strike retry budget toward a hard stop.

## Fix

1. **Change 1** — `applyModelPolicyFilter` now receives the workflow-spec required-tool subset via `getRequiredWorkflowToolsForAutoUnit(unitType)`, not the live active-tool snapshot. Soft adaptation still trims provider-incompatible tools post-selection.
2. **Change 2** — Per-pi baseline tool set captured in a WeakMap; restoreToolBaseline runs before each selectAndApplyModel evaluates policy. Cross-unit poisoning ends.
3. **Change 3** — New ModelPolicyDispatchBlockedError carries per-model deny reasons. Thrown message names rejected models + reasons (e.g. qwen3.6 (tool policy denied: web_search for openai-completions)) so users can act without digging through audit events.
4. **Change 4-A** — auto/loop.ts catches ModelPolicyDispatchBlockedError specifically; does NOT increment consecutiveErrors, emits unit-end with status: blocked, surfaces an actionable notification, pauses for manual attention.
   - Change 4-B (deferring unit-start emission until selection succeeds) deferred to a follow-up — the 4-A path already prevents the consecutive-error escalation; deferring unit-start requires deeper changes to phases.ts and the test surface.

## Test plan

src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts (new, 5 tests):

- [x] Vacuous-truth guard
- [x] Cross-unit poisoning
- [x] Genuinely-impossible negative throws typed error
- [x] Restore happened (call ordering)
- [x] Error message carries deny-reason fragment

src/resources/extensions/gsd/tests/auto-loop.test.ts (test #6 added):

- [x] Pre-send block is non-retryable

Existing regressions:

- [x] auto-model-selection.test.ts — 16/16 pass
- [x] auto-loop.test.ts — 56/56 pass
- [x] uok-model-policy.test.ts + model-router.test.ts — 68/68 pass
- [x] tsc --noEmit clean for all touched files (only pre-existing #4946 semver error remains)

Closes #4959
Closes #4681
Closes #4850

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Surfaces structured model-policy denial details to users (including per-model reasons), records blocked units with a clear reason, and pauses auto-mode into manual-attention without retrying.

* **Bug Fixes**
  * Prevents active-tool state from leaking across units by restoring and allowing clearing of a captured baseline at run start/stop and when resuming.

* **Tests**
  * Added regression tests covering denied dispatches, baseline restore/clear behavior, journal entries, UI notifications, and pause handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->