### PR TITLE
perf(startup): reduce GSD launch overhead

### DIFF
--- a/scripts/copy-resources.cjs
+++ b/scripts/copy-resources.cjs
@@ -1,10 +1,26 @@
 #!/usr/bin/env node
 const { spawnSync } = require('child_process');
-const { copyFileSync, mkdirSync, readdirSync, rmSync } = require('fs');
+const { createHash } = require('crypto');
+const { copyFileSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } = require('fs');
 const { dirname, join } = require('path');
+
+const SKIP_DIRS = new Set(['tests', '__tests__']);
+const SKIP_FILE_RE = /(?:^\.DS_Store$|\.test\.(?:cjs|mjs|js|json|md|py)$|\.spec\.(?:cjs|mjs|js|json|md|py)$)/;
+const FINGERPRINT_FILE = '.managed-resources-content-hash';
+
+function shouldSkip(entry) {
+  if (entry.isDirectory()) {
+    return SKIP_DIRS.has(entry.name);
+  }
+  return SKIP_FILE_RE.test(entry.name);
+}
 
 function copyNonTsFiles(srcDir, destDir) {
   for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    if (shouldSkip(entry)) {
+      continue;
+    }
+
     const srcPath = join(srcDir, entry.name);
     const destPath = join(destDir, entry.name);
 
@@ -39,6 +55,28 @@ function copyNonTsFiles(srcDir, destDir) {
   }
 }
 
+function collectFileEntries(dir, root, out) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === FINGERPRINT_FILE) continue;
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectFileEntries(fullPath, root, out);
+      continue;
+    }
+    const rel = fullPath.slice(root.length + 1).replaceAll('\\', '/');
+    const contentHash = createHash('sha256').update(readFileSync(fullPath)).digest('hex');
+    out.push(`${rel}:${contentHash}`);
+  }
+}
+
+function writeResourceFingerprint(rootDir) {
+  const entries = [];
+  collectFileEntries(rootDir, rootDir, entries);
+  entries.sort();
+  const hash = createHash('sha256').update(entries.join('\n')).digest('hex').slice(0, 16);
+  writeFileSync(join(rootDir, FINGERPRINT_FILE), `${hash}\n`);
+}
+
 rmSync('dist/resources', { recursive: true, force: true });
 
 const tscBin = require.resolve('typescript/bin/tsc');
@@ -51,3 +89,4 @@ if (compile.status !== 0) {
 }
 
 copyNonTsFiles('src/resources', 'dist/resources');
+writeResourceFingerprint('dist/resources');

--- a/scripts/watch-resources.js
+++ b/scripts/watch-resources.js
@@ -13,19 +13,72 @@
  */
 
 import { watch } from 'node:fs'
-import { cpSync, mkdirSync, rmSync } from 'node:fs'
-import { resolve, dirname } from 'node:path'
+import { createHash } from 'node:crypto'
+import { copyFileSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { resolve, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const src = resolve(__dirname, '..', 'src', 'resources')
 const dest = resolve(__dirname, '..', 'dist', 'resources')
+const SKIP_DIRS = new Set(['tests', '__tests__'])
+const SKIP_FILE_RE = /(?:^\.DS_Store$|\.test\.(?:cjs|mjs|js|json|md|py)$|\.spec\.(?:cjs|mjs|js|json|md|py)$)/
+const FINGERPRINT_FILE = '.managed-resources-content-hash'
+
+function shouldSkip(entry) {
+  if (entry.isDirectory()) {
+    return SKIP_DIRS.has(entry.name)
+  }
+  return SKIP_FILE_RE.test(entry.name)
+}
+
+function copyRuntimeResources(srcDir, destDir) {
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    if (shouldSkip(entry)) {
+      continue
+    }
+
+    const srcPath = join(srcDir, entry.name)
+    const destPath = join(destDir, entry.name)
+
+    if (entry.isDirectory()) {
+      copyRuntimeResources(srcPath, destPath)
+      continue
+    }
+
+    mkdirSync(dirname(destPath), { recursive: true })
+    copyFileSync(srcPath, destPath)
+  }
+}
+
+function collectFileEntries(dir, root, out) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === FINGERPRINT_FILE) continue
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      collectFileEntries(fullPath, root, out)
+      continue
+    }
+    const rel = fullPath.slice(root.length + 1).replaceAll('\\', '/')
+    const contentHash = createHash('sha256').update(readFileSync(fullPath)).digest('hex')
+    out.push(`${rel}:${contentHash}`)
+  }
+}
+
+function writeResourceFingerprint(rootDir) {
+  const entries = []
+  collectFileEntries(rootDir, rootDir, entries)
+  entries.sort()
+  const hash = createHash('sha256').update(entries.join('\n')).digest('hex').slice(0, 16)
+  writeFileSync(join(rootDir, FINGERPRINT_FILE), `${hash}\n`)
+}
 
 function sync() {
   // Remove dest first to mirror deletions from src (prevents stale files)
   rmSync(dest, { recursive: true, force: true })
   mkdirSync(dest, { recursive: true })
-  cpSync(src, dest, { recursive: true, force: true })
+  copyRuntimeResources(src, dest)
+  writeResourceFingerprint(dest)
 }
 
 // Initial sync

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -534,11 +534,7 @@ if (cliFlags.listModels !== undefined) {
     additionalExtensionPaths: cliFlags.extensions.length > 0 ? cliFlags.extensions : undefined,
   })
   await listModelsLoader.reload()
-  const listModelsExtensions = listModelsLoader.getExtensions()
-  for (const { name, config } of listModelsExtensions.runtime.pendingProviderRegistrations) {
-    modelRegistry.registerProvider(name, config)
-  }
-  listModelsExtensions.runtime.pendingProviderRegistrations = []
+  flushPendingProviderRegistrations(listModelsLoader, modelRegistry)
 
   const models = modelRegistry.getAvailable()
   if (models.length === 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -461,6 +461,33 @@ if (cliFlags.messages[0] === 'auto') {
   await runHeadlessFromAuto(buildHeadlessAutoArgs(cliFlags))
 }
 
+// ---------------------------------------------------------------------------
+// Worktree subcommand — `gsd worktree <list|merge|clean|remove>`
+// ---------------------------------------------------------------------------
+if (
+  !isPrintMode &&
+  cliFlags.listModels === undefined &&
+  (cliFlags.messages[0] === 'worktree' || cliFlags.messages[0] === 'wt')
+) {
+  const { handleList, handleMerge, handleClean, handleRemove } = await import('./worktree-cli.js')
+  const sub = cliFlags.messages[1]
+  const subArgs = cliFlags.messages.slice(2)
+
+  if (!sub || sub === 'list') {
+    await handleList(process.cwd())
+  } else if (sub === 'merge') {
+    await handleMerge(process.cwd(), subArgs)
+  } else if (sub === 'clean') {
+    await handleClean(process.cwd())
+  } else if (sub === 'remove' || sub === 'rm') {
+    await handleRemove(process.cwd(), subArgs)
+  } else {
+    process.stderr.write(`Unknown worktree command: ${sub}\n`)
+    process.stderr.write('Commands: list, merge [name], clean, remove <name>\n')
+  }
+  process.exit(0)
+}
+
 const {
   AuthStorage,
   DefaultResourceLoader,
@@ -694,29 +721,6 @@ if (isPrintMode) {
 }
 
 // ---------------------------------------------------------------------------
-// Worktree subcommand — `gsd worktree <list|merge|clean|remove>`
-// ---------------------------------------------------------------------------
-if (cliFlags.messages[0] === 'worktree' || cliFlags.messages[0] === 'wt') {
-  const { handleList, handleMerge, handleClean, handleRemove } = await import('./worktree-cli.js')
-  const sub = cliFlags.messages[1]
-  const subArgs = cliFlags.messages.slice(2)
-
-  if (!sub || sub === 'list') {
-    await handleList(process.cwd())
-  } else if (sub === 'merge') {
-    await handleMerge(process.cwd(), subArgs)
-  } else if (sub === 'clean') {
-    await handleClean(process.cwd())
-  } else if (sub === 'remove' || sub === 'rm') {
-    await handleRemove(process.cwd(), subArgs)
-  } else {
-    process.stderr.write(`Unknown worktree command: ${sub}\n`)
-    process.stderr.write('Commands: list, merge [name], clean, remove <name>\n')
-  }
-  process.exit(0)
-}
-
-// ---------------------------------------------------------------------------
 // Worktree flag (-w) — create/resume a worktree for the interactive session
 // ---------------------------------------------------------------------------
 if (cliFlags.worktree) {
@@ -775,7 +779,9 @@ markStartup('initResources')
 // Overlap resource loading with session manager setup — both are independent.
 // resourceLoader.reload() is the most expensive step (jiti compilation), so
 // starting it early shaves ~50-200ms off interactive startup.
-const resourceLoader = await buildResourceLoader(agentDir)
+const resourceLoader = await buildResourceLoader(agentDir, {
+  additionalExtensionPaths: cliFlags.extensions.length > 0 ? cliFlags.extensions : undefined,
+})
 const resourceLoadPromise = resourceLoader.reload()
 
 // While resources load, let session manager finish any async I/O it needs.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,7 @@ import {
 import { stopWebMode } from './web-mode.js'
 import { getProjectSessionsDir } from './project-sessions.js'
 import { markStartup, printStartupTimings } from './startup-timings.js'
-import { applyRtkProcessEnv, GSD_RTK_DISABLED_ENV } from './rtk-shared.js'
+import { applyRtkProcessEnv, GSD_RTK_DISABLED_ENV, isTruthy } from './rtk-shared.js'
 import type { EnsureRtkResult } from './rtk.js'
 
 type PiCodingAgentModule = typeof import('@gsd/pi-coding-agent')
@@ -162,21 +162,23 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
 let rtkBootstrapPromise: Promise<void> | undefined
 async function doRtkBootstrap(): Promise<void> {
   let rtkStatus: EnsureRtkResult | undefined
+  let rtkDisabled = isTruthy(process.env[GSD_RTK_DISABLED_ENV])
 
   // RTK is opt-in via experimental.rtk preference. Default: disabled.
   // Honor GSD_RTK_DISABLED if already explicitly set in the environment
   // (env var takes precedence over preferences for manual override).
-  if (!process.env[GSD_RTK_DISABLED_ENV]) {
+  if (!rtkDisabled) {
     const { loadEffectiveGSDPreferences } = await import('./resources/extensions/gsd/preferences.js')
     const prefs = loadEffectiveGSDPreferences()
     const rtkEnabled = prefs?.preferences.experimental?.rtk === true
     if (!rtkEnabled) {
       process.env[GSD_RTK_DISABLED_ENV] = '1'
+      rtkDisabled = true
     }
   }
   markStartup('rtkPreferenceCheck')
 
-  if (process.env[GSD_RTK_DISABLED_ENV]) {
+  if (rtkDisabled) {
     applyRtkProcessEnv(process.env)
     rtkStatus = {
       enabled: false,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,14 +1,8 @@
-import {
-  AuthStorage,
-  DefaultResourceLoader,
-  ModelRegistry,
-  runPackageCommand,
-  SettingsManager,
-  SessionManager,
-  createAgentSession,
-  InteractiveMode,
-  runPrintMode,
-  runRpcMode,
+import type {
+  DefaultResourceLoader as DefaultResourceLoaderInstance,
+  ModelRegistry as ModelRegistryInstance,
+  PackageCommand,
+  SettingsManager as SettingsManagerInstance,
 } from '@gsd/pi-coding-agent'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -34,8 +28,16 @@ import {
 import { stopWebMode } from './web-mode.js'
 import { getProjectSessionsDir } from './project-sessions.js'
 import { markStartup, printStartupTimings } from './startup-timings.js'
-import { bootstrapRtk, GSD_RTK_DISABLED_ENV } from './rtk.js'
-import { loadEffectiveGSDPreferences } from './resources/extensions/gsd/preferences.js'
+import { applyRtkProcessEnv, GSD_RTK_DISABLED_ENV } from './rtk-shared.js'
+import type { EnsureRtkResult } from './rtk.js'
+
+type PiCodingAgentModule = typeof import('@gsd/pi-coding-agent')
+
+let piCodingAgentModulePromise: Promise<PiCodingAgentModule> | undefined
+
+function loadPiCodingAgentModule(): Promise<PiCodingAgentModule> {
+  return (piCodingAgentModulePromise ??= import('@gsd/pi-coding-agent'))
+}
 
 // ---------------------------------------------------------------------------
 // V8 compile cache — Node 22+ can cache compiled bytecode across runs,
@@ -120,8 +122,8 @@ function printExtensionWarnings(warnings: ReadonlyArray<{ message: string }> | u
  */
 async function reapplyValidatedModelOnFallback(
   session: { setModel(model: { provider: string; id: string }): unknown | Promise<unknown> },
-  modelRegistry: ModelRegistry,
-  settingsManager: SettingsManager,
+  modelRegistry: ModelRegistryInstance,
+  settingsManager: SettingsManagerInstance,
   fallbackMessage: string | undefined,
 ): Promise<void> {
   if (!fallbackMessage) return
@@ -159,25 +161,45 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
 // so concurrent callers await the same initialization.
 let rtkBootstrapPromise: Promise<void> | undefined
 async function doRtkBootstrap(): Promise<void> {
+  let rtkStatus: EnsureRtkResult | undefined
+
   // RTK is opt-in via experimental.rtk preference. Default: disabled.
   // Honor GSD_RTK_DISABLED if already explicitly set in the environment
   // (env var takes precedence over preferences for manual override).
   if (!process.env[GSD_RTK_DISABLED_ENV]) {
+    const { loadEffectiveGSDPreferences } = await import('./resources/extensions/gsd/preferences.js')
     const prefs = loadEffectiveGSDPreferences()
     const rtkEnabled = prefs?.preferences.experimental?.rtk === true
     if (!rtkEnabled) {
       process.env[GSD_RTK_DISABLED_ENV] = '1'
     }
   }
+  markStartup('rtkPreferenceCheck')
 
-  const rtkStatus = await bootstrapRtk()
+  if (process.env[GSD_RTK_DISABLED_ENV]) {
+    applyRtkProcessEnv(process.env)
+    rtkStatus = {
+      enabled: false,
+      supported: true,
+      available: false,
+      source: 'disabled',
+      reason: `${GSD_RTK_DISABLED_ENV} is set`,
+    }
+  } else {
+    const { bootstrapRtk } = await import('./rtk.js')
+    rtkStatus = await bootstrapRtk()
+  }
   markStartup('bootstrapRtk')
   if (!rtkStatus.available && rtkStatus.supported && rtkStatus.enabled && rtkStatus.reason) {
     process.stderr.write(`[gsd] Warning: RTK unavailable — continuing without shell-command compression (${rtkStatus.reason}).\n`)
   }
 }
 function ensureRtkBootstrap(): Promise<void> {
-  return (rtkBootstrapPromise ??= doRtkBootstrap())
+  if (!rtkBootstrapPromise) {
+    markStartup('preRtkBootstrap')
+    rtkBootstrapPromise = doRtkBootstrap()
+  }
+  return rtkBootstrapPromise
 }
 
 // `gsd update` — update to the latest version via npm.
@@ -278,21 +300,26 @@ if (!process.stdin.isTTY && !isPrintMode && !hasSubcommand && !cliFlags.listMode
   printNonTtyErrorAndExit(undefined, false)
 }
 
-const packageCommand = await runPackageCommand({
-  appName: 'gsd',
-  args: process.argv.slice(2),
-  cwd: process.cwd(),
-  agentDir,
-  stdout: process.stdout,
-  stderr: process.stderr,
-  allowedCommands: new Set(['install', 'remove', 'list']),
-})
-if (packageCommand.handled) {
-  process.exit(packageCommand.exitCode)
+const packageCommandNames: ReadonlySet<PackageCommand> = new Set(['install', 'remove', 'list'])
+if (packageCommandNames.has(cliFlags.messages[0] as PackageCommand)) {
+  const { runPackageCommand } = await loadPiCodingAgentModule()
+  const packageCommand = await runPackageCommand({
+    appName: 'gsd',
+    args: process.argv.slice(2),
+    cwd: process.cwd(),
+    agentDir,
+    stdout: process.stdout,
+    stderr: process.stderr,
+    allowedCommands: packageCommandNames,
+  })
+  if (packageCommand.handled) {
+    process.exit(packageCommand.exitCode)
+  }
 }
 
 // `gsd config` — replay the setup wizard and exit
 if (cliFlags.messages[0] === 'config') {
+  const { AuthStorage } = await loadPiCodingAgentModule()
   const authStorage = AuthStorage.create(authFilePath)
   loadStoredEnvKeys(authStorage)
   await runOnboarding(authStorage)
@@ -328,6 +355,7 @@ if (cliFlags.web || (cliFlags.messages[0] === 'web' && cliFlags.messages[1] !== 
 
 // `gsd sessions` — list past sessions and pick one to resume
 if (cliFlags.messages[0] === 'sessions') {
+  const { SessionManager } = await loadPiCodingAgentModule()
   const cwd = process.cwd()
   const safePath = `--${cwd.replace(/^[/\\]/, '').replace(/[/\\:]/g, '-')}--`
   const projectSessionsDir = join(sessionsDir, safePath)
@@ -416,7 +444,7 @@ async function runHeadlessFromAuto(headlessArgs: string[]): Promise<never> {
   process.exit(0)
 }
 
-function flushPendingProviderRegistrations(resourceLoader: DefaultResourceLoader, modelRegistry: ModelRegistry): void {
+function flushPendingProviderRegistrations(resourceLoader: DefaultResourceLoaderInstance, modelRegistry: ModelRegistryInstance): void {
   const { runtime } = resourceLoader.getExtensions()
   for (const { name, config } of runtime.pendingProviderRegistrations) {
     modelRegistry.registerProvider(name, config)
@@ -430,6 +458,19 @@ function flushPendingProviderRegistrations(resourceLoader: DefaultResourceLoader
 if (cliFlags.messages[0] === 'auto') {
   await runHeadlessFromAuto(buildHeadlessAutoArgs(cliFlags))
 }
+
+const {
+  AuthStorage,
+  DefaultResourceLoader,
+  ModelRegistry,
+  SettingsManager,
+  SessionManager,
+  createAgentSession,
+  InteractiveMode,
+  runPrintMode,
+  runRpcMode,
+} = await loadPiCodingAgentModule()
+markStartup('loadPiCodingAgent')
 
 // Pi's tool bootstrap can mis-detect already-installed fd/rg on some systems
 // because spawnSync(..., ["--version"]) returns EPERM despite a zero exit code.
@@ -547,6 +588,7 @@ if (!settingsManager.getQuietStartup()) {
 if (!settingsManager.getCollapseChangelog()) {
   settingsManager.setCollapseChangelog(true)
 }
+markStartup('startupSettings')
 
 // ---------------------------------------------------------------------------
 // Print / subagent mode — single-shot execution, no TTY required
@@ -581,7 +623,7 @@ if (isPrintMode) {
   flushPendingProviderRegistrations(resourceLoader, modelRegistry)
   migrateAnthropicDefaultToClaudeCode({
     authStorage,
-    isClaudeCodeReady: modelRegistry.isProviderRequestReady('claude-code'),
+    isClaudeCodeReady: () => modelRegistry.isProviderRequestReady('claude-code'),
     settingsManager,
     modelRegistry,
   })
@@ -689,10 +731,11 @@ if (cliFlags.worktree) {
 // ---------------------------------------------------------------------------
 if (!cliFlags.worktree && !isPrintMode) {
   try {
-    const { handleStatusBanner } = await import('./worktree-cli.js')
-    await handleStatusBanner(process.cwd())
+    const { showWorktreeStatusBanner } = await import('./worktree-status-banner.js')
+    showWorktreeStatusBanner(process.cwd())
   } catch { /* non-fatal */ }
 }
+markStartup('worktreeStatusBanner')
 
 // ---------------------------------------------------------------------------
 // Auto-redirect: `gsd auto` with piped stdout → headless mode (#2732)
@@ -734,7 +777,7 @@ markStartup('initResources')
 // Overlap resource loading with session manager setup — both are independent.
 // resourceLoader.reload() is the most expensive step (jiti compilation), so
 // starting it early shaves ~50-200ms off interactive startup.
-const resourceLoader = buildResourceLoader(agentDir)
+const resourceLoader = await buildResourceLoader(agentDir)
 const resourceLoadPromise = resourceLoader.reload()
 
 // While resources load, let session manager finish any async I/O it needs.
@@ -744,10 +787,11 @@ markStartup('resourceLoader.reload')
 flushPendingProviderRegistrations(resourceLoader, modelRegistry)
 migrateAnthropicDefaultToClaudeCode({
   authStorage,
-  isClaudeCodeReady: modelRegistry.isProviderRequestReady('claude-code'),
+  isClaudeCodeReady: () => modelRegistry.isProviderRequestReady('claude-code'),
   settingsManager,
   modelRegistry,
 })
+markStartup('providerMigrations')
 
 const { session, extensionsResult, modelFallbackMessage: interactiveFallbackMsg } = await createAgentSession({
   authStorage,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 // GSD Startup Loader
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 import { fileURLToPath } from 'url'
 import { dirname, resolve, join, relative, delimiter } from 'path'
 import { existsSync, readFileSync, readdirSync, statSync, mkdirSync, symlinkSync, cpSync } from 'fs'

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -70,7 +70,7 @@ if (firstArg === '--help' || firstArg === '-h') {
 }
 
 import { agentDir, appRoot } from './app-paths.js'
-import { applyRtkProcessEnv } from './rtk.js'
+import { applyRtkProcessEnv } from './rtk-shared.js'
 import { serializeBundledExtensionPaths } from './bundled-extension-paths.js'
 import { discoverExtensionEntryPaths } from './extension-discovery.js'
 import { loadRegistry, readManifestFromEntryPath, isExtensionEnabled } from './extension-registry.js'

--- a/src/provider-migrations.ts
+++ b/src/provider-migrations.ts
@@ -2,7 +2,7 @@ import type { AuthStorage } from "@gsd/pi-coding-agent"
 
 type AnthropicMigrationDeps = {
   authStorage: Pick<AuthStorage, "getCredentialsForProvider">
-  isClaudeCodeReady: boolean
+  isClaudeCodeReady: boolean | (() => boolean)
   defaultProvider: string | undefined
   env?: NodeJS.ProcessEnv
 }
@@ -14,7 +14,7 @@ type MigrationModel = {
 
 type AnthropicDefaultMigrationDeps = {
   authStorage: Pick<AuthStorage, "getCredentialsForProvider">
-  isClaudeCodeReady: boolean
+  isClaudeCodeReady: boolean | (() => boolean)
   settingsManager: {
     getDefaultProvider(): string | undefined
     getDefaultModel(): string | undefined
@@ -45,11 +45,15 @@ export function shouldMigrateAnthropicToClaudeCode({
   defaultProvider,
   env = process.env,
 }: AnthropicMigrationDeps): boolean {
-  if (!isClaudeCodeReady || defaultProvider !== "anthropic") {
+  if (defaultProvider !== "anthropic") {
     return false
   }
 
-  return !hasDirectAnthropicApiKey(authStorage, env)
+  if (hasDirectAnthropicApiKey(authStorage, env)) {
+    return false
+  }
+
+  return typeof isClaudeCodeReady === "function" ? isClaudeCodeReady() : isClaudeCodeReady
 }
 
 export function migrateAnthropicDefaultToClaudeCode({

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -764,7 +764,14 @@ function getBundledExtensionKeys(): Set<string> {
   return _bundledExtensionKeys
 }
 
-export async function buildResourceLoader(agentDir: string): Promise<DefaultResourceLoaderType> {
+interface BuildResourceLoaderOptions {
+  additionalExtensionPaths?: string[]
+}
+
+export async function buildResourceLoader(
+  agentDir: string,
+  options: BuildResourceLoaderOptions = {},
+): Promise<DefaultResourceLoaderType> {
   const { DefaultResourceLoader, sortExtensionPaths } = await loadPiCodingAgentModule()
   const registry = loadRegistry()
   const piAgentDir = join(homedir(), '.pi', 'agent')
@@ -777,10 +784,14 @@ export async function buildResourceLoader(agentDir: string): Promise<DefaultReso
       if (!manifest) return true
       return isExtensionEnabled(registry, manifest.id)
     })
+  const additionalExtensionPaths = [
+    ...piExtensionPaths,
+    ...(options.additionalExtensionPaths ?? []),
+  ]
 
   return new DefaultResourceLoader({
     agentDir,
-    additionalExtensionPaths: piExtensionPaths,
+    additionalExtensionPaths,
     bundledExtensionKeys: bundledKeys,
     extensionPathsTransform: (paths: string[]) => {
       // 1. Filter community extensions through the GSD registry

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -1,4 +1,4 @@
-import { DefaultResourceLoader, sortExtensionPaths } from '@gsd/pi-coding-agent'
+import type { DefaultResourceLoader as DefaultResourceLoaderType } from '@gsd/pi-coding-agent'
 import { createHash } from 'node:crypto'
 import { homedir } from 'node:os'
 import { chmodSync, copyFileSync, cpSync, existsSync, lstatSync, mkdirSync, openSync, closeSync, readFileSync, readlinkSync, readdirSync, rmSync, statSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
@@ -7,6 +7,14 @@ import { fileURLToPath } from 'node:url'
 import { compareSemver } from './update-check.js'
 import { discoverExtensionEntryPaths } from './extension-discovery.js'
 import { loadRegistry, readManifestFromEntryPath, isExtensionEnabled, ensureRegistryEntries } from './extension-registry.js'
+
+type PiCodingAgentModule = typeof import('@gsd/pi-coding-agent')
+
+let piCodingAgentModulePromise: Promise<PiCodingAgentModule> | undefined
+
+function loadPiCodingAgentModule(): Promise<PiCodingAgentModule> {
+  return (piCodingAgentModulePromise ??= import('@gsd/pi-coding-agent'))
+}
 
 // Resolve resources directory — prefer dist/resources/ (stable, set at build time)
 // over src/resources/ (live working tree, changes with git branch).
@@ -27,6 +35,7 @@ const resourcesDir = (existsSync(distResources) && existsSync(join(distResources
   : srcResources
 const bundledExtensionsDir = join(resourcesDir, 'extensions')
 const resourceVersionManifestName = 'managed-resources.json'
+const resourceFingerprintFileName = '.managed-resources-content-hash'
 
 interface ManagedResourceManifest {
   gsdVersion: string
@@ -102,7 +111,7 @@ function writeManagedResourceManifest(agentDir: string): void {
   const manifest: ManagedResourceManifest = {
     gsdVersion: getBundledGsdVersion(),
     syncedAt: Date.now(),
-    contentHash: computeResourceFingerprint(),
+    contentHash: getCurrentResourceFingerprint(),
     installedExtensionRootFiles,
     installedExtensionDirs,
   }
@@ -152,9 +161,22 @@ export function computeResourceFingerprint(rootDir: string = resourcesDir): stri
   return createHash('sha256').update(entries.join('\n')).digest('hex').slice(0, 16)
 }
 
+function getCurrentResourceFingerprint(): string {
+  try {
+    const precomputed = readFileSync(join(resourcesDir, resourceFingerprintFileName), 'utf-8').trim()
+    if (/^[a-f0-9]{16}$/i.test(precomputed)) {
+      return precomputed
+    }
+  } catch {
+    // Source-tree and partial-build workflows may not have a precomputed hash.
+  }
+  return computeResourceFingerprint()
+}
+
 function collectFileEntries(dir: string, root: string, out: string[]): void {
   if (!existsSync(dir)) return
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === resourceFingerprintFileName) continue
     const fullPath = join(dir, entry.name)
     if (entry.isDirectory()) {
       collectFileEntries(fullPath, root, out)
@@ -568,7 +590,7 @@ export function initResources(agentDir: string, skillsDir: string = join(homedir
   // hotfixes within a release). The content hash catches those at ~1ms cost.
   if (manifest && manifest.gsdVersion === currentVersion) {
     // Version matches — check content fingerprint for same-version staleness.
-    const currentHash = computeResourceFingerprint()
+    const currentHash = getCurrentResourceFingerprint()
     const hasStaleExtensionFiles = hasStaleCompiledExtensionSiblings(extensionsDir, bundledExtensionsDir)
     if (manifest.contentHash && manifest.contentHash === currentHash && !hasStaleExtensionFiles) {
       return
@@ -742,7 +764,8 @@ function getBundledExtensionKeys(): Set<string> {
   return _bundledExtensionKeys
 }
 
-export function buildResourceLoader(agentDir: string): DefaultResourceLoader {
+export async function buildResourceLoader(agentDir: string): Promise<DefaultResourceLoaderType> {
+  const { DefaultResourceLoader, sortExtensionPaths } = await loadPiCodingAgentModule()
   const registry = loadRegistry()
   const piAgentDir = join(homedir(), '.pi', 'agent')
   const piExtensionsDir = join(piAgentDir, 'extensions')

--- a/src/resources/extensions/gsd/auto-runtime-state.ts
+++ b/src/resources/extensions/gsd/auto-runtime-state.ts
@@ -1,6 +1,4 @@
 // GSD auto-mode runtime state
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
-
 import { AutoSession } from "./auto/session.js";
 import type { CurrentUnit } from "./auto/session.js";
 import {

--- a/src/resources/extensions/gsd/auto-runtime-state.ts
+++ b/src/resources/extensions/gsd/auto-runtime-state.ts
@@ -1,0 +1,53 @@
+// GSD auto-mode runtime state
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { AutoSession } from "./auto/session.js";
+import type { CurrentUnit } from "./auto/session.js";
+import {
+  isDeterministicPolicyError,
+  isQueuedUserMessageSkip,
+  isToolInvocationError,
+  markToolEnd as markTrackedToolEnd,
+  markToolStart as markTrackedToolStart,
+} from "./auto-tool-tracking.js";
+
+export const autoSession = new AutoSession();
+
+export type AutoRuntimeSnapshot = {
+  active: boolean;
+  paused: boolean;
+  currentUnit: CurrentUnit | null;
+  basePath: string;
+};
+
+export function getAutoRuntimeSnapshot(): AutoRuntimeSnapshot {
+  return {
+    active: autoSession.active,
+    paused: autoSession.paused,
+    currentUnit: autoSession.currentUnit ? { ...autoSession.currentUnit } : null,
+    basePath: autoSession.basePath,
+  };
+}
+
+export function isAutoActive(): boolean {
+  return autoSession.active;
+}
+
+export function isAutoPaused(): boolean {
+  return autoSession.paused;
+}
+
+export function markToolStart(toolCallId: string, toolName?: string): void {
+  markTrackedToolStart(toolCallId, autoSession.active, toolName);
+}
+
+export function markToolEnd(toolCallId: string): void {
+  markTrackedToolEnd(toolCallId);
+}
+
+export function recordToolInvocationError(toolName: string, errorMsg: string): void {
+  if (!autoSession.active) return;
+  if (isToolInvocationError(errorMsg) || isQueuedUserMessageSkip(errorMsg) || isDeterministicPolicyError(errorMsg)) {
+    autoSession.lastToolInvocationError = `${toolName}: ${errorMsg}`;
+  }
+}

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -232,7 +232,6 @@ import { reorderForCaching } from "./prompt-ordering.js";
 // ─── Session State ─────────────────────────────────────────────────────────
 
 import {
-  AutoSession,
   STUB_RECOVERY_THRESHOLD,
   NEW_SESSION_TIMEOUT_MS,
 } from "./auto/session.js";
@@ -250,11 +249,12 @@ export type {
   UnitRouting,
   StartModel,
 } from "./auto/session.js";
+import { autoSession as s } from "./auto-runtime-state.js";
 
 // ── ENCAPSULATION INVARIANT ─────────────────────────────────────────────────
 // ALL mutable auto-mode state lives in the AutoSession class (auto/session.ts).
 // This file must NOT declare module-level `let` or `var` variables for state.
-// The single `s` instance below is the only mutable module-level binding.
+// The single shared `s` instance below is the only mutable AutoSession binding.
 //
 // When adding features or fixing bugs:
 //   - New mutable state → add a property to AutoSession, not a module-level variable
@@ -263,7 +263,6 @@ export type {
 //
 // Tests in auto-session-encapsulation.test.ts enforce this invariant.
 // ─────────────────────────────────────────────────────────────────────────────
-const s = new AutoSession();
 
 /** Throttle STATE.md rebuilds — at most once per 30 seconds */
 const STATE_REBUILD_MIN_INTERVAL_MS = 30_000;

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -2,24 +2,15 @@ import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { Text } from "@gsd/pi-tui";
 
-import { findMilestoneIds, nextMilestoneId, claimReservedId, getReservedMilestoneIds } from "../guided-flow.js";
 import { loadEffectiveGSDPreferences } from "../preferences.js";
 import { ensureDbOpen } from "./dynamic-tools.js";
 import { StringEnum } from "@gsd/pi-ai";
 import { logError } from "../workflow-logger.js";
 import { getErrorMessage } from "../error-utils.js";
-import {
-  executeCompleteMilestone,
-  executePlanMilestone,
-  executePlanSlice,
-  executeReplanSlice,
-  executeReassessRoadmap,
-  executeSaveGateResult,
-  executeSliceComplete,
-  executeSummarySave,
-  executeTaskComplete,
-  executeValidateMilestone,
-} from "../tools/workflow-tool-executors.js";
+
+async function loadWorkflowExecutors(): Promise<typeof import("../tools/workflow-tool-executors.js")> {
+  return import("../tools/workflow-tool-executors.js");
+}
 
 /**
  * Register an alias tool that shares the same execute function as its canonical counterpart.
@@ -302,6 +293,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_summary_save (formerly gsd_save_summary) ──────────────────────
 
   const summarySaveExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
+    const { executeSummarySave } = await loadWorkflowExecutors();
     return executeSummarySave(params, process.cwd());
   };
 
@@ -354,6 +346,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
     try {
       // Claim a reserved ID if the guided-flow already previewed one to the user.
       // This guarantees the ID shown in the UI matches the one materialised on disk.
+      const { claimReservedId, findMilestoneIds, getReservedMilestoneIds, nextMilestoneId } = await import("../guided-flow.js");
       const reserved = claimReservedId();
       if (reserved) {
         await ensureMilestoneDbRow(reserved);
@@ -435,6 +428,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_plan_milestone (gsd_milestone_plan alias) ─────────────────────
 
   const planMilestoneExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
+    const { executePlanMilestone } = await loadWorkflowExecutors();
     return executePlanMilestone(params, process.cwd());
   };
 
@@ -504,6 +498,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_plan_slice (gsd_slice_plan alias) ─────────────────────────────
 
   const planSliceExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
+    const { executePlanSlice } = await loadWorkflowExecutors();
     return executePlanSlice(params, process.cwd());
   };
 
@@ -626,6 +621,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_task_complete (gsd_complete_task alias) ────────────────────────
 
   const taskCompleteExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
+    const { executeTaskComplete } = await loadWorkflowExecutors();
     return executeTaskComplete(params, process.cwd());
   };
 
@@ -696,6 +692,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_slice_complete (gsd_complete_slice alias) ─────────────────────
 
   const sliceCompleteExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
+    const { executeSliceComplete } = await loadWorkflowExecutors();
     return executeSliceComplete(params, process.cwd());
   };
 
@@ -888,6 +885,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_complete_milestone ────────────────────────────────────────────
 
   const milestoneCompleteExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
+    const { executeCompleteMilestone } = await loadWorkflowExecutors();
     return executeCompleteMilestone(params, process.cwd());
   };
 
@@ -933,6 +931,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_validate_milestone (gsd_milestone_validate alias) ─────────────
 
   const milestoneValidateExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
+    const { executeValidateMilestone } = await loadWorkflowExecutors();
     return executeValidateMilestone(params, process.cwd());
   };
 
@@ -970,6 +969,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_replan_slice (gsd_slice_replan alias) ─────────────────────────
 
   const replanSliceExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
+    const { executeReplanSlice } = await loadWorkflowExecutors();
     return executeReplanSlice(params, process.cwd());
   };
 
@@ -1020,6 +1020,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_reassess_roadmap (gsd_roadmap_reassess alias) ─────────────────
 
   const reassessRoadmapExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
+    const { executeReassessRoadmap } = await loadWorkflowExecutors();
     return executeReassessRoadmap(params, process.cwd());
   };
 
@@ -1275,6 +1276,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_save_gate_result ──────────────────────────────────────────────
 
   const saveGateResultExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
+    const { executeSaveGateResult } = await loadWorkflowExecutors();
     return executeSaveGateResult(params, process.cwd());
   };
 

--- a/src/resources/extensions/gsd/bootstrap/exec-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/exec-tools.ts
@@ -6,12 +6,6 @@
 import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 
-import { executeGsdExec } from "../tools/exec-tool.js";
-import { executeExecSearch } from "../tools/exec-search-tool.js";
-import { executeResume } from "../tools/resume-tool.js";
-import { loadEffectiveGSDPreferences } from "../preferences.js";
-import { logWarning } from "../workflow-logger.js";
-
 export function registerExecTools(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "gsd_exec",
@@ -46,7 +40,12 @@ export function registerExecTools(pi: ExtensionAPI): void {
       ),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
-      let prefs: Awaited<ReturnType<typeof loadEffectiveGSDPreferences>> | null = null;
+      const [{ executeGsdExec }, { loadEffectiveGSDPreferences }, { logWarning }] = await Promise.all([
+        import("../tools/exec-tool.js"),
+        import("../preferences.js"),
+        import("../workflow-logger.js"),
+      ]);
+      let prefs: ReturnType<typeof loadEffectiveGSDPreferences> | null = null;
       try {
         prefs = loadEffectiveGSDPreferences();
       } catch (err) {
@@ -81,6 +80,7 @@ export function registerExecTools(pi: ExtensionAPI): void {
       limit: Type.Optional(Type.Number({ description: "Max results (default 20, cap 200)", minimum: 1, maximum: 200 })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+      const { executeExecSearch } = await import("../tools/exec-search-tool.js");
       return executeExecSearch(params as Parameters<typeof executeExecSearch>[0], {
         baseDir: process.cwd(),
       });
@@ -101,6 +101,7 @@ export function registerExecTools(pi: ExtensionAPI): void {
     ],
     parameters: Type.Object({}),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+      const { executeResume } = await import("../tools/resume-tool.js");
       return executeResume(params as Parameters<typeof executeResume>[0], {
         baseDir: process.cwd(),
       });

--- a/src/resources/extensions/gsd/bootstrap/query-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/query-tools.ts
@@ -3,8 +3,6 @@
 import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { ensureDbOpen } from "./dynamic-tools.js";
-import { executeMilestoneStatus } from "../tools/workflow-tool-executors.js";
-import { checkpointDatabase } from "../gsd-db.js";
 
 export function registerQueryTools(pi: ExtensionAPI): void {
   pi.registerTool({
@@ -29,6 +27,7 @@ export function registerQueryTools(pi: ExtensionAPI): void {
           details: { operation: "milestone_status", error: "db_unavailable" },
         };
       }
+      const { executeMilestoneStatus } = await import("../tools/workflow-tool-executors.js");
       return executeMilestoneStatus(params);
     },
   });
@@ -55,6 +54,7 @@ export function registerQueryTools(pi: ExtensionAPI): void {
           details: { operation: "checkpoint_db", error: "db_unavailable" },
         };
       }
+      const { checkpointDatabase } = await import("../gsd-db.js");
       checkpointDatabase();
       return {
         content: [{ type: "text", text: "WAL checkpoint complete. gsd.db is now up to date and safe to stage with git add." }],

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -3,9 +3,8 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
 import { registerExitCommand } from "../exit-command.js";
-import { registerWorktreeCommand } from "../worktree-command.js";
+import { registerLazyWorktreeCommands } from "../worktree-command-bootstrap.js";
 import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-extension-api.js";
-import { loadEcosystemExtensions } from "../ecosystem/loader.js";
 import { registerDbTools } from "./db-tools.js";
 import { registerDynamicTools } from "./dynamic-tools.js";
 import { registerExecTools } from "./exec-tools.js";
@@ -71,7 +70,7 @@ function installEpipeGuard(): void {
 export function registerGsdExtension(pi: ExtensionAPI): void {
   // Note: registerGSDCommand is called by index.ts before this function,
   // so we intentionally skip it here to avoid double-registration.
-  registerWorktreeCommand(pi);
+  registerLazyWorktreeCommands(pi);
   registerExitCommand(pi);
 
   // Wire the Layer 2 event emitter bridge so deeply-nested GSD code can emit
@@ -116,12 +115,14 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
     ["cmux-events", () => initCmuxEventListeners(pi.events)],
     ["hooks", () => registerHooks(pi, ecosystemHandlers)],
     ["ecosystem", () => {
-      void loadEcosystemExtensions(pi, ecosystemHandlers).catch((err) => {
-        logWarning(
-          "ecosystem",
-          `loader failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
+      void import("../ecosystem/loader.js")
+        .then(({ loadEcosystemExtensions }) => loadEcosystemExtensions(pi, ecosystemHandlers))
+        .catch((err) => {
+          logWarning(
+            "ecosystem",
+            `loader failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
     }],
   ];
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -138,7 +138,10 @@ export function registerHooks(
       prepareWorkflowMcpForProject(ctx, process.cwd());
     }
     await loadToolApiKeysForSession();
-    if (isAutoActive()) {
+    if (!isAutoActive()) {
+      const { initHealthWidget } = await import("../health-widget.js");
+      initHealthWidget(ctx);
+    } else {
       ctx.ui.setWidget("gsd-health", undefined);
     }
   });

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -5,25 +5,16 @@ import { isToolCallEventType } from "@gsd/pi-coding-agent";
 
 import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-extension-api.js";
 import { updateSnapshot } from "../ecosystem/gsd-extension-api.js";
-import { getEcosystemReadyPromise } from "../ecosystem/loader.js";
 
 import { buildMilestoneFileName, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "../paths.js";
-import { buildBeforeAgentStartResult } from "./system-context.js";
-import { handleAgentEnd } from "./agent-end-recovery.js";
 import { clearDiscussionFlowState, isDepthConfirmationAnswer, isQueuePhaseActive, markDepthVerified, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, isGateQuestionId, setPendingGate, clearPendingGate, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
 import { resolveManifest } from "../unit-context-manifest.js";
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
-import { cleanupQuickBranch } from "../quick.js";
-import { getDiscussionMilestoneId } from "../guided-flow.js";
-import { loadToolApiKeys } from "../commands-config.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
-import { deriveState } from "../state.js";
-import { getAutoDashboardData, isAutoActive, isAutoPaused, markToolEnd, markToolStart, recordToolInvocationError } from "../auto.js";
+import { getAutoRuntimeSnapshot, isAutoActive, isAutoPaused, markToolEnd, markToolStart, recordToolInvocationError } from "../auto-runtime-state.js";
 
-import { isParallelActive, shutdownParallel } from "../parallel-orchestrator.js";
 import { checkToolCallLoop, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
 import { saveActivityLog } from "../activity-log.js";
-import { resetAskUserQuestionsCache } from "../../ask-user-questions.js";
 import { recordToolCall as safetyRecordToolCall, recordToolResult as safetyRecordToolResult, saveEvidenceToDisk } from "../safety/evidence-collector.js";
 import { parseUnitId } from "../unit-id.js";
 import { classifyCommand } from "../safety/destructive-guard.js";
@@ -31,11 +22,30 @@ import { logWarning as safetyLogWarning } from "../workflow-logger.js";
 import { installNotifyInterceptor } from "./notify-interceptor.js";
 import { initNotificationStore } from "../notification-store.js";
 import { initNotificationWidget } from "../notification-widget.js";
-import { initHealthWidget } from "../health-widget.js";
 
 // Skip the welcome screen on the very first session_start — cli.ts already
 // printed it before the TUI launched. Only re-print on /clear (subsequent sessions).
 let isFirstSession = true;
+
+async function deriveGsdState(basePath: string) {
+  const { deriveState } = await import("../state.js");
+  return deriveState(basePath);
+}
+
+async function getDiscussionMilestoneIdFor(basePath: string): Promise<string | null> {
+  const { getDiscussionMilestoneId } = await import("../guided-flow.js");
+  return getDiscussionMilestoneId(basePath);
+}
+
+async function loadToolApiKeysForSession(): Promise<void> {
+  const { loadToolApiKeys } = await import("../commands-config.js");
+  loadToolApiKeys();
+}
+
+async function resetAskUserQuestionsTurnCache(): Promise<void> {
+  const { resetAskUserQuestionsCache } = await import("../../ask-user-questions.js");
+  resetAskUserQuestionsCache();
+}
 
 async function syncServiceTierStatus(ctx: ExtensionContext): Promise<void> {
   const { getEffectiveServiceTier, formatServiceTierFooterStatus } = await import("../service-tier.js");
@@ -60,11 +70,12 @@ export function registerHooks(
     installNotifyInterceptor(ctx);
     initNotificationWidget(ctx);
     if (!isAutoActive()) {
+      const { initHealthWidget } = await import("../health-widget.js");
       initHealthWidget(ctx);
     }
     resetWriteGateState();
     resetToolCallLoopGuard();
-    resetAskUserQuestionsCache();
+    await resetAskUserQuestionsTurnCache();
     await syncServiceTierStatus(ctx);
     await applyDisabledModelProviderPolicy(ctx);
     // Skip MCP auto-prep when running inside an auto-worktree (see session_switch below).
@@ -102,7 +113,7 @@ export function registerHooks(
         }
       } catch { /* non-fatal */ }
     }
-    loadToolApiKeys();
+    await loadToolApiKeysForSession();
     if (isAutoActive()) {
       ctx.ui.setWidget("gsd-health", undefined);
     }
@@ -113,7 +124,7 @@ export function registerHooks(
     installNotifyInterceptor(ctx);
     resetWriteGateState();
     resetToolCallLoopGuard();
-    resetAskUserQuestionsCache();
+    await resetAskUserQuestionsTurnCache();
     clearDiscussionFlowState();
     await syncServiceTierStatus(ctx);
     await applyDisabledModelProviderPolicy(ctx);
@@ -126,7 +137,7 @@ export function registerHooks(
       const { prepareWorkflowMcpForProject } = await import("../workflow-mcp-auto-prep.js");
       prepareWorkflowMcpForProject(ctx, process.cwd());
     }
-    loadToolApiKeys();
+    await loadToolApiKeysForSession();
     if (isAutoActive()) {
       ctx.ui.setWidget("gsd-health", undefined);
     }
@@ -134,15 +145,17 @@ export function registerHooks(
 
   pi.on("before_agent_start", async (event, ctx: ExtensionContext) => {
     // Wait for ecosystem loader to finish (no-op after first turn).
+    const { getEcosystemReadyPromise } = await import("../ecosystem/loader.js");
     await getEcosystemReadyPromise();
 
     // GSD's own context injection (existing behavior — unchanged).
+    const { buildBeforeAgentStartResult } = await import("./system-context.js");
     const gsdResult = await buildBeforeAgentStartResult(event, ctx);
 
     // Refresh the snapshot used by ecosystem getPhase()/getActiveUnit().
     // deriveState has its own ~100ms cache so this is cheap on repeat calls.
     try {
-      const state = await deriveState(process.cwd());
+      const state = await deriveGsdState(process.cwd());
       updateSnapshot(state);
     } catch {
       updateSnapshot(null);
@@ -181,7 +194,8 @@ export function registerHooks(
 
   pi.on("agent_end", async (event, ctx: ExtensionContext) => {
     resetToolCallLoopGuard();
-    resetAskUserQuestionsCache();
+    await resetAskUserQuestionsTurnCache();
+    const { handleAgentEnd } = await import("./agent-end-recovery.js");
     await handleAgentEnd(pi, event, ctx);
   });
 
@@ -190,6 +204,7 @@ export function registerHooks(
   // quick-return state is pending, so this is safe to call on every turn.
   pi.on("turn_end", async () => {
     try {
+      const { cleanupQuickBranch } = await import("../quick.js");
       cleanupQuickBranch();
     } catch {
       // Best-effort: don't break the turn lifecycle if cleanup fails.
@@ -206,7 +221,7 @@ export function registerHooks(
     const basePath = process.cwd();
     const { ensureDbOpen } = await import("./dynamic-tools.js");
     await ensureDbOpen();
-    const state = await deriveState(basePath);
+    const state = await deriveGsdState(basePath);
     if (!state.activeMilestone || !state.activeSlice) return;
     // Write checkpoint for ALL phases, not just "executing" — discuss, research,
     // and planning also carry in-memory state (user answers, gate verification)
@@ -268,7 +283,7 @@ export function registerHooks(
       const basePath = process.cwd();
       let activeContext: string | null = null;
       try {
-        const state = await deriveState(basePath);
+        const state = await deriveGsdState(basePath);
         if (state.activeMilestone && state.activeSlice && state.activeTask) {
           activeContext =
             `Active: ${state.activeMilestone.id} / ${state.activeSlice.id} / ${state.activeTask.id}` +
@@ -287,6 +302,7 @@ export function registerHooks(
   });
 
   pi.on("session_shutdown", async (_event, ctx: ExtensionContext) => {
+    const { isParallelActive, shutdownParallel } = await import("../parallel-orchestrator.js");
     if (isParallelActive()) {
       try {
         await shutdownParallel(process.cwd());
@@ -295,7 +311,7 @@ export function registerHooks(
       }
     }
     if (!isAutoActive() && !isAutoPaused()) return;
-    const dash = getAutoDashboardData();
+    const dash = getAutoRuntimeSnapshot();
     if (dash.currentUnit) {
       saveActivityLog(ctx, dash.basePath, dash.currentUnit.type, dash.currentUnit.id);
     }
@@ -324,7 +340,7 @@ export function registerHooks(
     // If ask_user_questions was called with a gate ID but hasn't been confirmed,
     // block all non-read-only tool calls to prevent the model from skipping gates.
     if (getPendingGate()) {
-      const milestoneId = getDiscussionMilestoneId(discussionBasePath);
+      const milestoneId = await getDiscussionMilestoneIdFor(discussionBasePath);
       if (isToolCallEventType("bash", event)) {
         const bashGuard = shouldBlockPendingGateBash(
           event.input.command,
@@ -365,7 +381,7 @@ export function registerHooks(
     // manifest's allowedPathGlobs), bash that isn't read-only, and
     // subagent dispatch. Closes the b23 bug class where a discuss-milestone
     // turn used the host Edit tool to modify user source files.
-    const dash = getAutoDashboardData();
+    const dash = getAutoRuntimeSnapshot();
     const activeUnitType = dash.currentUnit?.type;
     if (activeUnitType) {
       const manifest = resolveManifest(activeUnitType);
@@ -414,7 +430,7 @@ export function registerHooks(
     const result = shouldBlockContextWrite(
       event.toolName,
       event.input.path,
-      getDiscussionMilestoneId(discussionBasePath),
+      await getDiscussionMilestoneIdFor(discussionBasePath),
       isQueuePhaseActive(),
     );
     if (result.block) return result;
@@ -459,7 +475,7 @@ export function registerHooks(
       recordToolInvocationError(event.toolName, errorText);
     }
     if (event.toolName !== "ask_user_questions") return;
-    const milestoneId = getDiscussionMilestoneId(process.cwd());
+    const milestoneId = await getDiscussionMilestoneIdFor(process.cwd());
     const queueActive = isQueuePhaseActive();
 
     const details = event.details as any;
@@ -558,7 +574,7 @@ export function registerHooks(
       safetyRecordToolResult(event.toolCallId, event.toolName, event.result, event.isError);
       // Persist evidence to disk after each tool result so it survives a session
       // restart mid-unit (Bug #4385 — non-persisted evidence false positives).
-      const dash = getAutoDashboardData();
+      const dash = getAutoRuntimeSnapshot();
       if (dash.basePath && dash.currentUnit?.type === "execute-task") {
         const { milestone: pMid, slice: pSid, task: pTid } = parseUnitId(dash.currentUnit.id);
         if (pMid && pSid && pTid) {

--- a/src/resources/extensions/gsd/bootstrap/register-shortcuts.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-shortcuts.ts
@@ -4,12 +4,13 @@ import { join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 import { Key } from "@gsd/pi-tui";
 
-import { GSDDashboardOverlay } from "../dashboard-overlay.js";
-import { GSDNotificationOverlay } from "../notification-overlay.js";
-import { ParallelMonitorOverlay } from "../parallel-monitor-overlay.js";
 import { GSD_SHORTCUTS } from "../shortcut-defs.js";
-import { projectRoot } from "../commands/context.js";
 import { shortcutDesc } from "../../shared/mod.js";
+
+async function getProjectRoot(): Promise<string> {
+  const { projectRoot } = await import("../commands/context.js");
+  return projectRoot();
+}
 
 export function registerShortcuts(pi: ExtensionAPI): void {
   const overlayOptions = {
@@ -20,7 +21,10 @@ export function registerShortcuts(pi: ExtensionAPI): void {
   } as const;
 
   const openDashboardOverlay = async (ctx: ExtensionContext) => {
-    const basePath = projectRoot();
+    const [{ GSDDashboardOverlay }, basePath] = await Promise.all([
+      import("../dashboard-overlay.js"),
+      getProjectRoot(),
+    ]);
     if (!existsSync(join(basePath, ".gsd"))) {
       ctx.ui.notify("No .gsd/ directory found. Run /gsd to start.", "info");
       return;
@@ -35,6 +39,7 @@ export function registerShortcuts(pi: ExtensionAPI): void {
   };
 
   const openNotificationsOverlay = async (ctx: ExtensionContext) => {
+    const { GSDNotificationOverlay } = await import("../notification-overlay.js");
     await ctx.ui.custom<boolean>(
       (tui, theme, _kb, done) => new GSDNotificationOverlay(tui, theme, () => done(true)),
       {
@@ -51,12 +56,13 @@ export function registerShortcuts(pi: ExtensionAPI): void {
   };
 
   const openParallelOverlay = async (ctx: ExtensionContext) => {
-    const basePath = projectRoot();
+    const basePath = await getProjectRoot();
     const parallelDir = join(basePath, ".gsd", "parallel");
     if (!existsSync(parallelDir)) {
       ctx.ui.notify("No parallel workers found. Run /gsd parallel start first.", "info");
       return;
     }
+    const { ParallelMonitorOverlay } = await import("../parallel-monitor-overlay.js");
     await ctx.ui.custom<boolean>(
       (tui, theme, _kb, done) => new ParallelMonitorOverlay(tui, theme, () => done(true), basePath),
       {

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -15,7 +15,7 @@ import { resolveGsdRootFile, resolveSliceFile, resolveSlicePath, resolveTaskFile
 import { ensureCodebaseMapFresh, readCodebaseMap } from "../codebase-generator.js";
 import { hasSkillSnapshot, detectNewSkills, formatSkillsXml } from "../skill-discovery.js";
 import { getActiveAutoWorktreeContext } from "../auto-worktree.js";
-import { getActiveWorktreeName, getWorktreeOriginalCwd } from "../worktree-command.js";
+import { getActiveWorktreeName, getWorktreeOriginalCwd } from "../worktree-session-state.js";
 import { deriveState } from "../state.js";
 import { formatOverridesSection, formatShortcut, loadActiveOverrides, loadFile, parseContinue, parseSummary } from "../files.js";
 import { toPosixPath } from "../../shared/mod.js";

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -1,9 +1,8 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { loadRegistry } from "../workflow-templates.js";
-import { resolveProjectRoot } from "../worktree.js";
 
 const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
 
@@ -346,6 +345,77 @@ function getExtensionCompletions(prefix: string, action: string) {
   }
 }
 
+function normalizePathForCompare(path: string): string {
+  return path.replaceAll("\\", "/").replace(/\/+$/, "");
+}
+
+function findWorktreeSegment(normalizedPath: string): { gsdIdx: number; afterWorktrees: number } | null {
+  const directMarker = "/.gsd/worktrees/";
+  const directIdx = normalizedPath.indexOf(directMarker);
+  if (directIdx !== -1) {
+    return { gsdIdx: directIdx, afterWorktrees: directIdx + directMarker.length };
+  }
+
+  const symlinkMatch = normalizedPath.match(/\/\.gsd\/projects\/[a-f0-9]+\/worktrees\//);
+  if (symlinkMatch?.index !== undefined) {
+    return { gsdIdx: symlinkMatch.index, afterWorktrees: symlinkMatch.index + symlinkMatch[0].length };
+  }
+
+  return null;
+}
+
+function resolveProjectRootFromGitFile(worktreePath: string): string | null {
+  try {
+    let dir = worktreePath;
+    for (let i = 0; i < 30; i++) {
+      const gitPath = join(dir, ".git");
+      if (existsSync(gitPath)) {
+        const content = readFileSync(gitPath, "utf8").trim();
+        if (content.startsWith("gitdir: ")) {
+          const gitDir = resolve(dir, content.slice(8));
+          const dotGitDir = resolve(gitDir, "..", "..");
+          if (dotGitDir.endsWith(".git") || dotGitDir.endsWith(".git/") || dotGitDir.endsWith(".git\\")) {
+            return resolve(dotGitDir, "..");
+          }
+          const commonDirPath = join(gitDir, "commondir");
+          if (existsSync(commonDirPath)) {
+            const commonDir = readFileSync(commonDirPath, "utf8").trim();
+            return resolve(resolve(gitDir, commonDir), "..");
+          }
+        }
+        break;
+      }
+      const parent = resolve(dir, "..");
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Completion must stay best-effort.
+  }
+  return null;
+}
+
+function resolveProjectRootForCompletion(basePath: string): string {
+  if (process.env.GSD_PROJECT_ROOT) return process.env.GSD_PROJECT_ROOT;
+
+  const normalizedPath = normalizePathForCompare(basePath);
+  const segment = findWorktreeSegment(normalizedPath);
+  if (!segment) return basePath;
+
+  const separator = basePath.includes("\\") ? "\\" : "/";
+  const gsdMarker = `${separator}.gsd${separator}`;
+  const gsdIdx = basePath.indexOf(gsdMarker);
+  const candidate = gsdIdx !== -1 ? basePath.slice(0, gsdIdx) : basePath.slice(0, segment.gsdIdx);
+
+  const normalizedGsdHome = normalizePathForCompare(gsdHome);
+  const candidateGsdPath = normalizePathForCompare(join(candidate, ".gsd"));
+  if (candidateGsdPath === normalizedGsdHome || candidateGsdPath.startsWith(`${normalizedGsdHome}/`)) {
+    return resolveProjectRootFromGitFile(basePath) ?? basePath;
+  }
+
+  return candidate;
+}
+
 export function getGsdArgumentCompletions(prefix: string) {
   const hasTrailingSpace = prefix.endsWith(" ");
   const parts = prefix.trim().split(/\s+/);
@@ -406,7 +476,7 @@ export function getGsdArgumentCompletions(prefix: string) {
   // Workflow definition-name completion for `workflow run <name>` and `workflow validate <name>`
   if (command === "workflow" && (subcommand === "run" || subcommand === "validate") && parts.length <= 3) {
     try {
-      const defsDir = join(resolveProjectRoot(process.cwd()), ".gsd", "workflow-defs");
+      const defsDir = join(resolveProjectRootForCompletion(process.cwd()), ".gsd", "workflow-defs");
       if (existsSync(defsDir)) {
         return readdirSync(defsDir)
           .filter((f) => f.endsWith(".yaml") && f.startsWith(third))
@@ -443,7 +513,7 @@ export function getGsdArgumentCompletions(prefix: string) {
       } catch { /* ignore */ }
     };
     try {
-      const base = resolveProjectRoot(process.cwd());
+      const base = resolveProjectRootForCompletion(process.cwd());
       scanDir(join(base, ".gsd", "workflows"), "project");
       scanDir(join(base, ".gsd", "workflow-defs"), "project-legacy");
       scanDir(join(gsdHome, "workflows"), "global");

--- a/src/resources/extensions/gsd/dashboard-overlay.ts
+++ b/src/resources/extensions/gsd/dashboard-overlay.ts
@@ -21,7 +21,7 @@ import {
   type UnitMetrics,
 } from "./metrics.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
-import { getActiveWorktreeName } from "./worktree-command.js";
+import { getActiveWorktreeName } from "./worktree-session-state.js";
 import { getWorkerBatches, hasActiveWorkers, type WorkerEntry } from "../subagent/worker-registry.js";
 import { formatDuration, padRight, joinColumns, centerLine, fitColumns, STATUS_GLYPH, STATUS_COLOR } from "../shared/mod.js";
 import { estimateTimeRemaining } from "./auto-dashboard.js";

--- a/src/resources/extensions/gsd/prompt-loader.ts
+++ b/src/resources/extensions/gsd/prompt-loader.ts
@@ -7,14 +7,13 @@
  * Templates live at prompts/ relative to this module's directory.
  * They use {{variableName}} syntax for substitution.
  *
- * All templates are eagerly loaded into cache at module init via warmCache().
- * This prevents a running session from being invalidated when another `gsd`
- * launch overwrites ~/.gsd/agent/ with newer templates via initResources().
- * Without eager caching, the in-memory extension code (which knows variable
- * set A) can read a newer template from disk (which expects variable set B),
- * causing a "template declares {{X}} but no value was provided" crash
- * mid-session — especially for late-loading templates like complete-milestone
- * that aren't read until the end of a long auto-mode run.
+ * Templates are snapshotted shortly after module init via warmCache().
+ * This keeps import/extension-registration fast while still preventing a
+ * running session from being invalidated when another `gsd` launch overwrites
+ * ~/.gsd/agent/ with newer templates via initResources(). Without caching, the
+ * in-memory extension code (which knows variable set A) can read a newer
+ * template from disk (which expects variable set B), causing a
+ * "template declares {{X}} but no value was provided" crash mid-session.
  */
 
 import { readFileSync, readdirSync, existsSync } from "node:fs";
@@ -82,8 +81,8 @@ export function getTemplatesDir(): string {
   return templatesDir;
 }
 
-// Cache all templates eagerly at module load — a running session uses the
-// template versions that were on disk at startup, immune to later overwrites.
+// Cache all templates from a startup snapshot — a running session uses the
+// template versions that were on disk near startup, immune to later overwrites.
 const templateCache = new Map<string, string>();
 
 /**
@@ -124,8 +123,23 @@ function warmCache(): void {
   }
 }
 
-// Snapshot all templates at module load time
-warmCache();
+let warmCacheScheduled = false;
+
+function scheduleWarmCache(): void {
+  if (warmCacheScheduled) return;
+  warmCacheScheduled = true;
+
+  const run = () => {
+    warmCache();
+  };
+
+  const timer = setTimeout(run, 1000);
+  timer.unref?.();
+}
+
+// Snapshot the full prompt/template tree after import so extension startup only
+// pays for prompts that are actually needed immediately.
+scheduleWarmCache();
 
 /**
  * Load a prompt template and substitute variables.

--- a/src/resources/extensions/gsd/tests/auto-session-encapsulation.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-session-encapsulation.test.ts
@@ -18,6 +18,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const AUTO_TS_PATH = join(__dirname, "..", "auto.ts");
 const SESSION_TS_PATH = join(__dirname, "..", "auto", "session.ts");
+const RUNTIME_STATE_TS_PATH = join(__dirname, "..", "auto-runtime-state.ts");
 
 function getAutoTsSource(): string {
   return readFileSync(AUTO_TS_PATH, "utf-8");
@@ -25,6 +26,10 @@ function getAutoTsSource(): string {
 
 function getSessionTsSource(): string {
   return readFileSync(SESSION_TS_PATH, "utf-8");
+}
+
+function getRuntimeStateTsSource(): string {
+  return readFileSync(RUNTIME_STATE_TS_PATH, "utf-8");
 }
 
 // ── Invariant 1: No module-level mutable variables in auto.ts ────────────────
@@ -75,18 +80,18 @@ test("auto.ts has no module-level var declarations", () => {
 
 // ── Invariant 2: AutoSession singleton is the only mutable module-level binding ──
 
-test("auto.ts has exactly one module-level const for AutoSession", () => {
-  const source = getAutoTsSource();
+test("auto-runtime-state.ts has exactly one module-level const for AutoSession", () => {
+  const source = getRuntimeStateTsSource();
   const lines = source.split("\n");
 
   const sessionConsts = lines.filter(line =>
-    /^const\s+\w+\s*=\s*new\s+AutoSession/.test(line),
+    /^(export\s+)?const\s+\w+\s*=\s*new\s+AutoSession/.test(line),
   );
 
   assert.equal(
     sessionConsts.length,
     1,
-    `auto.ts should have exactly one \`const s = new AutoSession()\`. ` +
+    `auto-runtime-state.ts should have exactly one \`const autoSession = new AutoSession()\`. ` +
     `Found ${sessionConsts.length}: ${sessionConsts.join(", ")}`,
   );
 });
@@ -201,7 +206,6 @@ test("auto.ts module-level consts are only AutoSession instance, true constants,
 
   // Patterns that are acceptable at module level
   const allowedPatterns = [
-    /^const s = new AutoSession/,                 // The session singleton
     /^const [A-Z_]+\s*=/,                          // UPPER_CASE constants
     /^const \w+StateAccessors/,                    // Static accessor objects
     /^const \w+:\s*\w+\s*=/,                       // Typed constants

--- a/src/resources/extensions/gsd/tests/bootstrap-derive-state-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/bootstrap-derive-state-db-open.test.ts
@@ -32,7 +32,7 @@ describe("bootstrap deriveState DB guards (#3844)", () => {
     assert.ok(compactIdx > -1, "register-hooks should define session_before_compact");
     const compactSection = extractSourceRegion(registerHooksSrc, 'pi.on("session_before_compact"');
     const ensureIdx = compactSection.indexOf("ensureDbOpen()");
-    const deriveIdx = compactSection.indexOf("deriveState(basePath)");
+    const deriveIdx = compactSection.indexOf("deriveGsdState(basePath)");
     assert.ok(ensureIdx > -1, "session_before_compact should call ensureDbOpen()");
     assert.ok(deriveIdx > -1, "session_before_compact should derive state");
     assert.ok(ensureIdx < deriveIdx, "session_before_compact should open DB before deriveState");

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -12,7 +12,7 @@ import { mkdtempSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { autoLoop, resolveAgentEnd, _resetPendingResolve } from "../auto-loop.js";
+import { autoLoop, resolveAgentEnd, _hasPendingResolveForTest, _resetPendingResolve } from "../auto-loop.js";
 import type { LoopDeps } from "../auto/loop-deps.js";
 import type { SessionLockStatus } from "../session-lock.js";
 import { writeGraph, readGraph, type WorkflowGraph, type GraphStep } from "../graph.ts";
@@ -27,6 +27,17 @@ function makeTmpDir(): string {
   const dir = mkdtempSync(join(tmpdir(), "loop-integ-"));
   tmpDirs.push(dir);
   return dir;
+}
+
+async function resolveNextAgentEnd(timeoutMs = 3_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!_hasPendingResolveForTest()) {
+    if (Date.now() > deadline) {
+      throw new Error("Timed out waiting for pending agent_end resolver");
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  resolveAgentEnd({ messages: [{ role: "assistant" }] });
 }
 
 afterEach(() => {
@@ -276,19 +287,16 @@ describe("Custom engine loop integration", () => {
     // We need to resolve resolveAgentEnd for each step.
 
     // Step 1: step-a
-    await new Promise((r) => setTimeout(r, 80));
     unitCount++;
-    resolveAgentEnd({ messages: [{ role: "assistant" }] });
+    await resolveNextAgentEnd();
 
     // Step 2: step-b
-    await new Promise((r) => setTimeout(r, 80));
     unitCount++;
-    resolveAgentEnd({ messages: [{ role: "assistant" }] });
+    await resolveNextAgentEnd();
 
     // Step 3: step-c
-    await new Promise((r) => setTimeout(r, 80));
     unitCount++;
-    resolveAgentEnd({ messages: [{ role: "assistant" }] });
+    await resolveNextAgentEnd();
 
     // After step-c completes, engine.reconcile marks it complete, then
     // next deriveState sees isComplete=true → stopAuto → loop exits
@@ -398,8 +406,7 @@ describe("Custom engine loop integration", () => {
 
     const loopPromise = autoLoop(ctx, pi, s, deps);
 
-    await new Promise((r) => setTimeout(r, 80));
-    resolveAgentEnd({ messages: [{ role: "assistant" }] });
+    await resolveNextAgentEnd();
 
     await loopPromise;
 
@@ -460,12 +467,10 @@ describe("Custom engine loop integration", () => {
     const loopPromise = autoLoop(ctx, pi, s, deps);
 
     // Resolve step-a
-    await new Promise((r) => setTimeout(r, 80));
-    resolveAgentEnd({ messages: [{ role: "assistant" }] });
+    await resolveNextAgentEnd();
 
     // Resolve step-b
-    await new Promise((r) => setTimeout(r, 80));
-    resolveAgentEnd({ messages: [{ role: "assistant" }] });
+    await resolveNextAgentEnd();
 
     await loopPromise;
 
@@ -514,7 +519,9 @@ describe("Custom engine loop integration", () => {
     });
 
     const resolver = setInterval(() => {
-      resolveAgentEnd({ messages: [{ role: "assistant" }] });
+      if (_hasPendingResolveForTest()) {
+        resolveAgentEnd({ messages: [{ role: "assistant" }] });
+      }
     }, 25);
     let timeout: NodeJS.Timeout | undefined;
     try {
@@ -569,7 +576,9 @@ describe("Custom engine loop integration", () => {
     });
     const deps1 = makeMockDeps();
     const resolver1 = setInterval(() => {
-      resolveAgentEnd({ messages: [{ role: "assistant" }] });
+      if (_hasPendingResolveForTest()) {
+        resolveAgentEnd({ messages: [{ role: "assistant" }] });
+      }
       if (pi1.calls.length >= 2) {
         s1.active = false;
       }
@@ -614,7 +623,9 @@ describe("Custom engine loop integration", () => {
       },
     });
     const resolver2 = setInterval(() => {
-      resolveAgentEnd({ messages: [{ role: "assistant" }] });
+      if (_hasPendingResolveForTest()) {
+        resolveAgentEnd({ messages: [{ role: "assistant" }] });
+      }
     }, 25);
     let timeout2: NodeJS.Timeout | undefined;
     try {
@@ -677,16 +688,14 @@ describe("Custom engine loop integration", () => {
     const loopPromise = autoLoop(ctx, pi, s, deps);
 
     // Resolve step-a successfully
-    await new Promise((r) => setTimeout(r, 80));
-    resolveAgentEnd({ messages: [{ role: "assistant" }] });
+    await resolveNextAgentEnd();
 
     // Step-b enters runUnit — deactivate the session before resolving.
     // runUnit checks s.active after newSession and returns cancelled if false.
     // But since newSession resolves synchronously in our mock (before the
     // active check), the unit still runs. Instead, let's just cancel it.
-    await new Promise((r) => setTimeout(r, 80));
     // Resolve as cancelled to simulate a failed session
-    resolveAgentEnd({ messages: [{ role: "assistant" }] });
+    await resolveNextAgentEnd();
 
     // The reconcile will still run for step-b in this flow since
     // runUnitPhase returns "next" (not "break") for completed units.

--- a/src/resources/extensions/gsd/tests/quick-turn-end-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/quick-turn-end-cleanup.test.ts
@@ -23,19 +23,19 @@ describe("quick task turn_end cleanup (#2668)", () => {
     "utf-8",
   );
 
-  it("register-hooks.ts imports cleanupQuickBranch from quick.ts", () => {
+  it("register-hooks.ts loads cleanupQuickBranch from quick.ts", () => {
     assert.ok(
       hooksSource.includes("cleanupQuickBranch"),
       "register-hooks.ts must reference cleanupQuickBranch",
     );
 
-    // Verify it's imported (not just mentioned in a comment)
-    const importMatch = hooksSource.match(
-      /import\s*\{[^}]*cleanupQuickBranch[^}]*\}\s*from\s*["'][^"']*quick/,
-    );
+    // Verify it is loaded from quick.ts (static or lazy), not just mentioned in a comment.
+    const importMatch =
+      hooksSource.match(/import\s*\{[^}]*cleanupQuickBranch[^}]*\}\s*from\s*["'][^"']*quick/) ||
+      hooksSource.match(/const\s+\{\s*cleanupQuickBranch\s*\}\s*=\s*await\s+import\(["'][^"']*quick\.js["']\)/);
     assert.ok(
       importMatch,
-      "cleanupQuickBranch must be imported from quick module",
+      "cleanupQuickBranch must be loaded from quick module",
     );
   });
 

--- a/src/resources/extensions/gsd/tests/session-start-footer.test.ts
+++ b/src/resources/extensions/gsd/tests/session-start-footer.test.ts
@@ -7,9 +7,8 @@
  *
  * Testing strategy:
  *   1. Source-code regression guards: structural checks on register-hooks.ts.
- *   2. Behavioral integration test: fires the live session_start handler with a
- *      fake ctx when isAutoActive() is false (default) and confirms neither
- *      setFooter nor setWidget("gsd-health") is called.
+ *   2. Behavioral integration tests: fire the live session handlers with fake
+ *      contexts and confirm footer/widget behavior from runtime effects.
  *
  * Relates to #4314.
  */
@@ -21,6 +20,7 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+import { autoSession } from "../auto-runtime-state.ts";
 import { registerHooks } from "../bootstrap/register-hooks.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -68,39 +68,83 @@ test("session_start handler guards initHealthWidget with !isAutoActive()", () =>
   );
 });
 
-test("session_switch handler toggles gsd-health for auto and non-auto sessions", () => {
-  const sessionSwitchIdx = HOOKS_SOURCE.indexOf('"session_switch"');
-  assert.ok(sessionSwitchIdx > -1, "session_switch handler must exist");
+test("session_switch toggles gsd-health from runtime auto state without touching the footer", async (t) => {
+  const dir = join(
+    tmpdir(),
+    `gsd-session-switch-widget-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
 
-  const beforeAgentStartIdx = HOOKS_SOURCE.indexOf('"before_agent_start"');
-  assert.ok(beforeAgentStartIdx > sessionSwitchIdx, "before_agent_start handler must follow session_switch");
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  autoSession.reset();
+  t.after(() => {
+    autoSession.reset();
+    process.chdir(originalCwd);
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
 
-  const sessionSwitchBody = HOOKS_SOURCE.slice(sessionSwitchIdx, beforeAgentStartIdx);
+  const handlers = new Map<string, (event: unknown, ctx: any) => Promise<void> | void>();
+  const pi = {
+    on(event: string, handler: (event: unknown, ctx: any) => Promise<void> | void) {
+      handlers.set(event, handler);
+    },
+  } as any;
 
-  assert.ok(
-    sessionSwitchBody.includes("isAutoActive()"),
-    "session_switch handler must call isAutoActive()",
-  );
-  assert.ok(
-    sessionSwitchBody.includes("initHealthWidget"),
-    "session_switch handler must initialize gsd-health when auto is inactive",
-  );
-  assert.ok(
-    sessionSwitchBody.includes('setWidget("gsd-health", undefined)'),
-    "session_switch handler must call setWidget(\"gsd-health\", undefined) when auto is active",
-  );
-  assert.ok(
-    !sessionSwitchBody.includes("setFooter"),
-    "session_switch handler must NOT call setFooter",
-  );
+  registerHooks(pi, []);
 
-  const inactiveGuardIdx = sessionSwitchBody.indexOf("!isAutoActive()");
-  const healthIdx = sessionSwitchBody.indexOf("initHealthWidget");
-  const hideIdx = sessionSwitchBody.indexOf('setWidget("gsd-health", undefined)');
-  assert.ok(
-    inactiveGuardIdx > -1 && inactiveGuardIdx < healthIdx && healthIdx < hideIdx,
-    "session_switch must initialize before the auto-active hide branch",
+  const sessionSwitch = handlers.get("session_switch");
+  assert.ok(sessionSwitch, "session_switch handler must be registered");
+
+  let setFooterCallCount = 0;
+  const widgetCalls: Array<{ key: string; value: unknown }> = [];
+  const ctx = {
+    hasUI: true,
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setFooter: (_footer: unknown) => {
+        setFooterCallCount++;
+      },
+      setWorkingMessage: () => {},
+      onTerminalInput: () => () => {},
+      setWidget: (key: string, value: unknown) => {
+        widgetCalls.push({ key, value });
+      },
+    },
+    sessionManager: { getSessionId: () => null },
+    model: null,
+    modelRegistry: {
+      setDisabledModelProviders: () => {},
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => false,
+    },
+  };
+
+  autoSession.active = true;
+  await sessionSwitch!({ reason: "resume" }, ctx);
+  assert.deepEqual(
+    widgetCalls.filter((call) => call.key === "gsd-health").map((call) => call.value),
+    [undefined],
+    "session_switch should hide gsd-health when auto is active",
   );
+  assert.equal(setFooterCallCount, 0, "session_switch must not call setFooter when auto is active");
+
+  widgetCalls.length = 0;
+  autoSession.active = false;
+  await sessionSwitch!({ reason: "resume" }, ctx);
+  const healthWidgetValues = widgetCalls
+    .filter((call) => call.key === "gsd-health")
+    .map((call) => call.value);
+
+  assert.ok(healthWidgetValues.length >= 2, "session_switch should initialize gsd-health when auto is inactive");
+  assert.ok(
+    healthWidgetValues.every((value) => value !== undefined),
+    "session_switch must not hide gsd-health when auto is inactive",
+  );
+  assert.ok(Array.isArray(healthWidgetValues[0]), "initHealthWidget should publish initial health lines");
+  assert.equal(typeof healthWidgetValues.at(-1), "function", "initHealthWidget should register the live widget factory");
+  assert.equal(setFooterCallCount, 0, "session_switch must not call setFooter when auto is inactive");
 });
 
 // ─── Behavioral test: neither setFooter nor health suppression when auto inactive ─

--- a/src/resources/extensions/gsd/tests/session-start-footer.test.ts
+++ b/src/resources/extensions/gsd/tests/session-start-footer.test.ts
@@ -74,13 +74,19 @@ test("session_switch toggles gsd-health from runtime auto state without touching
     `gsd-session-switch-widget-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
   );
   mkdirSync(join(dir, ".gsd"), { recursive: true });
+  const tempGsdHome = join(dir, "home");
+  mkdirSync(tempGsdHome, { recursive: true });
 
   const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  process.env.GSD_HOME = tempGsdHome;
   process.chdir(dir);
   autoSession.reset();
   t.after(() => {
     autoSession.reset();
     process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
     try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
   });
 

--- a/src/resources/extensions/gsd/tests/session-start-footer.test.ts
+++ b/src/resources/extensions/gsd/tests/session-start-footer.test.ts
@@ -68,7 +68,7 @@ test("session_start handler guards initHealthWidget with !isAutoActive()", () =>
   );
 });
 
-test("session_switch handler suppresses gsd-health when isAutoActive()", () => {
+test("session_switch handler toggles gsd-health for auto and non-auto sessions", () => {
   const sessionSwitchIdx = HOOKS_SOURCE.indexOf('"session_switch"');
   assert.ok(sessionSwitchIdx > -1, "session_switch handler must exist");
 
@@ -82,12 +82,24 @@ test("session_switch handler suppresses gsd-health when isAutoActive()", () => {
     "session_switch handler must call isAutoActive()",
   );
   assert.ok(
+    sessionSwitchBody.includes("initHealthWidget"),
+    "session_switch handler must initialize gsd-health when auto is inactive",
+  );
+  assert.ok(
     sessionSwitchBody.includes('setWidget("gsd-health", undefined)'),
     "session_switch handler must call setWidget(\"gsd-health\", undefined) when auto is active",
   );
   assert.ok(
     !sessionSwitchBody.includes("setFooter"),
     "session_switch handler must NOT call setFooter",
+  );
+
+  const inactiveGuardIdx = sessionSwitchBody.indexOf("!isAutoActive()");
+  const healthIdx = sessionSwitchBody.indexOf("initHealthWidget");
+  const hideIdx = sessionSwitchBody.indexOf('setWidget("gsd-health", undefined)');
+  assert.ok(
+    inactiveGuardIdx > -1 && inactiveGuardIdx < healthIdx && healthIdx < hideIdx,
+    "session_switch must initialize before the auto-active hide branch",
   );
 });
 

--- a/src/resources/extensions/gsd/worktree-command.ts
+++ b/src/resources/extensions/gsd/worktree-command.ts
@@ -33,29 +33,21 @@ import { inferCommitType } from "./git-service.js";
 import type { FileLineStat } from "./worktree-manager.js";
 import { existsSync, realpathSync, readdirSync, rmSync, unlinkSync } from "node:fs";
 import { nativeMergeAbort } from "./native-git-bridge.js";
-import { join, sep } from "node:path";
+import { join } from "node:path";
+import {
+  clearWorktreeOriginalCwd,
+  ensureWorktreeOriginalCwdFromPath,
+  getActiveWorktreeName,
+  getWorktreeOriginalCwd,
+  setWorktreeOriginalCwd,
+} from "./worktree-session-state.js";
+
+export { getActiveWorktreeName, getWorktreeOriginalCwd } from "./worktree-session-state.js";
 
 /**
  * Tracks the original project root so we can switch back.
  * Set when we first chdir into a worktree, cleared on return.
  */
-let originalCwd: string | null = null;
-
-/** Get the original project root if currently in a worktree, or null. */
-export function getWorktreeOriginalCwd(): string | null {
-  return originalCwd;
-}
-
-/** Get the name of the active worktree, or null if not in one. */
-export function getActiveWorktreeName(): string | null {
-  if (!originalCwd) return null;
-  const cwd = process.cwd();
-  const wtDir = join(originalCwd, ".gsd", "worktrees");
-  if (!cwd.startsWith(wtDir)) return null;
-  const rel = cwd.slice(wtDir.length + 1);
-  const name = rel.split("/")[0] ?? rel.split("\\")[0];
-  return name || null;
-}
 
 // ─── Shared completions and handler (used by both /worktree and /wt) ────────
 
@@ -145,7 +137,7 @@ async function worktreeHandler(
       return;
     }
     // create and switch both do the same thing: switch if exists, create if not
-    const mainBase = originalCwd ?? basePath;
+    const mainBase = getWorktreeOriginalCwd() ?? basePath;
     const existing = listWorktrees(mainBase);
     if (existing.some(wt => wt.name === name)) {
       await handleSwitch(basePath, name, ctx);
@@ -157,7 +149,7 @@ async function worktreeHandler(
 
   if (trimmed === "merge" || trimmed.startsWith("merge ")) {
     const mergeArgs = trimmed.replace(/^merge\s*/, "").trim().split(/\s+/).filter(Boolean);
-    const mainBase = originalCwd ?? basePath;
+    const mainBase = getWorktreeOriginalCwd() ?? basePath;
     const activeWt = getActiveWorktreeName();
 
     if (mergeArgs.length === 0) {
@@ -191,7 +183,7 @@ async function worktreeHandler(
 
   if (trimmed === "remove" || trimmed.startsWith("remove ")) {
     const name = trimmed.replace(/^remove\s*/, "").trim();
-    const mainBase = originalCwd ?? basePath;
+    const mainBase = getWorktreeOriginalCwd() ?? basePath;
 
     if (name === "all") {
       await handleRemoveAll(mainBase, ctx);
@@ -213,7 +205,7 @@ async function worktreeHandler(
     return;
   }
 
-  const mainBase = originalCwd ?? basePath;
+  const mainBase = getWorktreeOriginalCwd() ?? basePath;
   const nameOnly = trimmed.split(/\s+/)[0]!;
   if (trimmed !== nameOnly) {
     ctx.ui.notify(`Unknown command. Did you mean /${alias} switch ${nameOnly}?`, "warning");
@@ -241,14 +233,7 @@ export function registerWorktreeCommand(pi: ExtensionAPI): void {
   // Restore worktree state after /reload.
   // The module-level originalCwd resets to null when extensions are re-loaded,
   // but process.cwd() is still inside the worktree. Detect this and recover.
-  if (!originalCwd) {
-    const cwd = process.cwd();
-    const marker = `${sep}.gsd${sep}worktrees${sep}`;
-    const markerIdx = cwd.indexOf(marker);
-    if (markerIdx !== -1) {
-      originalCwd = cwd.slice(0, markerIdx);
-    }
-  }
+  ensureWorktreeOriginalCwdFromPath();
 
   pi.registerCommand("worktree", {
     description: "Git worktrees (also /wt): /worktree <name> | list | merge | remove",
@@ -320,7 +305,7 @@ async function handleCreate(
     const commitMsg = autoCommitCurrentBranch(basePath, "worktree-switch", name);
 
     // Create from the main tree, not from inside another worktree
-    const mainBase = originalCwd ?? basePath;
+    const mainBase = getWorktreeOriginalCwd() ?? basePath;
     const info = createWorktree(mainBase, name);
 
     // Run user-configured post-create hook (#597) — e.g. copy .env, symlink assets
@@ -330,7 +315,7 @@ async function handleCreate(
     }
 
     // Track original cwd before switching
-    if (!originalCwd) originalCwd = basePath;
+    if (!getWorktreeOriginalCwd()) setWorktreeOriginalCwd(basePath);
 
     const prevCwd = process.cwd();
     process.chdir(info.path);
@@ -390,7 +375,7 @@ async function handleSwitch(
   ctx: ExtensionCommandContext,
 ): Promise<void> {
   try {
-    const mainBase = originalCwd ?? basePath;
+    const mainBase = getWorktreeOriginalCwd() ?? basePath;
     const wtPath = worktreePath(mainBase, name);
 
     if (!existsSync(wtPath)) {
@@ -405,7 +390,7 @@ async function handleSwitch(
     const commitMsg = autoCommitCurrentBranch(basePath, "worktree-switch", name);
 
     // Track original cwd before switching
-    if (!originalCwd) originalCwd = basePath;
+    if (!getWorktreeOriginalCwd()) setWorktreeOriginalCwd(basePath);
 
     const prevCwd = process.cwd();
     process.chdir(wtPath);
@@ -433,6 +418,7 @@ async function handleSwitch(
 }
 
 async function handleReturn(ctx: ExtensionCommandContext): Promise<void> {
+  const originalCwd = getWorktreeOriginalCwd();
   if (!originalCwd) {
     ctx.ui.notify("Already in the main project tree.", "info");
     return;
@@ -442,7 +428,7 @@ async function handleReturn(ctx: ExtensionCommandContext): Promise<void> {
   const commitMsg = autoCommitCurrentBranch(process.cwd(), "worktree-return", "worktree");
 
   const returnTo = originalCwd;
-  originalCwd = null;
+  clearWorktreeOriginalCwd();
 
   const prevCwd = process.cwd();
   process.chdir(returnTo);
@@ -504,7 +490,7 @@ async function handleList(
   ctx: ExtensionCommandContext,
 ): Promise<void> {
   try {
-    const mainBase = originalCwd ?? basePath;
+    const mainBase = getWorktreeOriginalCwd() ?? basePath;
     const worktrees = listWorktrees(mainBase);
 
     if (worktrees.length === 0) {
@@ -552,6 +538,7 @@ async function handleList(
       lines.push("");
     }
 
+    const originalCwd = getWorktreeOriginalCwd();
     if (originalCwd) {
       lines.push(`  ${CLR.label("main tree")}  ${CLR.path(originalCwd)}`);
     }
@@ -651,11 +638,11 @@ async function handleMerge(
 
     // Switch to the main tree before merging.
     // Must be on the main branch to run git merge --squash.
-    if (originalCwd) {
+    if (getWorktreeOriginalCwd()) {
       const prevCwd = process.cwd();
       process.chdir(basePath);
       nudgeGitBranchCache(prevCwd);
-      originalCwd = null;
+      clearWorktreeOriginalCwd();
     }
 
     // --- Deterministic merge path (preferred) ---
@@ -754,7 +741,7 @@ async function handleRemove(
   ctx: ExtensionCommandContext,
 ): Promise<void> {
   try {
-    const mainBase = originalCwd ?? basePath;
+    const mainBase = getWorktreeOriginalCwd() ?? basePath;
 
     // Validate the worktree exists before attempting removal
     const worktrees = listWorktrees(mainBase);
@@ -779,9 +766,9 @@ async function handleRemove(
     removeWorktree(mainBase, name, { deleteBranch: true });
 
     // If we were in that worktree, removeWorktree chdir'd us out — clear tracking
-    if (originalCwd && process.cwd() !== prevCwd) {
+    if (getWorktreeOriginalCwd() && process.cwd() !== prevCwd) {
       nudgeGitBranchCache(prevCwd);
-      originalCwd = null;
+      clearWorktreeOriginalCwd();
     }
 
     ctx.ui.notify(`${CLR.ok("✓")} Worktree ${CLR.name(name)} removed ${CLR.muted("(branch deleted)")}.`, "info");
@@ -796,7 +783,7 @@ async function handleRemoveAll(
   ctx: ExtensionCommandContext,
 ): Promise<void> {
   try {
-    const mainBase = originalCwd ?? basePath;
+    const mainBase = getWorktreeOriginalCwd() ?? basePath;
     const worktrees = listWorktrees(mainBase);
 
     if (worktrees.length === 0) {
@@ -830,9 +817,9 @@ async function handleRemoveAll(
     }
 
     // If we were in a worktree that got removed, clear tracking
-    if (originalCwd && process.cwd() !== prevCwd) {
+    if (getWorktreeOriginalCwd() && process.cwd() !== prevCwd) {
       nudgeGitBranchCache(prevCwd);
-      originalCwd = null;
+      clearWorktreeOriginalCwd();
     }
 
     const lines: string[] = [];

--- a/src/resources/extensions/gsd/worktree-session-state.ts
+++ b/src/resources/extensions/gsd/worktree-session-state.ts
@@ -1,0 +1,37 @@
+// GSD worktree session state
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+let originalCwd: string | null = null;
+
+export function getWorktreeOriginalCwd(): string | null {
+  return originalCwd;
+}
+
+export function setWorktreeOriginalCwd(cwd: string): void {
+  originalCwd = cwd;
+}
+
+export function clearWorktreeOriginalCwd(): void {
+  originalCwd = null;
+}
+
+export function ensureWorktreeOriginalCwdFromPath(cwd: string = process.cwd()): string | null {
+  if (originalCwd) return originalCwd;
+  const marker = `${/\\/.test(cwd) ? "\\" : "/"}.gsd${/\\/.test(cwd) ? "\\" : "/"}worktrees${/\\/.test(cwd) ? "\\" : "/"}`;
+  const markerIdx = cwd.indexOf(marker);
+  if (markerIdx !== -1) {
+    originalCwd = cwd.slice(0, markerIdx);
+  }
+  return originalCwd;
+}
+
+export function getActiveWorktreeName(): string | null {
+  if (!originalCwd) return null;
+  const cwd = process.cwd();
+  const wtDir = `${originalCwd.replace(/[\\/]+$/, "")}/.gsd/worktrees`.replaceAll("\\", "/");
+  const normalizedCwd = cwd.replaceAll("\\", "/");
+  if (!normalizedCwd.startsWith(`${wtDir}/`)) return null;
+  const rel = normalizedCwd.slice(wtDir.length + 1);
+  const name = rel.split("/")[0];
+  return name || null;
+}

--- a/src/resources/extensions/gsd/worktree-session-state.ts
+++ b/src/resources/extensions/gsd/worktree-session-state.ts
@@ -1,6 +1,4 @@
 // GSD worktree session state
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
-
 let originalCwd: string | null = null;
 
 export function getWorktreeOriginalCwd(): string | null {

--- a/src/rtk-shared.js
+++ b/src/rtk-shared.js
@@ -53,3 +53,23 @@ export function resolveSystemRtkPath(pathValue, platform = process.platform) {
 
   return null;
 }
+
+export function prependPathEntry(env, entry) {
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") ?? (process.platform === "win32" ? "Path" : "PATH");
+  const currentPath = env[pathKey] ?? "";
+  const parts = currentPath.split(delimiter).filter(Boolean);
+  if (!parts.includes(entry)) {
+    env[pathKey] = [entry, currentPath].filter(Boolean).join(delimiter);
+  }
+  return env;
+}
+
+export function applyRtkProcessEnv(env = process.env) {
+  prependPathEntry(env, getManagedRtkDir(env));
+  env[RTK_TELEMETRY_DISABLED_ENV] = "1";
+  return env;
+}
+
+export function buildRtkEnv(env = process.env) {
+  return applyRtkProcessEnv({ ...env });
+}

--- a/src/rtk-shared.ts
+++ b/src/rtk-shared.ts
@@ -56,3 +56,23 @@ export function resolveSystemRtkPath(
 
   return null;
 }
+
+export function prependPathEntry(env: NodeJS.ProcessEnv, entry: string): NodeJS.ProcessEnv {
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") ?? (process.platform === "win32" ? "Path" : "PATH");
+  const currentPath = env[pathKey] ?? "";
+  const parts = currentPath.split(delimiter).filter(Boolean);
+  if (!parts.includes(entry)) {
+    env[pathKey] = [entry, currentPath].filter(Boolean).join(delimiter);
+  }
+  return env;
+}
+
+export function applyRtkProcessEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  prependPathEntry(env, getManagedRtkDir(env));
+  env[RTK_TELEMETRY_DISABLED_ENV] = "1";
+  return env;
+}
+
+export function buildRtkEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  return applyRtkProcessEnv({ ...env });
+}

--- a/src/rtk.ts
+++ b/src/rtk.ts
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, chmodSync, readdirSync } from "node:fs";
 import { createWriteStream } from "node:fs";
 import { arch as osArch } from "node:os";
-import { delimiter, join } from "node:path";
+import { join } from "node:path";
 import { Readable } from "node:stream";
 import { finished } from "node:stream/promises";
 import extractZip from "extract-zip";
@@ -11,11 +11,14 @@ import {
   GSD_RTK_DISABLED_ENV,
   GSD_RTK_PATH_ENV,
   RTK_TELEMETRY_DISABLED_ENV,
+  applyRtkProcessEnv,
+  buildRtkEnv,
   getManagedRtkDir,
   getPathValue,
   getRtkBinaryName,
   isTruthy,
   isRtkEnabled,
+  prependPathEntry,
   resolveSystemRtkPath,
 } from "./rtk-shared.js";
 
@@ -25,9 +28,12 @@ export {
   GSD_RTK_DISABLED_ENV,
   GSD_RTK_PATH_ENV,
   RTK_TELEMETRY_DISABLED_ENV,
+  applyRtkProcessEnv,
+  buildRtkEnv,
   getManagedRtkDir,
   getRtkBinaryName,
   isRtkEnabled,
+  prependPathEntry,
 };
 
 const RTK_REPO = "rtk-ai/rtk";
@@ -56,26 +62,6 @@ export function getManagedRtkPath(
   targetDir: string = getManagedRtkDir(),
 ): string {
   return join(targetDir, getRtkBinaryName(platform));
-}
-
-export function prependPathEntry(env: NodeJS.ProcessEnv, entry: string): NodeJS.ProcessEnv {
-  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") ?? (process.platform === "win32" ? "Path" : "PATH");
-  const currentPath = env[pathKey] ?? "";
-  const parts = currentPath.split(delimiter).filter(Boolean);
-  if (!parts.includes(entry)) {
-    env[pathKey] = [entry, currentPath].filter(Boolean).join(delimiter);
-  }
-  return env;
-}
-
-export function applyRtkProcessEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
-  prependPathEntry(env, getManagedRtkDir(env));
-  env[RTK_TELEMETRY_DISABLED_ENV] = "1";
-  return env;
-}
-
-export function buildRtkEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
-  return applyRtkProcessEnv({ ...env });
 }
 
 export function resolveRtkAssetName(

--- a/src/tests/provider-migrations.test.ts
+++ b/src/tests/provider-migrations.test.ts
@@ -65,15 +65,37 @@ test("shouldMigrateAnthropicToClaudeCode allows OAuth-only anthropic users", () 
 })
 
 test("shouldMigrateAnthropicToClaudeCode stays off for other providers", () => {
+  let checkedClaudeCode = false
   assert.equal(
     shouldMigrateAnthropicToClaudeCode({
       authStorage: makeAuthStorage([{ type: "oauth" }]) as any,
-      isClaudeCodeReady: true,
+      isClaudeCodeReady: () => {
+        checkedClaudeCode = true
+        return true
+      },
       defaultProvider: "openai",
       env: {} as NodeJS.ProcessEnv,
     }),
     false,
   )
+  assert.equal(checkedClaudeCode, false)
+})
+
+test("shouldMigrateAnthropicToClaudeCode skips Claude probe for direct-key users", () => {
+  let checkedClaudeCode = false
+  assert.equal(
+    shouldMigrateAnthropicToClaudeCode({
+      authStorage: makeAuthStorage([{ type: "api_key", key: "sk-ant-test" }]) as any,
+      isClaudeCodeReady: () => {
+        checkedClaudeCode = true
+        return true
+      },
+      defaultProvider: "anthropic",
+      env: {} as NodeJS.ProcessEnv,
+    }),
+    false,
+  )
+  assert.equal(checkedClaudeCode, false)
 })
 
 test("migrateAnthropicDefaultToClaudeCode switches to matching claude-code model", () => {

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -104,6 +104,32 @@ test("buildResourceLoader excludes duplicate top-level pi extensions when bundle
   );
 });
 
+test("buildResourceLoader includes caller-provided additional extension paths", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-cli-"));
+  const fakeAgentDir = join(tmp, ".gsd", "agent");
+  const cliExtensionPath = join(tmp, "cli-extension.ts");
+  const restoreHomeEnv = overrideHomeEnv(tmp);
+
+  t.after(() => {
+    restoreHomeEnv();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  writeFileSync(cliExtensionPath, "export {};\n");
+
+  const { buildResourceLoader } = await import("../resource-loader.ts");
+  const loader = await buildResourceLoader(fakeAgentDir, {
+    additionalExtensionPaths: [cliExtensionPath],
+  }) as { additionalExtensionPaths?: string[] };
+  const additionalExtensionPaths = loader.additionalExtensionPaths ?? [];
+
+  assert.equal(
+    additionalExtensionPaths.includes(cliExtensionPath),
+    true,
+    "caller-provided extension paths should be threaded into the resource loader",
+  );
+});
+
 test("initResources manifest tracks all bundled extension subdirectories including remote-questions (#2367)", async () => {
   const { initResources } = await import("../resource-loader.ts");
   const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-manifest-"));

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -89,7 +89,7 @@ test("buildResourceLoader excludes duplicate top-level pi extensions when bundle
   writeFileSync(join(piExtensionsDir, "custom-extension.ts"), "export {};\n");
 
   const { buildResourceLoader } = await import("../resource-loader.ts");
-  const loader = buildResourceLoader(fakeAgentDir) as { additionalExtensionPaths?: string[] };
+  const loader = await buildResourceLoader(fakeAgentDir) as { additionalExtensionPaths?: string[] };
   const additionalExtensionPaths = loader.additionalExtensionPaths ?? [];
 
   assert.equal(

--- a/src/worktree-status-banner.ts
+++ b/src/worktree-status-banner.ts
@@ -1,0 +1,152 @@
+// GSD worktree startup banner
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, realpathSync } from 'node:fs'
+import { join, resolve, sep } from 'node:path'
+import chalk from 'chalk'
+
+interface WorktreeEntry {
+  path: string
+  branch: string
+  isBare: boolean
+}
+
+interface GsdWorktree {
+  name: string
+  branch: string
+}
+
+function normalizePath(path: string): string {
+  const normalized = path
+    .replaceAll('\\', '/')
+    .replace(/^\/\/\?\//, '')
+    .replace(/\/+$/, '')
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
+function gitExec(basePath: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd: basePath,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf-8',
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GCM_INTERACTIVE: 'Never' },
+    }).trim()
+  } catch {
+    return ''
+  }
+}
+
+function parseWorktreeList(output: string): WorktreeEntry[] {
+  if (!output) return []
+  const entries: WorktreeEntry[] = []
+  const blocks = output.replaceAll('\r\n', '\n').split('\n\n').filter(Boolean)
+  for (const block of blocks) {
+    const lines = block.split('\n')
+    const wtLine = lines.find((line) => line.startsWith('worktree '))
+    const branchLine = lines.find((line) => line.startsWith('branch '))
+    if (!wtLine) continue
+    entries.push({
+      path: wtLine.replace('worktree ', ''),
+      branch: branchLine ? branchLine.replace('branch refs/heads/', '') : '',
+      isBare: lines.some((line) => line === 'bare'),
+    })
+  }
+  return entries
+}
+
+function existingPathVariants(path: string): string[] {
+  const variants = [resolve(path)]
+  if (existsSync(path)) {
+    try {
+      variants.push(realpathSync(path))
+    } catch {
+      // Best effort only; the unresolved path is still useful for matching.
+    }
+  }
+  return [...new Set(variants.map(normalizePath))]
+}
+
+function findGsdWorktrees(basePath: string, entries: WorktreeEntry[]): GsdWorktree[] {
+  const roots = existingPathVariants(join(basePath, '.gsd', 'worktrees'))
+  const worktrees: GsdWorktree[] = []
+
+  for (const entry of entries) {
+    if (entry.isBare || !entry.branch) continue
+
+    const branchWorktreeName = entry.branch.startsWith('worktree/')
+      ? entry.branch.slice('worktree/'.length)
+      : entry.branch.startsWith('milestone/')
+        ? entry.branch.slice('milestone/'.length)
+        : null
+    const entryVariants = existingPathVariants(entry.path)
+    const matchedRoot = roots.find((root) =>
+      entryVariants.some((variant) => variant.startsWith(`${root}/`) || variant.startsWith(`${root}${sep}`)),
+    )
+    const matchesBranchLeaf = branchWorktreeName
+      ? entryVariants.some((variant) => variant.split('/').pop() === branchWorktreeName)
+      : false
+
+    if (!matchedRoot && !matchesBranchLeaf) continue
+
+    const matchedPath = matchedRoot
+      ? entryVariants.find((variant) => variant.startsWith(`${matchedRoot}/`) || variant.startsWith(`${matchedRoot}${sep}`))
+      : undefined
+    let name = matchedRoot && matchedPath ? matchedPath.slice(matchedRoot.length + 1) : ''
+    if ((!name || name.includes('/')) && branchWorktreeName && matchesBranchLeaf) {
+      name = branchWorktreeName
+    }
+    if (!name || name.includes('/')) continue
+
+    worktrees.push({ name, branch: entry.branch })
+  }
+
+  return worktrees
+}
+
+function detectMainBranch(basePath: string): string {
+  const symbolic = gitExec(basePath, ['symbolic-ref', 'refs/remotes/origin/HEAD'])
+  const remoteMatch = symbolic.match(/refs\/remotes\/origin\/(.+)$/)
+  if (remoteMatch?.[1]) return remoteMatch[1]
+  if (gitExec(basePath, ['show-ref', '--verify', 'refs/heads/main'])) return 'main'
+  if (gitExec(basePath, ['show-ref', '--verify', 'refs/heads/master'])) return 'master'
+  return gitExec(basePath, ['branch', '--show-current'])
+}
+
+function branchHasChanges(basePath: string, mainBranch: string, branch: string): boolean {
+  try {
+    execFileSync('git', ['diff', '--quiet', mainBranch, branch], {
+      cwd: basePath,
+      stdio: ['ignore', 'ignore', 'ignore'],
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GCM_INTERACTIVE: 'Never' },
+    })
+    return false
+  } catch {
+    return true
+  }
+}
+
+export function showWorktreeStatusBanner(basePath: string): void {
+  const worktreesDir = join(basePath, '.gsd', 'worktrees')
+  if (!existsSync(worktreesDir)) return
+
+  const entries = parseWorktreeList(gitExec(basePath, ['worktree', 'list', '--porcelain']))
+  const worktrees = findGsdWorktrees(basePath, entries)
+  if (worktrees.length === 0) return
+
+  const mainBranch = detectMainBranch(basePath)
+  if (!mainBranch) return
+
+  const withChanges = worktrees.filter((worktree) => branchHasChanges(basePath, mainBranch, worktree.branch))
+  if (withChanges.length === 0) return
+
+  const names = withChanges.map((worktree) => chalk.cyan(worktree.name)).join(', ')
+  process.stderr.write(
+    chalk.dim('[gsd] ') +
+    chalk.yellow(`${withChanges.length} worktree${withChanges.length === 1 ? '' : 's'} with unmerged changes: `) +
+    names + '\n' +
+    chalk.dim('[gsd] ') +
+    chalk.dim('Resume: gsd -w <name>  |  Merge: gsd worktree merge <name>  |  List: gsd worktree list\n\n'),
+  )
+}

--- a/src/worktree-status-banner.ts
+++ b/src/worktree-status-banner.ts
@@ -1,6 +1,4 @@
 // GSD worktree startup banner
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
-
 import { execFileSync } from 'node:child_process'
 import { existsSync, realpathSync } from 'node:fs'
 import { join, resolve, sep } from 'node:path'

--- a/web/components/gsd/app-shell.tsx
+++ b/web/components/gsd/app-shell.tsx
@@ -1,17 +1,13 @@
 "use client"
 
 import Image from "next/image"
+import dynamic from "next/dynamic"
 import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from "react"
 import { Menu, X } from "lucide-react"
 import { Sidebar, MilestoneExplorer, CollapsedMilestoneSidebar } from "@/components/gsd/sidebar"
 import { ShellTerminal } from "@/components/gsd/shell-terminal"
 import { Dashboard } from "@/components/gsd/dashboard"
-import { Roadmap } from "@/components/gsd/roadmap"
-import { FilesView } from "@/components/gsd/files-view"
-import { ActivityView } from "@/components/gsd/activity-view"
-import { VisualizerView } from "@/components/gsd/visualizer-view"
 import { StatusBar } from "@/components/gsd/status-bar"
-import { DualTerminal } from "@/components/gsd/dual-terminal"
 import { FocusedPanel } from "@/components/gsd/focused-panel"
 import { OnboardingGate } from "@/components/gsd/onboarding-gate"
 import { CommandSurface } from "@/components/gsd/command-surface"
@@ -29,7 +25,6 @@ import {
   useGSDWorkspaceState,
   useGSDWorkspaceActions,
 } from "@/lib/gsd-workspace-store"
-import { ChatMode } from "@/components/gsd/chat-mode"
 import { ScopeBadge } from "@/components/gsd/scope-badge"
 import { Badge } from "@/components/ui/badge"
 import { ProjectsPanel, ProjectSelectionGate } from "@/components/gsd/projects-view"
@@ -37,6 +32,37 @@ import { UpdateBanner } from "@/components/gsd/update-banner"
 import { getAuthToken } from "@/lib/auth"
 
 const KNOWN_VIEWS = new Set(["dashboard", "power", "chat", "roadmap", "files", "activity", "visualize"])
+
+const ViewLoading = () => (
+  <div className="h-full w-full p-4">
+    <Skeleton className="h-full w-full" />
+  </div>
+)
+
+const Roadmap = dynamic(() => import("@/components/gsd/roadmap").then((mod) => mod.Roadmap), {
+  loading: ViewLoading,
+  ssr: false,
+})
+const FilesView = dynamic(() => import("@/components/gsd/files-view").then((mod) => mod.FilesView), {
+  loading: ViewLoading,
+  ssr: false,
+})
+const ActivityView = dynamic(() => import("@/components/gsd/activity-view").then((mod) => mod.ActivityView), {
+  loading: ViewLoading,
+  ssr: false,
+})
+const VisualizerView = dynamic(() => import("@/components/gsd/visualizer-view").then((mod) => mod.VisualizerView), {
+  loading: ViewLoading,
+  ssr: false,
+})
+const DualTerminal = dynamic(() => import("@/components/gsd/dual-terminal").then((mod) => mod.DualTerminal), {
+  loading: ViewLoading,
+  ssr: false,
+})
+const ChatMode = dynamic(() => import("@/components/gsd/chat-mode").then((mod) => mod.ChatMode), {
+  loading: ViewLoading,
+  ssr: false,
+})
 
 function viewStorageKey(projectCwd: string): string {
   return `gsd-active-view:${projectCwd}`
@@ -482,7 +508,9 @@ function WorkspaceChrome() {
                 className="overflow-hidden"
                 style={{ height: isTerminalExpanded ? terminalHeight : 0, transition: terminalDragActive ? "none" : "height 200ms" }}
               >
-                <ShellTerminal className="h-full" projectCwd={workspace.boot?.project.cwd} />
+                {isTerminalExpanded && (
+                  <ShellTerminal className="h-full" projectCwd={workspace.boot?.project.cwd} />
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
## TL;DR
**What:** Cut GSD startup overhead by deferring expensive RTK/provider/resource/GSD extension work until it is actually needed.
**Why:** Startup had drifted into multi-second cold and warm launches, with `bootstrapRtk`, resource reload, and GSD extension imports dominating the path.
**How:** Added lazy startup paths, resource hash reuse, lightweight runtime state modules, and narrower startup timing probes.

## What
- Avoid eager RTK bootstrap when RTK is disabled or not needed during launch.
- Move provider migration readiness checks and RTK process env setup off the critical path.
- Precompute and reuse bundled resource hashes to reduce `resourceLoader.reload` work.
- Lazy-load heavy GSD extension modules, worktree/session helpers, overlays, command handlers, and workflow executors.
- Add lightweight startup/worktree status helpers so interactive startup can avoid importing larger worktree surfaces.
- Harden affected tests around lazy imports and custom-engine loop resolver timing.

## Why
Startup timing showed `bootstrapRtk`, `resourceLoader.reload`, and GSD extension initialization as the biggest remaining contributors. After the changes, observed startup timing dropped from multi-second launches to roughly 300ms steady-state in the local timing output.

Closes #5022

## How
The change preserves public behavior but shifts heavyweight imports and initialization behind demand-driven boundaries. Startup still prepares core session state, but worktree overlays, custom engine helpers, command catalogs, RTK install/bootstrap, and provider migration work now load only when their commands or runtime paths need them.

This PR is AI-assisted.

## Change type checklist
- [ ] feat
- [ ] fix
- [ ] refactor
- [x] test
- [ ] docs
- [ ] chore
- [x] perf

## Test plan
- [x] `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/tests/rtk.test.js`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/bootstrap-derive-state-db-open.test.ts src/resources/extensions/gsd/tests/quick-turn-end-cleanup.test.ts`
- [x] `npm run test:compile && node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.js`
- [x] Startup timing spot check with `GSD_STARTUP_TIMING=1 /usr/bin/time -p node dist/loader.js` showed about 298ms steady-state total locally.
- [ ] `npm run verify:pr` full-suite clean pass. Build/typecheck completed, but the unit fan-out remains noisy/long locally with intermittent `auto-loop` timing/MCP timeout failures; leaving this as draft until CI/full verification confirms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worktree status banner now reports unmerged worktree changes with resume/merge suggestions.
  * Auto-mode runtime state added with runtime status helpers and invocation tracking.

* **Performance**
  * More components and heavy CLI pieces lazy-load to speed startup; terminal mounts only when expanded.

* **Bug Fixes / Reliability**
  * Resource sync now ignores test/artifact files and writes a deterministic content fingerprint for reliable staleness checks.

* **Tests**
  * Updated integration tests to use runtime-driven checks for auto-mode and resource loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->