### PR TITLE
Support project-local .gsd boundaries in monorepos

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -435,7 +435,8 @@ export async function bootstrapAutoSession(
     // where isInheritedRepo() returns a false negative, e.g. stale .gsd at
     // the parent git root). See #2393 and related issue.
     const hasLocalGit = existsSync(join(base, ".git"));
-    if (!hasLocalGit || isInheritedRepo(base)) {
+    const hasLocalProjectGsd = existsSync(join(base, ".gsd"));
+    if ((!hasLocalGit && !hasLocalProjectGsd) || isInheritedRepo(base)) {
       const mainBranch =
         loadEffectiveGSDPreferences(base)?.preferences?.git?.main_branch || "main";
       nativeInit(base, mainBranch);

--- a/src/resources/extensions/gsd/path-utils.ts
+++ b/src/resources/extensions/gsd/path-utils.ts
@@ -1,0 +1,14 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Resolve an existing path through the filesystem, falling back to `resolve()`.
+ */
+export function canonicalizeExistingPath(path: string): string {
+  try {
+    // Use native realpath on Windows to resolve 8.3 short paths (e.g. RUNNER~1).
+    return process.platform === "win32" ? realpathSync.native(path) : realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -14,6 +14,7 @@ import { join, dirname, normalize } from "node:path";
 import { spawnSync } from "node:child_process";
 import { nativeScanGsdTree, type GsdTreeEntry } from "./native-parser-bridge.js";
 import { DIR_CACHE_MAX } from "./constants.js";
+import { findNearestGsdProjectRoot, isProjectGsdBoundary } from "./project-boundary.js";
 
 // ─── Directory Listing Cache ──────────────────────────────────────────────────
 
@@ -293,10 +294,11 @@ export function _clearGsdRootCache(): void {
  * Resolve the `.gsd` directory for a given project base path.
  *
  * Probe order:
- *   1. basePath/.gsd         — fast path (common case)
- *   2. git rev-parse root    — handles cwd-is-a-subdirectory
- *   3. Walk up from basePath — handles moved .gsd in an ancestor (bounded by git root)
- *   4. basePath/.gsd         — creation fallback (init scenario)
+ *   1. basePath/.gsd              — fast path (common case)
+ *   2. nearest ancestor .gsd      — explicit monorepo subproject boundary
+ *   3. git rev-parse root         — handles cwd-is-a-subdirectory
+ *   4. Walk up from basePath      — handles moved .gsd in an ancestor (bounded by git root)
+ *   5. basePath/.gsd              — creation fallback (init scenario)
  *
  * Result is cached per basePath for the process lifetime.
  */
@@ -361,7 +363,12 @@ function probeGsdRoot(rawBasePath: string): string {
   // Also check the resolved path for the worktree pattern (macOS /tmp → /private/tmp)
   if (basePath !== rawBasePath && isInsideGsdWorktree(basePath)) return local;
 
-  // 2. Git root anchor — used as both probe target and walk-up boundary
+  // 2. Explicit project boundary — monorepo subprojects can own their own
+  //    `.gsd/` directory without requiring a nested Git repository.
+  const projectRoot = findNearestGsdProjectRoot(basePath);
+  if (projectRoot) return join(projectRoot, ".gsd");
+
+  // 3. Git root anchor — used as both probe target and walk-up boundary
   //    Only walk if we're inside a git project — prevents escaping into
   //    unrelated filesystem territory when running outside any repo.
   let gitRoot: string | null = null;
@@ -378,22 +385,22 @@ function probeGsdRoot(rawBasePath: string): string {
 
   if (gitRoot) {
     const candidate = join(gitRoot, ".gsd");
-    if (existsSync(candidate)) return candidate;
+    if (isProjectGsdBoundary(candidate)) return candidate;
   }
 
-  // 3. Walk up from basePath to the git root (only if we are in a subdirectory)
+  // 4. Walk up from basePath to the git root (only if we are in a subdirectory)
   if (gitRoot && basePath !== gitRoot) {
     let cur = dirname(basePath);
     while (cur !== basePath) {
       const candidate = join(cur, ".gsd");
-      if (existsSync(candidate)) return candidate;
+      if (isProjectGsdBoundary(candidate)) return candidate;
       if (cur === gitRoot) break;
       basePath = cur;
       cur = dirname(cur);
     }
   }
 
-  // 4. Fallback for init/creation
+  // 5. Fallback for init/creation
   return local;
 }
 export function milestonesDir(basePath: string): string {

--- a/src/resources/extensions/gsd/project-boundary.ts
+++ b/src/resources/extensions/gsd/project-boundary.ts
@@ -1,0 +1,102 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { canonicalizeExistingPath } from "./path-utils.js";
+
+/**
+ * Normalize a path for equality checks across platforms and trailing slashes.
+ */
+function normalizedForCompare(path: string): string {
+  const resolved = canonicalizeExistingPath(path).replaceAll("\\", "/").replace(/\/+$/, "");
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+/**
+ * Return true when `gsdPath` resolves to the configured global GSD home.
+ */
+function isGlobalGsdHome(gsdPath: string): boolean {
+  const currentGsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
+  const normalizedGsdPath = normalizedForCompare(gsdPath);
+  const normalizedGsdHome = normalizedForCompare(currentGsdHome);
+  return normalizedGsdPath === normalizedGsdHome;
+}
+
+/**
+ * Return true when `gsdPath` is a project-local GSD boundary.
+ *
+ * The global user state directory (`~/.gsd` or `GSD_HOME`) is not a project
+ * boundary even when a user's home directory is itself inside a Git repository.
+ */
+export function isProjectGsdBoundary(gsdPath: string): boolean {
+  if (!existsSync(gsdPath)) return false;
+  try {
+    if (isGlobalGsdHome(gsdPath)) return false;
+    return statSync(gsdPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Convert a file path to its containing directory before ancestor searches.
+ */
+function normalizeStartPath(path: string): string {
+  try {
+    if (existsSync(path) && !statSync(path).isDirectory()) {
+      return resolve(path, "..");
+    }
+  } catch {
+    // Non-fatal: fall back to the input path.
+  }
+  return path;
+}
+
+/**
+ * Resolve the containing Git toplevel for `basePath`, or null outside Git.
+ */
+function resolveGitToplevel(basePath: string): string | null {
+  try {
+    const out = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd: basePath,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+    }).trim();
+    return out ? canonicalizeExistingPath(out) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find the nearest ancestor, including `basePath`, that owns a project-local
+ * `.gsd/` directory. The search is bounded by the containing Git toplevel when
+ * one exists, so unrelated parent directories cannot accidentally capture a
+ * project running outside a repository.
+ */
+export function findNearestGsdProjectRoot(basePath: string): string | null {
+  let dir = canonicalizeExistingPath(normalizeStartPath(basePath));
+  const gitRoot = resolveGitToplevel(dir);
+  const stopAt = gitRoot ? normalizedForCompare(gitRoot) : null;
+
+  for (let i = 0; i < 100; i++) {
+    if (isProjectGsdBoundary(join(dir, ".gsd"))) return dir;
+    if (stopAt && normalizedForCompare(dir) === stopAt) break;
+
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return null;
+}
+
+/**
+ * Compute a path that is stable inside a Git repository and useful for
+ * distinguishing explicit subprojects that share the same remote URL.
+ */
+export function gitRelativeProjectPath(projectRoot: string, gitRoot: string): string {
+  const rel = relative(canonicalizeExistingPath(gitRoot), canonicalizeExistingPath(projectRoot));
+  return rel === "" ? "." : rel.replaceAll("\\", "/");
+}

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -11,6 +11,8 @@ import { execFileSync } from "node:child_process";
 import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
+import { findNearestGsdProjectRoot, gitRelativeProjectPath } from "./project-boundary.js";
+import { canonicalizeExistingPath } from "./path-utils.js";
 
 const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
 
@@ -123,6 +125,11 @@ export function isInheritedRepo(basePath: string): boolean {
     const normalizedRoot = canonicalizeExistingPath(root);
     if (normalizedBase === normalizedRoot) return false; // basePath IS the root
 
+    // A real project-local .gsd directory at basePath is an explicit project
+    // boundary inside a larger repository. Bootstrap-created .gsd symlinks do
+    // not suppress inherited detection; existing startup flows rely on that.
+    if (isRealProjectGsdDirectory(join(normalizedBase, ".gsd"))) return false;
+
     // The git root is a proper ancestor. Check whether it already has .gsd
     // (i.e. the parent project was initialised with GSD).
     if (isProjectGsd(join(root, ".gsd"))) return false;
@@ -181,6 +188,29 @@ function isProjectGsd(gsdPath: string): boolean {
   return false;
 }
 
+/**
+ * Return true when `gsdPath` is a durable local project boundary directory.
+ *
+ * Unlike `isProjectGsd()`, this deliberately excludes symlinks because a
+ * temporary or external `.gsd` symlink at `basePath` does not prove the Git
+ * repository itself is project-local.
+ */
+function isRealProjectGsdDirectory(gsdPath: string): boolean {
+  if (!existsSync(gsdPath)) return false;
+
+  try {
+    const stat = lstatSync(gsdPath);
+    if (!stat.isDirectory()) return false;
+
+    const currentGsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
+    const normalizedGsdPath = canonicalizeExistingPath(gsdPath);
+    const normalizedGsdHome = canonicalizeExistingPath(currentGsdHome);
+    return normalizedGsdPath !== normalizedGsdHome;
+  } catch {
+    return false;
+  }
+}
+
 // ─── Repo Identity ──────────────────────────────────────────────────────────
 
 /**
@@ -197,19 +227,6 @@ function getRemoteUrl(basePath: string): string {
     }).trim();
   } catch {
     return "";
-  }
-}
-
-/**
- * Resolve the git toplevel (real root) for the given path.
- * For worktrees this returns the main repo root, not the worktree path.
- */
-function canonicalizeExistingPath(path: string): string {
-  try {
-    // Use native realpath on Windows to resolve 8.3 short paths (e.g. RUNNER~1)
-    return process.platform === "win32" ? realpathSync.native(path) : realpathSync(path);
-  } catch {
-    return resolve(path);
   }
 }
 
@@ -291,13 +308,27 @@ export function repoIdentity(basePath: string): string {
     return projectId;
   }
   const remoteUrl = getRemoteUrl(basePath);
+  const root = resolveGitRoot(basePath);
+  if (!isInsideWorktree(basePath)) {
+    const explicitProjectRoot = findNearestGsdProjectRoot(basePath);
+    if (explicitProjectRoot) {
+      const normalizedProject = canonicalizeExistingPath(explicitProjectRoot);
+      const normalizedRoot = canonicalizeExistingPath(root);
+      if (normalizedProject !== normalizedRoot) {
+        const projectPath = gitRelativeProjectPath(normalizedProject, normalizedRoot);
+        const input = remoteUrl
+          ? `${remoteUrl}\n${projectPath}`
+          : `${normalizedRoot}\n${projectPath}`;
+        return createHash("sha256").update(input).digest("hex").slice(0, 12);
+      }
+    }
+  }
   if (remoteUrl) {
     // Remote URL alone uniquely identifies the repo — path is redundant.
     // This makes moves transparent for repos with remotes (#2750).
     return createHash("sha256").update(remoteUrl).digest("hex").slice(0, 12);
   }
   // Local-only repo: include git root since there's no remote to anchor identity.
-  const root = resolveGitRoot(basePath);
   const input = `\n${root}`;
   return createHash("sha256").update(input).digest("hex").slice(0, 12);
 }
@@ -506,6 +537,7 @@ function ensureGsdSymlinkCore(projectPath: string): string {
   const externalPath = resolveExternalPathWithRecovery(projectPath);
   const localGsd = join(projectPath, ".gsd");
   const inWorktree = isInsideWorktree(projectPath);
+  const hasLocalProjectGsd = isProjectGsd(localGsd);
 
   // Guard: Never create a symlink at ~/.gsd — that's the user-level GSD home,
   // not a project .gsd. This can happen if resolveProjectRoot() or
@@ -521,7 +553,7 @@ function ensureGsdSymlinkCore(projectPath: string): string {
   // symlink in the subdirectory — that causes `.gsd 2` collision variants on
   // macOS (#2380). Worktrees are excluded because they legitimately need their
   // own .gsd symlink pointing at the shared external state dir.
-  if (!inWorktree) {
+  if (!inWorktree && !hasLocalProjectGsd) {
     try {
       const gitRoot = resolveGitRoot(projectPath);
       const normalizedProject = canonicalizeExistingPath(projectPath);

--- a/src/resources/extensions/gsd/tests/monorepo-project-boundary.test.ts
+++ b/src/resources/extensions/gsd/tests/monorepo-project-boundary.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+
+import { ensureGsdSymlink, isInheritedRepo, repoIdentity } from "../repo-identity.ts";
+import { gsdRoot, _clearGsdRootCache } from "../paths.ts";
+import { resolveProjectRoot } from "../worktree.ts";
+
+function run(command: string, cwd: string): string {
+  return execSync(command, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
+}
+
+function initRepo(): string {
+  const repo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-monorepo-boundary-")));
+  run("git init -b main", repo);
+  run('git config user.name "Pi Test"', repo);
+  run('git config user.email "pi@example.com"', repo);
+  run("git remote add origin git@github.com:example/monorepo.git", repo);
+  writeFileSync(join(repo, "README.md"), "# Monorepo\n", "utf-8");
+  run("git add README.md", repo);
+  run('git commit -m "chore: init"', repo);
+  return repo;
+}
+
+function writeProjectGsd(projectRoot: string, title: string): void {
+  mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
+  writeFileSync(join(projectRoot, ".gsd", "PROJECT.md"), `# ${title}\n`, "utf-8");
+}
+
+describe("monorepo project-local .gsd boundaries", () => {
+  const cleanup: string[] = [];
+
+  afterEach(() => {
+    _clearGsdRootCache();
+    for (const dir of cleanup.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    delete process.env.GSD_PROJECT_ID;
+    delete process.env.GSD_STATE_DIR;
+  });
+
+  test("gsdRoot prefers the nearest explicit subproject .gsd over the git root .gsd", () => {
+    const repo = initRepo();
+    cleanup.push(repo);
+    writeProjectGsd(repo, "Root Project");
+
+    const child = join(repo, "candidates", "autonomy-video-studio");
+    const childSrc = join(child, "src");
+    mkdirSync(childSrc, { recursive: true });
+    writeProjectGsd(child, "Autonomy Video Studio");
+
+    assert.equal(gsdRoot(childSrc), join(child, ".gsd"));
+    assert.equal(resolveProjectRoot(childSrc), child);
+  });
+
+  test("subdirectories without an explicit .gsd still fall back to the git root .gsd", () => {
+    const repo = initRepo();
+    cleanup.push(repo);
+    writeProjectGsd(repo, "Root Project");
+
+    const childSrc = join(repo, "packages", "tool", "src");
+    mkdirSync(childSrc, { recursive: true });
+
+    assert.equal(gsdRoot(childSrc), join(repo, ".gsd"));
+    assert.equal(resolveProjectRoot(childSrc), repo);
+  });
+
+  test("project-local .gsd prevents inherited-repo detection and nested git init pressure", () => {
+    const repo = initRepo();
+    cleanup.push(repo);
+
+    const child = join(repo, "candidates", "video-studio");
+    mkdirSync(child, { recursive: true });
+    assert.equal(isInheritedRepo(child), true);
+
+    writeProjectGsd(child, "Video Studio");
+    assert.equal(isInheritedRepo(child), false);
+  });
+
+  test("subproject identity is distinct from the parent repo identity without nested git", () => {
+    const repo = initRepo();
+    cleanup.push(repo);
+    writeProjectGsd(repo, "Root Project");
+
+    const child = join(repo, "candidates", "autonomy-video-studio");
+    mkdirSync(child, { recursive: true });
+    writeProjectGsd(child, "Autonomy Video Studio");
+
+    assert.notEqual(repoIdentity(child), repoIdentity(repo));
+    assert.match(repoIdentity(child), /^[0-9a-f]{12}$/);
+    assert.ok(!existsSync(join(child, ".git")), "subproject does not need a nested .git directory");
+  });
+
+  test("ensureGsdSymlink preserves an explicit subproject .gsd when the git root also has .gsd", () => {
+    const repo = initRepo();
+    const stateDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-monorepo-state-")));
+    cleanup.push(repo, stateDir);
+    process.env.GSD_STATE_DIR = stateDir;
+
+    ensureGsdSymlink(repo);
+    assert.ok(lstatSync(join(repo, ".gsd")).isSymbolicLink(), "repo root uses external state symlink");
+
+    const child = join(repo, "candidates", "autonomy-video-studio");
+    mkdirSync(child, { recursive: true });
+    writeProjectGsd(child, "Autonomy Video Studio");
+
+    const result = ensureGsdSymlink(child);
+    assert.equal(result, join(child, ".gsd"));
+    assert.ok(lstatSync(join(child, ".gsd")).isDirectory(), "explicit subproject .gsd stays local");
+  });
+});

--- a/src/resources/extensions/gsd/worktree-root.ts
+++ b/src/resources/extensions/gsd/worktree-root.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { findNearestGsdProjectRoot } from "./project-boundary.js";
 
 export interface WorktreeSegment {
   gsdIdx: number;
@@ -69,7 +70,9 @@ export function resolveWorktreeProjectRoot(
 function resolveProjectRootFromPath(path: string): string {
   const normalizedPath = path.replaceAll("\\", "/");
   const segment = findWorktreeSegment(normalizedPath);
-  if (!segment) return resolveGitWorkingTreeRoot(path) ?? path;
+  if (!segment) {
+    return findNearestGsdProjectRoot(path) ?? resolveGitWorkingTreeRoot(path) ?? path;
+  }
 
   const sepChar = path.includes("\\") ? "\\" : "/";
   const gsdMarker = `${sepChar}.gsd${sepChar}`;


### PR DESCRIPTION
## Summary

Adds explicit project-local `.gsd/` boundary support so subprojects inside a monorepo can own isolated GSD state without requiring nested Git repositories.

## Behavior

- `gsdRoot()` now prefers the nearest ancestor with a project-local `.gsd/` before falling back to the Git root.
- `resolveProjectRoot()` recognizes project-local `.gsd/` boundaries for normal paths while preserving existing worktree behavior.
- `repoIdentity()` distinguishes explicit subprojects that share the same Git remote by hashing the remote plus the Git-relative project path.
- `isInheritedRepo()` no longer pressures nested `git init` when the current directory has an explicit project-local `.gsd/`.
- `ensureGsdSymlink()` preserves an explicit subproject `.gsd/` even when the parent Git root already has GSD state.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts src/resources/extensions/gsd/tests/symlink-numbered-variants.test.ts src/resources/extensions/gsd/tests/project-relocation-recovery.test.ts src/resources/extensions/gsd/tests/monorepo-project-boundary.test.ts`
- `npm run build:pi`
- `npm run build:rpc-client && npm run build:mcp-server && npm run typecheck:extensions`
- `npm run test:compile && node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/monorepo-project-boundary.test.js dist-test/src/resources/extensions/gsd/tests/repo-identity-worktree.test.js dist-test/src/resources/extensions/gsd/tests/project-relocation-recovery.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced monorepo support with explicit project-local boundary detection.
  * Improved repository root discovery that prioritizes local project boundaries.
  * Initialization behavior refined to avoid unnecessary bootstrap when project-local state exists.

* **Quality**
  * More robust path handling and normalization across platforms.

* **Tests**
  * Added comprehensive test suite covering project boundaries, identity resolution, and symlink/state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->