### PR TITLE
test(gsd): replace auto thinking source-grep checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,6 +1414,16 @@
         "global-agent": "^3.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -591,6 +591,40 @@ export function _warnIfWorktreeMissingForTest(
   return false;
 }
 
+/** Test-only seam for behaviour tests that need a minimal active auto session. */
+export function _setAutoSessionStateForTest(state: {
+  active?: boolean;
+  paused?: boolean;
+  basePath?: string;
+  originalBasePath?: string;
+  originalThinkingLevel?: ReturnType<ExtensionAPI["getThinkingLevel"]> | null;
+  autoModeStartThinkingLevel?: ReturnType<ExtensionAPI["getThinkingLevel"]> | null;
+  currentMilestoneId?: string | null;
+}): void {
+  if (state.active !== undefined) s.active = state.active;
+  if (state.paused !== undefined) s.paused = state.paused;
+  if (state.basePath !== undefined) s.basePath = state.basePath;
+  if (state.originalBasePath !== undefined) s.originalBasePath = state.originalBasePath;
+  if (state.originalThinkingLevel !== undefined) s.originalThinkingLevel = state.originalThinkingLevel;
+  if (state.autoModeStartThinkingLevel !== undefined) s.autoModeStartThinkingLevel = state.autoModeStartThinkingLevel;
+  if (state.currentMilestoneId !== undefined) s.currentMilestoneId = state.currentMilestoneId;
+}
+
+/** Test-only seam for resetting auto-mode singleton state after behavioural tests. */
+export function _resetAutoSessionForTest(pi?: ExtensionAPI): void {
+  clearUnitTimeout();
+  stopAutoCommandPolling();
+  clearSliceProgressCache();
+  clearActivityLogState();
+  setLevelChangeCallback(null);
+  resetProactiveHealing();
+  restoreProjectRootEnv();
+  restoreMilestoneLockEnv();
+  _resetPendingResolve();
+  if (pi) clearToolBaseline(pi);
+  s.reset();
+}
+
 export function isAutoPaused(): boolean {
   return s.paused;
 }

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1660,6 +1660,7 @@ export async function runUnitPhase(
   }
 
   // Select and apply model (with tier escalation on retry — normal units only)
+  const autoModeStartThinkingLevel = s.autoModeStartThinkingLevel ?? undefined;
   const modelResult = await deps.selectAndApplyModel(
     ctx,
     pi,
@@ -1672,7 +1673,7 @@ export async function runUnitPhase(
     sidecarItem ? undefined : { isRetry, previousTier },
     undefined,
     s.manualSessionModelOverride,
-    s.autoModeStartThinkingLevel,
+    autoModeStartThinkingLevel,
   );
   s.currentUnitRouting =
     modelResult.routing as AutoSession["currentUnitRouting"];
@@ -1687,8 +1688,8 @@ export async function runUnitPhase(
     if (match) {
       const ok = await pi.setModel(match, { persist: false });
       if (ok) {
-        if (s.autoModeStartThinkingLevel) {
-          pi.setThinkingLevel(s.autoModeStartThinkingLevel);
+        if (autoModeStartThinkingLevel) {
+          pi.setThinkingLevel(autoModeStartThinkingLevel);
         }
         s.currentUnitModel = match as AutoSession["currentUnitModel"];
         ctx.ui.notify(`Hook model override: ${match.provider}/${match.id}`, "info");

--- a/src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts
@@ -1,39 +1,303 @@
-import test from "node:test";
+import test, { afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { extractSourceRegion } from "./test-helpers.ts";
 
-const autoSrc = readFileSync(join(import.meta.dirname, "..", "auto.ts"), "utf-8");
-const phasesSrc = readFileSync(join(import.meta.dirname, "..", "auto", "phases.ts"), "utf-8");
+import {
+  _resetAutoSessionForTest,
+  _setAutoSessionStateForTest,
+  stopAuto,
+} from "../auto.ts";
+import { getInFlightToolCount, markToolStart } from "../auto-tool-tracking.ts";
+import { resolveAgentEnd, _resetPendingResolve } from "../auto/resolve.ts";
+import { runUnitPhase } from "../auto/phases.js";
+import type { IterationContext, IterationData, LoopState } from "../auto/types.js";
+import type { LoopDeps } from "../auto/loop-deps.js";
 
-test("stopAuto restores original thinking level", () => {
-  assert.ok(
-    autoSrc.includes("if (pi && s.originalThinkingLevel)"),
-    "auto.ts should conditionally restore original thinking level in stopAuto",
-  );
-  assert.ok(
-    autoSrc.includes("pi.setThinkingLevel(s.originalThinkingLevel)"),
-    "auto.ts should call pi.setThinkingLevel with originalThinkingLevel",
-  );
+afterEach(() => {
+  _resetPendingResolve();
+  _resetAutoSessionForTest();
 });
 
-test("runUnitPhase threads captured thinking level into selectAndApplyModel", () => {
-  const callIdx = phasesSrc.indexOf("deps.selectAndApplyModel(");
-  assert.ok(callIdx > -1, "phases.ts should call selectAndApplyModel");
-  const callBlock = extractSourceRegion(phasesSrc, "deps.selectAndApplyModel(");
-  assert.ok(
-    callBlock.includes("s.autoModeStartThinkingLevel"),
-    "runUnitPhase should pass autoModeStartThinkingLevel to selectAndApplyModel",
-  );
+type ThinkingSnapshot = {
+  mode: "minimal" | "standard" | "full";
+  budgetTokens?: number;
+};
+
+function makeBase(): string {
+  return mkdtempSync(join(tmpdir(), "gsd-thinking-restore-"));
+}
+
+function makeCtx(models: Array<{ provider: string; id: string }> = []) {
+  const notifications: string[] = [];
+  return {
+    notifications,
+    ui: {
+      notify: (message: string) => { notifications.push(message); },
+      setStatus: () => {},
+      setWidget: () => {},
+    },
+    model: { provider: "test-provider", id: "current-model" },
+    modelRegistry: {
+      find: (provider: string, id: string) =>
+        models.find((model) => model.provider === provider && model.id === id),
+      getAvailable: () => models,
+      getProviderAuthMode: () => "apiKey",
+    },
+  } as any;
+}
+
+function makePi() {
+  const thinkingCalls: unknown[] = [];
+  const setModelCalls: unknown[] = [];
+  const callLog: string[] = [];
+  const pi = {
+    callLog,
+    thinkingCalls,
+    setModelCalls,
+    onSendMessage: null as null | (() => void),
+    sendMessage: () => {
+      callLog.push("sendMessage");
+      pi.onSendMessage?.();
+    },
+    setModel: async (...args: unknown[]) => {
+      callLog.push("setModel");
+      setModelCalls.push(args);
+      return true;
+    },
+    setThinkingLevel: (level: unknown) => {
+      callLog.push("setThinkingLevel");
+      thinkingCalls.push(level);
+    },
+    events: { emit: () => {} },
+  } as any;
+  return pi;
+}
+
+function makeSession(basePath: string, thinkingLevel: ThinkingSnapshot | null = null) {
+  return {
+    active: true,
+    verbose: false,
+    stepMode: false,
+    paused: false,
+    basePath,
+    originalBasePath: "",
+    currentMilestoneId: "M001",
+    currentUnit: null,
+    currentUnitRouting: null,
+    currentUnitModel: null,
+    currentDispatchedModelId: null,
+    completedUnits: [],
+    resourceVersionOnStart: null,
+    lastPromptCharCount: undefined,
+    lastBaselineCharCount: undefined,
+    lastBudgetAlertLevel: 0,
+    pendingVerificationRetry: null,
+    pendingCrashRecovery: null,
+    pendingQuickTasks: [],
+    sidecarQueue: [],
+    autoModeStartModel: null,
+    manualSessionModelOverride: null,
+    autoModeStartThinkingLevel: thinkingLevel,
+    unitDispatchCount: new Map<string, number>(),
+    unitLifetimeDispatches: new Map<string, number>(),
+    unitRecoveryCount: new Map<string, number>(),
+    verificationRetryCount: new Map<string, number>(),
+    gitService: null,
+    autoStartTime: Date.now(),
+    checkpointSha: null,
+    lastToolInvocationError: null,
+    lastGitActionFailure: null,
+    lastGitActionStatus: null,
+    cmdCtx: {
+      newSession: () => Promise.resolve({ cancelled: false }),
+      getContextUsage: () => ({ percent: 10, tokens: 1000, limit: 10000 }),
+    },
+    clearTimers: () => {},
+  } as any;
+}
+
+function makeDeps(overrides?: Partial<LoopDeps>): LoopDeps {
+  const baseDeps = {
+    lockBase: () => "/tmp/test-lock",
+    buildSnapshotOpts: () => ({}),
+    stopAuto: async () => {},
+    pauseAuto: async () => {},
+    clearUnitTimeout: () => {},
+    updateProgressWidget: () => {},
+    updateSessionLock: () => {},
+    getLedger: () => ({ units: [] }),
+    closeoutUnit: async () => {},
+    recordOutcome: () => {},
+    writeLock: () => {},
+    captureAvailableSkills: () => {},
+    ensurePreconditions: () => {},
+    updateSliceProgressCache: () => {},
+    selectAndApplyModel: async () => ({ routing: null, appliedModel: null }),
+    startUnitSupervision: () => {},
+    isDbAvailable: () => false,
+    reorderForCaching: (prompt: string) => prompt,
+    getSessionFile: () => "/tmp/session.json",
+    resolveModelId: (id: string, models: any[]) =>
+      models.find((model) => model.id === id || `${model.provider}/${model.id}` === id),
+    emitJournalEvent: () => {},
+  };
+  return { ...baseDeps, ...overrides } as unknown as LoopDeps;
+}
+
+function makeIC(
+  basePath: string,
+  deps: LoopDeps,
+  options?: {
+    thinkingLevel?: ThinkingSnapshot | null;
+    ctx?: ReturnType<typeof makeCtx>;
+    pi?: ReturnType<typeof makePi>;
+  },
+): IterationContext {
+  let seq = 0;
+  return {
+    ctx: options?.ctx ?? makeCtx(),
+    pi: options?.pi ?? makePi(),
+    s: makeSession(basePath, options?.thinkingLevel ?? null),
+    deps,
+    prefs: { safety_harness: { enabled: false } } as any,
+    iteration: 1,
+    flowId: randomUUID(),
+    nextSeq: () => ++seq,
+  };
+}
+
+function makeIterData(overrides?: Partial<IterationData>): IterationData {
+  return {
+    unitType: "hook/review",
+    unitId: "M001/S01/H01",
+    prompt: "do stuff",
+    finalPrompt: "do stuff",
+    pauseAfterUatDispatch: false,
+    state: {
+      phase: "executing",
+      activeMilestone: { id: "M001", title: "Test", status: "active" },
+      activeSlice: { id: "S01", title: "Slice 1" },
+      activeTask: { id: "T01" },
+      registry: [{ id: "M001", status: "active" }],
+      blockers: [],
+    } as any,
+    mid: "M001",
+    midTitle: "Test",
+    isRetry: false,
+    previousTier: undefined,
+    ...overrides,
+  };
+}
+
+async function runPhaseToCompletion(ic: IterationContext, iterData: IterationData): Promise<void> {
+  _resetPendingResolve();
+  const loopState: LoopState = {
+    recentUnits: [{ key: `${iterData.unitType}/${iterData.unitId}` }],
+    stuckRecoveryAttempts: 0,
+    consecutiveFinalizeTimeouts: 0,
+  };
+  const dispatched = new Promise<void>((resolve) => {
+    (ic.pi as ReturnType<typeof makePi>).onSendMessage = resolve;
+  });
+  const phasePromise = runUnitPhase(ic, iterData, loopState);
+  await dispatched;
+  resolveAgentEnd({ messages: [{ role: "assistant" }] });
+  const result = await phasePromise;
+  assert.equal(result.action, "next", JSON.stringify(result));
+}
+
+test("_resetAutoSessionForTest clears external auto-mode state", () => {
+  markToolStart("tool-call-1", true, "bash");
+  assert.equal(getInFlightToolCount(), 1);
+
+  _resetAutoSessionForTest();
+
+  assert.equal(getInFlightToolCount(), 0);
 });
 
-test("hook model override preserves captured thinking level", () => {
-  const hookIdx = phasesSrc.indexOf("const hookModelOverride = sidecarItem?.model ?? iterData.hookModelOverride;");
-  assert.ok(hookIdx > -1, "phases.ts should include hook model override handling");
-  const hookBlock = extractSourceRegion(phasesSrc, "const hookModelOverride = sidecarItem?.model ?? iterData.hookModelOverride;");
-  assert.ok(
-    hookBlock.includes("pi.setThinkingLevel(s.autoModeStartThinkingLevel)"),
-    "hook model override should re-apply captured thinking level after setModel",
-  );
+test("stopAuto restores the original thinking level", async () => {
+  const base = makeBase();
+  const pi = makePi();
+  const ctx = makeCtx();
+  const originalThinking: ThinkingSnapshot = { mode: "standard", budgetTokens: 4096 };
+  try {
+    _setAutoSessionStateForTest({
+      active: true,
+      basePath: base,
+      originalThinkingLevel: originalThinking as any,
+      currentMilestoneId: null,
+    });
+
+    await stopAuto(ctx, pi, "test-stop");
+
+    assert.deepEqual(pi.thinkingCalls, [originalThinking]);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("runUnitPhase threads captured thinking level into selectAndApplyModel", async () => {
+  const base = makeBase();
+  const capturedThinking: unknown[] = [];
+  const startThinking: ThinkingSnapshot = { mode: "full", budgetTokens: 8192 };
+  try {
+    const deps = makeDeps({
+      selectAndApplyModel: async (...args) => {
+        capturedThinking.push(args[11]);
+        return { routing: null, appliedModel: null };
+      },
+    });
+    const ic = makeIC(base, deps, { thinkingLevel: startThinking });
+
+    await runPhaseToCompletion(ic, makeIterData());
+
+    assert.deepEqual(capturedThinking, [startThinking]);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("runUnitPhase passes undefined when no thinking level was captured", async () => {
+  const base = makeBase();
+  const capturedThinking: unknown[] = [];
+  try {
+    const deps = makeDeps({
+      selectAndApplyModel: async (...args) => {
+        capturedThinking.push(args[11]);
+        return { routing: null, appliedModel: null };
+      },
+    });
+    const ic = makeIC(base, deps);
+
+    await runPhaseToCompletion(ic, makeIterData());
+
+    assert.deepEqual(capturedThinking, [undefined]);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("hook model override reapplies the captured thinking level after setModel", async () => {
+  const base = makeBase();
+  const startThinking: ThinkingSnapshot = { mode: "minimal", budgetTokens: 1024 };
+  const hookModel = { provider: "test-provider", id: "hook-model" };
+  const ctx = makeCtx([hookModel]);
+  const pi = makePi();
+  try {
+    const deps = makeDeps({
+      selectAndApplyModel: async () => ({ routing: null, appliedModel: null }),
+    });
+    const ic = makeIC(base, deps, { thinkingLevel: startThinking, ctx, pi });
+
+    await runPhaseToCompletion(ic, makeIterData({ hookModelOverride: "hook-model" }));
+
+    assert.deepEqual(pi.setModelCalls[0], [hookModel, { persist: false }]);
+    assert.deepEqual(pi.thinkingCalls, [startThinking]);
+    assert.deepEqual(pi.callLog.slice(0, 2), ["setModel", "setThinkingLevel"]);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Linked issue

Closes #4964

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Replace source-grep coverage in `auto-thinking-restore.test.ts` with runtime behavior tests.
**Why:** The old tests inspected source text instead of exercising the behavior they claimed to protect.
**How:** Add a small test-only auto-session seam and verify thinking restoration, phase routing, and hook override behavior through real calls.

## What

This rewrites `auto-thinking-restore.test.ts` so it no longer reads source files or asserts on implementation text. The replacement tests drive the public runtime paths around `stopAuto` and `runUnitPhase` using lightweight fakes.

A test-only reset/session-state seam was added to `auto.ts` so the behavior tests can set up minimal active auto-mode state without depending on source inspection.

## Why

Issue #4964 calls out that the previous test was pure source-grep coverage. That made it possible for the test to pass without proving that captured thinking levels are restored or threaded through runtime behavior.

## How

The new tests verify three behaviors directly:

1. `stopAuto` restores the original thinking level.
2. `runUnitPhase` passes the captured auto-mode thinking level into model selection.
3. A hook model override reapplies the captured thinking level after changing models.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts`
2. `rg -n "readFileSync|extractSourceRegion|autoSrc|phasesSrc|\.includes\(|indexOf\(" src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts` returned no matches
3. `npm run build`
4. `npm run typecheck:extensions`
5. `npm run test:unit`
6. `npm run test:integration`
7. `npm run verify:pr`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for auto-session behavior with improved isolation and runtime-based validations for thinking-level and model restore behavior.
  * Added test-only utilities to control and fully reset auto-session state during tests, enabling more reliable cleanup and deterministic test flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->