### PR TITLE
fix(safety): persist bash evidence at tool_call to close mid-unit re-dispatch race

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -445,6 +445,19 @@ export function registerHooks(
     markToolStart(event.toolCallId, event.toolName);
     safetyRecordToolCall(event.toolCallId, event.toolName, event.input as Record<string, unknown>);
 
+    // Persist immediately at dispatch so a mid-unit re-dispatch — which calls
+    // resetEvidence() + loadEvidenceFromDisk() in runUnitPhase — cannot wipe
+    // the entry between tool_call and tool_execution_end. Without this, the
+    // race window equals the tool's runtime, producing the "no bash calls"
+    // false positive when the LLM clearly ran a verification command.
+    const callDash = getAutoRuntimeSnapshot();
+    if (callDash.basePath && callDash.currentUnit?.type === "execute-task") {
+      const { milestone: cMid, slice: cSid, task: cTid } = parseUnitId(callDash.currentUnit.id);
+      if (cMid && cSid && cTid) {
+        saveEvidenceToDisk(callDash.basePath, cMid, cSid, cTid);
+      }
+    }
+
     // Destructive command classification (warn only, never block)
     if (isToolCallEventType("bash", event)) {
       const classification = classifyCommand(event.input.command);

--- a/src/resources/extensions/gsd/tests/safety-harness-false-positives.test.ts
+++ b/src/resources/extensions/gsd/tests/safety-harness-false-positives.test.ts
@@ -18,9 +18,11 @@ import { shouldBlockQueueExecution } from "../bootstrap/write-gate.ts";
 import {
   resetEvidence,
   recordToolCall,
+  recordToolResult,
   getEvidence,
   saveEvidenceToDisk,
   loadEvidenceFromDisk,
+  type BashEvidence,
 } from "../safety/evidence-collector.ts";
 import { validateFileChanges } from "../safety/file-change-validator.ts";
 
@@ -108,6 +110,38 @@ test("safety-harness-bug2: loadEvidenceFromDisk returns empty array when no file
   resetEvidence();
   loadEvidenceFromDisk(base, "M001", "S001", "T001");
   assert.equal(getEvidence().length, 0, "no evidence on fresh unit is correct — not a false positive");
+});
+
+test("safety-harness-bug2-race: bash evidence survives mid-unit reset between tool_call and tool_execution_end", (t) => {
+  // Reproduces the race where runUnitPhase re-fires (resetEvidence + loadEvidenceFromDisk)
+  // between a bash tool_call and its tool_execution_end. Pre-fix, the call entry lived
+  // only in memory until tool_execution_end; the reset wiped it and recordToolResult
+  // silently no-op'd, producing the "task complete with no bash calls" false positive.
+  // Post-fix, register-hooks.ts persists at tool_call time too — so the entry survives
+  // the reset via the disk round-trip.
+  const base = mkdtempSync(join(tmpdir(), "gsd-evidence-race-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  resetEvidence();
+
+  // tool_call fires: record AND persist (post-fix register-hooks.ts behavior).
+  recordToolCall("tc-bash-1", "bash", { command: "grep -q saveTodos app.js" });
+  saveEvidenceToDisk(base, "M001", "S01", "T02");
+
+  // Mid-unit race: runUnitPhase re-fires, calling resetEvidence + loadEvidenceFromDisk.
+  resetEvidence();
+  assert.equal(getEvidence().length, 0, "memory cleared by mid-unit reset");
+  loadEvidenceFromDisk(base, "M001", "S01", "T02");
+  assert.equal(getEvidence().length, 1, "entry restored from disk-persisted tool_call");
+
+  // tool_execution_end fires: result must update the restored entry by toolCallId.
+  recordToolResult("tc-bash-1", "bash", "Command exited with code 0\nfound\n", false);
+
+  const bash = getEvidence().filter((e): e is BashEvidence => e.kind === "bash");
+  assert.equal(bash.length, 1, "bash entry must survive race + result update");
+  assert.equal(bash[0].exitCode, 0, "result populated the restored entry");
+  assert.equal(bash[0].command, "grep -q saveTodos app.js", "command preserved across race");
+  assert.ok(bash[0].outputSnippet.includes("found"), "output snippet captured");
 });
 
 // ─── Bug 3: git diff HEAD~1 scope check ─────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Persist the safety-harness evidence file at `tool_call` time, not only at `tool_execution_end`.
**Why:** A `runUnitPhase` re-dispatch firing between `tool_call` and `tool_execution_end` wipes in-memory evidence, leaving disk empty, which produces a false-positive \"no bash calls were recorded\" warning.
**How:** Mirror the existing execute-task persistence guard in the `tool_call` hook so the disk file exists from dispatch onward and `loadEvidenceFromDisk()` can restore the entry across any mid-unit reset.

## What

- `src/resources/extensions/gsd/bootstrap/register-hooks.ts` — adds a `saveEvidenceToDisk()` call inside the `tool_call` handler, gated by the same `currentUnit?.type === \"execute-task\"` check used at `tool_execution_end` (`register-hooks.ts:580-586`).
- `src/resources/extensions/gsd/tests/safety-harness-false-positives.test.ts` — adds `safety-harness-bug2-race`, a regression test that deterministically simulates the race (`recordToolCall → saveEvidenceToDisk → resetEvidence → loadEvidenceFromDisk → recordToolResult`) and asserts the bash entry survives intact with its result populated.

## Why

Closes #5056.

The safety harness writes bash evidence in two phases:

1. `pi.on(\"tool_call\", …)` calls `safetyRecordToolCall()` — appends `{kind: \"bash\", …}` to the module-level `unitEvidence` array. **No disk write before this PR.**
2. `pi.on(\"tool_execution_end\", …)` calls `safetyRecordToolResult()` to update the entry with the result, then `saveEvidenceToDisk()`.

Between (1) and (2) the bash command is actually executing — that window can be seconds to minutes. If `runUnitPhase` re-fires during that window, it calls `resetEvidence()` then `loadEvidenceFromDisk()` (`phases.ts:~1447`). Because step 1 never persisted, the disk file has no entry, the in-memory array is now empty, and `recordToolResult()` at `evidence-collector.ts:228-229` silently no-ops because no entry matches the `toolCallId`. The post-unit check at `auto-post-unit.ts:825-839` then sees zero bash evidence and emits the false-positive warning — even though the bash call clearly ran (output visible in the TUI).

PR #4576 (the persistence work for bug #4385) closed the **session-restart** version of this gap by writing on `tool_execution_end`. It did not close the **mid-process re-dispatch** version because the in-memory wipe can happen before `tool_execution_end` fires.

This bug is symptom-equivalent to #4909 but has a different root cause; #4909 is independent and intentionally not closed by this PR.

## How

The `tool_call` hook now calls `saveEvidenceToDisk()` immediately after `safetyRecordToolCall()`, using the same `getAutoRuntimeSnapshot()` accessor and the same execute-task / `parseUnitId` guard as the existing `tool_execution_end` persistence path. Both `safetyRecordToolCall()` and `saveEvidenceToDisk()` are synchronous, so they execute as one unit before any Node.js yield — closing the race window entirely.

Cost: one small atomic JSON write (`writeFileSync(tmp) + renameSync`) per tool dispatch in execute-task units. Files are small (hundreds of bytes for typical task evidence). At 3–15 tools per task this is negligible.

The regression test calls `saveEvidenceToDisk` directly to simulate the new hook behavior — it verifies the **collector-level** invariant that a restored entry can still be matched by `toolCallId` after a `recordToolResult` post-reset. This is the specific link that was broken pre-fix and is not covered by the existing `safety-harness-bug2` round-trip test.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Test plan

- [x] All 17 tests in `safety-harness-false-positives.test.ts` and `auto-retry-mcp-churn-fixes.test.ts` pass on the compiled production build path (`test:compile` + `node --test`).
- [x] `typecheck:extensions` reports only one pre-existing error at `register-hooks.ts:58` (unrelated; verified by stashing the diff).
- [ ] Reviewer should checkout the branch and run `npm run verify:pr` (CONTRIBUTING.md §What reviewers verify).

## Disclosure

This PR is AI-assisted. Diagnosis, patch, and regression test were drafted with Claude Opus 4.7. Independent peer review by Codex CLI validated the fix as correct, race-complete, and properly scoped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed race condition causing false "no bash calls" errors by improving evidence persistence for tool calls in auto-mode, ensuring evidence survives temporary resets and reloads.

* **Tests**
  * Added test coverage for evidence recovery scenarios, verifying execution details including command, exit code, and output are properly preserved during evidence reset cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->