### PR TITLE
fix(gsd): allow review-tier subagent dispatch from validate-milestone

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -231,6 +231,7 @@ test('planning-dispatch mode is reserved for slice-level decomposition and compl
     "refine-slice",
     "complete-slice",
     "complete-milestone",
+    "validate-milestone",
   ]);
   for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
     const mode = (manifest as { tools: { mode: string } }).tools.mode;

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -381,7 +381,11 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: false,
     preferences: "active-only",
-    tools: TOOLS_PLANNING,
+    // planning-dispatch: validation is a verification-fan-out unit. It reads
+    // the milestone surface and dispatches reviewer/security/tester subagents
+    // to report findings without touching user source. Mirrors
+    // complete-milestone's policy. Write isolation to .gsd/ is preserved.
+    tools: TOOLS_PLANNING_DISPATCH_REVIEW,
     artifacts: {
       inline: ["roadmap", "slice-summary", "slice-uat", "requirements", "decisions", "templates"],
       excerpt: [],


### PR DESCRIPTION
## TL;DR

**What:** Switches `validate-milestone`'s tools-policy from `TOOLS_PLANNING` to `TOOLS_PLANNING_DISPATCH_REVIEW`.
**Why:** The current planning-only policy mechanically blocks the reviewer/security/tester fan-out validate-milestone is designed to do, stalling the milestone closeout flow.
**How:** One-line manifest change mirroring `complete-milestone`'s policy, plus updating the dispatch-allowlist test.

## What

- `src/resources/extensions/gsd/unit-context-manifest.ts` — change `validate-milestone.tools` from `TOOLS_PLANNING` to `TOOLS_PLANNING_DISPATCH_REVIEW`.
- `src/resources/extensions/gsd/tests/unit-context-manifest.test.ts` — add `validate-milestone` to the `allowedDispatchUnits` allowlist (the test that pins which unit types may declare planning-dispatch mode).

No other files touched. `.gsd/` write isolation is preserved — the only behavior change is opening the read-only specialist allowlist (`reviewer`, `security`, `tester`) for subagent dispatch.

## Why

Closes #5098.

`validate-milestone` is the verification fan-out unit that runs immediately before `complete-milestone`. Today, attempting to dispatch reviewer subagents from a `validate-milestone` unit hits the write-gate hard block:

```
HARD BLOCK: unit "validate-milestone" runs under tools-policy "planning"
— subagent dispatch is not permitted in planning units. This is a mechanical
gate enforced by manifest.tools (#4934).
```

`complete-milestone` already uses `TOOLS_PLANNING_DISPATCH_REVIEW`, with this rationale in `unit-context-manifest.ts:398-401`:

> completion is a high-leverage place to fan out to reviewer / security / tester subagents. They read the diff and report findings; they do not write user source. Write isolation to .gsd/ is preserved.

That rationale applies identically to `validate-milestone`. The current planning-only policy looks like a manifest oversight from #4934 rather than an intentional restriction.

## How

`TOOLS_PLANNING_DISPATCH_REVIEW` already exists in the manifest (line 286) with `allowedSubagents: ["reviewer", "security", "tester"]`, so this is a one-line policy switch:

```ts
"validate-milestone": {
  ...
- tools: TOOLS_PLANNING,
+ tools: TOOLS_PLANNING_DISPATCH_REVIEW,
}
```

The companion test (`unit-context-manifest.test.ts:228`) explicitly pins which unit types may declare `planning-dispatch` mode — extended consciously per the test's own comment ("extend the allowlist consciously when a new unit type genuinely benefits from subagent delegation").

### Alternatives considered

- **Loosening the write-gate**: rejected — the gate is correct; the manifest assignment was wrong.
- **Adding a dedicated `TOOLS_PLANNING_DISPATCH_VALIDATE` constant**: rejected — same agent allowlist as `TOOLS_PLANNING_DISPATCH_REVIEW`, no value in duplicating.

## Verification

- `npm run verify:pr` — pass (build:core + typecheck:extensions + test:unit).
- Manifest invariants in `unit-context-manifest.test.ts` continue to pass: `validate-milestone` now declares `planning-dispatch` mode, is on the allowlist, and inherits a non-empty `allowedSubagents`.

### Change type checklist

- [x] `fix` — Bug fix
- [ ] `feat`
- [ ] `refactor`
- [ ] `test`
- [ ] `docs`
- [ ] `chore`

### AI-assisted

This PR is AI-assisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validation process configuration to support controlled dispatch mode with modified tool-access policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->