### PR TITLE
fix(gsd/prefs-wizard): include discovered models in prefs picker

### DIFF
--- a/packages/pi-coding-agent/src/core/model-registry-discovery.test.ts
+++ b/packages/pi-coding-agent/src/core/model-registry-discovery.test.ts
@@ -158,10 +158,17 @@ describe("ModelRegistry discovery — OpenAI-compatible custom providers", () =>
 			"utf-8",
 		);
 
+		const minimaxDiscoveryUrl = "https://api.minimax.example/v1/models";
 		const prevFetch = globalThis.fetch;
 		let requestedUrl = "";
 		globalThis.fetch = (async (input: string | URL | Request) => {
 			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (!requestedUrl.startsWith("https://api.minimax.example")) {
+				return new Response(JSON.stringify({ data: [], models: [] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}
 			return new Response(
 				JSON.stringify({
 					data: [
@@ -191,7 +198,7 @@ describe("ModelRegistry discovery — OpenAI-compatible custom providers", () =>
 			const discovery = results.find((r) => r.provider === providerName);
 			assert.ok(discovery, "discovery result should include custom provider");
 			assert.equal(discovery?.error, undefined, "custom provider discovery should succeed");
-			assert.equal(requestedUrl, "https://api.minimax.example/v1/models");
+			assert.equal(requestedUrl, minimaxDiscoveryUrl);
 
 			const discovered = registry
 				.getAllWithDiscovered()
@@ -203,6 +210,21 @@ describe("ModelRegistry discovery — OpenAI-compatible custom providers", () =>
 			assert.equal(discovered?.maxTokens, 32768);
 			assert.equal(discovered?.reasoning, true);
 			assert.deepEqual(discovered?.input, ["text", "image"]);
+
+			const modelKeys = (models: { provider: string; id: string }[]) =>
+				[...new Set(models.map((m) => `${m.provider}/${m.id}`))].sort();
+
+			const availMerged = await registry.getAvailableWithDiscovered();
+			assert.ok(
+				availMerged.some((m) => m.provider === providerName && m.id === "MiniMax-M2.7-highspeed"),
+				"getAvailableWithDiscovered should expose discovered IDs for prefs-style pickers",
+			);
+
+			await registry.discoverModels();
+			const baseline = registry.getAllWithDiscovered().filter((m) => registry.isProviderRequestReady(m.provider));
+			const availAgain = await registry.getAvailableWithDiscovered();
+
+			assert.deepEqual(modelKeys(availAgain), modelKeys(baseline));
 		} finally {
 			globalThis.fetch = prevFetch;
 		}

--- a/packages/pi-coding-agent/src/core/model-registry-discovery.test.ts
+++ b/packages/pi-coding-agent/src/core/model-registry-discovery.test.ts
@@ -333,6 +333,55 @@ describe("ModelRegistry discovery — OpenAI-compatible custom providers", () =>
 		}
 	});
 
+	it("fresh cache entries are included in results even when deadline is already exceeded", async () => {
+		const providerName = `cached-after-deadline-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		const modelsPath = join(testDir, "models.json");
+		writeFileSync(
+			modelsPath,
+			JSON.stringify(
+				{
+					providers: {
+						[providerName]: {
+							baseUrl: "https://api.minimax.example",
+							apiKey: "test-key",
+							api: "openai-completions",
+							models: [{ id: "bootstrap-model" }],
+						},
+					},
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		);
+
+		const prevFetch = globalThis.fetch;
+		let fetchCalls = 0;
+		globalThis.fetch = (async () => {
+			fetchCalls++;
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof globalThis.fetch;
+
+		try {
+			const registry = new ModelRegistry(AuthStorage.inMemory({}), modelsPath);
+			// Seed a fresh cache entry directly so the provider has a valid cached result.
+			registry.getDiscoveryCache().set(providerName, [{ id: "cached-model", name: "Cached Model" }], 60_000);
+
+			// Run with a zero deadline — no fetch should start, but the cached entry must still appear.
+			const results = await registry.discoverModels([providerName], { deadlineMs: 0 });
+			assert.equal(fetchCalls, 0, "deadline 0 must not trigger a network fetch");
+			const result = results.find((r) => r.provider === providerName);
+			assert.ok(result, "fresh cache entry must be included in results despite exceeded deadline");
+			assert.equal(result?.models.length, 1, "cached models must be returned");
+			assert.equal(result?.models[0]?.id, "cached-model");
+		} finally {
+			globalThis.fetch = prevFetch;
+		}
+	});
+
 	it("getAvailableWithDiscovered returns discoveryErrors when a provider discovery fails", async () => {
 		const providerName = `err-discovery-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 		const modelsPath = join(testDir, "models.json");

--- a/packages/pi-coding-agent/src/core/model-registry-discovery.test.ts
+++ b/packages/pi-coding-agent/src/core/model-registry-discovery.test.ts
@@ -160,9 +160,12 @@ describe("ModelRegistry discovery — OpenAI-compatible custom providers", () =>
 
 		const minimaxDiscoveryUrl = "https://api.minimax.example/v1/models";
 		const prevFetch = globalThis.fetch;
-		let requestedUrl = "";
+		let lastMinimaxRequestUrl: string | undefined;
 		globalThis.fetch = (async (input: string | URL | Request) => {
-			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			const requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (requestedUrl.startsWith("https://api.minimax.example")) {
+				lastMinimaxRequestUrl = requestedUrl;
+			}
 			if (!requestedUrl.startsWith("https://api.minimax.example")) {
 				return new Response(JSON.stringify({ data: [], models: [] }), {
 					status: 200,
@@ -198,7 +201,7 @@ describe("ModelRegistry discovery — OpenAI-compatible custom providers", () =>
 			const discovery = results.find((r) => r.provider === providerName);
 			assert.ok(discovery, "discovery result should include custom provider");
 			assert.equal(discovery?.error, undefined, "custom provider discovery should succeed");
-			assert.equal(requestedUrl, minimaxDiscoveryUrl);
+			assert.equal(lastMinimaxRequestUrl, minimaxDiscoveryUrl);
 
 			const discovered = registry
 				.getAllWithDiscovered()
@@ -214,7 +217,7 @@ describe("ModelRegistry discovery — OpenAI-compatible custom providers", () =>
 			const modelKeys = (models: { provider: string; id: string }[]) =>
 				[...new Set(models.map((m) => `${m.provider}/${m.id}`))].sort();
 
-			const availMerged = await registry.getAvailableWithDiscovered();
+			const { models: availMerged } = await registry.getAvailableWithDiscovered();
 			assert.ok(
 				availMerged.some((m) => m.provider === providerName && m.id === "MiniMax-M2.7-highspeed"),
 				"getAvailableWithDiscovered should expose discovered IDs for prefs-style pickers",
@@ -222,9 +225,155 @@ describe("ModelRegistry discovery — OpenAI-compatible custom providers", () =>
 
 			await registry.discoverModels();
 			const baseline = registry.getAllWithDiscovered().filter((m) => registry.isProviderRequestReady(m.provider));
-			const availAgain = await registry.getAvailableWithDiscovered();
+			const { models: availAgain } = await registry.getAvailableWithDiscovered();
 
 			assert.deepEqual(modelKeys(availAgain), modelKeys(baseline));
+		} finally {
+			globalThis.fetch = prevFetch;
+		}
+	});
+
+	it("does not call fetch for discovery when provider is denylisted via setDisabledModelProviders", async () => {
+		const providerName = `disabled-discovery-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		const modelsPath = join(testDir, "models.json");
+		writeFileSync(
+			modelsPath,
+			JSON.stringify(
+				{
+					providers: {
+						[providerName]: {
+							baseUrl: "https://api.minimax.example",
+							apiKey: "disabled-test-key",
+							api: "openai-completions",
+							models: [{ id: "bootstrap-model" }],
+						},
+					},
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		);
+
+		const prevFetch = globalThis.fetch;
+		let fetchCalls = 0;
+		globalThis.fetch = (async () => {
+			fetchCalls++;
+			return new Response(JSON.stringify({ data: [] }), { status: 200, headers: { "content-type": "application/json" } });
+		}) as typeof globalThis.fetch;
+
+		try {
+			const registry = new ModelRegistry(
+				AuthStorage.inMemory({
+					[providerName]: { type: "api_key" as const, key: "sk-would-be-used" },
+				}),
+				modelsPath,
+			);
+			registry.getDiscoveryCache().clear(providerName);
+			registry.setDisabledModelProviders([providerName]);
+
+			const results = await registry.discoverModels([providerName]);
+			assert.equal(fetchCalls, 0, "denylisted provider must not hit discovery network");
+			assert.equal(
+				undefined,
+				results.find((r) => r.provider === providerName),
+				"denylisted provider should not produce a discovery result row",
+			);
+		} finally {
+			globalThis.fetch = prevFetch;
+		}
+	});
+
+	it("respects discoverModels deadlineMs before starting providers", async () => {
+		const providerName = `deadline-discovery-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		const modelsPath = join(testDir, "models.json");
+		writeFileSync(
+			modelsPath,
+			JSON.stringify(
+				{
+					providers: {
+						[providerName]: {
+							baseUrl: "https://api.minimax.example",
+							apiKey: "deadline-test-key",
+							api: "openai-completions",
+							models: [{ id: "bootstrap-model" }],
+						},
+					},
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		);
+
+		const prevFetch = globalThis.fetch;
+		let fetchCalls = 0;
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			fetchCalls++;
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (!url.startsWith("https://api.minimax.example")) {
+				return new Response(JSON.stringify({ data: [], models: [] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			return new Response(JSON.stringify({ data: [{ id: "x", name: "x" }] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof globalThis.fetch;
+
+		try {
+			const registry = new ModelRegistry(AuthStorage.inMemory({}), modelsPath);
+			registry.getDiscoveryCache().clear(providerName);
+			await registry.discoverModels([providerName], { deadlineMs: 0 });
+			assert.equal(fetchCalls, 0, "zero deadline must skip starting discovery fetch");
+		} finally {
+			globalThis.fetch = prevFetch;
+		}
+	});
+
+	it("getAvailableWithDiscovered returns discoveryErrors when a provider discovery fails", async () => {
+		const providerName = `err-discovery-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		const modelsPath = join(testDir, "models.json");
+		writeFileSync(
+			modelsPath,
+			JSON.stringify(
+				{
+					providers: {
+						[providerName]: {
+							baseUrl: "https://api.minimax.example",
+							apiKey: "err-test-key",
+							api: "openai-completions",
+							models: [{ id: "bootstrap-model" }],
+						},
+					},
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		);
+
+		const prevFetch = globalThis.fetch;
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			const requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (!requestedUrl.startsWith("https://api.minimax.example")) {
+				return new Response(JSON.stringify({ data: [], models: [] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			return new Response("{}", { status: 503, statusText: "Service Unavailable" });
+		}) as typeof globalThis.fetch;
+
+		try {
+			const registry = new ModelRegistry(AuthStorage.inMemory({}), modelsPath);
+			registry.getDiscoveryCache().clear(providerName);
+
+			const { models, discoveryErrors } = await registry.getAvailableWithDiscovered();
+			assert.ok(models.some((m) => m.provider === providerName && m.id === "bootstrap-model"));
+			assert.ok(discoveryErrors && discoveryErrors.some((e) => e.provider === providerName && e.message.length > 0));
 		} finally {
 			globalThis.fetch = prevFetch;
 		}

--- a/packages/pi-coding-agent/src/core/model-registry.ts
+++ b/packages/pi-coding-agent/src/core/model-registry.ts
@@ -879,11 +879,7 @@ export class ModelRegistry {
 				continue;
 			}
 
-			if (deadlineMs !== undefined && Date.now() - startedAt >= deadlineMs) {
-				break;
-			}
-
-			// Skip if cache is still fresh
+			// Serve from cache regardless of deadline — cache hits are free.
 			if (!this.discoveryCache.isStale(providerName)) {
 				const cached = this.discoveryCache.get(providerName);
 				if (cached) {
@@ -894,6 +890,12 @@ export class ModelRegistry {
 					});
 					continue;
 				}
+			}
+
+			// Only gate network fetches on the deadline; cached entries above are
+			// always included so discoveredModels stays complete even after timeout.
+			if (deadlineMs !== undefined && Date.now() - startedAt >= deadlineMs) {
+				continue;
 			}
 
 			try {

--- a/packages/pi-coding-agent/src/core/model-registry.ts
+++ b/packages/pi-coding-agent/src/core/model-registry.ts
@@ -555,6 +555,18 @@ export class ModelRegistry {
 	}
 
 	/**
+	 * Like {@link getAvailable} but runs {@link discoverModels} first so cached/live
+	 * discovery is merged in. Cache-fresh providers skip network; otherwise may await
+	 * key resolution or HTTP fetch. Drops models whose provider is not
+	 * {@link isProviderRequestReady} (same gate as {@link getAvailable}) and honours
+	 * {@link setDisabledModelProviders}.
+	 */
+	async getAvailableWithDiscovered(): Promise<Model<Api>[]> {
+		await this.discoverModels();
+		return this.getAllWithDiscovered().filter((m) => this.isProviderRequestReady(m.provider));
+	}
+
+	/**
 	 * Set provider IDs that should be excluded from model selection/routing.
 	 * This does not affect direct tool auth flows that resolve provider keys.
 	 */

--- a/packages/pi-coding-agent/src/core/model-registry.ts
+++ b/packages/pi-coding-agent/src/core/model-registry.ts
@@ -36,6 +36,22 @@ import { isLocalModel } from "./local-model-check.js";
 const Ajv = (AjvModule as any).default || AjvModule;
 const ajv = new Ajv();
 
+/** Options for {@link ModelRegistry.discoverModels}. */
+export interface DiscoverModelsOptions {
+	/**
+	 * Maximum wall time (ms) before stopping **starting** remaining providers.
+	 * In-flight fetches may still complete; does not cancel adapters.
+	 */
+	deadlineMs?: number;
+}
+
+/** Result of {@link ModelRegistry.getAvailableWithDiscovered}. */
+export interface AvailableWithDiscoveredResult<ApiType extends Api = Api> {
+	models: Model<ApiType>[];
+	/** Per-provider discovery failures from the last merged run (non-empty only). */
+	discoveryErrors?: { provider: string; message: string }[];
+}
+
 // Schema for OpenRouter routing preferences
 const OpenRouterRoutingSchema = Type.Object({
 	only: Type.Optional(Type.Array(Type.String())),
@@ -555,15 +571,22 @@ export class ModelRegistry {
 	}
 
 	/**
-	 * Like {@link getAvailable} but runs {@link discoverModels} first so cached/live
-	 * discovery is merged in. Cache-fresh providers skip network; otherwise may await
-	 * key resolution or HTTP fetch. Drops models whose provider is not
-	 * {@link isProviderRequestReady} (same gate as {@link getAvailable}) and honours
-	 * {@link setDisabledModelProviders}.
+	 * Runs {@link discoverModels} then returns models using the same readiness gate as
+	 * {@link getAvailable}. Providers in {@link setDisabledModelProviders} are omitted
+	 * from discovery (no cache read or network) and from the returned list.
 	 */
-	async getAvailableWithDiscovered(): Promise<Model<Api>[]> {
-		await this.discoverModels();
-		return this.getAllWithDiscovered().filter((m) => this.isProviderRequestReady(m.provider));
+	async getAvailableWithDiscovered(options?: {
+		discoverBudgetMs?: number;
+	}): Promise<AvailableWithDiscoveredResult<Api>> {
+		const discoverOpts: DiscoverModelsOptions | undefined =
+			options?.discoverBudgetMs !== undefined ? { deadlineMs: options.discoverBudgetMs } : undefined;
+		const results = await this.discoverModels(undefined, discoverOpts);
+		const discoveryErrors = results
+			.filter((r): r is DiscoveryResult & { error: string } => r.error !== undefined && r.error.length > 0)
+			.map((r) => ({ provider: r.provider, message: r.error }));
+
+		const models = this.getAllWithDiscovered().filter((m) => this.isProviderRequestReady(m.provider));
+		return discoveryErrors.length > 0 ? { models, discoveryErrors } : { models };
 	}
 
 	/**
@@ -835,15 +858,30 @@ export class ModelRegistry {
 	/**
 	 * Discover models from all providers that support discovery.
 	 * Results are cached and merged into the registry (never overrides existing models).
+	 *
+	 * Providers listed in {@link setDisabledModelProviders} are skipped entirely (no
+	 * cache read or network). Optional {@link DiscoverModelsOptions.deadlineMs} stops
+	 * starting further providers once elapsed; adapters may still finish in-flight work.
 	 */
-	async discoverModels(providers?: string[]): Promise<DiscoveryResult[]> {
+	async discoverModels(providers?: string[], options?: DiscoverModelsOptions): Promise<DiscoveryResult[]> {
 		const targetProviders = providers ?? this.getAutoDiscoverableProviders();
 		const results: DiscoveryResult[] = [];
+		const deadlineMs = options?.deadlineMs;
+		const startedAt = deadlineMs !== undefined ? Date.now() : 0;
 
 		for (const providerName of targetProviders) {
 			const providerApis = this.getProviderApis(providerName);
 			const adapter = getDiscoveryAdapter(providerName, providerApis);
 			if (!adapter.supportsDiscovery) continue;
+
+			const normalized = providerName.trim().toLowerCase();
+			if (this.disabledModelProviders.has(normalized)) {
+				continue;
+			}
+
+			if (deadlineMs !== undefined && Date.now() - startedAt >= deadlineMs) {
+				break;
+			}
 
 			// Skip if cache is still fresh
 			if (!this.discoveryCache.isStale(providerName)) {

--- a/packages/pi-coding-agent/src/index.ts
+++ b/packages/pi-coding-agent/src/index.ts
@@ -174,6 +174,7 @@ export { ModelDiscoveryCache } from "./core/discovery-cache.js";
 export type { DiscoveredModel, DiscoveryResult, ProviderDiscoveryAdapter } from "./core/model-discovery.js";
 export { getDiscoverableProviders, getDiscoveryAdapter } from "./core/model-discovery.js";
 export { ModelRegistry } from "./core/model-registry.js";
+export type { AvailableWithDiscoveredResult, DiscoverModelsOptions } from "./core/model-registry.js";
 export { ModelsJsonWriter } from "./core/models-json-writer.js";
 export type {
 	PackageManager,

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -11,6 +11,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  DEFAULT_MODEL_DISCOVERY_BUDGET_MS,
+  parseModelDiscoveryBudgetMs,
+} from "./preferences-types.js";
+import {
   getGlobalGSDPreferencesPath,
   getLegacyGlobalGSDPreferencesPath,
   getProjectGSDPreferencesPath,
@@ -431,6 +435,9 @@ export function buildCategorySummaries(prefs: Record<string, unknown>): Record<s
     if (prefs.auto_report !== undefined) parts.push(`report: ${prefs.auto_report ? "on" : "off"}`);
     if (prefs.show_token_cost) parts.push("cost-display");
     if (prefs.forensics_dedup) parts.push("forensics-dedup");
+    if (prefs.model_discovery_budget_ms !== undefined) {
+      parts.push(`model-disc: ${prefs.model_discovery_budget_ms}ms`);
+    }
     if (prefs.widget_mode) parts.push(`widget: ${prefs.widget_mode}`);
     if (experimentalRtk) parts.push("rtk");
     if (parts.length > 0) advancedSummary = parts.join(", ");
@@ -573,6 +580,15 @@ export function toPersistedModelId(provider: string, modelId: string): string {
     : `${normalizedProvider}/${normalizedModelId}`;
 }
 
+function resolvePrefsModelDiscoveryBudgetMs(prefs: Record<string, unknown>): number {
+  const staged = parseModelDiscoveryBudgetMs(prefs.model_discovery_budget_ms);
+  if (staged !== undefined) return staged;
+  const effective = loadEffectiveGSDPreferences()?.preferences;
+  const fromDisk = parseModelDiscoveryBudgetMs(effective?.model_discovery_budget_ms);
+  if (fromDisk !== undefined) return fromDisk;
+  return DEFAULT_MODEL_DISCOVERY_BUDGET_MS;
+}
+
 async function configureModels(ctx: ExtensionCommandContext, prefs: Record<string, unknown>): Promise<void> {
   const modelPhases = [
     "research",
@@ -586,7 +602,14 @@ async function configureModels(ctx: ExtensionCommandContext, prefs: Record<strin
   ] as const;
   const models: Record<string, unknown> = (prefs.models as Record<string, unknown>) ?? {};
 
-  const availableModels = await ctx.modelRegistry.getAvailableWithDiscovered();
+  const discoverBudgetMs = resolvePrefsModelDiscoveryBudgetMs(prefs);
+  const merged = await ctx.modelRegistry.getAvailableWithDiscovered({ discoverBudgetMs });
+  const availableModels = merged.models;
+  if (merged.discoveryErrors?.length) {
+    const parts = merged.discoveryErrors.slice(0, 3).map((e) => `${e.provider}: ${e.message}`);
+    const suffix = merged.discoveryErrors.length > 3 ? ` (+${merged.discoveryErrors.length - 3} more)` : "";
+    ctx.ui.notify(`Some providers failed discovery: ${parts.join("; ")}${suffix}`, "warning");
+  }
   if (availableModels.length > 0) {
     // Group models by provider, sorted alphabetically
     const byProvider = new Map<string, typeof availableModels>();
@@ -1536,6 +1559,26 @@ async function configureAdvanced(ctx: ExtensionCommandContext, prefs: Record<str
     prefs.min_request_interval_ms = minRequestInterval;
   }
 
+  const discoveryBudget = await promptInteger(
+    ctx,
+    "Model catalog discovery budget (ms, /gsd prefs → Models; caps wall time to start further providers, not per-fetch timeout)",
+    prefs.model_discovery_budget_ms,
+    "30000",
+  );
+  if (discoveryBudget === "clear") {
+    delete prefs.model_discovery_budget_ms;
+  } else if (discoveryBudget !== undefined) {
+    const parsedBudget = parseModelDiscoveryBudgetMs(discoveryBudget);
+    if (parsedBudget === undefined) {
+      ctx.ui.notify(
+        "Model catalog discovery budget must be a whole number between 1000 and 600000 (ms). Keeping previous value.",
+        "warning",
+      );
+    } else {
+      prefs.model_discovery_budget_ms = parsedBudget;
+    }
+  }
+
   const widget = await promptEnum(ctx, "Auto-mode widget display", prefs.widget_mode, ["full", "small", "min", "off"], "full");
   if (widget !== undefined) prefs.widget_mode = widget;
 
@@ -1728,6 +1771,7 @@ export function serializePreferencesToFrontmatter(prefs: Record<string, unknown>
     "notifications", "cmux", "remote_questions", "git",
     "stale_commit_threshold_minutes",
     "min_request_interval_ms",
+    "model_discovery_budget_ms",
     "post_unit_hooks", "pre_dispatch_hooks",
     "dynamic_routing", "disabled_model_providers", "uok", "token_profile",
     "service_tier", "flat_rate_providers",

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -586,7 +586,7 @@ async function configureModels(ctx: ExtensionCommandContext, prefs: Record<strin
   ] as const;
   const models: Record<string, unknown> = (prefs.models as Record<string, unknown>) ?? {};
 
-  const availableModels = ctx.modelRegistry.getAvailable();
+  const availableModels = await ctx.modelRegistry.getAvailableWithDiscovered();
   if (availableModels.length > 0) {
     // Group models by provider, sorted alphabetically
     const byProvider = new Map<string, typeof availableModels>();

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -128,6 +128,8 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
 
 - `min_request_interval_ms`: number — minimum integer milliseconds between auto-mode LLM request dispatches. Non-integer values are rounded down (e.g., `1000.9 → 1000`). Use this to proactively slow auto-mode on rate-limited providers and reduce 429 errors. Set to `0` to disable. Default: `0` (disabled).
 
+- `model_discovery_budget_ms`: number — optional wall-clock budget in milliseconds for **provider catalog discovery** when you open **`/gsd prefs` → Models** (`discoverModels`). Valid range `1000`–`600000` (decimals are rounded down). Same band as top-level timeouts like `context_mode.exec_timeout_ms`, but unrelated to sandbox execution — it only limits how long discovery may spend **starting** further providers overall, **not** the per-request HTTP timeout (discovery still uses roughly a 5s cap per fetch). Project preferences override global when both are set. Default when omitted: `30000`.
+
 - `git`: configures GSD's git behavior. All fields are optional — omit any to use defaults. Keys:
   - `auto_push`: boolean — automatically push commits to the remote after committing. Default: `false`.
   - `push_branches`: boolean — push the milestone branch to the remote after commits. Default: `false`.

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -89,6 +89,23 @@ export const MODE_DEFAULTS: Record<WorkflowMode, Partial<GSDPreferences>> = {
   },
 };
 
+/** Default wall-clock ms for `discoverModels` when `/gsd prefs` → Models runs and `model_discovery_budget_ms` is unset. */
+export const DEFAULT_MODEL_DISCOVERY_BUDGET_MS = 30_000;
+
+const MODEL_DISCOVERY_BUDGET_MS_MIN = 1_000;
+const MODEL_DISCOVERY_BUDGET_MS_MAX = 600_000;
+
+/**
+ * Parses a valid model catalog discovery budget (ms). Same band as `context_mode.exec_timeout_ms`.
+ * Returns undefined if absent or invalid.
+ */
+export function parseModelDiscoveryBudgetMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const floored = Math.floor(value);
+  if (floored < MODEL_DISCOVERY_BUDGET_MS_MIN || floored > MODEL_DISCOVERY_BUDGET_MS_MAX) return undefined;
+  return floored;
+}
+
 /** All recognized top-level keys in GSDPreferences. Used to detect typos / stale config. */
 export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "version",
@@ -134,6 +151,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "forensics_dedup",
   "show_token_cost",
   "min_request_interval_ms",
+  "model_discovery_budget_ms",
   "stale_commit_threshold_minutes",
   "context_management",
   "experimental",
@@ -382,6 +400,12 @@ export interface GSDPreferences {
   show_token_cost?: boolean;
   /** Proactive rate limiting: minimum milliseconds between auto-mode LLM requests. Prevents 429s on rate-limited providers. 0 = disabled (default). */
   min_request_interval_ms?: number;
+  /**
+   * Wall-clock budget (ms) for provider catalog discovery when opening `/gsd prefs` → Models (`discoverModels`).
+   * Caps how long discovery may spend starting further providers; each HTTP fetch may still use its own timeout (e.g. 5s).
+   * Valid range 1000–600000 (floored); omission uses DEFAULT_MODEL_DISCOVERY_BUDGET_MS (30s).
+   */
+  model_discovery_budget_ms?: number;
   /**
    * Minutes without a commit before flagging uncommitted changes as stale.
    * When the threshold is exceeded and the working tree is dirty, doctor will

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -15,8 +15,8 @@ import { normalizeStringArray } from "../shared/format-utils.js";
 import {
   KNOWN_PREFERENCE_KEYS,
   KNOWN_UNIT_TYPES,
-
   SKILL_ACTIONS,
+  parseModelDiscoveryBudgetMs,
   type WorkflowMode,
   type GSDPreferences,
   type GSDSkillRule,
@@ -1142,6 +1142,16 @@ export function validatePreferences(preferences: GSDPreferences): {
       validated.min_request_interval_ms = Math.floor(preferences.min_request_interval_ms);
     } else {
       errors.push("min_request_interval_ms must be a non-negative number <= 2147483647");
+    }
+  }
+
+  // ─── Model catalog discovery budget (prefs Models flow) ───────────
+  if (preferences.model_discovery_budget_ms !== undefined) {
+    const parsed = parseModelDiscoveryBudgetMs(preferences.model_discovery_budget_ms);
+    if (parsed !== undefined) {
+      validated.model_discovery_budget_ms = parsed;
+    } else {
+      errors.push("model_discovery_budget_ms must be a number between 1000 and 600000");
     }
   }
 

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -464,6 +464,7 @@ function mergePreferences(base: GSDPreferences, override: GSDPreferences): GSDPr
     forensics_dedup: override.forensics_dedup ?? base.forensics_dedup,
     show_token_cost: override.show_token_cost ?? base.show_token_cost,
     min_request_interval_ms: override.min_request_interval_ms ?? base.min_request_interval_ms,
+    model_discovery_budget_ms: override.model_discovery_budget_ms ?? base.model_discovery_budget_ms,
     codebase: (base.codebase || override.codebase)
       ? {
           ...(base.codebase ?? {}),

--- a/src/resources/extensions/gsd/tests/init-prefs-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/init-prefs-routing.test.ts
@@ -139,7 +139,7 @@ test("handlePrefsWizard — Advanced config writes min_request_interval_ms", asy
       "(keep current)",
       "── Save & Exit ──",
     ];
-    const inputResponses = ["250"];
+    const inputResponses = ["250", ""];
     const ctx = {
       ui: {
         notify: () => {},

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -250,6 +250,28 @@ test("min_request_interval_ms floors decimals and rejects timer overflow values"
   assert.equal(tooHigh.preferences.min_request_interval_ms, undefined);
 });
 
+test("model_discovery_budget_ms floors decimals and rejects out-of-range values", () => {
+  const valid = validatePreferences({ model_discovery_budget_ms: 30_000.7 });
+  assert.equal(valid.errors.length, 0);
+  assert.equal(valid.preferences.model_discovery_budget_ms, 30_000);
+
+  const minOk = validatePreferences({ model_discovery_budget_ms: 1000 });
+  assert.equal(minOk.errors.length, 0);
+  assert.equal(minOk.preferences.model_discovery_budget_ms, 1000);
+
+  const maxOk = validatePreferences({ model_discovery_budget_ms: 600_000 });
+  assert.equal(maxOk.errors.length, 0);
+  assert.equal(maxOk.preferences.model_discovery_budget_ms, 600_000);
+
+  const tooLow = validatePreferences({ model_discovery_budget_ms: 999 });
+  assert.ok(tooLow.errors.some(e => e.includes("model_discovery_budget_ms must be a number between 1000 and 600000")));
+  assert.equal(tooLow.preferences.model_discovery_budget_ms, undefined);
+
+  const tooHigh = validatePreferences({ model_discovery_budget_ms: 600_001 });
+  assert.ok(tooHigh.errors.some(e => e.includes("model_discovery_budget_ms must be a number between 1000 and 600000")));
+  assert.equal(tooHigh.preferences.model_discovery_budget_ms, undefined);
+});
+
 test("mixed valid/invalid/unknown keys handled correctly", () => {
   const { preferences, errors, warnings } = validatePreferences({
     uat_dispatch: true, totally_made_up: "value", budget_ceiling: "garbage",
@@ -753,6 +775,54 @@ test("loadEffectiveGSDPreferences exposes slice_parallel prefs to runtime caller
     assert.notEqual(loaded, null);
     assert.equal(loaded!.preferences.slice_parallel?.enabled, true);
     assert.equal(loaded!.preferences.slice_parallel?.max_workers, 3);
+  } finally {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  }
+});
+
+test("loadEffectiveGSDPreferences merges model_discovery_budget_ms with project overriding global", () => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-model-disc-project-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-model-disc-home-"));
+
+  try {
+    mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+
+    writeFileSync(
+      join(tempGsdHome, "PREFERENCES.md"),
+      [
+        "---",
+        "version: 1",
+        "model_discovery_budget_ms: 45000",
+        "budget_ceiling: 45",
+        "---",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    writeFileSync(
+      join(tempProject, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "version: 1",
+        "model_discovery_budget_ms: 120000",
+        "---",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    process.env.GSD_HOME = tempGsdHome;
+    process.chdir(tempProject);
+
+    const loaded = loadEffectiveGSDPreferences();
+    assert.notEqual(loaded, null);
+    assert.equal(loaded!.preferences.model_discovery_budget_ms, 120_000);
+    assert.equal(loaded!.preferences.budget_ceiling, 45);
   } finally {
     process.chdir(originalCwd);
     if (originalGsdHome === undefined) delete process.env.GSD_HOME;


### PR DESCRIPTION
Use this in the PR body (replace the issue line with a real `Closes #NNNN` before opening the PR):

---

## Linked issue

Closes #5195 

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** `/gsd prefs` model picker now uses provider model discovery so discovered IDs (e.g. OpenRouter) appear next to built-in registrations.  
**Why:** After running discovery, prefs still only listed static registry models, so users could not pick discovered models from the wizard.  
**How:** Added `ModelRegistry.getAvailableWithDiscovered()` (`discoverModels` + `getAllWithDiscovered`, filtered with the same auth/readiness rules as `getAvailable()`), and wired `configureModels` to await it.

## What

- **`packages/pi-coding-agent/src/core/model-registry.ts`** — New async `getAvailableWithDiscovered()`: runs full discovery (cache-first), then returns merged models gated by `isProviderRequestReady` / disabled providers, matching `getAvailable()` semantics for static models.  
- **`src/resources/extensions/gsd/commands-prefs-wizard.ts`** — `configureModels` loads `availableModels` via `await ctx.modelRegistry.getAvailableWithDiscovered()` instead of `getAvailable()`.  
- **`packages/pi-coding-agent/src/core/model-registry-discovery.test.ts`** — Assertions that the new API exposes a discovered custom-provider model and matches the auth-filtered merged list; fetch stub returns empty payloads for non–MiniMax URLs so parallel discovery in the same call does not pollute results.

## Why

Discovery populates a separate in-memory merge path (`discoveredModels` / cache). The prefs wizard only called `getAvailable()`, which reads the static `models` list, so discovered models never appeared even when discovery had already run or cache was warm.

## How

- Reuse existing `discoverModels()` + `getAllWithDiscovered()` instead of a second cache API.  
- Keep CLI `list-models --discover` behavior unchanged (still uses ungated `getAllWithDiscovered()` after discover).  
- **Alternative considered:** `getAllWithDiscovered()` without `discoverModels()` — rejected: would not hydrate from cache after a fresh process.  
- **Out of scope:** `/model` selector and `list-models` consolidation (different auth semantics today).

## Change type

- [ ] `feat` — New feature or capability  
- [x] `fix` — Bug fix  
- [ ] `refactor` — Code restructuring (no behavior change)  
- [x] `test` — Adding or updating tests  
- [ ] `docs` — Documentation only  
- [ ] `chore` — Build, CI, or tooling changes  

## Scope

- [ ] `pi-tui` — Terminal UI  
- [ ] `pi-ai` — AI/LLM layer  
- [ ] `pi-agent-core` — Agent orchestration  
- [x] `pi-coding-agent` — Coding agent  
- [x] `gsd extension` — GSD workflow  
- [ ] `native` — Native bindings  
- [ ] `ci/build` — Workflows, scripts, config  

## Breaking changes

- [x] No breaking changes  
- [ ] Yes — described above  

`getAvailable()` is unchanged; new API is additive.

## Test plan

- [x] CI passes  
- [x] New/updated tests included — `model-registry-discovery.test.ts` (`getAvailableWithDiscovered` + invariant vs filtered `getAllWithDiscovered`)  
- [ ] Manual testing — steps described above  
- [ ] No tests needed — explained above  

**Suggested manual check:** Configure OpenRouter key → run discovery (e.g. provider manager) → `/gsd prefs` → Models → confirm extra OpenRouter IDs appear vs before; stale cache should still populate without relying on UI discover in the same session.

## AI disclosure

- [x] This PR includes AI-assisted code — Implemented with Cursor; logic verified via targeted `node --test` on `model-registry-discovery` and repo `npm run verify:pr` / CI expectation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discovery-aware model selection and a configurable discovery time budget preference (validated and mergeable) are exposed to users.

* **Bug Fixes**
  * Discovery now skips disabled providers, honors zero-budget for starting fetches, surfaces per-provider discovery errors, and yields stable results when re-run.

* **Documentation**
  * Preferences reference updated to document the discovery budget option and valid range.

* **Tests**
  * Expanded tests for discovery behaviors and preference parsing/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->