### PR TITLE
fix(gsd): skip worktree isolation before first commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Auto mode is a state machine driven by files on disk. It reads `.gsd/STATE.md`, 
 
 2. **Context pre-loading** — The dispatch prompt includes inlined task plans, slice plans, prior task summaries, dependency summaries, roadmap excerpts, and decisions register. The LLM starts with everything it needs instead of spending tool calls reading files.
 
-3. **Git isolation** — When `git.isolation` is set to `worktree` or `branch`, each milestone runs on its own `milestone/<MID>` branch (in a worktree or in-place). All slice work commits sequentially — no branch switching, no merge conflicts. When the milestone completes, it's squash-merged to main as one clean commit. The default is `none` (work on the current branch), configurable via preferences.
+3. **Git isolation** — When `git.isolation` is set to `worktree` or `branch`, each milestone runs on its own `milestone/<MID>` branch (in a worktree or in-place). All slice work commits sequentially — no branch switching, no merge conflicts. When the milestone completes, it's squash-merged to main as one clean commit. The default is `none` (work on the current branch), configurable via preferences. If `worktree` is configured in a repo with no committed `HEAD`, GSD temporarily behaves as `none` until the first commit exists because git worktrees need a committed start point.
 
 4. **Crash recovery** — A lock file tracks the current unit. If the session dies, the next `/gsd auto` reads the surviving session file, synthesizes a recovery briefing from every tool call that made it to disk, and resumes with full context. Parallel orchestrator state is persisted to disk with PID liveness detection, so multi-worker sessions survive crashes too. In headless mode, crashes trigger automatic restart with exponential backoff (default 3 attempts).
 
@@ -606,7 +606,7 @@ auto_report: true
 | `skill_rules`                     | Situational rules for skill routing                                                                   |
 | `skill_staleness_days`            | Skills unused for N days get deprioritized (default: 60, 0 = disabled)                                |
 | `unique_milestone_ids`            | Uses unique milestone names to avoid clashes when working in teams of people                          |
-| `git.isolation`                   | `none` (default), `worktree`, or `branch` — enable worktree or branch isolation for milestone work    |
+| `git.isolation`                   | `none` (default), `worktree`, or `branch` — enable worktree or branch isolation for milestone work. `worktree` requires a committed `HEAD`; zero-commit repos temporarily run as `none`    |
 | `git.manage_gitignore`            | Set `false` to prevent GSD from modifying `.gitignore`                                                |
 | `verification_commands`           | Array of shell commands to run after task execution (e.g., `["npm run lint", "npm run test"]`)        |
 | `verification_auto_fix`           | Auto-retry on verification failures (default: true)                                                   |

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -53,9 +53,9 @@ The amount of context inlined is controlled by your [token profile](./token-opti
 
 GSD isolates milestone work using one of three modes (configured via `git.isolation` in preferences):
 
-- **`worktree`** (default): Each milestone runs in its own git worktree at `.gsd/worktrees/<MID>/` on a `milestone/<MID>` branch. All slice work commits sequentially — no branch switching, no merge conflicts mid-milestone. When the milestone completes, it's squash-merged to main as one clean commit.
+- **`none`** (default): Work happens directly on your current branch. No worktree, no milestone branch. Ideal for hot-reload workflows where file isolation breaks dev tooling.
+- **`worktree`**: Each milestone runs in its own git worktree at `.gsd/worktrees/<MID>/` on a `milestone/<MID>` branch. Worktree mode requires at least one commit; in a zero-commit repo with no committed `HEAD`, GSD temporarily runs as `none` until the first commit exists. All slice work commits sequentially, and the milestone is squash-merged to main as one clean commit.
 - **`branch`**: Work happens in the project root on a `milestone/<MID>` branch. Useful for submodule-heavy repos where worktrees don't work well.
-- **`none`**: Work happens directly on your current branch. No worktree, no milestone branch. Ideal for hot-reload workflows where file isolation breaks dev tooling.
 
 See [Git Strategy](./git-strategy.md) for details.
 

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -489,7 +489,7 @@ git:
   commit_type: feat           # override conventional commit prefix
   main_branch: main           # primary branch name
   merge_strategy: squash      # how worktree branches merge: "squash" or "merge"
-  isolation: worktree         # git isolation: "worktree", "branch", or "none"
+  isolation: none             # git isolation: "none" (default), "worktree", or "branch"
   commit_docs: true           # commit .gsd/ artifacts to git (set false to keep local)
   manage_gitignore: true      # set false to prevent GSD from modifying .gitignore
   worktree_post_create: .gsd/hooks/post-worktree-create  # script to run after worktree creation
@@ -507,7 +507,7 @@ git:
 | `commit_type` | string | (inferred) | Override conventional commit prefix (`feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`, `build`, `style`) |
 | `main_branch` | string | `"main"` | Primary branch name |
 | `merge_strategy` | string | `"squash"` | How worktree branches merge: `"squash"` (combine all commits) or `"merge"` (preserve individual commits) |
-| `isolation` | string | `"worktree"` | Auto-mode isolation: `"worktree"` (separate directory), `"branch"` (work in project root — useful for submodule-heavy repos), or `"none"` (no isolation — commits on current branch, no worktree or milestone branch) |
+| `isolation` | string | `"none"` | Auto-mode isolation: `"none"` (no isolation — commits on current branch, no worktree or milestone branch), `"worktree"` (separate directory), or `"branch"` (work in project root — useful for submodule-heavy repos). `worktree` requires a committed `HEAD`; zero-commit repos temporarily run as `none` until the first commit exists |
 | `commit_docs` | boolean | `true` | Commit `.gsd/` planning artifacts to git. Set `false` to keep local-only |
 | `manage_gitignore` | boolean | `true` | When `false`, GSD will not modify `.gitignore` at all — no baseline patterns, no self-healing. Use if you manage your own `.gitignore` |
 | `worktree_post_create` | string | (none) | Script to run after worktree creation. Receives `SOURCE_DIR` and `WORKTREE_DIR` env vars |
@@ -887,7 +887,7 @@ auto_supervisor:
 git:
   auto_push: true
   merge_strategy: squash
-  isolation: worktree         # "worktree", "branch", or "none"
+  isolation: none             # "none" (default), "worktree", or "branch"
   commit_docs: true
 
 # Skills

--- a/docs/user-docs/git-strategy.md
+++ b/docs/user-docs/git-strategy.md
@@ -8,27 +8,29 @@ GSD supports three isolation modes, configured via the `git.isolation` preferenc
 
 | Mode | Working Directory | Branch | Best For |
 |------|-------------------|--------|----------|
-| `worktree` (default) | `.gsd/worktrees/<MID>/` | `milestone/<MID>` | Most projects — full file isolation between milestones |
+| `none` (default) | Project root | Current branch (no milestone branch) | Most projects — no isolation overhead |
+| `worktree` | `.gsd/worktrees/<MID>/` | `milestone/<MID>` | Projects that need full file isolation between milestones |
 | `branch` | Project root | `milestone/<MID>` | Submodule-heavy repos where worktrees don't work well |
-| `none` | Project root | Current branch (no milestone branch) | Hot-reload workflows where file isolation breaks dev tooling |
 
-### `worktree` Mode (Default)
+### `none` Mode (Default)
+
+Work happens directly on your current branch. No worktree, no milestone branch. GSD still commits sequentially with conventional commit messages, but there's no branch isolation.
+
+Use this for hot-reload workflows where file isolation breaks dev tooling (e.g., file watchers that only see the project root), or for small projects where branch overhead isn't worth it.
+
+### `worktree` Mode
 
 Each milestone gets its own git worktree at `.gsd/worktrees/<MID>/` on a `milestone/<MID>` branch. All execution happens inside the worktree. On completion, the worktree is squash-merged to main as one clean commit. The worktree and branch are then cleaned up.
 
 This provides full file isolation — changes in a milestone can't interfere with your main working copy.
+
+Worktree mode requires the repository to have at least one commit. If `git.isolation: worktree` is configured in a zero-commit repo with no committed `HEAD`, GSD temporarily runs as `none` so startup can continue. After the first commit exists, the same preference resolves to `worktree`.
 
 ### `branch` Mode
 
 Work happens in the project root on a `milestone/<MID>` branch. No worktree is created. On completion, the branch is merged to main (squash or regular merge, per `merge_strategy`).
 
 Use this when worktrees cause problems — submodule-heavy repos, repos with hardcoded paths, or environments where worktree symlinks don't behave.
-
-### `none` Mode
-
-Work happens directly on your current branch. No worktree, no milestone branch. GSD still commits sequentially with conventional commit messages, but there's no branch isolation.
-
-Use this for hot-reload workflows where file isolation breaks dev tooling (e.g., file watchers that only see the project root), or for small projects where branch overhead isn't worth it.
 
 ## Branching Model (Worktree Mode)
 
@@ -138,7 +140,7 @@ mode: team    # shared repos — unique IDs, push branches, pre-merge checks
 | `git.push_branches` | `false` | `true` |
 | `git.pre_merge_check` | `false` | `true` |
 | `git.merge_strategy` | `"squash"` | `"squash"` |
-| `git.isolation` | `"worktree"` | `"worktree"` |
+| `git.isolation` | `"none"` | `"none"` |
 | `git.commit_docs` | `true` | `true` |
 | `unique_milestone_ids` | `false` | `true` |
 
@@ -160,7 +162,7 @@ git:
   commit_type: feat           # override commit type prefix
   main_branch: main           # primary branch name
   commit_docs: true           # commit .gsd/ to git
-  isolation: worktree         # "worktree", "branch", or "none"
+  isolation: none             # "none" (default), "worktree", or "branch"
   auto_pr: false              # create PR on milestone completion
   pr_target_branch: develop   # PR target branch (default: main)
 ```

--- a/docs/zh-CN/user-docs/auto-mode.md
+++ b/docs/zh-CN/user-docs/auto-mode.md
@@ -53,9 +53,9 @@ Plan (with integrated research) → Execute (per task) → Complete → Reassess
 
 GSD 支持三种 milestone 隔离模式（通过偏好设置中的 `git.isolation` 配置）：
 
-- **`worktree`**（默认）：每个 milestone 都运行在 `.gsd/worktrees/<MID>/` 下自己的 git worktree 中，分支名为 `milestone/<MID>`。所有 slice 工作都顺序提交，不需要切分支，也不会在 milestone 内部产生合并冲突。milestone 完成后，再整体 squash merge 回主分支，形成一个干净提交。
+- **`none`**（默认）：直接在当前分支工作。没有 worktree，也没有 milestone 分支。适合文件隔离会破坏开发工具的热重载场景。
+- **`worktree`**：每个 milestone 都运行在 `.gsd/worktrees/<MID>/` 下自己的 git worktree 中，分支名为 `milestone/<MID>`。Worktree 模式要求至少已有一个提交；在没有已提交 `HEAD` 的零提交仓库中，GSD 会临时按 `none` 运行，直到第一次提交存在。所有 slice 工作都会顺序提交，milestone 完成后再整体 squash merge 回主分支。
 - **`branch`**：工作发生在项目根目录下的 `milestone/<MID>` 分支上。适合子模块较多、worktree 表现不佳的仓库。
-- **`none`**：直接在当前分支工作。没有 worktree，也没有 milestone 分支。适合文件隔离会破坏开发工具的热重载场景。
 
 详见 [Git 策略](./git-strategy.md)。
 

--- a/docs/zh-CN/user-docs/configuration.md
+++ b/docs/zh-CN/user-docs/configuration.md
@@ -443,7 +443,7 @@ git:
   commit_type: feat           # 覆盖 conventional commit 前缀
   main_branch: main           # 主分支名称
   merge_strategy: squash      # worktree 分支合并方式："squash" 或 "merge"
-  isolation: worktree         # git isolation："worktree"、"branch" 或 "none"
+  isolation: none             # git isolation："none"（默认）、"worktree" 或 "branch"
   commit_docs: true           # 是否把 .gsd/ 产物提交到 git（设为 false 时仅保留本地）
   manage_gitignore: true      # 设为 false 时，GSD 不再修改 .gitignore
   worktree_post_create: .gsd/hooks/post-worktree-create  # worktree 创建后执行的脚本
@@ -461,7 +461,7 @@ git:
 | `commit_type` | string | （自动推断） | 覆盖 conventional commit 前缀（`feat`、`fix`、`refactor`、`docs`、`test`、`chore`、`perf`、`ci`、`build`、`style`） |
 | `main_branch` | string | `"main"` | 主分支名称 |
 | `merge_strategy` | string | `"squash"` | worktree 分支合并方式：`"squash"`（合并为单个提交）或 `"merge"`（保留单独提交） |
-| `isolation` | string | `"worktree"` | 自动模式隔离方式：`"worktree"`（独立目录）、`"branch"`（直接在项目根目录工作，适合子模块多的仓库）、`"none"`（无隔离，直接提交到当前分支） |
+| `isolation` | string | `"none"` | 自动模式隔离方式：`"none"`（无隔离，直接提交到当前分支）、`"worktree"`（独立目录）或 `"branch"`（直接在项目根目录工作，适合子模块多的仓库）。`worktree` 要求有已提交的 `HEAD`；零提交仓库会临时按 `none` 运行，直到第一次提交存在 |
 | `commit_docs` | boolean | `true` | 是否把 `.gsd/` planning 产物提交到 git。设为 `false` 则仅保留本地 |
 | `manage_gitignore` | boolean | `true` | 设为 `false` 后，GSD 将完全不修改 `.gitignore`，不会添加基础规则，也不会做自愈 |
 | `worktree_post_create` | string | （无） | worktree 创建后执行的脚本。环境变量中会传入 `SOURCE_DIR` 和 `WORKTREE_DIR` |
@@ -834,7 +834,7 @@ auto_supervisor:
 git:
   auto_push: true
   merge_strategy: squash
-  isolation: worktree         # "worktree", "branch", or "none"
+  isolation: none             # "none"（默认）、"worktree" 或 "branch"
   commit_docs: true
 
 # Skills

--- a/docs/zh-CN/user-docs/git-strategy.md
+++ b/docs/zh-CN/user-docs/git-strategy.md
@@ -8,27 +8,29 @@ GSD 支持三种隔离模式，通过 `git.isolation` 偏好设置：
 
 | 模式 | 工作目录 | 分支 | 适用场景 |
 |------|----------|------|----------|
-| `worktree`（默认） | `.gsd/worktrees/<MID>/` | `milestone/<MID>` | 大多数项目，milestones 之间文件完全隔离 |
+| `none`（默认） | 项目根目录 | 当前分支（不建 milestone 分支） | 大多数项目，不增加隔离开销 |
+| `worktree` | `.gsd/worktrees/<MID>/` | `milestone/<MID>` | 需要 milestone 之间完整文件隔离的项目 |
 | `branch` | 项目根目录 | `milestone/<MID>` | 子模块较多、worktree 表现不佳的仓库 |
-| `none` | 项目根目录 | 当前分支（不建 milestone 分支） | 热重载工作流中，文件隔离会破坏开发工具的场景 |
 
-### `worktree` 模式（默认）
+### `none` 模式（默认）
+
+工作直接发生在当前分支。没有 worktree，也没有 milestone 分支。GSD 依然会按顺序提交，并使用 conventional commit message，但不会提供分支级隔离。
+
+适用于热重载工作流中“文件隔离会破坏开发工具”的情况（例如只能监视项目根目录的文件监听器），或者很小的项目里不值得承担分支开销的情况。
+
+### `worktree` 模式
 
 每个 milestone 都会在 `.gsd/worktrees/<MID>/` 下拥有自己的 git worktree，对应一个 `milestone/<MID>` 分支。所有执行都发生在该 worktree 中。完成后，worktree 会被 squash merge 回主分支，形成一个干净的提交，然后清理对应 worktree 和分支。
 
 这提供了完整的文件隔离，某个 milestone 的变更不会干扰你的主工作副本。
+
+Worktree 模式要求仓库至少已有一个提交。如果在没有已提交 `HEAD` 的零提交仓库中配置了 `git.isolation: worktree`，GSD 会临时按 `none` 运行，让启动流程继续；第一次提交存在后，同一个偏好设置会重新解析为 `worktree`。
 
 ### `branch` 模式
 
 工作直接在项目根目录中的 `milestone/<MID>` 分支上进行，不会创建 worktree。完成后，该分支会被合并回主分支（是 squash merge 还是普通 merge 由 `merge_strategy` 控制）。
 
 当 worktree 会带来问题时使用它，例如：子模块较多的仓库、包含硬编码路径的仓库、或者 worktree symlink 表现异常的环境。
-
-### `none` 模式
-
-工作直接发生在当前分支。没有 worktree，也没有 milestone 分支。GSD 依然会按顺序提交，并使用 conventional commit message，但不会提供分支级隔离。
-
-适用于热重载工作流中“文件隔离会破坏开发工具”的情况（例如只能监视项目根目录的文件监听器），或者很小的项目里不值得承担分支开销的情况。
 
 ## 分支模型（worktree 模式）
 
@@ -127,7 +129,7 @@ mode: team    # 共享仓库：唯一 ID、推送分支、预合并检查
 | `git.push_branches` | `false` | `true` |
 | `git.pre_merge_check` | `false` | `true` |
 | `git.merge_strategy` | `"squash"` | `"squash"` |
-| `git.isolation` | `"worktree"` | `"worktree"` |
+| `git.isolation` | `"none"` | `"none"` |
 | `git.commit_docs` | `true` | `true` |
 | `unique_milestone_ids` | `false` | `true` |
 
@@ -149,7 +151,7 @@ git:
   commit_type: feat           # 覆盖提交类型前缀
   main_branch: main           # 主分支名称
   commit_docs: true           # 将 .gsd/ 提交到 git
-  isolation: worktree         # "worktree"、"branch" 或 "none"
+  isolation: none             # "none"（默认）、"worktree" 或 "branch"
   auto_pr: false              # milestone 完成时自动创建 PR
   pr_target_branch: develop   # PR 目标分支（默认 main）
 ```

--- a/gitbook/configuration/git-settings.md
+++ b/gitbook/configuration/git-settings.md
@@ -8,23 +8,25 @@ GSD supports three isolation modes, configured via `git.isolation` in preference
 
 | Mode | Working Directory | Branch | Best For |
 |------|-------------------|--------|----------|
-| `worktree` (default) | `.gsd/worktrees/<MID>/` | `milestone/<MID>` | Most projects — full isolation |
+| `none` (default) | Project root | Current branch | Most projects — no isolation overhead |
+| `worktree` | `.gsd/worktrees/<MID>/` | `milestone/<MID>` | Projects that need full isolation |
 | `branch` | Project root | `milestone/<MID>` | Submodule-heavy repos |
-| `none` | Project root | Current branch | Hot-reload workflows |
 
-### Worktree Mode (Default)
+### None Mode (Default)
+
+Work happens directly on your current branch. No worktree, no milestone branch. GSD still commits with conventional commit messages. Use this when file isolation breaks dev tooling (file watchers, hot-reload, etc.).
+
+### Worktree Mode
 
 Each milestone gets its own git worktree and branch. All execution happens inside the worktree. On completion, everything is squash-merged to main as one clean commit. The worktree and branch are then cleaned up.
 
 Changes in a milestone can't interfere with your main working copy.
 
+Worktree mode requires the repository to have at least one commit. If `git.isolation: worktree` is configured in a zero-commit repo with no committed `HEAD`, GSD temporarily runs as `none` until the first commit exists.
+
 ### Branch Mode
 
 Work happens in the project root on a `milestone/<MID>` branch. No worktree directory is created. Useful when worktrees cause problems with submodules or hardcoded paths.
-
-### None Mode
-
-Work happens directly on your current branch. No worktree, no milestone branch. GSD still commits with conventional commit messages. Use this when file isolation breaks dev tooling (file watchers, hot-reload, etc.).
 
 ## Branching Model
 
@@ -68,7 +70,7 @@ git:
   commit_type: feat           # override conventional commit prefix
   main_branch: main           # primary branch name
   merge_strategy: squash      # "squash" or "merge"
-  isolation: worktree         # "worktree", "branch", or "none"
+  isolation: none             # "none" (default), "worktree", or "branch"
   commit_docs: true           # commit .gsd/ artifacts to git
   manage_gitignore: true      # let GSD manage .gitignore
   auto_pr: false              # create PR on milestone completion

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -51,7 +51,7 @@ auto_supervisor:
 git:
   auto_push: true
   merge_strategy: squash
-  isolation: worktree
+  isolation: none
   collapse_cadence: milestone   # or "slice" — see Git & Worktrees docs
   # milestone_resquash applies only when collapse_cadence: "slice"
   # milestone_resquash: true    # collapse slice commits into one at milestone end
@@ -193,10 +193,12 @@ Git behavior. See [Git & Worktrees](git-settings.md).
 git:
   auto_push: false
   merge_strategy: squash
-  isolation: worktree
+  isolation: none
   commit_docs: true
   auto_pr: false
 ```
+
+Set `isolation: worktree` when you need milestone file isolation. Worktree mode requires a committed `HEAD`; in a zero-commit repo, GSD temporarily behaves as `none` until the first commit exists.
 
 ### `notifications`
 

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -91,11 +91,11 @@ GSD isolates milestone work using one of three modes:
 
 | Mode | How It Works | Best For |
 |------|-------------|----------|
-| `worktree` (default) | Each milestone gets its own directory and branch | Most projects |
+| `none` (default) | Work happens directly on your current branch | Most projects |
+| `worktree` | Each milestone gets its own directory and branch | Projects that need file isolation |
 | `branch` | Work happens in the project root on a milestone branch | Submodule-heavy repos |
-| `none` | Work happens directly on your current branch | Hot-reload workflows |
 
-In worktree mode, all commits are squash-merged to main as one clean commit when the milestone completes. See [Git & Worktrees](../configuration/git-settings.md).
+In worktree mode, all commits are squash-merged to main as one clean commit when the milestone completes. Worktree mode requires at least one commit; zero-commit repos temporarily run as `none` until `HEAD` exists. See [Git & Worktrees](../configuration/git-settings.md).
 
 ## Crash Recovery
 

--- a/mintlify-docs/guides/auto-mode.mdx
+++ b/mintlify-docs/guides/auto-mode.mdx
@@ -47,7 +47,7 @@ The amount of context inlined is controlled by your [token profile](/guides/toke
 GSD isolates milestone work using one of three modes (configured via `git.isolation` in preferences):
 
 - **`none`** (default) — work happens on your current branch. No isolation overhead.
-- **`worktree`** — each milestone runs in its own git worktree. Squash-merged to main on completion.
+- **`worktree`** — each milestone runs in its own git worktree. Requires at least one commit; zero-commit repos temporarily run as `none` until `HEAD` exists. Squash-merged to main on completion.
 - **`branch`** — work happens on a `milestone/<MID>` branch in the project root. Useful for submodule-heavy repos.
 
 See [git strategy](/guides/git-strategy) for details.

--- a/mintlify-docs/guides/git-strategy.mdx
+++ b/mintlify-docs/guides/git-strategy.mdx
@@ -23,6 +23,8 @@ Work happens directly on your current branch. No worktree, no milestone branch. 
 
 Each milestone gets its own git worktree on a `milestone/<MID>` branch. All execution happens inside the worktree. On completion, the worktree is squash-merged to main as one clean commit. The worktree and branch are cleaned up.
 
+Worktree mode requires the repository to have at least one commit. If `git.isolation: worktree` is configured in a zero-commit repo with no committed `HEAD`, GSD temporarily runs as `none` so startup can continue; worktree isolation takes effect after the first commit exists.
+
 ### `branch` mode
 
 Work happens in the project root on a `milestone/<MID>` branch. No worktree is created. On completion, the branch is merged to main.

--- a/mintlify-docs/guides/troubleshooting.mdx
+++ b/mintlify-docs/guides/troubleshooting.mdx
@@ -88,6 +88,8 @@ It checks file structure, referential integrity, completion state consistency, g
     git:
       isolation: worktree
     ```
+
+    In a brand-new repo, make an initial commit first. Until a committed `HEAD` exists, GSD temporarily runs worktree isolation as `none`.
   </Accordion>
 
   <Accordion title="Node.js version or git not found at startup">

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -62,7 +62,7 @@ import { validateFileChanges } from "./safety/file-change-validator.js";
 import { validateContent } from "./safety/content-validator.js";
 import { resolveSafetyHarnessConfig } from "./safety/safety-harness.js";
 import { resolveExpectedArtifactPath as resolveArtifactForContent } from "./auto-artifact-paths.js";
-import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { getIsolationMode, loadEffectiveGSDPreferences } from "./preferences.js";
 import { getSliceTasks } from "./gsd-db.js";
 import { runPreExecutionChecks, type PreExecutionResult } from "./pre-execution-checks.js";
 import { writePreExecutionEvidence, type PreExecutionCheckJSON } from "./verification-evidence.js";
@@ -650,7 +650,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         const prefs = prefsResult?.preferences;
         const { getCollapseCadence, mergeSliceToMain } = await import("./slice-cadence.js");
         if (getCollapseCadence(prefs) !== "slice") return;
-        if (prefs?.git?.isolation !== "worktree") return;
+        if (getIsolationMode(s.basePath) !== "worktree") return;
         if (s.isolationDegraded) return;
 
         const projectRoot = s.originalBasePath || s.basePath;

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -650,7 +650,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         const prefs = prefsResult?.preferences;
         const { getCollapseCadence, mergeSliceToMain } = await import("./slice-cadence.js");
         if (getCollapseCadence(prefs) !== "slice") return;
-        if (getIsolationMode(s.basePath) !== "worktree") return;
+        if (getIsolationMode(s.originalBasePath || s.basePath) !== "worktree") return;
         if (s.isolationDegraded) return;
 
         const projectRoot = s.originalBasePath || s.basePath;

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -373,10 +373,7 @@ export function startAutoDetached(
 
 /** Returns true if the project is configured for `isolation:worktree` mode. */
 export function shouldUseWorktreeIsolation(basePath?: string): boolean {
-  const prefs = loadEffectiveGSDPreferences(basePath)?.preferences?.git;
-  if (prefs?.isolation === "worktree") return true;
-  // Default is false — worktree isolation requires explicit opt-in
-  return false;
+  return getIsolationMode(basePath) === "worktree";
 }
 
 /** Crash recovery prompt — set by startAuto, consumed by the main loop */

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -87,7 +87,7 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
   | `git.push_branches`    | `false`      | `true`       |
   | `git.pre_merge_check`  | `false`      | `true`       |
   | `git.merge_strategy`   | `"squash"`   | `"squash"`   |
-  | `git.isolation`        | `"worktree"` | `"worktree"` |
+  | `git.isolation`        | `"none"`     | `"none"`     |
   | `unique_milestone_ids` | `false`      | `true`       |
 
   Quick setup: `/gsd mode` (global) or `/gsd mode project` (project-level).
@@ -137,7 +137,7 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
   - `commit_type`: string — override the conventional commit type prefix. Must be one of: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`, `build`, `style`. Default: inferred from diff content.
   - `main_branch`: string — the primary branch name for new git repos (e.g., `"main"`, `"master"`, `"trunk"`). Also used by `getMainBranch()` as the preferred branch when auto-detection is ambiguous. Default: `"main"`.
   - `merge_strategy`: `"squash"` or `"merge"` — controls how worktree branches are merged back. `"squash"` combines all commits into one; `"merge"` preserves individual commits. Default: `"squash"`.
-  - `isolation`: `"worktree"`, `"branch"`, or `"none"` — controls auto-mode git isolation strategy. `"worktree"` creates a milestone worktree for isolated work; `"branch"` works directly in the project root but creates a milestone branch (useful for submodule-heavy repos); `"none"` works directly on the current branch with no worktree or milestone branch (ideal for step-mode with hot reloads). Default: `"worktree"`.
+  - `isolation`: `"none"`, `"worktree"`, or `"branch"` — controls auto-mode git isolation strategy. `"none"` works directly on the current branch with no worktree or milestone branch (default, ideal for step-mode with hot reloads); `"worktree"` creates a milestone worktree for isolated work; `"branch"` works directly in the project root but creates a milestone branch (useful for submodule-heavy repos). `worktree` requires a committed `HEAD`; in a zero-commit repo, GSD temporarily treats it as `none` until the first commit exists. Default: `"none"`.
   - `manage_gitignore`: boolean — when `false`, GSD will not touch `.gitignore` at all. Useful when your project has a strictly managed `.gitignore` and you don't want GSD adding entries. Default: `true`.
   - `worktree_post_create`: string — script to run after a worktree is created (both auto-mode and manual `/worktree`). Receives `SOURCE_DIR` and `WORKTREE_DIR` as environment variables. Can be absolute or relative to project root. Runs with 30-second timeout. Failure is non-fatal (logged as warning). Default: none.
   - `auto_pr`: boolean — automatically create a GitHub pull request after a milestone branch is merged. Requires `gh` CLI to be installed. Default: `false`.
@@ -302,7 +302,7 @@ mode: solo
 ---
 ```
 
-Equivalent to setting `git.auto_push: true`, `git.push_branches: false`, `git.pre_merge_check: false`, `git.merge_strategy: squash`, `git.isolation: worktree`, `unique_milestone_ids: false`.
+Equivalent to setting `git.auto_push: true`, `git.push_branches: false`, `git.pre_merge_check: false`, `git.merge_strategy: squash`, `git.isolation: none`, `unique_milestone_ids: false`.
 
 **Team — unique IDs, push branches, pre-merge checks:**
 
@@ -313,7 +313,7 @@ mode: team
 ---
 ```
 
-Equivalent to setting `git.auto_push: false`, `git.push_branches: true`, `git.pre_merge_check: true`, `git.merge_strategy: squash`, `git.isolation: worktree`, `unique_milestone_ids: true`.
+Equivalent to setting `git.auto_push: false`, `git.push_branches: true`, `git.pre_merge_check: true`, `git.merge_strategy: squash`, `git.isolation: none`, `unique_milestone_ids: true`.
 
 **Mode with overrides — team mode but with auto-push:**
 

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -11,6 +11,7 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -21,6 +22,7 @@ import type { DynamicRoutingConfig } from "./model-router.js";
 import { normalizeStringArray } from "../shared/format-utils.js";
 import { logWarning } from "./workflow-logger.js";
 import { resolveProfileDefaults as _resolveProfileDefaults } from "./preferences-models.js";
+import { nativeIsRepo } from "./native-git-bridge.js";
 
 import {
   KNOWN_PREFERENCE_KEYS,
@@ -619,9 +621,24 @@ export function resolvePreDispatchHooks(): PreDispatchHookConfig[] {
  */
 export function getIsolationMode(basePath?: string): "none" | "worktree" | "branch" {
   const prefs = loadEffectiveGSDPreferences(basePath)?.preferences?.git;
-  if (prefs?.isolation === "worktree") return "worktree";
+  if (prefs?.isolation === "worktree") {
+    if (basePath && nativeIsRepo(basePath) && !hasCommittedHead(basePath)) return "none";
+    return "worktree";
+  }
   if (prefs?.isolation === "branch") return "branch";
   return "none"; // default — no isolation, work on current branch
+}
+
+function hasCommittedHead(basePath: string): boolean {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", "HEAD"], {
+      cwd: basePath,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function resolveParallelConfig(prefs: GSDPreferences | undefined): import("./types.js").ParallelConfig {

--- a/src/resources/extensions/gsd/tests/none-mode-gates.test.ts
+++ b/src/resources/extensions/gsd/tests/none-mode-gates.test.ts
@@ -11,9 +11,10 @@
  * prefs to the runner's cwd .gsd/PREFERENCES.md and clean up in finally.
  */
 
-import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { mkdirSync, writeFileSync, rmSync, existsSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
 
 import { shouldUseWorktreeIsolation } from "../auto.ts";
 import { getIsolationMode } from "../preferences.ts";
@@ -68,6 +69,49 @@ try {
   removeRunnerPreferences();
   invalidateAllCaches();
 }
+});
+
+test('worktree isolation is disabled for an unborn repo until the first commit', (t) => {
+  const repo = mkdtempSync(join(tmpdir(), "gsd-unborn-worktree-"));
+  t.after(() => {
+    rmSync(repo, { recursive: true, force: true });
+    invalidateAllCaches();
+  });
+
+  execFileSync("git", ["init"], { cwd: repo, stdio: ["ignore", "ignore", "ignore"] });
+  mkdirSync(join(repo, ".gsd"), { recursive: true });
+  writeFileSync(join(repo, ".gsd", "PREFERENCES.md"), [
+    "---",
+    "git:",
+    '  isolation: "worktree"',
+    "---",
+    "",
+  ].join("\n"));
+  invalidateAllCaches();
+
+  assert.deepStrictEqual(
+    getIsolationMode(repo),
+    "none",
+    "startup gates should not attempt worktree isolation before HEAD exists",
+  );
+  assert.deepStrictEqual(
+    shouldUseWorktreeIsolation(repo),
+    false,
+    "worktree-specific gates should share the same unborn-repo guard",
+  );
+
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: repo });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: repo });
+  writeFileSync(join(repo, "README.md"), "seed\n");
+  execFileSync("git", ["add", "."], { cwd: repo });
+  execFileSync("git", ["commit", "-m", "chore: init"], { cwd: repo, stdio: ["ignore", "ignore", "ignore"] });
+  invalidateAllCaches();
+
+  assert.deepStrictEqual(
+    getIsolationMode(repo),
+    "worktree",
+    "worktree isolation should re-enable once the repo has a committed HEAD",
+  );
 });
 
 // Test 4: shouldUseWorktreeIsolation returns false for no prefs (default: none)
@@ -149,4 +193,3 @@ test('Test 7: System prompt worktree block absent without active worktree', () =
   const ctx = getActiveAutoWorktreeContext();
   assert.ok(ctx === null, "getActiveAutoWorktreeContext() null confirms system prompt worktree block will not be injected");
 });
-

--- a/src/resources/extensions/gsd/tests/none-mode-gates.test.ts
+++ b/src/resources/extensions/gsd/tests/none-mode-gates.test.ts
@@ -112,6 +112,11 @@ test('worktree isolation is disabled for an unborn repo until the first commit',
     "worktree",
     "worktree isolation should re-enable once the repo has a committed HEAD",
   );
+  assert.deepStrictEqual(
+    shouldUseWorktreeIsolation(repo),
+    true,
+    "worktree-specific gates should re-enable once the repo has a committed HEAD",
+  );
 });
 
 // Test 4: shouldUseWorktreeIsolation returns false for no prefs (default: none)


### PR DESCRIPTION
## TL;DR
**What:** Makes worktree isolation resolve to `none` while a configured Git repo has no committed `HEAD`.
**Why:** Follow-up to #4530; auto startup still used `getIsolationMode()` directly and could attempt milestone worktrees after `git init` but before the initial commit.
**How:** Shares `shouldUseWorktreeIsolation()` with `getIsolationMode()` and guards only confirmed unborn Git repos, then re-enables worktree mode after the first commit.

## What
- Suppresses `git.isolation: worktree` only when `basePath` is an actual Git repo without a committed `HEAD`.
- Routes `shouldUseWorktreeIsolation()` through the same resolver used by auto startup.
- Adds regression coverage for an unborn repo becoming eligible again after its first commit.

## Why
Refs #4530. The earlier fix covered one gate, but auto startup and worktree resolver paths still consulted `getIsolationMode()` directly.

## How
`getIsolationMode(basePath)` now checks `nativeIsRepo(basePath)` before testing for a committed `HEAD`, so explicit worktree preferences for non-repo paths still load normally.

## Test plan
- [x] `npm run test:compile`
- [x] `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/none-mode-gates.test.js dist-test/src/resources/extensions/gsd/tests/preferences.test.js`
- [x] `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/progressive-planning.test.js`
- [x] `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/derive-state-db.test.js`
- [ ] `npm run verify:pr` attempted twice; build and typecheck passed both times, but the full unit suite hit unrelated timing-only flakes in `progressive-planning.test.js` and `derive-state-db.test.js`. Both failed targets passed when rerun directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Worktree isolation now temporarily disables for repositories without a committed HEAD and automatically resumes after the first commit.
  * Isolation evaluation now checks repository state at startup before enabling worktree behavior.

* **Documentation**
  * Made `none` the default isolation mode in docs and added guidance about the worktree→none startup fallback for zero-commit repos.

* **Tests**
  * Added an integration test that verifies startup fallback and re-evaluation after the initial commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->