### PR TITLE
fix(gsd): guard milestone self-merge

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -46,7 +46,12 @@ import {
   resolveGitHeadPath,
   nudgeGitBranchCache,
 } from "./worktree.js";
-import { MergeConflictError, readIntegrationBranch, RUNTIME_EXCLUSION_PATHS } from "./git-service.js";
+import {
+  MergeConflictError,
+  isValidIntegrationBranchName,
+  resolveMilestoneIntegrationBranch,
+  RUNTIME_EXCLUSION_PATHS,
+} from "./git-service.js";
 import { debugLog } from "./debug-logger.js";
 import { logWarning, logError } from "./workflow-logger.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
@@ -990,6 +995,39 @@ export function autoWorktreeBranch(milestoneId: string): string {
   return `milestone/${milestoneId}`;
 }
 
+function resolveSafeIntegrationStartPoint(
+  basePath: string,
+  milestoneId: string,
+  gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git ?? {},
+): string {
+  const resolved = resolveMilestoneIntegrationBranch(basePath, milestoneId, gitPrefs);
+  if (resolved.effectiveBranch) return resolved.effectiveBranch;
+
+  const prefBranch = gitPrefs.main_branch;
+  if (
+    prefBranch &&
+    isValidIntegrationBranchName(prefBranch) &&
+    nativeBranchExists(basePath, prefBranch)
+  ) {
+    return prefBranch;
+  }
+
+  const detectedBranch = nativeDetectMainBranch(basePath);
+  if (
+    detectedBranch &&
+    isValidIntegrationBranchName(detectedBranch) &&
+    nativeBranchExists(basePath, detectedBranch)
+  ) {
+    return detectedBranch;
+  }
+
+  throw new GSDError(
+    GSD_GIT_ERROR,
+    `Cannot resolve a safe integration branch for milestone ${milestoneId}. ` +
+      `Milestone branches cannot be used as integration targets; set git.main_branch to a real branch and retry.`,
+  );
+}
+
 // ─── Branch-mode Entry ─────────────────────────────────────────────────────
 
 /**
@@ -1013,23 +1051,7 @@ export function enterBranchModeForMilestone(
 
   if (!branchExists) {
     // Create the milestone branch from the integration branch start-point.
-    const integrationBranch =
-      readIntegrationBranch(basePath, milestoneId) ?? undefined;
-    const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git;
-    // Validate main_branch preference exists in the repo before using it —
-    // a stale preference (e.g. "master" when repo uses "main") would cause
-    // nativeBranchForceReset to fail with a bad start-point reference.
-    const validatedPrefBranch =
-      gitPrefs?.main_branch &&
-      typeof gitPrefs.main_branch === "string" &&
-      gitPrefs.main_branch.length > 0 &&
-      nativeBranchExists(basePath, gitPrefs.main_branch)
-        ? gitPrefs.main_branch
-        : undefined;
-    const startPoint =
-      integrationBranch ??
-      validatedPrefBranch ??
-      nativeDetectMainBranch(basePath);
+    const startPoint = resolveSafeIntegrationStartPoint(basePath, milestoneId);
 
     // TOCTOU ancestry guard (Issue #4980 HIGH-3).
     //
@@ -1229,10 +1251,7 @@ export function createAutoWorktree(
     //   3. nativeDetectMainBranch (origin/HEAD auto-detection)
     // Without tier 2, projects with main_branch=dev but origin/HEAD→master
     // would fork worktrees from the wrong (stale) branch.
-    const integrationBranch =
-      readIntegrationBranch(basePath, milestoneId) ?? undefined;
-    const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git;
-    const startPoint = integrationBranch ?? gitPrefs?.main_branch ?? undefined;
+    const startPoint = resolveSafeIntegrationStartPoint(basePath, milestoneId);
     info = createWorktree(basePath, milestoneId, {
       branch,
       startPoint,
@@ -1559,6 +1578,25 @@ function autoCommitDirtyState(cwd: string): boolean {
   }
 }
 
+function verifyNoopMergePostcondition(
+  basePath: string,
+  mainBranch: string,
+  milestoneBranch: string,
+): void {
+  const numstat = nativeDiffNumstat(basePath, mainBranch, milestoneBranch);
+  const codeChanges = numstat.filter(
+    (entry) => !entry.path.startsWith(".gsd/"),
+  );
+  if (codeChanges.length > 0) {
+    throw new GSDError(
+      GSD_GIT_ERROR,
+      `Squash merge produced nothing to commit but milestone branch "${milestoneBranch}" ` +
+        `has ${codeChanges.length} code file(s) not on "${mainBranch}". ` +
+        `Aborting worktree teardown to prevent data loss.`,
+    );
+  }
+}
+
 /**
  * Squash-merge the milestone branch into main with a rich commit message
  * listing all completed slices, then tear down the worktree.
@@ -1654,17 +1692,16 @@ export function mergeMilestoneToMain(
   //    "main": repos using "master" or a custom default branch would fail at
   //    checkout and leave the user with a broken merge state (#1668).
   const prefs = loadEffectiveGSDPreferences()?.preferences?.git ?? {};
-  const integrationBranch = readIntegrationBranch(
-    originalBasePath_,
-    milestoneId,
-  );
-  // Validate prefs.main_branch exists before using it — a stale preference
-  // (e.g. "master" when repo uses "main") causes merge failure (#3589).
-  const validatedPrefBranch = prefs.main_branch && nativeBranchExists(originalBasePath_, prefs.main_branch)
-    ? prefs.main_branch
-    : undefined;
-  const mainBranch =
-    integrationBranch ?? validatedPrefBranch ?? nativeDetectMainBranch(originalBasePath_);
+  const mainBranch = resolveSafeIntegrationStartPoint(originalBasePath_, milestoneId, prefs);
+
+  if (mainBranch === milestoneBranch) {
+    process.chdir(previousCwd);
+    throw new GSDError(
+      GSD_GIT_ERROR,
+      `Resolved integration branch "${mainBranch}" is the same as milestone branch "${milestoneBranch}". ` +
+        `Refusing to merge a milestone branch into itself. Repair the milestone integration branch metadata or git.main_branch before retrying.`,
+    );
+  }
 
   // Remove transient project-root state files before any branch or merge
   // operation. Untracked milestone metadata can otherwise block squash merges.
@@ -2139,23 +2176,11 @@ export function mergeMilestoneToMain(
   // Compare only non-.gsd/ paths — .gsd/ state files diverge normally and
   // are auto-resolved during the squash merge.
   if (nothingToCommit) {
-    const numstat = nativeDiffNumstat(
-      originalBasePath_,
-      mainBranch,
-      milestoneBranch,
-    );
-    const codeChanges = numstat.filter(
-      (entry) => !entry.path.startsWith(".gsd/"),
-    );
-    if (codeChanges.length > 0) {
-      // Milestone has unanchored code changes — abort teardown.
+    try {
+      verifyNoopMergePostcondition(originalBasePath_, mainBranch, milestoneBranch);
+    } catch (err) {
       process.chdir(previousCwd);
-      throw new GSDError(
-        GSD_GIT_ERROR,
-        `Squash merge produced nothing to commit but milestone branch "${milestoneBranch}" ` +
-          `has ${codeChanges.length} code file(s) not on "${mainBranch}". ` +
-          `Aborting worktree teardown to prevent data loss.`,
-      );
+      throw err;
     }
   }
 

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -105,6 +105,21 @@ export interface GitPreferences {
 
 export const VALID_BRANCH_NAME = /^[a-zA-Z0-9_\-\/.]+$/;
 
+export function isMilestoneBranchName(branch: string): boolean {
+  return branch.startsWith("milestone/");
+}
+
+export function isValidIntegrationBranchName(branch: string): boolean {
+  const trimmed = branch.trim();
+  if (trimmed === "") return false;
+  if (!VALID_BRANCH_NAME.test(trimmed)) return false;
+  if (SLICE_BRANCH_RE.test(trimmed)) return false;
+  if (QUICK_BRANCH_RE.test(trimmed)) return false;
+  if (WORKFLOW_BRANCH_RE.test(trimmed)) return false;
+  if (isMilestoneBranchName(trimmed)) return false;
+  return true;
+}
+
 export interface CommitOptions {
   message: string;
   allowEmpty?: boolean;
@@ -263,7 +278,7 @@ export function readIntegrationBranch(basePath: string, milestoneId: string): st
     if (!existsSync(metaFile)) return null;
     const data = JSON.parse(readFileSync(metaFile, "utf-8"));
     const branch = data?.integrationBranch;
-    if (typeof branch === "string" && branch.trim() !== "" && VALID_BRANCH_NAME.test(branch)) {
+    if (typeof branch === "string" && isValidIntegrationBranchName(branch)) {
       return branch;
     }
     return null;
@@ -290,18 +305,9 @@ export function writeIntegrationBranch(
   milestoneId: string,
   branch: string,
 ): void {
-  // Don't record slice branches as the integration target
-  if (SLICE_BRANCH_RE.test(branch)) return;
-  // Don't record quick-task branches — they are ephemeral and merge back
-  // to their origin branch on completion. Recording one as the integration
-  // target causes milestone merges to land on the wrong branch (#1293).
-  if (QUICK_BRANCH_RE.test(branch)) return;
-  // Don't record workflow-template branches (hotfix, bugfix, spike, etc.) —
-  // same root cause as quick-task branches (#2498). All templates create
-  // gsd/<templateId>/<slug> branches that are ephemeral.
-  if (WORKFLOW_BRANCH_RE.test(branch)) return;
-  // Validate
-  if (!VALID_BRANCH_NAME.test(branch)) return;
+  // Don't record ephemeral GSD branches or milestone branches as integration
+  // targets. Milestone branches are outputs of auto-mode, not safe merge bases.
+  if (!isValidIntegrationBranchName(branch)) return;
   // Skip if already recorded with the same branch (idempotent across restarts).
   // If recorded with a different branch, update it — the user started auto-mode
   // from a new branch and expects slices to merge back there (#300).
@@ -365,7 +371,7 @@ export function resolveMilestoneIntegrationBranch(
     };
   }
 
-  const configuredBranch = prefs.main_branch && VALID_BRANCH_NAME.test(prefs.main_branch)
+  const configuredBranch = prefs.main_branch && isValidIntegrationBranchName(prefs.main_branch)
     ? prefs.main_branch
     : null;
 
@@ -389,7 +395,7 @@ export function resolveMilestoneIntegrationBranch(
 
   try {
     const detectedBranch = nativeDetectMainBranch(basePath);
-    if (detectedBranch && VALID_BRANCH_NAME.test(detectedBranch) && nativeBranchExists(basePath, detectedBranch)) {
+    if (detectedBranch && isValidIntegrationBranchName(detectedBranch) && nativeBranchExists(basePath, detectedBranch)) {
       return {
         recordedBranch,
         effectiveBranch: detectedBranch,
@@ -816,7 +822,7 @@ export class GitServiceImpl {
    */
   getMainBranch(): string {
     // Explicit preference takes priority (double-check validity as defense-in-depth)
-    if (this.prefs.main_branch && VALID_BRANCH_NAME.test(this.prefs.main_branch)) {
+    if (this.prefs.main_branch && isValidIntegrationBranchName(this.prefs.main_branch)) {
       return this.prefs.main_branch;
     }
 

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
@@ -220,6 +220,32 @@ describe("auto-worktree-milestone-merge", { timeout: 300_000 }, () => {
     assert.strictEqual(mainLog.split("\n").length, 1, "main still has only init commit");
   });
 
+  test("refuses when integration branch resolves to milestone branch (#5024)", () => {
+    const repo = freshRepo();
+    run("git branch -M milestone/M502", repo);
+    writeFileSync(join(repo, "self-merge.ts"), "export const guarded = true;\n");
+    run("git add .", repo);
+    run('git commit -m "add self merge guard fixture"', repo);
+    process.chdir(repo);
+
+    const roadmap = makeRoadmap("M502", "Self merge guard", [
+      { id: "S01", title: "Self merge guard" },
+    ]);
+
+    let threw = false;
+    let errMsg = "";
+    try {
+      mergeMilestoneToMain(repo, "M502", roadmap);
+    } catch (err) {
+      threw = true;
+      errMsg = err instanceof Error ? err.message : String(err);
+    }
+
+    assert.ok(threw, "throws when integration branch is the milestone branch");
+    assert.match(errMsg, /safe integration branch|same as milestone branch/, "error explains invalid self-merge target");
+    assert.ok(run("git branch", repo).includes("milestone/M502"), "milestone branch is preserved");
+  });
+
   test("auto-push with bare remote", () => {
     const repo = freshRepo();
 

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -12,6 +12,7 @@ import {
   MergeConflictError,
   RUNTIME_EXCLUSION_PATHS,
   VALID_BRANCH_NAME,
+  isValidIntegrationBranchName,
   runGit,
   readIntegrationBranch,
   resolveMilestoneIntegrationBranch,
@@ -841,6 +842,18 @@ describe('git-service', async () => {
     rmSync(repo, { recursive: true, force: true });
   });
 
+  test('getMainBranch: ignores configured milestone branch', () => {
+    const repo = initBranchTestRepo();
+    run("git checkout -b milestone/M001", repo);
+    run("git checkout main", repo);
+
+    const svc = new GitServiceImpl(repo, { main_branch: "milestone/M001" });
+
+    assert.deepStrictEqual(svc.getMainBranch(), "main", "getMainBranch ignores milestone branches as integration targets");
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
   // ─── PreMergeCheckResult type export compile check ─────────────────────
 
   test('PreMergeCheckResult type export', () => {
@@ -964,6 +977,23 @@ describe('git-service', async () => {
     rmSync(repo, { recursive: true, force: true });
   });
 
+  test('Integration branch: rejects milestone branches', () => {
+    const repo = initBranchTestRepo();
+
+    writeIntegrationBranch(repo, "M001", "milestone/M001");
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M001"), null, "milestone branches are not recorded as integration branch");
+    assert.deepStrictEqual(isValidIntegrationBranchName("milestone/M001"), false, "milestone branches are not valid integration targets");
+
+    mkdirSync(join(repo, ".gsd", "milestones", "M002"), { recursive: true });
+    writeFileSync(
+      join(repo, ".gsd", "milestones", "M002", "M002-META.json"),
+      JSON.stringify({ integrationBranch: "milestone/M001" }, null, 2) + "\n",
+    );
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M002"), null, "stale milestone metadata is ignored");
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
   // ─── getMainBranch: uses integration branch when milestone set ────────
 
   test('getMainBranch: integration branch from milestone metadata', () => {
@@ -1070,6 +1100,19 @@ describe('git-service', async () => {
       resolved.reason.includes("deleted-branch") && resolved.reason.includes("trunk"),
       "configured fallback reason mentions stale branch and configured branch",
     );
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  test('Integration branch: resolver rejects configured milestone fallback', () => {
+    const repo = initBranchTestRepo();
+    run("git checkout -b milestone/M001", repo);
+    run("git checkout main", repo);
+    writeIntegrationBranch(repo, "M001", "deleted-branch");
+
+    const resolved = resolveMilestoneIntegrationBranch(repo, "M001", { main_branch: "milestone/M001" });
+    assert.deepStrictEqual(resolved.status, "fallback", "resolver falls back past milestone main_branch");
+    assert.deepStrictEqual(resolved.effectiveBranch, "main", "resolver uses detected default instead of milestone branch");
 
     rmSync(repo, { recursive: true, force: true });
   });

--- a/src/resources/extensions/gsd/tests/project-root-cwd-crash.test.ts
+++ b/src/resources/extensions/gsd/tests/project-root-cwd-crash.test.ts
@@ -42,12 +42,12 @@ describe('projectRoot cwd crash guard (#3598)', () => {
 
 describe('main_branch nativeBranchExists validation (#3589)', () => {
   test('prefs.main_branch is validated with nativeBranchExists', () => {
-    assert.match(worktreeSource, /nativeBranchExists\(.*prefs\.main_branch\)/,
+    assert.match(worktreeSource, /isValidIntegrationBranchName\(prefBranch\)[\s\S]*nativeBranchExists\(basePath,\s*prefBranch\)/,
       'nativeBranchExists should validate prefs.main_branch');
   });
 
-  test('validatedPrefBranch falls back to undefined when branch missing', () => {
-    assert.match(worktreeSource, /validatedPrefBranch[\s\S]*?:\s*undefined/,
-      'validatedPrefBranch should fall back to undefined');
+  test('missing or unsafe main_branch falls through to detected branch', () => {
+    assert.match(worktreeSource, /const detectedBranch = nativeDetectMainBranch\(basePath\)/,
+      'unsafe main_branch should fall through to detected branch');
   });
 });

--- a/src/resources/extensions/gsd/tests/worktree-journal-events.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-journal-events.test.ts
@@ -204,6 +204,38 @@ describe("worktree journal events", () => {
     assert.equal(failed!.data?.error, "conflict in main");
   });
 
+  test("branch mode does not emit worktree-merged when merge postcondition fails (#5024)", () => {
+    const s = makeSession({
+      basePath: tmp,
+      originalBasePath: tmp,
+    });
+    const deps = makeDeps({
+      isInAutoWorktree: () => false,
+      getIsolationMode: () => "branch",
+      getCurrentBranch: () => "milestone/M001",
+      mergeMilestoneToMain: () => {
+        throw new Error("noop merge postcondition failed");
+      },
+    });
+    const resolver = new WorktreeResolver(s, deps);
+
+    assert.throws(
+      () => resolver.mergeAndExit("M001", makeNotifyCtx()),
+      /noop merge postcondition failed/,
+    );
+
+    const entries = readJournalEntries(tmp);
+    assert.ok(
+      entries.some(e => e.eventType === "worktree-merge-start"),
+      "merge start is still recorded",
+    );
+    assert.equal(
+      entries.some(e => e.eventType === "worktree-merged"),
+      false,
+      "worktree-merged must only be emitted after merge postcondition passes",
+    );
+  });
+
   test("journal entries have valid flowId, seq, and ts fields", () => {
     const s = makeSession({ basePath: tmp, originalBasePath: tmp });
     const deps = makeDeps({ shouldUseWorktreeIsolation: () => false });

--- a/src/resources/extensions/gsd/tests/worktree-main-branch.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-main-branch.test.ts
@@ -12,9 +12,9 @@ test("auto-worktree.ts includes main_branch preference in startPoint fallback (#
     join(import.meta.dirname, "..", "auto-worktree.ts"),
     "utf-8",
   );
-  // The fix adds gitPrefs?.main_branch to the startPoint fallback chain
+  // The start-point resolver must keep git.main_branch in the fallback chain.
   assert.ok(
-    src.includes("gitPrefs?.main_branch") || src.includes("prefs.main_branch"),
+    src.includes("gitPrefs.main_branch") || src.includes("gitPrefs?.main_branch") || src.includes("prefs.main_branch"),
     "createAutoWorktree must check git.main_branch preference before falling back to nativeDetectMainBranch",
   );
 });


### PR DESCRIPTION
## Linked issue

Closes #5024

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Prevent auto-mode from recording, resolving, or merging a milestone branch as its own integration target.
**Why:** Stale metadata or an auto-start from `milestone/*` could otherwise make GSD repeatedly attempt an invalid self-merge and report misleading merge telemetry.
**How:** Centralize integration-branch validation, reject `milestone/*` at capture/read/resolution time, guard `mergeMilestoneToMain()`, and verify no-op merge postconditions before emitting branch-mode success.

## What

This updates the GSD worktree merge path so milestone branches are never accepted as integration branches. `writeIntegrationBranch()` now refuses to persist `milestone/*`, `readIntegrationBranch()` ignores stale milestone metadata, and integration fallback resolution rejects milestone branch names before consumers use them.

`createAutoWorktree()`, `enterBranchModeForMilestone()`, and `mergeMilestoneToMain()` now share a safe integration start-point resolver instead of consuming raw metadata independently. `mergeMilestoneToMain()` still keeps the hard final guard against `mainBranch === milestoneBranch`, and no-op merge completion now verifies that the non-`.gsd/` diff between the integration branch and milestone branch is empty before proceeding.

Regression coverage was added for milestone metadata rejection, configured milestone fallback rejection, unsafe self-merge resolution, and branch-mode merge failures that must not emit `worktree-merged` telemetry.

## Why

If integration metadata resolves to the milestone branch itself, `mergeMilestoneToMain()` can enter a self-merge/no-op path. The previous no-op safety check compared `mainBranch` to `milestoneBranch`, which becomes an empty self-diff in that failure mode. That can make an invalid merge look safe and let higher-level branch-mode telemetry report a completed merge.

The review follow-up also identified the root cause upstream of the merge helper: metadata capture and other consumers still trusted `milestone/*` as a possible integration branch. This PR now prevents the bad value from being recorded, ignores stale bad metadata if it already exists, and validates fallback branches before branch/worktree creation sees them.

Closes #5024.

## How

The integration-branch rule is centralized in `isValidIntegrationBranchName()`. It preserves existing rejection of slice, quick-task, workflow-template, and invalid branch names, and adds milestone branch rejection. The resolver path applies the same rule to recorded metadata, configured `git.main_branch`, and detected fallback branches.

`resolveSafeIntegrationStartPoint()` in auto-worktree uses that validated resolution for branch isolation, worktree isolation, and milestone finalization. If no safe integration branch can be found, GSD fails closed with a `GSDError` rather than creating or merging from a milestone branch.

`WorktreeResolver.mergeAndExit()` already emits `worktree-merged` only after the merge helper returns, so the telemetry fix relies on the helper throwing on failed guards/postconditions and adds a focused regression to lock that behavior.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual/local checks run:

- `git diff --check` passed.
- `npm run typecheck:extensions` passed.
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/git-service.test.ts` passed.
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts src/resources/extensions/gsd/tests/worktree-journal-events.test.ts` passed.
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/project-root-cwd-crash.test.ts` passed.
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/worktree-main-branch.test.ts` passed.
- Earlier `npm run verify:pr` completed build and typecheck, then failed in unit tests on an unrelated existing temp worktree start-point issue: `worktree-db-integration` attempted `git worktree add ... master` in a temp repo.

## AI disclosure

- [x] This PR includes AI-assisted code. The implementation and tests were created with Codex, then validated with the focused checks listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch validation and integration safety checks to prevent invalid merge operations.
  * Added protection against self-merge attempts when the integration branch resolves to the same branch as the milestone.
  * Enhanced error handling for invalid branch configurations with clearer validation messages.

* **Chores**
  * Refactored branch-name validation logic for consistency across integration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->