### PR TITLE
fix(tool-bootstrap): skip provisioning on Windows when tools are on PATH

### DIFF
--- a/src/tests/tool-bootstrap.test.ts
+++ b/src/tests/tool-bootstrap.test.ts
@@ -25,7 +25,7 @@ test("resolveToolFromPath finds fd via fdfind fallback", (t) => {
   assert.equal(resolved, join(tmp, "fdfind"));
 });
 
-test("ensureManagedTools provisions fd and rg into managed bin dir", (t) => {
+test("ensureManagedTools provisions fd and rg into managed bin dir", { skip: process.platform === "win32" }, (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-tool-bootstrap-provision-"));
   const sourceBin = join(tmp, "source-bin");
   const targetBin = join(tmp, "target-bin");
@@ -47,7 +47,7 @@ test("ensureManagedTools provisions fd and rg into managed bin dir", (t) => {
   assert.ok(lstatSync(join(targetBin, RG_TARGET)).isSymbolicLink() || lstatSync(join(targetBin, RG_TARGET)).isFile());
 });
 
-test("ensureManagedTools copies executable when symlink target already exists as a broken link", (t) => {
+test("ensureManagedTools copies executable when symlink target already exists as a broken link", { skip: process.platform === "win32" }, (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-tool-bootstrap-copy-"));
   const sourceBin = join(tmp, "source-bin");
   const targetBin = join(tmp, "target-bin");
@@ -67,4 +67,31 @@ test("ensureManagedTools copies executable when symlink target already exists as
   assert.equal(provisioned.length, 2);
   assert.ok(lstatSync(targetFd).isFile(), "fd fallback should replace broken symlink with a copied file");
   assert.match(readFileSync(targetFd, "utf8"), /echo fd/);
+});
+
+test("ensureManagedTools skips provisioning on Windows when tools are on PATH", (t) => {
+  // Regression test for #5111: on Windows, ensureManagedTools() must not
+  // copy/symlink tools into the managed bin dir when they're already on PATH.
+  // Package managers like pixi/conda use proxy shims that break when copied,
+  // and since the tools are already reachable via PATH, provisioning is
+  // unnecessary.
+  if (process.platform !== "win32") return;
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-tool-bootstrap-win32-skip-"));
+  const sourceBin = join(tmp, "source-bin");
+  const targetBin = join(tmp, "target-bin");
+
+  mkdirSync(sourceBin, { recursive: true });
+  mkdirSync(targetBin, { recursive: true });
+
+  t.after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  makeExecutable(sourceBin, "rg.exe");
+  makeExecutable(sourceBin, "fd.exe");
+
+  const provisioned = ensureManagedTools(targetBin, sourceBin);
+
+  assert.equal(provisioned.length, 0, "should not provision on Windows when tools are on PATH");
+  assert.ok(!existsSync(join(targetBin, "rg.exe")), "rg.exe must not exist in target bin");
+  assert.ok(!existsSync(join(targetBin, "fd.exe")), "fd.exe must not exist in target bin");
 });

--- a/src/tool-bootstrap.ts
+++ b/src/tool-bootstrap.ts
@@ -126,6 +126,14 @@ export function ensureManagedTools(targetDir: string, pathValue: string | undefi
     if (pathExistsIncludingBrokenSymlink(targetPath) && !isBrokenSymlink(targetPath)) continue;
     const sourcePath = resolveToolFromPath(tool, pathValue);
     if (!sourcePath) continue;
+
+    // On Windows, symlinks require elevated privileges and many package
+    // managers (pixi, conda) use proxy shims that break when copied alone.
+    // Since resolveToolFromPath() already proved the tool is on PATH and
+    // getShellEnv() preserves the full PATH, provisioning is unnecessary —
+    // child processes will find the tool via the system PATH entries.
+    if (process.platform === "win32") continue;
+
     provisioned.push(provisionTool(targetDir, tool, sourcePath));
   }
 


### PR DESCRIPTION
## TL;DR

**What:** Skip provisioning rg/fd into `~/.gsd/agent/bin/` on Windows when they're already on PATH.
**Why:** Copying pixi/conda proxy shims without their config directory breaks them.
**How:** Short-circuit `ensureManagedTools()` on win32 — tools found on PATH need no local copy.

## What

- `src/tool-bootstrap.ts` — on win32, `ensureManagedTools()` skips provisioning when `resolveToolFromPath()` succeeds
- `src/tests/tool-bootstrap.test.ts` — existing POSIX provisioning tests skip on win32; regression test for win32 skip

## Why

On Windows, `symlinkSync` requires elevated privileges, so `ensureManagedTools()` falls back to `copyFileSync`. Package managers like pixi/conda use proxy shims (~436KB) that delegate to the real binary via a sibling `trampoline_configuration/` directory. Copying just the shim breaks it — and `getShellEnv()` prepends the managed bin to PATH, shadowing the working system tool.

The error:
```
Diagnostic { message: "Couldn't open \"...\.gsd\agent\bin\trampoline_configuration\rg.json\"" }
```

Since `resolveToolFromPath()` already proved the tool is reachable on PATH and `getShellEnv()` preserves the full PATH, provisioning is unnecessary on Windows.

## How

Single guard: `if (process.platform === "win32") continue;` inside the provisioning loop. No heuristics, no shim detection — if we're on Windows and the tool is on PATH, we're done.

Closes #5111

- [x] `fix` — Bug fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows tool provisioning now uses system PATH tools when available instead of creating local copies.

* **Tests**
  * Added and updated platform-specific test cases for tool management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->