### PR TITLE
fix(gsd): refuse project writes when run from $HOME

### DIFF
--- a/src/resources/extensions/gsd/commands-codebase.ts
+++ b/src/resources/extensions/gsd/commands-codebase.ts
@@ -16,6 +16,7 @@ import {
 } from "./codebase-generator.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import type { CodebaseMapOptions } from "./codebase-generator.js";
+import { projectRoot } from "./commands/context.js";
 
 const USAGE =
   "Usage: /gsd codebase [generate|update|stats]\n\n" +
@@ -36,7 +37,7 @@ export async function handleCodebase(
   ctx: ExtensionCommandContext,
   _pi: ExtensionAPI,
 ): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot();
   const parts = args.trim().split(/\s+/);
   const sub = parts[0] ?? "";
 

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -203,7 +203,7 @@ export async function handleCapture(args: string, ctx: ExtensionCommandContext):
     return;
   }
 
-  const basePath = process.cwd();
+  const basePath = projectRoot();
 
   // Ensure .gsd/ exists — capture should work even without a milestone
   const gsdDir = gsdRoot(basePath);
@@ -270,7 +270,7 @@ export async function handleTriage(ctx: ExtensionCommandContext, pi: ExtensionAP
 }
 
 export async function handleSteer(change: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot();
   const state = await deriveState(basePath);
   const mid = state.activeMilestone?.id ?? "none";
   const sid = state.activeSlice?.id ?? "none";
@@ -343,7 +343,7 @@ export async function handleKnowledge(args: string, ctx: ExtensionCommandContext
   }
 
   const type = typeArg as "rule" | "pattern" | "lesson";
-  const basePath = process.cwd();
+  const basePath = projectRoot();
   const state = await deriveState(basePath);
   const scope = state.activeMilestone?.id
     ? `${state.activeMilestone.id}${state.activeSlice ? `/${state.activeSlice.id}` : ""}`

--- a/src/resources/extensions/gsd/commands-logs.ts
+++ b/src/resources/extensions/gsd/commands-logs.ts
@@ -15,6 +15,7 @@ import { existsSync, readdirSync, readFileSync, statSync, unlinkSync } from "nod
 import { join } from "node:path";
 import { gsdRoot } from "./paths.js";
 import { loadJsonFileOrNull } from "./json-persistence.js";
+import { projectRoot } from "./commands/context.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -243,7 +244,7 @@ function summarizeDebugLog(filePath: string): {
 // ─── Main Handler ───────────────────────────────────────────────────────────
 
 export async function handleLogs(args: string, ctx: ExtensionCommandContext): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot();
   const parts = args.trim().split(/\s+/).filter(Boolean);
   const subCmd = parts[0] ?? "";
 

--- a/src/resources/extensions/gsd/commands-scan.ts
+++ b/src/resources/extensions/gsd/commands-scan.ts
@@ -20,6 +20,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { join, relative } from "node:path";
 
 import { loadPrompt } from "./prompt-loader.js";
+import { projectRoot } from "./commands/context.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -86,7 +87,7 @@ export async function handleScan(
   ctx: ExtensionCommandContext,
   pi: ExtensionAPI,
 ): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot();
   const { focus } = parseScanArgs(args);
   const outputDir = join(basePath, ".gsd", "codebase");
   const outputPaths = buildScanOutputPaths(focus, basePath);

--- a/src/resources/extensions/gsd/commands-ship.ts
+++ b/src/resources/extensions/gsd/commands-ship.ts
@@ -17,6 +17,7 @@ import { getLedger, getProjectTotals, aggregateByModel, formatCost, formatTokenC
 import { nativeGetCurrentBranch, nativeDetectMainBranch } from "./native-git-bridge.js";
 import { formatDuration } from "../shared/format-utils.js";
 import { parseEvalReviewFrontmatter, type Verdict } from "./eval-review-schema.js";
+import { projectRoot } from "./commands/context.js";
 
 function git(basePath: string, args: readonly string[]): string {
   return execFileSync("git", args, { cwd: basePath, encoding: "utf-8" }).trim();
@@ -222,7 +223,7 @@ export async function handleShip(
   ctx: ExtensionCommandContext,
   _pi: ExtensionAPI,
 ): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot();
   const dryRun = args.includes("--dry-run");
   const draft = args.includes("--draft");
   const force = args.includes("--force");

--- a/src/resources/extensions/gsd/commands-workflow-templates.ts
+++ b/src/resources/extensions/gsd/commands-workflow-templates.ts
@@ -23,6 +23,7 @@ import { createGitService, runGit } from "./git-service.js";
 import { isAutoActive, isAutoPaused } from "./auto.js";
 import { getErrorMessage } from "./error-utils.js";
 import { resolvePlugin, type WorkflowPlugin } from "./workflow-plugins.js";
+import { projectRoot } from "./commands/context.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -196,7 +197,7 @@ export async function handleStart(
   // ─── Resume detection ───────────────────────────────────────────────────
   // /gsd start --resume or /gsd start resume → resume in-progress workflow
   if (trimmed === "--resume" || trimmed === "resume") {
-    const basePath = process.cwd();
+    const basePath = projectRoot();
     const inProgress = findInProgressWorkflows(basePath);
     if (inProgress.length === 0) {
       ctx.ui.notify("No in-progress workflows found.", "info");
@@ -247,7 +248,7 @@ export async function handleStart(
 
   // Show in-progress workflows when /gsd start is called with no args
   if (!trimmed) {
-    const basePath = process.cwd();
+    const basePath = projectRoot();
     const inProgress = findInProgressWorkflows(basePath);
     if (inProgress.length > 0) {
       const wf = inProgress[0];
@@ -346,7 +347,7 @@ export async function handleStart(
 
   const templateId = match.id;
   const template = match.template;
-  const basePath = process.cwd();
+  const basePath = projectRoot();
   const date = new Date().toISOString().split("T")[0];
 
   // Load the workflow template content — prefer a project/global plugin
@@ -581,7 +582,7 @@ export function dispatchMarkdownPhasePlugin(
   }
 
   const templateId = plugin.name;
-  const basePath = process.cwd();
+  const basePath = projectRoot();
   const date = new Date().toISOString().split("T")[0];
   let workflowContent: string;
   try {

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -11,9 +11,11 @@
 
 import { readdirSync, existsSync, realpathSync, Dirent } from "node:fs";
 import { join, dirname, normalize } from "node:path";
+import { homedir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { nativeScanGsdTree, type GsdTreeEntry } from "./native-parser-bridge.js";
 import { DIR_CACHE_MAX } from "./constants.js";
+import { gsdHome } from "./gsd-home.js";
 
 // ─── Directory Listing Cache ──────────────────────────────────────────────────
 
@@ -305,8 +307,42 @@ export function gsdRoot(basePath: string): string {
   if (cached) return cached;
 
   const result = probeGsdRoot(basePath);
+
+  // Defense-in-depth: if basePath resolves to the user's home directory and
+  // the result equals gsdHome(), refuse — project-scoped writes must never
+  // land in the global ~/.gsd. Paths under ~/.gsd/projects/<hash>/ are still
+  // valid (their basePath does not equal homedir).
+  assertNotGlobalGsdHome(basePath, result);
+
   gsdRootCache.set(basePath, result);
   return result;
+}
+
+function assertNotGlobalGsdHome(basePath: string, result: string): void {
+  const norm = (p: string): string => {
+    let r: string;
+    try { r = realpathSync.native(p); } catch { r = p; }
+    const s = r.replaceAll("\\", "/").replace(/\/+$/, "");
+    return process.platform === "win32" ? s.toLowerCase() : s;
+  };
+  let baseNorm: string;
+  let homeNorm: string;
+  let resultNorm: string;
+  let gsdHomeNorm: string;
+  try {
+    baseNorm = norm(basePath);
+    homeNorm = norm(homedir());
+    resultNorm = norm(result);
+    gsdHomeNorm = norm(gsdHome());
+  } catch {
+    return;
+  }
+  if (baseNorm === homeNorm && resultNorm === gsdHomeNorm) {
+    throw new Error(
+      `Refusing to use ${result} as a project .gsd directory — that is the global GSD home. ` +
+      `Run GSD from inside a project directory.`,
+    );
+  }
 }
 
 /**

--- a/src/resources/extensions/gsd/rethink.ts
+++ b/src/resources/extensions/gsd/rethink.ts
@@ -20,6 +20,7 @@ import { getMilestoneSlices, isDbAvailable } from "./gsd-db.js";
 import { buildExistingMilestonesContext } from "./guided-flow-queue.js";
 import { loadPrompt } from "./prompt-loader.js";
 import { isGsdGitignored } from "./gitignore.js";
+import { projectRoot } from "./commands/context.js";
 
 // ─── Entry Point ──────────────────────────────────────────────────────────────
 
@@ -33,7 +34,7 @@ export async function handleRethink(
     return;
   }
 
-  const basePath = process.cwd();
+  const basePath = projectRoot();
   const root = gsdRoot(basePath);
   if (!existsSync(root)) {
     ctx.ui.notify("No GSD project found. Run /gsd init first.", "warning");

--- a/src/resources/extensions/gsd/tests/gsd-root-home-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-root-home-guard.test.ts
@@ -1,0 +1,86 @@
+/**
+ * GSD2 — regression test for #5187: gsdRoot() must refuse to use the global
+ * GSD home (~/.gsd) as a project .gsd directory when basePath resolves to
+ * $HOME. Paths under ~/.gsd/projects/<hash>/ remain valid.
+ *
+ * Before the fix, gsdRoot(homedir()) returned ~/.gsd silently and downstream
+ * writes polluted the user's global state directory. After the fix, it throws.
+ */
+
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { gsdRoot, _clearGsdRootCache } from '../paths.ts';
+
+describe('gsdRoot() refuses ~/.gsd as project state when basePath is $HOME (#5187)', () => {
+  let fakeHome: string;
+  let savedHome: string | undefined;
+  let savedUserProfile: string | undefined;
+  let savedGsdHome: string | undefined;
+
+  beforeEach(() => {
+    fakeHome = realpathSync(mkdtempSync(join(tmpdir(), 'gsd-home-guard-')));
+    mkdirSync(join(fakeHome, '.gsd'), { recursive: true });
+
+    savedHome = process.env.HOME;
+    savedUserProfile = process.env.USERPROFILE;
+    savedGsdHome = process.env.GSD_HOME;
+
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+    delete process.env.GSD_HOME;
+
+    _clearGsdRootCache();
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = savedUserProfile;
+    if (savedGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = savedGsdHome;
+
+    _clearGsdRootCache();
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  test('throws when basePath is the home directory and result equals gsdHome()', () => {
+    assert.throws(
+      () => gsdRoot(fakeHome),
+      (err: unknown) => {
+        assert.ok(err instanceof Error, 'should throw an Error');
+        assert.match(
+          (err as Error).message,
+          /global GSD home|project .gsd directory/i,
+          'message should explain the refusal',
+        );
+        return true;
+      },
+    );
+  });
+
+  test('does NOT throw for paths under ~/.gsd/projects/<hash>/', () => {
+    const projectStateDir = join(fakeHome, '.gsd', 'projects', 'abcdef123456');
+    mkdirSync(join(projectStateDir, '.gsd'), { recursive: true });
+    _clearGsdRootCache();
+
+    const resolved = gsdRoot(projectStateDir);
+    assert.equal(resolved, join(projectStateDir, '.gsd'));
+  });
+
+  test('does NOT throw for an unrelated project directory that has its own .gsd', () => {
+    const projectDir = realpathSync(mkdtempSync(join(tmpdir(), 'gsd-home-guard-proj-')));
+    mkdirSync(join(projectDir, '.gsd'), { recursive: true });
+    _clearGsdRootCache();
+    try {
+      const resolved = gsdRoot(projectDir);
+      assert.equal(resolved, join(projectDir, '.gsd'));
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Stop project-scoped GSD commands from writing planning artifacts into the global `~/.gsd` home directory.
**Why:** When invoked from `$HOME`, several handlers wrote `STATE.md`, `REQUIREMENTS.md`, `CODEBASE.md`, `PREFERENCES.md`, and `milestones/` directly into `~/.gsd/` instead of `~/.gsd/projects/<repo-hash>/`, polluting the user's home and leaving `~/.gsd/projects/` empty.
**How:** Replace `process.cwd()` with `projectRoot()` in the affected handlers and add a defense-in-depth guard in `gsdRoot()`.

## What

Two coordinated changes in `src/resources/extensions/gsd/`:

1. **Replace `process.cwd()` with `projectRoot()`** in handlers that bypassed the project-validation chokepoint:
   - `commands-handlers.ts` — `handleCapture`, `handleSteer`, `handleKnowledge`
   - `commands-codebase.ts` — `handleCodebase`
   - `commands-scan.ts` — `handleScan`
   - `commands-ship.ts` — `handleShip`
   - `commands-workflow-templates.ts` — `handleStart` (resume / list / template / plugin paths, 4 sites)
   - `commands-logs.ts` — `handleLogs`
   - `rethink.ts` — `handleRethink`

2. **Defense-in-depth guard in `paths.ts:gsdRoot()`** — throw when `basePath` resolves to `homedir()` AND the result equals `gsdHome()`. Paths under `~/.gsd/projects/<hash>/` are unaffected (their basePath is not the home directory).

## Why

`projectRoot()` (`commands/context.ts:39`) calls `validateDirectory()` and throws `GSDNoProjectError` for `$HOME`; the dispatcher (`commands/dispatcher.ts:36`) already converts that to a friendly user-facing error. Other handlers route through it correctly. The handlers above did not, so they happily called `gsdRoot(homedir())`, which fast-paths to `~/.gsd` (the global home, which always exists) and proceeded to write project artifacts there.

The existing guard at `repo-identity.ts:519–523` prevents creating a bad `.gsd` *symlink* at home but returns silently — subsequent writes still land in the wrong location.

User-reported reproduction: `cd ~ && /gsd capture \"foo\"` produces `~/.gsd/CAPTURES.md` instead of failing fast.

Closes #5187

## How

`projectRoot()` already exists as the validated chokepoint, so no new helper was introduced — the patch is a one-line substitution per handler plus an import. The `gsdRoot()` guard is intentionally narrow: it keys on the conjunction (`basePath === homedir()` AND `result === gsdHome()`) rather than blindly throwing whenever the result equals `gsdHome()`, so legitimate global commands and paths under `~/.gsd/projects/<hash>/` are not affected.

Alternatives considered:
- A new `requireProjectBasePath()` wrapper — rejected as needless indirection over the existing `projectRoot()`.
- Throwing unconditionally in `gsdRoot()` when the result equals `gsdHome()` — rejected because it would break legitimate callers that operate on global state.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Testing

Type-check passes (`tsconfig.resources.json` and `tsconfig.json` clean). I have not added a regression test in this PR yet — happy to add one before merge: a `node:test` case that sets `HOME` to a temp dir, populates `\$HOME/.gsd/`, runs each affected handler with `withCommandCwd(\$HOME, …)`, and asserts each throws `GSDNoProjectError` and writes nothing into `\$HOME/.gsd/`. Let me know if you want that in this PR or as a follow-up.

## Migration / cleanup for affected users

Existing installs with polluted `~/.gsd/` should move `STATE.md`, `REQUIREMENTS.md`, `CODEBASE.md`, `PREFERENCES.md`, and `milestones/` into the appropriate `~/.gsd/projects/<hash>/` directory, or delete and re-run from inside the project.

---

*This PR was prepared with AI assistance.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently resolve command and operation paths from the project root rather than the current working directory.
  * Prevent GSD operations from resolving to the user home directory when that would mis-target the global GSD location.

* **Tests**
  * Added regression tests ensuring the GSD home-guard refuses the home directory and allows valid project locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->