### PR TITLE
fix(gsd): normalize worktree project roots

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -1685,6 +1685,58 @@ describe("validateProjectDir", () => {
     }
   });
 
+  it("accepts a worktree under the allowed root external .gsd state target", () => {
+    const allowedRoot = makeTmpBase();
+    const externalState = makeTmpBase();
+    const worktree = join(externalState, "worktrees", "M001");
+    mkdirSync(worktree, { recursive: true });
+    rmSync(join(allowedRoot, ".gsd"), { recursive: true, force: true });
+    symlinkSync(externalState, join(allowedRoot, ".gsd"), "dir");
+
+    const prevRoot = process.env.GSD_WORKFLOW_PROJECT_ROOT;
+    try {
+      process.env.GSD_WORKFLOW_PROJECT_ROOT = allowedRoot;
+      const result = validateProjectDir(worktree);
+      assert.equal(result, realpathSync(worktree));
+    } finally {
+      if (prevRoot === undefined) {
+        delete process.env.GSD_WORKFLOW_PROJECT_ROOT;
+      } else {
+        process.env.GSD_WORKFLOW_PROJECT_ROOT = prevRoot;
+      }
+      cleanup(allowedRoot);
+      cleanup(externalState);
+    }
+  });
+
+  it("rejects external-state sibling paths that only share a prefix", () => {
+    const allowedRoot = makeTmpBase();
+    const externalState = makeTmpBase();
+    const sibling = `${externalState}-sibling`;
+    const siblingWorktree = join(sibling, "worktrees", "M001");
+    mkdirSync(siblingWorktree, { recursive: true });
+    rmSync(join(allowedRoot, ".gsd"), { recursive: true, force: true });
+    symlinkSync(externalState, join(allowedRoot, ".gsd"), "dir");
+
+    const prevRoot = process.env.GSD_WORKFLOW_PROJECT_ROOT;
+    try {
+      process.env.GSD_WORKFLOW_PROJECT_ROOT = allowedRoot;
+      assert.throws(
+        () => validateProjectDir(siblingWorktree),
+        /configured workflow project root/,
+      );
+    } finally {
+      if (prevRoot === undefined) {
+        delete process.env.GSD_WORKFLOW_PROJECT_ROOT;
+      } else {
+        process.env.GSD_WORKFLOW_PROJECT_ROOT = prevRoot;
+      }
+      cleanup(allowedRoot);
+      cleanup(externalState);
+      cleanup(sibling);
+    }
+  });
+
   it("rejects relative paths", () => {
     assert.throws(
       () => validateProjectDir("relative/path"),

--- a/src/bundled-resource-path.ts
+++ b/src/bundled-resource-path.ts
@@ -1,5 +1,63 @@
+import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+export type FileExists = (path: string) => boolean;
+
+export function resolvePackageRoot(importUrl: string): string {
+  const moduleDir = dirname(fileURLToPath(importUrl));
+  return resolve(moduleDir, "..");
+}
+
+export function hasCompleteBundledResources(
+  resourcesDir: string,
+  fileExists: FileExists = existsSync,
+): boolean {
+  return fileExists(join(resourcesDir, "agents")) &&
+    fileExists(join(resourcesDir, "extensions"));
+}
+
+export function resolveBundledResourcesDirFromPackageRoot(
+  packageRoot: string,
+  fileExists: FileExists = existsSync,
+): string {
+  const distResources = join(packageRoot, "dist", "resources");
+  const srcResources = join(packageRoot, "src", "resources");
+  return hasCompleteBundledResources(distResources, fileExists)
+    ? distResources
+    : srcResources;
+}
+
+export function resolveBundledResourcesDir(
+  importUrl: string,
+  fileExists: FileExists = existsSync,
+): string {
+  return resolveBundledResourcesDirFromPackageRoot(resolvePackageRoot(importUrl), fileExists);
+}
+
+export function resolveBundledResource(
+  importUrl: string,
+  ...segments: string[]
+): string {
+  return join(resolveBundledResourcesDir(importUrl), ...segments);
+}
+
+export function resolveBundledGsdExtensionModule(
+  importUrl: string,
+  moduleFile: string,
+  fileExists: FileExists = existsSync,
+): string {
+  const packageRoot = resolvePackageRoot(importUrl);
+  const distResources = join(packageRoot, "dist", "resources");
+  const jsFile = moduleFile.replace(/\.ts$/, ".js");
+  const distModule = join(distResources, "extensions", "gsd", jsFile);
+  if (hasCompleteBundledResources(distResources, fileExists) && fileExists(distModule)) {
+    return distModule;
+  }
+
+  const tsFile = moduleFile.replace(/\.js$/, ".ts");
+  return join(packageRoot, "src", "resources", "extensions", "gsd", tsFile);
+}
 
 /**
  * Resolve bundled raw resource files from the package root.
@@ -12,7 +70,6 @@ export function resolveBundledSourceResource(
   importUrl: string,
   ...segments: string[]
 ): string {
-  const moduleDir = dirname(fileURLToPath(importUrl));
-  const packageRoot = resolve(moduleDir, "..");
+  const packageRoot = resolvePackageRoot(importUrl);
   return join(packageRoot, "src", "resources", ...segments);
 }

--- a/src/headless-query.ts
+++ b/src/headless-query.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from 'node:url'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import type { GSDState } from './resources/extensions/gsd/types.js'
-import { resolveBundledSourceResource } from './bundled-resource-path.js'
+import { resolveBundledGsdExtensionModule } from './bundled-resource-path.js'
 
 const jiti = createJiti(fileURLToPath(import.meta.url), { interopDefault: true, debug: false })
 const { existsSync } = await import('node:fs')
@@ -34,7 +34,8 @@ const { existsSync } = await import('node:fs')
  * #3471 contract can be exercised in tests without spawning a subprocess.
  */
 export function resolveGsdAgentExtensionsDir(env: NodeJS.ProcessEnv = process.env): string {
-  return join(env.GSD_AGENT_DIR || join(homedir(), '.gsd', 'agent'), 'extensions', 'gsd')
+  const agentRoot = env.GSD_AGENT_DIR || join(env.GSD_HOME || join(homedir(), '.gsd'), 'agent')
+  return join(agentRoot, 'extensions', 'gsd')
 }
 
 /**
@@ -49,15 +50,28 @@ export function shouldUseAgentExtensionsDir(opts: {
   const env = opts.env ?? process.env
   const fileExists = opts.fileExists ?? existsSync
   const agentDir = resolveGsdAgentExtensionsDir(env)
-  return { agentDir, useAgentDir: fileExists(join(agentDir, 'state.ts')) }
+  return {
+    agentDir,
+    useAgentDir: fileExists(join(agentDir, 'state.ts')) || fileExists(join(agentDir, 'state.js')),
+  }
 }
 
 const agentExtensionsDir = resolveGsdAgentExtensionsDir()
-const useAgentDir = existsSync(join(agentExtensionsDir, 'state.ts'))
+const { useAgentDir } = shouldUseAgentExtensionsDir({ env: process.env })
 const gsdExtensionPath = (...segments: string[]) =>
   useAgentDir
-    ? join(agentExtensionsDir, ...segments)
-    : resolveBundledSourceResource(import.meta.url, 'extensions', 'gsd', ...segments)
+    ? resolveAgentExtensionModule(agentExtensionsDir, segments)
+    : resolveBundledGsdExtensionModule(import.meta.url, segments.join('/'))
+
+function resolveAgentExtensionModule(agentDir: string, segments: string[]): string {
+  const requested = join(agentDir, ...segments)
+  if (existsSync(requested)) return requested
+  if (segments.length === 1 && segments[0].endsWith('.ts')) {
+    const jsPath = join(agentDir, segments[0].replace(/\.ts$/, '.js'))
+    if (existsSync(jsPath)) return jsPath
+  }
+  return requested
+}
 
 async function loadExtensionModules() {
   const stateModule = await jiti.import(gsdExtensionPath('state.ts'), {}) as any

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -71,6 +71,7 @@ if (firstArg === '--help' || firstArg === '-h') {
 import { agentDir, appRoot } from './app-paths.js'
 import { applyRtkProcessEnv } from './rtk-shared.js'
 import { serializeBundledExtensionPaths } from './bundled-extension-paths.js'
+import { resolveBundledResourcesDirFromPackageRoot } from './bundled-resource-path.js'
 import { discoverExtensionEntryPaths } from './extension-discovery.js'
 import { loadRegistry, readManifestFromEntryPath, isExtensionEnabled } from './extension-registry.js'
 import { renderLogo } from './logo.js'
@@ -141,9 +142,7 @@ process.env.GSD_BIN_PATH = process.argv[1]
 // GSD_WORKFLOW_PATH — absolute path to bundled GSD-WORKFLOW.md, used by patched gsd extension
 // when dispatching workflow prompts. Prefers dist/resources/ (stable, set at build time)
 // over src/resources/ (live working tree) — see resource-loader.ts for rationale.
-const distRes = join(gsdRoot, 'dist', 'resources')
-const srcRes = join(gsdRoot, 'src', 'resources')
-const resourcesDir = existsSync(distRes) ? distRes : srcRes
+const resourcesDir = resolveBundledResourcesDirFromPackageRoot(gsdRoot)
 process.env.GSD_WORKFLOW_PATH = join(resourcesDir, 'GSD-WORKFLOW.md')
 
 // GSD_BUNDLED_EXTENSION_PATHS — dynamically discovered bundled extension entry points.

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url'
 import { compareSemver } from './update-check.js'
 import { discoverExtensionEntryPaths } from './extension-discovery.js'
 import { loadRegistry, readManifestFromEntryPath, isExtensionEnabled, ensureRegistryEntries } from './extension-registry.js'
+import { resolveBundledResourcesDirFromPackageRoot } from './bundled-resource-path.js'
 
 type PiCodingAgentModule = typeof import('@gsd/pi-coding-agent')
 
@@ -25,14 +26,7 @@ function loadPiCodingAgentModule(): Promise<PiCodingAgentModule> {
 // dist/resources/ is populated by the build step (`npm run copy-resources`) and
 // reflects the built state, not the currently checked-out branch.
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
-const distResources = join(packageRoot, 'dist', 'resources')
-const srcResources = join(packageRoot, 'src', 'resources')
-// Use dist/resources only if it has the full expected structure.
-// A partial build (tsc without copy-resources) creates dist/resources/extensions/
-// but not agents/ or skills/, causing initResources to sync from an incomplete source.
-const resourcesDir = (existsSync(distResources) && existsSync(join(distResources, 'agents')))
-  ? distResources
-  : srcResources
+const resourcesDir = resolveBundledResourcesDirFromPackageRoot(packageRoot)
 const bundledExtensionsDir = join(resourcesDir, 'extensions')
 const resourceVersionManifestName = 'managed-resources.json'
 const resourceFingerprintFileName = '.managed-resources-content-hash'

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -46,6 +46,11 @@ import {
   resolveGitHeadPath,
   nudgeGitBranchCache,
 } from "./worktree.js";
+import {
+  isGsdWorktreePath,
+  normalizeWorktreePathForCompare,
+  resolveWorktreeProjectRoot,
+} from "./worktree-root.js";
 import { MergeConflictError, readIntegrationBranch, RUNTIME_EXCLUSION_PATHS } from "./git-service.js";
 import { debugLog } from "./debug-logger.js";
 import { logWarning, logError } from "./workflow-logger.js";
@@ -1196,6 +1201,8 @@ export function createAutoWorktree(
   basePath: string,
   milestoneId: string,
 ): string {
+  basePath = resolveWorktreeProjectRoot(basePath);
+
   // Check if repo has commits — git worktree requires a valid HEAD
   try {
     execFileSync("git", ["rev-parse", "--verify", "HEAD"], { cwd: basePath, stdio: "pipe" });
@@ -1355,6 +1362,8 @@ export function teardownAutoWorktree(
   milestoneId: string,
   opts: { preserveBranch?: boolean } = {},
 ): void {
+  originalBasePath = resolveWorktreeProjectRoot(originalBasePath);
+
   const branch = autoWorktreeBranch(milestoneId);
   const { preserveBranch = false } = opts;
   const previousCwd = process.cwd();
@@ -1406,16 +1415,28 @@ export function teardownAutoWorktree(
 
 /**
  * Detect if the process is currently inside an auto-worktree.
- * Checks both module state and git branch prefix.
+ * Uses the current directory structure plus git branch prefix so detection
+ * still works after process restart when module state has been reset.
  */
 export function isInAutoWorktree(basePath: string): boolean {
-  if (!originalBase) return false;
   const cwd = process.cwd();
-  const resolvedBase = existsSync(basePath) ? realpathSync(basePath) : basePath;
-  const wtDir = join(resolvedBase, ".gsd", "worktrees");
-  if (!cwd.startsWith(wtDir)) return false;
-  const branch = nativeGetCurrentBranch(cwd);
-  return branch.startsWith("milestone/");
+  if (!isGsdWorktreePath(cwd)) return false;
+
+  const projectRoot = resolveWorktreeProjectRoot(basePath, originalBase);
+  const cwdProjectRoot = resolveWorktreeProjectRoot(cwd, originalBase);
+  if (
+    normalizeWorktreePathForCompare(projectRoot) !==
+    normalizeWorktreePathForCompare(cwdProjectRoot)
+  ) {
+    return false;
+  }
+
+  try {
+    const branch = nativeGetCurrentBranch(cwd);
+    return branch.startsWith("milestone/");
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -1430,6 +1451,8 @@ export function getAutoWorktreePath(
   basePath: string,
   milestoneId: string,
 ): string | null {
+  basePath = resolveWorktreeProjectRoot(basePath);
+
   const p = worktreePath(basePath, milestoneId);
   if (!existsSync(p)) return null;
 
@@ -1458,6 +1481,8 @@ export function enterAutoWorktree(
   basePath: string,
   milestoneId: string,
 ): string {
+  basePath = resolveWorktreeProjectRoot(basePath);
+
   const p = worktreePath(basePath, milestoneId);
   if (!existsSync(p)) {
     throw new GSDError(
@@ -1512,6 +1537,10 @@ export function enterAutoWorktree(
  */
 export function getAutoWorktreeOriginalBase(): string | null {
   return originalBase;
+}
+
+export function _resetAutoWorktreeOriginalBaseForTests(): void {
+  originalBase = null;
 }
 
 export function getActiveAutoWorktreeContext(): {

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1550,11 +1550,14 @@ export function getActiveAutoWorktreeContext(): {
 } | null {
   if (!originalBase) return null;
   const cwd = process.cwd();
-  const resolvedBase = existsSync(originalBase)
-    ? realpathSync(originalBase)
-    : originalBase;
-  const wtDir = join(resolvedBase, ".gsd", "worktrees");
-  if (!cwd.startsWith(wtDir)) return null;
+  if (!isGsdWorktreePath(cwd)) return null;
+  const cwdProjectRoot = resolveWorktreeProjectRoot(cwd, originalBase);
+  if (
+    normalizeWorktreePathForCompare(cwdProjectRoot) !==
+    normalizeWorktreePathForCompare(originalBase)
+  ) {
+    return null;
+  }
   const worktreeName = detectWorktreeName(cwd);
   if (!worktreeName) return null;
   const branch = nativeGetCurrentBranch(cwd);

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -26,6 +26,7 @@ import {
 import { detectStuck } from "./detect-stuck.js";
 import { runUnit } from "./run-unit.js";
 import { debugLog } from "../debug-logger.js";
+import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { PROJECT_FILES, hasProjectFileInAncestor } from "../detection.js";
 import { MergeConflictError } from "../git-service.js";
 import { setCurrentPhase, clearCurrentPhase } from "../../shared/gsd-phase-state.js";
@@ -81,11 +82,7 @@ export function resetSessionTimeoutState(): void {
  * Exported for testing as _resolveReportBasePath.
  */
 export function _resolveReportBasePath(s: Pick<AutoSession, "originalBasePath" | "basePath">): string {
-  // Strip /.gsd/worktrees/ suffix when basePath is itself a worktree path and
-  // originalBasePath is falsy — prevents reports landing in the worktree (#3729).
-  const resolved = s.originalBasePath || s.basePath;
-  const markerIdx = resolved.indexOf("/.gsd/worktrees/");
-  return markerIdx !== -1 ? resolved.slice(0, markerIdx) : resolved;
+  return resolveWorktreeProjectRoot(s.basePath, s.originalBasePath);
 }
 
 /**
@@ -96,12 +93,7 @@ export function _resolveReportBasePath(s: Pick<AutoSession, "originalBasePath" |
 export function _resolveDispatchGuardBasePath(
   s: Pick<AutoSession, "originalBasePath" | "basePath">,
 ): string {
-  // Strip /.gsd/worktrees/ suffix when basePath is itself a worktree path and
-  // originalBasePath is falsy — prevents guard checks running against the
-  // worktree instead of the project root (#3729).
-  const resolved = s.originalBasePath || s.basePath;
-  const markerIdx = resolved.indexOf("/.gsd/worktrees/");
-  return markerIdx !== -1 ? resolved.slice(0, markerIdx) : resolved;
+  return resolveWorktreeProjectRoot(s.basePath, s.originalBasePath);
 }
 
 const PLAN_V2_GATE_PHASES: ReadonlySet<Phase> = new Set([

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -21,6 +21,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent
 import type { GitServiceImpl } from "../git-service.js";
 import type { CaptureEntry } from "../captures.js";
 import type { BudgetAlertLevel } from "../auto-budget.js";
+import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 
 // ─── Exported Types ──────────────────────────────────────────────────────────
 
@@ -226,12 +227,7 @@ export class AutoSession {
   }
 
   get lockBasePath(): string {
-    // Prefer originalBasePath (project root); fall back to basePath.
-    // Strip /.gsd/worktrees/ suffix if basePath is itself a worktree path
-    // to avoid reading/writing the lock inside the worktree (#3729).
-    const resolved = this.originalBasePath || this.basePath;
-    const markerIdx = resolved.indexOf("/.gsd/worktrees/");
-    return markerIdx !== -1 ? resolved.slice(0, markerIdx) : resolved;
+    return resolveWorktreeProjectRoot(this.basePath, this.originalBasePath);
   }
 
   reset(): void {

--- a/src/resources/extensions/gsd/tests/auto-session-encapsulation.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-session-encapsulation.test.ts
@@ -14,6 +14,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { AutoSession } from "../auto/session.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const AUTO_TS_PATH = join(__dirname, "..", "auto.ts");
@@ -31,6 +32,20 @@ function getSessionTsSource(): string {
 function getRuntimeStateTsSource(): string {
   return readFileSync(RUNTIME_STATE_TS_PATH, "utf-8");
 }
+
+test("AutoSession.lockBasePath uses GSD_PROJECT_ROOT for symlink-resolved worktrees", () => {
+  const savedProjectRoot = process.env.GSD_PROJECT_ROOT;
+  process.env.GSD_PROJECT_ROOT = "/real/project";
+  try {
+    const session = new AutoSession();
+    session.basePath = "/Users/dev/.gsd/projects/abc123/worktrees/M001/slices/S01";
+
+    assert.equal(session.lockBasePath, "/real/project");
+  } finally {
+    if (savedProjectRoot === undefined) delete process.env.GSD_PROJECT_ROOT;
+    else process.env.GSD_PROJECT_ROOT = savedProjectRoot;
+  }
+});
 
 // ── Invariant 1: No module-level mutable variables in auto.ts ────────────────
 

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, test, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, realpathSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, realpathSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
@@ -21,6 +21,7 @@ import {
   getAutoWorktreeOriginalBase,
   getActiveAutoWorktreeContext,
   syncGsdStateToWorktree,
+  _resetAutoWorktreeOriginalBaseForTests,
 } from "../../auto-worktree.ts";
 
 // Note: execSync is used intentionally in tests for git operations with
@@ -140,6 +141,42 @@ describe("auto-worktree lifecycle", () => {
 
     // Cleanup
     teardownAutoWorktree(tempDir, "M003");
+  });
+
+  test("symlink-resolved auto worktree is detected after module state reset", () => {
+    tempDir = createTempRepo();
+    const savedGsdHome = process.env.GSD_HOME;
+    const fakeHome = realpathSync(mkdtempSync(join(tmpdir(), "auto-wt-home-")));
+    const storage = join(fakeHome, ".gsd", "projects", "abc123def456");
+    mkdirSync(join(storage, "milestones", "M001"), { recursive: true });
+    writeFileSync(join(storage, "milestones", "M001", "CONTEXT.md"), "# M001\n");
+    symlinkSync(storage, join(tempDir, ".gsd"));
+    process.env.GSD_HOME = join(fakeHome, ".gsd");
+
+    try {
+      const wtPath = createAutoWorktree(tempDir, "M001");
+      const realWtPath = realpathSync(wtPath);
+      assert.ok(realWtPath.startsWith(storage), "git registered the symlink-resolved worktree path");
+
+      _resetAutoWorktreeOriginalBaseForTests();
+      process.chdir(join(realWtPath, ".gsd", "milestones", "M001"));
+
+      assert.ok(isInAutoWorktree(tempDir), "structural detection works without module originalBase");
+      const resolved = getAutoWorktreePath(realWtPath, "M001");
+      assert.ok(resolved, "existing worktree is found when basePath is the worktree path");
+      assert.equal(realpathSync(resolved!), realWtPath);
+      assert.equal(existsSync(join(realWtPath, ".gsd", "worktrees", "M001")), false);
+    } finally {
+      process.chdir(tempDir);
+      try {
+        teardownAutoWorktree(tempDir, "M001");
+      } catch {
+        // Best-effort cleanup for partially-created temp worktrees.
+      }
+      if (savedGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = savedGsdHome;
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
   });
 
   test("coexistence with manual worktree", async () => {

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts
@@ -166,6 +166,18 @@ describe("auto-worktree lifecycle", () => {
       assert.ok(resolved, "existing worktree is found when basePath is the worktree path");
       assert.equal(realpathSync(resolved!), realWtPath);
       assert.equal(existsSync(join(realWtPath, ".gsd", "worktrees", "M001")), false);
+
+      enterAutoWorktree(tempDir, "M001");
+      process.chdir(join(realWtPath, ".gsd", "milestones", "M001"));
+      assert.deepStrictEqual(
+        getActiveAutoWorktreeContext(),
+        {
+          originalBase: tempDir,
+          worktreeName: "M001",
+          branch: "milestone/M001",
+        },
+        "active context is detected from a symlink-resolved worktree cwd",
+      );
     } finally {
       process.chdir(tempDir);
       try {

--- a/src/resources/extensions/gsd/tests/milestone-report-path.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-report-path.test.ts
@@ -10,7 +10,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
-import { _resolveReportBasePath } from "../auto/phases.ts";
+import { _resolveDispatchGuardBasePath, _resolveReportBasePath } from "../auto/phases.ts";
 
 describe("_resolveReportBasePath", () => {
   test("uses originalBasePath when set (worktree scenario)", () => {
@@ -47,5 +47,22 @@ describe("_resolveReportBasePath", () => {
     };
 
     assert.equal(_resolveReportBasePath(session), "/home/user/repo");
+  });
+
+  test("uses GSD_PROJECT_ROOT for symlink-resolved worktree paths", () => {
+    const savedProjectRoot = process.env.GSD_PROJECT_ROOT;
+    process.env.GSD_PROJECT_ROOT = "/real/project";
+    try {
+      const session = {
+        originalBasePath: "",
+        basePath: "/Users/dev/.gsd/projects/abc123/worktrees/M001/slices/S01",
+      };
+
+      assert.equal(_resolveReportBasePath(session), "/real/project");
+      assert.equal(_resolveDispatchGuardBasePath(session), "/real/project");
+    } finally {
+      if (savedProjectRoot === undefined) delete process.env.GSD_PROJECT_ROOT;
+      else process.env.GSD_PROJECT_ROOT = savedProjectRoot;
+    }
   });
 });

--- a/src/resources/extensions/gsd/tests/steer-worktree-path.test.ts
+++ b/src/resources/extensions/gsd/tests/steer-worktree-path.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { appendOverride, loadActiveOverrides } from "../files.ts";
@@ -71,6 +71,22 @@ describe("steer worktree path resolution (#3476)", () => {
     // does not route overrides to a dead worktree.
     const result = getAutoWorktreePath(projectRoot, "M001");
     assert.equal(result, null, "returns null for worktree without .git file");
+  });
+
+  test("getAutoWorktreePath returns null when .git is a directory", () => {
+    mkdirSync(join(worktreePath, ".git"), { recursive: true });
+
+    const result = getAutoWorktreePath(projectRoot, "M001");
+
+    assert.equal(result, null, "returns null for standalone .git directories");
+  });
+
+  test("getAutoWorktreePath returns null when .git file is not a gitdir pointer", () => {
+    writeFileSync(join(worktreePath, ".git"), "not-a-gitdir\n", "utf-8");
+
+    const result = getAutoWorktreePath(projectRoot, "M001");
+
+    assert.equal(result, null, "returns null for invalid .git files");
   });
 
   test("override routing: inactive worktree directory should not receive overrides", async () => {

--- a/src/resources/extensions/gsd/tests/worktree-symlink-removal.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-symlink-removal.test.ts
@@ -20,7 +20,7 @@ import {
   listWorktrees,
   worktreePath,
 } from "../worktree-manager.ts";
-import { describe, test } from 'node:test';
+import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 
@@ -28,37 +28,41 @@ function run(command: string, cwd: string): string {
   return execSync(command, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
 }
 
-// Set up a test repo with .gsd/ as a symlink to an external directory,
-// mimicking the external state directory layout (~/.gsd/projects/<hash>/).
-// Resolve tmpdir to handle macOS /tmp -> /private/var/... symlink.
-const realTmp = realpathSync(tmpdir());
-const base = mkdtempSync(join(realTmp, "gsd-wt-symlink-test-"));
-const externalState = mkdtempSync(join(realTmp, "gsd-wt-symlink-ext-"));
-
-run("git init -b main", base);
-run('git config user.name "Test"', base);
-run('git config user.email "test@example.com"', base);
-
-// Create external state directory structure
-mkdirSync(join(externalState, "worktrees"), { recursive: true });
-
-// Create .gsd as a symlink to the external state directory
-symlinkSync(externalState, join(base, ".gsd"));
-
-// Verify the symlink is in place
-assert.ok(existsSync(join(base, ".gsd")), ".gsd symlink exists");
-assert.ok(
-  realpathSync(join(base, ".gsd")) === externalState,
-  ".gsd resolves to external state dir",
-);
-
-// Create initial commit so we have a valid repo
-writeFileSync(join(base, "README.md"), "# Test\n", "utf-8");
-run("git add .", base);
-run('git commit -m "init"', base);
-
-describe('worktree-symlink-removal', async () => {
+test('worktree-symlink-removal removes the git-registered symlink target safely', (t) => {
   console.log("\n=== #1852: removeWorktree with symlinked .gsd/ ===");
+
+  // Set up a test repo with .gsd/ as a symlink to an external directory,
+  // mimicking the external state directory layout (~/.gsd/projects/<hash>/).
+  // Resolve tmpdir to handle macOS /tmp -> /private/var/... symlink.
+  const realTmp = realpathSync(tmpdir());
+  const base = mkdtempSync(join(realTmp, "gsd-wt-symlink-test-"));
+  const externalState = mkdtempSync(join(realTmp, "gsd-wt-symlink-ext-"));
+  t.after(() => {
+    rmSync(base, { recursive: true, force: true });
+    rmSync(externalState, { recursive: true, force: true });
+  });
+
+  run("git init -b main", base);
+  run('git config user.name "Test"', base);
+  run('git config user.email "test@example.com"', base);
+
+  // Create external state directory structure
+  mkdirSync(join(externalState, "worktrees"), { recursive: true });
+
+  // Create .gsd as a symlink to the external state directory
+  symlinkSync(externalState, join(base, ".gsd"));
+
+  // Verify the symlink is in place
+  assert.ok(existsSync(join(base, ".gsd")), ".gsd symlink exists");
+  assert.ok(
+    realpathSync(join(base, ".gsd")) === externalState,
+    ".gsd resolves to external state dir",
+  );
+
+  // Create initial commit so we have a valid repo
+  writeFileSync(join(base, "README.md"), "# Test\n", "utf-8");
+  run("git add .", base);
+  run('git commit -m "init"', base);
 
   // Create a worktree — git will resolve the symlink and register
   // the worktree at the external path
@@ -127,7 +131,4 @@ describe('worktree-symlink-removal', async () => {
   const listed = listWorktrees(base);
   assert.deepStrictEqual(listed.length, 0, "no worktrees listed after removal");
 
-  // Cleanup
-  rmSync(base, { recursive: true, force: true });
-  rmSync(externalState, { recursive: true, force: true });
 });

--- a/src/resources/extensions/gsd/tests/worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree.test.ts
@@ -255,6 +255,14 @@ describe('worktree', async () => {
     "returns unchanged for non-worktree path",
   );
 
+  const nestedRepoDir = join(base, "packages", "demo");
+  mkdirSync(nestedRepoDir, { recursive: true });
+  assert.deepStrictEqual(
+    normalizePath(resolveProjectRoot(nestedRepoDir)),
+    normalizePath(base),
+    "resolves normal repo subdirectories to the project root",
+  );
+
   // Without GSD_PROJECT_ROOT, direct layout with nested subdirs
   assert.deepStrictEqual(
     resolveProjectRoot("/data/.gsd/worktrees/M003/nested"),

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -39,6 +39,11 @@ import {
   nativeWorktreeRemove,
 } from "./native-git-bridge.js";
 import { emitCanonicalRootRedirect } from "./worktree-telemetry.js";
+import {
+  isGsdWorktreePath,
+  normalizeWorktreePathForCompare,
+  resolveWorktreeProjectRoot,
+} from "./worktree-root.js";
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -75,6 +80,20 @@ function normalizePathForComparison(path: string): string {
   return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 
+function normalizeBasePathForWorktreeOps(basePath: string): string {
+  const resolved = resolveWorktreeProjectRoot(basePath);
+  if (
+    isGsdWorktreePath(basePath) &&
+    normalizeWorktreePathForCompare(resolved) === normalizeWorktreePathForCompare(basePath)
+  ) {
+    throw new GSDError(
+      GSD_GIT_ERROR,
+      `Cannot resolve project root from worktree path: ${basePath}. Run the command from the project root or set GSD_PROJECT_ROOT.`,
+    );
+  }
+  return resolved;
+}
+
 // ─── resolveGitDir ─────────────────────────────────────────────────────────
 
 /**
@@ -106,7 +125,7 @@ export function resolveGitDir(basePath: string): string {
 }
 
 export function worktreesDir(basePath: string): string {
-  return join(basePath, ".gsd", "worktrees");
+  return join(resolveWorktreeProjectRoot(basePath), ".gsd", "worktrees");
 }
 
 export function worktreePath(basePath: string, name: string): string {
@@ -195,6 +214,8 @@ export function resolveCanonicalMilestoneRoot(
  * @param opts.branch — override the default `worktree/<name>` branch name
  */
 export function createWorktree(basePath: string, name: string, opts: { branch?: string; startPoint?: string; reuseExistingBranch?: boolean } = {}): WorktreeInfo {
+  basePath = normalizeBasePathForWorktreeOps(basePath);
+
   // Validate name: alphanumeric, hyphens, underscores only
   if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
     throw new GSDError(GSD_PARSE_ERROR, `Invalid worktree name "${name}". Use only letters, numbers, hyphens, and underscores.`);
@@ -297,6 +318,8 @@ export function createWorktree(basePath: string, name: string, opts: { branch?: 
  * Uses native worktree list and filters to those under .gsd/worktrees/.
  */
 export function listWorktrees(basePath: string): WorktreeInfo[] {
+  basePath = normalizeBasePathForWorktreeOps(basePath);
+
   const baseVariants = [resolve(basePath)];
   if (existsSync(basePath)) {
     baseVariants.push(realpathSync(basePath));
@@ -459,6 +482,8 @@ export function removeWorktree(
   name: string,
   opts: { deleteBranch?: boolean; force?: boolean; branch?: string } = {},
 ): void {
+  basePath = normalizeBasePathForWorktreeOps(basePath);
+
   let wtPath = worktreePath(basePath, name);
   const branch = opts.branch ?? worktreeBranchName(name);
   const { deleteBranch = true, force = true } = opts;
@@ -714,6 +739,8 @@ function parseDiffNameStatus(entries: { status: string; path: string }[]): Workt
  * Returns a summary of added, modified, and removed GSD artifacts.
  */
 export function diffWorktreeGSD(basePath: string, name: string): WorktreeDiffSummary {
+  basePath = normalizeBasePathForWorktreeOps(basePath);
+
   const branch = worktreeBranchName(name);
   const mainBranch = nativeDetectMainBranch(basePath);
 
@@ -729,6 +756,8 @@ export function diffWorktreeGSD(basePath: string, name: string): WorktreeDiffSum
  * content, this correctly returns an empty diff.
  */
 export function diffWorktreeAll(basePath: string, name: string): WorktreeDiffSummary {
+  basePath = normalizeBasePathForWorktreeOps(basePath);
+
   const branch = worktreeBranchName(name);
   const mainBranch = nativeDetectMainBranch(basePath);
 
@@ -742,6 +771,8 @@ export function diffWorktreeAll(basePath: string, name: string): WorktreeDiffSum
  * Uses direct diff (not merge-base) so the preview matches the actual merge outcome.
  */
 export function diffWorktreeNumstat(basePath: string, name: string): FileLineStat[] {
+  basePath = normalizeBasePathForWorktreeOps(basePath);
+
   const branch = worktreeBranchName(name);
   const mainBranch = nativeDetectMainBranch(basePath);
 
@@ -760,6 +791,8 @@ export function diffWorktreeNumstat(basePath: string, name: string): FileLineSta
  * Returns the raw unified diff for LLM consumption.
  */
 export function getWorktreeGSDDiff(basePath: string, name: string): string {
+  basePath = normalizeBasePathForWorktreeOps(basePath);
+
   const branch = worktreeBranchName(name);
   const mainBranch = nativeDetectMainBranch(basePath);
 
@@ -771,6 +804,8 @@ export function getWorktreeGSDDiff(basePath: string, name: string): string {
  * Returns the raw unified diff for LLM consumption.
  */
 export function getWorktreeCodeDiff(basePath: string, name: string): string {
+  basePath = normalizeBasePathForWorktreeOps(basePath);
+
   const branch = worktreeBranchName(name);
   const mainBranch = nativeDetectMainBranch(basePath);
 
@@ -781,6 +816,8 @@ export function getWorktreeCodeDiff(basePath: string, name: string): string {
  * Get commit log for the worktree branch since it diverged from main.
  */
 export function getWorktreeLog(basePath: string, name: string): string {
+  basePath = normalizeBasePathForWorktreeOps(basePath);
+
   const branch = worktreeBranchName(name);
   const mainBranch = nativeDetectMainBranch(basePath);
 
@@ -795,6 +832,8 @@ export function getWorktreeLog(basePath: string, name: string): string {
  * Returns the merge commit message.
  */
 export function mergeWorktreeToMain(basePath: string, name: string, commitMessage: string): string {
+  basePath = normalizeBasePathForWorktreeOps(basePath);
+
   const branch = worktreeBranchName(name);
   const mainBranch = nativeDetectMainBranch(basePath);
   const current = nativeGetCurrentBranch(basePath);

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -23,6 +23,7 @@ import { emitJournalEvent } from "./journal.js";
 import { emitWorktreeCreated, emitWorktreeMerged } from "./worktree-telemetry.js";
 import { getCollapseCadence, getMilestoneResquash, resquashMilestoneOnMain } from "./slice-cadence.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { resolveWorktreeProjectRoot } from "./worktree-root.js";
 
 // ─── Dependency Interface ──────────────────────────────────────────────────
 
@@ -85,30 +86,19 @@ export interface NotifyCtx {
 // ─── Path Helpers ──────────────────────────────────────────────────────────
 
 /**
- * Worktree marker segment — present in any path produced by worktreePath().
- * Used to strip the worktree suffix and recover the project root (#3729).
- */
-const WORKTREE_MARKER = "/.gsd/worktrees/";
-
-/**
  * Resolve the project root from session path state.
  *
  * Prefers `originalBasePath` (always the project root when set), but falls
  * back to `basePath` when `originalBasePath` is falsy (e.g. fresh AutoSession
  * with default empty string). If `basePath` itself is inside a worktree
- * directory (contains `/.gsd/worktrees/`), strip that suffix to recover the
- * actual project root — preventing double-nested worktree paths (#3729).
+ * directory (including symlink-resolved ~/.gsd/projects/<hash>/worktrees
+ * paths), recover the actual project root to prevent double nesting (#3729).
  */
 export function resolveProjectRoot(
   originalBasePath: string,
   basePath: string,
 ): string {
-  let resolved = originalBasePath || basePath;
-  const markerIdx = resolved.indexOf(WORKTREE_MARKER);
-  if (markerIdx !== -1) {
-    resolved = resolved.slice(0, markerIdx);
-  }
-  return resolved;
+  return resolveWorktreeProjectRoot(basePath, originalBasePath);
 }
 
 // ─── WorktreeResolver ──────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/worktree-root.ts
+++ b/src/resources/extensions/gsd/worktree-root.ts
@@ -1,0 +1,144 @@
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export interface WorktreeSegment {
+  gsdIdx: number;
+  afterWorktrees: number;
+}
+
+export function normalizeWorktreePathForCompare(path: string): string {
+  let normalized: string;
+  try {
+    normalized = realpathSync(path);
+  } catch {
+    normalized = resolve(path);
+  }
+  const slashed = normalized.replaceAll("\\", "/");
+  const trimmed = slashed.replace(/\/+$/, "");
+  return process.platform === "win32" ? (trimmed || "/").toLowerCase() : (trimmed || "/");
+}
+
+/**
+ * Find the GSD worktree segment in both direct project layout and the
+ * symlink-resolved external-state layout used by ~/.gsd/projects/<hash>.
+ */
+export function findWorktreeSegment(normalizedPath: string): WorktreeSegment | null {
+  const directMarker = "/.gsd/worktrees/";
+  const directIdx = normalizedPath.indexOf(directMarker);
+  if (directIdx !== -1) {
+    return { gsdIdx: directIdx, afterWorktrees: directIdx + directMarker.length };
+  }
+
+  const externalRe = /\/\.gsd\/projects\/[^/]+\/worktrees\//;
+  const externalMatch = normalizedPath.match(externalRe);
+  if (externalMatch && externalMatch.index !== undefined) {
+    return {
+      gsdIdx: externalMatch.index,
+      afterWorktrees: externalMatch.index + externalMatch[0].length,
+    };
+  }
+
+  return null;
+}
+
+export function isGsdWorktreePath(path: string): boolean {
+  return findWorktreeSegment(path.replaceAll("\\", "/")) !== null;
+}
+
+/**
+ * Resolve the canonical project root for worktree operations.
+ *
+ * `originalBasePath` wins when available because session state already knows the
+ * root. `GSD_PROJECT_ROOT` is the next strongest signal for worker processes.
+ * Otherwise, derive the root from direct `.gsd/worktrees` paths, or recover it
+ * from the worktree `.git` file for symlink-resolved ~/.gsd/project paths.
+ */
+export function resolveWorktreeProjectRoot(
+  basePath: string,
+  originalBasePath?: string | null,
+): string {
+  const preferred =
+    originalBasePath?.trim() ||
+    process.env.GSD_PROJECT_ROOT?.trim() ||
+    basePath;
+
+  return resolveProjectRootFromPath(preferred);
+}
+
+function resolveProjectRootFromPath(path: string): string {
+  const normalizedPath = path.replaceAll("\\", "/");
+  const segment = findWorktreeSegment(normalizedPath);
+  if (!segment) return resolveGitWorkingTreeRoot(path) ?? path;
+
+  const sepChar = path.includes("\\") ? "\\" : "/";
+  const gsdMarker = `${sepChar}.gsd${sepChar}`;
+  const markerIdx = path.indexOf(gsdMarker);
+  const candidate = markerIdx !== -1
+    ? path.slice(0, markerIdx)
+    : path.slice(0, segment.gsdIdx);
+
+  const gsdHome = normalizeWorktreePathForCompare(process.env.GSD_HOME || join(homedir(), ".gsd"));
+  const candidateGsdPath = normalizeWorktreePathForCompare(join(candidate, ".gsd"));
+
+  if (candidateGsdPath === gsdHome || candidateGsdPath.startsWith(`${gsdHome}/`)) {
+    const realRoot = resolveProjectRootFromGitFile(path);
+    return realRoot ?? path;
+  }
+
+  return candidate;
+}
+
+function resolveGitWorkingTreeRoot(path: string): string | null {
+  try {
+    let dir = existsSync(path) && !statSync(path).isDirectory()
+      ? resolve(path, "..")
+      : path;
+
+    for (let i = 0; i < 30; i++) {
+      const gitPath = join(dir, ".git");
+      if (existsSync(gitPath)) return dir;
+
+      const parent = resolve(dir, "..");
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Non-fatal: callers either keep the original path or fail closed.
+  }
+  return null;
+}
+
+function resolveProjectRootFromGitFile(worktreePath: string): string | null {
+  try {
+    let dir = worktreePath;
+    for (let i = 0; i < 30; i++) {
+      const gitPath = join(dir, ".git");
+      if (existsSync(gitPath)) {
+        const content = readFileSync(gitPath, "utf8").trim();
+        if (content.startsWith("gitdir: ")) {
+          const gitDir = resolve(dir, content.slice(8));
+          const dotGitDir = resolve(gitDir, "..", "..");
+          if (dotGitDir.endsWith(".git") || dotGitDir.endsWith(".git/") || dotGitDir.endsWith(".git\\")) {
+            return resolve(dotGitDir, "..");
+          }
+
+          const commonDirPath = join(gitDir, "commondir");
+          if (existsSync(commonDirPath)) {
+            const commonDir = readFileSync(commonDirPath, "utf8").trim();
+            const resolvedCommonDir = resolve(gitDir, commonDir);
+            return resolve(resolvedCommonDir, "..");
+          }
+        }
+        break;
+      }
+
+      const parent = resolve(dir, "..");
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Non-fatal: callers either keep the original path or fail closed.
+  }
+  return null;
+}

--- a/src/resources/extensions/gsd/worktree.ts
+++ b/src/resources/extensions/gsd/worktree.ts
@@ -12,12 +12,16 @@
  * SLICE_BRANCH_RE) remain for backwards compatibility with legacy branches.
  */
 
-import { existsSync, readFileSync, realpathSync, utimesSync } from "node:fs";
-import { join, resolve, sep } from "node:path";
-import { homedir } from "node:os";
+import { existsSync, readFileSync, utimesSync } from "node:fs";
+import { join, resolve } from "node:path";
 
 import { GitServiceImpl, writeIntegrationBranch, type TaskCommitContext } from "./git-service.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
+import {
+  findWorktreeSegment,
+  resolveWorktreeProjectRoot,
+} from "./worktree-root.js";
+export { resolveWorktreeProjectRoot } from "./worktree-root.js";
 
 export { MergeConflictError } from "./git-service.js";
 export type { TaskCommitContext } from "./git-service.js";
@@ -79,29 +83,6 @@ export function captureIntegrationBranch(basePath: string, milestoneId: string):
 // ─── Pure Utility Functions (unchanged) ────────────────────────────────────
 
 /**
- * Find the worktrees segment in a path, supporting both direct
- * (`/.gsd/worktrees/`) and symlink-resolved (`/.gsd/projects/<hash>/worktrees/`)
- * layouts.  When `.gsd` is a symlink to `~/.gsd/projects/<hash>`, resolved
- * paths contain the intermediate `projects/<hash>/` segment that the old
- * single-marker check missed.
- */
-function findWorktreeSegment(normalizedPath: string): { gsdIdx: number; afterWorktrees: number } | null {
-  // Direct layout: /.gsd/worktrees/<name>
-  const directMarker = "/.gsd/worktrees/";
-  const idx = normalizedPath.indexOf(directMarker);
-  if (idx !== -1) {
-    return { gsdIdx: idx, afterWorktrees: idx + directMarker.length };
-  }
-  // Symlink-resolved layout: /.gsd/projects/<hash>/worktrees/<name>
-  const symlinkRe = /\/\.gsd\/projects\/[a-f0-9]+\/worktrees\//;
-  const match = normalizedPath.match(symlinkRe);
-  if (match && match.index !== undefined) {
-    return { gsdIdx: match.index, afterWorktrees: match.index + match[0].length };
-  }
-  return null;
-}
-
-/**
  * Detect the active worktree name from the current working directory.
  * Returns null if not inside a GSD worktree (.gsd/worktrees/<name>/).
  */
@@ -133,99 +114,7 @@ export function detectWorktreeName(basePath: string): string | null {
  * operate against the real project root, not a worktree subdirectory.
  */
 export function resolveProjectRoot(basePath: string): string {
-  // Layer 1: If the coordinator passed the real project root, use it.
-  if (process.env.GSD_PROJECT_ROOT) {
-    return process.env.GSD_PROJECT_ROOT;
-  }
-
-  const normalizedPath = basePath.replaceAll("\\", "/");
-  const seg = findWorktreeSegment(normalizedPath);
-  if (!seg) return basePath;
-
-  // Candidate root via the string-slice heuristic
-  const sepChar = basePath.includes("\\") ? "\\" : "/";
-  const gsdMarker = `${sepChar}.gsd${sepChar}`;
-  const gsdIdx = basePath.indexOf(gsdMarker);
-  const candidate = gsdIdx !== -1
-    ? basePath.slice(0, gsdIdx)
-    : basePath.slice(0, seg.gsdIdx);
-
-  // Layer 2: Guard against resolving to the user's home directory.
-  // When .gsd is a symlink into ~/.gsd/projects/<hash>, the resolved path
-  // contains /.gsd/ at the user-level boundary. Slicing there yields ~ — wrong.
-  const gsdHome = normalizePathForCompare(process.env.GSD_HOME || join(homedir(), ".gsd"));
-  const candidateGsdPath = normalizePathForCompare(join(candidate, ".gsd"));
-
-  if (candidateGsdPath === gsdHome || candidateGsdPath.startsWith(gsdHome + "/")) {
-    // The candidate is the home directory (or within it in a way that .gsd
-    // maps to the user-level GSD dir). Try to recover the real project root
-    // from the worktree's .git file.
-    const realRoot = resolveProjectRootFromGitFile(basePath);
-    if (realRoot) return realRoot;
-    // If git file resolution failed, return basePath unchanged rather than ~
-    return basePath;
-  }
-
-  return candidate;
-}
-
-/**
- * Recover the real project root from a worktree's .git file.
- *
- * Each git worktree has a `.git` file (not directory) containing:
- *   gitdir: /real/project/.git/worktrees/<name>
- *
- * Walking up from that gitdir gives us `/real/project/.git`, and its
- * parent is the real project root.
- */
-function resolveProjectRootFromGitFile(worktreePath: string): string | null {
-  try {
-    // Walk up from the worktree path to find the .git file
-    let dir = worktreePath;
-    for (let i = 0; i < 30; i++) {
-      const gitPath = join(dir, ".git");
-      if (existsSync(gitPath)) {
-        const content = readFileSync(gitPath, "utf8").trim();
-        if (content.startsWith("gitdir: ")) {
-          // gitdir points to: <real-project>/.git/worktrees/<name>
-          const gitDir = resolve(dir, content.slice(8));
-          // Walk up: .git/worktrees/<name> → .git/worktrees → .git → project root
-          const dotGitDir = resolve(gitDir, "..", "..");
-          // Verify this looks like a .git directory
-          if (dotGitDir.endsWith(".git") || dotGitDir.endsWith(".git/") || dotGitDir.endsWith(".git\\")) {
-            return resolve(dotGitDir, "..");
-          }
-          // Alternative: the commondir file inside the worktree gitdir
-          // points to the main .git directory
-          const commonDirPath = join(gitDir, "commondir");
-          if (existsSync(commonDirPath)) {
-            const commonDir = readFileSync(commonDirPath, "utf8").trim();
-            const resolvedCommonDir = resolve(gitDir, commonDir);
-            return resolve(resolvedCommonDir, "..");
-          }
-        }
-        break;
-      }
-      const parent = resolve(dir, "..");
-      if (parent === dir) break;
-      dir = parent;
-    }
-  } catch {
-    // Non-fatal — caller will use fallback
-  }
-  return null;
-}
-
-function normalizePathForCompare(path: string): string {
-  let normalized: string;
-  try {
-    normalized = realpathSync(path);
-  } catch {
-    normalized = resolve(path);
-  }
-  const slashed = normalized.replaceAll("\\", "/");
-  const trimmed = slashed.replace(/\/+$/, "");
-  return trimmed || "/";
+  return resolveWorktreeProjectRoot(basePath);
 }
 
 /**

--- a/src/tests/bundled-resource-path.test.ts
+++ b/src/tests/bundled-resource-path.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  resolveBundledGsdExtensionModule,
+  resolveBundledResourcesDirFromPackageRoot,
+} from "../bundled-resource-path.ts";
+
+test("partial dist/resources falls back to src/resources", () => {
+  const pkg = "/pkg";
+  const existing = new Set([
+    join(pkg, "dist", "resources", "extensions"),
+  ]);
+
+  const result = resolveBundledResourcesDirFromPackageRoot(pkg, (p) => existing.has(p));
+
+  assert.equal(result, join(pkg, "src", "resources"));
+});
+
+test("complete dist/resources is selected when expected roots exist", () => {
+  const pkg = "/pkg";
+  const existing = new Set([
+    join(pkg, "dist", "resources", "agents"),
+    join(pkg, "dist", "resources", "extensions"),
+  ]);
+
+  const result = resolveBundledResourcesDirFromPackageRoot(pkg, (p) => existing.has(p));
+
+  assert.equal(result, join(pkg, "dist", "resources"));
+});
+
+test("GSD extension module resolution falls back to source when dist module is missing", () => {
+  const pkg = "/pkg";
+  const fakeImportUrl = `file://${join(pkg, "src", "worktree-cli.ts")}`;
+  const existing = new Set([
+    join(pkg, "dist", "resources", "agents"),
+    join(pkg, "dist", "resources", "extensions"),
+  ]);
+
+  const result = resolveBundledGsdExtensionModule(
+    fakeImportUrl,
+    "worktree-root.ts",
+    (p) => existing.has(p),
+  );
+
+  assert.equal(result, join(pkg, "src", "resources", "extensions", "gsd", "worktree-root.ts"));
+});
+
+test("GSD extension module resolution uses compiled dist module when available", () => {
+  const pkg = "/pkg";
+  const fakeImportUrl = `file://${join(pkg, "src", "worktree-cli.ts")}`;
+  const existing = new Set([
+    join(pkg, "dist", "resources", "agents"),
+    join(pkg, "dist", "resources", "extensions"),
+    join(pkg, "dist", "resources", "extensions", "gsd", "worktree-manager.js"),
+  ]);
+
+  const result = resolveBundledGsdExtensionModule(
+    fakeImportUrl,
+    "worktree-manager.ts",
+    (p) => existing.has(p),
+  );
+
+  assert.equal(result, join(pkg, "dist", "resources", "extensions", "gsd", "worktree-manager.js"));
+});

--- a/src/tests/headless-query-extension-path.test.ts
+++ b/src/tests/headless-query-extension-path.test.ts
@@ -45,6 +45,23 @@ test('agent dir is selected when state.ts exists under it (#3471)', (t) => {
   assert.equal(result.useAgentDir, true)
 })
 
+test('agent dir is selected when synced JS state exists under it', (t) => {
+  const root = makeTempDir()
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+  const extDir = join(root, 'extensions', 'gsd')
+  mkdirSync(extDir, { recursive: true })
+  writeFileSync(join(extDir, 'state.js'), '// fixture')
+
+  const result = shouldUseAgentExtensionsDir({ env: { GSD_AGENT_DIR: root } })
+  assert.equal(result.agentDir, extDir)
+  assert.equal(result.useAgentDir, true)
+})
+
+test('GSD_HOME drives default agent dir when GSD_AGENT_DIR is absent', () => {
+  const root = resolveGsdAgentExtensionsDir({ GSD_HOME: '/custom/gsd-home' })
+  assert.equal(root, join('/custom/gsd-home', 'agent', 'extensions', 'gsd'))
+})
+
 test('agent dir is rejected when state.ts is absent (falls back to bundled)', (t) => {
   const root = makeTempDir()
   t.after(() => rmSync(root, { recursive: true, force: true }))
@@ -60,9 +77,12 @@ test('fileExists callback drives the decision (no real fs required)', () => {
     env: { GSD_AGENT_DIR: '/agent' },
     fileExists: (p) => {
       calls.push(p)
-      return true
+      return p.endsWith('state.js')
     },
   })
   assert.equal(result.useAgentDir, true)
-  assert.deepEqual(calls, [join('/agent', 'extensions', 'gsd', 'state.ts')])
+  assert.deepEqual(calls, [
+    join('/agent', 'extensions', 'gsd', 'state.ts'),
+    join('/agent', 'extensions', 'gsd', 'state.js'),
+  ])
 })

--- a/src/tests/worktree-cli-root.test.ts
+++ b/src/tests/worktree-cli-root.test.ts
@@ -1,0 +1,56 @@
+import { execSync } from "node:child_process";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, test } from "node:test";
+
+import { handleWorktreeFlag } from "../worktree-cli.ts";
+import { createWorktree, worktreePath } from "../resources/extensions/gsd/worktree-manager.ts";
+
+let cleanupPaths: string[] = [];
+let originalCwd = process.cwd();
+
+function run(command: string, cwd: string): string {
+  return execSync(command, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  }).trim();
+}
+
+function makeRepo(): string {
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-worktree-cli-root-")));
+  cleanupPaths.push(base);
+  run("git init -b main", base);
+  run('git config user.name "GSD Test"', base);
+  run('git config user.email "gsd@example.com"', base);
+  writeFileSync(join(base, "README.md"), "init\n", "utf-8");
+  run("git add -A && git commit -m init", base);
+  return base;
+}
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  delete process.env.GSD_CLI_WORKTREE;
+  delete process.env.GSD_CLI_WORKTREE_BASE;
+  for (const p of cleanupPaths.splice(0)) {
+    rmSync(p, { recursive: true, force: true });
+  }
+});
+
+test("gsd -w from inside a worktree creates the next worktree at the project root", async () => {
+  const base = makeRepo();
+  const alpha = createWorktree(base, "alpha");
+  process.chdir(alpha.path);
+
+  await handleWorktreeFlag("beta");
+
+  const expected = worktreePath(base, "beta");
+  const nested = join(alpha.path, ".gsd", "worktrees", "beta");
+  assert.equal(process.env.GSD_CLI_WORKTREE_BASE, base);
+  assert.equal(process.env.GSD_CLI_WORKTREE, "beta");
+  assert.equal(process.cwd(), expected);
+  assert.equal(existsSync(expected), true);
+  assert.equal(existsSync(nested), false);
+});

--- a/src/worktree-cli.ts
+++ b/src/worktree-cli.ts
@@ -23,11 +23,11 @@ import { createJiti } from '@mariozechner/jiti'
 import { fileURLToPath } from 'node:url'
 import { generateWorktreeName } from './worktree-name-gen.js'
 import { existsSync } from 'node:fs'
-import { resolveBundledSourceResource } from './bundled-resource-path.js'
+import { resolveBundledGsdExtensionModule } from './bundled-resource-path.js'
 
 const jiti = createJiti(fileURLToPath(import.meta.url), { interopDefault: true, debug: false })
 const gsdExtensionPath = (...segments: string[]) =>
-  resolveBundledSourceResource(import.meta.url, 'extensions', 'gsd', ...segments)
+  resolveBundledGsdExtensionModule(import.meta.url, segments.join('/'))
 
 // Lazily-loaded extension modules (loaded once on first use via jiti)
 let _ext: ExtensionModules | null = null
@@ -47,6 +47,7 @@ interface ExtensionModules {
   nativeCommitCountBetween: (basePath: string, from: string, to: string) => number
   inferCommitType: (name: string) => string
   autoCommitCurrentBranch: (wtPath: string, reason: string, name: string) => void
+  resolveWorktreeProjectRoot: (basePath: string) => string
 }
 
 interface WorktreeDiff {
@@ -82,6 +83,7 @@ interface GitServiceModule {
 
 interface WorktreeModule {
   autoCommitCurrentBranch: ExtensionModules['autoCommitCurrentBranch']
+  resolveWorktreeProjectRoot: ExtensionModules['resolveWorktreeProjectRoot']
 }
 
 function toErrorMessage(error: unknown): string {
@@ -118,6 +120,7 @@ async function loadExtensionModules(): Promise<ExtensionModules> {
     nativeCommitCountBetween: gitBridge.nativeCommitCountBetween,
     inferCommitType: gitSvc.inferCommitType,
     autoCommitCurrentBranch: wt.autoCommitCurrentBranch,
+    resolveWorktreeProjectRoot: wt.resolveWorktreeProjectRoot,
   }
   return _ext
 }
@@ -199,6 +202,7 @@ function formatStatus(s: WorktreeStatus): string {
 
 async function handleList(basePath: string): Promise<void> {
   const ext = await loadExtensionModules()
+  basePath = ext.resolveWorktreeProjectRoot(basePath)
   const worktrees = ext.listWorktrees(basePath)
 
   if (worktrees.length === 0) {
@@ -217,6 +221,7 @@ async function handleList(basePath: string): Promise<void> {
 
 async function handleMerge(basePath: string, args: string[]): Promise<void> {
   const ext = await loadExtensionModules()
+  basePath = ext.resolveWorktreeProjectRoot(basePath)
   const name = args[0]
   if (!name) {
     // If only one worktree exists, merge it
@@ -282,6 +287,7 @@ async function doMerge(ext: ExtensionModules, basePath: string, name: string): P
 
 async function handleClean(basePath: string): Promise<void> {
   const ext = await loadExtensionModules()
+  basePath = ext.resolveWorktreeProjectRoot(basePath)
   const worktrees = ext.listWorktrees(basePath)
   if (worktrees.length === 0) {
     process.stderr.write(chalk.dim('No worktrees to clean.\n'))
@@ -311,6 +317,7 @@ async function handleClean(basePath: string): Promise<void> {
 
 async function handleRemove(basePath: string, args: string[]): Promise<void> {
   const ext = await loadExtensionModules()
+  basePath = ext.resolveWorktreeProjectRoot(basePath)
   const name = args[0]
   if (!name) {
     process.stderr.write(chalk.red('Usage: gsd worktree remove <name>\n'))
@@ -341,6 +348,7 @@ async function handleRemove(basePath: string, args: string[]): Promise<void> {
 
 async function handleStatusBanner(basePath: string): Promise<void> {
   const ext = await loadExtensionModules()
+  basePath = ext.resolveWorktreeProjectRoot(basePath)
   const worktrees = ext.listWorktrees(basePath)
   if (worktrees.length === 0) return
 
@@ -370,7 +378,7 @@ async function handleStatusBanner(basePath: string): Promise<void> {
 
 async function handleWorktreeFlag(worktreeFlag: boolean | string): Promise<void> {
   const ext = await loadExtensionModules()
-  const basePath = process.cwd()
+  const basePath = ext.resolveWorktreeProjectRoot(process.cwd())
 
   // gsd -w (no name) — resume most recent worktree with changes, or create new
   if (worktreeFlag === true) {


### PR DESCRIPTION
## TL;DR

**What:** Normalizes GSD worktree project roots before manual and auto worktree operations.
**Why:** Running `gsd -w <name>` from inside an existing worktree could create a nested `.gsd/worktrees` tree.
**How:** Adds a shared worktree-root resolver, routes manual/auto worktree paths through it, and aligns bundled resource selection across CLI/headless/startup paths.

## What

- Adds a canonical internal `resolveWorktreeProjectRoot()` helper for normal repos, repo subdirectories, direct `.gsd/worktrees/<name>` paths, and symlink-resolved `~/.gsd/projects/<hash>/worktrees/<name>` paths.
- Updates manual worktree commands and `createWorktree()`/list/diff/remove/merge flows to normalize their base path before operating.
- Makes auto-worktree detection structural so restart/resume does not depend on module-local `originalBase` state.
- Centralizes bundled resource root selection so loader, resource sync, headless query, and manual worktree CLI do not silently choose different GSD extension copies.
- Repairs and expands regression coverage for symlinked worktrees, manual `gsd -w`, headless JS state detection, and MCP external-state project validation.

## Why

Closes #5050.

The bug came from treating raw `process.cwd()` as the project root. If the user ran `gsd -w beta` while inside `/repo/.gsd/worktrees/alpha`, the old path calculation could produce `/repo/.gsd/worktrees/alpha/.gsd/worktrees/beta`.

## How

The fix moves root detection into one shared helper, then applies that helper at both boundaries: user-facing CLI entrypoints and lower-level worktree manager operations. That gives the CLI correct env/status behavior while also preventing future internal callers from accidentally nesting worktrees.

The resource-loading change keeps manual `gsd worktree` behavior aligned with the same complete-`dist/resources` selection used by the loader/resource sync path, with source fallback retained for dev/test workflows.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

No intended breaking change. Worktrees remain under `<project-root>/.gsd/worktrees/<name>`. The change prevents accidental nested worktree creation and makes existing commands resolve back to the canonical project root.

## Verification

AI-assisted PR.

Passed locally:

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/bundled-resource-path.test.ts src/tests/headless-query-extension-path.test.ts src/tests/worktree-cli-root.test.ts` — 11/11 passed
- Worktree manager/resolver/safety source suite — 83/83 passed
- `src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts` — 11/11 passed
- `packages/mcp-server/src/workflow-tools.test.ts --test-name-pattern=validateProjectDir` — 6/6 passed
- `npm run typecheck:extensions` — passed
- `npx tsc --noEmit --project tsconfig.json` — passed
- `git diff --check` — passed

Required gate attempted:

- `npm run verify:pr` completed build/core/typecheck phases but failed during `test:unit` on local timing/time-out checks: context-store <5ms assertion, derive-state-db <25ms assertion, and one workflow MCP stdio timeout.
- The three failing files were rerun isolated immediately afterward and passed: 91/91.

Opened as draft until CI/local full `verify:pr` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree/project-root detection to correctly handle symlinked storage and canonicalize paths across commands and extensions.
  * More robust auto-worktree detection and `.git` handling to avoid false negatives.

* **New Features**
  * Agent-extension discovery now falls back to GSD_HOME and accepts either TypeScript or JavaScript state files.
  * Bundled resource resolution now prefers compiled resources when complete, with safe fallbacks to source files.

* **Tests**
  * Added extensive regression and integration tests covering symlinked state, worktree resolution, and extension/path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->