### PR TITLE
fix(gsd): preserve worktree isolation in /gsd handlers + harden MCP cwd

### DIFF
--- a/packages/mcp-server/src/parse-workflow-args.test.ts
+++ b/packages/mcp-server/src/parse-workflow-args.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression tests for parseWorkflowArgs cwd handling:
+ *  - Refuses when projectDir resolves to $HOME (defense-in-depth against the
+ *    MCP server's process.cwd() falling back to home).
+ *  - Routes writes to a sole active auto-worktree when milestoneId is omitted.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+
+import { _parseWorkflowArgsForTest } from "./workflow-tools.js";
+
+const minimalSchema = z.object({
+  projectDir: z.string().optional(),
+  milestoneId: z.string().optional(),
+});
+
+describe("parseWorkflowArgs $HOME guard", () => {
+  it("throws when projectDir resolves to the user's home directory", () => {
+    assert.throws(
+      () => _parseWorkflowArgsForTest(minimalSchema, { projectDir: homedir() }),
+      /home directory/i,
+    );
+  });
+});
+
+describe("parseWorkflowArgs sole-worktree fallback", () => {
+  it("routes writes to the lone auto-worktree when milestoneId is omitted", () => {
+    const project = realpathSync(mkdtempSync(join(tmpdir(), "gsd-mcp-wt-")));
+    try {
+      mkdirSync(join(project, ".gsd"), { recursive: true });
+      const wt = join(project, ".gsd", "worktrees", "M001");
+      mkdirSync(wt, { recursive: true });
+      writeFileSync(join(wt, ".git"), "gitdir: /fake/path/to/git\n");
+
+      const result = _parseWorkflowArgsForTest(minimalSchema, { projectDir: project });
+      assert.equal(result.projectDir, wt, "should re-route to the sole worktree");
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it("stays at project root when multiple worktrees exist (ambiguous)", () => {
+    const project = realpathSync(mkdtempSync(join(tmpdir(), "gsd-mcp-wt-multi-")));
+    try {
+      mkdirSync(join(project, ".gsd"), { recursive: true });
+      for (const id of ["M001", "M002"]) {
+        const wt = join(project, ".gsd", "worktrees", id);
+        mkdirSync(wt, { recursive: true });
+        writeFileSync(join(wt, ".git"), "gitdir: /fake/git\n");
+      }
+
+      const result = _parseWorkflowArgsForTest(minimalSchema, { projectDir: project });
+      assert.equal(result.projectDir, project, "ambiguous → keep project root");
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the explicit milestone worktree when milestoneId is provided", () => {
+    const project = realpathSync(mkdtempSync(join(tmpdir(), "gsd-mcp-wt-explicit-")));
+    try {
+      mkdirSync(join(project, ".gsd"), { recursive: true });
+      const wt = join(project, ".gsd", "worktrees", "M042");
+      mkdirSync(wt, { recursive: true });
+      writeFileSync(join(wt, ".git"), "gitdir: /fake/git\n");
+
+      const result = _parseWorkflowArgsForTest(minimalSchema, {
+        projectDir: project,
+        milestoneId: "M042",
+      });
+      assert.equal(result.projectDir, wt);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -2,7 +2,8 @@
  * Workflow MCP tools — exposes the core GSD mutation/read handlers over MCP.
  */
 
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, readdirSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { z } from "zod";
@@ -378,6 +379,50 @@ function resolveActiveWorktreeBasePath(
   return wtPath;
 }
 
+/**
+ * Fallback when the tool call has no milestoneId: if exactly one auto-worktree
+ * exists under `<projectRoot>/.gsd/worktrees/`, treat it as the active one.
+ * Multiple worktrees → ambiguous, return null and let writes go to project root.
+ */
+function resolveSoleActiveWorktree(projectRoot: string): string | null {
+  const worktreesDir = join(projectRoot, ".gsd", "worktrees");
+  if (!existsSync(worktreesDir)) return null;
+  let entries: string[];
+  try {
+    entries = readdirSync(worktreesDir);
+  } catch {
+    return null;
+  }
+  const live = entries
+    .map((name) => join(worktreesDir, name))
+    .filter((p) => existsSync(join(p, ".git")));
+  if (live.length !== 1) return null;
+  return live[0];
+}
+
+function isHomeDirectory(candidate: string): boolean {
+  let resolvedHome: string;
+  try {
+    resolvedHome = realpathSync(resolve(homedir()));
+  } catch {
+    resolvedHome = resolve(homedir());
+  }
+  let resolvedCandidate: string;
+  try {
+    resolvedCandidate = realpathSync(resolve(candidate));
+  } catch {
+    resolvedCandidate = resolve(candidate);
+  }
+  return resolvedCandidate === resolvedHome;
+}
+
+export function _parseWorkflowArgsForTest<T extends { projectDir?: string }>(
+  schema: z.ZodType<T>,
+  args: Record<string, unknown>,
+): T & { projectDir: string } {
+  return parseWorkflowArgs(schema, args);
+}
+
 function parseWorkflowArgs<T extends { projectDir?: string }>(
   schema: z.ZodType<T>,
   args: Record<string, unknown>,
@@ -387,14 +432,28 @@ function parseWorkflowArgs<T extends { projectDir?: string }>(
   // projectDir — default to process.cwd() which the MCP server inherited from
   // Claude Code (launched at the project root).
   const projectRootCandidate = parsed.projectDir ?? process.cwd();
+
+  // Defense-in-depth: refuse when the resolved candidate is the user's home
+  // directory. The MCP server's process.cwd() can be $HOME if launched from
+  // an unusual context; honoring it would write project artifacts into ~/.gsd.
+  if (isHomeDirectory(projectRootCandidate)) {
+    throw new Error(
+      `projectDir resolves to the user's home directory (${projectRootCandidate}). ` +
+      `Run the workflow tool from inside a project directory, or pass an explicit projectDir.`,
+    );
+  }
+
   const projectRoot = validateProjectDir(projectRootCandidate);
 
   // Step 2: if this tool call is scoped to a milestone that has an active
   // auto-worktree, re-route writes to the worktree's .gsd rather than the
   // project's shared .gsd. auto-mode's verifyExpectedArtifact runs against
   // the worktree, and a mismatch here causes every unit to retry once.
+  // When the agent omits milestoneId, fall back to the sole live worktree
+  // if exactly one exists — that's the active auto-mode session.
   const milestoneId = extractMilestoneId(parsed as Record<string, unknown>);
-  const worktreeBasePath = resolveActiveWorktreeBasePath(projectRoot, milestoneId);
+  const worktreeBasePath = resolveActiveWorktreeBasePath(projectRoot, milestoneId)
+    ?? (milestoneId ? null : resolveSoleActiveWorktree(projectRoot));
   const effectiveBasePath = worktreeBasePath ?? projectRoot;
 
   return {

--- a/src/resources/extensions/gsd/commands-codebase.ts
+++ b/src/resources/extensions/gsd/commands-codebase.ts
@@ -16,7 +16,7 @@ import {
 } from "./codebase-generator.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import type { CodebaseMapOptions } from "./codebase-generator.js";
-import { projectRoot } from "./commands/context.js";
+import { currentDirectoryRoot } from "./commands/context.js";
 
 const USAGE =
   "Usage: /gsd codebase [generate|update|stats]\n\n" +
@@ -37,7 +37,7 @@ export async function handleCodebase(
   ctx: ExtensionCommandContext,
   _pi: ExtensionAPI,
 ): Promise<void> {
-  const basePath = projectRoot();
+  const basePath = currentDirectoryRoot();
   const parts = args.trim().split(/\s+/);
   const sub = parts[0] ?? "";
 

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -24,7 +24,7 @@ import {
 } from "./doctor.js";
 import { isAutoActive, checkRemoteAutoSession } from "./auto.js";
 import { getAutoWorktreePath } from "./auto-worktree.js";
-import { projectRoot } from "./commands/context.js";
+import { currentDirectoryRoot, projectRoot } from "./commands/context.js";
 import { loadPrompt } from "./prompt-loader.js";
 
 const UPDATE_REGISTRY_URL = "https://registry.npmjs.org/gsd-pi/latest";
@@ -203,7 +203,7 @@ export async function handleCapture(args: string, ctx: ExtensionCommandContext):
     return;
   }
 
-  const basePath = projectRoot();
+  const basePath = currentDirectoryRoot();
 
   // Ensure .gsd/ exists — capture should work even without a milestone
   const gsdDir = gsdRoot(basePath);
@@ -270,7 +270,7 @@ export async function handleTriage(ctx: ExtensionCommandContext, pi: ExtensionAP
 }
 
 export async function handleSteer(change: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {
-  const basePath = projectRoot();
+  const basePath = currentDirectoryRoot();
   const state = await deriveState(basePath);
   const mid = state.activeMilestone?.id ?? "none";
   const sid = state.activeSlice?.id ?? "none";
@@ -343,7 +343,7 @@ export async function handleKnowledge(args: string, ctx: ExtensionCommandContext
   }
 
   const type = typeArg as "rule" | "pattern" | "lesson";
-  const basePath = projectRoot();
+  const basePath = currentDirectoryRoot();
   const state = await deriveState(basePath);
   const scope = state.activeMilestone?.id
     ? `${state.activeMilestone.id}${state.activeSlice ? `/${state.activeSlice.id}` : ""}`
@@ -372,7 +372,7 @@ Examples:
   }
 
   const [hookName, unitType, unitId] = parts;
-  const basePath = projectRoot();
+  const basePath = currentDirectoryRoot();
 
   // Import the hook trigger function
   const { triggerHookManually, formatHookStatus, getHookStatus } = await import("./post-unit-hooks.js");

--- a/src/resources/extensions/gsd/commands-logs.ts
+++ b/src/resources/extensions/gsd/commands-logs.ts
@@ -15,7 +15,7 @@ import { existsSync, readdirSync, readFileSync, statSync, unlinkSync } from "nod
 import { join } from "node:path";
 import { gsdRoot } from "./paths.js";
 import { loadJsonFileOrNull } from "./json-persistence.js";
-import { projectRoot } from "./commands/context.js";
+import { currentDirectoryRoot } from "./commands/context.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -244,7 +244,7 @@ function summarizeDebugLog(filePath: string): {
 // ─── Main Handler ───────────────────────────────────────────────────────────
 
 export async function handleLogs(args: string, ctx: ExtensionCommandContext): Promise<void> {
-  const basePath = projectRoot();
+  const basePath = currentDirectoryRoot();
   const parts = args.trim().split(/\s+/).filter(Boolean);
   const subCmd = parts[0] ?? "";
 

--- a/src/resources/extensions/gsd/commands-scan.ts
+++ b/src/resources/extensions/gsd/commands-scan.ts
@@ -20,7 +20,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { join, relative } from "node:path";
 
 import { loadPrompt } from "./prompt-loader.js";
-import { projectRoot } from "./commands/context.js";
+import { currentDirectoryRoot } from "./commands/context.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -87,7 +87,7 @@ export async function handleScan(
   ctx: ExtensionCommandContext,
   pi: ExtensionAPI,
 ): Promise<void> {
-  const basePath = projectRoot();
+  const basePath = currentDirectoryRoot();
   const { focus } = parseScanArgs(args);
   const outputDir = join(basePath, ".gsd", "codebase");
   const outputPaths = buildScanOutputPaths(focus, basePath);

--- a/src/resources/extensions/gsd/commands-ship.ts
+++ b/src/resources/extensions/gsd/commands-ship.ts
@@ -17,7 +17,7 @@ import { getLedger, getProjectTotals, aggregateByModel, formatCost, formatTokenC
 import { nativeGetCurrentBranch, nativeDetectMainBranch } from "./native-git-bridge.js";
 import { formatDuration } from "../shared/format-utils.js";
 import { parseEvalReviewFrontmatter, type Verdict } from "./eval-review-schema.js";
-import { projectRoot } from "./commands/context.js";
+import { currentDirectoryRoot } from "./commands/context.js";
 
 function git(basePath: string, args: readonly string[]): string {
   return execFileSync("git", args, { cwd: basePath, encoding: "utf-8" }).trim();
@@ -223,7 +223,7 @@ export async function handleShip(
   ctx: ExtensionCommandContext,
   _pi: ExtensionAPI,
 ): Promise<void> {
-  const basePath = projectRoot();
+  const basePath = currentDirectoryRoot();
   const dryRun = args.includes("--dry-run");
   const draft = args.includes("--draft");
   const force = args.includes("--force");

--- a/src/resources/extensions/gsd/commands-workflow-templates.ts
+++ b/src/resources/extensions/gsd/commands-workflow-templates.ts
@@ -23,7 +23,7 @@ import { createGitService, runGit } from "./git-service.js";
 import { isAutoActive, isAutoPaused } from "./auto.js";
 import { getErrorMessage } from "./error-utils.js";
 import { resolvePlugin, type WorkflowPlugin } from "./workflow-plugins.js";
-import { projectRoot } from "./commands/context.js";
+import { currentDirectoryRoot } from "./commands/context.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -197,7 +197,7 @@ export async function handleStart(
   // ─── Resume detection ───────────────────────────────────────────────────
   // /gsd start --resume or /gsd start resume → resume in-progress workflow
   if (trimmed === "--resume" || trimmed === "resume") {
-    const basePath = projectRoot();
+    const basePath = currentDirectoryRoot();
     const inProgress = findInProgressWorkflows(basePath);
     if (inProgress.length === 0) {
       ctx.ui.notify("No in-progress workflows found.", "info");
@@ -248,7 +248,7 @@ export async function handleStart(
 
   // Show in-progress workflows when /gsd start is called with no args
   if (!trimmed) {
-    const basePath = projectRoot();
+    const basePath = currentDirectoryRoot();
     const inProgress = findInProgressWorkflows(basePath);
     if (inProgress.length > 0) {
       const wf = inProgress[0];
@@ -347,7 +347,7 @@ export async function handleStart(
 
   const templateId = match.id;
   const template = match.template;
-  const basePath = projectRoot();
+  const basePath = currentDirectoryRoot();
   const date = new Date().toISOString().split("T")[0];
 
   // Load the workflow template content — prefer a project/global plugin
@@ -582,7 +582,7 @@ export function dispatchMarkdownPhasePlugin(
   }
 
   const templateId = plugin.name;
-  const basePath = projectRoot();
+  const basePath = currentDirectoryRoot();
   const date = new Date().toISOString().split("T")[0];
   let workflowContent: string;
   try {

--- a/src/resources/extensions/gsd/rethink.ts
+++ b/src/resources/extensions/gsd/rethink.ts
@@ -20,7 +20,7 @@ import { getMilestoneSlices, isDbAvailable } from "./gsd-db.js";
 import { buildExistingMilestonesContext } from "./guided-flow-queue.js";
 import { loadPrompt } from "./prompt-loader.js";
 import { isGsdGitignored } from "./gitignore.js";
-import { projectRoot } from "./commands/context.js";
+import { currentDirectoryRoot } from "./commands/context.js";
 
 // ─── Entry Point ──────────────────────────────────────────────────────────────
 
@@ -34,7 +34,7 @@ export async function handleRethink(
     return;
   }
 
-  const basePath = projectRoot();
+  const basePath = currentDirectoryRoot();
   const root = gsdRoot(basePath);
   if (!existsSync(root)) {
     ctx.ui.notify("No GSD project found. Run /gsd init first.", "warning");

--- a/src/resources/extensions/gsd/tests/handler-worktree-write-isolation.test.ts
+++ b/src/resources/extensions/gsd/tests/handler-worktree-write-isolation.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression: when /gsd handlers run with cwd inside a worktree, writes must
+ * land in the worktree's .gsd/, not the parent project's .gsd/.
+ *
+ * The fix in 01464a97 replaced `process.cwd()` with `projectRoot()` to block
+ * $HOME pollution, but `projectRoot()` walks UP from a worktree path to the
+ * outer project root — breaking the worktree isolation invariant agents rely
+ * on. The corrected pattern: handlers use `currentDirectoryRoot()`, which
+ * preserves the active cwd (worktree or project) and still throws when cwd
+ * is $HOME.
+ */
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, realpathSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
+
+import { currentDirectoryRoot, projectRoot, withCommandCwd, GSDNoProjectError } from "../commands/context.ts";
+
+describe("handlers preserve worktree cwd via currentDirectoryRoot()", () => {
+  let project: string;
+  let worktree: string;
+
+  beforeEach(() => {
+    project = realpathSync(mkdtempSync(join(tmpdir(), "gsd-wt-iso-")));
+    mkdirSync(join(project, ".gsd"), { recursive: true });
+    mkdirSync(join(project, ".git"), { recursive: true });
+    worktree = join(project, ".gsd", "worktrees", "M001");
+    mkdirSync(join(worktree, ".gsd"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(project, { recursive: true, force: true });
+  });
+
+  test("currentDirectoryRoot() returns the worktree path when cwd is the worktree", async () => {
+    const resolved = await withCommandCwd(worktree, async () => currentDirectoryRoot());
+    assert.equal(resolved, worktree, "must keep worktree path so writes isolate");
+  });
+
+  test("projectRoot() walks UP from worktree to the project root (legacy semantics)", async () => {
+    const resolved = await withCommandCwd(worktree, async () => projectRoot());
+    assert.equal(resolved, project, "projectRoot intentionally returns project, not worktree");
+  });
+
+  test("currentDirectoryRoot() throws GSDNoProjectError when cwd is $HOME", async () => {
+    await assert.rejects(
+      withCommandCwd(homedir(), async () => currentDirectoryRoot()),
+      (err: unknown) => err instanceof GSDNoProjectError,
+    );
+  });
+
+  test("currentDirectoryRoot() returns project root when cwd is project root", async () => {
+    const resolved = await withCommandCwd(project, async () => currentDirectoryRoot());
+    assert.equal(resolved, project);
+  });
+});


### PR DESCRIPTION
PR #5188 (#5187 home-pollution fix) replaced process.cwd() with projectRoot() across the /gsd handler surface. projectRoot() walks UP from a worktree path (.gsd/worktrees/<MID>/) to the parent project root, which breaks the worktree-isolation invariant agents rely on during /gsd auto: writes meant for the worktree's .gsd/ landed in the project's .gsd/ instead. The home-dir guard the original PR added is correct, but the wrong helper was used to apply it.

Direct code path (non-Claude models):
- commands-handlers.ts (handleCapture, handleSteer, handleKnowledge, handleRunHook), commands-codebase.ts, commands-scan.ts, commands-ship.ts, commands-logs.ts, commands-workflow-templates.ts (handleStart x4), rethink.ts: switch from projectRoot() to currentDirectoryRoot(). currentDirectoryRoot() keeps the active cwd (worktree or project) and still throws GSDNoProjectError when cwd is $HOME, so the #5187 home-pollution guard is preserved.
- handleDoctor / handleSkillHealth keep projectRoot() — they read project-wide state and have no isolation invariant to preserve.

MCP path (Claude Code CLI via packages/mcp-server):
- parseWorkflowArgs: add an isHomeDirectory() refusal so the MCP server's process.cwd() fallback can never resolve to ~/. Pollution could still slip past validateProjectDir when GSD_WORKFLOW_PROJECT_ROOT was unset.
- parseWorkflowArgs: when the agent omits milestoneId, fall back to resolveSoleActiveWorktree() — if exactly one auto-worktree exists, route writes there. Multiple worktrees → ambiguous, stay at project root. Avoids the "writes go to project .gsd while auto-mode runs in the worktree" mismatch that produced guaranteed per-unit retries.

Tests:
- src/resources/extensions/gsd/tests/handler-worktree-write-isolation.test.ts locks the contract: currentDirectoryRoot() preserves worktree path, projectRoot() walks up (legacy semantics), $HOME still throws.
- packages/mcp-server/src/parse-workflow-args.test.ts covers the new $HOME guard and the sole-worktree fallback (single, multiple, explicit-milestoneId).

Both new test files pass; all related regression tests (steer-worktree-path, captures, gsdroot-worktree-detection, gsd-no-project-error-runtime, gsd-root-home-guard, guided-flow-*, auto-loop, auto-start-worktree-db-path, auto-worktree-auto-resolve, auto-project-root-env, resume-dispatch-worktree, commands-*) pass.


## Linked issue

<!--
PRs without a linked issue will be closed.
Open or find an issue first: https://github.com/gsd-build/gsd-2/issues
-->

Closes #<!-- issue number — required -->

- [ ] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** <!-- One sentence — what does this change? -->
**Why:** <!-- One sentence — why is it needed? -->
**How:** <!-- One sentence — what's the approach? -->

## What

<!-- Detailed description of the change. What files, modules, or systems are affected? -->

## Why

<!-- The motivation. What problem does this solve? -->

## How

<!-- The approach. How does the implementation work? Key decisions and alternatives considered? -->

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [ ] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [ ] This PR includes AI-assisted code <!-- If so, note the tool and what was tested -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents using home directory as project directory, enhancing safety

* **Enhancements**
  * Commands now respect current working directory context instead of always using project root, improving worktree isolation
  * Improved automatic single-worktree selection when no specific milestone is provided

* **Tests**
  * Added comprehensive test coverage for worktree isolation and workflow argument validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->