### PR TITLE
fix(gsd): run slice workers through headless auto

### DIFF
--- a/src/resources/extensions/gsd/slice-parallel-orchestrator.ts
+++ b/src/resources/extensions/gsd/slice-parallel-orchestrator.ts
@@ -82,6 +82,7 @@ let sliceState: SliceOrchestratorState | null = null;
 
 const SLICE_ORCHESTRATOR_STATE_FILE = "slice-orchestrator.json";
 const TMP_SUFFIX = ".tmp";
+export const SLICE_WORKER_AUTO_ARGS = ["headless", "--json", "auto"] as const;
 
 interface PersistedSliceWorker {
   milestoneId: string;
@@ -356,7 +357,7 @@ export function getSliceOrchestratorState(): SliceOrchestratorState | null {
 /**
  * Start parallel execution for eligible slices within a milestone.
  *
- * For each eligible slice: create a worktree, spawn `gsd --mode json --print "/gsd auto"`
+ * For each eligible slice: create a worktree, spawn `gsd headless --json auto`
  * with env GSD_SLICE_LOCK=<SID> + GSD_MILESTONE_LOCK=<MID> + GSD_PARALLEL_WORKER=1.
  */
 export async function startSliceParallel(
@@ -598,8 +599,13 @@ function resolveGsdBin(): string | null {
 
 /**
  * Spawn a worker process for a slice.
- * The worker runs `gsd --mode json --print "/gsd auto"` in the slice's worktree
+ * The worker runs `gsd headless --json auto` in the slice's worktree
  * with GSD_SLICE_LOCK, GSD_MILESTONE_LOCK, and GSD_PARALLEL_WORKER set.
+ *
+ * Print-mode slash commands return after the command handler schedules
+ * auto-mode, so the worker process can exit before doing any LLM work. The
+ * headless auto entrypoint keeps the process alive until auto-mode reaches a
+ * terminal notification, matching milestone-level parallel workers.
  */
 function spawnSliceWorker(
   basePath: string,
@@ -616,7 +622,7 @@ function spawnSliceWorker(
 
   let child: ChildProcess;
   try {
-    child = spawn(process.execPath, [binPath, "--mode", "json", "--print", "/gsd auto"], {
+    child = spawn(process.execPath, [binPath, ...SLICE_WORKER_AUTO_ARGS], {
       cwd: worker.worktreePath,
       env: {
         ...process.env,

--- a/src/resources/extensions/gsd/tests/slice-parallel-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-parallel-orchestrator.test.ts
@@ -11,7 +11,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { restoreSliceState } from "../slice-parallel-orchestrator.ts";
+import { restoreSliceState, SLICE_WORKER_AUTO_ARGS } from "../slice-parallel-orchestrator.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const gsdDir = join(__dirname, "..");
@@ -98,6 +98,12 @@ describe("slice-parallel-orchestrator structural tests", () => {
       source.includes("GSD_PARALLEL_WORKER"),
       "Orchestrator must set GSD_PARALLEL_WORKER to prevent nested parallel",
     );
+  });
+
+  it("slice workers use headless auto instead of print-mode slash commands", () => {
+    const args: readonly string[] = SLICE_WORKER_AUTO_ARGS;
+    assert.deepEqual([...args], ["headless", "--json", "auto"]);
+    assert.equal(args.includes("--print"), false);
   });
 
   it("maxWorkers default is 2", () => {


### PR DESCRIPTION
## Linked issue

Closes #5037

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Runs slice-parallel workers through `gsd headless --json auto` instead of a print-mode slash command.
**Why:** Print-mode can return after scheduling auto-mode, leaving slice workers stopped before they complete any work.
**How:** Reuses a small exported slice-worker argument constant in the spawn path and adds regression coverage for the worker CLI args.

## What

This updates the slice-parallel worker launch path to use the same headless auto entrypoint already used by milestone-level parallel workers. It also documents why print-mode is unsafe for long-running auto workers and adds targeted test coverage to lock slice workers to `headless --json auto`.

## Why

Slice-parallel dispatch could start a worker process that exited before the auto-loop did work, leaving the coordinator with a stopped worker and zero completed units.

## How

`spawnSliceWorker` now launches workers with `headless --json auto`. The headless RPC command keeps the process alive until auto-mode emits a terminal notification, while the existing NDJSON stdout monitoring continues to work unchanged.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/slice-parallel-orchestrator.test.ts`
2. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/slice-parallel-orchestrator.test.ts src/resources/extensions/gsd/tests/parallel-worker-monitoring.test.ts`
3. `npm run build`
4. `npm run typecheck:extensions`
5. `npm run test:unit`
6. `npm run secret-scan -- --diff upstream/main...HEAD`
7. `git diff --check upstream/main...HEAD`

Broader integration note: `npm run test:integration` was started but was not counted as a pass signal because the suite did not exit after reaching `src/resources/extensions/async-jobs/await-tool.test.ts`. The same non-exiting behavior reproduces on clean current `upstream/main` with that file after all 9 assertions pass, so this is not caused by this diff.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated worker invocation arguments to use headless auto-mode instead of print-mode for improved task execution.
  * Added configuration constant for worker arguments.
  * Updated tests to verify new worker invocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->