### PR TITLE
feat(auto): proactive rate limiting via min_request_interval_ms (#2996)

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -295,6 +295,16 @@ auto_supervisor:
   hard_timeout_minutes: 30    # pause auto mode
 ```
 
+### `min_request_interval_ms`
+
+Minimum milliseconds between auto-mode LLM request dispatches. Use this to proactively slow auto-mode on rate-limited providers and reduce 429 errors. Set to `0` to disable.
+
+```yaml
+min_request_interval_ms: 1000   # wait at least 1 second between LLM requests
+```
+
+Default: `0` (disabled)
+
 ### `budget_ceiling`
 
 Maximum USD to spend during auto mode. No `$` sign — just the number.

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -120,6 +120,16 @@ auto_supervisor:
   hard_timeout_minutes: 30    # pause auto mode
 ```
 
+### `min_request_interval_ms`
+
+Minimum milliseconds between auto-mode LLM request dispatches. Use this to proactively slow auto-mode on rate-limited providers and reduce 429 errors. Set to `0` to disable.
+
+```yaml
+min_request_interval_ms: 1000   # wait at least 1 second between LLM requests
+```
+
+Default: `0` (disabled)
+
 ### `verification_commands`
 
 Shell commands that run after every task execution:

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -195,6 +195,19 @@ function resolveDispatchNodeKind(
   return "unit";
 }
 
+async function enforceMinRequestInterval(s: AutoSession, prefs: IterationContext["prefs"]): Promise<void> {
+  const minInterval = prefs?.min_request_interval_ms ?? 0;
+  if (minInterval > 0 && s.lastRequestTimestamp > 0) {
+    const elapsed = Date.now() - s.lastRequestTimestamp;
+    if (elapsed < minInterval) {
+      const waitMs = minInterval - elapsed;
+      debugLog("autoLoop", { phase: "rate-limit-wait", waitMs });
+      await new Promise<void>(r => setTimeout(r, waitMs));
+    }
+  }
+  s.lastRequestTimestamp = Date.now();
+}
+
 async function runUnitPhaseViaContract(
   dispatchContract: DispatchContract,
   ic: IterationContext,
@@ -468,6 +481,7 @@ export async function autoLoop(
         }
 
         // ── Unit execution (shared with dev path) ──
+        await enforceMinRequestInterval(s, prefs);
         const unitPhaseResult = await runUnitPhaseViaContract(
           dispatchContract,
           ic,
@@ -653,6 +667,7 @@ export async function autoLoop(
         });
       }
 
+      await enforceMinRequestInterval(s, prefs);
       const unitPhaseResult = await runUnitPhaseViaContract(
         dispatchContract,
         ic,

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -205,7 +205,6 @@ async function enforceMinRequestInterval(s: AutoSession, prefs: IterationContext
       await new Promise<void>(r => setTimeout(r, waitMs));
     }
   }
-  s.lastRequestTimestamp = Date.now();
 }
 
 async function runUnitPhaseViaContract(
@@ -214,13 +213,13 @@ async function runUnitPhaseViaContract(
   iterData: IterationData,
   loopState: LoopState,
   sidecarItem?: SidecarItem,
-): Promise<PhaseResult<{ unitStartedAt: number }>> {
+): Promise<PhaseResult<{ unitStartedAt?: number; requestDispatchedAt?: number }>> {
   if (dispatchContract === "legacy-direct") {
     return runUnitPhase(ic, iterData, loopState, sidecarItem);
   }
 
   const scheduler = new ExecutionGraphScheduler();
-  let outcome: PhaseResult<{ unitStartedAt: number }> | null = null;
+  let outcome: PhaseResult<{ unitStartedAt?: number; requestDispatchedAt?: number }> | null = null;
   const executeNode = async (): Promise<void> => {
     outcome = await runUnitPhase(ic, iterData, loopState, sidecarItem);
   };
@@ -488,6 +487,10 @@ export async function autoLoop(
           iterData,
           loopState,
         );
+        if (unitPhaseResult.action === "next") {
+          const requestTimestamp = unitPhaseResult.data.requestDispatchedAt ?? unitPhaseResult.data.unitStartedAt;
+          if (typeof requestTimestamp === "number") s.lastRequestTimestamp = requestTimestamp;
+        }
         deps.uokObserver?.onPhaseResult("unit", unitPhaseResult.action, {
           unitType: iterData.unitType,
           unitId: iterData.unitId,
@@ -675,6 +678,10 @@ export async function autoLoop(
         loopState,
         sidecarItem,
       );
+      if (unitPhaseResult.action === "next") {
+        const requestTimestamp = unitPhaseResult.data.requestDispatchedAt ?? unitPhaseResult.data.unitStartedAt;
+        if (typeof requestTimestamp === "number") s.lastRequestTimestamp = requestTimestamp;
+      }
       deps.uokObserver?.onPhaseResult("unit", unitPhaseResult.action, {
         unitType: iterData.unitType,
         unitId: iterData.unitId,

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1342,7 +1342,7 @@ export async function runUnitPhase(
   iterData: IterationData,
   loopState: LoopState,
   sidecarItem?: SidecarItem,
-): Promise<PhaseResult<{ unitStartedAt: number }>> {
+): Promise<PhaseResult<{ unitStartedAt?: number; requestDispatchedAt?: number }>> {
   const { ctx, pi, s, deps, prefs } = ic;
   const { unitType, unitId, prompt, state, mid } = iterData;
 
@@ -1860,7 +1860,7 @@ export async function runUnitPhase(
         );
         // Fall through to next iteration where dispatch will re-derive
         // and re-dispatch this unit.
-        return { action: "next", data: { unitStartedAt: s.currentUnit?.startedAt } };
+        return { action: "next", data: { unitStartedAt: s.currentUnit?.startedAt, requestDispatchedAt: unitResult.requestDispatchedAt } };
       }
     }
   }
@@ -1924,7 +1924,7 @@ export async function runUnitPhase(
     s.checkpointSha = null;
   }
 
-  return { action: "next", data: { unitStartedAt: s.currentUnit?.startedAt } };
+  return { action: "next", data: { unitStartedAt: s.currentUnit?.startedAt, requestDispatchedAt: unitResult.requestDispatchedAt } };
 }
 
 // ─── runFinalize ──────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -171,6 +171,7 @@ export async function runUnit(
   // ── Send the prompt ──
   debugLog("runUnit", { phase: "send-message", unitType, unitId });
 
+  const requestDispatchedAt = Date.now();
   pi.sendMessage(
     { customType: "gsd-auto", content: prompt, display: s.verbose },
     { triggerTurn: true },
@@ -201,6 +202,7 @@ export async function runUnit(
     unitId,
     status: result.status,
   });
+  const finalResult: UnitResult = { ...result, requestDispatchedAt };
 
   // Discard trailing follow-up messages (e.g. async_job_result notifications)
   // from the completed unit. Without this, queued follow-ups trigger wasteful
@@ -216,5 +218,5 @@ export async function runUnit(
     logWarning("engine", "clearQueue failed after unit completion", { error: String(e) });
   }
 
-  return result;
+  return finalResult;
 }

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -193,6 +193,8 @@ export class AutoSession {
   lastPromptCharCount: number | undefined;
   lastBaselineCharCount: number | undefined;
   pendingQuickTasks: CaptureEntry[] = [];
+  /** Timestamp of the last LLM request dispatch (ms since epoch). Used for proactive rate limiting. */
+  lastRequestTimestamp = 0;
 
   // ── Safety harness ───────────────────────────────────────────────────────
   /** SHA of the pre-unit git checkpoint ref. Cleared on success or rollback. */
@@ -294,6 +296,7 @@ export class AutoSession {
     this.lastPromptCharCount = undefined;
     this.lastBaselineCharCount = undefined;
     this.pendingQuickTasks = [];
+    this.lastRequestTimestamp = 0;
     this.sidecarQueue = [];
     this.rewriteAttemptCount = 0;
     this.consecutiveCompleteBootstraps = 0;

--- a/src/resources/extensions/gsd/auto/types.ts
+++ b/src/resources/extensions/gsd/auto/types.ts
@@ -66,6 +66,7 @@ export interface UnitResult {
   status: "completed" | "cancelled" | "error";
   event?: AgentEndEvent;
   errorContext?: ErrorContext;
+  requestDispatchedAt?: number;
 }
 
 // ─── Phase pipeline types ────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -1524,6 +1524,22 @@ async function configureAdvanced(ctx: ExtensionCommandContext, prefs: Record<str
   const tokenCost = await promptBoolean(ctx, "Show token cost in footer", prefs.show_token_cost, false);
   if (tokenCost !== undefined) prefs.show_token_cost = tokenCost;
 
+  const minRequestInterval = await promptInteger(
+    ctx,
+    "Minimum interval between auto-mode LLM requests (ms, 0 to disable)",
+    prefs.min_request_interval_ms,
+    "0",
+  );
+  if (minRequestInterval === "clear") {
+    delete prefs.min_request_interval_ms;
+  } else if (minRequestInterval !== undefined) {
+    if (minRequestInterval >= 0) {
+      prefs.min_request_interval_ms = minRequestInterval;
+    } else {
+      ctx.ui.notify("Minimum request interval must be 0 or greater. Keeping previous value.", "warning");
+    }
+  }
+
   const widget = await promptEnum(ctx, "Auto-mode widget display", prefs.widget_mode, ["full", "small", "min", "off"], "full");
   if (widget !== undefined) prefs.widget_mode = widget;
 
@@ -1715,6 +1731,7 @@ export function serializePreferencesToFrontmatter(prefs: Record<string, unknown>
     "budget_ceiling", "budget_enforcement", "context_pause_threshold",
     "notifications", "cmux", "remote_questions", "git",
     "stale_commit_threshold_minutes",
+    "min_request_interval_ms",
     "post_unit_hooks", "pre_dispatch_hooks",
     "dynamic_routing", "disabled_model_providers", "uok", "token_profile",
     "service_tier", "flat_rate_providers",

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -1533,11 +1533,7 @@ async function configureAdvanced(ctx: ExtensionCommandContext, prefs: Record<str
   if (minRequestInterval === "clear") {
     delete prefs.min_request_interval_ms;
   } else if (minRequestInterval !== undefined) {
-    if (minRequestInterval >= 0) {
-      prefs.min_request_interval_ms = minRequestInterval;
-    } else {
-      ctx.ui.notify("Minimum request interval must be 0 or greater. Keeping previous value.", "warning");
-    }
+    prefs.min_request_interval_ms = minRequestInterval;
   }
 
   const widget = await promptEnum(ctx, "Auto-mode widget display", prefs.widget_mode, ["full", "small", "min", "off"], "full");

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -126,7 +126,7 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
   - `idle_timeout_minutes`: minutes of inactivity before the supervisor intervenes (default: 10).
   - `hard_timeout_minutes`: minutes before the supervisor forces termination (default: 30).
 
-- `min_request_interval_ms`: integer milliseconds — minimum milliseconds between auto-mode LLM request dispatches. Non-integer values are rounded down (for example, `1000.9` becomes `1000`). Use this to proactively slow auto-mode on rate-limited providers and reduce 429 errors. Set to `0` to disable. Default: `0` (disabled).
+- `min_request_interval_ms`: number — minimum integer milliseconds between auto-mode LLM request dispatches. Non-integer values are rounded down (e.g., `1000.9 → 1000`). Use this to proactively slow auto-mode on rate-limited providers and reduce 429 errors. Set to `0` to disable. Default: `0` (disabled).
 
 - `git`: configures GSD's git behavior. All fields are optional — omit any to use defaults. Keys:
   - `auto_push`: boolean — automatically push commits to the remote after committing. Default: `false`.

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -126,6 +126,8 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
   - `idle_timeout_minutes`: minutes of inactivity before the supervisor intervenes (default: 10).
   - `hard_timeout_minutes`: minutes before the supervisor forces termination (default: 30).
 
+- `min_request_interval_ms`: number — minimum milliseconds between auto-mode LLM request dispatches. Use this to proactively slow auto-mode on rate-limited providers and reduce 429 errors. Set to `0` to disable. Default: `0` (disabled).
+
 - `git`: configures GSD's git behavior. All fields are optional — omit any to use defaults. Keys:
   - `auto_push`: boolean — automatically push commits to the remote after committing. Default: `false`.
   - `push_branches`: boolean — push the milestone branch to the remote after commits. Default: `false`.

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -126,7 +126,7 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
   - `idle_timeout_minutes`: minutes of inactivity before the supervisor intervenes (default: 10).
   - `hard_timeout_minutes`: minutes before the supervisor forces termination (default: 30).
 
-- `min_request_interval_ms`: number — minimum milliseconds between auto-mode LLM request dispatches. Use this to proactively slow auto-mode on rate-limited providers and reduce 429 errors. Set to `0` to disable. Default: `0` (disabled).
+- `min_request_interval_ms`: integer milliseconds — minimum milliseconds between auto-mode LLM request dispatches. Non-integer values are rounded down (for example, `1000.9` becomes `1000`). Use this to proactively slow auto-mode on rate-limited providers and reduce 429 errors. Set to `0` to disable. Default: `0` (disabled).
 
 - `git`: configures GSD's git behavior. All fields are optional — omit any to use defaults. Keys:
   - `auto_push`: boolean — automatically push commits to the remote after committing. Default: `false`.

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -133,6 +133,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "service_tier",
   "forensics_dedup",
   "show_token_cost",
+  "min_request_interval_ms",
   "stale_commit_threshold_minutes",
   "context_management",
   "experimental",
@@ -368,6 +369,8 @@ export interface GSDPreferences {
   forensics_dedup?: boolean;
   /** Opt-in: show per-prompt and cumulative session token cost in the footer. Default: false. */
   show_token_cost?: boolean;
+  /** Proactive rate limiting: minimum milliseconds between auto-mode LLM requests. Prevents 429s on rate-limited providers. 0 = disabled (default). */
+  min_request_interval_ms?: number;
   /**
    * Minutes without a commit before flagging uncommitted changes as stale.
    * When the threshold is exceeded and the working tree is dirty, doctor will

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -1122,6 +1122,19 @@ export function validatePreferences(preferences: GSDPreferences): {
     }
   }
 
+  // ─── Auto-Mode Request Interval ───────────────────────────────────
+  if (preferences.min_request_interval_ms !== undefined) {
+    if (
+      typeof preferences.min_request_interval_ms === "number" &&
+      Number.isFinite(preferences.min_request_interval_ms) &&
+      preferences.min_request_interval_ms >= 0
+    ) {
+      validated.min_request_interval_ms = Math.floor(preferences.min_request_interval_ms);
+    } else {
+      errors.push("min_request_interval_ms must be a non-negative number");
+    }
+  }
+
   // ─── Experimental Features ────────────────────────────────────────
   if (preferences.experimental !== undefined) {
     if (typeof preferences.experimental === "object" && preferences.experimental !== null) {

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -1127,11 +1127,12 @@ export function validatePreferences(preferences: GSDPreferences): {
     if (
       typeof preferences.min_request_interval_ms === "number" &&
       Number.isFinite(preferences.min_request_interval_ms) &&
-      preferences.min_request_interval_ms >= 0
+      preferences.min_request_interval_ms >= 0 &&
+      preferences.min_request_interval_ms <= 2_147_483_647
     ) {
       validated.min_request_interval_ms = Math.floor(preferences.min_request_interval_ms);
     } else {
-      errors.push("min_request_interval_ms must be a non-negative number");
+      errors.push("min_request_interval_ms must be a non-negative number <= 2147483647");
     }
   }
 

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -446,6 +446,7 @@ function mergePreferences(base: GSDPreferences, override: GSDPreferences): GSDPr
     service_tier: override.service_tier ?? base.service_tier,
     forensics_dedup: override.forensics_dedup ?? base.forensics_dedup,
     show_token_cost: override.show_token_cost ?? base.show_token_cost,
+    min_request_interval_ms: override.min_request_interval_ms ?? base.min_request_interval_ms,
     codebase: (base.codebase || override.codebase)
       ? {
           ...(base.codebase ?? {}),

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1,5 +1,8 @@
 import test, { mock } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   resolveAgentEnd,
@@ -734,7 +737,7 @@ function makeLoopSession(overrides?: Partial<Record<string, unknown>>) {
     verbose: false,
     stepMode: false,
     paused: false,
-    basePath: "/tmp/project",
+    basePath: mkdtempSync(join(tmpdir(), "gsd-auto-loop-")),
     originalBasePath: "",
     currentMilestoneId: "M001",
     currentUnit: null,

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -736,6 +736,7 @@ function makeLoopSession(overrides?: Partial<Record<string, unknown>>) {
     unitRecoveryCount: new Map<string, number>(),
     verificationRetryCount: new Map<string, number>(),
     gitService: null,
+    lastRequestTimestamp: 0,
     autoStartTime: Date.now(),
     cmdCtx: {
       newSession: () => Promise.resolve({ cancelled: false }),
@@ -2358,6 +2359,137 @@ test("autoLoop warns but proceeds for greenfield project (no project files) (#18
   assert.ok(
     greenfieldWarning,
     "should warn about greenfield project (no project files)",
+  );
+});
+
+// ── Proactive rate limiting (#2996) ──────────────────────────────────────────
+
+test("autoLoop enforces min_request_interval_ms delay between LLM dispatches (#2996)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  const pi = makeMockPi();
+  const originalSendMessage = pi.sendMessage;
+  const dispatchTimestamps: number[] = [];
+  pi.sendMessage = (...args: unknown[]) => {
+    dispatchTimestamps.push(Date.now());
+    return originalSendMessage(...args);
+  };
+
+  let iterCount = 0;
+
+  const s = makeLoopSession();
+
+  const deps = makeMockDeps({
+    loadEffectiveGSDPreferences: () => ({
+      preferences: { min_request_interval_ms: 300 },
+    }),
+    deriveState: async () => {
+      iterCount++;
+      deps.callLog.push("deriveState");
+      return {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Test", status: "active" },
+        activeSlice: { id: "S01", title: "Slice" },
+        activeTask: { id: "T01" },
+        registry: [{ id: "M001", status: "active" }],
+        blockers: [],
+      } as any;
+    },
+    postUnitPostVerification: async () => {
+      deps.callLog.push("postUnitPostVerification");
+      if (iterCount >= 2) {
+        s.active = false;
+      }
+      return "continue" as const;
+    },
+  });
+
+  const loopPromise = autoLoop(ctx, pi, s, deps);
+
+  await new Promise((r) => setTimeout(r, 100));
+  resolveAgentEnd(makeEvent());
+  await new Promise((r) => setTimeout(r, 500));
+  resolveAgentEnd(makeEvent());
+
+  await loopPromise;
+
+  assert.ok(iterCount >= 2, `expected at least 2 iterations, got ${iterCount}`);
+  assert.ok(dispatchTimestamps.length >= 2, `expected at least 2 dispatches, got ${dispatchTimestamps.length}`);
+
+  assert.ok(
+    (s as any).lastRequestTimestamp > 0,
+    "lastRequestTimestamp should be set after iterations",
+  );
+
+  const gap = dispatchTimestamps[1]! - dispatchTimestamps[0]!;
+  assert.ok(
+    gap >= 250,
+    `gap between dispatches should be >= 250ms (got ${gap}ms) due to min_request_interval_ms=300`,
+  );
+});
+
+test("autoLoop skips rate-limit delay when min_request_interval_ms is 0 (default)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  const pi = makeMockPi();
+  const originalSendMessage = pi.sendMessage;
+  const dispatchTimestamps: number[] = [];
+  pi.sendMessage = (...args: unknown[]) => {
+    dispatchTimestamps.push(Date.now());
+    return originalSendMessage(...args);
+  };
+
+  let iterCount = 0;
+
+  const s = makeLoopSession();
+
+  const deps = makeMockDeps({
+    loadEffectiveGSDPreferences: () => ({
+      preferences: {},
+    }),
+    deriveState: async () => {
+      iterCount++;
+      deps.callLog.push("deriveState");
+      return {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Test", status: "active" },
+        activeSlice: { id: "S01", title: "Slice" },
+        activeTask: { id: "T01" },
+        registry: [{ id: "M001", status: "active" }],
+        blockers: [],
+      } as any;
+    },
+    postUnitPostVerification: async () => {
+      deps.callLog.push("postUnitPostVerification");
+      if (iterCount >= 3) {
+        s.active = false;
+      }
+      return "continue" as const;
+    },
+  });
+
+  const loopPromise = autoLoop(ctx, pi, s, deps);
+
+  for (let i = 0; i < 3; i++) {
+    await new Promise((r) => setTimeout(r, 50));
+    resolveAgentEnd(makeEvent());
+  }
+
+  await loopPromise;
+
+  assert.ok(iterCount >= 3, `expected at least 3 iterations, got ${iterCount}`);
+  assert.ok(dispatchTimestamps.length >= 3, `expected at least 3 dispatches, got ${dispatchTimestamps.length}`);
+
+  const gap = dispatchTimestamps[2]! - dispatchTimestamps[1]!;
+  assert.ok(
+    gap < 150,
+    `gap should be < 150ms without rate limiting (got ${gap}ms)`,
   );
 });
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -26,6 +26,24 @@ function makeEvent(
   return { messages };
 }
 
+async function drainMicrotasks(turns = 20): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    await Promise.resolve();
+  }
+}
+
+async function waitForMicrotasks(
+  condition: () => boolean,
+  label: string,
+  turns = 500,
+): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    if (condition()) return;
+    await Promise.resolve();
+  }
+  assert.fail(`Timed out waiting for ${label}`);
+}
+
 /**
  * Build a minimal mock AutoSession with controllable newSession behavior.
  */
@@ -2366,131 +2384,155 @@ test("autoLoop warns but proceeds for greenfield project (no project files) (#18
 
 test("autoLoop enforces min_request_interval_ms delay between LLM dispatches (#2996)", async () => {
   _resetPendingResolve();
+  mock.timers.enable({ apis: ["Date", "setTimeout"], now: 1_000 });
 
-  const ctx = makeMockCtx();
-  ctx.ui.setStatus = () => {};
-  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
-  const pi = makeMockPi();
-  const originalSendMessage = pi.sendMessage;
-  const dispatchTimestamps: number[] = [];
-  pi.sendMessage = (...args: unknown[]) => {
-    dispatchTimestamps.push(Date.now());
-    return originalSendMessage(...args);
-  };
+  try {
+    const ctx = makeMockCtx();
+    ctx.ui.setStatus = () => {};
+    ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+    const pi = makeMockPi();
+    const originalSendMessage = pi.sendMessage;
+    const dispatchTimestamps: number[] = [];
+    pi.sendMessage = (...args: unknown[]) => {
+      dispatchTimestamps.push(Date.now());
+      return originalSendMessage(...args);
+    };
 
-  let iterCount = 0;
+    let iterCount = 0;
 
-  const s = makeLoopSession();
+    const s = makeLoopSession();
 
-  const deps = makeMockDeps({
-    loadEffectiveGSDPreferences: () => ({
-      preferences: { min_request_interval_ms: 300 },
-    }),
-    deriveState: async () => {
-      iterCount++;
-      deps.callLog.push("deriveState");
-      return {
-        phase: "executing",
-        activeMilestone: { id: "M001", title: "Test", status: "active" },
-        activeSlice: { id: "S01", title: "Slice" },
-        activeTask: { id: "T01" },
-        registry: [{ id: "M001", status: "active" }],
-        blockers: [],
-      } as any;
-    },
-    postUnitPostVerification: async () => {
-      deps.callLog.push("postUnitPostVerification");
-      if (iterCount >= 2) {
-        s.active = false;
-      }
-      return "continue" as const;
-    },
-  });
+    const deps = makeMockDeps({
+      loadEffectiveGSDPreferences: () => ({
+        preferences: { min_request_interval_ms: 300 },
+      }),
+      deriveState: async () => {
+        iterCount++;
+        deps.callLog.push("deriveState");
+        return {
+          phase: "executing",
+          activeMilestone: { id: "M001", title: "Test", status: "active" },
+          activeSlice: { id: "S01", title: "Slice" },
+          activeTask: { id: "T01" },
+          registry: [{ id: "M001", status: "active" }],
+          blockers: [],
+        } as any;
+      },
+      postUnitPostVerification: async () => {
+        deps.callLog.push("postUnitPostVerification");
+        if (iterCount >= 2) {
+          s.active = false;
+        }
+        return "continue" as const;
+      },
+    });
 
-  const loopPromise = autoLoop(ctx, pi, s, deps);
+    const loopPromise = autoLoop(ctx, pi, s, deps);
 
-  await new Promise((r) => setTimeout(r, 100));
-  resolveAgentEnd(makeEvent());
-  await new Promise((r) => setTimeout(r, 500));
-  resolveAgentEnd(makeEvent());
+    await waitForMicrotasks(() => dispatchTimestamps.length === 1, "first dispatch");
+    resolveAgentEnd(makeEvent());
+    await waitForMicrotasks(
+      () => deps.callLog.filter((entry) => entry === "resolveDispatch").length >= 2,
+      "second dispatch planning",
+    );
 
-  await loopPromise;
+    await drainMicrotasks(100);
+    mock.timers.tick(299);
+    await drainMicrotasks(100);
+    assert.equal(dispatchTimestamps.length, 1, "second dispatch should wait for the configured interval");
 
-  assert.ok(iterCount >= 2, `expected at least 2 iterations, got ${iterCount}`);
-  assert.ok(dispatchTimestamps.length >= 2, `expected at least 2 dispatches, got ${dispatchTimestamps.length}`);
+    mock.timers.tick(1);
+    await waitForMicrotasks(() => dispatchTimestamps.length === 2, "second dispatch");
+    resolveAgentEnd(makeEvent());
 
-  assert.ok(
-    (s as any).lastRequestTimestamp > 0,
-    "lastRequestTimestamp should be set after iterations",
-  );
+    await loopPromise;
 
-  const gap = dispatchTimestamps[1]! - dispatchTimestamps[0]!;
-  assert.ok(
-    gap >= 250,
-    `gap between dispatches should be >= 250ms (got ${gap}ms) due to min_request_interval_ms=300`,
-  );
+    assert.ok(iterCount >= 2, `expected at least 2 iterations, got ${iterCount}`);
+    assert.ok(dispatchTimestamps.length >= 2, `expected at least 2 dispatches, got ${dispatchTimestamps.length}`);
+
+    assert.equal(
+      (s as any).lastRequestTimestamp,
+      dispatchTimestamps[1],
+      "lastRequestTimestamp should record the actual dispatch time",
+    );
+
+    const gap = dispatchTimestamps[1]! - dispatchTimestamps[0]!;
+    assert.equal(
+      gap,
+      300,
+      `gap between dispatches should match min_request_interval_ms=300 (got ${gap}ms)`,
+    );
+  } finally {
+    mock.timers.reset();
+  }
 });
 
 test("autoLoop skips rate-limit delay when min_request_interval_ms is 0 (default)", async () => {
   _resetPendingResolve();
+  mock.timers.enable({ apis: ["Date", "setTimeout"], now: 2_000 });
 
-  const ctx = makeMockCtx();
-  ctx.ui.setStatus = () => {};
-  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
-  const pi = makeMockPi();
-  const originalSendMessage = pi.sendMessage;
-  const dispatchTimestamps: number[] = [];
-  pi.sendMessage = (...args: unknown[]) => {
-    dispatchTimestamps.push(Date.now());
-    return originalSendMessage(...args);
-  };
+  try {
+    const ctx = makeMockCtx();
+    ctx.ui.setStatus = () => {};
+    ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+    const pi = makeMockPi();
+    const originalSendMessage = pi.sendMessage;
+    const dispatchTimestamps: number[] = [];
+    pi.sendMessage = (...args: unknown[]) => {
+      dispatchTimestamps.push(Date.now());
+      return originalSendMessage(...args);
+    };
 
-  let iterCount = 0;
+    let iterCount = 0;
 
-  const s = makeLoopSession();
+    const s = makeLoopSession();
 
-  const deps = makeMockDeps({
-    loadEffectiveGSDPreferences: () => ({
-      preferences: {},
-    }),
-    deriveState: async () => {
-      iterCount++;
-      deps.callLog.push("deriveState");
-      return {
-        phase: "executing",
-        activeMilestone: { id: "M001", title: "Test", status: "active" },
-        activeSlice: { id: "S01", title: "Slice" },
-        activeTask: { id: "T01" },
-        registry: [{ id: "M001", status: "active" }],
-        blockers: [],
-      } as any;
-    },
-    postUnitPostVerification: async () => {
-      deps.callLog.push("postUnitPostVerification");
-      if (iterCount >= 3) {
-        s.active = false;
-      }
-      return "continue" as const;
-    },
-  });
+    const deps = makeMockDeps({
+      loadEffectiveGSDPreferences: () => ({
+        preferences: {},
+      }),
+      deriveState: async () => {
+        iterCount++;
+        deps.callLog.push("deriveState");
+        return {
+          phase: "executing",
+          activeMilestone: { id: "M001", title: "Test", status: "active" },
+          activeSlice: { id: "S01", title: "Slice" },
+          activeTask: { id: "T01" },
+          registry: [{ id: "M001", status: "active" }],
+          blockers: [],
+        } as any;
+      },
+      postUnitPostVerification: async () => {
+        deps.callLog.push("postUnitPostVerification");
+        if (iterCount >= 3) {
+          s.active = false;
+        }
+        return "continue" as const;
+      },
+    });
 
-  const loopPromise = autoLoop(ctx, pi, s, deps);
+    const loopPromise = autoLoop(ctx, pi, s, deps);
 
-  for (let i = 0; i < 3; i++) {
-    await new Promise((r) => setTimeout(r, 50));
-    resolveAgentEnd(makeEvent());
+    for (let i = 1; i <= 3; i++) {
+      await waitForMicrotasks(() => dispatchTimestamps.length === i, `dispatch ${i}`);
+      resolveAgentEnd(makeEvent());
+    }
+
+    await loopPromise;
+
+    assert.ok(iterCount >= 3, `expected at least 3 iterations, got ${iterCount}`);
+    assert.ok(dispatchTimestamps.length >= 3, `expected at least 3 dispatches, got ${dispatchTimestamps.length}`);
+
+    const gap = dispatchTimestamps[2]! - dispatchTimestamps[1]!;
+    assert.equal(
+      gap,
+      0,
+      `gap should be 0ms under mocked time without rate limiting (got ${gap}ms)`,
+    );
+  } finally {
+    mock.timers.reset();
   }
-
-  await loopPromise;
-
-  assert.ok(iterCount >= 3, `expected at least 3 iterations, got ${iterCount}`);
-  assert.ok(dispatchTimestamps.length >= 3, `expected at least 3 dispatches, got ${dispatchTimestamps.length}`);
-
-  const gap = dispatchTimestamps[2]! - dispatchTimestamps[1]!;
-  assert.ok(
-    gap < 150,
-    `gap should be < 150ms without rate limiting (got ${gap}ms)`,
-  );
 });
 
 // ─── #4850: pre-send model-policy block is non-retryable ────────────────────

--- a/src/resources/extensions/gsd/tests/init-prefs-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/init-prefs-routing.test.ts
@@ -145,10 +145,25 @@ test("handlePrefsWizard — Advanced config writes min_request_interval_ms", asy
         notify: () => {},
         select: async (_label: string, options: string[]) => {
           const response = selectResponses.shift();
+          if (response === undefined) {
+            throw new Error(
+              `Unexpected extra select prompt in handlePrefsWizard flow: selectResponses queue exhausted for "${_label}" ` +
+                "(expected no additional select prompts)",
+            );
+          }
           if (response === "Advanced") return options.find((option) => option.startsWith("Advanced"));
           return response;
         },
-        input: async () => inputResponses.shift() ?? "",
+        input: async () => {
+          const response = inputResponses.shift();
+          if (response === undefined) {
+            throw new Error(
+              "Unexpected extra input prompt in handlePrefsWizard flow: inputResponses queue exhausted " +
+                "(expected no additional input prompts)",
+            );
+          }
+          return response;
+        },
       },
       waitForIdle: async () => {},
       reload: async () => {},
@@ -156,8 +171,10 @@ test("handlePrefsWizard — Advanced config writes min_request_interval_ms", asy
 
     await handlePrefsWizard(ctx as any, "project", {}, { pathOverride: path });
 
+    assert.equal(selectResponses.length, 0, "Expected all queued selectResponses to be consumed");
+    assert.equal(inputResponses.length, 0, "Expected all queued inputResponses to be consumed");
     const content = readFileSync(path, "utf-8");
-    assert.match(content, /min_request_interval_ms: 250/);
+    assert.match(content, /^min_request_interval_ms\s*:\s*250$/m);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/init-prefs-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/init-prefs-routing.test.ts
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { mapInitPrefsToWizardShape } from "../init-wizard.ts";
-import { writePreferencesFile } from "../commands-prefs-wizard.ts";
+import { handlePrefsWizard, writePreferencesFile } from "../commands-prefs-wizard.ts";
 
 test("mapInitPrefsToWizardShape — full roundtrip with all fields", () => {
   const out = mapInitPrefsToWizardShape({
@@ -118,6 +118,46 @@ test("writePreferencesFile — falls back to default body for new files", async 
     await writePreferencesFile(path, { mode: "solo" }, null, { defaultBody: initBody });
     const content = readFileSync(path, "utf-8");
     assert.match(content, /Init body marker/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("handlePrefsWizard — Advanced config writes min_request_interval_ms", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-init-prefs-routing-"));
+  const path = join(tmp, "PREFERENCES.md");
+
+  try {
+    const selectResponses = [
+      "Advanced",
+      "(keep current)",
+      "(keep current)",
+      "(keep current)",
+      "(keep current)",
+      "(keep current)",
+      "(keep current)",
+      "(keep current)",
+      "── Save & Exit ──",
+    ];
+    const inputResponses = ["250"];
+    const ctx = {
+      ui: {
+        notify: () => {},
+        select: async (_label: string, options: string[]) => {
+          const response = selectResponses.shift();
+          if (response === "Advanced") return options.find((option) => option.startsWith("Advanced"));
+          return response;
+        },
+        input: async () => inputResponses.shift() ?? "",
+      },
+      waitForIdle: async () => {},
+      reload: async () => {},
+    };
+
+    await handlePrefsWizard(ctx as any, "project", {}, { pathOverride: path });
+
+    const content = readFileSync(path, "utf-8");
+    assert.match(content, /min_request_interval_ms: 250/);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/init-prefs-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/init-prefs-routing.test.ts
@@ -151,7 +151,13 @@ test("handlePrefsWizard — Advanced config writes min_request_interval_ms", asy
                 "(expected no additional select prompts)",
             );
           }
-          if (response === "Advanced") return options.find((option) => option.startsWith("Advanced"));
+          if (response === "Advanced") {
+            const advancedOption = options.find((option) => option.startsWith("Advanced"));
+            if (!advancedOption) {
+              throw new Error(`Expected an "Advanced" option in "${_label}" menu`);
+            }
+            return advancedOption;
+          }
           return response;
         },
         input: async () => {
@@ -174,7 +180,7 @@ test("handlePrefsWizard — Advanced config writes min_request_interval_ms", asy
     assert.equal(selectResponses.length, 0, "Expected all queued selectResponses to be consumed");
     assert.equal(inputResponses.length, 0, "Expected all queued inputResponses to be consumed");
     const content = readFileSync(path, "utf-8");
-    assert.match(content, /^min_request_interval_ms\s*:\s*250$/m);
+    assert.match(content, /^min_request_interval_ms:\s*250$/m);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -748,6 +748,54 @@ test("loadEffectiveGSDPreferences exposes slice_parallel prefs to runtime caller
   }
 });
 
+test("loadEffectiveGSDPreferences merges min_request_interval_ms with project overriding global (#2996)", () => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-rate-limit-project-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-rate-limit-home-"));
+
+  try {
+    mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+
+    writeFileSync(
+      join(tempGsdHome, "PREFERENCES.md"),
+      [
+        "---",
+        "version: 1",
+        "min_request_interval_ms: 250",
+        "stale_commit_threshold_minutes: 45",
+        "---",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    writeFileSync(
+      join(tempProject, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "version: 1",
+        "min_request_interval_ms: 100",
+        "---",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    process.env.GSD_HOME = tempGsdHome;
+    process.chdir(tempProject);
+
+    const loaded = loadEffectiveGSDPreferences();
+    assert.notEqual(loaded, null);
+    assert.equal(loaded!.preferences.min_request_interval_ms, 100);
+    assert.equal(loaded!.preferences.stale_commit_threshold_minutes, 45);
+  } finally {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  }
+});
+
 test("preferences paths use canonical uppercase filenames", () => {
   const originalCwd = process.cwd();
   const originalGsdHome = process.env.GSD_HOME;

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -236,6 +236,20 @@ test("valid values pass through correctly", () => {
   assert.equal(p3.auto_supervisor?.model, "claude-opus-4-6");
 });
 
+test("min_request_interval_ms floors decimals and rejects timer overflow values", () => {
+  const valid = validatePreferences({ min_request_interval_ms: 1000.9 });
+  assert.equal(valid.errors.length, 0);
+  assert.equal(valid.preferences.min_request_interval_ms, 1000);
+
+  const max = validatePreferences({ min_request_interval_ms: 2_147_483_647 });
+  assert.equal(max.errors.length, 0);
+  assert.equal(max.preferences.min_request_interval_ms, 2_147_483_647);
+
+  const tooHigh = validatePreferences({ min_request_interval_ms: 2_147_483_648 });
+  assert.ok(tooHigh.errors.some(e => e.includes("min_request_interval_ms must be a non-negative number <= 2147483647")));
+  assert.equal(tooHigh.preferences.min_request_interval_ms, undefined);
+});
+
 test("mixed valid/invalid/unknown keys handled correctly", () => {
   const { preferences, errors, warnings } = validatePreferences({
     uat_dispatch: true, totally_made_up: "value", budget_ceiling: "garbage",

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -763,7 +763,7 @@ test("loadEffectiveGSDPreferences merges min_request_interval_ms with project ov
         "---",
         "version: 1",
         "min_request_interval_ms: 250",
-        "stale_commit_threshold_minutes: 45",
+        "budget_ceiling: 45",
         "---",
       ].join("\n"),
       "utf-8",
@@ -786,7 +786,7 @@ test("loadEffectiveGSDPreferences merges min_request_interval_ms with project ov
     const loaded = loadEffectiveGSDPreferences();
     assert.notEqual(loaded, null);
     assert.equal(loaded!.preferences.min_request_interval_ms, 100);
-    assert.equal(loaded!.preferences.stale_commit_threshold_minutes, 45);
+    assert.equal(loaded!.preferences.budget_ceiling, 45);
   } finally {
     process.chdir(originalCwd);
     if (originalGsdHome === undefined) delete process.env.GSD_HOME;


### PR DESCRIPTION
## Linked issue

Closes #2996

- [x] I have linked an issue above.

## TL;DR

**What:** Adds an opt-in `min_request_interval_ms` preference that throttles auto-mode LLM dispatches to a configurable minimum interval.
**Why:** Lets users proactively avoid 429s on rate-limited providers without waiting for the reactive backoff path to kick in.
**How:** Tracks `lastRequestTimestamp` on `AutoSession` (cleared by `reset()`); `enforceMinRequestInterval()` in `auto/loop.ts` awaits the remainder of the interval before each `runUnitPhaseViaContract` dispatch (both linear and sidecar paths).

## Why this PR (and not the original #3028)

#3028 implemented the same feature but had drifted 153 commits behind main, with many touched files since deleted/refactored upstream (`extension-sdk/*` docs, `auto-recovery.test.ts`, `gate-state-canonicalization.test.ts`, etc.). I closed it and re-applied the ~280 LOC of real content fresh against current main.

## Files

- `preferences-types.ts` — `min_request_interval_ms?: number` on `GSDPreferences` + add to `KNOWN_PREFERENCE_KEYS`
- `preferences.ts` — merge line in `mergePreferences()`
- `preferences-validation.ts` — non-negative-number guard, floored to integer
- `auto/loop.ts` — `enforceMinRequestInterval()` helper + 2 call sites
- `auto/session.ts` — `lastRequestTimestamp` field + reset
- `commands-prefs-wizard.ts` — wizard prompt + serializer key list
- Docs: `configuration.md`, `gitbook/preferences.md`, `preferences-reference.md`
- Tests: 2 in `auto-loop.test.ts` (300ms enforces gap, 0=default skips delay) + 1 in `preferences.test.ts` (project overrides global)

## Change type

- [x] `feat` — New feature
- [x] `test` — Adding tests

## Scope

- [x] `gsd extension` — GSD workflow

## Test plan

- [x] CI passes
- [x] New tests included
- [x] `tsc --noEmit` clean for changed files
- [ ] Manual: set `min_request_interval_ms: 1000` in `.gsd/PREFERENCES.md`, run auto mode, verify ≥1s gap between LLM dispatches

## Default behavior

`0` = disabled (preserves existing behavior). No effect on users who don't set it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added min_request_interval_ms preference to throttle auto-mode LLM requests (default 0 = disabled); sessions now record request dispatch timestamps.

* **Documentation**
  * Updated configuration and preferences docs and examples; advanced preferences wizard saves the new field.

* **Validation & Merge**
  * Preference validated as a non-negative integer (floored, bounded) and included in merged effective preferences.

* **Tests**
  * Added tests for validation, merging, wizard, and proactive rate-limiting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->