### PR TITLE
fix(pi-ai): repair dangling XML tool parameters

### DIFF
--- a/packages/pi-ai/src/utils/repair-tool-json.ts
+++ b/packages/pi-ai/src/utils/repair-tool-json.ts
@@ -74,15 +74,19 @@ function parseXmlParameterValue(raw: string): unknown {
 }
 
 function extractXmlParameterBlocks(text: string): XmlParameterBlock[] {
-	const blocks: XmlParameterBlock[] = [];
+	const strictBlocks: XmlParameterBlock[] = [];
+	let hasNestedParameterOpening = false;
 	for (const match of text.matchAll(xmlParameterBlockPattern)) {
-		blocks.push({
+		const rawValue = match[2] ?? "";
+		hasNestedParameterOpening ||= rawValue.includes("<parameter");
+		strictBlocks.push({
 			name: match[1],
-			value: parseXmlParameterValue(match[2] ?? ""),
+			value: parseXmlParameterValue(rawValue),
 		});
 	}
-	if (blocks.length > 0) return blocks;
+	if (strictBlocks.length > 0 && !hasNestedParameterOpening) return strictBlocks;
 
+	const blocks: XmlParameterBlock[] = [];
 	const openings = [...text.matchAll(xmlParameterOpenPattern)];
 	for (let i = 0; i < openings.length; i++) {
 		const current = openings[i];

--- a/packages/pi-ai/src/utils/repair-tool-json.ts
+++ b/packages/pi-ai/src/utils/repair-tool-json.ts
@@ -61,6 +61,7 @@ type XmlParameterBlock = {
 };
 
 const xmlParameterBlockPattern = /<parameter\s+name="([^"]+)"\s*>([\s\S]*?)<\/parameter>/g;
+const xmlParameterOpenPattern = /<parameter\s+name="([^"]+)"\s*>/g;
 
 function parseXmlParameterValue(raw: string): unknown {
 	const trimmed = raw.trim();
@@ -78,6 +79,22 @@ function extractXmlParameterBlocks(text: string): XmlParameterBlock[] {
 		blocks.push({
 			name: match[1],
 			value: parseXmlParameterValue(match[2] ?? ""),
+		});
+	}
+	if (blocks.length > 0) return blocks;
+
+	const openings = [...text.matchAll(xmlParameterOpenPattern)];
+	for (let i = 0; i < openings.length; i++) {
+		const current = openings[i];
+		const next = openings[i + 1];
+		if (current.index === undefined) continue;
+
+		const start = current.index + current[0].length;
+		const end = next?.index ?? text.length;
+		const rawValue = text.slice(start, end).replace(/\s*<\/parameter>\s*$/, "");
+		blocks.push({
+			name: current[1],
+			value: parseXmlParameterValue(rawValue),
 		});
 	}
 	return blocks;

--- a/packages/pi-ai/src/utils/tests/repair-tool-json.test.ts
+++ b/packages/pi-ai/src/utils/tests/repair-tool-json.test.ts
@@ -163,6 +163,22 @@ describe("repairToolJson — XML parameter tag stripping (#3403)", () => {
 		assert.equal(parsed.oneLiner, "done");
 		assert.ok(!parsed.narrative.includes("<parameter"), "narrative should not retain leaked XML");
 	});
+
+	test("promotes mixed dangling and closed XML parameters from valid JSON string values", () => {
+		const malformed = JSON.stringify({
+			narrative:
+				'text.\n<parameter name="verification">all tests pass\n<parameter name="verificationEvidence">["npm test"]</parameter>',
+			oneLiner: "done",
+		});
+		const repaired = repairToolJson(malformed);
+		const parsed = JSON.parse(repaired);
+
+		assert.equal(parsed.narrative, "text.");
+		assert.equal(parsed.verification, "all tests pass");
+		assert.deepEqual(parsed.verificationEvidence, ["npm test"]);
+		assert.equal(parsed.oneLiner, "done");
+		assert.ok(!parsed.narrative.includes("<parameter"), "narrative should not retain leaked XML");
+	});
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/pi-ai/src/utils/tests/repair-tool-json.test.ts
+++ b/packages/pi-ai/src/utils/tests/repair-tool-json.test.ts
@@ -147,6 +147,22 @@ describe("repairToolJson — XML parameter tag stripping (#3403)", () => {
 		assert.equal(parsed.oneLiner, "done");
 		assert.ok(!parsed.narrative.includes("<parameter"), "narrative should not retain leaked XML");
 	});
+
+	test("promotes dangling XML parameters trapped inside valid JSON string values", () => {
+		const malformed = JSON.stringify({
+			narrative:
+				'text.\n<parameter name="verification">all tests pass\n<parameter name="verificationEvidence">["npm test"]',
+			oneLiner: "done",
+		});
+		const repaired = repairToolJson(malformed);
+		const parsed = JSON.parse(repaired);
+
+		assert.equal(parsed.narrative, "text.");
+		assert.equal(parsed.verification, "all tests pass");
+		assert.deepEqual(parsed.verificationEvidence, ["npm test"]);
+		assert.equal(parsed.oneLiner, "done");
+		assert.ok(!parsed.narrative.includes("<parameter"), "narrative should not retain leaked XML");
+	});
 });
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Linked issue

Closes #4770

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Repair dangling XML `<parameter>` tags that are embedded inside otherwise valid tool JSON string fields.
**Why:** The existing repair path detected those leaked tags but left required fields missing when the closing `</parameter>` tags were absent.
**How:** Fall back to parsing adjacent open `<parameter name="...">` boundaries when no strict closed XML parameter blocks are found.

## What

This updates `repairToolJson` so XML-parameter recovery can promote dangling parameter values out of a JSON string field. It keeps the existing strict closed-tag path first, then uses a fallback only when no closed parameter blocks are available.

A regression test covers a valid JSON payload where `verification` and `verificationEvidence` are trapped in a narrative string behind dangling open parameter tags.

## Why

Issue #4770 reports a third variant of leaked XML parameter syntax where the repair function detected XML but made no effective repair. That left structured tool fields missing even though the values were still recoverable from the payload.

## How

`extractXmlParameterBlocks` now collects closed `<parameter>...</parameter>` blocks as before. If none are present, it scans open `<parameter name="...">` markers and treats the content until the next marker or end of string as that parameter value. Existing value parsing and narrative cleanup then handle the promoted fields.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [x] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-ai/src/utils/tests/repair-tool-json.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:packages`

Manual verification:

1. Ran a before/after repro for JSON containing dangling `<parameter name="verification">` and `<parameter name="verificationEvidence">` content inside a string field.
2. Before the fix, XML was detected but `verification` stayed missing.
3. After the fix, `verification` and `verificationEvidence` are promoted and the narrative field is cleaned.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the JSON repair process to extract and promote parameter values from malformed or truncated XML fragments so important fields are preserved.
  * Removed leaked XML artifacts from narrative content while keeping primary text unchanged and producing valid repaired JSON.

* **Tests**
  * Added coverage for dangling and mixed/partially-closed XML parameter cases embedded in JSON strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->