### PR TITLE
fix(gsd): rederive state on empty plan graph

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -52,7 +52,7 @@ import { getEligibleSlices } from "../slice-parallel-eligibility.js";
 import { startSliceParallel } from "../slice-parallel-orchestrator.js";
 import { isDbAvailable, getMilestoneSlices } from "../gsd-db.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
-import { ensurePlanV2Graph, isMissingFinalizedContextResult } from "../uok/plan-v2.js";
+import { ensurePlanV2Graph, isEmptyPlanV2GraphResult, isMissingFinalizedContextResult } from "../uok/plan-v2.js";
 import { resolveUokFlags } from "../uok/flags.js";
 import { UokGateRunner } from "../uok/gate-runner.js";
 import { resetEvidence, loadEvidenceFromDisk } from "../safety/evidence-collector.js";
@@ -410,7 +410,18 @@ export async function runPreDispatch(
   // Derive state
   let state = await deps.deriveState(s.basePath);
   if (prefs?.uok?.plan_v2?.enabled && shouldRunPlanV2Gate(state.phase)) {
-    const compiled = ensurePlanV2Graph(s.basePath, state);
+    let compiled = ensurePlanV2Graph(s.basePath, state);
+    if (isEmptyPlanV2GraphResult(compiled)) {
+      deps.invalidateAllCaches();
+      state = await deps.deriveState(s.basePath);
+      compiled = shouldRunPlanV2Gate(state.phase)
+        ? ensurePlanV2Graph(s.basePath, state)
+        : {
+            ok: true,
+            reason: "empty plan-v2 graph recovered by state rederive",
+            nodeCount: 0,
+          };
+    }
     if (!compiled.ok) {
       const reason = compiled.reason ?? "Plan v2 compilation failed";
       if (isMissingFinalizedContextResult(compiled)) {

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -708,6 +708,69 @@ test("#4671: plan-v2 missing CONTEXT.md reaches dispatch recovery instead of pau
   }
 });
 
+test("plan-v2 empty graph rederives state before pausing", async () => {
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-plan-v2-empty-graph-"));
+  mkdirSync(join(basePath, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(
+    join(basePath, ".gsd", "milestones", "M001", "M001-CONTEXT.md"),
+    "# M001: Test\n\nFinalized context.\n",
+  );
+  openDatabase(join(basePath, ".gsd", "gsd.db"));
+  try {
+    let deriveCalls = 0;
+    let invalidateCalls = 0;
+    let pauseCalls = 0;
+    const capture = createEventCapture();
+    const deps = makeMockDeps(capture, {
+      pauseAuto: async () => { pauseCalls++; },
+      invalidateAllCaches: () => { invalidateCalls++; },
+      deriveState: async () => {
+        deriveCalls++;
+        if (deriveCalls === 1) {
+          return {
+            phase: "validating-milestone",
+            activeMilestone: { id: "M001", title: "Test", status: "active" },
+            activeSlice: null,
+            activeTask: null,
+            registry: [{ id: "M001", status: "active" }],
+            blockers: [],
+            recentDecisions: [],
+            nextAction: "Validate milestone M001.",
+          } as any;
+        }
+        return {
+          phase: "pre-planning",
+          activeMilestone: { id: "M001", title: "Test", status: "active" },
+          activeSlice: null,
+          activeTask: null,
+          registry: [{ id: "M001", status: "active" }],
+          blockers: [],
+          recentDecisions: [],
+          nextAction: "Plan milestone M001.",
+        } as any;
+      },
+    });
+    const ic = makeIC(deps, {
+      prefs: { uok: { plan_v2: { enabled: true } } } as any,
+    });
+    ic.s.basePath = basePath;
+
+    const result = await runPreDispatch(ic, {
+      recentUnits: [],
+      stuckRecoveryAttempts: 0,
+      consecutiveFinalizeTimeouts: 0,
+    });
+
+    assert.equal(result.action, "next");
+    assert.equal(deriveCalls, 2, "empty plan graph should trigger one state rederive");
+    assert.ok(invalidateCalls >= 1, "empty plan graph recovery should clear caches before rederive");
+    assert.equal(pauseCalls, 0, "recoverable empty graph should not pause auto-mode");
+  } finally {
+    closeDatabase();
+    rmSync(basePath, { recursive: true, force: true });
+  }
+});
+
 test("milestone-transition event is emitted when milestone changes", async () => {
   const capture = createEventCapture();
   const deps = makeMockDeps(capture, {

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -771,6 +771,58 @@ test("plan-v2 empty graph rederives state before pausing", async () => {
   }
 });
 
+test("plan-v2 empty graph pauses after one failed rederive", async () => {
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-plan-v2-empty-graph-pause-"));
+  mkdirSync(join(basePath, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(
+    join(basePath, ".gsd", "milestones", "M001", "M001-CONTEXT.md"),
+    "# M001: Test\n\nFinalized context.\n",
+  );
+  openDatabase(join(basePath, ".gsd", "gsd.db"));
+  try {
+    let deriveCalls = 0;
+    let invalidateCalls = 0;
+    let pauseCalls = 0;
+    const capture = createEventCapture();
+    const deps = makeMockDeps(capture, {
+      pauseAuto: async () => { pauseCalls++; },
+      invalidateAllCaches: () => { invalidateCalls++; },
+      deriveState: async () => {
+        deriveCalls++;
+        return {
+          phase: "validating-milestone",
+          activeMilestone: { id: "M001", title: "Test", status: "active" },
+          activeSlice: null,
+          activeTask: null,
+          registry: [{ id: "M001", status: "active" }],
+          blockers: [],
+          recentDecisions: [],
+          nextAction: "Validate milestone M001.",
+        } as any;
+      },
+    });
+    const ic = makeIC(deps, {
+      prefs: { uok: { plan_v2: { enabled: true } } } as any,
+    });
+    ic.s.basePath = basePath;
+
+    const result = await runPreDispatch(ic, {
+      recentUnits: [],
+      stuckRecoveryAttempts: 0,
+      consecutiveFinalizeTimeouts: 0,
+    });
+
+    assert.equal(result.action, "break");
+    assert.equal(result.reason, "plan-v2-gate-failed");
+    assert.equal(deriveCalls, 2, "empty plan graph should only rederive once");
+    assert.ok(invalidateCalls >= 1, "empty plan graph recovery should clear caches before rederive");
+    assert.equal(pauseCalls, 1, "persistent empty graph should pause auto-mode");
+  } finally {
+    closeDatabase();
+    rmSync(basePath, { recursive: true, force: true });
+  }
+});
+
 test("milestone-transition event is emitted when milestone changes", async () => {
   const capture = createEventCapture();
   const deps = makeMockDeps(capture, {

--- a/src/resources/extensions/gsd/tests/uok-plan-v2-wiring.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-plan-v2-wiring.test.ts
@@ -16,6 +16,7 @@ import type { GSDState, Phase } from "../types.ts";
 import {
   ensurePlanV2Graph,
   hasFinalizedMilestoneContext,
+  isEmptyPlanV2GraphResult,
   isMissingFinalizedContextResult,
 } from "../uok/plan-v2.ts";
 
@@ -204,4 +205,5 @@ test("plan-v2 ensure rejects empty executable graph", () => {
   const compiled = ensurePlanV2Graph(basePath, buildState("executing"));
   assert.equal(compiled.ok, false);
   assert.match(compiled.reason ?? "", /compiled graph is empty/i);
+  assert.equal(isEmptyPlanV2GraphResult(compiled), true);
 });

--- a/src/resources/extensions/gsd/uok/plan-v2.ts
+++ b/src/resources/extensions/gsd/uok/plan-v2.ts
@@ -21,6 +21,7 @@ export function isExecutionEntryPhase(phase: Phase): boolean {
 export interface PlanV2CompileResult {
   ok: boolean;
   reason?: string;
+  emptyGraph?: boolean;
   graphPath?: string;
   nodeCount?: number;
   clarifyRoundLimit?: number;
@@ -71,6 +72,10 @@ export function hasFinalizedMilestoneContext(basePath: string, milestoneId: stri
 
 export function isMissingFinalizedContextResult(result: PlanV2CompileResult): boolean {
   return !result.ok && result.finalizedContextIncluded === false;
+}
+
+export function isEmptyPlanV2GraphResult(result: PlanV2CompileResult): boolean {
+  return !result.ok && result.emptyGraph === true;
 }
 
 function countSliceResearchArtifacts(basePath: string, milestoneId: string, slices: SliceRow[]): number {
@@ -181,7 +186,12 @@ export function ensurePlanV2Graph(basePath: string, state: GSDState): PlanV2Comp
   const compiled = compileUnitGraphFromState(basePath, state);
   if (!compiled.ok) return compiled;
   if ((compiled.nodeCount ?? 0) <= 0) {
-    return { ok: false, reason: "compiled graph is empty" };
+    return {
+      ...compiled,
+      ok: false,
+      reason: "compiled graph is empty",
+      emptyGraph: true,
+    };
   }
   return compiled;
 }


### PR DESCRIPTION
## TL;DR

**What:** Re-derive GSD state once when the Plan V2 gate compiles an empty graph before failing closed.

**Why:** Auto-mode could pause with `Plan gate failed-closed: compiled graph is empty` when cached/rendered state said the milestone was validating but the DB hierarchy had no slices/tasks.

**How:** Mark empty Plan V2 graph results, clear auto caches, rederive state, and continue normal dispatch if the refreshed phase no longer needs the Plan V2 gate.

## Changes

- Preserve Plan V2 compile metadata on empty graph failures and expose an `emptyGraph` classifier.
- Add one cache invalidation + state rederive pass in `runPreDispatch` before pausing on an empty Plan V2 graph.
- Add regression coverage for the recovery path and assert the empty-graph classifier in the Plan V2 wiring test.

## Notes

This is separate from the unborn-repository worktree isolation warning covered by #5138. That warning still needs the worktree fallback fix; this PR handles the follow-on empty graph pause after requirements/project state changed underneath auto-mode.

## Test plan

- [x] `npm run test:compile`
- [x] `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/uok-plan-v2-wiring.test.js dist-test/src/resources/extensions/gsd/tests/journal-integration.test.js`
- [x] `npm run typecheck:extensions`
- [x] `npm run verify:pr`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plan v2 now recovers gracefully when a compiled plan is empty: it invalidates caches, re-derives state, and retries to avoid immediate failure.
  * When re-derivation shows the phase no longer matches Plan v2 gates, the system treats the empty compile as a recoverable outcome to prevent unnecessary interruptions.

* **Tests**
  * Added integration tests covering recovery and failure paths for empty-plan scenarios, including cache invalidation and auto-mode pause behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->