### PR TITLE
feat(gsd): introduce ctx.projectRoot foundation for workspace mode (RFC #5110, slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,25 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **pi-coding-agent**: new `projectRoot: string` field on `ExtensionContext` and
+  `ExtensionCommandContext`. Populated by the runner from `cwd` at construction
+  time via `git rev-parse --show-toplevel` (or `cwd` itself outside a repo) and
+  exposed to every extension. **Breaking interface change for extension
+  authors:** any extension that constructs an `ExtensionContext` literal in
+  tests or implements the type directly must now provide `projectRoot`. Set
+  `GSD_DEBUG=1` to surface diagnostic output when git resolution silently
+  falls back to `cwd`. Lays the foundation for opt-in workspace mode tracked
+  in #5110.
+
 ### Changed
-- **gsd**: thread `ctx.projectRoot` through every `/gsd …` handler instead of resolving `process.cwd()` at each call site. New `ExtensionContext.projectRoot` field is populated once per command invocation by the runner and resolves to the git toplevel of `cwd` (or `cwd` itself outside a repo). Behaviour-preserving refactor; no flag, no user-visible change. Lays the foundation for opt-in workspace mode tracked in #5110.
+- **gsd**: thread `ctx.projectRoot` through every `/gsd …` handler and
+  top-level `commands-*.ts` entry instead of resolving `process.cwd()` at each
+  call site. Path-resolution semantics are unchanged for users running gsd
+  from inside a single git repository on POSIX hosts; on Windows, the runner
+  now normalizes git's POSIX-separator output through `path.resolve` so
+  callers comparing `projectRoot` to native-separator paths get correct
+  equality and prefix matches.
 
 ### Deprecated
 - **mcp-server**: 11 `gsd_*` alias tools (`gsd_save_decision`, `gsd_update_requirement`, `gsd_save_requirement`, `gsd_generate_milestone_id`, `gsd_task_plan`, `gsd_slice_replan`, `gsd_complete_slice`, `gsd_milestone_complete`, `gsd_milestone_validate`, `gsd_roadmap_reassess`, `gsd_complete_task`) are entering a deprecation window. Each invocation now emits a `deprecation.mcp_alias_used` JSONL record to stderr. Use the canonical names (`gsd_decision_save`, etc.). The aliases will be removed in a future release after telemetry confirms zero usage. (#5031)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- **gsd**: thread `ctx.projectRoot` through every `/gsd …` handler instead of resolving `process.cwd()` at each call site. New `ExtensionContext.projectRoot` field is populated once per command invocation by the runner and resolves to the git toplevel of `cwd` (or `cwd` itself outside a repo). Behaviour-preserving refactor; no flag, no user-visible change. Lays the foundation for opt-in workspace mode tracked in #5110.
+
 ### Deprecated
 - **mcp-server**: 11 `gsd_*` alias tools (`gsd_save_decision`, `gsd_update_requirement`, `gsd_save_requirement`, `gsd_generate_milestone_id`, `gsd_task_plan`, `gsd_slice_replan`, `gsd_complete_slice`, `gsd_milestone_complete`, `gsd_milestone_validate`, `gsd_roadmap_reassess`, `gsd_complete_task`) are entering a deprecation window. Each invocation now emits a `deprecation.mcp_alias_used` JSONL record to stderr. Use the canonical names (`gsd_decision_save`, etc.). The aliases will be removed in a future release after telemetry confirms zero usage. (#5031)
 

--- a/packages/pi-coding-agent/src/core/extensions/project-root.test.ts
+++ b/packages/pi-coding-agent/src/core/extensions/project-root.test.ts
@@ -7,7 +7,7 @@ import assert from "node:assert";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 
 import { resolveProjectRoot } from "./project-root.js";
 
@@ -37,6 +37,34 @@ describe("resolveProjectRoot", () => {
 			const sub = join(repo, "nested", "deep");
 			mkdirSync(sub, { recursive: true });
 			assert.strictEqual(resolveProjectRoot(sub), repo);
+		} finally {
+			cleanup();
+		}
+	});
+
+	test("returned path uses native separators", () => {
+		// `git rev-parse --show-toplevel` always emits forward slashes (even on
+		// Windows). `resolveProjectRoot` must normalize so equality and prefix
+		// comparisons against values from `fs.realpathSync` / `path.join` work.
+		const { repo, cleanup } = makeRepo();
+		try {
+			const sub = join(repo, "nested", "deep");
+			mkdirSync(sub, { recursive: true });
+			const root = resolveProjectRoot(sub);
+			// On Windows: must not contain forward slashes (raw git output would).
+			// On POSIX: separator is "/" and path is unchanged.
+			if (sep === "\\") {
+				assert.ok(
+					!root.includes("/"),
+					`expected native separators on Windows, got: ${root}`,
+				);
+			}
+			// Cross-platform invariant: the returned root, when joined with a
+			// native-separator subpath, must remain a prefix-match of that path.
+			assert.ok(
+				sub.startsWith(root),
+				`expected ${sub} to start with ${root}`,
+			);
 		} finally {
 			cleanup();
 		}

--- a/packages/pi-coding-agent/src/core/extensions/project-root.test.ts
+++ b/packages/pi-coding-agent/src/core/extensions/project-root.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for project-root resolution.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resolveProjectRoot } from "./project-root.js";
+
+function makeRepo(): { repo: string; cleanup: () => void } {
+	const repo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-projroot-")));
+	execFileSync("git", ["init", "-q"], { cwd: repo });
+	writeFileSync(join(repo, "README.md"), "# test\n");
+	const cleanup = () => {
+		try { rmSync(repo, { recursive: true, force: true }); } catch { /* best effort */ }
+	};
+	return { repo, cleanup };
+}
+
+describe("resolveProjectRoot", () => {
+	test("resolves to git toplevel when cwd is the repo root", () => {
+		const { repo, cleanup } = makeRepo();
+		try {
+			assert.strictEqual(resolveProjectRoot(repo), repo);
+		} finally {
+			cleanup();
+		}
+	});
+
+	test("resolves to git toplevel when cwd is a subdir", () => {
+		const { repo, cleanup } = makeRepo();
+		try {
+			const sub = join(repo, "nested", "deep");
+			mkdirSync(sub, { recursive: true });
+			assert.strictEqual(resolveProjectRoot(sub), repo);
+		} finally {
+			cleanup();
+		}
+	});
+
+	test("returns cwd unchanged when not inside a git repo", (t) => {
+		const tmp = realpathSync(mkdtempSync(join(tmpdir(), "gsd-projroot-nogit-")));
+		try {
+			// Skip explicitly if tmp dir happens to be inside a parent git repo —
+			// otherwise the assertion below would be silently bypassed.
+			let parentGit = false;
+			try {
+				const result = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+					cwd: tmp,
+					encoding: "utf-8",
+					stdio: ["ignore", "pipe", "ignore"],
+				}).trim();
+				if (result.length > 0) parentGit = true;
+			} catch { /* not in a repo, expected */ }
+			if (parentGit) {
+				t.skip("Temporary directory is inside a parent git repo");
+				return;
+			}
+
+			assert.strictEqual(resolveProjectRoot(tmp), tmp);
+		} finally {
+			try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
+		}
+	});
+});

--- a/packages/pi-coding-agent/src/core/extensions/project-root.ts
+++ b/packages/pi-coding-agent/src/core/extensions/project-root.ts
@@ -7,6 +7,7 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { resolve as resolvePath } from "node:path";
 
 /**
  * Resolve the project root for a given cwd.
@@ -14,20 +15,55 @@ import { spawnSync } from "node:child_process";
  * Returns the git toplevel when `cwd` is inside a git repository, otherwise
  * returns `cwd` unchanged. Failures (git not on PATH, permission errors,
  * etc.) fall back to `cwd`.
+ *
+ * Output is normalized through `path.resolve` so the returned path uses
+ * native separators. `git rev-parse --show-toplevel` always emits forward
+ * slashes (even on Windows), which would otherwise mismatch values that
+ * downstream code obtains from `fs.realpathSync`, `path.join`, `process.cwd`,
+ * etc. (all native-separator on Windows). Without normalization, equality
+ * checks like `cwd === projectRoot` and `path.startsWith(projectRoot)` fail
+ * on Windows.
+ *
+ * NOTE: This is the runner-level / extension-API flavor. It only knows about
+ * `git rev-parse --show-toplevel` and is intentionally extension-agnostic.
+ *
+ * The GSD extension separately exports a `resolveProjectRoot` from
+ * `src/resources/extensions/gsd/worktree.ts` that is worktree-aware (peels a
+ * `.../.gsd/worktrees/<name>` path back to the parent project root). The two
+ * are *not* duplicates — the runner has no business knowing about GSD's
+ * worktree layout, and GSD handlers must keep operating against the parent
+ * project root even when invoked from inside a worktree.
  */
 export function resolveProjectRoot(cwd: string): string {
 	try {
 		const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
 			cwd,
 			encoding: "utf-8",
-			stdio: ["ignore", "pipe", "ignore"],
+			stdio: ["ignore", "pipe", "pipe"],
 		});
 		if (result.status === 0 && typeof result.stdout === "string") {
 			const toplevel = result.stdout.trim();
-			if (toplevel.length > 0) return toplevel;
+			if (toplevel.length > 0) return resolvePath(toplevel);
 		}
-	} catch {
-		// git not available, cwd unreadable, or other spawn failure — fall through.
+		// Status != 0 most commonly means "not in a git repo" — that's a normal
+		// fall-through to cwd, no diagnostic needed. Anything else (process
+		// could not be spawned, crash, etc.) is a silent fallback that masks
+		// real problems, so surface it when GSD_DEBUG is on.
+		if (result.error || (result.status !== 0 && result.status !== 128)) {
+			emitDebug(cwd, result.error?.message, result.stderr?.toString());
+		}
+	} catch (err) {
+		// git not available, cwd unreadable, or other spawn failure — fall
+		// through. Log only when explicitly debugging, so callers can find out
+		// why their projectRoot resolution silently degraded to cwd.
+		emitDebug(cwd, err instanceof Error ? err.message : String(err));
 	}
 	return cwd;
+}
+
+function emitDebug(cwd: string, ...details: Array<string | undefined>): void {
+	if (process.env.GSD_DEBUG !== "1" && process.env.GSD_DEBUG !== "true") return;
+	const tail = details.filter((d): d is string => typeof d === "string" && d.length > 0).join(" | ");
+	const suffix = tail.length > 0 ? `: ${tail}` : "";
+	process.stderr.write(`[gsd:project-root] git rev-parse failed for cwd=${cwd}${suffix}\n`);
 }

--- a/packages/pi-coding-agent/src/core/extensions/project-root.ts
+++ b/packages/pi-coding-agent/src/core/extensions/project-root.ts
@@ -1,0 +1,33 @@
+/**
+ * Project-root resolution for the extension context.
+ *
+ * Resolves the canonical "current project" path for a given working
+ * directory: the git toplevel of `cwd`, or `cwd` itself when `cwd` is
+ * not inside a git repository.
+ */
+
+import { spawnSync } from "node:child_process";
+
+/**
+ * Resolve the project root for a given cwd.
+ *
+ * Returns the git toplevel when `cwd` is inside a git repository, otherwise
+ * returns `cwd` unchanged. Failures (git not on PATH, permission errors,
+ * etc.) fall back to `cwd`.
+ */
+export function resolveProjectRoot(cwd: string): string {
+	try {
+		const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		if (result.status === 0 && typeof result.stdout === "string") {
+			const toplevel = result.stdout.trim();
+			if (toplevel.length > 0) return toplevel;
+		}
+	} catch {
+		// git not available, cwd unreadable, or other spawn failure — fall through.
+	}
+	return cwd;
+}

--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -75,6 +75,7 @@ import type {
 	VerifyFailure,
 	VerifyResultEvent,
 } from "./types.js";
+import { resolveProjectRoot } from "./project-root.js";
 
 // Keybindings for these actions cannot be overridden by extensions
 const RESERVED_ACTIONS_FOR_EXTENSION_CONFLICTS: ReadonlyArray<KeyAction> = [
@@ -215,6 +216,7 @@ export class ExtensionRunner {
 	private runtime: ExtensionRuntime;
 	private uiContext: ExtensionUIContext;
 	private cwd: string;
+	private projectRoot: string;
 	private sessionManager: SessionManager;
 	private modelRegistry: ModelRegistry;
 	private errorListeners: Set<ExtensionErrorListener> = new Set();
@@ -256,6 +258,7 @@ export class ExtensionRunner {
 		this.runtime = runtime;
 		this.uiContext = noOpUIContext;
 		this.cwd = cwd;
+		this.projectRoot = resolveProjectRoot(cwd);
 		this.sessionManager = sessionManager;
 		this.modelRegistry = modelRegistry;
 		// Bind emit methods into the shared runtime so createExtensionAPI can delegate to them.
@@ -658,6 +661,7 @@ export class ExtensionRunner {
 			ui: this.uiContext,
 			hasUI: this.hasUI(),
 			cwd: this.cwd,
+			projectRoot: this.projectRoot,
 			sessionManager: this.sessionManager,
 			modelRegistry: this.modelRegistry,
 			get model() {

--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -258,6 +258,11 @@ export class ExtensionRunner {
 		this.runtime = runtime;
 		this.uiContext = noOpUIContext;
 		this.cwd = cwd;
+		// Resolved once here. The runner exposes no setter, so this value is
+		// fixed for the runner's lifetime and equally fixed in every context
+		// returned by createContext(). When workspace mode introduces a
+		// runtime "active repo" switch (project_changed event), this needs
+		// to become a setter that re-runs resolveProjectRoot.
 		this.projectRoot = resolveProjectRoot(cwd);
 		this.sessionManager = sessionManager;
 		this.modelRegistry = modelRegistry;
@@ -653,7 +658,16 @@ export class ExtensionRunner {
 
 	/**
 	 * Create an ExtensionContext for use in event handlers and tool execution.
-	 * Context values are resolved at call time, so changes via bindCore/bindUI are reflected.
+	 *
+	 * Context values bound via `bindCore` / `bindUI` (ui, model, idle/abort, etc.)
+	 * are resolved at call time, so updates surface in subsequent contexts. By
+	 * contrast, `cwd` and `projectRoot` are fixed at constructor time — the
+	 * runner has no mutation channel for them today, so every context returned
+	 * by this method shares the same path values for the runner's lifetime.
+	 *
+	 * Once a per-runner mutation channel exists (planned alongside the
+	 * `project_changed` event for workspace mode), `cwd`/`projectRoot` will
+	 * become call-time-resolved as well.
 	 */
 	createContext(): ExtensionContext {
 		const getModel = this.getModel;

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -269,6 +269,14 @@ export interface ExtensionContext {
 	hasUI: boolean;
 	/** Current working directory */
 	cwd: string;
+	/**
+	 * Canonical "current project" root. Resolves to the git toplevel of `cwd`
+	 * when `cwd` is inside a git repository, otherwise to `cwd`. Extensions
+	 * that operate on per-project state (e.g. milestones, worktrees, project
+	 * metadata) should prefer `projectRoot` over `cwd`, since `cwd` may be a
+	 * subdirectory of the project.
+	 */
+	projectRoot: string;
 	/** Session manager (read-only) */
 	sessionManager: ReadonlySessionManager;
 	/** Model registry for API key resolution */

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -52,6 +52,7 @@ import type {
 	ExtensionUIDialogOptions,
 	ExtensionWidgetOptions,
 } from "../../core/extensions/index.js";
+import { resolveProjectRoot } from "../../core/extensions/project-root.js";
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.js";
 import { type AppAction, KeybindingsManager } from "../../core/keybindings.js";
 import { createCompactionSummaryMessage } from "../../core/messages.js";
@@ -1300,6 +1301,7 @@ export class InteractiveMode {
 			ui: this.createExtensionUIContext(),
 			hasUI: true,
 			cwd: process.cwd(),
+			projectRoot: resolveProjectRoot(process.cwd()),
 			sessionManager: this.sessionManager,
 			modelRegistry: this.session.modelRegistry,
 			model: this.session.model,

--- a/src/resources/extensions/gsd/bootstrap/register-shortcuts.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-shortcuts.ts
@@ -7,9 +7,9 @@ import { Key } from "@gsd/pi-tui";
 import { GSD_SHORTCUTS } from "../shortcut-defs.js";
 import { shortcutDesc } from "../../shared/mod.js";
 
-async function getProjectRoot(): Promise<string> {
+async function getProjectRoot(ctx: ExtensionContext): Promise<string> {
   const { projectRoot } = await import("../commands/context.js");
-  return projectRoot();
+  return projectRoot(ctx);
 }
 
 export function registerShortcuts(pi: ExtensionAPI): void {
@@ -23,7 +23,7 @@ export function registerShortcuts(pi: ExtensionAPI): void {
   const openDashboardOverlay = async (ctx: ExtensionContext) => {
     const [{ GSDDashboardOverlay }, basePath] = await Promise.all([
       import("../dashboard-overlay.js"),
-      getProjectRoot(),
+      getProjectRoot(ctx),
     ]);
     if (!existsSync(join(basePath, ".gsd"))) {
       ctx.ui.notify("No .gsd/ directory found. Run /gsd to start.", "info");
@@ -56,7 +56,7 @@ export function registerShortcuts(pi: ExtensionAPI): void {
   };
 
   const openParallelOverlay = async (ctx: ExtensionContext) => {
-    const basePath = await getProjectRoot();
+    const basePath = await getProjectRoot(ctx);
     const parallelDir = join(basePath, ".gsd", "parallel");
     if (!existsSync(parallelDir)) {
       ctx.ui.notify("No parallel workers found. Run /gsd parallel start first.", "info");

--- a/src/resources/extensions/gsd/commands-add-tests.ts
+++ b/src/resources/extensions/gsd/commands-add-tests.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { deriveState } from "./state.js";
 import { gsdRoot, resolveSliceFile } from "./paths.js";
 import { loadPrompt } from "./prompt-loader.js";
+import { projectRoot } from "./commands/context.js";
 
 function findLastCompletedSlice(basePath: string, milestoneId: string): string | null {
   // Scan disk for slices that have a SUMMARY.md (indicating completion)
@@ -91,7 +92,7 @@ export async function handleAddTests(
   ctx: ExtensionCommandContext,
   pi: ExtensionAPI,
 ): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
   const state = await deriveState(basePath);
 
   if (!state.activeMilestone) {

--- a/src/resources/extensions/gsd/commands-backlog.ts
+++ b/src/resources/extensions/gsd/commands-backlog.ts
@@ -12,6 +12,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 
 import { gsdRoot } from "./paths.js";
+import { projectRoot } from "./commands/context.js";
 
 interface BacklogItem {
   id: string;
@@ -161,7 +162,7 @@ export async function handleBacklog(
   ctx: ExtensionCommandContext,
   pi: ExtensionAPI,
 ): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
   const parts = args.trim().split(/\s+/);
   const sub = parts[0] ?? "";
   const rest = parts.slice(1).join(" ");

--- a/src/resources/extensions/gsd/commands-codebase.ts
+++ b/src/resources/extensions/gsd/commands-codebase.ts
@@ -16,6 +16,7 @@ import {
 } from "./codebase-generator.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import type { CodebaseMapOptions } from "./codebase-generator.js";
+import { projectRoot } from "./commands/context.js";
 
 const USAGE =
   "Usage: /gsd codebase [generate|update|stats]\n\n" +
@@ -36,7 +37,7 @@ export async function handleCodebase(
   ctx: ExtensionCommandContext,
   _pi: ExtensionAPI,
 ): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
   const parts = args.trim().split(/\s+/);
   const sub = parts[0] ?? "";
 

--- a/src/resources/extensions/gsd/commands-debug.ts
+++ b/src/resources/extensions/gsd/commands-debug.ts
@@ -10,6 +10,7 @@ import {
   type DebugSpecialistReview,
 } from "./debug-session-store.js";
 import { loadPrompt } from "./prompt-loader.js";
+import { projectRoot } from "./commands/context.js";
 
 export type DebugCommandIntent
   = { type: "usage" }
@@ -94,7 +95,7 @@ export function parseDebugCommand(args: string): DebugCommandIntent {
 
 export async function handleDebug(args: string, ctx: ExtensionCommandContext, pi?: ExtensionAPI): Promise<void> {
   const parsed = parseDebugCommand(args);
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
 
   if (parsed.type === "usage") {
     ctx.ui.notify(usageText(), "info");

--- a/src/resources/extensions/gsd/commands-eval-review.ts
+++ b/src/resources/extensions/gsd/commands-eval-review.ts
@@ -268,6 +268,7 @@ export async function buildEvalReviewContext(
   state: Extract<EvalReviewState, { kind: "ready" }>,
   milestoneId: string,
   now: () => Date = () => new Date(),
+  ctx?: ExtensionCommandContext,
 ): Promise<EvalReviewContext> {
   const summaryReadBudget = state.specPath
     ? MAX_CONTEXT_BYTES - SPEC_MARKER_RESERVE_BYTES
@@ -305,7 +306,7 @@ export async function buildEvalReviewContext(
 
   const truncated = summaryRead.truncated || specTruncated;
   const outputPath = evalReviewWritePath(state.sliceDir, state.sliceId);
-  const basePath = projectRoot();
+  const basePath = projectRoot(ctx);
   const relativeOutputPath = relative(basePath, outputPath);
 
   return {
@@ -625,7 +626,7 @@ export async function handleEvalReview(
     throw err;
   }
 
-  const basePath = projectRoot();
+  const basePath = projectRoot(ctx);
   const state = await deriveState(basePath);
   if (!state.activeMilestone) {
     ctx.ui.notify(
@@ -688,7 +689,7 @@ export async function handleEvalReview(
 
   let context: EvalReviewContext;
   try {
-    context = await buildEvalReviewContext(detected, milestoneId);
+    context = await buildEvalReviewContext(detected, milestoneId, () => new Date(), ctx);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     ctx.ui.notify(`Failed to build eval-review context: ${msg}`, "error");

--- a/src/resources/extensions/gsd/commands-extract-learnings.ts
+++ b/src/resources/extensions/gsd/commands-extract-learnings.ts
@@ -427,7 +427,7 @@ export async function handleExtractLearnings(
   }
 
   // projectRoot() throws GSDNoProjectError if no project found — intentional, handled by dispatcher
-  const basePath = projectRoot();
+  const basePath = projectRoot(ctx);
   const milestoneDir = resolveMilestonePath(basePath, milestoneId);
 
   if (!milestoneDir) {

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -107,9 +107,9 @@ export function isDoctorHealActionable(issue: { fixable: boolean; severity: stri
 
 export async function handleDoctor(args: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {
   const { jsonMode, dryRun, fixFlag, includeBuild, includeTests, mode, requestedScope } = parseDoctorArgs(args);
-  const scope = await selectDoctorScope(projectRoot(), requestedScope);
+  const scope = await selectDoctorScope(projectRoot(ctx), requestedScope);
   const effectiveScope = mode === "audit" ? requestedScope : scope;
-  const report = await runGSDDoctor(projectRoot(), {
+  const report = await runGSDDoctor(projectRoot(ctx), {
     fix: mode === "fix" || mode === "heal" || dryRun || fixFlag,
     dryRun,
     scope: effectiveScope,
@@ -155,7 +155,7 @@ export async function handleSkillHealth(args: string, ctx: ExtensionCommandConte
     formatSkillDetail,
   } = await import("./skill-health.js");
 
-  const basePath = projectRoot();
+  const basePath = projectRoot(ctx);
 
   // /gsd skill-health <skill-name> — detail view
   if (args && !args.startsWith("--")) {
@@ -203,7 +203,7 @@ export async function handleCapture(args: string, ctx: ExtensionCommandContext):
     return;
   }
 
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
 
   // Ensure .gsd/ exists — capture should work even without a milestone
   const gsdDir = gsdRoot(basePath);
@@ -270,7 +270,7 @@ export async function handleTriage(ctx: ExtensionCommandContext, pi: ExtensionAP
 }
 
 export async function handleSteer(change: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
   const state = await deriveState(basePath);
   const mid = state.activeMilestone?.id ?? "none";
   const sid = state.activeSlice?.id ?? "none";
@@ -343,7 +343,7 @@ export async function handleKnowledge(args: string, ctx: ExtensionCommandContext
   }
 
   const type = typeArg as "rule" | "pattern" | "lesson";
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
   const state = await deriveState(basePath);
   const scope = state.activeMilestone?.id
     ? `${state.activeMilestone.id}${state.activeSlice ? `/${state.activeSlice.id}` : ""}`
@@ -372,7 +372,7 @@ Examples:
   }
 
   const [hookName, unitType, unitId] = parts;
-  const basePath = projectRoot();
+  const basePath = projectRoot(ctx);
 
   // Import the hook trigger function
   const { triggerHookManually, formatHookStatus, getHookStatus } = await import("./post-unit-hooks.js");

--- a/src/resources/extensions/gsd/commands-inspect.ts
+++ b/src/resources/extensions/gsd/commands-inspect.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import { gsdRoot } from "./paths.js";
 import { logWarning } from "./workflow-logger.js";
 import { getErrorMessage } from "./error-utils.js";
+import { projectRoot } from "./commands/context.js";
 
 export interface InspectData {
   schemaVersion: number | null;
@@ -51,7 +52,7 @@ export async function handleInspect(ctx: ExtensionCommandContext): Promise<void>
     const { isDbAvailable, _getAdapter, openDatabase } = await import("./gsd-db.js");
 
     if (!isDbAvailable()) {
-      const gsdDir = gsdRoot(process.cwd());
+      const gsdDir = gsdRoot(projectRoot(ctx));
       const dbPath = join(gsdDir, "gsd.db");
       if (!existsSync(gsdDir) || !existsSync(dbPath) || !openDatabase(dbPath)) {
         ctx.ui.notify("No GSD database available. Run /gsd auto to create one.", "info");

--- a/src/resources/extensions/gsd/commands-logs.ts
+++ b/src/resources/extensions/gsd/commands-logs.ts
@@ -15,6 +15,7 @@ import { existsSync, readdirSync, readFileSync, statSync, unlinkSync } from "nod
 import { join } from "node:path";
 import { gsdRoot } from "./paths.js";
 import { loadJsonFileOrNull } from "./json-persistence.js";
+import { projectRoot } from "./commands/context.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -243,7 +244,7 @@ function summarizeDebugLog(filePath: string): {
 // ─── Main Handler ───────────────────────────────────────────────────────────
 
 export async function handleLogs(args: string, ctx: ExtensionCommandContext): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
   const parts = args.trim().split(/\s+/).filter(Boolean);
   const subCmd = parts[0] ?? "";
 

--- a/src/resources/extensions/gsd/commands-maintenance.ts
+++ b/src/resources/extensions/gsd/commands-maintenance.ts
@@ -190,7 +190,9 @@ export async function handleCleanupWorktrees(ctx: ExtensionCommandContext, baseP
 
   if (safeToRemove.length > 0) {
     lines.push(`Safe to remove (${safeToRemove.length}) — merged into main, clean:`);
-    const cwd = process.cwd();
+    // Use the invocation-time cwd, not process.cwd(): we are guarding against
+    // removing the user's current working directory out from under them.
+    const cwd = ctx.cwd;
     let removed = 0;
     for (const s of safeToRemove) {
       const wt = s.worktree;

--- a/src/resources/extensions/gsd/commands-mcp-status.ts
+++ b/src/resources/extensions/gsd/commands-mcp-status.ts
@@ -17,6 +17,7 @@ import { join, resolve } from "node:path";
 
 import { ensureProjectWorkflowMcpConfig } from "./mcp-project-config.js";
 import { gsdHome } from "./gsd-home.js";
+import { projectRoot } from "./commands/context.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -64,12 +65,12 @@ interface McpServerRawConfig {
   url?: string;
 }
 
-function readMcpConfigs(): McpServerRawConfig[] {
+function readMcpConfigs(basePath: string): McpServerRawConfig[] {
   const servers: McpServerRawConfig[] = [];
   const seen = new Set<string>();
   const configPaths = [
-    join(process.cwd(), ".mcp.json"),
-    join(process.cwd(), ".gsd", "mcp.json"),
+    join(basePath, ".mcp.json"),
+    join(basePath, ".gsd", "mcp.json"),
     join(gsdHome(), "mcp.json"),
   ];
 
@@ -183,7 +184,7 @@ export async function handleMcpStatus(
 ): Promise<void> {
   const trimmed = args.trim();
   const lowered = trimmed.toLowerCase();
-  const configs = readMcpConfigs();
+  const configs = readMcpConfigs(projectRoot(ctx));
 
   // /gsd mcp init [dir]
   if (!lowered || lowered === "status") {

--- a/src/resources/extensions/gsd/commands-memory.ts
+++ b/src/resources/extensions/gsd/commands-memory.ts
@@ -349,7 +349,10 @@ function handleExport(ctx: ExtensionCommandContext, target: string | undefined):
       })),
       sources,
     };
-    const abs = resolvePath(process.cwd(), target);
+    // User-supplied path: resolve relative to the invocation cwd, not the
+    // project root, so `/gsd memory export ./foo.json` writes where the user
+    // currently is.
+    const abs = resolvePath(ctx.cwd, target);
     writeFileSync(abs, JSON.stringify(payload, null, 2), "utf-8");
     ctx.ui.notify(
       `Exported ${payload.memories.length} memories, ${payload.relations.length} relations, ${payload.sources.length} sources → ${abs}`,
@@ -382,7 +385,9 @@ function handleImport(ctx: ExtensionCommandContext, target: string | undefined):
     return;
   }
   try {
-    const abs = resolvePath(process.cwd(), target);
+    // User-supplied path: resolve relative to the invocation cwd, not the
+    // project root.
+    const abs = resolvePath(ctx.cwd, target);
     const raw = readFileSync(abs, "utf-8");
     const parsed = JSON.parse(raw) as { memories?: ExportedMemory[]; relations?: ExportedRelation[] };
 

--- a/src/resources/extensions/gsd/commands-pr-branch.ts
+++ b/src/resources/extensions/gsd/commands-pr-branch.ts
@@ -15,6 +15,7 @@ import {
   nativeDetectMainBranch,
   nativeBranchExists,
 } from "./native-git-bridge.js";
+import { projectRoot } from "./commands/context.js";
 
 const EXCLUDED_PATHS = [".gsd", ".planning", "PLAN.md"] as const;
 
@@ -126,7 +127,7 @@ export async function handlePrBranch(
   args: string,
   ctx: ExtensionCommandContext,
 ): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
   const dryRun = args.includes("--dry-run");
   const nameMatch = args.match(/--name\s+(\S+)/);
 

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -21,6 +21,7 @@ import {
 } from "./preferences.js";
 import { loadFile, saveFile, splitFrontmatter, parseFrontmatterMap } from "./files.js";
 import { runClaudeImportFlow } from "./claude-import.js";
+import { projectRoot } from "./commands/context.js";
 
 /** Extract body content after frontmatter closing delimiter, or null if none. */
 function extractBodyAfterFrontmatter(content: string): string | null {
@@ -253,7 +254,7 @@ export async function handlePrefs(args: string, ctx: ExtensionCommandContext): P
     const effective = loadEffectiveGSDPreferences();
     let hasUnresolved = false;
     if (effective) {
-      const report = resolveAllSkillReferences(effective.preferences, process.cwd());
+      const report = resolveAllSkillReferences(effective.preferences, projectRoot(ctx));
       const resolved = [...report.resolutions.values()].filter(r => r.method !== "unresolved");
       hasUnresolved = report.warnings.length > 0;
       if (resolved.length > 0 || hasUnresolved) {

--- a/src/resources/extensions/gsd/commands-scan.ts
+++ b/src/resources/extensions/gsd/commands-scan.ts
@@ -20,6 +20,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { join, relative } from "node:path";
 
 import { loadPrompt } from "./prompt-loader.js";
+import { projectRoot } from "./commands/context.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -86,7 +87,7 @@ export async function handleScan(
   ctx: ExtensionCommandContext,
   pi: ExtensionAPI,
 ): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
   const { focus } = parseScanArgs(args);
   const outputDir = join(basePath, ".gsd", "codebase");
   const outputPaths = buildScanOutputPaths(focus, basePath);

--- a/src/resources/extensions/gsd/commands-session-report.ts
+++ b/src/resources/extensions/gsd/commands-session-report.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { getLedger, getProjectTotals, aggregateByModel, formatCost, formatTokenCount, loadLedgerFromDisk } from "./metrics.js";
 import type { UnitMetrics } from "./metrics.js";
 import { gsdRoot } from "./paths.js";
+import { projectRoot } from "./commands/context.js";
 import { formatDuration } from "../shared/format-utils.js";
 
 function formatSessionReport(units: UnitMetrics[]): string {
@@ -59,7 +60,7 @@ export async function handleSessionReport(
   args: string,
   ctx: ExtensionCommandContext,
 ): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
 
   // Get units from in-memory ledger or disk
   const ledger = getLedger();

--- a/src/resources/extensions/gsd/commands-ship.ts
+++ b/src/resources/extensions/gsd/commands-ship.ts
@@ -17,6 +17,7 @@ import { getLedger, getProjectTotals, aggregateByModel, formatCost, formatTokenC
 import { nativeGetCurrentBranch, nativeDetectMainBranch } from "./native-git-bridge.js";
 import { formatDuration } from "../shared/format-utils.js";
 import { parseEvalReviewFrontmatter, type Verdict } from "./eval-review-schema.js";
+import { projectRoot } from "./commands/context.js";
 
 function git(basePath: string, args: readonly string[]): string {
   return execFileSync("git", args, { cwd: basePath, encoding: "utf-8" }).trim();
@@ -222,7 +223,7 @@ export async function handleShip(
   ctx: ExtensionCommandContext,
   _pi: ExtensionAPI,
 ): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
   const dryRun = args.includes("--dry-run");
   const draft = args.includes("--draft");
   const force = args.includes("--force");

--- a/src/resources/extensions/gsd/commands-workflow-templates.ts
+++ b/src/resources/extensions/gsd/commands-workflow-templates.ts
@@ -23,6 +23,7 @@ import { createGitService, runGit } from "./git-service.js";
 import { isAutoActive, isAutoPaused } from "./auto.js";
 import { getErrorMessage } from "./error-utils.js";
 import { resolvePlugin, type WorkflowPlugin } from "./workflow-plugins.js";
+import { projectRoot } from "./commands/context.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -196,7 +197,7 @@ export async function handleStart(
   // ─── Resume detection ───────────────────────────────────────────────────
   // /gsd start --resume or /gsd start resume → resume in-progress workflow
   if (trimmed === "--resume" || trimmed === "resume") {
-    const basePath = process.cwd();
+    const basePath = projectRoot(ctx);
     const inProgress = findInProgressWorkflows(basePath);
     if (inProgress.length === 0) {
       ctx.ui.notify("No in-progress workflows found.", "info");
@@ -247,7 +248,7 @@ export async function handleStart(
 
   // Show in-progress workflows when /gsd start is called with no args
   if (!trimmed) {
-    const basePath = process.cwd();
+    const basePath = projectRoot(ctx);
     const inProgress = findInProgressWorkflows(basePath);
     if (inProgress.length > 0) {
       const wf = inProgress[0];
@@ -346,7 +347,7 @@ export async function handleStart(
 
   const templateId = match.id;
   const template = match.template;
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
   const date = new Date().toISOString().split("T")[0];
 
   // Load the workflow template content — prefer a project/global plugin
@@ -581,7 +582,7 @@ export function dispatchMarkdownPhasePlugin(
   }
 
   const templateId = plugin.name;
-  const basePath = process.cwd();
+  const basePath = projectRoot(ctx);
   const date = new Date().toISOString().split("T")[0];
   let workflowContent: string;
   try {

--- a/src/resources/extensions/gsd/commands-worktree.ts
+++ b/src/resources/extensions/gsd/commands-worktree.ts
@@ -127,7 +127,7 @@ export function formatCleanKeepReason(status: WorktreeStatus): string {
 // ─── Subcommand: list ───────────────────────────────────────────────────────
 
 async function handleList(ctx: ExtensionCommandContext): Promise<void> {
-  const basePath = projectRoot();
+  const basePath = projectRoot(ctx);
   const worktrees = listWorktrees(basePath);
   const statuses = worktrees.map((wt) => getStatus(basePath, wt.name, wt.path));
   ctx.ui.notify(formatWorktreeList(statuses), "info");
@@ -136,7 +136,7 @@ async function handleList(ctx: ExtensionCommandContext): Promise<void> {
 // ─── Subcommand: merge ──────────────────────────────────────────────────────
 
 async function handleMerge(args: string, ctx: ExtensionCommandContext): Promise<void> {
-  const basePath = projectRoot();
+  const basePath = projectRoot(ctx);
   const worktrees = listWorktrees(basePath);
   const trimmed = args.trim();
 
@@ -241,7 +241,7 @@ async function handleMerge(args: string, ctx: ExtensionCommandContext): Promise<
 // ─── Subcommand: clean ──────────────────────────────────────────────────────
 
 async function handleClean(ctx: ExtensionCommandContext): Promise<void> {
-  const basePath = projectRoot();
+  const basePath = projectRoot(ctx);
   const worktrees = listWorktrees(basePath);
   if (worktrees.length === 0) {
     ctx.ui.notify("No worktrees to clean.", "info");
@@ -281,7 +281,7 @@ async function handleClean(ctx: ExtensionCommandContext): Promise<void> {
 // ─── Subcommand: remove ─────────────────────────────────────────────────────
 
 async function handleRemove(args: string, ctx: ExtensionCommandContext): Promise<void> {
-  const basePath = projectRoot();
+  const basePath = projectRoot(ctx);
   const tokens = args.trim().split(/\s+/).filter(Boolean);
   const force = tokens.includes("--force");
   const name = tokens.find((t) => t !== "--force");

--- a/src/resources/extensions/gsd/commands/context.ts
+++ b/src/resources/extensions/gsd/commands/context.ts
@@ -41,12 +41,11 @@ export class GSDNoProjectError extends Error {
  */
 export function projectRoot(ctx?: ExtensionContext): string {
   let root: string;
-  let pathToCheck: string;
+  let cwd: string;
   if (ctx && typeof ctx.projectRoot === "string" && ctx.projectRoot.length > 0) {
     root = ctx.projectRoot;
-    pathToCheck = ctx.cwd && ctx.cwd !== root ? ctx.cwd : root;
+    cwd = ctx.cwd && ctx.cwd.length > 0 ? ctx.cwd : root;
   } else {
-    let cwd: string;
     try {
       cwd = ctx?.cwd ?? process.cwd();
     } catch {
@@ -54,11 +53,18 @@ export function projectRoot(ctx?: ExtensionContext): string {
       cwd = homedir();
     }
     root = resolveProjectRoot(cwd);
-    pathToCheck = root !== cwd ? cwd : root;
   }
-  const result = validateDirectory(pathToCheck);
-  if (result.severity === "blocked") {
-    throw new GSDNoProjectError(result.reason ?? "GSD must be run inside a project directory.");
+
+  // Validate the root itself first — a bad root (e.g. project deleted) should
+  // never be returned as if it were valid. Then, if cwd diverges from root,
+  // also validate cwd so commands like /gsd cleanup that operate on the
+  // current directory get a chance to fail with a meaningful reason rather
+  // than silently misfiring against an unrelated project root.
+  for (const candidate of root === cwd ? [root] : [root, cwd]) {
+    const result = validateDirectory(candidate);
+    if (result.severity === "blocked") {
+      throw new GSDNoProjectError(result.reason ?? "GSD must be run inside a project directory.");
+    }
   }
   return root;
 }

--- a/src/resources/extensions/gsd/commands/context.ts
+++ b/src/resources/extensions/gsd/commands/context.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@gsd/pi-coding-agent";
 
 import { checkRemoteAutoSession, isAutoActive, isAutoPaused, stopAutoRemote } from "../auto.js";
 import { validateDirectory } from "../validate-directory.js";
@@ -24,16 +24,38 @@ export class GSDNoProjectError extends Error {
   }
 }
 
-export function projectRoot(): string {
-  let cwd: string;
-  try {
-    cwd = process.cwd();
-  } catch {
-    // cwd directory was deleted (e.g. worktree teardown) — fall back to home (#3598)
-    cwd = homedir();
+/**
+ * Resolve and validate the current project root.
+ *
+ * When `ctx` is provided, sources the root from `ctx.projectRoot` (the
+ * canonical "current project" maintained by the runner). When `ctx` is
+ * omitted, falls back to `process.cwd()` resolved via `resolveProjectRoot`.
+ *
+ * In both cases the result is passed through `validateDirectory`; if the
+ * directory is rejected (e.g. inside a node_modules tree, deleted, etc.),
+ * a `GSDNoProjectError` is thrown.
+ *
+ * Prefer the ctx-aware overload from any handler that has an
+ * `ExtensionContext` in scope so the resolved root tracks the runner's
+ * notion of the current project rather than the process cwd.
+ */
+export function projectRoot(ctx?: ExtensionContext): string {
+  let root: string;
+  let pathToCheck: string;
+  if (ctx && typeof ctx.projectRoot === "string" && ctx.projectRoot.length > 0) {
+    root = ctx.projectRoot;
+    pathToCheck = ctx.cwd && ctx.cwd !== root ? ctx.cwd : root;
+  } else {
+    let cwd: string;
+    try {
+      cwd = ctx?.cwd ?? process.cwd();
+    } catch {
+      // cwd directory was deleted (e.g. worktree teardown) — fall back to home (#3598)
+      cwd = homedir();
+    }
+    root = resolveProjectRoot(cwd);
+    pathToCheck = root !== cwd ? cwd : root;
   }
-  const root = resolveProjectRoot(cwd);
-  const pathToCheck = root !== cwd ? cwd : root;
   const result = validateDirectory(pathToCheck);
   if (result.severity === "blocked") {
     throw new GSDNoProjectError(result.reason ?? "GSD must be run inside a project directory.");
@@ -61,7 +83,7 @@ export async function guardRemoteSession(
 ): Promise<boolean> {
   if (isAutoActive() || isAutoPaused()) return true;
 
-  const remote = checkRemoteAutoSession(projectRoot());
+  const remote = checkRemoteAutoSession(projectRoot(ctx));
   if (!remote.running || !remote.pid) return true;
 
   const unitLabel = remote.unitType && remote.unitId
@@ -124,7 +146,7 @@ export async function guardRemoteSession(
     return false;
   }
   if (choice === "stop") {
-    const result = stopAutoRemote(projectRoot());
+    const result = stopAutoRemote(projectRoot(ctx));
     if (result.found) {
       ctx.ui.notify(`Sent stop signal to auto-mode session (PID ${result.pid}). It will shut down gracefully.`, "info");
     } else if (result.error) {

--- a/src/resources/extensions/gsd/commands/handlers/auto.ts
+++ b/src/resources/extensions/gsd/commands/handlers/auto.ts
@@ -46,25 +46,25 @@ export async function handleAutoCommand(trimmed: string, ctx: ExtensionCommandCo
   if (trimmed === "next" || trimmed.startsWith("next ")) {
     if (trimmed.includes("--dry-run")) {
       const { handleDryRun } = await import("../../commands-maintenance.js");
-      await handleDryRun(ctx, projectRoot());
+      await handleDryRun(ctx, projectRoot(ctx));
       return true;
     }
     const { milestoneId, rest: afterMilestone } = parseMilestoneTarget(trimmed);
     const verboseMode = afterMilestone.includes("--verbose");
     const debugMode = afterMilestone.includes("--debug");
-    if (debugMode) enableDebug(projectRoot());
+    if (debugMode) enableDebug(projectRoot(ctx));
     if (!(await guardRemoteSession(ctx, pi))) return true;
 
     // Validate the milestone target exists and is not already complete.
     if (milestoneId) {
-      const allIds = findMilestoneIds(projectRoot());
+      const allIds = findMilestoneIds(projectRoot(ctx));
       if (!allIds.includes(milestoneId)) {
         ctx.ui.notify(`Milestone ${milestoneId} does not exist. Available: ${allIds.join(", ") || "(none)"}`, "error");
         return true;
       }
     }
 
-    startAutoDetached(ctx, pi, projectRoot(), verboseMode, {
+    startAutoDetached(ctx, pi, projectRoot(ctx), verboseMode, {
       step: true,
       milestoneLock: milestoneId,
     });
@@ -76,12 +76,12 @@ export async function handleAutoCommand(trimmed: string, ctx: ExtensionCommandCo
     const { milestoneId, rest: afterMilestone } = parseMilestoneTarget(afterYolo);
     const verboseMode = afterMilestone.includes("--verbose");
     const debugMode = afterMilestone.includes("--debug");
-    if (debugMode) enableDebug(projectRoot());
+    if (debugMode) enableDebug(projectRoot(ctx));
     if (!(await guardRemoteSession(ctx, pi))) return true;
 
     // Validate the milestone target exists and is not already complete.
     if (milestoneId) {
-      const allIds = findMilestoneIds(projectRoot());
+      const allIds = findMilestoneIds(projectRoot(ctx));
       if (!allIds.includes(milestoneId)) {
         ctx.ui.notify(`Milestone ${milestoneId} does not exist. Available: ${allIds.join(", ") || "(none)"}`, "error");
         return true;
@@ -89,7 +89,7 @@ export async function handleAutoCommand(trimmed: string, ctx: ExtensionCommandCo
     }
 
     if (yoloSeedFile) {
-      const resolved = resolve(projectRoot(), yoloSeedFile);
+      const resolved = resolve(projectRoot(ctx), yoloSeedFile);
       if (!existsSync(resolved)) {
         ctx.ui.notify(`Yolo seed file not found: ${resolved}`, "error");
         return true;
@@ -103,20 +103,20 @@ export async function handleAutoCommand(trimmed: string, ctx: ExtensionCommandCo
       // then auto-mode starts automatically via checkAutoStartAfterDiscuss
       // when the LLM says "Milestone X ready."
       const { showHeadlessMilestoneCreation } = await import("../../guided-flow.js");
-      await showHeadlessMilestoneCreation(ctx, pi, projectRoot(), seedContent);
+      await showHeadlessMilestoneCreation(ctx, pi, projectRoot(ctx), seedContent);
     } else if (milestoneId) {
-      startAutoDetached(ctx, pi, projectRoot(), verboseMode, {
+      startAutoDetached(ctx, pi, projectRoot(ctx), verboseMode, {
         milestoneLock: milestoneId,
       });
     } else {
-      startAutoDetached(ctx, pi, projectRoot(), verboseMode);
+      startAutoDetached(ctx, pi, projectRoot(ctx), verboseMode);
     }
     return true;
   }
 
   if (trimmed === "stop") {
     if (!isAutoActive() && !isAutoPaused()) {
-      const result = stopAutoRemote(projectRoot());
+      const result = stopAutoRemote(projectRoot(ctx));
       if (result.found) {
         ctx.ui.notify(`Sent stop signal to auto-mode session (PID ${result.pid}). It will shut down gracefully.`, "info");
       } else if (result.error) {
@@ -144,13 +144,13 @@ export async function handleAutoCommand(trimmed: string, ctx: ExtensionCommandCo
   }
 
   if (trimmed === "rate" || trimmed.startsWith("rate ")) {
-    await handleRate(trimmed.replace(/^rate\s*/, "").trim(), ctx, projectRoot());
+    await handleRate(trimmed.replace(/^rate\s*/, "").trim(), ctx, projectRoot(ctx));
     return true;
   }
 
   if (trimmed === "") {
     if (!(await guardRemoteSession(ctx, pi))) return true;
-    startAutoDetached(ctx, pi, projectRoot(), false, { step: true });
+    startAutoDetached(ctx, pi, projectRoot(ctx), false, { step: true });
     return true;
   }
 

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -144,7 +144,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
 }
 
 export async function handleStatus(ctx: ExtensionCommandContext): Promise<void> {
-  const basePath = projectRoot();
+  const basePath = projectRoot(ctx);
   // Open DB in cold sessions so status uses DB-backed state, not filesystem fallback (#3385)
   const { ensureDbOpen } = await import("../../bootstrap/dynamic-tools.js");
   await ensureDbOpen();
@@ -170,7 +170,7 @@ export async function handleStatus(ctx: ExtensionCommandContext): Promise<void> 
   );
 
   if (result === undefined) {
-    ctx.ui.notify(formatTextStatus(state), "info");
+    ctx.ui.notify(formatTextStatus(state, ctx), "info");
   }
 }
 
@@ -248,7 +248,7 @@ export async function handleSetup(args: string, ctx: ExtensionCommandContext, pi
 
   // Bare /gsd setup — render the hub: status + actions
   const globalConfigured = hasGlobalSetup();
-  const detection = detectProjectState(projectRoot());
+  const detection = detectProjectState(projectRoot(ctx));
   const onboardingDone = isOnboardingComplete();
   const record = readOnboardingRecord();
 
@@ -495,7 +495,7 @@ export async function handleCoreCommand(
   return false;
 }
 
-export function formatTextStatus(state: GSDState): string {
+export function formatTextStatus(state: GSDState, ctx?: ExtensionContext): string {
   const lines: string[] = ["GSD Status\n"];
   lines.push(formatProgressLine(computeProgressScore()));
   lines.push("");
@@ -538,7 +538,7 @@ export function formatTextStatus(state: GSDState): string {
     }
   }
 
-  const envResults = runEnvironmentChecks(projectRoot());
+  const envResults = runEnvironmentChecks(projectRoot(ctx));
   const envIssues = envResults.filter((result) => result.status !== "ok");
   if (envIssues.length > 0) {
     lines.push("");

--- a/src/resources/extensions/gsd/commands/handlers/escalate.ts
+++ b/src/resources/extensions/gsd/commands/handlers/escalate.ts
@@ -61,7 +61,7 @@ export async function handleEscalateCommand(
     return;
   }
 
-  const basePath = projectRoot();
+  const basePath = projectRoot(ctx);
   const prefs = loadEffectiveGSDPreferences()?.preferences;
   if (prefs?.phases?.mid_execution_escalation !== true) {
     ctx.ui.notify(

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -21,7 +21,7 @@ export async function handleOpsCommand(trimmed: string, ctx: ExtensionCommandCon
   if (trimmed === "init") {
     const { detectProjectState } = await import("../../detection.js");
     const { handleReinit, showProjectInit } = await import("../../init-wizard.js");
-    const basePath = projectRoot();
+    const basePath = projectRoot(ctx);
     const detection = detectProjectState(basePath);
     if (detection.state === "v2-gsd" || detection.state === "v2-gsd-empty") {
       await handleReinit(ctx, detection);
@@ -58,21 +58,21 @@ export async function handleOpsCommand(trimmed: string, ctx: ExtensionCommandCon
     return true;
   }
   if (trimmed === "history" || trimmed.startsWith("history ")) {
-    await handleHistory(trimmed.replace(/^history\s*/, "").trim(), ctx, projectRoot());
+    await handleHistory(trimmed.replace(/^history\s*/, "").trim(), ctx, projectRoot(ctx));
     return true;
   }
   if (trimmed === "undo-task" || trimmed.startsWith("undo-task ")) {
     const { handleUndoTask } = await import("../../undo.js");
-    await handleUndoTask(trimmed.replace(/^undo-task\s*/, "").trim(), ctx, pi, projectRoot());
+    await handleUndoTask(trimmed.replace(/^undo-task\s*/, "").trim(), ctx, pi, projectRoot(ctx));
     return true;
   }
   if (trimmed === "reset-slice" || trimmed.startsWith("reset-slice ")) {
     const { handleResetSlice } = await import("../../undo.js");
-    await handleResetSlice(trimmed.replace(/^reset-slice\s*/, "").trim(), ctx, pi, projectRoot());
+    await handleResetSlice(trimmed.replace(/^reset-slice\s*/, "").trim(), ctx, pi, projectRoot(ctx));
     return true;
   }
   if (trimmed === "undo" || trimmed.startsWith("undo ")) {
-    await handleUndo(trimmed.replace(/^undo\s*/, "").trim(), ctx, pi, projectRoot());
+    await handleUndo(trimmed.replace(/^undo\s*/, "").trim(), ctx, pi, projectRoot(ctx));
     return true;
   }
   if (trimmed === "skip") {
@@ -80,15 +80,15 @@ export async function handleOpsCommand(trimmed: string, ctx: ExtensionCommandCon
     return true;
   }
   if (trimmed.startsWith("skip ")) {
-    await handleSkip(trimmed.replace(/^skip\s*/, "").trim(), ctx, projectRoot());
+    await handleSkip(trimmed.replace(/^skip\s*/, "").trim(), ctx, projectRoot(ctx));
     return true;
   }
   if (trimmed === "recover") {
-    await handleRecover(ctx, projectRoot());
+    await handleRecover(ctx, projectRoot(ctx));
     return true;
   }
   if (trimmed === "export" || trimmed.startsWith("export ")) {
-    await handleExport(trimmed.replace(/^export\s*/, "").trim(), ctx, projectRoot());
+    await handleExport(trimmed.replace(/^export\s*/, "").trim(), ctx, projectRoot(ctx));
     return true;
   }
   if (trimmed === "cleanup projects" || trimmed.startsWith("cleanup projects ")) {
@@ -96,20 +96,20 @@ export async function handleOpsCommand(trimmed: string, ctx: ExtensionCommandCon
     return true;
   }
   if (trimmed === "cleanup worktrees") {
-    await handleCleanupWorktrees(ctx, projectRoot());
+    await handleCleanupWorktrees(ctx, projectRoot(ctx));
     return true;
   }
   if (trimmed === "cleanup") {
-    await handleCleanupBranches(ctx, projectRoot());
-    await handleCleanupSnapshots(ctx, projectRoot());
+    await handleCleanupBranches(ctx, projectRoot(ctx));
+    await handleCleanupSnapshots(ctx, projectRoot(ctx));
     return true;
   }
   if (trimmed === "cleanup branches") {
-    await handleCleanupBranches(ctx, projectRoot());
+    await handleCleanupBranches(ctx, projectRoot(ctx));
     return true;
   }
   if (trimmed === "cleanup snapshots") {
-    await handleCleanupSnapshots(ctx, projectRoot());
+    await handleCleanupSnapshots(ctx, projectRoot(ctx));
     return true;
   }
   if (trimmed.startsWith("capture ") || trimmed === "capture") {
@@ -117,7 +117,7 @@ export async function handleOpsCommand(trimmed: string, ctx: ExtensionCommandCon
     return true;
   }
   if (trimmed === "triage") {
-    await handleTriage(ctx, pi, process.cwd());
+    await handleTriage(ctx, pi, projectRoot(ctx));
     return true;
   }
   if (trimmed === "config") {
@@ -183,7 +183,7 @@ Examples:
       ctx.ui.notify("Usage: /gsd dispatch <phase>  (research|plan|execute|complete|reassess|uat|replan)", "warning");
       return true;
     }
-    await dispatchDirectPhase(ctx, pi, phase, projectRoot());
+    await dispatchDirectPhase(ctx, pi, phase, projectRoot(ctx));
     return true;
   }
   if (trimmed === "notifications" || trimmed.startsWith("notifications ")) {

--- a/src/resources/extensions/gsd/commands/handlers/parallel.ts
+++ b/src/resources/extensions/gsd/commands/handlers/parallel.ts
@@ -19,7 +19,7 @@ function emitParallelMessage(pi: ExtensionAPI, content: string): void {
   pi.sendMessage({ customType: "gsd-parallel", content, display: true });
 }
 
-export async function handleParallelCommand(trimmed: string, _ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<boolean> {
+export async function handleParallelCommand(trimmed: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<boolean> {
   if (!trimmed.startsWith("parallel")) return false;
 
   const parallelArgs = trimmed.slice("parallel".length).trim();
@@ -27,7 +27,7 @@ export async function handleParallelCommand(trimmed: string, _ctx: ExtensionComm
   const rest = restParts.join(" ");
 
   if (subcommand === "start" || subcommand === "") {
-    const root = projectRoot();
+    const root = projectRoot(ctx);
     const loaded = loadEffectiveGSDPreferences();
     const config = resolveParallelConfig(loaded?.preferences);
     if (!config.enabled) {
@@ -54,7 +54,7 @@ export async function handleParallelCommand(trimmed: string, _ctx: ExtensionComm
   }
 
   if (subcommand === "status") {
-    const root = projectRoot();
+    const root = projectRoot(ctx);
     refreshWorkerStatuses(root, { restoreIfNeeded: true });
     const workers = getWorkerStatuses(root);
     if (workers.length === 0 || !isParallelActive()) {
@@ -75,21 +75,21 @@ export async function handleParallelCommand(trimmed: string, _ctx: ExtensionComm
 
   if (subcommand === "stop") {
     const milestoneId = rest.trim() || undefined;
-    await stopParallel(projectRoot(), milestoneId);
+    await stopParallel(projectRoot(ctx), milestoneId);
     emitParallelMessage(pi, milestoneId ? `Stopped worker for ${milestoneId}.` : "All parallel workers stopped.");
     return true;
   }
 
   if (subcommand === "pause") {
     const milestoneId = rest.trim() || undefined;
-    pauseWorker(projectRoot(), milestoneId);
+    pauseWorker(projectRoot(ctx), milestoneId);
     emitParallelMessage(pi, milestoneId ? `Paused worker for ${milestoneId}.` : "All parallel workers paused.");
     return true;
   }
 
   if (subcommand === "resume") {
     const milestoneId = rest.trim() || undefined;
-    resumeWorker(projectRoot(), milestoneId);
+    resumeWorker(projectRoot(ctx), milestoneId);
     emitParallelMessage(pi, milestoneId ? `Resumed worker for ${milestoneId}.` : "All parallel workers resumed.");
     return true;
   }
@@ -97,24 +97,24 @@ export async function handleParallelCommand(trimmed: string, _ctx: ExtensionComm
   if (subcommand === "merge") {
     const milestoneId = rest.trim() || undefined;
     if (milestoneId) {
-      const result = await mergeCompletedMilestone(projectRoot(), milestoneId);
+      const result = await mergeCompletedMilestone(projectRoot(ctx), milestoneId);
       emitParallelMessage(pi, formatMergeResults([result]));
       return true;
     }
-    const workers = getWorkerStatuses(projectRoot());
+    const workers = getWorkerStatuses(projectRoot(ctx));
     if (workers.length === 0) {
       emitParallelMessage(pi, "No parallel workers to merge.");
       return true;
     }
-    const results = await mergeAllCompleted(projectRoot(), workers);
+    const results = await mergeAllCompleted(projectRoot(ctx), workers);
     emitParallelMessage(pi, formatMergeResults(results));
     return true;
   }
 
   if (subcommand === "watch") {
-    const root = projectRoot();
+    const root = projectRoot(ctx);
     const { ParallelMonitorOverlay } = await import("../../parallel-monitor-overlay.js");
-    await _ctx.ui.custom<void>(
+    await ctx.ui.custom<void>(
       (tui, theme, _kb, done) => new ParallelMonitorOverlay(tui, theme, () => done(), root),
       {
         overlay: true,

--- a/src/resources/extensions/gsd/commands/handlers/workflow.ts
+++ b/src/resources/extensions/gsd/commands/handlers/workflow.ts
@@ -182,7 +182,7 @@ function dispatchPluginByMode(
     case "yaml-step": {
       const overrides = parseWorkflowOverridesOnly(args);
       try {
-        const base = projectRoot();
+        const base = projectRoot(ctx);
         const runDir = createRun(base, plugin.name, Object.keys(overrides).length > 0 ? overrides : undefined);
         setActiveEngineId("custom");
         setActiveRunDir(runDir);
@@ -229,7 +229,7 @@ async function handleCustomWorkflow(
 ): Promise<boolean> {
   // Bare `/gsd workflow` — list plugins
   if (!sub) {
-    const base = projectRoot();
+    const base = projectRoot(ctx);
     const listing = listPluginsFormatted(base);
     ctx.ui.notify(listing, "info");
     return true;
@@ -254,7 +254,7 @@ async function handleCustomWorkflow(
     }
     const { defName, overrides } = parseWorkflowRunArgs(rest);
     try {
-      const base = projectRoot();
+      const base = projectRoot(ctx);
       const runDir = createRun(base, defName, Object.keys(overrides).length > 0 ? overrides : undefined);
       setActiveEngineId("custom");
       setActiveRunDir(runDir);
@@ -271,7 +271,7 @@ async function handleCustomWorkflow(
 
   // ── list [name] — list YAML runs ──
   if (head === "list") {
-    const base = projectRoot();
+    const base = projectRoot(ctx);
     const runs = listRuns(base, rest || undefined);
     if (runs.length === 0) {
       ctx.ui.notify("No workflow runs found.", "info");
@@ -291,7 +291,7 @@ async function handleCustomWorkflow(
       ctx.ui.notify("Usage: /gsd workflow info <name>", "warning");
       return true;
     }
-    const base = projectRoot();
+    const base = projectRoot(ctx);
     const plugin = resolvePlugin(base, rest);
     if (!plugin) {
       ctx.ui.notify(`Plugin not found: ${rest}\nRun /gsd workflow to list plugins.`, "warning");
@@ -326,7 +326,7 @@ async function handleCustomWorkflow(
       else if (t && !source) source = t;
     }
 
-    const base = projectRoot();
+    const base = projectRoot(ctx);
     try {
       const url = resolveSourceUrl(source);
       ctx.ui.notify(`Fetching ${url}…`, "info");
@@ -373,7 +373,7 @@ async function handleCustomWorkflow(
       ctx.ui.notify("Usage: /gsd workflow uninstall <name>", "warning");
       return true;
     }
-    const base = projectRoot();
+    const base = projectRoot(ctx);
     const result = uninstallPlugin(base, rest.trim());
     if (!result.removed) {
       ctx.ui.notify(
@@ -395,7 +395,7 @@ async function handleCustomWorkflow(
       ctx.ui.notify("Usage: /gsd workflow validate <name>", "warning");
       return true;
     }
-    const base = projectRoot();
+    const base = projectRoot(ctx);
     const plugin = resolvePlugin(base, rest);
 
     let raw: string;
@@ -469,7 +469,7 @@ async function handleCustomWorkflow(
       ctx.ui.notify("No custom workflow to resume. Use /gsd auto for dev workflow.", "warning");
       return true;
     }
-    startAutoDetached(ctx, pi, projectRoot(), false);
+    startAutoDetached(ctx, pi, projectRoot(ctx), false);
     ctx.ui.notify("Custom workflow resumed.", "info");
     return true;
   }
@@ -477,7 +477,7 @@ async function handleCustomWorkflow(
   // ── Direct dispatch: /gsd workflow <name> [args] ──
   // If the first token isn't a reserved subcommand, resolve it as a plugin.
   if (!RESERVED_SUBCOMMANDS.has(head)) {
-    const base = projectRoot();
+    const base = projectRoot(ctx);
     const plugin = resolvePlugin(base, head);
     if (plugin) {
       dispatchPluginByMode(plugin, rest, ctx, pi);
@@ -513,12 +513,12 @@ export async function handleWorkflowCommand(trimmed: string, ctx: ExtensionComma
 
   if (trimmed === "queue") {
     if (requireNotAutoActive("/gsd queue", ctx)) return true;
-    await showQueue(ctx, pi, projectRoot());
+    await showQueue(ctx, pi, projectRoot(ctx));
     return true;
   }
   if (trimmed === "discuss") {
     if (requireNotAutoActive("/gsd discuss", ctx)) return true;
-    await showDiscuss(ctx, pi, projectRoot());
+    await showDiscuss(ctx, pi, projectRoot(ctx));
     return true;
   }
   if (trimmed === "quick" || trimmed.startsWith("quick ")) {
@@ -528,7 +528,7 @@ export async function handleWorkflowCommand(trimmed: string, ctx: ExtensionComma
   }
   if (trimmed === "new-milestone" || trimmed.startsWith("new-milestone ")) {
     if (requireNotAutoActive("/gsd new-milestone", ctx)) return true;
-    const basePath = projectRoot();
+    const basePath = projectRoot(ctx);
     const args = trimmed.replace(/^new-milestone\s*/, "").trim();
     if (/(^|\s)--deep(\s|$)/.test(args)) {
       setPlanningDepth(basePath, "deep");
@@ -570,7 +570,7 @@ export async function handleWorkflowCommand(trimmed: string, ctx: ExtensionComma
   }
   if (trimmed === "park" || trimmed.startsWith("park ")) {
     if (requireNotAutoActive("/gsd park", ctx)) return true;
-    const basePath = projectRoot();
+    const basePath = projectRoot(ctx);
     const arg = trimmed.replace(/^park\s*/, "").trim();
     let targetId = arg;
     if (!targetId) {
@@ -596,7 +596,7 @@ export async function handleWorkflowCommand(trimmed: string, ctx: ExtensionComma
   }
   if (trimmed === "unpark" || trimmed.startsWith("unpark ")) {
     if (requireNotAutoActive("/gsd unpark", ctx)) return true;
-    const basePath = projectRoot();
+    const basePath = projectRoot(ctx);
     const arg = trimmed.replace(/^unpark\s*/, "").trim();
     let targetId = arg;
     if (!targetId) {

--- a/src/resources/extensions/gsd/health-widget.ts
+++ b/src/resources/extensions/gsd/health-widget.ts
@@ -97,7 +97,7 @@ const REFRESH_INTERVAL_MS = 60_000;
 export function initHealthWidget(ctx: ExtensionContext): void {
   if (!ctx.hasUI) return;
 
-  const basePath = projectRoot();
+  const basePath = projectRoot(ctx);
 
   // String-array fallback — used in RPC mode (factory is a no-op there)
   const initialData = loadHealthWidgetData(basePath);

--- a/src/resources/extensions/gsd/init-wizard.ts
+++ b/src/resources/extensions/gsd/init-wizard.ts
@@ -168,7 +168,7 @@ export async function showProjectInit(
   if (gitChoice === "not_yet") return { completed: false, bootstrapped: false };
 
   if (gitChoice === "customize") {
-    await customizeGitPrefs(ctx, prefs, signals);
+    await customizeGitPrefs(ctx, prefs, signals, basePath);
   }
 
   // ── Step 6: Custom instructions ────────────────────────────────────────────
@@ -433,9 +433,10 @@ async function customizeGitPrefs(
   ctx: ExtensionCommandContext,
   prefs: ProjectPreferences,
   signals: ProjectSignals,
+  basePath: string,
 ): Promise<void> {
   // Isolation strategy
-  const hasSubmodules = existsSync(join(process.cwd(), ".gitmodules"));
+  const hasSubmodules = existsSync(join(basePath, ".gitmodules"));
   const isolationActions = [
     { id: "worktree", label: "Worktree", description: "Isolated git worktree per milestone (recommended)", recommended: !hasSubmodules },
     { id: "branch", label: "Branch", description: "Work on branches in project root (better for submodules)", recommended: hasSubmodules },

--- a/src/resources/extensions/gsd/tests/project-root-cwd-crash.test.ts
+++ b/src/resources/extensions/gsd/tests/project-root-cwd-crash.test.ts
@@ -35,7 +35,7 @@ describe('projectRoot cwd crash guard (#3598)', () => {
   });
 
   test('projectRoot function is exported', () => {
-    assert.match(contextSource, /export function projectRoot\(\)/,
+    assert.match(contextSource, /export function projectRoot\(/,
       'projectRoot should be an exported function');
   });
 });

--- a/src/resources/extensions/gsd/tests/projectroot-re-resolution.test.ts
+++ b/src/resources/extensions/gsd/tests/projectroot-re-resolution.test.ts
@@ -65,13 +65,32 @@ describe("projectRoot(ctx) re-resolves from ctx every invocation", () => {
   });
 });
 
-describe("commands/handlers/ never reaches for process.cwd() directly", () => {
-  // Every handler resolves its base path through `projectRoot(ctx)`,
-  // never via `process.cwd()`. A stray `process.cwd()` in handlers/
-  // would silently target the wrong directory whenever cwd diverges
-  // from the invocation project root, and would slip past the
-  // module-scope test below.
-  test("no .ts file under commands/handlers/ contains process.cwd()", () => {
+describe("command surface never reaches for process.cwd() directly", () => {
+  // Every handler resolves its base path through `projectRoot(ctx)` (or
+  // explicitly through `ctx.cwd` when the actual invocation cwd is what's
+  // wanted, e.g. resolving a user-supplied relative path). A stray
+  // `process.cwd()` would silently target the wrong directory whenever
+  // cwd diverges from the invocation project root.
+  //
+  // Comments referencing the literal "process.cwd()" are allowed; this
+  // matcher only flags actual call expressions of the form `process.cwd(`.
+  // To enforce the rule, we strip line and block comments before scanning.
+  function findOffenders(src: string): number[] {
+    const stripped = src
+      // Block comments: /* ... */
+      .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "))
+      // Line comments: // ...
+      .replace(/\/\/[^\n]*/g, (m) => m.replace(/[^\n]/g, " "));
+    const offenders: number[] = [];
+    const re = /\bprocess\.cwd\s*\(/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(stripped)) !== null) {
+      offenders.push(stripped.slice(0, m.index).split("\n").length);
+    }
+    return offenders;
+  }
+
+  test("no .ts file under commands/handlers/ calls process.cwd()", () => {
     const offenders: string[] = [];
     function walk(dir: string): void {
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -80,10 +99,7 @@ describe("commands/handlers/ never reaches for process.cwd() directly", () => {
           walk(full);
         } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
           const src = readFileSync(full, "utf-8");
-          const re = /\bprocess\.cwd\s*\(/g;
-          let m: RegExpExecArray | null;
-          while ((m = re.exec(src)) !== null) {
-            const lineNo = src.slice(0, m.index).split("\n").length;
+          for (const lineNo of findOffenders(src)) {
             offenders.push(`${full}:${lineNo}`);
           }
         }
@@ -93,7 +109,26 @@ describe("commands/handlers/ never reaches for process.cwd() directly", () => {
     assert.deepEqual(
       offenders,
       [],
-      "handlers/ must resolve project root via projectRoot(ctx); found process.cwd() callsites",
+      "handlers/ must resolve project root via projectRoot(ctx) or ctx.cwd; found process.cwd() callsites",
+    );
+  });
+
+  test("no commands-*.ts (top-level) file calls process.cwd()", () => {
+    const offenders: string[] = [];
+    for (const entry of readdirSync(EXT_ROOT, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      if (!/^commands-.*\.ts$/.test(entry.name)) continue;
+      if (entry.name.endsWith(".test.ts")) continue;
+      const file = join(EXT_ROOT, entry.name);
+      const src = readFileSync(file, "utf-8");
+      for (const lineNo of findOffenders(src)) {
+        offenders.push(`${file}:${lineNo}`);
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      "commands-*.ts must resolve project root via projectRoot(ctx) or ctx.cwd; found process.cwd() callsites",
     );
   });
 });

--- a/src/resources/extensions/gsd/tests/projectroot-rerresolution.test.ts
+++ b/src/resources/extensions/gsd/tests/projectroot-rerresolution.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Invariants for `projectRoot(ctx)`: handlers must re-resolve the project
+ * root from `ctx` on every invocation.
+ *
+ *   1. Behavioural — calling `projectRoot(ctx)` with two different `ctx`
+ *      instances in sequence returns the value bound to the ctx of that
+ *      call, not a cached first-call value.
+ *
+ *   2. Structural — no `.ts` under `commands/handlers/` calls
+ *      `process.cwd()` directly; handlers must go through
+ *      `projectRoot(ctx)`.
+ *
+ *   3. Structural — no handler or top-level `commands-*.ts` file captures
+ *      `projectRoot(...)` at module scope. Module-scope bindings would
+ *      freeze the value at import time; every callsite must live inside
+ *      a function body.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { projectRoot } from "../commands/context.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HANDLERS_DIR = join(__dirname, "..", "commands", "handlers");
+const EXT_ROOT = join(__dirname, "..");
+
+function makeRepo(label: string): { root: string; cleanup: () => void } {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), `gsd-rerresolve-${label}-`)));
+  execFileSync("git", ["init", "-q"], { cwd: root });
+  writeFileSync(join(root, "README.md"), `# ${label}\n`);
+  // Mark as a valid GSD project for validateDirectory.
+  mkdirSync(join(root, ".gsd"), { recursive: true });
+  return {
+    root,
+    cleanup: () => {
+      try { rmSync(root, { recursive: true, force: true }); } catch { /* best effort */ }
+    },
+  };
+}
+
+describe("projectRoot(ctx) re-resolves from ctx every invocation", () => {
+  test("two different ctx values in sequence return two different roots", () => {
+    const a = makeRepo("a");
+    const b = makeRepo("b");
+    try {
+      const ctxA = { cwd: a.root, projectRoot: a.root } as never;
+      const ctxB = { cwd: b.root, projectRoot: b.root } as never;
+
+      // First call binds to ctxA.
+      assert.strictEqual(projectRoot(ctxA), a.root);
+      // Switching ctx must surface the new root, not a cached one.
+      assert.strictEqual(projectRoot(ctxB), b.root);
+      // Switching back must also re-resolve, not return the most recent.
+      assert.strictEqual(projectRoot(ctxA), a.root);
+    } finally {
+      a.cleanup();
+      b.cleanup();
+    }
+  });
+});
+
+describe("commands/handlers/ never reaches for process.cwd() directly", () => {
+  // Every handler resolves its base path through `projectRoot(ctx)`,
+  // never via `process.cwd()`. A stray `process.cwd()` in handlers/
+  // would silently target the wrong directory whenever cwd diverges
+  // from the invocation project root, and would slip past the
+  // module-scope test below.
+  test("no .ts file under commands/handlers/ contains process.cwd()", () => {
+    const offenders: string[] = [];
+    function walk(dir: string): void {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+          const src = readFileSync(full, "utf-8");
+          const re = /\bprocess\.cwd\s*\(/g;
+          let m: RegExpExecArray | null;
+          while ((m = re.exec(src)) !== null) {
+            const lineNo = src.slice(0, m.index).split("\n").length;
+            offenders.push(`${full}:${lineNo}`);
+          }
+        }
+      }
+    }
+    walk(HANDLERS_DIR);
+    assert.deepEqual(
+      offenders,
+      [],
+      "handlers/ must resolve project root via projectRoot(ctx); found process.cwd() callsites",
+    );
+  });
+});
+
+describe("no handler captures projectRoot at module scope", () => {
+  // A module-scope `const x = projectRoot(...)` would freeze the value at
+  // import time. Permitted patterns are inside function bodies only.
+  function listSources(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        out.push(...listSources(full));
+      } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  function isInsideFunction(src: string, callIdx: number): boolean {
+    // Walk backwards counting braces to determine depth at the call site.
+    // Module-scope statements have depth 0; anything inside a function body
+    // has depth >= 1. This catches both `const x = projectRoot(ctx)` at the
+    // top of a file and the same statement inside a function.
+    let depth = 0;
+    let inLineComment = false;
+    let inBlockComment = false;
+    let inString: '"' | "'" | "`" | null = null;
+    for (let i = 0; i < callIdx; i++) {
+      const ch = src[i];
+      const next = src[i + 1];
+      if (inLineComment) {
+        if (ch === "\n") inLineComment = false;
+        continue;
+      }
+      if (inBlockComment) {
+        if (ch === "*" && next === "/") { inBlockComment = false; i++; }
+        continue;
+      }
+      if (inString) {
+        if (ch === "\\") { i++; continue; }
+        if (ch === inString) inString = null;
+        continue;
+      }
+      if (ch === "/" && next === "/") { inLineComment = true; continue; }
+      if (ch === "/" && next === "*") { inBlockComment = true; continue; }
+      if (ch === '"' || ch === "'" || ch === "`") { inString = ch; continue; }
+      if (ch === "{") depth++;
+      else if (ch === "}") depth--;
+    }
+    return depth > 0;
+  }
+
+  test("handlers/ never call projectRoot() at module scope", () => {
+    const offenders: string[] = [];
+    for (const file of listSources(HANDLERS_DIR)) {
+      const src = readFileSync(file, "utf-8");
+      const re = /\bprojectRoot\s*\(/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src)) !== null) {
+        if (!isInsideFunction(src, m.index)) {
+          const lineNo = src.slice(0, m.index).split("\n").length;
+          offenders.push(`${file}:${lineNo}`);
+        }
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      "projectRoot(...) must only be called inside function bodies — found module-scope captures",
+    );
+  });
+
+  test("commands-*.ts (top-level) never call projectRoot() at module scope", () => {
+    const offenders: string[] = [];
+    for (const entry of readdirSync(EXT_ROOT, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      if (!/^commands-.*\.ts$/.test(entry.name)) continue;
+      if (entry.name.endsWith(".test.ts")) continue;
+      const file = join(EXT_ROOT, entry.name);
+      const src = readFileSync(file, "utf-8");
+      const re = /\bprojectRoot\s*\(/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src)) !== null) {
+        if (!isInsideFunction(src, m.index)) {
+          const lineNo = src.slice(0, m.index).split("\n").length;
+          offenders.push(`${file}:${lineNo}`);
+        }
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      "projectRoot(...) must only be called inside function bodies — found module-scope captures",
+    );
+  });
+});

--- a/src/resources/extensions/gsd/worktree.ts
+++ b/src/resources/extensions/gsd/worktree.ts
@@ -112,6 +112,16 @@ export function detectWorktreeName(basePath: string): string | null {
  *
  * Use this in commands that call `process.cwd()` to ensure they always
  * operate against the real project root, not a worktree subdirectory.
+ *
+ * NOTE: The pi-coding-agent runner ships a separate, simpler
+ * `resolveProjectRoot` at `packages/pi-coding-agent/src/core/extensions/
+ * project-root.ts` that runs `git rev-parse --show-toplevel` and is unaware
+ * of GSD worktrees. The runner's job is only to derive a "current project"
+ * for the generic `ExtensionContext.projectRoot` field — it does not know
+ * about GSD's worktree layout. The function in this module is GSD-specific
+ * and additionally peels worktree paths back to the parent project root.
+ * Both are intentional: the runner's flavor populates ctx; the GSD flavor
+ * is what gsd command handlers fall back to when no ctx is available.
  */
 export function resolveProjectRoot(basePath: string): string {
   return resolveWorktreeProjectRoot(basePath);


### PR DESCRIPTION
## Summary

Slice 1 of the workspace-mode RFC #5110: thread an explicit `projectRoot`
through every gsd handler instead of resolving `process.cwd()` at each call
site. Pure refactor on POSIX hosts; the only intentional behavior change is
on Windows, where the runner now normalizes `git rev-parse --show-toplevel`
output to native separators.

This is the "safe checkpoint" you asked for in the RFC thread before any
workspace-specific surface area lands.

## What changed

- `ExtensionContext` and `ExtensionCommandContext` gain
  `projectRoot: string`, populated once per command invocation by the runner
  via `resolveProjectRoot(cwd)`. **Breaking interface change** for extension
  authors who construct `ExtensionContext` literals directly (e.g. in
  tests) — they must now provide `projectRoot`. Documented under
  `### Added` in CHANGELOG.
- `projectRoot()` in `commands/context.ts` becomes ctx-aware: it prefers
  `ctx.projectRoot` when present and falls back to the existing
  `process.cwd()` path otherwise. Existing #3598 cwd-deleted guard preserved.
- ~30 handler files (`commands/handlers/*.ts` + every `commands-*.ts`)
  refactored from `process.cwd()` / module-scope `projectRoot()` to
  `projectRoot(ctx)` (or `ctx.cwd` when an actual invocation cwd is what's
  wanted, e.g. resolving a user-typed relative path).
- Windows-portability: `git rev-parse --show-toplevel` always emits
  POSIX-style forward slashes. The runner now passes that through
  `path.resolve` so equality / prefix comparisons against
  `realpathSync` / `path.join` results work on Windows.
- New `GSD_DEBUG=1` diagnostic in `resolveProjectRoot` surfaces silent
  fallbacks (spawn failures or non-128 git status) to stderr.

## Re: your bonus concern (no captured projectRoot)

You flagged that any code holding a captured `basePath` across a project
switch would silently keep operating on the old repo, and asked for a test
asserting handlers re-resolve from `ctx` per invocation.

Tests in `src/resources/extensions/gsd/tests/projectroot-re-resolution.test.ts`:

1. **Behavioural:** calling `projectRoot(ctx)` with two different ctx
   instances in sequence returns the value bound to *that call*, including
   when switching back. Guards against any future caching that might
   memoize on first-call ctx.
2. **Structural — `process.cwd()` ban:** scans every `.ts` file under
   `commands/handlers/` *and* every top-level `commands-*.ts` for
   `process.cwd()` callsites and asserts none exist (comment-stripped, so
   the literal string in docstrings doesn't false-positive).
3. **Structural — module-scope ban:** scans the same files for
   `projectRoot(...)` callsites and asserts none are at module scope
   (brace-depth tracker, comment/string-aware). A future
   `const captured = projectRoot(ctx)` at the top of a handler file would
   fail this test.

The structural tests are what make slice 3's `project_changed` event safe to
land later — every callsite is already inside a function body, and no
handler reaches around `ctx`.

## Lifecycle / cache caveat (re: NilsR0711's C3)

The runner caches `cwd` and `projectRoot` once at constructor time. There
is no setter today, so every `ctx` returned by `createContext()` shares the
same paths for the runner's lifetime. This **mirrors the existing `cwd`
semantics** — slice 1 deliberately doesn't introduce a mutation channel.
Slice 3 will pair the `project_changed` event with a runner-level setter
that re-runs `resolveProjectRoot`, at which point the structural tests
above ensure the new value flows through every callsite.

## Slice scope guarantee

This PR explicitly does **not** introduce:
- `.gsd-workspace.json` marker (slice 2)
- `~/.gsd/workspaces/<id>/state.json` or `GSD_ACTIVE_REPO` (slice 3)
- `project_changed` event (slice 3)
- `/gsd repo` subcommands (slice 3)
- Workspace UX, init wizard changes, doctor changes (later slices)

## Test plan

- [x] `npm run typecheck:extensions` — clean
- [x] `npm run verify:pr` end-to-end (Node 22, macOS):
  - **upstream/main baseline `42ef05fbe`:** 8188 passed / 40 failed /
    9 skipped
  - **this branch (after review fixes):** 8218 passed / 34 failed /
    9 skipped — +30 new passes, −6 net failures vs upstream
  - The 34 remaining failures all reproduce on upstream/main with no diff
    applied. They split into: (a) missing local prompt/skill resources
    (`/Users/.../.gsd/agent/extensions/gsd/prompts/...`) that the suite
    expects in the developer's home, (b) cleanup races
    (`ENOTEMPTY rmdirSync`) in `dist-test/` between parallel test
    processes. None touch slice 1's code paths.
- [x] CHANGELOG entry under `[Unreleased] / Added` (with the breaking
  interface change called out).

### Re: failing CI checks on first run

Both required checks went red on the initial submission. Status after the
review-fix commit:

| Check | Before | After this commit |
|---|---|---|
| `windows-portability` (`project-root.test.ts`, 2 fails) | ❌ | Should be ✅ — root cause was `git rev-parse --show-toplevel` returning POSIX `C:/...` while native fs returns `C:\...`. Fixed by `path.resolve` normalization (commit `3f0542537`). New test asserts the prefix-match invariant cross-platform. |
| `build` (linux, `write-gate: reopening a gate revokes…`) | ❌ 8250/1/9 | Will re-run. **Independent of this diff:** slice 1 doesn't touch `bootstrap/write-gate.*` (verified `git diff upstream/main..HEAD --stat`). The failing test relies on the `<repo>/.gsd/runtime/write-gate-state.json` snapshot file, which is shared across the parallel test processes (`--experimental-test-isolation=process`). The recent `dc6dea159` ("avoid write-gate snapshot temp collisions") uniquefied the *temp* path but not the *destination*, so a cross-process race on the destination remains. The same test passes locally in isolation and within its own file's full run. Happy to file a separate issue / fix in a follow-up PR if maintainers confirm the diagnosis. |

## RFC checklist (jeremymcs)

- [x] Q1: Slice 1 is pure-refactor on POSIX; sole behavior change is
      Windows path-separator normalization (a bug fix)
- [x] Bonus: tests assert handlers re-resolve from ctx per invocation
- [x] Bonus: no module-scope projectRoot capture or `process.cwd()` callsite
      under `commands/handlers/` or `commands-*.ts` (structural tests)
- [ ] Q2–Q5: deferred to slices 2–3 per your guidance

## Review-fix commit

`3f0542537` addresses NilsR0711's review:

- **C1** Windows path normalization (above)
- **C3** documented constructor-time lifecycle in JSDoc; mutation deferred
  to slice 3
- **M1** cross-referenced the two `resolveProjectRoot` exports (runner's
  git-toplevel flavor vs GSD's worktree-aware flavor)
- **M2** extended `process.cwd()` ban to `commands-*.ts`; refactored 9
  additional callsites
- **M3** validate `root` itself, not just `pathToCheck`
- **M4** `GSD_DEBUG=1` diagnostic for silent fallbacks
- **M5** CHANGELOG moved to `### Added`, breaking interface change
  documented, "behaviour-preserving" framing dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Threaded a canonical per-project root into extension command contexts so handlers derive paths from a resolved project root instead of the process working directory; behavior-preserving and prepares workspace mode.

* **Tests**
  * Added tests validating project-root resolution, re-resolution semantics, and enforcement of context-aware path usage.

* **Changelog**
  * Recorded the change under Unreleased → Changed for gsd.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
