### PR TITLE
fix(mcp-server): preserve snowflake-precision channel IDs in PREFERENCES.md parser

### DIFF
--- a/packages/mcp-server/src/remote-questions.test.ts
+++ b/packages/mcp-server/src/remote-questions.test.ts
@@ -24,6 +24,7 @@ import { join } from 'node:path';
 import {
   isRemoteConfigured,
   tryRemoteQuestions,
+  _parseSimpleFrontmatter,
   type RemoteQuestion,
 } from './remote-questions.js';
 
@@ -290,5 +291,61 @@ describe('remote-questions YAML frontmatter parsing (via isRemoteConfigured)', (
     makePrefsFile(tmpDir, 'remote_questions:\n  channel: discord\n  channel_id: "123456789012345678"\n');
     // No --- fences — not recognized as frontmatter
     assert.equal(isRemoteConfigured(), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _parseSimpleFrontmatter — scalar parsing contract
+// ---------------------------------------------------------------------------
+// Regression coverage for snowflake-precision loss: bare numerics or quoted
+// strings whose digits exceed Number.MAX_SAFE_INTEGER (2^53 - 1) must
+// round-trip as strings, not coerced through Number(). Discord, Telegram, and
+// Slack channel/chat IDs all routinely exceed that range.
+
+describe('_parseSimpleFrontmatter — scalar precision', () => {
+  it('preserves a quoted snowflake-shaped channel_id as a string', () => {
+    const content = '---\nremote_questions:\n  channel: discord\n  channel_id: "1234567890123456789"\n---\n';
+    const parsed = _parseSimpleFrontmatter(content);
+    const rq = parsed['remote_questions'] as Record<string, unknown>;
+    assert.equal(rq['channel_id'], '1234567890123456789');
+    assert.equal(typeof rq['channel_id'], 'string');
+  });
+
+  it('preserves a bare numeric channel_id larger than MAX_SAFE_INTEGER as a string', () => {
+    const content = '---\nremote_questions:\n  channel: discord\n  channel_id: 1234567890123456789\n---\n';
+    const parsed = _parseSimpleFrontmatter(content);
+    const rq = parsed['remote_questions'] as Record<string, unknown>;
+    assert.equal(rq['channel_id'], '1234567890123456789');
+    assert.equal(typeof rq['channel_id'], 'string');
+  });
+
+  it('still parses small bare integers as numbers', () => {
+    const content = '---\nremote_questions:\n  channel: discord\n  timeout_minutes: 10\n  poll_interval_seconds: 3\n---\n';
+    const parsed = _parseSimpleFrontmatter(content);
+    const rq = parsed['remote_questions'] as Record<string, unknown>;
+    assert.equal(rq['timeout_minutes'], 10);
+    assert.equal(typeof rq['timeout_minutes'], 'number');
+    assert.equal(rq['poll_interval_seconds'], 3);
+    assert.equal(typeof rq['poll_interval_seconds'], 'number');
+  });
+
+  it('parses booleans and nulls unchanged', () => {
+    const content = '---\nflags:\n  enabled: true\n  disabled: false\n  cleared: null\n  also_cleared: ~\n---\n';
+    const parsed = _parseSimpleFrontmatter(content);
+    const flags = parsed['flags'] as Record<string, unknown>;
+    assert.equal(flags['enabled'], true);
+    assert.equal(flags['disabled'], false);
+    assert.equal(flags['cleared'], null);
+    assert.equal(flags['also_cleared'], null);
+  });
+
+  it('treats quoted "true"/"false"/"null" as strings, not booleans', () => {
+    const content = '---\nlabels:\n  one: "true"\n  two: "null"\n---\n';
+    const parsed = _parseSimpleFrontmatter(content);
+    const labels = parsed['labels'] as Record<string, unknown>;
+    assert.equal(labels['one'], 'true');
+    assert.equal(typeof labels['one'], 'string');
+    assert.equal(labels['two'], 'null');
+    assert.equal(typeof labels['two'], 'string');
   });
 });

--- a/packages/mcp-server/src/remote-questions.ts
+++ b/packages/mcp-server/src/remote-questions.ts
@@ -121,7 +121,13 @@ function clampNumber(value: unknown, fallback: number, min: number, max: number)
  *     child: value
  *   ---
  * Sufficient for the flat remote_questions config block.
+ *
+ * @internal — exported for testing only
  */
+export function _parseSimpleFrontmatter(content: string): Record<string, unknown> {
+  return parseSimpleFrontmatter(content);
+}
+
 function parseSimpleFrontmatter(content: string): Record<string, unknown> {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/m);
   if (!match) return {};
@@ -163,10 +169,24 @@ function parseSimpleFrontmatter(content: string): Record<string, unknown> {
 }
 
 function parseSimpleScalar(raw: string): string | number | boolean | null {
-  const s = raw.replace(/^["']|["']$/g, '').trim();
+  const trimmed = raw.trim();
+  const quoted =
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"));
+  const s = quoted ? trimmed.slice(1, -1) : trimmed;
+  // Quoted scalars are always strings — preserves Discord/Telegram snowflake IDs
+  // and any other identifier that exceeds Number.MAX_SAFE_INTEGER.
+  if (quoted) return s;
   if (s === 'true') return true;
   if (s === 'false') return false;
   if (s === 'null' || s === '~') return null;
+  // Unquoted integers larger than 2^53-1 lose precision through Number();
+  // keep them as strings so snowflake-shaped bare numerics still round-trip.
+  if (s !== '' && /^-?\d+$/.test(s)) {
+    const n = Number(s);
+    if (!Number.isSafeInteger(n)) return s;
+    return n;
+  }
   const n = Number(s);
   if (s !== '' && !Number.isNaN(n)) return n;
   return s;


### PR DESCRIPTION
# fix(mcp-server): preserve snowflake-precision channel IDs in PREFERENCES.md parser

## Summary

The mcp-server's bundled YAML frontmatter parser silently truncates 64-bit Discord/Telegram channel IDs (and any integer above `Number.MAX_SAFE_INTEGER`, i.e. 2^53 − 1) by coercing every numeric-looking scalar through `Number()`. The `remote_questions` channel ID then fails the round-trip and Discord rejects the resulting API call with **`Unknown Channel`** (HTTP 404, code 10003).

The bug was reproducible on a real install: a `PREFERENCES.md` entry containing
```
channel_id: "1234567890123456789"
```
was being sent to Discord as `1234567890123456800` — a different snowflake. The existing channel-ID validator (`/^\d{17,20}$/`) doesn't catch this because the truncated value is still a 19-digit numeric string.

## Root cause

In `packages/mcp-server/src/remote-questions.ts`, `parseSimpleScalar`:

```ts
function parseSimpleScalar(raw: string): string | number | boolean | null {
  const s = raw.replace(/^["']|["']$/g, '').trim();   // strips quotes first
  // ...
  const n = Number(s);
  if (s !== '' && !Number.isNaN(n)) return n;          // coerces snowflake → lossy Number
  return s;
}
```

Two problems:

1. **Quotes are stripped before evaluating type**, so `"1234567890123456789"` is treated identically to bare `1234567890123456789`. YAML semantics put quoted scalars in the string lane regardless of content.
2. **Bare integers are unconditionally coerced** through `Number()`, which loses precision once the value exceeds 2^53 − 1.

`String(channelId)` later in `resolveRemoteConfig` (line 211) rebuilds the value from the now-lossy `number`, producing a different snowflake.

## Fix

`packages/mcp-server/src/remote-questions.ts`:

```ts
function parseSimpleScalar(raw: string): string | number | boolean | null {
  const trimmed = raw.trim();
  const quoted =
    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
    (trimmed.startsWith("'") && trimmed.endsWith("'"));
  const s = quoted ? trimmed.slice(1, -1) : trimmed;
  // Quoted scalars are always strings — preserves Discord/Telegram snowflake IDs
  // and any other identifier that exceeds Number.MAX_SAFE_INTEGER.
  if (quoted) return s;
  if (s === 'true') return true;
  if (s === 'false') return false;
  if (s === 'null' || s === '~') return null;
  // Unquoted integers larger than 2^53-1 lose precision through Number();
  // keep them as strings so snowflake-shaped bare numerics still round-trip.
  if (s !== '' && /^-?\d+$/.test(s)) {
    const n = Number(s);
    if (!Number.isSafeInteger(n)) return s;
    return n;
  }
  const n = Number(s);
  if (s !== '' && !Number.isNaN(n)) return n;
  return s;
}
```

Two behavioural changes, both YAML-correct:

- Quoted scalars are always strings.
- Bare integers above `Number.MAX_SAFE_INTEGER` are returned as strings instead of being silently truncated.

## Tests

- Exported `parseSimpleFrontmatter` as `_parseSimpleFrontmatter`, matching the existing `@internal — exported for testing only` convention used by `_buildImportCandidates` in `packages/mcp-server/src/workflow-tools.ts:454`.
- Added a new `describe` block in `remote-questions.test.ts` with 5 regression tests:
  - Quoted snowflake `"1234567890123456789"` round-trips as a string.
  - Bare snowflake `1234567890123456789` round-trips as a string.
  - Small bare integers (`timeout_minutes: 10`) still parse as numbers.
  - Booleans and nulls (`true` / `false` / `null` / `~`) parse unchanged.
  - Quoted `"true"` / `"null"` parse as strings, not booleans/null.

**Verified the new tests catch the bug** by reverting only the source fix and rerunning the suite: 3 of the 5 new tests fail with the actual truncated value (`actual: 1234567890123456800` vs `expected: '1234567890123456789'`). With the fix in place, all 21 tests in `remote-questions.test.ts` pass.

## Compatibility / risk

- **Behavioural change for callers reading numeric values from frontmatter.** The only fields affected in tree are integer-coerced ones; `clampNumber` (line 110) already calls `Number(value)` defensively on whatever it receives, so existing numeric paths (`timeout_minutes`, `poll_interval_seconds`) are unchanged. Snowflake IDs, which are passed through `String(...)`, now round-trip correctly.
- **No new dependencies.** Pure-Node test, same as the rest of the suite.
- **No public API surface change.** The new export is prefixed with `_` per the existing `@internal` convention.

## Related

- The full `~/.gsd/agent/extensions/remote-questions/` extension uses the proper `yaml` package and is unaffected — only the standalone copy bundled into `packages/mcp-server` had this bug.
- `CHANNEL_ID_PATTERNS` (line 94) is regex-based and could not detect the corruption because the truncated value remains shape-valid. No change to that surface is needed once the parser preserves the original digits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed precision loss when parsing large numeric identifiers.
  - Enhanced preservation of quoted and unquoted scalar values to maintain data integrity.

* **Tests**
  - Added comprehensive test coverage for scalar parsing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->