### PR TITLE
feat(mcp-client): read global MCP config from ~/.gsd/mcp.json

### DIFF
--- a/src/resources/extensions/gsd/commands-mcp-status.ts
+++ b/src/resources/extensions/gsd/commands-mcp-status.ts
@@ -120,7 +120,7 @@ export function formatMcpStatusReport(servers: McpServerStatus[]): string {
     return [
       "No MCP servers configured.",
       "",
-      "Add servers to .mcp.json, .gsd/mcp.json, or ~/.gsd/mcp.json to enable MCP integrations.",
+      "Add servers to .mcp.json, .gsd/mcp.json, or $GSD_HOME/mcp.json (default: ~/.gsd/mcp.json) to enable MCP integrations.",
       "Tip: run /gsd mcp init . to write the local GSD workflow MCP config.",
       "See: https://modelcontextprotocol.io/quickstart",
     ].join("\n");

--- a/src/resources/extensions/gsd/commands-mcp-status.ts
+++ b/src/resources/extensions/gsd/commands-mcp-status.ts
@@ -13,6 +13,7 @@
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { ensureProjectWorkflowMcpConfig } from "./mcp-project-config.js";
@@ -69,6 +70,7 @@ function readMcpConfigs(): McpServerRawConfig[] {
   const configPaths = [
     join(process.cwd(), ".mcp.json"),
     join(process.cwd(), ".gsd", "mcp.json"),
+    join(process.env.GSD_HOME || join(homedir(), ".gsd"), "mcp.json"),
   ];
 
   for (const configPath of configPaths) {
@@ -118,7 +120,7 @@ export function formatMcpStatusReport(servers: McpServerStatus[]): string {
     return [
       "No MCP servers configured.",
       "",
-      "Add servers to .mcp.json or .gsd/mcp.json to enable MCP integrations.",
+      "Add servers to .mcp.json, .gsd/mcp.json, or ~/.gsd/mcp.json to enable MCP integrations.",
       "Tip: run /gsd mcp init . to write the local GSD workflow MCP config.",
       "See: https://modelcontextprotocol.io/quickstart",
     ].join("\n");

--- a/src/resources/extensions/gsd/watch/header-renderer.ts
+++ b/src/resources/extensions/gsd/watch/header-renderer.ts
@@ -98,13 +98,15 @@ export function readGitBranch(projectRoot: string): string {
 }
 
 /**
- * Read MCP server names from .mcp.json or .gsd/mcp.json.
+ * Read MCP server names from .mcp.json, .gsd/mcp.json, and the global
+ * ~/.gsd/mcp.json (or $GSD_HOME/mcp.json).
  * Returns array of server name strings.
  */
 export function readMcpServerNames(projectRoot: string): string[] {
   const configPaths = [
     join(projectRoot, ".mcp.json"),
     join(projectRoot, ".gsd", "mcp.json"),
+    join(process.env.GSD_HOME || join(homedir(), ".gsd"), "mcp.json"),
   ];
   const names: string[] = [];
   const seen = new Set<string>();

--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -324,7 +324,7 @@ async function closeAll(): Promise<void> {
 // ─── Formatters ───────────────────────────────────────────────────────────────
 
 function formatServerList(servers: McpServerConfig[]): string {
-	if (servers.length === 0) return "No MCP servers configured. Add servers to .mcp.json, .gsd/mcp.json, or ~/.gsd/mcp.json.";
+	if (servers.length === 0) return "No MCP servers configured. Add servers to .mcp.json, .gsd/mcp.json, or $GSD_HOME/mcp.json (default: ~/.gsd/mcp.json).";
 
 	const lines: string[] = [`${servers.length} MCP servers configured:\n`];
 
@@ -387,7 +387,7 @@ export default function (pi: ExtensionAPI) {
 		name: "mcp_servers",
 		label: "MCP Servers",
 		description:
-			"List all available MCP servers configured in project files (.mcp.json, .gsd/mcp.json) or globally (~/.gsd/mcp.json). " +
+			"List all available MCP servers configured in project files (.mcp.json, .gsd/mcp.json) or globally ($GSD_HOME/mcp.json, default: ~/.gsd/mcp.json). " +
 			"Shows server names, transport type, and connection status. Use mcp_discover to get full tool schemas for a server.",
 		promptSnippet:
 			"List available MCP servers from project configuration",

--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -2,7 +2,8 @@
  * MCP Client Extension — Native MCP server integration for pi
  *
  * Provides on-demand access to MCP servers configured in project files
- * (.mcp.json, .gsd/mcp.json) using the @modelcontextprotocol/sdk Client
+ * (.mcp.json, .gsd/mcp.json) and the global ~/.gsd/mcp.json (or
+ * $GSD_HOME/mcp.json) using the @modelcontextprotocol/sdk Client
  * directly — no external CLI dependency required.
  *
  * Three tools:
@@ -24,6 +25,7 @@ import { Client } from "@modelcontextprotocol/sdk/client";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { readFileSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { buildHttpTransportOpts } from "./auth.js";
 import type { McpHttpAuthConfig } from "./auth.js";
@@ -102,6 +104,7 @@ function readConfigs(): McpServerConfig[] {
 	const configPaths = [
 		join(process.cwd(), ".mcp.json"),
 		join(process.cwd(), ".gsd", "mcp.json"),
+		join(process.env.GSD_HOME || join(homedir(), ".gsd"), "mcp.json"),
 	];
 
 	for (const configPath of configPaths) {
@@ -321,7 +324,7 @@ async function closeAll(): Promise<void> {
 // ─── Formatters ───────────────────────────────────────────────────────────────
 
 function formatServerList(servers: McpServerConfig[]): string {
-	if (servers.length === 0) return "No MCP servers configured. Add servers to .mcp.json or .gsd/mcp.json.";
+	if (servers.length === 0) return "No MCP servers configured. Add servers to .mcp.json, .gsd/mcp.json, or ~/.gsd/mcp.json.";
 
 	const lines: string[] = [`${servers.length} MCP servers configured:\n`];
 
@@ -384,7 +387,7 @@ export default function (pi: ExtensionAPI) {
 		name: "mcp_servers",
 		label: "MCP Servers",
 		description:
-			"List all available MCP servers configured in project files (.mcp.json, .gsd/mcp.json). " +
+			"List all available MCP servers configured in project files (.mcp.json, .gsd/mcp.json) or globally (~/.gsd/mcp.json). " +
 			"Shows server names, transport type, and connection status. Use mcp_discover to get full tool schemas for a server.",
 		promptSnippet:
 			"List available MCP servers from project configuration",

--- a/src/resources/extensions/mcp-client/tests/global-config.test.ts
+++ b/src/resources/extensions/mcp-client/tests/global-config.test.ts
@@ -29,23 +29,26 @@ before(() => {
 	cwdDir = realpathSync(mkdtempSync(join(tmpdir(), "mcp-cwd-")));
 	gsdHomeDir = realpathSync(mkdtempSync(join(tmpdir(), "mcp-gsdhome-")));
 
-	// Project-local fixture
+	// Project-local fixture (also defines `shared-server` for the precedence test)
 	writeFileSync(
 		join(cwdDir, ".mcp.json"),
 		JSON.stringify({
 			mcpServers: {
 				"project-server": { command: "echo", args: ["proj"] },
+				"shared-server": { command: "echo", args: ["from-project"] },
 			},
 		}),
 		"utf-8",
 	);
 
-	// Global fixture rooted at $GSD_HOME
+	// Global fixture rooted at $GSD_HOME (also defines `shared-server` to test
+	// that project-local takes precedence on name collision)
 	writeFileSync(
 		join(gsdHomeDir, "mcp.json"),
 		JSON.stringify({
 			mcpServers: {
 				"global-server": { command: "echo", args: ["glob"] },
+				"shared-server": { command: "echo", args: ["from-global"] },
 			},
 		}),
 		"utf-8",
@@ -74,4 +77,15 @@ test("#4757: project-local servers still resolve when global config exists", () 
 	const cfg = getServerConfig("project-server");
 	assert.ok(cfg, "project-local server must continue to resolve");
 	assert.equal(cfg?.sourcePath, join(cwdDir, ".mcp.json"));
+});
+
+test("#4757: project-local config wins on server-name collision", () => {
+	const cfg = getServerConfig("shared-server");
+	assert.ok(cfg, "shared server must resolve");
+	assert.equal(
+		cfg?.sourcePath,
+		join(cwdDir, ".mcp.json"),
+		"project-local config must take precedence over $GSD_HOME on name collision",
+	);
+	assert.deepEqual(cfg?.args, ["from-project"]);
 });

--- a/src/resources/extensions/mcp-client/tests/global-config.test.ts
+++ b/src/resources/extensions/mcp-client/tests/global-config.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression test for #4757 — readConfigs() must also read the global
+ * ~/.gsd/mcp.json (resolved as $GSD_HOME/mcp.json when GSD_HOME is set).
+ *
+ * Behaviour test against the exported getServerConfig — no source grep.
+ * The fixture is anchored via $GSD_HOME so the test never touches the
+ * developer's real ~/.gsd directory.
+ */
+
+import test, { before, after } from "node:test";
+import assert from "node:assert/strict";
+import { writeFileSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { getServerConfig } from "../index.js";
+
+let cwdDir: string;
+let gsdHomeDir: string;
+let originalCwd: string;
+let originalGsdHome: string | undefined;
+
+before(() => {
+	originalCwd = process.cwd();
+	originalGsdHome = process.env.GSD_HOME;
+
+	// realpathSync resolves any symlink in tmpdir() — on macOS /var → /private/var
+	// so process.cwd() after chdir matches what mkdtempSync returned.
+	cwdDir = realpathSync(mkdtempSync(join(tmpdir(), "mcp-cwd-")));
+	gsdHomeDir = realpathSync(mkdtempSync(join(tmpdir(), "mcp-gsdhome-")));
+
+	// Project-local fixture
+	writeFileSync(
+		join(cwdDir, ".mcp.json"),
+		JSON.stringify({
+			mcpServers: {
+				"project-server": { command: "echo", args: ["proj"] },
+			},
+		}),
+		"utf-8",
+	);
+
+	// Global fixture rooted at $GSD_HOME
+	writeFileSync(
+		join(gsdHomeDir, "mcp.json"),
+		JSON.stringify({
+			mcpServers: {
+				"global-server": { command: "echo", args: ["glob"] },
+			},
+		}),
+		"utf-8",
+	);
+
+	process.chdir(cwdDir);
+	process.env.GSD_HOME = gsdHomeDir;
+});
+
+after(() => {
+	process.chdir(originalCwd);
+	if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+	else process.env.GSD_HOME = originalGsdHome;
+	try { rmSync(cwdDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+	try { rmSync(gsdHomeDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+test("#4757: getServerConfig resolves servers declared in $GSD_HOME/mcp.json", () => {
+	const cfg = getServerConfig("global-server");
+	assert.ok(cfg, "server defined in $GSD_HOME/mcp.json must resolve");
+	assert.equal(cfg?.name, "global-server");
+	assert.equal(cfg?.sourcePath, join(gsdHomeDir, "mcp.json"));
+});
+
+test("#4757: project-local servers still resolve when global config exists", () => {
+	const cfg = getServerConfig("project-server");
+	assert.ok(cfg, "project-local server must continue to resolve");
+	assert.equal(cfg?.sourcePath, join(cwdDir, ".mcp.json"));
+});


### PR DESCRIPTION
## TL;DR

**What:** `mcp-client`, `/gsd mcp`, and the watch UI now also read `~/.gsd/mcp.json` (resolved as `$GSD_HOME/mcp.json`) on top of the existing project-local paths.
**Why:** Closes #4757 — without this, users have to duplicate global MCP servers in every project's `.mcp.json`. Inconsistent with the rest of GSD that already treats `~/.gsd/` as the global home.
**How:** Append the global path to `configPaths` in the three readers, using the existing `process.env.GSD_HOME || join(homedir(), ".gsd")` pattern that's already in 7+ other places in the codebase.

## What

Three reader sites and one new test:

- `src/resources/extensions/mcp-client/index.ts` — `readConfigs()`, file-level JSDoc, `mcp_servers` tool description, and the empty-state formatter message now include the global path.
- `src/resources/extensions/gsd/commands-mcp-status.ts` — `readMcpConfigs()` and the `formatMcpStatusReport` empty-state message updated symmetrically.
- `src/resources/extensions/gsd/watch/header-renderer.ts` — `readMcpServerNames()` updated so the watch header also lists globally-declared servers.
- `src/resources/extensions/mcp-client/tests/global-config.test.ts` — new `node:test` behavior coverage that fixtures `$GSD_HOME` to a sandbox tmpdir and asserts via the exported `getServerConfig`. No source-grep, no contact with the developer's real `~/.gsd`.

## Why

The issue identifies that `mcp_servers`, `mcp_discover`, `mcp_call`, and `/gsd mcp` only see project-local config. There is no documented reason for excluding the global config — the rest of the codebase already uses `~/.gsd/` (or `GSD_HOME`) for agent state, crash logs, sessions, etc.: `src/app-paths.ts`, `src/rtk-shared.ts`, `extensions/ttsr/rule-loader.ts`, `extensions/remote-questions/status.ts`, `extensions/search-the-web/provider.ts`, `extensions/gsd/repo-identity.ts`, `extensions/gsd/workflow-plugins.ts`, etc.

The watch header (`readMcpServerNames`) had the exact same code shape and was therefore the same bug; fixed in the same change for consistency.

## How

Path precedence stays "first wins on name collision". The global path is appended **last** in `configPaths`:

1. `<cwd>/.mcp.json`
2. `<cwd>/.gsd/mcp.json`
3. `$GSD_HOME/mcp.json` (defaulting to `~/.gsd/mcp.json`) — new

This matches the "project overrides global" convention used by Claude Code, Cursor, Windsurf, etc.

The new path is always consulted — there's no opt-in flag — because (a) the issue describes it as a missing default, not a feature to gate, and (b) the existing readers already silently skip non-existent paths via `existsSync`, so users without a `~/.gsd/mcp.json` see no behavior change.

### Tests

`global-config.test.ts` follows the same pattern as the existing `server-name-spaces.test.ts`:

- `mkdtempSync` + `realpathSync` sandboxes for both `process.cwd()` and `$GSD_HOME` (the `realpathSync` is to canonicalize macOS `/var → /private/var` so `process.cwd()` after `chdir` matches what we wrote)
- `before` writes fixture `mcp.json` files into both
- two tests assert `getServerConfig` resolves both global and project servers, and check `sourcePath` to prove which file each came from
- `after` restores `cwd` + `GSD_HOME` and rms the temp dirs

It does not import `readConfigs` directly — assertions go through the public `getServerConfig`, so this is a behaviour test, not a source-grep test.

## Verification

- ✅ Targeted: `node --test "dist-test/src/resources/extensions/mcp-client/tests/*.test.js"` — 7/7 pass (2 new + 5 existing #3029 cases)
- ✅ Full: `npm test` — all suites green (test:unit + test:integration + test:packages, ~2570 tests, 0 failures)
- ✅ `npm run build` — clean (core + web)
- ✅ `npx tsc --noEmit` — no errors

## Out of scope (potential follow-ups)

A handful of user-facing docs still mention only the project-local paths and would benefit from the same one-line update — happy to do them in a follow-up doc-only PR if you'd prefer to keep this PR focused:

- `gitbook/configuration/mcp-servers.md`
- `gitbook/reference/troubleshooting.md`
- `mintlify-docs/getting-started.mdx`
- `mintlify-docs/guides/configuration.mdx`
- `mintlify-docs/guides/troubleshooting.mdx`
- `docs/user-docs/configuration.md`
- `docs/user-docs/troubleshooting.md`

## Change type

- [x] `feat` — new functionality (read global MCP config)

## Disclosure

This PR is AI-assisted (Claude Code). The author understands the change and is responsible for the code.

Closes #4757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global MCP server configuration discovery added: the app now checks $GSD_HOME/mcp.json (or ~/.gsd/mcp.json when GSD_HOME is unset) in addition to project-level configs; empty-state guidance updated to mention the global search location.

* **Tests**
  * Added regression test validating resolution and precedence between global and project MCP configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->