### PR TITLE
feat(pi-coding-agent): opt-in per-call token telemetry (#5023)

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -162,6 +162,37 @@ Recommended verification order:
 | `GSD_CODING_AGENT_DIR` | `$GSD_HOME/agent` | Agent directory containing managed resources, extensions, and auth. Takes precedence over `GSD_HOME` for agent paths. |
 | `GSD_ALLOWED_COMMAND_PREFIXES` | (built-in list) | Comma-separated command prefixes allowed for `!command` value resolution. Overrides `allowedCommandPrefixes` in settings.json. See [Custom Models — Command Allowlist](custom-models.md#command-allowlist). |
 | `GSD_FETCH_ALLOWED_URLS` | (none) | Comma-separated hostnames exempted from `fetch_page` URL blocking. Overrides `fetchAllowedUrls` in settings.json. See [URL Blocking](#url-blocking-fetch_page). |
+| `PI_TOKEN_TELEMETRY` | (unset) | Set to literal `1` to emit opt-in per-call token telemetry as JSONL on stderr. Other values are ignored. |
+
+### Token Telemetry
+
+Set `PI_TOKEN_TELEMETRY=1` when you need raw per-call token and cache data for cost analysis or prompt-cache tuning. The stream is off by default and writes to stderr, so stdout remains available for the TUI or for headless `--json` events.
+
+```bash
+# Capture telemetry separately from headless JSONL events
+PI_TOKEN_TELEMETRY=1 gsd headless --json auto \
+  > gsd-events.jsonl \
+  2> token-telemetry.jsonl
+
+# Capture telemetry from an interactive session
+PI_TOKEN_TELEMETRY=1 gsd 2> token-telemetry.jsonl
+```
+
+Each line is one JSON object with this shape:
+
+| Field | Description |
+|-------|-------------|
+| `ts` | Assistant message timestamp in milliseconds since Unix epoch. |
+| `model` | Model identifier used for the call. |
+| `stopReason` | Provider stop reason recorded for the assistant message, such as `stop` or `error`. |
+| `input` | Input tokens reported for the call, excluding tokens served from prompt cache. |
+| `output` | Output tokens reported for the call. |
+| `cacheRead` | Input tokens read from prompt cache. |
+| `cacheWrite` | Input tokens written to prompt cache. |
+| `costTotal` | Provider total cost from the model registry. This is `0` when no rate is known for the model. |
+| `cacheHitRatio` | `cacheRead / (cacheRead + input)`. This is `0` when both values are zero and `1` for a full cache hit. |
+
+Telemetry is emitted per assistant API attempt, not per user turn. If a provider call records an error and auto-retry runs, the failed attempt can produce a line with `stopReason: "error"`, and each retry attempt that reaches an assistant message produces its own line. Keep all lines for billed-attempt accounting; group with session logs or timestamps downstream if you need a deduplicated final-response view.
 
 ## All Settings
 

--- a/gitbook/reference/environment-variables.md
+++ b/gitbook/reference/environment-variables.md
@@ -11,6 +11,7 @@
 | `GSD_FETCH_ALLOWED_URLS` | (none) | Comma-separated hostnames exempt from internal URL blocking. |
 | `GSD_ALLOWED_COMMAND_PREFIXES` | (built-in) | Comma-separated command prefixes allowed for value resolution. |
 | `GSD_WEB_PROJECT_CWD` | — | Default project path for `gsd --web` when `?project=` is not specified. |
+| `PI_TOKEN_TELEMETRY` | (unset) | Set to literal `1` to emit opt-in per-call token telemetry as JSONL on stderr. Other values are ignored. |
 
 ## LLM Provider Keys
 
@@ -42,6 +43,36 @@
 | `CONTEXT7_API_KEY` | Context7 documentation lookup |
 | `DISCORD_BOT_TOKEN` | Discord remote questions |
 | `TELEGRAM_BOT_TOKEN` | Telegram remote questions |
+
+## Token Telemetry
+
+Set `PI_TOKEN_TELEMETRY=1` to emit raw token and prompt-cache telemetry for each assistant API attempt. Telemetry writes to stderr, so stdout remains available for normal TUI output or headless `--json` events.
+
+```bash
+# Capture telemetry separately from headless JSONL events
+PI_TOKEN_TELEMETRY=1 gsd headless --json auto \
+  > gsd-events.jsonl \
+  2> token-telemetry.jsonl
+
+# Capture telemetry from an interactive session
+PI_TOKEN_TELEMETRY=1 gsd 2> token-telemetry.jsonl
+```
+
+Each line is one JSON object:
+
+| Field | Description |
+|-------|-------------|
+| `ts` | Assistant message timestamp in milliseconds since Unix epoch. |
+| `model` | Model identifier used for the call. |
+| `stopReason` | Provider stop reason recorded for the assistant message, such as `stop` or `error`. |
+| `input` | Input tokens reported for the call, excluding tokens served from prompt cache. |
+| `output` | Output tokens reported for the call. |
+| `cacheRead` | Input tokens read from prompt cache. |
+| `cacheWrite` | Input tokens written to prompt cache. |
+| `costTotal` | Provider total cost from the model registry. This is `0` when no rate is known for the model. |
+| `cacheHitRatio` | `cacheRead / (cacheRead + input)`. This is `0` when both values are zero and `1` for a full cache hit. |
+
+Records are per attempt, not per user turn. A retrying call can emit one line for the failed assistant message, usually with `stopReason: "error"`, plus one line for each retry attempt that reaches an assistant message. Keep every line for billed-attempt accounting; group with session logs or timestamps downstream if you need a deduplicated final-response view.
 
 ## URL Blocking
 

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -78,6 +78,7 @@ import { getLatestCompactionEntry } from "./session-manager.js";
 import type { SettingsManager } from "./settings-manager.js";
 import { BUILTIN_SLASH_COMMANDS, type SlashCommandInfo, type SlashCommandLocation } from "./slash-commands.js";
 import { buildSystemPrompt } from "./system-prompt.js";
+import { emitTokenTelemetry } from "./token-telemetry.js";
 import type { BashOperations } from "./tools/bash.js";
 import { createAllTools } from "./tools/index.js";
 
@@ -469,6 +470,12 @@ export class AgentSession {
 				this._cumulativeInputTokens += assistantMsg.usage?.input ?? 0;
 				this._cumulativeOutputTokens += assistantMsg.usage?.output ?? 0;
 				this._cumulativeToolCalls += assistantMsg.content.filter((c) => c.type === "toolCall").length;
+
+				// Per-call token telemetry (off by default; gated by PI_TOKEN_TELEMETRY=1).
+				// Note: a turn that retries emits one record per attempt — group by
+				// session/turn downstream if you want a deduplicated view. Both records
+				// are valid (each was a billed/attempted API call). #5023
+				emitTokenTelemetry(assistantMsg);
 
 				if (assistantMsg.stopReason !== "error") {
 					this._compactionOrchestrator.clearOverflowRecovery();

--- a/packages/pi-coding-agent/src/core/token-telemetry.ts
+++ b/packages/pi-coding-agent/src/core/token-telemetry.ts
@@ -1,0 +1,77 @@
+// @gsd/pi-coding-agent + token-telemetry — opt-in per-call token observability
+//
+// Emits a single JSON line per assistant message to stderr when
+// `PI_TOKEN_TELEMETRY=1` is set. Captures the cache_read_input_tokens and
+// cache_creation_input_tokens fields the providers already extract — so we
+// can empirically measure prompt-cache effectiveness (e.g. for #5019 and
+// future cache strategy work). Off by default — no behavior change.
+//
+// Capture pattern: `PI_TOKEN_TELEMETRY=1 npm start 2> token-telemetry.jsonl`
+
+import type { AssistantMessage } from "@gsd/pi-ai";
+
+/** Schema of one telemetry line. JSON-stable for downstream ingestion. */
+export interface TokenTelemetryRecord {
+	ts: number;
+	model: string;
+	stopReason: string;
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	/**
+	 * `usage.cost.total` from the provider. `0` when the provider's cost
+	 * registry has no rates for this model (e.g. unknown third-party providers)
+	 * — distinguish from a true zero-cost call by checking your model registry.
+	 */
+	costTotal: number;
+	/**
+	 * Fraction of new prompt tokens served from cache:
+	 * `cacheRead / (cacheRead + input)`. Range [0, 1].
+	 * - `0` when neither cacheRead nor input is present (no division by zero).
+	 * - `1` on a full cache hit (input = 0, cacheRead > 0).
+	 * Note: `input` here is `input_tokens` from the API, which already excludes
+	 * cache reads/writes — the denominator is total prompt tokens consumed.
+	 */
+	cacheHitRatio: number;
+}
+
+/** Build a telemetry record from a finished assistant message. */
+export function buildTokenTelemetryRecord(msg: AssistantMessage): TokenTelemetryRecord {
+	const input = msg.usage?.input ?? 0;
+	const output = msg.usage?.output ?? 0;
+	const cacheRead = msg.usage?.cacheRead ?? 0;
+	const cacheWrite = msg.usage?.cacheWrite ?? 0;
+	const costTotal = msg.usage?.cost?.total ?? 0;
+	const denom = cacheRead + input;
+	const cacheHitRatio = denom > 0 ? cacheRead / denom : 0;
+
+	return {
+		ts: msg.timestamp,
+		model: msg.model,
+		stopReason: msg.stopReason,
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		costTotal,
+		cacheHitRatio,
+	};
+}
+
+/**
+ * Emit a token-telemetry line if `PI_TOKEN_TELEMETRY=1`. No-op otherwise.
+ *
+ * Writes to stderr so it doesn't interfere with TUI/stdout. One JSON object
+ * per line. Errors during emission are swallowed — telemetry must never
+ * break the agent loop.
+ */
+export function emitTokenTelemetry(msg: AssistantMessage): void {
+	if (process.env.PI_TOKEN_TELEMETRY !== "1") return;
+	try {
+		const record = buildTokenTelemetryRecord(msg);
+		process.stderr.write(`${JSON.stringify(record)}\n`);
+	} catch {
+		// Telemetry must never break the agent loop. Swallow.
+	}
+}

--- a/packages/pi-coding-agent/src/tests/token-telemetry.test.ts
+++ b/packages/pi-coding-agent/src/tests/token-telemetry.test.ts
@@ -1,0 +1,200 @@
+// @gsd/pi-coding-agent + token-telemetry.test — coverage for #5023.
+// Verifies the env-gated emitter:
+//   - is silent by default (no behavior change for existing users)
+//   - emits a single valid JSON line when PI_TOKEN_TELEMETRY=1
+//   - record shape captures the cache breakdown the providers already extract
+//   - cacheHitRatio math is correct, including the no-input edge case
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import type { AssistantMessage } from "@gsd/pi-ai";
+
+import { buildTokenTelemetryRecord, emitTokenTelemetry } from "../core/token-telemetry.js";
+
+function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-6",
+		usage: {
+			input: 100,
+			output: 50,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 150,
+			cost: { input: 0.3, output: 0.75, cacheRead: 0, cacheWrite: 0, total: 1.05 },
+		},
+		stopReason: "stop",
+		timestamp: 1700000000000,
+		...overrides,
+	};
+}
+
+// ─── buildTokenTelemetryRecord ─────────────────────────────────────────────
+
+describe("buildTokenTelemetryRecord", () => {
+	test("captures all fields from a typical message", () => {
+		const msg = makeAssistantMessage();
+		const record = buildTokenTelemetryRecord(msg);
+		assert.deepEqual(record, {
+			ts: 1700000000000,
+			model: "claude-sonnet-4-6",
+			stopReason: "stop",
+			input: 100,
+			output: 50,
+			cacheRead: 0,
+			cacheWrite: 0,
+			costTotal: 1.05,
+			cacheHitRatio: 0,
+		});
+	});
+
+	test("cacheHitRatio = read / (read + input) when both present", () => {
+		const msg = makeAssistantMessage({
+			usage: {
+				input: 200,
+				output: 50,
+				cacheRead: 800,
+				cacheWrite: 0,
+				totalTokens: 1050,
+				cost: { input: 0.6, output: 0.75, cacheRead: 0.24, cacheWrite: 0, total: 1.59 },
+			},
+		});
+		const record = buildTokenTelemetryRecord(msg);
+		assert.equal(record.cacheRead, 800);
+		assert.equal(record.input, 200);
+		assert.equal(record.cacheHitRatio, 0.8);
+	});
+
+	test("cacheHitRatio = 0 when both read and input are 0 (no division-by-zero)", () => {
+		const msg = makeAssistantMessage({
+			usage: {
+				input: 0,
+				output: 50,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 50,
+				cost: { input: 0, output: 0.75, cacheRead: 0, cacheWrite: 0, total: 0.75 },
+			},
+		});
+		const record = buildTokenTelemetryRecord(msg);
+		assert.equal(record.cacheHitRatio, 0);
+	});
+
+	test("cacheHitRatio = 1 when only cacheRead present (full hit)", () => {
+		const msg = makeAssistantMessage({
+			usage: {
+				input: 0,
+				output: 50,
+				cacheRead: 5000,
+				cacheWrite: 0,
+				totalTokens: 5050,
+				cost: { input: 0, output: 0.75, cacheRead: 1.5, cacheWrite: 0, total: 2.25 },
+			},
+		});
+		const record = buildTokenTelemetryRecord(msg);
+		assert.equal(record.cacheHitRatio, 1);
+	});
+
+	test("cacheWrite is captured (the cache-miss-with-cache-control case from #5019)", () => {
+		const msg = makeAssistantMessage({
+			usage: {
+				input: 50,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 5000,
+				totalTokens: 5150,
+				cost: { input: 0.15, output: 1.5, cacheRead: 0, cacheWrite: 18.75, total: 20.4 },
+			},
+		});
+		const record = buildTokenTelemetryRecord(msg);
+		assert.equal(record.cacheWrite, 5000);
+		assert.equal(record.cacheHitRatio, 0, "no read = ratio 0 even when write is large");
+	});
+
+	test("error stopReason is captured verbatim", () => {
+		const msg = makeAssistantMessage({ stopReason: "error", errorMessage: "rate_limit" });
+		assert.equal(buildTokenTelemetryRecord(msg).stopReason, "error");
+	});
+});
+
+// ─── emitTokenTelemetry ────────────────────────────────────────────────────
+
+describe("emitTokenTelemetry", () => {
+	let captured: string[];
+	let originalWrite: typeof process.stderr.write;
+	let originalEnv: string | undefined;
+
+	beforeEach(() => {
+		captured = [];
+		originalWrite = process.stderr.write.bind(process.stderr);
+		// Replace stderr.write with a capture; preserve the same return contract.
+		process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+			captured.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+			return true;
+		}) as typeof process.stderr.write;
+		originalEnv = process.env.PI_TOKEN_TELEMETRY;
+	});
+
+	afterEach(() => {
+		process.stderr.write = originalWrite;
+		if (originalEnv === undefined) {
+			delete process.env.PI_TOKEN_TELEMETRY;
+		} else {
+			process.env.PI_TOKEN_TELEMETRY = originalEnv;
+		}
+	});
+
+	test("silent by default (env var unset)", () => {
+		delete process.env.PI_TOKEN_TELEMETRY;
+		emitTokenTelemetry(makeAssistantMessage());
+		assert.equal(captured.length, 0);
+	});
+
+	test("silent when env var has any non-'1' value", () => {
+		process.env.PI_TOKEN_TELEMETRY = "true"; // not literally "1"
+		emitTokenTelemetry(makeAssistantMessage());
+		assert.equal(captured.length, 0, "only literal '1' should enable telemetry");
+	});
+
+	test("emits a single JSON line when PI_TOKEN_TELEMETRY=1", () => {
+		process.env.PI_TOKEN_TELEMETRY = "1";
+		emitTokenTelemetry(makeAssistantMessage());
+		assert.equal(captured.length, 1);
+		assert.ok(captured[0].endsWith("\n"), "line must terminate with newline");
+		const parsed = JSON.parse(captured[0].trimEnd());
+		assert.equal(parsed.model, "claude-sonnet-4-6");
+		assert.equal(parsed.input, 100);
+		assert.equal(parsed.output, 50);
+	});
+
+	test("emitted JSON has the documented shape", () => {
+		process.env.PI_TOKEN_TELEMETRY = "1";
+		emitTokenTelemetry(makeAssistantMessage());
+		const parsed = JSON.parse(captured[0].trimEnd());
+		const keys = Object.keys(parsed).sort();
+		assert.deepEqual(keys, [
+			"cacheHitRatio",
+			"cacheRead",
+			"cacheWrite",
+			"costTotal",
+			"input",
+			"model",
+			"output",
+			"stopReason",
+			"ts",
+		]);
+	});
+
+	test("never throws — telemetry must not break the agent loop", () => {
+		process.env.PI_TOKEN_TELEMETRY = "1";
+		// Force a write failure to exercise the swallow path.
+		process.stderr.write = (() => {
+			throw new Error("simulated stderr failure");
+		}) as typeof process.stderr.write;
+		assert.doesNotThrow(() => emitTokenTelemetry(makeAssistantMessage()));
+	});
+});


### PR DESCRIPTION
## TL;DR

**What:** Opt-in env-gated emitter that logs per-assistant-message token usage as a single JSON line to stderr.
**Why:** Cumulative tracker today discards the cache breakdown the providers already extract — we cannot measure prompt-cache effectiveness or detect regressions.
**How:** `PI_TOKEN_TELEMETRY=1` enables; off by default. One JSON line per turn with cacheRead, cacheWrite, costTotal, cacheHitRatio.

Closes #5023

## What

- New `packages/pi-coding-agent/src/core/token-telemetry.ts` exporting `buildTokenTelemetryRecord(msg)` and `emitTokenTelemetry(msg)`
- `agent-session.ts` calls `emitTokenTelemetry(assistantMsg)` once per assistant message in `_handleAgentEvent`
- 11 regression tests covering record shape, ratio math, env gating, and the never-throws guarantee

## Why

`agent-session.ts:259-260` tracks cumulative input/output tokens but discards `cacheRead`/`cacheWrite`, which the Anthropic provider already extracts (`anthropic-shared.ts:618-619`). With no per-call surface, we cannot:

- Confirm a cache fix actually moved the needle (e.g. for #5019)
- Detect a cache-busting regression
- See which models / call types pay the cache-write premium most often

This PR is the foundation for measurable cache strategy work.

## How

```ts
export interface TokenTelemetryRecord {
  ts: number;
  model: string;
  stopReason: string;
  input: number;
  output: number;
  cacheRead: number;
  cacheWrite: number;
  costTotal: number;
  cacheHitRatio: number; // cacheRead / (cacheRead + input). [0,1].
}
```

- **Gating:** `PI_TOKEN_TELEMETRY === "1"` (literal `"1"` only — explicit and unambiguous; documented in test).
- **Output:** stderr, so it doesn't interfere with TUI/stdout. Capture via `2> token-telemetry.jsonl`.
- **Failure mode:** errors during emission are swallowed. Telemetry must never break the agent loop (tested).
- **Hook point:** right after the cumulative accumulation in `_handleAgentEvent`. Retried turns emit one record per attempt — comment at the wire-up site flags this for downstream consumers.
- **`cacheHitRatio` math:** `cacheRead / (cacheRead + input)`. Anthropic's `input_tokens` already excludes cache reads/writes, so the denominator equals total prompt tokens consumed. JSDoc documents the `0` and `1` edge cases.

## Considerations and trade-offs

- **`costTotal === 0` ambiguity:** could mean a free call OR an unregistered third-party provider. Documented in JSDoc; consumers should cross-reference their model registry if they need to disambiguate.
- **`cacheHitRatio` denominator choice:** `read / (read + input)` is the most defensible definition for "fraction of prompt tokens served from cache" given how this codebase populates `usage.input`. Alternatives like `read / (read + write)` would conflate two different metrics. JSDoc explains.

## Test plan

- [x] `npm run verify:pr` passes (build:core → typecheck:extensions → test:unit)
- [x] All 11 new tests pass
- [x] Pre-existing unrelated failure (ADR-012 allowlist staleness) is on files this PR doesn't touch — flagged for visibility only

## Change type

- [x] `feat` — New observability capability (no behavior change when disabled)

## Notes

This is an AI-assisted PR. All code is reviewed by the contributor. Builds on #5021 (cache-buster fix); the telemetry will let us empirically measure that PR's impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-call token telemetry (JSONL to stderr) when PI_TOKEN_TELEMETRY=1. Emits one record per assistant attempt (including retries) with timestamps, model, stop reason, input/output token counts, cache read/write, total cost, and cache hit ratio.

* **Tests**
  * Added tests validating telemetry fields, emission behavior, and that telemetry failures do not interrupt execution.

* **Documentation**
  * Added configuration and environment-variable guidance for enabling and capturing token telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->