### PR TITLE
fix(subagent): thread model override through subagent spawning

### DIFF
--- a/src/resources/extensions/subagent/index.ts
+++ b/src/resources/extensions/subagent/index.ts
@@ -264,9 +264,11 @@ function buildSubagentProcessArgs(
 	agent: AgentConfig,
 	task: string,
 	tmpPromptPath: string | null,
+	modelOverride?: string,
 ): string[] {
 	const args: string[] = ["--mode", "json", "-p", "--no-session"];
-	if (agent.model) args.push("--model", agent.model);
+	const effectiveModel = modelOverride || agent.model;
+	if (effectiveModel) args.push("--model", effectiveModel);
 	if (agent.tools && agent.tools.length > 0) args.push("--tools", agent.tools.join(","));
 	if (tmpPromptPath) args.push("--append-system-prompt", tmpPromptPath);
 	args.push(`Task: ${task}`);
@@ -336,6 +338,7 @@ async function runSingleAgent(
 	signal: AbortSignal | undefined,
 	onUpdate: OnUpdateCallback | undefined,
 	makeDetails: (results: SingleResult[]) => SubagentDetails,
+	modelOverride?: string,
 ): Promise<SingleResult> {
 	const agent = agents.find((a) => a.name === agentName);
 
@@ -400,7 +403,7 @@ async function runSingleAgent(
 			tmpPromptDir = tmp.dir;
 			tmpPromptPath = tmp.filePath;
 		}
-		const args = buildSubagentProcessArgs(agent, task, tmpPromptPath);
+		const args = buildSubagentProcessArgs(agent, task, tmpPromptPath, modelOverride);
 		let wasAborted = false;
 
 		const exitCode = await new Promise<number>((resolve) => {
@@ -480,10 +483,11 @@ async function runSingleAgentInCmuxSplit(
 	signal: AbortSignal | undefined,
 	onUpdate: OnUpdateCallback | undefined,
 	makeDetails: (results: SingleResult[]) => SubagentDetails,
+	modelOverride?: string,
 ): Promise<SingleResult> {
 	const agent = agents.find((a) => a.name === agentName);
 	if (!agent) {
-		return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails);
+		return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride);
 	}
 
 	let tmpPromptDir: string | null = null;
@@ -528,12 +532,12 @@ async function runSingleAgentInCmuxSplit(
 			? await cmuxClient.createSplit(directionOrSurfaceId as "right" | "down" | "left" | "up")
 			: directionOrSurfaceId;
 		if (!cmuxSurfaceId) {
-			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails);
+			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride);
 		}
 
 		const bundledPaths = (process.env.GSD_BUNDLED_EXTENSION_PATHS ?? "").split(path.delimiter).map((s) => s.trim()).filter(Boolean);
 		const extensionArgs = bundledPaths.flatMap((p) => ["--extension", p]);
-		const processArgs = [process.env.GSD_BIN_PATH!, ...extensionArgs, ...buildSubagentProcessArgs(agent, task, tmpPromptPath)];
+		const processArgs = [process.env.GSD_BIN_PATH!, ...extensionArgs, ...buildSubagentProcessArgs(agent, task, tmpPromptPath, modelOverride)];
 		// Normalize all paths to forward slashes before embedding in bash strings.
 		// On Windows, backslashes are interpreted as escape characters by bash,
 		// mangling paths like C:\Users\user into C:Useruser (#1436).
@@ -548,7 +552,7 @@ async function runSingleAgentInCmuxSplit(
 
 		const sent = await cmuxClient.sendSurface(cmuxSurfaceId, `bash -lc ${shellEscape(innerScript)}`);
 		if (!sent) {
-			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails);
+			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride);
 		}
 
 		const finished = await waitForFile(exitPath, signal);
@@ -595,12 +599,14 @@ const TaskItem = Type.Object({
 	agent: Type.String({ description: "Name of the agent to invoke" }),
 	task: Type.String({ description: "Task to delegate to the agent" }),
 	cwd: Type.Optional(Type.String({ description: "Working directory for the agent process" })),
+	model: Type.Optional(Type.String({ description: "Model override for this task (e.g. 'claude-sonnet-4-6')" })),
 });
 
 const ChainItem = Type.Object({
 	agent: Type.String({ description: "Name of the agent to invoke" }),
 	task: Type.String({ description: "Task with optional {previous} placeholder for prior output" }),
 	cwd: Type.Optional(Type.String({ description: "Working directory for the agent process" })),
+	model: Type.Optional(Type.String({ description: "Model override for this step (e.g. 'claude-sonnet-4-6')" })),
 });
 
 const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
@@ -618,6 +624,7 @@ const SubagentParams = Type.Object({
 		Type.Boolean({ description: "Prompt before running project-local agents. Default: false.", default: false }),
 	),
 	cwd: Type.Optional(Type.String({ description: "Working directory for the agent process (single mode)" })),
+	model: Type.Optional(Type.String({ description: "Model override for the subagent (e.g. 'claude-sonnet-4-6'). Takes precedence over the agent's frontmatter model." })),
 	isolated: Type.Optional(
 		Type.Boolean({
 			description:
@@ -767,6 +774,7 @@ export default function (pi: ExtensionAPI) {
 						signal,
 						chainUpdate,
 						makeDetails("chain"),
+						step.model || params.model,
 					);
 					results.push(result);
 
@@ -839,6 +847,7 @@ export default function (pi: ExtensionAPI) {
 					: [];
 				const results = await mapWithConcurrencyLimit(params.tasks, MAX_CONCURRENCY, async (t, index) => {
 					const workerId = registerWorker(t.agent, t.task, index, batchSize, batchId);
+					const taskModel = t.model || params.model;
 					const runTask = () => cmuxSplitsEnabled
 						? runSingleAgentInCmuxSplit(
 							cmuxClient,
@@ -857,6 +866,7 @@ export default function (pi: ExtensionAPI) {
 								}
 							},
 							makeDetails("parallel"),
+							taskModel,
 						)
 						: runSingleAgent(
 							ctx.cwd,
@@ -873,6 +883,7 @@ export default function (pi: ExtensionAPI) {
 								}
 							},
 							makeDetails("parallel"),
+							taskModel,
 						);
 					let result = await runTask();
 
@@ -931,6 +942,7 @@ export default function (pi: ExtensionAPI) {
 							signal,
 							onUpdate,
 							makeDetails("single"),
+							params.model,
 						)
 						: await runSingleAgent(
 							ctx.cwd,
@@ -942,6 +954,7 @@ export default function (pi: ExtensionAPI) {
 							signal,
 							onUpdate,
 							makeDetails("single"),
+							params.model,
 						);
 
 					// Capture and merge delta if isolated

--- a/src/resources/extensions/subagent/index.ts
+++ b/src/resources/extensions/subagent/index.ts
@@ -267,7 +267,7 @@ export function buildSubagentProcessArgs(
 	modelOverride?: string,
 ): string[] {
 	const args: string[] = ["--mode", "json", "-p", "--no-session"];
-	const effectiveModel = modelOverride || agent.model;
+	const effectiveModel = modelOverride ?? agent.model;
 	if (effectiveModel) args.push("--model", effectiveModel);
 	if (agent.tools && agent.tools.length > 0) args.push("--tools", agent.tools.join(","));
 	if (tmpPromptPath) args.push("--append-system-prompt", tmpPromptPath);

--- a/src/resources/extensions/subagent/index.ts
+++ b/src/resources/extensions/subagent/index.ts
@@ -260,7 +260,7 @@ function writePromptToTempFile(agentName: string, prompt: string): { dir: string
 	return { dir: tmpDir, filePath };
 }
 
-function buildSubagentProcessArgs(
+export function buildSubagentProcessArgs(
 	agent: AgentConfig,
 	task: string,
 	tmpPromptPath: string | null,

--- a/src/resources/extensions/subagent/index.ts
+++ b/src/resources/extensions/subagent/index.ts
@@ -384,7 +384,7 @@ async function runSingleAgent(
 		messages: [],
 		stderr: "",
 		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
-		model: agent.model,
+		model: modelOverride ?? agent.model,
 		step,
 	};
 
@@ -502,7 +502,7 @@ async function runSingleAgentInCmuxSplit(
 		messages: [],
 		stderr: "",
 		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
-		model: agent.model,
+		model: modelOverride ?? agent.model,
 		step,
 	};
 

--- a/src/resources/extensions/subagent/tests/model-override.test.ts
+++ b/src/resources/extensions/subagent/tests/model-override.test.ts
@@ -9,9 +9,10 @@ function makeAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
 		description: "A test agent",
 		systemPrompt: "You are a test agent",
 		source: "project" as const,
+		filePath: "test-agent.md",
 		tools: [],
 		...overrides,
-	} as AgentConfig;
+	};
 }
 
 describe("buildSubagentProcessArgs model override", () => {

--- a/src/resources/extensions/subagent/tests/model-override.test.ts
+++ b/src/resources/extensions/subagent/tests/model-override.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildSubagentProcessArgs } from "../index.js";
+import type { AgentConfig } from "../agents.js";
+
+function makeAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+	return {
+		name: "test-agent",
+		description: "A test agent",
+		systemPrompt: "You are a test agent",
+		source: "project" as const,
+		tools: [],
+		...overrides,
+	} as AgentConfig;
+}
+
+describe("buildSubagentProcessArgs model override", () => {
+	it("uses modelOverride when provided", () => {
+		const agent = makeAgent({ model: "claude-haiku-4-5-20251001" });
+		const args = buildSubagentProcessArgs(agent, "do something", null, "claude-sonnet-4-6");
+		const modelIndex = args.indexOf("--model");
+		assert.notEqual(modelIndex, -1, "should include --model flag");
+		assert.equal(args[modelIndex + 1], "claude-sonnet-4-6");
+	});
+
+	it("falls back to agent.model when no override provided", () => {
+		const agent = makeAgent({ model: "claude-haiku-4-5-20251001" });
+		const args = buildSubagentProcessArgs(agent, "do something", null);
+		const modelIndex = args.indexOf("--model");
+		assert.notEqual(modelIndex, -1, "should include --model flag");
+		assert.equal(args[modelIndex + 1], "claude-haiku-4-5-20251001");
+	});
+
+	it("omits --model when neither override nor agent.model is set", () => {
+		const agent = makeAgent({ model: undefined });
+		const args = buildSubagentProcessArgs(agent, "do something", null);
+		assert.equal(args.indexOf("--model"), -1, "should not include --model flag");
+	});
+
+	it("override takes precedence over agent.model", () => {
+		const agent = makeAgent({ model: "model-a" });
+		const args = buildSubagentProcessArgs(agent, "task", null, "model-b");
+		const modelIndex = args.indexOf("--model");
+		assert.equal(args[modelIndex + 1], "model-b");
+	});
+
+	it("uses override even when agent has no model", () => {
+		const agent = makeAgent({ model: undefined });
+		const args = buildSubagentProcessArgs(agent, "task", null, "model-override");
+		const modelIndex = args.indexOf("--model");
+		assert.notEqual(modelIndex, -1);
+		assert.equal(args[modelIndex + 1], "model-override");
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `model` parameter to `SubagentParams`, `TaskItem`, and `ChainItem` tool schemas
- Threads the model override through `buildSubagentProcessArgs` → `runSingleAgent` → `runSingleAgentInCmuxSplit` to the `--model` CLI flag
- Allows LLM to override an agent's frontmatter model at call time (e.g. route a `worker` to Sonnet for execution tasks)

## Context

Subscription users on flat-rate plans (Claude Max/Pro) who enable `allow_flat_rate_providers` for dynamic routing currently have no way to override the model at the subagent tool-call level. The agent frontmatter model is respected, but the LLM cannot route a subagent to a different model per-task. This means thinking/planning agents can't be routed to Opus while execution agents go to Sonnet within the same session.

The `model` parameter follows the same precedence pattern as `cwd`: task-level override > top-level override > agent frontmatter > dynamic routing default.

Related: #4394, #4386

## Test plan

- [x] Verified subagent spawning with explicit `model` parameter routes to the specified model
- [x] Verified agents without model override still use frontmatter model
- [x] Verified agents with no frontmatter model and no override inherit from dynamic routing
- [x] Confirmed Sonnet usage spike on Claude dashboard when spawning multiple Sonnet-routed agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional model override support at multiple levels (global, per-task, per-step) so individual subagent tasks can target specific models.
* **Bug Fixes**
  * Ensured consistent model selection and proper forwarding of overrides across split, fallback, and chained execution paths.
* **Tests**
  * Added tests verifying override precedence and behavior when agent or override models are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->