### PR TITLE
fix(pi-ai): expose xhigh for gpt-5.5 custom models

### DIFF
--- a/packages/pi-ai/src/models.test.ts
+++ b/packages/pi-ai/src/models.test.ts
@@ -347,6 +347,15 @@ describe("applyCapabilityPatches", () => {
 		assert.equal(patched.capabilities?.supportsServiceTier, true);
 	});
 
+	it("patches a GPT-5.5 custom model that has no capabilities", () => {
+		const model = syntheticModel({ id: "gpt-5.5-custom" });
+		assert.equal(model.capabilities, undefined);
+
+		const [patched] = applyCapabilityPatches([model]);
+		assert.equal(patched.capabilities?.supportsXhigh, true);
+		assert.equal(patched.capabilities?.supportsServiceTier, undefined);
+	});
+
 	it("patches a GPT-5.2 model", () => {
 		const model = syntheticModel({ id: "gpt-5.2" });
 		const [patched] = applyCapabilityPatches([model]);

--- a/packages/pi-ai/src/models/capability-patches.ts
+++ b/packages/pi-ai/src/models/capability-patches.ts
@@ -3,10 +3,18 @@ import type { Api, Model, ModelCapabilities } from "../types.js";
 type CapabilityPatch = { match: (m: Model<Api>) => boolean; caps: ModelCapabilities };
 
 export const CAPABILITY_PATCHES: CapabilityPatch[] = [
-	// GPT-5.x supports xhigh thinking and OpenAI service tiers
+	// GPT-5.2-5.4 support xhigh thinking and OpenAI service tiers
 	{
-		match: (m) => m.id.includes("gpt-5.2") || m.id.includes("gpt-5.3") || m.id.includes("gpt-5.4"),
+		match: (m) =>
+			m.id.includes("gpt-5.2") ||
+			m.id.includes("gpt-5.3") ||
+			m.id.includes("gpt-5.4"),
 		caps: { supportsXhigh: true, supportsServiceTier: true },
+	},
+	// GPT-5.5 supports xhigh thinking; service-tier support is gated separately.
+	{
+		match: (m) => m.id.includes("gpt-5.5"),
+		caps: { supportsXhigh: true },
 	},
 	// Anthropic Opus 4.6+ supports xhigh thinking
 	{


### PR DESCRIPTION
## Linked issue

Closes #4927

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Add a capability patch so custom GPT-5.5 model IDs expose `xhigh` thinking.
**Why:** Custom OpenAI-compatible GPT-5.5 models could miss `supportsXhigh`, which hid the `xhigh` thinking option even though the base model family supports it.
**How:** Add a GPT-5.5-specific capability patch for `supportsXhigh` while leaving service-tier support gated by the existing service-tier guard.

## What

This updates the `pi-ai` capability patch table so model IDs containing `gpt-5.5` receive `supportsXhigh: true`, including custom model aliases that do not ship explicit capabilities.

The regression coverage verifies that a synthetic `gpt-5.5-custom` model gains `supportsXhigh` and does not accidentally gain `supportsServiceTier`. Existing GPT-5.4 service-tier behavior remains covered.

## Why

Issue #4927 reports that GPT-5.5 custom models do not expose the `xhigh` thinking level unless the provider response already includes `supportsXhigh`. The patch table already handled nearby GPT-5 model families, but GPT-5.5 was missing.

## How

The existing GPT-5.2 through GPT-5.4 patch keeps both `supportsXhigh` and `supportsServiceTier`. GPT-5.5 gets a separate patch that only adds `supportsXhigh`, preserving the current service-tier behavior until that payload support is explicitly verified.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [x] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-ai/src/models.test.ts src/resources/extensions/gsd/tests/service-tier.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:packages`

Manual verification:

1. Ran a before/after repro for a synthetic custom OpenAI-compatible `gpt-5.5-custom` model.
2. Before the fix, the model had no `supportsXhigh` capability.
3. After the fix, the model has `supportsXhigh: true` while `supportsServiceTier` remains unset.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated capability handling for GPT-5.5 model to enable Xhigh support while adjusting service-tier support settings.

* **Tests**
  * Added regression test for GPT-5.5 model capability patching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->