### PR TITLE
fix(claude-code-cli): render AskUserQuestion in Interactive GSD pane (#5116)

### DIFF
--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -104,6 +104,34 @@ export interface ExtensionWidgetOptions {
 /** Raw terminal input listener for extensions. */
 export type TerminalInputHandler = (data: string) => { consume?: boolean; data?: string } | undefined;
 
+/** A single option presented to the user in an interview question. */
+export interface InterviewOption {
+	label: string;
+	description: string;
+	/** Optional markdown content shown alongside the option (e.g. preview panel). */
+	preview?: string;
+}
+
+/** A single question in an interview round. */
+export interface InterviewQuestion {
+	id: string;
+	header: string;
+	question: string;
+	allowMultiple: boolean;
+	options: InterviewOption[];
+}
+
+/** Aggregate result returned from an interview round.
+ *
+ * Structurally compatible with the `RoundResult` produced by GSD's shared
+ * interview UI (`src/resources/extensions/shared/interview-ui.ts`).
+ * Empty `answers` indicates the user dismissed the round without answering.
+ */
+export interface InterviewRoundResult {
+	endInterview: boolean;
+	answers: Record<string, { selected: string | string[]; notes: string }>;
+}
+
 /**
  * UI context for extensions to request interactive UI.
  * Each mode (interactive, RPC, print) provides its own implementation.
@@ -111,6 +139,21 @@ export type TerminalInputHandler = (data: string) => { consume?: boolean; data?:
 export interface ExtensionUIContext {
 	/** Show a selector and return the user's choice. When `opts.allowMultiple` is true, returns an array. */
 	select(title: string, options: string[], opts?: ExtensionUIDialogOptions): Promise<string | string[] | undefined>;
+
+	/**
+	 * Show a multi-question interview dialog.
+	 *
+	 * Returns the round result, or `undefined` if the UI cannot satisfy the
+	 * request (no interactive surface available). An empty `answers` object on
+	 * the result indicates the user dismissed the interview without answering.
+	 *
+	 * Optional: callers must check for `undefined` and fall back to a sequence
+	 * of `select` calls when this method is not implemented.
+	 */
+	askInterview?(
+		questions: InterviewQuestion[],
+		opts?: ExtensionUIDialogOptions,
+	): Promise<InterviewRoundResult | undefined>;
 
 	/** Show a confirmation dialog. */
 	confirm(title: string, message: string, opts?: ExtensionUIDialogOptions): Promise<boolean>;

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/extension-ui-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/extension-ui-controller.ts
@@ -6,6 +6,45 @@ import { appKey } from "../components/keybinding-hints.js";
 export function createExtensionUIContext(host: any): ExtensionUIContext {
 	return {
 		select: (title, options, opts) => host.showExtensionSelector(title, options, opts),
+		askInterview: async (questions, opts) => {
+			// Cross-package dynamic import: pi-coding-agent's tsconfig has
+			// rootDir: ./src, so a literal-string import path would trip
+			// TS6059. Indirecting through a variable hides the path from
+			// tsc's static analysis (same trick stream-adapter.ts uses for
+			// the SDK).
+			const interviewUiPath = "../../../../../../src/resources/extensions/shared/interview-ui.js";
+			let showInterviewRound: (
+				questions: unknown,
+				opts: { signal?: AbortSignal },
+				ctx: { ui: { custom: unknown } },
+			) => Promise<unknown>;
+			try {
+				const mod = (await import(/* webpackIgnore: true */ interviewUiPath)) as {
+					showInterviewRound: typeof showInterviewRound;
+				};
+				showInterviewRound = mod.showInterviewRound;
+			} catch (err) {
+				host.showExtensionNotify?.(
+					`AskUserQuestion: TUI interview surface unavailable (${err instanceof Error ? err.message : String(err)})`,
+					"warning",
+				);
+				return undefined;
+			}
+			try {
+				const result = await showInterviewRound(
+					questions as unknown,
+					{ signal: opts?.signal },
+					{ ui: { custom: host.showExtensionCustom.bind(host) } },
+				);
+				return result as any;
+			} catch (err) {
+				host.showExtensionNotify?.(
+					`AskUserQuestion: interview rendering failed (${err instanceof Error ? err.message : String(err)})`,
+					"warning",
+				);
+				return undefined;
+			}
+		},
 		confirm: (title, message, opts) => host.showExtensionConfirm(title, message, opts),
 		input: (title, placeholder, opts) => host.showExtensionInput(title, placeholder, opts),
 		notify: (message, type) => host.showExtensionNotify(message, type),

--- a/packages/pi-coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/pi-coding-agent/src/modes/rpc/rpc-mode.ts
@@ -218,6 +218,19 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 				"cancelled" in r && r.cancelled ? undefined : "values" in r ? r.values : "value" in r ? r.value : undefined,
 			),
 
+		askInterview: (questions, opts) =>
+			createDialogPromise(
+				opts,
+				undefined,
+				{ method: "interview", questions, timeout: opts?.timeout },
+				(r) =>
+					"cancelled" in r && r.cancelled
+						? undefined
+						: "answers" in r
+							? { endInterview: false, answers: r.answers }
+							: undefined,
+			),
+
 		confirm: (title, message, opts) =>
 			createDialogPromise(opts, false, { method: "confirm", title, message, timeout: opts?.timeout }, (r) =>
 				"cancelled" in r && r.cancelled ? false : "confirmed" in r ? r.confirmed : false,

--- a/packages/pi-coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/pi-coding-agent/src/modes/rpc/rpc-types.ts
@@ -297,6 +297,23 @@ export type RpcExtensionUIRequest =
 	| {
 			type: "extension_ui_request";
 			id: string;
+			method: "interview";
+			questions: Array<{
+				id: string;
+				header: string;
+				question: string;
+				allowMultiple: boolean;
+				options: Array<{
+					label: string;
+					description: string;
+					preview?: string;
+				}>;
+			}>;
+			timeout?: number;
+	  }
+	| {
+			type: "extension_ui_request";
+			id: string;
 			method: "notify";
 			message: string;
 			notifyType?: "info" | "warning" | "error";
@@ -328,7 +345,12 @@ export type RpcExtensionUIResponse =
 	| { type: "extension_ui_response"; id: string; value: string }
 	| { type: "extension_ui_response"; id: string; values: string[] }
 	| { type: "extension_ui_response"; id: string; confirmed: boolean }
-	| { type: "extension_ui_response"; id: string; cancelled: true };
+	| { type: "extension_ui_response"; id: string; cancelled: true }
+	| {
+			type: "extension_ui_response";
+			id: string;
+			answers: Record<string, { selected: string | string[]; notes: string }>;
+	  };
 
 // ============================================================================
 // Helper type for extracting command types

--- a/packages/rpc-client/src/rpc-types.ts
+++ b/packages/rpc-client/src/rpc-types.ts
@@ -359,6 +359,23 @@ export type RpcExtensionUIRequest =
 	| {
 			type: "extension_ui_request";
 			id: string;
+			method: "interview";
+			questions: Array<{
+				id: string;
+				header: string;
+				question: string;
+				allowMultiple: boolean;
+				options: Array<{
+					label: string;
+					description: string;
+					preview?: string;
+				}>;
+			}>;
+			timeout?: number;
+	  }
+	| {
+			type: "extension_ui_request";
+			id: string;
 			method: "notify";
 			message: string;
 			notifyType?: "info" | "warning" | "error";
@@ -390,7 +407,12 @@ export type RpcExtensionUIResponse =
 	| { type: "extension_ui_response"; id: string; value: string }
 	| { type: "extension_ui_response"; id: string; values: string[] }
 	| { type: "extension_ui_response"; id: string; confirmed: boolean }
-	| { type: "extension_ui_response"; id: string; cancelled: true };
+	| { type: "extension_ui_response"; id: string; cancelled: true }
+	| {
+			type: "extension_ui_response";
+			id: string;
+			answers: Record<string, { selected: string | string[]; notes: string }>;
+	  };
 
 // ============================================================================
 // Helper type for extracting command types

--- a/src/headless-ui.ts
+++ b/src/headless-ui.ts
@@ -234,6 +234,14 @@ export function handleExtensionUIRequest(
     case 'editor':
       client.sendUIResponse(id, { value: event.prefill ?? '' })
       break
+    case 'interview':
+      // No safe auto-answer for the SDK's native AskUserQuestion in headless
+      // mode — picking first option could submit something the user did not
+      // intend (e.g. "delete production data"). Cancel cleanly so the
+      // intercept denies the tool with "User declined to answer questions"
+      // and the model can fall back to plain text.
+      client.sendUIResponse(id, { cancelled: true })
+      break
     case 'notify':
     case 'setStatus':
     case 'setWidget':

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1024,7 +1024,7 @@ export function convertAskUserQuestionInputToQuestions(
 		}
 		const obj = item as Record<string, unknown>;
 
-		if (typeof obj.question !== "string" || obj.question.length === 0) {
+		if (typeof obj.question !== "string" || obj.question.trim().length === 0) {
 			return { ok: false, reason: `question ${index} missing question text` };
 		}
 		// Reject duplicate question texts: roundResultToAskUserQuestionAnswers
@@ -1034,7 +1034,7 @@ export function convertAskUserQuestionInputToQuestions(
 			return { ok: false, reason: `duplicate question text: ${obj.question}` };
 		}
 		seenQuestionTexts.add(obj.question);
-		if (typeof obj.header !== "string" || obj.header.length === 0) {
+		if (typeof obj.header !== "string" || obj.header.trim().length === 0) {
 			return { ok: false, reason: `question ${index} missing header` };
 		}
 		if (typeof obj.multiSelect !== "boolean") {
@@ -1052,7 +1052,7 @@ export function convertAskUserQuestionInputToQuestions(
 				return { ok: false, reason: `question ${index} option ${optionIndex} is not an object` };
 			}
 			const optionObj = rawOption as Record<string, unknown>;
-			if (typeof optionObj.label !== "string" || optionObj.label.length === 0) {
+			if (typeof optionObj.label !== "string" || optionObj.label.trim().length === 0) {
 				return { ok: false, reason: `question ${index} option ${optionIndex} missing label` };
 			}
 			// Reject duplicate option labels within the same question:
@@ -1100,19 +1100,31 @@ export function roundResultToAskUserQuestionAnswers(
 	input: AskUserQuestionInputShape,
 	result: RoundResult,
 ): Record<string, string> {
-	const answers: Record<string, string> = {};
+	// Null prototype: the answers map is keyed by model-controlled question
+	// text, so `__proto__` and friends could otherwise alias prototype
+	// fields. The intercept's caller does Object.keys(answers) so this
+	// stays compatible.
+	const answers = Object.create(null) as Record<string, string>;
 	for (let index = 0; index < input.questions.length; index += 1) {
 		const question = input.questions[index];
 		if (!question) continue;
 		const answer = result.answers[`q_${index}`];
 		if (!answer) continue;
+		// Only persist labels that exist in the original options. A buggy or
+		// custom askInterview implementation can't inject off-menu answers
+		// the LLM didn't see — those drop and the partial-answers guard in
+		// the intercept treats the question as unanswered.
+		const allowedLabels = new Set(question.options.map((option) => option.label));
 		const selected = answer.selected;
 		if (typeof selected === "string") {
-			if (selected.length === 0) continue;
+			if (selected.length === 0 || !allowedLabels.has(selected)) continue;
 			answers[question.question] = selected;
 		} else if (Array.isArray(selected)) {
 			if (selected.length === 0) continue;
-			answers[question.question] = selected.join(", ");
+			if (selected.some((label) => typeof label !== "string" || !allowedLabels.has(label))) continue;
+			// Dedupe multi-select choices before joining — a buggy UI could
+			// emit duplicates that misrepresent the user's intent.
+			answers[question.question] = [...new Set(selected)].join(", ");
 		}
 	}
 	return answers;
@@ -1288,7 +1300,10 @@ export function createClaudeCodeCanUseToolHandler(
 
 			return {
 				behavior: "allow",
-				updatedInput: { ..._input, answers },
+				// Spread answers into a plain object so the SDK gets a
+				// normally-prototyped value (the helper returns a null-proto
+				// map internally for safety).
+				updatedInput: { ..._input, answers: { ...answers } },
 				toolUseID: options.toolUseID,
 			};
 		}

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1045,6 +1045,7 @@ export function convertAskUserQuestionInputToQuestions(
 		}
 
 		const options: QuestionOption[] = [];
+		const seenOptionLabels = new Set<string>();
 		for (let optionIndex = 0; optionIndex < obj.options.length; optionIndex += 1) {
 			const rawOption = obj.options[optionIndex] as unknown;
 			if (!rawOption || typeof rawOption !== "object") {
@@ -1054,6 +1055,14 @@ export function convertAskUserQuestionInputToQuestions(
 			if (typeof optionObj.label !== "string" || optionObj.label.length === 0) {
 				return { ok: false, reason: `question ${index} option ${optionIndex} missing label` };
 			}
+			// Reject duplicate option labels within the same question:
+			// promptNativeAskUserQuestionWithDialogs maps a selection back to
+			// its label via indexOf, so duplicates collapse to the first
+			// match. Detecting at validation prevents silent answer drift.
+			if (seenOptionLabels.has(optionObj.label)) {
+				return { ok: false, reason: `question ${index} duplicate option label "${optionObj.label}"` };
+			}
+			seenOptionLabels.add(optionObj.label);
 			if (typeof optionObj.description !== "string") {
 				return { ok: false, reason: `question ${index} option ${optionIndex} missing description` };
 			}
@@ -1244,7 +1253,13 @@ export function createClaudeCodeCanUseToolHandler(
 				interviewResult,
 			);
 
-			if (Object.keys(answers).length === 0) {
+			// Require an answer for every question. The web FocusedPanel
+			// disables Submit until all are answered, but a custom
+			// ui.askInterview implementation could return a partial map —
+			// allowing that would feed the model a question it never
+			// answered. Treat partials the same as a dismiss.
+			const expectedCount = parsed.questions.length;
+			if (Object.keys(answers).length !== expectedCount) {
 				return {
 					behavior: "deny",
 					message: "User declined to answer questions",

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1016,6 +1016,7 @@ export function convertAskUserQuestionInputToQuestions(
 	}
 
 	const questions: Question[] = [];
+	const seenQuestionTexts = new Set<string>();
 	for (let index = 0; index < rawQuestions.length; index += 1) {
 		const item = rawQuestions[index] as unknown;
 		if (!item || typeof item !== "object") {
@@ -1026,6 +1027,13 @@ export function convertAskUserQuestionInputToQuestions(
 		if (typeof obj.question !== "string" || obj.question.length === 0) {
 			return { ok: false, reason: `question ${index} missing question text` };
 		}
+		// Reject duplicate question texts: roundResultToAskUserQuestionAnswers
+		// keys answers by question.question per the SDK contract, so duplicates
+		// would silently overwrite each other on the way back.
+		if (seenQuestionTexts.has(obj.question)) {
+			return { ok: false, reason: `duplicate question text: ${obj.question}` };
+		}
+		seenQuestionTexts.add(obj.question);
 		if (typeof obj.header !== "string" || obj.header.length === 0) {
 			return { ok: false, reason: `question ${index} missing header` };
 		}
@@ -1194,24 +1202,33 @@ export function createClaudeCodeCanUseToolHandler(
 				};
 			}
 
+			// Treat any rejection from the interview UI (RPC channel error,
+			// JSON serialization fault, mid-loop ui.select rejection) as a
+			// dismiss — the deny path below already produces the right
+			// fallback for the model.
 			let interviewResult: RoundResult | undefined;
-			if (typeof ui.askInterview === "function") {
-				// Cast across structurally-equivalent named types: ExtensionUIContext
-				// declares InterviewQuestion / InterviewRoundResult (in pi-coding-agent),
-				// while this file works with the original Question / RoundResult from
-				// the shared interview-ui module. Shapes match — only the names differ.
-				const askInterviewFn = ui.askInterview as (
-					questions: unknown,
-					opts?: { signal?: AbortSignal },
-				) => Promise<RoundResult | undefined>;
-				interviewResult = await askInterviewFn(parsed.questions, { signal: options.signal })
-					.catch(() => undefined);
-			} else {
-				interviewResult = await promptNativeAskUserQuestionWithDialogs(
-					parsed.questions,
-					ui,
-					options.signal,
-				);
+			try {
+				if (typeof ui.askInterview === "function") {
+					// Cast across structurally-equivalent named types:
+					// ExtensionUIContext declares InterviewQuestion /
+					// InterviewRoundResult (in pi-coding-agent), while this
+					// file works with the original Question / RoundResult from
+					// the shared interview-ui module. Shapes match — only the
+					// names differ.
+					const askInterviewFn = ui.askInterview as (
+						questions: unknown,
+						opts?: { signal?: AbortSignal },
+					) => Promise<RoundResult | undefined>;
+					interviewResult = await askInterviewFn(parsed.questions, { signal: options.signal });
+				} else {
+					interviewResult = await promptNativeAskUserQuestionWithDialogs(
+						parsed.questions,
+						ui,
+						options.signal,
+					);
+				}
+			} catch {
+				interviewResult = undefined;
 			}
 
 			if (!interviewResult || Object.keys(interviewResult.answers).length === 0) {

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1139,9 +1139,25 @@ async function promptNativeAskUserQuestionWithDialogs(
 ): Promise<RoundResult | undefined> {
 	const answers: Record<string, { selected: string | string[]; notes: string }> = {};
 	for (const q of questions) {
-		const displayLabels = q.options.map((o) =>
-			o.description ? `${o.label} — ${o.description}` : o.label,
-		);
+		// Build display labels with an explicit display→original-label map so
+		// the round-trip is injective. The `${label} — ${description}`
+		// formatting alone isn't injective (e.g. label="A — B"+description=""
+		// collides with label="A"+description="B"), so we disambiguate
+		// collisions with a numeric suffix and look up the original label
+		// via the map rather than Array.indexOf.
+		const displayToLabel = new Map<string, string>();
+		const displayLabels: string[] = [];
+		for (const o of q.options) {
+			const baseDisplay = o.description ? `${o.label} — ${o.description}` : o.label;
+			let display = baseDisplay;
+			let suffix = 2;
+			while (displayToLabel.has(display)) {
+				display = `${baseDisplay} (${suffix})`;
+				suffix += 1;
+			}
+			displayToLabel.set(display, o.label);
+			displayLabels.push(display);
+		}
 		const choice = await ui.select(
 			`${q.header}: ${q.question}`,
 			displayLabels,
@@ -1150,10 +1166,7 @@ async function promptNativeAskUserQuestionWithDialogs(
 		if (choice === undefined) {
 			return undefined;
 		}
-		const mapBack = (display: string): string => {
-			const idx = displayLabels.indexOf(display);
-			return idx >= 0 ? q.options[idx]!.label : display;
-		};
+		const mapBack = (display: string): string => displayToLabel.get(display) ?? display;
 		const selectedRaw = Array.isArray(choice) ? choice.map(mapBack) : mapBack(choice);
 		answers[q.id] = {
 			selected: q.allowMultiple
@@ -1211,10 +1224,15 @@ export function createClaudeCodeCanUseToolHandler(
 				};
 			}
 
-			// Treat any rejection from the interview UI (RPC channel error,
-			// JSON serialization fault, mid-loop ui.select rejection) as a
-			// dismiss — the deny path below already produces the right
-			// fallback for the model.
+			// askInterview contract: returns RoundResult on user response
+			// (empty answers = user dismissed); returns undefined when the
+			// implementation cannot satisfy the request (no interactive
+			// surface available). When askInterview returns undefined, fall
+			// back to the sequential ui.select prompt — same as when no
+			// askInterview is implemented at all. Rejections (RPC channel
+			// error, mid-loop ui.select rejection, etc.) are normalized to
+			// undefined so the deny path below produces a clean fallback
+			// for the model.
 			let interviewResult: RoundResult | undefined;
 			try {
 				if (typeof ui.askInterview === "function") {
@@ -1229,7 +1247,8 @@ export function createClaudeCodeCanUseToolHandler(
 						opts?: { signal?: AbortSignal },
 					) => Promise<RoundResult | undefined>;
 					interviewResult = await askInterviewFn(parsed.questions, { signal: options.signal });
-				} else {
+				}
+				if (interviewResult === undefined) {
 					interviewResult = await promptNativeAskUserQuestionWithDialogs(
 						parsed.questions,
 						ui,

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -27,7 +27,7 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { PartialMessageBuilder, ZERO_USAGE, mapUsage } from "./partial-builder.js";
 import { buildWorkflowMcpServers } from "../gsd/workflow-mcp.js";
-import { showInterviewRound, type Question, type RoundResult } from "../shared/tui.js";
+import { showInterviewRound, type Question, type QuestionOption, type RoundResult } from "../shared/tui.js";
 import type {
 	SDKAssistantMessage,
 	SDKMessage,
@@ -965,6 +965,193 @@ function formatToolInput(toolName: string, input: Record<string, unknown>): stri
 	return json.slice(0, 200) + "…";
 }
 
+// ---------------------------------------------------------------------------
+// AskUserQuestion intercept helpers
+// ---------------------------------------------------------------------------
+//
+// These helpers convert between the native Claude Agent SDK `AskUserQuestion`
+// tool input/output shape and GSD's `Question`/`RoundResult` interview types.
+// Kept TUI-free so they can be unit-tested in isolation; the canUseTool
+// intercept that wires them to the interview UI lives in the same file.
+
+/**
+ * Structural shape of an `AskUserQuestion` tool input — mirrors the SDK type
+ * without depending on the SDK re-export. Keep in sync with
+ * `@anthropic-ai/claude-agent-sdk` if the SDK widens or renames fields.
+ */
+interface AskUserQuestionInputShape {
+	questions: Array<{
+		question: string;
+		header: string;
+		multiSelect: boolean;
+		options: Array<{
+			label: string;
+			description: string;
+			preview?: string;
+		}>;
+	}>;
+}
+
+/** Result of converting native `AskUserQuestion` input into interview questions. */
+export type ConvertAskUserQuestionResult =
+	| { ok: true; questions: Question[] }
+	| { ok: false; reason: string };
+
+/**
+ * Convert a native `AskUserQuestion` tool input into GSD interview `Question`s.
+ *
+ * Validates the LLM-supplied shape defensively. On failure returns
+ * `{ ok: false, reason }` with a short human description. On success, each
+ * question is given a positional id (`q_0`, `q_1`, ...) and `allowMultiple`
+ * mirrors `multiSelect`. The LLM's option set is preserved verbatim — no
+ * "Other" / "None of the above" sentinel is appended, since that would
+ * silently change the answer space the LLM was reasoning over.
+ */
+export function convertAskUserQuestionInputToQuestions(
+	input: Record<string, unknown>,
+): ConvertAskUserQuestionResult {
+	const rawQuestions = (input as Partial<AskUserQuestionInputShape>).questions;
+	if (!Array.isArray(rawQuestions) || rawQuestions.length === 0) {
+		return { ok: false, reason: "missing questions array" };
+	}
+
+	const questions: Question[] = [];
+	for (let index = 0; index < rawQuestions.length; index += 1) {
+		const item = rawQuestions[index] as unknown;
+		if (!item || typeof item !== "object") {
+			return { ok: false, reason: `question ${index} is not an object` };
+		}
+		const obj = item as Record<string, unknown>;
+
+		if (typeof obj.question !== "string" || obj.question.length === 0) {
+			return { ok: false, reason: `question ${index} missing question text` };
+		}
+		if (typeof obj.header !== "string" || obj.header.length === 0) {
+			return { ok: false, reason: `question ${index} missing header` };
+		}
+		if (typeof obj.multiSelect !== "boolean") {
+			return { ok: false, reason: `question ${index} missing multiSelect boolean` };
+		}
+		if (!Array.isArray(obj.options) || obj.options.length === 0) {
+			return { ok: false, reason: `question ${index} empty options array` };
+		}
+
+		const options: QuestionOption[] = [];
+		for (let optionIndex = 0; optionIndex < obj.options.length; optionIndex += 1) {
+			const rawOption = obj.options[optionIndex] as unknown;
+			if (!rawOption || typeof rawOption !== "object") {
+				return { ok: false, reason: `question ${index} option ${optionIndex} is not an object` };
+			}
+			const optionObj = rawOption as Record<string, unknown>;
+			if (typeof optionObj.label !== "string" || optionObj.label.length === 0) {
+				return { ok: false, reason: `question ${index} option ${optionIndex} missing label` };
+			}
+			if (typeof optionObj.description !== "string") {
+				return { ok: false, reason: `question ${index} option ${optionIndex} missing description` };
+			}
+			const option: QuestionOption = {
+				label: optionObj.label,
+				description: optionObj.description,
+			};
+			if (typeof optionObj.preview === "string") {
+				option.preview = optionObj.preview;
+			}
+			options.push(option);
+		}
+
+		questions.push({
+			id: `q_${index}`,
+			question: obj.question,
+			header: obj.header,
+			allowMultiple: obj.multiSelect,
+			options,
+		});
+	}
+
+	return { ok: true, questions };
+}
+
+/**
+ * Convert a `RoundResult` from the interview UI back into the native
+ * `AskUserQuestion` answers map keyed by question text.
+ *
+ * Per the SDK doc-comment, multi-select answers are joined with ", " into a
+ * single string. Questions without an answer entry in the round result are
+ * omitted from the returned map.
+ */
+export function roundResultToAskUserQuestionAnswers(
+	input: AskUserQuestionInputShape,
+	result: RoundResult,
+): Record<string, string> {
+	const answers: Record<string, string> = {};
+	for (let index = 0; index < input.questions.length; index += 1) {
+		const question = input.questions[index];
+		if (!question) continue;
+		const answer = result.answers[`q_${index}`];
+		if (!answer) continue;
+		const selected = answer.selected;
+		if (typeof selected === "string") {
+			if (selected.length === 0) continue;
+			answers[question.question] = selected;
+		} else if (Array.isArray(selected)) {
+			if (selected.length === 0) continue;
+			answers[question.question] = selected.join(", ");
+		}
+	}
+	return answers;
+}
+
+/**
+ * Sequential `ui.select`-based fallback for the AskUserQuestion intercept used
+ * when the rich interview surface is unavailable (`ui.askInterview` not
+ * implemented). Each question becomes a separate `ui.select` call. The
+ * LLM-supplied option set is preserved verbatim.
+ *
+ * Option labels are formatted as `"label — description"` so the user sees the
+ * description in plain dialog UIs that don't render rich option metadata.
+ * Selection is mapped back to the original `label` so the answers map keys
+ * match what the LLM provided.
+ *
+ * Returns `undefined` if any question is dismissed (treated as a global
+ * decline).
+ */
+async function promptNativeAskUserQuestionWithDialogs(
+	questions: Question[],
+	ui: ExtensionUIContext,
+	signal: AbortSignal,
+): Promise<RoundResult | undefined> {
+	const answers: Record<string, { selected: string | string[]; notes: string }> = {};
+	for (const q of questions) {
+		const displayLabels = q.options.map((o) =>
+			o.description ? `${o.label} — ${o.description}` : o.label,
+		);
+		const choice = await ui.select(
+			`${q.header}: ${q.question}`,
+			displayLabels,
+			{ signal, ...(q.allowMultiple ? { allowMultiple: true } : {}) },
+		);
+		if (choice === undefined) {
+			return undefined;
+		}
+		const mapBack = (display: string): string => {
+			const idx = displayLabels.indexOf(display);
+			return idx >= 0 ? q.options[idx]!.label : display;
+		};
+		const selectedRaw = Array.isArray(choice) ? choice.map(mapBack) : mapBack(choice);
+		answers[q.id] = {
+			selected: q.allowMultiple
+				? Array.isArray(selectedRaw)
+					? selectedRaw
+					: [selectedRaw]
+				: Array.isArray(selectedRaw)
+					? selectedRaw[0] ?? ""
+					: selectedRaw,
+			notes: "",
+		};
+	}
+	return { endInterview: false, answers };
+}
+
 /**
  * Create a canUseTool handler that routes SDK permission requests through the
  * extension UI's select dialog, or auto-approves when no UI is available.
@@ -991,6 +1178,68 @@ export function createClaudeCodeCanUseToolHandler(
 		// Abort early if the signal is already fired
 		if (options.signal.aborted) {
 			return { behavior: "deny", message: "Aborted", toolUseID: options.toolUseID };
+		}
+
+		// AskUserQuestion intercept: drive GSD's interview UI directly instead
+		// of routing through the generic Allow/Always Allow/Deny permission
+		// flow. The native tool's job is to gather answers; the natural surface
+		// is the structured interview UI.
+		if (toolName === "AskUserQuestion") {
+			const parsed = convertAskUserQuestionInputToQuestions(_input);
+			if (!parsed.ok) {
+				return {
+					behavior: "deny",
+					message: `AskUserQuestion: ${parsed.reason}`,
+					toolUseID: options.toolUseID,
+				};
+			}
+
+			let interviewResult: RoundResult | undefined;
+			if (typeof ui.askInterview === "function") {
+				// Cast across structurally-equivalent named types: ExtensionUIContext
+				// declares InterviewQuestion / InterviewRoundResult (in pi-coding-agent),
+				// while this file works with the original Question / RoundResult from
+				// the shared interview-ui module. Shapes match — only the names differ.
+				const askInterviewFn = ui.askInterview as (
+					questions: unknown,
+					opts?: { signal?: AbortSignal },
+				) => Promise<RoundResult | undefined>;
+				interviewResult = await askInterviewFn(parsed.questions, { signal: options.signal })
+					.catch(() => undefined);
+			} else {
+				interviewResult = await promptNativeAskUserQuestionWithDialogs(
+					parsed.questions,
+					ui,
+					options.signal,
+				);
+			}
+
+			if (!interviewResult || Object.keys(interviewResult.answers).length === 0) {
+				return {
+					behavior: "deny",
+					message: "User declined to answer questions",
+					toolUseID: options.toolUseID,
+				};
+			}
+
+			const answers = roundResultToAskUserQuestionAnswers(
+				_input as unknown as AskUserQuestionInputShape,
+				interviewResult,
+			);
+
+			if (Object.keys(answers).length === 0) {
+				return {
+					behavior: "deny",
+					message: "User declined to answer questions",
+					toolUseID: options.toolUseID,
+				};
+			}
+
+			return {
+				behavior: "allow",
+				updatedInput: { ..._input, answers },
+				toolUseID: options.toolUseID,
+			};
 		}
 
 		// For Bash compound commands (e.g. "cd /path && gh pr list"),

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter-askuserquestion.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter-askuserquestion.test.ts
@@ -122,6 +122,19 @@ describe("convertAskUserQuestionInputToQuestions invalid inputs", () => {
 		assert.equal(r.questions[1].id, "q_1");
 		assert.equal(r.questions[1].allowMultiple, true);
 	});
+	test("rejects payloads with duplicate question text", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [
+				{ question: "Same?", header: "H1", multiSelect: false,
+					options: [{ label: "A", description: "" }] },
+				{ question: "Same?", header: "H2", multiSelect: false,
+					options: [{ label: "B", description: "" }] },
+			],
+		});
+		assert.equal(r.ok, false);
+		if (r.ok) return;
+		assert.match(r.reason, /duplicate question text: Same\?/);
+	});
 });
 
 describe("roundResultToAskUserQuestionAnswers", () => {

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter-askuserquestion.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter-askuserquestion.test.ts
@@ -135,6 +135,33 @@ describe("convertAskUserQuestionInputToQuestions invalid inputs", () => {
 		if (r.ok) return;
 		assert.match(r.reason, /duplicate question text: Same\?/);
 	});
+	test("rejects whitespace-only question text", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [{ question: "   ", header: "H", multiSelect: false,
+				options: [{ label: "A", description: "" }] }],
+		});
+		assert.equal(r.ok, false);
+		if (r.ok) return;
+		assert.match(r.reason, /question 0 missing question text/);
+	});
+	test("rejects whitespace-only header", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [{ question: "Q", header: "  ", multiSelect: false,
+				options: [{ label: "A", description: "" }] }],
+		});
+		assert.equal(r.ok, false);
+		if (r.ok) return;
+		assert.match(r.reason, /question 0 missing header/);
+	});
+	test("rejects whitespace-only option label", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [{ question: "Q", header: "H", multiSelect: false,
+				options: [{ label: "  ", description: "" }] }],
+		});
+		assert.equal(r.ok, false);
+		if (r.ok) return;
+		assert.match(r.reason, /option 0 missing label/);
+	});
 	test("rejects duplicate option labels within a question", () => {
 		const r = convertAskUserQuestionInputToQuestions({
 			questions: [
@@ -195,7 +222,7 @@ describe("roundResultToAskUserQuestionAnswers", () => {
 			endInterview: false,
 			answers: {},
 		});
-		assert.deepEqual(r, {});
+		assert.deepEqual({ ...r }, {});
 	});
 
 	test("omits questions with empty-string selected", () => {
@@ -203,7 +230,7 @@ describe("roundResultToAskUserQuestionAnswers", () => {
 			endInterview: false,
 			answers: { q_0: { selected: "", notes: "" } },
 		});
-		assert.deepEqual(r, {});
+		assert.deepEqual({ ...r }, {});
 	});
 
 	test("omits questions with empty-array selected", () => {
@@ -211,7 +238,39 @@ describe("roundResultToAskUserQuestionAnswers", () => {
 			endInterview: false,
 			answers: { q_1: { selected: [], notes: "" } },
 		});
-		assert.deepEqual(r, {});
+		assert.deepEqual({ ...r }, {});
+	});
+
+	test("ignores selections that are not in the original options", () => {
+		const r = roundResultToAskUserQuestionAnswers(input as any, {
+			endInterview: false,
+			answers: { q_0: { selected: "Z", notes: "" } },
+		});
+		assert.equal(r["Pick one"], undefined);
+	});
+
+	test("ignores multi-select arrays containing off-menu labels", () => {
+		const r = roundResultToAskUserQuestionAnswers(input as any, {
+			endInterview: false,
+			answers: { q_1: { selected: ["X", "BAD"], notes: "" } },
+		});
+		assert.equal(r["Pick many"], undefined);
+	});
+
+	test("dedupes multi-select selections", () => {
+		const r = roundResultToAskUserQuestionAnswers(input as any, {
+			endInterview: false,
+			answers: { q_1: { selected: ["X", "X", "Y"], notes: "" } },
+		});
+		assert.equal(r["Pick many"], "X, Y");
+	});
+
+	test("returns a null-prototype map (no inherited keys)", () => {
+		const r = roundResultToAskUserQuestionAnswers(input as any, {
+			endInterview: false,
+			answers: { q_0: { selected: "A", notes: "" } },
+		});
+		assert.equal(Object.getPrototypeOf(r), null);
 	});
 });
 

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter-askuserquestion.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter-askuserquestion.test.ts
@@ -135,6 +135,20 @@ describe("convertAskUserQuestionInputToQuestions invalid inputs", () => {
 		if (r.ok) return;
 		assert.match(r.reason, /duplicate question text: Same\?/);
 	});
+	test("rejects duplicate option labels within a question", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [
+				{ question: "Q", header: "H", multiSelect: false,
+					options: [
+						{ label: "A", description: "first" },
+						{ label: "A", description: "second" },
+					] },
+			],
+		});
+		assert.equal(r.ok, false);
+		if (r.ok) return;
+		assert.match(r.reason, /duplicate option label "A"/);
+	});
 });
 
 describe("roundResultToAskUserQuestionAnswers", () => {
@@ -297,5 +311,31 @@ describe("createClaudeCodeCanUseToolHandler — AskUserQuestion intercept", () =
 		if (result.behavior !== "allow") return;
 		const updatedInput = result.updatedInput as { answers: Record<string, string> };
 		assert.equal(updatedInput.answers["Pick one"], "A");
+	});
+
+	test("denies when answers are partial (count != questions)", async () => {
+		const twoQuestionInput = {
+			questions: [
+				{ question: "Q1", header: "H1", multiSelect: false,
+					options: [{ label: "A", description: "" }] },
+				{ question: "Q2", header: "H2", multiSelect: false,
+					options: [{ label: "B", description: "" }] },
+			],
+		};
+		const ui: any = {
+			askInterview: async () => ({
+				endInterview: false,
+				answers: { q_0: { selected: "A", notes: "" } },
+			}),
+		};
+		const handler = createClaudeCodeCanUseToolHandler(ui);
+		const result = await handler!("AskUserQuestion", twoQuestionInput as any, {
+			signal: new AbortController().signal,
+			toolUseID: "tu_6",
+			suggestions: [],
+		} as any);
+		assert.equal(result.behavior, "deny");
+		if (result.behavior !== "deny") return;
+		assert.equal(result.message, "User declined to answer questions");
 	});
 });

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter-askuserquestion.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter-askuserquestion.test.ts
@@ -1,0 +1,288 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+	convertAskUserQuestionInputToQuestions,
+	roundResultToAskUserQuestionAnswers,
+} from "../stream-adapter.ts";
+
+describe("convertAskUserQuestionInputToQuestions", () => {
+	test("converts a valid single-question single-select input", () => {
+		const input = {
+			questions: [
+				{
+					question: "Pick one",
+					header: "Q1",
+					multiSelect: false,
+					options: [
+						{ label: "A", description: "First" },
+						{ label: "B", description: "Second" },
+					],
+				},
+			],
+		};
+		const result = convertAskUserQuestionInputToQuestions(input);
+		assert.equal(result.ok, true);
+		if (!result.ok) return;
+		assert.equal(result.questions.length, 1);
+		assert.equal(result.questions[0].id, "q_0");
+		assert.equal(result.questions[0].header, "Q1");
+		assert.equal(result.questions[0].question, "Pick one");
+		assert.equal(result.questions[0].allowMultiple, false);
+		assert.equal(result.questions[0].options.length, 2);
+		assert.equal(result.questions[0].options[0].label, "A");
+		assert.equal(result.questions[0].options[0].description, "First");
+	});
+});
+
+describe("convertAskUserQuestionInputToQuestions invalid inputs", () => {
+	test("rejects missing questions array", () => {
+		const r = convertAskUserQuestionInputToQuestions({});
+		assert.equal(r.ok, false);
+		if (r.ok) return;
+		assert.match(r.reason, /missing questions array/);
+	});
+	test("rejects empty questions array", () => {
+		const r = convertAskUserQuestionInputToQuestions({ questions: [] });
+		assert.equal(r.ok, false);
+	});
+	test("rejects question missing question text", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [{ header: "H", multiSelect: false, options: [{ label: "A", description: "" }] }],
+		});
+		assert.equal(r.ok, false);
+		if (r.ok) return;
+		assert.match(r.reason, /question 0 missing question text/);
+	});
+	test("rejects question missing header", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [{ question: "Q", multiSelect: false, options: [{ label: "A", description: "" }] }],
+		});
+		assert.equal(r.ok, false);
+		if (r.ok) return;
+		assert.match(r.reason, /question 0 missing header/);
+	});
+	test("rejects question missing multiSelect boolean", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [{ question: "Q", header: "H", options: [{ label: "A", description: "" }] }],
+		});
+		assert.equal(r.ok, false);
+		if (r.ok) return;
+		assert.match(r.reason, /multiSelect boolean/);
+	});
+	test("rejects question with empty options array", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [{ question: "Q", header: "H", multiSelect: false, options: [] }],
+		});
+		assert.equal(r.ok, false);
+		if (r.ok) return;
+		assert.match(r.reason, /empty options array/);
+	});
+	test("rejects option missing label", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [{ question: "Q", header: "H", multiSelect: false, options: [{ description: "x" }] }],
+		});
+		assert.equal(r.ok, false);
+		if (r.ok) return;
+		assert.match(r.reason, /option 0 missing label/);
+	});
+	test("rejects option missing description", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [{ question: "Q", header: "H", multiSelect: false, options: [{ label: "L" }] }],
+		});
+		assert.equal(r.ok, false);
+		if (r.ok) return;
+		assert.match(r.reason, /option 0 missing description/);
+	});
+	test("preserves preview field when present", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [{
+				question: "Q", header: "H", multiSelect: false,
+				options: [{ label: "A", description: "d", preview: "```ts\nfoo\n```" }],
+			}],
+		});
+		assert.equal(r.ok, true);
+		if (!r.ok) return;
+		assert.equal(r.questions[0].options[0].preview, "```ts\nfoo\n```");
+	});
+	test("converts multi-question multi-select input", () => {
+		const r = convertAskUserQuestionInputToQuestions({
+			questions: [
+				{ question: "Q1", header: "H1", multiSelect: false,
+					options: [{ label: "A", description: "" }, { label: "B", description: "" }] },
+				{ question: "Q2", header: "H2", multiSelect: true,
+					options: [{ label: "X", description: "" }, { label: "Y", description: "" }] },
+			],
+		});
+		assert.equal(r.ok, true);
+		if (!r.ok) return;
+		assert.equal(r.questions.length, 2);
+		assert.equal(r.questions[0].id, "q_0");
+		assert.equal(r.questions[0].allowMultiple, false);
+		assert.equal(r.questions[1].id, "q_1");
+		assert.equal(r.questions[1].allowMultiple, true);
+	});
+});
+
+describe("roundResultToAskUserQuestionAnswers", () => {
+	const input = {
+		questions: [
+			{ question: "Pick one", header: "Q1", multiSelect: false,
+				options: [{ label: "A", description: "" }, { label: "B", description: "" }] },
+			{ question: "Pick many", header: "Q2", multiSelect: true,
+				options: [{ label: "X", description: "" }, { label: "Y", description: "" }] },
+		],
+	};
+
+	test("maps single-select string answer keyed by question text", () => {
+		const r = roundResultToAskUserQuestionAnswers(input as any, {
+			endInterview: false,
+			answers: { q_0: { selected: "A", notes: "" } },
+		});
+		assert.equal(r["Pick one"], "A");
+		assert.equal(r["Pick many"], undefined);
+	});
+
+	test("joins multi-select array with comma-space", () => {
+		const r = roundResultToAskUserQuestionAnswers(input as any, {
+			endInterview: false,
+			answers: { q_1: { selected: ["X", "Y"], notes: "" } },
+		});
+		assert.equal(r["Pick many"], "X, Y");
+	});
+
+	test("includes both questions when both answered", () => {
+		const r = roundResultToAskUserQuestionAnswers(input as any, {
+			endInterview: false,
+			answers: {
+				q_0: { selected: "B", notes: "" },
+				q_1: { selected: ["X"], notes: "" },
+			},
+		});
+		assert.equal(r["Pick one"], "B");
+		assert.equal(r["Pick many"], "X");
+	});
+
+	test("omits questions with no answer entry", () => {
+		const r = roundResultToAskUserQuestionAnswers(input as any, {
+			endInterview: false,
+			answers: {},
+		});
+		assert.deepEqual(r, {});
+	});
+
+	test("omits questions with empty-string selected", () => {
+		const r = roundResultToAskUserQuestionAnswers(input as any, {
+			endInterview: false,
+			answers: { q_0: { selected: "", notes: "" } },
+		});
+		assert.deepEqual(r, {});
+	});
+
+	test("omits questions with empty-array selected", () => {
+		const r = roundResultToAskUserQuestionAnswers(input as any, {
+			endInterview: false,
+			answers: { q_1: { selected: [], notes: "" } },
+		});
+		assert.deepEqual(r, {});
+	});
+});
+
+import { createClaudeCodeCanUseToolHandler } from "../stream-adapter.ts";
+
+describe("createClaudeCodeCanUseToolHandler — AskUserQuestion intercept", () => {
+	const validInput = {
+		questions: [
+			{
+				question: "Pick one",
+				header: "Q1",
+				multiSelect: false,
+				options: [
+					{ label: "A", description: "first" },
+					{ label: "B", description: "second" },
+				],
+			},
+		],
+	};
+
+	test("uses ui.askInterview when present and returns answers", async () => {
+		const ui: any = {
+			askInterview: async () => ({
+				endInterview: false,
+				answers: { q_0: { selected: "A", notes: "" } },
+			}),
+			select: async () => "Allow",
+		};
+		const handler = createClaudeCodeCanUseToolHandler(ui);
+		assert.ok(handler);
+		const controller = new AbortController();
+		const result = await handler!("AskUserQuestion", validInput as any, {
+			signal: controller.signal,
+			toolUseID: "tu_1",
+			suggestions: [],
+		} as any);
+		assert.equal(result.behavior, "allow");
+		if (result.behavior !== "allow") return;
+		const updatedInput = result.updatedInput as { answers: Record<string, string> };
+		assert.deepEqual(updatedInput.answers, { "Pick one": "A" });
+	});
+
+	test("denies with reason when input is malformed", async () => {
+		const ui: any = { askInterview: async () => undefined, select: async () => undefined };
+		const handler = createClaudeCodeCanUseToolHandler(ui);
+		const result = await handler!("AskUserQuestion", { not: "valid" } as any, {
+			signal: new AbortController().signal,
+			toolUseID: "tu_2",
+			suggestions: [],
+		} as any);
+		assert.equal(result.behavior, "deny");
+		if (result.behavior !== "deny") return;
+		assert.match(result.message ?? "", /^AskUserQuestion: /);
+	});
+
+	test("denies when askInterview returns empty answers", async () => {
+		const ui: any = {
+			askInterview: async () => ({ endInterview: false, answers: {} }),
+		};
+		const handler = createClaudeCodeCanUseToolHandler(ui);
+		const result = await handler!("AskUserQuestion", validInput as any, {
+			signal: new AbortController().signal,
+			toolUseID: "tu_3",
+			suggestions: [],
+		} as any);
+		assert.equal(result.behavior, "deny");
+		if (result.behavior !== "deny") return;
+		assert.equal(result.message, "User declined to answer questions");
+	});
+
+	test("denies when AbortSignal already fired", async () => {
+		const ui: any = { askInterview: async () => ({ endInterview: false, answers: {} }) };
+		const handler = createClaudeCodeCanUseToolHandler(ui);
+		const controller = new AbortController();
+		controller.abort();
+		const result = await handler!("AskUserQuestion", validInput as any, {
+			signal: controller.signal,
+			toolUseID: "tu_4",
+			suggestions: [],
+		} as any);
+		assert.equal(result.behavior, "deny");
+		if (result.behavior !== "deny") return;
+		assert.equal(result.message, "Aborted");
+	});
+
+	test("falls back to sequential ui.select when askInterview is undefined", async () => {
+		const ui: any = {
+			select: async (_title: string, options: string[]) => options[0],
+		};
+		const handler = createClaudeCodeCanUseToolHandler(ui);
+		const result = await handler!("AskUserQuestion", validInput as any, {
+			signal: new AbortController().signal,
+			toolUseID: "tu_5",
+			suggestions: [],
+		} as any);
+		assert.equal(result.behavior, "allow");
+		if (result.behavior !== "allow") return;
+		const updatedInput = result.updatedInput as { answers: Record<string, string> };
+		assert.equal(updatedInput.answers["Pick one"], "A");
+	});
+});

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter-askuserquestion.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter-askuserquestion.test.ts
@@ -313,6 +313,63 @@ describe("createClaudeCodeCanUseToolHandler — AskUserQuestion intercept", () =
 		assert.equal(updatedInput.answers["Pick one"], "A");
 	});
 
+	test("falls back to ui.select when askInterview returns undefined", async () => {
+		const ui: any = {
+			askInterview: async () => undefined,
+			select: async (_title: string, options: string[]) => options[0],
+		};
+		const handler = createClaudeCodeCanUseToolHandler(ui);
+		const result = await handler!("AskUserQuestion", validInput as any, {
+			signal: new AbortController().signal,
+			toolUseID: "tu_fb",
+			suggestions: [],
+		} as any);
+		assert.equal(result.behavior, "allow");
+		if (result.behavior !== "allow") return;
+		const updatedInput = result.updatedInput as { answers: Record<string, string> };
+		assert.equal(updatedInput.answers["Pick one"], "A");
+	});
+
+	test("fallback maps display labels back to original on collision", async () => {
+		// Construct two options whose display strings would collide if
+		// "label — description" weren't disambiguated:
+		// option 0 — label="A — B", description=""        → "A — B"
+		// option 1 — label="A",      description="B"       → "A — B"
+		// The fallback's Map adds " (2)" to the second to make it injective.
+		const collisionInput = {
+			questions: [
+				{
+					question: "Pick",
+					header: "Q",
+					multiSelect: false,
+					options: [
+						{ label: "A — B", description: "" },
+						{ label: "A", description: "B" },
+					],
+				},
+			],
+		};
+		// Capture what ui.select was offered, then pick the second label.
+		let offeredOptions: string[] = [];
+		const ui: any = {
+			select: async (_title: string, options: string[]) => {
+				offeredOptions = options;
+				return options[1];
+			},
+		};
+		const handler = createClaudeCodeCanUseToolHandler(ui);
+		const result = await handler!("AskUserQuestion", collisionInput as any, {
+			signal: new AbortController().signal,
+			toolUseID: "tu_collision",
+			suggestions: [],
+		} as any);
+		assert.equal(result.behavior, "allow");
+		if (result.behavior !== "allow") return;
+		assert.notEqual(offeredOptions[0], offeredOptions[1]);
+		const updatedInput = result.updatedInput as { answers: Record<string, string> };
+		assert.equal(updatedInput.answers["Pick"], "A");
+	});
+
 	test("denies when answers are partial (count != questions)", async () => {
 		const twoQuestionInput = {
 			questions: [

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1614,17 +1614,17 @@ describe("stream-adapter — canUseTool handler", () => {
 		const ui = { select: async (_p: string, opts: string[]) => opts.find((o) => o.startsWith("Always Allow"))!, notify: (msg: string) => notified.push(msg) };
 
 		const handler = createClaudeCodeCanUseToolHandler(ui as any);
-		const result = await handler!("AskUserQuestion", { questions: [{ question: "?", header: "h", multiSelect: false, options: [] }] }, makeOptions());
+		const result = await handler!("Glob", { pattern: "**/*.ts" }, makeOptions());
 
 		assert.equal(result.behavior, "allow");
 		assert.deepEqual((result as any).updatedPermissions, [{
 			type: "addRules",
-			rules: [{ toolName: "AskUserQuestion" }],
+			rules: [{ toolName: "Glob" }],
 			behavior: "allow",
 			destination: "localSettings",
 		}]);
 		assert.equal(notified.length, 1);
-		assert.match(notified[0], /AskUserQuestion/);
+		assert.match(notified[0], /Glob/);
 	});
 
 	test("Always Allow for non-Bash with empty suggestions array builds tool-name-only fallback rule", async () => {
@@ -1632,17 +1632,17 @@ describe("stream-adapter — canUseTool handler", () => {
 		const ui = { select: async (_p: string, opts: string[]) => opts.find((o) => o.startsWith("Always Allow"))!, notify: (msg: string) => notified.push(msg) };
 
 		const handler = createClaudeCodeCanUseToolHandler(ui as any);
-		const result = await handler!("AskUserQuestion", { questions: [{ question: "?", header: "h", multiSelect: false, options: [] }] }, makeOptions({ suggestions: [] }));
+		const result = await handler!("Glob", { pattern: "**/*.ts" }, makeOptions({ suggestions: [] }));
 
 		assert.equal(result.behavior, "allow");
 		assert.deepEqual((result as any).updatedPermissions, [{
 			type: "addRules",
-			rules: [{ toolName: "AskUserQuestion" }],
+			rules: [{ toolName: "Glob" }],
 			behavior: "allow",
 			destination: "localSettings",
 		}]);
 		assert.equal(notified.length, 1);
-		assert.match(notified[0], /AskUserQuestion/);
+		assert.match(notified[0], /Glob/);
 	});
 
 	test("prompt includes command text for Bash tools", async () => {

--- a/web/components/gsd/focused-panel.tsx
+++ b/web/components/gsd/focused-panel.tsx
@@ -419,7 +419,10 @@ function RequestBody({
     case "select":
       return <SelectRenderer request={request} onSubmit={onSubmit} disabled={disabled} />
     case "interview":
-      return <InterviewRenderer request={request} onSubmit={onSubmit} disabled={disabled} />
+      // Key by request.id so React remounts InterviewRenderer when the active
+      // request changes — guarantees a clean slate for singles/multis/preview
+      // state across queued requests.
+      return <InterviewRenderer key={request.id} request={request} onSubmit={onSubmit} disabled={disabled} />
     case "confirm":
       return <ConfirmRenderer request={request} onSubmit={onSubmit} onCancel={onCancel} disabled={disabled} />
     case "input":

--- a/web/components/gsd/focused-panel.tsx
+++ b/web/components/gsd/focused-panel.tsx
@@ -27,6 +27,7 @@ import { cn } from "@/lib/utils"
 function methodIcon(method: PendingUiRequest["method"]) {
   switch (method) {
     case "select":
+    case "interview":
       return <CheckSquare className="h-4 w-4" />
     case "confirm":
       return <MessageSquare className="h-4 w-4" />
@@ -41,6 +42,8 @@ function methodLabel(method: PendingUiRequest["method"]): string {
   switch (method) {
     case "select":
       return "Selection"
+    case "interview":
+      return "Interview"
     case "confirm":
       return "Confirmation"
     case "input":
@@ -228,6 +231,179 @@ function EditorRenderer({
   )
 }
 
+function InterviewRenderer({
+  request,
+  onSubmit,
+  disabled,
+}: {
+  request: Extract<PendingUiRequest, { method: "interview" }>
+  onSubmit: (value: Record<string, unknown>) => void
+  disabled: boolean
+}) {
+  const [singles, setSingles] = useState<Record<string, string>>({})
+  const [multis, setMultis] = useState<Record<string, Set<string>>>({})
+  const [openPreviews, setOpenPreviews] = useState<Set<string>>(new Set())
+
+  const togglePreview = (key: string) => {
+    setOpenPreviews((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  const allAnswered = request.questions.every((q) =>
+    q.allowMultiple ? (multis[q.id]?.size ?? 0) > 0 : Boolean(singles[q.id]),
+  )
+
+  const handleSubmit = () => {
+    const answers: Record<string, { selected: string | string[]; notes: string }> = {}
+    for (const q of request.questions) {
+      if (q.allowMultiple) {
+        const set = multis[q.id]
+        if (set && set.size > 0) {
+          answers[q.id] = { selected: Array.from(set), notes: "" }
+        }
+      } else {
+        const value = singles[q.id]
+        if (value) {
+          answers[q.id] = { selected: value, notes: "" }
+        }
+      }
+    }
+    onSubmit({ answers })
+  }
+
+  const totalSelected = request.questions.reduce(
+    (acc, q) =>
+      q.allowMultiple ? acc + (multis[q.id]?.size ?? 0) : acc + (singles[q.id] ? 1 : 0),
+    0,
+  )
+
+  return (
+    <div className="space-y-6" data-testid="focused-panel-interview">
+      {request.questions.map((q) => (
+        <div key={q.id} className="space-y-3" data-testid={`interview-question-${q.id}`}>
+          <div className="space-y-1">
+            <h3 className="text-sm font-semibold">{q.header}</h3>
+            <p className="text-sm text-muted-foreground">{q.question}</p>
+          </div>
+
+          {q.allowMultiple ? (
+            <div className="space-y-2">
+              {q.options.map((option, i) => {
+                const previewKey = `${q.id}::${i}`
+                const checked = multis[q.id]?.has(option.label) ?? false
+                return (
+                  <div key={option.label} className="space-y-1">
+                    <label
+                      className="flex cursor-pointer items-start gap-3 rounded-lg border border-border bg-background px-3 py-2.5 transition-colors hover:bg-accent/40"
+                      data-testid={`interview-option-${q.id}-${i}`}
+                    >
+                      <Checkbox
+                        checked={checked}
+                        onCheckedChange={(state) => {
+                          const next = new Set(multis[q.id] ?? new Set<string>())
+                          if (state) next.add(option.label)
+                          else next.delete(option.label)
+                          setMultis((prev) => ({ ...prev, [q.id]: next }))
+                        }}
+                        disabled={disabled}
+                      />
+                      <span className="flex-1 space-y-0.5">
+                        <span className="block text-sm font-medium">{option.label}</span>
+                        {option.description && (
+                          <span className="block text-xs text-muted-foreground">
+                            {option.description}
+                          </span>
+                        )}
+                      </span>
+                    </label>
+                    {option.preview && (
+                      <button
+                        type="button"
+                        className="ml-7 text-xs text-muted-foreground underline"
+                        onClick={() => togglePreview(previewKey)}
+                        disabled={disabled}
+                      >
+                        {openPreviews.has(previewKey) ? "Hide preview" : "Show preview"}
+                      </button>
+                    )}
+                    {option.preview && openPreviews.has(previewKey) && (
+                      <pre className="ml-7 max-h-48 overflow-auto rounded bg-muted px-3 py-2 text-xs">
+                        {option.preview}
+                      </pre>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <RadioGroup
+              value={singles[q.id] ?? ""}
+              onValueChange={(v) => setSingles((prev) => ({ ...prev, [q.id]: v }))}
+              disabled={disabled}
+            >
+              {q.options.map((option, i) => {
+                const previewKey = `${q.id}::${i}`
+                return (
+                  <div key={option.label} className="space-y-1">
+                    <label
+                      className="flex cursor-pointer items-start gap-3 rounded-lg border border-border bg-background px-3 py-2.5 transition-colors hover:bg-accent/40"
+                      data-testid={`interview-option-${q.id}-${i}`}
+                    >
+                      <RadioGroupItem value={option.label} id={`interview-${q.id}-${i}`} />
+                      <Label
+                        htmlFor={`interview-${q.id}-${i}`}
+                        className="flex-1 cursor-pointer space-y-0.5 font-normal"
+                      >
+                        <span className="block text-sm font-medium">{option.label}</span>
+                        {option.description && (
+                          <span className="block text-xs text-muted-foreground">
+                            {option.description}
+                          </span>
+                        )}
+                      </Label>
+                    </label>
+                    {option.preview && (
+                      <button
+                        type="button"
+                        className="ml-7 text-xs text-muted-foreground underline"
+                        onClick={() => togglePreview(previewKey)}
+                        disabled={disabled}
+                      >
+                        {openPreviews.has(previewKey) ? "Hide preview" : "Show preview"}
+                      </button>
+                    )}
+                    {option.preview && openPreviews.has(previewKey) && (
+                      <pre className="ml-7 max-h-48 overflow-auto rounded bg-muted px-3 py-2 text-xs">
+                        {option.preview}
+                      </pre>
+                    )}
+                  </div>
+                )
+              })}
+            </RadioGroup>
+          )}
+        </div>
+      ))}
+
+      <Button
+        onClick={handleSubmit}
+        disabled={disabled || !allAnswered}
+        className="w-full"
+        data-testid="focused-panel-interview-submit"
+      >
+        <Send className="h-4 w-4" />
+        {totalSelected > 0
+          ? `Submit (${totalSelected} selected)`
+          : "Submit"}
+      </Button>
+    </div>
+  )
+}
+
 function RequestBody({
   request,
   onSubmit,
@@ -242,6 +418,8 @@ function RequestBody({
   switch (request.method) {
     case "select":
       return <SelectRenderer request={request} onSubmit={onSubmit} disabled={disabled} />
+    case "interview":
+      return <InterviewRenderer request={request} onSubmit={onSubmit} disabled={disabled} />
     case "confirm":
       return <ConfirmRenderer request={request} onSubmit={onSubmit} onCancel={onCancel} disabled={disabled} />
     case "input":

--- a/web/lib/gsd-workspace-store.tsx
+++ b/web/lib/gsd-workspace-store.tsx
@@ -388,6 +388,7 @@ export type ExtensionUiRequestEvent =
   | { type: "extension_ui_request"; id: string; method: "confirm"; title: string; message: string; timeout?: number }
   | { type: "extension_ui_request"; id: string; method: "input"; title: string; placeholder?: string; timeout?: number }
   | { type: "extension_ui_request"; id: string; method: "editor"; title: string; prefill?: string }
+  | { type: "extension_ui_request"; id: string; method: "interview"; questions: Array<{ id: string; header: string; question: string; allowMultiple: boolean; options: Array<{ label: string; description: string; preview?: string }> }>; timeout?: number }
   | { type: "extension_ui_request"; id: string; method: "notify"; message: string; notifyType?: "info" | "warning" | "error" }
   | { type: "extension_ui_request"; id: string; method: "setStatus"; statusKey: string; statusText: string | undefined }
   | { type: "extension_ui_request"; id: string; method: "setWidget"; widgetKey: string; widgetLines: string[] | undefined; widgetPlacement?: "aboveEditor" | "belowEditor" }
@@ -504,7 +505,7 @@ export type WorkspaceOnboardingRequestState =
 // The `method` field discriminates the payload shape.
 export type PendingUiRequest = Extract<
   ExtensionUiRequestEvent,
-  { method: "select" | "confirm" | "input" | "editor" }
+  { method: "select" | "confirm" | "input" | "editor" | "interview" }
 >
 
 export interface ActiveToolExecution {
@@ -5010,6 +5011,7 @@ export class GSDWorkspaceStore {
       case "confirm":
       case "input":
       case "editor":
+      case "interview":
         this.patchState({
           pendingUiRequests: [...this.state.pendingUiRequests, event as PendingUiRequest],
         })


### PR DESCRIPTION
## Summary

Closes #5116.

When Claude Code (Opus 4.7) calls its native `AskUserQuestion` tool inside a GSD session with the Interactive GSD pane visible, the pane previously rendered the raw JSON of the questions payload as prompt text and the generic tool-permission button row (Allow / Always Allow / Deny / Submit). Approving never populated `updatedInput.answers`, so the SDK returned an empty result to the model — a hard stall in auto mode.

This change intercepts `AskUserQuestion` in `createClaudeCodeCanUseToolHandler`, drives a structured interview UI in both the TUI and the Interactive GSD (web) pane, and returns `updatedInput.answers` keyed by question text per the SDK contract. Deny on malformed input / dismiss / abort — never allow with empty answers.

### What's in the diff

- **TUI-free conversion helpers** (`stream-adapter.ts`):
  - `convertAskUserQuestionInputToQuestions` — defensive validation, returns `{ ok, questions } | { ok: false, reason }`. Multi-question + multi-select + per-option `preview` all supported. No synthetic "None of the above" appended.
  - `roundResultToAskUserQuestionAnswers` — keyed by original question text, multi-select joined with `", "`, empty selections omitted.
  - `promptNativeAskUserQuestionWithDialogs` — sequential `ui.select` fallback when `ui.askInterview` isn't available; option labels formatted as `"label — description"`, mapped back to original `label` on submit.
- **New optional `ExtensionUIContext.askInterview`** primitive (`pi-coding-agent`):
  - `InterviewQuestion` / `InterviewOption` / `InterviewRoundResult` types defined inline so the contract doesn't reach across packages.
  - RPC mode wires `askInterview` to a new `"interview"` request variant + `{ answers }` response, mirrored in `rpc-client`.
  - Interactive (TUI) mode delegates to the existing `showInterviewRound` via a variable-indirected dynamic import (so tsc's `rootDir` check doesn't follow the cross-package path).
- **Web `InterviewRenderer` in FocusedPanel**:
  - Per-question header + question, single-select via `RadioGroup`, multi-select via `Checkbox`, optional collapsible markdown preview per option, single bottom Submit disabled until every question has at least one selection.
  - `handleExtensionUiRequest` in the workspace store now routes `interview` events to `pendingUiRequests`.
- **Tests** — 22 unit + behavioral tests in `stream-adapter-askuserquestion.test.ts` covering helpers, allow path via `askInterview`, deny paths (malformed input, empty answers, aborted signal), sequential fallback. Two pre-existing tests that used `AskUserQuestion` as a generic non-Bash fixture for "Always Allow" rule construction were swapped to `Glob` since the new intercept short-circuits before the generic flow.

## Why this approach (vs. alternatives)

- **Reusing the GSD `ask_user_questions` MCP tool** was considered. Rejected because invoking the MCP tool from inside a `canUseTool` callback would require plumbing the MCP client into the SDK adapter and risks circularity. The intercept-based approach keeps the change contained.
- **Disabling `AskUserQuestion` entirely** was attempted in #4958 and closed. We make the tool work in the surfaces users actually have, without pulling it out of the model context.

## Test plan

- [x] Full unit suite — 8084 pass, 2 unrelated perf-timing flakes (`context-store: sub-5ms query timing` — environment-dependent, not touched by this change).
- [x] Full package-tests suite — clean across all workspace packages.
- [x] Full claude-code-cli suite — 163/163.
- [x] `scripts/check-source-grep-tests.sh` — pass.
- [x] `scripts/check-coderabbit-themes.mjs` — pass.
- [x] `tsc --noEmit` clean for all touched files.
- [x] Local manual smoke against the live reproduction:
  - Built local binary on debian linux-arm64.
  - Drove Opus 4.7 to call `AskUserQuestion` in Power User Mode.
  - Verified the Interactive GSD pane renders header + question + option cards with description, Submit posts answers, agent receives non-empty answers map and continues.
  - Verified deny on dismiss returns the correct "User declined to answer questions" message.

## Spec & plan

Captured in repo at:
- `docs/superpowers/specs/2026-04-29-askuserquestion-interactive-pane-design.md`
- `docs/superpowers/plans/2026-04-29-askuserquestion-interactive-pane.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interview questionnaire UI for multi-question dialogs with single/multiple-choice options, optional per-option previews, free-form notes, and a programmatic askInterview dialog across UI and RPC flows.

* **Behavior**
  * Headless/non-interactive flows treat interview prompts as cancelled; UI gates submit until all questions answered and maps structured answers back to callers.

* **Tests**
  * Added tests covering input validation, answer conversion, permission handling, and fallback selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->