### PR TITLE
fix(pi-ai): repair named XML parameter closers

### DIFF
--- a/packages/pi-ai/src/utils/repair-tool-json.ts
+++ b/packages/pi-ai/src/utils/repair-tool-json.ts
@@ -60,7 +60,6 @@ type XmlParameterBlock = {
 	value: unknown;
 };
 
-const xmlParameterBlockPattern = /<parameter\s+name="([^"]+)"\s*>([\s\S]*?)<\/parameter>/g;
 const xmlParameterOpenPattern = /<parameter\s+name="([^"]+)"\s*>/g;
 
 function parseXmlParameterValue(raw: string): unknown {
@@ -74,18 +73,6 @@ function parseXmlParameterValue(raw: string): unknown {
 }
 
 function extractXmlParameterBlocks(text: string): XmlParameterBlock[] {
-	const strictBlocks: XmlParameterBlock[] = [];
-	let hasNestedParameterOpening = false;
-	for (const match of text.matchAll(xmlParameterBlockPattern)) {
-		const rawValue = match[2] ?? "";
-		hasNestedParameterOpening ||= rawValue.includes("<parameter");
-		strictBlocks.push({
-			name: match[1],
-			value: parseXmlParameterValue(rawValue),
-		});
-	}
-	if (strictBlocks.length > 0 && !hasNestedParameterOpening) return strictBlocks;
-
 	const blocks: XmlParameterBlock[] = [];
 	const openings = [...text.matchAll(xmlParameterOpenPattern)];
 	for (let i = 0; i < openings.length; i++) {
@@ -94,8 +81,13 @@ function extractXmlParameterBlocks(text: string): XmlParameterBlock[] {
 		if (current.index === undefined) continue;
 
 		const start = current.index + current[0].length;
-		const end = next?.index ?? text.length;
-		const rawValue = text.slice(start, end).replace(/\s*<\/parameter>\s*$/, "");
+		const endCandidates = [
+			text.indexOf("</parameter>", start),
+			text.indexOf(`</${current[1]}>`, start),
+			next?.index ?? -1,
+		].filter((index) => index >= 0);
+		const end = endCandidates.length > 0 ? Math.min(...endCandidates) : text.length;
+		const rawValue = text.slice(start, end);
 		blocks.push({
 			name: current[1],
 			value: parseXmlParameterValue(rawValue),

--- a/packages/pi-ai/src/utils/tests/repair-tool-json.test.ts
+++ b/packages/pi-ai/src/utils/tests/repair-tool-json.test.ts
@@ -179,6 +179,22 @@ describe("repairToolJson — XML parameter tag stripping (#3403)", () => {
 		assert.equal(parsed.oneLiner, "done");
 		assert.ok(!parsed.narrative.includes("<parameter"), "narrative should not retain leaked XML");
 	});
+
+	test("promotes XML parameters with field-name closers and an unclosed trailing block", () => {
+		const malformed =
+			'{"oneLiner":"summary text.</oneLiner>\\n' +
+			'<parameter name=\\"narrative\\">long body.</narrative>\\n' +
+			'<parameter name=\\"verification\\">tests pass",' +
+			'"uatContent":"# UAT"}';
+		const repaired = repairToolJson(malformed);
+		const parsed = JSON.parse(repaired);
+
+		assert.equal(parsed.oneLiner, "summary text.");
+		assert.equal(parsed.narrative, "long body.");
+		assert.equal(parsed.verification, "tests pass");
+		assert.equal(parsed.uatContent, "# UAT");
+		assert.ok(!parsed.oneLiner.includes("<parameter"), "oneLiner should not retain leaked XML");
+	});
 });
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Linked issue

Closes #5129

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Repairs XML-style tool parameter recovery when a parameter is closed by its field name instead of `</parameter>`.
**Why:** Malformed tool JSON could leak field-name closing tags into promoted values.
**How:** The XML parameter extractor now ends each block at the earliest valid closer, same-name closer, next parameter opener, or end of text.

## What

This updates `repairToolJson` XML parameter extraction so values promoted from `<parameter name="...">` blocks do not keep same-name closing tags such as `</narrative>`. It also adds a regression test for a mixed malformed response containing a field-name closer and an unclosed trailing parameter.

## Why

When a model emitted XML-ish parameter wrappers inside malformed JSON, the repair path could promote the value but leave the field-name closing tag in the result. That produced repaired JSON with polluted string values.

## How

The fallback extractor now scans each parameter opener and chooses the earliest safe boundary from:

- `</parameter>`
- `</parameter-name>`
- the next `<parameter ...>` opener
- end of text

This keeps the existing fallback behavior for unclosed trailing parameters while also trimming field-name closers.

Manual proof:

1. Added a regression case with `</oneLiner>`, `<parameter name="narrative">...</narrative>`, and an unclosed trailing `verification` parameter.
2. Confirmed the new case fails before the repair.
3. Confirmed the repaired output now produces clean `oneLiner`, `narrative`, `verification`, and `uatContent` values.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [x] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-ai/src/utils/tests/repair-tool-json.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:packages`
5. `npm run test:unit`
6. `npm run test:integration`
7. `npm run verify:pr`
8. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed JSON repair tool's extraction logic for handling malformed XML-like parameter blocks with inconsistent closing patterns and unclosed trailing sections.

## Tests
* Added regression test case ensuring proper field extraction and JSON validity when processing XML-like tags with custom closure syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->