### PR TITLE
fix(gsd): refuse self-merge when integration branch == milestone branch (#5024)

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -990,6 +990,12 @@ export function autoWorktreeBranch(milestoneId: string): string {
   return `milestone/${milestoneId}`;
 }
 
+function normalizeLocalBranchRef(branch: string): string {
+  return branch.startsWith("refs/heads/")
+    ? branch.slice("refs/heads/".length)
+    : branch;
+}
+
 // ─── Branch-mode Entry ─────────────────────────────────────────────────────
 
 /**
@@ -1677,7 +1683,7 @@ export function mergeMilestoneToMain(
   // check (#1792) collapse to a false success, and the worktree-resolver
   // emits worktree-merged for work that never landed on a distinct
   // integration branch.
-  if (mainBranch === milestoneBranch) {
+  if (normalizeLocalBranchRef(mainBranch) === milestoneBranch) {
     process.chdir(previousCwd);
     throw new GSDError(
       GSD_GIT_ERROR,

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1646,6 +1646,10 @@ export function mergeMilestoneToMain(
   }
 
   // 3. chdir to original base
+  // Note: previousCwd captures the cwd at this point — i.e. the worktree cwd
+  // entering the function. Subsequent throws restore to previousCwd, leaving
+  // the caller in worktree-cwd; callers (worktree-resolver) are responsible
+  // for any further cwd movement on the error path.
   const previousCwd = process.cwd();
   process.chdir(originalBasePath_);
 
@@ -1665,6 +1669,24 @@ export function mergeMilestoneToMain(
     : undefined;
   const mainBranch =
     integrationBranch ?? validatedPrefBranch ?? nativeDetectMainBranch(originalBasePath_);
+
+  // Fail closed when the resolved integration branch is the milestone branch
+  // itself (#5024). Stale or corrupt metadata (e.g. integrationBranch recorded
+  // as "milestone/<MID>") would otherwise let the squash merge resolve to a
+  // self-merge: nothing-to-commit + empty self-diff in the post-merge safety
+  // check (#1792) collapse to a false success, and the worktree-resolver
+  // emits worktree-merged for work that never landed on a distinct
+  // integration branch.
+  if (mainBranch === milestoneBranch) {
+    process.chdir(previousCwd);
+    throw new GSDError(
+      GSD_GIT_ERROR,
+      `Resolved integration branch "${mainBranch}" is the same ref as milestone branch ` +
+      `"${milestoneBranch}" — refusing to self-merge. Integration branch metadata is invalid; ` +
+      `set a distinct main_branch in GSD preferences or repair the milestone integration record ` +
+      `before retrying milestone completion.`,
+    );
+  }
 
   // Remove transient project-root state files before any branch or merge
   // operation. Untracked milestone metadata can otherwise block squash merges.

--- a/src/resources/extensions/gsd/tests/merge-self-branch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/merge-self-branch-guard.test.ts
@@ -42,7 +42,7 @@ function createTempRepo(): string {
   return dir;
 }
 
-test("mergeMilestoneToMain refuses to self-merge when integration branch == milestone branch (#5024)", () => {
+function assertSelfMergeRefIsRejected(recordedIntegrationBranch: string): void {
   const savedCwd = process.cwd();
   let tempDir = "";
 
@@ -65,7 +65,7 @@ test("mergeMilestoneToMain refuses to self-merge when integration branch == mile
     mkdirSync(msDir, { recursive: true });
     writeFileSync(
       join(msDir, "M001-META.json"),
-      JSON.stringify({ integrationBranch: "milestone/M001" }),
+      JSON.stringify({ integrationBranch: recordedIntegrationBranch }),
     );
     git(["add", "."], tempDir);
     git(["commit", "-m", "chore: plant corrupt M001 meta"], tempDir);
@@ -113,4 +113,12 @@ test("mergeMilestoneToMain refuses to self-merge when integration branch == mile
     }
     rmSync(fakeHome, { recursive: true, force: true });
   }
+}
+
+test("mergeMilestoneToMain refuses exact milestone branch self-merge metadata (#5024)", () => {
+  assertSelfMergeRefIsRejected("milestone/M001");
+});
+
+test("mergeMilestoneToMain refuses refs/heads milestone branch self-merge metadata (#5024)", () => {
+  assertSelfMergeRefIsRejected("refs/heads/milestone/M001");
 });

--- a/src/resources/extensions/gsd/tests/merge-self-branch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/merge-self-branch-guard.test.ts
@@ -1,0 +1,116 @@
+// gsd-2 / merge-self-branch-guard.test.ts — regression for #5024
+//
+// mergeMilestoneToMain() must fail closed when the resolved integration
+// branch is the same ref as the milestone branch. Stale or corrupt
+// integration metadata (e.g. integrationBranch recorded as "milestone/<MID>")
+// would otherwise let the squash merge resolve to a self-merge: the post-
+// merge no-op safety check (#1792) compares main vs milestone and finds an
+// empty diff (because they're the same ref), so the helper returns success
+// for work that never landed on a distinct integration branch.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+import { mergeMilestoneToMain } from "../auto-worktree.ts";
+import { _resetServiceCache } from "../worktree.ts";
+import { _clearGsdRootCache } from "../paths.ts";
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
+}
+
+function createTempRepo(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "merge-self-guard-")));
+  git(["init"], dir);
+  git(["config", "user.email", "test@test.com"], dir);
+  git(["config", "user.name", "Test"], dir);
+  writeFileSync(join(dir, "README.md"), "# test\n");
+  git(["add", "."], dir);
+  git(["commit", "-m", "init"], dir);
+  git(["branch", "-M", "main"], dir);
+  return dir;
+}
+
+test("mergeMilestoneToMain refuses to self-merge when integration branch == milestone branch (#5024)", () => {
+  const savedCwd = process.cwd();
+  let tempDir = "";
+
+  // Isolate from user's global preferences so prefs.main_branch can't
+  // override the corrupt-metadata path under test.
+  const originalHome = process.env.HOME;
+  const fakeHome = realpathSync(mkdtempSync(join(tmpdir(), "gsd-fake-home-")));
+  process.env.HOME = fakeHome;
+  _clearGsdRootCache();
+  _resetServiceCache();
+
+  try {
+    tempDir = createTempRepo();
+
+    // Plant corrupt integration metadata: integrationBranch points at the
+    // milestone branch itself. Commit it so mergeMilestoneToMain's
+    // autoCommitDirtyState pre-step has nothing to capture and the
+    // postcondition (no new commits) cleanly reflects the guard.
+    const msDir = join(tempDir, ".gsd", "milestones", "M001");
+    mkdirSync(msDir, { recursive: true });
+    writeFileSync(
+      join(msDir, "M001-META.json"),
+      JSON.stringify({ integrationBranch: "milestone/M001" }),
+    );
+    git(["add", "."], tempDir);
+    git(["commit", "-m", "chore: plant corrupt M001 meta"], tempDir);
+
+    // Create the milestone branch ref so any pre-guard branch operations
+    // wouldn't fail for unrelated reasons.
+    git(["branch", "milestone/M001"], tempDir);
+
+    const mainHeadBefore = git(["rev-parse", "main"], tempDir);
+    const milestoneHeadBefore = git(["rev-parse", "milestone/M001"], tempDir);
+
+    process.chdir(tempDir);
+
+    assert.throws(
+      () => mergeMilestoneToMain(tempDir, "M001", ""),
+      (err: unknown) => {
+        assert.ok(err instanceof Error, "expected an Error to be thrown");
+        assert.match(
+          err.message,
+          /self-merge|same ref/i,
+          "error message should explain the self-merge refusal",
+        );
+        return true;
+      },
+    );
+
+    // Postcondition: neither branch should have been advanced by a merge
+    // commit. The guard fires before checkout/merge, so both refs must be
+    // unchanged from their pre-call state.
+    const mainHeadAfter = git(["rev-parse", "main"], tempDir);
+    const milestoneHeadAfter = git(["rev-parse", "milestone/M001"], tempDir);
+    assert.equal(mainHeadAfter, mainHeadBefore, "main must not have advanced");
+    assert.equal(
+      milestoneHeadAfter,
+      milestoneHeadBefore,
+      "milestone branch must not have advanced",
+    );
+  } finally {
+    process.chdir(savedCwd);
+    process.env.HOME = originalHome;
+    _clearGsdRootCache();
+    _resetServiceCache();
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** Hard guard in `mergeMilestoneToMain` that throws `GSDError` when the resolved integration branch is the same ref as the milestone branch.
**Why:** Stale/corrupt integration metadata could resolve `mainBranch` to `milestone/<MID>`, letting a self-merge collapse to a false success and emit `worktree-merged` for work that never landed on a distinct branch.
**How:** Throw immediately after `mainBranch` resolution, before any checkout/merge work. Telemetry suppression is automatic via error propagation.

## What

`src/resources/extensions/gsd/auto-worktree.ts`:

- New equal-branch guard placed immediately after the integration-branch resolution (between `mainBranch` assignment and `clearProjectRootStateFiles`).
- Clarifying comment on `previousCwd` capture clarifying that it captures `originalBasePath_` (post-chdir) so future readers don't assume guard restores worktree-cwd.

New test: `src/resources/extensions/gsd/tests/merge-self-branch-guard.test.ts` plants `.gsd/milestones/M001/M001-META.json` with `integrationBranch: "milestone/M001"`, calls `mergeMilestoneToMain`, asserts a `GSDError` is thrown with a self-merge / same-ref message, and asserts both branches' HEADs are unchanged from pre-call.

## Why

Closes #5024.

`mergeMilestoneToMain()` resolved `mainBranch` from milestone metadata, then preferences, then auto-detect, but did not guard against `mainBranch === milestoneBranch`. With stale metadata recording `integrationBranch: "milestone/<MID>"`, the squash merge resolved to a self-merge: nothing-to-commit + the post-merge no-op safety check (#1792) saw an empty self-diff (because `nativeDiffNumstat(main, milestone)` is empty when both refs are the same) and let the helper return success. `WorktreeResolver.mergeAndExit()` then emitted `worktree-merged` for work that never landed on a distinct integration branch.

## How

The guard fires before `clearProjectRootStateFiles`, before checkout, before stash, before shelter, before squash-merge. The `GSDError` propagates through `_mergeWorktreeMode` / `_mergeBranchMode` (both gate `actuallyMerged = true` on `mergeMilestoneToMain` returning normally) so the resolver's `worktree-merged` emission is suppressed; `worktree-merge-failed` fires on the error path instead. No separate postcondition check is needed.

### Pre-guard side-effects

`autoCommitDirtyState` and `reconcileWorktreeDb` run before the guard. Neither commits to the integration branch — both act on the worktree cwd or the milestone branch — and both are non-destructive if the function subsequently throws.

### AI-assisted

This PR is AI-assisted. Both the implementation and the issue analysis went through cross-AI peer review (Codex CLI) before submission.

## Tests

- New regression test for the equal-branch guard ✓
- Adjacent merge tests (`stale-worktree-cwd`, `double-merge-guard`, `merge-conflict-stops-loop`) all still pass ✓
- `npm run typecheck:extensions` clean ✓
- `npm run verify:pr` not run locally (heavy) — CI will run it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where corrupt or stale branch metadata could cause merge operations to incorrectly succeed in self-merge scenarios; the system now properly detects and rejects these invalid operations.

* **Tests**
  * Added test coverage for self-merge prevention logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->