### PR TITLE
fix(gsd): detect external milestone implementation commits

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -107,6 +107,17 @@ export function hasImplementationArtifacts(basePath: string, milestoneId?: strin
         const tagged = getChangedFilesFromMilestoneTaggedCommits(basePath, milestoneId);
         if (!tagged.ok) return "unknown";
         if (tagged.matched) return classifyImplementationFiles(tagged.files);
+
+        // Some projects keep `.gsd/` outside the git worktree (for example as
+        // a symlink into the per-project GSD store). In that topology the
+        // milestone-path history scan above has no tracked `.gsd/milestones/*`
+        // commits to bind `GSD-Task: Sxx/Tyy` trailers back to the milestone,
+        // even though the implementation commits are already on the integration
+        // branch. Fall back to GSD-tagged commits that explicitly reference the
+        // milestone ID in their message or changed non-.gsd paths.
+        const referenced = getChangedFilesFromMilestoneReferencedCommits(basePath, milestoneId);
+        if (!referenced.ok) return "unknown";
+        if (referenced.matched) return classifyImplementationFiles(referenced.files);
       }
       if (currentBranch && currentBranch !== "HEAD") return "absent";
       return "unknown";
@@ -251,6 +262,59 @@ function getChangedFilesFromMilestoneTaggedCommits(
     logWarning("recovery", `milestone-tagged commit scan failed: ${(e as Error).message}`);
     return { ok: false, matched: false, files: [] };
   }
+}
+
+function getChangedFilesFromMilestoneReferencedCommits(
+  basePath: string,
+  milestoneId: string,
+): { ok: boolean; matched: boolean; files: string[] } {
+  try {
+    const logOutput = execFileSync(
+      "git",
+      ["log", "--format=%H%x1f%B%x1e", "HEAD"],
+      { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
+    );
+    const records = logOutput
+      .split("\x1e")
+      .map((record) => record.trim())
+      .filter(Boolean)
+      .flatMap((record) => {
+        const sep = record.indexOf("\x1f");
+        if (sep === -1) return [];
+        const hash = record.slice(0, sep).trim();
+        const message = record.slice(sep + 1);
+        return [{ hash, message }];
+      });
+
+    const files = new Set<string>();
+    let matched = false;
+    for (const { hash, message } of records) {
+      if (!commitMessageHasGsdTrailer(message)) continue;
+
+      const commitFiles = getChangedFilesForCommit(basePath, hash);
+      if (!commitReferencesMilestone(message, milestoneId, commitFiles)) continue;
+
+      matched = true;
+      for (const file of commitFiles) {
+        files.add(file);
+      }
+    }
+
+    return { ok: true, matched, files: [...files] };
+  } catch (e) {
+    logWarning("recovery", `milestone-referenced commit scan failed: ${(e as Error).message}`);
+    return { ok: false, matched: false, files: [] };
+  }
+}
+
+function commitReferencesMilestone(message: string, milestoneId: string, files: readonly string[]): boolean {
+  if (message.includes(milestoneId)) return true;
+  return files.some((file) => isMilestoneNamedPath(file, milestoneId));
+}
+
+function isMilestoneNamedPath(file: string, milestoneId: string): boolean {
+  const normalized = file.replace(/\\/g, "/");
+  return normalized.split("/").includes(milestoneId);
 }
 
 function getChangedFilesForCommit(basePath: string, hash: string): string[] {

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -679,6 +679,25 @@ test("hasImplementationArtifacts finds milestone implementation commits after re
   }
 });
 
+test("hasImplementationArtifacts finds integration-branch milestone commits when .gsd is external (#4935)", () => {
+  const base = makeGitBase();
+  try {
+    writeFileSync(join(base, ".git", "info", "exclude"), ".gsd/\n");
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md"), "# Summary");
+
+    mkdirSync(join(base, "benchmarks", "M001"), { recursive: true });
+    writeFileSync(join(base, "benchmarks", "M001", "manifest.yaml"), "cases: []\n");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feat: materialize M001 evidence\n\nGSD-Task: S01/T01"], { cwd: base, stdio: "ignore" });
+
+    const result = hasImplementationArtifacts(base, "M001");
+    assert.equal(result, "present", "main self-diff retry should find M001 implementation commits even when .gsd is not tracked");
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("hasImplementationArtifacts rejects milestone-scoped main history with only .gsd commits (#4699)", () => {
   const base = makeGitBase();
   try {


### PR DESCRIPTION
When auto-mode completes a milestone from the integration branch, the implementation-artifact guard falls back to milestone-scoped git history. Repositories that keep .gsd outside the tracked worktree do not have .gsd/milestones/<id> commits, so the guard could incorrectly stop completion with 'no implementation files found' even after real implementation commits landed.

Add a secondary fallback over GSD-tagged commits that explicitly reference the milestone in the commit message or changed paths, then classify their changed files normally. This preserves the .gsd-only protection while allowing external-.gsd repositories to complete milestones.

## Linked issue

<!--
PRs without a linked issue will be closed.
Open or find an issue first: https://github.com/gsd-build/gsd-2/issues
-->

Closes #5033<!-- issue number — required -->

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds a fallback in `hasImplementationArtifacts()` that detects GSD-tagged implementation commits which explicitly reference the milestone when `.gsd/` milestone paths are external or untracked.

**Why:** After #4768, milestone completion can still false-fail in external-state `.gsd/` projects because the milestone-scoped fallback may not see tracked `.gsd/milestones/<id>` history to bind `GSD-Task:` trailers back to the milestone.

**How:** Scans GSD-tagged commits on `HEAD`, filters to commits that explicitly reference the milestone ID in the commit message or changed paths, then classifies the changed files with the existing implementation-file classifier.


## What

This PR fixes a residual complete-milestone artifact-verification gap for projects where `.gsd/` is outside the tracked worktree or otherwise excluded from git.

## Why

#4768 fixed complete-milestone self-diff failures by adding milestone-scoped implementation evidence detection. However, external-state `.gsd/` projects may not have tracked `.gsd/milestones/<id>` commits. In that topology, the existing fallback can fail to associate `GSD-Task: Sxx/Tyy` trailers with the active milestone even though the implementation commit is already on the integration branch.

That can cause the artifact guard to incorrectly conclude that no implementation files exist and stop or retry milestone completion.

## How

The new fallback scans `git log HEAD` for commits with GSD trailers, then checks whether each candidate commit explicitly references the milestone by either:

- including the milestone ID in the commit message, or
- touching a path segment matching the milestone ID, such as `benchmarks/M001/manifest.yaml`.

When a matching commit is found, the guard collects its changed files and passes them through the normal implementation-file classifier. This preserves the safety behavior that rejects `.gsd`-only planning artifacts while allowing external `.gsd/` projects to complete milestones when real implementation evidence exists.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code openai/gpt-5.5<!-- If so, note the tool and what was tested -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced artifact detection robustness with automatic fallback mechanism for integration branches when standard checks find no changed files.

* **Tests**
  * Added regression test verifying artifact detection functionality with excluded directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->