### PR TITLE
fix(windows): avoid DEP0190 in Claude CLI binary probes

### DIFF
--- a/src/claude-cli-check.ts
+++ b/src/claude-cli-check.ts
@@ -8,6 +8,22 @@
 import { execFileSync } from 'node:child_process'
 
 /**
+ * Spawn the Claude CLI without triggering Node's DEP0190.
+ *
+ * Passing `args` together with `shell: true` is deprecated in Node 22+
+ * because the args are concatenated into the command string without
+ * escaping. On Windows we still need a shell to resolve `.cmd` shims, so
+ * we invoke `cmd /c <command> <args...>` explicitly. On POSIX we don't
+ * need a shell at all.
+ */
+function spawnClaude(command: string, args: string[], opts: { timeout: number; stdio: 'pipe' }): Buffer {
+  if (process.platform === 'win32') {
+    return execFileSync('cmd', ['/c', command, ...args], opts)
+  }
+  return execFileSync(command, args, opts)
+}
+
+/**
  * Platform-correct binary name for the Claude Code CLI.
  *
  * On Windows, npm-global binaries are installed as `.cmd` shims and
@@ -51,10 +67,9 @@ function debugLog(...parts: unknown[]): void {
 function findWorkingCommand(): string | null {
   for (const command of CLAUDE_COMMAND_CANDIDATES) {
     try {
-      execFileSync(command, ['--version'], {
+      spawnClaude(command, ['--version'], {
         timeout: VERSION_TIMEOUT_MS,
         stdio: 'pipe',
-        shell: process.platform === 'win32',
       })
       debugLog('version probe ok via', command)
       return command
@@ -101,10 +116,9 @@ function parseAuthStatus(output: string): boolean | null {
 function probeAuth(command: string): boolean | null {
   // Try --json first (newer CLIs).
   try {
-    const out = execFileSync(command, ['auth', 'status', '--json'], {
+    const out = spawnClaude(command, ['auth', 'status', '--json'], {
       timeout: AUTH_TIMEOUT_MS,
       stdio: 'pipe',
-      shell: process.platform === 'win32',
     }).toString()
     debugLog('auth status --json output:', out.slice(0, 200))
     const parsed = parseAuthStatus(out)
@@ -115,10 +129,9 @@ function probeAuth(command: string): boolean | null {
 
   // Fallback: plain `auth status` (older CLIs that don't accept --json).
   try {
-    const out = execFileSync(command, ['auth', 'status'], {
+    const out = spawnClaude(command, ['auth', 'status'], {
       timeout: AUTH_TIMEOUT_MS,
       stdio: 'pipe',
-      shell: process.platform === 'win32',
     }).toString()
     debugLog('auth status output:', out.slice(0, 200))
     return parseAuthStatus(out)

--- a/src/resources/extensions/claude-code-cli/readiness.ts
+++ b/src/resources/extensions/claude-code-cli/readiness.ts
@@ -65,7 +65,7 @@ function debugLog(...parts: unknown[]): void {
  * Find the first candidate that responds to `--version`. Returns the
  * candidate name on success, null if none worked.
  *
- * On Windows with `shell: true`, a missing candidate surfaces as a
+ * On Windows with `cmd /c`, a missing candidate surfaces as a
  * non-zero exit from cmd.exe rather than ENOENT — so we cannot rely on
  * the error code to decide "try next". Treat any failure as "try next"
  * for the version probe; the only thing that matters for binary

--- a/src/resources/extensions/claude-code-cli/readiness.ts
+++ b/src/resources/extensions/claude-code-cli/readiness.ts
@@ -17,6 +17,22 @@
 import { execFileSync } from "node:child_process";
 
 /**
+ * Spawn the Claude CLI without triggering Node's DEP0190.
+ *
+ * Passing `args` together with `shell: true` is deprecated in Node 22+
+ * because the args are concatenated into the command string without
+ * escaping. On Windows we still need a shell to resolve `.cmd` shims, so
+ * we invoke `cmd /c <command> <args...>` explicitly. On POSIX we don't
+ * need a shell at all.
+ */
+function spawnClaude(command: string, args: string[], opts: { timeout: number; stdio: "pipe" }): Buffer {
+	if (process.platform === "win32") {
+		return execFileSync("cmd", ["/c", command, ...args], opts);
+	}
+	return execFileSync(command, args, opts);
+}
+
+/**
  * Candidate executable names for the Claude Code CLI.
  *
  * Keep the explicit win32 ternary selector for regression coverage (Issue #4424):
@@ -59,10 +75,9 @@ function debugLog(...parts: unknown[]): void {
 function findWorkingCommand(): string | null {
 	for (const command of CLAUDE_COMMAND_CANDIDATES) {
 		try {
-			execFileSync(command, ["--version"], {
+			spawnClaude(command, ["--version"], {
 				timeout: VERSION_TIMEOUT_MS,
 				stdio: "pipe",
-				shell: process.platform === "win32",
 			});
 			debugLog("version probe ok via", command);
 			return command;
@@ -110,10 +125,9 @@ function parseAuthStatus(output: string): boolean | null {
 function probeAuth(command: string): boolean | null {
 	// Try --json first (newer CLIs).
 	try {
-		const out = execFileSync(command, ["auth", "status", "--json"], {
+		const out = spawnClaude(command, ["auth", "status", "--json"], {
 			timeout: AUTH_TIMEOUT_MS,
 			stdio: "pipe",
-			shell: process.platform === "win32",
 		}).toString();
 		debugLog("auth status --json output:", out.slice(0, 200));
 		const parsed = parseAuthStatus(out);
@@ -124,10 +138,9 @@ function probeAuth(command: string): boolean | null {
 
 	// Fallback: plain `auth status` (older CLIs that don't accept --json).
 	try {
-		const out = execFileSync(command, ["auth", "status"], {
+		const out = spawnClaude(command, ["auth", "status"], {
 			timeout: AUTH_TIMEOUT_MS,
 			stdio: "pipe",
-			shell: process.platform === "win32",
 		}).toString();
 		debugLog("auth status output:", out.slice(0, 200));
 		return parseAuthStatus(out);

--- a/src/tests/claude-cli-dep0190-regression.test.ts
+++ b/src/tests/claude-cli-dep0190-regression.test.ts
@@ -17,11 +17,17 @@
 import test, { describe } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const srcRoot = join(__dirname, "..");
+const [nodeMajor, nodeMinor] = process.versions.node.split(".").map(Number);
+const supportsExperimentalStripTypes =
+	nodeMajor > 22 || (nodeMajor === 22 && nodeMinor >= 6);
+const stripTypesSkipReason = supportsExperimentalStripTypes
+	? undefined
+	: "--experimental-strip-types requires Node 22.6+";
 
 function runUnderThrowDeprecation(modulePath: string, exportName: string): { status: number | null; stderr: string } {
 	// Inline ESM script: import the module, call the named export. The function
@@ -32,6 +38,8 @@ function runUnderThrowDeprecation(modulePath: string, exportName: string): { sta
 		`try { ${exportName}(); } catch { /* binary missing on CI is fine */ }`,
 	].join("\n");
 
+	// --experimental-strip-types requires Node 22.6+; tests using this
+	// helper are skipped on older Node 22 builds.
 	const child = spawnSync(
 		process.execPath,
 		[
@@ -47,8 +55,8 @@ function runUnderThrowDeprecation(modulePath: string, exportName: string): { sta
 }
 
 describe("Issue #5017 — DEP0190 must not fire from Claude CLI probes", () => {
-	test("claude-cli-check.ts isClaudeBinaryInstalled() emits no DeprecationWarning", () => {
-		const modulePath = "file://" + join(srcRoot, "claude-cli-check.ts");
+	test("claude-cli-check.ts isClaudeBinaryInstalled() emits no DeprecationWarning", { skip: stripTypesSkipReason }, () => {
+		const modulePath = pathToFileURL(join(srcRoot, "claude-cli-check.ts")).href;
 		const { status, stderr } = runUnderThrowDeprecation(modulePath, "isClaudeBinaryInstalled");
 		assert.equal(
 			status,
@@ -57,10 +65,10 @@ describe("Issue #5017 — DEP0190 must not fire from Claude CLI probes", () => {
 		);
 	});
 
-	test("readiness.ts isClaudeBinaryPresent() emits no DeprecationWarning", () => {
-		const modulePath =
-			"file://" +
-			join(srcRoot, "resources", "extensions", "claude-code-cli", "readiness.ts");
+	test("readiness.ts isClaudeBinaryPresent() emits no DeprecationWarning", { skip: stripTypesSkipReason }, () => {
+		const modulePath = pathToFileURL(
+			join(srcRoot, "resources", "extensions", "claude-code-cli", "readiness.ts"),
+		).href;
 		const { status, stderr } = runUnderThrowDeprecation(modulePath, "isClaudeBinaryPresent");
 		assert.equal(
 			status,

--- a/src/tests/claude-cli-dep0190-regression.test.ts
+++ b/src/tests/claude-cli-dep0190-regression.test.ts
@@ -1,0 +1,71 @@
+// GSD2 — Regression test for Issue #5017 (DEP0190 from claude-cli-check.ts and readiness.ts)
+//
+// Issue #5017: on Windows the binary probe used `execFileSync(cmd, args, { shell: true })`
+// which Node 22+ rejects with `[DEP0190] DeprecationWarning: Passing args to a child
+// process with shell option true can lead to security vulnerabilities …`. The fix is
+// to invoke `cmd /c <command> <args...>` explicitly on Windows so no `shell: true` is
+// involved.
+//
+// The behavioural assertion: when the probe runs in a Node process started with
+// `--throw-deprecation`, ANY emitted DeprecationWarning becomes a thrown error and
+// the child exits non-zero. A clean (status 0) child proves no DEP0190 was emitted.
+//
+// On non-Windows the probe never used `shell: true`, so the test is vacuously green
+// there — but it still guards against a regression that re-introduces the deprecated
+// pattern on POSIX. On Windows CI it is the actual regression check.
+
+import test, { describe } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const srcRoot = join(__dirname, "..");
+
+function runUnderThrowDeprecation(modulePath: string, exportName: string): { status: number | null; stderr: string } {
+	// Inline ESM script: import the module, call the named export. The function
+	// internally invokes execFileSync — which is what triggered DEP0190 before
+	// the fix.
+	const script = [
+		`import { ${exportName} } from ${JSON.stringify(modulePath)};`,
+		`try { ${exportName}(); } catch { /* binary missing on CI is fine */ }`,
+	].join("\n");
+
+	const child = spawnSync(
+		process.execPath,
+		[
+			"--throw-deprecation",
+			"--experimental-strip-types",
+			"--input-type=module",
+			"-e",
+			script,
+		],
+		{ encoding: "utf-8", timeout: 30_000 },
+	);
+	return { status: child.status, stderr: child.stderr ?? "" };
+}
+
+describe("Issue #5017 — DEP0190 must not fire from Claude CLI probes", () => {
+	test("claude-cli-check.ts isClaudeBinaryInstalled() emits no DeprecationWarning", () => {
+		const modulePath = "file://" + join(srcRoot, "claude-cli-check.ts");
+		const { status, stderr } = runUnderThrowDeprecation(modulePath, "isClaudeBinaryInstalled");
+		assert.equal(
+			status,
+			0,
+			`Expected exit 0 (no deprecation) but got ${status}. stderr: ${stderr}`,
+		);
+	});
+
+	test("readiness.ts isClaudeBinaryPresent() emits no DeprecationWarning", () => {
+		const modulePath =
+			"file://" +
+			join(srcRoot, "resources", "extensions", "claude-code-cli", "readiness.ts");
+		const { status, stderr } = runUnderThrowDeprecation(modulePath, "isClaudeBinaryPresent");
+		assert.equal(
+			status,
+			0,
+			`Expected exit 0 (no deprecation) but got ${status}. stderr: ${stderr}`,
+		);
+	});
+});

--- a/src/tests/claude-cli-windows-detection.test.ts
+++ b/src/tests/claude-cli-windows-detection.test.ts
@@ -28,8 +28,15 @@ import { join } from "node:path";
 const WINDOWS_CLAUDE_SELECTOR =
 	/process\.platform\s*===\s*['"]win32['"]\s*\?\s*['"]claude\.cmd['"]\s*:\s*['"]claude['"]/;
 
+/**
+ * After Issue #5017 the binary is invoked via `cmd /c <command> <args...>`
+ * on Windows instead of `execFileSync(command, args, { shell: true })` —
+ * the latter triggers Node 22+'s DEP0190 deprecation warning. The
+ * assertion guards the explicit cmd.exe invocation so a future refactor
+ * can't silently re-introduce the deprecated pattern.
+ */
 const WINDOWS_CMD_SHELL_GUARD =
-	/shell\s*:\s*process\.platform\s*===\s*['"]win32['"]/;
+	/execFileSync\(\s*["']cmd["']\s*,\s*\[\s*["']\/c["']/;
 
 /**
  * Verifies the onboarding-level readiness check (`claude-cli-check.ts`)
@@ -52,7 +59,7 @@ function verifyCliCheckSelector(): void {
 	assert.match(
 		source,
 		WINDOWS_CMD_SHELL_GUARD,
-		"claude-cli-check.ts must pass shell: process.platform === 'win32' when spawning claude.cmd",
+		"claude-cli-check.ts must invoke claude via 'cmd /c' on Windows (Issue #5017 — avoids DEP0190)",
 	);
 }
 
@@ -83,7 +90,7 @@ function verifyReadinessSelector(): void {
 	assert.match(
 		source,
 		WINDOWS_CMD_SHELL_GUARD,
-		"readiness.ts must pass shell: process.platform === 'win32' when spawning claude.cmd",
+		"readiness.ts must invoke claude via 'cmd /c' on Windows (Issue #5017 — avoids DEP0190)",
 	);
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Replaces `execFileSync(cmd, args, { shell: true })` with explicit `cmd /c` invocation in the two Claude CLI binary probes.
**Why:** Node 22+ emits `[DEP0190]` for `shell: true` with an args array; on Windows this prints a deprecation warning every GSD startup.
**How:** Conditional spawn helper inlined in each module — Windows takes the `cmd /c <command> <args...>` path, POSIX calls `execFileSync` directly with no shell.

## What

- `src/claude-cli-check.ts` — version probe + two auth-status probes (`auth status --json` and `auth status` text fallback) routed through a new `spawnClaude()` helper.
- `src/resources/extensions/claude-code-cli/readiness.ts` — same three call sites, same helper inlined.
- `src/tests/claude-cli-windows-detection.test.ts` — existing source-grep guard updated: `WINDOWS_CMD_SHELL_GUARD` now matches `execFileSync('cmd', ['/c', …])` instead of the removed `shell:` option.
- `src/tests/claude-cli-dep0190-regression.test.ts` (new) — behavioural test: spawns each binary probe under `node --throw-deprecation`. Any emitted DeprecationWarning becomes a thrown error → non-zero exit. Exit 0 proves no DEP0190.

## Why

Closes #5017.

On Windows with Node v22+, every GSD startup printed:
```
(node:10200) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
```

`shell: true` was needed because Claude CLI ships as a `.cmd` shim — Node's `execFileSync` won't auto-resolve `.cmd` endings on Win32. But passing it together with an args array is exactly what DEP0190 deprecates.

PR #1827 already fixed the same pattern in `verification-gate.ts`. This applies the same fix to the two remaining call sites flagged in the issue.

## How

The helper:
```ts
function spawnClaude(command, args, opts) {
  if (process.platform === 'win32') {
    return execFileSync('cmd', ['/c', command, ...args], opts);
  }
  return execFileSync(command, args, opts);
}
```

- On Windows: `cmd.exe` resolves the `.cmd`/`.bat`/`.exe` shim itself; the args are passed as a true argv (no shell-string concatenation, no DEP0190).
- On POSIX: `shell: true` was never needed — direct `execFileSync` is shorter and faster.
- Behaviour is unchanged on both platforms: same timeout, same stdio, same iteration over `CLAUDE_COMMAND_CANDIDATES`.

### Verification

- New behavioural test (`claude-cli-dep0190-regression.test.ts`) — passes locally on macOS (Node 25.9.0). Will exercise the actual fix on Windows CI.
- `npm run build:core` — clean.
- `npm run typecheck:extensions` — clean.
- Existing `claude-cli-windows-detection.test.ts` and `claude-readiness-regression-4997.test.ts` — pass.

### Change type

- [x] `fix` — Bug fix

AI-assisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a platform-aware launcher for invoking the Claude CLI that runs commands directly on POSIX and uses explicit cmd /c on Windows.

* **Bug Fixes**
  * Eliminated Node.js deprecation warnings when executing Claude CLI commands across platforms.

* **Tests**
  * Added a regression test to ensure no deprecation warnings under strict deprecation settings.
  * Updated platform-specific execution tests to verify cmd /c behavior on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->