### PR TITLE
perf(pi-ai): cache breakpoint after compaction summary boundary (#5027)

### DIFF
--- a/packages/pi-ai/src/providers/anthropic-shared.cache-breakpoint.test.ts
+++ b/packages/pi-ai/src/providers/anthropic-shared.cache-breakpoint.test.ts
@@ -10,7 +10,7 @@ import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
 import { buildParams, convertMessages } from "./anthropic-shared.js";
-import type { Context, Message, Model } from "../types.js";
+import type { Context, Message, Model, Tool } from "../types.js";
 import type { AnthropicApi } from "./anthropic-shared.js";
 
 // Minimal model stub — convertMessages only reads `input` to decide whether to
@@ -27,6 +27,8 @@ function userMsg(text: string, opts: { cacheBreakpoint?: boolean } = {}): Messag
 	} as Message;
 }
 
+/** Produces a UserMessage whose content is an array of text blocks —
+ * the production shape emitted by `convertToLlm()` for compaction summaries. */
 function userMsgArray(text: string, opts: { cacheBreakpoint?: boolean } = {}): Message {
 	return {
 		role: "user",
@@ -102,17 +104,27 @@ describe("convertMessages — cache breakpoints (#5027)", () => {
 		assert.equal(hasCacheControl(result, result.length - 1), true, "last msg still gets the volatile-suffix anchor");
 	});
 
-	test("array-backed user cacheBreakpoint message: boundary and last user get breakpoints", () => {
+	test("array-content cacheBreakpoint message: breakpoint is applied (production shape for compaction summary)", () => {
+		// convertToLlm() emits compaction summaries as content:[{type:"text",...}];
+		// this exercises the array-backed branch in anthropic-shared.ts.
 		const result = convertMessages(
 			[
 				userMsgArray("[COMPACTION SUMMARY]", { cacheBreakpoint: true }),
+				assistantMsg("post-compaction response"),
 				userMsg("post-compaction turn"),
 			],
 			model,
 			false,
 			cacheControl,
 		);
-		assert.equal(hasCacheControl(result, 0), true, "array-backed compaction boundary gets a breakpoint");
+		const compactionIdx = result.findIndex(
+			(p) =>
+				p.role === "user" &&
+				Array.isArray(p.content) &&
+				(p.content as any)[0]?.text?.includes("COMPACTION SUMMARY"),
+		);
+		assert.ok(compactionIdx >= 0, "compaction summary param should be present");
+		assert.equal(hasCacheControl(result, compactionIdx), true, "array-content boundary gets cache_control");
 		assert.equal(hasCacheControl(result, result.length - 1), true, "last msg still gets the volatile-suffix anchor");
 	});
 
@@ -163,6 +175,22 @@ describe("convertMessages — cache breakpoints (#5027)", () => {
 		for (let i = 0; i < result.length; i++) {
 			assert.equal(hasCacheControl(result, i), false, `index ${i} should have no cache_control`);
 		}
+	});
+
+	test("array-content cacheBreakpoint on last message: deduplication guard prevents double application", () => {
+		// The boundary IS the last message — both anchors target the same param,
+		// so cache_control should appear exactly once.
+		const result = convertMessages(
+			[userMsg("prior turn"), userMsgArray("[BOUNDARY AS LAST]", { cacheBreakpoint: true })],
+			model,
+			false,
+			cacheControl,
+		);
+		const lastParam = result[result.length - 1];
+		assert.ok(lastParam && Array.isArray(lastParam.content), "last param has array content");
+		const cacheBlocks = (lastParam!.content as any[]).filter((b) => b.cache_control);
+		assert.equal(cacheBlocks.length, 1, "cache_control applied exactly once");
+		assert.equal(hasCacheControl(result, 0), false, "prior turn has no cache_control");
 	});
 });
 
@@ -220,30 +248,34 @@ describe("buildParams — 4-breakpoint limit safety in OAuth + boundary scenario
 		assert.equal(count, 3);
 	});
 
-	test("OAuth + system prompt + tools + boundary + last user: ≤4 breakpoints", () => {
+	test("OAuth + system prompt + tools + boundary + last user: exactly 4 breakpoints (ceiling)", () => {
+		// Worst-case breakpoint budget:
+		//   system(user prompt, 1) + last tool(1) + boundary(1) + last user(1) = 4.
+		// The "You are Claude Code" header intentionally carries NO cache_control
+		// when a user systemPrompt is present (#5027), which keeps us at 4 rather than 5.
+		const tool: Tool = {
+			name: "Read",
+			description: "Read a file from disk.",
+			parameters: {
+				type: "object" as const,
+				properties: {
+					path: { type: "string" },
+				},
+				required: ["path"],
+			} as any,
+		};
 		const ctx: Context = {
 			messages: [
 				userMsg("[COMPACTION SUMMARY]", { cacheBreakpoint: true }),
 				userMsg("post-compaction turn"),
 			],
 			systemPrompt: "You are a helpful coding assistant.",
-			tools: [
-				({
-					name: "Read",
-					description: "Read a file from disk.",
-					parameters: {
-						type: "object" as const,
-						properties: {
-							path: { type: "string" },
-						},
-						required: ["path"],
-					},
-				}) as any,
-			],
+			tools: [tool],
 		} as Context;
 		const params = buildParams(buildParamsModel, ctx, true) as any;
 		const count = countBreakpoints(params);
 		assert.ok(count <= 4, `must stay under Anthropic's 4-breakpoint limit, got ${count}`);
+		// system(1) + tool(1) + boundary(1) + last-user(1) = 4 exactly.
 		assert.equal(count, 4);
 	});
 

--- a/packages/pi-ai/src/providers/anthropic-shared.cache-breakpoint.test.ts
+++ b/packages/pi-ai/src/providers/anthropic-shared.cache-breakpoint.test.ts
@@ -1,0 +1,207 @@
+// @gsd/pi-ai + anthropic-shared.cache-breakpoint.test — coverage for #5027.
+// `convertMessages` must apply Anthropic `cache_control` to:
+//   - the last message (existing volatile-suffix anchor — preserved)
+//   - the most recent message flagged with `cacheBreakpoint: true`
+//     (new compaction-boundary anchor)
+// And it must NOT exceed the 4-breakpoint limit by treating multiple
+// breakpoints as one — only the most recent earns the marker.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildParams, convertMessages } from "./anthropic-shared.js";
+import type { Context, Message, Model } from "../types.js";
+import type { AnthropicApi } from "./anthropic-shared.js";
+
+// Minimal model stub — convertMessages only reads `input` to decide whether to
+// drop image blocks. Returning ["image"] keeps the conversion paths exercised.
+const model = { input: ["text", "image"] } as unknown as Model<AnthropicApi>;
+const cacheControl = { type: "ephemeral" as const };
+
+function userMsg(text: string, opts: { cacheBreakpoint?: boolean } = {}): Message {
+	return {
+		role: "user",
+		content: text,
+		timestamp: 0,
+		...(opts.cacheBreakpoint ? { cacheBreakpoint: true } : {}),
+	} as Message;
+}
+
+function assistantMsg(text: string): Message {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-6",
+		usage: {
+			input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	} as Message;
+}
+
+/** Returns whether the message at the given index has cache_control on its last block. */
+function hasCacheControl(params: ReturnType<typeof convertMessages>, index: number): boolean {
+	const param = params[index];
+	if (!param || param.role !== "user") return false;
+	if (!Array.isArray(param.content)) return false;
+	const lastBlock = param.content[param.content.length - 1];
+	return Boolean(lastBlock && (lastBlock as any).cache_control);
+}
+
+describe("convertMessages — cache breakpoints (#5027)", () => {
+	test("with no cacheControl option: no breakpoints are placed", () => {
+		const result = convertMessages([userMsg("hello"), assistantMsg("hi"), userMsg("again")], model, false);
+		for (let i = 0; i < result.length; i++) {
+			assert.equal(hasCacheControl(result, i), false, `index ${i} should have no cache_control`);
+		}
+	});
+
+	test("no cacheBreakpoint anywhere: only the last message gets cache_control (existing behavior preserved)", () => {
+		const result = convertMessages(
+			[userMsg("first"), assistantMsg("response"), userMsg("second")],
+			model,
+			false,
+			cacheControl,
+		);
+		assert.equal(hasCacheControl(result, 0), false, "first user msg has no breakpoint");
+		assert.equal(hasCacheControl(result, result.length - 1), true, "last msg gets the volatile-suffix anchor");
+	});
+
+	test("one cacheBreakpoint message: both that message AND the last message get breakpoints", () => {
+		const result = convertMessages(
+			[
+				userMsg("ancient"),
+				assistantMsg("ancient response"),
+				userMsg("[COMPACTION SUMMARY]", { cacheBreakpoint: true }),
+				assistantMsg("post-compaction response"),
+				userMsg("new turn"),
+			],
+			model,
+			false,
+			cacheControl,
+		);
+		// Find the compaction-summary index (it's the third user-shaped param)
+		const compactionIdx = result.findIndex(
+			(p) => p.role === "user" && Array.isArray(p.content) && (p.content as any)[0]?.text?.includes("COMPACTION SUMMARY"),
+		);
+		assert.ok(compactionIdx >= 0, "compaction summary should be in the params");
+		assert.equal(hasCacheControl(result, compactionIdx), true, "compaction boundary gets a breakpoint");
+		assert.equal(hasCacheControl(result, result.length - 1), true, "last msg still gets the volatile-suffix anchor");
+	});
+
+	test("multiple cacheBreakpoint messages: only the most recent one earns a breakpoint (4-limit safety)", () => {
+		const result = convertMessages(
+			[
+				userMsg("[OLD COMPACTION]", { cacheBreakpoint: true }),
+				assistantMsg("post-old response"),
+				userMsg("[NEW COMPACTION]", { cacheBreakpoint: true }),
+				assistantMsg("post-new response"),
+				userMsg("latest turn"),
+			],
+			model,
+			false,
+			cacheControl,
+		);
+		const oldIdx = result.findIndex(
+			(p) => p.role === "user" && Array.isArray(p.content) && (p.content as any)[0]?.text?.includes("OLD COMPACTION"),
+		);
+		const newIdx = result.findIndex(
+			(p) => p.role === "user" && Array.isArray(p.content) && (p.content as any)[0]?.text?.includes("NEW COMPACTION"),
+		);
+		assert.equal(hasCacheControl(result, oldIdx), false, "older boundary should not earn a breakpoint");
+		assert.equal(hasCacheControl(result, newIdx), true, "most recent boundary earns the breakpoint");
+		assert.equal(hasCacheControl(result, result.length - 1), true, "last msg still gets the volatile-suffix anchor");
+	});
+
+	test("cacheBreakpoint on the LAST message: only one breakpoint applied (deduplication)", () => {
+		// When the boundary message IS the last message, applying twice would be
+		// a no-op overwrite but the deduplication guard avoids the double-call.
+		const result = convertMessages(
+			[userMsg("hello"), userMsg("[BOUNDARY AS LAST]", { cacheBreakpoint: true })],
+			model,
+			false,
+			cacheControl,
+		);
+		assert.equal(hasCacheControl(result, result.length - 1), true);
+		// Only one user message besides the last, with no breakpoint
+		assert.equal(hasCacheControl(result, 0), false);
+	});
+
+	test("cacheBreakpoint flag is ignored when no cacheControl option is provided", () => {
+		const result = convertMessages(
+			[userMsg("[COMPACTION]", { cacheBreakpoint: true }), userMsg("turn")],
+			model,
+			false,
+		);
+		for (let i = 0; i < result.length; i++) {
+			assert.equal(hasCacheControl(result, i), false, `index ${i} should have no cache_control`);
+		}
+	});
+});
+
+// ─── 4-breakpoint-limit safety at buildParams level (OAuth path) ──────────
+
+/** Count cache_control occurrences across system + tools + messages params. */
+function countBreakpoints(params: { system?: any; tools?: any[]; messages: any[] }): number {
+	let n = 0;
+	if (Array.isArray(params.system)) {
+		for (const block of params.system) if (block.cache_control) n++;
+	}
+	if (Array.isArray(params.tools)) {
+		for (const tool of params.tools) if ((tool as any).cache_control) n++;
+	}
+	for (const m of params.messages) {
+		if (m.role === "user" && Array.isArray(m.content)) {
+			for (const block of m.content) if (block.cache_control) n++;
+		}
+	}
+	return n;
+}
+
+const buildParamsModel = {
+	id: "claude-sonnet-4-6",
+	baseUrl: "https://api.anthropic.com",
+	api: "anthropic-messages",
+	input: ["text", "image"],
+	maxTokens: 64000,
+} as unknown as Model<AnthropicApi>;
+
+describe("buildParams — 4-breakpoint limit safety in OAuth + boundary scenario (#5027)", () => {
+	test("OAuth + system prompt + last user: ≤2 breakpoints (no boundary, no tools)", () => {
+		const ctx: Context = {
+			messages: [userMsg("hello")],
+			systemPrompt: "You are a helpful coding assistant.",
+		} as Context;
+		const params = buildParams(buildParamsModel, ctx, true) as any;
+		assert.ok(countBreakpoints(params) <= 4, `expected ≤4 breakpoints, got ${countBreakpoints(params)}`);
+		// One on user system block, one on last user msg.
+		assert.equal(countBreakpoints(params), 2);
+	});
+
+	test("OAuth + system prompt + boundary + last user: ≤3 breakpoints (system de-duplicated)", () => {
+		const ctx: Context = {
+			messages: [
+				userMsg("[COMPACTION SUMMARY]", { cacheBreakpoint: true }),
+				userMsg("post-compaction turn"),
+			],
+			systemPrompt: "You are a helpful coding assistant.",
+		} as Context;
+		const params = buildParams(buildParamsModel, ctx, true) as any;
+		const count = countBreakpoints(params);
+		assert.ok(count <= 4, `must stay under Anthropic's 4-breakpoint limit, got ${count}`);
+		// system(1, the user's prompt — Claude Code header skipped) + boundary(1) + last(1) = 3.
+		assert.equal(count, 3);
+	});
+
+	test("OAuth header WITHOUT user systemPrompt still cache-marks the header", () => {
+		// When there's no user systemPrompt, the Claude Code header IS the
+		// last system block, so it correctly carries cache_control.
+		const ctx: Context = { messages: [userMsg("hello")] } as Context;
+		const params = buildParams(buildParamsModel, ctx, true) as any;
+		assert.equal(countBreakpoints(params), 2, "header(1) + last user(1) = 2");
+	});
+});

--- a/packages/pi-ai/src/providers/anthropic-shared.cache-breakpoint.test.ts
+++ b/packages/pi-ai/src/providers/anthropic-shared.cache-breakpoint.test.ts
@@ -27,6 +27,15 @@ function userMsg(text: string, opts: { cacheBreakpoint?: boolean } = {}): Messag
 	} as Message;
 }
 
+function userMsgArray(text: string, opts: { cacheBreakpoint?: boolean } = {}): Message {
+	return {
+		role: "user",
+		content: [{ type: "text", text }],
+		timestamp: 0,
+		...(opts.cacheBreakpoint ? { cacheBreakpoint: true } : {}),
+	} as Message;
+}
+
 function assistantMsg(text: string): Message {
 	return {
 		role: "assistant",
@@ -90,6 +99,20 @@ describe("convertMessages — cache breakpoints (#5027)", () => {
 		);
 		assert.ok(compactionIdx >= 0, "compaction summary should be in the params");
 		assert.equal(hasCacheControl(result, compactionIdx), true, "compaction boundary gets a breakpoint");
+		assert.equal(hasCacheControl(result, result.length - 1), true, "last msg still gets the volatile-suffix anchor");
+	});
+
+	test("array-backed user cacheBreakpoint message: boundary and last user get breakpoints", () => {
+		const result = convertMessages(
+			[
+				userMsgArray("[COMPACTION SUMMARY]", { cacheBreakpoint: true }),
+				userMsg("post-compaction turn"),
+			],
+			model,
+			false,
+			cacheControl,
+		);
+		assert.equal(hasCacheControl(result, 0), true, "array-backed compaction boundary gets a breakpoint");
 		assert.equal(hasCacheControl(result, result.length - 1), true, "last msg still gets the volatile-suffix anchor");
 	});
 
@@ -195,6 +218,33 @@ describe("buildParams — 4-breakpoint limit safety in OAuth + boundary scenario
 		assert.ok(count <= 4, `must stay under Anthropic's 4-breakpoint limit, got ${count}`);
 		// system(1, the user's prompt — Claude Code header skipped) + boundary(1) + last(1) = 3.
 		assert.equal(count, 3);
+	});
+
+	test("OAuth + system prompt + tools + boundary + last user: ≤4 breakpoints", () => {
+		const ctx: Context = {
+			messages: [
+				userMsg("[COMPACTION SUMMARY]", { cacheBreakpoint: true }),
+				userMsg("post-compaction turn"),
+			],
+			systemPrompt: "You are a helpful coding assistant.",
+			tools: [
+				({
+					name: "Read",
+					description: "Read a file from disk.",
+					parameters: {
+						type: "object" as const,
+						properties: {
+							path: { type: "string" },
+						},
+						required: ["path"],
+					},
+				}) as any,
+			],
+		} as Context;
+		const params = buildParams(buildParamsModel, ctx, true) as any;
+		const count = countBreakpoints(params);
+		assert.ok(count <= 4, `must stay under Anthropic's 4-breakpoint limit, got ${count}`);
+		assert.equal(count, 4);
 	});
 
 	test("OAuth header WITHOUT user systemPrompt still cache-marks the header", () => {

--- a/packages/pi-ai/src/providers/anthropic-shared.ts
+++ b/packages/pi-ai/src/providers/anthropic-shared.ts
@@ -262,6 +262,11 @@ export function convertMessages(
 	cacheControl?: { type: "ephemeral"; ttl?: "1h" },
 ): MessageParam[] {
 	const params: MessageParam[] = [];
+	// Indices into `params` for messages flagged with `cacheBreakpoint: true` —
+	// e.g. compaction summaries. We apply cache_control to the most recent one
+	// (in addition to the last message) so the stable summary + kept-history
+	// block can earn cache reads on every post-compaction turn. (#5027)
+	const breakpointIndices: number[] = [];
 
 	const transformedMessages = transformMessagesWithReport(messages, model, normalizeToolCallId, "anthropic-messages");
 
@@ -275,6 +280,7 @@ export function convertMessages(
 						role: "user",
 						content: sanitizeSurrogates(msg.content),
 					});
+					if (msg.cacheBreakpoint) breakpointIndices.push(params.length - 1);
 				}
 			} else {
 				const blocks: ContentBlockParam[] = msg.content.map((item) => {
@@ -306,6 +312,7 @@ export function convertMessages(
 					role: "user",
 					content: filteredBlocks,
 				});
+				if (msg.cacheBreakpoint) breakpointIndices.push(params.length - 1);
 			}
 		} else if (msg.role === "assistant") {
 			const blocks: ContentBlockParam[] = [];
@@ -403,29 +410,48 @@ export function convertMessages(
 	}
 
 	if (cacheControl && params.length > 0) {
-		const lastMessage = params[params.length - 1];
-		if (lastMessage.role === "user") {
-			if (Array.isArray(lastMessage.content)) {
-				const lastBlock = lastMessage.content[lastMessage.content.length - 1];
-				if (
-					lastBlock &&
-					(lastBlock.type === "text" || lastBlock.type === "image" || lastBlock.type === "tool_result")
-				) {
-					(lastBlock as any).cache_control = cacheControl;
-				}
-			} else if (typeof lastMessage.content === "string") {
-				lastMessage.content = [
-					{
-						type: "text",
-						text: lastMessage.content,
-						cache_control: cacheControl,
-					},
-				] as any;
-			}
+		// Apply to the volatile suffix anchor (last user message) — existing behavior.
+		applyCacheControlToParam(params, params.length - 1, cacheControl);
+
+		// Apply to the most recent compaction-boundary message, if any. Capping at
+		// one boundary keeps us safely under Anthropic's 4-breakpoint limit
+		// (system + tools + boundary + last user = 4). If multiple
+		// cacheBreakpoint messages are present, only the most recent one — the
+		// freshest stable boundary — earns the breakpoint. (#5027)
+		const mostRecentBreakpoint = breakpointIndices[breakpointIndices.length - 1];
+		if (mostRecentBreakpoint !== undefined && mostRecentBreakpoint !== params.length - 1) {
+			applyCacheControlToParam(params, mostRecentBreakpoint, cacheControl);
 		}
 	}
 
 	return params;
+}
+
+/** Apply `cache_control` to the last cacheable block of the user-role param at `index`. No-op for non-user roles. */
+function applyCacheControlToParam(
+	params: MessageParam[],
+	index: number,
+	cacheControl: { type: "ephemeral"; ttl?: "1h" },
+): void {
+	const param = params[index];
+	if (!param || param.role !== "user") return;
+	if (Array.isArray(param.content)) {
+		const lastBlock = param.content[param.content.length - 1];
+		if (
+			lastBlock &&
+			(lastBlock.type === "text" || lastBlock.type === "image" || lastBlock.type === "tool_result")
+		) {
+			(lastBlock as any).cache_control = cacheControl;
+		}
+	} else if (typeof param.content === "string") {
+		param.content = [
+			{
+				type: "text",
+				text: param.content,
+				cache_control: cacheControl,
+			},
+		] as any;
+	}
 }
 
 /** Convert GSD tools to Anthropic SDK tool definitions, applying cache control to the last entry. */
@@ -475,11 +501,17 @@ export function buildParams(
 	};
 
 	if (isOAuthToken) {
+		// Only the LAST system block carries `cache_control` — the boundary
+		// covers the entire system prefix up to that point. Putting cache_control
+		// on the short "You are Claude Code" header AND the user systemPrompt
+		// would consume two of Anthropic's 4 breakpoint slots for redundant
+		// coverage, leaving no room for a compaction-summary breakpoint. (#5027)
+		const hasUserSystemPrompt = Boolean(context.systemPrompt);
 		params.system = [
 			{
 				type: "text",
 				text: "You are Claude Code, Anthropic's official CLI for Claude.",
-				...(cacheControl ? { cache_control: cacheControl } : {}),
+				...(cacheControl && !hasUserSystemPrompt ? { cache_control: cacheControl } : {}),
 			},
 		];
 		if (context.systemPrompt) {

--- a/packages/pi-ai/src/types.ts
+++ b/packages/pi-ai/src/types.ts
@@ -201,6 +201,19 @@ export interface UserMessage {
 	role: "user";
 	content: string | (TextContent | ImageContent)[];
 	timestamp: number; // Unix timestamp in milliseconds
+	/**
+	 * Hint to provider adapters that this message marks a stable point in the
+	 * conversation suitable as a prompt-cache anchor. Providers that support
+	 * prompt caching (e.g. Anthropic) may apply a `cache_control` breakpoint
+	 * here so the prefix up to and including this message can earn cache
+	 * reads on subsequent turns.
+	 *
+	 * Optional and additive — providers that do not support caching, or
+	 * messages without the hint, behave exactly as before. Set by upstream
+	 * code that knows the message represents a stable boundary (e.g. a
+	 * compaction summary). (#5027)
+	 */
+	cacheBreakpoint?: boolean;
 }
 
 export interface AssistantMessage {

--- a/packages/pi-coding-agent/src/core/messages.ts
+++ b/packages/pi-coding-agent/src/core/messages.ts
@@ -207,6 +207,10 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 							{ type: "text" as const, text: COMPACTION_SUMMARY_PREFIX + m.summary + COMPACTION_SUMMARY_SUFFIX },
 						],
 						timestamp: m.timestamp,
+						// Stable point in the conversation — earn prompt-cache reads on the
+						// summary + kept history block on every post-compaction turn until
+						// the next compaction. (#5027)
+						cacheBreakpoint: true,
 					};
 				case "user":
 				case "assistant":


### PR DESCRIPTION
## TL;DR

**What:** Add an Anthropic `cache_control` breakpoint after the compaction-summary boundary so the stable summary + kept-history block earns cache reads on every post-compaction turn.
**Why:** Today only the volatile suffix gets a breakpoint; the post-compaction stable middle is billed at full input price every turn until the next compaction.
**How:** Generic `cacheBreakpoint?: boolean` hint on `UserMessage`; pi-coding-agent flags compaction summaries with it; the Anthropic adapter applies `cache_control` to the most recent flagged message in addition to the existing last-user-message anchor.

Closes #5027

## What

- `packages/pi-ai/src/types.ts` — add optional `cacheBreakpoint?: boolean` to `UserMessage` (additive, opt-in).
- `packages/pi-coding-agent/src/core/messages.ts` — set `cacheBreakpoint: true` on the user-shape message produced by the `compactionSummary` transform.
- `packages/pi-ai/src/providers/anthropic-shared.ts` — `convertMessages` tracks breakpoint indices during the conversion loop and applies `cache_control` to the most recent flagged message in addition to the existing last-user-message placement. Helper `applyCacheControlToParam` extracted to avoid duplicating the string/array branching across the two call sites.
- `packages/pi-ai/src/providers/anthropic-shared.ts` (separate fix) — in OAuth mode, when a user `systemPrompt` is present, the short "You are Claude Code" header block no longer carries its own `cache_control`. The user systemPrompt's breakpoint covers the entire system prefix; the redundant breakpoint freed a slot that overflowed the 4-breakpoint limit when combined with this PR's compaction boundary.

## Why

The audit identified this as the highest-ROI input-token win after the cache-buster fix in #5019. Estimated impact: 18-45K input tokens cached per post-compaction call. With Anthropic's prompt-cache discount (cache reads are ~10% of base input price), this compounds across every post-compaction turn until the next compaction or 5-minute TTL expiry.

## How

### Generic hint instead of compaction-specific coupling

`UserMessage` gets an optional `cacheBreakpoint?: boolean` field. Any consumer that knows a message represents a stable boundary can flag it. pi-ai's adapter reads the flag and applies `cache_control` accordingly. This keeps pi-ai independent of pi-coding-agent's compaction internals.

### "Most recent boundary wins" choice

If multiple `cacheBreakpoint` messages are present (e.g., multiple compactions in a session), only the most recent one earns the breakpoint. Older boundaries are stale relative to the cache TTL — keeping all of them would consume the limited breakpoint budget for no real gain. This decision is documented in the helper and tested with multiple-boundary fixtures.

### OAuth two-system-block redundancy

In OAuth mode, `buildParams` produced TWO system blocks (the Claude Code header + user systemPrompt) and applied `cache_control` to BOTH — that is two of Anthropic's 4 breakpoint slots for redundant coverage (the Claude Code header is fully contained in the user systemPrompt's cache prefix). With tools + last-user-message + compaction boundary, this overflows to 5 breakpoints.

Fix: only the LAST system block carries `cache_control`. When the user systemPrompt is present, the Claude Code header skips its own breakpoint. When no user systemPrompt is present, the header IS the last system block and correctly cache-marks itself.

This was caught by peer review and is a real pre-existing issue exposed by the new boundary breakpoint. Tests confirm OAuth + systemPrompt + boundary + last user = 3 breakpoints (well under the limit).

### Helper extraction

`applyCacheControlToParam` is extracted from the original inline last-user-message logic. Both call sites (last user, most-recent boundary) need the same string/array branching for cache_control placement; sharing the implementation prevents silent divergence.

## Test plan

- [x] `npm run build:core` and `npm run typecheck:extensions` both pass
- [x] All 9 new tests pass: 6 covering breakpoint placement in `convertMessages`, 3 covering the 4-breakpoint-limit safety at the `buildParams` level (including OAuth + boundary scenario)
- [ ] `npm run test:unit` reports 4 pre-existing flaky failures in `auto-loop.test.ts` — these don't touch this PR's changed surface and pass when the file is run in isolation (56/56). Plus the known ADR-012 allowlist-staleness pre-existing failure. None blocking; flagged here for visibility.

## Considerations

- **Other providers:** `cache_control` is an Anthropic-specific feature. The `cacheBreakpoint` field is generic — other providers that support prompt caching can implement the same pattern without further type changes.
- **Branch summary breakpoints:** Branch summaries (`role: "branchSummary"`) also represent stable points but are not flagged in this PR. Could be a future add if measurement (PR #5026) shows a meaningful uplift.
- **Type narrowing:** TypeScript correctly narrows `msg` to `UserMessage` inside the `if (msg.role === "user")` branch, so no cast is needed when reading `msg.cacheBreakpoint`.

## Change type

- [x] `perf` — Performance improvement (caching)
- [x] (incidental) `fix` — OAuth two-system-block redundancy fix; pre-existing issue exposed by this PR's boundary breakpoint addition

## Notes

This is an AI-assisted PR. Builds on #5021 (cache-buster fix) and #5026 (telemetry). All code is reviewed by the contributor. Peer review caught the OAuth overflow risk and is reflected in the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cache breakpoint functionality to mark conversation boundaries, enabling smarter prompt cache optimization and better capacity management for high-value cache points.

* **Tests**
  * Introduced comprehensive test coverage for cache breakpoint behavior, including constraint validation and deduplication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->