### PR TITLE
feat(gsd): stabilize deep planning mode and DB-primary requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ On first run, GSD launches a branded setup wizard that walks you through LLM pro
 | `/gsd`                  | Step mode — executes one unit at a time, pauses between each                  |
 | `/gsd next`             | Explicit step mode (same as bare `/gsd`)                                      |
 | `/gsd auto`             | Autonomous mode — researches, plans, executes, commits, repeats               |
-| `/gsd new-project --deep` | Bootstrap a project with staged project-level discovery                    |
+| `/gsd new-project [--deep]` | Bootstrap a project with staged project-level discovery                  |
 | `/gsd quick`            | Execute a quick task with GSD guarantees, skip planning overhead              |
 | `/gsd stop`             | Stop auto mode gracefully                                                     |
 | `/gsd steer`            | Hard-steer plan documents during execution                                    |

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -34,7 +34,7 @@ You can also opt in when starting project setup with `/gsd new-project --deep` o
 
 Deep mode keeps the normal slice execution loop, but first runs a one-time staged discovery flow before milestone-level planning:
 
-```
+```text
 Workflow Preferences -> Project Context -> Requirements -> Research Decision -> Optional Project Research -> Milestone Context/Roadmap
 ```
 
@@ -46,6 +46,8 @@ Workflow Preferences -> Project Context -> Requirements -> Research Decision -> 
 | `.gsd/runtime/research-decision.json` | `research-decision` | Records `research` or `skip`; this unit only asks the question and writes the marker |
 | `.gsd/research/STACK.md`, `FEATURES.md`, `ARCHITECTURE.md`, `PITFALLS.md` | `research-project`, only when the decision is `research` | Four parallel project-level research outputs for stack, feature norms, architecture, and pitfalls |
 | `.gsd/milestones/<MID>/M###-CONTEXT.md` and `M###-ROADMAP.md` | Normal milestone discussion/planning | Milestone-specific context and executable roadmap |
+
+`REQUIREMENTS.md` is rendered from the requirements stored in the GSD database. Agents should save individual requirements with `gsd_requirement_save`; a final `gsd_summary_save` for `REQUIREMENTS` will fail if no active requirement rows exist instead of treating caller-supplied markdown as canonical.
 
 Project research is informational, not binding. It cross-checks the requirements and surfaces table stakes, risks, and omissions; any new commitment should be added to `.gsd/REQUIREMENTS.md` before planning depends on it.
 

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -36,7 +36,7 @@ planning_depth: deep
 
 Deep mode runs one-time discovery gates before normal milestone planning:
 
-```
+```text
 Workflow Preferences -> Project Context -> Requirements -> Research Decision -> Optional Project Research -> Milestone Context/Roadmap
 ```
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -111,6 +111,8 @@ The workflow MCP surface includes:
 
 These tools use the same GSD workflow handlers as the native in-process tool path wherever a shared handler exists.
 
+`gsd_summary_save` computes artifact paths from the supplied IDs. `milestone_id` is required for milestone-, slice-, and task-scoped artifact types (`SUMMARY`, `RESEARCH`, `CONTEXT`, `ASSESSMENT`, `CONTEXT-DRAFT`) and should be omitted only for root-level `PROJECT`, `PROJECT-DRAFT`, `REQUIREMENTS`, and `REQUIREMENTS-DRAFT` artifacts. For final `REQUIREMENTS` saves, the tool renders content from active database requirement rows; callers must create those rows with `gsd_requirement_save` first.
+
 ### Interactive tools
 
 The packaged server exposes `ask_user_questions` through MCP form elicitation. This keeps the existing GSD answer payload shape while allowing Claude Code CLI and other elicitation-capable clients to surface structured user choices.

--- a/packages/mcp-server/src/import-candidates.test.ts
+++ b/packages/mcp-server/src/import-candidates.test.ts
@@ -33,16 +33,21 @@ describe("_buildImportCandidates", () => {
     );
   });
 
-  it("returns original path first", () => {
+  it("returns source TypeScript before stale JavaScript fallbacks", () => {
     const input = "../../../src/resources/extensions/gsd/db-writer.js";
     const candidates = _buildImportCandidates(input);
-    assert.equal(candidates[0], input, "first candidate should be the original path");
+    assert.deepEqual(candidates, [
+      "../../../src/resources/extensions/gsd/db-writer.ts",
+      "../../../src/resources/extensions/gsd/db-writer.js",
+      "../../../dist/resources/extensions/gsd/db-writer.ts",
+      "../../../dist/resources/extensions/gsd/db-writer.js",
+    ]);
   });
 
   it("handles paths without src/ or dist/ gracefully", () => {
     const candidates = _buildImportCandidates("./local-module.js");
     assert.equal(candidates.length, 2, "should have original + .ts variant only");
-    assert.equal(candidates[0], "./local-module.js");
-    assert.equal(candidates[1], "./local-module.ts");
+    assert.equal(candidates[0], "./local-module.ts");
+    assert.equal(candidates[1], "./local-module.js");
   });
 });

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -8,7 +8,7 @@ import { randomUUID } from "node:crypto";
 import { symlinkSync, realpathSync } from "node:fs";
 
 import { _getAdapter, closeDatabase } from "../../../src/resources/extensions/gsd/gsd-db.ts";
-import { registerWorkflowTools, WORKFLOW_TOOL_NAMES, validateProjectDir } from "./workflow-tools.ts";
+import { _buildImportCandidates, registerWorkflowTools, WORKFLOW_TOOL_NAMES, validateProjectDir } from "./workflow-tools.ts";
 
 function makeTmpBase(): string {
   const base = join(tmpdir(), `gsd-mcp-workflow-${randomUUID()}`);
@@ -78,6 +78,18 @@ describe("workflow MCP tools", () => {
     assert.deepEqual(server.tools.map((t) => t.name), [...WORKFLOW_TOOL_NAMES]);
   });
 
+  it("prefers source TypeScript before compiled dist fallbacks", () => {
+    assert.deepEqual(
+      _buildImportCandidates("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js"),
+      [
+        "../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js",
+        "../../../src/resources/extensions/gsd/tools/workflow-tool-executors.ts",
+        "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.js",
+        "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.ts",
+      ],
+    );
+  });
+
   it("gsd_summary_save writes artifact through the shared executor", async () => {
     const base = makeTmpBase();
     try {
@@ -138,6 +150,56 @@ describe("workflow MCP tools", () => {
         readFileSync(join(base, ".gsd", "PROJECT.md"), "utf-8"),
         "# Project\n\nRoot artifact",
       );
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("gsd_summary_save renders root REQUIREMENTS from DB rows, not provided markdown", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const requirementTool = server.tools.find((t) => t.name === "gsd_requirement_save");
+      const summaryTool = server.tools.find((t) => t.name === "gsd_summary_save");
+      assert.ok(requirementTool, "requirement tool should be registered");
+      assert.ok(summaryTool, "summary tool should be registered");
+
+      await requirementTool!.handler({
+        projectDir: base,
+        class: "primary-user-loop",
+        description: "MCP user can add a task",
+        why: "Core loop",
+        source: "user",
+        status: "active",
+        primary_owner: "M001/none yet",
+        supporting_slices: "none",
+        validation: "unmapped",
+      });
+
+      const result = await summaryTool!.handler({
+        projectDir: base,
+        artifact_type: "REQUIREMENTS",
+        content: "# Requirements\n\n## Active\n\n### R999 — Wrong markdown source\n\n- Description: This content must not become canonical.\n",
+      });
+
+      const text = (result as any).content[0].text as string;
+      assert.match(text, /Saved REQUIREMENTS artifact/);
+
+      const requirementsPath = join(base, ".gsd", "REQUIREMENTS.md");
+      const markdown = readFileSync(requirementsPath, "utf-8");
+      assert.match(markdown, /MCP user can add a task/);
+      assert.doesNotMatch(markdown, /R999|Wrong markdown source|This content must not become canonical/);
+
+      const row = _getAdapter()!
+        .prepare("SELECT id, description FROM requirements WHERE description = ?")
+        .get("MCP user can add a task") as Record<string, unknown> | undefined;
+      assert.ok(row, "requirement row should remain the canonical source");
+
+      const artifact = _getAdapter()!
+        .prepare("SELECT full_content FROM artifacts WHERE path = ?")
+        .get("REQUIREMENTS.md") as Record<string, unknown> | undefined;
+      assert.equal(artifact?.full_content, markdown);
     } finally {
       cleanup(base);
     }

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -82,10 +82,10 @@ describe("workflow MCP tools", () => {
     assert.deepEqual(
       _buildImportCandidates("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js"),
       [
-        "../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js",
         "../../../src/resources/extensions/gsd/tools/workflow-tool-executors.ts",
-        "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.js",
+        "../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js",
         "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.ts",
+        "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.js",
       ],
     );
   });
@@ -149,6 +149,27 @@ describe("workflow MCP tools", () => {
       assert.equal(
         readFileSync(join(base, ".gsd", "PROJECT.md"), "utf-8"),
         "# Project\n\nRoot artifact",
+      );
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("gsd_summary_save rejects milestone-scoped artifacts without milestone_id at schema parse", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_summary_save");
+      assert.ok(tool, "summary tool should be registered");
+
+      await assert.rejects(
+        () => tool!.handler({
+          projectDir: base,
+          artifact_type: "SUMMARY",
+          content: "# Summary\n",
+        }),
+        /milestone_id is required for milestone-scoped artifact types/,
       );
     } finally {
       cleanup(base);

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -428,6 +428,28 @@ function getSupportedSummaryArtifactTypes(executors: WorkflowToolExecutors): rea
   return executors.SUPPORTED_SUMMARY_ARTIFACT_TYPES;
 }
 
+function buildImportCandidates(relativePath: string): string[] {
+  const candidates: string[] = [relativePath];
+  const sourceTs = relativePath.endsWith(".js")
+    ? relativePath.replace(/\.js$/, ".ts")
+    : null;
+  if (sourceTs) candidates.push(sourceTs);
+
+  const swapped = relativePath.includes("/src/")
+    ? relativePath.replace("/src/", "/dist/")
+    : relativePath.includes("/dist/")
+      ? relativePath.replace("/dist/", "/src/")
+      : null;
+  if (swapped) {
+    candidates.push(swapped);
+    if (swapped.endsWith(".js")) {
+      candidates.push(swapped.replace(/\.js$/, ".ts"));
+    }
+  }
+
+  return [...new Set(candidates)];
+}
+
 function getWriteGateModuleCandidates(): string[] {
   const candidates: string[] = [];
   const explicitModule = process.env.GSD_WORKFLOW_WRITE_GATE_MODULE?.trim();
@@ -439,9 +461,8 @@ function getWriteGateModuleCandidates(): string[] {
   }
 
   candidates.push(
-    new URL("../../../src/resources/extensions/gsd/bootstrap/write-gate.js", import.meta.url).href,
-    new URL("../../../dist/resources/extensions/gsd/bootstrap/write-gate.js", import.meta.url).href,
-    new URL("../../../src/resources/extensions/gsd/bootstrap/write-gate.ts", import.meta.url).href,
+    ...buildImportCandidates("../../../src/resources/extensions/gsd/bootstrap/write-gate.js")
+      .map((p) => new URL(p, import.meta.url).href),
   );
 
   return [...new Set(candidates)];
@@ -453,22 +474,10 @@ function toFileUrl(modulePath: string): string {
 
 /** @internal — exported for testing only */
 export function _buildImportCandidates(relativePath: string): string[] {
-  // Build candidate paths: try the given path first, then swap src/<->dist/
-  // and try .ts extension. This handles both dev (tsx from src/) and prod
-  // (compiled from dist/) execution contexts.
-  const candidates: string[] = [relativePath];
-  const swapped = relativePath.includes("/src/")
-    ? relativePath.replace("/src/", "/dist/")
-    : relativePath.includes("/dist/")
-      ? relativePath.replace("/dist/", "/src/")
-      : null;
-  if (swapped) candidates.push(swapped);
-  // Also try .ts variants for dev-mode tsx execution
-  if (relativePath.endsWith(".js")) {
-    candidates.push(relativePath.replace(/\.js$/, ".ts"));
-    if (swapped) candidates.push(swapped.replace(/\.js$/, ".ts"));
-  }
-  return candidates;
+  // Build candidate paths: prefer source first, including the .ts source
+  // variant, before falling back to compiled dist. In source/dev execution a
+  // stale dist/resources tree must not silently override edited source files.
+  return buildImportCandidates(relativePath);
 }
 
 async function importLocalModule<T>(relativePath: string): Promise<T> {
@@ -497,9 +506,8 @@ function getWorkflowExecutorModuleCandidates(env: NodeJS.ProcessEnv = process.en
   }
 
   candidates.push(
-    new URL("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js", import.meta.url).href,
-    new URL("../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.js", import.meta.url).href,
-    new URL("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.ts", import.meta.url).href,
+    ...buildImportCandidates("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js")
+      .map((p) => new URL(p, import.meta.url).href),
   );
 
   return [...new Set(candidates)];

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -482,7 +482,10 @@ export function _buildImportCandidates(relativePath: string): string[] {
 }
 
 async function importLocalModule<T>(relativePath: string): Promise<T> {
-  const candidates = _buildImportCandidates(relativePath)
+  const rawCandidates = _buildImportCandidates(relativePath);
+  const candidates = (import.meta.url.includes("/dist-test/") || import.meta.url.includes("\\dist-test\\")
+    ? [...rawCandidates].sort((a, b) => Number(a.endsWith(".ts")) - Number(b.endsWith(".ts")))
+    : rawCandidates)
     .map((p) => new URL(p, import.meta.url).href);
 
   let lastErr: unknown;

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -1222,7 +1222,7 @@ const requirementUpdateSchema = z.object(requirementUpdateParams);
 
 const requirementSaveParams = {
   projectDir: projectDirParam,
-  class: z.string().describe("Requirement class"),
+  class: z.string().describe("Requirement class: core-capability, primary-user-loop, launchability, continuity, failure-visibility, integration, quality-attribute, operability, admin/support, compliance/security, differentiator, constraint, or anti-feature"),
   description: z.string().describe("Short description of the requirement"),
   why: z.string().describe("Why this requirement matters"),
   source: z.string().describe("Origin of the requirement"),

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -429,23 +429,24 @@ function getSupportedSummaryArtifactTypes(executors: WorkflowToolExecutors): rea
 }
 
 function buildImportCandidates(relativePath: string): string[] {
-  const candidates: string[] = [relativePath];
-  const sourceTs = relativePath.endsWith(".js")
-    ? relativePath.replace(/\.js$/, ".ts")
-    : null;
-  if (sourceTs) candidates.push(sourceTs);
+  const candidates: string[] = [];
+  const pushPreferredPair = (path: string | null) => {
+    if (!path) return;
+    if (path.endsWith(".js")) candidates.push(path.replace(/\.js$/, ".ts"));
+    candidates.push(path);
+  };
 
-  const swapped = relativePath.includes("/src/")
+  const sourcePath = relativePath.includes("/dist/")
+    ? relativePath.replace("/dist/", "/src/")
+    : relativePath;
+  const distPath = relativePath.includes("/src/")
     ? relativePath.replace("/src/", "/dist/")
     : relativePath.includes("/dist/")
-      ? relativePath.replace("/dist/", "/src/")
+      ? relativePath
       : null;
-  if (swapped) {
-    candidates.push(swapped);
-    if (swapped.endsWith(".js")) {
-      candidates.push(swapped.replace(/\.js$/, ".ts"));
-    }
-  }
+
+  pushPreferredPair(sourcePath);
+  pushPreferredPair(distPath);
 
   return [...new Set(candidates)];
 }
@@ -1202,7 +1203,22 @@ const summarySaveParams = {
   artifact_type: z.string().describe("Artifact type to save (SUMMARY, RESEARCH, CONTEXT, ASSESSMENT, CONTEXT-DRAFT, PROJECT, PROJECT-DRAFT, REQUIREMENTS, REQUIREMENTS-DRAFT)"),
   content: z.string().describe("The full markdown content of the artifact"),
 };
-const summarySaveSchema = z.object(summarySaveParams);
+const ROOT_SUMMARY_ARTIFACT_TYPES = new Set([
+  "PROJECT",
+  "PROJECT-DRAFT",
+  "REQUIREMENTS",
+  "REQUIREMENTS-DRAFT",
+]);
+const summarySaveSchema = z.object(summarySaveParams).superRefine((value, ctx) => {
+  const isRootArtifact = ROOT_SUMMARY_ARTIFACT_TYPES.has(value.artifact_type);
+  if (!isRootArtifact && (!value.milestone_id || value.milestone_id.trim() === "")) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["milestone_id"],
+      message: "milestone_id is required for milestone-scoped artifact types",
+    });
+  }
+});
 
 const decisionSaveParams = {
   projectDir: projectDirParam,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -144,7 +144,8 @@ const sourceLoaderPath = join(gsdRoot, 'src', 'loader.ts')
 const devCliPath = process.env.GSD_DEV_CLI_PATH?.trim() || join(gsdRoot, 'scripts', 'dev-cli.js')
 const explicitCliPath = process.env.GSD_CLI_PATH?.trim() || process.env.GSD_BIN_PATH?.trim()
 const isSourceLoader = invokedBinPath && resolve(invokedBinPath) === sourceLoaderPath
-const resolvedGsdBinPath = explicitCliPath || (isSourceLoader && existsSync(devCliPath) ? devCliPath : invokedBinPath)
+const rawGsdBinPath = explicitCliPath || (isSourceLoader && existsSync(devCliPath) ? devCliPath : invokedBinPath)
+const resolvedGsdBinPath = rawGsdBinPath ? resolve(rawGsdBinPath) : undefined
 process.env.GSD_BIN_PATH = resolvedGsdBinPath
 if (!process.env.GSD_CLI_PATH) {
   process.env.GSD_CLI_PATH = resolvedGsdBinPath

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -78,6 +78,7 @@ import {
   clearProjectResearchInflightMarker,
   finalizeProjectResearchTimeout,
 } from "./project-research-policy.js";
+import { validateArtifact } from "./schemas/validate.js";
 
 /** Maximum verification retry attempts before escalating to blocker placeholder (#2653). */
 const MAX_VERIFICATION_RETRIES = 3;
@@ -314,6 +315,38 @@ export const USER_DRIVEN_DEEP_UNITS = new Set([
   "research-decision",
 ]);
 export { isAwaitingUserInput } from "./user-input-boundary.js";
+
+function artifactValidationKind(unitType: string): "project" | "requirements" | null {
+  if (unitType === "discuss-project") return "project";
+  if (unitType === "discuss-requirements") return "requirements";
+  return null;
+}
+
+function describeArtifactVerificationFailure(unitType: string, unitId: string, basePath: string): string {
+  const artifactPath = resolveExpectedArtifactPath(unitType, unitId, basePath);
+  if (!artifactPath) {
+    return `Artifact verification failed: ${unitType} "${unitId}" has no resolvable artifact path.`;
+  }
+  const relPath = relative(basePath, artifactPath);
+  if (!existsSync(artifactPath)) {
+    return `Artifact verification failed: ${relPath} was not found on disk after unit execution.`;
+  }
+
+  const validationKind = artifactValidationKind(unitType);
+  if (validationKind) {
+    const result = validateArtifact(artifactPath, validationKind);
+    if (!result.ok) {
+      const errors = result.errors
+        .slice(0, MAX_NOTIFICATION_DETAILS)
+        .map((error) => `${error.code}: ${error.message}`)
+        .join("; ");
+      return `Artifact verification failed: ${relPath} exists but is invalid${errors ? ` (${errors})` : ""}.`;
+    }
+  }
+
+  const expected = diagnoseExpectedArtifact(unitType, unitId, basePath);
+  return `Artifact verification failed: ${relPath} exists but did not satisfy the ${unitType} completion contract${expected ? ` (${expected})` : ""}.`;
+}
 
 export async function autoCommitUnit(
   basePath: string,
@@ -1040,11 +1073,16 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         if (hasExpectedArtifact) {
           const retryKey = `${s.currentUnit.type}:${s.currentUnit.id}`;
           const attempt = (s.verificationRetryCount.get(retryKey) ?? 0) + 1;
+          const failureDetails = describeArtifactVerificationFailure(
+            s.currentUnit.type,
+            s.currentUnit.id,
+            s.basePath,
+          );
           if (attempt > MAX_ARTIFACT_VERIFICATION_RETRIES) {
             s.verificationRetryCount.delete(retryKey);
             debugLog("postUnit", { phase: "artifact-verify-exhausted", unitType: s.currentUnit.type, unitId: s.currentUnit.id, attempt });
             ctx.ui.notify(
-              `Artifact still missing for ${s.currentUnit.type} ${s.currentUnit.id} after ${MAX_ARTIFACT_VERIFICATION_RETRIES} retries — pausing auto-mode`,
+              `${failureDetails} Pausing auto-mode after ${MAX_ARTIFACT_VERIFICATION_RETRIES} retries.`,
               "error",
             );
             await pauseAuto(ctx, pi);
@@ -1053,12 +1091,12 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           s.verificationRetryCount.set(retryKey, attempt);
           s.pendingVerificationRetry = {
             unitId: s.currentUnit.id,
-            failureContext: `Artifact verification failed: expected artifact for ${s.currentUnit.type} "${s.currentUnit.id}" was not found on disk after unit execution (attempt ${attempt}/${MAX_ARTIFACT_VERIFICATION_RETRIES}).`,
+            failureContext: `${failureDetails} (attempt ${attempt}/${MAX_ARTIFACT_VERIFICATION_RETRIES}).`,
             attempt,
           };
           debugLog("postUnit", { phase: "artifact-verify-retry", unitType: s.currentUnit.type, unitId: s.currentUnit.id, attempt });
           ctx.ui.notify(
-            `Artifact missing for ${s.currentUnit.type} ${s.currentUnit.id} — retrying (attempt ${attempt}/${MAX_ARTIFACT_VERIFICATION_RETRIES})`,
+            `${failureDetails} Retrying (attempt ${attempt}/${MAX_ARTIFACT_VERIFICATION_RETRIES}).`,
             "warning",
           );
           return "retry";

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -105,8 +105,13 @@ export async function handleAgentEnd(
   // rejected" loop even though the files are on disk.
   clearPathCache();
 
-  if (await checkDeepProjectSetupAfterTurn(event, ctx, resolveAgentEndBasePath())) {
-    return;
+  try {
+    if (await checkDeepProjectSetupAfterTurn(event, ctx, resolveAgentEndBasePath())) {
+      return;
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logWarning("bootstrap", `checkDeepProjectSetupAfterTurn failed: ${message}`);
   }
 
   if (checkAutoStartAfterDiscuss()) {

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -275,7 +275,21 @@ export function registerDbTools(pi: ExtensionAPI): void {
       "The tool writes to the DB and regenerates .gsd/REQUIREMENTS.md automatically.",
     ],
     parameters: Type.Object({
-      class: Type.String({ description: "Requirement class: core-capability, primary-user-loop, launchability, continuity, failure-visibility, integration, quality-attribute, operability, admin/support, compliance/security, differentiator, constraint, or anti-feature" }),
+      class: StringEnum([
+        "core-capability",
+        "primary-user-loop",
+        "launchability",
+        "continuity",
+        "failure-visibility",
+        "integration",
+        "quality-attribute",
+        "operability",
+        "admin/support",
+        "compliance/security",
+        "differentiator",
+        "constraint",
+        "anti-feature",
+      ], { description: "Requirement class" }),
       description: Type.String({ description: "Short description of the requirement" }),
       why: Type.String({ description: "Why this requirement matters" }),
       source: Type.String({ description: "Origin of the requirement (e.g. 'user-research', 'design', 'M001')" }),
@@ -328,13 +342,22 @@ export function registerDbTools(pi: ExtensionAPI): void {
       "artifact_type must be one of: SUMMARY, RESEARCH, CONTEXT, ASSESSMENT, CONTEXT-DRAFT, PROJECT, PROJECT-DRAFT, REQUIREMENTS, REQUIREMENTS-DRAFT.",
       "Use CONTEXT-DRAFT for incremental draft persistence; use CONTEXT for the final milestone context after depth verification.",
     ],
-    parameters: Type.Object({
-      milestone_id: Type.Optional(Type.String({ description: "Milestone ID (e.g. M001). Omit only for PROJECT/PROJECT-DRAFT/REQUIREMENTS/REQUIREMENTS-DRAFT." })),
-      slice_id: Type.Optional(Type.String({ description: "Slice ID (e.g. S01)" })),
-      task_id: Type.Optional(Type.String({ description: "Task ID (e.g. T01)" })),
-      artifact_type: Type.String({ description: "One of: SUMMARY, RESEARCH, CONTEXT, ASSESSMENT, CONTEXT-DRAFT, PROJECT, PROJECT-DRAFT, REQUIREMENTS, REQUIREMENTS-DRAFT" }),
-      content: Type.String({ description: "The full markdown content of the artifact" }),
-    }),
+    parameters: Type.Union([
+      Type.Object({
+        milestone_id: Type.String({ description: "Milestone ID (e.g. M001)" }),
+        slice_id: Type.Optional(Type.String({ description: "Slice ID (e.g. S01)" })),
+        task_id: Type.Optional(Type.String({ description: "Task ID (e.g. T01)" })),
+        artifact_type: StringEnum(["SUMMARY", "RESEARCH", "CONTEXT", "ASSESSMENT", "CONTEXT-DRAFT"], { description: "Milestone-scoped artifact type" }),
+        content: Type.String({ description: "The full markdown content of the artifact" }),
+      }),
+      Type.Object({
+        milestone_id: Type.Optional(Type.String({ description: "Omit for root artifacts" })),
+        slice_id: Type.Optional(Type.String({ description: "Slice ID (e.g. S01)" })),
+        task_id: Type.Optional(Type.String({ description: "Task ID (e.g. T01)" })),
+        artifact_type: StringEnum(["PROJECT", "PROJECT-DRAFT", "REQUIREMENTS", "REQUIREMENTS-DRAFT"], { description: "Root artifact type" }),
+        content: Type.String({ description: "The full markdown content of the artifact" }),
+      }),
+    ]),
     execute: summarySaveExecute,
     renderCall(args: any, theme: any) {
       let text = theme.fg("toolTitle", theme.bold("summary_save "));

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -268,13 +268,14 @@ export function registerDbTools(pi: ExtensionAPI): void {
       "Requirement IDs are auto-assigned — never provide an ID manually.",
     promptSnippet: "Record a new GSD requirement to the database (auto-assigns ID, regenerates REQUIREMENTS.md)",
     promptGuidelines: [
-      "Use gsd_requirement_save when recording a new functional, non-functional, or operational requirement.",
+      "Use gsd_requirement_save when recording a new capability, quality attribute, constraint, or anti-feature requirement.",
+      "Use one of these classes: core-capability, primary-user-loop, launchability, continuity, failure-visibility, integration, quality-attribute, operability, admin/support, compliance/security, differentiator, constraint, anti-feature.",
       "Requirement IDs are auto-assigned (R001, R002, ...) — never guess or provide an ID.",
       "class, description, why, and source are required. All other fields are optional.",
       "The tool writes to the DB and regenerates .gsd/REQUIREMENTS.md automatically.",
     ],
     parameters: Type.Object({
-      class: Type.String({ description: "Requirement class (e.g. 'functional', 'non-functional', 'operational')" }),
+      class: Type.String({ description: "Requirement class: core-capability, primary-user-loop, launchability, continuity, failure-visibility, integration, quality-attribute, operability, admin/support, compliance/security, differentiator, constraint, or anti-feature" }),
       description: Type.String({ description: "Short description of the requirement" }),
       why: Type.String({ description: "Why this requirement matters" }),
       source: Type.String({ description: "Origin of the requirement (e.g. 'user-research', 'design', 'M001')" }),

--- a/src/resources/extensions/gsd/commands-bootstrap.ts
+++ b/src/resources/extensions/gsd/commands-bootstrap.ts
@@ -87,6 +87,12 @@ function getGsdArgumentCompletions(prefix: string) {
     ], "next");
   }
 
+  if ((parts[0] === "new-project" || parts[0] === "new-milestone") && parts.length <= 2) {
+    return filterStartsWith(partial, [
+      { cmd: "--deep", desc: "Enable deep planning mode (staged project-level discovery)" },
+    ], parts[0]);
+  }
+
   if (parts[0] === "mode" && parts.length <= 2) {
     return filterStartsWith(partial, [
       { cmd: "global", desc: "Edit global workflow mode" },

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -124,9 +124,9 @@ const STATUS_SECTION_MAP: Array<{ status: string; heading: string }> = [
 /**
  * Generate full REQUIREMENTS.md content from an array of Requirement objects.
  * Groups requirements by status into sections (## Active, ## Validated, etc.),
- * each containing ### RXXX — Description headings with bullet fields.
- * Only emits sections that have content. Appends Traceability table and
- * Coverage Summary at the bottom.
+ * each containing ### RXXX — Description headings with bullet fields. Empty
+ * status sections are emitted too because the deep-mode validator treats their
+ * presence as part of the canonical contract.
  */
 export function generateRequirementsMd(requirements: Requirement[]): string {
   const lines: string[] = [];
@@ -147,12 +147,10 @@ export function generateRequirementsMd(requirements: Requirement[]): string {
   // Emit sections in canonical order
   for (const { status, heading } of STATUS_SECTION_MAP) {
     const reqs = byStatus.get(status);
-    if (!reqs || reqs.length === 0) continue;
-
     lines.push(`## ${heading}`);
     lines.push('');
 
-    for (const r of reqs) {
+    for (const r of reqs ?? []) {
       lines.push(`### ${r.id} — ${r.description || 'Untitled'}`);
 
       // Emit bullet fields — only those with content
@@ -197,6 +195,42 @@ export function generateRequirementsMd(requirements: Requirement[]): string {
   lines.push(`- Unmapped active requirements: 0`);
 
   return lines.join('\n') + '\n';
+}
+
+function isRootCanonicalArtifact(opts: SaveArtifactOpts): boolean {
+  if (opts.milestone_id || opts.slice_id || opts.task_id) return false;
+  return (
+    opts.artifact_type === 'PROJECT' ||
+    opts.artifact_type === 'PROJECT-DRAFT' ||
+    opts.artifact_type === 'REQUIREMENTS' ||
+    opts.artifact_type === 'REQUIREMENTS-DRAFT'
+  );
+}
+
+function isFinalRequirementsArtifact(opts: SaveArtifactOpts): boolean {
+  return !opts.milestone_id &&
+    !opts.slice_id &&
+    !opts.task_id &&
+    opts.artifact_type === 'REQUIREMENTS' &&
+    opts.path === 'REQUIREMENTS.md';
+}
+
+async function parseFinalRequirementsForReconcile(opts: SaveArtifactOpts): Promise<Requirement[] | null> {
+  if (!isFinalRequirementsArtifact(opts)) return null;
+  const { parseRequirementsSections } = await import('./md-importer.js');
+  return parseRequirementsSections(opts.content);
+}
+
+async function replaceRequirementsTableFromArtifact(requirements: Requirement[]): Promise<void> {
+  const db = await import('./gsd-db.js');
+  db.transaction(() => {
+    const adapter = db._getAdapter();
+    if (!adapter) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+    adapter.prepare('DELETE FROM requirements').run();
+    for (const requirement of requirements) {
+      db.upsertRequirement(requirement);
+    }
+  });
 }
 
 // ─── Next Decision ID ─────────────────────────────────────────────────────
@@ -302,27 +336,39 @@ export async function saveRequirementToDb(
       const adapter = db._getAdapter();
       if (!adapter) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
 
+      const existingRow = adapter
+        .prepare(
+          `SELECT * FROM requirements
+           WHERE LOWER(TRIM(description)) = LOWER(TRIM(:description))
+             AND superseded_by IS NULL
+           ORDER BY id
+           LIMIT 1`,
+        )
+        .get({ ':description': fields.description });
+
       const row = adapter
         .prepare('SELECT MAX(CAST(SUBSTR(id, 2) AS INTEGER)) as max_num FROM requirements')
         .get();
       const maxNum = row ? (row['max_num'] as number | null) : null;
-      const nextId = (maxNum == null || isNaN(maxNum))
+      const nextId = existingRow
+        ? String(existingRow['id'])
+        : (maxNum == null || isNaN(maxNum))
         ? 'R001'
         : `R${String(maxNum + 1).padStart(3, '0')}`;
 
       const requirement: Requirement = {
         id: nextId,
-        class: fields.class,
-        status: fields.status ?? 'active',
+        class: fields.class || (existingRow?.['class'] as string | undefined) || '',
+        status: fields.status ?? (existingRow?.['status'] as string | undefined) ?? 'active',
         description: fields.description,
         why: fields.why,
         source: fields.source,
-        primary_owner: fields.primary_owner ?? '',
-        supporting_slices: fields.supporting_slices ?? '',
-        validation: fields.validation ?? '',
-        notes: fields.notes ?? '',
-        full_content: '',
-        superseded_by: null,
+        primary_owner: fields.primary_owner ?? (existingRow?.['primary_owner'] as string | undefined) ?? '',
+        supporting_slices: fields.supporting_slices ?? (existingRow?.['supporting_slices'] as string | undefined) ?? '',
+        validation: fields.validation ?? (existingRow?.['validation'] as string | undefined) ?? '',
+        notes: fields.notes ?? (existingRow?.['notes'] as string | undefined) ?? '',
+        full_content: (existingRow?.['full_content'] as string | undefined) ?? '',
+        superseded_by: (existingRow?.['superseded_by'] as string | null | undefined) ?? null,
       };
 
       db.upsertRequirement(requirement);
@@ -756,13 +802,17 @@ export async function saveArtifactToDb(
     if (!fullPath.startsWith(gsdDir)) {
       throw new GSDError(GSD_IO_ERROR, `saveArtifactToDb: path escapes .gsd/ directory: ${opts.path}`);
     }
+    const parsedRequirements = await parseFinalRequirementsForReconcile(opts);
 
     // Shrinkage guard: if the file already exists and the new content is
     // significantly smaller (<50%), preserve the richer file on disk and
-    // store its content in the DB instead of the abbreviated version.
+    // store its content in the DB instead of the abbreviated version. Root
+    // canonical artifacts are exempt: PROJECT/REQUIREMENTS saves are the user's
+    // explicit final contract, and cleanup/consolidation is often intentionally
+    // much smaller than a malformed accumulated file.
     let dbContent = opts.content;
     let skipDiskWrite = false;
-    if (existsSync(fullPath)) {
+    if (!isRootCanonicalArtifact(opts) && existsSync(fullPath)) {
       const existingSize = statSync(fullPath).size;
       const newSize = Buffer.byteLength(opts.content, 'utf-8');
       if (existingSize > 0 && newSize < existingSize * 0.5) {
@@ -790,6 +840,9 @@ export async function saveArtifactToDb(
         db.deleteArtifactByPath(opts.path);
         throw diskErr;
       }
+    }
+    if (parsedRequirements !== null) {
+      await replaceRequirementsTableFromArtifact(parsedRequirements);
     }
     // Invalidate file-read caches so deriveState() sees the updated markdown.
     // Do NOT clear the artifacts table — we just wrote to it intentionally.

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -304,9 +304,7 @@ export async function saveRequirementToDb(
     const db = await import('./gsd-db.js');
 
     // Atomic ID assignment + insert inside a transaction.
-    let createdNewRow = false;
-    let previousRequirement: Requirement | null = null;
-    const id = db.transaction(() => {
+    const txResult = db.transaction(() => {
       const adapter = db._getAdapter();
       if (!adapter) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
 
@@ -320,7 +318,7 @@ export async function saveRequirementToDb(
            LIMIT 1`,
         )
         .get({ ':description': fields.description });
-      previousRequirement = existingRow
+      const previousRow: Requirement | null = existingRow
         ? {
             id: existingRow['id'] as string,
             class: existingRow['class'] as string,
@@ -341,7 +339,6 @@ export async function saveRequirementToDb(
         .prepare('SELECT MAX(CAST(SUBSTR(id, 2) AS INTEGER)) as max_num FROM requirements')
         .get();
       const maxNum = row ? (row['max_num'] as number | null) : null;
-      createdNewRow = !existingRow;
       const nextId = existingRow
         ? String(existingRow['id'])
         : (maxNum == null || isNaN(maxNum))
@@ -364,8 +361,9 @@ export async function saveRequirementToDb(
       };
 
       db.upsertRequirement(requirement);
-      return nextId;
+      return { id: nextId, isNew: !existingRow, previousRow };
     });
+    const { id, isNew, previousRow } = txResult;
 
     // Fetch all requirements for full file regeneration
     const adapter = db._getAdapter();
@@ -396,10 +394,10 @@ export async function saveRequirementToDb(
     } catch (diskErr) {
       logError('manifest', 'disk write failed, rolling back DB row', { fn: 'saveRequirementToDb', error: String((diskErr as Error).message) });
       try {
-        if (createdNewRow) {
+        if (isNew) {
           db.deleteRequirementById(id);
-        } else if (previousRequirement) {
-          db.upsertRequirement(previousRequirement);
+        } else if (previousRow) {
+          db.upsertRequirement(previousRow);
         }
       } catch (rollbackErr) {
         logError('manifest', 'SPLIT BRAIN: disk write failed AND DB rollback failed — DB has orphaned row', { fn: 'saveRequirementToDb', id, error: String((rollbackErr as Error).message) });

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -304,6 +304,8 @@ export async function saveRequirementToDb(
     const db = await import('./gsd-db.js');
 
     // Atomic ID assignment + insert inside a transaction.
+    let createdNewRow = false;
+    let previousRequirement: Requirement | null = null;
     const id = db.transaction(() => {
       const adapter = db._getAdapter();
       if (!adapter) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
@@ -312,16 +314,34 @@ export async function saveRequirementToDb(
         .prepare(
           `SELECT * FROM requirements
            WHERE LOWER(TRIM(description)) = LOWER(TRIM(:description))
+             AND LOWER(COALESCE(status, 'active')) = 'active'
              AND superseded_by IS NULL
            ORDER BY id
            LIMIT 1`,
         )
         .get({ ':description': fields.description });
+      previousRequirement = existingRow
+        ? {
+            id: existingRow['id'] as string,
+            class: existingRow['class'] as string,
+            status: existingRow['status'] as string,
+            description: existingRow['description'] as string,
+            why: existingRow['why'] as string,
+            source: existingRow['source'] as string,
+            primary_owner: existingRow['primary_owner'] as string,
+            supporting_slices: existingRow['supporting_slices'] as string,
+            validation: existingRow['validation'] as string,
+            notes: existingRow['notes'] as string,
+            full_content: existingRow['full_content'] as string,
+            superseded_by: (existingRow['superseded_by'] as string) ?? null,
+          }
+        : null;
 
       const row = adapter
         .prepare('SELECT MAX(CAST(SUBSTR(id, 2) AS INTEGER)) as max_num FROM requirements')
         .get();
       const maxNum = row ? (row['max_num'] as number | null) : null;
+      createdNewRow = !existingRow;
       const nextId = existingRow
         ? String(existingRow['id'])
         : (maxNum == null || isNaN(maxNum))
@@ -376,7 +396,11 @@ export async function saveRequirementToDb(
     } catch (diskErr) {
       logError('manifest', 'disk write failed, rolling back DB row', { fn: 'saveRequirementToDb', error: String((diskErr as Error).message) });
       try {
-        db.deleteRequirementById(id);
+        if (createdNewRow) {
+          db.deleteRequirementById(id);
+        } else if (previousRequirement) {
+          db.upsertRequirement(previousRequirement);
+        }
       } catch (rollbackErr) {
         logError('manifest', 'SPLIT BRAIN: disk write failed AND DB rollback failed — DB has orphaned row', { fn: 'saveRequirementToDb', id, error: String((rollbackErr as Error).message) });
       }
@@ -774,17 +798,26 @@ export async function saveArtifactToDb(
     if (!fullPath.startsWith(gsdDir)) {
       throw new GSDError(GSD_IO_ERROR, `saveArtifactToDb: path escapes .gsd/ directory: ${opts.path}`);
     }
+    let contentToPersist = opts.content;
+    if (opts.artifact_type === 'REQUIREMENTS' && opts.path === 'REQUIREMENTS.md') {
+      const activeRequirements = db.getActiveRequirements();
+      if (activeRequirements.length === 0) {
+        throw new GSDError(GSD_STALE_STATE, 'saveArtifactToDb: REQUIREMENTS final save requires active DB-backed requirements');
+      }
+      contentToPersist = generateRequirementsMd(activeRequirements);
+    }
+
     // Shrinkage guard: if the file already exists and the new content is
     // significantly smaller (<50%), preserve the richer file on disk and
     // store its content in the DB instead of the abbreviated version. Root
     // canonical artifacts are exempt because their content is rendered from
     // canonical DB state, and cleanup/consolidation is often intentionally much
     // smaller than a malformed accumulated file.
-    let dbContent = opts.content;
+    let dbContent = contentToPersist;
     let skipDiskWrite = false;
     if (!isRootCanonicalArtifact(opts) && existsSync(fullPath)) {
       const existingSize = statSync(fullPath).size;
-      const newSize = Buffer.byteLength(opts.content, 'utf-8');
+      const newSize = Buffer.byteLength(contentToPersist, 'utf-8');
       if (existingSize > 0 && newSize < existingSize * 0.5) {
         logWarning('manifest', `new content (${newSize}B) is <50% of existing file (${existingSize}B), preserving disk file`, { fn: 'saveArtifactToDb', path: opts.path });
         dbContent = readFileSync(fullPath, 'utf-8');
@@ -804,7 +837,7 @@ export async function saveArtifactToDb(
     // Write the file to disk (only if we're not preserving a richer existing file)
     if (!skipDiskWrite) {
       try {
-        await saveFile(fullPath, opts.content);
+        await saveFile(fullPath, contentToPersist);
       } catch (diskErr) {
         logError('manifest', 'disk write failed, rolling back DB row', { fn: 'saveArtifactToDb', error: String((diskErr as Error).message) });
         db.deleteArtifactByPath(opts.path);

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -201,36 +201,8 @@ function isRootCanonicalArtifact(opts: SaveArtifactOpts): boolean {
   if (opts.milestone_id || opts.slice_id || opts.task_id) return false;
   return (
     opts.artifact_type === 'PROJECT' ||
-    opts.artifact_type === 'PROJECT-DRAFT' ||
-    opts.artifact_type === 'REQUIREMENTS' ||
-    opts.artifact_type === 'REQUIREMENTS-DRAFT'
+    opts.artifact_type === 'REQUIREMENTS'
   );
-}
-
-function isFinalRequirementsArtifact(opts: SaveArtifactOpts): boolean {
-  return !opts.milestone_id &&
-    !opts.slice_id &&
-    !opts.task_id &&
-    opts.artifact_type === 'REQUIREMENTS' &&
-    opts.path === 'REQUIREMENTS.md';
-}
-
-async function parseFinalRequirementsForReconcile(opts: SaveArtifactOpts): Promise<Requirement[] | null> {
-  if (!isFinalRequirementsArtifact(opts)) return null;
-  const { parseRequirementsSections } = await import('./md-importer.js');
-  return parseRequirementsSections(opts.content);
-}
-
-async function replaceRequirementsTableFromArtifact(requirements: Requirement[]): Promise<void> {
-  const db = await import('./gsd-db.js');
-  db.transaction(() => {
-    const adapter = db._getAdapter();
-    if (!adapter) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
-    adapter.prepare('DELETE FROM requirements').run();
-    for (const requirement of requirements) {
-      db.upsertRequirement(requirement);
-    }
-  });
 }
 
 // ─── Next Decision ID ─────────────────────────────────────────────────────
@@ -802,14 +774,12 @@ export async function saveArtifactToDb(
     if (!fullPath.startsWith(gsdDir)) {
       throw new GSDError(GSD_IO_ERROR, `saveArtifactToDb: path escapes .gsd/ directory: ${opts.path}`);
     }
-    const parsedRequirements = await parseFinalRequirementsForReconcile(opts);
-
     // Shrinkage guard: if the file already exists and the new content is
     // significantly smaller (<50%), preserve the richer file on disk and
     // store its content in the DB instead of the abbreviated version. Root
-    // canonical artifacts are exempt: PROJECT/REQUIREMENTS saves are the user's
-    // explicit final contract, and cleanup/consolidation is often intentionally
-    // much smaller than a malformed accumulated file.
+    // canonical artifacts are exempt because their content is rendered from
+    // canonical DB state, and cleanup/consolidation is often intentionally much
+    // smaller than a malformed accumulated file.
     let dbContent = opts.content;
     let skipDiskWrite = false;
     if (!isRootCanonicalArtifact(opts) && existsSync(fullPath)) {
@@ -840,9 +810,6 @@ export async function saveArtifactToDb(
         db.deleteArtifactByPath(opts.path);
         throw diskErr;
       }
-    }
-    if (parsedRequirements !== null) {
-      await replaceRequirementsTableFromArtifact(parsedRequirements);
     }
     // Invalidate file-read caches so deriveState() sees the updated markdown.
     // Do NOT clear the artifacts table — we just wrote to it intentionally.

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1304,7 +1304,7 @@ export function openDatabase(path: string): boolean {
     // node:sqlite loaded but failed to open this file — try better-sqlite3 as fallback.
     if (providerName === "node:sqlite") {
       try {
-        const mod = _require("better-sqlite3");
+        const mod = _require(BETTER_SQLITE3_PACKAGE);
         const Db = (mod && mod.default) ? mod.default : mod;
         if (typeof Db === "function") {
           rawDb = new Db(path);

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -62,7 +62,6 @@ import {
   formatPriorContextBrief,
 } from "./preparation.js";
 import { verifyExpectedArtifact } from "./auto-recovery.js";
-import { isAwaitingUserInput } from "./auto-post-unit.js";
 
 // ─── Re-exports (preserve public API for existing importers) ────────────────
 export {
@@ -329,7 +328,7 @@ export async function startDeepProjectSetupForeground(
 }
 
 export async function checkDeepProjectSetupAfterTurn(
-  event: { messages: any[] },
+  _event: { messages: any[] },
   ctx?: ExtensionContext,
   basePath?: string,
 ): Promise<boolean> {
@@ -339,7 +338,6 @@ export async function checkDeepProjectSetupAfterTurn(
   if (entry.currentUnitType && entry.currentUnitId) {
     const artifactReady = verifyExpectedArtifact(entry.currentUnitType, entry.currentUnitId, entry.basePath);
     if (!artifactReady) {
-      if (isAwaitingUserInput(event.messages)) return true;
       return false;
     }
   }

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -339,7 +339,7 @@ export async function checkDeepProjectSetupAfterTurn(
   if (entry.currentUnitType && entry.currentUnitId) {
     const artifactReady = verifyExpectedArtifact(entry.currentUnitType, entry.currentUnitId, entry.basePath);
     if (!artifactReady) {
-      if (isAwaitingUserInput(event.messages)) return false;
+      if (isAwaitingUserInput(event.messages)) return true;
       return false;
     }
   }

--- a/src/resources/extensions/gsd/prompts/guided-discuss-project.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-project.md
@@ -52,7 +52,7 @@ Ask **1–3 questions per round**. Each round targets one of:
 
 **Plain-text default:** Project discovery is open-ended. Ask question rounds in plain text unless you are presenting 2–3 concrete alternatives with clear tradeoffs.
 
-**If `{{structuredQuestionsAvailable}}` is `true` and you use `ask_user_questions`:** ask 1–3 questions per call. Every question object MUST include a stable lowercase `id`. Keep option labels short (3–5 words). Always include a freeform "Other / let me explain" option. Wait for each tool result before asking the next round.
+**If `{{structuredQuestionsAvailable}}` is `true` and you use `ask_user_questions`:** ask 1–3 questions per call. Every question object MUST include a stable lowercase `id`. Keep option labels short (3–5 words). Do not add a separate "Other" option; the question UI provides a freeform path automatically. Wait for each tool result before asking the next round.
 
 **If `{{structuredQuestionsAvailable}}` is `false`:** ask questions in plain text. Keep each round to 1–3 focused questions.
 
@@ -116,7 +116,7 @@ If they clarify, absorb the correction and re-verify.
 
 The depth verification is the only required confirmation gate. Do not add a second "ready to proceed?" gate after it.
 
-**CRITICAL — Non-bypassable gate:** The system mechanically blocks PROJECT.md writes until the user selects the "(Recommended)" option (structured path) or explicitly confirms (plain-text path). If the user declines, cancels, does not respond, or the tool fails, you MUST re-ask — never rationalize past the block.
+**CRITICAL — Confirmation gate:** Do not write final PROJECT.md until the user selects the "(Recommended)" option (structured path) or explicitly confirms (plain-text path). If the user declines, cancels, does not respond, or the tool fails, you MUST re-ask — never rationalize past the block.
 
 ---
 

--- a/src/resources/extensions/gsd/prompts/guided-discuss-requirements.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-requirements.md
@@ -104,7 +104,7 @@ Before the wrap-up gate, verify:
 
 If they adjust, absorb and re-verify.
 
-**CRITICAL — Non-bypassable gate:** The system blocks REQUIREMENTS.md writes until explicit confirmation. Never rationalize past it.
+**CRITICAL — Confirmation gate:** Do not write final REQUIREMENTS.md until explicit confirmation. Never rationalize past it.
 
 ---
 

--- a/src/resources/extensions/gsd/prompts/guided-discuss-requirements.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-requirements.md
@@ -114,7 +114,7 @@ Once the user confirms:
 
 1. Use the **Requirements** output template (inlined above) to render the final markdown in working memory.
 2. Every entry must conform to the `R###` format with all listed fields. Use `gsd_requirement_save` (NOT plain file edit) for each requirement so DB state is saved first.
-3. After all `gsd_requirement_save` calls complete, call `gsd_summary_save` with `artifact_type: "REQUIREMENTS"` and the full rendered markdown as `content`; omit `milestone_id`. This writes `.gsd/REQUIREMENTS.md` and persists the final requirements artifact.
+3. After all `gsd_requirement_save` calls complete, call `gsd_summary_save` with `artifact_type: "REQUIREMENTS"`; omit `milestone_id`. The requirements table is the source of truth, and this tool renders `.gsd/REQUIREMENTS.md` from DB state. Pass the rendered markdown as `content` for audit context only; do not rely on markdown to update DB rows.
 4. The file MUST contain all required sections: `## Active`, `## Validated`, `## Deferred`, `## Out of Scope`, `## Traceability`, `## Coverage Summary`. Empty sections are OK; missing sections are not.
 5. Print the final coverage summary in chat: `Active: N | Validated: N | Deferred: N | Out of Scope: N | Mapped to slices: N | Unmapped active: N`.
 6. Do NOT use `artifact_type: "CONTEXT"` and do NOT pass `milestone_id: "REQUIREMENTS"`; that creates a fake milestone instead of `.gsd/REQUIREMENTS.md`.

--- a/src/resources/extensions/gsd/prompts/guided-research-project.md
+++ b/src/resources/extensions/gsd/prompts/guided-research-project.md
@@ -36,7 +36,7 @@ Each task gets its own focused prompt. Each task writes one file.
 
 Prompt:
 
-> Research the standard stack for [domain] in 2026. Identify the dominant libraries, frameworks, runtimes, and infrastructure tools used by [domain] products. For each: current stable version, primary alternatives, why teams pick it, when to avoid it.
+> Research the standard stack for [domain] as of today. Identify the dominant libraries, frameworks, runtimes, and infrastructure tools used by [domain] products. For each: current stable version, primary alternatives, why teams pick it, when to avoid it.
 >
 > Constraints from PROJECT.md: [list any tech constraints / required frameworks the user already specified].
 >

--- a/src/resources/extensions/gsd/prompts/guided-workflow-preferences.md
+++ b/src/resources/extensions/gsd/prompts/guided-workflow-preferences.md
@@ -24,7 +24,7 @@ Use these recommended defaults without asking:
 - `branch_model: single` — all work on current branch
 - `uat_dispatch: true` — verification runs automatically; failures pause execution
 - `models.executor_class: balanced` — sensible cost/quality default
-- `research: skip` — skip project research by default; users can explicitly opt into research later
+- `research: skip` — deterministic default; the dedicated research-decision stage can later switch to `research`
 
 ---
 
@@ -37,6 +37,7 @@ Apply the defaults:
    - top-level `commit_policy: per-task`
    - top-level `branch_model: single`
    - top-level `uat_dispatch: true`
+   - top-level `research: skip`
    - nested `models.executor_class: balanced`
 3. Also set top-level `workflow_prefs_captured: true` — this is the single explicit marker the dispatch layer uses to know the wizard has run.
 4. Write `{{workingDirectory}}/.gsd/PREFERENCES.md` back with the merged frontmatter and the original body preserved unchanged. Frontmatter delimiters are exactly `---` on their own lines.
@@ -52,7 +53,7 @@ Apply the defaults:
      }
      ```
    Use `"skip"` unless an existing valid `{{workingDirectory}}/.gsd/runtime/research-decision.json` explicitly says `"research"` with `"source": "research-decision"` or `"source": "user"`.
-6. Print a concise summary in chat: each key on its own line, format `key: value`. Include `commit_policy`, `branch_model`, `uat_dispatch`, `models.executor_class`, and `research` (`research: skip` unless preserving an explicit user research decision).
+6. Print a concise summary in chat: each key on its own line, format `key: value`. Include `commit_policy`, `branch_model`, `uat_dispatch`, `models.executor_class`, and `research` (matching the preserved or pre-seeded runtime research decision).
 7. Say exactly: `"Workflow preferences saved."` — nothing else.
 
 Do NOT write to `.gsd/config.json`; runtime preferences load from `PREFERENCES.md`.

--- a/src/resources/extensions/gsd/schemas/validate.ts
+++ b/src/resources/extensions/gsd/schemas/validate.ts
@@ -296,7 +296,7 @@ function validateRequirementShape(r: ParsedRequirement, errors: ValidationError[
 
 // ─── ROADMAP.md ─────────────────────────────────────────────────────────
 
-function validateRoadmapContent(content: string, requirementsContent: string | null): ValidationResult {
+function validateRoadmapContent(content: string, requirementsContent: string | null, currentMilestoneId: string | null = null): ValidationResult {
   const errors: ValidationError[] = [];
   const warnings: ValidationError[] = [];
   const parsed = parseRoadmap(content);
@@ -374,8 +374,8 @@ function validateRoadmapContent(content: string, requirementsContent: string | n
     for (const s of parsed.slices) {
       const ownsAnyRequirement = reqs.requirements.some(r => {
         if (r.parentSection !== "Active") return false;
-        const m = r.primaryOwner.match(/^M\d{3}\/(S\d{2})$/);
-        return m && m[1] === s.id;
+        const m = r.primaryOwner.match(/^(M\d{3})\/(S\d{2})$/);
+        return m && m[1] === currentMilestoneId && m[2] === s.id;
       });
       if (!ownsAnyRequirement) {
         warnings.push(err("orphan-slice", `Slice ${s.id} owns no Active requirements`, s.id));
@@ -439,6 +439,10 @@ export function validateArtifact(
       return validateRequirementsContent(content, projectContent, roadmapsByMilestone);
     }
     case "roadmap":
-      return validateRoadmapContent(content, opts.crossRefs?.requirementsPath ? loadFile(opts.crossRefs.requirementsPath) : null);
+      return validateRoadmapContent(
+        content,
+        opts.crossRefs?.requirementsPath ? loadFile(opts.crossRefs.requirementsPath) : null,
+        filePath.match(/(?:^|[\\/])(M\d{3})(?:[\\/]|-)/)?.[1] ?? null,
+      );
   }
 }

--- a/src/resources/extensions/gsd/schemas/validate.ts
+++ b/src/resources/extensions/gsd/schemas/validate.ts
@@ -24,6 +24,8 @@ export interface ValidationResult {
 }
 
 export interface ValidateOptions {
+  /** Milestone ID (for example "M001") for the roadmap being validated. */
+  milestoneId?: string;
   crossRefs?: {
     projectPath?: string;
     requirementsPath?: string;
@@ -375,7 +377,9 @@ function validateRoadmapContent(content: string, requirementsContent: string | n
       const ownsAnyRequirement = reqs.requirements.some(r => {
         if (r.parentSection !== "Active") return false;
         const m = r.primaryOwner.match(/^(M\d{3})\/(S\d{2})$/);
-        return m && m[1] === currentMilestoneId && m[2] === s.id;
+        if (!m) return false;
+        if (currentMilestoneId !== null && m[1] !== currentMilestoneId) return false;
+        return m[2] === s.id;
       });
       if (!ownsAnyRequirement) {
         warnings.push(err("orphan-slice", `Slice ${s.id} owns no Active requirements`, s.id));
@@ -442,7 +446,7 @@ export function validateArtifact(
       return validateRoadmapContent(
         content,
         opts.crossRefs?.requirementsPath ? loadFile(opts.crossRefs.requirementsPath) : null,
-        filePath.match(/(?:^|[\\/])(M\d{3})(?:[\\/]|-)/)?.[1] ?? null,
+        opts.milestoneId ?? filePath.match(/(?:^|[\\/])(M\d{3})(?:[\\/]|-)/)?.[1] ?? null,
       );
   }
 }

--- a/src/resources/extensions/gsd/tests/db-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/db-writer.test.ts
@@ -22,6 +22,7 @@ import {
   generateRequirementsMd,
   nextDecisionId,
   saveDecisionToDb,
+  saveRequirementToDb,
   updateRequirementInDb,
   saveArtifactToDb,
   extractDeferredSliceRef,
@@ -244,20 +245,24 @@ describe('db-writer', () => {
     assert.ok(md.includes('## Coverage Summary'), 'has Coverage Summary section');
   });
 
-  test('generateRequirementsMd only populated sections', () => {
-    // Only active requirements — should only have Active section
+  test('generateRequirementsMd emits empty required sections', () => {
+    // Only active requirements, but deep-mode validation requires all sections.
     const activeOnly = SAMPLE_REQUIREMENTS.filter(r => r.status === 'active');
     const md = generateRequirementsMd(activeOnly);
     assert.ok(md.includes('## Active'), 'has Active section');
-    assert.ok(!md.includes('## Validated'), 'no Validated section when no validated reqs');
-    assert.ok(!md.includes('## Deferred'), 'no Deferred section when no deferred reqs');
-    assert.ok(!md.includes('## Out of Scope'), 'no Out of Scope section when no out-of-scope reqs');
+    assert.ok(md.includes('## Validated'), 'has empty Validated section');
+    assert.ok(md.includes('## Deferred'), 'has empty Deferred section');
+    assert.ok(md.includes('## Out of Scope'), 'has empty Out of Scope section');
   });
 
   test('generateRequirementsMd empty input', () => {
     const md = generateRequirementsMd([]);
     const parsed = parseRequirementsSections(md);
     assert.deepStrictEqual(parsed.length, 0, 'empty requirements produces empty parse');
+    assert.ok(md.includes('## Active'), 'empty requirements still has Active section');
+    assert.ok(md.includes('## Validated'), 'empty requirements still has Validated section');
+    assert.ok(md.includes('## Deferred'), 'empty requirements still has Deferred section');
+    assert.ok(md.includes('## Out of Scope'), 'empty requirements still has Out of Scope section');
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -541,6 +546,49 @@ describe('db-writer', () => {
     }
   });
 
+  test('saveRequirementToDb is idempotent for repeated descriptions', async () => {
+    const tmpDir = makeTmpDir();
+    const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+    openDatabase(dbPath);
+
+    try {
+      const first = await saveRequirementToDb({
+        class: 'primary-user-loop',
+        status: 'active',
+        description: 'User can add a task by pressing Enter',
+        why: 'Core capture loop',
+        source: 'user',
+        primary_owner: 'M001/none yet',
+        supporting_slices: 'none',
+        validation: 'unmapped',
+      }, tmpDir);
+      const retry = await saveRequirementToDb({
+        class: 'primary-user-loop',
+        status: 'active',
+        description: 'User can add a task by pressing Enter',
+        why: 'Core capture loop, restated on retry',
+        source: 'user',
+        primary_owner: 'M001/S01',
+        supporting_slices: 'none',
+        validation: 'mapped',
+      }, tmpDir);
+
+      assert.deepStrictEqual(retry.id, first.id, 'retry save reuses existing requirement ID');
+
+      const adapter = _getAdapter();
+      const rows = adapter!
+        .prepare('SELECT id, description, primary_owner, validation FROM requirements ORDER BY id')
+        .all() as Array<Record<string, unknown>>;
+      assert.deepStrictEqual(rows.length, 1, 'semantic duplicate does not create a new row');
+      assert.deepStrictEqual(rows[0]['id'], 'R001');
+      assert.deepStrictEqual(rows[0]['primary_owner'], 'M001/S01', 'retry updates the existing row');
+      assert.deepStrictEqual(rows[0]['validation'], 'mapped', 'retry updates validation');
+    } finally {
+      closeDatabase();
+      cleanupDir(tmpDir);
+    }
+  });
+
   // ═══════════════════════════════════════════════════════════════════════════
   // saveArtifactToDb Tests
   // ═══════════════════════════════════════════════════════════════════════════
@@ -624,6 +672,132 @@ describe('db-writer', () => {
         row!['full_content'],
         fullContent,
         'DB stores the richer disk content instead of abbreviated content',
+      );
+    } finally {
+      closeDatabase();
+      cleanupDir(tmpDir);
+    }
+  });
+
+  test('saveArtifactToDb — final REQUIREMENTS overwrites smaller canonical content and reconciles DB', async () => {
+    const tmpDir = makeTmpDir();
+    const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+    openDatabase(dbPath);
+
+    try {
+      upsertRequirement({
+        id: 'R999',
+        class: 'primary-user-loop',
+        status: 'active',
+        description: 'Stale duplicate requirement',
+        why: 'Old retry state',
+        source: 'test',
+        primary_owner: 'M001/none yet',
+        supporting_slices: 'none',
+        validation: 'unmapped',
+        notes: '',
+        full_content: '',
+        superseded_by: null,
+      });
+
+      const relPath = 'REQUIREMENTS.md';
+      const filePath = path.join(tmpDir, '.gsd', relPath);
+      const bloatedInvalidContent = [
+        '# Requirements',
+        '',
+        '## Active',
+        '',
+        ...Array.from({ length: 30 }, (_, i) => [
+          `### R${String(i + 1).padStart(3, '0')} — Duplicate`,
+          '- Class: primary-user-loop',
+          '- Status: active',
+          '- Description: Duplicate retry row',
+          '- Why it matters: Retry drift',
+          '- Source: test',
+          '- Primary owning slice: M001/none yet',
+          '- Supporting slices: none',
+          '- Validation: unmapped',
+          '- Notes:',
+          '',
+        ].join('\n')),
+        '## Traceability',
+        '',
+        '## Coverage Summary',
+        '',
+      ].join('\n');
+      fs.writeFileSync(filePath, bloatedInvalidContent);
+
+      const canonicalContent = [
+        '# Requirements',
+        '',
+        '## Active',
+        '',
+        '### R001 — Add task',
+        '- Class: primary-user-loop',
+        '- Status: active',
+        '- Description: User can add a task',
+        '- Why it matters: Core loop',
+        '- Source: user',
+        '- Primary owning slice: M001/none yet',
+        '- Supporting slices: none',
+        '- Validation: unmapped',
+        '- Notes: canonical',
+        '',
+        '## Validated',
+        '',
+        '## Deferred',
+        '',
+        '## Out of Scope',
+        '',
+        '## Traceability',
+        '',
+        '| ID | Class | Status | Primary owner | Supporting | Proof |',
+        '|---|---|---|---|---|---|',
+        '| R001 | primary-user-loop | active | M001/none yet | none | unmapped |',
+        '',
+        '## Coverage Summary',
+        '',
+        '- Active requirements: 1',
+        '- Mapped to slices: 0',
+        '- Validated: 0',
+        '- Unmapped active requirements: 1',
+        '',
+      ].join('\n');
+
+      assert.ok(
+        Buffer.byteLength(canonicalContent, 'utf-8') < Buffer.byteLength(bloatedInvalidContent, 'utf-8') * 0.5,
+        'test setup: canonical content is small enough that the generic shrinkage guard would trigger',
+      );
+
+      await saveArtifactToDb({
+        path: relPath,
+        artifact_type: 'REQUIREMENTS',
+        content: canonicalContent,
+      }, tmpDir);
+
+      assert.deepStrictEqual(
+        fs.readFileSync(filePath, 'utf-8'),
+        canonicalContent,
+        'final REQUIREMENTS save overwrites bloated existing file',
+      );
+
+      const adapter = _getAdapter();
+      const reqRows = adapter!
+        .prepare('SELECT id, description FROM requirements ORDER BY id')
+        .all() as Array<Record<string, unknown>>;
+      assert.deepStrictEqual(
+        reqRows.map((row) => [row['id'], row['description']]),
+        [['R001', 'User can add a task']],
+        'requirements table is reconciled to the canonical artifact',
+      );
+
+      const artifact = adapter!
+        .prepare('SELECT full_content FROM artifacts WHERE path = ?')
+        .get(relPath) as Record<string, unknown>;
+      assert.deepStrictEqual(
+        artifact['full_content'],
+        canonicalContent,
+        'artifact row stores canonical content',
       );
     } finally {
       closeDatabase();

--- a/src/resources/extensions/gsd/tests/db-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/db-writer.test.ts
@@ -565,7 +565,7 @@ describe('db-writer', () => {
       const retry = await saveRequirementToDb({
         class: 'primary-user-loop',
         status: 'active',
-        description: 'User can add a task by pressing Enter',
+        description: '  user CAN add a task by pressing Enter  ',
         why: 'Core capture loop, restated on retry',
         source: 'user',
         primary_owner: 'M001/S01',
@@ -679,26 +679,27 @@ describe('db-writer', () => {
     }
   });
 
-  test('saveArtifactToDb — final REQUIREMENTS overwrites smaller projection without reconciling DB rows', async () => {
+  test('saveArtifactToDb — final REQUIREMENTS renders from canonical DB rows', async () => {
     const tmpDir = makeTmpDir();
     const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
     openDatabase(dbPath);
 
     try {
-      upsertRequirement({
-        id: 'R999',
+      const canonicalRequirement: Requirement = {
+        id: 'R001',
         class: 'primary-user-loop',
         status: 'active',
-        description: 'Stale duplicate requirement',
-        why: 'Old retry state',
-        source: 'test',
+        description: 'User can add a task',
+        why: 'Core loop',
+        source: 'user',
         primary_owner: 'M001/none yet',
         supporting_slices: 'none',
         validation: 'unmapped',
-        notes: '',
+        notes: 'canonical',
         full_content: '',
         superseded_by: null,
-      });
+      };
+      upsertRequirement(canonicalRequirement);
 
       const relPath = 'REQUIREMENTS.md';
       const filePath = path.join(tmpDir, '.gsd', relPath);
@@ -727,42 +728,7 @@ describe('db-writer', () => {
       ].join('\n');
       fs.writeFileSync(filePath, bloatedInvalidContent);
 
-      const canonicalContent = [
-        '# Requirements',
-        '',
-        '## Active',
-        '',
-        '### R001 — Add task',
-        '- Class: primary-user-loop',
-        '- Status: active',
-        '- Description: User can add a task',
-        '- Why it matters: Core loop',
-        '- Source: user',
-        '- Primary owning slice: M001/none yet',
-        '- Supporting slices: none',
-        '- Validation: unmapped',
-        '- Notes: canonical',
-        '',
-        '## Validated',
-        '',
-        '## Deferred',
-        '',
-        '## Out of Scope',
-        '',
-        '## Traceability',
-        '',
-        '| ID | Class | Status | Primary owner | Supporting | Proof |',
-        '|---|---|---|---|---|---|',
-        '| R001 | primary-user-loop | active | M001/none yet | none | unmapped |',
-        '',
-        '## Coverage Summary',
-        '',
-        '- Active requirements: 1',
-        '- Mapped to slices: 0',
-        '- Validated: 0',
-        '- Unmapped active requirements: 1',
-        '',
-      ].join('\n');
+      const canonicalContent = generateRequirementsMd([canonicalRequirement]);
 
       assert.ok(
         Buffer.byteLength(canonicalContent, 'utf-8') < Buffer.byteLength(bloatedInvalidContent, 'utf-8') * 0.5,
@@ -772,7 +738,7 @@ describe('db-writer', () => {
       await saveArtifactToDb({
         path: relPath,
         artifact_type: 'REQUIREMENTS',
-        content: canonicalContent,
+        content: '# Requirements\n\n## Active\n\n### R999 — Wrong markdown source\n\n- Description: This input must not become canonical.\n',
       }, tmpDir);
 
       assert.deepStrictEqual(
@@ -787,7 +753,7 @@ describe('db-writer', () => {
         .all() as Array<Record<string, unknown>>;
       assert.deepStrictEqual(
         reqRows.map((row) => [row['id'], row['description']]),
-        [['R999', 'Stale duplicate requirement']],
+        [['R001', 'User can add a task']],
         'artifact save does not parse markdown back into the requirements table',
       );
 

--- a/src/resources/extensions/gsd/tests/db-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/db-writer.test.ts
@@ -679,7 +679,7 @@ describe('db-writer', () => {
     }
   });
 
-  test('saveArtifactToDb — final REQUIREMENTS renders from canonical DB rows', async () => {
+  test('saveArtifactToDb — final REQUIREMENTS renders from DB rows, ignoring caller-supplied markdown', async () => {
     const tmpDir = makeTmpDir();
     const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
     openDatabase(dbPath);
@@ -728,23 +728,25 @@ describe('db-writer', () => {
       ].join('\n');
       fs.writeFileSync(filePath, bloatedInvalidContent);
 
-      const canonicalContent = generateRequirementsMd([canonicalRequirement]);
-
       assert.ok(
-        Buffer.byteLength(canonicalContent, 'utf-8') < Buffer.byteLength(bloatedInvalidContent, 'utf-8') * 0.5,
-        'test setup: canonical content is small enough that the generic shrinkage guard would trigger',
+        Buffer.byteLength(generateRequirementsMd([canonicalRequirement]), 'utf-8') < Buffer.byteLength(bloatedInvalidContent, 'utf-8') * 0.5,
+        'test setup: DB-rendered content is small enough that the generic shrinkage guard would trigger',
       );
 
       await saveArtifactToDb({
         path: relPath,
         artifact_type: 'REQUIREMENTS',
-        content: '# Requirements\n\n## Active\n\n### R999 — Wrong markdown source\n\n- Description: This input must not become canonical.\n',
+        content: bloatedInvalidContent,
       }, tmpDir);
 
-      assert.deepStrictEqual(
-        fs.readFileSync(filePath, 'utf-8'),
-        canonicalContent,
-        'final REQUIREMENTS save overwrites bloated existing file',
+      const writtenContent = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(
+        writtenContent.includes('R001') && writtenContent.includes('User can add a task'),
+        'disk file contains DB-sourced R001 requirement',
+      );
+      assert.ok(
+        !writtenContent.includes('Duplicate retry row'),
+        'disk file does not contain caller-supplied bloated content',
       );
 
       const adapter = _getAdapter();
@@ -760,10 +762,14 @@ describe('db-writer', () => {
       const artifact = adapter!
         .prepare('SELECT full_content FROM artifacts WHERE path = ?')
         .get(relPath) as Record<string, unknown>;
-      assert.deepStrictEqual(
-        artifact['full_content'],
-        canonicalContent,
-        'artifact row stores canonical content',
+      const storedContent = artifact['full_content'] as string;
+      assert.ok(
+        storedContent.includes('R001') && storedContent.includes('User can add a task'),
+        'artifacts.full_content is DB-rendered output containing R001',
+      );
+      assert.ok(
+        !storedContent.includes('Duplicate retry row'),
+        'artifacts.full_content does not echo caller-supplied markdown payload',
       );
     } finally {
       closeDatabase();

--- a/src/resources/extensions/gsd/tests/db-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/db-writer.test.ts
@@ -679,7 +679,7 @@ describe('db-writer', () => {
     }
   });
 
-  test('saveArtifactToDb — final REQUIREMENTS overwrites smaller canonical content and reconciles DB', async () => {
+  test('saveArtifactToDb — final REQUIREMENTS overwrites smaller projection without reconciling DB rows', async () => {
     const tmpDir = makeTmpDir();
     const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
     openDatabase(dbPath);
@@ -787,8 +787,8 @@ describe('db-writer', () => {
         .all() as Array<Record<string, unknown>>;
       assert.deepStrictEqual(
         reqRows.map((row) => [row['id'], row['description']]),
-        [['R001', 'User can add a task']],
-        'requirements table is reconciled to the canonical artifact',
+        [['R999', 'Stale duplicate requirement']],
+        'artifact save does not parse markdown back into the requirements table',
       );
 
       const artifact = adapter!

--- a/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
@@ -1229,6 +1229,18 @@ test("deep project setup: user question does not masquerade as assistant input w
   );
 });
 
+test("deep project setup: user-quoted remote question failure does not pause auto-mode", () => {
+  const messages = [
+    {
+      role: "user",
+      content: "The log said: Remote questions failed (discord): Discord API HTTP 401",
+    },
+  ];
+
+  assert.equal(isAwaitingUserInput(messages), false);
+  assert.equal(shouldPauseForUserApprovalQuestion("discuss-project", messages), false);
+});
+
 test("deep project setup: plain-text approval wait is treated as waiting for user input", () => {
   assert.equal(
     isAwaitingUserInput([

--- a/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
@@ -1217,6 +1217,18 @@ test("deep project setup: remote question failure is treated as waiting for user
   );
 });
 
+test("deep project setup: user question does not masquerade as assistant input wait", () => {
+  assert.equal(
+    isAwaitingUserInput([
+      {
+        role: "user",
+        content: "Should we proceed?",
+      },
+    ]),
+    false,
+  );
+});
+
 test("deep project setup: plain-text approval wait is treated as waiting for user input", () => {
   assert.equal(
     isAwaitingUserInput([

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -899,8 +899,8 @@ test("executeSummarySave rejects final REQUIREMENTS when the DB source is empty"
     }, base));
 
     assert.equal(result.isError, true);
-    assert.equal(result.details.error, "requirements_table_empty");
-    assert.match(result.content[0].text, /requires active DB-backed requirements/);
+    assert.equal(result.details.error, "no_active_requirements");
+    assert.match(result.content[0].text, /no active requirements found/);
   } finally {
     closeDatabase();
     cleanup(base);

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -696,6 +696,21 @@ test("executeSummarySave supports root-level deep planning artifacts", async () 
     assert.equal(project.details.path, "PROJECT.md");
     assert.ok(existsSync(join(base, ".gsd", "PROJECT.md")));
 
+    upsertRequirement({
+      id: "R001",
+      class: "primary-user-loop",
+      status: "active",
+      description: "User can add a task",
+      why: "Core loop",
+      source: "user",
+      primary_owner: "M001/none yet",
+      supporting_slices: "none",
+      validation: "unmapped",
+      notes: "",
+      full_content: "",
+      superseded_by: null,
+    });
+
     const requirements = await inProjectDir(base, () => executeSummarySave({
       artifact_type: "REQUIREMENTS",
       content: "# Requirements\n\n## Active\n\n## Validated\n\n## Deferred\n\n## Out of Scope\n\n## Traceability\n\n## Coverage Summary\n",
@@ -868,6 +883,25 @@ test("executeSummarySave renders final REQUIREMENTS from the DB source of truth"
     assert.equal(artifact.full_content, content);
   } finally {
     clearDiscussionFlowState();
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeSummarySave rejects final REQUIREMENTS when the DB source is empty", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+
+    const result = await inProjectDir(base, () => executeSummarySave({
+      artifact_type: "REQUIREMENTS",
+      content: "# Requirements\n\n## Active\n\n",
+    }, base));
+
+    assert.equal(result.isError, true);
+    assert.equal(result.details.error, "requirements_table_empty");
+    assert.match(result.content[0].text, /requires active DB-backed requirements/);
+  } finally {
     closeDatabase();
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -10,6 +10,7 @@ import {
   closeDatabase,
   _getAdapter,
   insertGateRow,
+  upsertRequirement,
 } from "../gsd-db.ts";
 import { markApprovalGateVerified, markDepthVerified, clearDiscussionFlowState, loadWriteGateSnapshot, setPendingGate } from "../bootstrap/write-gate.ts";
 import {
@@ -701,6 +702,7 @@ test("executeSummarySave supports root-level deep planning artifacts", async () 
     }, base));
     assert.equal(requirements.isError, undefined);
     assert.equal(requirements.details.path, "REQUIREMENTS.md");
+    assert.equal(requirements.details.content_source, "requirements_table");
     assert.ok(existsSync(join(base, ".gsd", "REQUIREMENTS.md")));
 
     const db = _getAdapter();
@@ -779,6 +781,91 @@ test("executeSummarySave requires verified root approval in deep mode", async ()
     assert.equal(unblocked.isError, undefined);
     assert.equal(unblocked.details.path, "PROJECT.md");
     assert.ok(existsSync(join(base, ".gsd", "PROJECT.md")));
+  } finally {
+    clearDiscussionFlowState();
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeSummarySave renders final REQUIREMENTS from the DB source of truth", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    await inProjectDir(base, async () => {
+      markApprovalGateVerified("depth_verification_requirements_confirm", base);
+    });
+
+    upsertRequirement({
+      id: "R001",
+      class: "primary-user-loop",
+      status: "active",
+      description: "User can add a task",
+      why: "Core loop",
+      source: "user",
+      primary_owner: "M001/none yet",
+      supporting_slices: "none",
+      validation: "unmapped",
+      notes: "saved through requirement tool",
+      full_content: "",
+      superseded_by: null,
+    });
+
+    const requirementsPath = join(base, ".gsd", "REQUIREMENTS.md");
+    const bloatedMarkdown = [
+      "# Requirements",
+      "",
+      "## Active",
+      "",
+      ...Array.from({ length: 30 }, (_, i) => [
+        `### R${String(i + 100).padStart(3, "0")} — Duplicate`,
+        "- Class: primary-user-loop",
+        "- Status: active",
+        "- Description: Duplicate retry row",
+        "- Why it matters: Retry drift",
+        "- Source: test",
+        "- Primary owning slice: M001/none yet",
+        "- Supporting slices: none",
+        "- Validation: unmapped",
+        "",
+      ].join("\n")),
+    ].join("\n");
+    writeFileSync(requirementsPath, bloatedMarkdown);
+
+    const result = await inProjectDir(base, () => executeSummarySave({
+      artifact_type: "REQUIREMENTS",
+      content: "# Requirements\n\n## Active\n\n### R999 — Wrong markdown source\n\n- Description: This content must not become canonical.\n",
+    }, base));
+
+    assert.equal(result.isError, undefined);
+    assert.equal(result.details.path, "REQUIREMENTS.md");
+    assert.equal(result.details.content_source, "requirements_table");
+
+    const content = readFileSync(requirementsPath, "utf-8");
+    assert.match(content, /### R001 — User can add a task/);
+    assert.match(content, /## Validated/);
+    assert.match(content, /## Deferred/);
+    assert.match(content, /## Out of Scope/);
+    assert.doesNotMatch(content, /R999|Wrong markdown source|This content must not become canonical/);
+    assert.ok(
+      Buffer.byteLength(content, "utf-8") < Buffer.byteLength(bloatedMarkdown, "utf-8") * 0.5,
+      "test setup proves final DB projection may be much smaller than accumulated retry output",
+    );
+
+    const db = _getAdapter();
+    const reqRows = db!
+      .prepare("SELECT id, description FROM requirements ORDER BY id")
+      .all() as Array<Record<string, unknown>>;
+    assert.deepEqual(
+      reqRows.map((row) => [row.id, row.description]),
+      [["R001", "User can add a task"]],
+      "summary save must not parse markdown back into requirements rows",
+    );
+
+    const artifact = db!
+      .prepare("SELECT full_content FROM artifacts WHERE path = ?")
+      .get("REQUIREMENTS.md") as Record<string, unknown>;
+    assert.equal(artifact.full_content, content);
   } finally {
     clearDiscussionFlowState();
     closeDatabase();

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -147,8 +147,8 @@ export async function executeSummarySave(
       : null;
     if (params.artifact_type === "REQUIREMENTS" && activeRequirements?.length === 0) {
       return {
-        content: [{ type: "text", text: "Error saving artifact: REQUIREMENTS final save requires active DB-backed requirements. Save requirements with gsd_requirement_save first." }],
-        details: { operation: "save_summary", error: "requirements_table_empty" },
+        content: [{ type: "text", text: "Error: Cannot save REQUIREMENTS artifact — no active requirements found in the database. Call gsd_requirement_save for each requirement before calling gsd_summary_save(REQUIREMENTS)." }],
+        details: { operation: "save_summary", error: "no_active_requirements" },
         isError: true,
       };
     }

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -142,21 +142,33 @@ export async function executeSummarySave(
       relativePath = `milestones/${params.milestone_id}/${params.milestone_id}-${params.artifact_type}.md`;
     }
 
+    const activeRequirements = params.artifact_type === "REQUIREMENTS"
+      ? getActiveRequirements()
+      : null;
+    if (params.artifact_type === "REQUIREMENTS" && activeRequirements?.length === 0) {
+      return {
+        content: [{ type: "text", text: "Error saving artifact: REQUIREMENTS final save requires active DB-backed requirements. Save requirements with gsd_requirement_save first." }],
+        details: { operation: "save_summary", error: "requirements_table_empty" },
+        isError: true,
+      };
+    }
+
     const contentToSave = params.artifact_type === "REQUIREMENTS"
-      ? generateRequirementsMd(getActiveRequirements())
+      ? generateRequirementsMd(activeRequirements ?? [])
       : params.content;
     const contentSource = params.artifact_type === "REQUIREMENTS"
       ? "requirements_table"
       : "provided_content";
+    const isRootArtifact = isRootSummaryArtifactType(params.artifact_type);
 
     await saveArtifactToDb(
       {
         path: relativePath,
         artifact_type: params.artifact_type,
         content: contentToSave,
-        milestone_id: params.milestone_id,
-        slice_id: params.slice_id,
-        task_id: params.task_id,
+        milestone_id: isRootArtifact ? undefined : params.milestone_id,
+        slice_id: isRootArtifact ? undefined : params.slice_id,
+        task_id: isRootArtifact ? undefined : params.task_id,
       },
       basePath,
     );

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -2,6 +2,7 @@ import { ensureDbOpen } from "../bootstrap/dynamic-tools.js";
 import { sanitizeCompleteMilestoneParams } from "../bootstrap/sanitize-complete-milestone.js";
 import { loadWriteGateSnapshot, shouldBlockContextArtifactSaveInSnapshot, shouldBlockRootArtifactSaveInSnapshot } from "../bootstrap/write-gate.js";
 import {
+  getActiveRequirements,
   getMilestone,
   getSliceStatusSummary,
   getSliceTaskCounts,
@@ -9,7 +10,7 @@ import {
   saveGateResult,
 } from "../gsd-db.js";
 import { GATE_REGISTRY } from "../gate-registry.js";
-import { saveArtifactToDb } from "../db-writer.js";
+import { generateRequirementsMd, saveArtifactToDb } from "../db-writer.js";
 import { resolveMilestoneFile, resolveSliceFile } from "../paths.js";
 import { unlinkSync } from "node:fs";
 import type { CompleteMilestoneParams } from "./complete-milestone.js";
@@ -141,11 +142,18 @@ export async function executeSummarySave(
       relativePath = `milestones/${params.milestone_id}/${params.milestone_id}-${params.artifact_type}.md`;
     }
 
+    const contentToSave = params.artifact_type === "REQUIREMENTS"
+      ? generateRequirementsMd(getActiveRequirements())
+      : params.content;
+    const contentSource = params.artifact_type === "REQUIREMENTS"
+      ? "requirements_table"
+      : "provided_content";
+
     await saveArtifactToDb(
       {
         path: relativePath,
         artifact_type: params.artifact_type,
-        content: params.content,
+        content: contentToSave,
         milestone_id: params.milestone_id,
         slice_id: params.slice_id,
         task_id: params.task_id,
@@ -166,7 +174,7 @@ export async function executeSummarySave(
 
     return {
       content: [{ type: "text", text: `Saved ${params.artifact_type} artifact to ${relativePath}` }],
-      details: { operation: "save_summary", path: relativePath, artifact_type: params.artifact_type },
+      details: { operation: "save_summary", path: relativePath, artifact_type: params.artifact_type, content_source: contentSource },
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/resources/extensions/gsd/user-input-boundary.ts
+++ b/src/resources/extensions/gsd/user-input-boundary.ts
@@ -53,7 +53,11 @@ function lastAssistantText(messages: unknown[] | undefined): string {
 
 function anyMessageMatches(messages: unknown[] | undefined, pattern: RegExp): boolean {
   if (!Array.isArray(messages)) return false;
-  return messages.some((msg) => pattern.test(extractTextFromMessage(msg)));
+  return messages.some((msg) => {
+    if (!msg || typeof msg !== "object") return false;
+    if ((msg as { role?: unknown }).role === "user") return false;
+    return pattern.test(extractTextFromMessage(msg));
+  });
 }
 
 function hasApprovalQuestion(text: string): boolean {

--- a/src/resources/extensions/gsd/user-input-boundary.ts
+++ b/src/resources/extensions/gsd/user-input-boundary.ts
@@ -42,10 +42,18 @@ function extractTextFromMessage(msg: unknown): string {
 function lastAssistantText(messages: unknown[] | undefined): string {
   if (!Array.isArray(messages)) return "";
   for (let i = messages.length - 1; i >= 0; i--) {
-    const text = extractTextFromMessage(messages[i]).trim();
+    const msg = messages[i];
+    if (!msg || typeof msg !== "object") continue;
+    if ((msg as { role?: unknown }).role !== "assistant") continue;
+    const text = extractTextFromMessage(msg).trim();
     if (text) return text;
   }
   return "";
+}
+
+function anyMessageMatches(messages: unknown[] | undefined, pattern: RegExp): boolean {
+  if (!Array.isArray(messages)) return false;
+  return messages.some((msg) => pattern.test(extractTextFromMessage(msg)));
 }
 
 function hasApprovalQuestion(text: string): boolean {
@@ -120,10 +128,10 @@ export function isExplicitApprovalResponse(
 }
 
 export function isAwaitingUserInput(messages: unknown[] | undefined): boolean {
+  if (anyMessageMatches(messages, /ask_user_questions was cancelled before receiving a response/i)) return true;
+  if (anyMessageMatches(messages, REMOTE_QUESTION_FAILURE_RE)) return true;
   const text = lastAssistantText(messages);
   if (!text) return false;
-  if (/ask_user_questions was cancelled before receiving a response/i.test(text)) return true;
-  if (REMOTE_QUESTION_FAILURE_RE.test(text)) return true;
   if (APPROVAL_WAIT_RE.test(text)) return true;
   const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
   if (lines.some((line) => line.endsWith("?"))) return true;
@@ -131,10 +139,10 @@ export function isAwaitingUserInput(messages: unknown[] | undefined): boolean {
 }
 
 export function isAwaitingApprovalBoundary(messages: unknown[] | undefined): boolean {
+  if (anyMessageMatches(messages, /ask_user_questions was cancelled before receiving a response/i)) return true;
+  if (anyMessageMatches(messages, REMOTE_QUESTION_FAILURE_RE)) return true;
   const text = lastAssistantText(messages);
   if (!text) return false;
-  if (/ask_user_questions was cancelled before receiving a response/i.test(text)) return true;
-  if (REMOTE_QUESTION_FAILURE_RE.test(text)) return true;
   if (APPROVAL_WAIT_RE.test(text)) return true;
   return hasApprovalQuestion(text);
 }
@@ -144,10 +152,10 @@ export function shouldPauseForUserApprovalQuestion(
   messages: unknown[] | undefined,
 ): boolean {
   if (!unitType || !USER_APPROVAL_UNIT_TYPES.has(unitType)) return false;
+  if (anyMessageMatches(messages, /ask_user_questions was cancelled before receiving a response/i)) return true;
+  if (anyMessageMatches(messages, REMOTE_QUESTION_FAILURE_RE)) return true;
   const text = lastAssistantText(messages);
   if (!text) return false;
-  if (/ask_user_questions was cancelled before receiving a response/i.test(text)) return true;
-  if (REMOTE_QUESTION_FAILURE_RE.test(text)) return true;
   if (APPROVAL_WAIT_RE.test(text)) return true;
   if (unitType === "research-decision") return hasResearchDecisionQuestion(text);
   return hasApprovalQuestion(text);

--- a/src/tests/auto-resume-resource-loader.test.ts
+++ b/src/tests/auto-resume-resource-loader.test.ts
@@ -31,8 +31,8 @@ test("source dev CLI remains the child-process GSD_BIN_PATH", () => {
   );
   assert.ok(
     loaderSrc.includes("GSD_DEV_CLI_PATH") &&
-    loaderSrc.includes("const explicitCliPath = process.env.GSD_CLI_PATH?.trim() || process.env.GSD_BIN_PATH?.trim()") &&
-    loaderSrc.includes("isSourceLoader && existsSync(devCliPath) ? devCliPath : invokedBinPath"),
+    /const\s+explicitCliPath\s*=\s*process\.env\.GSD_CLI_PATH\?\.trim\(\)\s*\|\|\s*process\.env\.GSD_BIN_PATH\?\.trim\(\)/.test(loaderSrc) &&
+    /isSourceLoader\s*&&\s*existsSync\(devCliPath\)\s*\?\s*devCliPath\s*:\s*invokedBinPath/.test(loaderSrc),
     "loader.ts must preserve the dev CLI wrapper instead of exposing src/loader.ts to subagents",
   );
 });


### PR DESCRIPTION
## Summary

Closes #5152.

This PR stabilizes the `--deep` project setup workflow and tightens the DB-primary contract for requirements/artifact persistence.

Highlights:
- Adds deep planning setup stages for workflow preferences, project context, requirements, research decision, and optional project research.
- Adds artifact validators for deep-mode root artifacts and improves verification diagnostics when artifacts are invalid.
- Allows root-level `PROJECT` and `REQUIREMENTS` summary saves without fake milestone IDs.
- Makes requirement saves idempotent across retries by reusing an existing active row for the same normalized description.
- Keeps the requirements table canonical: final `gsd_summary_save(REQUIREMENTS)` renders from DB rows instead of parsing markdown back into DB.
- Preserves the single-writer invariant for `.gsd/gsd.db` writes.
- Ensures MCP workflow tools prefer source `.ts` modules before stale compiled `dist/` fallbacks during source/dev execution.

## DB-primary contract

The intended model is preserved explicitly:

- DB rows are canonical.
- Markdown files are projections/images of DB state.
- `gsd_requirement_save` writes requirement rows and regenerates `REQUIREMENTS.md`.
- Final `gsd_summary_save(REQUIREMENTS)` writes the root artifact from the requirements table, ignoring caller-provided markdown as canonical data.
- Markdown no longer reconciles back into requirement rows during final requirements save.

## Verification

Run locally:

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/db-writer.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts src/resources/extensions/gsd/tests/single-writer-invariant.test.ts src/resources/extensions/gsd/tests/prompt-contracts.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/db-writer.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts src/resources/extensions/gsd/tests/single-writer-invariant.test.ts src/resources/extensions/gsd/tests/prompt-contracts.test.ts src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts src/resources/extensions/gsd/tests/none-mode-gates.test.ts src/resources/extensions/gsd/tests/git-checkpoint.test.ts src/tests/auto-resume-resource-loader.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/mcp-server/src/workflow-tools.test.ts`
- `npm run typecheck:extensions`
- `npm run build:mcp-server`

Known local note:
- `npm run build:test -w @gsd-build/mcp-server` currently stops on an existing unrelated type error in `packages/mcp-server/src/readers/graph.test.ts` (`"surprise"` has no overlap with the graph node type union). The workflow-tools test passes directly with the repo's TS resolver.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer artifact verification diagnostics surfaced in UI and retry messages.
  * Autocomplete now suggests a `--deep` option for new-project/new-milestone.
  * Requirements are deduplicated and final REQUIREMENTS.md is rendered from the database.

* **Bug Fixes**
  * More robust handling of CLI path configuration.
  * Improved recovery and error handling in deep-project setup; deep setup now correctly pauses for user input.

* **Documentation**
  * Clarified `--deep` usage and updated deep-planning/requirements guidance.

* **Tests**
  * Added and expanded tests for requirements rendering, import ordering, and deep-mode flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->