### PR TITLE
fix(claude-code-cli): catch-all candidate iteration on Windows (follow-up to #4999)

### DIFF
--- a/src/claude-cli-check.ts
+++ b/src/claude-cli-check.ts
@@ -1,6 +1,9 @@
 // GSD2 — Claude CLI binary detection for onboarding
 // Lightweight check used at onboarding time (before extensions load).
 // The full readiness check with caching lives in the claude-code-cli extension.
+//
+// Set GSD_CLAUDE_DEBUG=1 to log probe output to stderr. Useful when
+// diagnosing platform-specific detection failures (Issue #4997).
 
 import { execFileSync } from 'node:child_process'
 
@@ -25,38 +28,42 @@ export const CLAUDE_COMMAND = process.platform === 'win32' ? 'claude.cmd' : 'cla
 const CLAUDE_COMMAND_CANDIDATES: string[] =
   process.platform === 'win32' ? [CLAUDE_COMMAND, 'claude.exe', 'claude'] : [CLAUDE_COMMAND]
 
-// Codes treated as "this candidate didn't run — try the next one" rather than
-// fatal failures. ETIMEDOUT/EAGAIN cover slow-spawn cases on Windows where
-// cmd.exe wrapping plus the Claude CLI startup path together exceed the
-// per-attempt timeout (Issue #4997 regression on Windows + Node 25).
-const SOFT_FAIL_CODES = new Set(['ENOENT', 'EINVAL', 'ETIMEDOUT', 'EAGAIN'])
-
 const VERSION_TIMEOUT_MS = 5_000
 // Auth probe needs more headroom on Windows because the spawn goes through
 // cmd.exe → claude.cmd → node → Claude CLI.
 const AUTH_TIMEOUT_MS = 15_000
 
+function debugLog(...parts: unknown[]): void {
+  if (process.env.GSD_CLAUDE_DEBUG) {
+    process.stderr.write(`[claude-cli-check] ${parts.map(p => (typeof p === 'string' ? p : JSON.stringify(p))).join(' ')}\n`)
+  }
+}
+
 /**
- * Try to run `args` against each candidate binary.
- * Returns the output buffer on first success, throws the last error if all fail.
+ * Find the first candidate that responds to `--version`. Returns the
+ * candidate name on success, null if none worked.
+ *
+ * On Windows with `shell: true`, a missing candidate surfaces as a
+ * non-zero exit from cmd.exe rather than ENOENT — so we cannot rely on
+ * the error code to decide "try next". Treat any failure as "try next"
+ * for the version probe.
  */
-function execClaudeCheck(args: string[], timeoutMs: number): Buffer {
-  let lastError: unknown
+function findWorkingCommand(): string | null {
   for (const command of CLAUDE_COMMAND_CANDIDATES) {
     try {
-      return execFileSync(command, args, {
-        timeout: timeoutMs,
+      execFileSync(command, ['--version'], {
+        timeout: VERSION_TIMEOUT_MS,
         stdio: 'pipe',
         shell: process.platform === 'win32',
       })
+      debugLog('version probe ok via', command)
+      return command
     } catch (error) {
-      lastError = error
-      const code = (error as NodeJS.ErrnoException | undefined)?.code
-      if (code && SOFT_FAIL_CODES.has(code)) continue
-      throw error
+      debugLog('version probe failed for', command, 'code=', (error as NodeJS.ErrnoException | undefined)?.code)
+      continue
     }
   }
-  throw lastError ?? new Error(`Claude CLI not found (tried: ${CLAUDE_COMMAND_CANDIDATES.join(', ')})`)
+  return null
 }
 
 /**
@@ -66,8 +73,10 @@ function execClaudeCheck(args: string[], timeoutMs: number): Buffer {
  * emit free-form text. Prefer the structured signal; fall back to a text
  * heuristic. The text heuristic only covers English phrasing.
  */
-function parseAuthStatus(output: string): boolean {
+function parseAuthStatus(output: string): boolean | null {
   const trimmed = output.trim()
+  if (!trimmed) return null
+
   if (trimmed.startsWith('{')) {
     try {
       const parsed = JSON.parse(trimmed) as { loggedIn?: unknown }
@@ -83,35 +92,54 @@ function parseAuthStatus(output: string): boolean {
   if (/not logged in|no credentials|unauthenticated|not authenticated/.test(lower)) {
     return false
   }
-  return true
+  if (/logged in|authenticated|signed in|email|subscription/.test(lower)) {
+    return true
+  }
+  return null
+}
+
+function probeAuth(command: string): boolean | null {
+  // Try --json first (newer CLIs).
+  try {
+    const out = execFileSync(command, ['auth', 'status', '--json'], {
+      timeout: AUTH_TIMEOUT_MS,
+      stdio: 'pipe',
+      shell: process.platform === 'win32',
+    }).toString()
+    debugLog('auth status --json output:', out.slice(0, 200))
+    const parsed = parseAuthStatus(out)
+    if (parsed !== null) return parsed
+  } catch (error) {
+    debugLog('auth status --json threw:', (error as Error).message?.slice(0, 200))
+  }
+
+  // Fallback: plain `auth status` (older CLIs that don't accept --json).
+  try {
+    const out = execFileSync(command, ['auth', 'status'], {
+      timeout: AUTH_TIMEOUT_MS,
+      stdio: 'pipe',
+      shell: process.platform === 'win32',
+    }).toString()
+    debugLog('auth status output:', out.slice(0, 200))
+    return parseAuthStatus(out)
+  } catch (error) {
+    debugLog('auth status threw:', (error as Error).message?.slice(0, 200))
+    return null
+  }
 }
 
 /**
  * Check if the `claude` binary is installed (regardless of auth state).
  */
 export function isClaudeBinaryInstalled(): boolean {
-  try {
-    execClaudeCheck(['--version'], VERSION_TIMEOUT_MS)
-    return true
-  } catch {
-    return false
-  }
+  return findWorkingCommand() !== null
 }
 
 /**
  * Check if the `claude` CLI is installed AND authenticated.
  */
 export function isClaudeCliReady(): boolean {
-  try {
-    execClaudeCheck(['--version'], VERSION_TIMEOUT_MS)
-  } catch {
-    return false
-  }
-
-  try {
-    const output = execClaudeCheck(['auth', 'status', '--json'], AUTH_TIMEOUT_MS).toString()
-    return parseAuthStatus(output)
-  } catch {
-    return false
-  }
+  const command = findWorkingCommand()
+  if (!command) return false
+  return probeAuth(command) === true
 }

--- a/src/resources/extensions/claude-code-cli/readiness.ts
+++ b/src/resources/extensions/claude-code-cli/readiness.ts
@@ -6,8 +6,12 @@
  * model-availability check.
  *
  * Auth verification runs `claude auth status --json` and inspects the
- * `loggedIn` field, falling back to a text heuristic when the JSON shape
- * is unavailable (older Claude CLI builds).
+ * `loggedIn` field, falling back to plain `claude auth status` and a text
+ * heuristic when the JSON shape is unavailable (older Claude CLI builds).
+ *
+ * Set GSD_CLAUDE_DEBUG=1 to print the probe's binary selection and auth
+ * outputs to stderr — useful when diagnosing platform-specific detection
+ * failures (Issue #4997).
  */
 
 import { execFileSync } from "node:child_process";
@@ -28,13 +32,6 @@ const CLAUDE_COMMAND = process.platform === "win32" ? "claude.cmd" : "claude";
  */
 const CLAUDE_COMMAND_CANDIDATES = process.platform === "win32" ? [CLAUDE_COMMAND, "claude.exe", "claude"] : [CLAUDE_COMMAND];
 
-// Codes treated as "this candidate didn't run — try the next one" rather than
-// fatal failures. ENOENT/EINVAL cover the original Windows .cmd shim cases.
-// ETIMEDOUT and EAGAIN cover slow-spawn cases where cmd.exe wrapping plus
-// the Claude CLI startup path together exceed the per-attempt timeout
-// (Issue #4997 regression on Windows + Node 25).
-const SOFT_FAIL_CODES = new Set(["ENOENT", "EINVAL", "ETIMEDOUT", "EAGAIN"]);
-
 // Keep the version probe snappy — `claude --version` is a quick path.
 const VERSION_TIMEOUT_MS = 5_000;
 // Auth status can be much slower on Windows because the spawn goes through
@@ -42,29 +39,39 @@ const VERSION_TIMEOUT_MS = 5_000;
 // without making startup feel hung when the CLI is genuinely missing.
 const AUTH_TIMEOUT_MS = 15_000;
 
+function debugLog(...parts: unknown[]): void {
+	if (process.env.GSD_CLAUDE_DEBUG) {
+		process.stderr.write(`[claude-readiness] ${parts.map((p) => (typeof p === "string" ? p : JSON.stringify(p))).join(" ")}\n`);
+	}
+}
+
 /**
- * Run the requested Claude CLI command against each supported executable name.
- * Returns the first successful output buffer and rethrows hard failures.
+ * Find the first candidate that responds to `--version`. Returns the
+ * candidate name on success, null if none worked.
+ *
+ * On Windows with `shell: true`, a missing candidate surfaces as a
+ * non-zero exit from cmd.exe rather than ENOENT — so we cannot rely on
+ * the error code to decide "try next". Treat any failure as "try next"
+ * for the version probe; the only thing that matters for binary
+ * detection is whether *some* candidate produces a `claude --version`
+ * line.
  */
-function execClaude(args: string[], timeoutMs: number): Buffer {
-	let lastError: unknown;
+function findWorkingCommand(): string | null {
 	for (const command of CLAUDE_COMMAND_CANDIDATES) {
 		try {
-			return execFileSync(command, args, {
-				timeout: timeoutMs,
+			execFileSync(command, ["--version"], {
+				timeout: VERSION_TIMEOUT_MS,
 				stdio: "pipe",
 				shell: process.platform === "win32",
 			});
+			debugLog("version probe ok via", command);
+			return command;
 		} catch (error) {
-			lastError = error;
-			const code = (error as NodeJS.ErrnoException | undefined)?.code;
-			if (code && SOFT_FAIL_CODES.has(code)) {
-				continue;
-			}
-			throw error;
+			debugLog("version probe failed for", command, "code=", (error as NodeJS.ErrnoException | undefined)?.code);
+			continue;
 		}
 	}
-	throw lastError ?? new Error(`Claude CLI executable not found (tried: ${CLAUDE_COMMAND_CANDIDATES.join(", ")})`);
+	return null;
 }
 
 /**
@@ -75,8 +82,10 @@ function execClaude(args: string[], timeoutMs: number): Buffer {
  * back to a text heuristic. Note: the text heuristic only covers English
  * phrasing — the JSON path is the durable signal.
  */
-function parseAuthStatus(output: string): boolean {
+function parseAuthStatus(output: string): boolean | null {
 	const trimmed = output.trim();
+	if (!trimmed) return null;
+
 	if (trimmed.startsWith("{")) {
 		try {
 			const parsed = JSON.parse(trimmed) as { loggedIn?: unknown };
@@ -92,8 +101,40 @@ function parseAuthStatus(output: string): boolean {
 	if (/not logged in|no credentials|unauthenticated|not authenticated/.test(lower)) {
 		return false;
 	}
-	// Exit-0 with non-error output and no negative markers — treat as authed.
-	return true;
+	if (/logged in|authenticated|signed in|email|subscription/.test(lower)) {
+		return true;
+	}
+	return null;
+}
+
+function probeAuth(command: string): boolean | null {
+	// Try --json first (newer CLIs).
+	try {
+		const out = execFileSync(command, ["auth", "status", "--json"], {
+			timeout: AUTH_TIMEOUT_MS,
+			stdio: "pipe",
+			shell: process.platform === "win32",
+		}).toString();
+		debugLog("auth status --json output:", out.slice(0, 200));
+		const parsed = parseAuthStatus(out);
+		if (parsed !== null) return parsed;
+	} catch (error) {
+		debugLog("auth status --json threw:", (error as Error).message?.slice(0, 200));
+	}
+
+	// Fallback: plain `auth status` (older CLIs that don't accept --json).
+	try {
+		const out = execFileSync(command, ["auth", "status"], {
+			timeout: AUTH_TIMEOUT_MS,
+			stdio: "pipe",
+			shell: process.platform === "win32",
+		}).toString();
+		debugLog("auth status output:", out.slice(0, 200));
+		return parseAuthStatus(out);
+	} catch (error) {
+		debugLog("auth status threw:", (error as Error).message?.slice(0, 200));
+		return null;
+	}
 }
 
 let cachedBinaryPresent: boolean | null = null;
@@ -114,32 +155,23 @@ function refreshCache(): void {
 	// Set timestamp first to prevent re-entrant checks during the same window
 	lastCheckMs = now;
 
-	// Check binary presence
-	try {
-		execClaude(["--version"], VERSION_TIMEOUT_MS);
-		cachedBinaryPresent = true;
-	} catch {
+	const command = findWorkingCommand();
+	if (!command) {
 		cachedBinaryPresent = false;
 		cachedAuthed = false;
 		return;
 	}
+	cachedBinaryPresent = true;
 
-	// Request JSON explicitly so older CLI builds that defaulted to text and
-	// newer builds that default to JSON produce a consistent shape.
-	try {
-		const output = execClaude(["auth", "status", "--json"], AUTH_TIMEOUT_MS).toString();
-		cachedAuthed = parseAuthStatus(output);
-	} catch (error) {
-		const code = (error as NodeJS.ErrnoException | undefined)?.code;
-		// Spawn-shape failures (timeout, transient) shouldn't be treated as
-		// "definitely not authed" — leave the previous value if we have one,
-		// otherwise default to false. The version probe already established
-		// the binary works, so a flaky auth probe is more likely transient.
-		if (code && SOFT_FAIL_CODES.has(code) && cachedAuthed !== null) {
-			return;
-		}
-		cachedAuthed = false;
+	const authed = probeAuth(command);
+	if (authed === null) {
+		// Couldn't determine auth state from CLI output. Don't clobber a
+		// previously known-good cache; otherwise default to false so we don't
+		// silently route requests to an unauthenticated CLI.
+		if (cachedAuthed === null) cachedAuthed = false;
+		return;
 	}
+	cachedAuthed = authed;
 }
 
 /**

--- a/src/tests/claude-readiness-regression-4997.test.ts
+++ b/src/tests/claude-readiness-regression-4997.test.ts
@@ -2,16 +2,18 @@
  * Regression tests for Issue #4997 — v2.78.0 stopped recognizing
  * authenticated Claude Code CLI installs on Windows.
  *
- * Two root causes are pinned by these tests:
+ * Three root causes are pinned by these tests:
  *   1. `claude auth status` emits JSON by default (`{"loggedIn": true}`).
  *      The previous text-only regex couldn't distinguish authed vs unauthed
  *      JSON output, and a hard reliance on text matching could break when
  *      the CLI's output format changed.
- *   2. With `shell: process.platform === 'win32'` the spawn goes through
- *      cmd.exe → claude.cmd → node, which can exceed a 5s timeout on cold
- *      starts. ETIMEDOUT was not in the soft-fail allowlist, so the auth
- *      probe threw and `cachedAuthed` was set to false even when the user
- *      was authenticated.
+ *   2. Older Claude CLIs don't accept `--json` — the probe must fall back
+ *      to plain `claude auth status`.
+ *   3. With `shell: process.platform === 'win32'` the spawn goes through
+ *      cmd.exe → claude.cmd → node. A missing first candidate surfaces as
+ *      a non-zero cmd.exe exit (no ENOENT errno) and a slow first
+ *      candidate can exceed the 5s timeout — both must advance to the
+ *      next candidate, not abort detection.
  *
  * These are source-level assertions because the production code paths
  * spawn a real binary; behaviour testing the live spawn would couple the
@@ -71,27 +73,47 @@ describe("Claude auth detection — JSON output (#4997)", () => {
   });
 });
 
-describe("Claude auth detection — ETIMEDOUT tolerance (#4997)", () => {
-  test("readiness.ts soft-fails ETIMEDOUT when iterating candidates", () => {
+describe("Claude auth detection — older CLI fallback (#4997)", () => {
+  test("readiness.ts falls back to plain auth status when --json fails", () => {
+    // Both the --json variant and a non-flag variant must appear so the
+    // probe can degrade to older CLIs that don't accept --json.
     assert.match(
       readinessSource,
-      /ETIMEDOUT/,
-      "readiness.ts must treat ETIMEDOUT as a soft-fail to allow candidate iteration",
+      /\["auth",\s*"status"\]/,
+      "readiness.ts must include a non-JSON auth status fallback",
     );
   });
 
-  test("claude-cli-check.ts soft-fails ETIMEDOUT when iterating candidates", () => {
+  test("claude-cli-check.ts falls back to plain auth status when --json fails", () => {
     assert.match(
       cliCheckSource,
-      /ETIMEDOUT/,
-      "claude-cli-check.ts must treat ETIMEDOUT as a soft-fail to allow candidate iteration",
+      /\['auth',\s*'status'\]/,
+      "claude-cli-check.ts must include a non-JSON auth status fallback",
+    );
+  });
+});
+
+describe("Claude auth detection — Windows candidate iteration (#4997)", () => {
+  test("readiness.ts uses a permissive 'find first working binary' probe", () => {
+    // With shell: true, a missing candidate surfaces as a non-zero cmd.exe
+    // exit rather than ENOENT — the iteration must catch any error and
+    // advance, not branch on errno codes.
+    assert.match(
+      readinessSource,
+      /findWorkingCommand|for\s*\(\s*const\s+command\s+of\s+CLAUDE_COMMAND_CANDIDATES[\s\S]*?catch[\s\S]*?continue/,
+      "readiness.ts must iterate candidates with a catch-all continue, not an errno allowlist",
+    );
+  });
+
+  test("claude-cli-check.ts uses a permissive 'find first working binary' probe", () => {
+    assert.match(
+      cliCheckSource,
+      /findWorkingCommand|for\s*\(\s*const\s+command\s+of\s+CLAUDE_COMMAND_CANDIDATES[\s\S]*?catch[\s\S]*?continue/,
+      "claude-cli-check.ts must iterate candidates with a catch-all continue, not an errno allowlist",
     );
   });
 
   test("readiness.ts uses a longer timeout for the auth probe", () => {
-    // Auth probe goes through cmd.exe → claude.cmd → node on Windows; 5s is
-    // not enough headroom on cold starts. Require an explicit auth timeout
-    // larger than the version probe.
     assert.match(
       readinessSource,
       /AUTH_TIMEOUT_MS\s*=\s*1[0-9]_?000/,
@@ -104,6 +126,24 @@ describe("Claude auth detection — ETIMEDOUT tolerance (#4997)", () => {
       cliCheckSource,
       /AUTH_TIMEOUT_MS\s*=\s*1[0-9]_?000/,
       "claude-cli-check.ts must define AUTH_TIMEOUT_MS >= 10s",
+    );
+  });
+});
+
+describe("Claude auth detection — debug logging (#4997)", () => {
+  test("readiness.ts honors GSD_CLAUDE_DEBUG", () => {
+    assert.match(
+      readinessSource,
+      /GSD_CLAUDE_DEBUG/,
+      "readiness.ts must support GSD_CLAUDE_DEBUG=1 for diagnosing platform-specific failures",
+    );
+  });
+
+  test("claude-cli-check.ts honors GSD_CLAUDE_DEBUG", () => {
+    assert.match(
+      cliCheckSource,
+      /GSD_CLAUDE_DEBUG/,
+      "claude-cli-check.ts must support GSD_CLAUDE_DEBUG=1 for diagnosing platform-specific failures",
     );
   });
 });


### PR DESCRIPTION
## TL;DR

**What:** Replace the errno-allowlist candidate iteration with a catch-all probe, add an `auth status --json` → plain `auth status` fallback, and gate probe diagnostics behind `GSD_CLAUDE_DEBUG=1`.
**Why:** The fix in #4999 still misses native Windows installs (no `claude.cmd` shim) because cmd.exe's "command not recognized" surfaces as a non-zero exit with no errno code — so the iteration aborted on the first missing candidate instead of trying `claude.exe` / bare `claude`.
**How:** Iterate candidates with a catch-all `try/continue`; the only thing that matters for binary detection is whether *some* candidate produces a `--version` line.

## What

- `src/resources/extensions/claude-code-cli/readiness.ts` — refactor `execClaude` into `findWorkingCommand` (catch-all candidate probe) + `probeAuth` (JSON-first with non-JSON fallback). `parseAuthStatus` now returns `null` for "could not determine" so the cache logic can preserve a previously known-good auth state across transient probe failures.
- `src/claude-cli-check.ts` — same restructure for the lightweight onboarding probe.
- `src/tests/claude-readiness-regression-4997.test.ts` — assert the catch-all iteration, the auth-status fallback, and `GSD_CLAUDE_DEBUG` support in both call sites.

## Why

Closes the remaining gap from #4997 — the user reported that even after the v2.78.0 fix landed, the CLI still wasn't detected on Windows (`/models` empty).

The previous iteration relied on `SOFT_FAIL_CODES = { ENOENT, EINVAL, ETIMEDOUT, EAGAIN }` to advance to the next candidate. With `shell: true`:

- A missing candidate goes through `cmd.exe`. cmd.exe prints `'claude.cmd' is not recognized…` and exits non-zero. The Node error has `status: 1` but no `code: 'ENOENT'`.
- The errno check `if (code && SOFT_FAIL_CODES.has(code))` is therefore false, and the iteration `throw`s instead of advancing.
- Result: native Windows installs (no npm `.cmd` shim, only `claude.exe` or a bare `claude` script) never get probed past the first missing candidate.

## How

1. **Catch-all iteration.** `findWorkingCommand` tries each candidate against `--version` and treats any failure as "try next". On success it returns the candidate name to use for downstream probes.
2. **JSON-first auth probe with fallback.** `probeAuth` runs `auth status --json` first and falls back to plain `auth status` if `--json` isn't supported — older CLIs reject the flag and would otherwise return null forever.
3. **Tristate parse.** `parseAuthStatus` returns `boolean | null`. `null` means "couldn't determine"; the cache layer preserves a previously known-good value rather than clobbering it to false.
4. **Diagnostic logging.** `GSD_CLAUDE_DEBUG=1` streams `[claude-readiness]` / `[claude-cli-check]` lines to stderr so users hitting platform-specific failures can share concrete probe output.

## Change type

- [x] `fix` — Bug fix

## Test plan

- [x] Updated regression suite (`claude-readiness-regression-4997.test.ts`) covers the catch-all iteration, the `auth status` fallback, and `GSD_CLAUDE_DEBUG` support — 20/20 passing.
- [x] Existing Windows detection tests (`claude-cli-windows-detection.test.ts`, `claude-exe-windows-detection.test.ts`) still pass.
- [x] Behavioral smoke on macOS: `isClaudeBinaryInstalled()` and `isClaudeCliReady()` return `true` against a real authed install.
- [ ] Reporter (Windows 11, Node 25.8.0, native install) to confirm `/models` populates and the CLI is detected. If not, the `GSD_CLAUDE_DEBUG=1` output will pinpoint the failure mode.

Refs #4997.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Claude CLI detection with more robust command probing
  * Enhanced authentication state verification to handle edge cases and unsupported CLI versions
  * Refined error handling with consistent fallback behavior across platforms
  * Upgraded debug logging for better CLI detection troubleshooting

* **Tests**
  * Updated regression test coverage for CLI detection and authentication flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->