### PR TITLE
chore(mcp-server): instrument 11 gsd_* alias tools with usage telemetry (#5031)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Deprecated
+- **mcp-server**: 11 `gsd_*` alias tools (`gsd_save_decision`, `gsd_update_requirement`, `gsd_save_requirement`, `gsd_generate_milestone_id`, `gsd_task_plan`, `gsd_slice_replan`, `gsd_complete_slice`, `gsd_milestone_complete`, `gsd_milestone_validate`, `gsd_roadmap_reassess`, `gsd_complete_task`) are entering a deprecation window. Each invocation now emits a `deprecation.mcp_alias_used` JSONL record to stderr. Use the canonical names (`gsd_decision_save`, etc.). The aliases will be removed in a future release after telemetry confirms zero usage. (#5031)
+
 ## [2.78.1] - 2026-04-25
 
 ### Fixed

--- a/packages/mcp-server/src/alias-telemetry.test.ts
+++ b/packages/mcp-server/src/alias-telemetry.test.ts
@@ -1,0 +1,78 @@
+// @gsd-build/mcp-server + alias-telemetry.test — coverage for #5031.
+// `logAliasUsage` must:
+//   - emit one valid JSON line per call to stderr with the documented shape
+//   - never throw, even if stderr.write fails (telemetry must not break MCP)
+//   - include the alias name and canonical name so downstream analysis can
+//     attribute usage and drive the eventual removal in step 2.
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { ALIAS_USAGE_EVENT, logAliasUsage } from "./alias-telemetry.js";
+
+describe("logAliasUsage", () => {
+	let captured: string[];
+	let originalWrite: typeof process.stderr.write;
+
+	beforeEach(() => {
+		captured = [];
+		originalWrite = process.stderr.write.bind(process.stderr);
+		process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+			captured.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+			return true;
+		}) as typeof process.stderr.write;
+	});
+
+	afterEach(() => {
+		process.stderr.write = originalWrite;
+	});
+
+	test("emits a single JSON line per call", () => {
+		logAliasUsage("gsd_save_decision", "gsd_decision_save");
+		assert.equal(captured.length, 1);
+		assert.ok(captured[0].endsWith("\n"), "line must terminate with newline");
+	});
+
+	test("emitted JSON has the documented shape", () => {
+		logAliasUsage("gsd_save_decision", "gsd_decision_save");
+		const parsed = JSON.parse(captured[0].trimEnd());
+		assert.equal(parsed.event, ALIAS_USAGE_EVENT);
+		assert.equal(parsed.alias, "gsd_save_decision");
+		assert.equal(parsed.canonical, "gsd_decision_save");
+		assert.equal(typeof parsed.ts, "number");
+	});
+
+	test("event field is namespaced under 'deprecation.' for grep-friendly filtering", () => {
+		logAliasUsage("gsd_save_decision", "gsd_decision_save");
+		const parsed = JSON.parse(captured[0].trimEnd());
+		assert.ok(
+			(parsed.event as string).startsWith("deprecation."),
+			`event '${parsed.event}' should be namespaced for 'grep deprecation' workflow`,
+		);
+	});
+
+	test("ts field is a recent timestamp (within ~5s of Date.now())", () => {
+		const before = Date.now();
+		logAliasUsage("gsd_x", "gsd_y");
+		const after = Date.now();
+		const parsed = JSON.parse(captured[0].trimEnd());
+		assert.ok(parsed.ts >= before && parsed.ts <= after, `ts ${parsed.ts} should be in [${before}, ${after}]`);
+	});
+
+	test("multiple calls emit multiple lines", () => {
+		logAliasUsage("a", "A");
+		logAliasUsage("b", "B");
+		logAliasUsage("c", "C");
+		assert.equal(captured.length, 3);
+		const aliases = captured.map((l) => JSON.parse(l.trimEnd()).alias);
+		assert.deepEqual(aliases, ["a", "b", "c"]);
+	});
+
+	test("never throws — telemetry must not break the MCP request handler", () => {
+		// Force a write failure to exercise the swallow path.
+		process.stderr.write = (() => {
+			throw new Error("simulated stderr failure");
+		}) as typeof process.stderr.write;
+		assert.doesNotThrow(() => logAliasUsage("x", "y"));
+	});
+});

--- a/packages/mcp-server/src/alias-telemetry.ts
+++ b/packages/mcp-server/src/alias-telemetry.ts
@@ -1,0 +1,30 @@
+// @gsd-build/mcp-server + alias-telemetry — usage telemetry on the 11 alias
+// `gsd_*` tools. Step 1 of a two-step deprecation (#5031). Always-on so we
+// actually capture data during the window. Single JSON line per invocation
+// to stderr — negligible overhead vs. the MCP request handler itself.
+//
+// Capture pattern: `<mcp-server-launch> 2>> alias-usage.jsonl`. After a
+// long-enough window with zero entries, the alias tools can be removed in
+// a follow-up PR. Filter with `grep deprecation` — the `event` field is
+// namespaced for that purpose.
+
+/** JSONL `event` field. Namespaced for `grep deprecation`. */
+export const ALIAS_USAGE_EVENT = "deprecation.mcp_alias_used" as const;
+
+/**
+ * Emit a single-line JSONL record signaling that an alias tool was invoked.
+ * Failures are swallowed — telemetry must never break MCP request handling.
+ */
+export function logAliasUsage(alias: string, canonical: string): void {
+	try {
+		const record = {
+			event: ALIAS_USAGE_EVENT,
+			ts: Date.now(),
+			alias,
+			canonical,
+		};
+		process.stderr.write(`${JSON.stringify(record)}\n`);
+	} catch {
+		// swallow — telemetry must never break the request handler
+	}
+}

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -7,6 +7,8 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { z } from "zod";
 
+import { logAliasUsage } from "./alias-telemetry.js";
+
 type WorkflowToolExecutors = {
   SUPPORTED_SUMMARY_ARTIFACT_TYPES: readonly string[];
   executeMilestoneStatus: (params: { milestoneId: string }, basePath?: string) => Promise<unknown>;
@@ -1340,6 +1342,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     "Alias for gsd_decision_save. Record a project decision to the GSD database and regenerate DECISIONS.md.",
     decisionSaveParams,
     async (args: Record<string, unknown>) => {
+      logAliasUsage("gsd_save_decision", "gsd_decision_save");
       const parsed = parseWorkflowArgs(decisionSaveSchema, args);
       const { projectDir, ...params } = parsed;
       await enforceWorkflowWriteGate("gsd_decision_save", projectDir);
@@ -1372,6 +1375,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     "Alias for gsd_requirement_update. Update an existing requirement in the GSD database and regenerate REQUIREMENTS.md.",
     requirementUpdateParams,
     async (args: Record<string, unknown>) => {
+      logAliasUsage("gsd_update_requirement", "gsd_requirement_update");
       const parsed = parseWorkflowArgs(requirementUpdateSchema, args);
       const { projectDir, id, ...updates } = parsed;
       await enforceWorkflowWriteGate("gsd_requirement_update", projectDir);
@@ -1404,6 +1408,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     "Alias for gsd_requirement_save. Record a new requirement to the GSD database and regenerate REQUIREMENTS.md.",
     requirementSaveParams,
     async (args: Record<string, unknown>) => {
+      logAliasUsage("gsd_save_requirement", "gsd_requirement_save");
       const parsed = parseWorkflowArgs(requirementSaveSchema, args);
       const { projectDir, ...params } = parsed;
       await enforceWorkflowWriteGate("gsd_requirement_save", projectDir);
@@ -1434,6 +1439,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     "Alias for gsd_milestone_generate_id. Generate the next milestone ID for a new GSD milestone.",
     milestoneGenerateIdParams,
     async (args: Record<string, unknown>) => {
+      logAliasUsage("gsd_generate_milestone_id", "gsd_milestone_generate_id");
       const { projectDir } = parseWorkflowArgs(milestoneGenerateIdSchema, args);
       await enforceWorkflowWriteGate("gsd_milestone_generate_id", projectDir);
       const id = await runSerializedWorkflowDbOperation(projectDir, () =>
@@ -1499,6 +1505,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     "Alias for gsd_plan_task. Write task planning state to the GSD database and render tasks/T##-PLAN.md from DB.",
     planTaskParams,
     async (args: Record<string, unknown>) => {
+      logAliasUsage("gsd_task_plan", "gsd_plan_task");
       const parsed = parseWorkflowArgs(planTaskSchema, args);
       const { projectDir, ...params } = parsed;
       await enforceWorkflowWriteGate("gsd_plan_task", projectDir, params.milestoneId);
@@ -1530,6 +1537,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     "Alias for gsd_replan_slice. Replan a slice after a blocker is discovered.",
     replanSliceParams,
     async (args: Record<string, unknown>) => {
+      logAliasUsage("gsd_slice_replan", "gsd_replan_slice");
       const parsed = parseWorkflowArgs(replanSliceSchema, args);
       return handleReplanSlice(parsed.projectDir, parsed);
     },
@@ -1550,6 +1558,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     "Alias for gsd_slice_complete. Record a completed slice to the GSD database and render summary/UAT artifacts.",
     sliceCompleteParams,
     async (args: Record<string, unknown>) => {
+      logAliasUsage("gsd_complete_slice", "gsd_slice_complete");
       const parsed = parseWorkflowArgs(sliceCompleteSchema, args);
       return handleSliceComplete(parsed.projectDir, parsed);
     },
@@ -1600,6 +1609,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     "Alias for gsd_complete_milestone. Record a completed milestone to the GSD database and render its SUMMARY.md.",
     completeMilestoneParams,
     async (args: Record<string, unknown>) => {
+      logAliasUsage("gsd_milestone_complete", "gsd_complete_milestone");
       const parsed = parseWorkflowArgs(completeMilestoneSchema, args);
       return handleCompleteMilestone(parsed.projectDir, parsed);
     },
@@ -1620,6 +1630,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     "Alias for gsd_validate_milestone. Validate a milestone and render VALIDATION.md.",
     validateMilestoneParams,
     async (args: Record<string, unknown>) => {
+      logAliasUsage("gsd_milestone_validate", "gsd_validate_milestone");
       const parsed = parseWorkflowArgs(validateMilestoneSchema, args);
       return handleValidateMilestone(parsed.projectDir, parsed);
     },
@@ -1640,6 +1651,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     "Alias for gsd_reassess_roadmap. Reassess a roadmap after slice completion.",
     reassessRoadmapParams,
     async (args: Record<string, unknown>) => {
+      logAliasUsage("gsd_roadmap_reassess", "gsd_reassess_roadmap");
       const parsed = parseWorkflowArgs(reassessRoadmapSchema, args);
       return handleReassessRoadmap(parsed.projectDir, parsed);
     },
@@ -1694,6 +1706,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     "Alias for gsd_task_complete. Record a completed task to the GSD database and render its SUMMARY.md.",
     taskCompleteParams,
     async (args: Record<string, unknown>) => {
+      logAliasUsage("gsd_complete_task", "gsd_task_complete");
       const parsed = parseWorkflowArgs(taskCompleteSchema, args);
       const { projectDir, ...taskArgs } = parsed;
       return handleTaskComplete(projectDir, taskArgs);


### PR DESCRIPTION
## TL;DR

**What:** Step 1 of deprecating the 11 alias `gsd_*` tools — instrument each one to emit a JSONL line to stderr on invocation.
**Why:** The aliases ship duplicate schemas to every session (~2,750 tokens cold-start). They need a usage-telemetry window before safe removal.
**How:** New `alias-telemetry.ts` exporting `logAliasUsage(alias, canonical)`; one-liner call added at the top of each of the 11 alias handlers in `workflow-tools.ts`. Always-on (no env gate). Event field is namespaced `deprecation.mcp_alias_used` for `grep deprecation` filtering.

Closes #5031

## What

- New `packages/mcp-server/src/alias-telemetry.ts` (~30 LoC) — exports `logAliasUsage(alias, canonical)` and `ALIAS_USAGE_EVENT` constant. Emits one JSONL record to stderr per call. Errors swallowed (telemetry must never break MCP request handling).
- `packages/mcp-server/src/workflow-tools.ts` — added one `logAliasUsage(alias, canonical)` call at the top of each of the 11 alias tool handlers.
- `packages/mcp-server/src/alias-telemetry.test.ts` — 6 regression tests covering shape, namespace, never-throws guarantee, and multi-call ordering.
- `CHANGELOG.md` — `[Unreleased] / Deprecated` entry listing the 11 aliases and noting the JSONL event name.

## Why

The original token audit (#5019 / #5021) identified the 11 alias `gsd_*` tools as a duplicate-schema waste — each ships a full tool definition to every session even though they're functionally identical to their canonical counterparts. Peer review on the audit flagged that direct removal is unsafe: in-flight sessions, persisted plans, and any third-party callers may still reference the old names. A telemetry window is required first so we can confirm zero usage.

## How

### `logAliasUsage` — minimal helper

```ts
export const ALIAS_USAGE_EVENT = "deprecation.mcp_alias_used" as const;

export function logAliasUsage(alias: string, canonical: string): void {
  try {
    const record = { event: ALIAS_USAGE_EVENT, ts: Date.now(), alias, canonical };
    process.stderr.write(`${JSON.stringify(record)}\n`);
  } catch {
    // swallow — telemetry must never break the request handler
  }
}
```

- **Always-on**, no env gate. Low-frequency events (one per alias call); the deprecation window's whole point is data capture.
- **Namespaced event**: `deprecation.mcp_alias_used` so operators can filter with `grep deprecation` without breaking JSON parsers (vs. a text prefix that would corrupt the JSONL stream).

### Alias mapping (11 pairs)

| Alias | Canonical |
|-------|-----------|
| `gsd_save_decision` | `gsd_decision_save` |
| `gsd_update_requirement` | `gsd_requirement_update` |
| `gsd_save_requirement` | `gsd_requirement_save` |
| `gsd_generate_milestone_id` | `gsd_milestone_generate_id` |
| `gsd_task_plan` | `gsd_plan_task` |
| `gsd_slice_replan` | `gsd_replan_slice` |
| `gsd_complete_slice` | `gsd_slice_complete` |
| `gsd_milestone_complete` | `gsd_complete_milestone` |
| `gsd_milestone_validate` | `gsd_validate_milestone` |
| `gsd_roadmap_reassess` | `gsd_reassess_roadmap` |
| `gsd_complete_task` | `gsd_task_complete` |

### Capture pattern

```bash
<mcp-server-launch> 2>> alias-usage.jsonl
# After deprecation window, analyze:
grep deprecation alias-usage.jsonl | jq -r '.alias' | sort | uniq -c
```

## Step 2 — removal policy

The aliases are eligible for removal in a follow-up PR after **30 consecutive days** of zero recorded usage in production telemetry. If usage is observed, the deprecation window is extended and the operator(s) using the alias are notified to migrate. This timeline is non-binding policy, captured here so the deprecation has a concrete end date rather than drifting indefinitely.

## Considerations

- **No env opt-out for telemetry.** Peer review suggested a `GSD_ALIAS_TELEMETRY=0` opt-out for compliance environments. Skipped for minimal scope; can be added if a real consumer asks.
- **No deprecation suffix in tool descriptions.** Could append `"(deprecated — use gsd_X)"` to each alias's description string. Skipped to keep this PR purely additive observability — adding deprecation language to the tool descriptions can be its own follow-up if desired.
- **No source-grep wiring test.** Peer review suggested asserting that all 11 canonical strings appear in `workflow-tools.ts` adjacent to `logAliasUsage` calls. CONTRIBUTING.md's "no source-grep tests" rule explicitly forbids this pattern (it tests how the code is *written*, not how it *behaves*). The 11 wirings are trivial one-liners following a clear pattern; the marginal regression risk is acceptable vs. the cost of building a heavy MCP-server integration mock.

## Test plan

- [x] `npm run build:core` and `npm run typecheck:extensions` pass
- [x] All 6 new tests pass: shape, namespace, ts recency, multi-call ordering, never-throws guarantee, JSON line format
- [x] `npm run verify:pr` reports only the pre-existing ADR-012 allowlist-staleness failure on files this PR doesn't touch — no new regressions

## Change type

- [x] `chore` — Telemetry instrumentation step 1 of deprecation. Pre-removal observability only; no functional behavior change to any tool's handling.

## Notes

This is an AI-assisted PR. Builds on #5021, #5026, and #5030. All code is reviewed by the contributor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Deprecated 11 `gsd_*` alias tools with automated deprecation telemetry
  * Using deprecated aliases now emits deprecation event records to stderr; scheduled for removal after telemetry confirms zero usage

* **Tests**
  * Added test suite for alias telemetry functionality, verifying event structure, timestamp accuracy, and error resilience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->