### PR TITLE
fix(pi-coding-agent): collectAutoExtensionEntries should include subdirs even when top-level entry exists

### DIFF
--- a/packages/pi-coding-agent/docs/aar/2026-04-30-extension-auto-discovery-early-return.md
+++ b/packages/pi-coding-agent/docs/aar/2026-04-30-extension-auto-discovery-early-return.md
@@ -1,0 +1,150 @@
+# AAR — pi-coding-agent extension auto-discovery early-return regression
+
+**Date:** 2026-04-30
+**Affected versions:** through `gsd-pi@2.78.1` (verified) — likely all prior versions that ship `collectAutoExtensionEntries` with the early-return shape.
+**Author:** Regis-RCR
+**Status:** Fix proposed in PR fixing `packages/pi-coding-agent/src/core/package-manager.ts`.
+
+## TL;DR
+
+When `~/.gsd/agent/extensions/` contains both a top-level `index.{ts,js}` (the typical shape of a user-installed extension wrapper) **and** subdirectories (the bundled extensions: `gsd`, `bg-shell`, `browser-tools`, `claude-code-cli`, ...), `collectAutoExtensionEntries(dir)` returned only the top-level entry and silently skipped every bundled subdirectory. Pi loaded the user wrapper but registered zero bundled-extension commands, so `/gsd <subcommand>` and friends fell through to the LLM as raw user text instead of being intercepted by the registered handler.
+
+## Symptom (production behavior observed)
+
+Reproduced during the `rcr-gain` project's M007 milestone pilot.
+
+- Environment: `gsd-pi@2.78.1` with a single top-level user extension installed at `~/.gsd/agent/extensions/index.js` (a wrapper for the EpsilonCode adapter).
+- Bundled extension subdirectories present alongside the wrapper: `gsd/`, `bg-shell/`, `browser-tools/`, `claude-code-cli/`, plus 14 others under the same parent.
+- Effect: invoking `gsd headless --output-format stream-json next` produced an agent run where:
+  - The agent's tool list contained zero `gsd_*` tools (expected: 49+).
+  - The first user message in the JSONL transcript was the literal string `/gsd next`, instead of the research-slice prompt that the bundled `gsd` extension is supposed to materialize when its slash command is intercepted.
+- Net effect: the slash-command system is silently broken; pi happily delivers the unprocessed slash command to the model as if it were a user utterance.
+
+## Root cause
+
+`packages/pi-coding-agent/src/core/package-manager.ts` — function `collectAutoExtensionEntries`, pre-fix shape:
+
+```ts
+function collectAutoExtensionEntries(dir: string): string[] {
+    const entries: string[] = [];
+    if (!existsSync(dir)) return entries;
+    // First check if this directory itself has explicit extension entries (package.json or index)
+    const rootEntries = resolveExtensionEntries(dir);
+    if (rootEntries) {
+        return rootEntries;       // <-- BUG
+    }
+    // Otherwise, discover extensions from directory contents
+    const dirEntries = readdirSync(dir, { withFileTypes: true });
+    // ... subdir traversal ...
+}
+```
+
+When `resolveExtensionEntries(dir)` finds either:
+1. a `package.json` declaring `pi.extensions[]` (manifest-driven), or
+2. a top-level `index.ts` / `index.js` (auto-detected wrapper),
+
+it returns a non-null array and the early-return fires. For case (1) this is intentional and correct — the manifest is authoritative (this is how a library directory like `cmux` opts out by declaring `"pi": {}` with no extensions, or how a maintainer enumerates a closed list of entries). For case (2), however, the early return is wrong: a top-level `index.{ts,js}` does **not** signal "ignore my siblings" — it simply marks the wrapper itself as one extension entry. Sibling subdirectories (the bundled extensions in the user/global scope) must still be enumerated.
+
+Conflating those two cases was the bug.
+
+## Reproduction steps
+
+Single-machine repro on macOS / Linux:
+
+```bash
+# 1. Set up a user-extension layout that mirrors gsd-pi's installed shape.
+mkdir -p ~/.gsd/agent/extensions
+cat > ~/.gsd/agent/extensions/index.js <<'EOF'
+// Minimal user extension wrapper.
+module.exports = {
+    register(pi) {
+        pi.registerCommand("user-stub", { description: "stub" }, async () => ({}));
+    },
+};
+EOF
+cat > ~/.gsd/agent/extensions/package.json <<'EOF'
+{ "name": "user-extensions", "type": "module" }
+EOF
+
+# 2. Drop a bundled-style subdir alongside it.
+mkdir -p ~/.gsd/agent/extensions/gsd
+cat > ~/.gsd/agent/extensions/gsd/index.js <<'EOF'
+module.exports = {
+    register(pi) {
+        pi.registerCommand("gsd", { description: "bundled stub" }, async () => ({}));
+    },
+};
+EOF
+
+# 3. Run any pi-coding-agent invocation that exercises slash dispatch:
+gsd headless --output-format stream-json next
+```
+
+Observation pre-fix:
+
+- The agent's tool catalog does not contain `gsd_*` commands.
+- The transcript's first user message reads literally `/gsd next`.
+
+Post-fix the bundled subdirectory is enumerated; `pi.registerCommand("gsd", ...)` runs; `/gsd next` is intercepted and resolves to the bundled handler.
+
+## Why the gsd-pi wrapper's `GSD_BUNDLED_EXTENSION_PATHS` env var doesn't help
+
+The outer `gsd-pi` loader (`dist/loader.js` in the published `gsd-pi` package) attempts to compensate by setting `process.env.GSD_BUNDLED_EXTENSION_PATHS` to the list of bundled-extension directories before spawning pi. That env var is intended as a hint that pi should treat as an additional discovery root.
+
+However a search of the `pi-coding-agent` source shows that the env var is never read:
+
+```bash
+grep -rln "GSD_BUNDLED_EXTENSION_PATHS" packages/pi-coding-agent/src/   # → no matches
+```
+
+So the loader plumbing is dead code on the consumer side. Whatever the original intent, the only working channel for bundled-extension discovery in user/global scope today is `collectAutoExtensionEntries` walking `~/.gsd/agent/extensions/`. The early-return bug therefore has no compensating fallback.
+
+## Verified workaround (no code change)
+
+Adding an explicit `pi.extensions` manifest at `~/.gsd/agent/extensions/package.json` listing every entry — the user wrapper plus every bundled subdir — routes through the **other** branch of `resolveExtensionEntries` (the one that reads `pkg.pi.extensions[]`) and resolves the entries correctly. The manifest branch is authoritative, the listed entries are returned, and pi loads them all.
+
+This was confirmed in the M007 pilot: enumerating 19 entries (1 wrapper + 18 bundled subdirs) restored 49 `gsd_*` tools in the registered tool list, and `/gsd next` was correctly intercepted.
+
+The workaround is brittle — it requires the user to know about the bug, list every bundled extension by hand, and re-edit the manifest whenever pi adds or removes a bundled extension. It is not viable as a long-term solution.
+
+## Proposed fix
+
+Stop conflating "manifest is authoritative" with "top-level index.{ts,js} found". The patch:
+
+1. Splits `resolveExtensionEntries` into a `resolveExtensionEntriesDetailed` that reports the source (`"manifest"` vs `"index"`), keeping the public-style helper as a thin wrapper for callers that only need the entries.
+2. In `collectAutoExtensionEntries`:
+   - When `source === "manifest"`: keep the early return. The manifest is authoritative; siblings are intentionally excluded. This preserves the opt-out contract for library directories.
+   - When `source === "index"`: add the top-level entry to the result, then **also** continue into subdirectory enumeration. Bundled subdirs are now picked up.
+   - When no top-level entry exists: behavior unchanged — enumerate subdirs and loose `.ts/.js` files at the root, as before.
+   - In the file-scan branch, skip any path that was already added via the top-level index resolution to avoid double-counting.
+3. Exports `collectAutoExtensionEntries` for unit testing. Treated as an internal API; no stability guarantee.
+
+Test additions in `packages/pi-coding-agent/src/core/package-manager.test.ts` (new file, 8 tests):
+
+- `returns an empty array when the directory does not exist`
+- `loads only the top-level index.js when no subdirs exist`
+- `loads only subdirs when no top-level index exists`
+- `loads top-level index.js AND bundled subdirs when both exist (regression for early-return bug)` — pinpoints this AAR's bug.
+- `does not double-count the top-level index.js when both branches see it`
+- `treats a pi.extensions manifest as authoritative — does not scan sibling subdirs` — protects the cmux-style opt-out contract.
+- `falls through to subdir discovery when package.json declares an empty pi block`
+- `ignores hidden directories and node_modules`
+
+All 8 pass locally with `node --test` against the esbuild-compiled output in `dist-test/`.
+
+## Impact
+
+Affects every `gsd-pi` user who has installed a custom user extension that landed as a top-level `index.{ts,js}` at `~/.gsd/agent/extensions/`. Specifically:
+
+- Anyone using `gsd`'s `--extension <source>` install path that materializes a top-level wrapper.
+- The EpsilonCode user extension pattern triggered the discovery in the M007 pilot; same root cause applies to any other wrapper of the same shape.
+
+For users without a top-level entry, the existing subdir enumeration already worked and the patch is a no-op (verified by the `loads only subdirs when no top-level index exists` test).
+
+## References
+
+- Source of bug: `packages/pi-coding-agent/src/core/package-manager.ts`, function `collectAutoExtensionEntries` and helper `resolveExtensionEntries`.
+- Companion downstream AAR: `/Users/regis/Development/GitHub/Regis-RCR/Experimental/epsiloncode/docs/aar/2026-04-30-sse-orphan-close-opus-4-7.md` (the EpsilonCode SSE incident that surfaced the bundled-discovery failure as a side-effect during the M007 pilot).
+- No upstream issue exists at the time of writing — `gh issue list -R gsd-build/gsd-2 --search "extension auto-discovery"` and `gh issue list -R gsd-build/gsd-2 --search "collectAutoExtensionEntries"` both returned no relevant matches on 2026-04-30.
+
+∵ Regis-RCR ∴

--- a/packages/pi-coding-agent/src/core/package-manager.test.ts
+++ b/packages/pi-coding-agent/src/core/package-manager.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { collectAutoExtensionEntries } from "./package-manager.js";
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeTempDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "package-manager-test-"));
+}
+
+function cleanDir(dir: string): void {
+	fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writeFile(dir: string, name: string, content = "// stub\n"): string {
+	const full = path.join(dir, name);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content);
+	return full;
+}
+
+function makeBundledExt(rootDir: string, name: string): string {
+	const sub = path.join(rootDir, name);
+	fs.mkdirSync(sub, { recursive: true });
+	const idx = path.join(sub, "index.js");
+	fs.writeFileSync(idx, `// ${name} entry\n`);
+	return idx;
+}
+
+// ─── collectAutoExtensionEntries ──────────────────────────────────────────────
+
+describe("collectAutoExtensionEntries", () => {
+	let extDir: string;
+
+	beforeEach(() => {
+		extDir = makeTempDir();
+	});
+
+	afterEach(() => {
+		cleanDir(extDir);
+	});
+
+	it("returns an empty array when the directory does not exist", () => {
+		cleanDir(extDir);
+		assert.deepEqual(collectAutoExtensionEntries(extDir), []);
+	});
+
+	it("loads only the top-level index.js when no subdirs exist", () => {
+		const idx = writeFile(extDir, "index.js", "// user wrapper\n");
+
+		const result = collectAutoExtensionEntries(extDir);
+
+		assert.deepEqual(result, [idx]);
+	});
+
+	it("loads only subdirs when no top-level index exists", () => {
+		const a = makeBundledExt(extDir, "gsd");
+		const b = makeBundledExt(extDir, "bg-shell");
+
+		const result = collectAutoExtensionEntries(extDir).sort();
+
+		assert.deepEqual(result, [a, b].sort());
+	});
+
+	it("loads top-level index.js AND bundled subdirs when both exist (regression for early-return bug)", () => {
+		// Reproduces the production scenario: a user-installed extension wrapper
+		// at `~/.gsd/agent/extensions/index.js` alongside bundled extension
+		// subdirectories. Pre-fix, the early return on the top-level entry
+		// caused every bundled extension to be silently skipped, which broke
+		// slash-command dispatch (e.g. `/gsd next` falling through to the LLM).
+		const userIdx = writeFile(extDir, "index.js", "// user wrapper\n");
+		const gsd = makeBundledExt(extDir, "gsd");
+		const bgShell = makeBundledExt(extDir, "bg-shell");
+		const browserTools = makeBundledExt(extDir, "browser-tools");
+		const claudeCodeCli = makeBundledExt(extDir, "claude-code-cli");
+
+		const result = collectAutoExtensionEntries(extDir).sort();
+
+		const expected = [userIdx, gsd, bgShell, browserTools, claudeCodeCli].sort();
+		assert.deepEqual(result, expected);
+	});
+
+	it("does not double-count the top-level index.js when both branches see it", () => {
+		const userIdx = writeFile(extDir, "index.js", "// user wrapper\n");
+		makeBundledExt(extDir, "gsd");
+
+		const result = collectAutoExtensionEntries(extDir);
+
+		const occurrences = result.filter((p) => p === userIdx).length;
+		assert.equal(occurrences, 1, "index.js must appear exactly once");
+	});
+
+	it("treats a pi.extensions manifest as authoritative — does not scan sibling subdirs", () => {
+		// The opt-out contract from `resolveExtensionEntries`: when a package.json
+		// declares `pi.extensions`, the maintainer has explicitly enumerated the
+		// entries. Sibling directories must be ignored. The manifest entry is
+		// returned as-resolved (directory path), matching the existing semantics.
+		makeBundledExt(extDir, "declared");
+		const declaredDir = path.join(extDir, "declared");
+		// Sibling subdir that the manifest does NOT list — must remain unloaded.
+		makeBundledExt(extDir, "not-declared");
+		fs.writeFileSync(
+			path.join(extDir, "package.json"),
+			JSON.stringify({
+				name: "user-extensions",
+				type: "module",
+				pi: { extensions: ["./declared"] },
+			}),
+		);
+
+		const result = collectAutoExtensionEntries(extDir);
+
+		assert.deepEqual(result, [declaredDir]);
+	});
+
+	it("falls through to subdir discovery when package.json declares an empty pi block", () => {
+		// Empty `pi: {}` means "this is a library, no auto-detect on this dir".
+		// `resolveExtensionEntries` returns null, and historical behavior was to
+		// then enumerate subdirs — preserve that.
+		const a = makeBundledExt(extDir, "gsd");
+		fs.writeFileSync(
+			path.join(extDir, "package.json"),
+			JSON.stringify({ name: "library", type: "module", pi: {} }),
+		);
+
+		const result = collectAutoExtensionEntries(extDir);
+
+		assert.deepEqual(result, [a]);
+	});
+
+	it("ignores hidden directories and node_modules", () => {
+		makeBundledExt(extDir, ".cache");
+		const nm = path.join(extDir, "node_modules", "some-pkg");
+		fs.mkdirSync(nm, { recursive: true });
+		fs.writeFileSync(path.join(nm, "index.js"), "// noise\n");
+		const real = makeBundledExt(extDir, "real");
+
+		const result = collectAutoExtensionEntries(extDir);
+
+		assert.deepEqual(result, [real]);
+	});
+});

--- a/packages/pi-coding-agent/src/core/package-manager.ts
+++ b/packages/pi-coding-agent/src/core/package-manager.ts
@@ -410,7 +410,14 @@ function readPiManifestFile(packageJsonPath: string): PiManifest | null {
 	}
 }
 
-function resolveExtensionEntries(dir: string): string[] | null {
+type ExtensionEntriesSource = "manifest" | "index";
+
+interface ResolvedExtensionEntries {
+	entries: string[];
+	source: ExtensionEntriesSource;
+}
+
+function resolveExtensionEntriesDetailed(dir: string): ResolvedExtensionEntries | null {
 	const packageJsonPath = join(dir, "package.json");
 	if (existsSync(packageJsonPath)) {
 		const manifest = readPiManifestFile(packageJsonPath);
@@ -428,33 +435,61 @@ function resolveExtensionEntries(dir: string): string[] | null {
 					entries.push(resolvedExtPath);
 				}
 			}
-			return entries.length > 0 ? entries : null;
+			return entries.length > 0 ? { entries, source: "manifest" } : null;
 		}
 	}
 
 	const indexTs = join(dir, "index.ts");
 	const indexJs = join(dir, "index.js");
 	if (existsSync(indexTs)) {
-		return [indexTs];
+		return { entries: [indexTs], source: "index" };
 	}
 	if (existsSync(indexJs)) {
-		return [indexJs];
+		return { entries: [indexJs], source: "index" };
 	}
 
 	return null;
 }
 
-function collectAutoExtensionEntries(dir: string): string[] {
+function resolveExtensionEntries(dir: string): string[] | null {
+	const resolved = resolveExtensionEntriesDetailed(dir);
+	return resolved ? resolved.entries : null;
+}
+
+// Exported for unit testing. Treat as an internal API — no stability guarantees.
+export function collectAutoExtensionEntries(dir: string): string[] {
 	const entries: string[] = [];
 	if (!existsSync(dir)) return entries;
 
-	// First check if this directory itself has explicit extension entries (package.json or index)
-	const rootEntries = resolveExtensionEntries(dir);
-	if (rootEntries) {
-		return rootEntries;
+	// Inspect the directory itself. There are three relevant shapes:
+	//   1. A package.json declaring "pi.extensions" (authoritative manifest).
+	//      The maintainer has explicitly enumerated entries — honor them and
+	//      do NOT scan subdirectories. This preserves the opt-out contract
+	//      (e.g. cmux declaring `"pi": {}` to disable auto-discovery).
+	//   2. A top-level index.ts / index.js with no manifest. This is the
+	//      common shape for a user-installed extension wrapper sitting at
+	//      `~/.gsd/agent/extensions/index.js`. The wrapper must coexist
+	//      with bundled-extension subdirectories living alongside it
+	//      (gsd, bg-shell, browser-tools, claude-code-cli, ...). Add the
+	//      top-level entry AND continue into subdirectory discovery.
+	//   3. Neither manifest nor index file. Fall through to subdir/file
+	//      auto-discovery as before.
+	//
+	// Pre-fix, this function early-returned in cases (1) AND (2) without
+	// scanning subdirectories. Case (1) is correct (manifest is authoritative)
+	// but case (2) silently skipped every bundled extension whenever a user
+	// extension was installed at the root, breaking slash-command dispatch.
+	const rootResolved = resolveExtensionEntriesDetailed(dir);
+	if (rootResolved?.source === "manifest") {
+		// Manifest is authoritative — return only what it declares.
+		return [...rootResolved.entries];
+	}
+	if (rootResolved?.source === "index") {
+		entries.push(...rootResolved.entries);
 	}
 
-	// Otherwise, discover extensions from directory contents
+	// Discover additional extensions from directory contents. Subdirs always
+	// contribute when there is no authoritative manifest at the root.
 	const ig = ignore();
 	addIgnoreRules(ig, dir, dir);
 
@@ -483,6 +518,12 @@ function collectAutoExtensionEntries(dir: string): string[] {
 			if (ig.ignores(ignorePath)) continue;
 
 			if (isFile && (entry.name.endsWith(".ts") || entry.name.endsWith(".js"))) {
+				// Avoid double-counting the top-level index.{ts,js} that was
+				// already added via rootResolved above. Other loose .ts/.js
+				// files at the root remain valid extension entry points.
+				if (rootResolved?.source === "index" && rootResolved.entries.includes(fullPath)) {
+					continue;
+				}
 				entries.push(fullPath);
 			} else if (isDir) {
 				const resolvedEntries = resolveExtensionEntries(fullPath);


### PR DESCRIPTION
## TL;DR

**What:** `collectAutoExtensionEntries` no longer early-returns when a top-level `index.{ts,js}` is found in the discovery root — it now also enumerates sibling subdirectories.
**Why:** Pre-fix, any user-installed extension that materialized a top-level `index.js` at `~/.gsd/agent/extensions/` caused every bundled extension subdirectory to be silently skipped, breaking slash-command dispatch (e.g. `/gsd next` falling through to the LLM as user text).
**How:** Split `resolveExtensionEntries` into a detailed variant that reports the entry source (`"manifest"` vs `"index"`). Manifest results still short-circuit (preserves the cmux-style opt-out contract). Index results are added, then subdir enumeration continues. 8 unit tests added.

## What

Files touched:

- `packages/pi-coding-agent/src/core/package-manager.ts` — fix in `collectAutoExtensionEntries`, plus a new `resolveExtensionEntriesDetailed` helper. Exports `collectAutoExtensionEntries` for unit testing (treated as internal API; no stability guarantee).
- `packages/pi-coding-agent/src/core/package-manager.test.ts` — new file, 8 `node:test` cases covering all branches of the auto-discovery logic.
- `packages/pi-coding-agent/docs/aar/2026-04-30-extension-auto-discovery-early-return.md` — full AAR with symptom, repro, root cause, dead-code analysis of `GSD_BUNDLED_EXTENSION_PATHS` in the outer loader, verified workaround, and impact.

## Why

Reproduced during the `rcr-gain` project's M007 pilot on `gsd-pi@2.78.1`.

**Production layout that triggers the bug:**

```
~/.gsd/agent/extensions/
├── index.js                 # user-installed wrapper (e.g. EpsilonCode adapter)
├── package.json             # { "type": "module" } — no pi.extensions
├── gsd/index.js             # bundled
├── bg-shell/index.js        # bundled
├── browser-tools/index.js   # bundled
├── claude-code-cli/index.js # bundled
└── ... 14 more bundled subdirs
```

**Effect:** pi loads the user wrapper successfully but registers zero bundled-extension commands. The agent's tool list contains no `gsd_*` tools (expected: 49+). The transcript's first user message is the literal string `/gsd next` instead of the materialized research-slice prompt. The slash-command system silently ships unprocessed slash text to the model.

**Root cause** (`packages/pi-coding-agent/src/core/package-manager.ts`, function `collectAutoExtensionEntries`, pre-fix):

```ts
const rootEntries = resolveExtensionEntries(dir);
if (rootEntries) {
    return rootEntries;       // BUG: early-return skips subdirs
}
// Otherwise, discover extensions from directory contents
```

`resolveExtensionEntries(dir)` returns non-null in two distinct cases:
1. A `package.json` declared `pi.extensions[]` — manifest-driven, authoritative, siblings should be excluded. Correct.
2. A top-level `index.ts` / `index.js` was auto-detected — common shape for a user-installed wrapper. Siblings should NOT be excluded.

Conflating those two cases was the bug.

**Note:** the outer `gsd-pi` loader sets `process.env.GSD_BUNDLED_EXTENSION_PATHS` with the bundled-extension paths, but `grep -rln "GSD_BUNDLED_EXTENSION_PATHS" packages/pi-coding-agent/src/` returns no matches — pi never reads it. Whatever the original intent of that plumbing, it does not currently compensate for the bug. (Cleanup of the dead env-var plumbing on the loader side is intentionally out of scope here.)

**Verified workaround** (no code change required): listing every entry explicitly in `~/.gsd/agent/extensions/package.json` under `pi.extensions[]` routes through the manifest branch and resolves correctly. Tested working in the M007 pilot — restored 49 `gsd_*` tools and correct `/gsd next` interception. Brittle (requires the user to know about the bug and re-edit on every bundled-extension change), so the patch lands the fix in the runtime.

## How

The patch splits the resolution helper to preserve the manifest opt-out contract while fixing the index case:

```ts
type ExtensionEntriesSource = "manifest" | "index";

interface ResolvedExtensionEntries {
    entries: string[];
    source: ExtensionEntriesSource;
}

function resolveExtensionEntriesDetailed(dir: string): ResolvedExtensionEntries | null { /* ... */ }
function resolveExtensionEntries(dir: string): string[] | null {
    const resolved = resolveExtensionEntriesDetailed(dir);
    return resolved ? resolved.entries : null;
}
```

In `collectAutoExtensionEntries`:

- `source === "manifest"` → keep early return. Manifest is authoritative; siblings excluded. Cmux-style opt-out preserved.
- `source === "index"` → push the top-level entry, then continue into subdirectory enumeration. **This is the fix.**
- No top-level entry → behavior unchanged: enumerate subdirs and loose `.ts/.js` files at the root.
- The file-scan branch explicitly skips any path already added via the top-level resolution (defense in depth — `addResource` already dedupes by path).

### Test additions (`packages/pi-coding-agent/src/core/package-manager.test.ts`, 8 cases, all passing locally)

- `returns an empty array when the directory does not exist`
- `loads only the top-level index.js when no subdirs exist`
- `loads only subdirs when no top-level index exists`
- `loads top-level index.js AND bundled subdirs when both exist (regression for early-return bug)` — pinpoints this PR's bug.
- `does not double-count the top-level index.js when both branches see it`
- `treats a pi.extensions manifest as authoritative — does not scan sibling subdirs` — protects the cmux-style opt-out contract.
- `falls through to subdir discovery when package.json declares an empty pi block`
- `ignores hidden directories and node_modules`

Verified via `npm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/packages/pi-coding-agent/src/core/package-manager.test.js` — 8 pass / 0 fail / 0 skip.

The broader pi-coding-agent test suite shows pre-existing failures unrelated to this change (interactive-mode tests fail to resolve `@gsd/pi-tui/dist/index.js` in dev environments without a built workspace). Comparing the suite on `main` vs this branch: same set of failures, plus 8 new passing tests from the additions here. CI can confirm.

### Behavior matrix

| Layout | Pre-fix | Post-fix | Notes |
|---|---|---|---|
| only `index.js`, no subdirs | `[index.js]` | `[index.js]` | unchanged |
| only subdirs, no top-level | `[...subdirs]` | `[...subdirs]` | unchanged |
| `index.js` + bundled subdirs | `[index.js]` | `[index.js, ...subdirs]` | **FIX** |
| `package.json` w/ `pi.extensions: [...]` | `[...declared]` | `[...declared]` | unchanged — manifest authoritative |
| `package.json` w/ `pi: {}` | `[...subdirs]` | `[...subdirs]` | unchanged — falls through |

## Disclosure

This PR is AI-assisted (Claude Code). The author has reviewed the diff, executed the tests locally, and is responsible for the change. No co-authorship is claimed.

## Reproduction

See `packages/pi-coding-agent/docs/aar/2026-04-30-extension-auto-discovery-early-return.md` for a self-contained shell repro and the M007 pilot context.

## Related

No prior issue exists at the time of opening. `gh issue list -R gsd-build/gsd-2 --search "extension auto-discovery"` and `gh issue list -R gsd-build/gsd-2 --search "collectAutoExtensionEntries"` returned no relevant matches on 2026-04-30. Happy to file a tracking issue if maintainers prefer; the AAR in this PR captures the same content.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Tests added (in same PR per `One concern per PR`: the tests directly cover the fixed function)
- [x] `docs` — AAR added under `packages/pi-coding-agent/docs/aar/` (in same PR for traceability)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed extension discovery issue preventing some bundled extensions and slash commands from being properly recognized during startup.

* **Tests**
  * Added comprehensive test suite for extension auto-discovery across various configuration scenarios.

* **Documentation**
  * Added architectural analysis documenting a production failure and resolution details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->