### PR TITLE
fix(gsd): close milestone-ID skip vector — phantom stub dirs no longer skew nextMilestoneId (#4996)

### DIFF
--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -14,6 +14,7 @@ It checks:
 - Completion state consistency
 - Git worktree health (worktree and branch modes only — skipped in none mode)
 - Stale lock files and orphaned runtime records
+- Disk-only orphan milestone stub directories
 
 ## Common Issues
 
@@ -139,6 +140,14 @@ rm -rf "$(dirname .gsd)/.gsd.lock"
 **Fix:**
 - Run `/gsd doctor fix` to rewrite the stale milestone metadata automatically when the fallback is obvious.
 - If GSD still blocks, recreate the missing branch or update your git preferences so `git.main_branch` points at a real branch.
+
+### `/gsd doctor` reports `orphan_milestone_dir`
+
+**Symptoms:** `/gsd doctor` shows a warning like `Orphan milestone directory: M003` with issue code `orphan_milestone_dir`.
+
+**What it means:** `.gsd/milestones/<MID>/` exists on disk, but GSD cannot find a DB milestone row, a matching `.gsd/worktrees/<MID>/` worktree, or any milestone content files. These disk-only stub directories can be left behind by interrupted or stale forward references and can skew the next milestone ID that GSD generates.
+
+**Fix:** Run `/gsd doctor fix` to remove the orphan milestone stub directory automatically. The auto-fix only targets disk-only stubs with no DB row, no worktree, and no content files; populated milestone directories and in-flight worktree-only milestones are not removed.
 
 ### Transient `EBUSY` / `EPERM` / `EACCES` while writing `.gsd/` files
 

--- a/gitbook/reference/troubleshooting.md
+++ b/gitbook/reference/troubleshooting.md
@@ -8,7 +8,7 @@ The built-in diagnostic tool validates `.gsd/` integrity:
 /gsd doctor
 ```
 
-It checks file structure, roadmap ↔ slice ↔ task consistency, completion state, git health, stale locks, and orphaned records.
+It checks file structure, roadmap ↔ slice ↔ task consistency, completion state, git health, stale locks, orphaned records, and disk-only milestone stubs.
 
 ## Common Issues
 
@@ -93,6 +93,12 @@ Auto mode was paused, stopped, or crashed mid-milestone, and the work is still o
 - `Unmerged exits > 0` on the producer side confirms which exit type caused it
 
 **Prevent recurrence:** If your milestones are large or sessions are frequently interrupted, consider setting `git.collapse_cadence: "slice"` in preferences — validated slices merge to main immediately, shrinking the orphan window from milestone-size to slice-size. See [Git & Worktrees](../configuration/git-settings.md#collapse-cadence).
+
+### `orphan_milestone_dir` doctor warning
+
+`/gsd doctor` can report `orphan_milestone_dir` when `.gsd/milestones/<MID>/` exists on disk but has no DB row, no matching `.gsd/worktrees/<MID>/` worktree, and no milestone content files. This is a disk-only stub, not stranded work, and it can skew future milestone ID generation.
+
+**Fix:** Run `/gsd doctor fix` to remove the orphan stub directory automatically. The fix only removes these empty disk-only milestone stubs; populated milestone directories and in-flight worktree-only milestones are preserved.
 
 ### Notifications not appearing on macOS
 

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -889,6 +889,32 @@ export const executeTaskComplete = async (params, projectDir) => {
     }
   });
 
+  it("gsd_milestone_generate_id skips DB-only queued milestone rows", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_milestone_generate_id");
+      assert.ok(tool, "milestone ID tool should be registered");
+
+      const first = await tool!.handler({ projectDir: base });
+      assert.equal((first as any).content[0].text, "M001");
+      assert.ok(!existsSync(join(base, ".gsd", "milestones", "M001")), "ID generation should not create a milestone dir");
+
+      closeDatabase();
+
+      const second = await tool!.handler({ projectDir: base });
+      assert.equal((second as any).content[0].text, "M002");
+
+      const rows = _getAdapter()!
+        .prepare("SELECT id FROM milestones ORDER BY id")
+        .all() as Array<Record<string, unknown>>;
+      assert.deepEqual(rows.map((row) => row["id"]), ["M001", "M002"]);
+    } finally {
+      cleanup(base);
+    }
+  });
+
   it("gsd_plan_task reopens the DB before inline task planning writes", async () => {
     const base = makeTmpBase();
     try {

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -847,6 +847,60 @@ async function ensureMilestoneDbRow(milestoneId: string): Promise<void> {
   }
 }
 
+/**
+ * Fix #4996: Shared helper for both gsd_milestone_generate_id and
+ * gsd_generate_milestone_id. Reuses the lowest reusable ghost milestone ID
+ * (a disk-only stub with no DB row, no worktree, no content files) before
+ * falling back to max+1. Uses the stricter `isReusableGhostMilestone` —
+ * not `isGhostMilestone` — to avoid racing with in-flight queued DB rows
+ * from an earlier call to this same tool.
+ */
+async function generateOrReuseMilestoneId(projectDir: string): Promise<string> {
+  const {
+    claimReservedId,
+    findMilestoneIds,
+    getReservedMilestoneIds,
+    nextMilestoneId,
+    milestoneIdSort,
+  } = await importLocalModule<any>("../../../src/resources/extensions/gsd/milestone-ids.js");
+
+  const reserved = claimReservedId();
+  if (reserved) {
+    await ensureMilestoneDbRow(reserved);
+    return reserved;
+  }
+
+  const allIds = [...new Set([...findMilestoneIds(projectDir), ...getReservedMilestoneIds()])];
+
+  // Attempt ghost-ID reuse before falling back to max+1.
+  const { isReusableGhostMilestone } = await importLocalModule<any>(
+    "../../../src/resources/extensions/gsd/state.js",
+  );
+  const sorted = [...allIds].sort(milestoneIdSort);
+  for (const candidate of sorted) {
+    if (isReusableGhostMilestone(projectDir, candidate)) {
+      await ensureMilestoneDbRow(candidate);
+      return candidate;
+    }
+  }
+
+  const prefsMod = await importLocalModule<any>(
+    "../../../src/resources/extensions/gsd/preferences.js",
+  ).catch(() => null);
+  // Graceful degradation: a corrupt preferences file should not crash
+  // milestone-id generation. Fall back to non-unique IDs if anything
+  // throws here — matches the pre-fix behavior for missing prefs.
+  let uniqueEnabled = false;
+  try {
+    uniqueEnabled = !!prefsMod?.loadEffectiveGSDPreferences?.()?.preferences?.unique_milestone_ids;
+  } catch {
+    uniqueEnabled = false;
+  }
+  const nextId = nextMilestoneId(allIds, uniqueEnabled);
+  await ensureMilestoneDbRow(nextId);
+  return nextId;
+}
+
 // projectDir is optional. When omitted, the server uses process.cwd(). This
 // prevents the agent from burning tokens reasoning about which absolute path
 // to pass (git root vs worktree vs symlink-resolved external state layout) —
@@ -1348,35 +1402,9 @@ export function registerWorkflowTools(server: McpToolServer): void {
     async (args: Record<string, unknown>) => {
       const { projectDir } = parseWorkflowArgs(milestoneGenerateIdSchema, args);
       await enforceWorkflowWriteGate("gsd_milestone_generate_id", projectDir);
-      const id = await runSerializedWorkflowDbOperation(projectDir, async () => {
-        const {
-          claimReservedId,
-          findMilestoneIds,
-          getReservedMilestoneIds,
-          nextMilestoneId,
-        } = await importLocalModule<any>("../../../src/resources/extensions/gsd/milestone-ids.js");
-        const reserved = claimReservedId();
-        if (reserved) {
-          await ensureMilestoneDbRow(reserved);
-          return reserved;
-        }
-        const allIds = [...new Set([...findMilestoneIds(projectDir), ...getReservedMilestoneIds()])];
-        const prefsMod = await importLocalModule<any>(
-          "../../../src/resources/extensions/gsd/preferences.js",
-        ).catch(() => null);
-        // Graceful degradation: a corrupt preferences file should not crash
-        // milestone-id generation. Fall back to non-unique IDs if anything
-        // throws here — matches the pre-fix behavior for missing prefs.
-        let uniqueEnabled = false;
-        try {
-          uniqueEnabled = !!prefsMod?.loadEffectiveGSDPreferences?.()?.preferences?.unique_milestone_ids;
-        } catch {
-          uniqueEnabled = false;
-        }
-        const nextId = nextMilestoneId(allIds, uniqueEnabled);
-        await ensureMilestoneDbRow(nextId);
-        return nextId;
-      });
+      const id = await runSerializedWorkflowDbOperation(projectDir, () =>
+        generateOrReuseMilestoneId(projectDir),
+      );
       return { content: [{ type: "text" as const, text: id }] };
     },
   );
@@ -1388,35 +1416,9 @@ export function registerWorkflowTools(server: McpToolServer): void {
     async (args: Record<string, unknown>) => {
       const { projectDir } = parseWorkflowArgs(milestoneGenerateIdSchema, args);
       await enforceWorkflowWriteGate("gsd_milestone_generate_id", projectDir);
-      const id = await runSerializedWorkflowDbOperation(projectDir, async () => {
-        const {
-          claimReservedId,
-          findMilestoneIds,
-          getReservedMilestoneIds,
-          nextMilestoneId,
-        } = await importLocalModule<any>("../../../src/resources/extensions/gsd/milestone-ids.js");
-        const reserved = claimReservedId();
-        if (reserved) {
-          await ensureMilestoneDbRow(reserved);
-          return reserved;
-        }
-        const allIds = [...new Set([...findMilestoneIds(projectDir), ...getReservedMilestoneIds()])];
-        const prefsMod = await importLocalModule<any>(
-          "../../../src/resources/extensions/gsd/preferences.js",
-        ).catch(() => null);
-        // Graceful degradation: a corrupt preferences file should not crash
-        // milestone-id generation. Fall back to non-unique IDs if anything
-        // throws here — matches the pre-fix behavior for missing prefs.
-        let uniqueEnabled = false;
-        try {
-          uniqueEnabled = !!prefsMod?.loadEffectiveGSDPreferences?.()?.preferences?.unique_milestone_ids;
-        } catch {
-          uniqueEnabled = false;
-        }
-        const nextId = nextMilestoneId(allIds, uniqueEnabled);
-        await ensureMilestoneDbRow(nextId);
-        return nextId;
-      });
+      const id = await runSerializedWorkflowDbOperation(projectDir, () =>
+        generateOrReuseMilestoneId(projectDir),
+      );
       return { content: [{ type: "text" as const, text: id }] };
     },
   );

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -847,6 +847,20 @@ async function ensureMilestoneDbRow(milestoneId: string): Promise<void> {
   }
 }
 
+async function findDatabaseMilestoneIds(): Promise<string[]> {
+  try {
+    const { getAllMilestones } = await importLocalModule<any>("../../../src/resources/extensions/gsd/gsd-db.js");
+    return (getAllMilestones?.() ?? [])
+      .map((milestone: unknown) => {
+        const id = (milestone as { id?: unknown })?.id;
+        return typeof id === "string" ? id : null;
+      })
+      .filter((id: string | null): id is string => id !== null);
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Fix #4996: Shared helper for both gsd_milestone_generate_id and
  * gsd_generate_milestone_id. Reuses the lowest reusable ghost milestone ID
@@ -870,7 +884,13 @@ async function generateOrReuseMilestoneId(projectDir: string): Promise<string> {
     return reserved;
   }
 
-  const allIds = [...new Set([...findMilestoneIds(projectDir), ...getReservedMilestoneIds()])];
+  const allIds = [
+    ...new Set([
+      ...findMilestoneIds(projectDir),
+      ...getReservedMilestoneIds(),
+      ...(await findDatabaseMilestoneIds()),
+    ]),
+  ];
 
   // Attempt ghost-ID reuse before falling back to max+1.
   const { isReusableGhostMilestone } = await importLocalModule<any>(
@@ -892,7 +912,7 @@ async function generateOrReuseMilestoneId(projectDir: string): Promise<string> {
   // throws here — matches the pre-fix behavior for missing prefs.
   let uniqueEnabled = false;
   try {
-    uniqueEnabled = !!prefsMod?.loadEffectiveGSDPreferences?.()?.preferences?.unique_milestone_ids;
+    uniqueEnabled = !!prefsMod?.loadEffectiveGSDPreferences?.(projectDir)?.preferences?.unique_milestone_ids;
   } catch {
     uniqueEnabled = false;
   }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1812,7 +1812,7 @@ const widgetStateAccessors: WidgetStateAccessors = {
  * Ensure directories, branches, and other prerequisites exist before
  * dispatching a unit. The LLM should never need to mkdir or git checkout.
  */
-function ensurePreconditions(
+export function ensurePreconditions(
   unitType: string,
   unitId: string,
   base: string,
@@ -1822,6 +1822,23 @@ function ensurePreconditions(
 
   const mDir = resolveMilestonePath(base, mid);
   if (!mDir) {
+    // Fix #4996: When dispatching a slice unit against an unrecognised milestone,
+    // only create the directory if the milestone has a DB row or a content file.
+    // Without this guard, forward-referenced unit IDs (e.g. from REQUIREMENTS.md)
+    // silently scaffold empty stub directories that later skew nextMilestoneId.
+    if (sid !== undefined) {
+      const hasDbRow = isDbAvailable() && getMilestone(mid) != null;
+      const hasContent = !!(
+        resolveMilestoneFile(base, mid, "CONTEXT")
+        || resolveMilestoneFile(base, mid, "CONTEXT-DRAFT")
+        || resolveMilestoneFile(base, mid, "ROADMAP")
+        || resolveMilestoneFile(base, mid, "SUMMARY")
+      );
+      if (!hasDbRow && !hasContent) {
+        logWarning("engine", `ensurePreconditions: skipping mkdir for unrecognised milestone ${mid} referenced by slice unit ${unitId} — no DB row and no content files exist`, { file: "auto.ts" });
+        return;
+      }
+    }
     const newDir = join(milestonesDir(base), mid);
     mkdirSync(join(newDir, "slices"), { recursive: true });
   }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -37,6 +37,7 @@ import {
   resolveTasksDir,
   resolveTaskFile,
   milestonesDir,
+  buildMilestoneFileName,
   buildTaskFileName,
 } from "./paths.js";
 import { invalidateAllCaches } from "./cache.js";
@@ -1808,6 +1809,14 @@ const widgetStateAccessors: WidgetStateAccessors = {
 
 // ─── Preconditions ────────────────────────────────────────────────────────────
 
+function hasMilestoneContentFile(base: string, mid: string): boolean {
+  const suffixes = ["CONTEXT", "CONTEXT-DRAFT", "ROADMAP", "SUMMARY"];
+  return suffixes.some((suffix) => {
+    if (resolveMilestoneFile(base, mid, suffix)) return true;
+    return existsSync(join(milestonesDir(base), buildMilestoneFileName(mid, suffix)));
+  });
+}
+
 /**
  * Ensure directories, branches, and other prerequisites exist before
  * dispatching a unit. The LLM should never need to mkdir or git checkout.
@@ -1828,12 +1837,7 @@ export function ensurePreconditions(
     // silently scaffold empty stub directories that later skew nextMilestoneId.
     if (sid !== undefined) {
       const hasDbRow = isDbAvailable() && getMilestone(mid) != null;
-      const hasContent = !!(
-        resolveMilestoneFile(base, mid, "CONTEXT")
-        || resolveMilestoneFile(base, mid, "CONTEXT-DRAFT")
-        || resolveMilestoneFile(base, mid, "ROADMAP")
-        || resolveMilestoneFile(base, mid, "SUMMARY")
-      );
+      const hasContent = hasMilestoneContentFile(base, mid);
       if (!hasDbRow && !hasContent) {
         logWarning("engine", `ensurePreconditions: skipping mkdir for unrecognised milestone ${mid} referenced by slice unit ${unitId} — no DB row and no content files exist`, { file: "auto.ts" });
         return;

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -37,7 +37,6 @@ import {
   resolveTasksDir,
   resolveTaskFile,
   milestonesDir,
-  buildMilestoneFileName,
   buildTaskFileName,
 } from "./paths.js";
 import { invalidateAllCaches } from "./cache.js";
@@ -1809,14 +1808,6 @@ const widgetStateAccessors: WidgetStateAccessors = {
 
 // ─── Preconditions ────────────────────────────────────────────────────────────
 
-function hasMilestoneContentFile(base: string, mid: string): boolean {
-  const suffixes = ["CONTEXT", "CONTEXT-DRAFT", "ROADMAP", "SUMMARY"];
-  return suffixes.some((suffix) => {
-    if (resolveMilestoneFile(base, mid, suffix)) return true;
-    return existsSync(join(milestonesDir(base), buildMilestoneFileName(mid, suffix)));
-  });
-}
-
 /**
  * Ensure directories, branches, and other prerequisites exist before
  * dispatching a unit. The LLM should never need to mkdir or git checkout.
@@ -1832,14 +1823,13 @@ export function ensurePreconditions(
   const mDir = resolveMilestonePath(base, mid);
   if (!mDir) {
     // Fix #4996: When dispatching a slice unit against an unrecognised milestone,
-    // only create the directory if the milestone has a DB row or a content file.
+    // only create the directory if the milestone has a DB row.
     // Without this guard, forward-referenced unit IDs (e.g. from REQUIREMENTS.md)
     // silently scaffold empty stub directories that later skew nextMilestoneId.
     if (sid !== undefined) {
       const hasDbRow = isDbAvailable() && getMilestone(mid) != null;
-      const hasContent = hasMilestoneContentFile(base, mid);
-      if (!hasDbRow && !hasContent) {
-        logWarning("engine", `ensurePreconditions: skipping mkdir for unrecognised milestone ${mid} referenced by slice unit ${unitId} — no DB row and no content files exist`, { file: "auto.ts" });
+      if (!hasDbRow) {
+        logWarning("engine", `ensurePreconditions: skipping mkdir for unrecognised milestone ${mid} referenced by slice unit ${unitId} — no DB row exists`, { file: "auto.ts" });
         return;
       }
     }

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -4,7 +4,7 @@ import { basename, dirname, join } from "node:path";
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
 import { cleanNumberedGsdVariants } from "./repo-identity.js";
 import { milestonesDir, gsdRoot, resolveGsdRootFile } from "./paths.js";
-import { deriveState, isReusableGhostMilestone } from "./state.js";
+import { deriveState, isGhostMilestone, isReusableGhostMilestone } from "./state.js";
 import { saveFile } from "./files.js";
 import { nativeIsRepo, nativeForEachRef, nativeUpdateRef } from "./native-git-bridge.js";
 import { readCrashLock, isLockProcessAlive, clearLock } from "./crash-recovery.js";
@@ -602,8 +602,11 @@ export async function checkRuntimeHealth(
   // for a phantom forward-reference. Surface as a fixable warning.
   try {
     const milestoneIds = findMilestoneIds(basePath);
+    const hasDbFile = existsSync(join(root, "gsd.db"));
     for (const mid of milestoneIds) {
-      if (isReusableGhostMilestone(basePath, mid)) {
+      const isOrphan = isReusableGhostMilestone(basePath, mid)
+        || (!hasDbFile && isGhostMilestone(basePath, mid));
+      if (isOrphan) {
         issues.push({
           severity: "warning",
           code: "orphan_milestone_dir",

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -4,7 +4,7 @@ import { basename, dirname, join } from "node:path";
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
 import { cleanNumberedGsdVariants } from "./repo-identity.js";
 import { milestonesDir, gsdRoot, resolveGsdRootFile } from "./paths.js";
-import { deriveState } from "./state.js";
+import { deriveState, isReusableGhostMilestone } from "./state.js";
 import { saveFile } from "./files.js";
 import { nativeIsRepo, nativeForEachRef, nativeUpdateRef } from "./native-git-bridge.js";
 import { readCrashLock, isLockProcessAlive, clearLock } from "./crash-recovery.js";
@@ -12,6 +12,7 @@ import { ensureGitignore, isGsdGitignored } from "./gitignore.js";
 import { readAllSessionStatuses, isSessionStale, removeSessionStatus } from "./session-status-io.js";
 import { recoverFailedMigration } from "./migrate-external.js";
 import { splitCompletedKey } from "./forensics.js";
+import { findMilestoneIds } from "./milestone-ids.js";
 
 export async function checkRuntimeHealth(
   basePath: string,
@@ -592,6 +593,40 @@ export async function checkRuntimeHealth(
     }
   } catch {
     // Non-fatal — snapshot ref check failed
+  }
+
+  // ── Orphan milestone directories (#4996) ──────────────────────────────
+  // Walk every milestone ID on disk. Any dir that has no DB row, no worktree,
+  // and no content files is an orphaned stub — it skews nextMilestoneId and
+  // was likely created by ensurePreconditions or showHeadlessMilestoneCreation
+  // for a phantom forward-reference. Surface as a fixable warning.
+  try {
+    const milestoneIds = findMilestoneIds(basePath);
+    for (const mid of milestoneIds) {
+      if (isReusableGhostMilestone(basePath, mid)) {
+        issues.push({
+          severity: "warning",
+          code: "orphan_milestone_dir",
+          scope: "milestone",
+          unitId: mid,
+          message: `Orphan milestone directory: ${mid} — directory exists on disk with no DB row, no worktree, and no content files. This stub skews milestone ID generation and should be removed.`,
+          file: `.gsd/milestones/${mid}`,
+          fixable: true,
+        });
+
+        if (shouldFix("orphan_milestone_dir")) {
+          try {
+            const orphanPath = join(milestonesDir(basePath), mid);
+            rmSync(orphanPath, { recursive: true, force: true });
+            fixesApplied.push(`removed orphan milestone directory: ${mid}`);
+          } catch {
+            // Non-fatal — leave for manual cleanup
+          }
+        }
+      }
+    }
+  } catch {
+    // Non-fatal — orphan milestone directory check failed
   }
 }
 

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -80,7 +80,9 @@ export type DoctorIssueCode =
   | "db_done_task_no_summary"
   | "db_duplicate_id"
   | "db_unavailable"
-  | "projection_drift";
+  | "projection_drift"
+  // Milestone filesystem/DB drift (#4996)
+  | "orphan_milestone_dir";
 
 /**
  * Issue codes that represent global or completion-critical state.

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -14,7 +14,7 @@ import { isDbAvailable, getMilestoneSlices } from "./gsd-db.js";
 import { parseRoadmapSlices } from "./roadmap-slices.js";
 import { loadPrompt, inlineTemplate } from "./prompt-loader.js";
 import { buildDiscussMilestonePrompt, buildSkillActivationBlock } from "./auto-prompts.js";
-import { deriveState } from "./state.js";
+import { deriveState, isReusableGhostMilestone } from "./state.js";
 import { invalidateAllCaches } from "./cache.js";
 import { startAutoDetached } from "./auto.js";
 import { clearLock } from "./crash-recovery.js";
@@ -44,7 +44,7 @@ import { showProjectInit, offerMigration } from "./init-wizard.js";
 import { validateDirectory } from "./validate-directory.js";
 import { showConfirm } from "../shared/tui.js";
 import { debugLog } from "./debug-logger.js";
-import { findMilestoneIds, nextMilestoneId, reserveMilestoneId, getReservedMilestoneIds, clearReservedMilestoneIds } from "./milestone-ids.js";
+import { findMilestoneIds, milestoneIdSort, nextMilestoneId, reserveMilestoneId, getReservedMilestoneIds, clearReservedMilestoneIds } from "./milestone-ids.js";
 import { parkMilestone, discardMilestone } from "./milestone-actions.js";
 import { selectAndApplyModel } from "./auto-model-selection.js";
 import { DISCUSS_TOOLS_ALLOWLIST } from "./constants.js";
@@ -79,8 +79,19 @@ import { logWarning } from "./workflow-logger.js";
  * Ensures any preview ID shown in the UI matches what `gsd_milestone_generate_id`
  * will later return.
  */
-function nextMilestoneIdReserved(existingIds: string[], uniqueEnabled: boolean): string {
+function nextMilestoneIdReserved(existingIds: string[], uniqueEnabled: boolean, basePath?: string): string {
   const allIds = [...new Set([...existingIds, ...getReservedMilestoneIds()])];
+  // Fix #4996: before falling back to max+1, find the lowest reusable ghost ID.
+  // A reusable ghost is a disk-only stub with no DB row and no content files.
+  if (basePath) {
+    const sorted = [...allIds].sort(milestoneIdSort);
+    for (const candidate of sorted) {
+      if (isReusableGhostMilestone(basePath, candidate)) {
+        reserveMilestoneId(candidate);
+        return candidate;
+      }
+    }
+  }
   const id = nextMilestoneId(allIds, uniqueEnabled);
   reserveMilestoneId(id);
   return id;
@@ -818,11 +829,13 @@ export async function showHeadlessMilestoneCreation(
   // Generate next milestone ID
   const existingIds = findMilestoneIds(basePath);
   const prefs = loadEffectiveGSDPreferences();
-  const nextId = nextMilestoneIdReserved(existingIds, prefs?.preferences?.unique_milestone_ids ?? false);
+  const nextId = nextMilestoneIdReserved(existingIds, prefs?.preferences?.unique_milestone_ids ?? false, basePath);
 
-  // Create milestone directory
-  const milestoneDir = join(gsdRoot(basePath), "milestones", nextId, "slices");
-  mkdirSync(milestoneDir, { recursive: true });
+  // Fix #4996: Do NOT pre-create the milestone directory here.
+  // atomicWriteAsync (used by all artifact writers) calls mkdir lazily before
+  // each write, so every path through saveArtifactToDb / saveFile is already
+  // lazy-mkdir-safe. Pre-creating the dir before the discuss flow runs leaves
+  // an orphan stub if discuss is abandoned — that stub later skews nextMilestoneId.
 
   // Build and dispatch the headless discuss prompt
   const prompt = buildHeadlessDiscussPrompt(nextId, seedContext, basePath);
@@ -1039,7 +1052,7 @@ export async function showDiscuss(
     } else if (choice === "skip_milestone") {
       const milestoneIds = findMilestoneIds(basePath);
       const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
-      const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds);
+      const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds, basePath);
       pendingAutoStartMap.set(basePath, { ctx, pi, basePath, milestoneId: nextId, step: false, createdAt: Date.now() });
       await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId, `New milestone ${nextId}.`, basePath), "gsd-run", ctx, "discuss-milestone");
     }
@@ -1444,7 +1457,7 @@ async function handleMilestoneActions(
   if (choice === "skip") {
     const milestoneIds = findMilestoneIds(basePath);
     const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
-    const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds);
+    const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds, basePath);
     pendingAutoStartMap.set(basePath, { ctx, pi, basePath, milestoneId: nextId, step: stepMode, createdAt: Date.now() });
     await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
       `New milestone ${nextId}.`,
@@ -1631,7 +1644,7 @@ export async function showSmartEntry(
     }
 
     const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
-    const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds);
+    const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds, basePath);
     const isFirst = milestoneIds.length === 0;
 
     if (isFirst) {
@@ -1711,7 +1724,7 @@ export async function showSmartEntry(
     if (choice === "new_milestone") {
       const milestoneIds = findMilestoneIds(basePath);
       const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
-      const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds);
+      const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds, basePath);
 
       pendingAutoStartMap.set(basePath, { ctx, pi, basePath, milestoneId: nextId, step: stepMode, createdAt: Date.now() });
       await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
@@ -1779,7 +1792,7 @@ export async function showSmartEntry(
     } else if (choice === "skip_milestone") {
       const milestoneIds = findMilestoneIds(basePath);
       const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
-      const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds);
+      const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds, basePath);
       pendingAutoStartMap.set(basePath, { ctx, pi, basePath, milestoneId: nextId, step: stepMode, createdAt: Date.now() });
       await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
         `New milestone ${nextId}.`,
@@ -1876,7 +1889,7 @@ export async function showSmartEntry(
       } else if (choice === "skip_milestone") {
         const milestoneIds = findMilestoneIds(basePath);
         const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
-        const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds);
+        const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds, basePath);
         pendingAutoStartMap.set(basePath, { ctx, pi, basePath, milestoneId: nextId, step: stepMode, createdAt: Date.now() });
         await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
           `New milestone ${nextId}.`,

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -46,6 +46,7 @@ import { showConfirm } from "../shared/tui.js";
 import { debugLog } from "./debug-logger.js";
 import { findMilestoneIds, clearReservedMilestoneIds } from "./milestone-ids.js";
 import { nextMilestoneIdReserved } from "./milestone-id-reservation.js";
+export { nextMilestoneIdReserved } from "./milestone-id-reservation.js";
 import { parkMilestone, discardMilestone } from "./milestone-actions.js";
 import { selectAndApplyModel } from "./auto-model-selection.js";
 import { DISCUSS_TOOLS_ALLOWLIST } from "./constants.js";
@@ -1029,6 +1030,8 @@ export async function showDiscuss(
         fastPathInstruction: "",
       }), "gsd-discuss", ctx, "discuss-milestone");
     } else if (choice === "skip_milestone") {
+      const { ensureDbOpen } = await import("./bootstrap/dynamic-tools.js");
+      await ensureDbOpen(basePath);
       const milestoneIds = findMilestoneIds(basePath);
       const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
       const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds, basePath);

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -14,7 +14,7 @@ import { isDbAvailable, getMilestoneSlices } from "./gsd-db.js";
 import { parseRoadmapSlices } from "./roadmap-slices.js";
 import { loadPrompt, inlineTemplate } from "./prompt-loader.js";
 import { buildDiscussMilestonePrompt, buildSkillActivationBlock } from "./auto-prompts.js";
-import { deriveState, isReusableGhostMilestone } from "./state.js";
+import { deriveState } from "./state.js";
 import { invalidateAllCaches } from "./cache.js";
 import { startAutoDetached } from "./auto.js";
 import { clearLock } from "./crash-recovery.js";
@@ -44,7 +44,8 @@ import { showProjectInit, offerMigration } from "./init-wizard.js";
 import { validateDirectory } from "./validate-directory.js";
 import { showConfirm } from "../shared/tui.js";
 import { debugLog } from "./debug-logger.js";
-import { findMilestoneIds, milestoneIdSort, nextMilestoneId, reserveMilestoneId, getReservedMilestoneIds, clearReservedMilestoneIds } from "./milestone-ids.js";
+import { findMilestoneIds, clearReservedMilestoneIds } from "./milestone-ids.js";
+import { nextMilestoneIdReserved } from "./milestone-id-reservation.js";
 import { parkMilestone, discardMilestone } from "./milestone-actions.js";
 import { selectAndApplyModel } from "./auto-model-selection.js";
 import { DISCUSS_TOOLS_ALLOWLIST } from "./constants.js";
@@ -71,31 +72,6 @@ export {
   buildExistingMilestonesContext,
 } from "./guided-flow-queue.js";
 import { logWarning } from "./workflow-logger.js";
-
-// ─── ID Generation with Reservation ─────────────────────────────────────────
-
-/**
- * Generate the next milestone ID, accounting for reserved IDs, and reserve it.
- * Ensures any preview ID shown in the UI matches what `gsd_milestone_generate_id`
- * will later return.
- */
-function nextMilestoneIdReserved(existingIds: string[], uniqueEnabled: boolean, basePath?: string): string {
-  const allIds = [...new Set([...existingIds, ...getReservedMilestoneIds()])];
-  // Fix #4996: before falling back to max+1, find the lowest reusable ghost ID.
-  // A reusable ghost is a disk-only stub with no DB row and no content files.
-  if (basePath) {
-    const sorted = [...allIds].sort(milestoneIdSort);
-    for (const candidate of sorted) {
-      if (isReusableGhostMilestone(basePath, candidate)) {
-        reserveMilestoneId(candidate);
-        return candidate;
-      }
-    }
-  }
-  const id = nextMilestoneId(allIds, uniqueEnabled);
-  reserveMilestoneId(id);
-  return id;
-}
 
 function needsPlanV2Gate(state: GSDState): boolean {
   return state.phase === "executing"
@@ -826,6 +802,9 @@ export async function showHeadlessMilestoneCreation(
   // Ensure .gsd/ is bootstrapped
   bootstrapGsdProject(basePath);
 
+  const { ensureDbOpen } = await import("./bootstrap/dynamic-tools.js");
+  await ensureDbOpen(basePath);
+
   // Generate next milestone ID
   const existingIds = findMilestoneIds(basePath);
   const prefs = loadEffectiveGSDPreferences();
@@ -1541,6 +1520,11 @@ export async function showSmartEntry(
   // ── Ensure .gitignore has baseline patterns ──────────────────────────
   ensureGitignore(basePath);
   untrackRuntimeFiles(basePath);
+
+  {
+    const { ensureDbOpen } = await import("./bootstrap/dynamic-tools.js");
+    await ensureDbOpen(basePath);
+  }
 
   // ── Self-heal stale runtime records from crashed auto-mode sessions ──
   selfHealRuntimeRecords(basePath, ctx);

--- a/src/resources/extensions/gsd/milestone-id-reservation.ts
+++ b/src/resources/extensions/gsd/milestone-id-reservation.ts
@@ -21,10 +21,11 @@ export function nextMilestoneIdReserved(
   uniqueEnabled: boolean,
   basePath?: string,
 ): string {
+  const reservedIds = getReservedMilestoneIds();
   const allIds = [
     ...new Set([
       ...existingIds,
-      ...getReservedMilestoneIds(),
+      ...reservedIds,
       ...getDatabaseMilestoneIds(),
     ]),
   ];
@@ -32,6 +33,7 @@ export function nextMilestoneIdReserved(
   if (basePath) {
     const sorted = [...allIds].sort(milestoneIdSort);
     for (const candidate of sorted) {
+      if (reservedIds.has(candidate)) continue;
       if (isReusableGhostMilestone(basePath, candidate)) {
         reserveMilestoneId(candidate);
         return candidate;

--- a/src/resources/extensions/gsd/milestone-id-reservation.ts
+++ b/src/resources/extensions/gsd/milestone-id-reservation.ts
@@ -1,0 +1,45 @@
+import { isDbAvailable, getAllMilestones } from "./gsd-db.js";
+import {
+  getReservedMilestoneIds,
+  milestoneIdSort,
+  nextMilestoneId,
+  reserveMilestoneId,
+} from "./milestone-ids.js";
+import { isReusableGhostMilestone } from "./state.js";
+
+function getDatabaseMilestoneIds(): string[] {
+  if (!isDbAvailable()) return [];
+  return getAllMilestones().map((milestone) => milestone.id);
+}
+
+/**
+ * Generate the next milestone ID, accounting for DB rows and in-process
+ * reservations, and reserve it.
+ */
+export function nextMilestoneIdReserved(
+  existingIds: string[],
+  uniqueEnabled: boolean,
+  basePath?: string,
+): string {
+  const allIds = [
+    ...new Set([
+      ...existingIds,
+      ...getReservedMilestoneIds(),
+      ...getDatabaseMilestoneIds(),
+    ]),
+  ];
+
+  if (basePath) {
+    const sorted = [...allIds].sort(milestoneIdSort);
+    for (const candidate of sorted) {
+      if (isReusableGhostMilestone(basePath, candidate)) {
+        reserveMilestoneId(candidate);
+        return candidate;
+      }
+    }
+  }
+
+  const id = nextMilestoneId(allIds, uniqueEnabled);
+  reserveMilestoneId(id);
+  return id;
+}

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -114,6 +114,49 @@ export function isGhostMilestone(basePath: string, mid: string): boolean {
   return !context && !draft && !roadmap && !summary;
 }
 
+/**
+ * A "reusable ghost" milestone is an orphaned filesystem stub that is safe
+ * to reclaim as the next milestone ID.
+ *
+ * Stricter than `isGhostMilestone`: returns true ONLY when ALL of the
+ * following hold:
+ *   1. No DB row exists for `mid` (any status, including "queued") — a DB row
+ *      means the milestone was intentionally registered by
+ *      `gsd_milestone_generate_id` and may have an in-flight discuss flow.
+ *      Reusing it would collide with that flow. (#4996 race window)
+ *   2. No worktree directory exists at `gsdRoot/worktrees/{mid}` — a worktree
+ *      means the milestone is legitimately in-flight.
+ *   3. No content files exist (CONTEXT, CONTEXT-DRAFT, ROADMAP, SUMMARY) —
+ *      any content means the discuss flow already ran.
+ *
+ * The looser `isGhostMilestone` also classifies queued-row-without-content as
+ * a ghost to help state queries filter phantoms. `isReusableGhostMilestone`
+ * intentionally does NOT reclaim those — a queued row is sufficient proof of
+ * a live in-flight ID reservation.
+ *
+ * Used by `nextMilestoneIdReserved` and both MCP ID-generator tools to fill
+ * gaps left by phantom directories before resorting to max+1.
+ */
+export function isReusableGhostMilestone(basePath: string, mid: string): boolean {
+  // Condition 1: no DB row (any status).
+  if (isDbAvailable()) {
+    const dbRow = getMilestone(mid);
+    if (dbRow != null) return false;
+  }
+
+  // Condition 2: no worktree.
+  const root = gsdRoot(basePath);
+  const wtPath = join(root, 'worktrees', mid);
+  if (existsSync(wtPath)) return false;
+
+  // Condition 3: no content files.
+  const context = resolveMilestoneFile(basePath, mid, "CONTEXT");
+  const draft   = resolveMilestoneFile(basePath, mid, "CONTEXT-DRAFT");
+  const roadmap = resolveMilestoneFile(basePath, mid, "ROADMAP");
+  const summary = resolveMilestoneFile(basePath, mid, "SUMMARY");
+  return !context && !draft && !roadmap && !summary;
+}
+
 // ─── Query Functions ───────────────────────────────────────────────────────
 
 /**

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -139,10 +139,9 @@ export function isGhostMilestone(basePath: string, mid: string): boolean {
  */
 export function isReusableGhostMilestone(basePath: string, mid: string): boolean {
   // Condition 1: no DB row (any status).
-  if (isDbAvailable()) {
-    const dbRow = getMilestone(mid);
-    if (dbRow != null) return false;
-  }
+  if (!isDbAvailable()) return false;
+  const dbRow = getMilestone(mid);
+  if (dbRow != null) return false;
 
   // Condition 2: no worktree.
   const root = gsdRoot(basePath);

--- a/src/resources/extensions/gsd/tests/deferred-milestone-dir-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/deferred-milestone-dir-4996.test.ts
@@ -10,10 +10,10 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { isReusableGhostMilestone } from "../state.ts";
-import { findMilestoneIds } from "../milestone-ids.ts";
-import { clearReservedMilestoneIds } from "../milestone-ids.ts";
+import { nextMilestoneIdReserved } from "../milestone-id-reservation.ts";
+import { clearReservedMilestoneIds, findMilestoneIds } from "../milestone-ids.ts";
 import { invalidateAllCaches } from "../cache.ts";
-import { closeDatabase } from "../gsd-db.ts";
+import { closeDatabase, openDatabase } from "../gsd-db.ts";
 
 function makeBase(prefix = "gsd-deferred-dir-"): string {
   const base = mkdtempSync(join(tmpdir(), prefix));
@@ -37,9 +37,9 @@ describe("deferred milestone dir creation (#4996)", () => {
 
   it("(a) fresh project: milestones dir has no M001 entry before any discuss flow", () => {
     base = makeBase();
-    // Simulate the state after bootstrapGsdProject but before showHeadlessMilestoneCreation
-    // runs dispatchWorkflow. With Fix #3, no milestone dir should be created by
-    // the ID-reservation path alone.
+    const nextId = nextMilestoneIdReserved(findMilestoneIds(base), false, base);
+    assert.equal(nextId, "M001", "reservation should choose M001 for a fresh project");
+
     const ids = findMilestoneIds(base);
     assert.equal(ids.length, 0, "no milestone dirs should exist before any discuss flow");
 
@@ -50,13 +50,12 @@ describe("deferred milestone dir creation (#4996)", () => {
 
   it("(b) abandoned discuss flow leaves no orphan: isReusableGhostMilestone returns false for non-existent dir", () => {
     base = makeBase();
-    // If no dir was ever created (Fix #3 working correctly), the check should
-    // return false because there's nothing to reclaim (the path doesn't exist).
-    // isReusableGhostMilestone operates on dirs that DO exist; if no dir exists,
-    // findMilestoneIds won't surface it, so it won't be evaluated. This test
-    // confirms the absence of a dir means no orphan to report.
+    const nextId = nextMilestoneIdReserved(findMilestoneIds(base), false, base);
+    assert.equal(nextId, "M001", "reservation should not require a pre-created directory");
+
     const m001Dir = join(base, ".gsd", "milestones", "M001");
     assert.ok(!existsSync(m001Dir), "no M001 dir should exist");
+    assert.equal(isReusableGhostMilestone(base, "M001"), false, "non-existent milestone should not be reusable");
     // findMilestoneIds only returns dirs that exist
     const ids = findMilestoneIds(base);
     assert.ok(!ids.includes("M001"), "M001 should not appear in findMilestoneIds when no dir exists");
@@ -64,11 +63,14 @@ describe("deferred milestone dir creation (#4996)", () => {
 
   it("(c) a stub dir left from a previous bug IS reusable but a newly-generated ID with no dir is not in the ghost list", () => {
     base = makeBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
     // Create a stub to represent a pre-existing phantom
     mkdirSync(join(base, ".gsd", "milestones", "M001", "slices"), { recursive: true });
 
     // isReusableGhostMilestone identifies the orphaned stub
     assert.ok(isReusableGhostMilestone(base, "M001"), "pre-existing stub should be identified as reusable ghost");
+    const nextId = nextMilestoneIdReserved(findMilestoneIds(base), false, base);
+    assert.equal(nextId, "M001", "reservation should reuse the pre-existing ghost");
 
     // The new ID (M002, which would be max+1 in this scenario but ghost reuse returns M001)
     // should not have a dir

--- a/src/resources/extensions/gsd/tests/deferred-milestone-dir-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/deferred-milestone-dir-4996.test.ts
@@ -5,9 +5,10 @@
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, existsSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { mkdtempSync, mkdirSync, existsSync, rmSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 
 import { isReusableGhostMilestone } from "../state.ts";
 import { nextMilestoneIdReserved } from "../milestone-id-reservation.ts";
@@ -15,11 +16,46 @@ import { clearReservedMilestoneIds, findMilestoneIds } from "../milestone-ids.ts
 import { invalidateAllCaches } from "../cache.ts";
 import { closeDatabase, openDatabase } from "../gsd-db.ts";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const GUIDED_FLOW_PATH = join(__dirname, "..", "guided-flow.ts");
+
+function getShowHeadlessBody(): string {
+  const source = readFileSync(GUIDED_FLOW_PATH, "utf-8");
+  const fnStart = source.indexOf("export async function showHeadlessMilestoneCreation");
+  assert.ok(fnStart > -1, "showHeadlessMilestoneCreation must exist in guided-flow.ts");
+  const nextExport = source.indexOf("\nexport ", fnStart + 1);
+  return source.slice(fnStart, nextExport === -1 ? source.length : nextExport);
+}
+
 function makeBase(prefix = "gsd-deferred-dir-"): string {
   const base = mkdtempSync(join(tmpdir(), prefix));
   mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
   return base;
 }
+
+describe("showHeadlessMilestoneCreation source guard (#4996)", () => {
+  it("does not call mkdirSync in the headless milestone creation path", () => {
+    const body = getShowHeadlessBody();
+    assert.doesNotMatch(
+      body,
+      /\bmkdirSync\s*\(/,
+      "showHeadlessMilestoneCreation must not pre-create milestone directories",
+    );
+  });
+
+  it("does not call mkdir or mkdirp before dispatchWorkflow", () => {
+    const body = getShowHeadlessBody();
+    const dispatchIdx = body.indexOf("dispatchWorkflow");
+    assert.ok(dispatchIdx > -1, "dispatchWorkflow must be present");
+
+    const beforeDispatch = body.slice(0, dispatchIdx);
+    assert.doesNotMatch(
+      beforeDispatch,
+      /\b(?:mkdir|mkdirp)\s*\(/,
+      "showHeadlessMilestoneCreation must defer directory creation until artifact write",
+    );
+  });
+});
 
 describe("deferred milestone dir creation (#4996)", () => {
   let base: string;

--- a/src/resources/extensions/gsd/tests/deferred-milestone-dir-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/deferred-milestone-dir-4996.test.ts
@@ -1,0 +1,78 @@
+// GSD Extension — Regression test for #4996: deferred milestone dir creation
+// Verifies that showHeadlessMilestoneCreation does not pre-create the milestone
+// directory before the discuss flow runs. The dir should only appear after a
+// writer (saveArtifactToDb / atomicWriteAsync) emits the first artifact.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { isReusableGhostMilestone } from "../state.ts";
+import { findMilestoneIds } from "../milestone-ids.ts";
+import { clearReservedMilestoneIds } from "../milestone-ids.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import { closeDatabase } from "../gsd-db.ts";
+
+function makeBase(prefix = "gsd-deferred-dir-"): string {
+  const base = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+describe("deferred milestone dir creation (#4996)", () => {
+  let base: string;
+
+  beforeEach(() => {
+    clearReservedMilestoneIds();
+  });
+
+  afterEach(() => {
+    try { closeDatabase(); } catch { /* ignore */ }
+    try { invalidateAllCaches(); } catch { /* ignore */ }
+    try { clearReservedMilestoneIds(); } catch { /* ignore */ }
+    try { rmSync(base, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it("(a) fresh project: milestones dir has no M001 entry before any discuss flow", () => {
+    base = makeBase();
+    // Simulate the state after bootstrapGsdProject but before showHeadlessMilestoneCreation
+    // runs dispatchWorkflow. With Fix #3, no milestone dir should be created by
+    // the ID-reservation path alone.
+    const ids = findMilestoneIds(base);
+    assert.equal(ids.length, 0, "no milestone dirs should exist before any discuss flow");
+
+    // And specifically M001 should not exist
+    const m001Dir = join(base, ".gsd", "milestones", "M001");
+    assert.ok(!existsSync(m001Dir), "M001 dir must not exist before the discuss flow runs");
+  });
+
+  it("(b) abandoned discuss flow leaves no orphan: isReusableGhostMilestone returns false for non-existent dir", () => {
+    base = makeBase();
+    // If no dir was ever created (Fix #3 working correctly), the check should
+    // return false because there's nothing to reclaim (the path doesn't exist).
+    // isReusableGhostMilestone operates on dirs that DO exist; if no dir exists,
+    // findMilestoneIds won't surface it, so it won't be evaluated. This test
+    // confirms the absence of a dir means no orphan to report.
+    const m001Dir = join(base, ".gsd", "milestones", "M001");
+    assert.ok(!existsSync(m001Dir), "no M001 dir should exist");
+    // findMilestoneIds only returns dirs that exist
+    const ids = findMilestoneIds(base);
+    assert.ok(!ids.includes("M001"), "M001 should not appear in findMilestoneIds when no dir exists");
+  });
+
+  it("(c) a stub dir left from a previous bug IS reusable but a newly-generated ID with no dir is not in the ghost list", () => {
+    base = makeBase();
+    // Create a stub to represent a pre-existing phantom
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices"), { recursive: true });
+
+    // isReusableGhostMilestone identifies the orphaned stub
+    assert.ok(isReusableGhostMilestone(base, "M001"), "pre-existing stub should be identified as reusable ghost");
+
+    // The new ID (M002, which would be max+1 in this scenario but ghost reuse returns M001)
+    // should not have a dir
+    const m002Dir = join(base, ".gsd", "milestones", "M002");
+    assert.ok(!existsSync(m002Dir), "a freshly-requested ID should have no dir until first artifact write");
+  });
+});

--- a/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-orphan-milestone-4996.test.ts
@@ -1,0 +1,100 @@
+// GSD Extension — Regression test for #4996: doctor orphan milestone dir check
+// Verifies that checkRuntimeHealth reports orphan_milestone_dir for empty stub
+// dirs with no DB row, does not report populated dirs, and does not report
+// legitimate in-flight worktree-only milestone dirs.
+
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { checkRuntimeHealth } from "../doctor-runtime-checks.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+} from "../gsd-db.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import type { DoctorIssue, DoctorIssueCode } from "../doctor-types.ts";
+
+function makeBase(prefix = "gsd-doctor-orphan-"): string {
+  const base = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+function stubDir(base: string, mid: string): void {
+  mkdirSync(join(base, ".gsd", "milestones", mid, "slices"), { recursive: true });
+}
+
+function populateDir(base: string, mid: string): void {
+  mkdirSync(join(base, ".gsd", "milestones", mid), { recursive: true });
+  writeFileSync(join(base, ".gsd", "milestones", mid, `${mid}-CONTEXT.md`), `# ${mid}\n`);
+}
+
+describe("gsd_doctor orphan milestone directory check (#4996)", () => {
+  let base: string;
+
+  afterEach(() => {
+    try { closeDatabase(); } catch { /* ignore */ }
+    try { invalidateAllCaches(); } catch { /* ignore */ }
+    try { rmSync(base, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it("(a) empty stub dir with no DB row is reported as orphan_milestone_dir", async () => {
+    base = makeBase();
+    stubDir(base, "M003");
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const orphan = issues.find(i => i.code === "orphan_milestone_dir" && i.unitId === "M003");
+    assert.ok(orphan, "should report orphan_milestone_dir for empty stub");
+    assert.equal(orphan?.severity, "warning");
+    assert.equal(orphan?.fixable, true);
+    assert.ok(orphan?.message.includes("M003"), "message should name the milestone");
+  });
+
+  it("(b) populated milestone dir is NOT reported", async () => {
+    base = makeBase();
+    populateDir(base, "M001");
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const orphan = issues.find(i => i.code === "orphan_milestone_dir" && i.unitId === "M001");
+    assert.ok(!orphan, "populated milestone dir must not be reported as orphan");
+  });
+
+  it("(c) worktree-only milestone (no content files, no DB row, but worktree exists) is NOT reported", async () => {
+    base = makeBase();
+    stubDir(base, "M003");
+    // Simulate a legitimate in-flight worktree
+    mkdirSync(join(base, ".gsd", "worktrees", "M003"), { recursive: true });
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const orphan = issues.find(i => i.code === "orphan_milestone_dir" && i.unitId === "M003");
+    assert.ok(!orphan, "milestone with a worktree must not be reported as orphan");
+  });
+
+  it("(d) queued DB row (in-flight ID) is NOT reported as orphan", async () => {
+    base = makeBase();
+    stubDir(base, "M003");
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M003", status: "queued" });
+
+    const issues: DoctorIssue[] = [];
+    const fixes: string[] = [];
+    await checkRuntimeHealth(base, issues, fixes, () => false);
+
+    const orphan = issues.find(i => i.code === "orphan_milestone_dir" && i.unitId === "M003");
+    assert.ok(!orphan, "queued DB row must block orphan report (in-flight race protection)");
+  });
+});

--- a/src/resources/extensions/gsd/tests/ensure-preconditions-guard-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/ensure-preconditions-guard-4996.test.ts
@@ -1,0 +1,100 @@
+// GSD Extension — Regression test for #4996: ensurePreconditions phantom dir guard
+// Verifies that ensurePreconditions does not create milestone directories for
+// forward-referenced slice unit IDs when the milestone has no DB row and no content files.
+
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { ensurePreconditions } from "../auto.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  isDbAvailable,
+} from "../gsd-db.ts";
+
+import type { GSDState } from "../types.ts";
+
+function makeBase(prefix = "gsd-precond-"): string {
+  const base = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+function makeMinimalState(): GSDState {
+  return {
+    activeMilestone: null,
+    activeSlice: null,
+    activeTask: null,
+    phase: "planning",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+  };
+}
+
+describe("ensurePreconditions phantom-dir guard (#4996)", () => {
+  let base: string;
+  let dbPath: string;
+
+  afterEach(() => {
+    try { closeDatabase(); } catch { /* ignore */ }
+    try { rmSync(base, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it("(a) slice unit ID for unknown milestone does NOT create dirs when no DB row and no content files", () => {
+    base = makeBase();
+    const state = makeMinimalState();
+
+    ensurePreconditions("execute-task", "M003/S01", base, state);
+
+    const milestoneDir = join(base, ".gsd", "milestones", "M003");
+    assert.ok(!existsSync(milestoneDir), "M003 dir must not be created for phantom slice dispatch");
+  });
+
+  it("(b) slice unit ID for milestone with DB row DOES create dirs", () => {
+    base = makeBase();
+    dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M003", status: "active" });
+    const state = makeMinimalState();
+
+    ensurePreconditions("execute-task", "M003/S01", base, state);
+
+    const milestoneDir = join(base, ".gsd", "milestones", "M003");
+    assert.ok(existsSync(milestoneDir), "M003 dir must be created when DB row exists");
+  });
+
+  it("(c) slice unit ID for milestone with CONTEXT.md content file DOES create dirs", () => {
+    base = makeBase();
+    const mid = "M003";
+    // Write content file without a DB row
+    const milestoneDir = join(base, ".gsd", "milestones", mid);
+    mkdirSync(milestoneDir, { recursive: true });
+    writeFileSync(join(milestoneDir, `${mid}-CONTEXT.md`), "# Context\n");
+    const state = makeMinimalState();
+
+    ensurePreconditions("execute-task", "M003/S01", base, state);
+
+    // The milestoneDir already exists; ensurePreconditions should proceed to create slices/
+    const slicesDir = join(milestoneDir, "slices");
+    // resolveMilestonePath finds the dir — so it goes through the sid branch, not the !mDir branch.
+    // The guard only fires when the dir does NOT exist yet. This test verifies
+    // that when content files exist alongside the dir the guard does not block the normal path.
+    assert.ok(existsSync(milestoneDir), "milestone dir should still exist (was pre-created with content)");
+  });
+
+  it("(d) milestone-only unit ID (no slice) still creates dir even with no DB row", () => {
+    base = makeBase();
+    const state = makeMinimalState();
+
+    ensurePreconditions("discuss-milestone", "M003", base, state);
+
+    const milestoneDir = join(base, ".gsd", "milestones", "M003");
+    assert.ok(existsSync(milestoneDir), "M003 dir must be created for milestone-only dispatch");
+  });
+});

--- a/src/resources/extensions/gsd/tests/ensure-preconditions-guard-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/ensure-preconditions-guard-4996.test.ts
@@ -1,6 +1,6 @@
 // GSD Extension — Regression test for #4996: ensurePreconditions phantom dir guard
 // Verifies that ensurePreconditions does not create milestone directories for
-// forward-referenced slice unit IDs when the milestone has no DB row and no content files.
+// forward-referenced slice unit IDs when the milestone has no DB row.
 
 import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
@@ -44,7 +44,7 @@ describe("ensurePreconditions phantom-dir guard (#4996)", () => {
     try { rmSync(base, { recursive: true, force: true }); } catch { /* ignore */ }
   });
 
-  it("(a) slice unit ID for unknown milestone does NOT create dirs when no DB row and no content files", () => {
+  it("(a) slice unit ID for unknown milestone does NOT create dirs when no DB row exists", () => {
     base = makeBase();
     const state = makeMinimalState();
 
@@ -67,19 +67,18 @@ describe("ensurePreconditions phantom-dir guard (#4996)", () => {
     assert.ok(existsSync(milestoneDir), "M003 dir must be created when DB row exists");
   });
 
-  it("(c) slice unit ID for milestone with CONTEXT.md content file DOES create dirs", () => {
+  it("(c) slice unit ID for existing milestone dir with CONTEXT.md content file uses normal scaffolding", () => {
     base = makeBase();
     const mid = "M003";
-    const milestonesPath = join(base, ".gsd", "milestones");
-    mkdirSync(milestonesPath, { recursive: true });
-    writeFileSync(join(milestonesPath, `${mid}-CONTEXT.md`), "# Context\n");
+    const milestoneDir = join(base, ".gsd", "milestones", mid);
+    mkdirSync(milestoneDir, { recursive: true });
+    writeFileSync(join(milestoneDir, `${mid}-CONTEXT.md`), "# Context\n");
     const state = makeMinimalState();
 
     ensurePreconditions("execute-task", "M003/S01", base, state);
 
-    const milestoneDir = join(milestonesPath, mid);
     const slicesDir = join(milestoneDir, "slices");
-    assert.ok(existsSync(slicesDir), "content-file fallback should allow slice scaffolding");
+    assert.ok(existsSync(slicesDir), "existing milestone dir should allow slice scaffolding");
   });
 
   it("(d) milestone-only unit ID (no slice) still creates dir even with no DB row", () => {

--- a/src/resources/extensions/gsd/tests/ensure-preconditions-guard-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/ensure-preconditions-guard-4996.test.ts
@@ -13,7 +13,6 @@ import {
   openDatabase,
   closeDatabase,
   insertMilestone,
-  isDbAvailable,
 } from "../gsd-db.ts";
 
 import type { GSDState } from "../types.ts";
@@ -39,7 +38,6 @@ function makeMinimalState(): GSDState {
 
 describe("ensurePreconditions phantom-dir guard (#4996)", () => {
   let base: string;
-  let dbPath: string;
 
   afterEach(() => {
     try { closeDatabase(); } catch { /* ignore */ }
@@ -58,7 +56,7 @@ describe("ensurePreconditions phantom-dir guard (#4996)", () => {
 
   it("(b) slice unit ID for milestone with DB row DOES create dirs", () => {
     base = makeBase();
-    dbPath = join(base, ".gsd", "gsd.db");
+    const dbPath = join(base, ".gsd", "gsd.db");
     openDatabase(dbPath);
     insertMilestone({ id: "M003", status: "active" });
     const state = makeMinimalState();
@@ -72,20 +70,16 @@ describe("ensurePreconditions phantom-dir guard (#4996)", () => {
   it("(c) slice unit ID for milestone with CONTEXT.md content file DOES create dirs", () => {
     base = makeBase();
     const mid = "M003";
-    // Write content file without a DB row
-    const milestoneDir = join(base, ".gsd", "milestones", mid);
-    mkdirSync(milestoneDir, { recursive: true });
-    writeFileSync(join(milestoneDir, `${mid}-CONTEXT.md`), "# Context\n");
+    const milestonesPath = join(base, ".gsd", "milestones");
+    mkdirSync(milestonesPath, { recursive: true });
+    writeFileSync(join(milestonesPath, `${mid}-CONTEXT.md`), "# Context\n");
     const state = makeMinimalState();
 
     ensurePreconditions("execute-task", "M003/S01", base, state);
 
-    // The milestoneDir already exists; ensurePreconditions should proceed to create slices/
+    const milestoneDir = join(milestonesPath, mid);
     const slicesDir = join(milestoneDir, "slices");
-    // resolveMilestonePath finds the dir — so it goes through the sid branch, not the !mDir branch.
-    // The guard only fires when the dir does NOT exist yet. This test verifies
-    // that when content files exist alongside the dir the guard does not block the normal path.
-    assert.ok(existsSync(milestoneDir), "milestone dir should still exist (was pre-created with content)");
+    assert.ok(existsSync(slicesDir), "content-file fallback should allow slice scaffolding");
   });
 
   it("(d) milestone-only unit ID (no slice) still creates dir even with no DB row", () => {

--- a/src/resources/extensions/gsd/tests/milestone-id-gap-reuse-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-id-gap-reuse-4996.test.ts
@@ -1,0 +1,122 @@
+// GSD Extension — Regression test for #4996: ghost milestone ID reuse
+// Verifies that isReusableGhostMilestone correctly identifies reclaim-safe stub dirs,
+// and that nextMilestoneIdReserved (guided-flow) prefers the lowest reusable ghost
+// over max+1. Also covers the race-window regression: a queued DB row must NOT be reused.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { isReusableGhostMilestone } from "../state.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+} from "../gsd-db.ts";
+import { clearReservedMilestoneIds } from "../milestone-ids.ts";
+import { invalidateAllCaches } from "../cache.ts";
+
+function makeBase(prefix = "gsd-gap-4996-"): string {
+  const base = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+function stubDir(base: string, mid: string): void {
+  // Create an empty stub — the phantom pattern
+  mkdirSync(join(base, ".gsd", "milestones", mid, "slices"), { recursive: true });
+}
+
+function populateDir(base: string, mid: string): void {
+  mkdirSync(join(base, ".gsd", "milestones", mid), { recursive: true });
+  writeFileSync(join(base, ".gsd", "milestones", mid, `${mid}-CONTEXT.md`), `# ${mid} Context\n`);
+}
+
+describe("isReusableGhostMilestone (#4996)", () => {
+  let base: string;
+
+  afterEach(() => {
+    try { closeDatabase(); } catch { /* ignore */ }
+    try { invalidateAllCaches(); } catch { /* ignore */ }
+    try { rmSync(base, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it("(a) empty stub dir with no DB row is reusable", () => {
+    base = makeBase();
+    stubDir(base, "M003");
+    assert.ok(isReusableGhostMilestone(base, "M003"), "empty stub with no DB row should be reusable");
+  });
+
+  it("(b) queued DB row with no content must NOT be reusable (race window regression)", () => {
+    base = makeBase();
+    stubDir(base, "M003");
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M003", status: "queued" });
+    // Even though no content files exist, the queued DB row means an in-flight discuss
+    // is reserving this ID — it must not be reclaimed.
+    assert.ok(!isReusableGhostMilestone(base, "M003"), "queued DB row must block reuse");
+  });
+
+  it("(c) populated milestone dir is not reusable", () => {
+    base = makeBase();
+    populateDir(base, "M001");
+    assert.ok(!isReusableGhostMilestone(base, "M001"), "populated dir must not be reusable");
+  });
+
+  it("(d) stub dir with worktree is not reusable (legitimate in-flight)", () => {
+    base = makeBase();
+    stubDir(base, "M003");
+    // Simulate an existing worktree
+    mkdirSync(join(base, ".gsd", "worktrees", "M003"), { recursive: true });
+    assert.ok(!isReusableGhostMilestone(base, "M003"), "dir with worktree must not be reusable");
+  });
+
+  it("(e) active DB row makes dir not reusable", () => {
+    base = makeBase();
+    stubDir(base, "M003");
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M003", status: "active" });
+    assert.ok(!isReusableGhostMilestone(base, "M003"), "active DB row must block reuse");
+  });
+});
+
+describe("primary regression: M003/M004 stubs returned as next ID (#4996)", () => {
+  let base: string;
+
+  beforeEach(() => {
+    clearReservedMilestoneIds();
+  });
+
+  afterEach(() => {
+    try { closeDatabase(); } catch { /* ignore */ }
+    try { invalidateAllCaches(); } catch { /* ignore */ }
+    try { clearReservedMilestoneIds(); } catch { /* ignore */ }
+    try { rmSync(base, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it("M001/M002 populated + M003/M004 stubs → isReusableGhostMilestone returns true for M003 and M004", () => {
+    base = makeBase();
+    populateDir(base, "M001");
+    populateDir(base, "M002");
+    stubDir(base, "M003");
+    stubDir(base, "M004");
+
+    assert.ok(isReusableGhostMilestone(base, "M003"), "M003 should be identified as reusable ghost");
+    assert.ok(isReusableGhostMilestone(base, "M004"), "M004 should be identified as reusable ghost");
+    assert.ok(!isReusableGhostMilestone(base, "M001"), "M001 should not be reusable");
+    assert.ok(!isReusableGhostMilestone(base, "M002"), "M002 should not be reusable");
+  });
+
+  it("when all dirs are populated, no ghost exists and the function returns false for all", () => {
+    base = makeBase();
+    populateDir(base, "M001");
+    populateDir(base, "M002");
+
+    assert.ok(!isReusableGhostMilestone(base, "M001"), "M001 is populated, not reusable");
+    assert.ok(!isReusableGhostMilestone(base, "M002"), "M002 is populated, not reusable");
+  });
+});

--- a/src/resources/extensions/gsd/tests/milestone-id-gap-reuse-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-id-gap-reuse-4996.test.ts
@@ -137,4 +137,16 @@ describe("primary regression: M003/M004 stubs returned as next ID (#4996)", () =
     const nextId = nextMilestoneIdReserved(findMilestoneIds(base), false, base);
     assert.equal(nextId, "M003", "ID reservation should fall back to max+1 when no ghost is reusable");
   });
+
+  it("does not return an already-reserved reusable ghost twice", () => {
+    base = makeBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    stubDir(base, "M001");
+
+    const firstId = nextMilestoneIdReserved(findMilestoneIds(base), false, base);
+    const secondId = nextMilestoneIdReserved(findMilestoneIds(base), false, base);
+
+    assert.equal(firstId, "M001", "first reservation should reuse the ghost");
+    assert.equal(secondId, "M002", "second reservation must skip the already-reserved ghost");
+  });
 });

--- a/src/resources/extensions/gsd/tests/milestone-id-gap-reuse-4996.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-id-gap-reuse-4996.test.ts
@@ -5,17 +5,18 @@
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { isReusableGhostMilestone } from "../state.ts";
+import { nextMilestoneIdReserved } from "../milestone-id-reservation.ts";
 import {
   openDatabase,
   closeDatabase,
   insertMilestone,
 } from "../gsd-db.ts";
-import { clearReservedMilestoneIds } from "../milestone-ids.ts";
+import { clearReservedMilestoneIds, findMilestoneIds } from "../milestone-ids.ts";
 import { invalidateAllCaches } from "../cache.ts";
 
 function makeBase(prefix = "gsd-gap-4996-"): string {
@@ -43,13 +44,20 @@ describe("isReusableGhostMilestone (#4996)", () => {
     try { rmSync(base, { recursive: true, force: true }); } catch { /* ignore */ }
   });
 
-  it("(a) empty stub dir with no DB row is reusable", () => {
+  it("(a) fails closed when the DB is unavailable", () => {
     base = makeBase();
+    stubDir(base, "M003");
+    assert.equal(isReusableGhostMilestone(base, "M003"), false, "closed DB should block reusable-ghost claims");
+  });
+
+  it("(b) empty stub dir with an open DB and no DB row is reusable", () => {
+    base = makeBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
     stubDir(base, "M003");
     assert.ok(isReusableGhostMilestone(base, "M003"), "empty stub with no DB row should be reusable");
   });
 
-  it("(b) queued DB row with no content must NOT be reusable (race window regression)", () => {
+  it("(c) queued DB row with no content must NOT be reusable (race window regression)", () => {
     base = makeBase();
     stubDir(base, "M003");
     const dbPath = join(base, ".gsd", "gsd.db");
@@ -60,21 +68,23 @@ describe("isReusableGhostMilestone (#4996)", () => {
     assert.ok(!isReusableGhostMilestone(base, "M003"), "queued DB row must block reuse");
   });
 
-  it("(c) populated milestone dir is not reusable", () => {
+  it("(d) populated milestone dir is not reusable", () => {
     base = makeBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
     populateDir(base, "M001");
     assert.ok(!isReusableGhostMilestone(base, "M001"), "populated dir must not be reusable");
   });
 
-  it("(d) stub dir with worktree is not reusable (legitimate in-flight)", () => {
+  it("(e) stub dir with worktree is not reusable (legitimate in-flight)", () => {
     base = makeBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
     stubDir(base, "M003");
     // Simulate an existing worktree
     mkdirSync(join(base, ".gsd", "worktrees", "M003"), { recursive: true });
     assert.ok(!isReusableGhostMilestone(base, "M003"), "dir with worktree must not be reusable");
   });
 
-  it("(e) active DB row makes dir not reusable", () => {
+  it("(f) active DB row makes dir not reusable", () => {
     base = makeBase();
     stubDir(base, "M003");
     const dbPath = join(base, ".gsd", "gsd.db");
@@ -100,6 +110,7 @@ describe("primary regression: M003/M004 stubs returned as next ID (#4996)", () =
 
   it("M001/M002 populated + M003/M004 stubs → isReusableGhostMilestone returns true for M003 and M004", () => {
     base = makeBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
     populateDir(base, "M001");
     populateDir(base, "M002");
     stubDir(base, "M003");
@@ -109,14 +120,21 @@ describe("primary regression: M003/M004 stubs returned as next ID (#4996)", () =
     assert.ok(isReusableGhostMilestone(base, "M004"), "M004 should be identified as reusable ghost");
     assert.ok(!isReusableGhostMilestone(base, "M001"), "M001 should not be reusable");
     assert.ok(!isReusableGhostMilestone(base, "M002"), "M002 should not be reusable");
+
+    const nextId = nextMilestoneIdReserved(findMilestoneIds(base), false, base);
+    assert.equal(nextId, "M003", "ID reservation should select the lowest reusable ghost");
   });
 
   it("when all dirs are populated, no ghost exists and the function returns false for all", () => {
     base = makeBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
     populateDir(base, "M001");
     populateDir(base, "M002");
 
     assert.ok(!isReusableGhostMilestone(base, "M001"), "M001 is populated, not reusable");
     assert.ok(!isReusableGhostMilestone(base, "M002"), "M002 is populated, not reusable");
+
+    const nextId = nextMilestoneIdReserved(findMilestoneIds(base), false, base);
+    assert.equal(nextId, "M003", "ID reservation should fall back to max+1 when no ghost is reusable");
   });
 });

--- a/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
+++ b/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
@@ -48,6 +48,6 @@ test("guided-flow complete branch offers a chooser for next milestone or status"
 
   assert.match(branchChunk, /showNextAction\(/, "complete branch should present a chooser");
   assert.match(branchChunk, /findMilestoneIds\(basePath\)/, "complete branch should compute the next milestone id");
-  assert.match(branchChunk, /nextMilestoneId(?:Reserved)?\(milestoneIds, uniqueMilestoneIds\)/, "complete branch should derive the next milestone id");
+  assert.match(branchChunk, /nextMilestoneId(?:Reserved)?\(milestoneIds, uniqueMilestoneIds(?:,\s*\w+)?\)/, "complete branch should derive the next milestone id");
   assert.match(branchChunk, /dispatchWorkflow\(pi, await prepareAndBuildDiscussPrompt\(/, "complete branch should dispatch the prepared discuss prompt");
 });

--- a/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
+++ b/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
@@ -55,3 +55,21 @@ test("guided-flow complete branch offers a chooser for next milestone or status"
   );
   assert.match(branchChunk, /dispatchWorkflow\(pi, await prepareAndBuildDiscussPrompt\(/, "complete branch should dispatch the prepared discuss prompt");
 });
+
+test("guided-flow needs-discussion skip branch opens the project DB before reserving a new milestone", () => {
+  const guidedFlowSource = readFileSync(join(import.meta.dirname, "..", "guided-flow.ts"), "utf-8");
+  const laterDbOpenIdx = guidedFlowSource.indexOf("// Ensure DB is open before querying slices (#2560).");
+  assert.ok(laterDbOpenIdx > -1, "guided-flow.ts should contain the post-draft DB-open guard");
+
+  const branchPrefix = guidedFlowSource.slice(0, laterDbOpenIdx);
+  const skipBranchIdx = branchPrefix.lastIndexOf('choice === "skip_milestone"');
+  assert.ok(skipBranchIdx > -1, "needs-discussion skip branch should be present");
+
+  const branchChunk = branchPrefix.slice(skipBranchIdx);
+  const ensureIdx = branchChunk.indexOf("ensureDbOpen(basePath)");
+  const reserveIdx = branchChunk.indexOf("nextMilestoneIdReserved");
+
+  assert.ok(ensureIdx > -1, "skip branch should open the project DB");
+  assert.ok(reserveIdx > -1, "skip branch should reserve the next milestone ID");
+  assert.ok(ensureIdx < reserveIdx, "project DB must be opened before milestone ID reservation");
+});

--- a/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
+++ b/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
@@ -48,6 +48,10 @@ test("guided-flow complete branch offers a chooser for next milestone or status"
 
   assert.match(branchChunk, /showNextAction\(/, "complete branch should present a chooser");
   assert.match(branchChunk, /findMilestoneIds\(basePath\)/, "complete branch should compute the next milestone id");
-  assert.match(branchChunk, /nextMilestoneId(?:Reserved)?\(milestoneIds, uniqueMilestoneIds(?:,\s*\w+)?\)/, "complete branch should derive the next milestone id");
+  assert.match(
+    branchChunk,
+    /nextMilestoneIdReserved\(milestoneIds,\s*uniqueMilestoneIds,\s*basePath\)/,
+    "complete branch should derive the next milestone id",
+  );
   assert.match(branchChunk, /dispatchWorkflow\(pi, await prepareAndBuildDiscussPrompt\(/, "complete branch should dispatch the prepared discuss prompt");
 });


### PR DESCRIPTION
## TL;DR

**What:** Closes the milestone-ID skip vector — phantom stub dirs no longer cause `nextMilestoneId` to leap past them.
**Why:** Real-world reproduction (#4996) showed M002 → M006, leaving M003-M005 as orphan empty stubs invisible to the workflow.
**How:** Four-part defense in depth: phantom-dir guard at the source (`ensurePreconditions`), ghost-ID reuse in `nextMilestoneId` (with strict no-DB-row criterion to avoid in-flight race), deferred dir creation in headless milestone flow, and a `gsd_doctor` drift check.

## What

- `src/resources/extensions/gsd/auto.ts` — `ensurePreconditions` no longer mkdirs for unknown milestones in slice dispatch.
- `src/resources/extensions/gsd/state.ts` — new `isReusableGhostMilestone` (strict, no-DB-row).
- `src/resources/extensions/gsd/guided-flow.ts` — `nextMilestoneIdReserved` reuses lowest ghost ID; `showHeadlessMilestoneCreation` no longer pre-creates milestone dir.
- `packages/mcp-server/src/workflow-tools.ts` — both ID-generator MCP tools use shared helper that reuses ghosts.
- `src/resources/extensions/gsd/doctor-runtime-checks.ts` — new check reports orphan milestone dirs.
- Regression tests for each fix, including the queued-row race window.

## Why

Closes #4996. See issue for full root-cause analysis with file:line citations.

## How

See issue #4996 — Proposed Fix section. The four mechanisms (phantom guard, ghost reuse, deferred mkdir, doctor) are each minimal and targeted; together they close the gap-creation vector at every layer.

## Test plan

- [x] Primary regression: phantom M003/M004 stub dirs + new milestone request → returns M003
- [x] Race regression: queued DB row + empty dir → not reused
- [x] Phantom guard: slice unit dispatch for unknown milestone does not mkdir
- [x] Lazy creation: showHeadlessMilestoneCreation does not pre-create dir
- [x] Doctor reports orphan dirs
- [x] `npm run verify:pr` passes (build clean, typecheck clean, 39 targeted tests pass, 0 new failures)

This PR is AI-assisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects orphan milestone stub directories and offers automatic cleanup via `/gsd doctor fix`; only empty disk‑only stubs are removed, populated or in‑flight milestones are preserved.
  * Milestone ID reservation now prefers reclaiming truly empty stub IDs to reduce orphan creation.

* **Bug Fixes**
  * Addresses #4996: deferred milestone-dir creation and safer in‑flight detection.

* **Documentation**
  * Troubleshooting guide updated with orphan_milestone_dir guidance.

* **Tests**
  * Added regression and integration tests covering detection, cleanup, and ID reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->