### PR TITLE
fix(auto): gate restoreToolBaseline by isAutoMode (Closes #4965)

### DIFF
--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -219,7 +219,15 @@ export async function selectAndApplyModel(
   // re-applied here so each unit starts from a clean slate.  Soft adaptation
   // (adjustToolSet at the bottom of this function) still trims for the
   // selected model.
-  restoreToolBaseline(pi);
+  //
+  // Auto-mode only (#4965): `guided-flow.ts:dispatchWorkflow` also calls
+  // `selectAndApplyModel` with `isAutoMode=false`. Guided-flow has its own
+  // narrow/restore via discuss-tool-scoping (guided-flow.ts:587-622) and no
+  // baseline-clear hook of its own, so an unconditional restore here would
+  // resurrect an auto-era baseline on guided-flow dispatches — silently
+  // overwriting any tool changes made interactively between auto sessions.
+  // The baseline is structurally an auto-mode concept; gate it accordingly.
+  if (isAutoMode) restoreToolBaseline(pi);
 
   if (modelConfig) {
     const availableModels = ctx.modelRegistry.getAvailable();

--- a/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection-tool-poisoning.test.ts
@@ -609,3 +609,134 @@ test("lifecycle: clearToolBaseline forces recapture; subsequent runs respect int
     env.cleanup();
   }
 });
+
+// ─── 7. Cross-mode isolation (#4965) ─────────────────────────────────────────
+//
+// `selectAndApplyModel` is called from two places: auto-mode (`isAutoMode=true`,
+// from auto/phases.ts) and guided-flow (`isAutoMode=false`, from guided-flow.ts).
+// The baseline lifecycle (clearToolBaseline) is owned by startAuto/stopAuto —
+// guided-flow has no equivalent clear hook. If `restoreToolBaseline` ran
+// unconditionally, an interactive guided-flow dispatch on a `pi` that previously
+// hosted an auto session would resurrect the auto-era baseline and silently
+// overwrite any user tool edits made between the auto and guided dispatches.
+// Therefore the restore is gated by `isAutoMode`. Guided-flow has its own
+// narrow/restore discipline via discuss-tool-scoping at guided-flow.ts:587-622.
+
+test("cross-mode (#4965): isAutoMode=false does NOT restore baseline even when one is recorded", async () => {
+  const env = makeTempProject();
+  try {
+    const availableModels = [
+      { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+    ];
+    const baselineTools = ["gsd_save_gate_result", "tool_a", "tool_b"];
+    const pi = makeRecordingPi(baselineTools);
+    clearToolBaseline(pi as unknown as object);
+
+    // ── Step 1: auto-mode call captures baseline [A, B, C] ──
+    await selectAndApplyModel(
+      makeCtx(availableModels),
+      pi as any,
+      "gate-evaluate",
+      "u-auto",
+      env.dir,
+      undefined,
+      false,
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      undefined,
+      /* isAutoMode */ true,
+    );
+
+    // ── Step 2: simulate user tool edit between auto and guided dispatches ──
+    pi.setActiveTools(["only_user_kept_tool"]);
+    const callsBeforeGuided = pi.__calls.length;
+
+    // ── Step 3: guided-flow dispatch (isAutoMode=false) ──
+    await selectAndApplyModel(
+      makeCtx(availableModels),
+      pi as any,
+      "gate-evaluate",
+      "u-guided",
+      env.dir,
+      undefined,
+      false,
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      undefined,
+      /* isAutoMode */ false,
+    );
+
+    const guidedCalls = pi.__calls.slice(callsBeforeGuided);
+    // The bug we're guarding against: a setActiveTools call during the guided
+    // dispatch that contains the auto-era baseline tools (which would mean the
+    // auto-captured baseline resurrected and overwrote the user's edit).
+    const baselineRestore = guidedCalls.find(
+      c => c.kind === "setActiveTools"
+        && Array.isArray(c.payload)
+        && baselineTools.every(t => (c.payload as string[]).includes(t)),
+    );
+    assert.equal(
+      baselineRestore,
+      undefined,
+      "guided-flow dispatch (isAutoMode=false) must NOT restore the auto-mode baseline",
+    );
+  } finally {
+    env.restoreEnv();
+    env.cleanup();
+  }
+});
+
+test("cross-mode (#4965): auto → guided → auto preserves the original auto-era baseline for the second auto run", async () => {
+  const env = makeTempProject();
+  try {
+    const availableModels = [
+      { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+    ];
+    const baselineTools = ["gsd_save_gate_result", "tool_a", "tool_b"];
+    const pi = makeRecordingPi(baselineTools);
+    clearToolBaseline(pi as unknown as object);
+
+    // Auto run 1 — captures baseline.
+    await selectAndApplyModel(
+      makeCtx(availableModels), pi as any, "gate-evaluate", "u1",
+      env.dir, undefined, false,
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      undefined, /* isAutoMode */ true,
+    );
+
+    // Guided dispatch in between — must not corrupt the baseline.
+    pi.setActiveTools(["narrow_for_guided"]);
+    await selectAndApplyModel(
+      makeCtx(availableModels), pi as any, "gate-evaluate", "u-guided",
+      env.dir, undefined, false,
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      undefined, /* isAutoMode */ false,
+    );
+
+    // Now narrow further (simulating any post-guided state) and run auto u2.
+    pi.setActiveTools(["something_completely_different"]);
+    const callsBeforeU2 = pi.__calls.length;
+
+    // Auto run 2 — must restore the ORIGINAL auto-era baseline, not the
+    // intervening narrow-for-guided state.
+    await selectAndApplyModel(
+      makeCtx(availableModels), pi as any, "gate-evaluate", "u2",
+      env.dir, undefined, false,
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      undefined, /* isAutoMode */ true,
+    );
+
+    const u2Calls = pi.__calls.slice(callsBeforeU2);
+    const restoreCall = u2Calls.find(
+      c => c.kind === "setActiveTools"
+        && Array.isArray(c.payload)
+        && (c.payload as string[]).length === baselineTools.length
+        && baselineTools.every(t => (c.payload as string[]).includes(t)),
+    );
+    assert.ok(
+      restoreCall,
+      "auto run 2 must restore the auto-era baseline [A, B, C] — proves guided-flow didn't corrupt it",
+    );
+  } finally {
+    env.restoreEnv();
+    env.cleanup();
+  }
+});


### PR DESCRIPTION
Closes #4965

## Summary

`selectAndApplyModel` was calling `restoreToolBaseline(pi)` unconditionally, but `guided-flow.ts:548` calls the same function with `isAutoMode=false`. Guided-flow has no `clearToolBaseline` hook of its own, so a guided-flow dispatch on a `pi` that previously hosted an auto session would resurrect the auto-era baseline and silently overwrite any tool changes made interactively between auto and guided dispatches.

The fix gates the restore by `isAutoMode`. The baseline is structurally an auto-mode concept (captured at auto start, restored to undo monotonic per-unit narrowing across auto units); gating it at the function level aligns the lifecycle with the hooks that own it (`startAuto` / `stopAuto`).

## Surfaced by

CodeRabbit Major finding on PR #4961 after merge. PR #4961 fixed the auto→auto case for #4959/#4681/#4850. This PR closes the auto→guided cross-mode leak that the same architectural choice exposed.

## Test plan

- [x] Test 7a — \`isAutoMode=false\` does NOT restore baseline even when one is recorded (negative assertion; reverting the gate makes this fail)
- [x] Test 7b — auto → guided → auto preserves the original auto-era baseline for the second auto run (proves guided-flow doesn't corrupt the WeakMap)
- [x] Existing tests 1a/1b/2/3a/3b/4/5/6 — all 10 pass locally
- [x] Anti-regression: temporarily reverting \`if (isAutoMode) restoreToolBaseline(pi)\` → 7a fails with the named assertion. Restoring → 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a bug where switching between guided flow and auto modes was causing user-configured tool settings to be unexpectedly overwritten with defaults.

* **Tests**
  * Added regression tests ensuring tool settings remain properly isolated between auto and guided flow modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->