### PR TITLE
fix(claude-code-cli): restore Claude subscription detection on Windows (#4997)

### DIFF
--- a/src/claude-cli-check.ts
+++ b/src/claude-cli-check.ts
@@ -25,24 +25,34 @@ export const CLAUDE_COMMAND = process.platform === 'win32' ? 'claude.cmd' : 'cla
 const CLAUDE_COMMAND_CANDIDATES: string[] =
   process.platform === 'win32' ? [CLAUDE_COMMAND, 'claude.exe', 'claude'] : [CLAUDE_COMMAND]
 
+// Codes treated as "this candidate didn't run — try the next one" rather than
+// fatal failures. ETIMEDOUT/EAGAIN cover slow-spawn cases on Windows where
+// cmd.exe wrapping plus the Claude CLI startup path together exceed the
+// per-attempt timeout (Issue #4997 regression on Windows + Node 25).
+const SOFT_FAIL_CODES = new Set(['ENOENT', 'EINVAL', 'ETIMEDOUT', 'EAGAIN'])
+
+const VERSION_TIMEOUT_MS = 5_000
+// Auth probe needs more headroom on Windows because the spawn goes through
+// cmd.exe → claude.cmd → node → Claude CLI.
+const AUTH_TIMEOUT_MS = 15_000
+
 /**
  * Try to run `args` against each candidate binary.
  * Returns the output buffer on first success, throws the last error if all fail.
  */
-function execClaudeCheck(args: string[]): Buffer {
+function execClaudeCheck(args: string[], timeoutMs: number): Buffer {
   let lastError: unknown
   for (const command of CLAUDE_COMMAND_CANDIDATES) {
     try {
       return execFileSync(command, args, {
-        timeout: 5_000,
+        timeout: timeoutMs,
         stdio: 'pipe',
         shell: process.platform === 'win32',
       })
     } catch (error) {
       lastError = error
       const code = (error as NodeJS.ErrnoException | undefined)?.code
-      // EINVAL can surface on Windows Git Bash for .cmd spawn failures.
-      if (code === 'ENOENT' || code === 'EINVAL') continue
+      if (code && SOFT_FAIL_CODES.has(code)) continue
       throw error
     }
   }
@@ -50,11 +60,38 @@ function execClaudeCheck(args: string[]): Buffer {
 }
 
 /**
+ * Decide auth state from `claude auth status` output.
+ *
+ * Newer Claude CLI builds emit JSON with a `loggedIn` boolean. Older builds
+ * emit free-form text. Prefer the structured signal; fall back to a text
+ * heuristic. The text heuristic only covers English phrasing.
+ */
+function parseAuthStatus(output: string): boolean {
+  const trimmed = output.trim()
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed) as { loggedIn?: unknown }
+      if (typeof parsed.loggedIn === 'boolean') {
+        return parsed.loggedIn
+      }
+    } catch {
+      // Fall through to text heuristic.
+    }
+  }
+
+  const lower = trimmed.toLowerCase()
+  if (/not logged in|no credentials|unauthenticated|not authenticated/.test(lower)) {
+    return false
+  }
+  return true
+}
+
+/**
  * Check if the `claude` binary is installed (regardless of auth state).
  */
 export function isClaudeBinaryInstalled(): boolean {
   try {
-    execClaudeCheck(['--version'])
+    execClaudeCheck(['--version'], VERSION_TIMEOUT_MS)
     return true
   } catch {
     return false
@@ -66,16 +103,14 @@ export function isClaudeBinaryInstalled(): boolean {
  */
 export function isClaudeCliReady(): boolean {
   try {
-    execClaudeCheck(['--version'])
+    execClaudeCheck(['--version'], VERSION_TIMEOUT_MS)
   } catch {
     return false
   }
 
   try {
-    const output = execClaudeCheck(['auth', 'status'])
-      .toString()
-      .toLowerCase()
-    return !(/not logged in|no credentials|unauthenticated|not authenticated/i.test(output))
+    const output = execClaudeCheck(['auth', 'status', '--json'], AUTH_TIMEOUT_MS).toString()
+    return parseAuthStatus(output)
   } catch {
     return false
   }

--- a/src/resources/extensions/claude-code-cli/readiness.ts
+++ b/src/resources/extensions/claude-code-cli/readiness.ts
@@ -42,6 +42,10 @@ const VERSION_TIMEOUT_MS = 5_000;
 // without making startup feel hung when the CLI is genuinely missing.
 const AUTH_TIMEOUT_MS = 15_000;
 
+/**
+ * Run the requested Claude CLI command against each supported executable name.
+ * Returns the first successful output buffer and rethrows hard failures.
+ */
 function execClaude(args: string[], timeoutMs: number): Buffer {
 	let lastError: unknown;
 	for (const command of CLAUDE_COMMAND_CANDIDATES) {
@@ -97,6 +101,10 @@ let cachedAuthed: boolean | null = null;
 let lastCheckMs = 0;
 const CHECK_INTERVAL_MS = 30_000;
 
+/**
+ * Refresh the cached binary/auth state when the cache window has expired.
+ * Preserves a known auth state across soft-fail auth probes.
+ */
 function refreshCache(): void {
 	const now = Date.now();
 	if (cachedBinaryPresent !== null && now - lastCheckMs < CHECK_INTERVAL_MS) {

--- a/src/resources/extensions/claude-code-cli/readiness.ts
+++ b/src/resources/extensions/claude-code-cli/readiness.ts
@@ -5,8 +5,9 @@
  * Results are cached for 30 seconds to avoid shelling out on every
  * model-availability check.
  *
- * Auth verification follows the T3 Code pattern: run `claude auth status`
- * and check the exit code + output for an authenticated session.
+ * Auth verification runs `claude auth status --json` and inspects the
+ * `loggedIn` field, falling back to a text heuristic when the JSON shape
+ * is unavailable (older Claude CLI builds).
  */
 
 import { execFileSync } from "node:child_process";
@@ -27,27 +28,68 @@ const CLAUDE_COMMAND = process.platform === "win32" ? "claude.cmd" : "claude";
  */
 const CLAUDE_COMMAND_CANDIDATES = process.platform === "win32" ? [CLAUDE_COMMAND, "claude.exe", "claude"] : [CLAUDE_COMMAND];
 
-function execClaude(args: string[]): Buffer {
+// Codes treated as "this candidate didn't run — try the next one" rather than
+// fatal failures. ENOENT/EINVAL cover the original Windows .cmd shim cases.
+// ETIMEDOUT and EAGAIN cover slow-spawn cases where cmd.exe wrapping plus
+// the Claude CLI startup path together exceed the per-attempt timeout
+// (Issue #4997 regression on Windows + Node 25).
+const SOFT_FAIL_CODES = new Set(["ENOENT", "EINVAL", "ETIMEDOUT", "EAGAIN"]);
+
+// Keep the version probe snappy — `claude --version` is a quick path.
+const VERSION_TIMEOUT_MS = 5_000;
+// Auth status can be much slower on Windows because the spawn goes through
+// cmd.exe → claude.cmd → node → Claude CLI. 15s leaves headroom on cold spawns
+// without making startup feel hung when the CLI is genuinely missing.
+const AUTH_TIMEOUT_MS = 15_000;
+
+function execClaude(args: string[], timeoutMs: number): Buffer {
 	let lastError: unknown;
 	for (const command of CLAUDE_COMMAND_CANDIDATES) {
 		try {
 			return execFileSync(command, args, {
-				timeout: 5_000,
+				timeout: timeoutMs,
 				stdio: "pipe",
 				shell: process.platform === "win32",
 			});
 		} catch (error) {
 			lastError = error;
 			const code = (error as NodeJS.ErrnoException | undefined)?.code;
-			// Windows Git Bash can surface `.cmd` spawn failures as EINVAL instead
-			// of ENOENT. Treat both as "try next candidate".
-			if (code === "ENOENT" || code === "EINVAL") {
+			if (code && SOFT_FAIL_CODES.has(code)) {
 				continue;
 			}
 			throw error;
 		}
 	}
 	throw lastError ?? new Error(`Claude CLI executable not found (tried: ${CLAUDE_COMMAND_CANDIDATES.join(", ")})`);
+}
+
+/**
+ * Decide auth state from `claude auth status` output.
+ *
+ * Newer Claude CLI builds emit JSON by default with a `loggedIn` boolean.
+ * Older builds emit free-form text. We prefer the structured signal and fall
+ * back to a text heuristic. Note: the text heuristic only covers English
+ * phrasing — the JSON path is the durable signal.
+ */
+function parseAuthStatus(output: string): boolean {
+	const trimmed = output.trim();
+	if (trimmed.startsWith("{")) {
+		try {
+			const parsed = JSON.parse(trimmed) as { loggedIn?: unknown };
+			if (typeof parsed.loggedIn === "boolean") {
+				return parsed.loggedIn;
+			}
+		} catch {
+			// Fall through to text heuristic.
+		}
+	}
+
+	const lower = trimmed.toLowerCase();
+	if (/not logged in|no credentials|unauthenticated|not authenticated/.test(lower)) {
+		return false;
+	}
+	// Exit-0 with non-error output and no negative markers — treat as authed.
+	return true;
 }
 
 let cachedBinaryPresent: boolean | null = null;
@@ -66,7 +108,7 @@ function refreshCache(): void {
 
 	// Check binary presence
 	try {
-		execClaude(["--version"]);
+		execClaude(["--version"], VERSION_TIMEOUT_MS);
 		cachedBinaryPresent = true;
 	} catch {
 		cachedBinaryPresent = false;
@@ -74,15 +116,20 @@ function refreshCache(): void {
 		return;
 	}
 
-	// Check auth status — exit code 0 with non-error output means authenticated
+	// Request JSON explicitly so older CLI builds that defaulted to text and
+	// newer builds that default to JSON produce a consistent shape.
 	try {
-		const output = execClaude(["auth", "status"])
-			.toString()
-			.toLowerCase();
-		// The CLI outputs "not logged in", "no credentials", or similar when unauthenticated
-		cachedAuthed = !(/not logged in|no credentials|unauthenticated|not authenticated/i.test(output));
-	} catch {
-		// Non-zero exit code means not authenticated
+		const output = execClaude(["auth", "status", "--json"], AUTH_TIMEOUT_MS).toString();
+		cachedAuthed = parseAuthStatus(output);
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException | undefined)?.code;
+		// Spawn-shape failures (timeout, transient) shouldn't be treated as
+		// "definitely not authed" — leave the previous value if we have one,
+		// otherwise default to false. The version probe already established
+		// the binary works, so a flaky auth probe is more likely transient.
+		if (code && SOFT_FAIL_CODES.has(code) && cachedAuthed !== null) {
+			return;
+		}
 		cachedAuthed = false;
 	}
 }

--- a/src/tests/claude-readiness-regression-4997.test.ts
+++ b/src/tests/claude-readiness-regression-4997.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression tests for Issue #4997 — v2.78.0 stopped recognizing
+ * authenticated Claude Code CLI installs on Windows.
+ *
+ * Two root causes are pinned by these tests:
+ *   1. `claude auth status` emits JSON by default (`{"loggedIn": true}`).
+ *      The previous text-only regex couldn't distinguish authed vs unauthed
+ *      JSON output, and a hard reliance on text matching could break when
+ *      the CLI's output format changed.
+ *   2. With `shell: process.platform === 'win32'` the spawn goes through
+ *      cmd.exe → claude.cmd → node, which can exceed a 5s timeout on cold
+ *      starts. ETIMEDOUT was not in the soft-fail allowlist, so the auth
+ *      probe threw and `cachedAuthed` was set to false even when the user
+ *      was authenticated.
+ *
+ * These are source-level assertions because the production code paths
+ * spawn a real binary; behaviour testing the live spawn would couple the
+ * suite to the local install state.
+ */
+
+import test, { describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const readinessSource = readFileSync(
+  join(__dirname, "..", "resources", "extensions", "claude-code-cli", "readiness.ts"),
+  "utf-8",
+);
+
+const cliCheckSource = readFileSync(
+  join(__dirname, "..", "claude-cli-check.ts"),
+  "utf-8",
+);
+
+describe("Claude auth detection — JSON output (#4997)", () => {
+  test("readiness.ts requests --json from claude auth status", () => {
+    assert.match(
+      readinessSource,
+      /\["auth",\s*"status",\s*"--json"\]/,
+      "readiness.ts must request structured JSON output",
+    );
+  });
+
+  test("claude-cli-check.ts requests --json from claude auth status", () => {
+    assert.match(
+      cliCheckSource,
+      /\['auth',\s*'status',\s*'--json'\]/,
+      "claude-cli-check.ts must request structured JSON output",
+    );
+  });
+
+  test("readiness.ts inspects the loggedIn field", () => {
+    assert.match(
+      readinessSource,
+      /loggedIn/,
+      "readiness.ts must inspect the loggedIn field from JSON output",
+    );
+  });
+
+  test("claude-cli-check.ts inspects the loggedIn field", () => {
+    assert.match(
+      cliCheckSource,
+      /loggedIn/,
+      "claude-cli-check.ts must inspect the loggedIn field from JSON output",
+    );
+  });
+});
+
+describe("Claude auth detection — ETIMEDOUT tolerance (#4997)", () => {
+  test("readiness.ts soft-fails ETIMEDOUT when iterating candidates", () => {
+    assert.match(
+      readinessSource,
+      /ETIMEDOUT/,
+      "readiness.ts must treat ETIMEDOUT as a soft-fail to allow candidate iteration",
+    );
+  });
+
+  test("claude-cli-check.ts soft-fails ETIMEDOUT when iterating candidates", () => {
+    assert.match(
+      cliCheckSource,
+      /ETIMEDOUT/,
+      "claude-cli-check.ts must treat ETIMEDOUT as a soft-fail to allow candidate iteration",
+    );
+  });
+
+  test("readiness.ts uses a longer timeout for the auth probe", () => {
+    // Auth probe goes through cmd.exe → claude.cmd → node on Windows; 5s is
+    // not enough headroom on cold starts. Require an explicit auth timeout
+    // larger than the version probe.
+    assert.match(
+      readinessSource,
+      /AUTH_TIMEOUT_MS\s*=\s*1[0-9]_?000/,
+      "readiness.ts must define AUTH_TIMEOUT_MS >= 10s",
+    );
+  });
+
+  test("claude-cli-check.ts uses a longer timeout for the auth probe", () => {
+    assert.match(
+      cliCheckSource,
+      /AUTH_TIMEOUT_MS\s*=\s*1[0-9]_?000/,
+      "claude-cli-check.ts must define AUTH_TIMEOUT_MS >= 10s",
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Restore Claude Code CLI subscription detection on Windows (and harden it for all OS).
**Why:** v2.78.0 introduced a 5s `auth status` timeout that, combined with cmd.exe shell wrapping added in the same release, threw `ETIMEDOUT` and forced `cachedAuthed = false` even when the user was authenticated.
**How:** Use `claude auth status --json` and parse `loggedIn`, treat `ETIMEDOUT`/`EAGAIN` as soft failures during candidate iteration, and split the per-call timeouts so the slower auth probe gets 15s.

## What

- `src/resources/extensions/claude-code-cli/readiness.ts` — request JSON from `claude auth status`, parse `loggedIn`, broaden the soft-fail allowlist, split version/auth timeouts, and stop clobbering a previously good auth state on transient failure.
- `src/claude-cli-check.ts` — same fixes applied to the lightweight onboarding probe.
- `src/tests/claude-readiness-regression-4997.test.ts` — new regression test pinning the `--json`/`loggedIn` path and the `ETIMEDOUT` tolerance for both call sites.

## Why

Closes #4997.

The v2.77.0 → v2.78.0 diff in the detection files was a single change: adding `shell: process.platform === 'win32'` to `execFileSync`. On Windows + Node 25, the spawn now goes through `cmd.exe → claude.cmd → node → Claude CLI`, which on cold starts can exceed the unchanged 5s timeout. `execFileSync` then throws with `code === 'ETIMEDOUT'`, which was not in the `ENOENT | EINVAL` allowlist used to advance to the next candidate. So the auth probe threw, and the catch handler set `cachedAuthed = false` — exactly the symptom the user reported (authenticated locally, but GSD says they're not).

Separately, `claude auth status` emits JSON by default (`{"loggedIn": true, ...}`). The text regex `/not logged in|.../` couldn't distinguish authed vs unauthed JSON output, so even when the probe succeeded the parse was unreliable on builds that emit `loggedIn: false`.

## How

1. **JSON-first auth parse with text fallback.** Pass `--json` explicitly and parse the `loggedIn` boolean. If the output isn't JSON-shaped (older CLI builds), fall back to the existing English text heuristic.
2. **ETIMEDOUT/EAGAIN are soft failures.** Promoted from "throw" to "try the next candidate" so a slow first candidate doesn't kill detection.
3. **Split timeouts.** `--version` keeps 5s; `auth status` gets 15s to absorb the cmd.exe → claude.cmd → node startup chain.
4. **Preserve prior cache on transient failure.** If a refresh hits a soft-fail mid-iteration and we already have a cached auth state, keep it rather than overwriting with false.

Validated by codex peer review before implementation. All 16 claude-detection tests pass; the 2 pre-existing `partial-builder`/`stream-adapter` failures are unrelated worktree-build issues that fail on the unmodified branch as well.

## Change type

- [x] `fix` — Bug fix

## Test plan

- [x] New regression test (`claude-readiness-regression-4997.test.ts`) covers the `--json`/`loggedIn` path and `ETIMEDOUT` tolerance for both `readiness.ts` and `claude-cli-check.ts`.
- [x] Existing Windows detection tests (`claude-cli-windows-detection.test.ts`, `claude-exe-windows-detection.test.ts`) still pass.
- [x] Behavioral smoke test on macOS: `isClaudeBinaryInstalled()` and `isClaudeCliReady()` both return `true` against a real authed install.
- [ ] Reporter (Windows 11, Node v25.8.0) to confirm the option appears in onboarding and that an existing `claude-code` auth.json is recognized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable timeouts for CLI command checks (short probe vs longer auth probe).
  * Implemented structured JSON-based authentication status detection with an English-text fallback.

* **Bug Fixes**
  * Broadened transient error handling to treat additional error codes as soft failures.
  * Preserve cached authentication state when transient probe failures occur.

* **Tests**
  * Added regression test covering authentication detection, timeouts, and transient-error tolerance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->