### PR TITLE
fix(gsd): dispatch new debug sessions

### DIFF
--- a/src/resources/extensions/gsd/commands-debug.ts
+++ b/src/resources/extensions/gsd/commands-debug.ts
@@ -116,6 +116,8 @@ export async function handleDebug(args: string, ctx: ExtensionCommandContext, pi
     try {
       const created = createDebugSession(basePath, { issue });
       const s = created.session;
+      const canDispatch = pi != null && typeof (pi as ExtensionAPI).sendMessage === "function";
+      const dispatchNote = canDispatch ? `\ndispatchMode=find_and_fix` : "";
       ctx.ui.notify(
         [
           `Debug session started: ${s.slug}`,
@@ -123,9 +125,33 @@ export async function handleDebug(args: string, ctx: ExtensionCommandContext, pi
           `Artifact: ${created.artifactPath}`,
           `Log: ${s.logPath}`,
           `Next: /gsd debug status ${s.slug} or /gsd debug continue ${s.slug}`,
-        ].join("\n"),
+        ].join("\n") + dispatchNote,
         "info",
       );
+      if (canDispatch) {
+        try {
+          const prompt = loadPrompt("debug-session-manager", {
+            goal: "find_and_fix",
+            issue: s.issue,
+            slug: s.slug,
+            mode: s.mode,
+            workingDirectory: basePath,
+            checkpointContext: "",
+            tddContext: "",
+            specialistContext: "",
+          });
+          pi.sendMessage(
+            { customType: "gsd-debug-start", content: prompt, display: false },
+            { triggerTurn: true },
+          );
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          ctx.ui.notify(
+            `Debug dispatch failed: ${msg}\nSession '${s.slug}' is persisted; retry with /gsd debug continue ${s.slug}`,
+            "warning",
+          );
+        }
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       ctx.ui.notify(

--- a/src/resources/extensions/gsd/tests/debug-command-handler.test.ts
+++ b/src/resources/extensions/gsd/tests/debug-command-handler.test.ts
@@ -136,6 +136,43 @@ describe("handleDebug lifecycle", () => {
     }
   });
 
+  test("issue-start dispatches a find_and_fix debug runner after creating the session", async () => {
+    const base = makeBase();
+    const ctx = createMockCtx();
+    const dispatched: Array<{
+      msg: { customType: string; content: string; display: boolean };
+      options: { triggerTurn: boolean };
+    }> = [];
+    const mockPi = {
+      sendMessage(
+        msg: { customType: string; content: string; display: boolean },
+        options: { triggerTurn: boolean },
+      ) {
+        dispatched.push({ msg, options });
+      },
+    };
+    const saved = process.cwd();
+    process.chdir(base);
+
+    try {
+      await handleDebug("Login fails on Safari", ctx as any, mockPi as any);
+
+      assert.equal(ctx.notifications[0].level, "info");
+      assert.match(ctx.notifications[0].message, /Debug session started: login-fails-on-safari/);
+      assert.match(ctx.notifications[0].message, /dispatchMode=find_and_fix/);
+      assert.equal(dispatched.length, 1);
+      assert.equal(dispatched[0].msg.customType, "gsd-debug-start");
+      assert.equal(dispatched[0].msg.display, false);
+      assert.equal(dispatched[0].options.triggerTurn, true);
+      assert.match(dispatched[0].msg.content, /`find_and_fix`/);
+      assert.match(dispatched[0].msg.content, /login-fails-on-safari/);
+      assert.match(dispatched[0].msg.content, /Login fails on Safari/);
+    } finally {
+      process.chdir(saved);
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
   test("list shows persisted session summaries with lifecycle metadata", async () => {
     const base = makeBase();
     const ctx = createMockCtx();


### PR DESCRIPTION
## Linked issue

Closes #5016

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Starts the debug runner immediately when `/gsd debug <issue>` creates a new debug session.
**Why:** The command previously persisted an active queued session but never dispatched the first runner turn.
**How:** Reuses the debug-session manager prompt with `find_and_fix`, sends a `gsd-debug-start` message with `triggerTurn: true`, and preserves the session with a warning if dispatch fails.

## What

This updates the normal debug issue-start path so it behaves like the existing diagnose and continue paths: after creating the session artifact, it dispatches the runner through `pi.sendMessage`.

The existing no-dispatch fallback is preserved when no Pi API is available, and dispatch failures now surface a warning while keeping the created session resumable.

## Why

`/gsd debug <issue text>` created a queued active session and then returned. That left users with session artifacts but no debug activity until they manually ran `continue`.

## How

The issue-start branch now builds the `debug-session-manager` prompt with `find_and_fix`, sends it as `gsd-debug-start`, and requests `triggerTurn: true`. A regression test asserts that a normal issue-start dispatch happens once and contains the expected goal, slug, issue text, and trigger options.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/debug-command-handler.test.ts`
2. `npm run typecheck:extensions`
3. `npm run build`
4. `npm run secret-scan -- --diff upstream/main...HEAD`
5. `git diff --check upstream/main...HEAD`

Broader suite note: `npm run test:unit` was attempted but not counted as a pass signal because `src/resources/extensions/gsd/tests/headless-query.test.ts` fails in this local environment with `Cannot find module 'yaml'` from an installed extension path. The same targeted failure reproduces on clean current `upstream/main`, so it is not caused by this diff.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debug sessions now automatically trigger a find-and-fix workflow upon creation.
  * Notifications now include dispatch mode information for debug operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->