### PR TITLE
fix(ollama): correct context window for cloud / long-variant models

### DIFF
--- a/src/resources/extensions/ollama/model-capabilities.ts
+++ b/src/resources/extensions/ollama/model-capabilities.ts
@@ -56,9 +56,43 @@ const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
 	["llama2", { contextWindow: 4096, maxTokens: 4096, ollamaOptions: { num_ctx: 4096 } }],
 
 	// ─── Qwen family ────────────────────────────────────────────────────
+	// Long-variant entries MUST appear before the bare `qwen3` base —
+	// `baseName.startsWith(pattern)` returns true for `qwen3.5`/`qwen3-coder`/
+	// `qwen3-next` against `qwen3`, and the first match wins (#4991).
+	// ref: qwen3-next 1M ctx — https://qwen.ai/blog?id=qwen3-next
+	["qwen3-next", { contextWindow: 1048576, maxTokens: 32768, ollamaOptions: { num_ctx: 1048576 } }],
+	// ref: qwen3-coder 256K ctx — https://qwenlm.github.io/blog/qwen3-coder/
+	["qwen3-coder", { contextWindow: 262144, maxTokens: 32768, ollamaOptions: { num_ctx: 262144 } }],
+	// ref: qwen3.5 / qwen3.6 1M ctx — Ollama Cloud release notes
+	["qwen3.6", { contextWindow: 1048576, maxTokens: 32768, ollamaOptions: { num_ctx: 1048576 } }],
+	["qwen3.5", { contextWindow: 1048576, maxTokens: 32768, ollamaOptions: { num_ctx: 1048576 } }],
 	["qwen3", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
 	["qwen2.5", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
 	["qwen2", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
+
+	// ─── GLM family (Z.ai, Ollama Cloud) ────────────────────────────────
+	// ref: glm 4.6 / 5.x 200K ctx — https://docs.z.ai/devpack/using5.1
+	// Long-variant entries before bare `glm-5` / `glm-4` would-be bases to
+	// avoid prefix shadowing (#4991).
+	["glm-5.1", { contextWindow: 204800, maxTokens: 16384, ollamaOptions: { num_ctx: 204800 } }],
+	["glm-5", { contextWindow: 204800, maxTokens: 16384, ollamaOptions: { num_ctx: 204800 } }],
+	["glm-4.6", { contextWindow: 204800, maxTokens: 16384, ollamaOptions: { num_ctx: 204800 } }],
+	["glm-4", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
+
+	// ─── Kimi K2 (Moonshot, Ollama Cloud) ──────────────────────────────
+	// ref: kimi-k2 256K ctx — https://platform.moonshot.ai/docs
+	// Same shadowing concern: kimi-k2-thinking and kimi-k2.{5,6} must
+	// match before any future bare `kimi-k2` entry (#4991).
+	["kimi-k2-thinking", { contextWindow: 262144, maxTokens: 16384, ollamaOptions: { num_ctx: 262144 } }],
+	["kimi-k2.6", { contextWindow: 262144, maxTokens: 16384, ollamaOptions: { num_ctx: 262144 } }],
+	["kimi-k2.5", { contextWindow: 262144, maxTokens: 16384, ollamaOptions: { num_ctx: 262144 } }],
+	["kimi-k2", { contextWindow: 262144, maxTokens: 16384, ollamaOptions: { num_ctx: 262144 } }],
+
+	// ─── MiniMax M2 (Ollama Cloud) ─────────────────────────────────────
+	// ref: minimax-m2 1M ctx — https://www.minimax.io/news/minimax-m2
+	["minimax-m2.7", { contextWindow: 1048576, maxTokens: 16384, ollamaOptions: { num_ctx: 1048576 } }],
+	["minimax-m2.5", { contextWindow: 1048576, maxTokens: 16384, ollamaOptions: { num_ctx: 1048576 } }],
+	["minimax-m2", { contextWindow: 1048576, maxTokens: 16384, ollamaOptions: { num_ctx: 1048576 } }],
 
 	// ─── Gemma family ───────────────────────────────────────────────────
 	["gemma3", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],

--- a/src/resources/extensions/ollama/tests/model-capabilities.test.ts
+++ b/src/resources/extensions/ollama/tests/model-capabilities.test.ts
@@ -84,6 +84,102 @@ describe("getModelCapabilities", () => {
 	});
 });
 
+// ─── Ordering / prefix-shadowing regression (#4991) ──────────────────────────
+//
+// The lookup is a linear scan over KNOWN_MODELS using `baseName.startsWith(pattern)`.
+// Cloud and long-variant model names share prefixes with their base families,
+// so the longer entries MUST appear earlier in the table — otherwise a base
+// like `qwen3` shadows `qwen3-coder`/`qwen3-next`/`qwen3.5` and the picker
+// reports the wrong context window. These tests pin the ordering.
+
+describe("getModelCapabilities — long-variant overrides aren't shadowed (#4991)", () => {
+	it("qwen3-coder reports 256K, not the qwen3 131K", () => {
+		const caps = getModelCapabilities("qwen3-coder:480b");
+		assert.equal(caps.contextWindow, 262144);
+		assert.equal(caps.ollamaOptions?.num_ctx, 262144);
+	});
+
+	it("qwen3-coder-next still resolves via the qwen3-coder entry", () => {
+		const caps = getModelCapabilities("qwen3-coder-next");
+		assert.equal(caps.contextWindow, 262144);
+	});
+
+	it("qwen3-next:80b reports 1M, not the qwen3 131K", () => {
+		const caps = getModelCapabilities("qwen3-next:80b");
+		assert.equal(caps.contextWindow, 1048576);
+	});
+
+	it("qwen3.5 / qwen3.6 cloud variants report 1M", () => {
+		assert.equal(getModelCapabilities("qwen3.5:397b").contextWindow, 1048576);
+		assert.equal(getModelCapabilities("qwen3.6:cloud").contextWindow, 1048576);
+	});
+
+	it("base qwen3 still resolves to its 131K entry", () => {
+		const caps = getModelCapabilities("qwen3:8b");
+		assert.equal(caps.contextWindow, 131072);
+	});
+
+	it("glm-5.1:cloud reports 200K", () => {
+		const caps = getModelCapabilities("glm-5.1:cloud");
+		assert.equal(caps.contextWindow, 204800);
+	});
+
+	it("glm-4.6:cloud reports 200K", () => {
+		const caps = getModelCapabilities("glm-4.6:cloud");
+		assert.equal(caps.contextWindow, 204800);
+	});
+
+	it("glm-4 base still resolves to its 131K entry", () => {
+		const caps = getModelCapabilities("glm-4:9b");
+		assert.equal(caps.contextWindow, 131072);
+	});
+
+	it("kimi-k2-thinking reports 256K (not shadowed by kimi-k2)", () => {
+		const caps = getModelCapabilities("kimi-k2-thinking");
+		assert.equal(caps.contextWindow, 262144);
+	});
+
+	it("kimi-k2.5:cloud and kimi-k2.6:cloud both report 256K", () => {
+		assert.equal(getModelCapabilities("kimi-k2.5:cloud").contextWindow, 262144);
+		assert.equal(getModelCapabilities("kimi-k2.6:cloud").contextWindow, 262144);
+	});
+
+	it("kimi-k2 base resolves to 256K", () => {
+		const caps = getModelCapabilities("kimi-k2:cloud");
+		assert.equal(caps.contextWindow, 262144);
+	});
+
+	it("minimax-m2.5:cloud and minimax-m2.7:cloud report 1M", () => {
+		assert.equal(getModelCapabilities("minimax-m2.5:cloud").contextWindow, 1048576);
+		assert.equal(getModelCapabilities("minimax-m2.7:cloud").contextWindow, 1048576);
+	});
+
+	it("minimax-m2 base resolves to 1M", () => {
+		const caps = getModelCapabilities("minimax-m2:cloud");
+		assert.equal(caps.contextWindow, 1048576);
+	});
+
+	it("ollamaOptions.num_ctx mirrors contextWindow for all new entries", () => {
+		// Inference time: num_ctx is what gets sent to Ollama on each chat.
+		// If contextWindow is right but num_ctx is stale, the model still
+		// gets truncated. Pin both sides.
+		for (const name of [
+			"qwen3-next:80b",
+			"qwen3-coder:480b",
+			"glm-5.1:cloud",
+			"kimi-k2-thinking",
+			"minimax-m2.7:cloud",
+		]) {
+			const caps = getModelCapabilities(name);
+			assert.equal(
+				caps.ollamaOptions?.num_ctx,
+				caps.contextWindow,
+				`${name}: num_ctx (${caps.ollamaOptions?.num_ctx}) must equal contextWindow (${caps.contextWindow})`,
+			);
+		}
+	});
+});
+
 // ─── estimateContextFromParams ───────────────────────────────────────────────
 
 describe("estimateContextFromParams", () => {


### PR DESCRIPTION
## TL;DR

**What:** Adds explicit `KNOWN_MODELS` entries for cloud and long-variant Ollama models (qwen3-coder, qwen3-next, qwen3.5, qwen3.6, glm-5.x, glm-4.6, kimi-k2.x, kimi-k2-thinking, minimax-m2.x) ahead of their base families.
**Why:** `baseName.startsWith(pattern)` lookup silently shadowed long-variant names with shorter base entries — `qwen3-coder:480b` reported 131K when actual is 256K, etc. Inference was being truncated to the wrong window.
**How:** Static-table extension (option 1 in #4991). Long-variant entries placed earlier in the array so first-match wins. New regression tests pin the ordering against future shadow regressions.

## What

- `src/resources/extensions/ollama/model-capabilities.ts` — adds entries for cloud and long-variant model names ahead of the base families:
  - **Qwen**: `qwen3-next` (1M), `qwen3-coder` (256K), `qwen3.6`/`qwen3.5` (1M), placed before the existing `qwen3` (131K).
  - **GLM** (new family): `glm-5.1`/`glm-5` (200K), `glm-4.6` (200K), `glm-4` (131K).
  - **Kimi K2** (new family): `kimi-k2-thinking`, `kimi-k2.6`, `kimi-k2.5`, `kimi-k2` (all 256K).
  - **MiniMax M2** (new family): `minimax-m2.7`, `minimax-m2.5`, `minimax-m2` (all 1M).
  - Each entry annotated with a `// ref:` citation.
  - `ollamaOptions.num_ctx` mirrors `contextWindow` on every new entry — both are user-visible (picker reads `contextWindow`, runtime sends `num_ctx`).
- `src/resources/extensions/ollama/tests/model-capabilities.test.ts` — 13 new tests in a `Long-variant overrides aren't shadowed (#4991)` describe block. Cover each shadow regression individually plus a `num_ctx === contextWindow` invariant pin.

## Why

Closes #4991.

`KNOWN_MODELS` lookup:
```ts
for (const [pattern, caps] of KNOWN_MODELS) {
  if (baseName === pattern || baseName.startsWith(pattern)) return caps;
}
```

Before this PR:
| Model | Reported ctx | Actual ctx |
|---|---|---|
| `qwen3-coder:480b` | 131K (via `qwen3`) | 256K |
| `qwen3-next:80b` | 131K (via `qwen3`) | 1M |
| `qwen3.5:397b` / `qwen3.6:cloud` | 131K (via `qwen3`) | 1M |
| `glm-5.1:cloud` / `glm-4.6:cloud` | est-fallback | 200K |
| `kimi-k2-thinking` / `kimi-k2.{5,6}:cloud` | est-fallback | 256K |
| `minimax-m2.{5,7}:cloud` | est-fallback | 1M |

This is **not cosmetic**. `ollamaOptions.num_ctx` ships to Ollama on every chat — long sessions on these models were being truncated to the wrong window with no user-visible signal.

## How

Picked option 1 from the issue (static-table extension) — consistent with the original PR #3371 direction and the file's existing comment: *"More specific entries should appear first."* Option 2 (live `/api/show` lookup) would be a larger architectural change; happy to follow up separately if maintainers want that direction.

Ordering rule, now both documented in the file and pinned by tests:
- Long-variant entries (`qwen3-coder`, `qwen3-next`, `qwen3.6`, `qwen3.5`) appear before the bare `qwen3`.
- Within each new family, decimal-version variants (`glm-5.1`, `kimi-k2.6`) appear before the bare base, so a future bare `kimi-k2:cloud` doesn't shadow `kimi-k2.6:cloud`.

### Verification

- `npx tsc --noEmit -p tsconfig.extensions.json` — clean.
- `node --test src/resources/extensions/ollama/tests/model-capabilities.test.ts` — 44/44 pass (13 new + all existing).

### Change type

- [x] `fix` — Bug fix

AI-assisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for additional Ollama model variants (Qwen, GLM, Kimi K2, MiniMax M2) with optimized context windows and token configurations for improved model detection and inference performance.

* **Tests**
  * Added regression tests to ensure reliable identification and correct capability assignment for model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->