### PR TITLE
fix(claude-code-cli): persist Always Allow for non-Bash tools

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1091,6 +1091,20 @@ export function createClaudeCodeCanUseToolHandler(
 							destination: "localSettings",
 						}];
 					}
+				} else if (!perms || (Array.isArray(perms) && perms.length === 0)) {
+					// Non-Bash tool with no SDK-supplied suggestions. Without a
+					// fallback rule the SDK would return `behavior: "allow"`
+					// with no `updatedPermissions`, so "Always Allow" silently
+					// fails to persist for tools whose input varies per call
+					// (e.g. AskUserQuestion with different `questions` payloads).
+					// A bare `{ toolName }` rule matches any input.
+					perms = [{
+						type: "addRules",
+						rules: [{ toolName }],
+						behavior: "allow",
+						destination: "localSettings",
+					}];
+					notifyLabel = toolName;
 				}
 				// Notify with the resolved pattern (label already previewed it)
 				if (notifyLabel) {

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1609,17 +1609,22 @@ describe("stream-adapter — canUseTool handler", () => {
 		assert.equal(notified.length, 0);
 	});
 
-	test("Always Allow for non-Bash without suggestions omits updatedPermissions", async () => {
+	test("Always Allow for non-Bash without suggestions builds tool-name-only fallback rule", async () => {
 		const notified: string[] = [];
 		const ui = { select: async (_p: string, opts: string[]) => opts.find((o) => o.startsWith("Always Allow"))!, notify: (msg: string) => notified.push(msg) };
 
 		const handler = createClaudeCodeCanUseToolHandler(ui as any);
-		const result = await handler!("Write", { file_path: "/tmp/test.txt" }, makeOptions());
+		const result = await handler!("AskUserQuestion", { questions: [{ question: "?", header: "h", multiSelect: false, options: [] }] }, makeOptions());
 
 		assert.equal(result.behavior, "allow");
-		assert.equal((result as any).updatedPermissions, undefined);
-		// No suggestions → no notification
-		assert.equal(notified.length, 0);
+		assert.deepEqual((result as any).updatedPermissions, [{
+			type: "addRules",
+			rules: [{ toolName: "AskUserQuestion" }],
+			behavior: "allow",
+			destination: "localSettings",
+		}]);
+		assert.equal(notified.length, 1);
+		assert.match(notified[0], /AskUserQuestion/);
 	});
 
 	test("prompt includes command text for Bash tools", async () => {

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1627,6 +1627,24 @@ describe("stream-adapter — canUseTool handler", () => {
 		assert.match(notified[0], /AskUserQuestion/);
 	});
 
+	test("Always Allow for non-Bash with empty suggestions array builds tool-name-only fallback rule", async () => {
+		const notified: string[] = [];
+		const ui = { select: async (_p: string, opts: string[]) => opts.find((o) => o.startsWith("Always Allow"))!, notify: (msg: string) => notified.push(msg) };
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		const result = await handler!("AskUserQuestion", { questions: [{ question: "?", header: "h", multiSelect: false, options: [] }] }, makeOptions({ suggestions: [] }));
+
+		assert.equal(result.behavior, "allow");
+		assert.deepEqual((result as any).updatedPermissions, [{
+			type: "addRules",
+			rules: [{ toolName: "AskUserQuestion" }],
+			behavior: "allow",
+			destination: "localSettings",
+		}]);
+		assert.equal(notified.length, 1);
+		assert.match(notified[0], /AskUserQuestion/);
+	});
+
 	test("prompt includes command text for Bash tools", async () => {
 		let selectPrompt = "";
 		const ui = {


### PR DESCRIPTION
## TL;DR

**What:** Fix Always Allow silently failing to persist for non-Bash tools (e.g. `AskUserQuestion`).
**Why:** Users were re-prompted on every invocation despite picking Always Allow.
**How:** Mirror the existing Bash fallback — build a tool-name-only `addRules` PermissionUpdate when the SDK supplies no suggestions.

## What

`src/resources/extensions/claude-code-cli/stream-adapter.ts` — `createClaudeCodeCanUseToolHandler`: add a non-Bash branch that constructs a fallback `PermissionUpdate` (`{ type: "addRules", rules: [{ toolName }], behavior: "allow", destination: "localSettings" }`) when `options.suggestions` is empty/undefined.

`src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts` — replace the regression test that asserted the old (buggy) "omits updatedPermissions" behavior with one that asserts the new fallback rule is emitted, using `AskUserQuestion` as the case.

## Why

The handler only built a fallback PermissionUpdate inside the `if (toolName === "Bash" ...)` branch. For any other tool whose input varies per call (most visibly `AskUserQuestion`, whose `questions` payload differs every invocation), the SDK doesn't supply `options.suggestions`. The handler then returned `{ behavior: "allow" }` with no `updatedPermissions`, leaving the SDK nothing to persist — Always Allow looked accepted in the UI but had no effect on the next call.

Closes #5095

## How

A bare `{ toolName }` rule (no `ruleContent`) matches any input for that tool, which is exactly the right semantics for tools where the input varies. The new branch only fires when `!perms || perms.length === 0`, so any future SDK-supplied suggestions still pass through unchanged. `destination: "localSettings"` matches the existing Bash fallback.

Bash retains its specialized handling (subcommand granularity via `buildBashPermissionPatternOptions` and the level picker) — the new branch is gated on the existing Bash block via `else if`.

### Test plan

- [x] Unit test: `Always Allow for non-Bash without suggestions builds tool-name-only fallback rule` asserts the exact `updatedPermissions` shape and the `Saved: AskUserQuestion` notify.
- [x] Existing tests pass (`Always Allow for non-Bash tools passes SDK suggestions through` confirms the SDK-suggestions path is untouched).
- [x] `npm run verify:pr` clean for the touched test file (2 failing tests on main are unrelated `derive-state-db` perf assertions).

This PR is AI-assisted and was peer-reviewed before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Always Allow" selections now reliably persist for tools that previously failed to save in certain workflows, ensuring users no longer need to re-authorize.
  * UI now produces a clear notification labeled with the tool name when "Always Allow" is applied.

* **Tests**
  * Coverage added for the non-default "Always Allow" path to verify permission persistence and notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->