### PR TITLE
fix(pi-coding-agent,gsd): preserve Anthropic prompt cache (#5019)

### DIFF
--- a/packages/pi-coding-agent/src/core/system-prompt.ts
+++ b/packages/pi-coding-agent/src/core/system-prompt.ts
@@ -55,6 +55,19 @@ export interface BuildSystemPromptOptions {
 	 * exception and the session stays consistent.
 	 */
 	skillFilter?: (skill: Skill) => boolean;
+	/**
+	 * Append a `Current date and time: <toLocaleString>` line to the system
+	 * prompt. Default: `false`.
+	 *
+	 * Anthropic prompt caching matches on byte-for-byte prefix equality.
+	 * Embedding a per-call timestamp in the system prompt invalidates the
+	 * cache on every request, forcing a full re-write that costs *more*
+	 * than an uncached call (cache-write premium). Most agentic flows do
+	 * not need wall-clock awareness in the system prompt — opt in only
+	 * when the consumer genuinely needs it (e.g. a clock-sensitive agent),
+	 * and inject it via a non-cached channel (user message) when possible.
+	 */
+	includeDateTime?: boolean;
 }
 
 /** Build the system prompt with tools, guidelines, and context */
@@ -69,20 +82,25 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		contextFiles: providedContextFiles,
 		skills: providedSkills,
 		skillFilter,
+		includeDateTime = false,
 	} = options;
 	const resolvedCwd = toPosixPath(cwd ?? process.cwd());
 
-	const now = new Date();
-	const dateTime = now.toLocaleString("en-US", {
-		weekday: "long",
-		year: "numeric",
-		month: "long",
-		day: "numeric",
-		hour: "2-digit",
-		minute: "2-digit",
-		second: "2-digit",
-		timeZoneName: "short",
-	});
+	// Per-call timestamps invalidate Anthropic prompt caching (the cache
+	// matches on byte-for-byte prefix equality). Compute lazily and only
+	// when explicitly opted in via `includeDateTime`.
+	const dateTimeLine = includeDateTime
+		? `\nCurrent date and time: ${new Date().toLocaleString("en-US", {
+			weekday: "long",
+			year: "numeric",
+			month: "long",
+			day: "numeric",
+			hour: "2-digit",
+			minute: "2-digit",
+			second: "2-digit",
+			timeZoneName: "short",
+		})}`
+		: "";
 
 	const appendSection = appendSystemPrompt ? `\n\n${appendSystemPrompt}` : "";
 
@@ -124,8 +142,8 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 			prompt += formatSkillsForPrompt(skills);
 		}
 
-		// Add date/time and working directory last
-		prompt += `\nCurrent date and time: ${dateTime}`;
+		// Add date/time (only when opted in — see includeDateTime docs) and working directory last
+		prompt += dateTimeLine;
 		prompt += `\nCurrent working directory: ${resolvedCwd}`;
 
 		// Append promptGuidelines from extension-registered tools.
@@ -272,8 +290,8 @@ Pi documentation (read only when the user asks about pi itself, its SDK, extensi
 		prompt += formatSkillsForPrompt(skills);
 	}
 
-	// Add date/time and working directory last
-	prompt += `\nCurrent date and time: ${dateTime}`;
+	// Add date/time (only when opted in — see includeDateTime docs) and working directory last
+	prompt += dateTimeLine;
 	prompt += `\nCurrent working directory: ${resolvedCwd}`;
 
 	return prompt;

--- a/packages/pi-coding-agent/src/tests/system-prompt-cache-stability.test.ts
+++ b/packages/pi-coding-agent/src/tests/system-prompt-cache-stability.test.ts
@@ -1,0 +1,102 @@
+// @gsd/pi-coding-agent + system-prompt-cache-stability.test — regression
+// coverage for #5019. The system prompt must NOT include a per-call timestamp
+// by default; embedding `Date.toLocaleString()` in the cached prefix
+// invalidates Anthropic prompt-cache hits on every request and incurs the
+// cache-write premium. The opt-in `includeDateTime` flag preserves the prior
+// behavior for callers that explicitly want clock awareness.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildSystemPrompt } from "../core/system-prompt.js";
+
+// ─── Default branch (no customPrompt) ──────────────────────────────────────
+
+test("buildSystemPrompt: default omits 'Current date and time' line", () => {
+	const prompt = buildSystemPrompt({ selectedTools: ["read", "edit"] });
+	assert.ok(
+		!prompt.includes("Current date and time:"),
+		`prompt should not include the dateTime line by default. Got:\n${prompt}`,
+	);
+});
+
+test("buildSystemPrompt: includeDateTime=true emits 'Current date and time' line", () => {
+	const prompt = buildSystemPrompt({
+		selectedTools: ["read", "edit"],
+		includeDateTime: true,
+	});
+	assert.match(
+		prompt,
+		/Current date and time: /,
+		"prompt should include the dateTime line when explicitly opted in",
+	);
+});
+
+test("buildSystemPrompt: includeDateTime=false explicit also omits the line", () => {
+	const prompt = buildSystemPrompt({
+		selectedTools: ["read", "edit"],
+		includeDateTime: false,
+	});
+	assert.ok(!prompt.includes("Current date and time:"));
+});
+
+// ─── Custom-prompt branch ──────────────────────────────────────────────────
+
+test("buildSystemPrompt (customPrompt): default omits 'Current date and time' line", () => {
+	const prompt = buildSystemPrompt({
+		customPrompt: "CUSTOM BASE",
+		selectedTools: ["read"],
+	});
+	assert.ok(!prompt.includes("Current date and time:"));
+});
+
+test("buildSystemPrompt (customPrompt): includeDateTime=true emits the line", () => {
+	const prompt = buildSystemPrompt({
+		customPrompt: "CUSTOM BASE",
+		selectedTools: ["read"],
+		includeDateTime: true,
+	});
+	assert.match(prompt, /Current date and time: /);
+});
+
+// ─── Cache-stability invariant ─────────────────────────────────────────────
+
+test("buildSystemPrompt: two back-to-back default calls produce identical prompts", async () => {
+	// The bug: the previous default-on `dateTime` line included `second: "2-digit"`,
+	// so two calls within the same second could match but any longer gap busted
+	// the cache. Asserting equality across a deliberate sub-second sleep proves
+	// the byte-for-byte stability that Anthropic prompt caching requires.
+	const first = buildSystemPrompt({ selectedTools: ["read", "edit"], cwd: "/tmp/example" });
+	await new Promise((resolve) => setTimeout(resolve, 1100));
+	const second = buildSystemPrompt({ selectedTools: ["read", "edit"], cwd: "/tmp/example" });
+	assert.equal(
+		first,
+		second,
+		"system prompt must be byte-for-byte stable across calls so the prompt cache can hit",
+	);
+});
+
+test("buildSystemPrompt: includeDateTime=true intentionally produces different prompts across the second boundary", async () => {
+	// Inverse of the cache-stability test: when callers opt in, the dateTime
+	// line is expected to vary. This documents the trade-off the flag exists
+	// to surface.
+	const first = buildSystemPrompt({
+		selectedTools: ["read"],
+		cwd: "/tmp/example",
+		includeDateTime: true,
+	});
+	await new Promise((resolve) => setTimeout(resolve, 1100));
+	const second = buildSystemPrompt({
+		selectedTools: ["read"],
+		cwd: "/tmp/example",
+		includeDateTime: true,
+	});
+	assert.notEqual(first, second, "opt-in dateTime is expected to vary across the second boundary");
+});
+
+// ─── Cwd preservation ──────────────────────────────────────────────────────
+
+test("buildSystemPrompt: 'Current working directory' line is preserved (only dateTime is removed)", () => {
+	const prompt = buildSystemPrompt({ selectedTools: ["read"], cwd: "/tmp/example" });
+	assert.match(prompt, /Current working directory: \/tmp\/example/);
+});

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -207,7 +207,14 @@ export async function buildBeforeAgentStartResult(
     ? `\n\n## Subagent Model\n\nWhen spawning subagents via the \`subagent\` tool, always pass \`model: "${subagentModelConfig.primary}"\` in the tool call parameters. Never omit this — always specify it explicitly.`
     : "";
 
-  const fullSystem = `${event.systemPrompt}\n\n[SYSTEM CONTEXT — GSD]\n\n${systemContent}${preferenceBlock}${knowledgeBlock}${codebaseBlock}${memoryBlock}${newSkillsBlock}${worktreeBlock}${subagentModelBlock}`;
+  // memoryBlock is FTS-queried against the user prompt and changes per call.
+  // Removing it from `fullSystem` keeps the system-prompt cache breakpoint
+  // stable across calls — the only scoped goal of this fix. The pi-ai
+  // Anthropic adapter additionally cache-marks the last user turn, so the
+  // memoryBlock injected via the context message may itself be cached up to
+  // that boundary; that's orthogonal and unchanged from prior behavior. The
+  // load-bearing win here is preserving the system+tools cache hit. (#5019)
+  const fullSystem = `${event.systemPrompt}\n\n[SYSTEM CONTEXT — GSD]\n\n${systemContent}${preferenceBlock}${knowledgeBlock}${codebaseBlock}${newSkillsBlock}${worktreeBlock}${subagentModelBlock}`;
 
   stopContextTimer({
     systemPromptSize: fullSystem.length,
@@ -216,17 +223,41 @@ export async function buildBeforeAgentStartResult(
     hasNewSkills: newSkillsBlock.length > 0,
   });
 
-  // Determine which context message to inject (guided execute takes priority)
-  const contextMessage = injection
-    ? { customType: "gsd-guided-context", content: injection, display: false as const }
-    : forensicsInjection
-      ? { customType: "gsd-forensics", content: forensicsInjection, display: false as const }
-      : null;
+  const contextMessage = buildContextMessage({ memoryBlock, injection, forensicsInjection });
 
   return {
     systemPrompt: fullSystem,
     ...(contextMessage ? { message: contextMessage } : {}),
   };
+}
+
+/**
+ * Route the per-call dynamic blocks (memory, guided-execute, forensics) into a
+ * single user-message context payload so they ride the volatile suffix instead
+ * of the cached system prefix. Priority when both memory and an injection are
+ * present: guided > forensics > memory-only. (#5019)
+ *
+ * Exported for direct unit testing — the surrounding bootstrap has too many
+ * filesystem and DB dependencies to exercise this routing logic in-place.
+ */
+export function buildContextMessage(opts: {
+  memoryBlock: string;
+  injection: string | null;
+  forensicsInjection: string | null;
+}): { customType: string; content: string; display: false } | null {
+  const memoryContent = opts.memoryBlock.trim();
+  if (opts.injection) {
+    const content = memoryContent ? `${memoryContent}\n\n${opts.injection}` : opts.injection;
+    return { customType: "gsd-guided-context", content, display: false as const };
+  }
+  if (opts.forensicsInjection) {
+    const content = memoryContent ? `${memoryContent}\n\n${opts.forensicsInjection}` : opts.forensicsInjection;
+    return { customType: "gsd-forensics", content, display: false as const };
+  }
+  if (memoryContent) {
+    return { customType: "gsd-memory", content: memoryContent, display: false as const };
+  }
+  return null;
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/system-context-message-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/system-context-message-routing.test.ts
@@ -1,0 +1,101 @@
+// GSD bootstrap + system-context-message-routing.test — regression coverage
+// for #5019. `memoryBlock` is FTS-queried against the user prompt and changes
+// per call; embedding it in the cached system prefix invalidates Anthropic
+// prompt-cache hits on every request. The fix routes memory through the
+// existing context-message channel (volatile user-message suffix) and combines
+// it with any active guided-execute or forensics injection.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildContextMessage } from "../bootstrap/system-context.ts";
+
+describe("buildContextMessage (#5019 — memory routing)", () => {
+  test("returns null when nothing to inject", () => {
+    const result = buildContextMessage({
+      memoryBlock: "",
+      injection: null,
+      forensicsInjection: null,
+    });
+    assert.equal(result, null);
+  });
+
+  test("whitespace-only memoryBlock counts as empty", () => {
+    const result = buildContextMessage({
+      memoryBlock: "   \n\n   ",
+      injection: null,
+      forensicsInjection: null,
+    });
+    assert.equal(result, null);
+  });
+
+  test("memory-only path emits gsd-memory message with trimmed content", () => {
+    const result = buildContextMessage({
+      memoryBlock: "\n\n[MEMORY]\nrule one\nrule two\n\n",
+      injection: null,
+      forensicsInjection: null,
+    });
+    assert.ok(result, "expected a context message");
+    assert.equal(result.customType, "gsd-memory");
+    assert.equal(result.content, "[MEMORY]\nrule one\nrule two");
+    assert.equal(result.display, false);
+  });
+
+  test("guided-execute injection alone emits gsd-guided-context", () => {
+    const result = buildContextMessage({
+      memoryBlock: "",
+      injection: "[GUIDED]\nexecute T01",
+      forensicsInjection: null,
+    });
+    assert.ok(result);
+    assert.equal(result.customType, "gsd-guided-context");
+    assert.equal(result.content, "[GUIDED]\nexecute T01");
+  });
+
+  test("forensics injection alone emits gsd-forensics", () => {
+    const result = buildContextMessage({
+      memoryBlock: "",
+      injection: null,
+      forensicsInjection: "[FORENSICS]\ninvestigation context",
+    });
+    assert.ok(result);
+    assert.equal(result.customType, "gsd-forensics");
+    assert.equal(result.content, "[FORENSICS]\ninvestigation context");
+  });
+
+  test("memory + guided injection: memory prepended, customType is gsd-guided-context", () => {
+    const result = buildContextMessage({
+      memoryBlock: "[MEMORY]\nrule one",
+      injection: "[GUIDED]\nexecute T01",
+      forensicsInjection: null,
+    });
+    assert.ok(result);
+    assert.equal(result.customType, "gsd-guided-context");
+    assert.equal(result.content, "[MEMORY]\nrule one\n\n[GUIDED]\nexecute T01");
+  });
+
+  test("memory + forensics: memory prepended, customType is gsd-forensics", () => {
+    const result = buildContextMessage({
+      memoryBlock: "[MEMORY]\nrule one",
+      injection: null,
+      forensicsInjection: "[FORENSICS]\ninvestigation context",
+    });
+    assert.ok(result);
+    assert.equal(result.customType, "gsd-forensics");
+    assert.equal(result.content, "[MEMORY]\nrule one\n\n[FORENSICS]\ninvestigation context");
+  });
+
+  test("guided takes precedence over forensics when both are somehow present", () => {
+    // The caller in buildBeforeAgentStartResult already gates forensics on
+    // `!injection`, but the helper's documented priority is guided > forensics.
+    // Test the contract directly so a future refactor can't silently flip it.
+    const result = buildContextMessage({
+      memoryBlock: "",
+      injection: "[GUIDED]",
+      forensicsInjection: "[FORENSICS]",
+    });
+    assert.ok(result);
+    assert.equal(result.customType, "gsd-guided-context");
+    assert.equal(result.content, "[GUIDED]");
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Stop two specific code paths from invalidating Anthropic prompt caching on every API call.
**Why:** Each cache-miss with `cache_control` set costs *more* than an uncached call (cache-write premium); the cached system prefix is currently rewritten on every request despite the breakpoints being correctly placed.
**How:** Gate the per-call timestamp behind a new opt-in `includeDateTime` option, and move the per-call `memoryBlock` (FTS-queried against the user prompt) out of the cached system prefix into the existing context-message channel.

Closes #5019

## What

Two surgical changes plus a small extracted helper, plus regression tests.

**`packages/pi-coding-agent/src/core/system-prompt.ts`**
- Add `includeDateTime?: boolean` to `BuildSystemPromptOptions`, default `false`.
- Compute the `Current date and time:` line lazily and only when explicitly opted in.
- Both branches (customPrompt + default) now emit the line conditionally.
- `Current working directory:` stays in the prompt — it's stable per session.

**`src/resources/extensions/gsd/bootstrap/system-context.ts`**
- Remove `${memoryBlock}` from the `fullSystem` string concatenation.
- Extract a small exported `buildContextMessage` helper (3 mutually exclusive routing branches: guided > forensics > memory-only) that combines memory with any active guided-execute or forensics injection.
- Memory now reaches the model via the context-message channel instead of the cached system prefix.

**Tests**
- `packages/pi-coding-agent/src/tests/system-prompt-cache-stability.test.ts` — 8 tests covering the `includeDateTime` gate (default off, opt-in on, customPrompt branch), the cache-stability invariant (two calls 1.1s apart produce identical prompts), and the inverse (opt-in produces different prompts across the second boundary).
- `src/resources/extensions/gsd/tests/system-context-message-routing.test.ts` — 8 tests covering every routing case in `buildContextMessage`.
- All 16 new tests pass.

## Why

A token-savings audit identified that Anthropic prompt caching was effectively disabled on every API call from this codebase, despite `cache_control` breakpoints being correctly placed. Two specific lines were the cause:

1. `buildSystemPrompt` appended `new Date().toLocaleString()` (with `second: "2-digit"` precision) to the system prompt unconditionally. The cache breakpoint sits on the system prompt block → it changed every call → 0% cache hit rate on the system + tools prefix.
2. `buildBeforeAgentStartResult` concatenated `loadMemoryBlock(event.prompt)` — an FTS query against the current user prompt — into `fullSystem` between two stable blocks.

A cache miss with `cache_control` set is more expensive than an uncached call because of the cache-write premium (~1.25× base for the 5-minute TTL). The codebase was paying the write premium on every request without ever earning a cache hit.

Conservative per-session estimates for ~5K stable system+tools prefix over a 50-turn session, current Anthropic pricing:
- Opus ($5/$25 input/output, $6.25 cache write, $0.50 cache read): ~$1.40 wasted/session
- Sonnet ($3/$15, $3.75/$0.30): ~$0.84/session
- Haiku ($1/$5, $1.25/$0.10): ~$0.28/session

These compound across every active session.

## How

### Fix #1 — `includeDateTime` gate

```ts
const dateTimeLine = includeDateTime
  ? `\nCurrent date and time: ${new Date().toLocaleString("en-US", { ... })}`
  : "";

// later, in both branches:
prompt += dateTimeLine;            // empty string when not opted in
prompt += `\nCurrent working directory: ${resolvedCwd}`;
```

### Fix #2 — extract `buildContextMessage`

The original caller had inline ternary routing between guided-execute and forensics injection. The fix extends this to 3 cases (guided > forensics > memory-only) and combines memory with any active injection.

```ts
const contextMessage = buildContextMessage({ memoryBlock, injection, forensicsInjection });
```

Extracted as exported function to enable direct unit tests — the surrounding `buildBeforeAgentStartResult` has too many filesystem and DB dependencies to exercise the routing logic in-place.

### Cache-fix correctness

The `pi-ai` Anthropic adapter cache-marks the last user turn as well as the system prompt block, so the context message carrying memoryBlock may itself be cache-marked. That's orthogonal and unchanged from prior behavior — the load-bearing win here is preserving the **system+tools cache hit**, which was 0% before this fix.

## Considerations and trade-offs

**Default behavior change for `buildSystemPrompt`.** This is a public API of `pi-coding-agent`. Previously the timestamp was always emitted; now it's opt-in. Most agentic flows do not need wall-clock awareness in the system prompt — and the cost of leaving it on is a cache miss on every request. Callers that genuinely need clock awareness should pass `includeDateTime: true` (and ideally inject the timestamp via a non-cached channel anyway). I'm flagging this explicitly so reviewers can decide whether to flip the default to `true` and have `system-context.ts` opt out instead — the cache fix would then only apply to GSD's call path. As implemented, the default is `false` because the cache-friendly path is the correct default for an agentic system.

**Future `buildBeforeAgentStartResult` integration test.** The new tests cover the extracted `buildContextMessage` helper directly, not the full integration through `buildBeforeAgentStartResult` (which has FTS/DB dependencies). A future test could inject a sentinel memoryBlock, call `buildBeforeAgentStartResult`, and assert the sentinel appears in `message.content` not `systemPrompt` — worth filing as a follow-up.

**Other cache vectors not addressed in this PR (separate follow-up):**
- Cache-hit/miss telemetry instrumentation
- Cache breakpoint after the compaction summary block
- MCP tool alias removal (~2,750 tokens cold-start)

These will land in a separate PR per "one concern per PR".

## Test plan

- [x] `npm run verify:pr` passes (build:core → typecheck:extensions → test:unit)
- [x] All 16 new regression tests pass
- [x] No source-grep tests; tests execute the actual code under test
- [x] Pre-existing unrelated failure (ADR-012 allowlist staleness) is on files this PR doesn't touch — flagged here for visibility only

```
✖ ADR-012: no stale entries in ALLOWED_FILES (pre-existing on main, files not modified by this PR)
✔ 7861 passed, 1 failed (unrelated), 9 skipped
```

## Change type

- [x] `fix` — Bug fix (cache-busting performance regression)

## Notes

This is an AI-assisted PR. All code is reviewed by the contributor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `includeDateTime` option to control timestamp inclusion in system prompts; disabled by default for improved consistency.

* **Bug Fixes**
  * Improved system prompt caching by removing per-call dynamic timestamps.
  * Refactored context message routing for better organization and reliability.

* **Tests**
  * Added regression test suites for prompt cache stability and context message routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->