### PR TITLE
fix(gsd): surface recent decisions in state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,6 +1414,16 @@
         "global-agent": "^3.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/src/resources/extensions/gsd/decisions-table.ts
+++ b/src/resources/extensions/gsd/decisions-table.ts
@@ -1,0 +1,67 @@
+import type { Decision, DecisionMadeBy } from './types.js';
+
+const VALID_MADE_BY = new Set(['human', 'agent', 'collaborative']);
+
+/**
+ * Parse a DECISIONS.md markdown table into Decision objects (without seq).
+ * Detects `(amends DXXX)` in the Decision column to build supersession info.
+ * Returns parsed rows with superseded_by set to null; callers handle chaining.
+ */
+export function parseDecisionsTable(content: string): Omit<Decision, 'seq'>[] {
+  const lines = content.split('\n');
+  const results: Omit<Decision, 'seq'>[] = [];
+
+  // Map from amended ID -> amending ID for supersession.
+  const amendsMap = new Map<string, string>();
+
+  for (const line of lines) {
+    // Skip non-table lines, header, and separator.
+    if (!line.trim().startsWith('|')) continue;
+    const trimmed = line.trim();
+    if (/^\|[\s-|]+\|$/.test(trimmed)) continue;
+
+    const cells = trimmed.split('|').map(c => c.trim());
+    if (cells.length > 0 && cells[0] === '') cells.shift();
+    if (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
+
+    if (cells.length < 7) continue;
+
+    const id = cells[0].trim();
+    if (id === '#' || id.toLowerCase() === 'id') continue;
+    if (!/^D\d+/.test(id)) continue;
+
+    const when_context = cells[1].trim();
+    const scope = cells[2].trim();
+    const decisionText = cells[3].trim();
+    const choice = cells[4].trim();
+    const rationale = cells[5].trim();
+    const revisable = cells[6].trim();
+    const rawMadeBy = cells.length >= 8 ? cells[7].trim().toLowerCase() : 'agent';
+    const made_by = (VALID_MADE_BY.has(rawMadeBy) ? rawMadeBy : 'agent') as DecisionMadeBy;
+
+    const amendsMatch = decisionText.match(/\(amends\s+(D\d+)\)/i);
+    if (amendsMatch) {
+      amendsMap.set(amendsMatch[1], id);
+    }
+
+    results.push({
+      id,
+      when_context,
+      scope,
+      decision: decisionText,
+      choice,
+      rationale,
+      revisable,
+      made_by,
+      superseded_by: null,
+    });
+  }
+
+  for (const row of results) {
+    if (amendsMap.has(row.id)) {
+      row.superseded_by = amendsMap.get(row.id)!;
+    }
+  }
+
+  return results;
+}

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -6,7 +6,9 @@
 
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join, relative } from 'node:path';
-import type { Decision, Requirement } from './types.js';
+import type { Requirement } from './types.js';
+import { parseDecisionsTable } from './decisions-table.js';
+export { parseDecisionsTable } from './decisions-table.js';
 import {
   upsertDecision,
   upsertRequirement,
@@ -33,84 +35,6 @@ import { findMilestoneIds } from './guided-flow.js';
 import { parseRoadmap, parsePlan } from './parsers-legacy.js';
 import { parseContextDependsOn } from './files.js';
 import { logWarning } from './workflow-logger.js';
-
-// ─── DECISIONS.md Parser ───────────────────────────────────────────────────
-
-const VALID_MADE_BY = new Set(['human', 'agent', 'collaborative']);
-
-/**
- * Parse a DECISIONS.md markdown table into Decision objects (without seq).
- * Detects `(amends DXXX)` in the Decision column to build supersession info.
- * Returns parsed rows with superseded_by set to null; callers handle chaining.
- */
-export function parseDecisionsTable(content: string): Omit<Decision, 'seq'>[] {
-  const lines = content.split('\n');
-  const results: Omit<Decision, 'seq'>[] = [];
-
-  // Map from amended ID → amending ID for supersession
-  const amendsMap = new Map<string, string>();
-
-  for (const line of lines) {
-    // Skip non-table lines, header, and separator
-    if (!line.trim().startsWith('|')) continue;
-    const trimmed = line.trim();
-    // Skip separator rows like |---|---|...|
-    if (/^\|[\s-|]+\|$/.test(trimmed)) continue;
-
-    // Split on | and strip leading/trailing empty cells
-    const cells = trimmed.split('|').map(c => c.trim());
-    // Remove first and last empty strings from leading/trailing |
-    if (cells.length > 0 && cells[0] === '') cells.shift();
-    if (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
-
-    if (cells.length < 7) continue;
-
-    const id = cells[0].trim();
-    // Skip header row
-    if (id === '#' || id.toLowerCase() === 'id') continue;
-    // Must look like a decision ID (D followed by digits)
-    if (!/^D\d+/.test(id)) continue;
-
-    const when_context = cells[1].trim();
-    const scope = cells[2].trim();
-    const decisionText = cells[3].trim();
-    const choice = cells[4].trim();
-    const rationale = cells[5].trim();
-    const revisable = cells[6].trim();
-    // Made By column is optional for backward compatibility — defaults to 'agent'
-    const rawMadeBy = cells.length >= 8 ? cells[7].trim().toLowerCase() : 'agent';
-    const made_by = (VALID_MADE_BY.has(rawMadeBy) ? rawMadeBy : 'agent') as import('./types.js').DecisionMadeBy;
-
-    // Detect (amends DXXX) in the Decision column
-    const amendsMatch = decisionText.match(/\(amends\s+(D\d+)\)/i);
-    if (amendsMatch) {
-      amendsMap.set(amendsMatch[1], id);
-    }
-
-    results.push({
-      id,
-      when_context,
-      scope,
-      decision: decisionText,
-      choice,
-      rationale,
-      revisable,
-      made_by,
-      superseded_by: null,
-    });
-  }
-
-  // Apply supersession: if D010 amends D001, set D001.superseded_by = D010
-  // Handle chains: if D020 amends D010 and D010 amends D001,
-  // D001.superseded_by = D010, D010.superseded_by = D020
-  for (const row of results) {
-    if (amendsMap.has(row.id)) {
-      row.superseded_by = amendsMap.get(row.id)!;
-    }
-  }
-
-  return results;
-}
 
 // ─── REQUIREMENTS.md Parser ────────────────────────────────────────────────
 

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -40,12 +40,13 @@ import { isClosedStatus, isDeferredStatus } from './status-guards.js';
 import { nativeBatchParseGsdFiles, type BatchParsedFile } from './native-parser-bridge.js';
 
 import { join, resolve } from 'path';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { debugCount, debugTime } from './debug-logger.js';
 import { logWarning } from './workflow-logger.js';
 import { extractVerdict } from './verdict-parser.js';
 import { detectPendingEscalation } from './escalation.js';
 import { isTerminalMilestoneSummaryContent } from './milestone-summary-classifier.js';
+import { parseDecisionsTable } from './decisions-table.js';
 
 import {
   isDbAvailable,
@@ -59,6 +60,7 @@ import {
   getRequirementCounts,
   getLatestAssessmentByScope,
   getPendingGateCountForTurn,
+  _getAdapter,
   type MilestoneRow,
   type SliceRow,
   type TaskRow,
@@ -206,6 +208,58 @@ let _telemetry = { dbDeriveCount: 0, markdownDeriveCount: 0 };
 export function getDeriveTelemetry() { return { ..._telemetry }; }
 export function resetDeriveTelemetry() { _telemetry = { dbDeriveCount: 0, markdownDeriveCount: 0 }; }
 
+const RECENT_DECISION_LIMIT = 5;
+
+type RecentDecisionRow = {
+  id: string;
+  decision: string;
+  choice: string;
+};
+
+function formatRecentDecision(row: RecentDecisionRow): string {
+  const choice = row.choice.trim();
+  return choice ? `${row.id}: ${row.decision.trim()} - ${choice}` : `${row.id}: ${row.decision.trim()}`;
+}
+
+function parseRecentDecisionRows(content: string): RecentDecisionRow[] {
+  return parseDecisionsTable(content)
+    .filter((row) => row.superseded_by == null)
+    .map((row) => ({
+      id: row.id,
+      decision: row.decision,
+      choice: row.choice,
+    }));
+}
+
+function loadRecentDecisionsFromDb(): string[] | null {
+  if (!isDbAvailable()) return null;
+  const adapter = _getAdapter();
+  if (!adapter) return null;
+
+  try {
+    const rows = adapter
+      .prepare("SELECT id, decision, choice FROM decisions WHERE superseded_by IS NULL ORDER BY seq DESC LIMIT ?")
+      .all(RECENT_DECISION_LIMIT) as RecentDecisionRow[];
+    return rows.map(formatRecentDecision);
+  } catch {
+    return null;
+  }
+}
+
+function loadRecentDecisions(basePath: string): string[] {
+  const dbDecisions = loadRecentDecisionsFromDb();
+  if (dbDecisions != null) return dbDecisions;
+
+  try {
+    const decisionsPath = resolveGsdRootFile(basePath, "DECISIONS");
+    if (!existsSync(decisionsPath)) return [];
+    const rows = parseRecentDecisionRows(readFileSync(decisionsPath, "utf8"));
+    return rows.slice(-RECENT_DECISION_LIMIT).reverse().map(formatRecentDecision);
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Invalidate the deriveState() cache. Call this whenever planning files on disk
  * may have changed (unit completion, merges, file writes).
@@ -350,6 +404,7 @@ export async function deriveState(
   }
 
   stopTimer({ phase: result.phase, milestone: result.activeMilestone?.id });
+  result.recentDecisions = loadRecentDecisions(basePath);
   debugCount("deriveStateCalls");
   _stateCache = { basePath: cacheKey, result, timestamp: Date.now() };
   return result;

--- a/src/resources/extensions/gsd/tests/derive-state.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { deriveState, isSliceComplete, isMilestoneComplete, isGhostMilestone } from '../state.ts';
+import { closeDatabase, insertDecision, openDatabase } from '../gsd-db.ts';
 
 // This suite exercises the explicit legacy markdown derivation path.
 process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK = '1';
@@ -60,6 +61,10 @@ function writeRequirements(base: string, content: string): void {
   writeFileSync(join(base, '.gsd', 'REQUIREMENTS.md'), content);
 }
 
+function writeDecisions(base: string, content: string): void {
+  writeFileSync(join(base, '.gsd', 'DECISIONS.md'), content);
+}
+
 function cleanup(base: string): void {
   rmSync(base, { recursive: true, force: true });
 }
@@ -84,6 +89,95 @@ describe('derive-state', async () => {
       assert.deepStrictEqual(state.progress?.milestones?.done, 0, 'milestones done = 0');
       assert.deepStrictEqual(state.progress?.milestones?.total, 0, 'milestones total = 0');
     } finally {
+      cleanup(base);
+    }
+  });
+
+  test('loads recent decisions from DECISIONS.md into derived state', async () => {
+    const base = createFixtureBase();
+    try {
+      writeDecisions(base, `# Decisions
+
+| # | When | Scope | Decision | Choice | Rationale | Revisable? | Made By |
+|---|---|---|---|---|---|---|---|
+| D001 | M001/S01 | architecture | Keep state projection canonical | Use deriveState output | Shared source of truth | yes | agent |
+| D002 | M001/S02 | workflow | Keep PRs standalone | Avoid dependency chains | Reviewer clarity | yes | collaborative |
+`);
+
+      const state = await deriveState(base);
+
+      assert.deepStrictEqual(state.recentDecisions, [
+        "D002: Keep PRs standalone - Avoid dependency chains",
+        "D001: Keep state projection canonical - Use deriveState output",
+      ]);
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  test('uses empty DB decisions as authoritative over DECISIONS.md fallback', async () => {
+    const base = createFixtureBase();
+    try {
+      closeDatabase();
+      assert.equal(openDatabase(join(base, '.gsd', 'gsd.db')), true);
+      writeDecisions(base, `# Decisions
+
+| # | When | Scope | Decision | Choice | Rationale | Revisable? | Made By |
+|---|---|---|---|---|---|---|---|
+| D999 | M999/S99 | workflow | Stale markdown decision | Do not show | DB is authoritative | yes | agent |
+`);
+
+      const state = await deriveState(base);
+
+      assert.deepStrictEqual(state.recentDecisions, []);
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test('loads recent decisions from DB before DECISIONS.md fallback', async () => {
+    const base = createFixtureBase();
+    try {
+      closeDatabase();
+      assert.equal(openDatabase(join(base, '.gsd', 'gsd.db')), true);
+      insertDecision({
+        id: 'D010',
+        when_context: 'M001/S01',
+        scope: 'workflow',
+        decision: 'Keep runtime state DB-first',
+        choice: 'Use database decisions',
+        rationale: 'State projection should match authoritative storage',
+        revisable: 'yes',
+        made_by: 'agent',
+        superseded_by: null,
+      });
+      insertDecision({
+        id: 'D011',
+        when_context: 'M001/S02',
+        scope: 'workflow',
+        decision: 'Keep markdown fallback explicit',
+        choice: 'Use DECISIONS.md only when DB is unavailable',
+        rationale: 'Avoid stale file data overriding live DB state',
+        revisable: 'yes',
+        made_by: 'agent',
+        superseded_by: null,
+      });
+      writeDecisions(base, `# Decisions
+
+| # | When | Scope | Decision | Choice | Rationale | Revisable? | Made By |
+|---|---|---|---|---|---|---|---|
+| D999 | M999/S99 | workflow | Stale markdown decision | Do not show | DB is authoritative | yes | agent |
+`);
+
+      const state = await deriveState(base);
+
+      assert.deepStrictEqual(state.recentDecisions, [
+        'D011: Keep markdown fallback explicit - Use DECISIONS.md only when DB is unavailable',
+        'D010: Keep runtime state DB-first - Use database decisions',
+      ]);
+    } finally {
+      closeDatabase();
       cleanup(base);
     }
   });


### PR DESCRIPTION
## Linked issue

Closes #5122

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Populates `recentDecisions` in derived GSD state.
**Why:** `STATE.md` and headless state queries could show an empty recent-decisions list even when decisions existed.
**How:** `deriveState` now loads recent decisions from the database when available, with a `DECISIONS.md` fallback for file-based fixtures and workspaces.

## What

This updates the GSD state projection so `recentDecisions` is populated centrally before derived state is cached and returned. It adds a regression test proving that decisions written in `DECISIONS.md` appear in the derived state.

## Why

The derived state shape already included `recentDecisions`, but it was always initialized as an empty array. That made state output less useful for review and headless workflows because recent decisions were not surfaced even when the project had recorded them.

## How

The state derivation path now:

- loads up to five non-superseded decisions from the database when DB state is available
- falls back to parsing `.gsd/DECISIONS.md` when DB state is unavailable
- formats each entry consistently as `<id>: <decision> - <choice>`
- assigns the result once, just before caching and returning derived state

Manual proof:

1. Added a fixture with two decision rows in `DECISIONS.md`.
2. Confirmed `deriveState` returned an empty `recentDecisions` array before the fix.
3. Confirmed `deriveState` now returns the latest decisions in newest-first order.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/derive-state.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:unit`
5. `npm run test:integration`
6. `npm run verify:pr`
7. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recent decisions are now displayed (up to 5 most-recent), formatted compactly with decision and choice for quick reference.

* **Behavior / Reliability**
  * If database access is unavailable, the system falls back to reading a local decisions file; read/parse or DB failures yield an empty list rather than errors.
  * Parsing recognizes supersessions and normalizes author types for consistent display.

* **Tests**
  * Added tests covering DB precedence, file fallback, ordering and formatting.

* **Refactor**
  * Decision-parsing logic extracted into a shared module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->