### PR TITLE
fix(auto): cancelled unit with 0 tool calls triggers model fallback instead of infinite re-dispatch (#5143)

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -45,8 +45,12 @@ import {
 } from "../workflow-logger.js";
 import { gsdRoot } from "../paths.js";
 import { atomicWriteSync } from "../atomic-write.js";
-import { verifyExpectedArtifact, diagnoseExpectedArtifact, buildLoopRemediationSteps } from "../auto-recovery.js";
+import { verifyExpectedArtifact, diagnoseExpectedArtifact, buildLoopRemediationSteps, writeBlockerPlaceholder } from "../auto-recovery.js";
 import { writeUnitRuntimeRecord } from "../unit-runtime.js";
+import { resolveModelWithFallbacksForUnit, getNextFallbackModel } from "../preferences.js";
+import { resolveModelId as resolveModelForFallback } from "../auto-model-selection.js";
+import { blockModel, isModelBlocked } from "../blocked-models.js";
+import { setCurrentDispatchedModelId } from "../auto.js";
 import { withTimeout, FINALIZE_PRE_TIMEOUT_MS, FINALIZE_POST_TIMEOUT_MS } from "./finalize-timeout.js";
 import { getEligibleSlices } from "../slice-parallel-eligibility.js";
 import { startSliceParallel } from "../slice-parallel-orchestrator.js";
@@ -1680,6 +1684,145 @@ export async function runUnitPhase(
 
   if (unitResult.status === "cancelled") {
     const errorCategory = unitResult.errorContext?.category;
+
+    // ── Zero-progress check for cancelled units (#5143) ────────────
+    // Cancelled units bypass the zero tool-call guard (line ~1877) because
+    // every cancelled branch returns before reaching it. When a model returns
+    // an empty response (0 content items, 0 tokens), the unit resolves as
+    // cancelled — but re-dispatching to the same model will produce the same
+    // failure indefinitely across sessions (stuck-detection window resets).
+    //
+    // Close out the unit to populate the metrics ledger, then check whether
+    // the model produced zero tool calls. If so, try a model fallback (same
+    // pattern as agent-end-recovery.ts for provider errors). Only write a
+    // blocker placeholder if no fallback is available.
+    //
+    // Transient cancellations (session creation timeout, recoverable session
+    // failure) are excluded because retrying those *might* succeed.
+    let closeoutAlreadyRan = false;
+    if (!unitResult.errorContext?.isTransient && s.currentUnit) {
+      await deps.closeoutUnit(
+        ctx,
+        s.basePath,
+        unitType,
+        unitId,
+        s.currentUnit.startedAt,
+        deps.buildSnapshotOpts(unitType, unitId),
+      );
+      closeoutAlreadyRan = true;
+
+      const cancelledLedger = deps.getLedger() as { units: Array<{ type: string; id: string; startedAt: number; toolCalls: number }> } | null;
+      if (cancelledLedger?.units) {
+        const cancelledUnit = [...cancelledLedger.units].reverse().find(
+          (u: { type: string; id: string; startedAt: number; toolCalls: number }) =>
+            u.type === unitType && u.id === unitId && u.startedAt === s.currentUnit?.startedAt,
+        );
+        if (cancelledUnit && (cancelledUnit.toolCalls ?? 0) === 0) {
+          debugLog("runUnitPhase", {
+            phase: "cancelled-zero-tool-calls",
+            unitType,
+            unitId,
+            errorCategory,
+            warning: "Cancelled unit with 0 tool calls — model produced nothing",
+          });
+
+          // Try model fallback before giving up (mirrors agent-end-recovery.ts
+          // pattern for provider errors). Block the dead model so it isn't
+          // re-selected on restart, then walk the configured fallback chain,
+          // then try the auto-mode start model.
+          const failedProvider = s.currentUnitModel?.provider ?? ctx.model?.provider;
+          const failedId = s.currentUnitModel?.id ?? ctx.model?.id;
+          if (failedProvider && failedId) {
+            try {
+              blockModel(s.basePath, failedProvider, failedId, "empty response (0 tool calls, 0 tokens)");
+              ctx.ui.notify(
+                `Blocked ${failedProvider}/${failedId} for this project — returned empty response.`,
+                "warning",
+              );
+            } catch (err) {
+              logWarning("engine", `Failed to persist blocked model: ${err instanceof Error ? err.message : String(err)}`);
+            }
+          }
+
+          let fellBack = false;
+          const modelConfig = resolveModelWithFallbacksForUnit(unitType);
+          if (modelConfig && modelConfig.fallbacks.length > 0) {
+            const availableModels = ctx.modelRegistry.getAvailable();
+            let cursorModelId: string | undefined = ctx.model?.id;
+            while (true) {
+              const nextModelId = getNextFallbackModel(cursorModelId, modelConfig);
+              if (!nextModelId) break;
+              const candidate = resolveModelForFallback(nextModelId, availableModels, ctx.model?.provider);
+              if (candidate && !isModelBlocked(s.basePath, candidate.provider, candidate.id)) {
+                const ok = await pi.setModel(candidate, { persist: false });
+                if (ok) {
+                  setCurrentDispatchedModelId({ provider: candidate.provider, id: candidate.id });
+                  ctx.ui.notify(
+                    `${unitType} ${unitId} — model returned empty response (0 tool calls). ` +
+                    `Switched to fallback ${candidate.provider}/${candidate.id}.`,
+                    "warning",
+                  );
+                  fellBack = true;
+                  break;
+                }
+              }
+              cursorModelId = nextModelId;
+            }
+          }
+          // Fallback chain exhausted — try auto-mode start model if it isn't
+          // the one we just blocked and isn't itself blocked.
+          if (!fellBack && s.autoModeStartModel) {
+            const startProvider = s.autoModeStartModel.provider;
+            const startId = s.autoModeStartModel.id;
+            if (
+              !(startProvider === failedProvider && startId === failedId) &&
+              !isModelBlocked(s.basePath, startProvider, startId)
+            ) {
+              const startModel = ctx.modelRegistry.getAvailable().find(
+                (m: any) => m.provider === startProvider && m.id === startId,
+              );
+              if (startModel) {
+                const ok = await pi.setModel(startModel, { persist: false });
+                if (ok) {
+                  setCurrentDispatchedModelId({ provider: startModel.provider, id: startModel.id });
+                  ctx.ui.notify(
+                    `${unitType} ${unitId} — model returned empty response (0 tool calls). ` +
+                    `Restored session model ${startModel.provider}/${startModel.id}.`,
+                    "warning",
+                  );
+                  fellBack = true;
+                }
+              }
+            }
+          }
+
+          if (fellBack) {
+            // Re-dispatch with the new model — next iteration will call
+            // selectAndApplyModel which respects the active model.
+            await deps.autoCommitUnit?.(s.basePath, unitType, unitId, ctx);
+            await emitCancelledUnitEnd(ic, unitType, unitId, unitStartSeq, unitResult.errorContext);
+            return { action: "next", data: { unitStartedAt: s.currentUnit?.startedAt, requestDispatchedAt: unitResult.requestDispatchedAt } };
+          }
+
+          // No fallback available — write blocker placeholder so pipeline advances
+          writeBlockerPlaceholder(
+            unitType,
+            unitId,
+            s.basePath,
+            `Model returned empty response (0 tool calls, 0 tokens) for ${unitType} "${unitId}". ` +
+            `No fallback model available. The model may not support this prompt structure.`,
+          );
+          ctx.ui.notify(
+            `${unitType} ${unitId} — model returned empty response (0 tool calls), no fallback available. Wrote blocker placeholder.`,
+            "warning",
+          );
+          await deps.autoCommitUnit?.(s.basePath, unitType, unitId, ctx);
+          await emitCancelledUnitEnd(ic, unitType, unitId, unitStartSeq, unitResult.errorContext);
+          return { action: "next", data: { unitStartedAt: s.currentUnit?.startedAt, requestDispatchedAt: unitResult.requestDispatchedAt } };
+        }
+      }
+    }
+
     // Provider-error pause: agent_end recovery normally pauses before this
     // branch. Provider readiness failures happen before dispatch, so pause here
     // if nothing upstream already did.
@@ -1788,7 +1931,8 @@ export async function runUnitPhase(
       return { action: "break", reason: "session-timeout" };
     }
     // All other cancelled states (structural errors, non-transient failures): hard stop
-    if (s.currentUnit) {
+    // Guard: closeoutUnit may have already run in the zero-progress check above (#5143).
+    if (s.currentUnit && !closeoutAlreadyRan) {
       await deps.closeoutUnit(
         ctx,
         s.basePath,

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2606,3 +2606,312 @@ test("autoLoop classifies ModelPolicyDispatchBlockedError as blocked, not a retr
   assert.equal(pausedTurn!.unitType, "research-slice", "onTurnResult must receive the blocked unitType from the typed error");
   assert.equal(pausedTurn!.unitId, "M001/S01", "onTurnResult must receive the blocked unitId from the typed error");
 });
+
+// ─── Cancelled unit with 0 tool calls writes blocker placeholder (#5143) ────
+
+test("cancelled unit with 0 tool calls tries model fallback before blocker placeholder (#5143)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  // Provide modelRegistry with getAvailable so fallback resolution works
+  ctx.modelRegistry = {
+    getProviderAuthMode: () => "api-key",
+    isProviderRequestReady: () => true,
+    getAvailable: () => [
+      { provider: "anthropic", id: "claude-sonnet-4-20250514" },
+      { provider: "openai", id: "gpt-4o" },
+    ],
+  };
+  ctx.model = { provider: "anthropic", id: "claude-sonnet-4-20250514" };
+  const pi = makeMockPi();
+
+  let iterationCount = 0;
+  const notifications: string[] = [];
+  ctx.ui.notify = (msg: string) => { notifications.push(msg); };
+
+  const s = makeLoopSession();
+  // Set a different start model so the session-model fallback has something to try
+  s.autoModeStartModel = { provider: "openai", id: "gpt-4o" };
+
+  const mockLedger = {
+    version: 1,
+    projectStartedAt: Date.now(),
+    units: [] as any[],
+  };
+
+  const setModelCalls: any[] = [];
+  pi.setModel = async (model: any) => {
+    setModelCalls.push(model);
+    return true;
+  };
+
+  const deps = makeMockDeps({
+    deriveState: async () => {
+      deps.callLog.push("deriveState");
+      iterationCount++;
+      if (iterationCount > 2) {
+        s.active = false;
+      }
+      return {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Test", status: "active" },
+        activeSlice: { id: "S01", title: "Slice 1" },
+        activeTask: { id: "T01" },
+        registry: [{ id: "M001", status: "active" }],
+        blockers: [],
+      } as any;
+    },
+    resolveDispatch: async () => {
+      deps.callLog.push("resolveDispatch");
+      return {
+        action: "dispatch" as const,
+        unitType: "research-slice",
+        unitId: "M001/S01",
+        prompt: "research the feature",
+      };
+    },
+    closeoutUnit: async () => {
+      mockLedger.units.push({
+        type: "research-slice",
+        id: "M001/S01",
+        startedAt: s.currentUnit?.startedAt ?? Date.now(),
+        toolCalls: 0,
+        assistantMessages: 0,
+        tokens: { input: 0, output: 0, total: 0, cacheRead: 0, cacheWrite: 0 },
+        cost: 0,
+      });
+    },
+    getLedger: () => mockLedger,
+    postUnitPostVerification: async () => {
+      deps.callLog.push("postUnitPostVerification");
+      s.active = false;
+      return "continue" as const;
+    },
+  });
+
+  const loopPromise = autoLoop(ctx, pi, s, deps);
+
+  // First iteration: resolve as cancelled (non-transient) — should try fallback
+  await new Promise((r) => setTimeout(r, 50));
+  resolveAgentEndCancelled({
+    message: "Provider error: Request timed out.",
+    category: "provider",
+    isTransient: false,
+  });
+
+  await new Promise((r) => setTimeout(r, 50));
+  s.active = false;
+  await loopPromise;
+
+  // Model fallback should have been attempted via autoModeStartModel
+  const fallbackCall = setModelCalls.find(
+    (m: any) => m.provider === "openai" && m.id === "gpt-4o",
+  );
+  assert.ok(
+    fallbackCall,
+    `should have tried fallback model (autoModeStartModel), setModel calls: ${JSON.stringify(setModelCalls)}`,
+  );
+
+  // Should NOT have written a blocker placeholder (fallback succeeded)
+  const blockerNotification = notifications.find(
+    (n) => n.includes("blocker placeholder"),
+  );
+  assert.equal(
+    blockerNotification,
+    undefined,
+    "should NOT write blocker placeholder when model fallback is available",
+  );
+
+  // Verify the loop did NOT call stopAuto
+  assert.ok(
+    !deps.callLog.includes("stopAuto"),
+    "should NOT have called stopAuto — unit should advance via model fallback",
+  );
+});
+
+test("cancelled unit with 0 tool calls writes blocker when no fallback available (#5143)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  const pi = makeMockPi();
+
+  let iterationCount = 0;
+  const notifications: string[] = [];
+  ctx.ui.notify = (msg: string) => { notifications.push(msg); };
+
+  const s = makeLoopSession();
+  // No autoModeStartModel — simulates no fallback available
+  s.autoModeStartModel = null;
+
+  const mockLedger = {
+    version: 1,
+    projectStartedAt: Date.now(),
+    units: [] as any[],
+  };
+
+  const setModelCalls: any[] = [];
+  pi.setModel = async (model: any) => {
+    setModelCalls.push(model);
+    return true;
+  };
+
+  const deps = makeMockDeps({
+    deriveState: async () => {
+      deps.callLog.push("deriveState");
+      iterationCount++;
+      if (iterationCount > 2) {
+        s.active = false;
+      }
+      return {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Test", status: "active" },
+        activeSlice: { id: "S01", title: "Slice 1" },
+        activeTask: { id: "T01" },
+        registry: [{ id: "M001", status: "active" }],
+        blockers: [],
+      } as any;
+    },
+    resolveDispatch: async () => {
+      deps.callLog.push("resolveDispatch");
+      return {
+        action: "dispatch" as const,
+        unitType: "research-slice",
+        unitId: "M001/S01",
+        prompt: "research the feature",
+      };
+    },
+    closeoutUnit: async () => {
+      mockLedger.units.push({
+        type: "research-slice",
+        id: "M001/S01",
+        startedAt: s.currentUnit?.startedAt ?? Date.now(),
+        toolCalls: 0,
+        assistantMessages: 0,
+        tokens: { input: 0, output: 0, total: 0, cacheRead: 0, cacheWrite: 0 },
+        cost: 0,
+      });
+    },
+    getLedger: () => mockLedger,
+    postUnitPostVerification: async () => {
+      deps.callLog.push("postUnitPostVerification");
+      s.active = false;
+      return "continue" as const;
+    },
+  });
+
+  const loopPromise = autoLoop(ctx, pi, s, deps);
+
+  await new Promise((r) => setTimeout(r, 50));
+  resolveAgentEndCancelled({
+    message: "Provider error: Request timed out.",
+    category: "provider",
+    isTransient: false,
+  });
+
+  await new Promise((r) => setTimeout(r, 50));
+  s.active = false;
+  await loopPromise;
+
+  // Should have written a blocker placeholder (no fallback available)
+  const blockerNotification = notifications.find(
+    (n) => n.includes("blocker placeholder"),
+  );
+  assert.ok(
+    blockerNotification,
+    `should notify about blocker placeholder when no fallback available, got: ${notifications.join("; ")}`,
+  );
+
+  assert.ok(
+    !deps.callLog.includes("stopAuto"),
+    "should NOT have called stopAuto — unit should advance via blocker placeholder",
+  );
+});
+
+test("cancelled unit with tool calls > 0 does NOT write blocker placeholder (#5143)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  const pi = makeMockPi();
+
+  let iterationCount = 0;
+  const notifications: string[] = [];
+  ctx.ui.notify = (msg: string) => { notifications.push(msg); };
+
+  const s = makeLoopSession();
+
+  const mockLedger = {
+    version: 1,
+    projectStartedAt: Date.now(),
+    units: [] as any[],
+  };
+
+  const deps = makeMockDeps({
+    deriveState: async () => {
+      deps.callLog.push("deriveState");
+      iterationCount++;
+      return {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Test", status: "active" },
+        activeSlice: { id: "S01", title: "Slice 1" },
+        activeTask: { id: "T01" },
+        registry: [{ id: "M001", status: "active" }],
+        blockers: [],
+      } as any;
+    },
+    resolveDispatch: async () => {
+      deps.callLog.push("resolveDispatch");
+      return {
+        action: "dispatch" as const,
+        unitType: "research-slice",
+        unitId: "M001/S01",
+        prompt: "research the feature",
+      };
+    },
+    closeoutUnit: async () => {
+      // Simulate snapshotUnitMetrics — unit made some progress
+      mockLedger.units.push({
+        type: "research-slice",
+        id: "M001/S01",
+        startedAt: s.currentUnit?.startedAt ?? Date.now(),
+        toolCalls: 3,
+        assistantMessages: 2,
+        tokens: { input: 500, output: 300, total: 800, cacheRead: 0, cacheWrite: 0 },
+        cost: 0.25,
+      });
+    },
+    getLedger: () => mockLedger,
+    postUnitPostVerification: async () => {
+      deps.callLog.push("postUnitPostVerification");
+      s.active = false;
+      return "continue" as const;
+    },
+  });
+
+  const loopPromise = autoLoop(ctx, pi, s, deps);
+
+  // Resolve as cancelled (non-transient) — but the unit made progress
+  await new Promise((r) => setTimeout(r, 50));
+  resolveAgentEndCancelled({
+    message: "Provider error: connection reset.",
+    category: "provider",
+    isTransient: false,
+  });
+
+  await loopPromise;
+
+  // Should NOT have the blocker placeholder notification
+  const blockerNotification = notifications.find(
+    (n) => n.includes("blocker placeholder"),
+  );
+  assert.equal(
+    blockerNotification,
+    undefined,
+    "should NOT write blocker placeholder when cancelled unit has tool calls > 0",
+  );
+});


### PR DESCRIPTION
## TL;DR

**What:** Cancelled units with 0 tool calls now trigger model fallback (then blocker placeholder) instead of infinite re-dispatch.
**Why:** Models returning empty responses cause an infinite loop because the zero tool-call guard is bypassed for cancelled units.
**How:** Add a zero-progress check at the top of the cancelled-unit handler that mirrors `agent-end-recovery.ts` — block dead model, walk fallback chain, try session start model, then blocker placeholder as last resort.

## What

Two files changed:
- `src/resources/extensions/gsd/auto/phases.ts` — new zero-progress check in the cancelled-unit handler (`runUnitPhase`)
- `src/resources/extensions/gsd/tests/auto-loop.test.ts` — three regression tests

## Why

When a model returns an empty response (0 content items, 0 tokens), the provider layer resolves the unit as `cancelled`. Every cancelled branch in `runUnitPhase` returns `{ action: "break" }` before reaching the zero tool-call guard at line ~1877. The unit gets re-dispatched to the same dead model indefinitely — the stuck-detection window resets between auto-mode sessions so the 3-consecutive threshold is never met.

Closes #5143

## How

The fix inserts a zero-progress check at the top of the cancelled-unit block (before the provider/timeout/session-failed branches):

1. **Close out the unit** — calls `closeoutUnit` to populate the metrics ledger (currently skipped for provider-paused units)
2. **Check for 0 tool calls** — queries the ledger for the just-closed unit
3. **Block the dead model** — `blockModel()` persists to `.gsd/runtime/blocked-models.json` so it is not re-selected on restart (same pattern as `agent-end-recovery.ts`)
4. **Walk fallback chain** — `resolveModelWithFallbacksForUnit` → `getNextFallbackModel` loop, skipping blocked models via `isModelBlocked`
5. **Try session start model** — if the fallback chain is empty, try `autoModeStartModel` (with blocked-model check)
6. **Blocker placeholder** — if no model is available, write a blocker placeholder via `writeBlockerPlaceholder` so the pipeline advances

Steps 3–5 mirror the exact pattern from `agent-end-recovery.ts` (lines 170–230). The one intentional difference: recovery mechanism. `agent-end-recovery.ts` fires during a live session and sends a continuation prompt (`pi.sendMessage`). Our code fires after the unit was cancelled (session already torn down), so it returns `action: "next"` for a fresh re-dispatch with the new model.

Transient cancellations (session creation timeout, recoverable session failure) are excluded — retrying those *might* succeed.

### Recovery strategy for cancelled + 0 tool calls

| Stage | Action |
|---|---|
| Block dead model | Persist to `blocked-models.json` |
| Fallback chain | Walk configured fallbacks, skip blocked |
| Session start model | Try if different from blocked model |
| Blocker placeholder | Last resort — pipeline advances past unit |

### Regression tests

- **Cancelled + 0 tool calls + fallback available** → model switched, no blocker, no stopAuto
- **Cancelled + 0 tool calls + no fallback** → blocker placeholder written, no stopAuto
- **Cancelled + tool calls > 0** → no blocker placeholder written (unit made progress)

## AI assistance

This PR was developed with AI assistance (GSD agent). The code is understood and can be explained in full.

- [x] `fix` — Bug fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved handling of cancelled requests by attempting configured model fallbacks
  * Enhanced error management with graceful fallback mechanism instead of hard stops

* **Tests**
  * Added regression tests for model fallback and cancellation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->