### PR TITLE
fix(extensions): drop semver dep, replace with inline isVersionGreater

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "playwright": "^1.58.2",
         "proper-lockfile": "^4.1.2",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.4",
         "sharp": "^0.34.5",
         "sql.js": "^1.14.1",
         "strip-ansi": "^7.1.0",
@@ -57,7 +56,6 @@
       "devDependencies": {
         "@types/node": "^24.12.0",
         "@types/picomatch": "^4.0.2",
-        "@types/semver": "^7.7.1",
         "c8": "^11.0.0",
         "esbuild": "^0.25.12",
         "jiti": "^2.6.1",
@@ -909,7 +907,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2712,7 +2709,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -2726,7 +2724,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -2740,7 +2739,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -2754,7 +2754,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -2768,7 +2769,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -2782,7 +2784,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -2796,7 +2799,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -2810,7 +2814,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -2824,7 +2829,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -2838,7 +2844,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -2852,7 +2859,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -2866,7 +2874,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -2880,7 +2889,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -2894,7 +2904,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -2908,7 +2919,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -2922,7 +2934,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -2936,7 +2949,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -2950,7 +2964,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -2964,7 +2979,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -2978,7 +2994,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -2992,7 +3009,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -3006,7 +3024,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -3020,7 +3039,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -3034,7 +3054,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -3048,7 +3069,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
@@ -4136,7 +4158,8 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/hosted-git-info": {
       "version": "3.0.5",
@@ -4208,7 +4231,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4237,13 +4259,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/sql.js": {
@@ -4533,7 +4548,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5406,7 +5420,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5561,6 +5574,7 @@
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -6075,7 +6089,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6928,6 +6941,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7259,7 +7273,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7340,6 +7353,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7517,7 +7531,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7527,7 +7540,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7641,6 +7653,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8201,6 +8214,7 @@
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
@@ -8489,6 +8503,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8506,6 +8521,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8523,6 +8539,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8540,6 +8557,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8557,6 +8575,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8574,6 +8593,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8591,6 +8611,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8608,6 +8629,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8625,6 +8647,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8642,6 +8665,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8659,6 +8683,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8676,6 +8701,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8693,6 +8719,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8710,6 +8737,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8727,6 +8755,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8744,6 +8773,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8761,6 +8791,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8778,6 +8809,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8795,6 +8827,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8812,6 +8845,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8829,6 +8863,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8846,6 +8881,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8863,6 +8899,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8880,6 +8917,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8897,6 +8935,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8914,6 +8953,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8925,6 +8965,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9153,7 +9194,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9290,7 +9330,6 @@
     "packages/pi-coding-agent": {
       "name": "@gsd/pi-coding-agent",
       "version": "2.78.1",
-      "peer": true,
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
         "@silvia-odwyer/photon-node": "^0.3.4",
@@ -9319,7 +9358,6 @@
     "packages/pi-tui": {
       "name": "@gsd/pi-tui",
       "version": "2.78.1",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.6.2",
         "get-east-asian-width": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "playwright": "^1.58.2",
     "proper-lockfile": "^4.1.2",
     "proxy-agent": "^6.5.0",
-    "semver": "^7.7.4",
     "sharp": "^0.34.5",
     "sql.js": "^1.14.1",
     "strip-ansi": "^7.1.0",
@@ -138,7 +137,6 @@
   "devDependencies": {
     "@types/node": "^24.12.0",
     "@types/picomatch": "^4.0.2",
-    "@types/semver": "^7.7.1",
     "c8": "^11.0.0",
     "esbuild": "^0.25.12",
     "jiti": "^2.6.1",

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -12,7 +12,47 @@ import { dirname, join, resolve } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { lockSync, unlockSync } from "proper-lockfile";
-import semver from "semver";
+
+/**
+ * Strict numeric comparison of two npm-style version strings.
+ *
+ * Returns true when `a` is strictly greater than `b`. Compares the dotted
+ * release components numerically (so `1.10.0` > `1.9.0`) and treats any
+ * prerelease suffix (`-beta.1`, `-rc.2`) as less than the equivalent
+ * release version (`1.0.0` > `1.0.0-beta.1`). Sufficient for npm package
+ * version comparison in the extension installer; we don't need the full
+ * semver range/intersect machinery here.
+ *
+ * Replaces the earlier `import semver from "semver"` — that import broke
+ * `tsc -p tsconfig.json` whenever `@types/semver` failed to install
+ * (Issue #4946) because the file is pulled in transitively despite being
+ * under the `src/resources` exclude.
+ */
+export function isVersionGreater(a: string, b: string): boolean {
+  const split = (v: string): { release: number[]; pre: string | null } => {
+    const dash = v.indexOf("-");
+    const release = (dash === -1 ? v : v.slice(0, dash))
+      .split(".")
+      .map(part => Number.parseInt(part, 10) || 0);
+    const pre = dash === -1 ? null : v.slice(dash + 1);
+    return { release, pre };
+  };
+  const sa = split(a);
+  const sb = split(b);
+  const len = Math.max(sa.release.length, sb.release.length);
+  for (let i = 0; i < len; i++) {
+    const ai = sa.release[i] ?? 0;
+    const bi = sb.release[i] ?? 0;
+    if (ai !== bi) return ai > bi;
+  }
+  // Release components equal — a release version beats any prerelease,
+  // and prerelease strings are compared lexicographically (good enough
+  // for `beta.1` vs `beta.2`, the only realistic case here).
+  if (sa.pre === null && sb.pre !== null) return true;
+  if (sa.pre !== null && sb.pre === null) return false;
+  if (sa.pre !== null && sb.pre !== null) return sa.pre > sb.pre;
+  return false;
+}
 
 const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
 
@@ -538,7 +578,7 @@ async function updateSingleExtension(
     return;
   }
 
-  if (semver.gt(latest, current)) {
+  if (isVersionGreater(latest, current)) {
     ctx.ui.notify(`Updating "${id}": v${current} → v${latest}...`, "info");
     await handleInstall(packageName, ctx);
   } else {
@@ -599,7 +639,7 @@ async function updateAllExtensions(
       continue;
     }
 
-    if (semver.gt(latest, current)) {
+    if (isVersionGreater(latest, current)) {
       ctx.ui.notify(`  ${entry.id}: v${current} → v${latest} (updating)`, "info");
       await handleInstall(packageName, ctx);
       updated++;

--- a/src/resources/extensions/gsd/tests/commands-extensions-version-compare.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-extensions-version-compare.test.ts
@@ -1,0 +1,58 @@
+// GSD2 — Regression test for Issue #4946 isVersionGreater (commands-extensions.ts)
+//
+// Covers the inline npm-version comparator that replaced the `semver` import in
+// commands-extensions.ts. The original import broke `tsc -p tsconfig.json` whenever
+// `@types/semver` failed to install — the file is type-checked transitively despite
+// being under the `src/resources` exclude. The replacement keeps the same comparison
+// semantics for the realistic input space (npm extension version strings) without
+// pulling in the full semver type surface.
+
+import test, { describe } from "node:test";
+import assert from "node:assert/strict";
+import { isVersionGreater } from "../commands-extensions.ts";
+
+describe("isVersionGreater — npm extension version comparison (#4946)", () => {
+	test("strictly greater patch beats lesser patch", () => {
+		assert.equal(isVersionGreater("1.2.4", "1.2.3"), true);
+		assert.equal(isVersionGreater("1.2.3", "1.2.4"), false);
+	});
+
+	test("equal versions are not strictly greater", () => {
+		assert.equal(isVersionGreater("1.2.3", "1.2.3"), false);
+	});
+
+	test("numeric (not lexicographic) component comparison", () => {
+		// Lexicographic compare would say "1.10.0" < "1.9.0".
+		assert.equal(isVersionGreater("1.10.0", "1.9.0"), true);
+		assert.equal(isVersionGreater("1.9.0", "1.10.0"), false);
+	});
+
+	test("major bump beats minor and patch differences", () => {
+		assert.equal(isVersionGreater("2.0.0", "1.99.99"), true);
+		assert.equal(isVersionGreater("1.99.99", "2.0.0"), false);
+	});
+
+	test("missing trailing components default to zero", () => {
+		assert.equal(isVersionGreater("1.2", "1.1.9"), true);
+		assert.equal(isVersionGreater("1", "0.9.9"), true);
+		assert.equal(isVersionGreater("1.2", "1.2.0"), false);
+	});
+
+	test("release version beats prerelease at the same release number", () => {
+		assert.equal(isVersionGreater("1.0.0", "1.0.0-beta.1"), true);
+		assert.equal(isVersionGreater("1.0.0-beta.1", "1.0.0"), false);
+	});
+
+	test("prerelease ordering: beta.2 > beta.1, rc.1 > beta.9", () => {
+		assert.equal(isVersionGreater("1.0.0-beta.2", "1.0.0-beta.1"), true);
+		assert.equal(isVersionGreater("1.0.0-rc.1", "1.0.0-beta.9"), true);
+	});
+
+	test("non-numeric junk in components doesn't crash — coerces to 0", () => {
+		// Defensive: we don't throw on garbage input; we treat unparseable
+		// components as 0. This matches the behaviour the extension installer
+		// can rely on without surfacing an error to the user.
+		assert.equal(isVersionGreater("1.x.0", "1.0.0"), false);
+		assert.equal(isVersionGreater("abc", "0.0.1"), false);
+	});
+});


### PR DESCRIPTION
## TL;DR

**What:** Removes the `semver` runtime + `@types/semver` dev dependencies and replaces the single `semver.gt(...)` call site with a small inline `isVersionGreater()` helper.
**Why:** `tsc -p tsconfig.json` failed on main when `@types/semver` wasn't installed; the file pulling it in is transitively included despite the `src/resources` exclude.
**How:** Inline numeric comparator covers the realistic input space (npm extension version strings). 8 unit tests pin the behaviour.

## What

- `src/resources/extensions/gsd/commands-extensions.ts` — drops `import semver from "semver"`, adds an exported `isVersionGreater(a, b)` helper, swaps the two `semver.gt(...)` call sites.
- `package.json` — removes `semver` (deps) and `@types/semver` (devDeps).
- `package-lock.json` — `npm install --package-lock-only` regenerates and prunes transitive copies of `semver` that only existed because of our direct dep.
- `src/resources/extensions/gsd/tests/commands-extensions-version-compare.test.ts` (new) — 8 cases covering numeric ordering (`1.10.0 > 1.9.0`), missing components, prerelease vs release (`1.0.0 > 1.0.0-beta.1`), and graceful handling of non-numeric input.

## Why

Closes #4946.

The reporter saw `tsc --noEmit -p tsconfig.json` fail with:
```
src/resources/extensions/gsd/commands-extensions.ts(15,20): error TS7016:
  Could not find a declaration file for module 'semver'.
```

Investigation: even though `tsconfig.json` declares `exclude: ["src/resources", ...]`, `tsc --listFiles` shows the file IS in the program — it's transitively imported from `src/cli.ts` via `preferences.ts`. So its `semver` import must always resolve.

That import existed for one purpose: `semver.gt(latest, current)` in the npm-extension update path. We don't need a 2 MB dependency for one comparison — and dropping it removes the `@types/semver` install requirement entirely, which is the real fix to the reporter's symptom (no shim, no docs, no env-specific reinstall instructions).

## How

`isVersionGreater(a, b)`:
1. Splits each version on `-` to separate release from prerelease.
2. Splits release on `.` and parses each component as an integer (defaults to 0 on non-numeric input — matches the defensive behaviour an extension installer needs).
3. Compares components positionally; first non-equal pair decides.
4. If release components are equal: a release version (no `-`) beats any prerelease; otherwise compares prerelease strings lexicographically (covers the realistic `beta.1` / `beta.2` / `rc.1` cases).

Tested behaviour:
- `1.2.4 > 1.2.3`
- `1.10.0 > 1.9.0` (the lexicographic-comparison trap)
- `2.0.0 > 1.99.99`
- `1.2 > 1.1.9` (missing components default to 0)
- `1.0.0 > 1.0.0-beta.1` (release beats prerelease)
- `1.0.0-rc.1 > 1.0.0-beta.9`
- `isVersionGreater("abc", "0.0.1") === false` (no throws on garbage)

### Verification

- `npx tsc --noEmit -p tsconfig.json` — clean (was failing per #4946).
- `npx tsc --noEmit -p tsconfig.extensions.json` — clean.
- New test file passes (8/8).
- `npm install --package-lock-only` regenerated lockfile cleanly.

### Change type

- [x] `fix` — Bug fix

AI-assisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed external version comparison dependency and replaced with streamlined internal logic for extension upgrade detection.
* **Tests**
  * Added comprehensive test coverage for version comparison across npm-style version string scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->