### PR TITLE
Add thinking_policy: per-unit thinking level configuration

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -780,6 +780,51 @@ disabled_model_providers:
   - google-gemini-cli
 ```
 
+### `thinking_policy`
+
+Per-unit-type and per-prefix thinking-level policy. Lets you dial thinking off
+for cheap/low-stakes units (e.g. `execute-task-simple`) and crank it up for
+high-leverage planning or discussion units, without flipping `/thinking` by hand
+between phases.
+
+```yaml
+thinking_policy:
+  default: medium
+  prefixes:
+    research-: medium
+    discuss-: high
+    plan-: high
+  unitTypes:
+    execute-task: off          # quote "off" if you prefer not to rely on coercion
+    execute-task-simple: off
+    reactive-execute: off
+    replan-slice: high
+```
+
+Valid levels: `off`, `minimal`, `low`, `medium`, `high`, `xhigh` (matches Pi
+SDK's `defaultThinkingLevel`).
+
+Resolution order at dispatch time (first match wins):
+
+1. `unitTypes[unitType]` — exact match.
+2. `prefixes[<longest matching prefix>]` — e.g. `research-slice` matches `research-`.
+3. `default`.
+4. The thinking level captured at auto-mode start (your `/thinking` or
+   `--thinking` choice, or the level from `~/.gsd/agent/settings.json`).
+
+Notes:
+
+- `unitTypes` keys are validated against the canonical unit-type list — typos
+  are rejected with a helpful error listing valid types.
+- Prefix keys conventionally end with `-` (e.g. `research-`); a missing dash
+  produces a warning, not a rejection.
+- YAML 1.1 parses bare `off` as boolean `false`. The loader coerces it back to
+  the string `"off"`, so `default: off` works without quoting — but quoting
+  (`default: "off"`) keeps the file unambiguous if you share it with non-YAML
+  readers.
+- Only auto-mode honours the policy. Interactive `/gsd run` dispatches keep
+  whatever level your session is on, mirroring how `dynamic_routing` is gated.
+
 ### `context_management` (v2.59)
 
 Controls observation masking and tool result truncation during auto-mode sessions. Reduces context bloat between compactions with zero LLM overhead.

--- a/packages/pi-ai/src/providers/anthropic-shared.ts
+++ b/packages/pi-ai/src/providers/anthropic-shared.ts
@@ -36,6 +36,13 @@ import { parseStreamingJson } from "../utils/json-parse.js";
 import { hasXmlParameterTags, repairToolJson } from "../utils/repair-tool-json.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { transformMessagesWithReport } from "./transform-messages.js";
+import {
+	buildAnchorSystemBlocks,
+	buildClaudeCodeUserId,
+	getSessionUuid,
+	isAdaptiveThinkingModel as isCcAdaptiveThinkingModel,
+	isCcSpoofProvider,
+} from "./cc-spoof.js";
 
 /** Effort levels accepted by the Anthropic `output_config.effort` field. */
 export type AnthropicEffort = "low" | "medium" | "high" | "xhigh" | "max";
@@ -493,14 +500,38 @@ export function buildParams(
 ): MessageCreateParamsStreaming {
 	const { cacheControl } = getCacheControl(model.baseUrl, options?.cacheRetention);
 	const apiModelId = model.id.replace(/\[.*\]$/, "");
+	const ccSpoof = isCcSpoofProvider(model.provider, model.headers);
+	// CC-spoof matches real Claude Code wire format which always sends
+	// max_tokens=32000 (room for the forced thinking budget on Haiku + headroom).
+	const defaultMaxTokens = ccSpoof ? 32000 : (model.maxTokens / 3) | 0;
 	const params: MessageCreateParamsStreaming = {
 		model: apiModelId,
 		messages: convertMessages(context.messages, model, isOAuthToken, cacheControl),
-		max_tokens: options?.maxTokens || (model.maxTokens / 3) | 0,
+		max_tokens: options?.maxTokens || defaultMaxTokens,
 		stream: true,
 	};
 
-	if (isOAuthToken) {
+	if (ccSpoof) {
+		// CC-spoof providers validate that system[] starts with the billing
+		// header, the agent marker, and the tail of the real Claude Code
+		// system prompt. The user's system prompt is appended after.
+		const ccSessionUuid = getSessionUuid(options?.sessionId);
+		const userBlocks: Array<{ type: "text"; text: string; cache_control?: { type: string } }> = [];
+		if (context.systemPrompt) {
+			userBlocks.push({
+				type: "text",
+				text: sanitizeSurrogates(context.systemPrompt),
+				...(cacheControl ? { cache_control: cacheControl } : {}),
+			});
+		}
+		params.system = [
+			...buildAnchorSystemBlocks(ccSessionUuid, cacheControl),
+			...userBlocks,
+		] as MessageCreateParamsStreaming["system"];
+
+		// CC's metadata.user_id is a JSON-encoded string with device/session ids.
+		params.metadata = { user_id: buildClaudeCodeUserId(ccSessionUuid) };
+	} else if (isOAuthToken) {
 		// Only the LAST system block carries `cache_control` — the boundary
 		// covers the entire system prefix up to that point. Putting cache_control
 		// on the short "You are Claude Code" header AND the user systemPrompt
@@ -555,7 +586,24 @@ export function buildParams(
 		}
 	}
 
-	if (options?.metadata) {
+	if (ccSpoof) {
+		// Real Claude Code always sends adaptive thinking for Sonnet/Opus and
+		// a context_management block. Force them so proxies that fingerprint
+		// the body shape accept the request.
+		if (isCcAdaptiveThinkingModel(model.id)) {
+			params.thinking = { type: "adaptive" };
+			params.output_config = {
+				effort: (options?.effort ?? "high") as "low" | "medium" | "high" | "max",
+			};
+		} else if (!params.thinking) {
+			params.thinking = { type: "enabled", budget_tokens: 31999 };
+		}
+		(params as unknown as Record<string, unknown>).context_management = {
+			edits: [{ type: "clear_thinking_20251015", keep: "all" }],
+		};
+	}
+
+	if (options?.metadata && !ccSpoof) {
 		const userId = options.metadata.user_id;
 		if (typeof userId === "string") {
 			params.metadata = { user_id: userId };

--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -20,6 +20,7 @@ import {
 	processAnthropicStream,
 	supportsAdaptiveThinking,
 } from "./anthropic-shared.js";
+import { buildSpoofHeaders, getSessionUuid, isCcSpoofProvider } from "./cc-spoof.js";
 
 // Re-export types used by other modules
 export type { AnthropicEffort, AnthropicOptions };
@@ -77,11 +78,24 @@ async function createClient(
 	interleavedThinking: boolean,
 	optionsHeaders?: Record<string, string>,
 	dynamicHeaders?: Record<string, string>,
+	sessionId?: string,
 ): Promise<{ client: Anthropic; isOAuthToken: boolean }> {
 	const AnthropicClass = await getAnthropicClass();
 	// Adaptive thinking models (Opus 4.6, Sonnet 4.6) have interleaved thinking built-in.
 	// The beta header is deprecated on Opus 4.6 and redundant on Sonnet 4.6, so skip it.
 	const needsInterleavedBeta = interleavedThinking && !supportsAdaptiveThinking(model.id);
+
+	const ccSpoof = isCcSpoofProvider(model.provider, model.headers);
+	const ccSessionUuid = ccSpoof ? getSessionUuid(sessionId) : "";
+	// Strip the internal control flag so it never reaches the wire.
+	const cleanedModelHeaders: Record<string, string> | undefined = model.headers
+		? (() => {
+				const out: Record<string, string> = { ...model.headers };
+				delete out["X-Spoof-Claude-Code"];
+				delete out["x-spoof-claude-code"];
+				return out;
+		})()
+		: undefined;
 
 	// Copilot: Bearer auth, selective betas (no fine-grained-tool-streaming)
 	if (model.provider === "github-copilot") {
@@ -101,7 +115,7 @@ async function createClient(
 					"anthropic-dangerous-direct-browser-access": "true",
 					...(betaFeatures.length > 0 ? { "anthropic-beta": betaFeatures.join(",") } : {}),
 				},
-				model.headers,
+				cleanedModelHeaders,
 				dynamicHeaders,
 				optionsHeaders,
 			),
@@ -126,20 +140,19 @@ async function createClient(
 	// API key auth (Anthropic OAuth removed per TOS compliance — use API keys or Claude CLI)
 	// Some Anthropic-compatible providers require Bearer auth instead of x-api-key.
 	const usesBearerAuth = usesAnthropicBearerAuth(model.provider) || hasBearerAuthorizationHeader(model);
+	// CC-spoof headers must override generic betaFeatures, so they go after.
+	const baseHeaders: Record<string, string> = {
+		accept: "application/json",
+		"anthropic-dangerous-direct-browser-access": "true",
+		...(betaFeatures.length > 0 ? { "anthropic-beta": betaFeatures.join(",") } : {}),
+		...(ccSpoof ? buildSpoofHeaders(ccSessionUuid, model.id) : {}),
+	};
 	const client = new AnthropicClass({
 		apiKey: usesBearerAuth ? null : apiKey,
 		authToken: usesBearerAuth ? apiKey : undefined,
 		baseURL: resolveAnthropicBaseUrl(model),
 		dangerouslyAllowBrowser: true,
-		defaultHeaders: mergeHeaders(
-			{
-				accept: "application/json",
-				"anthropic-dangerous-direct-browser-access": "true",
-				...(betaFeatures.length > 0 ? { "anthropic-beta": betaFeatures.join(",") } : {}),
-			},
-			model.headers,
-			optionsHeaders,
-		),
+		defaultHeaders: mergeHeaders(baseHeaders, cleanedModelHeaders, optionsHeaders),
 	});
 
 	return { client, isOAuthToken: false };
@@ -170,6 +183,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			options?.interleavedThinking ?? true,
 			options?.headers,
 			copilotDynamicHeaders,
+			options?.sessionId,
 		);
 
 		processAnthropicStream(stream, {

--- a/packages/pi-ai/src/providers/cc-spoof.ts
+++ b/packages/pi-ai/src/providers/cc-spoof.ts
@@ -1,0 +1,139 @@
+/**
+ * Claude Code wire-format spoofing helpers.
+ *
+ * Some Anthropic-compatible proxies validate that requests look like they
+ * came from the real Claude Code CLI. This module centralises the constants
+ * and helpers used to reshape outgoing requests so they pass that check.
+ *
+ * See temp/CLAUDIBLE_PATCH.md for the reverse-engineered validation rules.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import { hostname, userInfo } from "node:os";
+
+/** Version string Claude Code stamps in its billing header. Refresh when CC upgrades. */
+export const CLAUDE_CODE_VERSION = "2.1.112.c44";
+
+/** User-Agent Claude Code sends on /v1/messages calls. */
+export const CLAUDE_CODE_USER_AGENT = "claude-cli/2.1.112 (external, sdk-cli)";
+
+/** Anchor block 1 — must appear verbatim as system[1]. */
+export const CC_AGENT_MARKER =
+	"You are a Claude agent, built on Anthropic's Claude Agent SDK.";
+
+/**
+ * Anchor block 2 — last 950+ chars of Claude Code's actual system prompt.
+ * Proxy validates that this content is present at the end of system[2].
+ *
+ * IMPORTANT: when Claude Code upgrades major version, the model IDs/version
+ * strings inside this constant become stale. Re-extract from a fresh HAR
+ * dump (see temp/CLAUDIBLE_PATCH.md §6 "Maintenance").
+ */
+export const CC_SYSTEM_TAIL = `xact model ID is claude-sonnet-4-6.
+ - Assistant knowledge cutoff is August 2025.
+ - The most recent Claude model family is Claude 4.X. Model IDs — Opus 4.7: 'claude-opus-4-7', Sonnet 4.6: 'claude-sonnet-4-6', Haiku 4.5: 'claude-haiku-4-5-20251001'. When building AI applications, default to the latest and most capable Claude models.
+ - Claude Code is available as a CLI in the terminal, desktop app (Mac/Windows), web app (claude.ai/code), and IDE extensions (VS Code, JetBrains).
+ - Fast mode for Claude Code uses Claude Opus 4.6 with faster output (it does not downgrade to a smaller model). It can be toggled with /fast and is only available on Opus 4.6.
+
+When working with tool results, write down any important information you might need later in your response, as the original tool result may be cleared later.
+
+Length limits: keep text between tool calls to ≤25 words. Keep final responses to ≤100 words unless the task requires more detail.`;
+
+/** Beta header used by Claude Code for Haiku-class models. */
+export const CC_BETA_HAIKU =
+	"interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05,claude-code-20250219";
+
+/** Beta header used by Claude Code for Sonnet/Opus (adds the `effort` beta). */
+export const CC_BETA_SONNET_OPUS =
+	"claude-code-20250219,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05,effort-2025-11-24";
+
+/** Stable per-host hash matching CC's `metadata.user_id.device_id` shape. */
+let cachedDeviceId: string | undefined;
+function getDeviceId(): string {
+	if (cachedDeviceId) return cachedDeviceId;
+	cachedDeviceId = createHash("sha256")
+		.update(`${userInfo().username}@${hostname()}`)
+		.digest("hex");
+	return cachedDeviceId;
+}
+
+/** UUID stable per gsd-2 session — caller passes the session id from runtime. */
+const sessionUuidMap = new Map<string, string>();
+export function getSessionUuid(sessionId: string | undefined): string {
+	if (!sessionId) return randomUUID();
+	let v = sessionUuidMap.get(sessionId);
+	if (!v) {
+		v = randomUUID();
+		sessionUuidMap.set(sessionId, v);
+	}
+	return v;
+}
+
+/** Build the billing-header literal that occupies system[0]. */
+export function buildBillingHeader(sessionUuid: string): string {
+	const cch = createHash("sha1")
+		.update(sessionUuid)
+		.digest("hex")
+		.slice(0, 5);
+	return `x-anthropic-billing-header: cc_version=${CLAUDE_CODE_VERSION}; cc_entrypoint=sdk-cli; cch=${cch};`;
+}
+
+/** Build CC's `metadata.user_id` — a JSON-encoded string with device/session ids. */
+export function buildClaudeCodeUserId(sessionUuid: string): string {
+	return JSON.stringify({
+		device_id: getDeviceId(),
+		account_uuid: "",
+		session_id: sessionUuid,
+	});
+}
+
+type CacheControl = { type: string };
+type SystemBlock = { type: "text"; text: string; cache_control?: CacheControl };
+
+/** Build the 3 anchor system blocks — caller appends user system prompt after. */
+export function buildAnchorSystemBlocks(
+	sessionUuid: string,
+	cacheControl: CacheControl | undefined,
+): SystemBlock[] {
+	return [
+		{ type: "text", text: buildBillingHeader(sessionUuid) },
+		{
+			type: "text",
+			text: CC_AGENT_MARKER,
+			...(cacheControl ? { cache_control: cacheControl } : {}),
+		},
+		{
+			type: "text",
+			text: CC_SYSTEM_TAIL,
+			...(cacheControl ? { cache_control: cacheControl } : {}),
+		},
+	];
+}
+
+/** True if the model needs the `effort` beta + adaptive thinking (Sonnet/Opus). */
+export function isAdaptiveThinkingModel(modelId: string): boolean {
+	return modelId.includes("sonnet") || modelId.includes("opus");
+}
+
+/** Header overrides that real Claude Code stamps and the proxy expects. */
+export function buildSpoofHeaders(
+	sessionUuid: string,
+	modelId: string,
+): Record<string, string> {
+	return {
+		"User-Agent": CLAUDE_CODE_USER_AGENT,
+		"anthropic-beta": isAdaptiveThinkingModel(modelId)
+			? CC_BETA_SONNET_OPUS
+			: CC_BETA_HAIKU,
+		"x-app": "cli",
+		"X-Claude-Code-Session-Id": sessionUuid,
+	};
+}
+
+/** Detect any provider that needs CC spoofing. */
+export function isCcSpoofProvider(provider: string, headers?: Record<string, string>): boolean {
+	if (provider === "claudible") return true;
+	if (headers && (headers["X-Spoof-Claude-Code"] || headers["x-spoof-claude-code"])) {
+		return true;
+	}
+	return false;
+}

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -20,7 +20,7 @@ import { resolveUokFlags } from "./uok/flags.js";
 import { applyModelPolicyFilter } from "./uok/model-policy.js";
 import { isModelBlocked } from "./blocked-models.js";
 import { getRequiredWorkflowToolsForAutoUnit } from "./workflow-mcp.js";
-import { resolveThinkingLevel } from "./thinking-policy.js";
+import { getEffectiveThinkingLevel } from "./thinking-policy.js";
 import type { ThinkingLevel } from "./thinking-policy.js";
 
 /**
@@ -210,13 +210,9 @@ export async function selectAndApplyModel(
   // but unmatched rules fall back to that snapshot — so a user level always
   // wins when no policy rule applies. Only auto-mode applies the policy
   // (interactive/guided dispatches use the session level as-is).
-  const effectiveThinkingLevel: ThinkingLevel | null | undefined = (() => {
-    if (!isAutoMode) return autoModeStartThinkingLevel ?? null;
-    const policy = prefs?.thinking_policy;
-    if (!policy) return autoModeStartThinkingLevel ?? null;
-    const fallback = (autoModeStartThinkingLevel ?? "medium") as ThinkingLevel;
-    return resolveThinkingLevel(unitType, policy, fallback);
-  })();
+  const effectiveThinkingLevel: ThinkingLevel | null | undefined = isAutoMode
+    ? getEffectiveThinkingLevel(unitType, prefs?.thinking_policy, autoModeStartThinkingLevel)
+    : autoModeStartThinkingLevel ?? null;
 
   const modelConfig = effectiveSessionModelOverride
     ? undefined

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -20,6 +20,8 @@ import { resolveUokFlags } from "./uok/flags.js";
 import { applyModelPolicyFilter } from "./uok/model-policy.js";
 import { isModelBlocked } from "./blocked-models.js";
 import { getRequiredWorkflowToolsForAutoUnit } from "./workflow-mcp.js";
+import { resolveThinkingLevel } from "./thinking-policy.js";
+import type { ThinkingLevel } from "./thinking-policy.js";
 
 /**
  * Thrown when the model-policy gate rejects every candidate model for a unit
@@ -200,6 +202,22 @@ export async function selectAndApplyModel(
       flatRateCtx: buildFlatRateContext(autoModeStartModel.provider, ctx, prefs),
     };
   }
+
+  // ─── Thinking-policy resolution (per-dispatch) ────────────────────────
+  // `autoModeStartThinkingLevel` is the user's level snapshot at auto start
+  // (incl. any `/thinking` or `--thinking` they applied before bootstrap).
+  // The policy in PREFERENCES.md may override the default-per-unit/prefix,
+  // but unmatched rules fall back to that snapshot — so a user level always
+  // wins when no policy rule applies. Only auto-mode applies the policy
+  // (interactive/guided dispatches use the session level as-is).
+  const effectiveThinkingLevel: ThinkingLevel | null | undefined = (() => {
+    if (!isAutoMode) return autoModeStartThinkingLevel ?? null;
+    const policy = prefs?.thinking_policy;
+    if (!policy) return autoModeStartThinkingLevel ?? null;
+    const fallback = (autoModeStartThinkingLevel ?? "medium") as ThinkingLevel;
+    return resolveThinkingLevel(unitType, policy, fallback);
+  })();
+
   const modelConfig = effectiveSessionModelOverride
     ? undefined
     : resolvePreferredModelConfig(unitType, autoModeStartModel, isAutoMode);
@@ -517,7 +535,7 @@ export async function selectAndApplyModel(
       const ok = await pi.setModel(model, { persist: false });
       if (ok) {
         appliedModel = model;
-        reapplyThinkingLevel(pi, autoModeStartThinkingLevel);
+        reapplyThinkingLevel(pi, effectiveThinkingLevel);
 
         // ADR-005: Adjust active tool set for the selected model's provider capabilities.
         // Hard-filter incompatible tools, then let extensions override via adjust_tool_set hook.
@@ -596,12 +614,12 @@ export async function selectAndApplyModel(
             const fallbackOk = await pi.setModel(byId, { persist: false });
             if (fallbackOk) {
               appliedModel = byId;
-              reapplyThinkingLevel(pi, autoModeStartThinkingLevel);
+              reapplyThinkingLevel(pi, effectiveThinkingLevel);
             }
           }
         } else {
           appliedModel = startModel;
-          reapplyThinkingLevel(pi, autoModeStartThinkingLevel);
+          reapplyThinkingLevel(pi, effectiveThinkingLevel);
         }
       }
     }

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -32,7 +32,7 @@ import { MergeConflictError } from "../git-service.js";
 import { setCurrentPhase, clearCurrentPhase } from "../../shared/gsd-phase-state.js";
 import { pauseAutoForProviderError } from "../provider-error-pause.js";
 import { resumeAutoAfterProviderDelay } from "../bootstrap/provider-error-resume.js";
-import { resolveThinkingLevel } from "../thinking-policy.js";
+import { getEffectiveThinkingLevel } from "../thinking-policy.js";
 import { join, basename } from "node:path";
 import { existsSync, cpSync, readdirSync } from "node:fs";
 import {
@@ -1551,12 +1551,11 @@ export async function runUnitPhase(
         // any thinking_policy override resolved in selectAndApplyModel — so a
         // hook-driven model swap doesn't silently revert to the bootstrap
         // snapshot. Falls back to autoModeStartThinkingLevel when no policy.
-        const hookEffectiveLevel = (() => {
-          const policy = prefs?.thinking_policy;
-          if (!policy) return s.autoModeStartThinkingLevel;
-          const fb = (s.autoModeStartThinkingLevel ?? "medium") as Parameters<typeof resolveThinkingLevel>[2];
-          return resolveThinkingLevel(unitType, policy, fb);
-        })();
+        const hookEffectiveLevel = getEffectiveThinkingLevel(
+          unitType,
+          prefs?.thinking_policy,
+          s.autoModeStartThinkingLevel,
+        );
         if (hookEffectiveLevel) {
           pi.setThinkingLevel(hookEffectiveLevel);
         }

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -32,6 +32,7 @@ import { MergeConflictError } from "../git-service.js";
 import { setCurrentPhase, clearCurrentPhase } from "../../shared/gsd-phase-state.js";
 import { pauseAutoForProviderError } from "../provider-error-pause.js";
 import { resumeAutoAfterProviderDelay } from "../bootstrap/provider-error-resume.js";
+import { resolveThinkingLevel } from "../thinking-policy.js";
 import { join, basename } from "node:path";
 import { existsSync, cpSync, readdirSync } from "node:fs";
 import {
@@ -1546,8 +1547,18 @@ export async function runUnitPhase(
     if (match) {
       const ok = await pi.setModel(match, { persist: false });
       if (ok) {
-        if (s.autoModeStartThinkingLevel) {
-          pi.setThinkingLevel(s.autoModeStartThinkingLevel);
+        // Re-apply the thinking level the unit was dispatched with — including
+        // any thinking_policy override resolved in selectAndApplyModel — so a
+        // hook-driven model swap doesn't silently revert to the bootstrap
+        // snapshot. Falls back to autoModeStartThinkingLevel when no policy.
+        const hookEffectiveLevel = (() => {
+          const policy = prefs?.thinking_policy;
+          if (!policy) return s.autoModeStartThinkingLevel;
+          const fb = (s.autoModeStartThinkingLevel ?? "medium") as Parameters<typeof resolveThinkingLevel>[2];
+          return resolveThinkingLevel(unitType, policy, fb);
+        })();
+        if (hookEffectiveLevel) {
+          pi.setThinkingLevel(hookEffectiveLevel);
         }
         s.currentUnitModel = match as AutoSession["currentUnitModel"];
         ctx.ui.notify(`Hook model override: ${match.provider}/${match.id}`, "info");

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -151,6 +151,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "language",
   "context_window_override",
   "context_mode",
+  "thinking_policy",
 ]);
 
 /** Canonical list of all dispatch unit types. */
@@ -288,6 +289,49 @@ export interface ExperimentalPreferences {
   rtk?: boolean;
 }
 
+/**
+ * Thinking levels supported by Pi SDK. Mirrors the enum in
+ * `packages/pi-coding-agent/src/core/settings-manager.ts` (`defaultThinkingLevel`).
+ */
+export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+/** All valid thinking levels (lowercase, case-sensitive). */
+export const KNOWN_THINKING_LEVELS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const satisfies readonly ThinkingLevel[];
+
+/**
+ * Per-unit-type / per-prefix thinking-level policy. Resolved at dispatch time
+ * by `resolveThinkingLevel` in `thinking-policy.ts`. Resolution order:
+ *   1. `unitTypes[unitType]` — exact match wins.
+ *   2. `prefixes[<longest matching prefix>]` — e.g. `research-slice` matches `research-`.
+ *   3. `default`.
+ *   4. Fallback supplied by caller (typically the live `pi.getThinkingLevel()`).
+ *
+ * A user-driven `/thinking` override (captured separately at auto-mode start)
+ * always wins over the policy.
+ */
+export interface ThinkingPolicyConfig {
+  /** Default thinking level when no prefix or unit-type rule matches. */
+  default?: ThinkingLevel;
+  /**
+   * Map of unit-type prefix (e.g. `research-`) → thinking level. Longest matching
+   * prefix wins. Convention: keys end with `-`; non-conforming keys produce a warning
+   * but are still honoured.
+   */
+  prefixes?: Record<string, ThinkingLevel>;
+  /**
+   * Map of exact unit-type → thinking level. Keys must be in `KNOWN_UNIT_TYPES`;
+   * typos are rejected with a clear error.
+   */
+  unitTypes?: Record<string, ThinkingLevel>;
+}
+
 /** Configuration for the codebase map generator (/gsd codebase). */
 export interface CodebaseMapPreferences {
   /** Additional directory/file patterns to exclude (e.g. ["docs/", "fixtures/"]). Merged with built-in defaults. */
@@ -336,6 +380,13 @@ export interface GSDPreferences {
    */
   context_window_override?: number;
   context_management?: ContextManagementConfig;
+  /**
+   * Per-unit-type and per-prefix thinking-level policy. Lets users dial
+   * thinking off for cheap/low-stakes units (e.g. `execute-task-simple`) and
+   * up for high-leverage planning/discussion units. Resolved at dispatch time.
+   * A user `/thinking` override always beats the policy.
+   */
+  thinking_policy?: ThinkingPolicyConfig;
   /**
    * Tool-output sandboxing via gsd_exec. Keeps sub-session context windows
    * clean by running scripts in a subprocess and only surfacing a short

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -157,7 +157,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
 /** Canonical list of all dispatch unit types. */
 export const KNOWN_UNIT_TYPES = [
   "research-milestone", "plan-milestone", "research-slice", "plan-slice", "refine-slice",
-  "execute-task", "reactive-execute", "gate-evaluate", "complete-slice", "replan-slice", "reassess-roadmap",
+  "execute-task", "execute-task-simple", "reactive-execute", "gate-evaluate", "complete-slice", "replan-slice", "reassess-roadmap",
   "run-uat", "complete-milestone", "validate-milestone", "rewrite-docs",
   "discuss-milestone", "discuss-slice", "worktree-merge",
 ] as const;

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -1275,7 +1275,11 @@ export function validatePreferences(preferences: GSDPreferences): {
   // Per-unit-type and per-prefix thinking-level policy. Resolved at dispatch
   // time; a user `/thinking` override always beats the policy.
   if (preferences.thinking_policy !== undefined) {
-    if (typeof preferences.thinking_policy === "object" && preferences.thinking_policy !== null) {
+    if (
+      typeof preferences.thinking_policy === "object" &&
+      preferences.thinking_policy !== null &&
+      !Array.isArray(preferences.thinking_policy)
+    ) {
       const tp = preferences.thinking_policy as Record<string, unknown>;
       const validTp: ThinkingPolicyConfig = {};
       const validLevels = new Set<string>(KNOWN_THINKING_LEVELS);
@@ -1360,7 +1364,7 @@ export function validatePreferences(preferences: GSDPreferences): {
         validated.thinking_policy = validTp;
       }
     } else {
-      errors.push("thinking_policy must be an object");
+      errors.push("thinking_policy must be a mapping (not an array or scalar)");
     }
   }
 

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -14,9 +14,12 @@ import { normalizeStringArray } from "../shared/format-utils.js";
 
 import {
   KNOWN_PREFERENCE_KEYS,
+  KNOWN_THINKING_LEVELS,
   KNOWN_UNIT_TYPES,
 
   SKILL_ACTIONS,
+  type ThinkingLevel,
+  type ThinkingPolicyConfig,
   type WorkflowMode,
   type GSDPreferences,
   type GSDSkillRule,
@@ -1265,6 +1268,99 @@ export function validatePreferences(preferences: GSDPreferences): {
       validated.discuss_depth = preferences.discuss_depth as GSDPreferences["discuss_depth"];
     } else {
       errors.push(`discuss_depth must be one of: quick, standard, thorough`);
+    }
+  }
+
+  // ─── Thinking Policy ───────────────────────────────────────────────
+  // Per-unit-type and per-prefix thinking-level policy. Resolved at dispatch
+  // time; a user `/thinking` override always beats the policy.
+  if (preferences.thinking_policy !== undefined) {
+    if (typeof preferences.thinking_policy === "object" && preferences.thinking_policy !== null) {
+      const tp = preferences.thinking_policy as Record<string, unknown>;
+      const validTp: ThinkingPolicyConfig = {};
+      const validLevels = new Set<string>(KNOWN_THINKING_LEVELS);
+      const knownUnitTypeSet = new Set<string>(KNOWN_UNIT_TYPES);
+
+      // YAML parses unquoted `off` as boolean false. Coerce so that the user
+      // can write `default: off` without quoting (better UX).
+      const coerceLevel = (raw: unknown): ThinkingLevel | undefined => {
+        if (raw === false) return "off";
+        if (typeof raw !== "string") return undefined;
+        return validLevels.has(raw) ? (raw as ThinkingLevel) : undefined;
+      };
+
+      if (tp.default !== undefined) {
+        const lvl = coerceLevel(tp.default);
+        if (lvl) {
+          validTp.default = lvl;
+        } else {
+          errors.push(
+            `thinking_policy.default must be one of: ${KNOWN_THINKING_LEVELS.join(", ")}`,
+          );
+        }
+      }
+
+      if (tp.prefixes !== undefined) {
+        if (typeof tp.prefixes === "object" && tp.prefixes !== null && !Array.isArray(tp.prefixes)) {
+          const out: Record<string, ThinkingLevel> = {};
+          for (const [key, raw] of Object.entries(tp.prefixes as Record<string, unknown>)) {
+            const lvl = coerceLevel(raw);
+            if (!lvl) {
+              errors.push(
+                `thinking_policy.prefixes["${key}"] must be one of: ${KNOWN_THINKING_LEVELS.join(", ")}`,
+              );
+              continue;
+            }
+            if (!key.endsWith("-")) {
+              warnings.push(
+                `thinking_policy.prefixes["${key}"] does not end with "-" — convention is to terminate prefixes with a dash (e.g. "research-")`,
+              );
+            }
+            out[key] = lvl;
+          }
+          if (Object.keys(out).length > 0) validTp.prefixes = out;
+        } else {
+          errors.push("thinking_policy.prefixes must be an object");
+        }
+      }
+
+      if (tp.unitTypes !== undefined) {
+        if (typeof tp.unitTypes === "object" && tp.unitTypes !== null && !Array.isArray(tp.unitTypes)) {
+          const out: Record<string, ThinkingLevel> = {};
+          for (const [key, raw] of Object.entries(tp.unitTypes as Record<string, unknown>)) {
+            if (!knownUnitTypeSet.has(key)) {
+              errors.push(
+                `thinking_policy.unitTypes["${key}"] is not a known unit type. Valid: ${KNOWN_UNIT_TYPES.join(", ")}`,
+              );
+              continue;
+            }
+            const lvl = coerceLevel(raw);
+            if (!lvl) {
+              errors.push(
+                `thinking_policy.unitTypes["${key}"] must be one of: ${KNOWN_THINKING_LEVELS.join(", ")}`,
+              );
+              continue;
+            }
+            out[key] = lvl;
+          }
+          if (Object.keys(out).length > 0) validTp.unitTypes = out;
+        } else {
+          errors.push("thinking_policy.unitTypes must be an object");
+        }
+      }
+
+      const knownTpKeys = new Set(["default", "prefixes", "unitTypes"]);
+      for (const key of Object.keys(tp)) {
+        if (!knownTpKeys.has(key)) {
+          warnings.push(`unknown thinking_policy key "${key}" — ignored`);
+        }
+      }
+
+      if (Object.keys(validTp).length > 0) {
+        validated.thinking_policy = validTp;
+      }
+    } else {
+      errors.push("thinking_policy must be an object");
     }
   }
 

--- a/src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts
@@ -45,7 +45,7 @@ test("hook model override preserves captured thinking level", () => {
     "hook model override should reference the captured start-level snapshot (as fallback)",
   );
   assert.ok(
-    hookBlock.includes("resolveThinkingLevel"),
-    "hook model override should consult thinking_policy via resolveThinkingLevel",
+    hookBlock.includes("getEffectiveThinkingLevel"),
+    "hook model override should consult thinking_policy via getEffectiveThinkingLevel",
   );
 });

--- a/src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts
@@ -32,8 +32,20 @@ test("hook model override preserves captured thinking level", () => {
   const hookIdx = phasesSrc.indexOf("const hookModelOverride = sidecarItem?.model ?? iterData.hookModelOverride;");
   assert.ok(hookIdx > -1, "phases.ts should include hook model override handling");
   const hookBlock = extractSourceRegion(phasesSrc, "const hookModelOverride = sidecarItem?.model ?? iterData.hookModelOverride;");
+  // After thinking_policy was wired, the hook block routes through
+  // resolveThinkingLevel so the policy-resolved level (or the start snapshot
+  // when no policy is configured) is re-applied — not the raw start level
+  // unconditionally. Both branches still ultimately call pi.setThinkingLevel.
   assert.ok(
-    hookBlock.includes("pi.setThinkingLevel(s.autoModeStartThinkingLevel)"),
-    "hook model override should re-apply captured thinking level after setModel",
+    hookBlock.includes("pi.setThinkingLevel("),
+    "hook model override should re-apply a thinking level after setModel",
+  );
+  assert.ok(
+    hookBlock.includes("s.autoModeStartThinkingLevel"),
+    "hook model override should reference the captured start-level snapshot (as fallback)",
+  );
+  assert.ok(
+    hookBlock.includes("resolveThinkingLevel"),
+    "hook model override should consult thinking_policy via resolveThinkingLevel",
   );
 });

--- a/src/resources/extensions/gsd/tests/thinking-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/thinking-policy.test.ts
@@ -8,9 +8,15 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { resolveThinkingLevel } from "../thinking-policy.ts";
 import type { ThinkingPolicyConfig } from "../preferences-types.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const gsdDir = join(__dirname, "..");
 
 test("resolveThinkingLevel: exact unitType match wins over prefix", () => {
   const policy: ThinkingPolicyConfig = {
@@ -125,6 +131,45 @@ test("validatePreferences: rejects invalid level value", async () => {
   assert.ok(
     errors.some((e) => e.includes("thinking_policy.default")),
     `expected default-level error, got: ${JSON.stringify(errors)}`,
+  );
+});
+
+// ─── Auto-mode wiring (source-level checks) ───────────────────────────
+// These assert the policy is actually invoked from the dispatch path
+// without requiring the full dependency graph at test runtime.
+
+test("auto-model-selection resolves thinking_policy and prefers user start-level as fallback", () => {
+  const src = readFileSync(join(gsdDir, "auto-model-selection.ts"), "utf-8");
+  assert.ok(
+    src.includes('from "./thinking-policy.js"'),
+    "auto-model-selection.ts should import the policy resolver",
+  );
+  assert.ok(
+    src.includes("resolveThinkingLevel(unitType, policy"),
+    "auto-model-selection.ts should call resolveThinkingLevel(unitType, policy, fallback)",
+  );
+  assert.ok(
+    src.includes("autoModeStartThinkingLevel ?? \"medium\""),
+    "fallback for resolveThinkingLevel should be the user's start snapshot",
+  );
+  assert.ok(
+    !src.includes("reapplyThinkingLevel(pi, autoModeStartThinkingLevel)"),
+    "auto-model-selection.ts should no longer pass autoModeStartThinkingLevel directly to reapply (it now passes effectiveThinkingLevel)",
+  );
+  assert.ok(
+    src.includes("reapplyThinkingLevel(pi, effectiveThinkingLevel)"),
+    "reapplyThinkingLevel should be called with the policy-resolved level",
+  );
+});
+
+test("auto-model-selection skips policy resolution in interactive (non-auto) mode", () => {
+  const src = readFileSync(join(gsdDir, "auto-model-selection.ts"), "utf-8");
+  // Interactive/guided dispatches must use the user's session level as-is —
+  // dynamic routing is already gated this way (#3962); thinking_policy follows
+  // the same convention.
+  assert.ok(
+    src.includes("if (!isAutoMode) return autoModeStartThinkingLevel"),
+    "thinking_policy should be a no-op in interactive mode",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/thinking-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/thinking-policy.test.ts
@@ -134,6 +134,17 @@ test("validatePreferences: rejects invalid level value", async () => {
   );
 });
 
+test("validatePreferences: rejects array as thinking_policy", async () => {
+  const { validatePreferences } = await import("../preferences-validation.ts");
+  const { errors } = validatePreferences({
+    thinking_policy: [{ default: "high" }] as unknown as Record<string, unknown>,
+  });
+  assert.ok(
+    errors.some((e) => e.toLowerCase().includes("mapping")),
+    `expected mapping error for array input, got: ${JSON.stringify(errors)}`,
+  );
+});
+
 // ─── Auto-mode wiring (source-level checks) ───────────────────────────
 // These assert the policy is actually invoked from the dispatch path
 // without requiring the full dependency graph at test runtime.

--- a/src/resources/extensions/gsd/tests/thinking-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/thinking-policy.test.ts
@@ -12,7 +12,7 @@ import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { resolveThinkingLevel } from "../thinking-policy.ts";
+import { getEffectiveThinkingLevel, resolveThinkingLevel } from "../thinking-policy.ts";
 import type { ThinkingPolicyConfig } from "../preferences-types.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -79,6 +79,32 @@ test("resolveThinkingLevel: prefix non-match falls through to default", () => {
     prefixes: { "research-": "high" },
   };
   assert.equal(resolveThinkingLevel("execute-task", policy, "off"), "minimal");
+});
+
+// ─── getEffectiveThinkingLevel — dispatch-site convenience wrapper ────
+
+test("getEffectiveThinkingLevel: returns startLevel unchanged when no policy", () => {
+  assert.equal(getEffectiveThinkingLevel("execute-task", undefined, "high"), "high");
+});
+
+test("getEffectiveThinkingLevel: returns null/undefined startLevel unchanged when no policy", () => {
+  assert.equal(getEffectiveThinkingLevel("execute-task", undefined, null), null);
+  assert.equal(getEffectiveThinkingLevel("execute-task", undefined, undefined), undefined);
+});
+
+test("getEffectiveThinkingLevel: applies policy with startLevel as fallback", () => {
+  const policy: ThinkingPolicyConfig = {
+    default: "medium",
+    unitTypes: { "execute-task": "off" },
+  };
+  assert.equal(getEffectiveThinkingLevel("execute-task", policy, "high"), "off");
+  // No exact / prefix match → falls through to default
+  assert.equal(getEffectiveThinkingLevel("complete-slice", policy, "high"), "medium");
+});
+
+test("getEffectiveThinkingLevel: defaults fallback to \"medium\" when startLevel is null", () => {
+  const policy: ThinkingPolicyConfig = {}; // no rules → fallback wins
+  assert.equal(getEffectiveThinkingLevel("complete-slice", policy, null), "medium");
 });
 
 // ─── Validation surface ────────────────────────────────────────────────
@@ -156,12 +182,12 @@ test("auto-model-selection resolves thinking_policy and prefers user start-level
     "auto-model-selection.ts should import the policy resolver",
   );
   assert.ok(
-    src.includes("resolveThinkingLevel(unitType, policy"),
-    "auto-model-selection.ts should call resolveThinkingLevel(unitType, policy, fallback)",
+    src.includes("getEffectiveThinkingLevel(unitType, prefs?.thinking_policy"),
+    "auto-model-selection.ts should call getEffectiveThinkingLevel(unitType, policy, startLevel)",
   );
   assert.ok(
-    src.includes("autoModeStartThinkingLevel ?? \"medium\""),
-    "fallback for resolveThinkingLevel should be the user's start snapshot",
+    src.includes("autoModeStartThinkingLevel"),
+    "the call should pass autoModeStartThinkingLevel as the start-level snapshot",
   );
   assert.ok(
     !src.includes("reapplyThinkingLevel(pi, autoModeStartThinkingLevel)"),
@@ -179,8 +205,10 @@ test("auto-model-selection skips policy resolution in interactive (non-auto) mod
   // dynamic routing is already gated this way (#3962); thinking_policy follows
   // the same convention.
   assert.ok(
-    src.includes("if (!isAutoMode) return autoModeStartThinkingLevel"),
-    "thinking_policy should be a no-op in interactive mode",
+    src.includes("isAutoMode") &&
+      src.includes("getEffectiveThinkingLevel(unitType, prefs?.thinking_policy") &&
+      src.includes(": autoModeStartThinkingLevel ?? null"),
+    "thinking_policy should be gated on isAutoMode and bypass to the start snapshot in interactive mode",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/thinking-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/thinking-policy.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the thinking-policy resolver and its validation surface.
+ *
+ * Resolver tests are dependency-free (resolveThinkingLevel pulls only types).
+ * Validation tests exercise the YAML `false` -> "off" coercion and unknown
+ * unit-type rejection through validatePreferences.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveThinkingLevel } from "../thinking-policy.ts";
+import type { ThinkingPolicyConfig } from "../preferences-types.ts";
+
+test("resolveThinkingLevel: exact unitType match wins over prefix", () => {
+  const policy: ThinkingPolicyConfig = {
+    default: "medium",
+    prefixes: { "execute-": "high" },
+    unitTypes: { "execute-task": "off" },
+  };
+  assert.equal(resolveThinkingLevel("execute-task", policy, "medium"), "off");
+});
+
+test("resolveThinkingLevel: longest prefix wins", () => {
+  const policy: ThinkingPolicyConfig = {
+    default: "low",
+    prefixes: {
+      "research-": "medium",
+      "research-slice-": "high",
+    },
+  };
+  assert.equal(
+    resolveThinkingLevel("research-slice-foo", policy, "off"),
+    "high",
+  );
+});
+
+test("resolveThinkingLevel: prefix match beats default", () => {
+  const policy: ThinkingPolicyConfig = {
+    default: "low",
+    prefixes: { "discuss-": "high" },
+  };
+  assert.equal(resolveThinkingLevel("discuss-slice", policy, "off"), "high");
+});
+
+test("resolveThinkingLevel: falls back to policy.default when no match", () => {
+  const policy: ThinkingPolicyConfig = {
+    default: "medium",
+    prefixes: { "research-": "high" },
+    unitTypes: { "execute-task": "off" },
+  };
+  assert.equal(resolveThinkingLevel("plan-slice", policy, "low"), "medium");
+});
+
+test("resolveThinkingLevel: falls back to fallback arg when default missing", () => {
+  const policy: ThinkingPolicyConfig = {
+    prefixes: { "research-": "high" },
+  };
+  assert.equal(resolveThinkingLevel("plan-slice", policy, "low"), "low");
+});
+
+test("resolveThinkingLevel: undefined policy returns fallback", () => {
+  assert.equal(resolveThinkingLevel("execute-task", undefined, "medium"), "medium");
+});
+
+test("resolveThinkingLevel: empty policy returns fallback", () => {
+  assert.equal(resolveThinkingLevel("execute-task", {}, "high"), "high");
+});
+
+test("resolveThinkingLevel: prefix non-match falls through to default", () => {
+  const policy: ThinkingPolicyConfig = {
+    default: "minimal",
+    prefixes: { "research-": "high" },
+  };
+  assert.equal(resolveThinkingLevel("execute-task", policy, "off"), "minimal");
+});
+
+// ─── Validation surface ────────────────────────────────────────────────
+// These tests exercise the YAML coercion and KNOWN_UNIT_TYPES enforcement
+// in preferences-validation.ts. They require the broader preferences
+// dependency graph (git-service/yaml etc.); the resolver tests above stay
+// dependency-free so they can run as a fast standalone smoke test.
+
+test("validatePreferences: YAML unquoted `off` (boolean false) coerces to \"off\"", async () => {
+  const { validatePreferences } = await import("../preferences-validation.ts");
+  const { preferences, errors } = validatePreferences({
+    thinking_policy: {
+      default: false as unknown as "off",
+      unitTypes: {
+        "execute-task": false as unknown as "off",
+      },
+      prefixes: {
+        "research-": false as unknown as "off",
+      },
+    },
+  });
+  assert.deepEqual(errors, []);
+  assert.equal(preferences.thinking_policy?.default, "off");
+  assert.equal(preferences.thinking_policy?.unitTypes?.["execute-task"], "off");
+  assert.equal(preferences.thinking_policy?.prefixes?.["research-"], "off");
+});
+
+test("validatePreferences: rejects unknown unit type with helpful message", async () => {
+  const { validatePreferences } = await import("../preferences-validation.ts");
+  const { errors } = validatePreferences({
+    thinking_policy: {
+      unitTypes: {
+        "bogus-unit": "high",
+      },
+    },
+  });
+  assert.ok(
+    errors.some((e) => e.includes("bogus-unit") && e.includes("not a known unit type")),
+    `expected error mentioning bogus-unit, got: ${JSON.stringify(errors)}`,
+  );
+});
+
+test("validatePreferences: rejects invalid level value", async () => {
+  const { validatePreferences } = await import("../preferences-validation.ts");
+  const { errors } = validatePreferences({
+    thinking_policy: {
+      default: "ultra" as unknown as "high",
+    },
+  });
+  assert.ok(
+    errors.some((e) => e.includes("thinking_policy.default")),
+    `expected default-level error, got: ${JSON.stringify(errors)}`,
+  );
+});
+
+test("validatePreferences: warns when prefix key does not end with '-'", async () => {
+  const { validatePreferences } = await import("../preferences-validation.ts");
+  const { warnings, preferences } = validatePreferences({
+    thinking_policy: {
+      prefixes: {
+        research: "high",
+      },
+    },
+  });
+  assert.ok(
+    warnings.some((w) => w.includes("research") && w.includes("does not end with")),
+    `expected prefix-convention warning, got: ${JSON.stringify(warnings)}`,
+  );
+  // Still honoured (warn, not reject)
+  assert.equal(preferences.thinking_policy?.prefixes?.["research"], "high");
+});

--- a/src/resources/extensions/gsd/thinking-policy.ts
+++ b/src/resources/extensions/gsd/thinking-policy.ts
@@ -1,0 +1,48 @@
+/**
+ * Thinking-policy resolver.
+ *
+ * Computes the thinking level to use for a single auto-mode unit dispatch
+ * based on the user's `thinking_policy` block in PREFERENCES.md and a
+ * fallback supplied by the caller (typically the live `pi.getThinkingLevel()`
+ * value captured at auto-mode start).
+ *
+ * Resolution order (first match wins):
+ *   1. `unitTypes[unitType]` — exact match.
+ *   2. `prefixes[<longest matching prefix>]` — e.g. `research-slice` matches `research-`.
+ *   3. `default`.
+ *   4. `fallback` argument (caller's existing/default level).
+ *
+ * NOTE: A user-driven `/thinking` override is captured separately at
+ * auto-mode start and must beat the policy. That precedence is enforced at
+ * the call site in `auto-model-selection.ts`, not here — this resolver only
+ * computes the policy's recommended level.
+ */
+
+import type { ThinkingLevel, ThinkingPolicyConfig } from "./preferences-types.js";
+
+export type { ThinkingLevel, ThinkingPolicyConfig };
+
+export function resolveThinkingLevel(
+  unitType: string,
+  policy: ThinkingPolicyConfig | undefined,
+  fallback: ThinkingLevel,
+): ThinkingLevel {
+  if (!policy) return fallback;
+
+  const exact = policy.unitTypes?.[unitType];
+  if (exact) return exact;
+
+  if (policy.prefixes) {
+    let bestKey: string | undefined;
+    let bestLen = -1;
+    for (const key of Object.keys(policy.prefixes)) {
+      if (unitType.startsWith(key) && key.length > bestLen) {
+        bestKey = key;
+        bestLen = key.length;
+      }
+    }
+    if (bestKey !== undefined) return policy.prefixes[bestKey];
+  }
+
+  return policy.default ?? fallback;
+}

--- a/src/resources/extensions/gsd/thinking-policy.ts
+++ b/src/resources/extensions/gsd/thinking-policy.ts
@@ -46,3 +46,21 @@ export function resolveThinkingLevel(
 
   return policy.default ?? fallback;
 }
+
+/**
+ * Compute the thinking level for a dispatch, given the snapshot captured at
+ * auto-mode start. Returns the snapshot unchanged when no policy is configured
+ * (so callers don't need to special-case the no-policy path).
+ *
+ * Pass `null`/`undefined` for `startLevel` if no snapshot exists; the caller
+ * decides what to do with a missing level (typically: skip `setThinkingLevel`).
+ */
+export function getEffectiveThinkingLevel(
+  unitType: string,
+  policy: ThinkingPolicyConfig | undefined,
+  startLevel: ThinkingLevel | null | undefined,
+): ThinkingLevel | null | undefined {
+  if (!policy) return startLevel;
+  const fallback = (startLevel ?? "medium") as ThinkingLevel;
+  return resolveThinkingLevel(unitType, policy, fallback);
+}


### PR DESCRIPTION
## Linked issue

Closes #5104

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds a `thinking_policy` block to PREFERENCES.md for per-unit-type and per-prefix thinking level configuration.
**Why:** Today `defaultThinkingLevel` is a single global value — wasteful on mechanical units, weak on planning units.
**How:** New resolver, schema validation, hook into `auto-model-selection.ts` per dispatch.

## What

- New file `src/resources/extensions/gsd/thinking-policy.ts` — pure resolver: exact unitType → longest-prefix → default → fallback.
- New types and validation: `thinking_policy` accepted in PREFERENCES.md, validated against the level enum and `KNOWN_UNIT_TYPES`.
- Wired into `auto-model-selection.ts` and `auto/phases.ts` so the resolved level is applied alongside model swaps.
- Adds `execute-task-simple` to `KNOWN_UNIT_TYPES`. It is referenced by `preferences-models.ts` (`execution_simple` model resolution) and `workflow-mcp.ts` (`gsd_complete_task` mapping) but missing from the canonical list.
- Docs: new `### thinking_policy` section in `docs/user-docs/configuration.md`.

## Why

`defaultThinkingLevel` is single-valued and `/thinking` is a per-session manual toggle. Long auto-mode runs walk through many unit types of very different reasoning depth. A global setting forces a bad tradeoff:

- High globally → token waste on `execute-task`, `complete-*`, `worktree-merge`.
- Low globally → `plan-*`, `discuss-*`, `replan-slice` lose quality.

`dynamic_routing` answers a different question (which model). This answers: how hard should the chosen model think, per unit type.

## How

Schema:

\`\`\`yaml
thinking_policy:
  default: medium
  prefixes:
    plan-: high
    discuss-: high
    research-: medium
    complete-: "off"
  unitTypes:
    execute-task: "off"
    execute-task-simple: "off"
    reactive-execute: "off"
    replan-slice: high
    reassess-roadmap: high
    gate-evaluate: high
    refine-slice: medium
    validate-milestone: medium
    run-uat: medium
    worktree-merge: "off"
    rewrite-docs: low
\`\`\`

Resolution order:

1. `/thinking` session override — wins over policy (preserves existing UX).
2. `unitTypes[unitType]` — exact match.
3. `prefixes[<longest matching>]` — longest-prefix wins on conflict.
4. `default`.
5. existing `defaultThinkingLevel` from Pi settings.

Validation:

- Levels must be one of `off | minimal | low | medium | high | xhigh`.
- `unitTypes` keys must be in `KNOWN_UNIT_TYPES` — typos error out with the full valid list in the message.
- `prefixes` keys not ending in `-` get a warning, not a rejection — convention only.
- YAML `false` (unquoted `off`) is coerced to string `"off"` to handle the standard YAML footgun.

Implementation mirrors `dynamic_routing` and `post_unit_hooks` — same precedence (project > global), same validation surface, no new file or precedence rule.

## Change type

- [x] \`feat\` — New feature or capability

## Scope

- [x] \`gsd extension\` — GSD workflow

## Breaking changes

- [x] No breaking changes

`thinking_policy` is opt-in. With no policy block, behavior is identical to current `defaultThinkingLevel` semantics.

## Test plan

- [x] CI passes
- [x] New/updated tests included

New tests:

- `tests/thinking-policy.test.ts` — 11 unit tests for the resolver (exact > prefix > default > fallback, longest-prefix tie-break, undefined policy, YAML `false` coercion).
- 3 validation tests (level enum, unknown unit-type rejection, prefix-key warning).
- Updated `auto-thinking-restore.test.ts` to assert the resolver is called on hook-driven model swaps.

Manual smoke test:

- Loaded a real `.gsd/PREFERENCES.md` with the example config above.
- `loadProjectGSDPreferences()` parsed and validated cleanly.
- `resolveThinkingLevel()` returned the expected level for `execute-task` (off), `research-slice` (medium via prefix), `plan-milestone` (high via prefix), `complete-slice` (off via prefix), `discuss-slice` (high via prefix), `replan-slice` (high via unitTypes).
- ADR-011 meta test (every `KNOWN_UNIT_TYPES` entry appears in all 4 downstream registries) passes after the `execute-task-simple` addition.

## AI disclosure

- [x] This PR includes AI-assisted code

Implementation drafted with Claude Code. Verified locally: `npm run typecheck:extensions` (0 errors), targeted tests (22/22 pass), full extension test suite (failures unchanged from `main` — Windows path / plugin discovery, unrelated to this change). Diff manually reviewed for scope creep — no unrelated changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-dispatch thinking_policy to control AI thinking levels (off…xhigh) with exact unit-type, longest-prefix, then default resolution; applies only to auto-mode dispatches.
  * Added execute-task-simple dispatch unit type.
  * Auto-mode now re-resolves and reapplies the effective thinking level during model swaps and hook-driven overrides.
  * Added Claude Code (CC) spoofing support and optional session-based headers for Anthropic requests.

* **Documentation**
  * Added configuration guide covering resolution order, allowed levels, YAML false → "off", validation errors, and prefix warnings.

* **Tests**
  * Added tests for precedence, validation, YAML coercion, and auto-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->