### PR TITLE
ci(dev-publish): verify npm reachability and clarify failure messaging

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -131,7 +131,8 @@ jobs:
             echo "Attempt $i failed — waiting 10s for npm registry propagation..."
             sleep 10
           done
-          echo "::error::Failed to install gsd-pi@${DEV_VERSION} after 6 attempts. The @dev tag may point at a broken artifact — deprecate it with: npm deprecate gsd-pi@${DEV_VERSION} 'broken build'"
+          echo "::error::Failed to install gsd-pi@${DEV_VERSION} after 6 attempts."
+          echo "::error::Recommended actions: (1) investigate the failing step above, (2) if the version exists on npm, deprecate it with 'npm deprecate gsd-pi@${DEV_VERSION} \"broken build; see Actions run\"', (3) cut a fix and re-run Dev Publish."
           exit 1
 
       - name: Run smoke tests (against installed binary)

--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -98,6 +98,14 @@ jobs:
           else
             npm publish --tag dev
           fi
+          echo "Verifying gsd-pi@${VERSION} is reachable on npm..."
+          for i in 1 2 3 4 5; do
+            npm view "gsd-pi@${VERSION}" version 2>/dev/null && echo "Confirmed: gsd-pi@${VERSION} is live." && exit 0
+            echo "Attempt $i: not yet visible — waiting 10s..."
+            sleep 10
+          done
+          echo "::error::Publish step succeeded but gsd-pi@${VERSION} is not reachable on npm after 50s. Check NPM_TOKEN permissions and registry config."
+          exit 1
 
   dev-verify:
     name: Dev Verify (installed package)
@@ -144,6 +152,6 @@ jobs:
         env:
           DEV_VERSION: ${{ needs.dev-publish.outputs.dev-version }}
         run: |
-          echo "::error::Post-publish verification failed for gsd-pi@${DEV_VERSION}. The @dev tag still points at this version on npm."
-          echo "::error::Recommended actions: (1) investigate the failing step above, (2) deprecate the broken version with 'npm deprecate gsd-pi@${DEV_VERSION} \"broken build; see Actions run\"', (3) cut a fix and re-run Dev Publish."
+          echo "::error::Post-publish verification failed for gsd-pi@${DEV_VERSION}."
+          echo "::error::Recommended actions: (1) investigate the failing step above, (2) if the version exists on npm, deprecate it with 'npm deprecate gsd-pi@${DEV_VERSION} \"broken build; see Actions run\"', (3) cut a fix and re-run Dev Publish."
           exit 1


### PR DESCRIPTION
## TL;DR

**What:** Poll `npm view gsd-pi@${VERSION}` after `npm publish` until the version is visible, and reword the `dev-verify` failure message.
**Why:** `dev-verify` was racing npm registry propagation, and the failure message misdirected maintainers when publish itself failed.
**How:** 5×10s reachability loop in the publish job; qualified language in the verify-failure message.

## What

`.github/workflows/dev-publish.yml`:

1. After `npm publish`, poll `npm view gsd-pi@${VERSION}` up to 5×10s. Exit 0 on first success; exit 1 with a `::error::` line pointing at NPM_TOKEN / registry config if the version never appears.
2. Reword the `dev-verify` failure message: drop the unconditional "@dev tag still points at this version" claim and qualify the `npm deprecate` recommendation with "if the version exists on npm".

## Why

Closes #4989.

- **Reachability poll:** the npm registry can take seconds to make a freshly published version visible. Without a guard, the downstream `dev-verify` job that immediately tries to install the new version fails on a transient "not found" before propagation completes. Failures show up as flaky CI rather than real publish problems.
- **Clarified messaging:** if `npm publish` fails partway, the `@dev` tag may not have moved at all — telling maintainers to `npm deprecate` a version that may not exist is misleading. Qualifying the suggestion makes the runbook honest about both failure modes.

## How

Reachability loop runs inside the existing publish step, so a real publish/permissions failure still surfaces as a `::error::` from the same job rather than masquerading as a `dev-verify` failure later.

## Test plan

- [ ] Next dev publish run picks up the loop; confirm the new "Verifying gsd-pi@... is reachable on npm..." log line.
- [ ] No regression in the success path — the loop exits on first hit, typical case is one extra `npm view` call.
- [ ] On a deliberately broken token, the publish job fails with the new error pointing at `NPM_TOKEN permissions and registry config`.

## Change type

- [x] `ci` — CI/CD configuration

## Disclosure

This PR is AI-assisted (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dev publishing workflow with post-publish registry visibility verification
  * Enhanced error messaging for dev tag verification process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->