### PR TITLE
fix(gsd): cap claude-code context budgeting

### DIFF
--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -120,6 +120,7 @@ export async function dispatchDirectPhase(
           {
             sessionContextWindow: ctx.model?.contextWindow,
             modelRegistry: ctx.modelRegistry as MinimalModelRegistry | undefined,
+            sessionProvider: ctx.model?.provider,
           },
         );
       } else {
@@ -151,6 +152,7 @@ export async function dispatchDirectPhase(
         {
           sessionContextWindow: ctx.model?.contextWindow,
           modelRegistry: ctx.modelRegistry as MinimalModelRegistry | undefined,
+          sessionProvider: ctx.model?.provider,
         },
       );
       break;

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -106,6 +106,8 @@ export interface DispatchContext {
   sessionContextWindow?: number;
   /** Model registry forwarded to the budget engine so it can look up the configured executor model. */
   modelRegistry?: MinimalModelRegistry;
+  /** Session model provider, used for provider-specific effective context windows. */
+  sessionProvider?: string;
 }
 
 type ReassessmentChecker = typeof checkNeedsReassessment;
@@ -860,7 +862,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
     // auto-heal without either adding an explicit `setSliceSketchFlag(..., false)`
     // call here or doing so inside the plan-slice tool handler.
     name: "refining → refine-slice",
-    match: async ({ state, mid, midTitle, basePath, prefs, sessionContextWindow, modelRegistry }) => {
+    match: async ({ state, mid, midTitle, basePath, prefs, sessionContextWindow, modelRegistry, sessionProvider }) => {
       if (state.phase !== "refining") return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice.id;
@@ -885,7 +887,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           unitId: `${mid}/${sid}`,
           prompt: await buildPlanSlicePrompt(
             mid, midTitle, sid, sTitle, basePath, undefined,
-            { ...(softScopeHint ? { softScopeHint } : {}), sessionContextWindow, modelRegistry },
+            { ...(softScopeHint ? { softScopeHint } : {}), sessionContextWindow, modelRegistry, sessionProvider },
           ),
         };
       }
@@ -895,14 +897,14 @@ export const DISPATCH_RULES: DispatchRule[] = [
         unitId: `${mid}/${sid}`,
         prompt: await buildRefineSlicePrompt(
           mid, midTitle, sid, sTitle, basePath, undefined,
-          { sessionContextWindow, modelRegistry },
+          { sessionContextWindow, modelRegistry, sessionProvider },
         ),
       };
     },
   },
   {
     name: "planning → plan-slice",
-    match: async ({ state, mid, midTitle, basePath, sessionContextWindow, modelRegistry, session }) => {
+    match: async ({ state, mid, midTitle, basePath, sessionContextWindow, modelRegistry, sessionProvider, session }) => {
       if (state.phase !== "planning") return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -931,7 +933,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           sTitle,
           basePath,
           undefined,
-          { sessionContextWindow, modelRegistry, priorPreExecFailure },
+          { sessionContextWindow, modelRegistry, sessionProvider, priorPreExecFailure },
         ),
       };
     },
@@ -992,7 +994,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "executing → reactive-execute (parallel dispatch)",
-    match: async ({ state, mid, midTitle, basePath, prefs, sessionContextWindow, modelRegistry }) => {
+    match: async ({ state, mid, midTitle, basePath, prefs, sessionContextWindow, modelRegistry, sessionProvider }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;
       if (!state.activeSlice) return null; // fall through
 
@@ -1095,7 +1097,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
             selected,
             basePath,
             subagentModel,
-            { sessionContextWindow, modelRegistry },
+            { sessionContextWindow, modelRegistry, sessionProvider },
           ),
         };
       } catch (err) {
@@ -1107,7 +1109,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "executing → execute-task (recover missing task plan → plan-slice)",
-    match: async ({ state, mid, midTitle, basePath, sessionContextWindow, modelRegistry }) => {
+    match: async ({ state, mid, midTitle, basePath, sessionContextWindow, modelRegistry, sessionProvider }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -1132,7 +1134,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
             sTitle,
             basePath,
             undefined,
-            { sessionContextWindow, modelRegistry },
+            { sessionContextWindow, modelRegistry, sessionProvider },
           ),
         };
       }
@@ -1142,7 +1144,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "executing → execute-task",
-    match: async ({ state, mid, basePath, sessionContextWindow, modelRegistry }) => {
+    match: async ({ state, mid, basePath, sessionContextWindow, modelRegistry, sessionProvider }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -1161,7 +1163,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           tid,
           tTitle,
           basePath,
-          { sessionContextWindow, modelRegistry },
+          { sessionContextWindow, modelRegistry, sessionProvider },
         ),
       };
     },

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -99,16 +99,17 @@ function capPreamble(preamble: string): string {
 function formatExecutorConstraints(
   sessionContextWindow?: number,
   modelRegistry?: MinimalModelRegistry,
+  sessionProvider?: string,
 ): string {
   let windowTokens: number;
   try {
     const prefs = loadEffectiveGSDPreferences();
-    windowTokens = resolveExecutorContextWindow(modelRegistry, prefs?.preferences, sessionContextWindow);
+    windowTokens = resolveExecutorContextWindow(modelRegistry, prefs?.preferences, sessionContextWindow, sessionProvider);
   } catch (e) {
     logWarning("prompt", `resolveExecutorContextWindow failed: ${(e as Error).message}`);
     // Delegate to the budget engine without prefs (the path that just threw)
     // so DEFAULT_CONTEXT_WINDOW stays the single source of truth.
-    windowTokens = resolveExecutorContextWindow(undefined, undefined, sessionContextWindow);
+    windowTokens = resolveExecutorContextWindow(undefined, undefined, sessionContextWindow, sessionProvider);
   }
   const budgets = computeBudgets(windowTokens);
   const { min, max } = budgets.taskCountRange;
@@ -1627,10 +1628,11 @@ async function renderSlicePrompt(options: {
   extraVars?: Record<string, string>;
   sessionContextWindow?: number;
   modelRegistry?: MinimalModelRegistry;
+  sessionProvider?: string;
 }): Promise<string> {
   const {
     mid, sid, sTitle, base, level, promptTemplate, prependBlocks = [], extraVars = {},
-    sessionContextWindow, modelRegistry,
+    sessionContextWindow, modelRegistry, sessionProvider,
   } = options;
 
   const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
@@ -1683,7 +1685,7 @@ async function renderSlicePrompt(options: {
   if (overridesInline) inlined.unshift(overridesInline);
 
   const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
-  const executorContextConstraints = formatExecutorConstraints(sessionContextWindow, modelRegistry);
+  const executorContextConstraints = formatExecutorConstraints(sessionContextWindow, modelRegistry, sessionProvider);
   const outputRelPath = relSliceFile(base, mid, sid, "PLAN");
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
 
@@ -1717,6 +1719,7 @@ export async function buildPlanSlicePrompt(
     softScopeHint?: string;
     sessionContextWindow?: number;
     modelRegistry?: MinimalModelRegistry;
+    sessionProvider?: string;
     /** Failure context from a prior pre-exec gate run (#4551). When present, a
      *  "Fix these specific issues" section is appended so the LLM addresses the
      *  exact problems instead of producing an identical plan that fails again. */
@@ -1760,6 +1763,7 @@ export async function buildPlanSlicePrompt(
     prependBlocks,
     sessionContextWindow: options?.sessionContextWindow,
     modelRegistry: options?.modelRegistry,
+    sessionProvider: options?.sessionProvider,
   });
 }
 
@@ -1772,7 +1776,7 @@ export async function buildPlanSlicePrompt(
  */
 export async function buildRefineSlicePrompt(
   mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
-  options?: { sessionContextWindow?: number; modelRegistry?: MinimalModelRegistry },
+  options?: { sessionContextWindow?: number; modelRegistry?: MinimalModelRegistry; sessionProvider?: string },
 ): Promise<string> {
   // Pull the stored sketch scope from the DB — the hard constraint we plan within.
   let sketchScope = "";
@@ -1801,6 +1805,7 @@ export async function buildRefineSlicePrompt(
     extraVars: { sketchScope },
     sessionContextWindow: options?.sessionContextWindow,
     modelRegistry: options?.modelRegistry,
+    sessionProvider: options?.sessionProvider,
   });
 }
 
@@ -1813,6 +1818,8 @@ export interface ExecuteTaskPromptOptions {
   sessionContextWindow?: number;
   /** Model registry forwarded to the budget engine for executor-model lookup. */
   modelRegistry?: MinimalModelRegistry;
+  /** Session model provider, used for provider-specific effective context windows. */
+  sessionProvider?: string;
 }
 
 export async function buildExecuteTaskPrompt(
@@ -1904,7 +1911,7 @@ export async function buildExecuteTaskPrompt(
 
   // Compute verification budget for the executor's context window (issue #707)
   const prefs = loadEffectiveGSDPreferences();
-  const contextWindow = resolveExecutorContextWindow(opts.modelRegistry, prefs?.preferences, opts.sessionContextWindow);
+  const contextWindow = resolveExecutorContextWindow(opts.modelRegistry, prefs?.preferences, opts.sessionContextWindow, opts.sessionProvider);
   const budgets = computeBudgets(contextWindow);
   const verificationBudget = `~${Math.round(budgets.verificationBudgetChars / 1000)}K chars`;
 
@@ -2587,7 +2594,7 @@ export async function buildReactiveExecutePrompt(
   mid: string, midTitle: string, sid: string, sTitle: string,
   readyTaskIds: string[], base: string,
   subagentModel?: string,
-  opts?: { sessionContextWindow?: number; modelRegistry?: MinimalModelRegistry },
+  opts?: { sessionContextWindow?: number; modelRegistry?: MinimalModelRegistry; sessionProvider?: string },
 ): Promise<string> {
   const { loadSliceTaskIO, deriveTaskGraph, graphMetrics } = await import("./reactive-graph.js");
 
@@ -2633,6 +2640,7 @@ export async function buildReactiveExecutePrompt(
         carryForwardPaths: depPaths,
         sessionContextWindow: opts?.sessionContextWindow,
         modelRegistry: opts?.modelRegistry,
+        sessionProvider: opts?.sessionProvider,
       },
     );
 

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -944,6 +944,15 @@ export async function bootstrapAutoSession(
         : "Will loop until milestone complete.";
     ctx.ui.notify(`${modeLabel} started. ${scopeMsg}`, "info");
 
+    const providerReportedWindow = ctx.model?.contextWindow ?? 0;
+    const contextOverride = loadEffectiveGSDPreferences(base)?.preferences.context_window_override;
+    if (providerReportedWindow > 500_000 && contextOverride === undefined) {
+      ctx.ui.notify(
+        `Model reports a ${Math.round(providerReportedWindow / 1000)}K context window. If the provider's real API limit is lower, set context_window_override in .gsd/PREFERENCES.md so wrap-up signals fire before context overflow.`,
+        "warning",
+      );
+    }
+
     // Show dynamic routing status so users know upfront if models will be
     // downgraded for simple tasks (#3962).
     // Use the same effective logic as selectAndApplyModel: check flat-rate

--- a/src/resources/extensions/gsd/auto-timers.ts
+++ b/src/resources/extensions/gsd/auto-timers.ts
@@ -309,6 +309,7 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
     ctx.modelRegistry as Parameters<typeof resolveExecutorContextWindow>[0],
     prefs as Parameters<typeof resolveExecutorContextWindow>[1],
     ctx.model?.contextWindow,
+    ctx.model?.provider,
   );
   const continueHereThreshold = computeBudgets(executorContextWindow).continueThresholdPercent;
   s.continueHereHandle = setInterval(() => {

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -968,6 +968,7 @@ export async function runDispatch(
     session: s,
     structuredQuestionsAvailable,
     sessionContextWindow: ctx.model?.contextWindow,
+    sessionProvider: ctx.model?.provider,
     modelRegistry: ctx.modelRegistry as MinimalModelRegistry | undefined,
   });
 

--- a/src/resources/extensions/gsd/context-budget.ts
+++ b/src/resources/extensions/gsd/context-budget.ts
@@ -29,6 +29,9 @@ const CHARS_PER_TOKEN = 4;
 /** Default context window when none can be resolved (D002) */
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 
+/** Conservative effective context for Claude Code subscription routing (#4676) */
+const CLAUDE_CODE_EFFECTIVE_CONTEXT_WINDOW = 200_000;
+
 /** Percentage of context consumed before suggesting a continue-here checkpoint */
 const CONTINUE_THRESHOLD_PERCENT = 70;
 
@@ -175,6 +178,7 @@ export function resolveExecutorContextWindow(
   registry: MinimalModelRegistry | undefined,
   preferences: MinimalPreferences | undefined,
   sessionContextWindow?: number,
+  sessionProvider?: string,
 ): number {
   // Step 1: Try configured executor model
   if (preferences?.models?.execution && registry) {
@@ -186,14 +190,14 @@ export function resolveExecutorContextWindow(
     if (modelId) {
       const model = findModelById(registry, modelId);
       if (model && model.contextWindow > 0) {
-        return model.contextWindow;
+        return resolveEffectiveContextWindow(model.contextWindow, model.provider);
       }
     }
   }
 
   // Step 2: Fall back to session context window
   if (sessionContextWindow && sessionContextWindow > 0) {
-    return sessionContextWindow;
+    return resolveEffectiveContextWindow(sessionContextWindow, sessionProvider);
   }
 
   // Step 3: Fall back to default (D002)
@@ -221,6 +225,13 @@ function resolveTaskCountMax(contextWindow: number): number {
     if (contextWindow >= threshold) return max;
   }
   return 3; // fallback — unreachable given tiers include 0
+}
+
+function resolveEffectiveContextWindow(contextWindow: number, provider?: string): number {
+  if (provider?.toLowerCase() === "claude-code" && contextWindow > CLAUDE_CODE_EFFECTIVE_CONTEXT_WINDOW) {
+    return CLAUDE_CODE_EFFECTIVE_CONTEXT_WINDOW;
+  }
+  return contextWindow;
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/context-budget.test.ts
+++ b/src/resources/extensions/gsd/tests/context-budget.test.ts
@@ -199,6 +199,18 @@ describe("context-budget: resolveExecutorContextWindow", () => {
     assert.equal(result, 128_000);
   });
 
+  it("uses conservative effective context for configured claude-code models", () => {
+    const registry = makeRegistry([
+      makeModel("claude-sonnet-4-6", "claude-code", 1_000_000),
+    ]);
+    const prefs: MinimalPreferences = {
+      models: { execution: "claude-code/claude-sonnet-4-6" },
+    };
+
+    const result = resolveExecutorContextWindow(registry, prefs);
+    assert.equal(result, 200_000);
+  });
+
   it("supports provider/model format in preferences", () => {
     const registry = makeRegistry([
       makeModel("gpt-4o", "openai", 128_000),
@@ -244,6 +256,22 @@ describe("context-budget: resolveExecutorContextWindow", () => {
 
     const result = resolveExecutorContextWindow(registry, prefs, 128_000);
     assert.equal(result, 128_000);
+  });
+
+  it("uses conservative effective context for claude-code session window fallback", () => {
+    const registry = makeRegistry([]);
+    const prefs: MinimalPreferences = { models: {} };
+
+    const result = resolveExecutorContextWindow(registry, prefs, 1_000_000, "claude-code");
+    assert.equal(result, 200_000);
+  });
+
+  it("does not cap large non-claude-code session windows", () => {
+    const registry = makeRegistry([]);
+    const prefs: MinimalPreferences = { models: {} };
+
+    const result = resolveExecutorContextWindow(registry, prefs, 1_000_000, "openai");
+    assert.equal(result, 1_000_000);
   });
 
   it("falls back to 200K when no session and no executor model", () => {

--- a/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
@@ -521,7 +521,7 @@ describe("prompt-budget: modelRegistry + sessionContextWindow wiring", () => {
     );
     assert.match(
       autoPromptsSrc,
-      /formatExecutorConstraints\(sessionContextWindow,\s*modelRegistry\)/,
+      /formatExecutorConstraints\(sessionContextWindow,\s*modelRegistry(?:,\s*sessionProvider)?\)/,
       "renderSlicePrompt must forward both to formatExecutorConstraints",
     );
   });

--- a/src/resources/extensions/gsd/tests/token-counter.test.ts
+++ b/src/resources/extensions/gsd/tests/token-counter.test.ts
@@ -20,6 +20,10 @@ describe("token-counter: getCharsPerToken", () => {
     assert.equal(getCharsPerToken("anthropic"), 3.5);
   });
 
+  it("returns 3.5 for claude-code", () => {
+    assert.equal(getCharsPerToken("claude-code"), 3.5);
+  });
+
   it("returns 4.0 for openai", () => {
     assert.equal(getCharsPerToken("openai"), 4.0);
   });
@@ -48,6 +52,11 @@ describe("token-counter: estimateTokensForProvider", () => {
 
   it("estimates tokens for anthropic using 3.5 chars/token ratio", () => {
     const tokens = estimateTokensForProvider(sampleText, "anthropic");
+    assert.equal(tokens, Math.ceil(1000 / 3.5));
+  });
+
+  it("estimates tokens for claude-code using 3.5 chars/token ratio", () => {
+    const tokens = estimateTokensForProvider(sampleText, "claude-code");
     assert.equal(tokens, Math.ceil(1000 / 3.5));
   });
 

--- a/src/resources/extensions/gsd/token-counter.ts
+++ b/src/resources/extensions/gsd/token-counter.ts
@@ -1,7 +1,8 @@
-export type TokenProvider = "anthropic" | "openai" | "google" | "mistral" | "bedrock" | "unknown";
+export type TokenProvider = "anthropic" | "claude-code" | "openai" | "google" | "mistral" | "bedrock" | "unknown";
 
 const CHARS_PER_TOKEN_BY_PROVIDER: Record<TokenProvider, number> = {
 	anthropic: 3.5,
+	"claude-code": 3.5,
 	openai: 4.0,
 	google: 4.0,
 	mistral: 3.8,


### PR DESCRIPTION
## TL;DR

**What:** Caps GSD's effective context budgeting for `claude-code` at 200K and uses the Anthropic token heuristic for `claude-code`.
**Why:** `claude-code` can report a 1M context window while the practical API limit is lower, causing wrap-up signals to fire too late and auto-mode units to loop on context overflow.
**How:** Applies provider-aware effective context resolution, threads the session provider through auto budget call sites, and warns when a model reports >500K without `context_window_override`.

## What

- Adds `claude-code` to provider-aware token estimation at 3.5 chars/token.
- Resolves `claude-code` budgeting through a conservative 200K effective context window while leaving provider model metadata intact.
- Threads `ctx.model.provider` through dispatch, prompt, and timer budget resolution so session fallback windows are provider-aware.
- Emits a startup warning for provider-reported context windows above 500K when no override is configured.
- Adds regression coverage for `claude-code` context-window and token-estimation behavior.

## Why

`claude-code` subscription routing can advertise a 1M context window, so GSD's 70% wrap-up threshold was calculated around 700K tokens. In practice, units can hit the real API limit around 200K before GSD sends the wrap-up signal, causing retries and repeated pauses.

Closes #4676

## How

`resolveExecutorContextWindow()` now converts `claude-code` registry and session fallback windows to a conservative 200K effective budget. Auto-mode paths that previously passed only `ctx.model.contextWindow` now also pass `ctx.model.provider`, allowing the context engine to distinguish `claude-code` from other large-context providers.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/context-budget.test.ts src/resources/extensions/gsd/tests/token-counter.test.ts src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts`
- [x] `npm run typecheck:extensions`
- [x] `npm run verify:pr` mostly passed; first run hit one transient timing assertion in `derive-state-db.test.js` (`<25ms`, got `43.293ms`), then isolated rerun passed: `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test dist-test/src/resources/extensions/gsd/tests/derive-state-db.test.js`

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the "claude-code" provider with intelligent context window management.
  * Introduced startup warning when a model has an unusually large context window without user override.

* **Improvements**
  * Enhanced provider-aware token counting for improved accuracy.
  * Extended session provider context throughout dispatch and prompt workflows for better session awareness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->