### PR TITLE
feat(gsd): add worktree {list,merge,clean,remove} to TUI dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ On first run, GSD launches a branded setup wizard that walks you through LLM pro
 | `/gsd logs`             | Browse activity, debug, and metrics logs                                      |
 | `/gsd export --html`    | Generate HTML report for current or completed milestone                       |
 | `/worktree` (`/wt`)     | Git worktree lifecycle — create, switch, merge, remove                        |
+| `/gsd worktree` (`/gsd wt`) | TUI worktree management — list, merge, clean, remove with safety checks   |
 | `/voice`                | Toggle real-time speech-to-text (macOS, Linux)                                |
 | `/exit`                 | Graceful shutdown — saves session state before exiting                        |
 | `/kill`                 | Kill GSD process immediately                                                  |

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -26,6 +26,7 @@
 | `/gsd history` | View execution history (supports `--cost`, `--phase`, `--model` filters) |
 | `/gsd forensics` | Full-access GSD debugger — structured anomaly detection, unit traces, and LLM-guided root-cause analysis for auto-mode failures |
 | `/gsd cleanup` | Clean up GSD state files and stale worktrees |
+| `/gsd worktree` (`/gsd wt`) | Manage GSD worktrees from the TUI |
 | `/gsd visualize` | Open workflow visualizer (progress, deps, metrics, timeline) |
 | `/gsd export --html` | Generate self-contained HTML report for current or completed milestone |
 | `/gsd export --html --all` | Generate retrospective reports for all milestones at once |
@@ -190,6 +191,24 @@ Enable with `github.enabled: true` in preferences. Requires `gh` CLI installed a
 | Command | Description |
 |---------|-------------|
 | `/worktree` (`/wt`) | Git worktree lifecycle — create, switch, merge, remove |
+
+## GSD Worktree Commands
+
+Use `/gsd worktree` from an active TUI session to inspect and clean up GSD-managed worktrees without leaving the conversation. `/gsd wt` is an alias.
+
+| Command | Description |
+|---------|-------------|
+| `/gsd worktree list` | Show each worktree, branch, path, clean/unmerged/uncommitted status, diff stats, and commit count. Alias: `/gsd worktree ls`. |
+| `/gsd worktree merge [name]` | Merge a worktree into the detected main branch, then remove the worktree and its branch. The name is optional only when exactly one worktree exists. |
+| `/gsd worktree clean` | Remove only merged or empty worktrees. Worktrees with unmerged diffs or uncommitted changes are kept. |
+| `/gsd worktree remove <name> [--force]` | Remove a named worktree and delete its branch. Refuses unmerged or uncommitted work unless `--force` is supplied. Alias: `/gsd worktree rm`. |
+
+Safety behavior:
+
+- `merge` auto-commits dirty worktree changes before merging when possible.
+- `merge` refuses to continue if the project root is not on the detected main branch; check out the main branch and rerun it.
+- `clean` never deletes worktrees with pending file changes.
+- `remove` requires `--force` to discard unmerged or uncommitted work.
 
 ## Telegram Commands
 

--- a/docs/user-docs/git-strategy.md
+++ b/docs/user-docs/git-strategy.md
@@ -103,7 +103,7 @@ Auto mode creates and manages worktrees automatically:
 
 ### Manual
 
-Use the `/worktree` (or `/wt`) command for manual worktree management:
+Use the `/worktree` (or `/wt`) command for standalone manual worktree management:
 
 ```
 /worktree create
@@ -111,6 +111,17 @@ Use the `/worktree` (or `/wt`) command for manual worktree management:
 /worktree merge
 /worktree remove
 ```
+
+Inside an active GSD TUI session, use `/gsd worktree` (or `/gsd wt`) for worktree commands that report through the session UI:
+
+```
+/gsd worktree list
+/gsd worktree merge [name]
+/gsd worktree clean
+/gsd worktree remove <name> [--force]
+```
+
+`list` shows each worktree's branch, path, diff stats, commit count, and whether it is clean, unmerged, or has uncommitted changes. `merge` brings a worktree back into the detected main branch and removes it afterward; if the worktree has dirty files, GSD tries to auto-commit them before merging. `clean` removes only merged or empty worktrees and keeps anything with pending changes. `remove` refuses to discard unmerged or uncommitted work unless you pass `--force`.
 
 ## Workflow Modes
 

--- a/gitbook/configuration/git-settings.md
+++ b/gitbook/configuration/git-settings.md
@@ -173,7 +173,7 @@ GSD-Task: M001/S01/T01
 
 ## Manual Worktree Management
 
-Use `/worktree` (or `/wt`) for manual worktree operations:
+Use `/worktree` (or `/wt`) for standalone manual worktree operations:
 
 ```
 /worktree create
@@ -181,6 +181,17 @@ Use `/worktree` (or `/wt`) for manual worktree operations:
 /worktree merge
 /worktree remove
 ```
+
+Inside an active GSD TUI session, use `/gsd worktree` (or `/gsd wt`) for worktree commands that report through the session UI:
+
+```
+/gsd worktree list
+/gsd worktree merge [name]
+/gsd worktree clean
+/gsd worktree remove <name> [--force]
+```
+
+`list` shows each worktree's branch, path, diff stats, commit count, and whether it is clean, unmerged, or has uncommitted changes. `merge` brings a worktree back into the detected main branch and removes it afterward; if the worktree has dirty files, GSD tries to auto-commit them before merging. `clean` removes only merged or empty worktrees and keeps anything with pending changes. `remove` refuses to discard unmerged or uncommitted work unless you pass `--force`.
 
 ## Self-Healing
 

--- a/gitbook/reference/commands.md
+++ b/gitbook/reference/commands.md
@@ -25,6 +25,7 @@
 | `/gsd history` | View execution history (supports `--cost`, `--phase`, `--model` filters) |
 | `/gsd forensics` | Full debugger for auto-mode failures (includes worktree lifecycle telemetry) |
 | `/gsd cleanup` | Clean up state files and stale worktrees |
+| `/gsd worktree` (`/gsd wt`) | Manage GSD worktrees from the TUI |
 | `/gsd visualize` | Open workflow visualizer |
 | `/gsd export --html` | Generate HTML report for current milestone |
 | `/gsd export --html --all` | Generate reports for all milestones |
@@ -123,6 +124,24 @@
 | `/thinking` | Toggle thinking level |
 | `/voice` | Toggle speech-to-text |
 | `/worktree` (`/wt`) | Git worktree management |
+
+## GSD Worktree Commands
+
+Use `/gsd worktree` from an active TUI session to inspect and clean up GSD-managed worktrees without leaving the conversation. `/gsd wt` is an alias.
+
+| Command | Description |
+|---------|-------------|
+| `/gsd worktree list` | Show each worktree, branch, path, clean/unmerged/uncommitted status, diff stats, and commit count. Alias: `/gsd worktree ls`. |
+| `/gsd worktree merge [name]` | Merge a worktree into the detected main branch, then remove the worktree and its branch. The name is optional only when exactly one worktree exists. |
+| `/gsd worktree clean` | Remove only merged or empty worktrees. Worktrees with unmerged diffs or uncommitted changes are kept. |
+| `/gsd worktree remove <name> [--force]` | Remove a named worktree and delete its branch. Refuses unmerged or uncommitted work unless `--force` is supplied. Alias: `/gsd worktree rm`. |
+
+Safety behavior:
+
+- `merge` auto-commits dirty worktree changes before merging when possible.
+- `merge` refuses to continue if the project root is not on the detected main branch; check out the main branch and rerun it.
+- `clean` never deletes worktrees with pending file changes.
+- `remove` requires `--force` to discard unmerged or uncommitted work.
 
 ## In-Session Update
 

--- a/src/resources/extensions/gsd/commands-worktree.ts
+++ b/src/resources/extensions/gsd/commands-worktree.ts
@@ -181,15 +181,6 @@ async function handleMerge(args: string, ctx: ExtensionCommandContext): Promise<
 
   try {
     mergeWorktreeToMain(basePath, target, commitMessage);
-    removeWorktree(basePath, target, { deleteBranch: true });
-    ctx.ui.notify(
-      [
-        `Merged ${target} → ${mainBranch}`,
-        `  ${status.filesChanged} file${status.filesChanged === 1 ? "" : "s"}, +${status.linesAdded} -${status.linesRemoved}`,
-        `  commit: ${commitMessage.split("\n")[0]}`,
-      ].join("\n"),
-      "info",
-    );
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (err instanceof GSDError && err.code === GSD_GIT_ERROR) {
@@ -203,6 +194,29 @@ async function handleMerge(args: string, ctx: ExtensionCommandContext): Promise<
         "error",
       );
     }
+    return;
+  }
+
+  const successLines = [
+    `Merged ${target} → ${mainBranch}`,
+    `  ${status.filesChanged} file${status.filesChanged === 1 ? "" : "s"}, +${status.linesAdded} -${status.linesRemoved}`,
+    `  commit: ${commitMessage.split("\n")[0]}`,
+  ];
+
+  try {
+    removeWorktree(basePath, target, { deleteBranch: true });
+    ctx.ui.notify(successLines.join("\n"), "info");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const cleanupLines = [
+      ...successLines,
+      "",
+      `Cleanup failed after the merge succeeded: ${msg}`,
+      err instanceof GSDError && err.code === GSD_GIT_ERROR
+        ? `Switch to ${mainBranch} (e.g. 'git checkout ${mainBranch}'), then remove the worktree manually with /gsd worktree remove ${target} --force.`
+        : `Remove the worktree manually with /gsd worktree remove ${target} --force, or run 'git worktree prune' to clean up dangling registrations.`,
+    ];
+    ctx.ui.notify(cleanupLines.join("\n"), "warning");
   }
 }
 
@@ -231,7 +245,11 @@ async function handleClean(ctx: ExtensionCommandContext): Promise<void> {
     } else {
       const reason = !status.exists
         ? "directory missing — run 'git worktree prune' to unregister"
-        : `${status.filesChanged} changed file${status.filesChanged === 1 ? "" : "s"}`;
+        : status.uncommitted && status.filesChanged > 0
+          ? `has uncommitted changes and ${status.filesChanged} changed file${status.filesChanged === 1 ? "" : "s"}`
+          : status.uncommitted
+            ? "has uncommitted changes"
+            : `${status.filesChanged} changed file${status.filesChanged === 1 ? "" : "s"}`;
       kept.push(`${wt.name} (${reason})`);
     }
   }

--- a/src/resources/extensions/gsd/commands-worktree.ts
+++ b/src/resources/extensions/gsd/commands-worktree.ts
@@ -180,10 +180,16 @@ async function handleMerge(args: string, ctx: ExtensionCommandContext): Promise<
     try {
       autoCommitCurrentBranch(wt.path, "worktree-merge", target);
     } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
       ctx.ui.notify(
-        `Auto-commit before merge failed: ${err instanceof Error ? err.message : String(err)}`,
-        "warning",
+        [
+          `Auto-commit before merge failed: ${msg}`,
+          "",
+          `Commit or stash changes in ${wt.path}, then re-run /gsd worktree merge ${target}.`,
+        ].join("\n"),
+        "error",
       );
+      return;
     }
   }
 
@@ -296,7 +302,7 @@ async function handleRemove(args: string, ctx: ExtensionCommandContext): Promise
   if ((status.filesChanged > 0 || status.uncommitted) && !force) {
     ctx.ui.notify(
       [
-        `Worktree "${name}" has unmerged changes (${status.filesChanged} file${status.filesChanged === 1 ? "" : "s"}).`,
+        `Worktree "${name}" has pending changes (${formatCleanKeepReason(status)}).`,
         "",
         `  Merge first:     /gsd worktree merge ${name}`,
         `  Or force-remove: /gsd worktree remove ${name} --force`,

--- a/src/resources/extensions/gsd/commands-worktree.ts
+++ b/src/resources/extensions/gsd/commands-worktree.ts
@@ -112,6 +112,18 @@ export function formatWorktreeList(statuses: WorktreeStatus[]): string {
   return lines.join("\n");
 }
 
+export function formatCleanKeepReason(status: WorktreeStatus): string {
+  if (!status.exists) {
+    return "directory missing — run 'git worktree prune' to unregister";
+  }
+
+  if (status.filesChanged > 0) {
+    return `${status.filesChanged} changed file${status.filesChanged === 1 ? "" : "s"}${status.uncommitted ? ", uncommitted" : ""}`;
+  }
+
+  return "uncommitted changes";
+}
+
 // ─── Subcommand: list ───────────────────────────────────────────────────────
 
 async function handleList(ctx: ExtensionCommandContext): Promise<void> {
@@ -243,13 +255,7 @@ async function handleClean(ctx: ExtensionCommandContext): Promise<void> {
         kept.push(`${wt.name} (failed: ${msg})`);
       }
     } else {
-      const reason = !status.exists
-        ? "directory missing — run 'git worktree prune' to unregister"
-        : status.uncommitted && status.filesChanged > 0
-          ? `has uncommitted changes and ${status.filesChanged} changed file${status.filesChanged === 1 ? "" : "s"}`
-          : status.uncommitted
-            ? "has uncommitted changes"
-            : `${status.filesChanged} changed file${status.filesChanged === 1 ? "" : "s"}`;
+      const reason = formatCleanKeepReason(status);
       kept.push(`${wt.name} (${reason})`);
     }
   }

--- a/src/resources/extensions/gsd/commands-worktree.ts
+++ b/src/resources/extensions/gsd/commands-worktree.ts
@@ -1,0 +1,353 @@
+// GSD-2 — In-TUI handler for /gsd worktree commands (list, merge, clean, remove).
+//
+// Mirrors the CLI subcommands in src/worktree-cli.ts but emits results via
+// ctx.ui.notify() instead of writing colored output to stderr. Reuses the
+// same extension modules (worktree-manager, native-git-bridge, etc.) so the
+// behavior is identical to the CLI surface.
+
+import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import { existsSync } from "node:fs";
+
+import { projectRoot } from "./commands/context.js";
+import {
+  listWorktrees,
+  removeWorktree,
+  mergeWorktreeToMain,
+  diffWorktreeAll,
+  diffWorktreeNumstat,
+  worktreeBranchName,
+} from "./worktree-manager.js";
+import {
+  nativeHasChanges,
+  nativeDetectMainBranch,
+  nativeCommitCountBetween,
+} from "./native-git-bridge.js";
+import { inferCommitType } from "./git-service.js";
+import { autoCommitCurrentBranch } from "./worktree.js";
+import { GSDError, GSD_GIT_ERROR } from "./errors.js";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface WorktreeStatus {
+  name: string;
+  path: string;
+  branch: string;
+  exists: boolean;
+  filesChanged: number;
+  linesAdded: number;
+  linesRemoved: number;
+  uncommitted: boolean;
+  commits: number;
+}
+
+// ─── Status helper ─────────────────────────────────────────────────────────
+
+function getStatus(basePath: string, name: string, wtPath: string): WorktreeStatus {
+  const diff = diffWorktreeAll(basePath, name);
+  const numstat = diffWorktreeNumstat(basePath, name);
+  const filesChanged = diff.added.length + diff.modified.length + diff.removed.length;
+  let linesAdded = 0;
+  let linesRemoved = 0;
+  for (const s of numstat) {
+    linesAdded += s.added;
+    linesRemoved += s.removed;
+  }
+
+  let uncommitted = false;
+  try {
+    uncommitted = existsSync(wtPath) && nativeHasChanges(wtPath);
+  } catch {
+    // native check failure → treat as clean for display purposes
+  }
+
+  let commits = 0;
+  try {
+    const main = nativeDetectMainBranch(basePath);
+    commits = nativeCommitCountBetween(basePath, main, worktreeBranchName(name));
+  } catch {
+    // commit count unavailable → leave at 0
+  }
+
+  return {
+    name,
+    path: wtPath,
+    branch: worktreeBranchName(name),
+    exists: existsSync(wtPath),
+    filesChanged,
+    linesAdded,
+    linesRemoved,
+    uncommitted,
+    commits,
+  };
+}
+
+// ─── Formatters (exported for tests) ────────────────────────────────────────
+
+export function formatWorktreeList(statuses: WorktreeStatus[]): string {
+  if (statuses.length === 0) {
+    return "No worktrees.\n\nCreate one from the CLI: gsd -w <name>";
+  }
+
+  const lines: string[] = [`Worktrees — ${statuses.length}`, ""];
+  for (const s of statuses) {
+    const badge = s.uncommitted
+      ? "(uncommitted)"
+      : s.filesChanged > 0
+        ? "(unmerged)"
+        : "(clean)";
+    lines.push(`  ${s.name} ${badge}`);
+    lines.push(`    branch  ${s.branch}`);
+    lines.push(`    path    ${s.path}`);
+    if (s.filesChanged > 0) {
+      lines.push(
+        `    diff    ${s.filesChanged} file${s.filesChanged === 1 ? "" : "s"}, +${s.linesAdded} -${s.linesRemoved}, ${s.commits} commit${s.commits === 1 ? "" : "s"}`,
+      );
+    }
+    lines.push("");
+  }
+  lines.push("Commands:");
+  lines.push("  /gsd worktree merge <name>   Merge into main and clean up");
+  lines.push("  /gsd worktree remove <name>  Remove a worktree (--force to skip safety checks)");
+  lines.push("  /gsd worktree clean          Remove all merged/empty worktrees");
+  return lines.join("\n");
+}
+
+// ─── Subcommand: list ───────────────────────────────────────────────────────
+
+async function handleList(ctx: ExtensionCommandContext): Promise<void> {
+  const basePath = projectRoot();
+  const worktrees = listWorktrees(basePath);
+  const statuses = worktrees.map((wt) => getStatus(basePath, wt.name, wt.path));
+  ctx.ui.notify(formatWorktreeList(statuses), "info");
+}
+
+// ─── Subcommand: merge ──────────────────────────────────────────────────────
+
+async function handleMerge(args: string, ctx: ExtensionCommandContext): Promise<void> {
+  const basePath = projectRoot();
+  const worktrees = listWorktrees(basePath);
+  const trimmed = args.trim();
+
+  let target = trimmed;
+  if (!target) {
+    if (worktrees.length === 1) {
+      target = worktrees[0].name;
+    } else if (worktrees.length === 0) {
+      ctx.ui.notify("No worktrees to merge.", "info");
+      return;
+    } else {
+      const names = worktrees.map((w) => w.name).join(", ");
+      ctx.ui.notify(`Usage: /gsd worktree merge <name>\n\nWorktrees: ${names}`, "warning");
+      return;
+    }
+  }
+
+  const wt = worktrees.find((w) => w.name === target);
+  if (!wt) {
+    const available = worktrees.map((w) => w.name).join(", ") || "(none)";
+    ctx.ui.notify(`Worktree "${target}" not found.\n\nAvailable: ${available}`, "error");
+    return;
+  }
+
+  const status = getStatus(basePath, target, wt.path);
+  if (status.filesChanged === 0 && !status.uncommitted) {
+    try {
+      removeWorktree(basePath, target, { deleteBranch: true });
+      ctx.ui.notify(`Removed empty worktree ${target}.`, "info");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      ctx.ui.notify(
+        `Worktree partially removed: ${msg}\n\nRun 'git worktree prune' to clean up any dangling registrations.`,
+        "error",
+      );
+    }
+    return;
+  }
+
+  if (status.uncommitted) {
+    try {
+      autoCommitCurrentBranch(wt.path, "worktree-merge", target);
+    } catch (err) {
+      ctx.ui.notify(
+        `Auto-commit before merge failed: ${err instanceof Error ? err.message : String(err)}`,
+        "warning",
+      );
+    }
+  }
+
+  const commitType = inferCommitType(target);
+  const mainBranch = nativeDetectMainBranch(basePath);
+  const commitMessage = `${commitType}: merge worktree ${target}\n\nGSD-Worktree: ${target}`;
+
+  try {
+    mergeWorktreeToMain(basePath, target, commitMessage);
+    removeWorktree(basePath, target, { deleteBranch: true });
+    ctx.ui.notify(
+      [
+        `Merged ${target} → ${mainBranch}`,
+        `  ${status.filesChanged} file${status.filesChanged === 1 ? "" : "s"}, +${status.linesAdded} -${status.linesRemoved}`,
+        `  commit: ${commitMessage.split("\n")[0]}`,
+      ].join("\n"),
+      "info",
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (err instanceof GSDError && err.code === GSD_GIT_ERROR) {
+      ctx.ui.notify(
+        `Merge requires the main branch to be checked out: ${msg}\n\nSwitch to ${mainBranch} (e.g. 'git checkout ${mainBranch}'), then re-run /gsd worktree merge ${target}.`,
+        "error",
+      );
+    } else {
+      ctx.ui.notify(
+        `Merge failed: ${msg}\n\nResolve conflicts manually, then run /gsd worktree merge ${target} again.`,
+        "error",
+      );
+    }
+  }
+}
+
+// ─── Subcommand: clean ──────────────────────────────────────────────────────
+
+async function handleClean(ctx: ExtensionCommandContext): Promise<void> {
+  const basePath = projectRoot();
+  const worktrees = listWorktrees(basePath);
+  if (worktrees.length === 0) {
+    ctx.ui.notify("No worktrees to clean.", "info");
+    return;
+  }
+
+  const removed: string[] = [];
+  const kept: string[] = [];
+  for (const wt of worktrees) {
+    const status = getStatus(basePath, wt.name, wt.path);
+    if (status.filesChanged === 0 && !status.uncommitted) {
+      try {
+        removeWorktree(basePath, wt.name, { deleteBranch: true });
+        removed.push(wt.name);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        kept.push(`${wt.name} (failed: ${msg})`);
+      }
+    } else {
+      const reason = !status.exists
+        ? "directory missing — run 'git worktree prune' to unregister"
+        : `${status.filesChanged} changed file${status.filesChanged === 1 ? "" : "s"}`;
+      kept.push(`${wt.name} (${reason})`);
+    }
+  }
+
+  const lines: string[] = [`Cleaned ${removed.length} worktree${removed.length === 1 ? "" : "s"}.`];
+  if (removed.length > 0) {
+    lines.push("", "Removed:");
+    for (const n of removed) lines.push(`  ✓ ${n}`);
+  }
+  if (kept.length > 0) {
+    lines.push("", "Kept:");
+    for (const n of kept) lines.push(`  ─ ${n}`);
+  }
+  ctx.ui.notify(lines.join("\n"), "info");
+}
+
+// ─── Subcommand: remove ─────────────────────────────────────────────────────
+
+async function handleRemove(args: string, ctx: ExtensionCommandContext): Promise<void> {
+  const basePath = projectRoot();
+  const tokens = args.trim().split(/\s+/).filter(Boolean);
+  const force = tokens.includes("--force");
+  const name = tokens.find((t) => t !== "--force");
+  if (!name) {
+    ctx.ui.notify("Usage: /gsd worktree remove <name> [--force]", "warning");
+    return;
+  }
+
+  const worktrees = listWorktrees(basePath);
+  const wt = worktrees.find((w) => w.name === name);
+  if (!wt) {
+    const available = worktrees.map((w) => w.name).join(", ") || "(none)";
+    ctx.ui.notify(`Worktree "${name}" not found.\n\nAvailable: ${available}`, "error");
+    return;
+  }
+
+  const status = getStatus(basePath, name, wt.path);
+  if ((status.filesChanged > 0 || status.uncommitted) && !force) {
+    ctx.ui.notify(
+      [
+        `Worktree "${name}" has unmerged changes (${status.filesChanged} file${status.filesChanged === 1 ? "" : "s"}).`,
+        "",
+        `  Merge first:     /gsd worktree merge ${name}`,
+        `  Or force-remove: /gsd worktree remove ${name} --force`,
+      ].join("\n"),
+      "warning",
+    );
+    return;
+  }
+
+  try {
+    removeWorktree(basePath, name, { deleteBranch: true });
+    ctx.ui.notify(`Removed worktree ${name}.`, "info");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(
+      `Worktree partially removed: ${msg}\n\nRun 'git worktree prune' to clean up any dangling registrations.`,
+      "error",
+    );
+  }
+}
+
+// ─── Help text ──────────────────────────────────────────────────────────────
+
+const HELP_TEXT = [
+  "Usage: /gsd worktree <command> [args]",
+  "",
+  "Commands:",
+  "  list                       Show all worktrees with status",
+  "  merge [name]               Merge a worktree into main, then remove it",
+  "  remove <name> [--force]    Remove a worktree (refuses unmerged changes without --force)",
+  "  clean                      Remove all merged/empty worktrees",
+  "",
+  "The -w flag (CLI only) creates/resumes worktrees on session start:",
+  "  gsd -w               Auto-name a new worktree, or resume the only active one",
+  "  gsd -w my-feature    Create or resume a named worktree",
+].join("\n");
+
+// ─── Dispatcher ─────────────────────────────────────────────────────────────
+
+export async function handleWorktree(args: string, ctx: ExtensionCommandContext): Promise<void> {
+  const trimmed = args.trim();
+  const lowered = trimmed.toLowerCase();
+
+  if (!lowered || lowered === "help" || lowered === "--help" || lowered === "-h") {
+    ctx.ui.notify(HELP_TEXT, "info");
+    return;
+  }
+
+  try {
+    if (lowered === "list" || lowered === "ls") {
+      await handleList(ctx);
+      return;
+    }
+    if (lowered === "merge" || lowered.startsWith("merge ")) {
+      await handleMerge(trimmed.replace(/^merge\s*/i, ""), ctx);
+      return;
+    }
+    if (lowered === "clean") {
+      await handleClean(ctx);
+      return;
+    }
+    if (
+      lowered === "remove" ||
+      lowered.startsWith("remove ") ||
+      lowered === "rm" ||
+      lowered.startsWith("rm ")
+    ) {
+      const stripped = trimmed.replace(/^(remove|rm)\s*/i, "");
+      await handleRemove(stripped, ctx);
+      return;
+    }
+
+    ctx.ui.notify(`Unknown worktree command: ${trimmed}\n\n${HELP_TEXT}`, "warning");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(`Worktree command failed: ${msg}`, "error");
+  }
+}

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -15,7 +15,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|fast|mcp|rethink|workflow|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language";
+  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|fast|mcp|rethink|workflow|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language|worktree";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -84,6 +84,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "add-tests", desc: "Generate tests for completed slices" },
   { cmd: "scan", desc: "Rapid codebase assessment — lightweight alternative to full map (--focus tech|arch|quality|concerns|tech+arch)" },
   { cmd: "language", desc: "Set or clear the global response language (e.g. /gsd language Chinese)" },
+  { cmd: "worktree", desc: "Manage worktrees from the TUI (list, merge, clean, remove)" },
 ];
 
 const NESTED_COMPLETIONS: CompletionMap = {
@@ -299,6 +300,12 @@ const NESTED_COMPLETIONS: CompletionMap = {
   language: [
     { cmd: "off",   desc: "Clear the language preference (revert to default)" },
     { cmd: "clear", desc: "Alias for off — clear the language preference" },
+  ],
+  worktree: [
+    { cmd: "list",   desc: "Show all worktrees with status" },
+    { cmd: "merge",  desc: "Merge a worktree into main and clean up" },
+    { cmd: "clean",  desc: "Remove all merged/empty worktrees" },
+    { cmd: "remove", desc: "Remove a worktree (--force to skip safety checks)" },
   ],
 };
 

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -130,6 +130,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd forensics      Examine execution logs and post-mortem analysis",
     "  /gsd export         Export milestone/slice results  [--json|--markdown|--html] [--all]",
     "  /gsd cleanup        Remove merged branches or snapshots  [branches|snapshots]",
+    "  /gsd worktree       Manage worktrees from the TUI  [list|merge|clean|remove]",
     "  /gsd migrate        Migrate .planning/ (v1) to .gsd/ (v2) format",
     "  /gsd remote         Control remote auto-mode  [slack|discord|status|disconnect]",
     "  /gsd inspect        Show SQLite DB diagnostics (schema, row counts, recent entries)",

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -262,5 +262,15 @@ Examples:
     await handleScan(trimmed.replace(/^scan\s*/, "").trim(), ctx, pi);
     return true;
   }
+  if (
+    trimmed === "worktree" ||
+    trimmed.startsWith("worktree ") ||
+    trimmed === "wt" ||
+    trimmed.startsWith("wt ")
+  ) {
+    const { handleWorktree } = await import("../../commands-worktree.js");
+    await handleWorktree(trimmed.replace(/^(worktree|wt)\s*/, "").trim(), ctx);
+    return true;
+  }
   return false;
 }

--- a/src/resources/extensions/gsd/tests/commands-worktree-clean.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-worktree-clean.test.ts
@@ -31,3 +31,18 @@ test("clean keep reason includes uncommitted context with changed files", () => 
   const reason = formatCleanKeepReason(mkStatus({ filesChanged: 2, uncommitted: true }));
   assert.equal(reason, "2 changed files, uncommitted");
 });
+
+test("clean keep reason flags missing directory with prune hint", () => {
+  const reason = formatCleanKeepReason(mkStatus({ exists: false }));
+  assert.equal(reason, "directory missing — run 'git worktree prune' to unregister");
+});
+
+test("clean keep reason reports changed files without uncommitted suffix", () => {
+  const reason = formatCleanKeepReason(mkStatus({ filesChanged: 2, uncommitted: false }));
+  assert.equal(reason, "2 changed files");
+});
+
+test("clean keep reason uses singular form for a single changed file", () => {
+  const reason = formatCleanKeepReason(mkStatus({ filesChanged: 1, uncommitted: false }));
+  assert.equal(reason, "1 changed file");
+});

--- a/src/resources/extensions/gsd/tests/commands-worktree-clean.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-worktree-clean.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  formatCleanKeepReason,
+  type WorktreeStatus,
+} from "../commands-worktree.ts";
+
+function mkStatus(over: Partial<WorktreeStatus>): WorktreeStatus {
+  const name = over.name ?? "feat-x";
+  return {
+    name,
+    path: `/repo/.gsd/worktrees/${name}`,
+    branch: `gsd/${name}`,
+    exists: true,
+    filesChanged: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    uncommitted: false,
+    commits: 0,
+    ...over,
+  };
+}
+
+test("clean keep reason shows uncommitted-only worktrees clearly", () => {
+  const reason = formatCleanKeepReason(mkStatus({ uncommitted: true }));
+  assert.equal(reason, "uncommitted changes");
+});
+
+test("clean keep reason includes uncommitted context with changed files", () => {
+  const reason = formatCleanKeepReason(mkStatus({ filesChanged: 2, uncommitted: true }));
+  assert.equal(reason, "2 changed files, uncommitted");
+});

--- a/src/tests/commands-worktree.test.ts
+++ b/src/tests/commands-worktree.test.ts
@@ -53,7 +53,7 @@ test("unmerged worktree shows (unmerged) badge with diff stats", () => {
     }),
   ]);
   assert.match(out, /feature-y \(unmerged\)/);
-  assert.match(out, /3 files, \+42 -7, 2 commits/);
+  assert.match(out, /\bdiff\s+3 files, \+42 -7, 2 commits\b/);
 });
 
 test("singular file/commit pluralization", () => {
@@ -66,7 +66,7 @@ test("singular file/commit pluralization", () => {
       commits: 1,
     }),
   ]);
-  assert.match(out, /1 file, \+1 -0, 1 commit/);
+  assert.match(out, /\bdiff\s+1 file, \+1 -0, 1 commit\b/);
 });
 
 test("count header matches number of worktrees", () => {

--- a/src/tests/commands-worktree.test.ts
+++ b/src/tests/commands-worktree.test.ts
@@ -1,0 +1,79 @@
+// GSD-2 — Unit tests for /gsd worktree formatter and dispatcher
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  formatWorktreeList,
+  type WorktreeStatus,
+} from "../../dist/resources/extensions/gsd/commands-worktree.js";
+
+function mkStatus(over: Partial<WorktreeStatus>): WorktreeStatus {
+  const name = over.name ?? "feat-x";
+  return {
+    name,
+    path: `/repo/.gsd/worktrees/${name}`,
+    branch: `gsd/${name}`,
+    exists: true,
+    filesChanged: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    uncommitted: false,
+    commits: 0,
+    ...over,
+  };
+}
+
+test("empty list shows hint to create one", () => {
+  const out = formatWorktreeList([]);
+  assert.match(out, /No worktrees\./);
+  assert.match(out, /gsd -w/);
+});
+
+test("clean worktree shows (clean) badge and no diff line", () => {
+  const out = formatWorktreeList([mkStatus({ name: "alpha" })]);
+  assert.match(out, /alpha \(clean\)/);
+  assert.match(out, /branch\s+gsd\/alpha/);
+  assert.match(out, /path\s+\/repo\/\.gsd/);
+  assert.doesNotMatch(out, /diff\s+/);
+});
+
+test("uncommitted worktree shows (uncommitted) badge", () => {
+  const out = formatWorktreeList([mkStatus({ name: "wip", uncommitted: true })]);
+  assert.match(out, /wip \(uncommitted\)/);
+});
+
+test("unmerged worktree shows (unmerged) badge with diff stats", () => {
+  const out = formatWorktreeList([
+    mkStatus({
+      name: "feature-y",
+      filesChanged: 3,
+      linesAdded: 42,
+      linesRemoved: 7,
+      commits: 2,
+    }),
+  ]);
+  assert.match(out, /feature-y \(unmerged\)/);
+  assert.match(out, /3 files, \+42 -7, 2 commits/);
+});
+
+test("singular file/commit pluralization", () => {
+  const out = formatWorktreeList([
+    mkStatus({
+      name: "single",
+      filesChanged: 1,
+      linesAdded: 1,
+      linesRemoved: 0,
+      commits: 1,
+    }),
+  ]);
+  assert.match(out, /1 file, \+1 -0, 1 commit/);
+});
+
+test("count header matches number of worktrees", () => {
+  const out = formatWorktreeList([
+    mkStatus({ name: "a" }),
+    mkStatus({ name: "b" }),
+    mkStatus({ name: "c" }),
+  ]);
+  assert.match(out, /Worktrees — 3/);
+});


### PR DESCRIPTION
## Linked issue

Closes #5054

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Wire `/gsd worktree {list,merge,clean,remove}` into the TUI slash-command dispatcher so they work inside the TUI, not just the CLI.
**Why:** Every invocation of `/gsd worktree ...` in the TUI currently falls through to `Warning: Unknown command` because the dispatcher had no route for the `worktree`/`wt` prefix.
**How:** New `commands-worktree.ts` handler reusing existing extension modules; new dispatcher route in `ops.ts` with lazy import; help text and tab-completion wired up.

## What

Five files changed:

- **`src/resources/extensions/gsd/commands-worktree.ts`** (new) — in-TUI handler implementing `list`, `merge`, `clean`, and `remove`. Reuses `worktree-manager.ts`, `native-git-bridge.ts`, `git-service.ts`, and `worktree.ts` — the same modules the CLI calls. Results are emitted via `ctx.ui.notify(...)` rather than writing colored output to stderr.
- **`src/resources/extensions/gsd/commands/handlers/ops.ts`** (modified) — added one dispatcher route catching the `worktree` / `wt` prefix (with optional subcommand and args) and lazy-importing the handler.
- **`src/resources/extensions/gsd/commands/handlers/core.ts`** (modified) — one new line adding `worktree` to the MAINTENANCE section of `/gsd help`.
- **`src/resources/extensions/gsd/commands/catalog.ts`** (modified) — added `worktree` to `GSD_COMMAND_DESCRIPTION`, `TOP_LEVEL_SUBCOMMANDS`, and a nested completion block for the four subcommands.
- **`src/tests/commands-worktree.test.ts`** (new) — 6 unit tests covering the output formatter: empty list hint, clean/uncommitted/unmerged badges, diff-stat display, plural/singular counts, and count header correctness.

No CLI behavior changes. No breaking changes.

## Why

The `gsd worktree` CLI subcommands are fully implemented and documented, but the TUI dispatcher had no route for them. Users who live in the TUI had to drop to a plain shell for every worktree operation — breaking the TUI-centric multi-worktree workflow described in `docs/working-in-teams.md`.

Closes #5054.

## How

The dispatcher route in `ops.ts` follows the same lazy-import pattern used by other `ops.ts` entries. The handler uses `projectRoot()` (not `process.cwd()`) as `basePath` to resolve correctly inside worktree contexts.

Three correctness issues found in peer review and addressed before this PR:

1. **Merge catch block (HIGH):** Previously emitted a "resolve conflicts manually" hint for all errors. `mergeWorktreeToMain` actually throws `GSDError(GSD_GIT_ERROR, ...)` when the caller is not on the main branch — distinct from `GSDError(GSD_MERGE_CONFLICT, ...)`. Fixed by branching the catch on `err instanceof GSDError && err.code === GSD_GIT_ERROR` and emitting a "switch to `{mainBranch}` first" message instead.
2. **handleClean orphan display (MEDIUM):** Orphaned worktrees (directory deleted, branch still registered) were listed under "Kept" with the misleading label `"{name} (N changed files)"`. Fixed by checking `!status.exists` and emitting `"directory missing — run 'git worktree prune' to unregister"` instead.
3. **removeWorktree failure handling (LOW):** Bare `removeWorktree` calls in `handleMerge` (empty-worktree path) and `handleRemove` were unguarded. Wrapped in `try/catch` blocks that emit a "partially removed — run `git worktree prune`" hint instead of falling through to the generic top-level handler.

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Build and test results on this branch:

```
npm run build       → clean (0 errors)

node --test src/tests/commands-worktree.test.ts src/tests/welcome-screen.test.ts
✔ empty list shows hint to create one
✔ clean worktree shows (clean) badge and no diff line
✔ uncommitted worktree shows (uncommitted) badge
✔ unmerged worktree shows (unmerged) badge with diff stats
✔ singular file/commit pluralization
✔ count header matches number of worktrees
✔ renders GSD logo
✔ renders version
✔ renders GSD project state or fallback hint
✔ renders cwd hint
✔ skips when not a TTY
✔ renders without model or provider
✔ renders remote channel in tools row
✔ omits remote channel when not provided
✔ Active row truncates with ellipsis when milestone text overflows panel width
✔ Active row does not truncate short milestone text
✔ separator lines extend to full terminal width on wide terminals

pass 17 / 17  |  fail 0
```

Manual verification: typed `/gsd worktree list` inside TUI before this change → `Warning: Unknown`. After this change → formatted worktree table with badge per entry.

## AI disclosure

- [x] This PR includes AI-assisted code — implementation reviewed and peer-reviewed by Codex; all three flagged issues were addressed before commit; contributor can explain every changed line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/gsd worktree` (alias `/gsd wt`) with `list`/`ls`, `merge`, `clean`, and `remove` for TUI worktree management. `merge` may auto-commit dirty worktrees, auto-select a single target, integrates into the detected main branch, and reports post-merge cleanup status. `clean` removes only merged/empty worktrees; `remove` refuses unsafe deletes unless `--force` and reports partial-removal issues.

* **Documentation**
  * Updated help, README, and user docs describing the new worktree commands and safety behaviors.

* **Tests**
  * Added unit tests for list formatting, clean-reason messaging, and related output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->