### PR TITLE
fix(gsd): anchor cwd at project root in mergeAndExit

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -2372,5 +2372,20 @@ export function mergeMilestoneToMain(
   originalBase = null;
   nudgeGitBranchCache(previousCwd);
 
+  // 15. Anchor cwd at the project root on success-return. Step 12 removed
+  // the worktree dir; if cwd was inside it, every subsequent process.cwd()
+  // would throw ENOENT and trip auto/run-unit.ts:50's session-failed cancel
+  // path (the de73fb43d regression that closes headless gsd auto). Step 3
+  // already chdir'd here, but defending the success-return contract makes
+  // future maintainers safe against intervening chdir's between step 3 and
+  // here.
+  try {
+    if (process.cwd() !== originalBasePath_) {
+      process.chdir(originalBasePath_);
+    }
+  } catch (err) {
+    logWarning("worktree", `chdir to project root after merge failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
   return { commitMessage, pushed, prCreated, codeFilesChanged };
 }

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -2380,9 +2380,9 @@ export function mergeMilestoneToMain(
   // future maintainers safe against intervening chdir's between step 3 and
   // here.
   try {
-    if (process.cwd() !== originalBasePath_) {
-      process.chdir(originalBasePath_);
-    }
+    // process.cwd() can throw ENOENT when cwd was removed, so attempt
+    // recovery directly.
+    process.chdir(originalBasePath_);
   } catch (err) {
     logWarning("worktree", `chdir to project root after merge failed: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/src/resources/extensions/gsd/tests/stash-pop-gsd-conflict.test.ts
+++ b/src/resources/extensions/gsd/tests/stash-pop-gsd-conflict.test.ts
@@ -21,6 +21,7 @@ import { _clearGsdRootCache } from "../paths.ts";
 // Isolate from user's global preferences (which may have git.main_branch set)
 let originalHome: string | undefined;
 let fakeHome: string;
+const testCwd = process.cwd();
 
 test.before(() => {
   originalHome = process.env.HOME;
@@ -36,6 +37,11 @@ test.after(() => {
   _resetServiceCache();
   rmSync(fakeHome, { recursive: true, force: true });
 });
+
+function cleanupTempRepo(repo: string): void {
+  try { process.chdir(testCwd); } catch { /* best-effort */ }
+  try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* cleanup best-effort */ }
+}
 
 function run(cmd: string, cwd: string): string {
   return execSync(cmd, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
@@ -106,7 +112,7 @@ test("#2766: stash pop conflict on .gsd/ files is auto-resolved", () => {
     try { stashList = run("git stash list", repo); } catch { /* empty stash */ }
     assert.strictEqual(stashList, "", "stash is empty after .gsd/ conflict auto-resolution");
   } finally {
-    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* cleanup best-effort */ }
+    cleanupTempRepo(repo);
   }
 });
 
@@ -141,6 +147,6 @@ test("#2766: stash pop conflict on non-.gsd files preserves stash for manual res
       "merge succeeds even with non-.gsd stash pop conflict",
     );
   } finally {
-    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* cleanup best-effort */ }
+    cleanupTempRepo(repo);
   }
 });

--- a/src/resources/extensions/gsd/tests/stash-queued-context-files.test.ts
+++ b/src/resources/extensions/gsd/tests/stash-queued-context-files.test.ts
@@ -35,6 +35,7 @@ import { _clearGsdRootCache } from "../paths.ts";
 // Isolate from user's global preferences (which may have git.main_branch set)
 let originalHome: string | undefined;
 let fakeHome: string;
+const testCwd = process.cwd();
 
 test.before(() => {
   originalHome = process.env.HOME;
@@ -50,6 +51,13 @@ test.after(() => {
   _resetServiceCache();
   rmSync(fakeHome, { recursive: true, force: true });
 });
+
+function cleanupTempPaths(...paths: string[]): void {
+  try { process.chdir(testCwd); } catch { /* best-effort */ }
+  for (const p of paths) {
+    rmSync(p, { recursive: true, force: true });
+  }
+}
 
 function run(cmd: string, cwd: string): string {
   return execSync(cmd, {
@@ -271,7 +279,7 @@ test("#2505: mergeMilestoneToMain preserves queued CONTEXT files (not swept into
       }
     }
   } finally {
-    rmSync(repo, { recursive: true, force: true });
+    cleanupTempPaths(repo);
   }
 });
 
@@ -308,8 +316,7 @@ test("#2505: pre-merge stash handles symlinked .gsd without traversing it", () =
     assert.equal(readFileSync(join(repo, "README.md"), "utf-8").replace(/\r\n/g, "\n"), "# test\n\nDirty change.\n");
     assert.equal(readFileSync(join(repo, "local-note.txt"), "utf-8"), "local scratch\n");
   } finally {
-    rmSync(repo, { recursive: true, force: true });
-    rmSync(stateDir, { recursive: true, force: true });
+    cleanupTempPaths(repo, stateDir);
   }
 });
 
@@ -375,7 +382,7 @@ test("#2505: back-to-back merges preserve queued CONTEXT files", () => {
       "M013 context content preserved after back-to-back merges",
     );
   } finally {
-    rmSync(repo, { recursive: true, force: true });
+    cleanupTempPaths(repo);
   }
 });
 
@@ -430,7 +437,6 @@ test("#4573: gitignored .gsd symlink does not break pre-merge stash", () => {
       ".gsd symlink remains in place",
     );
   } finally {
-    rmSync(repo, { recursive: true, force: true });
-    rmSync(stateDir, { recursive: true, force: true });
+    cleanupTempPaths(repo, stateDir);
   }
 });

--- a/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   WorktreeResolver,
   type WorktreeResolverDeps,
@@ -1141,4 +1144,86 @@ test("mergeAndExit propagates non-MergeConflictError to caller (#4380)", () => {
     (err: unknown) => err === permissionError,
     "non-MergeConflictError must propagate to the caller, not be swallowed",
   );
+});
+
+// ─── Regression: mergeAndExit anchors cwd at project root before merge work ─
+// (de73fb43d headless `gsd auto` exits-on-task regression)
+//
+// Background: the auto loop runs tasks inside the milestone worktree
+// (process.cwd() === worktreePath). When the milestone completes, the
+// worktree dir is torn down. If cwd was still inside it at that moment,
+// every subsequent process.cwd() throws ENOENT — and after de73fb43d
+// auto/run-unit.ts:50 turns that ENOENT into a session-failed cancel,
+// which in headless mode bubbles up to a "Auto-mode stopped" notify
+// and process.exit(0). mergeAndExit must therefore guarantee cwd is
+// anchored at the project root regardless of which merge path runs.
+
+test("mergeAndExit chdirs to project root before merge work (regression: headless gsd auto exit)", () => {
+  // Set up real dirs so process.chdir actually succeeds. realpathSync
+  // canonicalizes the macOS /var → /private/var symlink so equality holds.
+  const projectRoot = realpathSync(mkdtempSync(join(tmpdir(), "gsd-resolver-cwd-")));
+  const worktreePath = join(projectRoot, ".gsd/worktrees/M001");
+  mkdirSync(worktreePath, { recursive: true });
+  const previousCwd = process.cwd();
+
+  try {
+    process.chdir(worktreePath);
+    assert.equal(process.cwd(), worktreePath, "precondition: cwd is in worktree");
+
+    const s = makeSession({
+      basePath: worktreePath,
+      originalBasePath: projectRoot,
+    });
+    const deps = makeDeps({
+      isInAutoWorktree: () => true,
+      getIsolationMode: () => "worktree",
+    });
+    const ctx = makeNotifyCtx();
+    const resolver = new WorktreeResolver(s, deps);
+
+    resolver.mergeAndExit("M001", ctx);
+
+    assert.equal(
+      process.cwd(),
+      projectRoot,
+      "mergeAndExit must leave cwd at the project root, not the (about-to-be-removed) worktree",
+    );
+  } finally {
+    try { process.chdir(previousCwd); } catch { /* best-effort */ }
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("mergeAndExit anchors cwd even on isolation-degraded skip path", () => {
+  // The skip paths (isolation-degraded, mode-none, missing-original-base)
+  // bypass the per-mode merge helpers entirely. They must still leave cwd
+  // at the project root so a subsequent worktree teardown elsewhere does
+  // not strand cwd in a deleted dir.
+  const projectRoot = realpathSync(mkdtempSync(join(tmpdir(), "gsd-resolver-cwd-degraded-")));
+  const worktreePath = join(projectRoot, ".gsd/worktrees/M001");
+  mkdirSync(worktreePath, { recursive: true });
+  const previousCwd = process.cwd();
+
+  try {
+    process.chdir(worktreePath);
+    const s = makeSession({
+      basePath: worktreePath,
+      originalBasePath: projectRoot,
+    });
+    s.isolationDegraded = true;
+    const deps = makeDeps({ getIsolationMode: () => "worktree" });
+    const ctx = makeNotifyCtx();
+    const resolver = new WorktreeResolver(s, deps);
+
+    resolver.mergeAndExit("M001", ctx);
+
+    assert.equal(
+      process.cwd(),
+      projectRoot,
+      "isolation-degraded skip must still anchor cwd at project root",
+    );
+  } finally {
+    try { process.chdir(previousCwd); } catch { /* best-effort */ }
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
 });

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -404,6 +404,30 @@ export class WorktreeResolver {
   mergeAndExit(milestoneId: string, ctx: NotifyCtx): void {
     this.validateMilestoneId(milestoneId);
 
+    // Anchor cwd at the project root before any merge work. Some merge code
+    // paths (mergeMilestoneToMain, slice-cadence) chdir explicitly; others
+    // (branch-mode, isolation-degraded skip, missing-original-base skip)
+    // do not. If the worktree dir is later torn down while cwd still points
+    // into it, every subsequent process.cwd() throws ENOENT — and after
+    // de73fb43d that surfaces as a session-failed cancel and (in headless
+    // mode) terminates the whole gsd process. Best-effort: silent on
+    // failure so existing test fixtures that use synthetic paths still pass.
+    if (this.s.originalBasePath) {
+      try {
+        if (process.cwd() !== this.s.originalBasePath) {
+          process.chdir(this.s.originalBasePath);
+        }
+      } catch (err) {
+        debugLog("WorktreeResolver", {
+          action: "mergeAndExit",
+          phase: "pre-merge-chdir-failed",
+          milestoneId,
+          originalBasePath: this.s.originalBasePath,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
     // #4764 — telemetry: record start timestamp so we can emit merge duration.
     const mergeStartedAt = new Date().toISOString();
     const mergeStartMs = Date.now();

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -414,9 +414,9 @@ export class WorktreeResolver {
     // failure so existing test fixtures that use synthetic paths still pass.
     if (this.s.originalBasePath) {
       try {
-        if (process.cwd() !== this.s.originalBasePath) {
-          process.chdir(this.s.originalBasePath);
-        }
+        // process.cwd() can throw ENOENT when cwd was removed, so attempt
+        // recovery directly.
+        process.chdir(this.s.originalBasePath);
       } catch (err) {
         debugLog("WorktreeResolver", {
           action: "mergeAndExit",


### PR DESCRIPTION
## TL;DR

**What:** Anchor `process.cwd()` at the project root before any merge work in `WorktreeResolver.mergeAndExit()`, and re-anchor on success-return in `mergeMilestoneToMain()`.
**Why:** Headless `gsd auto` exits early after a milestone merge because some merge paths leave cwd inside the deleted worktree dir, so subsequent `process.cwd()` throws ENOENT and trips the post-`de73fb43d` cancel path.
**How:** chdir to `originalBasePath` at entry of `mergeAndExit` (covering branch-mode + skip paths), plus a defensive re-anchor at the success-return of `mergeMilestoneToMain`. Two regression tests with real tempdirs.

## What

- `src/resources/extensions/gsd/worktree-resolver.ts` — `mergeAndExit()` chdir's to `originalBasePath` at entry, before any merge work, with a debug log on failure.
- `src/resources/extensions/gsd/auto-worktree.ts` — `mergeMilestoneToMain()` re-anchors cwd to `originalBasePath_` at the success-return, after step 12 removes the worktree directory.
- `src/resources/extensions/gsd/tests/worktree-resolver.test.ts` — two new regression tests using real tempdirs (with `realpathSync` for the macOS `/var`→`/private/var` symlink): the standard merge path and the isolation-degraded skip path.

## Why

Closes #5079.

The auto loop runs inside the milestone worktree, so `process.cwd() === worktreePath` at merge time. `mergeAndExit` has multiple merge paths:

- `mergeMilestoneToMain` and the slice-cadence path chdir explicitly during the merge.
- The branch-mode, isolation-degraded skip, and missing-`originalBasePath` skip paths do **not** chdir.

When the worktree dir is torn down (step 12 in `mergeMilestoneToMain`, or by external teardown on the skip paths), cwd still points into the deleted directory. Every subsequent `process.cwd()` throws `ENOENT`. Commit `de73fb43d` correctly converts that ENOENT into a session-failed cancel at the dispatch layer (`auto/run-unit.ts:50`) — and in headless mode that cancel terminates the whole `gsd auto` process with "Auto-mode stopped".

`de73fb43d` is right at its layer; it just exposed a latent contract violation in `mergeAndExit`: not all merge paths anchor cwd back to the project root.

## How

1. **Entry-time anchor in `mergeAndExit`** is the primary fix. It guarantees every merge path — including the skip paths that bypass the per-mode helpers — leaves cwd at the project root. Best-effort with a debug log on chdir failure (silent in tests so the existing fixtures with synthetic paths still pass).
2. **Success-return anchor in `mergeMilestoneToMain`** is defensive. Step 3 already chdir's, but step 12 removes the worktree, and any intervening chdir between 3 and 12 would re-strand cwd. The success-return guard makes the contract robust against future maintainers.
3. **Regression tests** create a real tempdir + `.gsd/worktrees/M001/` subdir, chdir into the worktree, run `mergeAndExit`, and assert cwd === project root afterward. `realpathSync` canonicalizes the macOS `/var` symlink so the equality holds.

### Alternatives considered

- *Catch the ENOENT in `auto/run-unit.ts:50` and recover.* Reverts the spirit of `de73fb43d`, which deliberately treats a broken cwd as fatal. The right fix is to not break cwd in the first place.
- *Only patch `mergeMilestoneToMain`.* Misses the skip paths that never enter the per-mode helpers.

## Change type

- [x] `fix` — Bug fix

## Test plan

- [x] New regression test: `mergeAndExit chdirs to project root before merge work`
- [x] New regression test: `mergeAndExit anchors cwd even on isolation-degraded skip path`
- [ ] `npm run verify:pr` clean locally
- [ ] Manual: headless `gsd auto` advances past a milestone merge instead of exiting

## AI-assisted contribution

This PR was AI-assisted. Author understands and stands behind the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge/cleanup reliability by ensuring the process working directory is re-anchored and emitting a warning/debug event if restoring it fails, preventing invalid cwd after worktree teardown.

* **Tests**
  * Added regression tests and centralized cleanup to verify and restore working directory integrity across merge, skip, and cleanup paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->