### PR TITLE
fix(gsd): defer empty-turn nudge on mid-line approval prompts

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -696,14 +696,14 @@ export function maybeHandleEmptyIntentTurn(
   // path, handled by maybeHandleReadyPhraseWithoutFiles.
   if (READY_PHRASE_RE.test(text)) return false;
 
-  // Skip if the LLM is clearly handing back to the user. Last-line `?` is
-  // the strongest signal, but discuss flows often end with a freeform
-  // question followed by a closing remark ("…what should we build? I'll
-  // pick one if you don't care."). Treat ANY non-empty line ending in `?`
-  // as a question-asked signal — false negatives here auto-reply to the
+  // Skip if the LLM is clearly handing back to the user. Discuss flows
+  // often pose a question and follow it with a conditional intent on the
+  // same line ("Did I capture that correctly? If so, I'll write the
+  // requirements."). A line-trailing `?` check misses these because the
+  // line ends in `.`. Match any sentence-terminating `?` (followed by
+  // whitespace or end-of-text) — false negatives here auto-reply to the
   // user, which is a much worse failure mode than a missed nudge.
-  const lines = text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
-  if (lines.some((l) => l.endsWith("?"))) return false;
+  if (/\?(?:\s|$)/.test(text)) return false;
 
   // Must contain a commit-intent phrase — this is the stall we care about.
   if (!COMMIT_INTENT_RE.test(text)) return false;

--- a/src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts
+++ b/src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts
@@ -344,6 +344,40 @@ describe("#4573 maybeHandleEmptyIntentTurn", () => {
     }
   });
 
+  test("single-line approval prompt with mid-line `?` and conditional intent → treated as user-handoff (regression: #5187 follow-up)", () => {
+    // Regression for the discuss-milestone case where the LLM presented a
+    // depth summary and ended with: "Did I capture that correctly? If so,
+    // say yes and I'll write requirements and the roadmap preview."
+    // The previous heuristic only checked for lines *ending* in `?`, so
+    // this single-line paragraph (terminating in `.`) bypassed the
+    // user-handoff guard, then COMMIT_INTENT_RE matched "I'll write" and
+    // the nudge auto-replied while the user was meant to approve.
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleEmptyIntentTurn(
+        {
+          messages: [
+            assistantMsg(
+              "Did I capture that correctly? If so, say yes and I'll write requirements and the roadmap preview.",
+            ),
+          ],
+        },
+        false,
+      );
+      assert.equal(handled, false, "any sentence-terminating ? must defer to the user");
+      assert.equal(cap.messages.length, 0);
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
   test('"Let me make sure" meta phrase → not flagged as commit intent (regression)', () => {
     const base = mkBase();
     try {


### PR DESCRIPTION
Closes #5192

## Summary

- Empty-turn detector's question-handoff guard only checked for line-trailing `?`, so single-line approval prompts like *"Did I capture that correctly? If so, I'll write…"* bypassed it. `COMMIT_INTENT_RE` then matched the conditional `"I'll write"` and the recovery nudge auto-replied while the user was meant to approve.
- Replace `lines.some((l) => l.endsWith("?"))` with `/\?(?:\s|$)/.test(text)` — match any sentence-terminating `?`, mid-line or trailing.
- Aligns with the file's stated bias: *false negatives here auto-reply to the user, which is a much worse failure mode than a missed nudge.*

## Why this also fixes the "regresses to an earlier prompt" symptom

The state-loss isn't a separate bug. The unwanted nudge re-prompts the LLM with no concrete instruction during a turn it had already closed by handing back to the user. Suppressing the nudge prevents the re-prompt, so there's nothing for the LLM to drift from.

## Test plan

- [x] New regression test in `ready-phrase-no-files-4573.test.ts` using the exact text from the reported session — fails against the old check, passes after the fix.
- [x] `npx tsx --test src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts` — all 19 tests pass.
- [ ] Reviewer: walk a `discuss-milestone` flow, confirm the agent waits at depth-summary approval prompts instead of self-nudging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of user-handoff questions to prevent unnecessary auto-recovery prompts when question marks appear within messages (handles sentence-ending question marks more accurately).

* **Tests**
  * Added unit test covering mid-sentence/question-mark scenarios to ensure empty-turn recovery is not incorrectly triggered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->