### PR TITLE
fix(gsd): suppress nested git enoent warnings

### DIFF
--- a/src/resources/extensions/gsd/tests/worktree-nested-git-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-nested-git-safety.test.ts
@@ -19,6 +19,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { findNestedGitDirs } from "../worktree-manager.ts";
+import { _resetLogs, drainLogs, setStderrLoggingEnabled } from "../workflow-logger.ts";
 
 function makeRoot(t: { after: (fn: () => void) => void }): string {
   const dir = mkdtempSync(join(tmpdir(), "gsd-nested-git-"));
@@ -38,6 +39,29 @@ test("#2616: findNestedGitDirs detects a nested repo at the top level", (t) => {
   assert.ok(
     found.includes(scaffolded),
     `expected ${scaffolded} in findNestedGitDirs output, got ${JSON.stringify(found)}`,
+  );
+});
+
+test("#5065: findNestedGitDirs does not warn for ordinary directories without .git children", (t) => {
+  const root = makeRoot(t);
+  const previousStderrLogging = setStderrLoggingEnabled(false);
+  t.after(() => {
+    setStderrLoggingEnabled(previousStderrLogging);
+    _resetLogs();
+  });
+  _resetLogs();
+
+  mkdirSync(join(root, "app", "components"), { recursive: true });
+  mkdirSync(join(root, "packages", "api", "src"), { recursive: true });
+
+  const found = findNestedGitDirs(root);
+  const logs = drainLogs();
+
+  assert.deepEqual(found, []);
+  assert.equal(
+    logs.filter((entry) => entry.component === "worktree").length,
+    0,
+    `ordinary missing .git probes must not emit worktree warnings; got ${JSON.stringify(logs)}`,
   );
 });
 

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -462,7 +462,9 @@ export function findNestedGitDirs(rootPath: string): string[] {
           continue;
         }
       } catch (e) {
-        logWarning("worktree", `existsSync/.git check failed for ${fullPath}: ${(e as Error).message}`);
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          logWarning("worktree", `.git check failed for ${fullPath}: ${(e as Error).message}`);
+        }
       }
 
       walk(fullPath, depth + 1);


### PR DESCRIPTION
## Linked issue

Closes #5065

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Suppresses expected missing-`.git` warnings while scanning ordinary worktree directories for nested repositories.
**Why:** Normal directories do not contain `.git` children, so treating those negative probes as warnings floods milestone cleanup output.
**How:** Ignores `ENOENT` from the nested `.git` probe, preserves warnings for unexpected filesystem errors, and adds regression coverage around the workflow logger output.

## What

This updates `findNestedGitDirs()` so ordinary directories without a `.git` child do not emit worktree warnings during cleanup scans. The nested repository detection behavior is unchanged: real nested `.git` directories are still reported, `.git` files are still ignored, and excluded directories are still skipped.

## Why

The scanner probes each directory for a `.git` child. A missing child is the expected case for normal project directories, but it was logged as a warning. That made healthy milestone teardown look noisy and potentially broken.

## How

The `.git` probe catch now ignores `ENOENT` and only logs unexpected errors. A targeted regression test creates ordinary nested directories, runs `findNestedGitDirs()`, drains the workflow logger, and asserts that no worktree warnings were emitted.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/worktree-nested-git-safety.test.ts`
2. `npm run typecheck:extensions`
3. `npm run build`
4. `npm run secret-scan -- --diff upstream/main...HEAD`
5. `git diff --check upstream/main...HEAD`

Broader suite note: `npm run test:unit` was attempted but not counted as a pass signal because `src/resources/extensions/gsd/tests/headless-query.test.ts` fails in this local environment with `Cannot find module 'yaml'` from an installed extension path. The same targeted failure reproduces on clean current `upstream/main`, so it is not caused by this diff.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning system to suppress false alerts when scanning standard directories without nested Git repositories.

* **Tests**
  * Added test validation to ensure directory scanning does not produce unnecessary warnings in normal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->