### PR TITLE
fix(gsd): preserve infrastructure git add failures

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -38,6 +38,7 @@ import {
 } from "./native-git-bridge.js";
 import { GSDError, GSD_MERGE_CONFLICT, GSD_GIT_ERROR } from "./errors.js";
 import { getErrorMessage } from "./error-utils.js";
+import { isInfrastructureError } from "./auto/infra-errors.js";
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -991,6 +992,17 @@ function buildTurnSnapshotLabel(unitType: string, unitId: string): string {
     .replace(/^[-/]+|[-/]+$/g, "") || "turn";
 }
 
+export function handleTurnGitActionError(action: TurnGitActionMode, err: unknown): TurnGitActionResult {
+  if (isInfrastructureError(err)) {
+    throw err;
+  }
+  return {
+    action,
+    status: "failed",
+    error: getErrorMessage(err),
+  };
+}
+
 export function runTurnGitAction(args: {
   basePath: string;
   action: TurnGitActionMode;
@@ -1029,11 +1041,7 @@ export function runTurnGitAction(args: {
       dirty: nativeHasChanges(args.basePath),
     };
   } catch (err) {
-    return {
-      action: args.action,
-      status: "failed",
-      error: getErrorMessage(err),
-    };
+    return handleTurnGitActionError(args.action, err);
   }
 }
 

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { GSDError, GSD_GIT_ERROR } from "./errors.js";
 import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { getErrorMessage } from "./error-utils.js";
+import { isInfrastructureError } from "./auto/infra-errors.js";
 
 // Issue #453: keep auto-mode bookkeeping on the stable git CLI path unless a
 // caller explicitly opts into the native helper.
@@ -846,6 +847,10 @@ export function nativeAddAllWithExclusions(basePath: string, exclusions: readonl
     });
   } catch (err: unknown) {
     const stderr = (err as { stderr?: string })?.stderr ?? "";
+    const infraCode = isInfrastructureError(err) ?? isInfrastructureError(stderr);
+    if (infraCode) {
+      throw err;
+    }
     // git exits 1 when pathspec exclusions reference paths already covered
     // by .gitignore. The staging itself succeeds — only suppress that case.
     if (stderr.includes("ignored by one of your .gitignore files")) {
@@ -860,7 +865,8 @@ export function nativeAddAllWithExclusions(basePath: string, exclusions: readonl
       fallbackStageWithSymlinkedDotGsd(basePath);
       return;
     }
-    throw new GSDError(GSD_GIT_ERROR, `git add -A with exclusions failed in ${basePath}: ${getErrorMessage(err)}`);
+    const stderrDetail = stderr.trim() ? `; stderr: ${stderr.trim()}` : "";
+    throw new GSDError(GSD_GIT_ERROR, `git add -A with exclusions failed in ${basePath}: ${getErrorMessage(err)}${stderrDetail}`);
   }
 }
 

--- a/src/resources/extensions/gsd/tests/native-git-infra-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/native-git-infra-errors.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { git } from "./test-utils.ts";
+import { GSD_GIT_ERROR } from "../errors.js";
+
+test("nativeAddAllWithExclusions preserves infrastructure failures from git add", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-native-git-infra-"));
+  const repo = join(base, "repo");
+  const bin = join(base, "bin");
+  mkdirSync(repo);
+  mkdirSync(bin);
+
+  const fakeGit = join(bin, "git");
+  writeFileSync(
+    fakeGit,
+    "#!/bin/sh\n" +
+      "echo 'fatal: ENFILE: file table overflow' >&2\n" +
+      "exit 1\n",
+    "utf-8",
+  );
+  chmodSync(fakeGit, 0o755);
+
+  const originalPath = process.env.PATH ?? "";
+  try {
+    git(repo, "init");
+    git(repo, "config", "user.email", "test@example.com");
+    git(repo, "config", "user.name", "Test User");
+    writeFileSync(join(repo, "README.md"), "# Test\n", "utf-8");
+
+    process.env.PATH = `${bin}:${originalPath}`;
+    const { nativeAddAllWithExclusions } = await import("../native-git-bridge.ts");
+
+    assert.throws(
+      () => nativeAddAllWithExclusions(repo, [".gsd/activity/"]),
+      (err) => {
+        const shaped = err as { code?: string; stderr?: string; message?: string };
+        assert.notEqual(shaped.code, GSD_GIT_ERROR);
+        assert.match(`${shaped.stderr ?? ""}${shaped.message ?? ""}`, /ENFILE/);
+        return true;
+      },
+    );
+  } finally {
+    process.env.PATH = originalPath;
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-import { runTurnGitAction } from "../git-service.ts";
+import { handleTurnGitActionError, runTurnGitAction } from "../git-service.ts";
 
 function run(cmd: string, cwd: string): string {
   return execSync(cmd, { cwd, stdio: "pipe", encoding: "utf-8" }).trim();
@@ -82,4 +82,18 @@ test("uok gitops turn action commit creates commit with unit trailer", () => {
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }
+});
+
+test("uok gitops turn action rethrows infrastructure failures", () => {
+  const err = Object.assign(new Error("ENFILE: file table overflow"), { code: "ENFILE" });
+
+  assert.throws(() => handleTurnGitActionError("commit", err), (thrown) => thrown === err);
+});
+
+test("uok gitops turn action keeps non-infrastructure git failures recoverable", () => {
+  const result = handleTurnGitActionError("commit", new Error("nothing to commit"));
+
+  assert.equal(result.action, "commit");
+  assert.equal(result.status, "failed");
+  assert.equal(result.error, "nothing to commit");
 });


### PR DESCRIPTION
## Linked issue

Closes #4652

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Preserve infrastructure-class git staging failures instead of converting them into generic git failures.
**Why:** `ENFILE`/`EMFILE` file-descriptor exhaustion should stay visible as infrastructure failures with the original errno evidence.
**How:** Detect infrastructure errors before git-error wrapping and keep normal git failures on the recoverable path.

## What

This updates the GSD extension git path so `nativeAddAllWithExclusions` rethrows infrastructure-class failures before it wraps git staging errors. It also gives turn git action handling the same distinction: infrastructure failures propagate, while ordinary git failures still return a recoverable failed result.

Regression coverage now exercises both the native staging path and the turn-action helper.

## Why

Issue #4652 reports that `ENFILE`/`EMFILE` can be misclassified as git failures. That hides the actual resource-exhaustion cause and can send recovery down the wrong path.

## How

The implementation checks errors and stderr with the existing infrastructure-error classifier before creating a `GSD_GIT_ERROR`. The turn git action path now uses a small exported helper so tests can verify infrastructure failures are rethrown while non-infrastructure git failures remain recoverable.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/native-git-infra-errors.test.ts src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts src/resources/extensions/gsd/tests/infra-error.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:unit`
5. `npm run test:integration`
6. `npm run verify:pr`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to better distinguish and report system-level failures separately from standard errors, with enhanced error messages including additional diagnostic context for troubleshooting.

* **Tests**
  * Added test coverage for system-level error scenarios and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->