### PR TITLE
fix(auto): harden state-machine edge cases

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -110,6 +110,38 @@ export interface DispatchRule {
   match: (ctx: DispatchContext) => Promise<DispatchAction | null>;
 }
 
+async function readUatGateVerdict(
+  basePath: string,
+  mid: string,
+  sliceId: string,
+): Promise<{ verdict: string; uatType: UatType | undefined } | null> {
+  const uatFile = resolveSliceFile(basePath, mid, sliceId, "UAT");
+  const assessmentFile = resolveSliceFile(basePath, mid, sliceId, "ASSESSMENT");
+
+  const uatContent = uatFile ? await loadFile(uatFile) : null;
+  const uatType = uatContent ? extractUatType(uatContent) : undefined;
+
+  const assessmentContent = assessmentFile ? await loadFile(assessmentFile) : null;
+  if (assessmentContent) {
+    const assessmentVerdict = extractVerdict(assessmentContent);
+    if (assessmentVerdict) {
+      return {
+        verdict: assessmentVerdict,
+        uatType: uatType ?? extractUatType(assessmentContent),
+      };
+    }
+  }
+
+  if (uatContent) {
+    const legacyUatVerdict = extractVerdict(uatContent);
+    if (legacyUatVerdict) {
+      return { verdict: legacyUatVerdict, uatType };
+    }
+  }
+
+  return null;
+}
+
 function missingSliceStop(mid: string, phase: string): DispatchAction {
   return {
     action: "stop",
@@ -349,27 +381,22 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // Only applies when UAT dispatch is enabled
       if (!prefs?.uat_dispatch) return null;
 
-      const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
-
-      // DB-first: get completed slices from DB
-      let completedSliceIds: string[];
+      // DB-first: get closed slices from DB
+      let closedSliceIds: string[];
       if (isDbAvailable()) {
-        completedSliceIds = getMilestoneSlices(mid)
-          .filter(s => s.status === "complete")
+        closedSliceIds = getMilestoneSlices(mid)
+          .filter(s => isClosedStatus(s.status))
           .map(s => s.id);
       } else {
         return null;
       }
 
-      for (const sliceId of completedSliceIds) {
-        const resultFile = resolveSliceFile(basePath, mid, sliceId, "UAT");
-        if (!resultFile) continue;
-        const content = await loadFile(resultFile);
-        if (!content) continue;
-        const verdict = extractVerdict(content);
-        const uatType = extractUatType(content);
+      for (const sliceId of closedSliceIds) {
+        const result = await readUatGateVerdict(basePath, mid, sliceId);
+        if (!result) continue;
+        const { verdict, uatType } = result;
 
-        if (verdict && !isAcceptableUatVerdict(verdict, uatType)) {
+        if (!isAcceptableUatVerdict(verdict, uatType)) {
           return {
             action: "stop" as const,
             reason: `UAT verdict for ${sliceId} is "${verdict}" — blocking progression until resolved.\nReview the UAT result and update the verdict to PASS, or re-run /gsd auto after fixing.`,

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -381,14 +381,20 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // Only applies when UAT dispatch is enabled
       if (!prefs?.uat_dispatch) return null;
 
-      // DB-first: get closed slices from DB
+      // DB-first: prefer closed slices from DB; fall back to ROADMAP on disk.
       let closedSliceIds: string[];
       if (isDbAvailable()) {
         closedSliceIds = getMilestoneSlices(mid)
           .filter(s => isClosedStatus(s.status))
           .map(s => s.id);
       } else {
-        return null;
+        // Filesystem fallback for degraded / unmigrated projects.
+        // `slice.done` in the parsed ROADMAP is the disk-level closed signal.
+        const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
+        const roadmapContent = roadmapFile ? await loadFile(roadmapFile) : null;
+        if (!roadmapContent) return null;
+        const roadmap = parseRoadmap(roadmapContent);
+        closedSliceIds = roadmap.slices.filter(s => s.done).map(s => s.id);
       }
 
       for (const sliceId of closedSliceIds) {

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -87,20 +87,32 @@ export function clearInFlightTools(): void {
 // ─── Tool invocation error classification (#2883) ────────────────────────
 
 /**
- * Patterns that indicate a tool invocation failed due to malformed or truncated
- * JSON arguments — as opposed to a normal business-logic error from the tool
- * handler. When these errors occur, retrying the same unit will produce the same
- * failure, so the retry loop must be broken.
+ * Patterns that indicate a tool invocation failed deterministically before
+ * useful work could be completed — as opposed to a normal business-logic error
+ * from the tool handler. When these errors occur, retrying the same unit will
+ * produce the same failure, so the retry loop must be broken.
  */
 const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON/i;
+const DETERMINISTIC_POLICY_ERROR_RE = /(?:^|\b)(?:HARD BLOCK:|Blocked: \/gsd queue is a planning tool|Direct writes to \.gsd\/STATE\.md and \.gsd\/gsd\.db are blocked|This is a mechanical gate)/i;
 
 /**
- * Returns true if the error message indicates a tool invocation failure due to
- * malformed/truncated arguments (as opposed to a normal tool execution error).
+ * Returns true if the error message indicates a deterministic invocation or
+ * policy failure (as opposed to a normal tool execution error).
  */
 export function isToolInvocationError(errorMsg: string): boolean {
   if (!errorMsg) return false;
-  return TOOL_INVOCATION_ERROR_RE.test(errorMsg);
+  return TOOL_INVOCATION_ERROR_RE.test(errorMsg) || isDeterministicPolicyError(errorMsg);
+}
+
+/**
+ * Returns true if the error message indicates a deterministic policy gate
+ * blocked the tool call before execution. Retrying the same unit without
+ * changing behavior will hit the same gate, so auto-mode should pause instead
+ * of re-dispatching.
+ */
+export function isDeterministicPolicyError(errorMsg: string): boolean {
+  if (!errorMsg) return false;
+  return DETERMINISTIC_POLICY_ERROR_RE.test(errorMsg);
 }
 
 /**

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -337,6 +337,25 @@ function normalizeSessionFilePath(raw: unknown): string | null {
   return candidate;
 }
 
+function synthesizePausedSessionRecovery(
+  basePath: string,
+  unitType: string,
+  unitId: string,
+  sessionFile: string,
+): ReturnType<typeof synthesizeCrashRecovery> {
+  const activityDir = join(gsdRoot(basePath), "activity");
+  return synthesizeCrashRecovery(basePath, unitType, unitId, sessionFile, activityDir);
+}
+
+export function _synthesizePausedSessionRecoveryForTest(
+  basePath: string,
+  unitType: string,
+  unitId: string,
+  sessionFile: string,
+): ReturnType<typeof synthesizeCrashRecovery> {
+  return synthesizePausedSessionRecovery(basePath, unitType, unitId, sessionFile);
+}
+
 export function startAutoDetached(
   ctx: ExtensionCommandContext,
   pi: ExtensionAPI,
@@ -1571,16 +1590,6 @@ export async function startAuto(
       return;
     }
 
-    // Lock acquired — now safe to delete the pause file
-    if (s.pausedSessionFile) {
-      try { unlinkSync(s.pausedSessionFile); } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-          logWarning("session", `pause file cleanup failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
-        }
-      }
-      s.pausedSessionFile = null;
-    }
-
     s.paused = false;
     s.active = true;
     s.verbose = verboseMode;
@@ -1678,13 +1687,11 @@ export async function startAuto(
     invalidateAllCaches();
 
     if (s.pausedSessionFile) {
-      const activityDir = join(gsdRoot(s.basePath), "activity");
-      const recovery = synthesizeCrashRecovery(
+      const recovery = synthesizePausedSessionRecovery(
         s.basePath,
         s.currentUnit?.type ?? s.pausedUnitType ?? "unknown",
         s.currentUnit?.id ?? s.pausedUnitId ?? "unknown",
-        s.pausedSessionFile ?? undefined,
-        activityDir,
+        s.pausedSessionFile,
       );
       if (recovery && recovery.trace.toolCallCount > 0) {
         s.pendingCrashRecovery = recovery.prompt;

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -201,6 +201,7 @@ async function closeoutAndStop(
       s.currentUnit.startedAt,
       deps.buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id),
     );
+    s.currentUnit = null;
   }
   await deps.stopAuto(ctx, pi, reason);
 }
@@ -2101,6 +2102,8 @@ export async function runFinalize(
 
   // Both pre and post verification completed without timeout — reset counter
   loopState.consecutiveFinalizeTimeouts = 0;
+  s.currentUnit = null;
+  clearCurrentPhase();
 
   // Surface accumulated workflow-logger issues for this unit to the user.
   // Warnings/errors logged during the unit are buffered in the logger and

--- a/src/resources/extensions/gsd/bootstrap/provider-error-resume.ts
+++ b/src/resources/extensions/gsd/bootstrap/provider-error-resume.ts
@@ -6,14 +6,12 @@ import type {
 
 import { getAutoDashboardData, startAuto, type AutoDashboardData } from "../auto.js";
 import { resetTransientRetryState } from "./agent-end-recovery.js";
-import { resetSessionTimeoutState } from "../auto/phases.js";
 
 type AutoResumeSnapshot = Pick<AutoDashboardData, "active" | "paused" | "stepMode" | "basePath">;
 
 export interface ProviderErrorResumeDeps {
   getSnapshot(): AutoResumeSnapshot;
   resetTransientRetryState(): void;
-  resetSessionTimeoutState(): void;
   startAuto(
     ctx: ExtensionCommandContext,
     pi: ExtensionAPI,
@@ -26,7 +24,6 @@ export interface ProviderErrorResumeDeps {
 const defaultDeps: ProviderErrorResumeDeps = {
   getSnapshot: () => getAutoDashboardData(),
   resetTransientRetryState,
-  resetSessionTimeoutState,
   startAuto,
 };
 
@@ -48,11 +45,10 @@ export async function resumeAutoAfterProviderDelay(
     return "missing-base";
   }
 
-  // Reset retry counters before restarting — without this, counters
-  // accumulate across pause/resume cycles and permanently lock out
-  // auto-resume after their respective MAX thresholds.
+  // Reset provider-error retry state before restarting. Session-creation
+  // timeout state intentionally survives delayed resumes so the bounded
+  // auto-resume limit cannot be reset into an infinite pause/resume loop.
   deps.resetTransientRetryState();
-  deps.resetSessionTimeoutState();
 
   await deps.startAuto(
     ctx as ExtensionCommandContext,

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -393,7 +393,7 @@ export function registerHooks(
     if (isAutoActive() && typeof event.toolCallId === "string") {
       markToolEnd(event.toolCallId);
     }
-    if (isAutoActive() && event.isError && event.toolName.startsWith("gsd_")) {
+    if (isAutoActive() && event.isError) {
       const resultPayload = ("result" in event ? event.result : undefined) as any;
       const errorText = typeof resultPayload === "string"
         ? resultPayload
@@ -489,9 +489,9 @@ export function registerHooks(
 
   pi.on("tool_execution_end", async (event) => {
     markToolEnd(event.toolCallId);
-    // #2883: Capture tool invocation errors (malformed/truncated JSON arguments)
+    // #2883/#4974: Capture deterministic invocation/policy errors
     // so postUnitPreVerification can break the retry loop instead of re-dispatching.
-    if (event.isError && event.toolName.startsWith("gsd_")) {
+    if (event.isError) {
       const errorText = typeof event.result === "string"
         ? event.result
         : (typeof event.result?.content?.[0]?.text === "string" ? event.result.content[0].text : String(event.result));

--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -188,13 +188,14 @@ function ensureExitHandler(_gsdDir: string): void {
     // Lock files accumulate across main project .gsd/, worktree .gsd/,
     // and projects registry paths — cleanup must cover all of them.
     for (const dir of _lockDirRegistry) {
+      const lockFile = join(dir, LOCK_FILE);
+      const ownsRegisteredLock = isLockFileOwnedByCurrentProcess(lockFile);
       try {
-        const lockFile = join(dir, LOCK_FILE);
-        if (existsSync(lockFile)) unlinkSync(lockFile);
+        if (ownsRegisteredLock && existsSync(lockFile)) unlinkSync(lockFile);
       } catch { /* best-effort */ }
       try {
         const lockDir = join(dir + ".lock");
-        if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
+        if (ownsRegisteredLock && existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
       } catch { /* best-effort */ }
     }
   });
@@ -526,10 +527,13 @@ export function releaseSessionLock(basePath: string): void {
     _releaseFunction = null;
   }
 
-  // Remove the lock file at the current path
+  // Remove the lock file at the current path only if it still belongs to us.
+  // Lost-lock cleanup can run after another process has taken ownership; in
+  // that case deleting auto.lock would erase the newer owner's evidence.
   const lp = lockPath(basePath);
+  const ownsPrimaryLock = isLockFileOwnedByCurrentProcess(lp);
   try {
-    if (existsSync(lp)) unlinkSync(lp);
+    if (ownsPrimaryLock && existsSync(lp)) unlinkSync(lp);
   } catch {
     // Non-fatal
   }
@@ -540,12 +544,12 @@ export function releaseSessionLock(basePath: string): void {
   const lockTarget = effectiveLockTarget(gsdDir);
   try {
     const lockDir = join(lockTarget + ".lock");
-    if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
+    if (ownsPrimaryLock && existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
   } catch {
     // Non-fatal
   }
   // Also clean the per-milestone parallel directory itself if it exists
-  if (lockTarget !== gsdDir) {
+  if (ownsPrimaryLock && lockTarget !== gsdDir) {
     try {
       if (existsSync(lockTarget)) rmSync(lockTarget, { recursive: true, force: true });
     } catch {
@@ -556,13 +560,14 @@ export function releaseSessionLock(basePath: string): void {
   // Clean ALL registered lock paths (#1578) — lock files accumulate across
   // main project .gsd/, worktree .gsd/, and projects registry paths.
   for (const dir of _lockDirRegistry) {
+    const lockFile = join(dir, LOCK_FILE);
+    const ownsRegisteredLock = isLockFileOwnedByCurrentProcess(lockFile);
     try {
-      const lockFile = join(dir, LOCK_FILE);
-      if (existsSync(lockFile)) unlinkSync(lockFile);
+      if (ownsRegisteredLock && existsSync(lockFile)) unlinkSync(lockFile);
     } catch { /* best-effort */ }
     try {
       const lockDir = join(dir + ".lock");
-      if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
+      if (ownsRegisteredLock && existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
     } catch { /* best-effort */ }
   }
   _lockDirRegistry.clear();
@@ -617,6 +622,11 @@ function readExistingLockData(lp: string): SessionLockData | null {
   } catch {
     return null;
   }
+}
+
+function isLockFileOwnedByCurrentProcess(lp: string): boolean {
+  const existing = readExistingLockData(lp);
+  return existing?.pid === process.pid;
 }
 
 /**

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -347,6 +347,7 @@ function diskMilestoneInsert(basePath: string, mid: string): {
   const roadmapContent = loadSync(resolveMilestoneFile(basePath, mid, "ROADMAP"));
   const summaryContent = loadSync(resolveMilestoneFile(basePath, mid, "SUMMARY"));
   const roadmap = roadmapContent ? parseRoadmap(roadmapContent) : null;
+  const summary = summaryContent ? parseSummary(summaryContent) : null;
   const summaryTerminal = summaryContent != null && isTerminalMilestoneSummaryContent(summaryContent);
   const parked = resolveMilestoneFile(basePath, mid, "PARKED") !== null;
 
@@ -354,7 +355,9 @@ function diskMilestoneInsert(basePath: string, mid: string): {
     id: mid,
     title: roadmap
       ? stripMilestonePrefix(roadmap.title)
-      : extractContextTitle(contextContent || draftContent, mid),
+      : (contextContent || draftContent)
+        ? extractContextTitle(contextContent || draftContent, mid)
+        : (summary?.title || mid),
     status: parked ? "parked" : summaryTerminal ? "complete" : "active",
     depends_on: parseContextDependsOn(contextContent ?? draftContent),
   };

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -267,7 +267,7 @@ export async function deriveState(basePath: string): Promise<GSDState> {
       let synced = false;
       for (const diskId of diskIds) {
         if (!isGhostMilestone(basePath, diskId)) {
-          insertMilestone({ id: diskId, status: 'active' });
+          insertMilestone(diskMilestoneInsert(basePath, diskId));
           synced = true;
         }
       }
@@ -327,6 +327,39 @@ function extractContextTitle(content: string | null, fallback: string): string {
 // Alias kept for backward compatibility within this file.
 const isStatusDone = isClosedStatus;
 
+function loadSync(path: string | null): string | null {
+  if (!path) return null;
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function diskMilestoneInsert(basePath: string, mid: string): {
+  id: string;
+  title?: string;
+  status: string;
+  depends_on: string[];
+} {
+  const contextContent = loadSync(resolveMilestoneFile(basePath, mid, "CONTEXT"));
+  const draftContent = !contextContent ? loadSync(resolveMilestoneFile(basePath, mid, "CONTEXT-DRAFT")) : null;
+  const roadmapContent = loadSync(resolveMilestoneFile(basePath, mid, "ROADMAP"));
+  const summaryContent = loadSync(resolveMilestoneFile(basePath, mid, "SUMMARY"));
+  const roadmap = roadmapContent ? parseRoadmap(roadmapContent) : null;
+  const summaryTerminal = summaryContent != null && isTerminalMilestoneSummaryContent(summaryContent);
+  const parked = resolveMilestoneFile(basePath, mid, "PARKED") !== null;
+
+  return {
+    id: mid,
+    title: roadmap
+      ? stripMilestonePrefix(roadmap.title)
+      : extractContextTitle(contextContent || draftContent, mid),
+    status: parked ? "parked" : summaryTerminal ? "complete" : "active",
+    depends_on: parseContextDependsOn(contextContent ?? draftContent),
+  };
+}
+
 /**
  * Derive GSD state from the milestones/slices/tasks DB tables.
  * Flag files (PARKED, VALIDATION, CONTINUE, REPLAN, REPLAN-TRIGGER, CONTEXT-DRAFT)
@@ -342,7 +375,7 @@ function reconcileDiskToDb(basePath: string): MilestoneRow[] {
   let synced = false;
   for (const diskId of diskIds) {
     if (!dbIdSet.has(diskId) && !isGhostMilestone(basePath, diskId)) {
-      insertMilestone({ id: diskId, status: 'active' });
+      insertMilestone(diskMilestoneInsert(basePath, diskId));
       synced = true;
     }
   }
@@ -677,32 +710,12 @@ function resolveSliceDependencies(activeMilestoneSlices: SliceRow[]): { activeSl
     }
   }
 
-  let bestFallback: SliceRow | null = null;
-  let bestFallbackSatisfied = -1;
-
   for (const s of activeMilestoneSlices) {
     if (isStatusDone(s.status)) continue;
     if (isDeferredStatus(s.status)) continue;
     if (s.depends.every(dep => doneSliceIds.has(dep))) {
       return { activeSlice: { id: s.id, title: s.title }, activeSliceRow: s };
     }
-    const satisfied = s.depends.filter(dep => doneSliceIds.has(dep)).length;
-    if (satisfied > bestFallbackSatisfied || (satisfied === bestFallbackSatisfied && !bestFallback)) {
-      bestFallback = s;
-      bestFallbackSatisfied = satisfied;
-    }
-  }
-
-  if (bestFallback) {
-    const unmet = bestFallback.depends.filter(dep => !doneSliceIds.has(dep));
-    logWarning(
-      "state",
-      `No slice has all deps satisfied — falling back to ${bestFallback.id} ` +
-        `(${bestFallbackSatisfied}/${bestFallback.depends.length} deps met, ` +
-        `unmet: ${unmet.join(", ")})`,
-      { mid: activeMilestoneSlices[0]?.milestone_id, sid: bestFallback.id },
-    );
-    return { activeSlice: { id: bestFallback.id, title: bestFallback.title }, activeSliceRow: bestFallback };
   }
 
   return { activeSlice: null, activeSliceRow: null };
@@ -716,14 +729,19 @@ async function reconcileSliceTasks(
 ): Promise<TaskRow[]> {
   let tasks = getSliceTasks(milestoneId, sliceId);
 
-  if (tasks.length === 0 && planFile) {
+  // #3600/#4974: import missing plan-file tasks even when the DB already has
+  // a partial task set. Existing DB task statuses stay authoritative.
+  if (planFile) {
     try {
       const planContent = await loadFile(planFile);
       if (planContent) {
         const diskPlan = parsePlan(planContent);
         if (diskPlan.tasks.length > 0) {
+          const dbTaskIds = new Set(tasks.map(t => t.id));
+          let inserted = 0;
           for (let i = 0; i < diskPlan.tasks.length; i++) {
             const t = diskPlan.tasks[i];
+            if (dbTaskIds.has(t.id)) continue;
             try {
               insertTask({
                 id: t.id,
@@ -733,12 +751,15 @@ async function reconcileSliceTasks(
                 status: t.done ? 'complete' : 'pending',
                 sequence: i + 1,
               });
+              inserted++;
             } catch (insertErr) {
               logWarning("reconcile", `failed to insert task ${t.id} from plan file: ${insertErr instanceof Error ? insertErr.message : String(insertErr)}`);
             }
           }
-          tasks = getSliceTasks(milestoneId, sliceId);
-          logWarning("reconcile", `imported ${tasks.length} tasks from plan file for ${milestoneId}/${sliceId} — DB was empty (#3600)`, { mid: milestoneId, sid: sliceId });
+          if (inserted > 0) {
+            tasks = getSliceTasks(milestoneId, sliceId);
+            logWarning("reconcile", `imported ${inserted} missing task(s) from plan file for ${milestoneId}/${sliceId}`, { mid: milestoneId, sid: sliceId });
+          }
         }
       }
     } catch (err) {
@@ -1569,31 +1590,12 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
       };
     }
   } else {
-    let bestFallbackLegacy: { id: string; title: string; depends: string[] } | null = null;
-    let bestFallbackLegacySatisfied = -1;
-
     for (const s of activeRoadmap.slices) {
       if (s.done) continue;
       if (s.depends.every(dep => doneSliceIds.has(dep))) {
         activeSlice = { id: s.id, title: s.title };
         break;
       }
-      const satisfied = s.depends.filter(dep => doneSliceIds.has(dep)).length;
-      if (satisfied > bestFallbackLegacySatisfied) {
-        bestFallbackLegacy = s;
-        bestFallbackLegacySatisfied = satisfied;
-      }
-    }
-
-    if (!activeSlice && bestFallbackLegacy) {
-      const unmet = bestFallbackLegacy.depends.filter(dep => !doneSliceIds.has(dep));
-      logWarning(
-        "state",
-        `No slice has all deps satisfied — falling back to ${bestFallbackLegacy.id} ` +
-          `(${bestFallbackLegacySatisfied}/${bestFallbackLegacy.depends.length} deps met, ` +
-          `unmet: ${unmet.join(", ")})`,
-      );
-      activeSlice = { id: bestFallbackLegacy.id, title: bestFallbackLegacy.title };
     }
   }
 

--- a/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
@@ -223,6 +223,84 @@ test("selectAndApplyModel honors explicit phase models without downgrading (#361
   }
 });
 
+test("selectAndApplyModel escalates dynamic routing tier when retry metadata is provided", async (t) => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = makeTempDir("gsd-routing-retry-project-");
+  const tempGsdHome = makeTempDir("gsd-routing-retry-home-");
+  const setModelCalls: string[] = [];
+  const notifications: Array<{ message: string; level: string }> = [];
+
+  t.after(() => {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  });
+
+  mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+  writeFileSync(
+    join(tempProject, ".gsd", "PREFERENCES.md"),
+    [
+      "---",
+      "dynamic_routing:",
+      "  enabled: true",
+      "  hooks: false",
+      "  budget_pressure: false",
+      "  tier_models:",
+      "    light: claude-haiku-4-5",
+      "    standard: claude-sonnet-4-6",
+      "    heavy: claude-opus-4-6",
+      "---",
+    ].join("\n"),
+    "utf-8",
+  );
+  process.env.GSD_HOME = tempGsdHome;
+  process.chdir(tempProject);
+
+  const availableModels = [
+    { id: "claude-haiku-4-5", provider: "anthropic", api: "anthropic-messages" },
+    { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+    { id: "claude-opus-4-6", provider: "anthropic", api: "anthropic-messages" },
+  ];
+
+  const result = await selectAndApplyModel(
+    {
+      modelRegistry: { getAvailable: () => availableModels },
+      sessionManager: { getSessionId: () => "test-session" },
+      ui: { notify: (message: string, level: string) => notifications.push({ message, level }) },
+      model: { provider: "anthropic", id: "claude-opus-4-6", api: "anthropic-messages" },
+    } as any,
+    {
+      setModel: async (model: { provider: string; id: string }) => {
+        setModelCalls.push(`${model.provider}/${model.id}`);
+        return true;
+      },
+      emitBeforeModelSelect: async () => undefined,
+      getActiveTools: () => [],
+      emitAdjustToolSet: async () => undefined,
+      setActiveTools: () => {},
+    } as any,
+    "execute-task",
+    "M001/S01/T01",
+    tempProject,
+    undefined,
+    false,
+    { provider: "anthropic", id: "claude-opus-4-6" },
+    { isRetry: true, previousTier: "light" },
+    true,
+  );
+
+  assert.deepEqual(setModelCalls, ["anthropic/claude-sonnet-4-6"]);
+  assert.deepEqual(result.routing, { tier: "standard", modelDowngraded: true });
+  assert.equal(result.appliedModel?.id, "claude-sonnet-4-6");
+  assert.ok(
+    notifications.some(n => n.message.includes("Tier escalation: light") && n.message.includes("standard")),
+    "retry metadata should produce a visible tier escalation notification",
+  );
+});
+
 // ─── resolveModelId tests ─────────────────────────────────────────────────
 
 test("resolveModelId: bare ID resolves to claude-code when session is claude-code (#3772)", () => {

--- a/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runFinalize } from "../auto/phases.ts";
+import { AutoSession } from "../auto/session.ts";
+
+test("runFinalize clears currentUnit after successful finalize", async () => {
+  const s = new AutoSession();
+  s.basePath = "/tmp/gsd-finalize-current-unit";
+  s.currentUnit = {
+    type: "execute-task",
+    id: "M001/S01/T01",
+    startedAt: Date.now(),
+  };
+
+  const deps = {
+    clearUnitTimeout() {},
+    buildSnapshotOpts() {
+      return {};
+    },
+    stopAuto: async () => {},
+    pauseAuto: async () => {},
+    updateProgressWidget() {},
+    postUnitPreVerification: async () => "continue",
+    runPostUnitVerification: async () => "continue",
+    postUnitPostVerification: async () => "continue",
+  };
+
+  const result = await runFinalize(
+    {
+      ctx: { ui: { notify() {} } },
+      pi: {},
+      s,
+      deps,
+      prefs: undefined,
+      iteration: 1,
+      flowId: "flow-1",
+      nextSeq: () => 1,
+    } as any,
+    {
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      prompt: "",
+      finalPrompt: "",
+      pauseAfterUatDispatch: false,
+      state: {} as any,
+      mid: "M001",
+      midTitle: "Milestone",
+      isRetry: false,
+      previousTier: undefined,
+    },
+    {
+      recentUnits: [],
+      stuckRecoveryAttempts: 0,
+      consecutiveFinalizeTimeouts: 0,
+    },
+  );
+
+  assert.equal(result.action, "next");
+  assert.equal(s.currentUnit, null);
+});

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -403,9 +403,12 @@ console.log('\n=== complete-task: handler idempotency ===');
   const r1 = await handleCompleteTask(params, basePath);
   assertTrue(!('error' in r1), 'first call should succeed');
 
-  // Verify only 1 task row
+  // Verify complete-task did not duplicate T01. State reconciliation may import
+  // the remaining plan task from disk so the DB stays aligned with S01-PLAN.md.
   const tasks = getSliceTasks('M001', 'S01');
-  assertEq(tasks.length, 1, 'should have exactly 1 task row after first call');
+  assertEq(tasks.length, 2, 'should have T01 plus reconciled T02 after first call');
+  assertEq(tasks.filter(t => t.id === 'T01').length, 1, 'should have exactly one T01 row after first call');
+  assertEq(tasks.find(t => t.id === 'T02')?.status, 'pending', 'T02 should be reconciled as pending');
 
   // Second call with same params — state machine guard rejects (task is already complete)
   const r2 = await handleCompleteTask(params, basePath);
@@ -414,9 +417,10 @@ console.log('\n=== complete-task: handler idempotency ===');
     assertMatch(r2.error, /already complete/, 'error should mention already complete');
   }
 
-  // Still only 1 task row (no duplication from rejected second call)
+  // Still no duplicate rows from the rejected second call.
   const tasksAfter = getSliceTasks('M001', 'S01');
-  assertEq(tasksAfter.length, 1, 'should still have exactly 1 task row after rejected second call');
+  assertEq(tasksAfter.length, 2, 'should still have T01 plus reconciled T02 after rejected second call');
+  assertEq(tasksAfter.filter(t => t.id === 'T01').length, 1, 'should still have exactly one T01 row');
 
   cleanupDir(basePath);
   cleanup(dbPath);

--- a/src/resources/extensions/gsd/tests/crash-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/crash-recovery.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -21,6 +21,7 @@ import {
 } from "../interrupted-session.ts";
 import { gsdRoot } from "../paths.ts";
 import type { GSDState } from "../types.ts";
+import { _synthesizePausedSessionRecoveryForTest } from "../auto.ts";
 
 function makeTmpBase(): string {
   const base = join(tmpdir(), `gsd-test-${randomUUID()}`);
@@ -165,6 +166,54 @@ test("readPausedSessionMetadata reads paused-session metadata when present", () 
   } finally {
     cleanup(base);
   }
+});
+
+test("paused session recovery consumes JSONL without deleting the evidence file", (t) => {
+  const base = makeTmpBase();
+  t.after(() => cleanup(base));
+
+  const sessionFile = join(base, "paused-session.jsonl");
+  writeFileSync(
+    sessionFile,
+    [
+      JSON.stringify({ type: "session", id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              name: "bash",
+              id: "tool-1",
+              arguments: { command: "echo paused" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "toolResult",
+          toolCallId: "tool-1",
+          toolName: "bash",
+          isError: false,
+          content: "paused\n",
+        },
+      }),
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const recovery = _synthesizePausedSessionRecoveryForTest(
+    base,
+    "execute-task",
+    "M001/S01/T01",
+    sessionFile,
+  );
+
+  assert.equal(recovery?.trace.toolCallCount, 1);
+  assert.equal(existsSync(sessionFile), true, "paused JSONL must remain available after synthesis");
 });
 
 test("readPausedSessionMetadata preserves unitType and unitId through round-trip", () => {

--- a/src/resources/extensions/gsd/tests/derive-state-crossval.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-crossval.test.ts
@@ -351,9 +351,9 @@ skills_used: []
       const dbState = await deriveStateFromDb(base);
 
       assertStatesEqual(dbState, fileState, 'E-blocked');
-      // With partial-dep fallback, circular deps no longer block — fallback picks first eligible slice
-      assert.deepStrictEqual(dbState.phase, 'planning', 'E-blocked: phase is planning (fallback picks a slice)');
-      assert.ok(dbState.activeSlice !== null, 'E-blocked: activeSlice is set via fallback');
+      assert.deepStrictEqual(dbState.phase, 'blocked', 'E-blocked: phase is blocked when no slice deps are satisfied');
+      assert.deepStrictEqual(dbState.activeSlice, null, 'E-blocked: no activeSlice is selected through unmet deps');
+      assert.ok(dbState.blockers.some(b => b.includes('No slice eligible')), 'E-blocked: blocker explains no eligible slice');
 
       closeDatabase();
     } finally {

--- a/src/resources/extensions/gsd/tests/derive-state-db-disk-reconcile.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db-disk-reconcile.test.ts
@@ -112,6 +112,46 @@ async function main(): Promise<void> {
     cleanup(base);
   }
 
+  console.log("\n=== #4974: summary-only disk milestones keep parsed title ===");
+
+  {
+    const summaryOnlyBase = createFixtureBase();
+    const summaryOnlyDbPath = join(summaryOnlyBase, ".gsd", "gsd.db");
+
+    try {
+      openDatabase(summaryOnlyDbPath);
+      insertMilestone({ id: "M001", title: "M001: Existing DB Milestone", status: "complete", depends_on: [] });
+
+      writeFile(
+        summaryOnlyBase,
+        "milestones/M002/SUMMARY.md",
+        `---\nid: M002\nstatus: complete\n---\n\n# M002: Summary-Only Milestone\n\nComplete.`,
+      );
+
+      invalidateStateCache();
+      const state = await deriveStateFromDb(summaryOnlyBase);
+      const m002Entry = state.registry.find((m) => m.id === "M002");
+
+      assertTrue(
+        m002Entry !== undefined,
+        "M002 summary-only disk milestone should appear in state.registry (#4974)",
+      );
+      assertEq(
+        m002Entry?.title,
+        "Summary-Only Milestone",
+        "M002 summary-only disk milestone should use parsed SUMMARY title (#4974)",
+      );
+      assertEq(
+        m002Entry?.status,
+        "complete",
+        "M002 summary-only disk milestone should reconcile as complete (#4974)",
+      );
+    } finally {
+      closeDatabase();
+      cleanup(summaryOnlyBase);
+    }
+  }
+
   report();
 }
 

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -14,6 +14,7 @@ import {
   getAllMilestones,
   insertSlice,
   insertTask,
+  getSliceTasks,
   updateTaskStatus,
 } from '../gsd-db.ts';
 // ─── Fixture Helpers ───────────────────────────────────────────────────────
@@ -268,6 +269,93 @@ describe('derive-state-db', async () => {
       closeDatabase();
       cleanup(base);
     }
+  });
+
+  test('derive-state-db: partial task rows reconcile missing plan tasks before summarizing', async (t) => {
+    const base = createFixtureBase();
+    t.after(() => {
+      closeDatabase();
+      cleanup(base);
+    });
+
+    const partialTaskPlan = `# S01: First Slice
+
+**Goal:** Test partial task DB reconciliation.
+**Demo:** Tests pass.
+
+## Tasks
+
+- [x] **T01: Existing Complete** \`est:10m\`
+  Already complete in DB.
+
+- [ ] **T02: Missing Pending** \`est:10m\`
+  Missing from DB but present in the plan.
+`;
+    writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT);
+    writeFile(base, 'milestones/M001/slices/S01/S01-PLAN.md', partialTaskPlan);
+    writeFile(base, 'milestones/M001/slices/S01/tasks/.gitkeep', '');
+    writeFile(base, 'milestones/M001/slices/S01/tasks/T01-PLAN.md', '# T01 Plan');
+    writeFile(base, 'milestones/M001/slices/S01/tasks/T02-PLAN.md', '# T02 Plan');
+
+    openDatabase(':memory:');
+    insertMilestone({ id: 'M001', title: 'Test Milestone', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'First Slice', status: 'active', risk: 'low', depends: [] });
+    insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'Existing Complete', status: 'complete' });
+
+    invalidateStateCache();
+    const state = await deriveState(base);
+
+    const dbTasks = getSliceTasks('M001', 'S01');
+    assert.deepStrictEqual(dbTasks.length, 2, 'partial-task-db: missing T02 imported from plan');
+    assert.deepStrictEqual(dbTasks.find(t => t.id === 'T01')?.status, 'complete', 'partial-task-db: existing complete T01 preserved');
+    assert.deepStrictEqual(dbTasks.find(t => t.id === 'T02')?.status, 'pending', 'partial-task-db: missing T02 inserted pending');
+    assert.deepStrictEqual(state.phase, 'executing', 'partial-task-db: phase remains executing, not summarizing');
+    assert.deepStrictEqual(state.activeTask?.id, 'T02', 'partial-task-db: activeTask is missing plan task T02');
+    assert.deepStrictEqual(state.progress?.tasks, { done: 1, total: 2 }, 'partial-task-db: task progress includes reconciled plan task');
+  });
+
+  test('derive-state-db: empty DB disk import preserves milestone completion and dependencies', async (t) => {
+    const base = createFixtureBase();
+    t.after(() => {
+      closeDatabase();
+      cleanup(base);
+    });
+
+    writeFile(base, 'milestones/M001/M001-ROADMAP.md', `# M001: Foundation
+
+**Vision:** Foundation.
+
+## Slices
+
+- [x] **S01: Done** \`risk:low\` \`depends:[]\`
+  > After this: Done.
+`);
+    writeFile(base, 'milestones/M001/M001-VALIDATION.md', '---\nverdict: pass\nremediation_round: 0\n---\n\nPassed.');
+    writeFile(base, 'milestones/M001/M001-SUMMARY.md', '# M001 Summary\n\nDone.');
+    writeFile(base, 'milestones/M002/M002-CONTEXT.md', '---\ndepends_on:\n  - M001\n---\n\n# M002: Dependent\n');
+    writeFile(base, 'milestones/M002/M002-ROADMAP.md', `# M002: Dependent
+
+**Vision:** Active work.
+
+## Slices
+
+- [ ] **S01: Work** \`risk:low\` \`depends:[]\`
+  > After this: Done.
+`);
+    writeFile(base, 'milestones/M003/M003-CONTEXT.md', '---\ndepends_on:\n  - M002\n---\n\n# M003: Blocked\n');
+
+    openDatabase(':memory:');
+
+    invalidateStateCache();
+    const state = await deriveState(base);
+
+    const milestones = getAllMilestones();
+    assert.deepStrictEqual(milestones.find(m => m.id === 'M001')?.status, 'complete', 'disk-import: terminal summary imports M001 as complete');
+    assert.deepStrictEqual(milestones.find(m => m.id === 'M002')?.depends_on, ['M001'], 'disk-import: M002 depends_on imported from CONTEXT');
+    assert.deepStrictEqual(milestones.find(m => m.id === 'M003')?.depends_on, ['M002'], 'disk-import: M003 depends_on imported from CONTEXT');
+    assert.deepStrictEqual(state.activeMilestone?.id, 'M002', 'disk-import: M002 is active because M001 completion satisfies dependency');
+    assert.deepStrictEqual(state.registry.find(e => e.id === 'M001')?.status, 'complete', 'disk-import: M001 registry status is complete');
+    assert.deepStrictEqual(state.registry.find(e => e.id === 'M003')?.status, 'pending', 'disk-import: M003 stays pending on unmet M002 dependency');
   });
 
   // ─── Test 5: Requirements counting from disk (DB no longer used for content) ─
@@ -616,10 +704,10 @@ describe('derive-state-db', async () => {
       invalidateStateCache();
       const dbState = await deriveStateFromDb(base);
 
-      // With partial-dep fallback, circular deps no longer block — fallback picks first eligible slice
-      assert.deepStrictEqual(dbState.phase, 'planning', 'blocked-db: phase is planning (fallback picks a slice)');
+      assert.deepStrictEqual(dbState.phase, 'blocked', 'blocked-db: phase is blocked when no slice deps are satisfied');
       assert.deepStrictEqual(dbState.phase, fileState.phase, 'blocked-db: phase matches filesystem');
-      assert.ok(dbState.activeSlice !== null, 'blocked-db: activeSlice is set via fallback');
+      assert.deepStrictEqual(dbState.activeSlice, null, 'blocked-db: no activeSlice is selected through unmet deps');
+      assert.ok(dbState.blockers.some(b => b.includes('No slice eligible')), 'blocked-db: blocker explains no eligible slice');
 
       closeDatabase();
     } finally {

--- a/src/resources/extensions/gsd/tests/derive-state.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state.test.ts
@@ -431,7 +431,7 @@ Continue from step 2.
       cleanup(base1);
     }
 
-    // Case B: S01 depends on nonexistent S99 -> fallback picks best available slice
+    // Case B: S01 depends on nonexistent S99 -> no slice is eligible
     const base2 = createFixtureBase();
     try {
       writeRoadmap(base2, 'M001', `# M001: Test Milestone
@@ -446,8 +446,9 @@ Continue from step 2.
 
       const state2 = await deriveState(base2);
 
-      assert.deepStrictEqual(state2.phase, 'planning', 'blocked-B: phase is planning (fallback picks S01)');
-      assert.deepStrictEqual(state2.activeSlice?.id, 'S01', 'blocked-B: activeSlice is S01 via fallback');
+      assert.deepStrictEqual(state2.phase, 'blocked', 'blocked-B: phase is blocked when dependency is unsatisfied');
+      assert.deepStrictEqual(state2.activeSlice, null, 'blocked-B: no activeSlice selected through unmet deps');
+      assert.ok(state2.blockers.some(b => b.includes('No slice eligible')), 'blocked-B: blocker explains no eligible slice');
     } finally {
       cleanup(base2);
     }

--- a/src/resources/extensions/gsd/tests/dispatcher-stuck-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatcher-stuck-planning.test.ts
@@ -4,7 +4,7 @@
  * Verify that state.ts contains the disk-to-DB task reconciliation logic
  * that prevents the dispatcher from getting stuck in an infinite planning
  * loop when the planner writes a PLAN.md but never calls the persistence
- * tool, leaving the DB with zero task rows.
+ * tool, leaving the DB with zero or partial task rows.
  */
 
 import { describe, test } from "node:test";
@@ -24,7 +24,8 @@ describe("dispatcher stuck-planning reconciliation (#3656)", () => {
   });
 
   test("contains plan-file task reconciliation block", () => {
-    assert.match(source, /tasks\.length\s*===\s*0\s*&&\s*planFile/);
+    assert.match(source, /if\s*\(\s*planFile\s*\)/);
+    assert.match(source, /dbTaskIds\.has\(t\.id\)/);
   });
 
   test("calls insertTask for each disk plan task", () => {

--- a/src/resources/extensions/gsd/tests/integration/state-machine-edge-cases.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/state-machine-edge-cases.test.ts
@@ -277,6 +277,14 @@ function buildDispatchCtx(
   };
 }
 
+function getUatVerdictGate(): import("../../auto-dispatch.ts").DispatchRule {
+  const rule = DISPATCH_RULES.find(
+    r => r.name === "uat-verdict-gate (non-PASS blocks progression)",
+  );
+  assert.ok(rule, "uat-verdict-gate rule should be registered");
+  return rule;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Test Suite
 // ═══════════════════════════════════════════════════════════════════════════
@@ -355,10 +363,13 @@ describe("state derivation failures", () => {
     const state2 = await deriveState(base);
     assert.equal(state2.phase, "executing", "cached result should still show executing");
 
-    // After explicit invalidation, should reflect the DB mutation
+    // After explicit invalidation, should reflect the DB mutation and reconcile
+    // missing plan tasks instead of prematurely summarizing a partial DB row set.
     invalidateStateCache();
     const state3 = await deriveState(base);
-    assert.equal(state3.phase, "summarizing", "after cache invalidation should show summarizing");
+    assert.equal(state3.phase, "executing", "after cache invalidation should continue with the missing plan task");
+    assert.equal(state3.activeTask?.id, "T02", "missing plan task T02 should be imported and selected");
+    assert.deepEqual(state3.progress?.tasks, { done: 1, total: 2 });
   });
 
   test("corrupt ROADMAP: binary content does not crash deriveState", async () => {
@@ -691,7 +702,7 @@ describe("transition boundary failures", () => {
     );
   });
 
-  test("blocked state: all slices have unmet deps → fallback picks slice", async () => {
+  test("blocked state: all slices have unmet deps → blocks", async () => {
     base = makeTempDir();
     const mDir = join(base, ".gsd", "milestones", "M001");
     mkdirSync(join(mDir, "slices", "S01", "tasks"), { recursive: true });
@@ -736,9 +747,9 @@ describe("transition boundary failures", () => {
 
     invalidateAllCaches();
     const state = await deriveStateFromDb(base);
-    // With partial-dep fallback, circular deps no longer block — fallback picks first eligible slice
-    assert.equal(state.phase, "planning", "circular deps: fallback picks a slice instead of blocking");
-    assert.ok(state.activeSlice !== null, "activeSlice set via fallback");
+    assert.equal(state.phase, "blocked", "circular deps: no slice should be selected through unmet deps");
+    assert.equal(state.activeSlice, null, "activeSlice should remain null when all deps are blocked");
+    assert.ok(state.blockers.some(b => b.includes("No slice eligible")));
   });
 });
 
@@ -868,6 +879,76 @@ describe("dispatch failure modes", () => {
     // run-uat should come before uat-verdict-gate
     assert.ok(runUatIdx < uatGateIdx, "run-uat should precede uat-verdict-gate");
   });
+
+  test("UAT verdict gate: ASSESSMENT FAIL blocks closed slice progression", async () => {
+    base = createFullFixture();
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Active", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "First", status: "complete" });
+    insertSlice({ id: "S02", milestoneId: "M001", title: "Second", status: "pending" });
+
+    const s01Dir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(
+      join(s01Dir, "S01-UAT.md"),
+      "# UAT File\n\n## UAT Type\n\n- UAT mode: artifact-driven\n",
+    );
+    writeFileSync(
+      join(s01Dir, "S01-ASSESSMENT.md"),
+      "---\nverdict: FAIL\n---\n# UAT Assessment\n",
+    );
+
+    const ctx = buildDispatchCtx(base, "M001", {
+      phase: "planning",
+      activeSlice: { id: "S02", title: "Second" },
+      activeTask: null,
+    });
+    ctx.prefs = { uat_dispatch: true } as any;
+
+    const result = await getUatVerdictGate().match(ctx);
+    assert.equal(result?.action, "stop", "ASSESSMENT FAIL should block progression");
+    assert.ok(
+      (result as any).reason?.includes('UAT verdict for S01 is "fail"'),
+      "stop reason should report normalized ASSESSMENT verdict",
+    );
+  });
+
+  for (const status of ["done", "skipped"]) {
+    test(`UAT verdict gate: legacy closed status "${status}" is gated`, async () => {
+      base = createFullFixture();
+      openDatabase(join(base, ".gsd", "gsd.db"));
+      insertMilestone({ id: "M001", title: "Active", status: "active" });
+      insertSlice({ id: "S01", milestoneId: "M001", title: "First", status });
+      insertSlice({ id: "S02", milestoneId: "M001", title: "Second", status: "pending" });
+
+      const s01Dir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+      writeFileSync(
+        join(s01Dir, "S01-UAT.md"),
+        "# UAT File\n\n## UAT Type\n\n- UAT mode: artifact-driven\n",
+      );
+      writeFileSync(
+        join(s01Dir, "S01-ASSESSMENT.md"),
+        "---\nverdict: needs-remediation\n---\n# UAT Assessment\n",
+      );
+
+      const ctx = buildDispatchCtx(base, "M001", {
+        phase: "planning",
+        activeSlice: { id: "S02", title: "Second" },
+        activeTask: null,
+      });
+      ctx.prefs = { uat_dispatch: true } as any;
+
+      const result = await getUatVerdictGate().match(ctx);
+      assert.equal(
+        result?.action,
+        "stop",
+        `${status} slices should be treated as closed for UAT verdict gating`,
+      );
+      assert.ok(
+        (result as any).reason?.includes('UAT verdict for S01 is "needs-remediation"'),
+        "stop reason should report normalized ASSESSMENT verdict",
+      );
+    });
+  }
 });
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/integration/state-machine-edge-cases.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/state-machine-edge-cases.test.ts
@@ -912,6 +912,62 @@ describe("dispatch failure modes", () => {
     );
   });
 
+  test("UAT verdict gate: ROADMAP fallback gates done slices when DB is unavailable", async () => {
+    base = createFullFixture();
+    const mDir = join(base, ".gsd", "milestones", "M001");
+    writeFileSync(
+      join(mDir, "M001-ROADMAP.md"),
+      [
+        "# M001: Edge Case Milestone",
+        "",
+        "## Vision",
+        "Prove edge case correctness.",
+        "",
+        "## Success Criteria",
+        "- All edge cases handled",
+        "",
+        "## Slices",
+        "",
+        "- [x] **S01: First Feature** `risk:low` `depends:[]`",
+        "  - After this: First feature proven.",
+        "",
+        "- [ ] **S02: Second Feature** `risk:low` `depends:[]`",
+        "  - After this: Second feature proven.",
+        "",
+        "## Boundary Map",
+        "",
+        "| From | To | Produces | Consumes |",
+        "|------|----|----------|----------|",
+        "| S01 | terminal | feature-a | nothing |",
+        "| S02 | terminal | feature-b | nothing |",
+      ].join("\n"),
+    );
+
+    const s01Dir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(
+      join(s01Dir, "S01-UAT.md"),
+      "# UAT File\n\n## UAT Type\n\n- UAT mode: artifact-driven\n",
+    );
+    writeFileSync(
+      join(s01Dir, "S01-ASSESSMENT.md"),
+      "---\nverdict: needs-remediation\n---\n# UAT Assessment\n",
+    );
+
+    const ctx = buildDispatchCtx(base, "M001", {
+      phase: "planning",
+      activeSlice: { id: "S02", title: "Second" },
+      activeTask: null,
+    });
+    ctx.prefs = { uat_dispatch: true } as any;
+
+    const result = await getUatVerdictGate().match(ctx);
+    assert.equal(result?.action, "stop", "ROADMAP done slices should be gated without DB");
+    assert.ok(
+      (result as any).reason?.includes('UAT verdict for S01 is "needs-remediation"'),
+      "stop reason should report normalized ASSESSMENT verdict from disk fallback",
+    );
+  });
+
   for (const status of ["done", "skipped"]) {
     test(`UAT verdict gate: legacy closed status "${status}" is gated`, async () => {
       base = createFullFixture();

--- a/src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts
@@ -936,9 +936,11 @@ describe("state-machine-live-validation", () => {
       insertMilestone({ id: "M001", title: "Active", status: "active" });
       insertSlice({ id: "S01", milestoneId: "M001", title: "First", status: "in_progress" });
       insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", status: "pending" });
+      insertTask({ id: "T02", sliceId: "S01", milestoneId: "M001", status: "pending" });
 
       // Complete task + slice
       await handleCompleteTask(makeTaskParams("T01", "S01", "M001") as any, base);
+      await handleCompleteTask(makeTaskParams("T02", "S01", "M001") as any, base);
       await handleCompleteSlice(makeSliceParams("S01", "M001") as any, base);
       assert.ok(isClosedStatus(getSlice("M001", "S01")!.status));
 
@@ -946,9 +948,11 @@ describe("state-machine-live-validation", () => {
       await handleReopenSlice({ milestoneId: "M001", sliceId: "S01" }, base);
       assert.equal(getSlice("M001", "S01")!.status, "in_progress");
       assert.equal(getTask("M001", "S01", "T01")!.status, "pending");
+      assert.equal(getTask("M001", "S01", "T02")!.status, "pending");
 
       // Re-complete task + slice succeeds
       await handleCompleteTask(makeTaskParams("T01", "S01", "M001") as any, base);
+      await handleCompleteTask(makeTaskParams("T02", "S01", "M001") as any, base);
       const r = await handleCompleteSlice(makeSliceParams("S01", "M001") as any, base);
       assert.ok(!("error" in r), `re-complete slice: ${JSON.stringify(r)}`);
       assert.ok(isClosedStatus(getSlice("M001", "S01")!.status));

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -410,7 +410,6 @@ test("resumeAutoAfterProviderDelay restarts paused auto-mode from the recorded b
         basePath: "/tmp/project",
       }),
       resetTransientRetryState: () => {},
-      resetSessionTimeoutState: () => {},
       startAuto: async (_ctx, _pi, base, verboseMode, options) => {
         startCalls.push({ base, verboseMode, step: options?.step });
       },
@@ -436,7 +435,6 @@ test("resumeAutoAfterProviderDelay does not double-start when auto-mode is alrea
         basePath: "/tmp/project",
       }),
       resetTransientRetryState: () => {},
-      resetSessionTimeoutState: () => {},
       startAuto: async () => {
         startCalls += 1;
       },
@@ -468,7 +466,6 @@ test("resumeAutoAfterProviderDelay leaves auto paused when no base path is avail
         basePath: "",
       }),
       resetTransientRetryState: () => {},
-      resetSessionTimeoutState: () => {},
       startAuto: async () => {
         startCalls += 1;
       },
@@ -485,7 +482,7 @@ test("resumeAutoAfterProviderDelay leaves auto paused when no base path is avail
   ]);
 });
 
-test("resumeAutoAfterProviderDelay resets provider retry state before restarting auto-mode", async () => {
+test("resumeAutoAfterProviderDelay resets provider retry state without clearing session-timeout attempts", async () => {
   const calls: string[] = [];
 
   const result = await resumeAutoAfterProviderDelay(
@@ -501,9 +498,6 @@ test("resumeAutoAfterProviderDelay resets provider retry state before restarting
       resetTransientRetryState: () => {
         calls.push("reset-transient");
       },
-      resetSessionTimeoutState: () => {
-        calls.push("reset-session-timeout");
-      },
       startAuto: async () => {
         calls.push("start-auto");
       },
@@ -513,7 +507,6 @@ test("resumeAutoAfterProviderDelay resets provider retry state before restarting
   assert.equal(result, "resumed");
   assert.deepEqual(calls, [
     "reset-transient",
-    "reset-session-timeout",
     "start-auto",
   ]);
 });

--- a/src/resources/extensions/gsd/tests/session-lock-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/session-lock-regression.test.ts
@@ -243,6 +243,35 @@ describe('session-lock-regression', async () => {
     }
   }
 
+  // ─── 7d. Releasing after ownership loss preserves newer owner ─────────
+  test('releaseSessionLock preserves newer owner after PID mismatch', (t) => {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-session-lock-'));
+    mkdirSync(join(base, '.gsd'), { recursive: true });
+    t.after(() => {
+      rmSync(base, { recursive: true, force: true });
+    });
+
+    const acquired = acquireSessionLock(base);
+    assert.ok(acquired.acquired, 'initial lock acquired');
+
+    const lockFile = join(gsdRoot(base), 'auto.lock');
+    const newerOwner = {
+      pid: process.pid + 1000,
+      startedAt: new Date().toISOString(),
+      unitType: 'execute-task',
+      unitId: 'M001/S01/T02',
+      unitStartedAt: new Date().toISOString(),
+    };
+    writeFileSync(lockFile, JSON.stringify(newerOwner, null, 2));
+
+    releaseSessionLock(base);
+
+    assert.ok(existsSync(lockFile), 'foreign lock file must not be deleted by stale owner release');
+    const after = JSON.parse(readFileSync(lockFile, 'utf-8'));
+    assert.deepStrictEqual(after.pid, newerOwner.pid, 'newer owner PID is preserved');
+    assert.deepStrictEqual(after.unitId, newerOwner.unitId, 'newer owner metadata is preserved');
+  });
+
   // ─── 8. Acquire after release is possible ─────────────────────────────
   console.log('\n=== 8. acquire after release → re-acquirable ===');
   {

--- a/src/resources/extensions/gsd/tests/state-machine-full-walkthrough.test.ts
+++ b/src/resources/extensions/gsd/tests/state-machine-full-walkthrough.test.ts
@@ -835,9 +835,9 @@ describe("state-machine-full-walkthrough", () => {
       assert.ok(state.blockers.length > 0, "should have blockers");
     });
 
-    test("no eligible slice (all deps unmet) → fallback picks slice with most deps satisfied", async () => {
+    test("no eligible slice (all deps unmet) → blocked", async () => {
       const base = createFixtureBase();
-      // S01 depends on S00 which doesn't exist — fallback picks S01 anyway
+      // S01 depends on S00 which doesn't exist.
       writeRoadmap(base, "M001", [
         "# M001: Test Milestone",
         "",
@@ -851,9 +851,9 @@ describe("state-machine-full-walkthrough", () => {
       invalidateStateCache();
       const state = await deriveState(base);
 
-      // With partial-dep fallback, S01 is picked despite unmet dep on S00
-      assert.equal(state.phase, "planning");
-      assert.equal(state.activeSlice?.id, "S01");
+      assert.equal(state.phase, "blocked");
+      assert.equal(state.activeSlice, null);
+      assert.ok(state.blockers.some(b => b.includes("No slice eligible")));
     });
   });
 

--- a/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
@@ -44,7 +44,19 @@ describe("#2883: tool invocation error tracking on AutoSession", () => {
 
 // ─── isToolInvocationError classifier ────────────────────────────────────
 
-import { isToolInvocationError, isQueuedUserMessageSkip } from "../auto-tool-tracking.ts";
+import {
+  isDeterministicPolicyError,
+  isToolInvocationError,
+  isQueuedUserMessageSkip,
+} from "../auto-tool-tracking.ts";
+import {
+  shouldBlockContextWrite,
+  shouldBlockPendingGateInSnapshot,
+  shouldBlockQueueExecutionInSnapshot,
+  resetWriteGateState,
+  type WriteGateSnapshot,
+} from "../bootstrap/write-gate.ts";
+import { BLOCKED_WRITE_ERROR } from "../write-intercept.ts";
 
 describe("#2883: isToolInvocationError classification", () => {
   test("detects JSON validation failure pattern", () => {
@@ -89,11 +101,59 @@ describe("#2883: isToolInvocationError classification", () => {
     );
   });
 
+  test("detects raw write-gate CONTEXT failures for non-GSD write tools", () => {
+    resetWriteGateState();
+    const result = shouldBlockContextWrite(
+      "write",
+      "/tmp/project/.gsd/milestones/M001/M001-CONTEXT.md",
+      "M001",
+      false,
+    );
+
+    assert.equal(result.block, true);
+    assert.equal(isDeterministicPolicyError(result.reason ?? ""), true);
+    assert.equal(isToolInvocationError(result.reason ?? ""), true);
+  });
+
+  test("detects raw pending-gate failures for non-GSD write tools", () => {
+    const snapshot: WriteGateSnapshot = {
+      verifiedDepthMilestones: [],
+      activeQueuePhase: false,
+      pendingGateId: "depth_verification_M001",
+    };
+    const result = shouldBlockPendingGateInSnapshot(snapshot, "write", "M001", false);
+
+    assert.equal(result.block, true);
+    assert.equal(isDeterministicPolicyError(result.reason ?? ""), true);
+    assert.equal(isToolInvocationError(result.reason ?? ""), true);
+  });
+
+  test("detects queue-mode policy blocks for raw write/edit/bash tools", () => {
+    const snapshot: WriteGateSnapshot = {
+      verifiedDepthMilestones: [],
+      activeQueuePhase: true,
+      pendingGateId: null,
+    };
+    const writeResult = shouldBlockQueueExecutionInSnapshot(snapshot, "write", "src/app.ts", true);
+    const bashResult = shouldBlockQueueExecutionInSnapshot(snapshot, "bash", "npm run build", true);
+
+    assert.equal(writeResult.block, true);
+    assert.equal(bashResult.block, true);
+    assert.equal(isDeterministicPolicyError(writeResult.reason ?? ""), true);
+    assert.equal(isToolInvocationError(bashResult.reason ?? ""), true);
+  });
+
+  test("detects direct STATE.md/gsd.db write-intercept policy blocks", () => {
+    assert.equal(isDeterministicPolicyError(BLOCKED_WRITE_ERROR), true);
+    assert.equal(isToolInvocationError(BLOCKED_WRITE_ERROR), true);
+  });
+
   test("returns false for normal tool errors (business logic)", () => {
     assert.equal(
       isToolInvocationError("Slice S01 is already complete"),
       false,
     );
+    assert.equal(isDeterministicPolicyError("Slice S01 is already complete"), false);
   });
 
   test("returns false for empty string", () => {


### PR DESCRIPTION
## TL;DR
**What:** Hardens auto-mode state-machine edge cases around UAT gating, disk/DB reconciliation, deterministic tool errors, session locks, paused-session recovery, provider delayed resume, and current-unit lifecycle cleanup.
**Why:** These gaps could let auto-mode advance past failed UAT, skip missing plan tasks, re-run deterministic policy failures, erase newer lock ownership, or lose paused-session recovery evidence.
**How:** Tightened the state guards, preserved disk metadata during DB import, reconciled partial task rows, made policy failures deterministic, guarded lock cleanup by PID ownership, and added regression coverage for each affected path.

## What
- Use ASSESSMENT verdicts before legacy UAT verdicts and gate all closed slice statuses.
- Reconcile missing plan tasks even when the DB already has partial task rows.
- Preserve disk-derived milestone title, dependencies, parked state, and terminal summary completion during disk-to-DB import.
- Remove dependency fallback slice selection so unmet/circular slice dependencies block instead of dispatching the wrong slice.
- Classify deterministic write-gate/write-intercept policy failures from raw tools so auto-mode pauses instead of retry-looping.
- Preserve paused JSONL evidence for resume recovery.
- Preserve session-timeout counters across delayed provider resumes.
- Guard session-lock release and exit cleanup so stale owners do not delete newer lock metadata.
- Clear `currentUnit` after successful finalize/closeout.

## Why
Closes #4974.

## How
- Added targeted tests in state derivation, UAT dispatch, session lock, crash recovery, provider resume, model selection retry metadata, tool invocation classification, complete-task reconciliation, live state-machine validation, and finalize lifecycle.
- Kept changes scoped to auto-mode state-machine surfaces and regression coverage.

## Change type checklist
- [ ] feat
- [x] fix
- [ ] refactor
- [x] test
- [ ] docs
- [ ] chore

## Breaking changes
None.

## AI assistance
AI-assisted implementation, review, and verification.

## Test plan
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --experimental-test-isolation=process --test --test-concurrency=1 src/resources/extensions/gsd/tests/derive-state-db.test.ts src/resources/extensions/gsd/tests/derive-state.test.ts src/resources/extensions/gsd/tests/derive-state-deps.test.ts src/resources/extensions/gsd/tests/derive-state-crossval.test.ts src/resources/extensions/gsd/tests/dispatcher-stuck-planning.test.ts src/resources/extensions/gsd/tests/complete-task.test.ts src/resources/extensions/gsd/tests/state-machine-full-walkthrough.test.ts src/resources/extensions/gsd/tests/integration/state-machine-edge-cases.test.ts src/resources/extensions/gsd/tests/integration/run-uat.test.ts src/resources/extensions/gsd/tests/session-lock-regression.test.ts src/resources/extensions/gsd/tests/provider-errors.test.ts src/resources/extensions/gsd/tests/crash-recovery.test.ts src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts src/resources/extensions/gsd/tests/auto-model-selection.test.ts src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts` (365 pass)
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --experimental-test-isolation=process --test --test-concurrency=1 src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts` (37 pass)
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --experimental-test-isolation=process --test --test-concurrency=1 src/resources/extensions/gsd/tests/auto-loop.test.ts src/resources/extensions/gsd/tests/auto-post-unit-step-message.test.ts` (60 pass; required clearing stale local `/tmp/project/.gsd/runtime/stuck-state.json` from a prior run)
- [x] `git diff --check`
- [ ] `npm run typecheck:extensions` (blocked in this worktree by missing workspace package declarations such as `@gsd/pi-coding-agent`, `@gsd/pi-tui`, `@gsd/pi-ai`, `@gsd/native`)
- [ ] `npm run test:compile` (blocked in this worktree by missing `node_modules/esbuild`; CI build runs this in a clean install)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Safer session-lock cleanup that avoids removing locks owned by other processes
  * Ensure session state is reliably cleared after finalization
  * Stricter dependency handling that prevents selecting ineligible slices
  * Plan-file task imports now add missing tasks without overwriting existing state
  * Delayed auto-resume no longer resets session-timeout tracking

* **New Features**
  * Broader error classification to detect deterministic policy/write-gate failures
  * Dispatch gating now evaluates verdicts from multiple sources for accurate outcomes
  * Resume flow preserves paused-session evidence and exposes a test entry for recovery synthesis

* **Tests**
  * Added and expanded tests covering error classification, lock ownership, dependency blocking, recovery synthesis, and task reconciliation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->