### PR TITLE
fix(gsd): preserve auto session handoff in terminals

### DIFF
--- a/docs/dev/warp-auto-disconnect-findings.md
+++ b/docs/dev/warp-auto-disconnect-findings.md
@@ -1,0 +1,62 @@
+# Warp Auto Disconnect Investigation
+
+Date: 2026-04-27
+
+Issue: https://github.com/gsd-build/gsd-2/issues/5086
+
+## Issue
+
+When running GSD auto-mode in Warp.app, the terminal can return to a shell prompt while the GSD task/process keeps running. The visible symptom is a disconnected terminal: the foreground UI is gone, but work continues in the background.
+
+## Observed Evidence
+
+- In the `a64353464` project, S01 finished at `2026-04-27T16:33:19Z`.
+- GSD immediately dispatched the next unit, `plan-slice-M001-S02`, at `2026-04-27T16:33:21Z`.
+- No new S02 session file was created.
+- The prior session then recorded `Claude Code process aborted by user` at `2026-04-27T16:33:21Z`.
+- A process scan also showed multiple orphaned `gsd` processes with `PPID=1` and `TTY=??`, matching the user's report that the PID/task was still running while the terminal was no longer attached.
+
+## Root Cause Hypothesis
+
+The auto-mode unit handoff resolves the current unit from the `agent_end` extension event handler. The auto loop then immediately calls `ctx.newSession()` for the next unit.
+
+`AgentSession.newSession()` currently always calls `abort()` before disconnecting from the current agent. That order is correct when a user switches sessions while a turn is still active, because the old turn must emit `agent_end` before the event bus is disconnected.
+
+However, during the auto-mode handoff, `newSession()` can be called while the prior `agent_end` event is still being processed. In that state, the provider turn has already emitted enough completion signal for auto-mode to advance, but the agent loop may not have fully settled. Calling `abort()` at that moment can turn the just-completed provider turn into an aborted assistant message, which matches the recorded `Claude Code process aborted by user` event.
+
+## Secondary Finding
+
+There is also a shell-entry routing risk in `src/cli.ts`: plain `gsd auto` is currently routed through headless mode before the later TTY-aware piped-output gate. If a user launches `gsd auto` directly from a terminal, this path can bypass the interactive TUI lifecycle entirely. This is related but distinct from the observed `agent_end` handoff abort.
+
+## Sunday Night PR Review
+
+The regression window matches the Sunday night PRs pushed on 2026-04-26 and just after midnight on 2026-04-27:
+
+| PR | Merge Time (CT) | Relevance |
+| --- | --- | --- |
+| #5051 `fix/worktree-root-normalization` | 2026-04-26 20:00 | Medium. Changed worktree root detection and lock/report base paths under auto-mode. This altered the path context used by later auto units. |
+| #5058 `fix/safety-harness-bash-evidence-race` | 2026-04-26 22:06 | Low. Persists bash evidence earlier in the tool-call lifecycle. Important for false positives, but it does not explain terminal detachment. |
+| #5055 `feat/worktree-tui-commands` | 2026-04-26 22:13 | Low. Adds worktree TUI commands; no direct auto unit/session lifecycle changes. |
+| #5060 `chore/expose-bundled-skills` | 2026-04-26 22:22 | Low to medium. Can influence model behavior and tool-selection prompts, but does not change session ownership. The trace did show unavailable lowercase `bash`/`read` tool attempts, which may be prompt/model fallout rather than the disconnect trigger. |
+| #5062 `fix/worktree-path-injection` | 2026-04-27 00:33 | High. Moves cwd anchoring immediately before `newSession()` in `auto/run-unit.ts` and hook dispatch. This is the closest code change to the observed failure point: auto completed S01, dispatched S02, then recorded an aborted provider turn before a new S02 session file existed. |
+
+Most likely regression path: #5051 changed the worktree/root substrate, then #5062 made every auto unit session switch depend on a synchronous cwd anchor immediately followed by `ctx.newSession()`. That exposed the existing `newSession()` behavior of always aborting the current turn, even when called from inside the prior turn's `agent_end` handling.
+
+## Implemented Fix
+
+Added a narrow lifecycle distinction in `AgentSession`:
+
+- If `newSession()` or `switchSession()` is called during `agent_end` extension processing, wait for the already-ending provider loop to become idle instead of aborting it.
+- Preserve the existing abort-before-disconnect behavior for normal user-initiated session switches while a turn is genuinely active.
+
+This keeps the existing #4243 ordering guarantee while preventing auto-mode from aborting a turn that already reached `agent_end`.
+
+Also tightened `src/cli.ts` so `gsd auto` only redirects to headless when stdin or stdout is not a TTY. Terminal launches stay on the interactive path, preserving Warp/iTerm/Terminal foreground ownership.
+
+## Reproduction And Verification
+
+- Added a regression test that simulates `newSession()` being called while an `agent_end` extension handler is in progress.
+- Confirmed the test failed before the fix because `newSession()` called `abort()`.
+- Added a CLI source-level regression test proving terminal `gsd auto` is not unconditionally routed to headless.
+- Confirmed the CLI test failed before the TTY-gated redirect fix.
+- Confirmed both focused suites pass after the fix.

--- a/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
@@ -173,7 +173,7 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 		assert.equal(order.includes("abort"), false);
 	});
 
-	it("newSession() skips waitForIdle during agent_end processing once already idle", async () => {
+	it("newSession() waits during agent_end processing even once already idle", async () => {
 		const session = await createSession();
 		const order: string[] = [];
 
@@ -193,7 +193,7 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 
 		const ok = await session.newSession();
 		assert.equal(ok, true);
-		assert.deepEqual(order, ["_disconnectFromAgent"]);
+		assert.deepEqual(order, ["waitForIdle", "_disconnectFromAgent"]);
 		assert.equal(order.includes("abort"), false);
 	});
 
@@ -361,6 +361,7 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 		assert.equal(compactionChecks, 0);
 		assert.equal(listenerAgentEnds, 0);
 		assert.equal((session as any)._lastAssistantMessage, undefined);
+		assert.equal((session as any)._sessionSwitchPending, false);
 		assert.equal((session as any)._sessionTransitionStartedDuringAgentEnd, false);
 	});
 
@@ -395,7 +396,33 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 		assert.equal(compactionChecks, 0);
 		assert.equal(listenerAgentEnds, 0);
 		assert.equal((session as any)._lastAssistantMessage, undefined);
+		assert.equal((session as any)._sessionSwitchPending, false);
 		assert.equal((session as any)._sessionTransitionStartedDuringAgentEnd, false);
+	});
+
+	it("agent_end post-handlers bail while a session switch is pending", async () => {
+		const session = await createSession();
+		const assistantMessage = makeAssistantMessage("old pending response");
+		let compactionChecks = 0;
+		let listenerAgentEnds = 0;
+
+		(session as any)._lastAssistantMessage = assistantMessage;
+		(session as any)._sessionSwitchPending = true;
+		(session as any)._compactionOrchestrator.checkCompaction = async () => {
+			compactionChecks++;
+		};
+		session.subscribe((event: any) => {
+			if (event.type === "agent_end") listenerAgentEnds++;
+		});
+
+		await (session as any)._processAgentEvent({
+			type: "agent_end",
+			messages: [assistantMessage],
+		});
+
+		assert.equal(compactionChecks, 0);
+		assert.equal(listenerAgentEnds, 1);
+		assert.equal((session as any)._lastAssistantMessage, undefined);
 	});
 
 	it("switchSession() invokes abort() before _disconnectFromAgent()", async () => {

--- a/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
@@ -128,6 +128,50 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 		assert.deepEqual(order, ["waitForIdle", "_disconnectFromAgent"]);
 	});
 
+	it("newSession() during agent_end preserves the previous session for resume", async () => {
+		const session = await createSession({ persistSessions: true });
+		const previousSessionFile = session.sessionFile;
+		assert.ok(previousSessionFile, "need a persisted session file");
+
+		session.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "persisted prompt" }],
+		} as any);
+		session.sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "persisted response" }],
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				total: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		} as any);
+		session.agent.replaceMessages(session.sessionManager.buildSessionContext().messages);
+
+		(session as any)._processingAgentEnd = true;
+		(session as any).agent.waitForIdle = async () => {};
+
+		const ok = await session.newSession();
+		assert.equal(ok, true);
+		assert.notEqual(session.sessionFile, previousSessionFile);
+		assert.deepEqual(session.messages, []);
+
+		(session as any)._processingAgentEnd = false;
+		const switched = await session.switchSession(previousSessionFile);
+		assert.equal(switched, true);
+
+		const restoredText = session.messages
+			.flatMap((message: any) => message.content ?? [])
+			.filter((part: any) => part.type === "text")
+			.map((part: any) => part.text);
+		assert.deepEqual(restoredText, ["persisted prompt", "persisted response"]);
+	});
+
 	it("switchSession() invokes abort() before _disconnectFromAgent()", async () => {
 		const session = await createSession({ persistSessions: true });
 		// Seed a session file to switch to (switchSession reads from the session manager).

--- a/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
@@ -106,7 +106,7 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 		);
 	});
 
-	it("newSession() waits instead of aborting while agent_end handlers are still running", async () => {
+	it("newSession() waits instead of aborting while agent_end processing is still streaming", async () => {
 		const session = await createSession();
 		const order: string[] = [];
 		let releaseIdle!: () => void;
@@ -115,6 +115,7 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 		});
 
 		(session as any)._processingAgentEnd = true;
+		(session as any).agent.state.isStreaming = true;
 		(session as any).agent.waitForIdle = () => {
 			order.push("waitForIdle");
 			return idle;
@@ -129,12 +130,38 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 		};
 
 		const pendingNewSession = session.newSession();
+		await Promise.resolve();
 		assert.deepEqual(order, ["waitForIdle"]);
+		assert.equal(order.includes("abort"), false);
 
 		releaseIdle();
 		const ok = await pendingNewSession;
 		assert.equal(ok, true);
 		assert.deepEqual(order, ["waitForIdle", "_disconnectFromAgent"]);
+		assert.equal(order.includes("abort"), false);
+	});
+
+	it("newSession() skips waitForIdle during agent_end processing once already idle", async () => {
+		const session = await createSession();
+		const order: string[] = [];
+
+		(session as any)._processingAgentEnd = true;
+		(session as any).agent.state.isStreaming = false;
+		(session as any).agent.waitForIdle = async () => {
+			order.push("waitForIdle");
+		};
+		(session as any).abort = async () => {
+			order.push("abort");
+		};
+		const originalDisconnect = (session as any)._disconnectFromAgent.bind(session);
+		(session as any)._disconnectFromAgent = () => {
+			order.push("_disconnectFromAgent");
+			originalDisconnect();
+		};
+
+		const ok = await session.newSession();
+		assert.equal(ok, true);
+		assert.deepEqual(order, ["_disconnectFromAgent"]);
 		assert.equal(order.includes("abort"), false);
 	});
 
@@ -205,7 +232,7 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 		assert.deepEqual(restoredText, ["persisted prompt", "persisted response"]);
 	});
 
-	it("switchSession() waits instead of aborting while agent_end handlers are still running", async () => {
+	it("switchSession() waits instead of aborting while agent_end processing is still streaming", async () => {
 		const session = await createSession({ persistSessions: true });
 		const previousSessionFile = session.sessionFile;
 		assert.ok(previousSessionFile, "need a persisted session file");
@@ -244,6 +271,7 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 		});
 
 		(session as any)._processingAgentEnd = true;
+		(session as any).agent.state.isStreaming = true;
 		(session as any).agent.waitForIdle = () => {
 			order.push("waitForIdle");
 			return idle;
@@ -258,7 +286,9 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 		};
 
 		const pendingSwitch = session.switchSession(previousSessionFile);
+		await Promise.resolve();
 		assert.deepEqual(order, ["waitForIdle"]);
+		assert.equal(order.includes("abort"), false);
 		assert.equal(session.sessionFile, activeSessionFile);
 		assert.deepEqual(session.messages, []);
 

--- a/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
@@ -106,6 +106,28 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 		);
 	});
 
+	it("newSession() waits instead of aborting while agent_end handlers are still running", async () => {
+		const session = await createSession();
+		const order: string[] = [];
+
+		(session as any)._processingAgentEnd = true;
+		(session as any).agent.waitForIdle = async () => {
+			order.push("waitForIdle");
+		};
+		(session as any).abort = async () => {
+			order.push("abort");
+		};
+		const originalDisconnect = (session as any)._disconnectFromAgent.bind(session);
+		(session as any)._disconnectFromAgent = () => {
+			order.push("_disconnectFromAgent");
+			originalDisconnect();
+		};
+
+		const ok = await session.newSession();
+		assert.equal(ok, true);
+		assert.deepEqual(order, ["waitForIdle", "_disconnectFromAgent"]);
+	});
+
 	it("switchSession() invokes abort() before _disconnectFromAgent()", async () => {
 		const session = await createSession({ persistSessions: true });
 		// Seed a session file to switch to (switchSession reads from the session manager).

--- a/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
@@ -109,10 +109,15 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 	it("newSession() waits instead of aborting while agent_end handlers are still running", async () => {
 		const session = await createSession();
 		const order: string[] = [];
+		let releaseIdle!: () => void;
+		const idle = new Promise<void>((resolve) => {
+			releaseIdle = resolve;
+		});
 
 		(session as any)._processingAgentEnd = true;
-		(session as any).agent.waitForIdle = async () => {
+		(session as any).agent.waitForIdle = () => {
 			order.push("waitForIdle");
+			return idle;
 		};
 		(session as any).abort = async () => {
 			order.push("abort");
@@ -123,9 +128,37 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 			originalDisconnect();
 		};
 
-		const ok = await session.newSession();
+		const pendingNewSession = session.newSession();
+		assert.deepEqual(order, ["waitForIdle"]);
+
+		releaseIdle();
+		const ok = await pendingNewSession;
 		assert.equal(ok, true);
 		assert.deepEqual(order, ["waitForIdle", "_disconnectFromAgent"]);
+		assert.equal(order.includes("abort"), false);
+	});
+
+	it("abort() marks synthetic agent_end processing while extension handlers run", async () => {
+		const session = await createSession();
+		const observedProcessingStates: boolean[] = [];
+
+		(session as any).agent.abort = () => {};
+		(session as any).agent.waitForIdle = async () => {};
+		(session as any)._extensionRunner = {
+			emit: async (event: any) => {
+				if (event.type === "agent_end") {
+					observedProcessingStates.push((session as any)._processingAgentEnd);
+				}
+			},
+			emitStop: async () => {
+				observedProcessingStates.push((session as any)._processingAgentEnd);
+			},
+		};
+
+		await session.abort();
+
+		assert.deepEqual(observedProcessingStates, [true, true]);
+		assert.equal((session as any)._processingAgentEnd, false);
 	});
 
 	it("newSession() during agent_end preserves the previous session for resume", async () => {
@@ -170,6 +203,77 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 			.filter((part: any) => part.type === "text")
 			.map((part: any) => part.text);
 		assert.deepEqual(restoredText, ["persisted prompt", "persisted response"]);
+	});
+
+	it("switchSession() waits instead of aborting while agent_end handlers are still running", async () => {
+		const session = await createSession({ persistSessions: true });
+		const previousSessionFile = session.sessionFile;
+		assert.ok(previousSessionFile, "need a persisted session file");
+
+		session.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "switch persisted prompt" }],
+		} as any);
+		session.sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "switch persisted response" }],
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				total: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		} as any);
+		session.agent.replaceMessages(session.sessionManager.buildSessionContext().messages);
+
+		const ok = await session.newSession();
+		assert.equal(ok, true);
+		const activeSessionFile = session.sessionFile;
+		assert.ok(activeSessionFile, "need an active session file");
+		assert.notEqual(activeSessionFile, previousSessionFile);
+		assert.deepEqual(session.messages, []);
+
+		const order: string[] = [];
+		let releaseIdle!: () => void;
+		const idle = new Promise<void>((resolve) => {
+			releaseIdle = resolve;
+		});
+
+		(session as any)._processingAgentEnd = true;
+		(session as any).agent.waitForIdle = () => {
+			order.push("waitForIdle");
+			return idle;
+		};
+		(session as any).abort = async () => {
+			order.push("abort");
+		};
+		const originalDisconnect = (session as any)._disconnectFromAgent.bind(session);
+		(session as any)._disconnectFromAgent = () => {
+			order.push("_disconnectFromAgent");
+			originalDisconnect();
+		};
+
+		const pendingSwitch = session.switchSession(previousSessionFile);
+		assert.deepEqual(order, ["waitForIdle"]);
+		assert.equal(session.sessionFile, activeSessionFile);
+		assert.deepEqual(session.messages, []);
+
+		releaseIdle();
+		const switched = await pendingSwitch;
+		assert.equal(switched, true);
+		assert.deepEqual(order, ["waitForIdle", "_disconnectFromAgent"]);
+		assert.equal(order.includes("abort"), false);
+		assert.equal(session.sessionFile, previousSessionFile);
+
+		const restoredText = session.messages
+			.flatMap((message: any) => message.content ?? [])
+			.filter((part: any) => part.type === "text")
+			.map((part: any) => part.text);
+		assert.deepEqual(restoredText, ["switch persisted prompt", "switch persisted response"]);
 	});
 
 	it("switchSession() invokes abort() before _disconnectFromAgent()", async () => {

--- a/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
@@ -77,6 +77,38 @@ function recordCallOrder<O extends object>(
 	return order;
 }
 
+function makeAssistantMessage(text: string) {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			total: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	} as any;
+}
+
+function installAgentEndSessionTransition(
+	session: AgentSession,
+	transition: () => Promise<unknown>,
+): void {
+	(session as any)._extensionRunner = {
+		hasHandlers: () => false,
+		emit: async (event: any) => {
+			if (event.type === "agent_end") {
+				await transition();
+			}
+		},
+		emitStop: async () => {},
+	};
+}
+
 describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 	beforeEach(() => {
 		testDir = mkdtempSync(join(tmpdir(), "agent-session-abort-"));
@@ -304,6 +336,66 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 			.filter((part: any) => part.type === "text")
 			.map((part: any) => part.text);
 		assert.deepEqual(restoredText, ["switch persisted prompt", "switch persisted response"]);
+	});
+
+	it("newSession() during agent_end skips stale post-handlers after the transition starts", async () => {
+		const session = await createSession();
+		const assistantMessage = makeAssistantMessage("old response");
+		let compactionChecks = 0;
+		let listenerAgentEnds = 0;
+
+		(session as any)._lastAssistantMessage = assistantMessage;
+		(session as any)._compactionOrchestrator.checkCompaction = async () => {
+			compactionChecks++;
+		};
+		session.subscribe((event: any) => {
+			if (event.type === "agent_end") listenerAgentEnds++;
+		});
+		installAgentEndSessionTransition(session, () => session.newSession());
+
+		await (session as any)._processAgentEvent({
+			type: "agent_end",
+			messages: [assistantMessage],
+		});
+
+		assert.equal(compactionChecks, 0);
+		assert.equal(listenerAgentEnds, 0);
+		assert.equal((session as any)._lastAssistantMessage, undefined);
+		assert.equal((session as any)._sessionTransitionStartedDuringAgentEnd, false);
+	});
+
+	it("switchSession() during agent_end skips stale post-handlers after the transition starts", async () => {
+		const session = await createSession({ persistSessions: true });
+		const previousSessionFile = session.sessionFile;
+		assert.ok(previousSessionFile, "need a persisted session file");
+
+		const ok = await session.newSession();
+		assert.equal(ok, true);
+		assert.notEqual(session.sessionFile, previousSessionFile);
+
+		const assistantMessage = makeAssistantMessage("old switch response");
+		let compactionChecks = 0;
+		let listenerAgentEnds = 0;
+
+		(session as any)._lastAssistantMessage = assistantMessage;
+		(session as any)._compactionOrchestrator.checkCompaction = async () => {
+			compactionChecks++;
+		};
+		session.subscribe((event: any) => {
+			if (event.type === "agent_end") listenerAgentEnds++;
+		});
+		installAgentEndSessionTransition(session, () => session.switchSession(previousSessionFile));
+
+		await (session as any)._processAgentEvent({
+			type: "agent_end",
+			messages: [assistantMessage],
+		});
+
+		assert.equal(session.sessionFile, previousSessionFile);
+		assert.equal(compactionChecks, 0);
+		assert.equal(listenerAgentEnds, 0);
+		assert.equal((session as any)._lastAssistantMessage, undefined);
+		assert.equal((session as any)._sessionTransitionStartedDuringAgentEnd, false);
 	});
 
 	it("switchSession() invokes abort() before _disconnectFromAgent()", async () => {

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -273,6 +273,9 @@ export class AgentSession {
 	private _extensionRunner: ExtensionRunner | undefined = undefined;
 	private _turnIndex = 0;
 	private _processingAgentEnd = false;
+	/** True while newSession()/switchSession() is in progress; signals agent_end
+	 * post-handlers to bail rather than corrupt new-session state. */
+	private _sessionSwitchPending = false;
 	private _processingQueuedAgentEnd = false;
 	private _sessionTransitionStartedDuringAgentEnd = false;
 
@@ -510,6 +513,13 @@ export class AgentSession {
 
 		// Check auto-retry and auto-compaction after agent completes
 		if (event.type === "agent_end" && this._lastAssistantMessage) {
+			// A session transition started during agent_end handler execution -
+			// bail to avoid running retry/compaction against new-session state.
+			if (this._sessionSwitchPending) {
+				this._lastAssistantMessage = undefined;
+				return;
+			}
+
 			const msg = this._lastAssistantMessage;
 			this._lastAssistantMessage = undefined;
 
@@ -1597,12 +1607,13 @@ export class AgentSession {
 
 	private async _settleCurrentTurnForSessionTransition(): Promise<void> {
 		if (this._processingAgentEnd) {
-			// RPC waitForIdle() waits for the next agent_end event (60s timeout).
-			// During agent_end handlers the agent may already be idle; only wait if
-			// a stream is still in flight to avoid an unnecessary timeout.
-			if (this.isStreaming) {
-				await this.agent.waitForIdle();
-			}
+			// Wait for the agent to fully settle. When called from inside an
+			// agent_end extension handler, the agent may already be idle - but
+			// _processAgentEvent still has retry/compaction tail work to run after
+			// _emitExtensionEvent returns. waitForIdle() is effectively a no-op when
+			// already idle, so awaiting it unconditionally is safe and ensures we
+			// don't proceed into the session reset while that tail is still on the stack.
+			await this.agent.waitForIdle();
 
 			if (this._processingQueuedAgentEnd) {
 				this._sessionTransitionStartedDuringAgentEnd = true;
@@ -1646,18 +1657,23 @@ export class AgentSession {
 			}
 		}
 
-		await this._settleCurrentTurnForSessionTransition();
+		this._sessionSwitchPending = true;
+		try {
+			await this._settleCurrentTurnForSessionTransition();
 
-		// #3731: If the caller aborted (e.g. runUnit() timed out and restored cwd to
-		// project root), discard this session before capturing process.cwd() and
-		// rebuilding the tool runtime. Without this check, the late newSession()
-		// would rebuild tools with root cwd, breaking worktree isolation.
-		if (options?.abortSignal?.aborted) {
-			return false;
+			// #3731: If the caller aborted (e.g. runUnit() timed out and restored cwd to
+			// project root), discard this session before capturing process.cwd() and
+			// rebuilding the tool runtime. Without this check, the late newSession()
+			// would rebuild tools with root cwd, breaking worktree isolation.
+			if (options?.abortSignal?.aborted) {
+				return false;
+			}
+
+			this._disconnectFromAgent();
+			this.agent.reset();
+		} finally {
+			this._sessionSwitchPending = false;
 		}
-
-		this._disconnectFromAgent();
-		this.agent.reset();
 		// Update cwd to current process directory — auto-mode may have chdir'd
 		// into a worktree since the original session was created.
 		const previousCwd = this._cwd;
@@ -2508,8 +2524,13 @@ export class AgentSession {
 			}
 		}
 
-		await this._settleCurrentTurnForSessionTransition();
-		this._disconnectFromAgent();
+		this._sessionSwitchPending = true;
+		try {
+			await this._settleCurrentTurnForSessionTransition();
+			this._disconnectFromAgent();
+		} finally {
+			this._sessionSwitchPending = false;
+		}
 		this._steeringMessages = [];
 		this._followUpMessages = [];
 		this._pendingNextTurnMessages = [];

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1578,7 +1578,12 @@ export class AgentSession {
 
 	private async _settleCurrentTurnForSessionTransition(): Promise<void> {
 		if (this._processingAgentEnd) {
-			await this.agent.waitForIdle();
+			// RPC waitForIdle() resolves on the next agent_end event. During
+			// agent_end handlers the current event already fired, so skip the wait
+			// once the agent is already idle.
+			if (this.isStreaming) {
+				await this.agent.waitForIdle();
+			}
 			return;
 		}
 

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -272,6 +272,7 @@ export class AgentSession {
 	// Extension system
 	private _extensionRunner: ExtensionRunner | undefined = undefined;
 	private _turnIndex = 0;
+	private _processingAgentEnd = false;
 
 	private _resourceLoader: ResourceLoader;
 	private _customTools: ToolDefinition[];
@@ -627,20 +628,25 @@ export class AgentSession {
 			this._turnIndex = 0;
 			await this._extensionRunner.emit({ type: "agent_start" });
 		} else if (event.type === "agent_end") {
-			await this._extensionRunner.emit({ type: "agent_end", messages: event.messages });
-			// `stop` fires on true quiescence: the agent cleanly completed and is now
-			// waiting for the user. Use the last assistant message's stopReason to
-			// distinguish clean completion from error/cancellation.
-			const last = event.messages[event.messages.length - 1];
-			const stopReason: "completed" | "cancelled" | "error" | "blocked" =
-				last?.role === "assistant"
-					? last.stopReason === "aborted"
-						? "cancelled"
-						: last.stopReason === "error"
-							? "error"
-							: "completed"
-					: "completed";
-			await this._extensionRunner.emitStop({ reason: stopReason, lastMessage: last });
+			this._processingAgentEnd = true;
+			try {
+				await this._extensionRunner.emit({ type: "agent_end", messages: event.messages });
+				// `stop` fires on true quiescence: the agent cleanly completed and is now
+				// waiting for the user. Use the last assistant message's stopReason to
+				// distinguish clean completion from error/cancellation.
+				const last = event.messages[event.messages.length - 1];
+				const stopReason: "completed" | "cancelled" | "error" | "blocked" =
+					last?.role === "assistant"
+						? last.stopReason === "aborted"
+							? "cancelled"
+							: last.stopReason === "error"
+								? "error"
+								: "completed"
+						: "completed";
+				await this._extensionRunner.emitStop({ reason: stopReason, lastMessage: last });
+			} finally {
+				this._processingAgentEnd = false;
+			}
 		} else if (event.type === "turn_start") {
 			const extensionEvent: TurnStartEvent = {
 				type: "turn_start",
@@ -1564,6 +1570,19 @@ export class AgentSession {
 		}
 	}
 
+	private async _settleCurrentTurnForSessionTransition(): Promise<void> {
+		if (this._processingAgentEnd) {
+			await this.agent.waitForIdle();
+			return;
+		}
+
+		// #4243: Normal session transitions must abort before disconnecting so
+		// message_end/agent_end events fire while listeners are still connected.
+		// During agent_end handling the turn is already ending; aborting there can
+		// convert a successful auto-mode handoff into an aborted provider message.
+		await this.abort();
+	}
+
 	/**
 	 * Start a new session, optionally with initial messages and parent tracking.
 	 * Clears all messages and starts a new session.
@@ -1592,10 +1611,7 @@ export class AgentSession {
 			}
 		}
 
-	// #4243: Must call abort() BEFORE _disconnectFromAgent() so that
-	// message_end/agent_end events fire and the #4216 finalization code
-	// can run before we unsubscribe from the event bus.
-	await this.abort();
+		await this._settleCurrentTurnForSessionTransition();
 
 		// #3731: If the caller aborted (e.g. runUnit() timed out and restored cwd to
 		// project root), discard this session before capturing process.cwd() and
@@ -1605,8 +1621,8 @@ export class AgentSession {
 			return false;
 		}
 
-	this._disconnectFromAgent();
-	this.agent.reset();
+		this._disconnectFromAgent();
+		this.agent.reset();
 		// Update cwd to current process directory — auto-mode may have chdir'd
 		// into a worktree since the original session was created.
 		const previousCwd = this._cwd;
@@ -2457,12 +2473,9 @@ export class AgentSession {
 			}
 		}
 
-	// #4243: Must call abort() BEFORE _disconnectFromAgent() so that
-	// message_end/agent_end events fire and the #4216 finalization code
-	// can run before we unsubscribe from the event bus.
-	await this.abort();
-	this._disconnectFromAgent();
-	this._steeringMessages = [];
+		await this._settleCurrentTurnForSessionTransition();
+		this._disconnectFromAgent();
+		this._steeringMessages = [];
 		this._followUpMessages = [];
 		this._pendingNextTurnMessages = [];
 

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1552,21 +1552,27 @@ export class AgentSession {
 		// between tool execution and response processing. Also fire Stop so
 		// Layer 0 hooks see a consistent view of session quiescence.
 		if (!this.isStreaming && this._extensionRunner) {
-			const messages = this.agent.state.messages;
-			await this._extensionRunner.emit({
-				type: "agent_end",
-				messages,
-			});
-			const last = messages[messages.length - 1];
-			const stopReason: "completed" | "cancelled" | "error" | "blocked" =
-				last?.role === "assistant"
-					? last.stopReason === "aborted"
-						? "cancelled"
-						: last.stopReason === "error"
-							? "error"
-							: "completed"
-					: "cancelled";
-			await this._extensionRunner.emitStop({ reason: stopReason, lastMessage: last });
+			const wasProcessingAgentEnd = this._processingAgentEnd;
+			this._processingAgentEnd = true;
+			try {
+				const messages = this.agent.state.messages;
+				await this._extensionRunner.emit({
+					type: "agent_end",
+					messages,
+				});
+				const last = messages[messages.length - 1];
+				const stopReason: "completed" | "cancelled" | "error" | "blocked" =
+					last?.role === "assistant"
+						? last.stopReason === "aborted"
+							? "cancelled"
+							: last.stopReason === "error"
+								? "error"
+								: "completed"
+						: "cancelled";
+				await this._extensionRunner.emitStop({ reason: stopReason, lastMessage: last });
+			} finally {
+				this._processingAgentEnd = wasProcessingAgentEnd;
+			}
 		}
 	}
 

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -273,6 +273,8 @@ export class AgentSession {
 	private _extensionRunner: ExtensionRunner | undefined = undefined;
 	private _turnIndex = 0;
 	private _processingAgentEnd = false;
+	private _processingQueuedAgentEnd = false;
+	private _sessionTransitionStartedDuringAgentEnd = false;
 
 	private _resourceLoader: ResourceLoader;
 	private _customTools: ToolDefinition[];
@@ -434,7 +436,23 @@ export class AgentSession {
 		}
 
 		// Emit to extensions first
-		await this._emitExtensionEvent(event);
+		let skipAgentEndPostHandlers = false;
+		if (event.type === "agent_end") {
+			this._processingQueuedAgentEnd = true;
+			try {
+				await this._emitExtensionEvent(event);
+			} finally {
+				this._processingQueuedAgentEnd = false;
+				skipAgentEndPostHandlers = this._sessionTransitionStartedDuringAgentEnd;
+				this._sessionTransitionStartedDuringAgentEnd = false;
+			}
+
+			if (skipAgentEndPostHandlers) {
+				return;
+			}
+		} else {
+			await this._emitExtensionEvent(event);
+		}
 
 		// Notify all listeners
 		this._emit(event);
@@ -622,15 +640,16 @@ export class AgentSession {
 
 	/** Emit extension events based on agent events */
 	private async _emitExtensionEvent(event: AgentEvent): Promise<void> {
-		if (!this._extensionRunner) return;
+		const extensionRunner = this._extensionRunner;
+		if (!extensionRunner) return;
 
 		if (event.type === "agent_start") {
 			this._turnIndex = 0;
-			await this._extensionRunner.emit({ type: "agent_start" });
+			await extensionRunner.emit({ type: "agent_start" });
 		} else if (event.type === "agent_end") {
 			this._processingAgentEnd = true;
 			try {
-				await this._extensionRunner.emit({ type: "agent_end", messages: event.messages });
+				await extensionRunner.emit({ type: "agent_end", messages: event.messages });
 				// `stop` fires on true quiescence: the agent cleanly completed and is now
 				// waiting for the user. Use the last assistant message's stopReason to
 				// distinguish clean completion from error/cancellation.
@@ -643,7 +662,7 @@ export class AgentSession {
 								? "error"
 								: "completed"
 						: "completed";
-				await this._extensionRunner.emitStop({ reason: stopReason, lastMessage: last });
+				await extensionRunner.emitStop({ reason: stopReason, lastMessage: last });
 			} finally {
 				this._processingAgentEnd = false;
 			}
@@ -653,7 +672,7 @@ export class AgentSession {
 				turnIndex: this._turnIndex,
 				timestamp: Date.now(),
 			};
-			await this._extensionRunner.emit(extensionEvent);
+			await extensionRunner.emit(extensionEvent);
 		} else if (event.type === "turn_end") {
 			const extensionEvent: TurnEndEvent = {
 				type: "turn_end",
@@ -661,27 +680,27 @@ export class AgentSession {
 				message: event.message,
 				toolResults: event.toolResults,
 			};
-			await this._extensionRunner.emit(extensionEvent);
+			await extensionRunner.emit(extensionEvent);
 			this._turnIndex++;
 		} else if (event.type === "message_start") {
 			const extensionEvent: MessageStartEvent = {
 				type: "message_start",
 				message: event.message,
 			};
-			await this._extensionRunner.emit(extensionEvent);
+			await extensionRunner.emit(extensionEvent);
 		} else if (event.type === "message_update") {
 			const extensionEvent: MessageUpdateEvent = {
 				type: "message_update",
 				message: event.message,
 				assistantMessageEvent: event.assistantMessageEvent,
 			};
-			await this._extensionRunner.emit(extensionEvent);
+			await extensionRunner.emit(extensionEvent);
 		} else if (event.type === "message_end") {
 			const extensionEvent: MessageEndEvent = {
 				type: "message_end",
 				message: event.message,
 			};
-			await this._extensionRunner.emit(extensionEvent);
+			await extensionRunner.emit(extensionEvent);
 		} else if (event.type === "tool_execution_start") {
 			const extensionEvent: ToolExecutionStartEvent = {
 				type: "tool_execution_start",
@@ -689,7 +708,7 @@ export class AgentSession {
 				toolName: event.toolName,
 				args: event.args,
 			};
-			await this._extensionRunner.emit(extensionEvent);
+			await extensionRunner.emit(extensionEvent);
 		} else if (event.type === "tool_execution_update") {
 			const extensionEvent: ToolExecutionUpdateEvent = {
 				type: "tool_execution_update",
@@ -698,7 +717,7 @@ export class AgentSession {
 				args: event.args,
 				partialResult: event.partialResult,
 			};
-			await this._extensionRunner.emit(extensionEvent);
+			await extensionRunner.emit(extensionEvent);
 		} else if (event.type === "tool_execution_end") {
 			const extensionEvent: ToolExecutionEndEvent = {
 				type: "tool_execution_end",
@@ -707,7 +726,7 @@ export class AgentSession {
 				result: event.result,
 				isError: event.isError,
 			};
-			await this._extensionRunner.emit(extensionEvent);
+			await extensionRunner.emit(extensionEvent);
 		}
 	}
 
@@ -1578,11 +1597,16 @@ export class AgentSession {
 
 	private async _settleCurrentTurnForSessionTransition(): Promise<void> {
 		if (this._processingAgentEnd) {
-			// RPC waitForIdle() resolves on the next agent_end event. During
-			// agent_end handlers the current event already fired, so skip the wait
-			// once the agent is already idle.
+			// RPC waitForIdle() waits for the next agent_end event (60s timeout).
+			// During agent_end handlers the agent may already be idle; only wait if
+			// a stream is still in flight to avoid an unnecessary timeout.
 			if (this.isStreaming) {
 				await this.agent.waitForIdle();
+			}
+
+			if (this._processingQueuedAgentEnd) {
+				this._sessionTransitionStartedDuringAgentEnd = true;
+				this._lastAssistantMessage = undefined;
 			}
 			return;
 		}

--- a/src/cli-auto-routing.ts
+++ b/src/cli-auto-routing.ts
@@ -1,0 +1,8 @@
+export function shouldRedirectAutoToHeadless(
+  subcommand: string | undefined,
+  stdinIsTTY: boolean | undefined,
+  stdoutIsTTY: boolean | undefined,
+): boolean {
+  if (subcommand !== 'auto') return false
+  return stdinIsTTY !== true || stdoutIsTTY !== true
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { shouldRunOnboarding, runOnboarding } from './onboarding.js'
 import chalk from 'chalk'
 import { checkForUpdates } from './update-check.js'
 import { shouldBypassManagedResourceMismatchGate } from './cli-policy.js'
+import { shouldRedirectAutoToHeadless } from './cli-auto-routing.js'
 import { printHelp, printSubcommandHelp } from './help-text.js'
 import { applySecurityOverrides } from './security-overrides.js'
 import { validateConfiguredModel } from './startup-model-validation.js'
@@ -454,10 +455,10 @@ function flushPendingProviderRegistrations(resourceLoader: DefaultResourceLoader
   runtime.pendingProviderRegistrations = []
 }
 
-// `gsd auto [args...]` — shorthand for `gsd headless auto [args...]` (#2732)
-// Without this, `gsd auto` falls through to the interactive TUI which hangs
-// when stdin/stdout are piped (non-TTY environments).
-if (cliFlags.messages[0] === 'auto') {
+// `gsd auto [args...]` with piped stdin/stdout — shorthand for
+// `gsd headless auto [args...]` (#2732). Keep terminal TTY launches in the
+// interactive path so Warp/iTerm/Terminal retain foreground ownership.
+if (shouldRedirectAutoToHeadless(cliFlags.messages[0], process.stdin.isTTY, process.stdout.isTTY)) {
   await runHeadlessFromAuto(buildHeadlessAutoArgs(cliFlags))
 }
 
@@ -738,17 +739,6 @@ if (!cliFlags.worktree && !isPrintMode) {
   } catch { /* non-fatal */ }
 }
 markStartup('worktreeStatusBanner')
-
-// ---------------------------------------------------------------------------
-// Auto-redirect: `gsd auto` with piped stdout → headless mode (#2732)
-// When stdout is not a TTY (e.g. `gsd auto | cat`, `gsd auto > file`),
-// the TUI cannot render and the process hangs. Redirect to headless mode
-// which handles non-interactive output gracefully.
-// ---------------------------------------------------------------------------
-if (cliFlags.messages[0] === 'auto' && !process.stdout.isTTY) {
-  process.stderr.write('[gsd] stdout is not a terminal — running auto-mode in headless mode.\n')
-  await runHeadlessFromAuto(cliFlags.messages.slice(1))
-}
 
 // ---------------------------------------------------------------------------
 // Interactive mode — normal TTY session

--- a/src/tests/auto-mode-piped.test.ts
+++ b/src/tests/auto-mode-piped.test.ts
@@ -1,106 +1,29 @@
 /**
  * Tests for `gsd auto` routing — verifies that `auto` is recognized as a
- * subcommand alias for `headless auto` so it doesn't fall through to the
- * interactive TUI, which hangs when stdin/stdout are piped.
+ * subcommand alias for `headless auto` only when stdin or stdout are not TTYs.
  *
  * Regression test for #2732.
  */
 
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 
-const projectRoot = join(fileURLToPath(import.meta.url), '..', '..', '..')
+import { shouldRedirectAutoToHeadless } from '../cli-auto-routing.js'
 
-// ---------------------------------------------------------------------------
-// Source-level verification: cli.ts must handle 'auto' before TUI
-// ---------------------------------------------------------------------------
-
-/**
- * Read cli.ts and verify the 'auto' subcommand is routed before the
- * interactive TUI code path. This is the definitive test — if cli.ts doesn't
- * handle 'auto', piped invocations will hang (#2732).
- */
-function cliSourceHandlesAutoBeforeTUI(): boolean {
-  const cliSource = readFileSync(join(projectRoot, 'src', 'cli.ts'), 'utf-8')
-
-  // Find the position of the 'auto' subcommand handler
-  // It should appear as: messages[0] === 'auto'
-  const autoHandlerMatch = cliSource.match(
-    /messages\[0\]\s*===\s*['"]auto['"]/,
-  )
-  if (!autoHandlerMatch) return false
-
-  // Find the position of the InteractiveMode TUI entry
-  const tuiMatch = cliSource.match(/new\s+InteractiveMode\s*\(/)
-  if (!tuiMatch) return false
-
-  // The auto handler must appear BEFORE the TUI in the source
-  const autoPos = cliSource.indexOf(autoHandlerMatch[0])
-  const tuiPos = cliSource.indexOf(tuiMatch[0])
-
-  return autoPos < tuiPos
-}
-
-// ═══════════════════════════════════════════════════════════════════════════
-// Core regression test: `gsd auto` must be handled before TUI (#2732)
-// ═══════════════════════════════════════════════════════════════════════════
-
-test('cli.ts handles `auto` subcommand before interactive TUI (#2732)', () => {
-  assert.ok(
-    cliSourceHandlesAutoBeforeTUI(),
-    'cli.ts must route messages[0] === "auto" to a handler BEFORE ' +
-    'reaching `new InteractiveMode()`. Without this, `gsd auto` with ' +
-    'piped stdin/stdout falls through to the TUI and hangs.',
-  )
+test('routes `gsd auto` with piped stdout to headless mode (#2732)', () => {
+  assert.equal(shouldRedirectAutoToHeadless('auto', true, false), true)
 })
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Verify the auto handler routes to headless (not a stub/no-op)
-// ═══════════════════════════════════════════════════════════════════════════
-
-test('cli.ts routes `auto` to headless runner', () => {
-  const cliSource = readFileSync(join(projectRoot, 'src', 'cli.ts'), 'utf-8')
-
-  // The auto handler block should import or reference headless
-  // Look for the auto block and check it contains runHeadless or headless
-  const autoBlockRegex = /messages\[0\]\s*===\s*['"]auto['"][\s\S]*?runHeadless/
-  assert.ok(
-    autoBlockRegex.test(cliSource),
-    '`auto` subcommand handler must invoke runHeadless to delegate to headless mode',
-  )
+test('routes `gsd auto` with piped stdin to headless mode', () => {
+  assert.equal(shouldRedirectAutoToHeadless('auto', false, true), true)
 })
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Verify piped-mode hint in error message when auto mode is not available
-// ═══════════════════════════════════════════════════════════════════════════
-
-test('TTY error message mentions `gsd auto` as a non-interactive alternative', () => {
-  const cliSource = readFileSync(join(projectRoot, 'src', 'cli.ts'), 'utf-8')
-
-  // The TTY error message should mention auto as an alternative
-  assert.ok(
-    cliSource.includes('gsd auto') || cliSource.includes('gsd headless'),
-    'TTY error hints should mention headless/auto mode as alternatives',
-  )
+test('keeps terminal `gsd auto` on the interactive path', () => {
+  assert.equal(shouldRedirectAutoToHeadless('auto', true, true), false)
 })
 
-// ═══════════════════════════════════════════════════════════════════════════
-// `gsd headless` still works (no regression)
-// ═══════════════════════════════════════════════════════════════════════════
-
-test('cli.ts handles `headless` subcommand before interactive TUI', () => {
-  const cliSource = readFileSync(join(projectRoot, 'src', 'cli.ts'), 'utf-8')
-
-  const headlessMatch = cliSource.match(/messages\[0\]\s*===\s*['"]headless['"]/)
-  const tuiMatch = cliSource.match(/new\s+InteractiveMode\s*\(/)
-
-  assert.ok(headlessMatch, 'headless subcommand handler exists')
-  assert.ok(tuiMatch, 'InteractiveMode TUI exists')
-
-  const headlessPos = cliSource.indexOf(headlessMatch![0])
-  const tuiPos = cliSource.indexOf(tuiMatch![0])
-  assert.ok(headlessPos < tuiPos, 'headless handler is before TUI')
+test('does not route non-auto subcommands through auto headless mode', () => {
+  assert.equal(shouldRedirectAutoToHeadless('headless', true, false), false)
+  assert.equal(shouldRedirectAutoToHeadless('config', true, false), false)
+  assert.equal(shouldRedirectAutoToHeadless(undefined, false, false), false)
 })

--- a/src/tests/auto-mode-piped.test.ts
+++ b/src/tests/auto-mode-piped.test.ts
@@ -7,6 +7,11 @@
 
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { shouldRedirectAutoToHeadless } from '../cli-auto-routing.js'
 
@@ -16,6 +21,138 @@ test('routes `gsd auto` with piped stdout to headless mode (#2732)', () => {
 
 test('routes `gsd auto` with piped stdin to headless mode', () => {
   assert.equal(shouldRedirectAutoToHeadless('auto', false, true), true)
+})
+
+test('src/cli.ts routes `gsd auto` with piped stdout through the headless entrypoint', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'gsd-auto-cli-route-'))
+  const loaderPath = join(tempDir, 'stub-loader.mjs')
+  try {
+    writeFileSync(loaderPath, `
+import { existsSync } from 'node:fs'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const root = pathToFileURL(process.cwd() + '/').href
+const modules = new Map([
+  ['stub:pi-coding-agent', \`
+    export class AuthStorage {}
+    export const DEFAULT_MAX_BYTES = 0
+    export const DEFAULT_MAX_LINES = 0
+    export function createBashTool() {}
+    export function createEditTool() {}
+    export function createReadTool() {}
+    export function createWriteTool() {}
+    export function formatSize() { return '' }
+    export function getAgentDir() { return '' }
+    export function getAllToolCompatibility() { return {} }
+    export function getLoadedSkills() { return [] }
+    export function getToolCompatibility() { return {} }
+    export function importExtensionModule() { return {} }
+    export function isToolCallEventType() { return false }
+    export function parseFrontmatter() { return {} }
+    export function setAllowedCommandPrefixes() {}
+    export function truncateHead(value) { return value }
+  \`],
+  ['stub:pi-ai', \`
+    export async function completeSimple() { return {} }
+    export function getEnvApiKey() { return undefined }
+    export function getProviderCapabilities() { return {} }
+    export function isAnthropicApi() { return false }
+    export function StringEnum() { return {} }
+  \`],
+  ['stub:pi-tui', \`
+    export const Key = {}
+    export const Text = {}
+    export function matchesKey() { return false }
+    export function truncateToWidth(value) { return String(value) }
+    export function visibleWidth(value) { return String(value).length }
+    export function wrapTextWithAnsi(value) { return [String(value)] }
+  \`],
+  ['stub:chalk', \`
+    const passthrough = (value) => String(value)
+    passthrough.bold = passthrough
+    passthrough.dim = passthrough
+    passthrough.yellow = passthrough
+    passthrough.green = passthrough
+    passthrough.cyan = passthrough
+    passthrough.red = passthrough
+    export default passthrough
+  \`],
+  ['stub:headless', \`
+    export function parseHeadlessArgs(argv) {
+      process.stderr.write('AUTO_REDIRECT_ARGV ' + JSON.stringify(argv) + '\\\\n')
+      return { argv }
+    }
+    export async function runHeadless(options) {
+      process.stderr.write('AUTO_REDIRECT_RUN ' + JSON.stringify(options) + '\\\\n')
+    }
+  \`],
+])
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === '@gsd/pi-coding-agent') return { url: 'stub:pi-coding-agent', shortCircuit: true }
+  if (specifier === '@gsd/pi-ai' || specifier === '@gsd/pi-ai/oauth') return { url: 'stub:pi-ai', shortCircuit: true }
+  if (specifier === '@gsd/pi-tui') return { url: 'stub:pi-tui', shortCircuit: true }
+  if (specifier === 'chalk') return { url: 'stub:chalk', shortCircuit: true }
+  if (specifier === './headless.js' && context.parentURL?.endsWith('/src/cli.ts')) {
+    return { url: 'stub:headless', shortCircuit: true }
+  }
+  if (
+    specifier.endsWith('.js') &&
+    (specifier.startsWith('./') || specifier.startsWith('../')) &&
+    context.parentURL?.startsWith(root)
+  ) {
+    const url = new URL(specifier.replace(/\\.js$/, '.ts'), context.parentURL)
+    if (existsSync(fileURLToPath(url))) return { url: url.href, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+
+export async function load(url, context, nextLoad) {
+  const source = modules.get(url)
+  if (source !== undefined) return { format: 'module', source, shortCircuit: true }
+  return nextLoad(url, context)
+}
+`)
+
+    const registerLoader = `
+      import { register } from 'node:module'
+      import { pathToFileURL } from 'node:url'
+      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true })
+      Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: false })
+      register(${JSON.stringify(pathToFileURL(loaderPath).href)}, pathToFileURL('./'))
+    `
+    const result = spawnSync(process.execPath, [
+      '--import',
+      `data:text/javascript,${encodeURIComponent(registerLoader)}`,
+      '--experimental-strip-types',
+      join(process.cwd(), 'src', 'cli.ts'),
+      'auto',
+      '--model',
+      'test-model',
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        GSD_HOME: join(tempDir, 'home'),
+        GSD_RTK_DISABLED: '1',
+      },
+      encoding: 'utf8',
+      input: '',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    const markerLine = result.stderr
+      .split(/\r?\n/)
+      .find((line) => line.startsWith('AUTO_REDIRECT_ARGV '))
+    assert.ok(markerLine, result.stderr)
+
+    const headlessArgv = JSON.parse(markerLine.slice('AUTO_REDIRECT_ARGV '.length)) as string[]
+    assert.deepEqual(headlessArgv.slice(2), ['headless', '--model', 'test-model', 'auto'])
+    assert.match(result.stderr, /AUTO_REDIRECT_RUN /)
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
 })
 
 test('keeps terminal `gsd auto` on the interactive path', () => {

--- a/src/tests/auto-piped-io.test.ts
+++ b/src/tests/auto-piped-io.test.ts
@@ -14,6 +14,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { shouldRedirectAutoToHeadless } from "../cli-auto-routing.js";
+
 // ─── Extracted detection logic (mirrors cli.ts) ───────────────────────────
 
 /**
@@ -29,20 +31,6 @@ const EXPLICIT_SUBCOMMANDS = new Set([
   "sessions",
   "web",
 ]);
-
-/**
- * Detect whether the current subcommand should be auto-redirected
- * to headless mode when stdout is not a TTY.
- *
- * Returns true when: the subcommand is "auto" AND stdout is piped.
- */
-function shouldRedirectAutoToHeadless(
-  subcommand: string | undefined,
-  stdoutIsTTY: boolean,
-): boolean {
-  if (stdoutIsTTY) return false;
-  return subcommand === "auto";
-}
 
 /**
  * Check whether interactive mode can be entered.
@@ -66,18 +54,22 @@ function isExplicitSubcommand(subcommand: string | undefined): boolean {
 // ─── shouldRedirectAutoToHeadless ─────────────────────────────────────────
 
 test("redirects 'auto' to headless when stdout is piped", () => {
-  assert.ok(shouldRedirectAutoToHeadless("auto", false));
+  assert.ok(shouldRedirectAutoToHeadless("auto", true, false));
 });
 
-test("does NOT redirect 'auto' when stdout is a TTY", () => {
-  assert.ok(!shouldRedirectAutoToHeadless("auto", true));
+test("redirects 'auto' to headless when stdin is piped", () => {
+  assert.ok(shouldRedirectAutoToHeadless("auto", false, true));
+});
+
+test("does NOT redirect 'auto' when stdin and stdout are TTY", () => {
+  assert.ok(!shouldRedirectAutoToHeadless("auto", true, true));
 });
 
 test("does NOT redirect non-auto subcommands when stdout is piped", () => {
-  assert.ok(!shouldRedirectAutoToHeadless("headless", false));
-  assert.ok(!shouldRedirectAutoToHeadless("config", false));
-  assert.ok(!shouldRedirectAutoToHeadless("update", false));
-  assert.ok(!shouldRedirectAutoToHeadless(undefined, false));
+  assert.ok(!shouldRedirectAutoToHeadless("headless", true, false));
+  assert.ok(!shouldRedirectAutoToHeadless("config", true, false));
+  assert.ok(!shouldRedirectAutoToHeadless("update", true, false));
+  assert.ok(!shouldRedirectAutoToHeadless(undefined, true, false));
 });
 
 // ─── canEnterInteractiveMode ──────────────────────────────────────────────
@@ -130,7 +122,7 @@ test("scenario: 'gsd auto 2>&1 | cat' — should redirect to headless", () => {
   assert.ok(!canEnterInteractiveMode(stdinIsTTY, stdoutIsTTY));
 
   // Auto should be redirected to headless
-  assert.ok(shouldRedirectAutoToHeadless(subcommand, stdoutIsTTY));
+  assert.ok(shouldRedirectAutoToHeadless(subcommand, stdinIsTTY, stdoutIsTTY));
 });
 
 test("scenario: 'gsd auto > /tmp/output.txt' — should redirect to headless", () => {
@@ -139,7 +131,7 @@ test("scenario: 'gsd auto > /tmp/output.txt' — should redirect to headless", (
   const stdoutIsTTY = false;
 
   assert.ok(!canEnterInteractiveMode(stdinIsTTY, stdoutIsTTY));
-  assert.ok(shouldRedirectAutoToHeadless(subcommand, stdoutIsTTY));
+  assert.ok(shouldRedirectAutoToHeadless(subcommand, stdinIsTTY, stdoutIsTTY));
 });
 
 test("scenario: 'gsd auto' in terminal — normal interactive mode", () => {
@@ -148,7 +140,7 @@ test("scenario: 'gsd auto' in terminal — normal interactive mode", () => {
   const stdoutIsTTY = true;
 
   assert.ok(canEnterInteractiveMode(stdinIsTTY, stdoutIsTTY));
-  assert.ok(!shouldRedirectAutoToHeadless(subcommand, stdoutIsTTY));
+  assert.ok(!shouldRedirectAutoToHeadless(subcommand, stdinIsTTY, stdoutIsTTY));
 });
 
 test("scenario: 'echo msg | gsd auto' — stdin piped, should redirect", () => {
@@ -156,10 +148,9 @@ test("scenario: 'echo msg | gsd auto' — stdin piped, should redirect", () => {
   const stdinIsTTY = false;
   const stdoutIsTTY = true; // stdout is TTY even though stdin is piped
 
-  // stdout is TTY, so auto redirect doesn't trigger...
-  assert.ok(!shouldRedirectAutoToHeadless(subcommand, stdoutIsTTY));
-  // ...but interactive mode is blocked because stdin is piped
+  // Interactive mode is blocked because stdin is piped, so auto redirects to headless.
   assert.ok(!canEnterInteractiveMode(stdinIsTTY, stdoutIsTTY));
+  assert.ok(shouldRedirectAutoToHeadless(subcommand, stdinIsTTY, stdoutIsTTY));
 });
 
 test("scenario: 'echo msg | gsd auto | cat' — both piped", () => {
@@ -168,5 +159,5 @@ test("scenario: 'echo msg | gsd auto | cat' — both piped", () => {
   const stdoutIsTTY = false;
 
   assert.ok(!canEnterInteractiveMode(stdinIsTTY, stdoutIsTTY));
-  assert.ok(shouldRedirectAutoToHeadless(subcommand, stdoutIsTTY));
+  assert.ok(shouldRedirectAutoToHeadless(subcommand, stdinIsTTY, stdoutIsTTY));
 });


### PR DESCRIPTION
## TL;DR

**What:** Prevent `/gsd auto` from detaching from Warp during auto-mode unit handoff.
**Why:** Auto-mode could abort a provider turn while handling `agent_end`, leaving the task running but the terminal disconnected.
**How:** Wait for already-ending provider turns instead of aborting during `agent_end`, and keep terminal `gsd auto` launches on the interactive path unless stdin/stdout are piped.

## What

- Tracks when `AgentSession` is processing `agent_end` and settles that turn before `newSession()` / `switchSession()` transitions.
- Preserves the existing abort-before-disconnect behavior for normal active session switches.
- Adds a shared CLI routing helper so `gsd auto` only redirects to headless when stdin or stdout is not a TTY.
- Replaces source-shape CLI tests with behavior-level routing tests.
- Documents the Warp auto-disconnect investigation and Sunday-night PR review.

## Why

Warp could return to the shell while GSD auto-mode work continued in the background. Process/session evidence showed an auto unit boundary where S01 completed, S02 dispatch began, no S02 session file appeared, and the prior session recorded `Claude Code process aborted by user` at the same timestamp.

Closes #5086

## How

`AgentSession` now distinguishes normal user-initiated transitions from transitions requested while an `agent_end` extension handler is still running. In the latter case, the provider loop is already ending, so the session waits for idle instead of issuing an abort that can turn a successful handoff into an aborted provider message.

The CLI routing change extracts the auto/headless decision into `shouldRedirectAutoToHeadless()`. Terminal launches with both stdin and stdout attached remain interactive; piped invocations still delegate to headless mode.

## Change Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Test Plan

- [x] `npm run test:compile >/tmp/gsd-test-compile.log && node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=spec --test dist-test/src/tests/auto-mode-piped.test.js dist-test/src/tests/auto-piped-io.test.js dist-test/packages/pi-coding-agent/src/core/agent-session-abort-order.test.js`
- [x] `npm run verify:pr`

## AI Assistance

This PR is AI-assisted. The investigation, patch, and verification were performed locally before opening the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented auto-mode terminal detachments by making session switches wait for in-progress turn completion and preserving prior session state for resumption.
  * `auto` now redirects to headless only when the command is not running in an interactive terminal.

* **Documentation**
  * Added an investigation report documenting observed auto-mode detach behavior and verification steps.

* **Tests**
  * Added regression tests for session-transition timing and interactive/headless CLI routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->