### PR TITLE
fix(gsd): point orphan branch hint to doctor fix

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -315,7 +315,7 @@ export function auditOrphanedMilestoneBranches(
       // Branch is NOT merged — preserve for safety, warn the user
       warnings.push(
         `Branch ${branch} exists for completed milestone ${milestoneId} but is NOT merged into ${mainBranch}. ` +
-        `This may contain unmerged work. Merge manually or run \`/gsd health --fix\` to resolve.`,
+        `This may contain unmerged work. Merge manually or run \`/gsd doctor fix\` to resolve.`,
       );
 
       // #4764 telemetry

--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -804,7 +804,7 @@ function detectMissingArtifacts(completedKeys: string[], basePath: string, activ
  * the forensics memory-bloat guard in forensics-journal.test.ts — per-event
  * detail stays in the journal itself where the LLM can query it on demand.
  */
-function detectWorktreeOrphans(
+export function detectWorktreeOrphans(
   summary: WorktreeTelemetrySummary,
   anomalies: ForensicAnomaly[],
 ): void {
@@ -822,7 +822,7 @@ function detectWorktreeOrphans(
         reason === "in-progress-unmerged"
           ? "Auto-mode exited without completing a milestone; live work sits on an unmerged milestone branch. Run `/gsd auto` to resume, or merge manually."
           : reason === "complete-unmerged"
-            ? "A completed milestone's branch was never merged back to main. Run `/gsd health --fix` to resolve."
+            ? "A completed milestone's branch was never merged back to main. Run `/gsd doctor fix` to resolve."
             : `Reason: ${reason}.`,
     });
   }

--- a/src/resources/extensions/gsd/tests/forensics-stuck-loops.test.ts
+++ b/src/resources/extensions/gsd/tests/forensics-stuck-loops.test.ts
@@ -9,7 +9,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import type { UnitMetrics } from "../metrics.js";
-import { detectStuckLoops, type ForensicAnomaly } from "../forensics.js";
+import type { WorktreeTelemetrySummary } from "../worktree-telemetry.js";
+import { detectStuckLoops, detectWorktreeOrphans, type ForensicAnomaly } from "../forensics.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -162,4 +163,28 @@ test("#3760 detectStuckLoops still flags repeated dispatches within one auto ses
     anomalies[0].details.includes("Cross-session recovery runs are ignored"),
     `details should explain the session-aware rule: ${anomalies[0].details}`,
   );
+});
+
+test("#4711 detectWorktreeOrphans suggests doctor fix for completed unmerged branches", () => {
+  const anomalies: ForensicAnomaly[] = [];
+  const summary: WorktreeTelemetrySummary = {
+    worktreesCreated: 0,
+    worktreesMerged: 0,
+    orphansDetected: 1,
+    orphansByReason: { "complete-unmerged": 1 },
+    mergeDurationsMs: [],
+    mergeConflicts: 0,
+    exitsByReason: {},
+    exitsWithUnmergedWork: 0,
+    canonicalRedirects: 0,
+    slicesMerged: 0,
+    sliceMergeConflicts: 0,
+    milestoneResquashes: 0,
+  };
+
+  detectWorktreeOrphans(summary, anomalies);
+
+  assert.equal(anomalies.length, 1);
+  assert.match(anomalies[0]!.details, /\/gsd doctor fix/);
+  assert.doesNotMatch(anomalies[0]!.details, /\/gsd health --fix/);
 });

--- a/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
@@ -101,6 +101,14 @@ describe("auditOrphanedMilestoneBranches", () => {
       result.warnings.some(w => w.includes("NOT merged")),
       "should warn about unmerged branch",
     );
+    assert.ok(
+      result.warnings.some(w => w.includes("/gsd doctor fix")),
+      `warning should suggest the real remediation command; got: ${JSON.stringify(result.warnings)}`,
+    );
+    assert.ok(
+      result.warnings.every(w => !w.includes("/gsd health --fix")),
+      `warning must not suggest the removed health --fix command; got: ${JSON.stringify(result.warnings)}`,
+    );
 
     // Branch should still exist (data safety)
     const branches = run("git branch --list milestone/M001", dir);


### PR DESCRIPTION
## Linked issue

Closes #4711

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Replace the orphan-branch remediation hint from `/gsd health --fix` to `/gsd doctor fix`.
**Why:** The health subcommand does not accept `--fix`, so the warning sends users to a dead command.
**How:** Update bootstrap and forensics orphan-branch messages and add regression coverage for both outputs.

## What

- `auditOrphanedMilestoneBranches` now suggests `/gsd doctor fix` for completed milestone branches not merged into main.
- Worktree-orphan forensics details use the same valid command.
- Regression tests cover the orphan-audit warning and forensics anomaly details.

## Why

#4711 reports that users are asked to run `/gsd health --fix`, which is not recognized. The doctor path already owns fixable stale milestone branch cleanup, so the warning should point there.

## How

The change keeps data-safety semantics unchanged: unmerged branches are still preserved. Only the remediation text changes. `detectWorktreeOrphans` is exported so its user-facing detail string can be verified directly without source-grep.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated/manual verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --experimental-test-isolation=process --test src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts src/resources/extensions/gsd/tests/forensics-stuck-loops.test.ts` — 17 pass.
2. `npm run build` — pass.
3. `npm run typecheck:extensions` — pass.
4. `git diff --check` — pass.
5. `npm run secret-scan` — pass.

Manual before/after:

- Before fix, current main emitted `/gsd health --fix` in the orphan audit and forensics worktree-orphan guidance.
- After fix, both outputs suggest `/gsd doctor fix` and regression tests assert the stale command is absent.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated remediation guidance for unmerged milestone branches to recommend the correct command, improving clarity on how to resolve branch state issues.

* **Tests**
  * Added test coverage validating updated remediation command suggestions and branch state detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->