### PR TITLE
fix(mcp-server): try host elicitation before remote channel for ask_user_questions

### DIFF
--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -863,6 +863,68 @@ describe('createMcpServer tool registration', () => {
     assert.equal(remoteCalls, 1);
     assert.equal(result.content[0]?.text, 'remote response');
   });
+
+  it('ask_user_questions falls back to remote when local elicitation is unavailable', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue with the current summary.' },
+          { label: 'Not quite', description: 'I need to clarify the depth further.' },
+        ],
+      },
+    ];
+    let remoteCalls = 0;
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        throw new Error('MCP host does not support elicitation');
+      },
+      isRemoteConfigured() {
+        return true;
+      },
+      async tryRemoteQuestions(remoteQuestions) {
+        remoteCalls++;
+        assert.equal(remoteQuestions, questions);
+        return { content: [{ type: 'text', text: 'remote response' }] };
+      },
+    });
+
+    assert.equal(remoteCalls, 1);
+    assert.equal(result.content[0]?.text, 'remote response');
+  });
+
+  it('ask_user_questions reports both local and remote errors when both paths fail', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue with the current summary.' },
+          { label: 'Not quite', description: 'I need to clarify the depth further.' },
+        ],
+      },
+    ];
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        throw new Error('ask_user_questions timed out after 10 minutes');
+      },
+      isRemoteConfigured() {
+        return true;
+      },
+      async tryRemoteQuestions() {
+        throw new Error('remote transport failed');
+      },
+    });
+
+    assert.equal('isError' in result && result.isError, true);
+    assert.match(result.content[0]?.text ?? '', /Local elicitation failed/);
+    assert.match(result.content[0]?.text ?? '', /remote transport failed/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -17,6 +17,7 @@ import { EventEmitter } from 'node:events';
 
 import { SessionManager } from './session-manager.js';
 import {
+  askUserQuestionsHandler,
   buildAskUserQuestionsElicitRequest,
   createMcpServer,
   formatAskUserQuestionsElicitResult,
@@ -782,6 +783,85 @@ describe('createMcpServer tool registration', () => {
         },
       }),
     );
+  });
+
+  it('ask_user_questions returns local elicitation answers before trying remote', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue with the current summary.' },
+          { label: 'Not quite', description: 'I need to clarify the depth further.' },
+        ],
+      },
+    ];
+    let remoteCalls = 0;
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        return {
+          action: 'accept',
+          content: {
+            depth_verification_M001: 'Yes, you got it (Recommended)',
+          },
+        };
+      },
+      isRemoteConfigured() {
+        return true;
+      },
+      async tryRemoteQuestions() {
+        remoteCalls++;
+        return { content: [{ type: 'text', text: 'remote response' }] };
+      },
+    });
+
+    assert.equal(remoteCalls, 0);
+    assert.equal(
+      result.content[0]?.text,
+      JSON.stringify({
+        answers: {
+          depth_verification_M001: {
+            answers: ['Yes, you got it (Recommended)'],
+          },
+        },
+      }),
+    );
+  });
+
+  it('ask_user_questions falls back to remote when local elicitation is cancelled', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue with the current summary.' },
+          { label: 'Not quite', description: 'I need to clarify the depth further.' },
+        ],
+      },
+    ];
+    let remoteCalls = 0;
+    const signal = AbortSignal.abort();
+
+    const result = await askUserQuestionsHandler(questions, { signal }, {
+      async elicitInput() {
+        return { action: 'cancel' };
+      },
+      isRemoteConfigured() {
+        return true;
+      },
+      async tryRemoteQuestions(remoteQuestions, receivedSignal) {
+        remoteCalls++;
+        assert.equal(remoteQuestions, questions);
+        assert.equal(receivedSignal, signal);
+        return { content: [{ type: 'text', text: 'remote response' }] };
+      },
+    });
+
+    assert.equal(remoteCalls, 1);
+    assert.equal(result.content[0]?.text, 'remote response');
   });
 });
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -394,6 +394,24 @@ interface AskUserQuestionsHandlerDeps {
   tryRemoteQuestions(questions: AskUserQuestion[], signal?: AbortSignal): Promise<RemoteToolResult | null>;
 }
 
+function isLocalElicitFallbackError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const message = err.message.toLowerCase();
+  return (
+    message.includes('timed out after') ||
+    message.includes('elicit') ||
+    message.includes('elicitation') ||
+    message.includes('host') ||
+    message.includes('not supported') ||
+    message.includes('method not found') ||
+    message.includes('-32601')
+  );
+}
+
+function formatErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export async function askUserQuestionsHandler(
   questions: AskUserQuestion[],
   extra: McpToolExtra | undefined,
@@ -407,18 +425,35 @@ export async function askUserQuestionsHandler(
     // Cursor, etc.) before any configured remote channel. A misconfigured
     // remote (e.g. expired Discord token returning 401) must not block the
     // depth-verification gate when the user is sitting in front of the host.
-    const elicitation = await withElicitTimeout(
-      deps.elicitInput(buildAskUserQuestionsElicitRequest(questions)),
-      'ask_user_questions',
-    );
-    if (elicitation.action === 'accept' && elicitation.content) {
-      return textContent(formatAskUserQuestionsElicitResult(questions, elicitation));
+    let localElicitError: unknown;
+    try {
+      const elicitation = await withElicitTimeout(
+        deps.elicitInput(buildAskUserQuestionsElicitRequest(questions)),
+        'ask_user_questions',
+      );
+      if (elicitation.action === 'accept' && elicitation.content) {
+        return textContent(formatAskUserQuestionsElicitResult(questions, elicitation));
+      }
+    } catch (err) {
+      if (!isLocalElicitFallbackError(err)) throw err;
+      localElicitError = err;
+      console.warn(`[gsd:mcp] ask_user_questions local elicitation unavailable; trying remote fallback: ${formatErrorMessage(err)}`);
     }
 
     // Local cancelled / unavailable — fall back to the configured remote
     // channel (Discord, Slack, Telegram) if one is set.
     if (deps.isRemoteConfigured()) {
-      const remoteResult = await deps.tryRemoteQuestions(questions, extra?.signal);
+      let remoteResult: RemoteToolResult | null;
+      try {
+        remoteResult = await deps.tryRemoteQuestions(questions, extra?.signal);
+      } catch (err) {
+        if (localElicitError) {
+          throw new Error(
+            `Local elicitation failed (${formatErrorMessage(localElicitError)}); remote fallback failed (${formatErrorMessage(err)})`,
+          );
+        }
+        throw err;
+      }
       if (remoteResult) {
         const details = remoteResult.details as Record<string, unknown> | undefined;
         if (details?.['timed_out'] || details?.['error']) {
@@ -427,6 +462,8 @@ export async function askUserQuestionsHandler(
         return textContent(remoteResult.content[0]?.text ?? '');
       }
     }
+
+    if (localElicitError) throw localElicitError;
 
     return textContent('ask_user_questions was cancelled before receiving a response');
   } catch (err) {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -17,6 +17,7 @@ import { spawn } from 'node:child_process';
 import { z } from 'zod';
 import type { SessionManager } from './session-manager.js';
 import { isRemoteConfigured, tryRemoteQuestions } from './remote-questions.js';
+import type { RemoteToolResult } from './remote-questions.js';
 import { readProgress } from './readers/state.js';
 import { readRoadmap } from './readers/roadmap.js';
 import { readHistory } from './readers/metrics.js';
@@ -387,6 +388,52 @@ export function formatAskUserQuestionsElicitResult(
   return JSON.stringify({ answers });
 }
 
+interface AskUserQuestionsHandlerDeps {
+  elicitInput(params: AskUserQuestionsElicitRequest): Promise<AskUserQuestionsElicitResult>;
+  isRemoteConfigured(): boolean;
+  tryRemoteQuestions(questions: AskUserQuestion[], signal?: AbortSignal): Promise<RemoteToolResult | null>;
+}
+
+export async function askUserQuestionsHandler(
+  questions: AskUserQuestion[],
+  extra: McpToolExtra | undefined,
+  deps: AskUserQuestionsHandlerDeps,
+): Promise<ToolContent> {
+  try {
+    const validationError = validateAskUserQuestionsPayload(questions);
+    if (validationError) return errorContent(validationError);
+
+    // Local-first: try the MCP host's elicitation channel (Claude Code,
+    // Cursor, etc.) before any configured remote channel. A misconfigured
+    // remote (e.g. expired Discord token returning 401) must not block the
+    // depth-verification gate when the user is sitting in front of the host.
+    const elicitation = await withElicitTimeout(
+      deps.elicitInput(buildAskUserQuestionsElicitRequest(questions)),
+      'ask_user_questions',
+    );
+    if (elicitation.action === 'accept' && elicitation.content) {
+      return textContent(formatAskUserQuestionsElicitResult(questions, elicitation));
+    }
+
+    // Local cancelled / unavailable — fall back to the configured remote
+    // channel (Discord, Slack, Telegram) if one is set.
+    if (deps.isRemoteConfigured()) {
+      const remoteResult = await deps.tryRemoteQuestions(questions, extra?.signal);
+      if (remoteResult) {
+        const details = remoteResult.details as Record<string, unknown> | undefined;
+        if (details?.['timed_out'] || details?.['error']) {
+          return textContent(remoteResult.content[0]?.text ?? 'Remote questions timed out or failed');
+        }
+        return textContent(remoteResult.content[0]?.text ?? '');
+      }
+    }
+
+    return textContent('ask_user_questions was cancelled before receiving a response');
+  } catch (err) {
+    return errorContent(err instanceof Error ? err.message : String(err));
+  }
+}
+
 // ---------------------------------------------------------------------------
 // secure_env_collect handler (extracted so tests can drive it directly)
 // ---------------------------------------------------------------------------
@@ -750,39 +797,11 @@ export async function createMcpServer(
     },
     async (args: Record<string, unknown>, extra?: McpToolExtra) => {
       const { questions } = args as unknown as AskUserQuestionsParams;
-      try {
-        const validationError = validateAskUserQuestionsPayload(questions);
-        if (validationError) return errorContent(validationError);
-
-        // Local-first: try the MCP host's elicitation channel (Claude Code,
-        // Cursor, etc.) before any configured remote channel. A misconfigured
-        // remote (e.g. expired Discord token returning 401) must not block the
-        // depth-verification gate when the user is sitting in front of the host.
-        const elicitation = await withElicitTimeout(
-          server.server.elicitInput(buildAskUserQuestionsElicitRequest(questions)),
-          'ask_user_questions',
-        );
-        if (elicitation.action === 'accept' && elicitation.content) {
-          return textContent(formatAskUserQuestionsElicitResult(questions, elicitation));
-        }
-
-        // Local cancelled / unavailable — fall back to the configured remote
-        // channel (Discord, Slack, Telegram) if one is set.
-        if (isRemoteConfigured()) {
-          const remoteResult = await tryRemoteQuestions(questions, extra?.signal);
-          if (remoteResult) {
-            const details = remoteResult.details as Record<string, unknown> | undefined;
-            if (details?.['timed_out'] || details?.['error']) {
-              return textContent(remoteResult.content[0]?.text ?? 'Remote questions timed out or failed');
-            }
-            return textContent(remoteResult.content[0]?.text ?? '');
-          }
-        }
-
-        return textContent('ask_user_questions was cancelled before receiving a response');
-      } catch (err) {
-        return errorContent(err instanceof Error ? err.message : String(err));
-      }
+      return askUserQuestionsHandler(questions, extra, {
+        elicitInput: (params) => server.server.elicitInput(params),
+        isRemoteConfigured,
+        tryRemoteQuestions,
+      });
     },
   );
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -754,32 +754,32 @@ export async function createMcpServer(
         const validationError = validateAskUserQuestionsPayload(questions);
         if (validationError) return errorContent(validationError);
 
-        // Delegate to remote-questions manager when a remote channel is configured
-        // (Discord, Slack, Telegram). This path is the only one reachable for
-        // Claude Code-under-gsd sessions, which have no local TUI.
+        // Local-first: try the MCP host's elicitation channel (Claude Code,
+        // Cursor, etc.) before any configured remote channel. A misconfigured
+        // remote (e.g. expired Discord token returning 401) must not block the
+        // depth-verification gate when the user is sitting in front of the host.
+        const elicitation = await withElicitTimeout(
+          server.server.elicitInput(buildAskUserQuestionsElicitRequest(questions)),
+          'ask_user_questions',
+        );
+        if (elicitation.action === 'accept' && elicitation.content) {
+          return textContent(formatAskUserQuestionsElicitResult(questions, elicitation));
+        }
+
+        // Local cancelled / unavailable — fall back to the configured remote
+        // channel (Discord, Slack, Telegram) if one is set.
         if (isRemoteConfigured()) {
           const remoteResult = await tryRemoteQuestions(questions, extra?.signal);
           if (remoteResult) {
             const details = remoteResult.details as Record<string, unknown> | undefined;
             if (details?.['timed_out'] || details?.['error']) {
-              // Surface timeout/error as plain text so the LLM knows to retry
               return textContent(remoteResult.content[0]?.text ?? 'Remote questions timed out or failed');
             }
             return textContent(remoteResult.content[0]?.text ?? '');
           }
-          // resolveRemoteConfig() returned null between isRemoteConfigured() and
-          // tryRemoteQuestions() (e.g. env var was cleared) — fall through to local.
         }
 
-        const elicitation = await withElicitTimeout(
-          server.server.elicitInput(buildAskUserQuestionsElicitRequest(questions)),
-          'ask_user_questions',
-        );
-        if (elicitation.action !== 'accept' || !elicitation.content) {
-          return textContent('ask_user_questions was cancelled before receiving a response');
-        }
-
-        return textContent(formatAskUserQuestionsElicitResult(questions, elicitation));
+        return textContent('ask_user_questions was cancelled before receiving a response');
       } catch (err) {
         return errorContent(err instanceof Error ? err.message : String(err));
       }


### PR DESCRIPTION
## TL;DR

**What:** Reorders `ask_user_questions` in the MCP server to try the host's elicitation channel before the configured remote channel.
**Why:** A stale/broken remote (e.g. expired Discord token) was dead-ending the call and blocking deep-mode depth-verification gates even when the user was sitting in front of Claude Code / Cursor.
**How:** Try `server.server.elicitInput(...)` first; only fall back to `tryRemoteQuestions(...)` if the host returns `cancel`/`decline`/unavailable.

## What

`packages/mcp-server/src/server.ts` — single handler reorder in the `ask_user_questions` tool. No new code paths, no schema changes.

Old order:
1. If remote is configured → `tryRemoteQuestions` (and stop on success or error).
2. Otherwise → host elicitation.

New order:
1. Always try host elicitation first.
2. If host returned `accept` with content → return it.
3. Otherwise, if remote is configured → `tryRemoteQuestions`.
4. Otherwise → \"cancelled before receiving a response\" sentinel.

## Why

Closes #5159.

When a remote questions channel is configured but broken (expired Discord bot token, revoked Slack webhook, etc.), the old order would call into the remote first, get a 401-class failure, and surface that error as the tool result — even when the user was actively in a host session that could have answered immediately. Deep-planning-mode is the most exposed surface because every depth-verification gate (`discuss-project`, `discuss-requirements`, `research-decision`) routes through `ask_user_questions`. A stale token effectively bricked deep-mode bootstrap until the user manually cleared the env vars.

The host's elicitation channel is the most reliable surface when a host session is active, and remote channels are explicitly the \"user is away from the host\" fallback. Local-first matches that intent.

Headless / disconnected hosts (no MCP elicitation handler) are unaffected — `elicitInput` returns a non-`accept` action and the existing remote path runs as before.

## How

The host call short-circuits on `elicitation.action === 'accept' && elicitation.content`, returning the formatted result immediately. Any other outcome (cancel, decline, host unavailable) falls through to the existing remote-or-sentinel path. No changes to `tryRemoteQuestions`, `isRemoteConfigured`, `withElicitTimeout`, or `formatAskUserQuestionsElicitResult`.

## Verification

- `npm run typecheck:extensions` — clean.
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/mcp-server/src/mcp-server.test.ts packages/mcp-server/src/remote-questions.test.ts` — 60/60 pass.

## Change type

- [x] `fix` — Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Question prompts now validate and try local input first, fall back to remote only when appropriate, surface combined local/remote errors, and return clear timeout/failure messages for remote issues.
* **Tests**
  * Added unit tests covering local acceptance, local cancellation triggering remote fallback, local elicit failures falling back to remote, and combined-failure error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->