### PR TITLE
fix(auto): unblock discuss-milestone in non-interactive sessions; classify deterministic errors as non-retriable

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -61,6 +61,8 @@ import { resolveUokFlags } from "./uok/flags.js";
 import { selectReactiveDispatchBatch } from "./uok/execution-graph.js";
 import { getMilestonePipelineVariant } from "./milestone-scope-classifier.js";
 import { EXECUTION_ENTRY_PHASES, hasFinalizedMilestoneContext } from "./uok/plan-v2.js";
+import { isAutoActive } from "./auto.js";
+import { markDepthVerified } from "./bootstrap/write-gate.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -276,6 +278,16 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // Align with the plan-v2 gate's lookup semantics: whitespace-only counts
       // as missing, and an auto worktree may fall back to GSD_PROJECT_ROOT.
       if (hasFinalizedMilestoneContext(basePath, mid)) return null;
+      // H6 fix (#4973): In auto-mode there is no human to answer the
+      // depth-verification ask_user_questions, so the write-gate deadlocks.
+      // Pre-mark the milestone as depth-verified so gsd_summary_save({artifact_type:"CONTEXT"})
+      // is not blocked. Safe ordering: session_switch fires clearDiscussionFlowState()
+      // (register-hooks.ts:106) before before_agent_start, which fires before resolveDispatch
+      // reaches this match fn — so this call always happens after any session-switch reset.
+      // Interactive sessions (isAutoActive()===false) are unaffected.
+      if (isAutoActive()) {
+        markDepthVerified(mid);
+      }
       return {
         action: "dispatch",
         unitType: "discuss-milestone",
@@ -411,6 +423,12 @@ export const DISPATCH_RULES: DispatchRule[] = [
     name: "needs-discussion → discuss-milestone",
     match: async ({ state, mid, midTitle, basePath, structuredQuestionsAvailable }) => {
       if (state.phase !== "needs-discussion") return null;
+      // H6 fix (#4973): auto-mark depth-verified so the write-gate does not
+      // deadlock in non-interactive (auto-mode) runs. See ordering note at
+      // "execution-entry phase (no context) → discuss-milestone" above.
+      if (isAutoActive()) {
+        markDepthVerified(mid);
+      }
       return {
         action: "dispatch",
         unitType: "discuss-milestone",
@@ -431,6 +449,12 @@ export const DISPATCH_RULES: DispatchRule[] = [
       const contextFile = resolveMilestoneFile(basePath, mid, "CONTEXT");
       const hasContext = !!(contextFile && (await loadFile(contextFile)));
       if (hasContext) return null; // fall through to next rule
+      // H6 fix (#4973): auto-mark depth-verified so the write-gate does not
+      // deadlock in non-interactive (auto-mode) runs. See ordering note at
+      // "execution-entry phase (no context) → discuss-milestone" above.
+      if (isAutoActive()) {
+        markDepthVerified(mid);
+      }
       return {
         action: "dispatch",
         unitType: "discuss-milestone",

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -286,7 +286,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // reaches this match fn — so this call always happens after any session-switch reset.
       // Interactive sessions (isAutoActive()===false) are unaffected.
       if (isAutoActive()) {
-        markDepthVerified(mid);
+        markDepthVerified(mid, basePath);
       }
       return {
         action: "dispatch",
@@ -427,7 +427,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // deadlock in non-interactive (auto-mode) runs. See ordering note at
       // "execution-entry phase (no context) → discuss-milestone" above.
       if (isAutoActive()) {
-        markDepthVerified(mid);
+        markDepthVerified(mid, basePath);
       }
       return {
         action: "dispatch",
@@ -453,7 +453,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // deadlock in non-interactive (auto-mode) runs. See ordering note at
       // "execution-entry phase (no context) → discuss-milestone" above.
       if (isAutoActive()) {
-        markDepthVerified(mid);
+        markDepthVerified(mid, basePath);
       }
       return {
         action: "dispatch",

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -99,7 +99,7 @@ export async function selectAndApplyModel(
   prefs: GSDPreferences | undefined,
   verbose: boolean,
   autoModeStartModel: { provider: string; id: string; flatRateCtx?: FlatRateContext } | null,
-  retryContext?: { isRetry: boolean; previousTier?: string; isDeterministicError?: boolean },
+  retryContext?: { isRetry: boolean; previousTier?: string },
   /** When false (interactive/guided-flow), skip dynamic routing and use the session model.
    *  Dynamic routing only applies in auto-mode where cost optimization is expected. (#3962) */
   isAutoMode = true,
@@ -236,14 +236,14 @@ export async function selectAndApplyModel(
         const availableModelIds = routingEligibleModels.map(m => `${m.provider}/${m.id}`);
 
         // Escalate tier on retry when escalate_on_failure is enabled (default: true).
-        // #4973: Skip escalation entirely for deterministic policy errors — the model
-        // tier is irrelevant because a structural gate (not model quality) caused the
-        // failure. Escalating only wastes money on the same deterministic rejection.
+        // #4973: Deterministic policy errors are short-circuited at the postUnit
+        // level (auto-post-unit.ts writes a placeholder and returns "continue"),
+        // so this code path only runs for legitimate model-quality retries where
+        // tier escalation is the right response.
         if (
           retryContext?.isRetry &&
           retryContext.previousTier &&
-          routingConfig.escalate_on_failure !== false &&
-          !retryContext.isDeterministicError
+          routingConfig.escalate_on_failure !== false
         ) {
           const escalated = escalateTier(retryContext.previousTier as ComplexityTier);
           if (escalated) {

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -99,7 +99,7 @@ export async function selectAndApplyModel(
   prefs: GSDPreferences | undefined,
   verbose: boolean,
   autoModeStartModel: { provider: string; id: string; flatRateCtx?: FlatRateContext } | null,
-  retryContext?: { isRetry: boolean; previousTier?: string },
+  retryContext?: { isRetry: boolean; previousTier?: string; isDeterministicError?: boolean },
   /** When false (interactive/guided-flow), skip dynamic routing and use the session model.
    *  Dynamic routing only applies in auto-mode where cost optimization is expected. (#3962) */
   isAutoMode = true,
@@ -235,11 +235,15 @@ export async function selectAndApplyModel(
         );
         const availableModelIds = routingEligibleModels.map(m => `${m.provider}/${m.id}`);
 
-        // Escalate tier on retry when escalate_on_failure is enabled (default: true)
+        // Escalate tier on retry when escalate_on_failure is enabled (default: true).
+        // #4973: Skip escalation entirely for deterministic policy errors — the model
+        // tier is irrelevant because a structural gate (not model quality) caused the
+        // failure. Escalating only wastes money on the same deterministic rejection.
         if (
           retryContext?.isRetry &&
           retryContext.previousTier &&
-          routingConfig.escalate_on_failure !== false
+          routingConfig.escalate_on_failure !== false &&
+          !retryContext.isDeterministicError
         ) {
           const escalated = escalateTier(retryContext.previousTier as ComplexityTier);
           if (escalated) {
@@ -249,6 +253,17 @@ export async function selectAndApplyModel(
               `Tier escalation: ${retryContext.previousTier} → ${escalated} (retry after failure)`,
               "info",
             );
+          } else {
+            // #4973: Already at max tier — keep previousTier rather than letting
+            // fresh classification silently downgrade the model back to a lower tier.
+            // Without this, a light-start unit on retry 3 would revert to the light
+            // model after escalating to heavy on retries 1 and 2.
+            const tierOrder: Record<string, number> = { light: 0, standard: 1, heavy: 2 };
+            const prevOrder = tierOrder[retryContext.previousTier] ?? 0;
+            const freshOrder = tierOrder[classification.tier] ?? 0;
+            if (prevOrder > freshOrder) {
+              classification = { ...classification, tier: retryContext.previousTier as ComplexityTier, reason: "retained escalated tier from retry" };
+            }
           }
         }
 

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -72,6 +72,7 @@ import { UokGateRunner } from "./uok/gate-runner.js";
 import { writeTurnGitTransaction } from "./uok/gitops.js";
 import { isClosedStatus } from "./status-guards.js";
 import { detectAbandonMilestone } from "./abandon-detect.js";
+import { isDeterministicPolicyError } from "./auto-tool-tracking.js";
 
 /** Maximum verification retry attempts before escalating to blocker placeholder (#2653). */
 const MAX_VERIFICATION_RETRIES = 3;
@@ -908,10 +909,22 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       // After MAX_VERIFICATION_RETRIES, escalate to writeBlockerPlaceholder so the
       // pipeline can advance instead of looping forever (#2653).
       //
-      // HOWEVER, if the DB is unavailable (db_unavailable), the artifact was never
-      // written because the completion tool failed at the infra level. Retrying
-      // can never succeed and produces a costly re-dispatch loop (#2517).
-      if (!triggerArtifactVerified && !isDbAvailable()) {
+      // #4973: Deterministic policy rejections (e.g. context_write_blocked from the
+      // write-gate) are checked FIRST — before the DB-availability check — because
+      // they are structural gates that will fire on every retry regardless of DB or
+      // model tier. Short-circuit immediately by writing a blocker placeholder.
+      if (!triggerArtifactVerified && s.lastToolInvocationError && isDeterministicPolicyError(s.lastToolInvocationError)) {
+        debugLog("postUnit", { phase: "deterministic-policy-error-placeholder", unitType: s.currentUnit.type, unitId: s.currentUnit.id, error: s.lastToolInvocationError });
+        const reason = `Deterministic policy rejection for ${s.currentUnit.type} "${s.currentUnit.id}": ${s.lastToolInvocationError}. Retrying cannot resolve this gate — writing blocker placeholder to advance pipeline.`;
+        s.lastToolInvocationError = null;
+        s.pendingVerificationRetry = null;
+        writeBlockerPlaceholder(s.currentUnit.type, s.currentUnit.id, s.basePath, reason);
+        ctx.ui.notify(
+          `${s.currentUnit.type} ${s.currentUnit.id} — deterministic policy rejection, wrote blocker placeholder (no retries) (#4973)`,
+          "warning",
+        );
+        // Fall through to "continue" — do NOT enter the retry or db-unavailable paths.
+      } else if (!triggerArtifactVerified && !isDbAvailable()) {
         // DB infra failure — do NOT retry; the completion tool returned
         // db_unavailable so the artifact was never written. Retrying would
         // produce an infinite re-dispatch loop (#2517).

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -914,10 +914,12 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       // they are structural gates that will fire on every retry regardless of DB or
       // model tier. Short-circuit immediately by writing a blocker placeholder.
       if (!triggerArtifactVerified && s.lastToolInvocationError && isDeterministicPolicyError(s.lastToolInvocationError)) {
+        const retryKey = `${s.currentUnit.type}:${s.currentUnit.id}`;
         debugLog("postUnit", { phase: "deterministic-policy-error-placeholder", unitType: s.currentUnit.type, unitId: s.currentUnit.id, error: s.lastToolInvocationError });
         const reason = `Deterministic policy rejection for ${s.currentUnit.type} "${s.currentUnit.id}": ${s.lastToolInvocationError}. Retrying cannot resolve this gate — writing blocker placeholder to advance pipeline.`;
         s.lastToolInvocationError = null;
         s.pendingVerificationRetry = null;
+        s.verificationRetryCount.delete(retryKey);
         writeBlockerPlaceholder(s.currentUnit.type, s.currentUnit.id, s.basePath, reason);
         ctx.ui.notify(
           `${s.currentUnit.type} ${s.currentUnit.id} — deterministic policy rejection, wrote blocker placeholder (no retries) (#4973)`,

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -125,9 +125,14 @@ export function isQueuedUserMessageSkip(errorMsg: string): boolean {
  */
 export const DETERMINISTIC_POLICY_ERROR_STRINGS = [
   // gsd_summary_save write-gate: CONTEXT artifact blocked pending depth verification (#4973).
-  // Matches the fallback text in workflow-tool-executors.ts and the verbose reason from write-gate.ts.
+  // Matches the fallback text in workflow-tool-executors.ts and the verbose reason
+  // from shouldBlockContextArtifactSaveInSnapshot at write-gate.ts:432-442.
   "context write blocked",
   "CONTEXT without depth verification",
+  // Raw write tool gate (#4973): shouldBlockContextWrite at write-gate.ts:390-399 emits
+  // "Cannot write to milestone CONTEXT.md without depth verification." for direct
+  // write tool calls to *-CONTEXT.md paths (different code path than gsd_summary_save).
+  "CONTEXT.md without depth verification",
 ] as const;
 
 /**

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -112,3 +112,30 @@ export function isQueuedUserMessageSkip(errorMsg: string): boolean {
   if (!errorMsg) return false;
   return /^Skipped due to queued user message\.?$/i.test(errorMsg.trim());
 }
+
+// ─── Deterministic policy error classification (#4973) ─────────────────────
+
+/**
+ * Known deterministic policy error substrings. Each entry is a stable string
+ * that will appear in the tool error text content when the corresponding
+ * policy gate fires. Retrying these errors will always produce the same outcome.
+ *
+ * Add new entries here as new deterministic gates are introduced. Do NOT use
+ * regex — explicit substrings keep the list auditable.
+ */
+export const DETERMINISTIC_POLICY_ERROR_STRINGS = [
+  // gsd_summary_save write-gate: CONTEXT artifact blocked pending depth verification (#4973).
+  // Matches the fallback text in workflow-tool-executors.ts and the verbose reason from write-gate.ts.
+  "context write blocked",
+  "CONTEXT without depth verification",
+] as const;
+
+/**
+ * Returns true if the error message indicates a deterministic policy rejection
+ * (a structural gate that will fire on every retry regardless of model quality).
+ * Used by postUnitPreVerification to short-circuit the retry loop (#4973).
+ */
+export function isDeterministicPolicyError(errorMsg: string): boolean {
+  if (!errorMsg) return false;
+  return DETERMINISTIC_POLICY_ERROR_STRINGS.some(s => errorMsg.includes(s));
+}

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -84,6 +84,7 @@ import {
   clearInFlightTools,
   isToolInvocationError,
   isQueuedUserMessageSkip,
+  isDeterministicPolicyError,
 } from "./auto-tool-tracking.js";
 import { closeoutUnit } from "./auto-unit-closeout.js";
 import { recoverTimedOutUnit } from "./auto-timeout-recovery.js";
@@ -544,12 +545,14 @@ export function markToolEnd(toolCallId: string): void {
 /**
  * Record a tool invocation error on the current session (#2883).
  * Called from tool_execution_end when a GSD tool fails with isError.
- * Only stores the error if it matches the tool-invocation-error pattern
- * (malformed/truncated JSON), not normal business-logic errors.
+ * Stores the error if it matches:
+ *   - tool-invocation-error pattern (malformed/truncated JSON)
+ *   - queued-user-message skip pattern
+ *   - deterministic policy rejection (#4973, e.g. context_write_blocked)
  */
 export function recordToolInvocationError(toolName: string, errorMsg: string): void {
   if (!s.active) return;
-  if (isToolInvocationError(errorMsg) || isQueuedUserMessageSkip(errorMsg)) {
+  if (isToolInvocationError(errorMsg) || isQueuedUserMessageSkip(errorMsg) || isDeterministicPolicyError(errorMsg)) {
     s.lastToolInvocationError = `${toolName}: ${errorMsg}`;
   }
 }

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -18,6 +18,7 @@ import { loadToolApiKeys } from "../commands-config.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
 import { deriveState } from "../state.js";
 import { getAutoDashboardData, isAutoActive, isAutoPaused, markToolEnd, markToolStart, recordToolInvocationError } from "../auto.js";
+import { isDeterministicPolicyError } from "../auto-tool-tracking.js";
 
 import { isParallelActive, shutdownParallel } from "../parallel-orchestrator.js";
 import { checkToolCallLoop, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
@@ -393,7 +394,7 @@ export function registerHooks(
     if (isAutoActive() && typeof event.toolCallId === "string") {
       markToolEnd(event.toolCallId);
     }
-    if (isAutoActive() && event.isError && event.toolName.startsWith("gsd_")) {
+    if (isAutoActive() && event.isError) {
       const resultPayload = ("result" in event ? event.result : undefined) as any;
       const errorText = typeof resultPayload === "string"
         ? resultPayload
@@ -402,7 +403,12 @@ export function registerHooks(
             : (typeof (event as any).content === "string"
                 ? (event as any).content
                 : String(resultPayload ?? "")));
-      recordToolInvocationError(event.toolName, errorText);
+      // #4973: Capture deterministic policy errors regardless of tool prefix —
+      // the raw `write` tool can hit shouldBlockContextWrite and would otherwise
+      // be missed by the gsd_-only filter.
+      if (event.toolName.startsWith("gsd_") || isDeterministicPolicyError(errorText)) {
+        recordToolInvocationError(event.toolName, errorText);
+      }
     }
     if (event.toolName !== "ask_user_questions") return;
     const milestoneId = getDiscussionMilestoneId(process.cwd());
@@ -491,11 +497,15 @@ export function registerHooks(
     markToolEnd(event.toolCallId);
     // #2883: Capture tool invocation errors (malformed/truncated JSON arguments)
     // so postUnitPreVerification can break the retry loop instead of re-dispatching.
-    if (event.isError && event.toolName.startsWith("gsd_")) {
+    if (event.isError) {
       const errorText = typeof event.result === "string"
         ? event.result
         : (typeof event.result?.content?.[0]?.text === "string" ? event.result.content[0].text : String(event.result));
-      recordToolInvocationError(event.toolName, errorText);
+      // #4973: Capture deterministic policy errors regardless of tool prefix —
+      // matches the same gate used by tool_result above for the raw `write` path.
+      if (event.toolName.startsWith("gsd_") || isDeterministicPolicyError(errorText)) {
+        recordToolInvocationError(event.toolName, errorText);
+      }
     }
     // Safety harness: record tool execution results for evidence cross-referencing
     if (isAutoActive()) {

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -18,7 +18,6 @@ import { loadToolApiKeys } from "../commands-config.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
 import { deriveState } from "../state.js";
 import { getAutoDashboardData, isAutoActive, isAutoPaused, markToolEnd, markToolStart, recordToolInvocationError } from "../auto.js";
-import { isDeterministicPolicyError } from "../auto-tool-tracking.js";
 
 import { isParallelActive, shutdownParallel } from "../parallel-orchestrator.js";
 import { checkToolCallLoop, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
@@ -403,12 +402,9 @@ export function registerHooks(
             : (typeof (event as any).content === "string"
                 ? (event as any).content
                 : String(resultPayload ?? "")));
-      // #4973: Capture deterministic policy errors regardless of tool prefix —
-      // the raw `write` tool can hit shouldBlockContextWrite and would otherwise
-      // be missed by the gsd_-only filter.
-      if (event.toolName.startsWith("gsd_") || isDeterministicPolicyError(errorText)) {
-        recordToolInvocationError(event.toolName, errorText);
-      }
+      // Let recordToolInvocationError classify the failure so non-gsd_ harness
+      // errors and deterministic policy rejections are handled consistently.
+      recordToolInvocationError(event.toolName, errorText);
     }
     if (event.toolName !== "ask_user_questions") return;
     const milestoneId = getDiscussionMilestoneId(process.cwd());
@@ -501,11 +497,9 @@ export function registerHooks(
       const errorText = typeof event.result === "string"
         ? event.result
         : (typeof event.result?.content?.[0]?.text === "string" ? event.result.content[0].text : String(event.result));
-      // #4973: Capture deterministic policy errors regardless of tool prefix —
-      // matches the same gate used by tool_result above for the raw `write` path.
-      if (event.toolName.startsWith("gsd_") || isDeterministicPolicyError(errorText)) {
-        recordToolInvocationError(event.toolName, errorText);
-      }
+      // Let recordToolInvocationError classify the failure so non-gsd_ harness
+      // errors and deterministic policy rejections are handled consistently.
+      recordToolInvocationError(event.toolName, errorText);
     }
     // Safety harness: record tool execution results for evidence cross-referencing
     if (isAutoActive()) {

--- a/src/resources/extensions/gsd/tests/auto-deterministic-error-classification-4973.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-deterministic-error-classification-4973.test.ts
@@ -329,22 +329,6 @@ describe("Test 6 — non-deterministic failures use standard retry; tier escalat
     );
   });
 
-  test("deterministic error: isDeterministicError flag skips escalation in selectAndApplyModel (type contract)", () => {
-    // Verify the retryContext shape accepted by selectAndApplyModel includes isDeterministicError.
-    // This is a compile-time contract test: if the type is wrong, tsc will error during build.
-    // The value assignment below will fail to typecheck if the field is not declared.
-    type RetryContext = Parameters<
-      typeof import("../auto-model-selection.ts")["selectAndApplyModel"]
-    >[8];
-
-    // Structural check: the type must accept isDeterministicError: true
-    const retryCtx: RetryContext = { isRetry: true, previousTier: "standard", isDeterministicError: true };
-    assert.ok(retryCtx.isDeterministicError === true, "isDeterministicError field accepted in retryContext type");
-
-    // And without it (optional field)
-    const retryCtxMinimal: RetryContext = { isRetry: true, previousTier: "standard" };
-    assert.ok(retryCtxMinimal.isDeterministicError === undefined, "isDeterministicError is optional");
-  });
 });
 
 // Cleanup all temp dirs after the test suite completes

--- a/src/resources/extensions/gsd/tests/auto-deterministic-error-classification-4973.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-deterministic-error-classification-4973.test.ts
@@ -1,0 +1,355 @@
+// GSD-2 + Regression tests for deterministic policy error classification (#4973)
+//
+// When gsd_summary_save returns context_write_blocked (a deterministic write-gate
+// rejection), the retry controller must NOT re-dispatch with escalating model tiers.
+// Instead it must write a blocker placeholder and advance the pipeline immediately.
+//
+// Test 5 — deterministic error short-circuits retry:
+//   - isDeterministicPolicyError correctly classifies context_write_blocked errors
+//   - recordToolInvocationError captures deterministic errors in lastToolInvocationError
+//   - postUnitPreVerification returns "continue" (not "retry"), writes placeholder,
+//     leaves pendingVerificationRetry null — zero additional model calls dispatched
+//
+// Test 6 — model-quality failures still use standard retry path:
+//   - non-deterministic failures set pendingVerificationRetry and return "retry"
+//   - tier escalates on retry 1 (previousTier "standard" → "heavy")
+//   - tier is RETAINED at "heavy" on subsequent retries (no downgrade back to fresh
+//     classification when already at max tier) — "escalate once" semantics
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import {
+  isDeterministicPolicyError,
+  DETERMINISTIC_POLICY_ERROR_STRINGS,
+} from "../auto-tool-tracking.ts";
+import { AutoSession } from "../auto/session.ts";
+import { _setAutoActiveForTest } from "../auto.ts";
+import { escalateTier } from "../model-router.ts";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const tmpDirs: string[] = [];
+
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-test-4973-${randomUUID().slice(0, 8)}-`));
+  tmpDirs.push(base);
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  return base;
+}
+
+function resetAutoState(): void {
+  _setAutoActiveForTest(false);
+}
+
+// ─── Test 5: Deterministic error short-circuits retry ─────────────────────
+
+describe("Test 5 — isDeterministicPolicyError classifier (#4973)", () => {
+  // ── Classifier unit tests ──────────────────────────────────────────────
+
+  test("classifies context_write_blocked fallback text as deterministic", () => {
+    // This is the text emitted by workflow-tool-executors.ts when contextGuard.reason
+    // is undefined: `Error saving artifact: ${contextGuard.reason ?? "context write blocked"}`
+    const errorText = "gsd_summary_save: Error saving artifact: context write blocked";
+    assert.strictEqual(
+      isDeterministicPolicyError(errorText),
+      true,
+      "fallback context_write_blocked text must be classified as deterministic",
+    );
+  });
+
+  test("classifies write-gate verbose reason as deterministic", () => {
+    // This is the text when shouldBlockContextArtifactSaveInSnapshot returns its reason:
+    // "HARD BLOCK: Cannot save milestone CONTEXT without depth verification for M001. ..."
+    const verboseError = [
+      "gsd_summary_save: Error saving artifact:",
+      "HARD BLOCK: Cannot save milestone CONTEXT without depth verification for M001.",
+      "This is a mechanical gate — you MUST NOT proceed, retry, or rationalize past this block.",
+    ].join(" ");
+    assert.strictEqual(
+      isDeterministicPolicyError(verboseError),
+      true,
+      "verbose write-gate reason containing 'CONTEXT without depth verification' must be classified as deterministic",
+    );
+  });
+
+  test("returns false for malformed-JSON errors (separate classification path)", () => {
+    assert.strictEqual(
+      isDeterministicPolicyError("Unexpected end of JSON input"),
+      false,
+      "malformed-JSON errors are not deterministic policy errors",
+    );
+    assert.strictEqual(
+      isDeterministicPolicyError("Validation failed for tool gsd_complete_slice"),
+      false,
+    );
+  });
+
+  test("returns false for normal business-logic tool errors", () => {
+    assert.strictEqual(
+      isDeterministicPolicyError("Slice S01 is already complete"),
+      false,
+    );
+    assert.strictEqual(
+      isDeterministicPolicyError("Error saving artifact: db_unavailable"),
+      false,
+    );
+  });
+
+  test("returns false for empty string", () => {
+    assert.strictEqual(isDeterministicPolicyError(""), false);
+  });
+
+  test("DETERMINISTIC_POLICY_ERROR_STRINGS list is non-empty and contains context_write_blocked entry", () => {
+    assert.ok(
+      DETERMINISTIC_POLICY_ERROR_STRINGS.length > 0,
+      "must have at least one known deterministic error string",
+    );
+    const hasContextWriteBlocked = DETERMINISTIC_POLICY_ERROR_STRINGS.some(
+      (s) => s.includes("context write blocked") || s.includes("CONTEXT without depth verification"),
+    );
+    assert.ok(hasContextWriteBlocked, "must include context_write_blocked family entries");
+  });
+});
+
+describe("Test 5 — recordToolInvocationError captures deterministic errors (#4973)", () => {
+  beforeEach(resetAutoState);
+  afterEach(resetAutoState);
+
+  test("lastToolInvocationError is NOT set for deterministic errors on current main (pre-fix baseline)", () => {
+    // This test documents the FIXED behavior: deterministic errors ARE captured.
+    // On current main (before this fix), recordToolInvocationError would NOT store
+    // context_write_blocked because it only checked isToolInvocationError and
+    // isQueuedUserMessageSkip.  After the fix, it also checks isDeterministicPolicyError.
+    //
+    // We test the fixed behavior here: the error IS captured.
+    _setAutoActiveForTest(true);
+
+    // Import recordToolInvocationError from auto.ts (it delegates to auto-tool-tracking.ts)
+    // We test indirectly via the session state: after calling recordToolInvocationError,
+    // lastToolInvocationError should be set for deterministic errors.
+    //
+    // Since recordToolInvocationError is not exported directly, we verify the fix
+    // through the AutoSession field behavior documented in the classifier tests above.
+    // The recordToolInvocationError integration is exercised in the postUnitPreVerification
+    // integration test below.
+    const s = new AutoSession();
+    assert.strictEqual(s.lastToolInvocationError, null, "starts null");
+
+    // Simulate what postUnitPreVerification checks: if isDeterministicPolicyError
+    // matches on lastToolInvocationError, the short-circuit fires.
+    // The value is set by recordToolInvocationError (tested via auto.ts integration).
+    s.lastToolInvocationError = "gsd_summary_save: Error saving artifact: context write blocked";
+    assert.ok(
+      isDeterministicPolicyError(s.lastToolInvocationError),
+      "classifier recognises the stored error — short-circuit will fire",
+    );
+    assert.strictEqual(s.pendingVerificationRetry, null, "pendingVerificationRetry starts null");
+  });
+
+  test("AutoSession.lastToolInvocationError can hold a deterministic policy error string", () => {
+    const s = new AutoSession();
+    s.lastToolInvocationError = "gsd_summary_save: Error saving artifact: context write blocked";
+    assert.ok(s.lastToolInvocationError);
+    assert.ok(isDeterministicPolicyError(s.lastToolInvocationError));
+  });
+
+  test("AutoSession.lastToolInvocationError is cleared on reset()", () => {
+    const s = new AutoSession();
+    s.lastToolInvocationError = "gsd_summary_save: Error saving artifact: context write blocked";
+    s.reset();
+    assert.strictEqual(s.lastToolInvocationError, null);
+  });
+});
+
+describe("Test 5 — postUnitPreVerification short-circuits on deterministic error (#4973)", () => {
+  // This integration test calls postUnitPreVerification with a deterministic error
+  // in lastToolInvocationError and asserts that:
+  //   1. pendingVerificationRetry is NOT set (no retry dispatched)
+  //   2. the blocker placeholder is written to disk
+  //   3. the function returns "continue" (not "retry" or "dispatched")
+
+  let base = "";
+  beforeEach(() => {
+    base = makeTmpBase();
+    _setAutoActiveForTest(true);
+  });
+  afterEach(() => {
+    _setAutoActiveForTest(false);
+    // Cleanup is handled by tmpDirs at process exit; individual cleanup here
+    // is best-effort only so as not to mask assertion failures.
+  });
+
+  test("returns 'continue' and writes placeholder for context_write_blocked — no pendingVerificationRetry set", async () => {
+    const { postUnitPreVerification } = await import("../auto-post-unit.ts");
+
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = base;
+    s.currentUnit = { type: "discuss-milestone", id: "M001", startedAt: Date.now() };
+    // Set the deterministic error that would be recorded by recordToolInvocationError
+    s.lastToolInvocationError = "gsd_summary_save: Error saving artifact: context write blocked";
+
+    let pauseCalled = false;
+    const ctx = {
+      ui: { notify: () => {} },
+    } as any;
+    const pi = {} as any;
+
+    const pctx = {
+      s,
+      ctx,
+      pi,
+      buildSnapshotOpts: () => ({}) as any,
+      lockBase: () => base,
+      stopAuto: async () => {},
+      pauseAuto: async () => { pauseCalled = true; },
+      updateProgressWidget: () => {},
+    } as any;
+
+    const result = await postUnitPreVerification(pctx, { skipSettleDelay: true });
+
+    // Core assertion: deterministic error short-circuits — returns "continue",
+    // no retry, and the placeholder is written so the pipeline can advance.
+    assert.strictEqual(result, "continue", "must return 'continue', not 'retry' or 'dispatched'");
+    assert.strictEqual(s.pendingVerificationRetry, null, "pendingVerificationRetry must NOT be set");
+    assert.strictEqual(s.lastToolInvocationError, null, "lastToolInvocationError cleared after handling");
+    assert.strictEqual(pauseCalled, false, "pauseAuto must NOT be called for deterministic errors");
+
+    // The blocker placeholder must exist on disk so the pipeline can advance.
+    const placeholderPath = join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md");
+    assert.ok(
+      existsSync(placeholderPath),
+      `blocker placeholder must be written at ${placeholderPath}`,
+    );
+  });
+});
+
+// ─── Test 6: Model-quality failures use standard retry path ──────────────────
+
+describe("Test 6 — non-deterministic failures use standard retry; tier escalates once (#4973)", () => {
+  // ── escalateTier behavior (existing, unchanged) ───────────────────────────
+
+  test("escalateTier: light → standard → heavy → null (max)", () => {
+    assert.strictEqual(escalateTier("light"), "standard");
+    assert.strictEqual(escalateTier("standard"), "heavy");
+    assert.strictEqual(escalateTier("heavy"), null, "heavy is the max tier — no further escalation");
+  });
+
+  test("standard-start retry: escalates to heavy on retry 1, stays at heavy on retry 2 (escalateTier returns null)", () => {
+    // Simulate what selectAndApplyModel does across two retries for a standard-start unit.
+    // Retry 1: previousTier = "standard", escalateTier → "heavy". Applied tier = "heavy".
+    const tier1 = escalateTier("standard");
+    assert.strictEqual(tier1, "heavy", "retry 1: standard escalates to heavy");
+
+    // Retry 2: previousTier = "heavy" (from retry 1 result), escalateTier → null.
+    // The "retain escalated tier" fix kicks in: prevOrder(heavy=2) > freshOrder(standard=1),
+    // so the tier stays at "heavy" rather than reverting to fresh classification.
+    const tier2 = escalateTier("heavy");
+    assert.strictEqual(tier2, null, "retry 2: heavy cannot escalate further");
+
+    // Verify the tier-order comparison used in selectAndApplyModel (#4973 fix):
+    const tierOrder: Record<string, number> = { light: 0, standard: 1, heavy: 2 };
+    const prevOrder = tierOrder["heavy"] ?? 0;      // 2 (from retry 1 result)
+    const freshOrder = tierOrder["standard"] ?? 0;  // 1 (fresh classifyUnitComplexity for a standard unit)
+    assert.ok(
+      prevOrder > freshOrder,
+      "prevOrder(heavy=2) > freshOrder(standard=1) — the fix retains 'heavy' and prevents revert",
+    );
+  });
+
+  test("light-start retry 3: escalated tier is retained, not reverted to 'light'", () => {
+    // Without the fix: retry 3 would see previousTier="heavy" (from retry 2),
+    // escalateTier returns null, and fresh classification is "light" — the model
+    // reverts to a cheap light-tier model. With the fix, we retain "heavy".
+
+    // Retry 1: light → standard
+    assert.strictEqual(escalateTier("light"), "standard");
+    // Retry 2: standard → heavy
+    assert.strictEqual(escalateTier("standard"), "heavy");
+    // Retry 3: heavy → null (can't escalate), fix retains "heavy" instead of reverting to "light"
+    assert.strictEqual(escalateTier("heavy"), null);
+
+    // The fix logic: when escalateTier returns null, compare prevOrder vs freshOrder.
+    const tierOrder: Record<string, number> = { light: 0, standard: 1, heavy: 2 };
+    const prevOrderRetry3 = tierOrder["heavy"] ?? 0;  // 2
+    const freshOrderLight = tierOrder["light"] ?? 0;  // 0
+    assert.ok(
+      prevOrderRetry3 > freshOrderLight,
+      "on retry 3, prevOrder(heavy=2) > freshOrder(light=0) — 'heavy' must be retained, not reverted",
+    );
+  });
+
+  test("non-deterministic error: session sets pendingVerificationRetry (standard retry path)", () => {
+    // Simulate what postUnitPreVerification does for a non-deterministic failure:
+    // no lastToolInvocationError → falls into the standard retry path → sets pendingVerificationRetry.
+    const s = new AutoSession();
+    s.currentUnit = { type: "plan-slice", id: "M001:S01", startedAt: Date.now() };
+
+    // Simulate the retry count increment (as postUnitPreVerification does internally)
+    const retryKey = `${s.currentUnit.type}:${s.currentUnit.id}`;
+    const attempt = (s.verificationRetryCount.get(retryKey) ?? 0) + 1;
+    s.verificationRetryCount.set(retryKey, attempt);
+
+    // Simulate setting pendingVerificationRetry (what the "else" branch does)
+    s.pendingVerificationRetry = {
+      unitId: s.currentUnit.id,
+      failureContext: `Artifact verification failed: expected artifact for ${s.currentUnit.type} "${s.currentUnit.id}" was not found on disk after unit execution (attempt ${attempt}).`,
+      attempt,
+    };
+
+    assert.ok(s.pendingVerificationRetry !== null, "standard retry path sets pendingVerificationRetry");
+    assert.strictEqual(s.pendingVerificationRetry.attempt, 1, "attempt is 1");
+    assert.ok(
+      s.pendingVerificationRetry.failureContext.includes("plan-slice"),
+      "failureContext references the unit type",
+    );
+  });
+
+  test("isDeterministicPolicyError returns false for non-deterministic verification failure", () => {
+    // A plain 'artifact not found' is NOT a deterministic policy error.
+    // The standard retry path must still fire for these.
+    assert.strictEqual(
+      isDeterministicPolicyError(""),
+      false,
+      "empty error (no tool error) is not deterministic",
+    );
+    assert.strictEqual(
+      isDeterministicPolicyError("Artifact not found on disk"),
+      false,
+      "plain artifact-missing message is not a deterministic policy error",
+    );
+    assert.strictEqual(
+      isDeterministicPolicyError("existsSync returned false"),
+      false,
+    );
+  });
+
+  test("deterministic error: isDeterministicError flag skips escalation in selectAndApplyModel (type contract)", () => {
+    // Verify the retryContext shape accepted by selectAndApplyModel includes isDeterministicError.
+    // This is a compile-time contract test: if the type is wrong, tsc will error during build.
+    // The value assignment below will fail to typecheck if the field is not declared.
+    type RetryContext = Parameters<
+      typeof import("../auto-model-selection.ts")["selectAndApplyModel"]
+    >[8];
+
+    // Structural check: the type must accept isDeterministicError: true
+    const retryCtx: RetryContext = { isRetry: true, previousTier: "standard", isDeterministicError: true };
+    assert.ok(retryCtx.isDeterministicError === true, "isDeterministicError field accepted in retryContext type");
+
+    // And without it (optional field)
+    const retryCtxMinimal: RetryContext = { isRetry: true, previousTier: "standard" };
+    assert.ok(retryCtxMinimal.isDeterministicError === undefined, "isDeterministicError is optional");
+  });
+});
+
+// Cleanup all temp dirs after the test suite completes
+process.on("exit", () => {
+  for (const dir of tmpDirs) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});

--- a/src/resources/extensions/gsd/tests/auto-deterministic-error-classification-4973.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-deterministic-error-classification-4973.test.ts
@@ -193,6 +193,7 @@ describe("Test 5 — postUnitPreVerification short-circuits on deterministic err
     s.currentUnit = { type: "discuss-milestone", id: "M001", startedAt: Date.now() };
     // Set the deterministic error that would be recorded by recordToolInvocationError
     s.lastToolInvocationError = "gsd_summary_save: Error saving artifact: context write blocked";
+    s.verificationRetryCount.set("discuss-milestone:M001", 2);
 
     let pauseCalled = false;
     const ctx = {
@@ -217,6 +218,7 @@ describe("Test 5 — postUnitPreVerification short-circuits on deterministic err
     // no retry, and the placeholder is written so the pipeline can advance.
     assert.strictEqual(result, "continue", "must return 'continue', not 'retry' or 'dispatched'");
     assert.strictEqual(s.pendingVerificationRetry, null, "pendingVerificationRetry must NOT be set");
+    assert.strictEqual(s.verificationRetryCount.has("discuss-milestone:M001"), false, "deterministic short-circuit clears stale retry count");
     assert.strictEqual(s.lastToolInvocationError, null, "lastToolInvocationError cleared after handling");
     assert.strictEqual(pauseCalled, false, "pauseAuto must NOT be called for deterministic errors");
 

--- a/src/resources/extensions/gsd/tests/auto-discuss-milestone-deadlock-4973.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-discuss-milestone-deadlock-4973.test.ts
@@ -1,0 +1,180 @@
+// GSD-2 + Regression tests for auto-mode discuss-milestone write-gate deadlock (#4973)
+//
+// The depth-verification write-gate in write-gate.ts:415-443 blocks
+// gsd_summary_save({artifact_type:"CONTEXT"}) until markDepthVerified() is
+// called. In interactive mode this happens when the user picks the confirmation
+// option in ask_user_questions. In auto-mode there is no human — the gate
+// deadlocked every discuss-milestone unit, wasting 200K-360K tokens per run.
+//
+// Fix: each dispatch rule that fires a discuss-milestone unit now calls
+// markDepthVerified(mid) when isAutoActive() is true, before returning the
+// dispatch action. These tests verify:
+//   Test 1 — CONTEXT artifact save unblocks after markDepthVerified
+//   Test 2 — raw write to *-CONTEXT.md unblocks after markDepthVerified
+//   Test 3 — session_switch ordering: clearDiscussionFlowState clears the mark
+//   Test 4 — interactive sessions (isAutoActive===false) are unaffected
+
+import { describe, test, afterEach, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  markDepthVerified,
+  clearDiscussionFlowState,
+  shouldBlockContextArtifactSaveInSnapshot,
+  shouldBlockContextWrite,
+  loadWriteGateSnapshot,
+  isMilestoneDepthVerifiedInSnapshot,
+} from '../bootstrap/write-gate.ts';
+
+import { _setAutoActiveForTest } from '../auto.ts';
+
+// Reset all relevant state before and after each test.
+function resetState(): void {
+  _setAutoActiveForTest(false);
+  clearDiscussionFlowState();
+}
+
+describe('auto-discuss-milestone-deadlock-4973', () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  // ── Test 1 ──────────────────────────────────────────────────────────────
+  // CONTEXT artifact save via gsd_summary_save is blocked before the mark
+  // and unblocked after it. This is the exact path that deadlocked in #4973:
+  // workflow-tool-executors.ts calls shouldBlockContextArtifactSaveInSnapshot
+  // against a snapshot that had no verified milestones.
+  test('Test 1: CONTEXT artifact save unblocks after markDepthVerified (auto-mode)', () => {
+    _setAutoActiveForTest(true);
+
+    // Before mark: blocked
+    const snapshotBefore = loadWriteGateSnapshot();
+    const beforeResult = shouldBlockContextArtifactSaveInSnapshot(
+      snapshotBefore,
+      'CONTEXT',
+      'M001',
+      null,
+    );
+    assert.strictEqual(beforeResult.block, true, 'should block before markDepthVerified');
+
+    // Simulate what the dispatch rule now does in auto-mode
+    markDepthVerified('M001');
+
+    // After mark: unblocked
+    const snapshotAfter = loadWriteGateSnapshot();
+    const afterResult = shouldBlockContextArtifactSaveInSnapshot(
+      snapshotAfter,
+      'CONTEXT',
+      'M001',
+      null,
+    );
+    assert.strictEqual(afterResult.block, false, 'should not block after markDepthVerified');
+  });
+
+  // ── Test 2 ──────────────────────────────────────────────────────────────
+  // Raw write tool to a *-CONTEXT.md path is also gated. The register-hooks
+  // tool_call handler calls shouldBlockContextWrite for write events.
+  test('Test 2: raw write to M001-CONTEXT.md unblocks after markDepthVerified (auto-mode)', () => {
+    _setAutoActiveForTest(true);
+
+    const contextPath = '.gsd/milestones/M001/M001-CONTEXT.md';
+
+    // Before mark: blocked
+    const beforeResult = shouldBlockContextWrite('write', contextPath, 'M001');
+    assert.strictEqual(beforeResult.block, true, 'write should be blocked before markDepthVerified');
+
+    // Simulate dispatch rule auto-mark
+    markDepthVerified('M001');
+
+    // After mark: unblocked
+    const afterResult = shouldBlockContextWrite('write', contextPath, 'M001');
+    assert.strictEqual(afterResult.block, false, 'write should not be blocked after markDepthVerified');
+  });
+
+  // ── Test 3 ──────────────────────────────────────────────────────────────
+  // Documents the session_switch ordering contract.
+  //
+  // When auto-mode dispatches a new session, the event sequence is:
+  //   session_switch → clearDiscussionFlowState() (register-hooks.ts:106)
+  //   before_agent_start fires
+  //   resolveDispatch is called → discuss-milestone rule match fn runs
+  //   markDepthVerified(mid) is called HERE (after the clear)
+  //
+  // This test demonstrates that clearDiscussionFlowState() (the session_switch
+  // side effect) clears any previously set mark, and that calling
+  // markDepthVerified after the clear correctly re-establishes it — proving
+  // the dispatch-site call site is safe regardless of prior session state.
+  test('Test 3: session_switch ordering — clearDiscussionFlowState clears mark; dispatch-site call re-establishes it', () => {
+    // Simulate a mark from a prior session
+    markDepthVerified('M001');
+    let snapshot = loadWriteGateSnapshot();
+    assert.strictEqual(
+      isMilestoneDepthVerifiedInSnapshot(snapshot, 'M001'),
+      true,
+      'precondition: mark set from prior session',
+    );
+
+    // session_switch fires clearDiscussionFlowState() — this is exactly what
+    // register-hooks.ts:106 does
+    clearDiscussionFlowState();
+    snapshot = loadWriteGateSnapshot();
+    assert.strictEqual(
+      isMilestoneDepthVerifiedInSnapshot(snapshot, 'M001'),
+      false,
+      'session_switch (clearDiscussionFlowState) must clear the mark',
+    );
+
+    // Now the dispatch rule fires (after session_switch cleared state)
+    // and re-establishes the mark for the new session
+    _setAutoActiveForTest(true);
+    markDepthVerified('M001'); // this is what the dispatch rule does
+
+    snapshot = loadWriteGateSnapshot();
+    assert.strictEqual(
+      isMilestoneDepthVerifiedInSnapshot(snapshot, 'M001'),
+      true,
+      'dispatch-site markDepthVerified re-establishes the mark after session_switch cleared it',
+    );
+
+    // And the artifact save is now unblocked for this session
+    const result = shouldBlockContextArtifactSaveInSnapshot(snapshot, 'CONTEXT', 'M001', null);
+    assert.strictEqual(result.block, false, 'CONTEXT save unblocked in the new session');
+  });
+
+  // ── Test 4 ──────────────────────────────────────────────────────────────
+  // Interactive sessions (isAutoActive()===false) must NOT be auto-marked.
+  // The dispatch rules guard the markDepthVerified call with isAutoActive(),
+  // so in a non-auto session the gate still requires the human to confirm.
+  // This test passes on both current main AND with the fix applied.
+  test('Test 4: interactive sessions unaffected — gate still blocks unverified milestones when auto is off', () => {
+    _setAutoActiveForTest(false);
+
+    // Do NOT call markDepthVerified — simulating that dispatch rule's
+    // isAutoActive() guard prevented the auto-mark (as it should for
+    // interactive sessions)
+
+    // CONTEXT artifact save is still blocked
+    const snapshotResult = shouldBlockContextArtifactSaveInSnapshot(
+      loadWriteGateSnapshot(),
+      'CONTEXT',
+      'M002',
+      null,
+    );
+    assert.strictEqual(
+      snapshotResult.block,
+      true,
+      'CONTEXT save must still be blocked in interactive mode without depth verification',
+    );
+
+    // Raw write to CONTEXT.md is still blocked
+    const writeResult = shouldBlockContextWrite(
+      'write',
+      '.gsd/milestones/M002/M002-CONTEXT.md',
+      'M002',
+    );
+    assert.strictEqual(
+      writeResult.block,
+      true,
+      'write to CONTEXT.md must still be blocked in interactive mode',
+    );
+  });
+});

--- a/src/resources/extensions/gsd/tests/auto-discuss-milestone-deadlock-4973.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-discuss-milestone-deadlock-4973.test.ts
@@ -26,6 +26,7 @@ import {
   isMilestoneDepthVerifiedInSnapshot,
 } from '../bootstrap/write-gate.ts';
 
+import { DISPATCH_RULES, type DispatchContext } from '../auto-dispatch.ts';
 import { _setAutoActiveForTest } from '../auto.ts';
 
 // Reset all relevant state before and after each test.
@@ -175,6 +176,71 @@ describe('auto-discuss-milestone-deadlock-4973', () => {
       writeResult.block,
       true,
       'write to CONTEXT.md must still be blocked in interactive mode',
+    );
+  });
+
+  // ── Test 5 ──────────────────────────────────────────────────────────────
+  // The actual fix lives inside the discuss-milestone dispatch rules at
+  // auto-dispatch.ts:280-291, :423-432, :449-458. This test invokes the
+  // "needs-discussion → discuss-milestone" rule directly and asserts that
+  // (a) the rule auto-marks depth-verified when isAutoActive() is true, and
+  // (b) it does NOT mark when isAutoActive() is false.
+  //
+  // This is the test codex flagged as missing: Tests 1-4 above only exercise
+  // the markDepthVerified primitive — they pass on origin/main. This Test 5
+  // FAILS on origin/main (the rule does nothing for the gate) and PASSES with
+  // the fix (the rule calls markDepthVerified inside isAutoActive()).
+  test('Test 5: needs-discussion dispatch rule auto-marks depth-verified in auto-mode', async () => {
+    const rule = DISPATCH_RULES.find(r => r.name === 'needs-discussion → discuss-milestone');
+    assert.ok(rule, 'dispatch rule must exist');
+
+    const baseCtx = {
+      basePath: '/tmp/4973-rule-test-nonexistent',
+      mid: 'M005',
+      midTitle: 'Test Milestone',
+      state: { phase: 'needs-discussion' },
+      prefs: undefined,
+      structuredQuestionsAvailable: 'false',
+    } as unknown as DispatchContext;
+
+    // ── Auto-mode case: the rule must call markDepthVerified ──
+    _setAutoActiveForTest(true);
+    let snap = loadWriteGateSnapshot();
+    assert.strictEqual(
+      isMilestoneDepthVerifiedInSnapshot(snap, 'M005'),
+      false,
+      'precondition: M005 not yet marked',
+    );
+
+    // The rule's match fn calls markDepthVerified(mid) BEFORE awaiting
+    // buildDiscussMilestonePrompt — so even if the prompt build fails because
+    // basePath doesn't exist, the side effect (mark) has already happened.
+    try { await rule!.match(baseCtx); } catch { /* prompt build may fail; we only care about the mark */ }
+
+    snap = loadWriteGateSnapshot();
+    assert.strictEqual(
+      isMilestoneDepthVerifiedInSnapshot(snap, 'M005'),
+      true,
+      'auto-mode: dispatch rule must call markDepthVerified(mid) — this fails on origin/main without the H6 fix',
+    );
+
+    // ── Interactive case: the rule must NOT call markDepthVerified ──
+    clearDiscussionFlowState();
+    _setAutoActiveForTest(false);
+    snap = loadWriteGateSnapshot();
+    assert.strictEqual(
+      isMilestoneDepthVerifiedInSnapshot(snap, 'M005'),
+      false,
+      'precondition: state cleared',
+    );
+
+    try { await rule!.match(baseCtx); } catch { /* prompt build may fail */ }
+
+    snap = loadWriteGateSnapshot();
+    assert.strictEqual(
+      isMilestoneDepthVerifiedInSnapshot(snap, 'M005'),
+      false,
+      'interactive mode: dispatch rule must NOT call markDepthVerified — humans still confirm',
     );
   });
 });


### PR DESCRIPTION
## TL;DR

**What:** Auto-mode `discuss-milestone` no longer deadlocks on the depth-verification write-gate; deterministic policy errors short-circuit the retry/escalate loop instead of burning paid model calls.
**Why:** M002 in a real auto-mode run wasted ~\$1.35 / 1.04M tokens looping on `context_write_blocked` before writing a synthetic placeholder. See #4973.
**How:** Auto-mark depth-verified at the three `discuss-milestone` dispatch sites when `isAutoActive()` is true (interactive sessions unaffected). Add an explicit deterministic-error classifier and short-circuit retry when it matches.

Closes #4973

## What

Two causally-chained fixes split into three commits for review clarity:

**Commit 1 — `fix(auto): bypass depth-verification gate in non-interactive sessions (#4973)`**
- `auto-dispatch.ts`: at all three `discuss-milestone` dispatch rule sites, call `markDepthVerified(mid)` when `isAutoActive()` is true. Comment cites the `session_switch → before_agent_start → resolveDispatch` ordering that makes this safe against state resets.
- New regression file `auto-discuss-milestone-deadlock-4973.test.ts` (5 tests) — Tests 1-4 document gate semantics, Test 5 invokes the dispatch rule directly and asserts the side effect.

**Commit 2 — `fix(auto): classify deterministic policy errors as non-retriable (#4973)`**
- New `isDeterministicPolicyError` classifier in `auto-tool-tracking.ts` with an explicit (auditable) substring list — no regex.
- `auto.ts` extends `recordToolInvocationError` to capture deterministic policy errors into `lastToolInvocationError`.
- `auto-post-unit.ts` short-circuits `postUnitPreVerification` on deterministic errors: writes blocker placeholder, clears retry state, returns "continue" — zero retries.
- `auto-model-selection.ts` adds a "retain escalated tier" guard so a previously-escalated retry can't silently downgrade when fresh classification returns a lower tier.
- New regression file `auto-deterministic-error-classification-4973.test.ts` (15 tests) covering the classifier, the postUnit short-circuit, and the escalation policy.

**Commit 3 — `fix(auto): codex review feedback (#4973)`**
- Classifier list extended with `"CONTEXT.md without depth verification"` for the raw `write` tool path through `shouldBlockContextWrite`.
- `register-hooks.ts` widens the `recordToolInvocationError` gate so deterministic errors from non-`gsd_*` tools (raw `write`) reach `lastToolInvocationError`.
- Removed dead `isDeterministicError` flag from `retryContext` type and the unreachable branch in `selectAndApplyModel` — the H3 short-circuit fires before `selectAndApplyModel` runs, so the flag was never reachable.
- Added Test 5 to the H6 file: invokes the actual dispatch rule (codex flagged Tests 1-4 as tautological — they pass on `origin/main`).

## Why

A real auto-mode run on milestone M002 produced this telemetry:

| Time (UTC) | Unit | Tokens | Cost |
|---|---|---:|---:|
| 02:19:02-02:20:07 | discuss-milestone M002 (try 1) | 251,178 | \$0.3540 |
| 02:20:07-02:21:17 | discuss-milestone M002 (retry 1) | 212,720 | \$0.2862 |
| 02:21:17-02:23:03 | discuss-milestone M002 (retry 2) | 363,343 | \$0.4229 |
| 02:23:03-02:24:20 | discuss-milestone M002 (retry 3) | 210,988 | \$0.2896 |

Each call logged `verify-fail discuss-milestone M002: existsSync false for ...M002-CONTEXT.md`. Total wasted: ~1.04M tokens / **\$1.35**, and the milestone "completed" with a synthetic placeholder CONTEXT.md instead of real context.

**Root cause (validated by parallel debug investigation + 3 codex peer reviews):**

The depth-verification write-gate at `bootstrap/write-gate.ts:415-443` rejects every `gsd_summary_save({artifact_type:"CONTEXT"})` until `markDepthVerified` is called. The flag has exactly **one** caller (`bootstrap/register-hooks.ts:446`) — fires only when a human selects the depth-confirmation option in `ask_user_questions`. Auto-mode has no human. The flag stays false forever. Every CONTEXT save is blocked. The model produces 200K-360K tokens of conversation output per attempt that goes nowhere.

The retry policy at `auto-post-unit.ts:77` (`MAX_VERIFICATION_RETRIES=3`) treats every failure as a model-quality failure — `selectAndApplyModel(isRetry:true)` calls `escalateTier` on each retry, so failures cost progressively more. A `context_write_blocked` rejection is a **deterministic policy** error: no model, however capable, can succeed against it. The retry controller had no way to distinguish that from a model-quality failure.

The depth-verification gate was introduced in v2.73.0 (#4079) to prevent the model from rushing past the interview protocol before a human confirms thoroughness. It is an interactive-session safety mechanism — it was not designed to block autonomous pipelines where the pipeline itself is the authority. The gate's protection (preventing the model from short-circuiting a human conversation) is irrelevant in auto-mode because there is no human conversation to short-circuit.

The recent merged fix #4957 / `0cee04a0c` addressed a related but distinct symptom (the `AskUserQuestion` harness tool causing `InputValidationError`); it did not address the depth-verification deadlock.

## How

**Approach (b) auto-mark-depth-verified, explicitly chosen over alternatives:**

- ❌ **(a) Bypass-in-auto:** Returning `{block:false}` unconditionally when `isAutoActive()` would silently remove gate coverage from any future auto-mode code path that invokes `gsd_summary_save({artifact_type:"CONTEXT"})` for unrelated reasons. The chosen approach scopes the unlock to the specific milestone being discussed.
- ❌ **(c) Separate write path:** Adding a parallel tool/path doubles the maintenance surface and doesn't address the raw `write` tool gate.
- ✅ **(b)** scopes the change to dispatch-time, preserves gate semantics for interactive sessions, and naturally covers both write-gate variants because `verifiedDepthMilestones` is shared.

**Cost behavior:** A deterministic write-gate rejection now costs 1 paid call (not 4). Non-deterministic verification failures preserve the existing retry/escalate semantics.

**Ordering:** `session_switch` fires `clearDiscussionFlowState` before `before_agent_start`, which fires before `resolveDispatch` reaches the rule's `match` fn — so the auto-mark always happens after any session-switch reset. Test 3 in the H6 regression file documents this contract.

## Test plan

- [x] `npm run build` succeeds
- [x] New regression tests (5 H6 + 15 H3 = 20 total) all pass
- [x] Test 5 invokes the actual dispatch rule (verified to fail on `origin/main` without the fix)
- [x] 650-test blast-radius sweep (auto-mode, write-gate, dispatcher, recovery, model selection, tool tracking, register-hooks, post-unit) — all pass
- [x] `git status` clean before commits — no incidental files
- [x] Branch off `main`, no dependency on #4957's branch
- [ ] CI green (run on push)

## Reviewer notes

- **#4957 is complementary, not duplicate.** It addresses the harness-tool `AskUserQuestion` symptom; this PR addresses the underlying `markDepthVerified` deadlock. They land independently.
- **Follow-up issues to file** (out of scope here, surfaced by the parallel debug investigation): worktree symlink path divergence in `db-writer.ts` vs `gsdRoot()` (latent; not active in this incident); dispatcher circuit-breaker for "downstream artifacts already exist when re-dispatching upstream" (defense-in-depth); `verification-gate.ts` decoupling from the safety evidence collector (independent false-positive completion path).
- **R010 metadata drift** observed in M002 forensics is orthogonal to the state-machine bug and will get its own issue.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` `refactor` `test` `docs` `chore`

AI-assisted; multi-agent debug investigation + 3 rounds of Codex peer review (plan, synthesis, diff).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented write-gate deadlocks by auto-marking verified milestones when auto-mode is active.
  * Short-circuited retries for deterministic policy rejections, ensured such errors are recorded, and broadened error capture to more tool failures.
  * Preserved previously escalated model tiers on subsequent retries to avoid silent downgrades.

* **Tests**
  * Added regression suites for deterministic-error classification, retry control flow, and deadlock prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->