### PR TITLE
fix(tui): preserve pasted images on regular submit

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.test.ts
@@ -159,6 +159,7 @@ function getSlashCommandName(text: string): string {
 
 function createHost(options: HostOptions = {}) {
 	const prompted: string[] = [];
+	const promptOptions: any[] = [];
 	const errors: string[] = [];
 	const warnings: string[] = [];
 	const tips: string[] = [];
@@ -186,8 +187,9 @@ function createHost(options: HostOptions = {}) {
 			isBashRunning: false,
 			isCompacting: false,
 			isStreaming: false,
-			prompt: async (text: string) => {
+			prompt: async (text: string, options?: any) => {
 				prompted.push(text);
+				promptOptions.push(options);
 			},
 		},
 		ui: {
@@ -235,6 +237,7 @@ function createHost(options: HostOptions = {}) {
 	return {
 		host: host as typeof host & { defaultEditor: typeof editor & { onSubmit: (text: string) => Promise<void> } },
 		prompted,
+		promptOptions,
 		errors,
 		warnings,
 		tips,
@@ -243,6 +246,19 @@ function createHost(options: HostOptions = {}) {
 		getSettingsOpened: () => settingsOpened,
 	};
 }
+
+test("input-controller: regular prompt submit preserves pending images", async () => {
+	const { host, prompted, promptOptions } = createHost();
+	host.pendingImages.push({ ...TEST_IMAGE });
+
+	await host.defaultEditor.onSubmit("describe this image [Image #1]");
+
+	assert.deepEqual(prompted, ["describe this image [Image #1]"]);
+	assert.equal(promptOptions[0]?.images?.length, 1);
+	assert.equal(promptOptions[0].images[0].mimeType, "image/png");
+	assert.equal(promptOptions[0].images[0].data, TEST_IMAGE.data);
+	assert.equal(host.pendingImages.length, 0);
+});
 
 test("input-controller: built-in slash commands stay in TUI dispatch", async () => {
 	const { host, prompted, errors, getSettingsOpened, getEditorText } = createHost();

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.ts
@@ -133,7 +133,7 @@ export function setupEditorSubmitHandler(host: InteractiveModeStateHost & {
 		// submitPromptsDirectly is false — still dispatch via session.prompt so user input
 		// is not silently discarded.
 		try {
-			await host.session.prompt(text);
+			await host.session.prompt(text, { images });
 		} catch (error: unknown) {
 			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 			host.showError(errorMessage);


### PR DESCRIPTION
## Linked issue

Closes #5005

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Preserve pending pasted image attachments when the interactive editor uses the regular submit path.
**Why:** The editor could show an `[Image #1]` placeholder while sending only text to the model.
**How:** Pass the consumed `images` array into `session.prompt()` for the standard submit branch and add a regression test for that path.

## What

This updates the interactive input controller so regular prompt submission forwards pending image attachments, matching the direct-submit, streaming, and compaction paths.

The test coverage now asserts that a pending pasted image survives the regular submit path and reaches `session.prompt(text, { images })`.

## Why

When users paste an image, the TUI inserts an `[Image #1]` placeholder. On the regular submit path, the controller consumed pending images but called `session.prompt(text)` without passing them along, so providers received only the placeholder text.

## How

The fix reuses the already-consumed `images` value in the regular submit branch. No provider or clipboard handling changes are needed.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where pasted or attached images were being lost when submitting text through certain input paths. Images are now correctly forwarded along with text submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->