### PR TITLE
fix(gsd): surface real SQL errors from capture_thought instead of swallowing

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1429,8 +1429,8 @@ export function transaction<T>(fn: () => T): T {
     }
   }
 
-  _txDepth++;
   currentDb.exec("BEGIN");
+  _txDepth++;
   try {
     const result = fn();
     currentDb.exec("COMMIT");
@@ -1462,8 +1462,8 @@ export function readTransaction<T>(fn: () => T): T {
     }
   }
 
-  _txDepth++;
   currentDb.exec("BEGIN DEFERRED");
+  _txDepth++;
   try {
     const result = fn();
     currentDb.exec("COMMIT");

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1405,6 +1405,16 @@ export function checkpointDatabase(): void {
 
 let _txDepth = 0;
 
+/**
+ * Whether the current call is running inside an active SQLite transaction.
+ * Statement-time recovery paths (e.g. VACUUM retry on a malformed memory
+ * store) MUST gate on this — SQLite refuses VACUUM inside a transaction
+ * and would mask the original error with a secondary "cannot VACUUM" throw.
+ */
+export function isInTransaction(): boolean {
+  return _txDepth > 0;
+}
+
 export function transaction<T>(fn: () => T): T {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
 

--- a/src/resources/extensions/gsd/memory-store.ts
+++ b/src/resources/extensions/gsd/memory-store.ts
@@ -512,7 +512,7 @@ export function createMemory(fields: {
   if (!adapter) return null;
 
   try {
-    return doCreateMemory(adapter, fields);
+    return transaction(() => doCreateMemory(adapter, fields));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
 
@@ -522,8 +522,10 @@ export function createMemory(fields: {
     if (message.toLowerCase().includes('malformed') && !isInTransaction()) {
       try {
         adapter.prepare('VACUUM').run();
-        process.stderr.write('memory-store: recovered malformed memory store via VACUUM\n');
-        return doCreateMemory(adapter, fields);
+        const recoveryMessage = 'recovered malformed memory store via VACUUM';
+        process.stderr.write(`memory-store: ${recoveryMessage}\n`);
+        logWarning('memory-store', recoveryMessage);
+        return transaction(() => doCreateMemory(adapter, fields));
       } catch (retryErr) {
         const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
         logWarning('memory-store', `VACUUM recovery for memory store failed: ${retryMsg}`);

--- a/src/resources/extensions/gsd/memory-store.ts
+++ b/src/resources/extensions/gsd/memory-store.ts
@@ -7,6 +7,7 @@ import {
   isDbAvailable,
   _getAdapter,
   transaction,
+  isInTransaction,
   insertMemoryRow,
   rewriteMemoryId,
   updateMemoryContentRow,
@@ -19,6 +20,7 @@ import {
   deleteMemoryRelationsFor,
 } from './gsd-db.js';
 import { createMemoryRelation, isValidRelation } from './memory-relations.js';
+import { logWarning } from './workflow-logger.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -487,7 +489,13 @@ export function nextMemoryId(): string {
  * Insert a new memory with a race-safe auto-assigned ID.
  * Uses AUTOINCREMENT seq to derive the ID after insert, avoiding
  * the read-then-write race in concurrent scenarios (e.g. worktrees).
- * Returns the assigned ID, or null on failure.
+ * Returns the assigned ID, or null when the DB is unavailable.
+ *
+ * Throws on genuine SQL errors (corruption, missing tables, constraint
+ * violations) so callers can surface the underlying message instead of
+ * collapsing the failure to a generic "create_failed". See issue #4967 —
+ * the previous bare-catch swallowed "database disk image is malformed"
+ * errors, leaving the memory subsystem broken without any signal.
  */
 export function createMemory(fields: {
   category: string;
@@ -504,32 +512,66 @@ export function createMemory(fields: {
   if (!adapter) return null;
 
   try {
-    const now = new Date().toISOString();
-    // Insert with a temporary placeholder ID — seq is auto-assigned
-    const placeholder = `_TMP_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-    insertMemoryRow({
-      id: placeholder,
-      category: fields.category,
-      content: fields.content,
-      confidence: fields.confidence ?? 0.8,
-      sourceUnitType: fields.source_unit_type ?? null,
-      sourceUnitId: fields.source_unit_id ?? null,
-      createdAt: now,
-      updatedAt: now,
-      scope: fields.scope ?? 'project',
-      tags: fields.tags ?? [],
-      structuredFields: fields.structuredFields ?? null,
-    });
-    // Derive the real ID from the assigned seq (SELECT is still fine via adapter)
-    const row = adapter.prepare('SELECT seq FROM memories WHERE id = :id').get({ ':id': placeholder });
-    if (!row) return placeholder; // fallback — should not happen
-    const seq = row['seq'] as number;
-    const realId = `MEM${String(seq).padStart(3, '0')}`;
-    rewriteMemoryId(placeholder, realId);
-    return realId;
-  } catch {
-    return null;
+    return doCreateMemory(adapter, fields);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    // Targeted recovery: a malformed memory store can sometimes be rebuilt
+    // by VACUUM. Skip when inside a transaction — SQLite refuses VACUUM
+    // there and a secondary throw would mask the real fault.
+    if (message.toLowerCase().includes('malformed') && !isInTransaction()) {
+      try {
+        adapter.prepare('VACUUM').run();
+        process.stderr.write('memory-store: recovered malformed memory store via VACUUM\n');
+        return doCreateMemory(adapter, fields);
+      } catch (retryErr) {
+        const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+        logWarning('memory-store', `VACUUM recovery for memory store failed: ${retryMsg}`);
+        // Surface the *original* malformed error — it's the actionable signal.
+        throw err;
+      }
+    }
+
+    throw err;
   }
+}
+
+function doCreateMemory(
+  adapter: NonNullable<ReturnType<typeof _getAdapter>>,
+  fields: {
+    category: string;
+    content: string;
+    confidence?: number;
+    source_unit_type?: string;
+    source_unit_id?: string;
+    scope?: string;
+    tags?: string[];
+    structuredFields?: Record<string, unknown> | null;
+  },
+): string {
+  const now = new Date().toISOString();
+  // Insert with a temporary placeholder ID — seq is auto-assigned
+  const placeholder = `_TMP_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  insertMemoryRow({
+    id: placeholder,
+    category: fields.category,
+    content: fields.content,
+    confidence: fields.confidence ?? 0.8,
+    sourceUnitType: fields.source_unit_type ?? null,
+    sourceUnitId: fields.source_unit_id ?? null,
+    createdAt: now,
+    updatedAt: now,
+    scope: fields.scope ?? 'project',
+    tags: fields.tags ?? [],
+    structuredFields: fields.structuredFields ?? null,
+  });
+  // Derive the real ID from the assigned seq (SELECT is still fine via adapter)
+  const row = adapter.prepare('SELECT seq FROM memories WHERE id = :id').get({ ':id': placeholder });
+  if (!row) return placeholder; // fallback — should not happen
+  const seq = row['seq'] as number;
+  const realId = `MEM${String(seq).padStart(3, '0')}`;
+  rewriteMemoryId(placeholder, realId);
+  return realId;
 }
 
 /**
@@ -728,8 +770,17 @@ export function applyMemoryActions(
       }
       enforceMemoryCap();
     });
-  } catch {
-    // non-fatal — transaction will have rolled back
+  } catch (err) {
+    // Non-fatal — the transaction has rolled back. We log a warning so a
+    // degraded memory subsystem (e.g. malformed store, missing tables) is
+    // visible to forensics instead of silently dropping every CREATE — see
+    // issue #4967, where this swallow combined with createMemory's bare
+    // catch hid SQLite corruption from the auto-mode flow entirely.
+    const message = err instanceof Error ? err.message : String(err);
+    logWarning(
+      'memory-store',
+      `applyMemoryActions failed (memory subsystem degraded): ${message}`,
+    );
   }
 }
 

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -18,6 +18,8 @@ import {
   getActiveDecisions,
   getActiveRequirements,
   transaction,
+  readTransaction,
+  isInTransaction,
   _getAdapter,
   _resetProvider,
   insertMilestone,
@@ -381,6 +383,34 @@ describe('gsd-db', () => {
     assert.ok(d10 !== null, 'D010 should survive the failed transaction');
 
     closeDatabase();
+  });
+
+  test('gsd-db: failed BEGIN does not poison transaction depth', () => {
+    openDatabase(':memory:');
+    const adapter = _getAdapter()!;
+
+    const assertFailedBeginLeavesDepthClear = (label: string, fn: () => void) => {
+      adapter.exec('BEGIN');
+      try {
+        let threw = false;
+        try {
+          fn();
+        } catch {
+          threw = true;
+        }
+        assert.equal(threw, true, `${label} should surface the SQLite BEGIN failure`);
+        assert.equal(isInTransaction(), false, `${label} failed BEGIN must not leave depth active`);
+      } finally {
+        adapter.exec('ROLLBACK');
+      }
+    };
+
+    try {
+      assertFailedBeginLeavesDepthClear('transaction', () => transaction(() => undefined));
+      assertFailedBeginLeavesDepthClear('readTransaction', () => readTransaction(() => undefined));
+    } finally {
+      closeDatabase();
+    }
   });
 
   test('gsd-db: recreates missing verification evidence dedup index after removing duplicate rows', () => {

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -329,3 +329,54 @@ test('memory-store: schema includes memories table', () => {
 
   closeDatabase();
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// regression #4967 — createMemory must not silently swallow SQL errors
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('memory-store: createMemory throws on memory-table SQL errors (regression #4967)', () => {
+  openDatabase(':memory:');
+
+  const adapter = _getAdapter()!;
+  // Drop FTS + dependents first to satisfy SQLite's trigger ordering, then
+  // the base memories table. IF EXISTS makes setup robust against schema
+  // versions that may not have created every dependent (e.g. embeddings).
+  adapter.prepare('DROP TABLE IF EXISTS memory_embeddings').run();
+  adapter.prepare('DROP TABLE IF EXISTS memories_fts').run();
+  adapter.prepare('DROP TABLE IF EXISTS memories').run();
+
+  // Pre-fix behaviour: returns null and the caller has no idea why.
+  // Post-fix behaviour: throws so the caller can surface the real SQL message.
+  assert.throws(
+    () => createMemory({ category: 'gotcha', content: 'broken store' }),
+    /memories|no such table/i,
+    'createMemory must surface SQL errors instead of returning null',
+  );
+
+  closeDatabase();
+});
+
+test('memory-store: applyMemoryActions stays non-fatal when memory store is broken (regression #4967)', () => {
+  openDatabase(':memory:');
+
+  const adapter = _getAdapter()!;
+  // Drop FTS + dependents first to satisfy SQLite's trigger ordering, then
+  // the base memories table. IF EXISTS makes setup robust against schema
+  // versions that may not have created every dependent (e.g. embeddings).
+  adapter.prepare('DROP TABLE IF EXISTS memory_embeddings').run();
+  adapter.prepare('DROP TABLE IF EXISTS memories_fts').run();
+  adapter.prepare('DROP TABLE IF EXISTS memories').run();
+
+  // applyMemoryActions wraps createMemory in a transaction with an outer
+  // catch. Even with createMemory now throwing, applyMemoryActions must not
+  // crash the auto-mode flow that calls it (memory extraction is best-effort).
+  const actions: MemoryAction[] = [
+    { action: 'CREATE', category: 'gotcha', content: 'inside-transaction call' },
+  ];
+  assert.doesNotThrow(
+    () => applyMemoryActions(actions),
+    'applyMemoryActions must absorb thrown errors so callers continue',
+  );
+
+  closeDatabase();
+});

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -5,6 +5,11 @@ import {
   _getAdapter,
 } from '../gsd-db.ts';
 import {
+  _resetLogs,
+  peekLogs,
+  setStderrLoggingEnabled,
+} from '../workflow-logger.ts';
+import {
   getActiveMemories,
   getActiveMemoriesRanked,
   nextMemoryId,
@@ -354,6 +359,78 @@ test('memory-store: createMemory throws on memory-table SQL errors (regression #
   );
 
   closeDatabase();
+});
+
+test('memory-store: VACUUM retry rolls back partial memory and logs recovery', () => {
+  openDatabase(':memory:');
+
+  const adapter = _getAdapter()!;
+  const originalPrepareMethod = adapter.prepare;
+  const originalPrepare = adapter.prepare.bind(adapter);
+  const previousStderrLogging = setStderrLoggingEnabled(false);
+  const streamAny = process.stderr as unknown as {
+    write: (chunk: string | Uint8Array, ...rest: unknown[]) => boolean;
+  };
+  const originalStderrWrite = streamAny.write.bind(streamAny);
+  let selectFailures = 0;
+  let vacuumRuns = 0;
+  _resetLogs();
+
+  adapter.prepare = ((sql: string) => {
+    if (sql === 'SELECT seq FROM memories WHERE id = :id' && selectFailures === 0) {
+      const stmt = originalPrepare(sql);
+      return {
+        run: (...params: unknown[]) => stmt.run(...params),
+        get: (..._params: unknown[]) => {
+          selectFailures++;
+          throw new Error('database disk image is malformed');
+        },
+        all: (...params: unknown[]) => stmt.all(...params),
+      };
+    }
+
+    if (sql === 'VACUUM') {
+      const stmt = originalPrepare(sql);
+      return {
+        run: (...params: unknown[]) => {
+          vacuumRuns++;
+          return stmt.run(...params);
+        },
+        get: (...params: unknown[]) => stmt.get(...params),
+        all: (...params: unknown[]) => stmt.all(...params),
+      };
+    }
+
+    return originalPrepare(sql);
+  }) as typeof adapter.prepare;
+  streamAny.write = (): boolean => true;
+
+  try {
+    const id = createMemory({ category: 'gotcha', content: 'recover without duplicate' });
+    assert.equal(id, 'MEM001', 'retry should create a single first memory');
+
+    const rows = adapter.prepare('SELECT id FROM memories ORDER BY seq').all();
+    assert.deepStrictEqual(
+      rows.map((row) => row['id']),
+      ['MEM001'],
+      'failed first attempt should not leave a live _TMP_ memory behind',
+    );
+    assert.equal(selectFailures, 1, 'test should simulate one malformed SELECT after INSERT');
+    assert.equal(vacuumRuns, 1, 'malformed recovery should run VACUUM once');
+    assert.ok(
+      peekLogs().some((entry) =>
+        entry.component === 'memory-store' &&
+        entry.message === 'recovered malformed memory store via VACUUM'
+      ),
+      'successful VACUUM recovery should be emitted to the workflow logger',
+    );
+  } finally {
+    adapter.prepare = originalPrepareMethod;
+    streamAny.write = originalStderrWrite;
+    setStderrLoggingEnabled(previousStderrLogging);
+    _resetLogs();
+    closeDatabase();
+  }
 });
 
 test('memory-store: applyMemoryActions stays non-fatal when memory store is broken (regression #4967)', () => {

--- a/src/resources/extensions/gsd/tests/memory-tools.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-tools.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { closeDatabase, openDatabase } from '../gsd-db.ts';
+import { _getAdapter, closeDatabase, openDatabase } from '../gsd-db.ts';
 import { createMemory, supersedeMemory } from '../memory-store.ts';
 import {
   executeGsdGraph,
@@ -292,4 +292,36 @@ test('memory-tools: gsd_graph errors when DB is closed', () => {
   const result = executeGsdGraph({ mode: 'query', memoryId: 'MEM001' });
   assert.ok(result.isError);
   assert.equal(result.details.error, 'db_unavailable');
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// regression #4967 — capture_thought must surface real SQL errors
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('memory-tools: capture_thought surfaces underlying SQL error (regression #4967)', () => {
+  openDatabase(':memory:');
+
+  // Simulate the real-world failure mode where the memories table is gone.
+  // The original bug was a "database disk image is malformed" on the memory
+  // store; dropping the table produces a deterministic statement-time SQL
+  // error of the same shape — a thrown sqlite error during INSERT.
+  const adapter = _getAdapter()!;
+  adapter.prepare('DROP TABLE IF EXISTS memory_embeddings').run();
+  adapter.prepare('DROP TABLE IF EXISTS memories_fts').run();
+  adapter.prepare('DROP TABLE IF EXISTS memories').run();
+
+  const result = executeMemoryCapture({
+    category: 'gotcha',
+    content: 'should reveal the real reason',
+  });
+
+  assert.ok(result.isError, 'broken store should produce an error result');
+  assert.equal(result.details.operation, 'memory_capture');
+
+  const err = String(result.details.error ?? '');
+  assert.notEqual(err, 'create_failed', 'must not collapse to opaque create_failed');
+  assert.ok(err.length > 0, 'error detail must be populated');
+  assert.match(err, /memories|no such table/i, 'error must reference the underlying SQL fault');
+
+  closeDatabase();
 });

--- a/src/resources/extensions/gsd/tools/memory-tools.ts
+++ b/src/resources/extensions/gsd/tools/memory-tools.ts
@@ -96,8 +96,24 @@ export function executeMemoryCapture(params: MemoryCaptureParams): ToolExecution
   const tags = normalizeTags(params.tags);
 
   const structuredFields = normalizeStructuredFields(params.structuredFields);
-  const id = createMemory({ category, content, confidence, scope, tags, structuredFields });
+  let id: string | null;
+  try {
+    id = createMemory({ category, content, confidence, scope, tags, structuredFields });
+  } catch (err) {
+    // Surface the underlying SQL message (e.g. "database disk image is
+    // malformed", "no such table: memories") so the operator gets the
+    // actionable signal instead of an opaque "create_failed". See #4967.
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [{ type: "text", text: `Error: failed to create memory: ${message}` }],
+      details: { operation: "memory_capture", error: message },
+      isError: true,
+    };
+  }
   if (!id) {
+    // DB unavailable or adapter missing — distinct from the SQL-error path
+    // above. Keep the legacy create_failed token here so any consumers that
+    // explicitly key on the unavailable case continue to work.
     return {
       content: [{ type: "text", text: "Error: failed to create memory." }],
       details: { operation: "memory_capture", error: "create_failed" },

--- a/src/resources/extensions/gsd/workflow-logger.ts
+++ b/src/resources/extensions/gsd/workflow-logger.ts
@@ -66,6 +66,7 @@ export type LogComponent =
   | "memory-embeddings" // Memory layer embedding generation
   | "memory-ingest"     // Memory layer ingestion pipeline
   | "memory-backfill"   // ADR-013: decisions->memories backfill
+  | "memory-store"      // Memory CRUD layer — surfaces SQLite/store-level faults (#4967)
   | "context-mode"     // Context-mode exec sandbox and compaction snapshot
   | "preflight"        // Clean-root preflight gate at milestone completion
   | "postUnit";     // Post-unit processing (abandon detection, overrides)


### PR DESCRIPTION
## TL;DR

**What:** `capture_thought` now reports the underlying SQLite error (e.g. "database disk image is malformed") instead of an opaque `create_failed`, and attempts a one-shot VACUUM recovery for malformed memory stores.
**Why:** A bare-catch in `createMemory` collapsed every fault into `null`, the tool layer mapped that to `details.error: "create_failed"`, and there was no statement-time repair path. The whole memory subsystem could go silently broken while auto-mode kept completing tasks.
**How:** Let `createMemory` throw genuine SQL errors, add a transaction-safe VACUUM-and-retry, surface the real message in the tool result, and log a warning when `applyMemoryActions` rolls back.

## What

Six files changed:

- `src/resources/extensions/gsd/gsd-db.ts` — exports new `isInTransaction()` helper. `_txDepth` was module-private and statement-time recovery paths need it to know when VACUUM is unsafe.
- `src/resources/extensions/gsd/memory-store.ts`
  - `createMemory()` now throws on SQL errors. Keeps `null` only for the "DB unavailable" case so the file's degrade-gracefully contract still holds for the closed-DB path the rest of the module relies on.
  - Adds a one-shot `VACUUM` recovery path for "malformed" SQLite errors, gated on `!isInTransaction()` (see *How* below).
  - `applyMemoryActions()`'s outer catch now logs a `memory-store` warning instead of silently swallowing rollbacks.
- `src/resources/extensions/gsd/tools/memory-tools.ts` — `executeMemoryCapture()` wraps the `createMemory` call in `try/catch` and surfaces the underlying SQL message in both the user-visible text and `details.error`. The legacy `create_failed` token is preserved only for the DB-unavailable path so any consumer keying on it still works.
- `src/resources/extensions/gsd/workflow-logger.ts` — adds `"memory-store"` to the `LogComponent` union.
- Two regression tests under `src/resources/extensions/gsd/tests/`.

## Why

Issue #4967 — the GSD-2 memory subsystem was failing silently. A `complete-slice` run hit `gsd_capture_thought` against a malformed `.gsd/gsd.db`, the tool returned `Error: failed to create memory.` with `details.error: "create_failed"`, auto-mode immediately advanced to `gsd_complete_slice`, and the durable-knowledge layer stayed broken across the rest of the milestone. `PRAGMA integrity_check` on the checkpointed DB confirmed `database disk image is malformed`, but none of that signal reached the operator.

Three combined bugs:

1. `memory-store.ts createMemory()` had a bare `catch { return null; }` that swallowed every error.
2. `tools/memory-tools.ts executeMemoryCapture()` mapped that `null` to opaque `details.error: "create_failed"`.
3. `gsd-db.ts` only attempted VACUUM recovery during `openDatabase()` / `initSchema()`. Statement-time corruption never triggered any repair attempt.

This PR addresses all three. `applyMemoryActions`'s silent catch (the path memory extraction takes during auto-mode closeout) now leaves a warning trail too, so a degraded subsystem is visible in forensics even when no user-facing tool call surfaces it.

Closes #4967

## How

### 1. `createMemory()` throws genuine errors

Refactored the body into a `doCreateMemory(adapter, fields)` helper. The exported wrapper:

```ts
if (!isDbAvailable()) return null;        // DB-closed contract preserved
const adapter = _getAdapter();
if (!adapter) return null;
try {
  return doCreateMemory(adapter, fields);
} catch (err) {
  // ...recovery...
  throw err;                               // surface real SQL errors
}
```

All four pre-existing call sites of `createMemory` already sit inside outer `try/catch` blocks (`memory-tools` adds one in this PR, `memory-backfill`/`commands-memory`/`db-writer` already have them) so the new throw propagates cleanly without crashing any caller.

### 2. Transaction-safe VACUUM retry

The peer review caught a fifth caller — `applyMemoryActions` calls `createMemory` inside `transaction()`. Naively running VACUUM there would throw "cannot VACUUM from within a transaction" and mask the original error. The recovery path is gated:

```ts
if (message.toLowerCase().includes('malformed') && !isInTransaction()) {
  try {
    adapter.prepare('VACUUM').run();
    return doCreateMemory(adapter, fields);
  } catch (retryErr) {
    logWarning('memory-store', `VACUUM recovery for memory store failed: ${retryMsg}`);
    throw err;                             // surface ORIGINAL malformed error
  }
}
```

When the retry itself fails we re-throw the *original* malformed error, not the retry error — the malformed message is the actionable signal.

### 3. Tool-layer surfacing

```ts
try {
  id = createMemory({ ... });
} catch (err) {
  const message = err instanceof Error ? err.message : String(err);
  return {
    content: [{ type: "text", text: `Error: failed to create memory: ${message}` }],
    details: { operation: "memory_capture", error: message },
    isError: true,
  };
}
```

Operators now see e.g. `details.error: "database disk image is malformed"` instead of `"create_failed"`.

## Test plan

- [x] New regression: `memory-tools: capture_thought surfaces underlying SQL error (regression #4967)` — drops the `memories` table, asserts `details.error` is non-empty, not `"create_failed"`, and references the underlying SQL fault.
- [x] New regression: `memory-store: createMemory throws on memory-table SQL errors (regression #4967)` — same setup, asserts `createMemory` throws instead of returning `null`.
- [x] New regression: `memory-store: applyMemoryActions stays non-fatal when memory store is broken (regression #4967)` — covers the 5th caller path; asserts `applyMemoryActions` absorbs the throw inside its `transaction()` so auto-mode keeps moving.
- [x] All 96 memory-related unit tests pass under the project's `node:test` runner with `--experimental-strip-types`.
- [x] `npx tsc --noEmit` clean.
- [x] `scripts/check-source-grep-tests.sh` and `scripts/check-coderabbit-themes.mjs` both pass.

## Notes

- Approach validated by an independent peer review (Codex CLI) which surfaced the `applyMemoryActions` 5th-caller path before implementation. The `isInTransaction()` export and the gated VACUUM retry both come directly from that review.
- AI-assisted contribution. Authored and tested by Jeremy; reviewed locally before pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a transaction-state check for callers to detect active DB transactions.
  * New log component label for memory-store entries.

* **Bug Fixes**
  * Memory creation now surfaces SQL errors instead of returning null.
  * Added conditional recovery (VACUUM + retry) for malformed stores; improved rollback behavior.
  * Failures during memory application now emit warning logs.

* **Tests**
  * Added regression tests covering error reporting, recovery, and transaction-state correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->