### PR TITLE
feat(ollama): configurable probe/request timeouts via env vars

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -163,6 +163,15 @@ Recommended verification order:
 | `GSD_ALLOWED_COMMAND_PREFIXES` | (built-in list) | Comma-separated command prefixes allowed for `!command` value resolution. Overrides `allowedCommandPrefixes` in settings.json. See [Custom Models — Command Allowlist](custom-models.md#command-allowlist). |
 | `GSD_FETCH_ALLOWED_URLS` | (none) | Comma-separated hostnames exempted from `fetch_page` URL blocking. Overrides `fetchAllowedUrls` in settings.json. See [URL Blocking](#url-blocking-fetch_page). |
 
+### Ollama
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OLLAMA_HOST` | `http://localhost:11434` | Ollama server URL. A bare `host:port` value is treated as `http://host:port`. |
+| `OLLAMA_API_KEY` | (none) | Bearer token for remote or cloud Ollama endpoints. Local Ollama ignores this header. |
+| `OLLAMA_PROBE_TIMEOUT_MS` | `1500` | Startup health-check timeout in milliseconds. Unset, empty, non-numeric, zero, or negative values fall back to the default. Values above `2147483647` ms are capped to Node.js's maximum timer delay. |
+| `OLLAMA_REQUEST_TIMEOUT_MS` | `10000` | Per-request REST timeout in milliseconds. Unset, empty, non-numeric, zero, or negative values fall back to the default. Values above `2147483647` ms are capped to Node.js's maximum timer delay. |
+
 ## All Settings
 
 ### `models`

--- a/gitbook/reference/environment-variables.md
+++ b/gitbook/reference/environment-variables.md
@@ -33,6 +33,15 @@
 | `GOOGLE_APPLICATION_CREDENTIALS` | Vertex AI (ADC) |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI |
 
+## Ollama
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OLLAMA_HOST` | `http://localhost:11434` | Ollama server URL. A bare `host:port` value is treated as `http://host:port`. |
+| `OLLAMA_API_KEY` | (none) | Bearer token for remote or cloud Ollama endpoints. Local Ollama ignores this header. |
+| `OLLAMA_PROBE_TIMEOUT_MS` | `1500` | Startup health-check timeout in milliseconds. Unset, empty, non-numeric, zero, or negative values fall back to the default. Values above `2147483647` ms are capped to Node.js's maximum timer delay. |
+| `OLLAMA_REQUEST_TIMEOUT_MS` | `10000` | Per-request REST timeout in milliseconds. Unset, empty, non-numeric, zero, or negative values fall back to the default. Values above `2147483647` ms are capped to Node.js's maximum timer delay. |
+
 ## Tool API Keys
 
 | Variable | Purpose |

--- a/src/resources/extensions/ollama/index.ts
+++ b/src/resources/extensions/ollama/index.ts
@@ -119,17 +119,31 @@ export default function ollama(pi: ExtensionAPI) {
 		// In headless/auto mode, await the probe so the fallback resolver can
 		// see Ollama before the first LLM call (#3531 race condition).
 		// In interactive mode, keep it async for fast startup.
+		// Surface probe failures under GSD_DEBUG so users can diagnose silent
+		// "Ollama is missing from /model" reports without patching dist/. The
+		// probe still soft-fails (registration is best-effort) — we just stop
+		// dropping the error on the floor. See #4982.
+		const debugOllama = (where: string, error: unknown): void => {
+			if (process.env.GSD_DEBUG) {
+				const msg = error instanceof Error ? error.message : String(error);
+				process.stderr.write(`[ollama] ${where} probe failed: ${msg}\n`);
+			}
+		};
+
 		if (!ctx.hasUI) {
 			try {
 				await probeAndRegister(pi);
-			} catch { /* non-fatal */ }
+			} catch (error) {
+				debugOllama("headless", error);
+			}
 		} else {
 			probeAndRegister(pi)
 				.then((found) => {
 					ctx.ui.setStatus("ollama", found ? "Ollama" : undefined);
 				})
-				.catch(() => {
+				.catch((error) => {
 					ctx.ui.setStatus("ollama", undefined);
+					debugOllama("interactive", error);
 				});
 		}
 	});

--- a/src/resources/extensions/ollama/ollama-client.ts
+++ b/src/resources/extensions/ollama/ollama-client.ts
@@ -21,6 +21,7 @@ import { parseNDJsonStream } from "./ndjson-stream.js";
 const DEFAULT_HOST = "http://localhost:11434";
 const DEFAULT_PROBE_TIMEOUT_MS = 1500;
 const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 /**
  * Parse a positive integer from an environment variable, falling back to
@@ -35,7 +36,7 @@ export function envPositiveInt(name: string, fallback: number): number {
 	if (!raw) return fallback;
 	const parsed = Number.parseInt(raw, 10);
 	if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
-	return parsed;
+	return Math.min(parsed, MAX_TIMER_DELAY_MS);
 }
 
 /**

--- a/src/resources/extensions/ollama/ollama-client.ts
+++ b/src/resources/extensions/ollama/ollama-client.ts
@@ -19,8 +19,44 @@ import type {
 import { parseNDJsonStream } from "./ndjson-stream.js";
 
 const DEFAULT_HOST = "http://localhost:11434";
-const PROBE_TIMEOUT_MS = 1500;
-const REQUEST_TIMEOUT_MS = 10000;
+const DEFAULT_PROBE_TIMEOUT_MS = 1500;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
+
+/**
+ * Parse a positive integer from an environment variable, falling back to
+ * `fallback` when the var is unset, empty, non-numeric, zero, or negative.
+ *
+ * Defensive parsing: a typo like `OLLAMA_PROBE_TIMEOUT_MS=abc` or
+ * `OLLAMA_PROBE_TIMEOUT_MS=0` should not silently disable the timeout —
+ * fall back to the documented default instead.
+ */
+export function envPositiveInt(name: string, fallback: number): number {
+	const raw = process.env[name];
+	if (!raw) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+	return parsed;
+}
+
+/**
+ * Effective probe timeout for the startup `isRunning()` health check.
+ * Override with `OLLAMA_PROBE_TIMEOUT_MS=<ms>` for slower networks (LAN
+ * Ollama hosts, cloud endpoints, contended cold starts).
+ *
+ * Resolved at call time — tests and downstream callers can mutate
+ * `process.env` between invocations and pick up the new value.
+ */
+export function getProbeTimeoutMs(): number {
+	return envPositiveInt("OLLAMA_PROBE_TIMEOUT_MS", DEFAULT_PROBE_TIMEOUT_MS);
+}
+
+/**
+ * Effective per-request timeout for REST calls. Override with
+ * `OLLAMA_REQUEST_TIMEOUT_MS=<ms>`.
+ */
+export function getRequestTimeoutMs(): number {
+	return envPositiveInt("OLLAMA_REQUEST_TIMEOUT_MS", DEFAULT_REQUEST_TIMEOUT_MS);
+}
 
 /**
  * Get the Ollama host URL from OLLAMA_HOST or default.
@@ -57,7 +93,7 @@ function withAuth(options: RequestInit = {}): RequestInit {
 	};
 }
 
-async function fetchWithTimeout(url: string, options: RequestInit = {}, timeoutMs = REQUEST_TIMEOUT_MS): Promise<Response> {
+async function fetchWithTimeout(url: string, options: RequestInit = {}, timeoutMs = getRequestTimeoutMs()): Promise<Response> {
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), timeoutMs);
 	try {
@@ -77,7 +113,7 @@ export async function isRunning(): Promise<boolean> {
 		const host = getOllamaHost();
 		const isCloud = host.includes("ollama.com") || host.includes("cloud");
 		const probeUrl = isCloud ? `${host}/api/tags` : `${host}/`;
-		const timeout = isCloud ? REQUEST_TIMEOUT_MS : PROBE_TIMEOUT_MS;
+		const timeout = isCloud ? getRequestTimeoutMs() : getProbeTimeoutMs();
 		const response = await fetchWithTimeout(probeUrl, isCloud ? { method: "GET" } : {}, timeout);
 		return response.ok;
 	} catch {

--- a/src/resources/extensions/ollama/tests/ollama-client-timeout-env.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-client-timeout-env.test.ts
@@ -11,6 +11,7 @@ import {
 	envPositiveInt,
 	getProbeTimeoutMs,
 	getRequestTimeoutMs,
+	MAX_TIMER_DELAY_MS,
 } from "../ollama-client.js";
 
 const PROBE_VAR = "OLLAMA_PROBE_TIMEOUT_MS";
@@ -74,6 +75,12 @@ describe("envPositiveInt — defensive fallback", () => {
 	it("parses leading digits and discards trailing junk (parseInt semantics)", () => {
 		withEnv("__GSD_TEST_INT__", "1500ms", () => {
 			assert.equal(envPositiveInt("__GSD_TEST_INT__", 42), 1500);
+		});
+	});
+
+	it("caps values above Node's maximum timer delay", () => {
+		withEnv("__GSD_TEST_INT__", "9999999999999", () => {
+			assert.equal(envPositiveInt("__GSD_TEST_INT__", 42), MAX_TIMER_DELAY_MS);
 		});
 	});
 });

--- a/src/resources/extensions/ollama/tests/ollama-client-timeout-env.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-client-timeout-env.test.ts
@@ -1,0 +1,134 @@
+// GSD2 — Tests for OLLAMA_PROBE_TIMEOUT_MS / OLLAMA_REQUEST_TIMEOUT_MS env vars (#5003 / #4982)
+//
+// Pinned defaults: 1500 ms probe, 10 000 ms request. The defaults must be
+// preserved when the env var is unset, empty, non-numeric, zero, or negative
+// so a typo or fat-fingered value can't silently disable the timeout. When
+// the env var is set to a valid positive integer it overrides the default.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+	envPositiveInt,
+	getProbeTimeoutMs,
+	getRequestTimeoutMs,
+} from "../ollama-client.js";
+
+const PROBE_VAR = "OLLAMA_PROBE_TIMEOUT_MS";
+const REQUEST_VAR = "OLLAMA_REQUEST_TIMEOUT_MS";
+
+function withEnv(name: string, value: string | undefined, run: () => void): void {
+	const prior = process.env[name];
+	if (value === undefined) {
+		delete process.env[name];
+	} else {
+		process.env[name] = value;
+	}
+	try {
+		run();
+	} finally {
+		if (prior === undefined) {
+			delete process.env[name];
+		} else {
+			process.env[name] = prior;
+		}
+	}
+}
+
+describe("envPositiveInt — defensive fallback", () => {
+	it("returns fallback when var is unset", () => {
+		withEnv("__GSD_TEST_INT__", undefined, () => {
+			assert.equal(envPositiveInt("__GSD_TEST_INT__", 42), 42);
+		});
+	});
+
+	it("returns fallback when var is empty string", () => {
+		withEnv("__GSD_TEST_INT__", "", () => {
+			assert.equal(envPositiveInt("__GSD_TEST_INT__", 42), 42);
+		});
+	});
+
+	it("returns fallback when var is non-numeric", () => {
+		withEnv("__GSD_TEST_INT__", "abc", () => {
+			assert.equal(envPositiveInt("__GSD_TEST_INT__", 42), 42);
+		});
+	});
+
+	it("returns fallback when var is zero (would silently disable timeout)", () => {
+		withEnv("__GSD_TEST_INT__", "0", () => {
+			assert.equal(envPositiveInt("__GSD_TEST_INT__", 42), 42);
+		});
+	});
+
+	it("returns fallback when var is negative", () => {
+		withEnv("__GSD_TEST_INT__", "-100", () => {
+			assert.equal(envPositiveInt("__GSD_TEST_INT__", 42), 42);
+		});
+	});
+
+	it("returns parsed value when var is a positive integer", () => {
+		withEnv("__GSD_TEST_INT__", "5000", () => {
+			assert.equal(envPositiveInt("__GSD_TEST_INT__", 42), 5000);
+		});
+	});
+
+	it("parses leading digits and discards trailing junk (parseInt semantics)", () => {
+		withEnv("__GSD_TEST_INT__", "1500ms", () => {
+			assert.equal(envPositiveInt("__GSD_TEST_INT__", 42), 1500);
+		});
+	});
+});
+
+describe("getProbeTimeoutMs — OLLAMA_PROBE_TIMEOUT_MS override", () => {
+	beforeEach(() => {
+		delete process.env[PROBE_VAR];
+	});
+	afterEach(() => {
+		delete process.env[PROBE_VAR];
+	});
+
+	it("defaults to 1500 ms when unset", () => {
+		assert.equal(getProbeTimeoutMs(), 1500);
+	});
+
+	it("honours a positive override", () => {
+		process.env[PROBE_VAR] = "5000";
+		assert.equal(getProbeTimeoutMs(), 5000);
+	});
+
+	it("falls back to 1500 ms on a zero override (typo guard)", () => {
+		process.env[PROBE_VAR] = "0";
+		assert.equal(getProbeTimeoutMs(), 1500);
+	});
+
+	it("re-reads the env var on every call", () => {
+		process.env[PROBE_VAR] = "2000";
+		assert.equal(getProbeTimeoutMs(), 2000);
+		process.env[PROBE_VAR] = "8000";
+		assert.equal(getProbeTimeoutMs(), 8000);
+		delete process.env[PROBE_VAR];
+		assert.equal(getProbeTimeoutMs(), 1500);
+	});
+});
+
+describe("getRequestTimeoutMs — OLLAMA_REQUEST_TIMEOUT_MS override", () => {
+	beforeEach(() => {
+		delete process.env[REQUEST_VAR];
+	});
+	afterEach(() => {
+		delete process.env[REQUEST_VAR];
+	});
+
+	it("defaults to 10 000 ms when unset", () => {
+		assert.equal(getRequestTimeoutMs(), 10000);
+	});
+
+	it("honours a positive override", () => {
+		process.env[REQUEST_VAR] = "30000";
+		assert.equal(getRequestTimeoutMs(), 30000);
+	});
+
+	it("falls back to 10 000 ms on non-numeric input", () => {
+		process.env[REQUEST_VAR] = "thirty-seconds";
+		assert.equal(getRequestTimeoutMs(), 10000);
+	});
+});

--- a/src/resources/extensions/ollama/tests/ollama-client-timeout-env.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-client-timeout-env.test.ts
@@ -78,8 +78,14 @@ describe("envPositiveInt — defensive fallback", () => {
 		});
 	});
 
-	it("caps values above Node's maximum timer delay", () => {
-		withEnv("__GSD_TEST_INT__", "9999999999999", () => {
+	it("clamps values above MAX_TIMER_DELAY_MS to prevent setTimeout overflow", () => {
+		withEnv("__GSD_TEST_INT__", String(MAX_TIMER_DELAY_MS + 1), () => {
+			assert.equal(envPositiveInt("__GSD_TEST_INT__", 42), MAX_TIMER_DELAY_MS);
+		});
+	});
+
+	it("accepts MAX_TIMER_DELAY_MS exactly", () => {
+		withEnv("__GSD_TEST_INT__", String(MAX_TIMER_DELAY_MS), () => {
 			assert.equal(envPositiveInt("__GSD_TEST_INT__", 42), MAX_TIMER_DELAY_MS);
 		});
 	});


### PR DESCRIPTION
## TL;DR

**What:** Adds `OLLAMA_PROBE_TIMEOUT_MS` and `OLLAMA_REQUEST_TIMEOUT_MS` env vars to override the hard-coded 1500 ms / 10 000 ms Ollama timeouts; also surfaces previously-silent probe failures under `GSD_DEBUG`.
**Why:** The 1500 ms startup probe intermittently times out on slower disks, LAN/remote Ollama, and cloud endpoints — Ollama silently disappears from the model picker with no diagnostic.
**How:** Defensive `envPositiveInt(name, fallback)` parser falls back on unset/empty/non-numeric/zero/negative input. `getProbeTimeoutMs()` / `getRequestTimeoutMs()` resolve at call time so changes are picked up live. Defaults unchanged (1500 / 10000).

## What

- `src/resources/extensions/ollama/ollama-client.ts` — replaces `PROBE_TIMEOUT_MS` / `REQUEST_TIMEOUT_MS` constants with `getProbeTimeoutMs()` / `getRequestTimeoutMs()`. New shared `envPositiveInt(name, fallback)` helper. All three exported for testability.
- `src/resources/extensions/ollama/index.ts` — replaces the `.catch(() => {})` silent swallows in the session-start probe path with a `debugOllama()` helper that writes a one-line diagnostic to stderr when `GSD_DEBUG` is set. Registration still soft-fails as before — only the diagnostic gets unblocked.
- `src/resources/extensions/ollama/tests/ollama-client-timeout-env.test.ts` (new) — 12 cases covering env-parsing fallbacks (unset, empty, `abc`, `0`, `-100`, valid integer, `1500ms`-style trailing junk) and live re-read on every call.

## Why

Closes #5003 (env var configurability), closes #4982 (probe timeout too tight + silent failures).

The 1500 ms startup probe is exceeded under several real-world setups:
- Slow disk + contended IO when GSD boots alongside other heavy processes.
- Remote Ollama over a high-latency link (LAN host, tunnel).
- Cloud endpoints (`OLLAMA_HOST=https://ollama.com`) where TLS handshake alone can exceed 1.5 s on a cold connection.

When the probe times out, the provider silently fails to register and the model picker shows no Ollama models. Reporters' workarounds today: patch `dist/` (overwritten on every build), maintain a fork, or assume Ollama is broken.

`OLLAMA_HOST` and `OLLAMA_API_KEY` already configure this same client via env, so this is a consistent surface area.

## How

The defensive parser:
```ts
function envPositiveInt(name, fallback) {
  const raw = process.env[name];
  if (!raw) return fallback;
  const parsed = Number.parseInt(raw, 10);
  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
  return parsed;
}
```

A typo like `OLLAMA_PROBE_TIMEOUT_MS=abc` or `=0` falls back to the documented default rather than silently disabling the timeout (`AbortController.abort()` with `0` ms = abort instantly).

Resolved at call time (not module load) so tests can mutate `process.env` between invocations and the production probe picks up overrides without a process restart.

The debug logging in index.ts:
```ts
const debugOllama = (where, error) => {
  if (process.env.GSD_DEBUG) {
    process.stderr.write(`[ollama] ${where} probe failed: ${msg}\n`);
  }
};
```

Default behaviour unchanged (no GSD_DEBUG → no output). This lets users self-diagnose silent failures without patching `dist/.../index.js`.

### Verification

- `npx tsc --noEmit -p tsconfig.extensions.json` — clean.
- `node --test ollama-client-timeout-env.test.ts ollama-client.test.ts` — 18/18 pass.

### Change type

- [x] `feat` — New env-var surface
- [x] `fix` — Surfaces previously-silent probe failures (closes #4982)

AI-assisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment variables added for configuring Ollama probe and request timeouts with sane defaults and clamping to safe limits.

* **Bug Fixes**
  * Probe failures no longer get silently discarded; errors are surfaced to debug output when debug mode is enabled while preserving soft-fail behavior.

* **Tests**
  * Unit tests added to validate env var parsing, fallback, clamping, and re-read behavior.

* **Documentation**
  * User docs updated with Ollama env vars, defaults, and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->