### PR TITLE
fix(ollama): detect thinking capability and forward strength to /api/chat

### DIFF
--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -104,16 +104,9 @@ export function isToolInvocationError(errorMsg: string): boolean {
   return TOOL_INVOCATION_ERROR_RE.test(errorMsg) || isDeterministicPolicyError(errorMsg);
 }
 
-/**
- * Returns true if the error message indicates a deterministic policy gate
- * blocked the tool call before execution. Retrying the same unit without
- * changing behavior will hit the same gate, so auto-mode should pause instead
- * of re-dispatching.
- */
-export function isDeterministicPolicyError(errorMsg: string): boolean {
-  if (!errorMsg) return false;
-  return DETERMINISTIC_POLICY_ERROR_RE.test(errorMsg);
-}
+// (isDeterministicPolicyError merged below — see "Deterministic policy error
+// classification" section. The merged definition checks BOTH the regex and the
+// substring list to preserve behaviour from the two original definitions.)
 
 /**
  * Returns true if the error message indicates the tool was skipped because
@@ -149,10 +142,12 @@ export const DETERMINISTIC_POLICY_ERROR_STRINGS = [
 
 /**
  * Returns true if the error message indicates a deterministic policy rejection
- * (a structural gate that will fire on every retry regardless of model quality).
- * Used by postUnitPreVerification to short-circuit the retry loop (#4973).
+ * — either a regex-matched policy gate (HARD BLOCK, queue, etc.) or one of the
+ * known substring markers from #4973. Retrying these errors will always
+ * produce the same outcome, so auto-mode should pause rather than re-dispatch.
  */
 export function isDeterministicPolicyError(errorMsg: string): boolean {
   if (!errorMsg) return false;
+  if (DETERMINISTIC_POLICY_ERROR_RE.test(errorMsg)) return true;
   return DETERMINISTIC_POLICY_ERROR_STRINGS.some(s => errorMsg.includes(s));
 }

--- a/src/resources/extensions/ollama/model-capabilities.ts
+++ b/src/resources/extensions/ollama/model-capabilities.ts
@@ -28,9 +28,22 @@ export interface ModelCapability {
 // window is authoritative. For unknown/estimated models, num_ctx is NOT sent
 // to avoid OOM risk — Ollama uses its own safe default instead.
 const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
-	// ─── Reasoning models ───────────────────────────────────────────────
-	["deepseek-r1", { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["qwq", { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	// ─── Reasoning models (fallback when /api/show capabilities is absent) ──
+	// IMPORTANT: matching is `baseName === pattern || baseName.startsWith(pattern)`,
+	// so more specific patterns must appear before more general ones.
+	["deepseek-r1",       { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["deepseek-v3.1",     { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["deepseek-v4-flash", { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["deepseek-v4",       { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["qwq",               { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["gpt-oss",           { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["glm-4",             { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["glm-5",             { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["kimi-k2",           { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["minimax-m2",        { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["nemotron-3",        { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["gemma4",            { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["gemini-3-flash",    { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
 
 	// ─── Vision models ──────────────────────────────────────────────────
 	["llava", { contextWindow: 4096, input: ["text", "image"], ollamaOptions: { num_ctx: 4096 } }],
@@ -56,7 +69,10 @@ const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
 	["llama2", { contextWindow: 4096, maxTokens: 4096, ollamaOptions: { num_ctx: 4096 } }],
 
 	// ─── Qwen family ────────────────────────────────────────────────────
-	["qwen3", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
+	// qwen3 family (qwen3, qwen3-next, qwen3.5, qwen3-coder) supports hybrid thinking;
+	// /api/show capabilities is authoritative — this table entry is only consulted
+	// when ollama omits the capabilities field.
+	["qwen3", { contextWindow: 131072, maxTokens: 32768, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["qwen2.5", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
 	["qwen2", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
 

--- a/src/resources/extensions/ollama/ollama-chat-provider.ts
+++ b/src/resources/extensions/ollama/ollama-chat-provider.ts
@@ -21,6 +21,7 @@ import {
 	type StopReason,
 	type TextContent,
 	type ThinkingContent,
+	type ThinkingLevel,
 	type Tool,
 	type ToolCall,
 	type Usage,
@@ -146,6 +147,13 @@ export function streamOllamaChat(
 			}
 
 			for await (const chunk of chat(request, options?.signal)) {
+				// Native thinking field (ollama 0.4+ for reasoning models). Emit before
+				// content so blocks open in the natural reasoning-then-answer order.
+				const thinking = chunk.message?.thinking ?? "";
+				if (thinking) {
+					emitDelta("thinking", thinking);
+				}
+
 				// Handle text content — process independently of tool_calls
 				// (a chunk may contain both content and tool_calls)
 				const content = chunk.message?.content ?? "";
@@ -188,6 +196,30 @@ export function streamOllamaChat(
 }
 
 // ─── Request building ───────────────────────────────────────────────────────
+
+/**
+ * Map a SimpleStreamOptions.reasoning ThinkingLevel to ollama's `think` field.
+ *
+ * - Returns `undefined` when the model doesn't support reasoning, or when no
+ *   level was requested (preserving existing default behaviour: ollama uses
+ *   the model's built-in default).
+ * - `"minimal"` turns thinking off (`think: false`) — universally supported.
+ * - `"low" | "medium" | "high"` are passed through as strings; gpt-oss honors
+ *   them as strength levels, other thinking models treat any present value
+ *   as "thinking enabled".
+ * - `"xhigh"` is collapsed to `"high"` (ollama caps strength at high).
+ */
+export function buildThinkParam(
+	model: Model<Api>,
+	options?: SimpleStreamOptions,
+): boolean | "low" | "medium" | "high" | undefined {
+	if (!model.reasoning) return undefined;
+	const level: ThinkingLevel | undefined = options?.reasoning;
+	if (level === undefined) return undefined;
+	if (level === "minimal") return false;
+	if (level === "xhigh") return "high";
+	return level;
+}
 
 function buildRequest(
 	model: Model<Api>,
@@ -243,6 +275,13 @@ function buildRequest(
 	// Tools
 	if (context.tools?.length) {
 		request.tools = convertTools(context.tools);
+	}
+
+	// Thinking strength (ollama 0.4+). Only set when both the model is reasoning-capable
+	// and the caller explicitly requested a level — otherwise ollama uses its default.
+	const think = buildThinkParam(model, options);
+	if (think !== undefined) {
+		request.think = think;
 	}
 
 	return request;

--- a/src/resources/extensions/ollama/ollama-discovery.ts
+++ b/src/resources/extensions/ollama/ollama-discovery.ts
@@ -57,16 +57,20 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 	const caps = getModelCapabilities(info.name);
 	const parameterSize = info.details?.parameter_size ?? "";
 
-	// /api/tags doesn't include context length; /api/show does via "{arch}.context_length" in model_info.
+	// Always call /api/show — it carries two pieces of info absent from /api/tags:
+	// the per-architecture context_length, and (ollama 0.4+) a `capabilities` array
+	// like ["thinking", "completion", "tools"]. The capabilities array is the
+	// authoritative source for reasoning detection on cloud-routed models that
+	// don't appear in the static KNOWN_MODELS table.
 	let showContextWindow: number | undefined;
-	if (caps.contextWindow === undefined) {
-		try {
-			const showData = await deps.showModel(info.name);
-			showContextWindow = extractContextFromModelInfo(showData.model_info);
-		} catch (err) {
-			// non-fatal: fall through to estimate
-			if (process.env.GSD_DEBUG) console.warn(`[ollama] /api/show failed for ${info.name}:`, err instanceof Error ? err.message : String(err));
-		}
+	let showCapabilities: string[] | undefined;
+	try {
+		const showData = await deps.showModel(info.name);
+		showContextWindow = extractContextFromModelInfo(showData.model_info);
+		showCapabilities = showData.capabilities;
+	} catch (err) {
+		// non-fatal: fall through to table/estimate
+		if (process.env.GSD_DEBUG) console.warn(`[ollama] /api/show failed for ${info.name}:`, err instanceof Error ? err.message : String(err));
 	}
 
 	// Determine context window: known table > /api/show > estimate from param size > default
@@ -79,13 +83,17 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 	const maxTokens =
 		caps.maxTokens ?? Math.min(Math.floor(contextWindow / 4), 16384);
 
-	// Detect vision from families or known table
+	// Detect vision: /api/show capabilities > known table > model families heuristic
 	const hasVision =
+		showCapabilities?.includes("vision") ??
 		caps.input?.includes("image") ??
 		(info.details?.families?.some((f) => f === "clip" || f === "mllama") ?? false);
 
-	// Detect reasoning from known table
-	const reasoning = caps.reasoning ?? false;
+	// Detect reasoning: /api/show capabilities (authoritative) > known table fallback
+	const reasoning =
+		showCapabilities?.includes("thinking") ??
+		caps.reasoning ??
+		false;
 
 	return {
 		id: info.name,

--- a/src/resources/extensions/ollama/tests/model-capabilities.test.ts
+++ b/src/resources/extensions/ollama/tests/model-capabilities.test.ts
@@ -82,6 +82,48 @@ describe("getModelCapabilities", () => {
 		const caps = getModelCapabilities("Llama3.1:8B");
 		assert.equal(caps.contextWindow, 131072);
 	});
+
+	// ─── New reasoning-model fallback entries (cloud + local) ──────────────────
+	// These exist as a fallback for ollama versions whose /api/show response
+	// does not include the `capabilities` array. When capabilities are present,
+	// detection happens dynamically in ollama-discovery.ts.
+
+	it("flags gpt-oss as reasoning (covers :20b, :120b, :*-cloud)", () => {
+		assert.equal(getModelCapabilities("gpt-oss:20b").reasoning, true);
+		assert.equal(getModelCapabilities("gpt-oss:120b-cloud").reasoning, true);
+	});
+
+	it("flags deepseek-v3.1/v4 family as reasoning", () => {
+		assert.equal(getModelCapabilities("deepseek-v3.1:671b-cloud").reasoning, true);
+		assert.equal(getModelCapabilities("deepseek-v4-flash:cloud").reasoning, true);
+	});
+
+	it("flags glm-4.x/5.x family as reasoning", () => {
+		assert.equal(getModelCapabilities("glm-4.6:cloud").reasoning, true);
+		assert.equal(getModelCapabilities("glm-5.1:cloud").reasoning, true);
+	});
+
+	it("flags kimi-k2 family as reasoning", () => {
+		assert.equal(getModelCapabilities("kimi-k2:1t-cloud").reasoning, true);
+		assert.equal(getModelCapabilities("kimi-k2.6:cloud").reasoning, true);
+	});
+
+	it("flags qwen3 as reasoning (hybrid thinking model)", () => {
+		assert.equal(getModelCapabilities("qwen3:8b").reasoning, true);
+		assert.equal(getModelCapabilities("qwen3-next:cloud").reasoning, true);
+	});
+
+	it("flags minimax-m2 family as reasoning", () => {
+		assert.equal(getModelCapabilities("minimax-m2.7:cloud").reasoning, true);
+	});
+
+	it("flags gemma4 (with thinking) as reasoning", () => {
+		assert.equal(getModelCapabilities("gemma4:31b-cloud").reasoning, true);
+	});
+
+	it("flags gemini-3-flash-preview as reasoning", () => {
+		assert.equal(getModelCapabilities("gemini-3-flash-preview:cloud").reasoning, true);
+	});
 });
 
 // ─── estimateContextFromParams ───────────────────────────────────────────────

--- a/src/resources/extensions/ollama/tests/ollama-chat-provider-stream.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-chat-provider-stream.test.ts
@@ -80,3 +80,70 @@ describe("Ollama stream terminal chunk handling", () => {
     assert.equal(result, "one-shot", "single done chunk with content should work");
   });
 });
+
+// ─── Native thinking field on chunks (ollama 0.4+) ───────────────────────────
+// Reasoning-capable cloud models (e.g. glm-5.1:cloud) emit thinking in a
+// separate `message.thinking` field, not inline as <think> tags. The provider
+// must capture this channel; otherwise the reasoning trace is silently dropped.
+
+interface OllamaChunkWithThink {
+  done: boolean;
+  done_reason?: string;
+  message?: { content?: string; thinking?: string; tool_calls?: unknown[] };
+}
+
+function simulateThinkingStreamLoop(chunks: OllamaChunkWithThink[]): { thinking: string; content: string } {
+  let thinking = "";
+  let content = "";
+
+  for (const chunk of chunks) {
+    // Mirrors the dual-channel logic in ollama-chat-provider.ts:
+    // emit thinking before content so blocks open in reasoning-then-answer order.
+    const t = chunk.message?.thinking ?? "";
+    if (t) thinking += t;
+
+    const c = chunk.message?.content ?? "";
+    if (c) content += c;
+
+    if (chunk.done) break;
+  }
+
+  return { thinking, content };
+}
+
+describe("Ollama stream thinking-field handling", () => {
+  it("captures thinking from a separate message.thinking channel", () => {
+    const chunks: OllamaChunkWithThink[] = [
+      { done: false, message: { thinking: "Let me think... " } },
+      { done: false, message: { thinking: "2+2 = 4." } },
+      { done: false, message: { content: "The answer is " } },
+      { done: true, done_reason: "stop", message: { content: "4." } },
+    ];
+
+    const { thinking, content } = simulateThinkingStreamLoop(chunks);
+    assert.equal(thinking, "Let me think... 2+2 = 4.");
+    assert.equal(content, "The answer is 4.");
+  });
+
+  it("captures thinking from the terminal done:true chunk", () => {
+    // Some models flush all reasoning on the final chunk.
+    const chunks: OllamaChunkWithThink[] = [
+      { done: false, message: { content: "answer" } },
+      { done: true, done_reason: "stop", message: { thinking: "post-hoc trace" } },
+    ];
+
+    const { thinking, content } = simulateThinkingStreamLoop(chunks);
+    assert.equal(thinking, "post-hoc trace");
+    assert.equal(content, "answer");
+  });
+
+  it("handles a chunk with both thinking and content together", () => {
+    const chunks: OllamaChunkWithThink[] = [
+      { done: true, done_reason: "stop", message: { thinking: "T", content: "C" } },
+    ];
+
+    const { thinking, content } = simulateThinkingStreamLoop(chunks);
+    assert.equal(thinking, "T");
+    assert.equal(content, "C");
+  });
+});

--- a/src/resources/extensions/ollama/tests/ollama-chat-provider-think.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-chat-provider-think.test.ts
@@ -1,0 +1,58 @@
+// GSD2 — Tests for ollama think-parameter mapping
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Api, Model, SimpleStreamOptions } from "@gsd/pi-ai";
+import { buildThinkParam } from "../ollama-chat-provider.js";
+
+function modelStub(reasoning: boolean, id = "gpt-oss:20b"): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions" as Api,
+		provider: "ollama",
+		baseUrl: "http://localhost:11434",
+		reasoning,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131072,
+		maxTokens: 32768,
+	};
+}
+
+describe("buildThinkParam — gating", () => {
+	it("returns undefined when model.reasoning is false", () => {
+		const m = modelStub(false);
+		const opts: SimpleStreamOptions = { reasoning: "high" };
+		assert.equal(buildThinkParam(m, opts), undefined);
+	});
+
+	it("returns undefined when options.reasoning is undefined (preserve existing default)", () => {
+		const m = modelStub(true);
+		assert.equal(buildThinkParam(m, {}), undefined);
+		assert.equal(buildThinkParam(m, undefined), undefined);
+	});
+});
+
+describe("buildThinkParam — ThinkingLevel mapping", () => {
+	const m = modelStub(true);
+
+	it("maps 'minimal' to false (turn thinking off)", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "minimal" }), false);
+	});
+
+	it("passes 'low' through as string", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "low" }), "low");
+	});
+
+	it("passes 'medium' through as string", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "medium" }), "medium");
+	});
+
+	it("passes 'high' through as string", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "high" }), "high");
+	});
+
+	it("collapses 'xhigh' to 'high' (ollama caps at high)", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "xhigh" }), "high");
+	});
+});

--- a/src/resources/extensions/ollama/tests/ollama-discovery.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-discovery.test.ts
@@ -14,19 +14,19 @@ function tagsStub(name: string, parameterSize = ""): OllamaTagsResponse {
 	return { models: [modelStub(name, parameterSize)] };
 }
 
-function showStub(modelInfo: Record<string, unknown>): OllamaShowResponse {
-	return { modelfile: "", parameters: "", template: "", details: EMPTY_DETAILS, model_info: modelInfo };
+function showStub(modelInfo: Record<string, unknown>, capabilities?: string[]): OllamaShowResponse {
+	return { modelfile: "", parameters: "", template: "", details: EMPTY_DETAILS, model_info: modelInfo, capabilities };
 }
 
 describe("discoverModels — context window resolution", () => {
-	it("uses known table context window without calling /api/show", async () => {
-		let showCalled = false;
+	it("prefers known table context window over /api/show value", async () => {
+		// /api/show is now always called (to read capabilities), but the static
+		// table still wins for context window when both sources have a value.
 		const models = await discoverModels({
 			listModels: async () => tagsStub("llama3.2:latest", "3B"),
-			showModel: async () => { showCalled = true; throw new Error("should not be called"); },
+			showModel: async () => showStub({ "llama.context_length": 4096 }),
 		});
 		assert.equal(models[0].contextWindow, 131072);
-		assert.equal(showCalled, false);
 	});
 
 	it("uses context_length from /api/show model_info for unknown model", async () => {
@@ -51,5 +51,61 @@ describe("discoverModels — context window resolution", () => {
 			showModel: async () => { throw new Error("network error"); },
 		});
 		assert.equal(models[0].contextWindow, 8192);
+	});
+});
+
+describe("discoverModels — reasoning detection from /api/show capabilities", () => {
+	it("flags reasoning=true when capabilities include 'thinking' (cloud model)", async () => {
+		// Real-world: glm-5.1:cloud → /api/show returns capabilities: ['thinking', 'completion', 'tools']
+		const models = await discoverModels({
+			listModels: async () => tagsStub("glm-5.1:cloud"),
+			showModel: async () => showStub({ "glm5.1.context_length": 131072 }, ["thinking", "completion", "tools"]),
+		});
+		assert.equal(models[0].reasoning, true);
+	});
+
+	it("flags reasoning=false when capabilities array is present but excludes 'thinking'", async () => {
+		// A genuinely non-thinking model with capabilities returned should respect the API
+		const models = await discoverModels({
+			listModels: async () => tagsStub("totally-unknown-model:7b", "7B"),
+			showModel: async () => showStub({}, ["completion", "tools"]),
+		});
+		assert.equal(models[0].reasoning, false);
+	});
+
+	it("falls back to KNOWN_MODELS table when /api/show omits capabilities", async () => {
+		// Older ollama versions don't return capabilities field
+		const models = await discoverModels({
+			listModels: async () => tagsStub("deepseek-r1:8b"),
+			showModel: async () => showStub({}),
+		});
+		assert.equal(models[0].reasoning, true);
+	});
+
+	it("falls back to KNOWN_MODELS table when /api/show throws", async () => {
+		const models = await discoverModels({
+			listModels: async () => tagsStub("qwq:32b"),
+			showModel: async () => { throw new Error("network error"); },
+		});
+		assert.equal(models[0].reasoning, true);
+	});
+
+	it("defaults reasoning=false for unknown model with no capabilities and no /api/show", async () => {
+		const models = await discoverModels({
+			listModels: async () => tagsStub("brand-new-model:7b", "7B"),
+			showModel: async () => { throw new Error("network error"); },
+		});
+		assert.equal(models[0].reasoning, false);
+	});
+
+	it("calls /api/show even when context window is known in table (to pick up capabilities)", async () => {
+		// Behavior change: previously skipped /api/show when table had context window.
+		// Now must always call to learn about thinking capability.
+		let showCalled = false;
+		await discoverModels({
+			listModels: async () => tagsStub("llama3.2:latest", "3B"),
+			showModel: async () => { showCalled = true; return showStub({}, ["completion"]); },
+		});
+		assert.equal(showCalled, true);
 	});
 });

--- a/src/resources/extensions/ollama/types.ts
+++ b/src/resources/extensions/ollama/types.ts
@@ -37,6 +37,12 @@ export interface OllamaShowResponse {
 	template: string;
 	details: OllamaModelDetails;
 	model_info: Record<string, unknown>;
+	/**
+	 * Model capability flags exposed by ollama 0.4+. Common values:
+	 * "completion", "tools", "vision", "thinking", "embedding", "insert".
+	 * Older ollama versions and some cloud-routed models may omit this field.
+	 */
+	capabilities?: string[];
 }
 
 // ─── /api/ps ────────────────────────────────────────────────────────────────
@@ -93,6 +99,13 @@ export interface OllamaChatOptions {
 export interface OllamaChatMessage {
 	role: "system" | "user" | "assistant" | "tool";
 	content: string;
+	/**
+	 * Reasoning trace returned by ollama 0.4+ when `think` is enabled on the
+	 * request. This is a separate channel from `content`; older models (and
+	 * some local models without native thinking support) emit thinking inline
+	 * as `<think>...</think>` tags in `content` instead.
+	 */
+	thinking?: string;
 	images?: string[];
 	tool_calls?: OllamaToolCall[];
 	/** Tool name — required for role: "tool" messages to correlate results with calls. */
@@ -136,6 +149,13 @@ export interface OllamaChatRequest {
 		num_gpu?: number;
 	};
 	keep_alive?: string;
+	/**
+	 * Controls thinking on reasoning models (ollama 0.4+).
+	 * - `true`/`false` toggles thinking on/off (universal form)
+	 * - `"low" | "medium" | "high"` sets thinking strength (gpt-oss style)
+	 * Omit to use the model's default behaviour.
+	 */
+	think?: boolean | "low" | "medium" | "high";
 }
 
 export interface OllamaChatResponse {


### PR DESCRIPTION
## Problem

Cloud-routed and modern reasoning models pulled via `ollama pull` (e.g. `gpt-oss:120b-cloud`, `glm-5.1:cloud`, `kimi-k2.6:cloud`, `deepseek-v4-flash:cloud`, `qwen3-coder:480b-cloud`, `gemini-3-flash-preview:cloud`, `gemma4:31b-cloud`, `minimax-m2.7:cloud`) are silently treated as **non-reasoning**. As a result the GSD 2 UI hides the thinking-strength selector for them. Even when reasoning is configured, the chat provider:

1. Never forwards the chosen strength to ollama (`OllamaChatRequest` had no `think` field at all).
2. Discards the reasoning trace ollama returns in `message.thinking`, because the streaming loop only reads `message.content`.

Net effect: users **cannot set thinking strength on any cloud-pulled ollama model**, and even if they could, the trace would be lost.

## Root cause

`enrichModel` in `ollama-discovery.ts` only consulted the static `KNOWN_MODELS` table and only called `/api/show` when the table lacked a context window. The table contained only `deepseek-r1` and `qwq` as `reasoning: true`, missing every model in the table above. Cloud models almost never appear in such a static table, so they all resolved to `reasoning: false`.

Verified empirically against the user's local ollama:

```
$ curl -s http://localhost:11434/api/show -d '{"name":"glm-5.1:cloud"}'
  ... "capabilities": ["thinking", "completion", "tools"] ...

$ curl -s http://localhost:11434/api/chat -d '{"model":"glm-5.1:cloud", ...,"think":"high"}'
  message.thinking: "Let me think... 2+2 = 4..."
  message.content:  "4"
```

So `/api/show.capabilities` is the authoritative signal, and `/api/chat` does honour `think` — both were just not wired up.

## Fix

End-to-end, four small surgical changes:

1. **Dynamic capability detection** (`ollama-discovery.ts`)
   `enrichModel` now always calls `/api/show` and reads the `capabilities` array (ollama 0.4+). `\"thinking\"` -> `reasoning: true`. Vision detection follows the same precedence (`/api/show` > table > family heuristic).

2. **Extend the static table as fallback** (`model-capabilities.ts`)
   Added entries for `gpt-oss`, `deepseek-v3.1`, `deepseek-v4(-flash)`, `glm-4`, `glm-5`, `kimi-k2`, `minimax-m2`, `nemotron-3`, `gemma4`, `gemini-3-flash`. Marked `qwen3` as reasoning per its hybrid-thinking design. This only kicks in when ollama omits `capabilities` (older versions or unusual cloud routes).

3. **Forward strength to ollama** (`ollama-chat-provider.ts`)
   New exported helper `buildThinkParam(model, options)` maps `SimpleStreamOptions.reasoning` to `OllamaChatRequest.think`:

   | ThinkingLevel | ollama `think` |
   |---|---|
   | `undefined` | omitted (preserves existing default) |
   | `"minimal"` | `false` |
   | `"low"` / `"medium"` / `"high"` | passed through as string |
   | `"xhigh"` | `"high"` (ollama caps strength at high) |

   Only set when `model.reasoning` is true and the caller requested a level.

4. **Surface the native thinking channel** (`ollama-chat-provider.ts`)
   The streaming loop now also emits `chunk.message.thinking` as a thinking delta. The existing inline `<think>` parser is retained for older/local models that emit thinking inline.

## Tests

- `tests/model-capabilities.test.ts` — new entries covered for all the above families
- `tests/ollama-discovery.test.ts` — capability-array detection, table fallback, /api/show failure path, and the behaviour change that /api/show is now always called
- `tests/ollama-chat-provider-think.test.ts` (new) — `buildThinkParam` ThinkingLevel mapping and gating
- `tests/ollama-chat-provider-stream.test.ts` — dual-channel (`thinking` + `content`) stream handling

`npm run test:compile && node --test dist-test/src/resources/extensions/ollama/**/*.test.js` -> **66/66 pass**.

`npx tsc --noEmit -p tsconfig.extensions.json` is clean for everything I touched. (Two pre-existing errors in `gsd/graph-context.ts` and `gsd/tools/complete-slice.ts` about `@gsd-build/mcp-server` not being built — unrelated.)

## Prerequisite commit

Includes one separate commit `fix(auto): merge duplicate isDeterministicPolicyError definitions`. The two definitions in `auto-tool-tracking.ts` (added across the #4973 fixup commits) make the file fail to compile, blocking the entire `npm run test:compile` and `npm run build:core` pipelines from `main`. Without it I couldn't run the test suite to verify this fix. Happy to split into a separate PR if maintainers prefer — flag it and I'll do that.

## Verification steps

1. `ollama pull glm-5.1:cloud` (or any other thinking model)
2. In GSD 2: model picker should now show the thinking-strength selector for cloud reasoning models
3. Send a request with strength = high
4. Both reasoning trace and the answer should render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native streaming support for Ollama's reasoning/thinking blocks
  * Enhanced Ollama model discovery to automatically detect reasoning capabilities from model metadata
  * Expanded reasoning model support for additional Ollama model families

* **Bug Fixes**
  * Improved deterministic policy error detection to reduce false negatives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->