### PR TITLE
fix(gsd): allow compaction in auto-mode and write CONTINUE checkpoint

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -216,21 +216,11 @@ export function registerHooks(
   });
 
   pi.on("session_before_compact", async () => {
-    // Only cancel compaction while auto-mode is actively running.
-    // Paused auto-mode should allow compaction — the user may be doing
-    // interactive work (#3165).
-    if (isAutoActive()) {
-      return { cancel: true };
-    }
     const basePath = process.cwd();
     const { ensureDbOpen } = await import("./dynamic-tools.js");
     await ensureDbOpen();
     const state = await deriveGsdState(basePath);
     if (!state.activeMilestone || !state.activeSlice) return;
-    // Write checkpoint for ALL phases, not just "executing" — discuss, research,
-    // and planning also carry in-memory state (user answers, gate verification)
-    // that would be lost on compaction (#4258).
-    // if (state.phase !== "executing") return;
 
     const sliceDir = resolveSlicePath(basePath, state.activeMilestone.id, state.activeSlice.id);
     if (!sliceDir) return;

--- a/src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts
@@ -1,20 +1,9 @@
-/**
- * Regression test for #3696 — prompt step ordering and runtime fixes
- *
- * 1. complete-milestone.md: gsd_requirement_update (step 9) before
- *    gsd_complete_milestone (step 10)
- * 2. complete-slice.md: uses gsd_requirement_update
- * 3. register-extension.ts: _gsdEpipeGuard logs instead of re-throwing
- * 4. register-hooks.ts: session_before_compact only checks isAutoActive
- */
 
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { extractSourceRegion } from "./test-helpers.ts";
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
@@ -28,10 +17,6 @@ const completeSliceMd = readFileSync(
 );
 const registerExtSrc = readFileSync(
   join(__dirname, '..', 'bootstrap', 'register-extension.ts'),
-  'utf-8',
-);
-const registerHooksSrc = readFileSync(
-  join(__dirname, '..', 'bootstrap', 'register-hooks.ts'),
   'utf-8',
 );
 
@@ -68,45 +53,3 @@ describe('register-extension _gsdEpipeGuard (#3696)', () => {
   });
 });
 
-describe('register-hooks session_before_compact (#3696)', () => {
-  test('session_before_compact only checks isAutoActive', () => {
-    // Anchor on the full registration token rather than the bare event name —
-    // prevents matching unrelated substring occurrences.
-    const compactIdx = registerHooksSrc.indexOf('pi.on("session_before_compact"');
-    assert.ok(compactIdx > -1, 'session_before_compact hook should exist');
-    // The first check in the handler should be isAutoActive(), not isAutoPaused().
-    // Bound the region to this single handler — register-hooks.ts contains
-    // multiple pi.on("session_before_compact") handlers and a later handler
-    // legitimately references isAutoPaused.
-    const afterCompact = extractSourceRegion(
-      registerHooksSrc,
-      'pi.on("session_before_compact"',
-      'pi.on("',
-      // NB: endAnchor search starts AFTER the startAnchor, so the next
-      // pi.on("... matches the subsequent handler rather than this one.
-    );
-    assert.match(afterCompact, /isAutoActive\(\)/,
-      'session_before_compact should check isAutoActive()');
-    // Should NOT block compaction when paused
-    assert.ok(
-      !afterCompact.includes('isAutoPaused()'),
-      'session_before_compact should not check isAutoPaused',
-    );
-  });
-
-  test('session_before_compact does not gate checkpointing to executing phase (#4258)', () => {
-    const compactIdx = registerHooksSrc.indexOf('session_before_compact');
-    assert.ok(compactIdx > -1, 'session_before_compact hook should exist');
-
-    const preCheckpointSection = registerHooksSrc.slice(
-      compactIdx,
-      registerHooksSrc.indexOf('const sliceDir', compactIdx),
-    );
-
-    const normalized = preCheckpointSection.replace(/\/\/.*$/gm, '');
-    assert.ok(
-      !/if\s*\(\s*state\.phase\s*!==\s*['"]executing['"]\s*\)\s*\{?\s*return\b/.test(normalized),
-      'session_before_compact should not early-return on non-executing phases',
-    );
-  });
-});

--- a/src/resources/extensions/gsd/tests/register-hooks-compaction-checkpoint.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-compaction-checkpoint.test.ts
@@ -8,6 +8,7 @@ import { registerHooks } from "../bootstrap/register-hooks.ts";
 import { parseContinue } from "../files.ts";
 import { closeDatabase } from "../gsd-db.ts";
 import { deriveState, invalidateStateCache } from "../state.ts";
+import { autoSession } from "../auto-runtime-state.ts";
 
 function createPlanningFixtureBase(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-compact-checkpoint-"));
@@ -90,4 +91,61 @@ test("register-hooks writes CONTINUE checkpoint during planning phase without ac
   assert.equal(parsed.frontmatter.status, "compacted");
   assert.match(parsed.completedWork, /planning phase/i, "completed-work should capture non-executing phase context");
   assert.match(parsed.nextAction, /slice S01/i, "next action should route resume to the active slice");
+});
+
+test("register-hooks writes CONTINUE checkpoint AND allows compaction while auto-mode is active", async (t) => {
+  const base = createPlanningFixtureBase();
+  const originalCwd = process.cwd();
+  process.chdir(base);
+  invalidateStateCache();
+  closeDatabase();
+
+  const wasActive = autoSession.active;
+  autoSession.active = true;
+
+  t.after(() => {
+    autoSession.active = wasActive;
+    invalidateStateCache();
+    closeDatabase();
+    process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>();
+  const pi = {
+    on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  } as any;
+
+  registerHooks(pi, []);
+
+  const compactHandlers = handlers.get("session_before_compact");
+  assert.ok(compactHandlers && compactHandlers.length > 0, "session_before_compact handler should be registered");
+
+  const results: Array<unknown> = [];
+  for (const handler of compactHandlers ?? []) {
+    results.push(await handler({}));
+  }
+
+  for (const r of results) {
+    assert.notDeepStrictEqual(
+      r,
+      { cancel: true },
+      "auto-mode must NOT cancel compaction — that path causes silent session death",
+    );
+    if (r && typeof r === "object" && "cancel" in (r as Record<string, unknown>)) {
+      assert.notEqual((r as { cancel?: unknown }).cancel, true, "no handler may return cancel:true under auto-mode");
+    }
+  }
+
+  const continuePath = join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-CONTINUE.md");
+  assert.ok(existsSync(continuePath), "auto-active compaction must still write the CONTINUE checkpoint");
+
+  const parsed = parseContinue(readFileSync(continuePath, "utf-8"));
+  assert.equal(parsed.frontmatter.status, "compacted");
+  assert.equal(parsed.frontmatter.milestone, "M001");
+  assert.equal(parsed.frontmatter.slice, "S01");
 });


### PR DESCRIPTION
## TL;DR

**What:** Remove the auto-mode early-cancel in the `session_before_compact` hook so the existing CONTINUE checkpoint write runs.
**Why:** The cancel branch caused silent session death — it blocked both pi-side compaction (now safe) and the recovery checkpoint that follows in the same handler.
**How:** Drop the `if (isAutoActive()) return { cancel: true }` branch; replace the forbidden source-grep guards that pinned the old code shape with a behavioral regression test.

## What

- `src/resources/extensions/gsd/bootstrap/register-hooks.ts` — remove the auto-mode cancel branch from the first `session_before_compact` handler. The remaining handler body (CONTINUE.md write via `formatContinue`) now runs unconditionally; the second `session_before_compact` handler (context-mode `last-snapshot.md`) is unchanged.
- `src/resources/extensions/gsd/tests/register-hooks-compaction-checkpoint.test.ts` — add behavioral regression test that flips `autoSession.active = true`, registers the real hooks, drives the compact handlers, and asserts (a) no handler returns `{ cancel: true }` and (b) `S01-CONTINUE.md` is written with `status: compacted`.
- `src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts` — delete two obsolete source-grep guards that asserted on the source text of the old cancel branch. CONTRIBUTING.md forbids source-grep tests; the behavioral coverage now lives in the compaction-checkpoint test.

## Why

In auto-mode the agent runs many iterations between user input. When the LLM context approaches the model limit, pi triggers `session_before_compact` to compress prior turns. The handler in this repo returned `{ cancel: true }` whenever `isAutoActive()` — which short-circuited:

1. pi's compaction (safe under the recent pi-side fix, but not allowed to run here),
2. AND the CONTINUE.md checkpoint write that follows in the same handler.

Net effect: the session hits the model's context wall with no recovery artifact, the agent stops cleanly, and no resume path exists. From the user's perspective the auto run dies silently.

The fix is the minimal one: stop cancelling. The CONTINUE.md / last-snapshot.md checkpoint paths already exist, are tested, and are the established GSD recovery convention. They now run for auto-mode too, and `/gsd resume` picks the session back up from the checkpoint.

Closes #5147.

## How

Single behavioral change: remove three lines (the `if (isAutoActive()) { return { cancel: true }; }` block) plus its trailing comment block. Everything downstream in the handler is unchanged.

The replaced tests are the more interesting part of the diff. The originals at `prompt-step-ordering.test.ts:71–112` were source-grep — they read `register-hooks.ts` as a string and regex-matched on `isAutoActive()` and the absence of `state.phase !== "executing"`. CONTRIBUTING.md §"No source-grep tests" forbids this pattern, and §"What contributors must provide" requires that behavior changes replace tests covering the old behavior rather than leaving passing-but-wrong assertions in place.

The replacement test exercises `registerHooks` against a real fixture: planning-phase milestone/slice on disk, `autoSession.active = true`, all registered `session_before_compact` handlers driven, then assertions on the actual return values (`cancel:true` forbidden) and the on-disk artifact (`S01-CONTINUE.md` present, frontmatter `status: compacted`). The test fails on `main` and passes after this commit.

### Verification

- `npm run typecheck:extensions`: green.
- `npm run verify:pr`: 3 pre-existing failures only (`stream-adapter-askuserquestion`, 2× `isBunInstall` in `update-cmd-diagnostics`), reproduced on stashed `HEAD` — unrelated to this change.
- New behavioral test fails before the fix, passes after.
- The sibling `register-hooks-depth-verification.test.ts` suite still passes.

### Considered alternatives

- **A separate `runtime/pre-compact-checkpoint.json` mechanism with a new schema and an iteration-start restore hook.** Rejected because none of the required primitives exist in this repo (no `runtime/` convention, no `completedUnits` field on `AutoSession`, `iteration-start` is a journal event not a pi extension hook). Building it would create two competing checkpoint truths (CONTINUE.md vs. JSON) and reintroduce the gap class the existing CONTINUE.md tests already close.

## AI disclosure

This PR was prepared with AI assistance (Claude Opus 4.7). No AI is credited as commit author or co-author. The author has reviewed and verified each line of the diff and is able to defend the design choices above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Compaction checkpoints are now consistently created during database maintenance operations, ensuring reliable recovery state tracking.

* **Tests**
  * Updated test suite to validate checkpoint creation behavior during auto-mode compaction operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->