### PR TITLE
feat(gsd): add smart /gsd launcher wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,18 +338,23 @@ Auto mode is a state machine driven by files on disk. It reads `.gsd/STATE.md`, 
 
 12. **Escape hatch** — Press Escape to pause. The conversation is preserved. Interact with the agent, inspect what happened, or just `/gsd auto` to resume from disk state.
 
-### `/gsd` and `/gsd next` — Step Mode
+### `/gsd` — Smart Launcher
 
-By default, `/gsd` runs in **step mode**: the same state machine as auto mode, but it pauses between units with a wizard showing what completed and what's next. You advance one step at a time, review the output, and continue when ready.
+Bare `/gsd` opens the smart launcher wizard. It reads the current `.gsd/` state, detects active or interrupted sessions, then shows a short action list with the recommended action highlighted and preselected. Use it when you want GSD to choose the safest next entry point instead of remembering the exact subcommand.
 
-- **No `.gsd/` directory** → Start a new project. Discussion flow captures your vision, constraints, and preferences.
-- **Milestone exists, no roadmap** → Discuss or research the milestone.
-- **Roadmap exists, slices pending** → Plan the next slice, execute one task, or switch to auto.
-- **Mid-task** → Resume from where you left off.
+The launcher appears whenever you type `/gsd` with no subcommand in an interactive session. Explicit subcommands still bypass it: `/gsd next` runs one step, `/gsd auto` runs continuously, and `/gsd status` opens the dashboard.
 
-`/gsd next` is an explicit alias for step mode. You can switch from step → auto mid-session via the wizard.
+| Current state | Recommended action |
+|---------------|--------------------|
+| No `.gsd/` directory | Initialize project |
+| Initialized, no milestones | Quick task when available; otherwise create the first milestone |
+| Recoverable interrupted session | Resume |
+| Auto-mode already active | View status, with stop available |
+| Milestone needs context or a roadmap | Discuss first |
+| Roadmap-ready work | Step next, with auto available |
+| Current milestones complete | Start a new milestone |
 
-Step mode is the on-ramp. Auto mode is the highway.
+`/gsd next` is the explicit step-mode command. It executes one guided unit and pauses, using the same state machine as auto mode.
 
 ---
 
@@ -386,9 +391,11 @@ Open a terminal in your project and run:
 gsd
 ```
 
-GSD opens an interactive agent session. From there, you have two ways to work:
+GSD opens an interactive agent session. From there, you have three common ways to work:
 
-**`/gsd` — step mode.** Type `/gsd` and GSD executes one unit of work at a time, pausing between each with a wizard showing what completed and what's next. Same state machine as auto mode, but you stay in the loop. No project yet? It starts the discussion flow. Roadmap exists? It plans or executes the next step.
+**`/gsd` — smart launcher.** Type `/gsd` and GSD shows a state-aware wizard with a recommended action: initialize, resume, discuss, step next, go auto, quick task, status, or start a new milestone.
+
+**`/gsd next` — step mode.** Type `/gsd next` to execute one guided unit and pause. Same state machine as auto mode, but you stay in the loop.
 
 **`/gsd auto` — autonomous mode.** Type `/gsd auto` and walk away. GSD researches, plans, executes, verifies, commits, and advances through every slice until the milestone is complete. Fresh context window per task. No babysitting.
 
@@ -447,8 +454,8 @@ On first run, GSD launches a branded setup wizard that walks you through LLM pro
 
 | Command                 | What it does                                                                  |
 | ----------------------- | ----------------------------------------------------------------------------- |
-| `/gsd`                  | Step mode — executes one unit at a time, pauses between each                  |
-| `/gsd next`             | Explicit step mode (same as bare `/gsd`)                                      |
+| `/gsd`                  | Smart launcher wizard — recommends the safest next action for current state   |
+| `/gsd next`             | Explicit step mode — executes one unit, then pauses                           |
 | `/gsd auto`             | Autonomous mode — researches, plans, executes, commits, repeats               |
 | `/gsd new-project --deep` | Bootstrap a project with staged project-level discovery                    |
 | `/gsd quick`            | Execute a quick task with GSD guarantees, skip planning overhead              |

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -4,8 +4,8 @@
 
 | Command | Description |
 |---------|-------------|
-| `/gsd` | Step mode — execute one unit at a time, pause between each |
-| `/gsd next` | Explicit step mode (same as `/gsd`) |
+| `/gsd` | Smart launcher wizard — recommends the safest next action for the current project state |
+| `/gsd next` | Explicit step mode — execute one guided unit, then pause |
 | `/gsd auto` | Autonomous mode — research, plan, execute, commit, repeat |
 | `/gsd quick` | Execute a quick task with GSD guarantees (atomic commits, state tracking) without full planning overhead |
 | `/gsd stop` | Stop auto mode gracefully |
@@ -39,6 +39,22 @@
 | `/gsd logs` | Browse activity logs, debug logs, and metrics |
 | `/gsd remote` | Control remote auto-mode |
 | `/gsd help` | Categorized command reference with descriptions for all GSD subcommands |
+
+### Bare `/gsd` Smart Launcher
+
+Bare `/gsd` opens a state-aware launcher wizard in interactive sessions. It checks whether the project is initialized, whether auto-mode is active, whether an interrupted session can resume, and where the current milestone is in the workflow, then highlights a recommended action.
+
+| Project state | Recommended action |
+|---------------|--------------------|
+| No `.gsd/` directory | Initialize project |
+| Initialized with no milestones | Quick task when available; otherwise create the first milestone |
+| Recoverable interrupted session | Resume |
+| Auto-mode already active | View status, with stop available |
+| Milestone needs context or a roadmap | Discuss first |
+| Roadmap-ready work | Step next, with auto available |
+| Current milestones complete | Start a new milestone |
+
+Use `/gsd next` when you want to skip the launcher and directly run one step. Use `/gsd auto` when you want continuous execution.
 
 ## Configuration & Diagnostics
 

--- a/docs/user-docs/getting-started.md
+++ b/docs/user-docs/getting-started.md
@@ -315,18 +315,19 @@ Or configure per-phase models in preferences — see [Configuration](./configura
 
 ---
 
-## Two Ways to Work
+## Common Ways to Work
 
-### Step Mode — `/gsd`
+### Smart Launcher — `/gsd`
 
-Type `/gsd` inside a session. GSD executes one unit of work at a time, pausing between each with a wizard showing what completed and what's next.
+Type `/gsd` inside a session to open the smart launcher. GSD reads the project state and highlights a recommended action before you commit to a path.
 
-- **No `.gsd/` directory** — starts a discussion flow to capture your project vision
-- **Milestone exists, no roadmap** — discuss or research the milestone
-- **Roadmap exists, slices pending** — plan the next slice or execute a task
-- **Mid-task** — resume where you left off
+- **No `.gsd/` directory** — initialize the project, optionally with deep discovery
+- **Initialized, no milestones** — run a quick task when available or create the first milestone
+- **Recoverable interrupted session** — resume where it left off
+- **Milestone exists, no roadmap** — discuss first or create the roadmap
+- **Roadmap exists, slices pending** — step next or switch to auto mode
 
-Step mode keeps you in the loop, reviewing output between each step.
+Use `/gsd next` to skip the launcher and execute one guided unit directly. Step mode keeps you in the loop, reviewing output between each step.
 
 ### Auto Mode — `/gsd auto`
 

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -269,7 +269,7 @@ rm -rf "$(dirname .gsd)/.gsd.lock"
 
 ### Session lock stolen by `/gsd` in another terminal
 
-**Symptoms:** Running `/gsd` (step mode) in a second terminal causes a running auto-mode session to lose its lock.
+**Symptoms:** Running `/gsd` in a second terminal causes a running auto-mode session to lose its lock.
 
 **Fix:** Fixed in v2.36.0. Bare `/gsd` no longer steals the session lock from a running auto-mode session. Upgrade to the latest version.
 

--- a/gitbook/README.md
+++ b/gitbook/README.md
@@ -53,10 +53,11 @@ See [Installation](getting-started/installation.md) for detailed setup instructi
 
 | Mode | Command | Best For |
 |------|---------|----------|
-| **Step** | `/gsd` | Staying in the loop, reviewing each step |
+| **Launcher** | `/gsd` | Picking the recommended next action for the current project state |
+| **Step** | `/gsd next` | Staying in the loop, reviewing each step |
 | **Auto** | `/gsd auto` | Walking away, overnight builds, batch work |
 
-The recommended workflow: run auto mode in one terminal, steer from another. See [Step Mode](core-concepts/step-mode.md) and [Auto Mode](core-concepts/auto-mode.md).
+The recommended workflow: use `/gsd` when you want state-aware guidance, run auto mode in one terminal, and steer from another. See [Step Mode](core-concepts/step-mode.md) and [Auto Mode](core-concepts/auto-mode.md).
 
 ## Requirements
 

--- a/gitbook/core-concepts/step-mode.md
+++ b/gitbook/core-concepts/step-mode.md
@@ -5,10 +5,10 @@ Step mode is GSD's interactive, one-step-at-a-time workflow. You stay in the loo
 ## Starting Step Mode
 
 ```
-/gsd
+/gsd next
 ```
 
-GSD reads the state of your `.gsd/` directory and presents a wizard showing what's completed and what's next. It then executes one unit of work and pauses.
+GSD reads the state of your `.gsd/` directory, executes one guided unit of work, and pauses. Bare `/gsd` opens the smart launcher first; choose **Step next** there when you want the wizard to pick the safest step-mode entry point.
 
 ## How It Works
 
@@ -16,8 +16,8 @@ Step mode adapts to your project's current state:
 
 | State | What Happens |
 |-------|-------------|
-| No `.gsd/` directory | Starts a discussion flow to capture your project vision |
-| Milestone exists, no roadmap | Opens a discussion or research phase for the milestone |
+| No `.gsd/` directory | Use bare `/gsd` to initialize the project first |
+| Milestone exists, no roadmap | Opens a discussion or roadmap phase for the milestone |
 | Roadmap exists, slices pending | Plans the next slice or executes the next task |
 | Mid-task | Resumes where you left off |
 

--- a/gitbook/getting-started/first-project.md
+++ b/gitbook/getting-started/first-project.md
@@ -10,14 +10,15 @@ gsd
 
 GSD shows a welcome screen with your version, active model, and available tool keys.
 
-## Start a Discussion
+## Start from the Smart Launcher
 
-Type `/gsd` to enter step mode. GSD reads the state of your project directory and determines the next logical action:
+Type `/gsd` to open the smart launcher. GSD reads the state of your project directory and highlights the recommended next action:
 
-- **No `.gsd/` directory** — starts a discussion flow to capture your project vision
-- **Milestone exists, no roadmap** — discuss or research the milestone
-- **Roadmap exists, slices pending** — plan the next slice or execute a task
-- **Mid-task** — resume where you left off
+- **No `.gsd/` directory** — initialize the project
+- **Initialized, no milestones** — run a quick task when available or create the first milestone
+- **Recoverable interrupted session** — resume where it left off
+- **Milestone exists, no roadmap** — discuss first or create the roadmap
+- **Roadmap exists, slices pending** — step next or switch to auto mode
 
 For a new project, GSD will ask you to describe what you want to build. Talk through your vision — GSD captures requirements, architectural decisions, and scope.
 

--- a/gitbook/reference/commands.md
+++ b/gitbook/reference/commands.md
@@ -4,7 +4,8 @@
 
 | Command | Description |
 |---------|-------------|
-| `/gsd` | Step mode — execute one unit at a time |
+| `/gsd` | Smart launcher wizard — recommends the safest next action for the current project state |
+| `/gsd next` | Explicit step mode — execute one guided unit, then pause |
 | `/gsd auto` | Autonomous mode — research, plan, execute, commit, repeat |
 | `/gsd quick` | Quick task with GSD guarantees but no full planning |
 | `/gsd stop` | Stop auto mode gracefully |
@@ -37,6 +38,22 @@
 | `/gsd logs` | Browse activity and debug logs |
 | `/gsd remote` | Control remote auto-mode |
 | `/gsd help` | Show all available commands |
+
+### Bare `/gsd` Smart Launcher
+
+Bare `/gsd` opens a state-aware launcher wizard in interactive sessions. It checks whether the project is initialized, whether auto-mode is active, whether an interrupted session can resume, and where the current milestone is in the workflow, then highlights a recommended action.
+
+| Project state | Recommended action |
+|---------------|--------------------|
+| No `.gsd/` directory | Initialize project |
+| Initialized with no milestones | Quick task when available; otherwise create the first milestone |
+| Recoverable interrupted session | Resume |
+| Auto-mode already active | View status, with stop available |
+| Milestone needs context or a roadmap | Discuss first |
+| Roadmap-ready work | Step next, with auto available |
+| Current milestones complete | Start a new milestone |
+
+Use `/gsd next` when you want to skip the launcher and directly run one step. Use `/gsd auto` when you want continuous execution.
 
 ## Configuration & Diagnostics
 

--- a/mintlify-docs/getting-started.mdx
+++ b/mintlify-docs/getting-started.mdx
@@ -56,16 +56,19 @@ GSD auto-selects a default model after login. Switch anytime:
 
 Or configure per-phase models in [preferences](/guides/configuration).
 
-## Two ways to work
+## Common ways to work
 
 <Tabs>
-  <Tab title="Step mode">
-    Type `/gsd` inside a session. GSD executes one unit at a time, pausing between each with a wizard showing what completed and what's next.
+  <Tab title="Smart launcher">
+    Type `/gsd` inside a session to open the smart launcher. GSD reads the project state and highlights a recommended action before you commit to a path.
 
-    - **No `.gsd/` directory** → starts a discussion to capture your project vision
-    - **Milestone exists, no roadmap** → discuss or research the milestone
-    - **Roadmap exists, slices pending** → plan the next slice or execute a task
-    - **Mid-task** → resume where you left off
+    - **No `.gsd/` directory** → initialize the project, optionally with deep discovery
+    - **Initialized, no milestones** → run a quick task when available or create the first milestone
+    - **Recoverable interrupted session** → resume where it left off
+    - **Milestone exists, no roadmap** → discuss first or create the roadmap
+    - **Roadmap exists, slices pending** → step next or switch to auto mode
+
+    Use `/gsd next` to skip the launcher and execute one guided unit directly.
   </Tab>
   <Tab title="Auto mode">
     Type `/gsd auto` and walk away. GSD autonomously researches, plans, executes, verifies, commits, and advances through every slice until the milestone is complete.

--- a/mintlify-docs/guides/commands.mdx
+++ b/mintlify-docs/guides/commands.mdx
@@ -7,8 +7,8 @@ description: "Every GSD command, keyboard shortcut, and CLI flag."
 
 | Command | Description |
 |---------|-------------|
-| `/gsd` | Step mode — execute one unit at a time, pause between each |
-| `/gsd next` | Explicit step mode (same as `/gsd`) |
+| `/gsd` | Smart launcher wizard — recommends the safest next action for the current project state |
+| `/gsd next` | Explicit step mode — execute one guided unit, then pause |
 | `/gsd auto` | Autonomous mode — research, plan, execute, commit, repeat |
 | `/gsd quick` | Execute a quick task with GSD guarantees without full planning overhead |
 | `/gsd stop` | Stop auto mode gracefully |
@@ -42,6 +42,22 @@ description: "Every GSD command, keyboard shortcut, and CLI flag."
 | `/gsd logs` | Browse activity logs, debug logs, and metrics |
 | `/gsd remote` | Control remote auto-mode |
 | `/gsd help` | Categorized command reference |
+
+### Bare `/gsd` smart launcher
+
+Bare `/gsd` opens a state-aware launcher wizard in interactive sessions. It checks whether the project is initialized, whether auto-mode is active, whether an interrupted session can resume, and where the current milestone is in the workflow, then highlights a recommended action.
+
+| Project state | Recommended action |
+|---------------|--------------------|
+| No `.gsd/` directory | Initialize project |
+| Initialized with no milestones | Quick task when available; otherwise create the first milestone |
+| Recoverable interrupted session | Resume |
+| Auto-mode already active | View status, with stop available |
+| Milestone needs context or a roadmap | Discuss first |
+| Roadmap-ready work | Step next, with auto available |
+| Current milestones complete | Start a new milestone |
+
+Use `/gsd next` when you want to skip the launcher and directly run one step. Use `/gsd auto` when you want continuous execution.
 
 ## Configuration and diagnostics
 

--- a/mintlify-docs/introduction.mdx
+++ b/mintlify-docs/introduction.mdx
@@ -44,16 +44,18 @@ Plan → Execute (per task) → Complete → Reassess Roadmap → Next Slice
 
 Every phase gets a fresh context window with pre-loaded context — no accumulated garbage, no degraded quality.
 
-## Two ways to work
+## Common ways to work
 
 <Tabs>
-  <Tab title="Step mode">
-    Type `/gsd` inside a session. GSD executes one unit at a time, pausing between each so you can review.
+  <Tab title="Smart launcher">
+    Type `/gsd` inside a session. GSD opens a state-aware launcher, recommends the next safe action, and lets you choose step mode, auto mode, setup, resume, quick task, or status depending on the project state.
 
     ```bash
     gsd
     /gsd
     ```
+
+    Use `/gsd next` when you want to run one guided unit directly.
   </Tab>
   <Tab title="Auto mode">
     Type `/gsd auto` and walk away. GSD autonomously researches, plans, executes, verifies, and commits until the milestone is complete.

--- a/src/resources/extensions/gsd/commands/handlers/auto.ts
+++ b/src/resources/extensions/gsd/commands/handlers/auto.ts
@@ -150,7 +150,8 @@ export async function handleAutoCommand(trimmed: string, ctx: ExtensionCommandCo
 
   if (trimmed === "") {
     if (!(await guardRemoteSession(ctx, pi))) return true;
-    startAutoDetached(ctx, pi, projectRoot(), false, { step: true });
+    const { showSmartLauncher } = await import("../../smart-launcher.js");
+    await showSmartLauncher(ctx, pi, projectRoot());
     return true;
   }
 

--- a/src/resources/extensions/gsd/smart-launcher.ts
+++ b/src/resources/extensions/gsd/smart-launcher.ts
@@ -1,0 +1,499 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import type { GSDState } from "./types.js";
+import type {
+  InterruptedSessionAssessment,
+  InterruptedSessionClassification,
+} from "./interrupted-session.js";
+
+import { showConfirm, showNextAction } from "../shared/tui.js";
+import { join } from "node:path";
+import { unlinkSync } from "node:fs";
+import { startAutoDetached, isAutoActive } from "./auto.js";
+import { assessInterruptedSession, formatInterruptedSessionRunningMessage } from "./interrupted-session.js";
+import { clearLock } from "./crash-recovery.js";
+import { detectProjectState, hasGsdBootstrapArtifacts } from "./detection.js";
+import { deriveState } from "./state.js";
+import { findMilestoneIds } from "./milestone-ids.js";
+import { gsdRoot } from "./paths.js";
+import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { setPlanningDepth } from "./planning-depth.js";
+import { validateDirectory } from "./validate-directory.js";
+import { logWarning } from "./workflow-logger.js";
+
+export type LauncherStateKind =
+  | "uninitialized"
+  | "first-project"
+  | "new-milestone"
+  | "interrupted"
+  | "planning"
+  | "executing"
+  | "complete";
+
+export type LauncherActionId =
+  | "init"
+  | "quick"
+  | "deep_project"
+  | "deep_milestone"
+  | "step"
+  | "auto"
+  | "status"
+  | "template"
+  | "discuss"
+  | "plan"
+  | "resume"
+  | "stop"
+  | "ship"
+  | "setup"
+  | "not_yet";
+
+export interface SmartLauncherFacts {
+  hasBootstrapArtifacts: boolean;
+  milestoneCount: number;
+  autoActive: boolean;
+  deepStagePending: boolean;
+  interruptedClassification: InterruptedSessionClassification;
+  state: GSDState | null;
+}
+
+export interface SmartLauncherAction {
+  id: LauncherActionId;
+  label: string;
+  description: string;
+  recommended?: boolean;
+}
+
+export interface SmartLauncherModel {
+  kind: LauncherStateKind;
+  title: string;
+  summary: string[];
+  actions: SmartLauncherAction[];
+}
+
+function quickAction(): SmartLauncherAction {
+  return {
+    id: "quick",
+    label: "Quick task",
+    description: "Handle a small one-off task without full milestone ceremony.",
+  };
+}
+
+function statusAction(): SmartLauncherAction {
+  return {
+    id: "status",
+    label: "View status",
+    description: "Open the progress dashboard for the current project.",
+  };
+}
+
+function firstActiveAction(actions: SmartLauncherAction[]): SmartLauncherAction[] {
+  if (actions.some((action) => action.recommended)) return actions;
+  return actions.map((action, index) => index === 0 ? { ...action, recommended: true } : action);
+}
+
+function canOfferQuick(facts: SmartLauncherFacts): boolean {
+  return facts.hasBootstrapArtifacts &&
+    !facts.autoActive &&
+    facts.interruptedClassification !== "running" &&
+    facts.interruptedClassification !== "recoverable";
+}
+
+function stateTitle(state: GSDState | null): string {
+  if (state?.activeMilestone) {
+    const slice = state.activeSlice ? ` / ${state.activeSlice.id}` : "";
+    return `GSD — ${state.activeMilestone.id}${slice}`;
+  }
+  if (state?.lastCompletedMilestone) {
+    return `GSD — ${state.lastCompletedMilestone.id}`;
+  }
+  return "GSD — Get Shit Done";
+}
+
+export function buildSmartLauncherModel(facts: SmartLauncherFacts): SmartLauncherModel {
+  const state = facts.state;
+
+  if (facts.autoActive) {
+    return {
+      kind: "interrupted",
+      title: "GSD — Auto-mode Active",
+      summary: ["Auto-mode is already running. Choose a safe control action."],
+      actions: firstActiveAction([
+        statusAction(),
+        {
+          id: "stop",
+          label: "Stop auto-mode",
+          description: "Ask the active auto session to stop gracefully.",
+        },
+      ]),
+    };
+  }
+
+  if (facts.interruptedClassification === "recoverable") {
+    return {
+      kind: "interrupted",
+      title: "GSD — Resume Work",
+      summary: ["A paused or interrupted GSD session can be resumed."],
+      actions: firstActiveAction([
+        {
+          id: "resume",
+          label: "Resume",
+          description: "Pick up the interrupted session where it left off.",
+        },
+        {
+          id: "step",
+          label: "Continue manually",
+          description: "Open the guided step flow instead of direct recovery.",
+        },
+        statusAction(),
+        {
+          id: "stop",
+          label: "Stop/reset",
+          description: "Clear the active auto-mode session through the normal stop flow.",
+        },
+      ]),
+    };
+  }
+
+  if (facts.interruptedClassification === "running") {
+    return {
+      kind: "interrupted",
+      title: "GSD — Session Running",
+      summary: ["Another GSD session appears to be running."],
+      actions: firstActiveAction([statusAction()]),
+    };
+  }
+
+  if (!facts.hasBootstrapArtifacts) {
+    return {
+      kind: "uninitialized",
+      title: "GSD — Start Here",
+      summary: ["No initialized GSD project was found in this directory."],
+      actions: firstActiveAction([
+        {
+          id: "init",
+          label: "Initialize project",
+          description: "Run the project init wizard and create local GSD state.",
+        },
+        {
+          id: "deep_project",
+          label: "Deep new project",
+          description: "Initialize and use staged project discovery before planning.",
+        },
+        {
+          id: "setup",
+          label: "Setup",
+          description: "Open provider, key, and preference configuration.",
+        },
+      ]),
+    };
+  }
+
+  const hasMilestones = facts.milestoneCount > 0 || (state?.registry.length ?? 0) > 0;
+  if (!hasMilestones) {
+    const actions: SmartLauncherAction[] = [
+      ...(canOfferQuick(facts) ? [quickAction()] : []),
+      {
+        id: "step",
+        label: facts.deepStagePending ? "Continue deep discovery" : "Create first milestone",
+        description: facts.deepStagePending
+          ? "Continue the staged project discovery flow."
+          : "Start the guided first-milestone flow.",
+      },
+      {
+        id: "deep_project",
+        label: "Deep project discovery",
+        description: "Use staged project, requirements, and research setup before planning.",
+      },
+      {
+        id: "template",
+        label: "Run template",
+        description: "Open workflow template choices such as bugfix, spike, or refactor.",
+      },
+      {
+        id: "setup",
+        label: "Setup",
+        description: "Review GSD configuration for this project.",
+      },
+    ];
+    return {
+      kind: "first-project",
+      title: "GSD — New Project",
+      summary: ["No milestones exist yet. Pick how much structure this work needs."],
+      actions: firstActiveAction(actions),
+    };
+  }
+
+  if (state?.phase === "complete") {
+    const actions: SmartLauncherAction[] = [
+      {
+        id: "step",
+        label: "Start new milestone",
+        description: "Define and plan the next milestone.",
+      },
+      {
+        id: "deep_milestone",
+        label: "Deep next milestone",
+        description: "Use staged discovery before creating the next milestone.",
+      },
+      {
+        id: "ship",
+        label: "Ship/status",
+        description: "Prepare shipping artifacts or review what was built.",
+      },
+      ...(canOfferQuick(facts) ? [quickAction()] : []),
+      statusAction(),
+    ];
+    return {
+      kind: "complete",
+      title: stateTitle(state),
+      summary: ["All current milestones are complete."],
+      actions: firstActiveAction(actions),
+    };
+  }
+
+  if (!state?.activeMilestone) {
+    const actions: SmartLauncherAction[] = [
+      {
+        id: "step",
+        label: "Create next milestone",
+        description: "Define the next milestone from the guided flow.",
+      },
+      {
+        id: "deep_milestone",
+        label: "Deep next milestone",
+        description: "Use staged discovery before creating the next milestone.",
+      },
+      ...(canOfferQuick(facts) ? [quickAction()] : []),
+      statusAction(),
+    ];
+    return {
+      kind: "new-milestone",
+      title: "GSD — Next Milestone",
+      summary: ["No active milestone is selected."],
+      actions: firstActiveAction(actions),
+    };
+  }
+
+  if (state.phase === "pre-planning" || state.phase === "needs-discussion") {
+    const actions: SmartLauncherAction[] = [
+      {
+        id: "discuss",
+        label: "Discuss first",
+        description: "Capture context and decisions before planning.",
+      },
+      {
+        id: "plan",
+        label: "Create roadmap",
+        description: "Decompose the milestone and move to the next planning unit.",
+      },
+      {
+        id: "deep_milestone",
+        label: "Deepen discovery",
+        description: "Enable deep mode and continue staged discovery.",
+      },
+      ...(canOfferQuick(facts) ? [quickAction()] : []),
+      statusAction(),
+    ];
+    return {
+      kind: "planning",
+      title: stateTitle(state),
+      summary: [`${state.activeMilestone.id}: ${state.activeMilestone.title}`, "This milestone needs context or a roadmap."],
+      actions: firstActiveAction(actions),
+    };
+  }
+
+  const actions: SmartLauncherAction[] = [
+    {
+      id: "step",
+      label: "Step next",
+      description: "Execute one guided unit, then pause.",
+    },
+    {
+      id: "auto",
+      label: "Go auto",
+      description: "Run continuously until the next stop condition.",
+    },
+    ...(canOfferQuick(facts) ? [quickAction()] : []),
+    statusAction(),
+  ];
+  return {
+    kind: "executing",
+    title: stateTitle(state),
+    summary: [state.nextAction || "Work is ready to continue."],
+    actions: firstActiveAction(actions),
+  };
+}
+
+async function promptQuickDescription(ctx: ExtensionCommandContext): Promise<string | null> {
+  const input = await ctx.ui.input(
+    "Quick task",
+    "Describe the small task to execute",
+  );
+  const description = input?.trim() ?? "";
+  if (!description) {
+    ctx.ui.notify("Quick task cancelled — no task description provided.", "info");
+    return null;
+  }
+  return description;
+}
+
+async function runLauncherAction(
+  action: LauncherActionId,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+  basePath: string,
+  interrupted: InterruptedSessionAssessment | null,
+): Promise<void> {
+  switch (action) {
+    case "init": {
+      const { showSmartEntry } = await import("./guided-flow.js");
+      await showSmartEntry(ctx, pi, basePath);
+      return;
+    }
+    case "deep_project":
+    case "deep_milestone": {
+      setPlanningDepth(basePath, "deep");
+      ctx.ui.notify("Deep planning mode enabled (.gsd/PREFERENCES.md updated).", "info");
+      const { showSmartEntry } = await import("./guided-flow.js");
+      await showSmartEntry(ctx, pi, basePath);
+      return;
+    }
+    case "step":
+    case "plan": {
+      startAutoDetached(ctx, pi, basePath, false, { step: true });
+      return;
+    }
+    case "auto": {
+      startAutoDetached(ctx, pi, basePath, false);
+      return;
+    }
+    case "resume": {
+      startAutoDetached(ctx, pi, basePath, false, {
+        interrupted: interrupted ?? undefined,
+        step: interrupted?.pausedSession?.stepMode ?? false,
+      });
+      return;
+    }
+    case "stop": {
+      const { handleAutoCommand } = await import("./commands/handlers/auto.js");
+      await handleAutoCommand("stop", ctx, pi);
+      return;
+    }
+    case "status": {
+      const { handleStatus } = await import("./commands/handlers/core.js");
+      await handleStatus(ctx);
+      return;
+    }
+    case "setup": {
+      const { handleSetup } = await import("./commands/handlers/core.js");
+      await handleSetup("", ctx, pi);
+      return;
+    }
+    case "template": {
+      const { handleStart } = await import("./commands-workflow-templates.js");
+      await handleStart("", ctx, pi);
+      return;
+    }
+    case "quick": {
+      const description = await promptQuickDescription(ctx);
+      if (!description) return;
+      const { handleQuick } = await import("./quick.js");
+      await handleQuick(description, ctx, pi);
+      return;
+    }
+    case "discuss": {
+      const { showDiscuss } = await import("./guided-flow.js");
+      await showDiscuss(ctx, pi, basePath);
+      return;
+    }
+    case "ship": {
+      const { handleShip } = await import("./commands-ship.js");
+      await handleShip("", ctx, pi);
+      return;
+    }
+    case "not_yet":
+      return;
+  }
+}
+
+export async function showSmartLauncher(
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+  basePath: string,
+): Promise<void> {
+  const dirCheck = validateDirectory(basePath);
+  if (dirCheck.severity === "blocked") {
+    ctx.ui.notify(dirCheck.reason!, "error");
+    return;
+  }
+  if (dirCheck.severity === "warning") {
+    const proceed = await showConfirm(ctx, {
+      title: "GSD — Unusual Directory",
+      message: dirCheck.reason!,
+      confirmLabel: "Continue anyway",
+      declineLabel: "Cancel",
+    });
+    if (!proceed) return;
+  }
+
+  const detection = detectProjectState(basePath);
+  const hasBootstrap = hasGsdBootstrapArtifacts(gsdRoot(basePath));
+  let interrupted: InterruptedSessionAssessment | null = null;
+  let state: GSDState | null = null;
+  let deepStagePending = false;
+
+  if (hasBootstrap) {
+    interrupted = await assessInterruptedSession(basePath);
+    if (interrupted.classification === "running") {
+      ctx.ui.notify(formatInterruptedSessionRunningMessage(interrupted), "error");
+      return;
+    }
+    if (interrupted.classification === "stale") {
+      clearLock(basePath);
+      if (interrupted.pausedSession) {
+        try {
+          unlinkSync(join(gsdRoot(basePath), "runtime", "paused-session.json"));
+        } catch (err) {
+          logWarning("command", `stale paused-session cleanup failed before launcher state derivation: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+      interrupted = null;
+    }
+
+    try {
+      const { ensureDbOpen } = await import("./bootstrap/dynamic-tools.js");
+      await ensureDbOpen(basePath);
+    } catch (err) {
+      logWarning("command", `DB open skipped before launcher state derivation: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    state = await deriveState(basePath);
+    const { hasPendingDeepStage } = await import("./auto-dispatch.js");
+    deepStagePending = hasPendingDeepStage(
+      loadEffectiveGSDPreferences(basePath)?.preferences,
+      basePath,
+    );
+  }
+
+  const milestoneCount = hasBootstrap
+    ? Math.max(findMilestoneIds(basePath).length, state?.registry.length ?? 0)
+    : detection.v2?.milestoneCount ?? 0;
+
+  const model = buildSmartLauncherModel({
+    hasBootstrapArtifacts: hasBootstrap,
+    milestoneCount,
+    autoActive: isAutoActive(),
+    deepStagePending,
+    interruptedClassification: interrupted?.classification ?? "none",
+    state,
+  });
+
+  const choice = await showNextAction(ctx, {
+    title: model.title,
+    summary: model.summary,
+    actions: model.actions,
+    notYetMessage: "Run /gsd when ready.",
+  }) as LauncherActionId;
+
+  if (choice === "not_yet") return;
+  await runLauncherAction(choice, ctx, pi, basePath, interrupted);
+}

--- a/src/resources/extensions/gsd/tests/smart-launcher.test.ts
+++ b/src/resources/extensions/gsd/tests/smart-launcher.test.ts
@@ -1,0 +1,139 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { GSDState } from "../types.ts";
+import {
+  buildSmartLauncherModel,
+  type SmartLauncherFacts,
+} from "../smart-launcher.ts";
+
+function state(overrides: Partial<GSDState>): GSDState {
+  return {
+    activeMilestone: null,
+    activeSlice: null,
+    activeTask: null,
+    phase: "pre-planning",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+    ...overrides,
+  };
+}
+
+function facts(overrides: Partial<SmartLauncherFacts>): SmartLauncherFacts {
+  return {
+    hasBootstrapArtifacts: true,
+    milestoneCount: 0,
+    autoActive: false,
+    deepStagePending: false,
+    interruptedClassification: "none",
+    state: state({}),
+    ...overrides,
+  };
+}
+
+function actionIds(model: ReturnType<typeof buildSmartLauncherModel>): string[] {
+  return model.actions.map((action) => action.id);
+}
+
+test("smart launcher classifies uninitialized projects and offers setup choices", () => {
+  const model = buildSmartLauncherModel(facts({
+    hasBootstrapArtifacts: false,
+    milestoneCount: 0,
+    state: null,
+  }));
+
+  assert.equal(model.kind, "uninitialized");
+  assert.deepEqual(actionIds(model), ["init", "deep_project", "setup"]);
+});
+
+test("smart launcher offers first-project choices when initialized with no milestones", () => {
+  const model = buildSmartLauncherModel(facts({
+    milestoneCount: 0,
+    state: state({ registry: [] }),
+  }));
+
+  assert.equal(model.kind, "first-project");
+  assert.deepEqual(actionIds(model), ["quick", "step", "deep_project", "template", "setup"]);
+});
+
+test("smart launcher prioritizes recoverable interrupted sessions", () => {
+  const model = buildSmartLauncherModel(facts({
+    milestoneCount: 1,
+    interruptedClassification: "recoverable",
+    state: state({
+      activeMilestone: { id: "M001", title: "Build" },
+      phase: "executing",
+      registry: [{ id: "M001", title: "Build", status: "active" }],
+    }),
+  }));
+
+  assert.equal(model.kind, "interrupted");
+  assert.deepEqual(actionIds(model), ["resume", "step", "status", "stop"]);
+});
+
+test("smart launcher offers discuss and plan choices for pre-planning milestones", () => {
+  const model = buildSmartLauncherModel(facts({
+    milestoneCount: 1,
+    state: state({
+      activeMilestone: { id: "M001", title: "Build" },
+      phase: "pre-planning",
+      registry: [{ id: "M001", title: "Build", status: "active" }],
+    }),
+  }));
+
+  assert.equal(model.kind, "planning");
+  assert.deepEqual(actionIds(model), ["discuss", "plan", "deep_milestone", "quick", "status"]);
+});
+
+test("smart launcher offers step and auto choices for roadmap-ready work", () => {
+  const model = buildSmartLauncherModel(facts({
+    milestoneCount: 1,
+    state: state({
+      activeMilestone: { id: "M001", title: "Build" },
+      activeSlice: { id: "S01", title: "Core" },
+      phase: "planning",
+      registry: [{ id: "M001", title: "Build", status: "active" }],
+    }),
+  }));
+
+  assert.equal(model.kind, "executing");
+  assert.deepEqual(actionIds(model), ["step", "auto", "quick", "status"]);
+});
+
+test("smart launcher suppresses quick and mutation-heavy choices while auto-mode is active", () => {
+  const model = buildSmartLauncherModel(facts({
+    autoActive: true,
+    milestoneCount: 1,
+    state: state({
+      activeMilestone: { id: "M001", title: "Build" },
+      activeSlice: { id: "S01", title: "Core" },
+      phase: "executing",
+      registry: [{ id: "M001", title: "Build", status: "active" }],
+    }),
+  }));
+
+  assert.equal(model.kind, "interrupted");
+  assert.deepEqual(actionIds(model), ["status", "stop"]);
+});
+
+test("bare /gsd routes through the smart launcher while /gsd next keeps direct step mode", () => {
+  const autoHandlerSource = readFileSync(
+    join(import.meta.dirname, "..", "commands", "handlers", "auto.ts"),
+    "utf-8",
+  );
+
+  assert.match(
+    autoHandlerSource,
+    /if\s*\(\s*trimmed\s*===\s*""\s*\)\s*\{[\s\S]*showSmartLauncher\(/,
+    "bare /gsd should call showSmartLauncher",
+  );
+  assert.match(
+    autoHandlerSource,
+    /trimmed\s*===\s*"next"[\s\S]*startAutoDetached\(ctx,\s*pi,\s*projectRoot\(\),\s*verboseMode,\s*\{[\s\S]*step:\s*true/s,
+    "/gsd next should still start step mode directly",
+  );
+});

--- a/src/resources/extensions/gsd/tests/smart-launcher.test.ts
+++ b/src/resources/extensions/gsd/tests/smart-launcher.test.ts
@@ -1,13 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 import type { GSDState } from "../types.ts";
 import {
   buildSmartLauncherModel,
   type SmartLauncherFacts,
 } from "../smart-launcher.ts";
+import { handleAutoCommand } from "../commands/handlers/auto.ts";
 
 function state(overrides: Partial<GSDState>): GSDState {
   return {
@@ -120,20 +122,31 @@ test("smart launcher suppresses quick and mutation-heavy choices while auto-mode
   assert.deepEqual(actionIds(model), ["status", "stop"]);
 });
 
-test("bare /gsd routes through the smart launcher while /gsd next keeps direct step mode", () => {
-  const autoHandlerSource = readFileSync(
-    join(import.meta.dirname, "..", "commands", "handlers", "auto.ts"),
-    "utf-8",
-  );
+test("bare /gsd opens the smart launcher wizard", async (t) => {
+  const previousCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-smart-launcher-route-"));
+  t.after(() => {
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  });
 
-  assert.match(
-    autoHandlerSource,
-    /if\s*\(\s*trimmed\s*===\s*""\s*\)\s*\{[\s\S]*showSmartLauncher\(/,
-    "bare /gsd should call showSmartLauncher",
-  );
-  assert.match(
-    autoHandlerSource,
-    /trimmed\s*===\s*"next"[\s\S]*startAutoDetached\(ctx,\s*pi,\s*projectRoot\(\),\s*verboseMode,\s*\{[\s\S]*step:\s*true/s,
-    "/gsd next should still start step mode directly",
-  );
+  process.chdir(base);
+  const prompts: string[] = [];
+  const notifications: string[] = [];
+  const ctx = {
+    ui: {
+      custom: async () => undefined,
+      select: async (title: string, labels: string[]) => {
+        prompts.push(title);
+        return labels[labels.length - 1];
+      },
+      notify: (message: string) => notifications.push(message),
+    },
+  };
+
+  const handled = await handleAutoCommand("", ctx as any, {} as any);
+
+  assert.equal(handled, true);
+  assert.deepEqual(prompts, ["GSD — Start Here"]);
+  assert.deepEqual(notifications, []);
 });


### PR DESCRIPTION
## Linked issue

Closes gsd-build/gsd-2#5123

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Bare `/gsd` now opens a state-aware launcher wizard instead of always jumping directly into step mode.
**Why:** Users need context-sensitive choices for new projects, new milestones, resume states, planning, execution, and completion.
**How:** Add a smart launcher classifier/entrypoint, route only bare `/gsd` through it, and delegate selected actions to existing GSD flows.

## What

Adds `smart-launcher.ts` under the GSD extension. The launcher derives project/session facts, builds contextual `showNextAction()` menus, prompts for quick-task descriptions, handles stale interrupted-session cleanup, and delegates actions to existing flows such as guided entry, auto-mode, quick tasks, templates, setup, status, discuss, and ship.

Updates the bare `/gsd` route in the auto command handler to call the launcher. Explicit `/gsd next`, `/gsd auto`, `/gsd quick`, and `/gsd start <template>` behavior remains direct.

Adds node:test coverage for launcher classification, active-auto quick suppression, recoverable resume menus, pre-planning choices, execution choices, and the bare `/gsd` command path using a fake command context rather than source-grep assertions.

## Why

Bare `/gsd` previously meant step mode regardless of where the project was. That made first-run setup, milestone creation, interrupted sessions, and quick/deep workflow selection feel hidden behind separate commands. A smart launcher makes `/gsd` behave like a command center while preserving `/gsd next` for users who want the old direct step-mode fast path.

## How

The implementation separates pure classification from runtime dispatch:

- `buildSmartLauncherModel()` accepts discovered facts and returns a menu model.
- `showSmartLauncher()` performs directory/session/state detection, opens the shared next-action UI, and executes the selected action.
- Quick tasks are only offered when `.gsd/` is initialized and no active/recoverable auto session makes them unsafe.
- Deep project/milestone choices enable deep planning mode before falling back into the existing guided flow.

This keeps the launcher thin and avoids reimplementing GSD workflow logic.

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Validation run locally:

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/smart-launcher.test.ts src/resources/extensions/gsd/tests/quick-auto-guard.test.ts src/resources/extensions/gsd/tests/smart-entry-complete.test.ts`
- `npm run typecheck:extensions`
- `npm run test:compile`

## AI disclosure

- [x] This PR includes AI-assisted code

This implementation and test update were prepared with OpenAI Codex. The code was locally verified with the commands listed above.
