### PR TITLE
fix(gsd): match canonical tool-block types in empty-turn recovery

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -315,12 +315,29 @@ function extractAssistantText(msg: any): string {
 
 /**
  * Return true if the assistant message contains any tool-use block.
+ *
+ * The canonical pi-ai `AssistantMessage.content` (see packages/pi-ai/src/types.ts)
+ * uses `type: "toolCall"` and `type: "serverToolUse"` for tool invocations —
+ * every provider (anthropic-direct, claude-code-cli, openai, etc.) normalizes
+ * incoming tool blocks into these two shapes before they reach guided-flow.
+ *
+ * The Anthropic API wire shape `"tool_use"` / `"server_tool_use"` does NOT appear
+ * in the internal AssistantMessage — those literals are only used when sending
+ * messages back out to the Anthropic API. Matching them here was a latent bug:
+ * `hasToolUse` returned `false` for every real tool call, which let the
+ * empty-turn nudge fire and pre-empt MCP tools that block on the user
+ * (e.g. `ask_user_questions`). See investigation in PR for #4658.
  */
 function hasToolUse(msg: any): boolean {
   if (!msg) return false;
   const content = msg.content;
   if (!Array.isArray(content)) return false;
-  return content.some((b: any) => b && typeof b === "object" && (b.type === "tool_use" || b.type === "tool-use"));
+  return content.some(
+    (b: any) =>
+      b &&
+      typeof b === "object" &&
+      (b.type === "toolCall" || b.type === "serverToolUse"),
+  );
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts
+++ b/src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts
@@ -72,8 +72,11 @@ function assistantMsg(
     // claude-code-cli, openai — normalizes incoming tool blocks into these
     // shapes before they reach guided-flow. The Anthropic-wire literal
     // "tool_use" never appears here.
-    const blockType = opts.toolUse === "serverToolUse" ? "serverToolUse" : "toolCall";
-    content.push({ type: blockType, id: "test-id", name: "whatever", arguments: {} });
+    if (opts.toolUse === "serverToolUse") {
+      content.push({ type: "serverToolUse", id: "test-id", name: "web_search", input: {} });
+    } else {
+      content.push({ type: "toolCall", id: "test-id", name: "whatever", arguments: {} });
+    }
   }
   return { role: "assistant", content };
 }

--- a/src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts
+++ b/src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts
@@ -60,10 +60,21 @@ function mkBase(): string {
   return base;
 }
 
-function assistantMsg(text: string, opts: { toolUse?: boolean } = {}): any {
+function assistantMsg(
+  text: string,
+  opts: { toolUse?: boolean | "toolCall" | "serverToolUse" } = {},
+): any {
   const content: any[] = [];
   if (text) content.push({ type: "text", text });
-  if (opts.toolUse) content.push({ type: "tool_use", name: "whatever", input: {} });
+  if (opts.toolUse) {
+    // The canonical pi-ai AssistantMessage uses "toolCall" / "serverToolUse"
+    // (see packages/pi-ai/src/types.ts). Every provider — anthropic-direct,
+    // claude-code-cli, openai — normalizes incoming tool blocks into these
+    // shapes before they reach guided-flow. The Anthropic-wire literal
+    // "tool_use" never appears here.
+    const blockType = opts.toolUse === "serverToolUse" ? "serverToolUse" : "toolCall";
+    content.push({ type: blockType, id: "test-id", name: "whatever", arguments: {} });
+  }
   return { role: "assistant", content };
 }
 
@@ -305,6 +316,65 @@ describe("#4573 maybeHandleEmptyIntentTurn", () => {
       });
       const handled = maybeHandleEmptyIntentTurn(
         { messages: [assistantMsg("I'll write the file now.", { toolUse: true })] },
+        false,
+      );
+      assert.equal(handled, false);
+      assert.equal(cap.messages.length, 0);
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  // Regression for #4658 — under claude-code-cli, MCP tool calls (e.g.
+  // ask_user_questions) reach guided-flow as canonical "toolCall" / "serverToolUse"
+  // blocks. Pre-fix, hasToolUse only matched the Anthropic-wire literal "tool_use",
+  // so the empty-turn nudge fired during pre-question narration and pre-empted the
+  // user's chance to answer.
+  test("cc-cli MCP tool call surfaced as canonical toolCall → not flagged", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleEmptyIntentTurn(
+        {
+          messages: [
+            assistantMsg("Let me call ask_user_questions to gather your preferences.", {
+              toolUse: "toolCall",
+            }),
+          ],
+        },
+        false,
+      );
+      assert.equal(handled, false);
+      assert.equal(cap.messages.length, 0);
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  test("serverToolUse block (cc-cli web search etc.) → not flagged", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleEmptyIntentTurn(
+        {
+          messages: [
+            assistantMsg("Let me invoke the search tool now.", {
+              toolUse: "serverToolUse",
+            }),
+          ],
+        },
         false,
       );
       assert.equal(handled, false);


### PR DESCRIPTION
## TL;DR

**What:** Fix `hasToolUse` in guided-flow to match canonical pi-ai tool-block discriminators (`toolCall` / `serverToolUse`) instead of the Anthropic wire literal (`tool_use`).
**Why:** Under claude-code-cli the empty-turn recovery nudge pre-empts MCP `ask_user_questions`, so users never get to answer.
**How:** One-line widening of the type check at the consumer + test helper fix + cc-cli regression tests.

## What

- `src/resources/extensions/gsd/guided-flow.ts` — `hasToolUse` now matches the canonical pi-ai discriminators `"toolCall"` and `"serverToolUse"`. Removed the misleading `"tool_use"` / `"tool-use"` literals (they never matched anything internally).
- `src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts` — fix the test helper, which had the same wire-format mistake, and add two regression tests for `toolCall` and `serverToolUse` block shapes.

## Why

Closes #4987.

When the active LLM provider is **claude-code-cli** and the agent invokes the MCP tool `mcp__gsd-workflow__ask_user_questions`, the user never gets a chance to answer. Instead the system fires:

> Empty-turn detected: LLM announced intent but called no tool. Prompting it to execute.

…and injects a synthetic system message with `triggerTurn: true`, pre-empting the user.

**Root cause:** the canonical pi-ai `AssistantMessage.content` (`packages/pi-ai/src/types.ts:159, 168, 208`) uses `type: "toolCall"` and `type: "serverToolUse"`. Every provider normalizes incoming wire-format blocks into these canonical shapes before the message reaches guided-flow:

- anthropic-direct → `packages/pi-ai/src/providers/anthropic-shared.ts:668, 680`
- claude-code-cli  → `src/resources/extensions/claude-code-cli/partial-builder.ts:54, 91`, assembled in `stream-adapter.ts:1509`

The check at `guided-flow.ts:319-323` was looking for the Anthropic API wire literal (`"tool_use"`), which never appears in the internal `AssistantMessage`. It returned `false` for every real tool call. Latent for all providers; visibly broken under cc-cli because the LLM's pre-tool narration (`"Let me call ask_user_questions…"`) trips `COMMIT_INTENT_RE` at `guided-flow.ts:426-427`, so `maybeHandleEmptyIntentTurn` fires and pre-empts the user's answer.

The interactive-tool gate `hasInteractiveToolInFlight()` (`auto-tool-tracking.ts:73`) doesn't save us either: under cc-cli the SDK runs the tool inside its own loop, so by the time `handleAgentEnd` fires the tool has already completed and the gate is `false`.

## How

Single normalization point at the consumer. The canonical pi-ai type is the contract, and every provider already produces it — guided-flow just needs to read the right discriminator. Widening to also accept the wire literals was considered as a defensive measure; rejected because those literals never appear internally and matching them would muddy the contract.

The existing test helper hand-wrote the wire-format `tool_use`, so the "tool-use block → not flagged" test was passing against a shape that does not exist in production. Helper now emits canonical types and accepts a string discriminator (`toolCall` | `serverToolUse`) for explicit coverage.

### Tests

```
▶ #4573 maybeHandleEmptyIntentTurn
  ✔ commit-intent WITH tool-use block → not flagged
  ✔ cc-cli MCP tool call surfaced as canonical toolCall → not flagged
  ✔ serverToolUse block (cc-cli web search etc.) → not flagged
  …
ℹ tests 28  pass 28  fail 0
```

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] Targeted suite: `ready-phrase-no-files-4573.test.js`, `agent-end-retry.test.js`, `guided-flow-dynamic-routing.test.js` — 28/28 pass
- [ ] CI (`verify:pr`)
- [ ] Manual: run `/gsd-discuss-phase` under claude-code-cli and confirm `ask_user_questions` reaches the user before the empty-turn nudge fires

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Disclosure

This PR is AI-assisted (Claude Code). Diagnosis cross-validated via Codex peer review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of tool invocation blocks so guided-flow recovery reliably recognizes canonical tool call formats from different AI providers.

* **Tests**
  * Added regression tests and updated test helpers to ensure consistent handling of tool invocation blocks and prevent incorrect empty-intent/nudge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->