### PR TITLE
fix(gsd): bind milestone-tagged commits when .gsd/ is gitignored (#5033)

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -214,12 +214,39 @@ function getChangedFilesFromMilestoneTaggedCommits(
   basePath: string,
   milestoneId: string,
 ): { ok: boolean; matched: boolean; files: string[] } {
+  // Primary: path-scoped log against .gsd/milestones/<id>. Fast and unbounded
+  // by depth when .gsd/ is tracked in git.
+  const scoped = scanGsdTaggedCommits(basePath, milestoneId, [
+    "log", "--format=%H%x1f%B%x1e", "HEAD", "--", `.gsd/milestones/${milestoneId}`,
+  ]);
+  if (!scoped.ok) return scoped;
+  if (scoped.matched) return scoped;
+
+  // Fallback (#5033): when .gsd/ is gitignored / external / untracked, the
+  // path-scoped scan matches no commits even though GSD-tagged commits
+  // referencing the milestone exist on the integration branch. Re-scan all
+  // of HEAD's history and rely on commitMatchesMilestone to bind by
+  // explicit milestone mention in the message body.
+  //
+  // Intentionally unbounded — symmetric with the primary scan, and avoids
+  // reintroducing the rolling-depth failure class removed in #4699 where
+  // milestone evidence aged out behind unrelated activity.
+  return scanGsdTaggedCommits(basePath, milestoneId, [
+    "log", "--format=%H%x1f%B%x1e", "HEAD",
+  ]);
+}
+
+function scanGsdTaggedCommits(
+  basePath: string,
+  milestoneId: string,
+  gitArgs: readonly string[],
+): { ok: boolean; matched: boolean; files: string[] } {
   try {
-    const logOutput = execFileSync(
-      "git",
-      ["log", "--format=%H%x1f%B%x1e", "HEAD", "--", `.gsd/milestones/${milestoneId}`],
-      { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
-    );
+    const logOutput = execFileSync("git", [...gitArgs], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
     const records = logOutput
       .split("\x1e")
       .map((record) => record.trim())
@@ -270,13 +297,21 @@ function commitMatchesMilestone(message: string, milestoneId: string, files: rea
   if (commitTrailerStartsWithMilestone(message, milestoneId)) return true;
 
   // Meaningful execute-task commits currently store task scope as Sxx/Tyy
-  // rather than Mxx/Sxx/Tyy. Bind those commits back to the milestone only
-  // when the commit also touched this milestone's artifacts.
+  // rather than Mxx/Sxx/Tyy. Bind those commits back to the milestone when
+  // either the commit touched this milestone's artifacts, or — for projects
+  // where .gsd/ is gitignored/external (#5033) — the message explicitly
+  // names the milestone.
   if (/^GSD-Task:\s*S[^/\s]+\/T\S+/m.test(message)) {
-    return files.some((file) => isMilestoneArtifactPath(file, milestoneId));
+    if (files.some((file) => isMilestoneArtifactPath(file, milestoneId))) return true;
+    if (commitMessageMentionsMilestone(message, milestoneId)) return true;
   }
 
   return false;
+}
+
+function commitMessageMentionsMilestone(message: string, milestoneId: string): boolean {
+  const escapedMilestone = milestoneId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escapedMilestone}\\b`).test(message);
 }
 
 function commitTrailerStartsWithMilestone(message: string, milestoneId: string): boolean {

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -9,6 +9,7 @@
 
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 import { parseUnitId } from "./unit-id.js";
+import { MILESTONE_ID_RE } from "./milestone-ids.js";
 import { appendEvent } from "./workflow-events.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { clearParseCache } from "./files.js";
@@ -310,6 +311,8 @@ function commitMatchesMilestone(message: string, milestoneId: string, files: rea
 }
 
 function commitMessageMentionsMilestone(message: string, milestoneId: string): boolean {
+  if (!MILESTONE_ID_RE.test(milestoneId)) return false;
+
   const escapedMilestone = milestoneId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return new RegExp(`\\b${escapedMilestone}\\b`).test(message);
 }

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -731,6 +731,39 @@ test("hasImplementationArtifacts uses milestone path history instead of rolling 
   }
 });
 
+test("hasImplementationArtifacts finds implementation commits when .gsd/ is gitignored (#5033)", () => {
+  const base = makeGitBase();
+  try {
+    // Simulate external/untracked .gsd/ via .git/info/exclude — milestone
+    // planning artifacts never enter git, but real implementation files do.
+    writeFileSync(join(base, ".git", "info", "exclude"), ".gsd/\n");
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md"),
+      "# Summary",
+    );
+
+    mkdirSync(join(base, "benchmarks", "M001"), { recursive: true });
+    writeFileSync(join(base, "benchmarks", "M001", "manifest.yaml"), "cases: []\n");
+
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync(
+      "git",
+      ["commit", "-m", "feat: materialize M001 evidence\n\nGSD-Task: S01/T01"],
+      { cwd: base, stdio: "ignore" },
+    );
+
+    const result = hasImplementationArtifacts(base, "M001");
+    assert.equal(
+      result,
+      "present",
+      "milestone-tagged commit binding must work when .gsd/ is gitignored",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("hasImplementationArtifacts returns true on non-git directory (fail-open)", () => {
   const base = join(tmpdir(), `gsd-test-nogit-${randomUUID()}`);
   mkdirSync(base, { recursive: true });

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -764,6 +764,31 @@ test("hasImplementationArtifacts finds implementation commits when .gsd/ is giti
   }
 });
 
+test("hasImplementationArtifacts ignores malformed milestone IDs in commit-message fallback", () => {
+  const base = makeGitBase();
+  try {
+    writeFileSync(join(base, ".git", "info", "exclude"), ".gsd/\n");
+    mkdirSync(join(base, "src"), { recursive: true });
+    writeFileSync(join(base, "src", "feature.ts"), "export function feature() {}\n");
+
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync(
+      "git",
+      ["commit", "-m", "feat: materialize M001(foo evidence\n\nGSD-Task: S01/T01"],
+      { cwd: base, stdio: "ignore" },
+    );
+
+    const result = hasImplementationArtifacts(base, "M001(");
+    assert.equal(
+      result,
+      "absent",
+      "malformed milestone IDs must not bind implementation commits through message scanning",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("hasImplementationArtifacts returns true on non-git directory (fail-open)", () => {
   const base = join(tmpdir(), `gsd-test-nogit-${randomUUID()}`);
   mkdirSync(base, { recursive: true });


### PR DESCRIPTION
## TL;DR

**What:** Add a fallback in `hasImplementationArtifacts` so milestone implementation commits are detected even when `.gsd/` is gitignored / external / untracked.
**Why:** External-state projects falsely fail milestone completion with "no implementation files found" because the existing milestone-scoped scan filters by `.gsd/milestones/<id>` paths that aren't tracked.
**How:** When the path-scoped scan finds nothing, scan all of HEAD's history and bind GSD-Task-tagged commits to the milestone via explicit milestone-ID mention in the message body.

## What

Two changes in `src/resources/extensions/gsd/auto-recovery.ts`:

1. Extracted the per-commit binding loop into a `scanGsdTaggedCommits()` helper so it can be invoked with two different `git log` argv vectors.
2. When the primary path-scoped scan (`-- .gsd/milestones/<id>`) returns no matched records, retry with an unscoped `git log HEAD` and let `commitMatchesMilestone` bind by message-body mention.
3. Extended `commitMatchesMilestone` for the `GSD-Task: Sxx/Tyy` trailer form: also accept commits whose message body matches `\b<milestoneId>\b` via a new `commitMessageMentionsMilestone()` helper.

New test: `hasImplementationArtifacts finds implementation commits when .gsd/ is gitignored (#5033)` — uses `.git/info/exclude` to gitignore `.gsd/`, commits real files under `benchmarks/M001/` with `feat: materialize M001 evidence` / `GSD-Task: S01/T01`, and asserts `hasImplementationArtifacts(base, "M001") === "present"`.

## Why

Closes #5033.

`hasImplementationArtifacts()` returned `absent` when running against a project where `.gsd/` is excluded from git (external-state projects, symlink layouts, `.git/info/exclude`-based exclusion). The milestone-scoped fallback added in #4699 binds GSD-tagged commits by running `git log -- .gsd/milestones/<id>` as a path filter — but if those paths aren't tracked, no commits match, the binding never runs, and milestone completion fails with "no implementation files found" even though the integration branch has real implementation commits.

## How

The fallback chain is now:

1. Path-scoped scan (fast, unbounded by depth, fires when `.gsd/` is tracked).
2. Unscoped HEAD scan (fires when path-scoped finds nothing — the external-`.gsd/` case).

`commitMatchesMilestone` keeps its existing two binding paths (milestone-prefixed trailer; `Sxx/Tyy` trailer + `.gsd/milestones/<id>/...` path touch) and adds a third: `Sxx/Tyy` trailer + `\b<milestoneId>\b` in the message body. The `.gsd/`-only-rejection guarantee from #4699 is preserved — `classifyImplementationFiles` still drops paths under `.gsd/`, so a `.gsd/`-only commit that mentions the milestone still classifies as `absent`.

The unscoped scan is intentionally unbounded — symmetric with the primary scan and avoids reintroducing the rolling-depth failure class removed in #4699.

### Coverage limit

The fix only binds commits whose message body contains the milestone ID as a token. Commits with a `GSD-Task: Sxx/Tyy` trailer that don't reference the milestone in the body remain unbound and still return `absent`. The issue reproducer puts `M001` in the commit subject so this matches the contract requested.

### AI-assisted

This PR is AI-assisted. Both the implementation and the issue analysis went through cross-AI peer review (Codex CLI) before submission.

## Tests

- New regression test reproducing issue scenario ✓
- All 44 tests in `auto-recovery.test.ts` pass ✓
- `npm run typecheck:extensions` clean ✓
- `npm run verify:pr` not run locally (heavy) — CI will run it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced milestone tracking reliability with a primary path-scoped scan and a fallback to broader commit scanning
  * Milestone detection now also recognizes explicit milestone mentions in commit messages and ignores malformed milestone IDs
  
* **Tests**
  * Added regression tests for milestone detection when git directories are excluded and for malformed milestone IDs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->