### PR TITLE
fix(gsd): classify stream INTERNAL_ERROR as transient

### DIFF
--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -59,7 +59,7 @@ const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|fet
 // Context overflow errors (context window/length exceeded) should be treated as server-class
 // transient errors so auto-mode can retry with reduced budget or fall back to a larger-context model.
 // See: https://github.com/gsd-build/gsd-2/issues/4528
-const SERVER_RE = /internal server error|500|502|503|overloaded|server_error|api_error|service.?unavailable|context (?:window|length) exceed|context window exceed/i;
+const SERVER_RE = /internal(?: server)?[ _-]?error|500|502|503|overloaded|server_error|api_error|service.?unavailable|context (?:window|length) exceed|context window exceed/i;
 // ECONNRESET/ECONNREFUSED are in NETWORK_RE (same-model retry first).
 const CONNECTION_RE = /terminated|connection.?(?:refused|error)|other side closed|EPIPE|network.?(?:is\s+)?unavailable|stream_exhausted(?:_without_result)?/i;
 // Catch-all for V8 JSON.parse errors: all modern variants end with "in JSON at position \d+".

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -103,6 +103,13 @@ test("classifyError detects Codex server_error from extracted message", () => {
   assert.ok("retryAfterMs" in result && result.retryAfterMs === 30_000);
 });
 
+test("classifyError detects stream INTERNAL_ERROR received from peer as transient server", () => {
+  const result = classifyError("stream error: stream ID 75; INTERNAL_ERROR; received from peer");
+  assert.ok(isTransient(result));
+  assert.equal(result.kind, "server");
+  assert.ok("retryAfterMs" in result && result.retryAfterMs === 30_000);
+});
+
 test("classifyError detects overloaded error", () => {
   const result = classifyError("overloaded_error: Overloaded");
   assert.ok(isTransient(result));


### PR DESCRIPTION
## Linked issue

Closes #5013

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Classify provider stream `INTERNAL_ERROR` reset messages as transient server errors.
**Why:** Auto-mode was routing those recoverable provider resets through the unknown/permanent pause path.
**How:** Broaden the existing server-error classifier to match `internal_error` / `INTERNAL_ERROR` variants and add a regression test for the observed stream reset shape.

## What

This updates the GSD provider error classifier in `src/resources/extensions/gsd/error-classifier.ts` so internal server-error strings with spaces, underscores, or hyphens are treated as server-class transient errors.

It also adds a regression test in `src/resources/extensions/gsd/tests/provider-errors.test.ts` for:

```text
stream error: stream ID 75; INTERNAL_ERROR; received from peer
```

## Why

When an OpenAI-compatible streaming provider resets an in-flight stream with `INTERNAL_ERROR`, `classifyError(...)` previously returned `unknown`. The auto-mode recovery path treats unknown/permanent provider errors as indefinite provider pauses instead of allowing the existing transient retry/backoff/resume handling to take over.

Related but distinct issues:

- #4693 covers completion-state reconciliation after a provider stream fails around task completion.
- #4707 covers broader provider 500 / empty-stream handling.

This PR fixes the narrow classifier miss for `INTERNAL_ERROR` transport reset strings.

## How

The existing `SERVER_RE` already handled `internal server error`, numeric 5xx responses, `server_error`, and similar transient provider conditions. This change folds the internal-error variants into that same server class with:

```text
internal(?: server)?[ _-]?error
```

That keeps the fix small, provider-agnostic, and aligned with the existing classifier behavior rather than adding a new recovery path.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated and focused checks run locally:

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/provider-errors.test.ts`
  - Before the classifier change, the new regression failed on `assert.ok(isTransient(result))`.
  - After the classifier change, it passed: 78 passed, 0 failed.
- `npm run build` — passed.
- `npm run typecheck:extensions` — passed.
- `npm run test:unit` — passed: 7858 passed, 0 failed, 9 skipped.
- `npm run verify:pr` — passed: `build:core`, `typecheck:extensions`, and `test:unit` completed successfully; unit result 7858 passed, 0 failed, 9 skipped.
- `npm run secret-scan` — passed: no secrets detected.

Additional wider-suite note:

- `npm run test:integration` was attempted but interrupted after a quiet stall in the existing `src/resources/extensions/async-jobs/await-tool.test.ts` process, outside the changed classifier path. The PR-specific regression and `verify:pr` coverage are green.

## AI disclosure

- [x] This PR includes AI-assisted code

This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and classification of server-related errors to be properly routed through retry and fallback mechanisms.

* **Tests**
  * Added test coverage for additional error message patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->