### PR TITLE
fix(gsd): anchor subagent dispatch to canonical worktree path

### DIFF
--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -30,6 +30,8 @@ import {
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { pauseAuto } from "./auto.js";
+import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
+import { logWarning } from "./workflow-logger.js";
 import {
   getWorkflowTransportSupportError,
   getRequiredWorkflowToolsForAutoUnit,
@@ -49,6 +51,12 @@ export async function dispatchDirectPhase(
     ctx.ui.notify("Cannot dispatch: no active milestone.", "warning");
     return;
   }
+
+  // Switch the dispatch base to the canonical milestone worktree if one
+  // exists. Without this, /gsd dispatch invoked from the project root would
+  // build prompts and create a session anchored to the project root even
+  // though the milestone's actual code lives in the worktree.
+  base = resolveCanonicalMilestoneRoot(base, mid);
 
   const normalized = phase.toLowerCase();
   let unitType: string;
@@ -277,6 +285,17 @@ export async function dispatchDirectPhase(
   }
 
   ctx.ui.notify(`Dispatching ${unitType} for ${unitId}...`, "info");
+
+  // Ensure cwd matches base BEFORE newSession() captures it. Synchronous —
+  // no awaits between chdir and newSession.
+  try {
+    if (process.cwd() !== base) {
+      process.chdir(base);
+    }
+  } catch (err) {
+    logWarning("engine", `chdir failed before direct-dispatch newSession: ${err instanceof Error ? err.message : String(err)}`, { file: "auto-direct-dispatch.ts" });
+  }
+
   const result = await ctx.newSession();
   if (result.cancelled) {
     ctx.ui.notify("Session creation cancelled.", "warning");

--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -52,6 +52,8 @@ export async function dispatchDirectPhase(
     return;
   }
 
+  const projectRoot = base;
+
   // Switch the dispatch base to the canonical milestone worktree if one
   // exists. Without this, /gsd dispatch invoked from the project root would
   // build prompts and create a session anchored to the project root even
@@ -272,7 +274,7 @@ export async function dispatchDirectPhase(
     ctx.model?.provider,
     getRequiredWorkflowToolsForAutoUnit(unitType),
     {
-      projectRoot: base,
+      projectRoot,
       surface: "direct phase dispatch",
       unitType,
       authMode: ctx.model?.provider ? ctx.modelRegistry.getProviderAuthMode(ctx.model.provider) : undefined,
@@ -293,7 +295,10 @@ export async function dispatchDirectPhase(
       process.chdir(base);
     }
   } catch (err) {
-    logWarning("engine", `chdir failed before direct-dispatch newSession: ${err instanceof Error ? err.message : String(err)}`, { file: "auto-direct-dispatch.ts" });
+    const msg = `Failed to chdir before direct-dispatch newSession (basePath: ${base}): ${err instanceof Error ? err.message : String(err)}`;
+    logWarning("engine", msg, { file: "auto-direct-dispatch.ts", basePath: base, error: err instanceof Error ? err.message : String(err) });
+    ctx.ui.notify(`${msg}. Cancelling dispatch to avoid running in the wrong directory.`, "error");
+    return;
   }
 
   const result = await ctx.newSession();

--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -58,7 +58,7 @@ export async function dispatchDirectPhase(
   // exists. Without this, /gsd dispatch invoked from the project root would
   // build prompts and create a session anchored to the project root even
   // though the milestone's actual code lives in the worktree.
-  base = resolveCanonicalMilestoneRoot(base, mid);
+  const dispatchBase = resolveCanonicalMilestoneRoot(base, mid);
 
   const normalized = phase.toLowerCase();
   let unitType: string;
@@ -80,7 +80,7 @@ export async function dispatchDirectPhase(
 
         // When require_slice_discussion is enabled, pause auto-mode before
         // each new slice so the user can discuss requirements first (#789).
-        const sliceContextFile = resolveSliceFile(base, mid, sid, "CONTEXT");
+        const sliceContextFile = resolveSliceFile(dispatchBase, mid, sid, "CONTEXT");
         const requireDiscussion = loadEffectiveGSDPreferences()?.preferences?.phases?.require_slice_discussion;
         if (requireDiscussion && !sliceContextFile) {
           ctx.ui.notify(
@@ -93,11 +93,11 @@ export async function dispatchDirectPhase(
 
         unitType = "research-slice";
         unitId = `${mid}/${sid}`;
-        prompt = await buildResearchSlicePrompt(mid, midTitle, sid, sTitle, base);
+        prompt = await buildResearchSlicePrompt(mid, midTitle, sid, sTitle, dispatchBase);
       } else {
         unitType = "research-milestone";
         unitId = mid;
-        prompt = await buildResearchMilestonePrompt(mid, midTitle, base);
+        prompt = await buildResearchMilestonePrompt(mid, midTitle, dispatchBase);
       }
       break;
     }
@@ -116,7 +116,7 @@ export async function dispatchDirectPhase(
         unitType = "plan-slice";
         unitId = `${mid}/${sid}`;
         prompt = await buildPlanSlicePrompt(
-          mid, midTitle, sid, sTitle, base, undefined,
+          mid, midTitle, sid, sTitle, dispatchBase, undefined,
           {
             sessionContextWindow: ctx.model?.contextWindow,
             modelRegistry: ctx.modelRegistry as MinimalModelRegistry | undefined,
@@ -125,7 +125,7 @@ export async function dispatchDirectPhase(
       } else {
         unitType = "plan-milestone";
         unitId = mid;
-        prompt = await buildPlanMilestonePrompt(mid, midTitle, base);
+        prompt = await buildPlanMilestonePrompt(mid, midTitle, dispatchBase);
       }
       break;
     }
@@ -147,7 +147,7 @@ export async function dispatchDirectPhase(
       unitType = "execute-task";
       unitId = `${mid}/${sid}/${tid}`;
       prompt = await buildExecuteTaskPrompt(
-        mid, sid, sTitle, tid, tTitle, base,
+        mid, sid, sTitle, tid, tTitle, dispatchBase,
         {
           sessionContextWindow: ctx.model?.contextWindow,
           modelRegistry: ctx.modelRegistry as MinimalModelRegistry | undefined,
@@ -169,11 +169,11 @@ export async function dispatchDirectPhase(
         }
         unitType = "complete-slice";
         unitId = `${mid}/${sid}`;
-        prompt = await buildCompleteSlicePrompt(mid, midTitle, sid, sTitle, base);
+        prompt = await buildCompleteSlicePrompt(mid, midTitle, sid, sTitle, dispatchBase);
       } else {
         unitType = "complete-milestone";
         unitId = mid;
-        prompt = await buildCompleteMilestonePrompt(mid, midTitle, base);
+        prompt = await buildCompleteMilestonePrompt(mid, midTitle, dispatchBase);
       }
       break;
     }
@@ -187,7 +187,7 @@ export async function dispatchDirectPhase(
       }
       if (completedSliceIds.length === 0) {
         // File-based fallback: parse roadmap checkboxes
-        const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
+        const roadmapPath = resolveMilestoneFile(dispatchBase, mid, "ROADMAP");
         if (roadmapPath) {
           const roadmapContent = await loadFile(roadmapPath);
           if (roadmapContent) {
@@ -202,7 +202,7 @@ export async function dispatchDirectPhase(
       const completedSliceId = completedSliceIds[completedSliceIds.length - 1];
       unitType = "reassess-roadmap";
       unitId = `${mid}/${completedSliceId}`;
-      prompt = await buildReassessRoadmapPrompt(mid, midTitle, completedSliceId, base);
+      prompt = await buildReassessRoadmapPrompt(mid, midTitle, completedSliceId, dispatchBase);
       break;
     }
 
@@ -218,7 +218,7 @@ export async function dispatchDirectPhase(
       }
       if (uatCompletedSliceIds.length === 0) {
         // File-based fallback: parse roadmap checkboxes
-        const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
+        const roadmapPath = resolveMilestoneFile(dispatchBase, mid, "ROADMAP");
         if (roadmapPath) {
           const roadmapContent = await loadFile(roadmapPath);
           if (roadmapContent) {
@@ -231,7 +231,7 @@ export async function dispatchDirectPhase(
         return;
       }
       const sid = uatCompletedSliceIds[uatCompletedSliceIds.length - 1];
-      const uatFile = resolveSliceFile(base, mid, sid, "UAT");
+      const uatFile = resolveSliceFile(dispatchBase, mid, sid, "UAT");
       if (!uatFile) {
         ctx.ui.notify("Cannot dispatch run-uat: no UAT file found.", "warning");
         return;
@@ -241,10 +241,10 @@ export async function dispatchDirectPhase(
         ctx.ui.notify("Cannot dispatch run-uat: UAT file is empty.", "warning");
         return;
       }
-      const uatPath = relSliceFile(base, mid, sid, "UAT");
+      const uatPath = relSliceFile(dispatchBase, mid, sid, "UAT");
       unitType = "run-uat";
       unitId = `${mid}/${sid}`;
-      prompt = await buildRunUatPrompt(mid, sid, uatPath, uatContent, base);
+      prompt = await buildRunUatPrompt(mid, sid, uatPath, uatContent, dispatchBase);
       break;
     }
 
@@ -258,7 +258,7 @@ export async function dispatchDirectPhase(
       }
       unitType = "replan-slice";
       unitId = `${mid}/${sid}`;
-      prompt = await buildReplanSlicePrompt(mid, midTitle, sid, sTitle, base);
+      prompt = await buildReplanSlicePrompt(mid, midTitle, sid, sTitle, dispatchBase);
       break;
     }
 
@@ -288,26 +288,38 @@ export async function dispatchDirectPhase(
 
   ctx.ui.notify(`Dispatching ${unitType} for ${unitId}...`, "info");
 
-  // Ensure cwd matches base BEFORE newSession() captures it. Synchronous —
-  // no awaits between chdir and newSession.
-  try {
-    if (process.cwd() !== base) {
-      process.chdir(base);
-    }
-  } catch (err) {
-    const msg = `Failed to chdir before direct-dispatch newSession (basePath: ${base}): ${err instanceof Error ? err.message : String(err)}`;
-    logWarning("engine", msg, { file: "auto-direct-dispatch.ts", basePath: base, error: err instanceof Error ? err.message : String(err) });
-    ctx.ui.notify(`${msg}. Cancelling dispatch to avoid running in the wrong directory.`, "error");
-    return;
-  }
+  const originalCwd = process.cwd();
 
-  const result = await ctx.newSession();
-  if (result.cancelled) {
-    ctx.ui.notify("Session creation cancelled.", "warning");
-    return;
+  try {
+    // Ensure cwd matches dispatchBase BEFORE newSession() captures it. Synchronous —
+    // no awaits between chdir and newSession.
+    try {
+      if (process.cwd() !== dispatchBase) {
+        process.chdir(dispatchBase);
+      }
+    } catch (err) {
+      const msg = `Failed to chdir before direct-dispatch newSession (basePath: ${dispatchBase}): ${err instanceof Error ? err.message : String(err)}`;
+      logWarning("engine", msg, { file: "auto-direct-dispatch.ts", basePath: dispatchBase, error: err instanceof Error ? err.message : String(err) });
+      ctx.ui.notify(`${msg}. Cancelling dispatch to avoid running in the wrong directory.`, "error");
+      return;
+    }
+
+    const result = await ctx.newSession();
+    if (result.cancelled) {
+      ctx.ui.notify("Session creation cancelled.", "warning");
+      return;
+    }
+    pi.sendMessage(
+      { customType: "gsd-dispatch", content: prompt, display: false },
+      { triggerTurn: true },
+    );
+  } finally {
+    try {
+      if (process.cwd() !== originalCwd) {
+        process.chdir(originalCwd);
+      }
+    } catch (err) {
+      logWarning("engine", `Failed to restore cwd after direct dispatch: ${err instanceof Error ? err.message : String(err)}`, { file: "auto-direct-dispatch.ts", basePath: originalCwd });
+    }
   }
-  pi.sendMessage(
-    { customType: "gsd-dispatch", content: prompt, display: false },
-    { triggerTurn: true },
-  );
 }

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1209,6 +1209,7 @@ export async function buildDiscussMilestonePrompt(
   const discussTemplates = inlineTemplate("context", "Context");
 
   const basePrompt = loadPrompt("guided-discuss-milestone", {
+    workingDirectory: base,
     milestoneId: mid,
     milestoneTitle: midTitle,
     inlinedTemplates: discussTemplates,
@@ -2587,6 +2588,7 @@ export async function buildParallelResearchSlicesPrompt(
   }
 
   return loadPrompt("parallel-research-slices", {
+    workingDirectory: basePath,
     mid,
     midTitle,
     sliceCount: String(slices.length),
@@ -2629,6 +2631,8 @@ export async function buildGateEvaluatePrompt(
 
     const subPrompt = [
       `You are evaluating quality gate **${def.id}** for slice ${sid} (${sTitle}).`,
+      "",
+      `**Working directory:** \`${base}\``,
       "",
       `## Question: ${def.question}`,
       "",
@@ -2746,6 +2750,7 @@ export async function buildRewriteDocsPrompt(
   const documentList = docList.length > 0 ? docList.join("\n") : "- No active plan documents found.";
 
   return loadPrompt("rewrite-docs", {
+    workingDirectory: base,
     milestoneId: mid,
     milestoneTitle: midTitle,
     sliceId: sid ?? "none",

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -2632,7 +2632,7 @@ export async function buildGateEvaluatePrompt(
     const subPrompt = [
       `You are evaluating quality gate **${def.id}** for slice ${sid} (${sTitle}).`,
       "",
-      `**Working directory:** \`${base}\``,
+      `**Working directory:** \`${base}\`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT \`cd\` to any other directory.`,
       "",
       `## Question: ${def.question}`,
       "",

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -2625,6 +2625,7 @@ export async function buildGateEvaluatePrompt(
 
   const subagentSections: string[] = [];
   const gateListLines: string[] = [];
+  const normalizedBase = base.replaceAll("\\", "/");
 
   for (const def of gateDefs) {
     gateListLines.push(`- **${def.id}**: ${def.question}`);
@@ -2632,7 +2633,7 @@ export async function buildGateEvaluatePrompt(
     const subPrompt = [
       `You are evaluating quality gate **${def.id}** for slice ${sid} (${sTitle}).`,
       "",
-      `**Working directory:** \`${base}\`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT \`cd\` to any other directory.`,
+      `**Working directory:** \`${normalizedBase}\`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT \`cd\` to any other directory.`,
       "",
       `## Question: ${def.question}`,
       "",

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1883,6 +1883,14 @@ export async function dispatchHookUnit(
     startedAt: hookStartedAt,
   };
 
+  // Ensure cwd matches basePath BEFORE newSession() captures it (#1389).
+  // newSession() snapshots process.cwd() during construction; chdir-ing
+  // afterward leaves the session rooted to whatever cwd was when the call
+  // was made. Must be synchronous — no awaits between chdir and newSession.
+  try { if (process.cwd() !== s.basePath) process.chdir(s.basePath); } catch (err) {
+    logWarning("engine", `chdir failed before hook newSession: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
+  }
+
   const result = await s.cmdCtx!.newSession();
   if (result.cancelled) {
     await stopAuto(ctx, pi);
@@ -1938,11 +1946,6 @@ export async function dispatchHookUnit(
 
   ctx.ui.setStatus("gsd-auto", s.stepMode ? "next" : "auto");
   ctx.ui.notify(`Running post-unit hook: ${hookName}`, "info");
-
-  // Ensure cwd matches basePath before hook dispatch (#1389)
-  try { if (process.cwd() !== s.basePath) process.chdir(s.basePath); } catch (err) {
-    logWarning("engine", `chdir failed before hook dispatch: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
-  }
 
   debugLog("dispatchHookUnit", {
     phase: "send-message",

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1864,15 +1864,20 @@ export async function dispatchHookUnit(
   hookModel: string | undefined,
   targetBasePath: string,
 ): Promise<boolean> {
+  const wasActive = s.active;
+  const previousBasePath = s.basePath;
+  const previousCurrentUnit = s.currentUnit ? { ...s.currentUnit } : null;
+
   if (!s.active) {
     s.active = true;
     s.stepMode = true;
     s.cmdCtx = ctx as ExtensionCommandContext;
-    s.basePath = targetBasePath;
     s.autoStartTime = Date.now();
     s.currentUnit = null;
     s.pendingQuickTasks = [];
   }
+
+  s.basePath = targetBasePath;
 
   const hookUnitType = `hook/${hookName}`;
   const hookStartedAt = Date.now();
@@ -1888,7 +1893,16 @@ export async function dispatchHookUnit(
   // afterward leaves the session rooted to whatever cwd was when the call
   // was made. Must be synchronous — no awaits between chdir and newSession.
   try { if (process.cwd() !== s.basePath) process.chdir(s.basePath); } catch (err) {
-    logWarning("engine", `chdir failed before hook newSession: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
+    const msg = `Failed to chdir before hook newSession (basePath: ${s.basePath}): ${err instanceof Error ? err.message : String(err)}`;
+    logWarning("engine", msg, { file: "auto.ts", basePath: s.basePath, error: err instanceof Error ? err.message : String(err) });
+    ctx.ui.notify(`${msg}. Cancelling hook dispatch to avoid running in the wrong directory.`, "error");
+    if (wasActive) {
+      s.basePath = previousBasePath;
+      s.currentUnit = previousCurrentUnit;
+    } else {
+      s.reset();
+    }
+    return false;
   }
 
   const result = await s.cmdCtx!.newSession();

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -40,6 +40,20 @@ export async function runUnit(
 ): Promise<UnitResult> {
   debugLog("runUnit", { phase: "start", unitType, unitId });
 
+  // Ensure cwd matches basePath BEFORE newSession() captures it. The new
+  // session reads process.cwd() during construction to anchor its tool
+  // runtime and system prompt; if cwd has drifted (async_bash, background
+  // jobs, prior unit cleanup), the session would otherwise be rooted to
+  // the wrong directory. Must be synchronous — no awaits between chdir
+  // and newSession (#1389, #4762 follow-up).
+  try {
+    if (process.cwd() !== s.basePath) {
+      process.chdir(s.basePath);
+    }
+  } catch (e) {
+    logWarning("engine", "Failed to chdir to basePath before newSession", { basePath: s.basePath, error: String(e) });
+  }
+
   // ── Session creation with timeout ──
   debugLog("runUnit", { phase: "session-create", unitType, unitId });
 
@@ -119,17 +133,6 @@ export async function runUnit(
   const unitPromise = new Promise<UnitResult>((resolve) => {
     _setCurrentResolve(resolve);
   });
-
-  // Ensure cwd matches basePath before dispatch (#1389).
-  // async_bash and background jobs can drift cwd away from the worktree.
-  // Realigning here prevents commits from landing on the wrong branch.
-  try {
-    if (process.cwd() !== s.basePath) {
-      process.chdir(s.basePath);
-    }
-  } catch (e) {
-    logWarning("engine", "Failed to chdir to basePath before dispatch", { basePath: s.basePath, error: String(e) });
-  }
 
   // ── Provider request-readiness pre-check (#4555) ──
   // Verify the provider can accept requests before dispatching. If the token

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -51,7 +51,16 @@ export async function runUnit(
       process.chdir(s.basePath);
     }
   } catch (e) {
-    logWarning("engine", "Failed to chdir to basePath before newSession", { basePath: s.basePath, error: String(e) });
+    const msg = `Failed to chdir to basePath before newSession (basePath: ${s.basePath}): ${String(e)}`;
+    logWarning("engine", msg, { basePath: s.basePath, error: String(e) });
+    return {
+      status: "cancelled",
+      errorContext: {
+        message: msg,
+        category: "session-failed",
+        isTransient: true,
+      },
+    };
   }
 
   // ── Session creation with timeout ──

--- a/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
@@ -1,3 +1,5 @@
+**Working directory:** `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
+
 Discuss milestone {{milestoneId}} ("{{milestoneTitle}}"). Identify gray areas, ask the user about them, and write `{{milestoneId}}-CONTEXT.md` in the milestone directory with the decisions. Use the **Context** output template below. If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load and follow; do not override required artifact rules.
 
 **Structured questions available: {{structuredQuestionsAvailable}}**

--- a/src/resources/extensions/gsd/prompts/parallel-research-slices.md
+++ b/src/resources/extensions/gsd/prompts/parallel-research-slices.md
@@ -1,5 +1,7 @@
 # Parallel Slice Research
 
+**Working directory:** `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
+
 You are dispatching parallel research agents for **{{sliceCount}} slices** in milestone **{{mid}} — {{midTitle}}**.
 
 ## Slices to Research

--- a/src/resources/extensions/gsd/prompts/rewrite-docs.md
+++ b/src/resources/extensions/gsd/prompts/rewrite-docs.md
@@ -1,5 +1,7 @@
 You are executing GSD auto-mode.
 
+**Working directory:** `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
+
 ## UNIT: Rewrite Documents — Apply Override(s) for Milestone {{milestoneId}} ("{{milestoneTitle}}")
 
 An override was issued by the user that changes a fundamental decision or approach. Your job is to propagate this change across all active planning documents so they are internally consistent and future tasks execute correctly.

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -63,6 +63,7 @@ function makeMockSession(opts?: {
   const session = {
     active: true,
     verbose: false,
+    basePath: process.cwd(),
     cmdCtx: {
       newSession: (options?: { abortSignal?: AbortSignal }) => {
         opts?.onNewSessionStart?.(session);

--- a/src/resources/extensions/gsd/tests/worktree-path-injection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-path-injection.test.ts
@@ -1,0 +1,178 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const previousGsdHome = process.env.GSD_HOME;
+process.env.GSD_HOME = process.env.GSD_HOME_TEST_OVERRIDE
+  ?? join(tmpdir(), `gsd-test-home-${process.pid}-${Date.now()}`);
+
+after(() => {
+  if (previousGsdHome === undefined) {
+    delete process.env.GSD_HOME;
+  } else {
+    process.env.GSD_HOME = previousGsdHome;
+  }
+});
+
+const { dispatchDirectPhase } = await import("../auto-direct-dispatch.ts");
+const {
+  buildDiscussMilestonePrompt,
+  buildParallelResearchSlicesPrompt,
+  buildRewriteDocsPrompt,
+} = await import("../auto-prompts.ts");
+const { invalidateStateCache } = await import("../state.ts");
+const { resolveAgentEnd, runUnit, _resetPendingResolve } = await import("../auto-loop.js");
+
+function writeMilestone(base: string, mid = "M001", title = "Worktree Path Injection"): void {
+  const milestoneDir = join(base, ".gsd", "milestones", mid);
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(
+    join(milestoneDir, `${mid}-CONTEXT.md`),
+    `# ${mid}: ${title}\n\nContext.\n`,
+    "utf-8",
+  );
+  writeFileSync(
+    join(milestoneDir, `${mid}-ROADMAP.md`),
+    [
+      `# ${mid}: ${title}`,
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: First slice** `risk:low` `depends:[]`",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+function makeLiveMilestoneWorktree(base: string, mid = "M001"): string {
+  const worktreeRoot = join(base, ".gsd", "worktrees", mid);
+  mkdirSync(worktreeRoot, { recursive: true });
+  writeFileSync(
+    join(worktreeRoot, ".git"),
+    `gitdir: ${join(base, ".git", "worktrees", mid)}\n`,
+    "utf-8",
+  );
+  writeMilestone(worktreeRoot, mid);
+  return worktreeRoot;
+}
+
+async function waitFor(condition: () => boolean, label: string): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  assert.fail(`Timed out waiting for ${label}`);
+}
+
+test("runUnit changes cwd to basePath before creating a new session", async (t) => {
+  _resetPendingResolve();
+
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-rununit-base-"));
+  const drifted = mkdtempSync(join(tmpdir(), "gsd-rununit-drift-"));
+  t.after(() => {
+    process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+    rmSync(drifted, { recursive: true, force: true });
+  });
+
+  process.chdir(drifted);
+
+  let cwdAtNewSession: string | undefined;
+  const session = {
+    active: true,
+    basePath: base,
+    verbose: false,
+    cmdCtx: {
+      newSession: () => {
+        cwdAtNewSession = process.cwd();
+        return Promise.resolve({ cancelled: false });
+      },
+    },
+  } as any;
+  const pi = {
+    calls: [] as unknown[],
+    sendMessage(...args: unknown[]) {
+      this.calls.push(args);
+    },
+  } as any;
+  const ctx = { ui: { notify: () => {} }, model: { id: "test-model" } } as any;
+
+  const resultPromise = runUnit(ctx, pi, session, "task", "T01", "prompt");
+  await waitFor(() => pi.calls.length === 1, "runUnit dispatch");
+  resolveAgentEnd({ messages: [{ role: "assistant" }] });
+
+  const result = await resultPromise;
+  assert.equal(result.status, "completed");
+  assert.equal(cwdAtNewSession, base);
+});
+
+test("direct dispatch redirects to the canonical milestone worktree before newSession", async (t) => {
+  invalidateStateCache();
+
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-direct-base-"));
+  const drifted = mkdtempSync(join(tmpdir(), "gsd-direct-drift-"));
+  writeMilestone(base);
+  const worktreeRoot = makeLiveMilestoneWorktree(base);
+
+  t.after(() => {
+    process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+    rmSync(drifted, { recursive: true, force: true });
+    invalidateStateCache();
+  });
+
+  process.chdir(drifted);
+
+  let cwdAtNewSession: string | undefined;
+  let sentPrompt: string | undefined;
+  const ctx = {
+    ui: { notify: () => {} },
+    newSession: async () => {
+      cwdAtNewSession = process.cwd();
+      return { cancelled: false };
+    },
+  } as any;
+  const pi = {
+    sendMessage(message: { content: string }) {
+      sentPrompt = message.content;
+    },
+  } as any;
+
+  await dispatchDirectPhase(ctx, pi, "research-milestone", base);
+
+  assert.equal(cwdAtNewSession, worktreeRoot);
+  assert.ok(sentPrompt?.includes(worktreeRoot), "prompt should name the canonical worktree root");
+});
+
+test("worktree-aware prompt builders include the explicit working directory", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-prompt-base-"));
+  writeMilestone(base);
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const prompts = await Promise.all([
+    buildDiscussMilestonePrompt("M001", "Worktree Path Injection", base),
+    buildParallelResearchSlicesPrompt(
+      "M001",
+      "Worktree Path Injection",
+      [{ id: "S01", title: "First slice" }],
+      base,
+    ),
+    buildRewriteDocsPrompt(
+      "M001",
+      "Worktree Path Injection",
+      null,
+      base,
+      [{ change: "Refresh docs", timestamp: "2026-04-27T00:00:00.000Z", appliedAt: "test" }] as any,
+    ),
+  ]);
+
+  for (const prompt of prompts) {
+    assert.match(prompt, /working directory/i);
+    assert.ok(prompt.includes(base), "prompt should include the provided working directory");
+  }
+});

--- a/src/resources/extensions/gsd/tests/worktree-path-injection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-path-injection.test.ts
@@ -1,6 +1,6 @@
 import test, { after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -23,7 +23,7 @@ const {
   buildRewriteDocsPrompt,
 } = await import("../auto-prompts.ts");
 const { invalidateStateCache } = await import("../state.ts");
-const { resolveAgentEnd, runUnit, _resetPendingResolve } = await import("../auto-loop.js");
+const { resolveAgentEnd, runUnit, _resetPendingResolve } = await import("../auto-loop.ts");
 
 function writeMilestone(base: string, mid = "M001", title = "Worktree Path Injection"): void {
   const milestoneDir = join(base, ".gsd", "milestones", mid);
@@ -71,8 +71,8 @@ test("runUnit changes cwd to basePath before creating a new session", async (t) 
   _resetPendingResolve();
 
   const originalCwd = process.cwd();
-  const base = mkdtempSync(join(tmpdir(), "gsd-rununit-base-"));
-  const drifted = mkdtempSync(join(tmpdir(), "gsd-rununit-drift-"));
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rununit-base-")));
+  const drifted = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rununit-drift-")));
   t.after(() => {
     process.chdir(originalCwd);
     rmSync(base, { recursive: true, force: true });
@@ -110,12 +110,57 @@ test("runUnit changes cwd to basePath before creating a new session", async (t) 
   assert.equal(cwdAtNewSession, base);
 });
 
+test("runUnit cancels before creating a session when basePath chdir fails", async (t) => {
+  _resetPendingResolve();
+
+  const originalCwd = process.cwd();
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rununit-missing-base-")));
+  const drifted = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rununit-missing-drift-")));
+  rmSync(base, { recursive: true, force: true });
+  t.after(() => {
+    process.chdir(originalCwd);
+    rmSync(drifted, { recursive: true, force: true });
+  });
+
+  process.chdir(drifted);
+
+  let newSessionCalled = false;
+  const session = {
+    active: true,
+    basePath: base,
+    verbose: false,
+    cmdCtx: {
+      newSession: () => {
+        newSessionCalled = true;
+        return Promise.resolve({ cancelled: false });
+      },
+    },
+  } as any;
+  const pi = {
+    calls: [] as unknown[],
+    sendMessage(...args: unknown[]) {
+      this.calls.push(args);
+    },
+  } as any;
+  const ctx = { ui: { notify: () => {} }, model: { id: "test-model" } } as any;
+
+  const result = await runUnit(ctx, pi, session, "task", "T01", "prompt");
+
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.errorContext?.category, "session-failed");
+  assert.equal(result.errorContext?.isTransient, true);
+  assert.match(result.errorContext?.message ?? "", /Failed to chdir to basePath before newSession/);
+  assert.ok(result.errorContext?.message.includes(base), "error should include the failed basePath");
+  assert.equal(newSessionCalled, false, "newSession must not run after chdir failure");
+  assert.equal(pi.calls.length, 0, "unit must not dispatch after chdir failure");
+});
+
 test("direct dispatch redirects to the canonical milestone worktree before newSession", async (t) => {
   invalidateStateCache();
 
   const originalCwd = process.cwd();
-  const base = mkdtempSync(join(tmpdir(), "gsd-direct-base-"));
-  const drifted = mkdtempSync(join(tmpdir(), "gsd-direct-drift-"));
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-direct-base-")));
+  const drifted = realpathSync(mkdtempSync(join(tmpdir(), "gsd-direct-drift-")));
   writeMilestone(base);
   const worktreeRoot = makeLiveMilestoneWorktree(base);
 
@@ -150,7 +195,7 @@ test("direct dispatch redirects to the canonical milestone worktree before newSe
 });
 
 test("worktree-aware prompt builders include the explicit working directory", async (t) => {
-  const base = mkdtempSync(join(tmpdir(), "gsd-prompt-base-"));
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-prompt-base-")));
   writeMilestone(base);
   t.after(() => rmSync(base, { recursive: true, force: true }));
 

--- a/src/resources/extensions/gsd/tests/worktree-path-injection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-path-injection.test.ts
@@ -4,11 +4,16 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+const ownsGsdHome = process.env.GSD_HOME_TEST_OVERRIDE === undefined;
 const previousGsdHome = process.env.GSD_HOME;
+const synthesizedGsdHome = join(tmpdir(), `gsd-test-home-${process.pid}-${Date.now()}`);
 process.env.GSD_HOME = process.env.GSD_HOME_TEST_OVERRIDE
-  ?? join(tmpdir(), `gsd-test-home-${process.pid}-${Date.now()}`);
+  ?? synthesizedGsdHome;
 
 after(() => {
+  if (ownsGsdHome) {
+    rmSync(synthesizedGsdHome, { recursive: true, force: true });
+  }
   if (previousGsdHome === undefined) {
     delete process.env.GSD_HOME;
   } else {
@@ -60,11 +65,17 @@ function makeLiveMilestoneWorktree(base: string, mid = "M001"): string {
 }
 
 async function waitFor(condition: () => boolean, label: string): Promise<void> {
-  for (let i = 0; i < 100; i++) {
+  const rawTimeout = process.env.READABLE_WAIT_TIMEOUT_MS;
+  const parsedTimeout = rawTimeout === undefined ? NaN : Number.parseInt(rawTimeout, 10);
+  const timeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : 1000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
     if (condition()) return;
-    await new Promise((resolve) => setTimeout(resolve, 1));
+    await new Promise((resolve) => setTimeout(resolve, 5));
   }
-  assert.fail(`Timed out waiting for ${label}`);
+  if (condition()) return;
+  assert.fail(`Timed out waiting for ${label} after ${timeoutMs}ms`);
 }
 
 test("runUnit changes cwd to basePath before creating a new session", async (t) => {
@@ -191,6 +202,7 @@ test("direct dispatch redirects to the canonical milestone worktree before newSe
   await dispatchDirectPhase(ctx, pi, "research-milestone", base);
 
   assert.equal(cwdAtNewSession, worktreeRoot);
+  assert.equal(process.cwd(), drifted);
   assert.ok(sentPrompt?.includes(worktreeRoot), "prompt should name the canonical worktree root");
 });
 

--- a/src/resources/skills/lint/SKILL.md
+++ b/src/resources/skills/lint/SKILL.md
@@ -7,6 +7,10 @@ description: Lint and format code. Auto-detects ESLint, Biome, Prettier, or lang
 Lint and format code in the current project. Auto-detect the project's linter and formatter toolchain, run them against the target files, and report results grouped by severity with actionable fix suggestions.
 </objective>
 
+<working_directory_awareness>
+**Before running any `git` or build command:** check whether your dispatch context specifies a working directory (look for "Working directory:" in your initial prompt). If it does and `pwd` does not match it, prefix every git invocation with `-C <that path>` (e.g. `git -C /path/to/worktree diff --name-only`) and run linters/formatters with the explicit path argument. Linting the wrong directory is a silent failure mode.
+</working_directory_awareness>
+
 <arguments>
 This skill accepts optional arguments after `/lint`:
 

--- a/src/resources/skills/review/SKILL.md
+++ b/src/resources/skills/review/SKILL.md
@@ -23,6 +23,10 @@ The reviewer reads both the diff and the surrounding source files to understand 
 The purpose is to review and report findings. Making changes during review conflates the reviewer and author roles. Present findings and let the user decide what to act on.
 </analysis_only_rule>
 
+<working_directory_awareness>
+**Before running any `git` command:** check whether your dispatch context specifies a working directory (look for "Working directory:" in your initial prompt). If it does and `pwd` does not match it, prefix every git invocation with `-C <that path>` (e.g. `git -C /path/to/worktree diff --cached`). Reviewing the wrong directory's diff is a silent failure mode — the review will look correct but cover the wrong code.
+</working_directory_awareness>
+
 <quick_start>
 
 <determine_review_scope>

--- a/src/resources/skills/test/SKILL.md
+++ b/src/resources/skills/test/SKILL.md
@@ -151,6 +151,9 @@ Failures:
 **Suggest what to test when no arguments are given.**
 
 **A. Check recent changes:**
+
+> **Working directory check:** if your dispatch context specifies a working directory and `pwd` does not match it, prefix the git commands below with `-C <that path>` (e.g. `git -C /path/to/worktree diff --name-only HEAD~5`).
+
 - Run `git diff --name-only HEAD~5` to find recently changed files
 - Run `git diff --name-only --cached` for staged files
 - Filter to source files (exclude configs, docs, lockfiles)


### PR DESCRIPTION
## Linked issue

Closes #5061

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Anchors every subagent spawned by GSD's dispatch, gate, and review flows to the canonical milestone worktree path instead of the project root.
**Why:** Reviewer and auditor subagents were silently operating against the wrong directory, causing quality gates to evaluate project-root code instead of the active milestone worktree.
**How:** Three-layer fix — move chdir before newSession(), correct the path source in direct dispatch, inject workingDirectory into prompt builders, and teach skill files to use git -C.

## What

Ten files across the GSD extension and bundled skills:

- `src/resources/extensions/gsd/auto/run-unit.ts` — chdir moved before `newSession()`
- `src/resources/extensions/gsd/auto.ts` — chdir in `dispatchHookUnit` moved before `newSession()`
- `src/resources/extensions/gsd/auto-direct-dispatch.ts` — added `resolveCanonicalMilestoneRoot(base, mid)` resolution and chdir before `newSession()`; caller-side path corrected from `projectRoot()` to the worktree path
- `src/resources/extensions/gsd/auto-prompts.ts` — `workingDirectory: base` injected into `buildRewriteDocsPrompt`, `buildParallelResearchSlicesPrompt`, `buildGateEvaluatePrompt` (per-gate subPrompt), and `buildDiscussMilestonePrompt`
- `src/resources/extensions/gsd/prompts/rewrite-docs.md` — `{{workingDirectory}}` directive added
- `src/resources/extensions/gsd/prompts/parallel-research-slices.md` — `{{workingDirectory}}` directive added
- `src/resources/extensions/gsd/prompts/guided-discuss-milestone.md` — `{{workingDirectory}}` directive added
- `src/resources/skills/review/SKILL.md` — `<working_directory_awareness>` block added
- `src/resources/skills/lint/SKILL.md` — `<working_directory_awareness>` block added
- `src/resources/skills/test/SKILL.md` — `<working_directory_awareness>` block added

## Why

When a milestone has an isolated worktree, subagents spawned for review, audit, and gate evaluation were operating against the project root. Root cause confirmed by a 4-layer parallel debug + Codex peer review:

1. **chdir timing** — `chdir` in `run-unit.ts:127-132` and `auto.ts:1942-1945` fired after `newSession()` had already captured `process.cwd()` to anchor the session's tool runtime and system prompt. The guard was too late to have any effect.
2. **Wrong path source** — `auto-direct-dispatch.ts` had no chdir at all and its caller passed `projectRoot()` rather than the worktree path.
3. **Missing workingDirectory in prompt builders** — `buildRewriteDocsPrompt`, `buildParallelResearchSlicesPrompt`, `buildGateEvaluatePrompt`, and `buildDiscussMilestonePrompt` all called `loadPrompt` without `workingDirectory`, so spawned subagents had no path anchor in their prompt body.
4. **Bare git commands in skills** — `review/SKILL.md`, `lint/SKILL.md`, `test/SKILL.md` issued `git diff` and `git diff --cached` with no `-C <path>` flag, silently inheriting whatever cwd the spawning agent had.

Concrete example: a reviewer team for M003 grep'd the project root and reported the implementation as "missing" — the code was committed in the M003 worktree. The failure mode is hidden; output looks plausible.

## How

**Layer 1 (dispatch):** chdir relocated to immediately before `newSession()` in both `run-unit.ts` and `auto.ts`. In `auto-direct-dispatch.ts`, added `resolveCanonicalMilestoneRoot(base, mid)` and chdir before session init; corrected the caller to pass the worktree path instead of `projectRoot()`.

**Layer 2 (prompt builders):** `workingDirectory: base` added to the four identified `loadPrompt` call sites. Matching `{{workingDirectory}}` substitution directives added to `rewrite-docs.md`, `parallel-research-slices.md`, and `guided-discuss-milestone.md`. The `buildGateEvaluatePrompt` inline subPrompt now embeds the working-directory line per gate.

**Layer 3 (skills):** `<working_directory_awareness>` block added to `review/SKILL.md`, `lint/SKILL.md`, and `test/SKILL.md` instructing agents to check `pwd` against the dispatched working directory and prefix `git -C <path>` when they differ.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

`npm run build` passes clean on this branch. Manual verification: run a milestone dispatch with an active worktree and confirm the spawned session's cwd matches `.gsd/projects/<id>/worktrees/<MID>/` rather than the project root. Full regression test to be added per CONTRIBUTING.md review feedback.

## AI disclosure

- [x] This PR includes AI-assisted code — parallel debug team + Codex peer review used for root-cause analysis; fix authored and validated by the human contributor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions and dispatch now start in the resolved canonical working directory; if changing directories fails the operation is cancelled, an error is reported, and prior session state is restored when applicable.
* **New Features**
  * Prompts include an explicit working-directory field so subagents constrain file/shell ops to that directory.
* **Documentation**
  * Skill docs updated with guidance to run tools against an explicit path (e.g., using git -C).
* **Tests**
  * New tests validate CWD/worktree handling and prompt working-directory inclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->