### PR TITLE
[codex] Refactor GSD runtime state around authoritative DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,9 @@ This is what makes GSD different. Run it, walk away, come back to built software
 /gsd auto
 ```
 
-Auto mode is a state machine driven by files on disk. It reads `.gsd/STATE.md`, determines the next unit of work, creates a fresh agent session, injects a focused prompt with all relevant context pre-inlined, and lets the LLM execute. When the LLM finishes, auto mode reads disk state again and dispatches the next unit.
+Auto mode is a state machine driven by the GSD database at the project root. It derives the next unit of work from authoritative SQLite state, creates a fresh agent session, injects a focused prompt with all relevant context pre-inlined, and lets the LLM execute. When the LLM finishes, auto mode persists the result to the database, refreshes markdown projections such as `STATE.md`, and dispatches the next unit.
+
+The database is authoritative for milestones, slices, tasks, requirements, decisions, summaries, and completion status. Markdown under `.gsd/` is a rendered projection for review, prompts, and git-friendly history; it is not a runtime fallback unless you explicitly run a recovery/import command. In worktree mode, project-root DB state remains authoritative and worktree markdown projections are not synced back as state.
 
 **What happens under the hood:**
 
@@ -499,6 +501,7 @@ Every dispatch is carefully constructed. The LLM never wastes tool calls on orie
 
 | Artifact           | Purpose                                                         |
 | ------------------ | --------------------------------------------------------------- |
+| `gsd.db`           | Authoritative runtime state for hierarchy and completion        |
 | `PROJECT.md`       | Living doc — what the project is right now                      |
 | `REQUIREMENTS.md`  | Project-level capability contract and out-of-scope list         |
 | `DECISIONS.md`     | Append-only register of architectural decisions                 |
@@ -506,7 +509,7 @@ Every dispatch is carefully constructed. The LLM never wastes tool calls on orie
 | `RUNTIME.md`       | Runtime context — API endpoints, env vars, services (v2.39)     |
 | `runtime/research-decision.json` | Deep-mode marker for project research vs skip       |
 | `research/*.md`    | Optional deep-mode project research: stack, features, architecture, pitfalls |
-| `STATE.md`         | Quick-glance dashboard — always read first                      |
+| `STATE.md`         | Quick-glance dashboard rendered from the database                |
 | `M001-ROADMAP.md`  | Milestone plan with slice checkboxes, risk levels, dependencies |
 | `M001-CONTEXT.md`  | User decisions from the discuss phase                           |
 | `M001-RESEARCH.md` | Codebase and ecosystem research                                 |
@@ -708,7 +711,7 @@ The best practice for working in teams is to ensure unique milestone names acros
 .gsd/completed-units*.json
 # State manifest — workflow state for recovery
 .gsd/state-manifest.json
-# Derived state cache — regenerated from plan/roadmap files on disk
+# Derived state projection — regenerated from the authoritative database
 .gsd/STATE.md
 # Per-developer token/cost accumulator
 .gsd/metrics.json
@@ -720,7 +723,7 @@ The best practice for working in teams is to ensure unique milestone names acros
 .gsd/worktrees/
 # Parallel orchestration IPC and worker status
 .gsd/parallel/
-# SQLite database and WAL sidecars — checkpoint state, forensics data
+# SQLite database and WAL sidecars — authoritative runtime state, local only
 .gsd/gsd.db*
 # Daily-rotated event journal — structured event log for forensics
 .gsd/journal/
@@ -785,7 +788,7 @@ gsd (CLI binary)
 - **`pkg/` shim directory** — `PI_PACKAGE_DIR` points here (not project root) to avoid Pi's theme resolution collision with our `src/` directory. Contains only `piConfig` and theme assets.
 - **Two-file loader pattern** — `loader.ts` sets all env vars with zero SDK imports, then dynamic-imports `cli.ts` which does static SDK imports. This ensures `PI_PACKAGE_DIR` is set before any SDK code evaluates.
 - **Always-overwrite sync** — `npm update -g` takes effect immediately. Bundled extensions and agents are synced to `~/.gsd/agent/` on every launch, not just first run.
-- **State lives on disk** — `.gsd/` is the source of truth. Auto mode reads it, writes it, and advances based on what it finds. No in-memory state survives across sessions.
+- **DB-authoritative state** — the project-root GSD database is the runtime source of truth. `.gsd/` markdown files are rendered projections for review, prompt context, and git history. No in-memory state survives across sessions.
 
 ---
 

--- a/docs/dev/ADR-001-branchless-worktree-architecture.md
+++ b/docs/dev/ADR-001-branchless-worktree-architecture.md
@@ -5,6 +5,8 @@
 **Deciders:** Lex Christopherson
 **Advisors:** Claude Opus 4.6, Gemini 2.5 Pro, GPT-5.4 (Codex)
 
+> **Current state model:** This ADR predates the DB-authoritative runtime model. Its git/worktree decision still applies, but current GSD treats the project-root database as authoritative and uses markdown files as rendered projections. The database is not silently rebuilt from markdown during normal runtime; use explicit recovery commands when importing markdown state is required.
+
 ## Context
 
 GSD uses git for isolation during autonomous coding sessions. The current architecture (shipped in M003, v2.13.0) creates a **worktree per milestone** with **slice branches inside each worktree**. Each slice (`S01`, `S02`, ...) gets its own branch (`gsd/M001/S01`) within the worktree, which merges back to the milestone branch (`milestone/M001`) via `--no-ff` when the slice completes. The milestone branch squash-merges to `main` when the milestone completes.
@@ -111,8 +113,8 @@ main ─────────────────────────
 .gsd/auto.lock           — crash detection sentinel
 .gsd/metrics.json        — token/cost accumulator
 .gsd/completed-units.json — dispatch idempotency tracker
-.gsd/STATE.md            — derived state cache (rebuilt by deriveState())
-.gsd/gsd.db              — SQLite cache (rebuilt from tracked markdown by importers)
+.gsd/STATE.md            — rendered state projection
+.gsd/gsd.db              — authoritative runtime database (local, gitignored)
 .gsd/DISCUSSION-MANIFEST.json — discussion phase tracking
 .gsd/milestones/**/*-CONTINUE.md — interrupted-work markers
 .gsd/milestones/**/continue.md   — legacy continue markers
@@ -209,7 +211,7 @@ Squash merge collapses all commits into one on `main`. Mitigations:
 
 **3. SQLite DB desync after `git reset`**
 
-If tracked markdown rolls back via `git reset --hard`, the gitignored `gsd.db` doesn't. Mitigation: the importer layer (M001/S02) rebuilds the DB from markdown on startup. The DB is a cache, markdown is truth.
+If tracked markdown rolls back via `git reset --hard`, the gitignored `gsd.db` does not. Current GSD treats the database as authoritative during runtime and does not silently import markdown projections. Operators should use explicit recovery/import commands when markdown is the intended source after database loss or corruption.
 
 **4. Disk space with multiple worktrees**
 

--- a/docs/dev/PRD-branchless-worktree-architecture.md
+++ b/docs/dev/PRD-branchless-worktree-architecture.md
@@ -7,6 +7,8 @@
 
 ---
 
+> **Current state model:** This PRD predates the DB-authoritative runtime model. Its worktree architecture remains historical context, but current GSD treats the project-root database as authoritative and renders markdown projections from it. Markdown import is an explicit recovery path, not a normal runtime fallback.
+
 ## Problem Statement
 
 GSD's auto-mode is unreliable. Users experience:
@@ -276,7 +278,7 @@ Validated by three independent models:
 | Attack | Severity | Mitigation |
 |--------|----------|------------|
 | Parallel milestone code conflict at squash-merge | Medium | `git rebase main` before squash. Rare in single-user. |
-| SQLite desync after `git reset --hard` | Low | DB rebuilt from tracked markdown on startup (M001/S02 importers). |
+| SQLite desync after `git reset --hard` | Low | Current runtime treats DB state as authoritative; use explicit recovery/import when markdown should repopulate the DB. |
 | Ghost lock after SIGKILL | Low | Existing heartbeat lock detection handles this. |
 | Squash merge loses bisect granularity | Low | Commit messages tag slices. Branch preservable if needed. |
 | Disk space with multiple worktrees | Low | Single active milestone at a time. Immediate cleanup. |
@@ -370,7 +372,7 @@ Resolution: Worktree is on `milestone/M001` branch, independent of `main`. Manua
 
 ## Dependencies
 
-- **M001 (Memory Database):** The SQLite database (`gsd.db`) must remain gitignored. The M001/S02 importer layer rebuilds it from tracked markdown. This PRD's `.gitignore` update explicitly ignores `gsd.db`.
+- **M001 (Memory Database):** The SQLite database (`gsd.db`) must remain gitignored. Current GSD treats it as authoritative runtime state; importing rendered markdown is an explicit recovery operation rather than a startup fallback. This PRD's `.gitignore` update explicitly ignores `gsd.db`.
 
 - **PR #487:** Must be closed. The `resolveMainWorktreeRoot` approach (sharing `.gsd/` across worktrees) contradicts tracked-artifact architecture.
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -27,9 +27,9 @@ vscode-extension/         VS Code extension — chat participant (@gsd), sidebar
 
 ## Key Design Decisions
 
-### State Lives on Disk
+### DB-Authoritative Project State
 
-`.gsd/` is the sole source of truth. Auto mode reads it, writes it, and advances based on what it finds. No in-memory state survives across sessions. This enables crash recovery, multi-terminal steering, and session resumption.
+GSD stores runtime workflow state in the project-root SQLite database. Auto mode derives phases, completion status, requirements, decisions, summaries, and hierarchy from that database, then renders markdown projections in `.gsd/` for human review, prompt context, and git-friendly history. No in-memory state survives across sessions. This enables crash recovery, multi-terminal steering, and session resumption while avoiding silent markdown re-imports during normal runtime.
 
 ### Two-File Loader Pattern
 
@@ -111,7 +111,7 @@ Performance-critical operations use a Rust N-API engine:
 The auto mode dispatch pipeline:
 
 ```
-1.  Read disk state (STATE.md, roadmap, plans)
+1.  Derive project state from the database
 2.  Determine next unit type and ID
 3.  Classify complexity → select model tier
 4.  Apply budget pressure adjustments
@@ -155,7 +155,7 @@ Phase skipping (from token profile) gates steps 2-3: if a phase is skipped, the 
 | `visualizer-data.ts` | Data loading for visualizer tabs |
 | `visualizer-views.ts` | Tab renderers (progress, deps, metrics, timeline, discussion status) |
 | `metrics.ts` | Token and cost tracking ledger |
-| `state.ts` | State derivation from disk |
+| `state.ts` | DB-authoritative state derivation with explicit legacy markdown fallback for tests/recovery |
 | `session-lock.ts` | OS-level exclusive session locking (proper-lockfile) |
 | `crash-recovery.ts` | Lock file management for crash detection and recovery |
 | `preferences.ts` | Preference loading, merging, validation |

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -4,7 +4,7 @@ Auto mode is GSD's autonomous execution engine. Run `/gsd auto`, walk away, come
 
 ## How It Works
 
-Auto mode is a **state machine driven by files on disk**. It reads `.gsd/STATE.md`, determines the next unit of work, creates a fresh agent session, injects a focused prompt with all relevant context pre-inlined, and lets the LLM execute. When the LLM finishes, auto mode reads disk state again and dispatches the next unit.
+Auto mode is a **state machine driven by the GSD database at the project root**. It derives the next unit of work from the authoritative SQLite state, creates a fresh agent session, injects a focused prompt with all relevant context pre-inlined, and lets the LLM execute. When the LLM finishes, auto mode persists the result to the database, refreshes markdown projections such as `STATE.md`, and dispatches the next unit.
 
 ### The Loop
 
@@ -21,6 +21,12 @@ Plan (with integrated research) → Execute (per task) → Complete → Reassess
 - **Complete** — writes summary, UAT script, marks roadmap, commits
 - **Reassess** — checks if the roadmap still makes sense
 - **Validate Milestone** — reconciliation gate after all slices complete; compares roadmap success criteria against actual results, catches gaps before sealing the milestone
+
+### State Authority
+
+The SQLite database is the runtime source of truth for milestones, slices, tasks, requirements, decisions, summaries, and completion status. Markdown files in `.gsd/` are rendered projections for review, prompts, and git-friendly history; editing a projection does not override the database unless a command imports or saves that change through GSD.
+
+In worktree mode, the project-root database and project-root `.gsd/` state remain authoritative. Worktree markdown projections are useful diagnostics, but they are not synced back as runtime state. If the database is unavailable, runtime state derivation refuses to silently rebuild from markdown. The legacy markdown derivation path is only enabled when `GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK=1`, which exists for tests and explicit recovery scenarios.
 
 ### Deep Planning Mode
 
@@ -267,7 +273,7 @@ Press **Escape**. The conversation is preserved. You can interact with the agent
 /gsd auto
 ```
 
-Auto mode reads disk state and picks up where it left off.
+Auto mode derives the latest database state and picks up where it left off.
 
 ### Stop
 

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -60,6 +60,7 @@
 | `/gsd hooks` | Show configured post-unit and pre-dispatch hooks |
 | `/gsd run-hook` | Manually trigger a specific hook |
 | `/gsd migrate` | Migrate a v1 `.planning` directory to `.gsd` format |
+| `/gsd recover` | Explicitly reconstruct database hierarchy state from rendered markdown after database loss or corruption |
 
 ## Milestone Management
 

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -168,6 +168,7 @@ Recommended verification order:
 | `GSD_PROJECT_ID` | (auto-hash) | Override the automatic project identity hash. Per-project state goes to `$GSD_HOME/projects/<GSD_PROJECT_ID>/` instead of the computed hash. Useful for CI/CD or sharing state across clones of the same repo. (v2.39) |
 | `GSD_STATE_DIR` | `$GSD_HOME` | Per-project state root. Controls where `projects/<repo-hash>/` directories are created. Takes precedence over `GSD_HOME` for project state. |
 | `GSD_CODING_AGENT_DIR` | `$GSD_HOME/agent` | Agent directory containing managed resources, extensions, and auth. Takes precedence over `GSD_HOME` for agent paths. |
+| `GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK` | (unset) | Set to literal `1` only for tests or explicit recovery workflows that must derive state from rendered markdown when the database is unavailable. Normal runtime treats the database as authoritative and refuses silent markdown fallback. |
 | `GSD_ALLOWED_COMMAND_PREFIXES` | (built-in list) | Comma-separated command prefixes allowed for `!command` value resolution. Overrides `allowedCommandPrefixes` in settings.json. See [Custom Models — Command Allowlist](custom-models.md#command-allowlist). |
 | `GSD_FETCH_ALLOWED_URLS` | (none) | Comma-separated hostnames exempted from `fetch_page` URL blocking. Overrides `fetchAllowedUrls` in settings.json. See [URL Blocking](#url-blocking-fetch_page). |
 | `PI_TOKEN_TELEMETRY` | (unset) | Set to literal `1` to emit opt-in per-call token telemetry as JSONL on stderr. Other values are ignored. |

--- a/docs/user-docs/getting-started.md
+++ b/docs/user-docs/getting-started.md
@@ -374,15 +374,16 @@ Milestone  →  a shippable version (4-10 slices)
 
 The iron rule: **a task must fit in one context window.** If it can't, it's two tasks.
 
-All state lives on disk in `.gsd/`:
+GSD keeps authoritative runtime state in the project-root SQLite database and renders markdown projections into `.gsd/` for review, prompts, and git history:
 
 ```
 .gsd/
+  gsd.db              — authoritative runtime database (local, gitignored)
   PROJECT.md          — what the project is right now
   REQUIREMENTS.md     — requirement contract
   DECISIONS.md        — append-only architectural decisions
   KNOWLEDGE.md        — cross-session rules and patterns
-  STATE.md            — quick-glance status
+  STATE.md            — quick-glance status rendered from the database
   milestones/
     M001/
       M001-ROADMAP.md — slice plan with dependencies

--- a/docs/user-docs/migration.md
+++ b/docs/user-docs/migration.md
@@ -18,6 +18,7 @@ The migration tool:
 
 - Parses your old `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, phase directories, plans, summaries, and research
 - Maps phases → slices, plans → tasks, milestones → milestones
+- Writes the imported hierarchy into the GSD database, then renders markdown projections from that database
 - Preserves completion state (`[x]` phases stay done, summaries carry over)
 - Consolidates research files into the new structure
 - Shows a preview before writing anything
@@ -45,4 +46,12 @@ After migrating, verify the output with:
 /gsd doctor
 ```
 
-This checks `.gsd/` integrity and flags any structural issues.
+This checks database and projection integrity and flags any structural issues. Use `/gsd inspect` when you need database diagnostics.
+
+If an existing project has markdown artifacts but a missing or damaged database, start GSD once so the database opens, then run:
+
+```
+/gsd recover
+```
+
+`/gsd recover` reconstructs the milestone, slice, and task hierarchy from the rendered markdown on disk. It is an explicit recovery/import operation; normal runtime does not silently derive state from markdown.

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -306,13 +306,23 @@ If adaptive model routing is producing bad results, clear the routing history:
 rm .gsd/routing-history.json
 ```
 
-### Full state rebuild
+### Refresh rendered state
 
 ```
 /gsd doctor
 ```
 
-Doctor rebuilds `STATE.md` from plan and roadmap files on disk and fixes detected inconsistencies.
+Doctor checks the authoritative database, refreshes `STATE.md` from derived database state, and fixes detected projection or runtime-file inconsistencies.
+
+### Recover database hierarchy from markdown
+
+Use this only when the database is missing, damaged, or known to be stale but the rendered milestone, slice, and task markdown on disk is the best available source:
+
+```
+/gsd recover
+```
+
+`/gsd recover` clears and reconstructs the database hierarchy tables from markdown, then derives state again to verify the result. Normal runtime does not silently import markdown projections, and worktree markdown is not synced back as authoritative state.
 
 ## Getting Help
 
@@ -355,9 +365,9 @@ Doctor rebuilds `STATE.md` from plan and roadmap files on disk and fixes detecte
 
 **Symptoms:** `gsd_decision_save` (or its alias `gsd_save_decision`), `gsd_requirement_update` (or `gsd_update_requirement`), or `gsd_summary_save` (or `gsd_save_summary`) fail with this error.
 
-**Cause:** The SQLite database wasn't initialized. This happens in manual `/gsd` sessions (non-auto mode) on versions before v2.29.
+**Cause:** The SQLite database was not initialized or could not be opened. Runtime state derivation will not silently fall back to markdown projections.
 
-**Fix:** Updated in v2.29+ to auto-initialize the database on first tool call. Upgrade to the latest version.
+**Fix:** Upgrade to the latest version, then run a GSD command from the project root to initialize or open the database. Use `/gsd inspect` for database diagnostics. If the database was lost or corrupted and markdown artifacts are the only usable state, run `/gsd recover` after GSD has opened the database.
 
 ## Verification Issues
 

--- a/docs/user-docs/working-in-teams.md
+++ b/docs/user-docs/working-in-teams.md
@@ -29,6 +29,7 @@ Share planning artifacts (milestones, roadmaps, decisions) while keeping runtime
 .gsd/auto.lock
 .gsd/completed-units.json
 .gsd/STATE.md
+.gsd/gsd.db*
 .gsd/metrics.json
 .gsd/activity/
 .gsd/runtime/
@@ -45,7 +46,7 @@ Share planning artifacts (milestones, roadmaps, decisions) while keeping runtime
 - `.gsd/milestones/` — roadmaps, plans, summaries, research
 
 **What stays local** (gitignored):
-- Lock files, metrics, state cache, runtime records, worktrees, activity logs
+- Database files, lock files, metrics, state projections, runtime records, worktrees, activity logs
 
 ### 3. Commit the Preferences
 

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -8,7 +8,7 @@ Auto mode is GSD's autonomous execution engine. Run `/gsd auto`, walk away, come
 /gsd auto
 ```
 
-GSD reads `.gsd/STATE.md`, determines the next unit of work, creates a fresh AI session with all relevant context, and lets the AI execute. When it finishes, GSD reads disk state again and dispatches the next unit. This continues until the milestone is complete.
+GSD derives the next unit of work from the authoritative SQLite database at the project root, creates a fresh AI session with all relevant context, and lets the AI execute. When it finishes, GSD persists the result to the database, refreshes markdown projections such as `STATE.md`, and dispatches the next unit. This continues until the milestone is complete.
 
 ## The Execution Loop
 
@@ -25,6 +25,12 @@ Plan → Execute (per task) → Complete → Reassess Roadmap → Next Slice
 - **Complete** — writes summary, UAT script, marks roadmap, commits
 - **Reassess** — checks if the roadmap still makes sense after what was learned
 - **Validate** — after all slices, verifies success criteria were actually met
+
+## State Authority
+
+The GSD database is the runtime source of truth for milestones, slices, tasks, requirements, decisions, summaries, and completion status. Markdown files in `.gsd/` are rendered projections for review, prompts, and git-friendly history; editing a projection does not override the database unless a GSD command imports or saves the change.
+
+In worktree mode, the project-root database and project-root `.gsd/` state remain authoritative. Worktree markdown projections are diagnostics, not state to sync back. Runtime state derivation does not silently rebuild from markdown when the database is unavailable. The legacy markdown fallback is only enabled with `GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK=1` for tests and explicit recovery work.
 
 ## Deep Planning Mode
 
@@ -62,7 +68,7 @@ Press **Escape**. The conversation is preserved. You can interact with the agent
 /gsd auto
 ```
 
-Auto mode reads disk state and picks up where it left off.
+Auto mode derives the latest database state and picks up where it left off.
 
 ### Stop
 

--- a/gitbook/core-concepts/project-structure.md
+++ b/gitbook/core-concepts/project-structure.md
@@ -37,12 +37,15 @@ Examples:
 - "Implement JWT middleware"
 - "Build the login form component"
 
-## The `.gsd/` Directory
+## Project State
 
-All project state lives on disk in a `.gsd/` directory at your project root:
+GSD keeps authoritative runtime state in the project-root SQLite database and renders markdown projections into `.gsd/` for review, prompts, and git history. The markdown files are useful to read and commit, but completion status and queue position come from the database unless you run an explicit import or recovery command.
+
+The `.gsd/` directory looks like this:
 
 ```
 .gsd/
+  gsd.db              — authoritative runtime database (local, gitignored)
   PROJECT.md          — living description of what the project is
   REQUIREMENTS.md     — requirement contract (active/validated/deferred)
   DECISIONS.md        — append-only architectural decisions log
@@ -73,7 +76,8 @@ All project state lives on disk in a `.gsd/` directory at your project root:
 | `DECISIONS.md` | Append-only log of architectural decisions with rationale |
 | `KNOWLEDGE.md` | Rules, patterns, and lessons learned across sessions — GSD reads this at the start of every task |
 | `RUNTIME.md` | Runtime context like API URLs, ports, and environment variables |
-| `STATE.md` | Current status at a glance — auto-generated, don't edit manually |
+| `gsd.db` | Authoritative runtime state for workflow hierarchy, completion, requirements, decisions, and summaries |
+| `STATE.md` | Current status at a glance — rendered from the database, don't edit manually |
 
 ## How Work Flows
 

--- a/gitbook/features/teams.md
+++ b/gitbook/features/teams.md
@@ -35,6 +35,7 @@ Share planning artifacts while keeping runtime files local:
 .gsd/auto.lock
 .gsd/completed-units.json
 .gsd/STATE.md
+.gsd/gsd.db*
 .gsd/metrics.json
 .gsd/activity/
 .gsd/runtime/
@@ -51,7 +52,7 @@ Share planning artifacts while keeping runtime files local:
 - `.gsd/milestones/` — roadmaps, plans, summaries, research
 
 **What stays local** (gitignored):
-- Lock files, metrics, state, activity logs, worktrees
+- Database files, lock files, metrics, state projections, activity logs, worktrees
 
 ## Commit the Config
 

--- a/gitbook/getting-started/first-project.md
+++ b/gitbook/getting-started/first-project.md
@@ -98,15 +98,16 @@ Shows each session's date, message count, and preview so you can choose which to
 
 ## What's on Disk
 
-All state lives in `.gsd/` inside your project:
+GSD keeps authoritative runtime state in the project-root SQLite database and renders markdown projections into `.gsd/` inside your project:
 
 ```
 .gsd/
+  gsd.db              — authoritative runtime database (local, gitignored)
   PROJECT.md          — what the project is
   REQUIREMENTS.md     — requirement contract
   DECISIONS.md        — architectural decisions
   KNOWLEDGE.md        — cross-session rules and patterns
-  STATE.md            — quick-glance status
+  STATE.md            — quick-glance status rendered from the database
   milestones/
     M001/
       M001-ROADMAP.md — slice plan with dependencies

--- a/gitbook/reference/commands.md
+++ b/gitbook/reference/commands.md
@@ -53,6 +53,7 @@
 | `/gsd skill-health` | Skill lifecycle dashboard |
 | `/gsd hooks` | Show configured hooks |
 | `/gsd migrate` | Migrate v1 `.planning` to `.gsd` format |
+| `/gsd recover` | Explicitly reconstruct database hierarchy state from rendered markdown after database loss or corruption |
 
 ## Milestone Management
 

--- a/gitbook/reference/environment-variables.md
+++ b/gitbook/reference/environment-variables.md
@@ -8,6 +8,7 @@
 | `GSD_PROJECT_ID` | (auto-hash) | Override automatic project identity hash. Useful for CI/CD or sharing state across repo clones. |
 | `GSD_STATE_DIR` | `$GSD_HOME` | Per-project state root. Controls where `projects/<repo-hash>/` directories are created. |
 | `GSD_CODING_AGENT_DIR` | `$GSD_HOME/agent` | Agent directory for extensions, auth, and managed resources. |
+| `GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK` | (unset) | Set to literal `1` only for tests or explicit recovery workflows that must derive state from rendered markdown when the database is unavailable. Normal runtime treats the database as authoritative and refuses silent markdown fallback. |
 | `GSD_FETCH_ALLOWED_URLS` | (none) | Comma-separated hostnames exempt from internal URL blocking. |
 | `GSD_ALLOWED_COMMAND_PREFIXES` | (built-in) | Comma-separated command prefixes allowed for value resolution. |
 | `GSD_WEB_PROJECT_CWD` | — | Default project path for `gsd --web` when `?project=` is not specified. |

--- a/gitbook/reference/migration.md
+++ b/gitbook/reference/migration.md
@@ -18,6 +18,7 @@ The migration tool:
 
 - Parses your old `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, phase directories, plans, summaries, and research
 - Maps phases → slices, plans → tasks, milestones → milestones
+- Writes the imported hierarchy into the GSD database, then renders markdown projections from that database
 - Preserves completion state (`[x]` phases stay done, summaries carry over)
 - Consolidates research files into the new structure
 - Shows a preview before writing anything
@@ -46,3 +47,11 @@ After migrating, verify the output:
 ```
 
 This checks `.gsd/` integrity and flags any structural issues.
+
+Use `/gsd inspect` for database diagnostics. If a project has markdown artifacts but a missing or damaged database, start GSD once so the database opens, then run:
+
+```
+/gsd recover
+```
+
+`/gsd recover` reconstructs the milestone, slice, and task hierarchy from rendered markdown. It is an explicit recovery/import operation; normal runtime does not silently derive state from markdown.

--- a/gitbook/reference/troubleshooting.md
+++ b/gitbook/reference/troubleshooting.md
@@ -141,13 +141,23 @@ Then `/gsd auto` to restart from current state.
 rm .gsd/routing-history.json
 ```
 
-### Full state rebuild
+### Refresh rendered state
 
 ```
 /gsd doctor
 ```
 
-Rebuilds `STATE.md` from plan and roadmap files and fixes inconsistencies.
+Checks the authoritative database, refreshes `STATE.md` from derived database state, and fixes projection or runtime-file inconsistencies.
+
+### Recover database hierarchy from markdown
+
+Use this only when the database is missing, damaged, or known to be stale but the rendered milestone, slice, and task markdown on disk is the best available source:
+
+```
+/gsd recover
+```
+
+`/gsd recover` clears and reconstructs the database hierarchy tables from markdown, then derives state again to verify the result. Normal runtime does not silently import markdown projections, and worktree markdown is not synced back as authoritative state.
 
 ## Getting Help
 

--- a/scripts/dist-test-resolve.mjs
+++ b/scripts/dist-test-resolve.mjs
@@ -12,6 +12,10 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
+// Compiled legacy state tests exercise markdown derivation through deriveState().
+// Production/runtime keeps this fallback disabled unless explicitly requested.
+process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK ??= '1';
+
 // dist-test root — everything compiled lands here
 const DIST_TEST = new URL('../dist-test/', import.meta.url).href;
 

--- a/src/resources/extensions/browser-tools/tools/intent.ts
+++ b/src/resources/extensions/browser-tools/tools/intent.ts
@@ -1,6 +1,5 @@
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
-import { Type } from "@sinclair/typebox";
-import { StringEnum } from "@gsd/pi-ai";
+import { type TUnsafe, Type } from "@sinclair/typebox";
 import { diffCompactStates } from "../core.js";
 import type { ToolDeps, CompactPageState } from "../state.js";
 import {
@@ -24,6 +23,18 @@ const INTENTS = [
 ] as const;
 
 type Intent = (typeof INTENTS)[number];
+
+function StringEnum<T extends readonly string[]>(
+	values: T,
+	options?: { description?: string; default?: T[number] },
+): TUnsafe<T[number]> {
+	return Type.Unsafe<T[number]>({
+		type: "string",
+		enum: values as any,
+		...(options?.description && { description: options.description }),
+		...(options?.default && { default: options.default }),
+	});
+}
 
 // ---------------------------------------------------------------------------
 // Scoring evaluate script — runs entirely in-browser via page.evaluate()

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -854,13 +854,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
     // while a slice is still `is_sketch=1`, fall through to a standard
     // plan-slice so the loop doesn't dead-end.
     //
-    // Note on the flag-OFF downgrade: plan-slice does not explicitly clear
-    // `is_sketch`. After it writes PLAN.md, the auto-heal in state.ts's
-    // `deriveStateFromDb` (via `autoHealSketchFlags`) flips the flag on the
-    // next iteration. That implicit coupling is the sole mechanism that
-    // reconciles `is_sketch=1` on the plan-slice path — do not remove the
-    // auto-heal without either adding an explicit `setSliceSketchFlag(..., false)`
-    // call here or doing so inside the plan-slice tool handler.
+    // Note on the flag-OFF downgrade: DB slice metadata is authoritative.
+    // PLAN.md is only a projection, so plan-slice/refine-slice handlers must
+    // explicitly clear `is_sketch` when a sketch becomes a full plan.
     name: "refining → refine-slice",
     match: async ({ state, mid, midTitle, basePath, prefs, sessionContextWindow, modelRegistry, sessionProvider }) => {
       if (state.phase !== "refining") return null;

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -14,7 +14,7 @@ import type { GSDPreferences } from "./preferences.js";
 import type { UatType } from "./files.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
-import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, updateMilestoneStatus } from "./gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 
@@ -35,7 +35,6 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "
 import { logWarning, logError } from "./workflow-logger.js";
 import { join } from "node:path";
 import { hasImplementationArtifacts } from "./auto-recovery.js";
-import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
 import {
   buildDiscussMilestonePrompt,
   buildDiscussProjectPrompt,
@@ -1235,15 +1234,6 @@ export const DISPATCH_RULES: DispatchRule[] = [
         }
       }
 
-      const existingSummary = resolveMilestoneFile(basePath, mid, "SUMMARY");
-      let summaryOutcome: "success" | "failure" | "unknown" = "unknown";
-      if (existingSummary) {
-        const summaryContent = await loadFile(existingSummary);
-        if (summaryContent) {
-          summaryOutcome = classifyMilestoneSummaryContent(summaryContent);
-        }
-      }
-
       // Safety guard (#2675): block completion when VALIDATION verdict is
       // needs-remediation. The state machine treats needs-remediation as
       // terminal (to prevent validate-milestone loops per #832), but
@@ -1324,48 +1314,6 @@ export const DISPATCH_RULES: DispatchRule[] = [
         }
       } catch (err) { /* fall through — don't block on DB errors */
         logWarning("dispatch", `verification class check failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
-
-      // Disk/DB mismatch handling (#4658): SUMMARY presence alone is not enough.
-      // Apply post-gate policy:
-      // - success summary: reconcile DB and skip re-dispatch
-      // - failure summary: pause/fail-closed
-      // - unknown summary: pause/fail-closed
-      if (existingSummary) {
-        const milestone = isDbAvailable() ? getMilestone(mid) : null;
-        const status = milestone?.status ?? (isDbAvailable() ? "missing" : "unavailable");
-
-        if (summaryOutcome === "success") {
-          if (!isDbAvailable()) {
-            logWarning("dispatch", `Milestone ${mid} SUMMARY indicates completion while DB is unavailable — skipping duplicate complete-milestone dispatch`);
-            return { action: "skip" };
-          }
-          try {
-            updateMilestoneStatus(mid, "complete", new Date().toISOString());
-            logWarning("dispatch", `Milestone ${mid} SUMMARY indicates completion while DB status was "${status}" — reconciled DB to complete (#4658)`);
-            return { action: "skip" };
-          } catch (err) {
-            return {
-              action: "stop",
-              level: "warning",
-              reason: `Milestone ${mid} SUMMARY indicates completion but DB reconciliation failed (${err instanceof Error ? err.message : String(err)}). Auto-mode paused for manual review.`,
-            };
-          }
-        }
-
-        if (summaryOutcome === "failure") {
-          return {
-            action: "stop",
-            level: "warning",
-            reason: `Milestone ${mid} has a failure-path SUMMARY while DB status is "${status}". Auto-mode will not promote completion from failure artifacts. Re-run complete-milestone only after blockers are resolved and verification passes.`,
-          };
-        }
-
-        return {
-          action: "stop",
-          level: "warning",
-          reason: `Milestone ${mid} has an ambiguous SUMMARY while DB status is "${status}". Auto-mode paused instead of promoting completion from file presence alone.`,
-        };
       }
 
       return {

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1,6 +1,6 @@
 /**
  * Post-unit processing for auto-loop — auto-commit, doctor run,
- * state rebuild, worktree sync, DB dual-write, hooks, triage, and
+ * state rebuild, projection checks, DB tool closeout, hooks, triage, and
  * quick-task dispatch.
  *
  * Split into two functions called sequentially by auto-loop with
@@ -42,7 +42,7 @@ import {
 } from "./auto-recovery.js";
 import { regenerateIfMissing } from "./workflow-projections.js";
 import { syncStateToProjectRoot } from "./auto-worktree.js";
-import { isDbAvailable, getTask, getSlice, getMilestone, updateTaskStatus, updateSliceStatus, _getAdapter } from "./gsd-db.js";
+import { isDbAvailable, getTask, getSlice, getMilestone, updateTaskStatus, _getAdapter } from "./gsd-db.js";
 import { renderPlanCheckboxes } from "./markdown-renderer.js";
 import { consumeSignal } from "./session-status-io.js";
 import {
@@ -160,9 +160,8 @@ export interface RogueFileWrite {
  * the completion tool. A "rogue" file is one that exists on disk but has
  * no corresponding DB row with status "complete".
  *
- * This is a safety-net diagnostic (D003). The existing migrateFromMarkdown()
- * in postUnitPostVerification() eventually ingests rogue files, but explicit
- * detection provides immediate diagnostics so operators know the prompt failed.
+ * This is a safety-net diagnostic (D003). Runtime detection never imports
+ * markdown into the DB; explicit migration/import/recovery commands own that.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function hasNonEmptyFields(row: Record<string, any> | null, fields: string[]): boolean {
@@ -201,14 +200,7 @@ export function detectRogueFileWrites(
 
     const dbRow = getSlice(mid, sid);
     if (!dbRow || dbRow.status !== "complete") {
-      // Auto-remediate: SUMMARY exists on disk but DB is stale — sync DB to
-      // match filesystem instead of reporting as rogue (#3633).
-      try {
-        updateSliceStatus(mid, sid, "complete", new Date().toISOString());
-      } catch {
-        // If DB update fails, fall back to rogue detection so the issue is visible
-        rogues.push({ path: summaryPath, unitType, unitId });
-      }
+      rogues.push({ path: summaryPath, unitType, unitId });
     }
   } else if (unitType === "plan-milestone") {
     if (!mid) return [];
@@ -738,7 +730,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
               "error",
             );
             // Stop auto AND signal the outer postUnit flow to exit early.
-            // Without the flag, subsequent hooks (triage, rogue detection,
+            // Without the flag, subsequent hooks (triage,
             // DB writes) would keep running against a conflicted main
             // checkout after the loop was already told to stop.
             const { stopAuto } = await import("./auto.js");
@@ -758,7 +750,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         }
       });
       // Exit early after stopAuto so the rest of post-unit processing
-      // (triage, rogue detection, hook dispatch, DB writes) doesn't run
+      // (triage, hook dispatch, DB writes) doesn't run
       // against a conflicted main checkout. Return "dispatched" to match
       // the convention used by other stop/pauseAuto paths in this function
       // (see signal handling earlier: stop/pause also return "dispatched").
@@ -811,17 +803,6 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       } catch (err) {
         logError("engine", "triage resolution failed", { error: (err as Error).message });
       }
-    }
-
-    // Rogue file detection — safety net for LLM bypassing completion tools (D003)
-    try {
-      const rogueFiles = detectRogueFileWrites(s.currentUnit.type, s.currentUnit.id, s.basePath);
-      for (const rogue of rogueFiles) {
-        logWarning("engine", "rogue file write detected", { path: rogue.path, unitId: rogue.unitId });
-        ctx.ui.notify(`Rogue file write detected: ${rogue.path}`, "warning");
-      }
-    } catch (e) {
-      debugLog("postUnit", { phase: "rogue-detection", error: String(e) });
     }
 
     // ── Safety harness: post-unit validation ──

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -855,18 +855,11 @@ export async function bootstrapAutoSession(
     const gsdDbPath = resolveProjectRootDbPath(s.basePath);
     const gsdDirPath = join(s.basePath, ".gsd");
     if (existsSync(gsdDirPath) && !existsSync(gsdDbPath)) {
-      const hasDecisions = existsSync(join(gsdDirPath, "DECISIONS.md"));
-      const hasRequirements = existsSync(join(gsdDirPath, "REQUIREMENTS.md"));
-      const hasMilestones = existsSync(join(gsdDirPath, "milestones"));
       try {
         const { openDatabase: openDb } = await import("./gsd-db.js");
         openDb(gsdDbPath);
-        if (hasDecisions || hasRequirements || hasMilestones) {
-          const { migrateFromMarkdown } = await import("./md-importer.js");
-          migrateFromMarkdown(s.basePath);
-        }
       } catch (err) {
-        logError("engine", `auto-migration failed: ${(err as Error).message}`);
+        logError("engine", `failed to initialize project database: ${(err as Error).message}`);
       }
     }
     if (existsSync(gsdDbPath) && !isDbAvailable()) {

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -459,6 +459,10 @@ export function syncStateToProjectRoot(
   // project root and never appear in the dashboard or skill-health reports.
   safeCopy(join(wtGsd, "metrics.json"), join(prGsd, "metrics.json"), { force: true });
 
+  // completed-units.json — runtime completion diagnostics used to avoid
+  // re-dispatching work already completed in an isolated worktree.
+  safeCopy(join(wtGsd, "completed-units.json"), join(prGsd, "completed-units.json"), { force: true });
+
   // Runtime records — unit dispatch diagnostics used by selfHealRuntimeRecords().
   // Without this, a crash during a unit leaves the runtime record only in the
   // worktree. If the next session resolves basePath before worktree re-entry,
@@ -1586,7 +1590,7 @@ export function mergeMilestoneToMain(
       const contract = resolveGsdPathContract(worktreeCwd, originalBasePath_);
       const worktreeDbPath = join(contract.worktreeGsd ?? join(worktreeCwd, ".gsd"), "gsd.db");
       const mainDbPath = contract.projectDb;
-      if (!isSamePath(worktreeDbPath, mainDbPath)) {
+      if (existsSync(worktreeDbPath) && !isSamePath(worktreeDbPath, mainDbPath)) {
         reconcileWorktreeDb(mainDbPath, worktreeDbPath);
       }
     } catch (err) {

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -90,9 +90,8 @@ const LEGACY_DEEP_SETUP_RUNTIME_UNIT_FILES = new Set([
 // ─── Shared Constants & Helpers ─────────────────────────────────────────────
 
 /**
- * Root-level .gsd/ state files synced between worktree and project root.
- * Single source of truth — used by syncGsdStateToWorktree, syncWorktreeStateBack,
- * and the dispatch-level sync functions.
+ * Root-level .gsd/ projections copied from project root into worktrees for
+ * compatibility. Project root remains the canonical state/projection root.
  */
 const ROOT_STATE_FILES = [
   "DECISIONS.md",
@@ -108,6 +107,11 @@ const ROOT_STATE_FILES = [
   // Forward-sync (main → worktree) is handled explicitly in syncGsdStateToWorktree().
   // Back-sync (worktree → main) must NEVER overwrite the project root's copy
   // because the project root is authoritative for preferences (#2684).
+] as const;
+
+const ROOT_DIAGNOSTIC_FILES = [
+  "completed-units.json",
+  "metrics.json",
 ] as const;
 
 /**
@@ -194,7 +198,7 @@ const VERDICT_RE = /verdict:\s*[\w-]+/i;
  * destination when the source copy contains a `verdict:` field.
  *
  * This is the targeted fix for the UAT stuck-loop (#2821): the main
- * safeCopyRecursive uses force:false to protect worktree-authoritative
+ * safeCopyRecursive uses force:false to protect worktree-local projection
  * files (#1886), but ASSESSMENT files written by run-uat must be
  * forward-synced when the project root has a verdict. Without this,
  * the worktree retains a stale FAIL or missing ASSESSMENT and
@@ -272,9 +276,9 @@ function clearProjectRootStateFiles(basePath: string, milestoneId: string): void
     }
   }
 
-  // Clean up entire synced milestone directory and runtime/units.
-  // syncStateToProjectRoot() copies these into the project root during
-  // execution.  If they remain as untracked files when we attempt
+  // Clean up legacy synced milestone directories and runtime/units.
+  // Older versions copied these into the project root during execution.
+  // If they remain as untracked files when we attempt
   // `git merge --squash`, git rejects the merge with "local changes would
   // be overwritten", causing silent data loss (#1738).
   const syncedDirs = [
@@ -360,7 +364,7 @@ export function syncProjectRootToWorktree(
 
   // Copy milestone directory from project root to worktree — additive only.
   // force:false prevents cpSync from overwriting existing worktree files.
-  // Without this, worktree-authoritative files (e.g. VALIDATION.md written
+  // Without this, worktree-local files (e.g. VALIDATION.md written
   // by validate-milestone) get clobbered by stale project root copies,
   // causing an infinite re-validation loop (#1886).
   safeCopyRecursive(
@@ -370,7 +374,7 @@ export function syncProjectRootToWorktree(
   );
 
   // Force-sync ASSESSMENT files that have a verdict from project root (#2821).
-  // The additive-only copy above preserves worktree-authoritative files, but
+  // The additive-only copy above preserves worktree-local files, but
   // ASSESSMENT files are special: after run-uat writes a verdict and post-unit
   // syncs it to the project root, the worktree may retain a stale copy (e.g.
   // verdict:fail while the project root has verdict:pass from a retry). On
@@ -427,9 +431,10 @@ export function syncProjectRootToWorktree(
 }
 
 /**
- * Sync dispatch-critical .gsd/ state files from worktree to project root.
+ * Sync worktree diagnostics from worktree to project root.
  * Only runs when inside an auto-worktree (worktreePath differs from projectRoot).
- * Copies: STATE.md + active milestone directory (roadmap, slice plans, task summaries).
+ * DB/project-root state remains authoritative; markdown projections are not
+ * copied from the worktree back to the project root.
  * Non-fatal — sync failure should never block dispatch.
  */
 export function syncStateToProjectRoot(
@@ -449,23 +454,12 @@ export function syncStateToProjectRoot(
   // Compare realpaths and skip when they resolve to the same physical path (#2184).
   if (isSamePath(wtGsd, prGsd)) return;
 
-  // 1. STATE.md — the quick-glance status used by initial deriveState()
-  safeCopy(join(wtGsd, "STATE.md"), join(prGsd, "STATE.md"), { force: true });
-
-  // 2. Milestone directory — ROADMAP, slice PLANs, task summaries
-  // Copy the entire milestone .gsd subtree so deriveState reads current checkboxes
-  safeCopyRecursive(
-    join(wtGsd, "milestones", milestoneId),
-    join(prGsd, "milestones", milestoneId),
-    { force: true },
-  );
-
-  // 3. metrics.json — session cost/token tracking (#2313).
+  // metrics.json — session cost/token tracking (#2313).
   // Without this, metrics accumulated in the worktree are invisible from the
   // project root and never appear in the dashboard or skill-health reports.
   safeCopy(join(wtGsd, "metrics.json"), join(prGsd, "metrics.json"), { force: true });
 
-  // 4. Runtime records — unit dispatch state used by selfHealRuntimeRecords().
+  // Runtime records — unit dispatch diagnostics used by selfHealRuntimeRecords().
   // Without this, a crash during a unit leaves the runtime record only in the
   // worktree. If the next session resolves basePath before worktree re-entry,
   // selfHeal can't find or clear the stale record (#769).
@@ -638,8 +632,9 @@ export function cleanStaleRuntimeUnits(
  * missing milestones, CONTEXT, ROADMAP, DECISIONS, REQUIREMENTS, and
  * PROJECT files from the main repo's .gsd/ into the worktree's .gsd/.
  *
- * Only adds missing content — never overwrites existing files in the worktree
- * (the worktree's execution state is authoritative for in-progress work).
+ * Only adds missing content — never overwrites existing files in the worktree.
+ * Worktree files are compatibility projections; DB/project root remains
+ * authoritative for runtime state.
  */
 export function syncGsdStateToWorktree(
   mainBasePath: string,
@@ -791,24 +786,17 @@ export function syncGsdStateToWorktree(
 }
 
 /**
- * Sync milestone artifacts from worktree back to the main external state directory.
- * Called before milestone merge to ensure completion artifacts (SUMMARY, VALIDATION,
- * updated ROADMAP) are visible from the project root (#1412).
+ * Sync compatibility artifacts from worktree back to the main external state
+ * directory. Canonical workflow state lives in the project DB; worktree .gsd
+ * content is legacy projection/diagnostic data only.
  *
  * Syncs:
- *   1. Root-level .gsd/ files (REQUIREMENTS, PROJECT, DECISIONS, KNOWLEDGE,
- *      OVERRIDES) — the worktree's versions overwrite main's because the
- *      worktree is the authoritative execution context.
- *   2. ALL milestone directories found in the worktree — not just the
- *      current milestoneId. The complete-milestone unit may create artifacts
- *      for the *next* milestone (CONTEXT, ROADMAP, new requirements) which
- *      must survive worktree teardown.
+ *   1. Legacy worktree DBs are reconciled into the canonical project DB.
+ *   2. Runtime diagnostic files may be copied for operator visibility.
  *
- * History: Originally only synced milestones/<milestoneId>/ and assumed
- * root-level files would be carried by the squash merge. In practice,
- * .gsd/ files are often untracked (gitignored or never committed), so the
- * squash merge carries nothing. This caused next-milestone artifacts and
- * updated REQUIREMENTS/PROJECT to be silently lost on teardown.
+ * Markdown milestone directories are projections and are not copied from
+ * worktrees into the project root. Current workflow state must arrive through
+ * the shared project DB or the pre-upgrade DB reconciliation path above.
  */
 export function syncWorktreeStateBack(
   mainBasePath: string,
@@ -842,13 +830,10 @@ export function syncWorktreeStateBack(
     }
   }
 
-  // ── 1. Sync root-level .gsd/ files back ──────────────────────────────
-  // The worktree is authoritative — complete-milestone updates REQUIREMENTS,
-  // PROJECT, etc. These must overwrite main's copies so they survive teardown.
-  // Also includes QUEUE.md, completed-units.json, and metrics.json which are
-  // written during milestone closeout and lost on teardown without explicit sync
-  // (#1787, #2313).
-  for (const f of ROOT_STATE_FILES) {
+  // ── 1. Sync root-level diagnostic files back ─────────────────────────
+  // Markdown/JSON state projections remain project-root/DB authoritative.
+  // These diagnostic files are copied for observability only.
+  for (const f of ROOT_DIAGNOSTIC_FILES) {
     const src = join(wtGsd, f);
     const dst = join(mainGsd, f);
     if (existsSync(src)) {
@@ -862,121 +847,7 @@ export function syncWorktreeStateBack(
     }
   }
 
-  // ── 2. Sync ALL milestone directories ────────────────────────────────
-  // The complete-milestone unit may create next-milestone artifacts (e.g.
-  // M007 setup while closing M006). We must sync every milestone directory
-  // in the worktree, not just the current one.
-  const wtMilestonesDir = join(wtGsd, "milestones");
-  if (!existsSync(wtMilestonesDir)) return { synced };
-
-  try {
-    const wtMilestones = readdirSync(wtMilestonesDir, { withFileTypes: true })
-      .filter((d) => d.isDirectory())
-      .map((d) => d.name);
-
-    for (const mid of wtMilestones) {
-      // Skip the current milestone being merged — its files are already in the
-      // milestone branch and would conflict with the squash merge (#3641).
-      if (mid === milestoneId) continue;
-      syncMilestoneDir(wtGsd, mainGsd, mid, synced);
-    }
-  } catch (err) {
-    /* non-fatal */
-    logWarning("worktree", `milestone sync-back failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
-
   return { synced };
-}
-
-function syncCurrentMilestoneStateAfterMerge(
-  mainBasePath: string,
-  worktreePath: string,
-  milestoneId: string,
-): { synced: string[] } {
-  const contract = resolveGsdPathContract(worktreePath, mainBasePath);
-  const mainGsd = contract.projectGsd;
-  const wtGsd = contract.worktreeGsd ?? join(worktreePath, ".gsd");
-  const synced: string[] = [];
-
-  if (isSamePath(mainGsd, wtGsd)) return { synced };
-  if (!existsSync(wtGsd) || !existsSync(mainGsd)) return { synced };
-
-  syncMilestoneDir(wtGsd, mainGsd, milestoneId, synced);
-  return { synced };
-}
-
-/**
- * Sync a single milestone directory from worktree to main.
- * Copies milestone-level .md files, slice-level files, and task summaries.
- */
-/** Copy matching files from srcDir to dstDir (non-fatal per file). */
-function syncDirFiles(
-  srcDir: string,
-  dstDir: string,
-  filter: (name: string) => boolean,
-  synced: string[],
-  prefix: string,
-): void {
-  try {
-    for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
-      if (!entry.isFile() || !filter(entry.name)) continue;
-      try {
-        cpSync(join(srcDir, entry.name), join(dstDir, entry.name), { force: true });
-        synced.push(`${prefix}${entry.name}`);
-      } catch (err) {
-        /* non-fatal */
-        logWarning("worktree", `file copy failed (${prefix}${entry.name}): ${err instanceof Error ? err.message : String(err)}`);
-      }
-    }
-  } catch (err) {
-    /* non-fatal — srcDir may not be readable */
-    logWarning("worktree", `directory read failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
-}
-
-function syncMilestoneDir(
-  wtGsd: string,
-  mainGsd: string,
-  mid: string,
-  synced: string[],
-): void {
-  const wtMilestoneDir = join(wtGsd, "milestones", mid);
-  const mainMilestoneDir = join(mainGsd, "milestones", mid);
-
-  if (!existsSync(wtMilestoneDir)) return;
-  mkdirSync(mainMilestoneDir, { recursive: true });
-
-  const isMd = (name: string): boolean => name.endsWith(".md");
-
-  // Sync milestone-level files (SUMMARY, VALIDATION, ROADMAP, CONTEXT)
-  syncDirFiles(wtMilestoneDir, mainMilestoneDir, isMd, synced, `milestones/${mid}/`);
-
-  // Sync slice-level files (summaries, UATs) and task summaries (#1678)
-  const wtSlicesDir = join(wtMilestoneDir, "slices");
-  const mainSlicesDir = join(mainMilestoneDir, "slices");
-  if (!existsSync(wtSlicesDir)) return;
-
-  try {
-    for (const sliceEntry of readdirSync(wtSlicesDir, { withFileTypes: true })) {
-      if (!sliceEntry.isDirectory()) continue;
-      const sid = sliceEntry.name;
-      const wtSliceDir = join(wtSlicesDir, sid);
-      const mainSliceDir = join(mainSlicesDir, sid);
-      mkdirSync(mainSliceDir, { recursive: true });
-
-      syncDirFiles(wtSliceDir, mainSliceDir, isMd, synced, `milestones/${mid}/slices/${sid}/`);
-
-      const wtTasksDir = join(wtSliceDir, "tasks");
-      const mainTasksDir = join(mainSliceDir, "tasks");
-      if (existsSync(wtTasksDir)) {
-        mkdirSync(mainTasksDir, { recursive: true });
-        syncDirFiles(wtTasksDir, mainTasksDir, isMd, synced, `milestones/${mid}/slices/${sid}/tasks/`);
-      }
-    }
-  } catch (err) {
-    /* non-fatal */
-    logWarning("worktree", `milestone slice sync failed (${mid}): ${err instanceof Error ? err.message : String(err)}`);
-  }
 }
 // ─── Worktree Post-Create Hook (#597) ────────────────────────────────────────
 
@@ -1163,10 +1034,9 @@ export function enterBranchModeForMilestone(
  * directory at the project root and apply any [x] checkbox states that are
  * ahead of the worktree version (forward-only: never downgrade [x] → [ ]).
  *
- * This is safe because syncStateToProjectRoot() is the authoritative source
- * of post-task state at the project root — it writes the same [x] the LLM
- * produced, then the auto-commit follows. If the commit never happened, the
- * filesystem copy is still valid and correct.
+ * This is forward-only compatibility for legacy projection copies. The DB
+ * remains authoritative; this never downgrades checked boxes in a local
+ * worktree projection.
  */
 function reconcilePlanCheckboxes(
   projectRoot: string,
@@ -2251,27 +2121,6 @@ export function mergeMilestoneToMain(
 
   // 9a-iii. Restore sheltered queued milestone directories (#2505).
   restoreShelter();
-
-  // 9a-iv. Preserve current milestone artifacts that may be untracked in git.
-  // syncWorktreeStateBack intentionally skips the current milestone before the
-  // squash merge to avoid conflicting with the merge content. Once the squash
-  // commit is complete, copy those files back so summaries, validation, and
-  // task outputs survive worktree teardown in external/.gitignored .gsd setups.
-  try {
-    const { synced } = syncCurrentMilestoneStateAfterMerge(
-      originalBasePath_,
-      worktreeCwd,
-      milestoneId,
-    );
-    if (synced.length > 0) {
-      debugLog("mergeMilestoneToMain", {
-        phase: "current-milestone-sync-after-merge",
-        synced: synced.length,
-      });
-    }
-  } catch (err) {
-    logWarning("worktree", `current milestone sync after merge failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
 
   // 9b. Safety check (#1792): if nothing was committed, verify the milestone
   // work is already on the integration branch before allowing teardown.

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -32,7 +32,7 @@ import {
 import { atomicWriteSync } from "./atomic-write.js";
 import { execFileSync } from "node:child_process";
 import { safeCopy, safeCopyRecursive } from "./safe-fs.js";
-import { gsdRoot } from "./paths.js";
+import { gsdRoot, resolveGsdPathContract } from "./paths.js";
 import {
   createWorktree,
   removeWorktree,
@@ -349,8 +349,9 @@ export function syncProjectRootToWorktree(
   if (!worktreePath_ || !projectRoot || worktreePath_ === projectRoot) return;
   if (!milestoneId) return;
 
-  const prGsd = join(projectRoot, ".gsd");
-  const wtGsd = join(worktreePath_, ".gsd");
+  const contract = resolveGsdPathContract(worktreePath_, projectRoot);
+  const prGsd = contract.projectGsd;
+  const wtGsd = contract.worktreeGsd ?? join(worktreePath_, ".gsd");
 
   // When .gsd is a symlink to the same external directory in both locations,
   // cpSync rejects the copy because source === destination (ERR_FS_CP_EINVAL).
@@ -390,11 +391,9 @@ export function syncProjectRootToWorktree(
     { force: true },
   );
 
-  // Delete worktree gsd.db ONLY if it is empty (0 bytes).
-  // An empty DB is stale/corrupt and should be rebuilt (#853).
-  // A non-empty DB was populated by gsd-migrate on respawn and must be
-  // preserved — deleting it truncates the file to 0 bytes when
-  // openDatabase re-creates it, causing "no such table" failures (#2815).
+  // Delete a legacy worktree-local gsd.db ONLY if it is empty (0 bytes).
+  // Runtime opens contract.projectDb; this cleanup only removes corrupt
+  // pre-upgrade local DB projections.
   try {
     const wtDb = join(wtGsd, "gsd.db");
     let deleteSidecars = false;
@@ -441,8 +440,9 @@ export function syncStateToProjectRoot(
   if (!worktreePath_ || !projectRoot || worktreePath_ === projectRoot) return;
   if (!milestoneId) return;
 
-  const wtGsd = join(worktreePath_, ".gsd");
-  const prGsd = join(projectRoot, ".gsd");
+  const contract = resolveGsdPathContract(worktreePath_, projectRoot);
+  const wtGsd = contract.worktreeGsd ?? join(worktreePath_, ".gsd");
+  const prGsd = contract.projectGsd;
 
   // When .gsd is a symlink to the same external directory in both locations,
   // cpSync rejects the copy because source === destination (ERR_FS_CP_EINVAL).
@@ -645,8 +645,9 @@ export function syncGsdStateToWorktree(
   mainBasePath: string,
   worktreePath_: string,
 ): { synced: string[] } {
-  const mainGsd = gsdRoot(mainBasePath);
-  const wtGsd = gsdRoot(worktreePath_);
+  const contract = resolveGsdPathContract(worktreePath_, mainBasePath);
+  const mainGsd = contract.projectGsd;
+  const wtGsd = contract.worktreeGsd ?? join(worktreePath_, ".gsd");
   const synced: string[] = [];
 
   // If both resolve to the same directory (symlink), no sync needed
@@ -814,8 +815,9 @@ export function syncWorktreeStateBack(
   worktreePath: string,
   milestoneId: string,
 ): { synced: string[] } {
-  const mainGsd = gsdRoot(mainBasePath);
-  const wtGsd = gsdRoot(worktreePath);
+  const contract = resolveGsdPathContract(worktreePath, mainBasePath);
+  const mainGsd = contract.projectGsd;
+  const wtGsd = contract.worktreeGsd ?? join(worktreePath, ".gsd");
   const synced: string[] = [];
 
   // If both resolve to the same directory (symlink), no sync needed
@@ -829,7 +831,7 @@ export function syncWorktreeStateBack(
   // files. This handles in-flight worktrees that were created before the
   // upgrade to shared WAL mode.
   const wtLocalDb = join(wtGsd, "gsd.db");
-  const mainDb = join(mainGsd, "gsd.db");
+  const mainDb = contract.projectDb;
   if (existsSync(wtLocalDb) && existsSync(mainDb)) {
     try {
       reconcileWorktreeDb(mainDb, wtLocalDb);
@@ -891,8 +893,9 @@ function syncCurrentMilestoneStateAfterMerge(
   worktreePath: string,
   milestoneId: string,
 ): { synced: string[] } {
-  const mainGsd = gsdRoot(mainBasePath);
-  const wtGsd = gsdRoot(worktreePath);
+  const contract = resolveGsdPathContract(worktreePath, mainBasePath);
+  const mainGsd = contract.projectGsd;
+  const wtGsd = contract.worktreeGsd ?? join(worktreePath, ".gsd");
   const synced: string[] = [];
 
   if (isSamePath(mainGsd, wtGsd)) return { synced };
@@ -1710,8 +1713,9 @@ export function mergeMilestoneToMain(
   // database (#2823).
   if (isDbAvailable()) {
     try {
-      const worktreeDbPath = join(worktreeCwd, ".gsd", "gsd.db");
-      const mainDbPath = join(originalBasePath_, ".gsd", "gsd.db");
+      const contract = resolveGsdPathContract(worktreeCwd, originalBasePath_);
+      const worktreeDbPath = join(contract.worktreeGsd ?? join(worktreeCwd, ".gsd"), "gsd.db");
+      const mainDbPath = contract.projectDb;
       if (!isSamePath(worktreeDbPath, mainDbPath)) {
         reconcileWorktreeDb(mainDbPath, worktreeDbPath);
       }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -195,6 +195,7 @@ import {
 import { isDbAvailable, getMilestone } from "./gsd-db.js";
 import { countPendingCaptures } from "./captures.js";
 import { CMUX_CHANNELS, type CmuxLogLevel } from "../shared/cmux-events.js";
+import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
 
 function makeCmuxEmitters(pi: ExtensionAPI) {
   return {
@@ -1511,8 +1512,16 @@ export async function startAuto(
           // fallback only for unmigrated/offline projects.
           const mDir = resolveMilestonePath(base, meta.milestoneId);
           let summaryIsTerminal = false;
-          if (isDbAvailable()) {
-            const milestoneRow = getMilestone(meta.milestoneId);
+          let dbAvailable = isDbAvailable();
+          let milestoneRow = dbAvailable ? getMilestone(meta.milestoneId) : null;
+          if (!milestoneRow) {
+            const opened = await ensureDbOpen(base);
+            dbAvailable = opened || isDbAvailable();
+            if (dbAvailable) {
+              milestoneRow = getMilestone(meta.milestoneId);
+            }
+          }
+          if (dbAvailable) {
             summaryIsTerminal = !!milestoneRow && isClosedStatus(milestoneRow.status);
           } else {
             const summaryFile = resolveMilestoneFile(base, meta.milestoneId, "SUMMARY");

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -175,6 +175,7 @@ import { getErrorMessage } from "./error-utils.js";
 import { recoverFailedMigration } from "./migrate-external.js";
 import { initRegistry, convertDispatchRules } from "./rule-registry.js";
 import { emitJournalEvent as _emitJournalEvent, type JournalEntry } from "./journal.js";
+import { isClosedStatus } from "./status-guards.js";
 import {
   type AutoDashboardData,
   updateProgressWidget as _updateProgressWidget,
@@ -1506,14 +1507,21 @@ export async function startAuto(
           );
         if (shouldResumePausedSession) {
           // Validate the milestone still exists and isn't already complete (#1664).
+          // DB status is authoritative when available; SUMMARY.md is a legacy
+          // fallback only for unmigrated/offline projects.
           const mDir = resolveMilestonePath(base, meta.milestoneId);
-          const summaryFile = resolveMilestoneFile(base, meta.milestoneId, "SUMMARY");
           let summaryIsTerminal = false;
-          if (summaryFile) {
-            try {
-              summaryIsTerminal = classifyMilestoneSummaryContent(readFileSync(summaryFile, "utf-8")) !== "failure";
-            } catch {
-              summaryIsTerminal = false;
+          if (isDbAvailable()) {
+            const milestoneRow = getMilestone(meta.milestoneId);
+            summaryIsTerminal = !!milestoneRow && isClosedStatus(milestoneRow.status);
+          } else {
+            const summaryFile = resolveMilestoneFile(base, meta.milestoneId, "SUMMARY");
+            if (summaryFile) {
+              try {
+                summaryIsTerminal = classifyMilestoneSummaryContent(readFileSync(summaryFile, "utf-8")) !== "failure";
+              } catch {
+                summaryIsTerminal = false;
+              }
             }
           }
           if (!mDir || summaryIsTerminal) {

--- a/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
@@ -1,11 +1,12 @@
 import { existsSync } from "node:fs";
-import { join, sep } from "node:path";
+import { dirname } from "node:path";
 
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { createBashTool, createEditTool, createReadTool, createWriteTool } from "@gsd/pi-coding-agent";
 
 import { DEFAULT_BASH_TIMEOUT_SECS } from "../constants.js";
 import { setLogBasePath, logWarning } from "../workflow-logger.js";
+import { resolveGsdPathContract } from "../paths.js";
 
 /**
  * Resolve the correct DB path for the current working directory.
@@ -14,75 +15,16 @@ import { setLogBasePath, logWarning } from "../workflow-logger.js";
  * returns `<basePath>/.gsd/gsd.db`.
  */
 export function resolveProjectRootDbPath(basePath: string): string {
-  // Detect worktree: look for `.gsd/worktrees/` in the path segments.
-  // A worktree path looks like: /project/root/.gsd/worktrees/M001/...
-  // We need to resolve back to /project/root/.gsd/gsd.db
-  const marker = `${sep}.gsd${sep}worktrees${sep}`;
-  const idx = basePath.indexOf(marker);
-  if (idx !== -1) {
-    const projectRoot = basePath.slice(0, idx);
-    return join(projectRoot, ".gsd", "gsd.db");
-  }
-
-  // Also handle forward-slash paths on all platforms
-  const fwdMarker = "/.gsd/worktrees/";
-  const fwdIdx = basePath.indexOf(fwdMarker);
-  if (fwdIdx !== -1) {
-    const projectRoot = basePath.slice(0, fwdIdx);
-    return join(projectRoot, ".gsd", "gsd.db");
-  }
-
-  // External-state layout: ~/.gsd/projects/<hash>/worktrees/<MID>/...
-  // Resolve to ~/.gsd/projects/<hash>/gsd.db (the canonical project DB) (#2952).
-  // Must be checked before the generic symlink-resolved handler: both match
-  // /.gsd/projects/<hash>/worktrees/ but require different resolution targets.
-  const extRe = /[/\\]\.gsd[/\\]projects[/\\][a-f0-9]+[/\\]worktrees(?:[/\\]|$)/;
-  const extMatch = extRe.exec(basePath);
-  if (extMatch) {
-    const matchStr = extMatch[0];
-    // Find the "/worktrees" portion within the match and slice up to it
-    const wtIdx = matchStr.search(/[/\\]worktrees(?:[/\\]|$)/);
-    const projectStateRoot = basePath.slice(0, extMatch.index + wtIdx);
-    return join(projectStateRoot, "gsd.db");
-  }
-
-  // Symlink-resolved layout: /.gsd/projects/<hash>/worktrees/M001/...
-  // The project root is everything before /.gsd/projects/ (#2517)
-  const symlinkMarker = `${sep}.gsd${sep}projects${sep}`;
-  const symlinkIdx = basePath.indexOf(symlinkMarker);
-  if (symlinkIdx !== -1) {
-    const afterProjects = basePath.slice(symlinkIdx + symlinkMarker.length);
-    // Expect: <hash>/worktrees/...
-    const worktreeSeg = `${sep}worktrees${sep}`;
-    if (afterProjects.includes(worktreeSeg)) {
-      const projectRoot = basePath.slice(0, symlinkIdx);
-      return join(projectRoot, ".gsd", "gsd.db");
-    }
-  }
-
-  // Forward-slash variant for symlink-resolved layout
-  const fwdSymlinkMarker = "/.gsd/projects/";
-  const fwdSymlinkIdx = basePath.indexOf(fwdSymlinkMarker);
-  if (fwdSymlinkIdx !== -1) {
-    const afterProjects = basePath.slice(fwdSymlinkIdx + fwdSymlinkMarker.length);
-    if (afterProjects.includes("/worktrees/")) {
-      const projectRoot = basePath.slice(0, fwdSymlinkIdx);
-      return join(projectRoot, ".gsd", "gsd.db");
-    }
-  }
-
-
-  return join(basePath, ".gsd", "gsd.db");
+  return resolveGsdPathContract(basePath).projectDb;
 }
 
 export async function ensureDbOpen(basePath: string = process.cwd()): Promise<boolean> {
   try {
     const db = await import("../gsd-db.js");
-    const dbPath = resolveProjectRootDbPath(basePath);
-    const gsdDir = join(basePath, ".gsd");
-
-    // Derive the project root from the DB path (strip .gsd/gsd.db)
-    const projectRoot = join(dbPath, "..", "..");
+    const contract = resolveGsdPathContract(basePath);
+    const dbPath = contract.projectDb;
+    const gsdDir = contract.projectGsd;
+    const projectRoot = dirname(dirname(dbPath));
 
     // Open existing DB file (may be at project root for worktrees)
     if (existsSync(dbPath)) {
@@ -91,26 +33,9 @@ export async function ensureDbOpen(basePath: string = process.cwd()): Promise<bo
       return opened;
     }
 
-    // No DB file — create + migrate from Markdown if .gsd/ has content
+    // No DB file — create an empty authoritative DB. Markdown migration is
+    // explicit-only; runtime startup must not import projections into state.
     if (existsSync(gsdDir)) {
-      const hasDecisions = existsSync(join(gsdDir, "DECISIONS.md"));
-      const hasRequirements = existsSync(join(gsdDir, "REQUIREMENTS.md"));
-      const hasMilestones = existsSync(join(gsdDir, "milestones"));
-      if (hasDecisions || hasRequirements || hasMilestones) {
-        const opened = db.openDatabase(dbPath);
-        if (opened) {
-          setLogBasePath(projectRoot);
-          try {
-            const { migrateFromMarkdown } = await import("../md-importer.js");
-            migrateFromMarkdown(basePath);
-          } catch (err) {
-            logWarning("bootstrap", `ensureDbOpen auto-migration failed: ${(err as Error).message}`);
-          }
-        }
-        return opened;
-      }
-
-      // .gsd/ exists but has no Markdown content (fresh project) — create empty DB
       const opened = db.openDatabase(dbPath);
       if (opened) setLogBasePath(projectRoot);
       return opened;

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -634,34 +634,7 @@ export async function updateRequirementInDb(
   try {
     const db = await import('./gsd-db.js');
 
-    let existing = db.getRequirementById(id);
-
-    // If requirement doesn't exist in DB, seed the entire requirements table
-    // from REQUIREMENTS.md first (#3346). This handles the standard workflow
-    // where requirements are authored in markdown during discussion but never
-    // imported into the database — making gsd_requirement_update always fail
-    // with "not_found" at milestone completion.
-    if (!existing) {
-      const reqFilePath = resolveGsdRootFile(basePath, 'REQUIREMENTS');
-      try {
-        const content = readFileSync(reqFilePath, 'utf-8');
-        const { parseRequirementsSections } = await import('./md-importer.js');
-        const parsed = parseRequirementsSections(content);
-        if (parsed.length > 0) {
-          logWarning('manifest', `Seeding ${parsed.length} requirements from REQUIREMENTS.md into DB (first update triggers import)`, { fn: 'updateRequirementInDb' });
-          for (const req of parsed) {
-            // Only seed if not already in DB (avoid overwriting concurrent inserts)
-            if (!db.getRequirementById(req.id)) {
-              db.upsertRequirement(req);
-            }
-          }
-          // Re-check after seeding
-          existing = db.getRequirementById(id);
-        }
-      } catch {
-        // REQUIREMENTS.md missing or unparseable — fall through to skeleton
-      }
-    }
+    const existing = db.getRequirementById(id);
 
     const base: Requirement = existing ?? {
       id,
@@ -717,11 +690,7 @@ export async function updateRequirementInDb(
     try {
       await saveFile(filePath, md);
     } catch (diskErr) {
-      logError('manifest', 'disk write failed, reverting DB row', { fn: 'updateRequirementInDb', error: String((diskErr as Error).message) });
-      if (existing) {
-        db.upsertRequirement(existing);
-      }
-      throw diskErr;
+      logWarning('projection', 'REQUIREMENTS.md projection write failed; DB requirement update remains committed', { fn: 'updateRequirementInDb', id, error: String((diskErr as Error).message) });
     }
     // Invalidate file-read caches so deriveState() sees the updated markdown.
     // Do NOT clear the artifacts table — we just wrote to it intentionally.

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -741,20 +741,19 @@ export async function saveArtifactToDb(
       contentToPersist = generateRequirementsMd(activeRequirements);
     }
 
-    // Shrinkage guard: if the file already exists and the new content is
-    // significantly smaller (<50%), preserve the richer file on disk and
-    // store its content in the DB instead of the abbreviated version. Root
-    // canonical artifacts are exempt because their content is rendered from
-    // canonical DB state, and cleanup/consolidation is often intentionally much
-    // smaller than a malformed accumulated file.
-    let dbContent = contentToPersist;
+    // Shrinkage guard: if the projection file already exists and the new
+    // content is significantly smaller (<50%), preserve the richer file on
+    // disk, but keep the DB row authoritative with the caller-provided content.
+    // The disk file is a stale projection until the next explicit render.
+    // Root canonical artifacts are exempt because their content is rendered
+    // from canonical DB state, and cleanup/consolidation is often intentionally
+    // much smaller than a malformed accumulated file.
     let skipDiskWrite = false;
     if (!isRootCanonicalArtifact(opts) && existsSync(fullPath)) {
       const existingSize = statSync(fullPath).size;
       const newSize = Buffer.byteLength(contentToPersist, 'utf-8');
       if (existingSize > 0 && newSize < existingSize * 0.5) {
-        logWarning('manifest', `new content (${newSize}B) is <50% of existing file (${existingSize}B), preserving disk file`, { fn: 'saveArtifactToDb', path: opts.path });
-        dbContent = readFileSync(fullPath, 'utf-8');
+        logWarning('projection', `new content (${newSize}B) is <50% of existing projection (${existingSize}B), preserving disk file while DB remains authoritative`, { fn: 'saveArtifactToDb', path: opts.path });
         skipDiskWrite = true;
       }
     }
@@ -765,7 +764,7 @@ export async function saveArtifactToDb(
       milestone_id: opts.milestone_id ?? null,
       slice_id: opts.slice_id ?? null,
       task_id: opts.task_id ?? null,
-      full_content: dbContent,
+      full_content: contentToPersist,
     });
 
     // Write the file to disk (only if we're not preserving a richer existing file)

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -318,23 +318,6 @@ export async function saveRequirementToDb(
            LIMIT 1`,
         )
         .get({ ':description': fields.description });
-      const previousRow: Requirement | null = existingRow
-        ? {
-            id: existingRow['id'] as string,
-            class: existingRow['class'] as string,
-            status: existingRow['status'] as string,
-            description: existingRow['description'] as string,
-            why: existingRow['why'] as string,
-            source: existingRow['source'] as string,
-            primary_owner: existingRow['primary_owner'] as string,
-            supporting_slices: existingRow['supporting_slices'] as string,
-            validation: existingRow['validation'] as string,
-            notes: existingRow['notes'] as string,
-            full_content: existingRow['full_content'] as string,
-            superseded_by: (existingRow['superseded_by'] as string) ?? null,
-          }
-        : null;
-
       const row = adapter
         .prepare('SELECT MAX(CAST(SUBSTR(id, 2) AS INTEGER)) as max_num FROM requirements')
         .get();
@@ -361,9 +344,9 @@ export async function saveRequirementToDb(
       };
 
       db.upsertRequirement(requirement);
-      return { id: nextId, isNew: !existingRow, previousRow };
+      return { id: nextId };
     });
-    const { id, isNew, previousRow } = txResult;
+    const { id } = txResult;
 
     // Fetch all requirements for full file regeneration
     const adapter = db._getAdapter();
@@ -392,17 +375,7 @@ export async function saveRequirementToDb(
     try {
       await saveFile(filePath, md);
     } catch (diskErr) {
-      logError('manifest', 'disk write failed, rolling back DB row', { fn: 'saveRequirementToDb', error: String((diskErr as Error).message) });
-      try {
-        if (isNew) {
-          db.deleteRequirementById(id);
-        } else if (previousRow) {
-          db.upsertRequirement(previousRow);
-        }
-      } catch (rollbackErr) {
-        logError('manifest', 'SPLIT BRAIN: disk write failed AND DB rollback failed — DB has orphaned row', { fn: 'saveRequirementToDb', id, error: String((rollbackErr as Error).message) });
-      }
-      throw diskErr;
+      logWarning('projection', 'REQUIREMENTS.md projection write failed; DB requirement remains committed', { fn: 'saveRequirementToDb', id, error: String((diskErr as Error).message) });
     }
     invalidateStateCache();
     clearPathCache();
@@ -538,13 +511,7 @@ export async function saveDecisionToDb(
     try {
       await saveFile(filePath, md);
     } catch (diskErr) {
-      logError('manifest', 'disk write failed, rolling back DB row', { fn: 'saveDecisionToDb', error: String((diskErr as Error).message) });
-      try {
-        db.deleteDecisionById(id);
-      } catch (rollbackErr) {
-        logError('manifest', 'SPLIT BRAIN: disk write failed AND DB rollback failed — DB has orphaned row', { fn: 'saveDecisionToDb', id, error: String((rollbackErr as Error).message) });
-      }
-      throw diskErr;
+      logWarning('projection', 'DECISIONS.md projection write failed; DB decision remains committed', { fn: 'saveDecisionToDb', id, error: String((diskErr as Error).message) });
     }
     // #2661: When a decision defers a slice, update the slice status in the DB
     // so the dispatcher skips it. Without this, STATE.md and DECISIONS.md are
@@ -837,9 +804,7 @@ export async function saveArtifactToDb(
       try {
         await saveFile(fullPath, contentToPersist);
       } catch (diskErr) {
-        logError('manifest', 'disk write failed, rolling back DB row', { fn: 'saveArtifactToDb', error: String((diskErr as Error).message) });
-        db.deleteArtifactByPath(opts.path);
-        throw diskErr;
+        logWarning('projection', 'artifact projection write failed; DB artifact remains committed', { fn: 'saveArtifactToDb', path: opts.path, error: String((diskErr as Error).message) });
       }
     }
     // Invalidate file-read caches so deriveState() sees the updated markdown.

--- a/src/resources/extensions/gsd/dispatch-guard.ts
+++ b/src/resources/extensions/gsd/dispatch-guard.ts
@@ -63,7 +63,7 @@ export function getPriorSliceCompletionBlocker(
       const summaryPath = resolveMilestoneFile(base, mid, "SUMMARY");
       let summaryContent: string | null = null;
       try { summaryContent = summaryPath ? readFileSync(summaryPath, "utf-8") : null; } catch { /* ignore */ }
-      if (!summaryContent || classifyMilestoneSummaryContent(summaryContent) !== "failure") {
+      if (summaryContent && classifyMilestoneSummaryContent(summaryContent) !== "failure") {
         continue;
       }
     }

--- a/src/resources/extensions/gsd/dispatch-guard.ts
+++ b/src/resources/extensions/gsd/dispatch-guard.ts
@@ -54,20 +54,15 @@ export function getPriorSliceCompletionBlocker(
     // completion, which is wrong when the SUMMARY is a failure-path report
     // (verification FAILED, blocker placeholder, etc.). Resolve as follows:
     //   1. When DB is available and status is closed → skip (authoritative).
-    //   2. When SUMMARY exists but looks like a failure/blocker report →
-    //      do not short-circuit; fall through to the slice-level check so
-    //      the guard can still block dependents of an active milestone.
-    //   3. Otherwise (SUMMARY without failure markers) → skip. Preserves
-    //      the #1716 contract where a completed milestone with unchecked
-    //      remediation slices is still treated as done.
-    const summaryPath = resolveMilestoneFile(base, mid, "SUMMARY");
+    //   2. When DB is unavailable, legacy SUMMARY.md fallback may skip.
+    //      DB-backed projects must not treat SUMMARY.md as authoritative.
     if (isDbAvailable()) {
       const milestoneRow = getMilestone(mid);
       if (milestoneRow && isClosedStatus(milestoneRow.status)) continue;
-    }
-    if (summaryPath) {
+    } else {
+      const summaryPath = resolveMilestoneFile(base, mid, "SUMMARY");
       let summaryContent: string | null = null;
-      try { summaryContent = readFileSync(summaryPath, "utf-8"); } catch { /* ignore */ }
+      try { summaryContent = summaryPath ? readFileSync(summaryPath, "utf-8") : null; } catch { /* ignore */ }
       if (!summaryContent || classifyMilestoneSummaryContent(summaryContent) !== "failure") {
         continue;
       }

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 
 import type { DoctorIssue } from "./doctor-types.js";
 import { isDbAvailable, _getAdapter } from "./gsd-db.js";
-import { resolveMilestoneFile } from "./paths.js";
+import { resolveGsdPathContract, resolveMilestoneFile } from "./paths.js";
 import { deriveState } from "./state.js";
 import { readEvents } from "./workflow-events.js";
 import { renderAllProjections } from "./workflow-projections.js";
@@ -13,7 +13,7 @@ export async function checkEngineHealth(
   issues: DoctorIssue[],
   fixesApplied: string[],
 ): Promise<void> {
-  const dbPath = join(basePath, ".gsd", "gsd.db");
+  const dbPath = resolveGsdPathContract(basePath).projectDb;
 
   if (!isDbAvailable() && existsSync(dbPath)) {
     issues.push({

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -181,7 +181,7 @@ function openRawDb(path: string): unknown {
   return new Database(path);
 }
 
-export const SCHEMA_VERSION = 22;
+export const SCHEMA_VERSION = 23;
 
 function indexExists(db: DbAdapter, name: string): boolean {
   return !!db.prepare(
@@ -354,7 +354,8 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
         verification_uat TEXT NOT NULL DEFAULT '',
         definition_of_done TEXT NOT NULL DEFAULT '[]',
         requirement_coverage TEXT NOT NULL DEFAULT '',
-        boundary_map_markdown TEXT NOT NULL DEFAULT ''
+        boundary_map_markdown TEXT NOT NULL DEFAULT '',
+        sequence INTEGER DEFAULT 0
       )
     `);
 
@@ -1229,6 +1230,17 @@ function migrateSchema(db: DbAdapter): void {
       ensureColumn(db, "assessments", "scope", "ALTER TABLE assessments ADD COLUMN scope TEXT NOT NULL DEFAULT ''");
       db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
         ":version": 22,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
+
+    if (currentVersion < 23) {
+      // v23: milestone queue ordering moves into the canonical DB. The
+      // historical QUEUE-ORDER.json file remains a projection, but runtime
+      // derivation must not read it as authoritative state.
+      ensureColumn(db, "milestones", "sequence", "ALTER TABLE milestones ADD COLUMN sequence INTEGER DEFAULT 0");
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 23,
         ":applied_at": new Date().toISOString(),
       });
     }
@@ -2497,6 +2509,7 @@ export interface MilestoneRow {
   definition_of_done: string[];
   requirement_coverage: string;
   boundary_map_markdown: string;
+  sequence: number;
 }
 
 function rowToMilestone(row: Record<string, unknown>): MilestoneRow {
@@ -2518,6 +2531,7 @@ function rowToMilestone(row: Record<string, unknown>): MilestoneRow {
     definition_of_done: JSON.parse((row["definition_of_done"] as string) || "[]"),
     requirement_coverage: (row["requirement_coverage"] as string) ?? "",
     boundary_map_markdown: (row["boundary_map_markdown"] as string) ?? "",
+    sequence: Number(row["sequence"] ?? 0),
   };
 }
 
@@ -2545,7 +2559,9 @@ function rowToArtifact(row: Record<string, unknown>): ArtifactRow {
 
 export function getAllMilestones(): MilestoneRow[] {
   if (!currentDb) return [];
-  const rows = currentDb.prepare("SELECT * FROM milestones ORDER BY id").all();
+  const rows = currentDb.prepare(
+    "SELECT * FROM milestones ORDER BY CASE WHEN sequence > 0 THEN 0 ELSE 1 END, sequence, id",
+  ).all();
   return rows.map(rowToMilestone);
 }
 
@@ -2554,6 +2570,22 @@ export function getMilestone(id: string): MilestoneRow | null {
   const row = currentDb.prepare("SELECT * FROM milestones WHERE id = :id").get({ ":id": id });
   if (!row) return null;
   return rowToMilestone(row);
+}
+
+export function setMilestoneQueueOrder(order: string[]): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  currentDb.exec("BEGIN IMMEDIATE");
+  try {
+    currentDb.prepare("UPDATE milestones SET sequence = 0").run();
+    const stmt = currentDb.prepare("UPDATE milestones SET sequence = :sequence WHERE id = :id");
+    order.forEach((id, index) => {
+      stmt.run({ ":id": id, ":sequence": index + 1 });
+    });
+    currentDb.exec("COMMIT");
+  } catch (err) {
+    currentDb.exec("ROLLBACK");
+    throw err;
+  }
 }
 
 /**
@@ -2751,6 +2783,8 @@ export function reconcileWorktreeDb(
       // fall through to the main DB's existing value (not a literal default)
       // so reconcile never silently clears state the main tree has recorded.
       const hasDecisionSource = wtInfo.some((col) => col["name"] === "source");
+      const wtMilestoneInfo = adapter.prepare("PRAGMA wt.table_info('milestones')").all();
+      const hasMilestoneSequence = wtMilestoneInfo.some((col) => col["name"] === "sequence");
       const wtSliceInfo = adapter.prepare("PRAGMA wt.table_info('slices')").all();
       const hasIsSketch = wtSliceInfo.some((col) => col["name"] === "is_sketch");
       const hasSketchScope = wtSliceInfo.some((col) => col["name"] === "sketch_scope");
@@ -2824,7 +2858,7 @@ export function reconcileWorktreeDb(
             id, title, status, depends_on, created_at, completed_at,
             vision, success_criteria, key_risks, proof_strategy,
             verification_contract, verification_integration, verification_operational, verification_uat,
-            definition_of_done, requirement_coverage, boundary_map_markdown
+            definition_of_done, requirement_coverage, boundary_map_markdown, sequence
           )
           SELECT w.id, w.title,
                  CASE
@@ -2842,7 +2876,8 @@ export function reconcileWorktreeDb(
                  END,
                  w.vision, w.success_criteria, w.key_risks, w.proof_strategy,
                  w.verification_contract, w.verification_integration, w.verification_operational, w.verification_uat,
-                 w.definition_of_done, w.requirement_coverage, w.boundary_map_markdown
+                 w.definition_of_done, w.requirement_coverage, w.boundary_map_markdown,
+                 ${hasMilestoneSequence ? "COALESCE(w.sequence, 0)" : "COALESCE(m.sequence, 0)"}
           FROM wt.milestones w
           LEFT JOIN milestones m ON m.id = w.id
         `).run());
@@ -3129,6 +3164,20 @@ export function getAssessment(path: string): Record<string, unknown> | null {
   const row = currentDb.prepare(
     `SELECT * FROM assessments WHERE path = :path`,
   ).get({ ":path": path });
+  return row ?? null;
+}
+
+export function getLatestAssessmentByScope(
+  milestoneId: string,
+  scope: string,
+): Record<string, unknown> | null {
+  if (!currentDb) return null;
+  const row = currentDb.prepare(
+    `SELECT * FROM assessments
+      WHERE milestone_id = :mid AND scope = :scope
+      ORDER BY created_at DESC
+      LIMIT 1`,
+  ).get({ ":mid": milestoneId, ":scope": scope });
   return row ?? null;
 }
 
@@ -3619,8 +3668,8 @@ export function restoreManifest(manifest: StateManifest): void {
       `INSERT INTO milestones (id, title, status, depends_on, created_at, completed_at,
         vision, success_criteria, key_risks, proof_strategy,
         verification_contract, verification_integration, verification_operational, verification_uat,
-        definition_of_done, requirement_coverage, boundary_map_markdown)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        definition_of_done, requirement_coverage, boundary_map_markdown, sequence)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
     for (const m of manifest.milestones) {
       msStmt.run(
@@ -3629,7 +3678,7 @@ export function restoreManifest(manifest: StateManifest): void {
         m.vision, JSON.stringify(m.success_criteria), JSON.stringify(m.key_risks),
         JSON.stringify(m.proof_strategy),
         m.verification_contract, m.verification_integration, m.verification_operational, m.verification_uat,
-        JSON.stringify(m.definition_of_done), m.requirement_coverage, m.boundary_map_markdown,
+        JSON.stringify(m.definition_of_done), m.requirement_coverage, m.boundary_map_markdown, m.sequence ?? 0,
       );
     }
 

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1602,6 +1602,34 @@ export function getActiveRequirements(): Requirement[] {
   }));
 }
 
+export function getRequirementCounts(): {
+  active: number;
+  validated: number;
+  deferred: number;
+  outOfScope: number;
+  blocked: number;
+  total: number;
+} {
+  if (!currentDb) {
+    return { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 };
+  }
+  const rows = currentDb
+    .prepare("SELECT lower(status) as status, COUNT(*) as count FROM requirements GROUP BY lower(status)")
+    .all();
+  const counts = { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 };
+  for (const row of rows) {
+    const status = String(row["status"] ?? "");
+    const count = Number(row["count"] ?? 0);
+    counts.total += count;
+    if (status === "active") counts.active += count;
+    else if (status === "validated") counts.validated += count;
+    else if (status === "deferred") counts.deferred += count;
+    else if (status === "out-of-scope" || status === "out_of_scope") counts.outOfScope += count;
+    else if (status === "blocked") counts.blocked += count;
+  }
+  return counts;
+}
+
 export function getDbOwnerPid(): number {
   return currentPid;
 }

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -1,9 +1,8 @@
 // GSD Markdown Renderer — DB → Markdown file generation
 //
 // Transforms DB state into correct markdown files on disk.
-// Each render function reads from DB (with disk fallback),
-// patches content to match DB status, writes atomically to disk,
-// stores updated content in the artifacts table, and invalidates caches.
+// Each render function reads from DB, writes a markdown projection to disk,
+// stores generated content in the artifacts table, and invalidates caches.
 //
 // Critical invariant: rendered markdown must round-trip through
 // parseRoadmap(), parsePlan(), parseSummary() in files.ts.
@@ -85,9 +84,9 @@ function taskSummaryForSlicePlan(description: string): string {
 }
 
 /**
- * Load artifact content from DB first, falling back to reading from disk.
- * On disk fallback, stores the content in the artifacts table for future use.
- * Returns null if content is unavailable from both sources.
+ * Load artifact content from DB first, falling back to reading from disk as a
+ * legacy projection compatibility path. Disk fallback content is deliberately
+ * not stored back into DB; markdown is not authoritative during runtime.
  */
 function loadArtifactContent(
   artifactPath: string,
@@ -105,7 +104,8 @@ function loadArtifactContent(
     return artifact.full_content;
   }
 
-  // Fall back to disk
+  // Fall back to disk for legacy projection patching only. Do not import this
+  // content into DB; missing/stale DB artifacts should be regenerated from rows.
   if (!absPath) {
     process.stderr.write(
       `markdown-renderer: artifact not found in DB or on disk: ${artifactPath}\n`,
@@ -119,21 +119,6 @@ function loadArtifactContent(
   } catch {
     logWarning("renderer", `cannot read file from disk: ${absPath}`);
     return null;
-  }
-
-  // Store in DB for future use (graceful degradation path)
-  try {
-    insertArtifact({
-      path: artifactPath,
-      artifact_type: opts.artifact_type,
-      milestone_id: opts.milestone_id,
-      slice_id: opts.slice_id ?? null,
-      task_id: opts.task_id ?? null,
-      full_content: content,
-    });
-  } catch {
-    // Non-fatal: we have the content, DB storage is best-effort
-    logWarning("renderer", `failed to store disk fallback in DB: ${artifactPath}`);
   }
 
   return content;
@@ -517,10 +502,8 @@ export async function renderRoadmapCheckboxes(
   }
 
   if (!content) {
-    process.stderr.write(
-      `markdown-renderer: no roadmap content available for ${milestoneId}\n`,
-    );
-    return false;
+    await renderRoadmapFromDb(basePath, milestoneId);
+    return true;
   }
 
   // Apply checkbox patches for each slice
@@ -590,10 +573,8 @@ export async function renderPlanCheckboxes(
   }
 
   if (!content) {
-    process.stderr.write(
-      `markdown-renderer: no plan content available for ${milestoneId}/${sliceId}\n`,
-    );
-    return false;
+    await renderPlanFromDb(basePath, milestoneId, sliceId);
+    return true;
   }
 
   // Apply checkbox patches for each task

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -84,44 +84,19 @@ function taskSummaryForSlicePlan(description: string): string {
 }
 
 /**
- * Load artifact content from DB first, falling back to reading from disk as a
- * legacy projection compatibility path. Disk fallback content is deliberately
- * not stored back into DB; markdown is not authoritative during runtime.
+ * Load artifact content from the DB. Markdown projections are not authoritative
+ * during runtime; when the artifact row is missing, callers regenerate from DB
+ * rows instead of patching disk fallback content and storing it back.
  */
 function loadArtifactContent(
   artifactPath: string,
-  absPath: string | null,
-  opts: {
-    artifact_type: string;
-    milestone_id: string;
-    slice_id?: string;
-    task_id?: string;
-  },
 ): string | null {
-  // Try DB first
   const artifact = getArtifact(artifactPath);
   if (artifact && artifact.full_content) {
     return artifact.full_content;
   }
 
-  // Fall back to disk for legacy projection patching only. Do not import this
-  // content into DB; missing/stale DB artifacts should be regenerated from rows.
-  if (!absPath) {
-    process.stderr.write(
-      `markdown-renderer: artifact not found in DB or on disk: ${artifactPath}\n`,
-    );
-    return null;
-  }
-
-  let content: string;
-  try {
-    content = readFileSync(absPath, "utf-8");
-  } catch {
-    logWarning("renderer", `cannot read file from disk: ${absPath}`);
-    return null;
-  }
-
-  return content;
+  return null;
 }
 
 /**
@@ -492,13 +467,10 @@ export async function renderRoadmapCheckboxes(
   const absPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
   const artifactPath = absPath ? toArtifactPath(absPath, basePath) : null;
 
-  // Load content from DB (with disk fallback)
+  // Load content from DB; regenerate from DB rows when the artifact is absent.
   let content: string | null = null;
   if (artifactPath) {
-    content = loadArtifactContent(artifactPath, absPath, {
-      artifact_type: "ROADMAP",
-      milestone_id: milestoneId,
-    });
+    content = loadArtifactContent(artifactPath);
   }
 
   if (!content) {
@@ -565,11 +537,7 @@ export async function renderPlanCheckboxes(
 
   let content: string | null = null;
   if (artifactPath) {
-    content = loadArtifactContent(artifactPath, absPath, {
-      artifact_type: "PLAN",
-      milestone_id: milestoneId,
-      slice_id: sliceId,
-    });
+    content = loadArtifactContent(artifactPath);
   }
 
   if (!content) {

--- a/src/resources/extensions/gsd/parallel-merge.ts
+++ b/src/resources/extensions/gsd/parallel-merge.ts
@@ -37,7 +37,7 @@ export type MergeOrder = "sequential" | "by-completion";
  * Uses a subprocess to avoid disrupting the global DB singleton.
  * Returns true when milestones.status = 'complete' in project gsd.db.
  */
-export function isMilestoneCompleteInWorktreeDb(basePath: string, mid: string): boolean {
+export function isMilestoneCompleteInProjectDb(basePath: string, mid: string): boolean {
   const workRoot = join(basePath, ".gsd", "worktrees", mid);
   const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
   if (!existsSync(dbPath)) return false;
@@ -64,7 +64,7 @@ function discoverDbCompletedMilestones(basePath: string): Set<string> {
   const worktreeDir = join(basePath, ".gsd", "worktrees");
   try {
     for (const entry of readdirSync(worktreeDir)) {
-      if (entry.startsWith("M") && isMilestoneCompleteInWorktreeDb(basePath, entry)) {
+      if (entry.startsWith("M") && isMilestoneCompleteInProjectDb(basePath, entry)) {
         completed.add(entry);
       }
     }
@@ -79,9 +79,9 @@ function discoverDbCompletedMilestones(basePath: string): Set<string> {
  * Sequential: merge in milestone ID order (M001 before M002).
  * By-completion: merge in the order milestones finished.
  *
- * When basePath is provided, also checks worktree SQLite DBs as the
- * source of truth — workers with stale orchestrator state (e.g. "error")
- * are included if their worktree DB shows status='complete'.
+ * When basePath is provided, also checks the canonical project DB as the
+ * source of truth. Workers with stale orchestrator state (e.g. "error")
+ * are included if their project DB row shows status='complete'.
  * See: https://github.com/gsd-build/gsd-2/issues/2812
  */
 export function determineMergeOrder(
@@ -94,7 +94,7 @@ export function determineMergeOrder(
     workers.filter(w => w.state === "stopped").map(w => w.milestoneId),
   );
 
-  // When basePath is available, also check worktree DBs for milestones
+  // When basePath is available, also check the project DB for milestones
   // whose orchestrator state is stale but are actually complete (#2812)
   const dbCompleted = basePath ? discoverDbCompletedMilestones(basePath) : new Set<string>();
 
@@ -110,7 +110,7 @@ export function determineMergeOrder(
     if (w) {
       allMergeable.push(w);
     } else {
-      // Milestone discovered from worktree DB but not in workers list
+      // Milestone discovered from project DB but not in workers list
       allMergeable.push({
         milestoneId: mid,
         title: mid,

--- a/src/resources/extensions/gsd/parallel-merge.ts
+++ b/src/resources/extensions/gsd/parallel-merge.ts
@@ -9,7 +9,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { loadFile } from "./files.js";
-import { resolveMilestoneFile } from "./paths.js";
+import { resolveGsdPathContract, resolveMilestoneFile } from "./paths.js";
 import { mergeMilestoneToMain } from "./auto-worktree.js";
 import { MergeConflictError } from "./git-service.js";
 import { removeSessionStatus } from "./session-status-io.js";
@@ -33,12 +33,13 @@ export type MergeOrder = "sequential" | "by-completion";
 // ─── Merge Queue ───────────────────────────────────────────────────────────
 
 /**
- * Check whether a milestone is complete by querying its worktree SQLite DB.
+ * Check whether a milestone is complete by querying the canonical project DB.
  * Uses a subprocess to avoid disrupting the global DB singleton.
- * Returns true when milestones.status = 'complete' in the worktree's gsd.db.
+ * Returns true when milestones.status = 'complete' in project gsd.db.
  */
 export function isMilestoneCompleteInWorktreeDb(basePath: string, mid: string): boolean {
-  const dbPath = join(basePath, ".gsd", "worktrees", mid, ".gsd", "gsd.db");
+  const workRoot = join(basePath, ".gsd", "worktrees", mid);
+  const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
   if (!existsSync(dbPath)) return false;
 
   try {
@@ -55,8 +56,8 @@ export function isMilestoneCompleteInWorktreeDb(basePath: string, mid: string): 
 }
 
 /**
- * Discover milestone IDs with status='complete' in their worktree DB,
- * scanning .gsd/worktrees/<MID>/.gsd/gsd.db for each worktree directory.
+ * Discover milestone IDs with status='complete' in the canonical DB,
+ * using worktree directories only to enumerate active parallel workers.
  */
 function discoverDbCompletedMilestones(basePath: string): Set<string> {
   const completed = new Set<string>();

--- a/src/resources/extensions/gsd/parallel-monitor-overlay.ts
+++ b/src/resources/extensions/gsd/parallel-monitor-overlay.ts
@@ -17,6 +17,7 @@ import { truncateToWidth, visibleWidth, matchesKey, Key } from "@gsd/pi-tui";
 
 import { formatDuration, STATUS_GLYPH, STATUS_COLOR } from "../shared/mod.js";
 import { formattedShortcutPair } from "./shortcut-defs.js";
+import { resolveGsdPathContract } from "./paths.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -126,7 +127,8 @@ function discoverWorkers(basePath: string): string[] {
 }
 
 function querySliceProgress(basePath: string, mid: string): SliceProgress[] {
-  const dbPath = join(basePath, ".gsd", "worktrees", mid, ".gsd", "gsd.db");
+  const workRoot = join(basePath, ".gsd", "worktrees", mid);
+  const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
   if (!existsSync(dbPath)) return [];
 
   try {
@@ -166,7 +168,8 @@ function extractCostFromNdjson(basePath: string, mid: string): number {
 }
 
 function queryRecentCompletions(basePath: string, mid: string): string[] {
-  const dbPath = join(basePath, ".gsd", "worktrees", mid, ".gsd", "gsd.db");
+  const workRoot = join(basePath, ".gsd", "worktrees", mid);
+  const dbPath = resolveGsdPathContract(workRoot, basePath).projectDb;
   if (!existsSync(dbPath)) return [];
   try {
     const sql = `SELECT id, slice_id, one_liner FROM tasks WHERE milestone_id='${mid}' AND status='complete' AND completed_at IS NOT NULL ORDER BY completed_at DESC LIMIT 5`;

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -10,12 +10,13 @@
  */
 
 import { readdirSync, existsSync, realpathSync, Dirent } from "node:fs";
-import { join, dirname, normalize } from "node:path";
+import { join, dirname, normalize, resolve } from "node:path";
 import { homedir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { nativeScanGsdTree, type GsdTreeEntry } from "./native-parser-bridge.js";
 import { DIR_CACHE_MAX } from "./constants.js";
 import { gsdHome } from "./gsd-home.js";
+import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "./worktree-root.js";
 
 // ─── Directory Listing Cache ──────────────────────────────────────────────────
 
@@ -286,6 +287,56 @@ const LEGACY_GSD_ROOT_FILES: Record<GSDRootFileKey, string> = {
 
 const gsdRootCache = new Map<string, string>();
 
+export interface GsdPathContract {
+  /** Canonical repo/project root where authoritative state lives. */
+  projectRoot: string;
+  /** Current execution root, which may be an auto-worktree. */
+  workRoot: string;
+  /** Canonical authoritative .gsd directory. */
+  projectGsd: string;
+  /** Legacy worktree-local .gsd projection directory, when applicable. */
+  worktreeGsd: string | null;
+  /** Canonical authoritative SQLite DB path. */
+  projectDb: string;
+  /** True when workRoot is inside a GSD worktree layout. */
+  isWorktree: boolean;
+}
+
+export function resolveGsdPathContract(
+  workRoot: string,
+  originalProjectRoot?: string | null,
+): GsdPathContract {
+  const resolvedWorkRoot = resolve(workRoot || process.cwd());
+  const isWorktree = isGsdWorktreePath(resolvedWorkRoot);
+  if (isWorktree && !originalProjectRoot?.trim()) {
+    const externalMatch = /[/\\]\.gsd[/\\]projects[/\\][^/\\]+[/\\]worktrees(?:[/\\]|$)/.exec(resolvedWorkRoot);
+    if (externalMatch) {
+      const worktreesIdx = externalMatch[0].search(/[/\\]worktrees(?:[/\\]|$)/);
+      const projectGsd = resolvedWorkRoot.slice(0, externalMatch.index + worktreesIdx);
+      return {
+        projectRoot: dirname(dirname(projectGsd)),
+        workRoot: resolvedWorkRoot,
+        projectGsd,
+        worktreeGsd: join(resolvedWorkRoot, ".gsd"),
+        projectDb: join(projectGsd, "gsd.db"),
+        isWorktree,
+      };
+    }
+  }
+  const projectRoot = resolve(resolveWorktreeProjectRoot(resolvedWorkRoot, originalProjectRoot));
+  const projectGsd = join(projectRoot, ".gsd");
+  const worktreeGsd = isWorktree ? join(resolvedWorkRoot, ".gsd") : null;
+
+  return {
+    projectRoot,
+    workRoot: resolvedWorkRoot,
+    projectGsd,
+    worktreeGsd,
+    projectDb: join(projectGsd, "gsd.db"),
+    isWorktree,
+  };
+}
+
 /** Exported for tests only — do not call in production code. */
 export function _clearGsdRootCache(): void {
   gsdRootCache.clear();
@@ -378,6 +429,9 @@ function isInsideGsdWorktree(p: string): boolean {
 }
 
 function probeGsdRoot(rawBasePath: string): string {
+  const contract = resolveGsdPathContract(rawBasePath);
+  if (contract.isWorktree) return contract.projectGsd;
+
   // 1. Fast path — check the input path directly
   const local = join(rawBasePath, ".gsd");
   if (existsSync(local)) return local;

--- a/src/resources/extensions/gsd/queue-order.ts
+++ b/src/resources/extensions/gsd/queue-order.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { gsdRoot } from "./paths.js";
 import { milestoneIdSort } from "./milestone-ids.js";
 import { loadJsonFileOrNull, saveJsonFile } from "./json-persistence.js";
+import { isDbAvailable, setMilestoneQueueOrder } from "./gsd-db.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -63,9 +64,13 @@ export function loadQueueOrder(basePath: string): string[] | null {
 }
 
 /**
- * Save a custom queue order to disk.
+ * Save a custom queue order. The DB sequence is canonical when a DB
+ * connection is open; QUEUE-ORDER.json remains a compatibility projection.
  */
 export function saveQueueOrder(basePath: string, order: string[]): void {
+  if (isDbAvailable()) {
+    setMilestoneQueueOrder(order);
+  }
   const data: QueueOrderFile = {
     order,
     updatedAt: new Date().toISOString(),

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -58,6 +58,7 @@ import {
   getReplanHistory,
   getSlice,
   getRequirementCounts,
+  getLatestAssessmentByScope,
   getPendingGateCountForTurn,
   type MilestoneRow,
   type SliceRow,
@@ -232,14 +233,7 @@ export async function getActiveMilestoneId(basePath: string): Promise<string | n
   if (isDbAvailable()) {
     const allMilestones = getAllMilestones();
     if (allMilestones.length > 0) {
-      // Respect queue-order.json so /gsd queue reordering is honored (#2556).
-      // Without this, the DB path uses lexicographic sort while the dispatch
-      // guard uses queue order — causing a deadlock.
-      const customOrder = loadQueueOrder(basePath);
-      const sortedIds = sortByQueueOrder(allMilestones.map(m => m.id), customOrder);
-      const byId = new Map(allMilestones.map(m => [m.id, m]));
-      for (const id of sortedIds) {
-        const m = byId.get(id)!;
+      for (const m of allMilestones) {
         if (isClosedStatus(m.status) || m.status === "parked") continue;
         return m.id;
       }
@@ -388,14 +382,10 @@ async function buildRegistryAndFindActive(
     }
 
     const slices = getMilestoneSlices(m.id);
-    if (slices.length === 0 && !isStatusDone(m.status) && m.status !== 'queued') {
-      if (isGhostMilestone(basePath, m.id)) continue;
-    }
 
     // DB-authoritative completeness (#4179): only trust completeMilestoneIds,
     // which is itself derived from DB status. SUMMARY-file presence alone must
-    // not imply completion. The summary file may still be consulted below as a
-    // title source for legitimately-complete milestones whose DB row has no title.
+    // not imply completion.
     if (completeMilestoneIds.has(m.id)) {
       const title = stripMilestonePrefix(m.title) || m.id;
       registry.push({ id: m.id, title, status: 'complete' });
@@ -404,14 +394,7 @@ async function buildRegistryAndFindActive(
 
     const allSlicesDone = slices.length > 0 && slices.every(s => isStatusDone(s.status));
 
-    let title = stripMilestonePrefix(m.title) || m.id;
-    if (title === m.id) {
-      const contextFile = resolveMilestoneFile(basePath, m.id, "CONTEXT");
-      const draftFile = resolveMilestoneFile(basePath, m.id, "CONTEXT-DRAFT");
-      const contextContent = contextFile ? await loadFile(contextFile) : null;
-      const draftContent = draftFile && !contextContent ? await loadFile(draftFile) : null;
-      title = extractContextTitle(contextContent || draftContent, m.id);
-    }
+    const title = stripMilestonePrefix(m.title) || m.id;
 
     if (!activeMilestoneFound) {
       const deps = m.depends_on;
@@ -423,41 +406,22 @@ async function buildRegistryAndFindActive(
       }
 
       if (m.status === 'queued' && slices.length === 0) {
-        const contextFile = resolveMilestoneFile(basePath, m.id, "CONTEXT");
-        const draftFile = resolveMilestoneFile(basePath, m.id, "CONTEXT-DRAFT");
-        if (!contextFile && !draftFile) {
-          if (!firstDeferredQueuedShell) {
-            firstDeferredQueuedShell = { id: m.id, title, deps };
-          }
-          registry.push({ id: m.id, title, status: 'pending', ...(deps.length > 0 ? { dependsOn: deps } : {}) });
-          continue;
+        if (!firstDeferredQueuedShell) {
+          firstDeferredQueuedShell = { id: m.id, title, deps };
         }
+        registry.push({ id: m.id, title, status: 'pending', ...(deps.length > 0 ? { dependsOn: deps } : {}) });
+        continue;
       }
 
       if (allSlicesDone) {
-        const validationFile = resolveMilestoneFile(basePath, m.id, "VALIDATION");
-        const validationContent = validationFile ? await loadFile(validationFile) : null;
-        const validationTerminal = validationContent ? isValidationTerminal(validationContent) : false;
-
-        // DB-authoritative (#4179): completeness is already decided by
-        // completeMilestoneIds above. If we reached this branch, the DB says
-        // the milestone is NOT complete — so any SUMMARY file on disk is an
-        // orphan (crashed complete-milestone, partial merge, manual edit) and
-        // must not short-circuit this path. When validation is terminal, fall
-        // through to the default active-push below so `complete-milestone` can
-        // re-run idempotently.
-        if (!validationTerminal) {
-          activeMilestone = { id: m.id, title };
-          activeMilestoneSlices = slices;
-          activeMilestoneFound = true;
-          registry.push({ id: m.id, title, status: 'active', ...(deps.length > 0 ? { dependsOn: deps } : {}) });
-          continue;
-        }
+        activeMilestone = { id: m.id, title };
+        activeMilestoneSlices = slices;
+        activeMilestoneFound = true;
+        registry.push({ id: m.id, title, status: 'active', ...(deps.length > 0 ? { dependsOn: deps } : {}) });
+        continue;
       }
 
-      const contextFile = resolveMilestoneFile(basePath, m.id, "CONTEXT");
-      const draftFile = resolveMilestoneFile(basePath, m.id, "CONTEXT-DRAFT");
-      if (!contextFile && draftFile) activeMilestoneHasDraft = true;
+      if (m.status === 'needs-discussion') activeMilestoneHasDraft = true;
 
       activeMilestone = { id: m.id, title };
       activeMilestoneSlices = slices;
@@ -553,10 +517,9 @@ async function handleAllSlicesDone(
   milestoneProgress: { done: number, total: number },
   sliceProgress: { done: number, total: number }
 ): Promise<GSDState> {
-  const validationFile = resolveMilestoneFile(basePath, activeMilestone.id, "VALIDATION");
-  const validationContent = validationFile ? await loadFile(validationFile) : null;
-  const validationTerminal = validationContent ? isValidationTerminal(validationContent) : false;
-  const verdict = validationContent ? extractVerdict(validationContent) : undefined;
+  const validation = getLatestAssessmentByScope(activeMilestone.id, "milestone-validation");
+  const verdict = typeof validation?.status === "string" ? validation.status : undefined;
+  const validationTerminal = verdict != null && verdict !== "";
 
   if (!validationTerminal) {
     return {
@@ -630,14 +593,6 @@ async function detectBlockers(basePath: string, milestoneId: string, sliceId: st
     if (ct.blocker_discovered) {
       return ct.id;
     }
-    const summaryFile = resolveTaskFile(basePath, milestoneId, sliceId, ct.id, "SUMMARY");
-    if (!summaryFile) continue;
-    const summaryContent = await loadFile(summaryFile);
-    if (!summaryContent) continue;
-    const summary = parseSummary(summaryContent);
-    if (summary.frontmatter.blocker_discovered) {
-      return ct.id;
-    }
   }
   return null;
 }
@@ -647,23 +602,10 @@ function checkReplanTrigger(basePath: string, milestoneId: string, sliceId: stri
   return !!sliceRow?.replan_triggered_at;
 }
 
-async function checkInterruptedWork(basePath: string, milestoneId: string, sliceId: string): Promise<boolean> {
-  const sDir = resolveSlicePath(basePath, milestoneId, sliceId);
-  const continueFile = sDir ? resolveSliceFile(basePath, milestoneId, sliceId, "CONTINUE") : null;
-  return !!(continueFile && await loadFile(continueFile)) ||
-    !!(sDir && await loadFile(join(sDir, "continue.md")));
-}
-
 export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   const requirements = getRequirementCounts();
 
   const allMilestones = getAllMilestones();
-
-  const customOrder = loadQueueOrder(basePath);
-  const sortedIds = sortByQueueOrder(allMilestones.map(m => m.id), customOrder);
-  const byId = new Map(allMilestones.map(m => [m.id, m]));
-  allMilestones.length = 0;
-  for (const id of sortedIds) allMilestones.push(byId.get(id)!);
 
   const milestoneLock = process.env.GSD_MILESTONE_LOCK;
   const milestones = milestoneLock
@@ -694,28 +636,16 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
     return handleNoActiveMilestone(registry, requirements, milestoneProgress);
   }
 
-  const hasRoadmap = resolveMilestoneFile(basePath, activeMilestone.id, "ROADMAP") !== null;
-
   if (activeMilestoneSlices.length === 0) {
-    if (!hasRoadmap) {
-      const phase = activeMilestoneHasDraft ? 'needs-discussion' as const : 'pre-planning' as const;
-      const nextAction = activeMilestoneHasDraft
-        ? `Discuss draft context for milestone ${activeMilestone.id}.`
-        : `Plan milestone ${activeMilestone.id}.`;
-      return {
-        activeMilestone, activeSlice: null, activeTask: null,
-        phase, recentDecisions: [], blockers: [],
-        nextAction, registry, requirements,
-        progress: { milestones: milestoneProgress },
-      };
-    }
-
+    const phase = activeMilestoneHasDraft ? 'needs-discussion' as const : 'pre-planning' as const;
+    const nextAction = activeMilestoneHasDraft
+      ? `Discuss draft context for milestone ${activeMilestone.id}.`
+      : `Plan milestone ${activeMilestone.id}.`;
     return {
       activeMilestone, activeSlice: null, activeTask: null,
-      phase: 'pre-planning', recentDecisions: [], blockers: [],
-      nextAction: `Milestone ${activeMilestone.id} has a roadmap but no slices defined. Add slices to the roadmap.`,
-      registry, requirements,
-      progress: { milestones: milestoneProgress, slices: { done: 0, total: 0 } },
+      phase, recentDecisions: [], blockers: [],
+      nextAction, registry, requirements,
+      progress: { milestones: milestoneProgress },
     };
   }
 
@@ -874,14 +804,10 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
     }
   }
 
-  const hasInterrupted = await checkInterruptedWork(basePath, activeMilestone.id, activeSlice.id);
-
   return {
     activeMilestone, activeSlice, activeTask,
     phase: 'executing', recentDecisions: [], blockers: [],
-    nextAction: hasInterrupted
-      ? `Resume interrupted work on ${activeTask.id}: ${activeTask.title} in slice ${activeSlice.id}. Read continue.md first.`
-      : `Execute ${activeTask.id}: ${activeTask.title} in slice ${activeSlice.id}.`,
+    nextAction: `Execute ${activeTask.id}: ${activeTask.title} in slice ${activeSlice.id}.`,
     registry, requirements,
     progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
   };

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -1,5 +1,5 @@
 // GSD Extension — State Derivation
-// DB-primary state derivation with filesystem fallback for unmigrated projects.
+// DB-authoritative runtime derivation with explicit legacy filesystem fallback.
 // Pure TypeScript, zero Pi dependencies.
 
 import type {
@@ -46,7 +46,6 @@ import { logWarning } from './workflow-logger.js';
 import { extractVerdict } from './verdict-parser.js';
 import { detectPendingEscalation } from './escalation.js';
 import { isTerminalMilestoneSummaryContent } from './milestone-summary-classifier.js';
-import { loadEffectiveGSDPreferences } from './preferences.js';
 
 import {
   isDbAvailable,
@@ -219,9 +218,16 @@ export function invalidateStateCache(): void {
  * Returns the ID of the first incomplete milestone, or null if all are complete.
  */
 export async function getActiveMilestoneId(basePath: string): Promise<string | null> {
-  // Parallel worker isolation
-  const milestoneLock = process.env.GSD_MILESTONE_LOCK;
+  // Parallel worker isolation. Normal DB state derivation remains DB-only;
+  // lock env vars are execution routing for explicit worker processes.
+  const milestoneLock = process.env.GSD_PARALLEL_WORKER ? process.env.GSD_MILESTONE_LOCK : undefined;
   if (milestoneLock) {
+    if (isDbAvailable()) {
+      const locked = getAllMilestones().find(m => m.id === milestoneLock);
+      if (!locked || isClosedStatus(locked.status) || locked.status === "parked") return null;
+      return locked.id;
+    }
+
     const milestoneIds = findMilestoneIds(basePath);
     if (!milestoneIds.includes(milestoneLock)) return null;
     const lockedParked = resolveMilestoneFile(basePath, milestoneLock, "PARKED");
@@ -265,12 +271,12 @@ export async function getActiveMilestoneId(basePath: string): Promise<string | n
 }
 
 /**
- * Reconstruct GSD state from DB (primary) or filesystem (fallback).
+ * Reconstruct GSD state from the authoritative DB.
  * STATE.md is a rendered cache of this output.
  *
  * When DB is available, queries milestone/slice/task tables directly.
- * Falls back to filesystem parsing for unmigrated projects or when DB
- * has zero milestones (e.g. first run before migration).
+ * Legacy filesystem parsing is available only through an explicit opt-in for
+ * tests/recovery flows; runtime must not silently infer state from markdown.
  */
 export async function deriveState(basePath: string): Promise<GSDState> {
   // Return cached result if within the TTL window for the same basePath
@@ -285,22 +291,36 @@ export async function deriveState(basePath: string): Promise<GSDState> {
   const stopTimer = debugTime("derive-state-impl");
   let result: GSDState;
 
-  // Dual-path: DB-backed derivation is authoritative whenever the DB is open.
-  // Markdown remains a fallback only when no DB connection is available.
+  // DB-backed derivation is authoritative whenever the DB is open.
+  // Markdown fallback is explicit-only; runtime degrade must not infer state
+  // from ROADMAP.md, PLAN.md, SUMMARY.md, REQUIREMENTS.md, or flag files.
   if (isDbAvailable()) {
     const stopDbTimer = debugTime("derive-state-db");
     result = await deriveStateFromDb(basePath);
     stopDbTimer({ phase: result.phase, milestone: result.activeMilestone?.id });
     _telemetry.dbDeriveCount++;
-  } else {
-    // Only warn when DB initialization was attempted and failed — not when
-    // the DB simply hasn't been opened yet (e.g. during before_agent_start
-    // context injection which runs before any tool invocation opens the DB).
+  } else if (process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK === "1") {
     if (wasDbOpenAttempted()) {
-      logWarning("state", "DB unavailable — using filesystem state derivation (degraded mode)");
+      logWarning("state", "DB unavailable — using explicit legacy filesystem state derivation");
     }
     result = await _deriveStateImpl(basePath);
     _telemetry.markdownDeriveCount++;
+  } else {
+    if (wasDbOpenAttempted()) {
+      logWarning("state", "DB unavailable — refusing implicit markdown state derivation");
+    }
+    result = {
+      activeMilestone: null,
+      activeSlice: null,
+      activeTask: null,
+      phase: "pre-planning",
+      recentDecisions: [],
+      blockers: ["DB unavailable — runtime markdown state derivation is disabled"],
+      nextAction: "Open or create the canonical GSD database before deriving workflow state.",
+      registry: [],
+      requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+      progress: { milestones: { done: 0, total: 0 } },
+    };
   }
 
   stopTimer({ phase: result.phase, milestone: result.activeMilestone?.id });
@@ -565,7 +585,7 @@ function resolveSliceDependencies(activeMilestoneSlices: SliceRow[]): { activeSl
     activeMilestoneSlices.filter(s => isStatusDone(s.status)).map(s => s.id)
   );
 
-  const sliceLock = process.env.GSD_SLICE_LOCK;
+  const sliceLock = process.env.GSD_PARALLEL_WORKER ? process.env.GSD_SLICE_LOCK : undefined;
   if (sliceLock) {
     const lockedSlice = activeMilestoneSlices.find(s => s.id === sliceLock);
     if (lockedSlice) {
@@ -607,7 +627,7 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
 
   const allMilestones = getAllMilestones();
 
-  const milestoneLock = process.env.GSD_MILESTONE_LOCK;
+  const milestoneLock = process.env.GSD_PARALLEL_WORKER ? process.env.GSD_MILESTONE_LOCK : undefined;
   const milestones = milestoneLock
     ? allMilestones.filter(m => m.id === milestoneLock)
     : allMilestones;
@@ -662,10 +682,11 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   const activeSliceContext = resolveSliceDependencies(activeMilestoneSlices);
   if (!activeSliceContext.activeSlice) {
     // If locked slice wasn't found, it returns null but logs warning, we need to return 'blocked'
-    if (process.env.GSD_SLICE_LOCK) {
+    const sliceLock = process.env.GSD_PARALLEL_WORKER ? process.env.GSD_SLICE_LOCK : undefined;
+    if (sliceLock) {
       return {
         activeMilestone, activeSlice: null, activeTask: null,
-        phase: 'blocked', recentDecisions: [], blockers: [`GSD_SLICE_LOCK=${process.env.GSD_SLICE_LOCK} not found in active milestone slices`],
+        phase: 'blocked', recentDecisions: [], blockers: [`GSD_SLICE_LOCK=${sliceLock} not found in active milestone slices`],
         nextAction: 'Slice lock references a non-existent slice — check orchestrator dispatch.',
         registry, requirements,
         progress: { milestones: milestoneProgress, slices: sliceProgress },
@@ -682,9 +703,9 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   const { activeSlice, activeSliceRow } = activeSliceContext;
 
   // ADR-011: DB slice metadata is authoritative for sketch refinement.
-  // PLAN.md is a projection and is deliberately not used to infer this state.
-  const progressive = loadEffectiveGSDPreferences()?.preferences?.phases?.progressive_planning === true;
-  if (progressive && activeSliceRow?.is_sketch === 1) {
+  // PLAN.md and preference flags are projections/configuration and are
+  // deliberately not used to infer whether the slice itself is a sketch.
+  if (activeSliceRow?.is_sketch === 1) {
     return {
       activeMilestone, activeSlice, activeTask: null,
       phase: 'refining', recentDecisions: [], blockers: [],
@@ -823,12 +844,12 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
   const milestoneIds = sortByQueueOrder(diskIds, customOrder);
 
   // ── Parallel worker isolation ──────────────────────────────────────────
-  // When GSD_MILESTONE_LOCK is set, this process is a parallel worker
+  // When GSD_PARALLEL_WORKER and GSD_MILESTONE_LOCK are set, this process is a parallel worker
   // scoped to a single milestone. Filter the milestone list so this worker
   // only sees its assigned milestone (all others are treated as if they
   // don't exist). This gives each worker complete isolation without
   // modifying any other state derivation logic.
-  const milestoneLock = process.env.GSD_MILESTONE_LOCK;
+  const milestoneLock = process.env.GSD_PARALLEL_WORKER ? process.env.GSD_MILESTONE_LOCK : undefined;
   if (milestoneLock && milestoneIds.includes(milestoneLock)) {
     milestoneIds.length = 0;
     milestoneIds.push(milestoneLock);
@@ -1291,8 +1312,8 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
   let activeSlice: ActiveRef | null = null;
 
   // ── Slice-level parallel worker isolation ─────────────────────────────
-  // When GSD_SLICE_LOCK is set, override activeSlice to only the locked slice.
-  const sliceLockLegacy = process.env.GSD_SLICE_LOCK;
+  // When GSD_PARALLEL_WORKER and GSD_SLICE_LOCK are set, override activeSlice to only the locked slice.
+  const sliceLockLegacy = process.env.GSD_PARALLEL_WORKER ? process.env.GSD_SLICE_LOCK : undefined;
   if (sliceLockLegacy) {
     const lockedSlice = activeRoadmap.slices.find(s => s.id === sliceLockLegacy);
     if (lockedSlice) {

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -40,13 +40,13 @@ import { isClosedStatus, isDeferredStatus } from './status-guards.js';
 import { nativeBatchParseGsdFiles, type BatchParsedFile } from './native-parser-bridge.js';
 
 import { join, resolve } from 'path';
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import { debugCount, debugTime } from './debug-logger.js';
-import { logWarning, logError } from './workflow-logger.js';
+import { logWarning } from './workflow-logger.js';
 import { extractVerdict } from './verdict-parser.js';
-import { loadEffectiveGSDPreferences } from './preferences.js';
 import { detectPendingEscalation } from './escalation.js';
 import { isTerminalMilestoneSummaryContent } from './milestone-summary-classifier.js';
+import { loadEffectiveGSDPreferences } from './preferences.js';
 
 import {
   isDbAvailable,
@@ -57,13 +57,8 @@ import {
   getSliceTasks,
   getReplanHistory,
   getSlice,
-  insertMilestone,
-  insertSlice,
-  insertTask,
-  updateSliceStatus,
-  updateTaskStatus,
+  getRequirementCounts,
   getPendingGateCountForTurn,
-  autoHealSketchFlags,
   type MilestoneRow,
   type SliceRow,
   type TaskRow,
@@ -296,36 +291,13 @@ export async function deriveState(basePath: string): Promise<GSDState> {
   const stopTimer = debugTime("derive-state-impl");
   let result: GSDState;
 
-  // Dual-path: try DB-backed derivation first when hierarchy tables are populated
+  // Dual-path: DB-backed derivation is authoritative whenever the DB is open.
+  // Markdown remains a fallback only when no DB connection is available.
   if (isDbAvailable()) {
-    let dbMilestones = getAllMilestones();
-
-    // Disk→DB reconciliation when DB is empty but disk has milestones (#2631).
-    // deriveStateFromDb() does its own reconciliation, but deriveState() skips
-    // it entirely when the DB is empty. Sync here so the DB path is used when
-    // disk milestones exist but haven't been migrated yet.
-    if (dbMilestones.length === 0) {
-      const diskIds = findMilestoneIds(basePath);
-      let synced = false;
-      for (const diskId of diskIds) {
-        if (!isGhostMilestone(basePath, diskId)) {
-          insertMilestone(diskMilestoneInsert(basePath, diskId));
-          synced = true;
-        }
-      }
-      if (synced) dbMilestones = getAllMilestones();
-    }
-
-    if (dbMilestones.length > 0) {
-      const stopDbTimer = debugTime("derive-state-db");
-      result = await deriveStateFromDb(basePath);
-      stopDbTimer({ phase: result.phase, milestone: result.activeMilestone?.id });
-      _telemetry.dbDeriveCount++;
-    } else {
-      // DB open but no milestones on disk either — use filesystem path
-      result = await _deriveStateImpl(basePath);
-      _telemetry.markdownDeriveCount++;
-    }
+    const stopDbTimer = debugTime("derive-state-db");
+    result = await deriveStateFromDb(basePath);
+    stopDbTimer({ phase: result.phase, milestone: result.activeMilestone?.id });
+    _telemetry.dbDeriveCount++;
   } else {
     // Only warn when DB initialization was attempted and failed — not when
     // the DB simply hasn't been opened yet (e.g. during before_agent_start
@@ -369,115 +341,11 @@ function extractContextTitle(content: string | null, fallback: string): string {
 // Alias kept for backward compatibility within this file.
 const isStatusDone = isClosedStatus;
 
-function loadSync(path: string | null): string | null {
-  if (!path) return null;
-  try {
-    return readFileSync(path, "utf-8");
-  } catch {
-    return null;
-  }
-}
-
-function diskMilestoneInsert(basePath: string, mid: string): {
-  id: string;
-  title?: string;
-  status: string;
-  depends_on: string[];
-} {
-  const contextContent = loadSync(resolveMilestoneFile(basePath, mid, "CONTEXT"));
-  const draftContent = !contextContent ? loadSync(resolveMilestoneFile(basePath, mid, "CONTEXT-DRAFT")) : null;
-  const roadmapContent = loadSync(resolveMilestoneFile(basePath, mid, "ROADMAP"));
-  const summaryContent = loadSync(resolveMilestoneFile(basePath, mid, "SUMMARY"));
-  const roadmap = roadmapContent ? parseRoadmap(roadmapContent) : null;
-  const summary = summaryContent ? parseSummary(summaryContent) : null;
-  const summaryTerminal = summaryContent != null && isTerminalMilestoneSummaryContent(summaryContent);
-  const parked = resolveMilestoneFile(basePath, mid, "PARKED") !== null;
-
-  return {
-    id: mid,
-    title: roadmap
-      ? stripMilestonePrefix(roadmap.title)
-      : (contextContent || draftContent)
-        ? extractContextTitle(contextContent || draftContent, mid)
-        : (summary?.title || mid),
-    status: parked ? "parked" : summaryTerminal ? "complete" : "active",
-    depends_on: parseContextDependsOn(contextContent ?? draftContent),
-  };
-}
-
 /**
  * Derive GSD state from the milestones/slices/tasks DB tables.
- * Flag files (PARKED, VALIDATION, CONTINUE, REPLAN, REPLAN-TRIGGER, CONTEXT-DRAFT)
- * are still checked on the filesystem since they aren't in DB tables.
- * Requirements also stay file-based via parseRequirementCounts().
- *
- * Must produce field-identical GSDState to _deriveStateImpl() for the same project.
+ * Markdown files are projections only in this path; they are never imported,
+ * reconciled, or used as completion signals.
  */
-function reconcileDiskToDb(basePath: string): MilestoneRow[] {
-  let allMilestones = getAllMilestones();
-  const dbIdSet = new Set(allMilestones.map(m => m.id));
-  const diskIds = findMilestoneIds(basePath);
-  let synced = false;
-  for (const diskId of diskIds) {
-    if (!dbIdSet.has(diskId) && !isGhostMilestone(basePath, diskId)) {
-      insertMilestone(diskMilestoneInsert(basePath, diskId));
-      synced = true;
-    }
-  }
-  if (synced) allMilestones = getAllMilestones();
-
-  for (const mid of diskIds) {
-    if (isGhostMilestone(basePath, mid)) continue;
-    const roadmapPath = resolveMilestoneFile(basePath, mid, "ROADMAP");
-    if (!roadmapPath) continue;
-
-    const dbSlices = getMilestoneSlices(mid);
-    const dbSliceIds = new Set(dbSlices.map(s => s.id));
-
-    let roadmapContent: string;
-    try {
-      roadmapContent = readFileSync(roadmapPath, "utf-8");
-    } catch (err) {
-      logWarning("state", "reconcileDiskToDb: roadmap read failed, skipping milestone", {
-        mid,
-        error: (err as Error).message,
-      });
-      continue;
-    }
-
-    const parsed = parseRoadmap(roadmapContent);
-    for (const s of parsed.slices) {
-      if (dbSliceIds.has(s.id)) continue;
-      const summaryPath = resolveSliceFile(basePath, mid, s.id, "SUMMARY");
-      const sliceStatus = (s.done || summaryPath) ? "complete" : "pending";
-      insertSlice({
-        id: s.id, milestoneId: mid, title: s.title,
-        status: sliceStatus, risk: s.risk,
-        depends: s.depends, demo: s.demo,
-      });
-    }
-
-    // Reconcile stale *existing* slice rows (#3599): a slice row may exist in
-    // the DB with status "pending" even though disk artifacts (SUMMARY) prove
-    // completion — the same class of desync that task-level reconciliation
-    // (further below) already handles.  Without this, the dependency resolver
-    // builds doneSliceIds from stale DB rows and downstream slices stay blocked
-    // forever with "No slice eligible".
-    for (const dbSlice of dbSlices) {
-      if (isStatusDone(dbSlice.status)) continue;
-      const summaryPath = resolveSliceFile(basePath, mid, dbSlice.id, "SUMMARY");
-      if (summaryPath) {
-        try {
-          updateSliceStatus(mid, dbSlice.id, "complete");
-          logWarning("reconcile", `slice ${mid}/${dbSlice.id} status reconciled from "${dbSlice.status}" to "complete" (#3599)`, { mid, sid: dbSlice.id });
-        } catch (e) {
-          logError("reconcile", `failed to update slice ${dbSlice.id}`, { sid: dbSlice.id, error: (e as Error).message });
-        }
-      }
-    }
-  }
-  return allMilestones;
-}
 
 function buildCompletenessSet(basePath: string, milestones: MilestoneRow[]) {
   const completeMilestoneIds = new Set<string>();
@@ -488,8 +356,7 @@ function buildCompletenessSet(basePath: string, milestones: MilestoneRow[]) {
   // (crashed complete-milestone turn, partial merge, manual edit) must not
   // flip derived state to complete and cascade into a false auto-merge (#4179).
   for (const m of milestones) {
-    const parkedFile = resolveMilestoneFile(basePath, m.id, "PARKED");
-    if (parkedFile || m.status === 'parked') {
+    if (m.status === 'parked') {
       parkedMilestoneIds.add(m.id);
       continue;
     }
@@ -530,16 +397,7 @@ async function buildRegistryAndFindActive(
     // not imply completion. The summary file may still be consulted below as a
     // title source for legitimately-complete milestones whose DB row has no title.
     if (completeMilestoneIds.has(m.id)) {
-      let title = stripMilestonePrefix(m.title) || m.id;
-      if (!m.title) {
-        const summaryFile = resolveMilestoneFile(basePath, m.id, "SUMMARY");
-        if (summaryFile) {
-          const summaryContent = await loadFile(summaryFile);
-          if (summaryContent) {
-            title = parseSummary(summaryContent).title || m.id;
-          }
-        }
-      }
+      const title = stripMilestonePrefix(m.title) || m.id;
       registry.push({ id: m.id, title, status: 'complete' });
       continue;
     }
@@ -766,72 +624,6 @@ function resolveSliceDependencies(activeMilestoneSlices: SliceRow[]): { activeSl
   return { activeSlice: null, activeSliceRow: null };
 }
 
-async function reconcileSliceTasks(
-  basePath: string,
-  milestoneId: string,
-  sliceId: string,
-  planFile: string
-): Promise<TaskRow[]> {
-  let tasks = getSliceTasks(milestoneId, sliceId);
-
-  // #3600/#4974: import missing plan-file tasks even when the DB already has
-  // a partial task set. Existing DB task statuses stay authoritative.
-  if (planFile) {
-    try {
-      const planContent = await loadFile(planFile);
-      if (planContent) {
-        const diskPlan = parsePlan(planContent);
-        if (diskPlan.tasks.length > 0) {
-          const dbTaskIds = new Set(tasks.map(t => t.id));
-          let inserted = 0;
-          for (let i = 0; i < diskPlan.tasks.length; i++) {
-            const t = diskPlan.tasks[i];
-            if (dbTaskIds.has(t.id)) continue;
-            try {
-              insertTask({
-                id: t.id,
-                sliceId,
-                milestoneId,
-                title: t.title,
-                status: t.done ? 'complete' : 'pending',
-                sequence: i + 1,
-              });
-              inserted++;
-            } catch (insertErr) {
-              logWarning("reconcile", `failed to insert task ${t.id} from plan file: ${insertErr instanceof Error ? insertErr.message : String(insertErr)}`);
-            }
-          }
-          if (inserted > 0) {
-            tasks = getSliceTasks(milestoneId, sliceId);
-            logWarning("reconcile", `imported ${inserted} missing task(s) from plan file for ${milestoneId}/${sliceId}`, { mid: milestoneId, sid: sliceId });
-          }
-        }
-      }
-    } catch (err) {
-      logError("reconcile", `plan-file task import failed for ${milestoneId}/${sliceId}: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
-
-  let reconciled = false;
-  for (const t of tasks) {
-    if (isStatusDone(t.status)) continue;
-    const summaryPath = resolveTaskFile(basePath, milestoneId, sliceId, t.id, "SUMMARY");
-    if (summaryPath && existsSync(summaryPath)) {
-      try {
-        updateTaskStatus(milestoneId, sliceId, t.id, "complete", new Date().toISOString());
-        logWarning("reconcile", `task ${milestoneId}/${sliceId}/${t.id} status reconciled from "${t.status}" to "complete" (#2514)`, { mid: milestoneId, sid: sliceId, tid: t.id });
-        reconciled = true;
-      } catch (e) {
-        logError("reconcile", `failed to update task ${t.id}`, { tid: t.id, error: (e as Error).message });
-      }
-    }
-  }
-  if (reconciled) {
-    tasks = getSliceTasks(milestoneId, sliceId);
-  }
-  return tasks;
-}
-
 async function detectBlockers(basePath: string, milestoneId: string, sliceId: string, tasks: TaskRow[]): Promise<string | null> {
   const completedTasks = tasks.filter(t => isStatusDone(t.status));
   for (const ct of completedTasks) {
@@ -852,10 +644,7 @@ async function detectBlockers(basePath: string, milestoneId: string, sliceId: st
 
 function checkReplanTrigger(basePath: string, milestoneId: string, sliceId: string): boolean {
   const sliceRow = getSlice(milestoneId, sliceId);
-  const dbTriggered = !!sliceRow?.replan_triggered_at;
-  const diskTriggered = !dbTriggered &&
-    !!resolveSliceFile(basePath, milestoneId, sliceId, "REPLAN-TRIGGER");
-  return dbTriggered || diskTriggered;
+  return !!sliceRow?.replan_triggered_at;
 }
 
 async function checkInterruptedWork(basePath: string, milestoneId: string, sliceId: string): Promise<boolean> {
@@ -866,9 +655,9 @@ async function checkInterruptedWork(basePath: string, milestoneId: string, slice
 }
 
 export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
-  const requirements = parseRequirementCounts(await loadFile(resolveGsdRootFile(basePath, "REQUIREMENTS")));
+  const requirements = getRequirementCounts();
 
-  let allMilestones = reconcileDiskToDb(basePath);
+  const allMilestones = getAllMilestones();
 
   const customOrder = loadQueueOrder(basePath);
   const sortedIds = sortByQueueOrder(allMilestones.map(m => m.id), customOrder);
@@ -940,15 +729,7 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
     return handleAllSlicesDone(basePath, activeMilestone, registry, requirements, milestoneProgress, sliceProgress);
   }
 
-  // ADR-011 auto-heal: if a slice has a PLAN on disk but is still flagged is_sketch=1
-  // (e.g. a crash between plan-slice write and the sketch flip), reconcile before
-  // running phase derivation so the flag doesn't misroute state.
-  autoHealSketchFlags(activeMilestone.id, (sid) =>
-    !!resolveSliceFile(basePath, activeMilestone.id, sid, "PLAN"),
-  );
-  // Re-read slices after auto-heal so downstream reads see fresh is_sketch values.
-  const healedSlices = getMilestoneSlices(activeMilestone.id);
-  const activeSliceContext = resolveSliceDependencies(healedSlices);
+  const activeSliceContext = resolveSliceDependencies(activeMilestoneSlices);
   if (!activeSliceContext.activeSlice) {
     // If locked slice wasn't found, it returns null but logs warning, we need to return 'blocked'
     if (process.env.GSD_SLICE_LOCK) {
@@ -970,32 +751,20 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   }
   const { activeSlice, activeSliceRow } = activeSliceContext;
 
-  const planFile = resolveSliceFile(basePath, activeMilestone.id, activeSlice.id, "PLAN");
-  if (!planFile) {
-    // ADR-011: sketch slices with progressive_planning enabled enter the
-    // `refining` phase — a refine-slice unit expands the sketch into a full plan
-    // before execution. When the flag is off, sketches are indistinguishable
-    // from a missing plan and fall through to the normal `planning` phase.
-    const progressive = loadEffectiveGSDPreferences()?.preferences?.phases?.progressive_planning === true;
-    if (progressive && activeSliceRow?.is_sketch === 1) {
-      return {
-        activeMilestone, activeSlice, activeTask: null,
-        phase: 'refining', recentDecisions: [], blockers: [],
-        nextAction: `Refine sketch slice ${activeSlice.id} (${activeSlice.title}) using prior slice context.`,
-        registry, requirements,
-        progress: { milestones: milestoneProgress, slices: sliceProgress },
-      };
-    }
+  // ADR-011: DB slice metadata is authoritative for sketch refinement.
+  // PLAN.md is a projection and is deliberately not used to infer this state.
+  const progressive = loadEffectiveGSDPreferences()?.preferences?.phases?.progressive_planning === true;
+  if (progressive && activeSliceRow?.is_sketch === 1) {
     return {
       activeMilestone, activeSlice, activeTask: null,
-      phase: 'planning', recentDecisions: [], blockers: [],
-      nextAction: `Plan slice ${activeSlice.id} (${activeSlice.title}).`,
+      phase: 'refining', recentDecisions: [], blockers: [],
+      nextAction: `Refine sketch slice ${activeSlice.id} (${activeSlice.title}) using prior slice context.`,
       registry, requirements,
       progress: { milestones: milestoneProgress, slices: sliceProgress },
     };
   }
 
-  const tasks = await reconcileSliceTasks(basePath, activeMilestone.id, activeSlice.id, planFile);
+  const tasks = getSliceTasks(activeMilestone.id, activeSlice.id);
   
   const taskProgress = {
     done: tasks.filter(t => isStatusDone(t.status)).length,
@@ -1018,27 +787,13 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
     return {
       activeMilestone, activeSlice, activeTask: null,
       phase: 'planning', recentDecisions: [], blockers: [],
-      nextAction: `Slice ${activeSlice.id} has a plan file but no tasks. Add tasks to the plan.`,
+      nextAction: `Slice ${activeSlice.id} has no DB tasks. Plan slice tasks before execution.`,
       registry, requirements,
       progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
     };
   }
 
   const activeTask: ActiveRef = { id: activeTaskRow.id, title: activeTaskRow.title };
-
-  const tasksDir = resolveTasksDir(basePath, activeMilestone.id, activeSlice.id);
-  if (tasksDir && existsSync(tasksDir) && tasks.length > 0) {
-    const allFiles = readdirSync(tasksDir).filter(f => f.endsWith(".md"));
-    if (allFiles.length === 0) {
-      return {
-        activeMilestone, activeSlice, activeTask: null,
-        phase: 'planning', recentDecisions: [], blockers: [],
-        nextAction: `Task plan files missing for ${activeSlice.id}. Run plan-slice to generate task plans.`,
-        registry, requirements,
-        progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
-      };
-    }
-  }
 
   // ── Quality gate evaluation check ──────────────────────────────────
   // Pause before execution only when gates owned by the `gate-evaluate`

--- a/src/resources/extensions/gsd/tests/artifact-corruption-2630.test.ts
+++ b/src/resources/extensions/gsd/tests/artifact-corruption-2630.test.ts
@@ -107,6 +107,7 @@ function makeMilestoneRow(overrides?: Partial<MilestoneRow>): MilestoneRow {
     definition_of_done: [],
     requirement_coverage: '',
     boundary_map_markdown: '',
+    sequence: 0,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/auto-paused-session-validation.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-session-validation.test.ts
@@ -40,6 +40,12 @@ test("auto.ts validates milestone before restoring paused session (#1664)", () =
     "auto.ts must check for SUMMARY file to detect completed milestones",
   );
 
+  assert.ok(
+    source.includes("await ensureDbOpen(base)") &&
+      source.indexOf("await ensureDbOpen(base)") < source.indexOf('resolveMilestoneFile(base, meta.milestoneId, "SUMMARY")'),
+    "auto.ts must open the canonical DB before using SUMMARY as a paused-session fallback",
+  );
+
   // Resume path must sanitize paused session file metadata before unlink/recovery.
   assert.ok(
     source.includes("normalizeSessionFilePath(meta.sessionFile ?? null)"),

--- a/src/resources/extensions/gsd/tests/auto-remediate-slice-status.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-remediate-slice-status.test.ts
@@ -1,13 +1,12 @@
 /**
- * Regression test for #3673 — auto-remediate stale slice DB status
+ * Regression test for DB-authoritative rogue detection.
  *
- * When complete-slice fails after writing SUMMARY.md but before calling
- * updateSliceStatus(), the DB stays stale and the post-unit check
- * previously reported this as a "rogue" artifact, causing infinite
- * re-dispatch. The fix calls updateSliceStatus() to sync the DB.
+ * A SUMMARY.md on disk is a projection/diagnostic. Runtime post-unit checks
+ * must not use it to mark the DB slice complete; explicit import/recovery
+ * commands own markdown-to-DB behavior.
  *
- * This structural test verifies updateSliceStatus is imported and called
- * in the complete-slice branch of auto-post-unit.ts.
+ * This structural test verifies the complete-slice rogue branch reports the
+ * stale projection without calling updateSliceStatus().
  */
 
 import { describe, test } from 'node:test';
@@ -22,38 +21,26 @@ const __dirname = dirname(__filename);
 
 const source = readFileSync(join(__dirname, '..', 'auto-post-unit.ts'), 'utf-8');
 
-describe('auto-remediate stale slice status (#3673)', () => {
-  test('updateSliceStatus is imported from gsd-db', () => {
-    assert.match(source, /import\s*\{[^}]*updateSliceStatus[^}]*\}\s*from\s*["']\.\/gsd-db/,
-      'updateSliceStatus should be imported from gsd-db');
+describe('DB-authoritative slice rogue detection', () => {
+  test('updateSliceStatus is not imported for post-unit rogue reconciliation', () => {
+    assert.doesNotMatch(source, /import\s*\{[^}]*updateSliceStatus[^}]*\}\s*from\s*["']\.\/gsd-db/,
+      'auto-post-unit must not import updateSliceStatus for disk-to-DB reconciliation');
   });
 
-  test('updateSliceStatus is called with "complete" status', () => {
-    assert.match(source, /updateSliceStatus\(mid,\s*sid,\s*["']complete["']/,
-      'updateSliceStatus should be called with "complete" status');
+  test('complete-slice rogue branch does not mark DB complete from disk', () => {
+    assert.doesNotMatch(source, /updateSliceStatus\(mid,\s*sid,\s*["']complete["']/,
+      'SUMMARY.md on disk must not mark slice complete in DB');
   });
 
-  test('remediation is wrapped in try-catch for fallback to rogue detection', () => {
-    // The updateSliceStatus call should be in a try block with a catch
-    // that falls back to rogues.push
-    const updateIdx = source.indexOf('updateSliceStatus(mid, sid');
-    assert.ok(updateIdx > 0, 'updateSliceStatus call should exist');
-
-    // Find surrounding try-catch
-    const before = source.slice(Math.max(0, updateIdx - 200), updateIdx);
-    assert.match(before, /try\s*\{/,
-      'updateSliceStatus should be inside a try block');
-
-    // Bound the region to stop before the rogue fallback so /catch/ only
-    // matches this try block's catch, not an unrelated later one.
-    const after = extractSourceRegion(source, 'updateSliceStatus(mid, sid', 'rogues.push({');
-    assert.match(after, /catch/,
-      'try block should have a catch for fallback');
+  test('explicit rogue diagnostic reports stale slice summary projection', () => {
+    const branch = extractSourceRegion(source, 'unitType === "complete-slice"', 'unitType === "plan-milestone"');
+    assert.match(branch, /rogues\.push\(\{\s*path:\s*summaryPath,\s*unitType,\s*unitId\s*\}\)/,
+      'complete-slice branch should report stale SUMMARY.md as rogue');
   });
 
-  test('rogue detection still exists as fallback', () => {
-    // rogues.push should appear in the catch block
-    assert.match(source, /rogues\.push\(\{.*path:\s*summaryPath/,
-      'rogues.push fallback should still exist');
+  test('post-unit runtime does not call rogue diagnostics automatically', () => {
+    const postUnit = extractSourceRegion(source, 'export async function postUnitPostVerification');
+    assert.doesNotMatch(postUnit, /detectRogueFileWrites\(/,
+      'runtime post-unit path must not scan disk projections for rogue files');
   });
 });

--- a/src/resources/extensions/gsd/tests/complete-task-rollback-evidence.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task-rollback-evidence.test.ts
@@ -41,7 +41,7 @@ const VALID_PARAMS = {
   ],
 };
 
-describe("complete-task rollback cleans up verification_evidence (#2724)", () => {
+describe("complete-task projection failures keep DB completion committed", () => {
   let base: string;
 
   afterEach(() => {
@@ -75,7 +75,7 @@ describe("complete-task rollback cleans up verification_evidence (#2724)", () =>
     assert.equal(rows.length, 2, "should have 2 evidence rows after success");
   });
 
-  it("deletes verification_evidence rows on disk-render rollback", async () => {
+  it("keeps task completion and verification_evidence when disk projection write fails", async () => {
     base = makeTmpBase();
     openDatabase(join(base, ".gsd", "gsd.db"));
     insertMilestone({ id: "M001" });
@@ -87,20 +87,19 @@ describe("complete-task rollback cleans up verification_evidence (#2724)", () =>
     writeFileSync(tasksDir, "not-a-directory");
 
     const result = await handleCompleteTask(VALID_PARAMS, base);
-    assert.ok("error" in result, "should return error when disk write fails");
+    assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
+    assert.equal(result.stale, true, "result should report stale projection");
 
-    // Task should be rolled back to pending
     const adapter = _getAdapter()!;
     const task = adapter.prepare(
       `SELECT status FROM tasks WHERE milestone_id = 'M001' AND slice_id = 'S01' AND id = 'T01'`,
     ).get() as { status: string } | undefined;
     assert.ok(task, "task row should still exist");
-    assert.equal(task!.status, "pending", "task status should be rolled back to pending");
+    assert.equal(task!.status, "complete", "task status should remain complete");
 
-    // Verification evidence should be cleaned up — no orphaned rows
     const evidenceRows = adapter.prepare(
       `SELECT * FROM verification_evidence WHERE task_id = 'T01' AND slice_id = 'S01' AND milestone_id = 'M001'`,
     ).all();
-    assert.equal(evidenceRows.length, 0, "verification_evidence should be empty after rollback");
+    assert.equal(evidenceRows.length, 2, "verification_evidence should remain committed");
   });
 });

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -446,10 +446,13 @@ console.log('\n=== complete-task: handler with missing plan file ===');
   const params = makeValidParams();
   const result = await handleCompleteTask(params, basePath);
 
-  // Should succeed even without plan file — just skip checkbox toggle
+  // Should succeed and regenerate the missing plan projection from DB.
   assertTrue(!('error' in result), 'handler should succeed without plan file');
   if (!('error' in result)) {
     assertTrue(fs.existsSync(result.summaryPath), 'summary should be written even without plan file');
+    const planPath = path.join(basePath, '.gsd', 'milestones', 'M001', 'slices', 'S01', 'S01-PLAN.md');
+    assertTrue(fs.existsSync(planPath), 'missing plan projection should be regenerated from DB');
+    assertTrue(fs.readFileSync(planPath, 'utf-8').includes('[x] **T01:'), 'regenerated plan should reflect DB task completion');
   }
 
   cleanupDir(basePath);

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -403,12 +403,11 @@ console.log('\n=== complete-task: handler idempotency ===');
   const r1 = await handleCompleteTask(params, basePath);
   assertTrue(!('error' in r1), 'first call should succeed');
 
-  // Verify complete-task did not duplicate T01. State reconciliation may import
-  // the remaining plan task from disk so the DB stays aligned with S01-PLAN.md.
+  // Verify complete-task did not duplicate T01. S01-PLAN.md is a projection,
+  // so the remaining plan task is not imported implicitly.
   const tasks = getSliceTasks('M001', 'S01');
-  assertEq(tasks.length, 2, 'should have T01 plus reconciled T02 after first call');
+  assertEq(tasks.length, 1, 'should only have the completed DB task after first call');
   assertEq(tasks.filter(t => t.id === 'T01').length, 1, 'should have exactly one T01 row after first call');
-  assertEq(tasks.find(t => t.id === 'T02')?.status, 'pending', 'T02 should be reconciled as pending');
 
   // Second call with same params — state machine guard rejects (task is already complete)
   const r2 = await handleCompleteTask(params, basePath);
@@ -419,7 +418,7 @@ console.log('\n=== complete-task: handler idempotency ===');
 
   // Still no duplicate rows from the rejected second call.
   const tasksAfter = getSliceTasks('M001', 'S01');
-  assertEq(tasksAfter.length, 2, 'should still have T01 plus reconciled T02 after rejected second call');
+  assertEq(tasksAfter.length, 1, 'should still only have T01 after rejected second call');
   assertEq(tasksAfter.filter(t => t.id === 'T01').length, 1, 'should still have exactly one T01 row');
 
   cleanupDir(basePath);

--- a/src/resources/extensions/gsd/tests/completed-at-reconcile.test.ts
+++ b/src/resources/extensions/gsd/tests/completed-at-reconcile.test.ts
@@ -1,15 +1,9 @@
 /**
- * Behavioural regression test for #4129.
+ * Behavioural regression test for DB-authoritative task completion.
  *
- * When deriveStateFromDb's reconcileSliceTasks finds a SUMMARY.md on disk
- * for a task whose DB row is still pending, it flips the row to "complete".
- * Before #4129, the call to updateTaskStatus omitted the completedAt
- * timestamp, leaving completed_at NULL forever.
- *
- * The fix passes new Date().toISOString() as the 5th argument; this test
- * exercises that path end-to-end and asserts the column is populated.
- *
- * Refs #4829 (rewrite from positional source-grep).
+ * A task SUMMARY.md on disk is a projection, not a completion command.
+ * deriveStateFromDb must not flip a pending DB task to complete or invent a
+ * completed_at timestamp from disk evidence.
  */
 
 import { describe, test, beforeEach, afterEach } from 'node:test';
@@ -46,27 +40,26 @@ function setupProject(): void {
     `# M001\n\n## Slices\n\n- [ ] **S01: Slice** \`risk:low\` \`depends:[]\`\n  - After this: works\n`,
   );
 
-  // Plan file for the slice so reconcile can populate task list if DB is empty.
+  // Plan file for the slice. It is a projection and must not drive DB state.
   writeFileSync(
     join(basePath, '.gsd', 'milestones', 'M001', 'slices', 'S01', 'S01-PLAN.md'),
     `# S01: Slice\n\n## Tasks\n\n- [ ] **T01: Test task** \`est:30m\`\n  - Do: x\n  - Verify: y\n`,
   );
 
-  // The summary file: this is the on-disk evidence that flips the task
-  // status to "complete" inside reconcileSliceTasks.
+  // The summary file is a projection and must not complete the task.
   writeFileSync(
     join(basePath, '.gsd', 'milestones', 'M001', 'slices', 'S01', 'tasks', 'T01-SUMMARY.md'),
     '---\nid: T01\nparent: S01\nmilestone: M001\nblocker_discovered: false\n---\n# T01\n',
   );
 }
 
-describe('completed_at reconcile (#4129)', () => {
+describe('completed_at DB-authoritative derivation', () => {
   beforeEach(() => {
     setupProject();
     openDatabase(join(basePath, '.gsd', 'gsd.db'));
     insertMilestone({ id: 'M001', title: 'M001', status: 'active' });
     insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Slice', status: 'active' });
-    // Task is "pending" in DB, but SUMMARY.md exists on disk → reconcile flips it.
+    // Task is "pending" in DB, even though SUMMARY.md exists on disk.
     insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'Test task', status: 'pending' });
     invalidateStateCache();
   });
@@ -76,24 +69,16 @@ describe('completed_at reconcile (#4129)', () => {
     try { rmSync(basePath, { recursive: true, force: true }); } catch { /* */ }
   });
 
-  test('reconcileSliceTasks sets completed_at when flipping a pending task to complete via SUMMARY.md', async () => {
+  test('deriveStateFromDb does not set completed_at from a disk SUMMARY projection', async () => {
     const before = getTask('M001', 'S01', 'T01');
     assert.strictEqual(before?.status, 'pending', 'task starts pending');
     assert.strictEqual(before?.completed_at, null, 'task starts with completed_at NULL');
 
-    // Trigger the reconcile path (state.ts → reconcileSliceTasks).
+    // Derive runtime state. Disk SUMMARY.md must not mutate the DB row.
     await deriveStateFromDb(basePath);
 
     const after = getTask('M001', 'S01', 'T01');
-    assert.strictEqual(after?.status, 'complete', 'task should be flipped to complete');
-    assert.ok(
-      typeof after?.completed_at === 'string' && after.completed_at.length > 0,
-      `completed_at must be populated by reconcileSliceTasks (#4129); got ${JSON.stringify(after?.completed_at)}`,
-    );
-    // Sanity: timestamp parses as a valid ISO date.
-    assert.ok(
-      !Number.isNaN(Date.parse(after!.completed_at!)),
-      `completed_at should be a valid ISO timestamp, got ${after!.completed_at}`,
-    );
+    assert.strictEqual(after?.status, 'pending', 'task remains pending');
+    assert.strictEqual(after?.completed_at, null, 'completed_at remains NULL');
   });
 });

--- a/src/resources/extensions/gsd/tests/completed-units-metrics-sync.test.ts
+++ b/src/resources/extensions/gsd/tests/completed-units-metrics-sync.test.ts
@@ -58,6 +58,19 @@ test("#2313: syncStateToProjectRoot should sync metrics.json", () => {
   );
 });
 
+test("syncStateToProjectRoot should back-sync completed-units.json", () => {
+  const syncSrcPath = join(import.meta.dirname, "..", "auto-worktree.ts");
+  const syncSrc = readFileSync(syncSrcPath, "utf-8");
+  const fnIdx = syncSrc.indexOf("export function syncStateToProjectRoot(");
+  assert.ok(fnIdx !== -1, "syncStateToProjectRoot exists");
+  const fnBlock = syncSrc.slice(fnIdx, syncSrc.indexOf("// ─── Resource Staleness", fnIdx));
+
+  assert.ok(
+    fnBlock.includes('"completed-units.json"'),
+    "syncStateToProjectRoot should copy completed-units.json back to the project root",
+  );
+});
+
 test("#2313: syncWorktreeStateBack should include metrics.json in ROOT_DIAGNOSTIC_FILES", () => {
   const autoWorktreeSrcPath = join(import.meta.dirname, "..", "auto-worktree.ts");
   const autoWorktreeSrc = readFileSync(autoWorktreeSrcPath, "utf-8");

--- a/src/resources/extensions/gsd/tests/completed-units-metrics-sync.test.ts
+++ b/src/resources/extensions/gsd/tests/completed-units-metrics-sync.test.ts
@@ -58,13 +58,13 @@ test("#2313: syncStateToProjectRoot should sync metrics.json", () => {
   );
 });
 
-test("#2313: syncWorktreeStateBack should include metrics.json in ROOT_STATE_FILES", () => {
+test("#2313: syncWorktreeStateBack should include metrics.json in ROOT_DIAGNOSTIC_FILES", () => {
   const autoWorktreeSrcPath = join(import.meta.dirname, "..", "auto-worktree.ts");
   const autoWorktreeSrc = readFileSync(autoWorktreeSrcPath, "utf-8");
 
-  // Find the ROOT_STATE_FILES constant (single source of truth for both sync directions)
-  const constIdx = autoWorktreeSrc.indexOf("ROOT_STATE_FILES");
-  assert.ok(constIdx !== -1, "ROOT_STATE_FILES constant exists");
+  // Find the ROOT_DIAGNOSTIC_FILES constant used for worktree copy-back.
+  const constIdx = autoWorktreeSrc.indexOf("ROOT_DIAGNOSTIC_FILES");
+  assert.ok(constIdx !== -1, "ROOT_DIAGNOSTIC_FILES constant exists");
 
   // Get the array content
   const arrayStart = autoWorktreeSrc.indexOf("[", constIdx);
@@ -73,7 +73,7 @@ test("#2313: syncWorktreeStateBack should include metrics.json in ROOT_STATE_FIL
 
   assert.ok(
     rootFilesBlock.includes("metrics.json"),
-    "metrics.json should be in ROOT_STATE_FILES list",
+    "metrics.json should be in ROOT_DIAGNOSTIC_FILES list",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/db-path-worktree-symlink.test.ts
+++ b/src/resources/extensions/gsd/tests/db-path-worktree-symlink.test.ts
@@ -47,7 +47,7 @@ const symlinkResult = resolveProjectRootDbPath(symlinkPath);
 assertEq(
   symlinkResult,
   join("/home/user/myproject/.gsd/projects/abc123def", "gsd.db"),
-  "/.gsd/projects/<hash>/worktrees/ resolves to hash-level DB (#2517, updated for #2952)",
+  "/.gsd/projects/<hash>/worktrees/ resolves to external project state DB",
 );
 
 // Windows-style separators for symlink layout
@@ -57,7 +57,7 @@ if (sep === "\\") {
   assertEq(
     winResult,
     join("C:\\Users\\dev\\project\\.gsd\\projects\\abc123def", "gsd.db"),
-    "Windows /.gsd/projects/<hash>/worktrees/ resolves to hash-level DB",
+    "Windows /.gsd/projects/<hash>/worktrees/ resolves to external project state DB",
   );
 } else {
   // On non-Windows, test forward-slash variant explicitly
@@ -66,7 +66,7 @@ if (sep === "\\") {
   assertEq(
     fwdResult,
     join("/home/user/myproject/.gsd/projects/abc123def", "gsd.db"),
-    "Forward-slash /.gsd/projects/<hash>/worktrees/ resolves to hash-level DB on POSIX",
+    "Forward-slash /.gsd/projects/<hash>/worktrees/ resolves to external project state DB on POSIX",
   );
 }
 
@@ -76,7 +76,7 @@ const deepResult = resolveProjectRootDbPath(deepSymlinkPath);
 assertEq(
   deepResult,
   join("/home/user/myproject/.gsd/projects/deadbeef42", "gsd.db"),
-  "Deep /.gsd/projects/<hash>/worktrees/ path resolves to hash-level DB (#2952)",
+  "Deep /.gsd/projects/<hash>/worktrees/ path resolves to external project state DB",
 );
 
 // Non-worktree path should be unchanged

--- a/src/resources/extensions/gsd/tests/db-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/db-writer.test.ts
@@ -481,7 +481,7 @@ describe('db-writer', () => {
     }
   });
 
-  test('updateRequirementInDb — seeds from REQUIREMENTS.md when DB empty (#3346)', async () => {
+  test('updateRequirementInDb — ignores REQUIREMENTS.md projection when DB empty', async () => {
     const tmpDir = makeTmpDir();
     const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
     openDatabase(dbPath);
@@ -515,31 +515,28 @@ describe('db-writer', () => {
       ].join('\n');
       fs.writeFileSync(path.join(tmpDir, '.gsd', 'REQUIREMENTS.md'), reqContent);
 
-      // DB is empty — no requirements seeded. Update R005 to "validated".
-      // Before #3346 fix: this would create a skeleton with empty fields.
-      // After fix: this seeds all 3 requirements from REQUIREMENTS.md first.
+      // DB is empty. REQUIREMENTS.md is a projection and must not be imported
+      // implicitly by a runtime DB write.
       await updateRequirementInDb('R005', {
         status: 'validated',
         validation: 'S02 — auth flow verified',
       }, tmpDir);
 
-      // R005 should have the update AND the original content from markdown
+      // R005 should have the requested update only; disk projection content is ignored.
       const r005 = getRequirementById('R005');
       assert.ok(r005, 'R005 should exist');
       assert.equal(r005!.status, 'validated', 'status should be updated');
       assert.equal(r005!.validation, 'S02 — auth flow verified', 'validation should be updated');
-      assert.equal(r005!.class, 'functional', 'class should be preserved from REQUIREMENTS.md');
-      assert.ok(r005!.description?.includes('authentication') || r005!.full_content?.includes('authentication'),
-        'original content should be preserved');
+      assert.equal(r005!.class, '', 'class should not be imported from REQUIREMENTS.md');
+      assert.ok(!r005!.description?.includes('authentication'), 'description should not be imported');
+      assert.ok(!r005!.full_content?.includes('authentication'), 'full content should not be imported');
 
-      // R007 and R001 should also be seeded (not just the one being updated)
+      // Other requirements in the projection are not seeded.
       const r007 = getRequirementById('R007');
-      assert.ok(r007, 'R007 should be seeded from REQUIREMENTS.md');
-      assert.equal(r007!.status, 'active', 'R007 status should be active');
+      assert.equal(r007, null, 'R007 should not be imported from REQUIREMENTS.md');
 
       const r001 = getRequirementById('R001');
-      assert.ok(r001, 'R001 should be seeded from REQUIREMENTS.md');
-      assert.equal(r001!.status, 'validated', 'R001 status should be validated (from section heading)');
+      assert.equal(r001, null, 'R001 should not be imported from REQUIREMENTS.md');
     } finally {
       closeDatabase();
       cleanupDir(tmpDir);

--- a/src/resources/extensions/gsd/tests/db-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/db-writer.test.ts
@@ -660,15 +660,16 @@ describe('db-writer', () => {
         'disk file preserved — shrinkage guard prevented overwrite',
       );
 
-      // DB should contain the full disk content, not the abbreviated content
+      // DB should keep the caller-provided content. The larger disk file is a
+      // stale projection, not runtime authority.
       const adapter = _getAdapter();
       const row = adapter!
         .prepare('SELECT full_content FROM artifacts WHERE path = ?')
         .get(relPath);
       assert.deepStrictEqual(
         row!['full_content'],
-        fullContent,
-        'DB stores the richer disk content instead of abbreviated content',
+        abbreviatedContent,
+        'DB stores caller-provided content instead of importing disk projection content',
       );
     } finally {
       closeDatabase();

--- a/src/resources/extensions/gsd/tests/derive-state-crossval.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-crossval.test.ts
@@ -20,7 +20,7 @@ import {
   insertSlice,
   insertTask,
 } from '../gsd-db.ts';
-import { migrateHierarchyToDb } from '../md-importer.ts';
+import { migrateFromMarkdown, migrateHierarchyToDb } from '../md-importer.ts';
 import type { GSDState } from '../types.ts';
 
 // ─── Fixture Helpers ───────────────────────────────────────────────────────
@@ -479,12 +479,13 @@ skills_used: []
 
       // Step 2: Migrate markdown to DB
       openDatabase(':memory:');
-      const counts = migrateHierarchyToDb(base);
+      const counts = migrateFromMarkdown(base);
 
       // Verify migration populated correctly
-      assert.ok(counts.milestones >= 1, 'G-roundtrip: migrated milestones');
-      assert.ok(counts.slices >= 2, 'G-roundtrip: migrated slices');
-      assert.ok(counts.tasks >= 3, 'G-roundtrip: migrated tasks');
+      assert.ok(counts.hierarchy.milestones >= 1, 'G-roundtrip: migrated milestones');
+      assert.ok(counts.hierarchy.slices >= 2, 'G-roundtrip: migrated slices');
+      assert.ok(counts.hierarchy.tasks >= 3, 'G-roundtrip: migrated tasks');
+      assert.equal(counts.requirements, 3, 'G-roundtrip: migrated requirements');
 
       // Step 3: Get DB-backed state
       invalidateStateCache();

--- a/src/resources/extensions/gsd/tests/derive-state-db-disk-reconcile.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db-disk-reconcile.test.ts
@@ -1,10 +1,9 @@
 /**
  * derive-state-db-disk-reconcile.test.ts — #2416
  *
- * After migration to DB-backed state, milestones that exist on disk
- * (in .gsd/milestones/) but were never imported into the DB become
- * invisible to deriveStateFromDb(). This test verifies that
- * deriveStateFromDb reconciles disk milestones with DB milestones.
+ * DB-authoritative state: milestones that exist only as markdown projections
+ * are not imported by deriveStateFromDb(). Explicit migration/import is the
+ * only markdown-to-DB path.
  */
 
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -17,7 +16,6 @@ import {
   closeDatabase,
   insertMilestone,
   insertSlice,
-  insertTask,
 } from "../gsd-db.ts";
 import { createTestContext } from "./test-helpers.ts";
 
@@ -58,7 +56,7 @@ const ROADMAP_CONTENT = `# M002: Disk-Only Milestone
 `;
 
 async function main(): Promise<void> {
-  console.log("\n=== #2416: deriveStateFromDb reconciles disk milestones ===");
+  console.log("\n=== deriveStateFromDb does not reconcile disk milestones ===");
 
   // Set up: M001 in DB, M002 on disk only
   const base = createFixtureBase();
@@ -81,12 +79,9 @@ async function main(): Promise<void> {
     invalidateStateCache();
     const state = await deriveStateFromDb(base);
 
-    // M002 should be visible in the registry
+    // M002 is disk-only and should not be visible in DB-backed state.
     const m002Entry = state.registry.find((m) => m.id === "M002");
-    assertTrue(
-      m002Entry !== undefined,
-      "M002 (disk-only milestone) should appear in state.registry (#2416)",
-    );
+    assertEq(m002Entry, undefined, "M002 disk-only milestone should not appear in DB-backed state");
 
     // M001 should still be in the registry
     const m001Entry = state.registry.find((m) => m.id === "M001");
@@ -95,24 +90,14 @@ async function main(): Promise<void> {
       "M001 (DB milestone) should still appear in state.registry",
     );
 
-    // The active milestone should be M002 (since M001 is complete)
-    assertTrue(
-      state.activeMilestone !== null,
-      "There should be an active milestone",
-    );
-    if (state.activeMilestone) {
-      assertEq(
-        state.activeMilestone.id,
-        "M002",
-        "Active milestone should be M002 (disk-only, not complete) (#2416)",
-      );
-    }
+    assertEq(state.activeMilestone, null, "No active milestone should be inferred from disk-only markdown");
+    assertEq(state.phase, "complete", "DB-only complete milestone drives complete state");
   } finally {
     closeDatabase();
     cleanup(base);
   }
 
-  console.log("\n=== #4974: summary-only disk milestones keep parsed title ===");
+    console.log("\n=== summary-only disk milestones are not imported ===");
 
   {
     const summaryOnlyBase = createFixtureBase();
@@ -132,20 +117,7 @@ async function main(): Promise<void> {
       const state = await deriveStateFromDb(summaryOnlyBase);
       const m002Entry = state.registry.find((m) => m.id === "M002");
 
-      assertTrue(
-        m002Entry !== undefined,
-        "M002 summary-only disk milestone should appear in state.registry (#4974)",
-      );
-      assertEq(
-        m002Entry?.title,
-        "Summary-Only Milestone",
-        "M002 summary-only disk milestone should use parsed SUMMARY title (#4974)",
-      );
-      assertEq(
-        m002Entry?.status,
-        "complete",
-        "M002 summary-only disk milestone should reconcile as complete (#4974)",
-      );
+      assertEq(m002Entry, undefined, "M002 summary-only disk milestone should not appear without explicit import");
     } finally {
       closeDatabase();
       cleanup(summaryOnlyBase);

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -12,6 +12,7 @@ import {
   isDbAvailable,
   insertMilestone,
   insertRequirement,
+  insertAssessment,
   getAllMilestones,
   insertSlice,
   insertTask,
@@ -841,6 +842,13 @@ describe('derive-state-db', async () => {
       openDatabase(':memory:');
       insertMilestone({ id: 'M001', title: 'Stuck Remediation', status: 'active' });
       insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Done Slice', status: 'complete', risk: 'low', depends: [] });
+      insertAssessment({
+        path: 'milestones/M001/M001-VALIDATION.md',
+        milestoneId: 'M001',
+        status: 'needs-remediation',
+        scope: 'milestone-validation',
+        fullContent: 'verdict: needs-remediation',
+      });
 
       invalidateStateCache();
       const dbState = await deriveStateFromDb(base);
@@ -882,6 +890,13 @@ describe('derive-state-db', async () => {
       openDatabase(':memory:');
       insertMilestone({ id: 'M001', title: 'Complete Test', status: 'active' });
       insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Done Slice', status: 'complete', risk: 'low', depends: [] });
+      insertAssessment({
+        path: 'milestones/M001/M001-VALIDATION.md',
+        milestoneId: 'M001',
+        status: 'pass',
+        scope: 'milestone-validation',
+        fullContent: 'verdict: pass',
+      });
 
       invalidateStateCache();
       const dbState = await deriveStateFromDb(base);
@@ -1134,8 +1149,8 @@ describe('derive-state-db', async () => {
     }
   });
 
-  // ─── Test 22: Needs-discussion — CONTEXT-DRAFT exists ─────────────────
-  test('derive-state-db: needs-discussion via DB', async () => {
+  // ─── Test 22: Needs-discussion — DB status, not CONTEXT-DRAFT ─────────
+  test('derive-state-db: needs-discussion via DB status', async () => {
     const base = createFixtureBase();
     try {
       writeFile(base, 'milestones/M001/M001-CONTEXT-DRAFT.md', '# M001: Draft\n\nDraft content.');
@@ -1144,7 +1159,7 @@ describe('derive-state-db', async () => {
       const fileState = await _deriveStateImpl(base);
 
       openDatabase(':memory:');
-      insertMilestone({ id: 'M001', title: 'Draft', status: 'active' });
+      insertMilestone({ id: 'M001', title: 'Draft', status: 'needs-discussion' });
 
       invalidateStateCache();
       const dbState = await deriveStateFromDb(base);

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -133,9 +133,9 @@ describe('derive-state-db', async () => {
       writeFile(base, 'milestones/M001/slices/S01/tasks/T01-PLAN.md', '# T01 Plan');
       writeFile(base, 'REQUIREMENTS.md', REQUIREMENTS_CONTENT);
 
-      // Derive state from files only (no DB)
+      // Derive state from the explicit legacy file-only path (no DB)
       invalidateStateCache();
-      const fileState = await deriveState(base);
+      const fileState = await _deriveStateImpl(base);
 
       // Now open DB, insert matching artifacts + milestone hierarchy
       openDatabase(':memory:');
@@ -196,10 +196,12 @@ describe('derive-state-db', async () => {
     }
   });
 
-  // ─── Test 2: Fallback when DB unavailable ─────────────────────────────
-  test('derive-state-db: fallback when DB unavailable', async () => {
+  // ─── Test 2: DB-unavailable runtime does not derive from markdown ──────
+  test('derive-state-db: DB-unavailable runtime does not derive from markdown by default', async () => {
     const base = createFixtureBase();
+    const prev = process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK;
     try {
+      process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK = '0';
       writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT);
       writeFile(base, 'milestones/M001/slices/S01/S01-PLAN.md', PLAN_CONTENT);
       writeFile(base, 'milestones/M001/slices/S01/tasks/.gitkeep', '');
@@ -210,11 +212,43 @@ describe('derive-state-db', async () => {
       invalidateStateCache();
       const state = await deriveState(base);
 
+      assert.deepStrictEqual(state.phase, 'pre-planning', 'runtime degrade: phase is pre-planning');
+      assert.deepStrictEqual(state.activeMilestone, null, 'runtime degrade: markdown milestone is not imported');
+      assert.deepStrictEqual(state.activeSlice, null, 'runtime degrade: markdown slice is not imported');
+      assert.deepStrictEqual(state.activeTask, null, 'runtime degrade: markdown task is not imported');
+      assert.ok(
+        state.blockers.some(b => b.includes('DB unavailable')),
+        'runtime degrade: blocker explains unavailable DB',
+      );
+    } finally {
+      if (prev === undefined) delete process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK;
+      else process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK = prev;
+      cleanup(base);
+    }
+  });
+
+  test('derive-state-db: explicit legacy markdown fallback remains opt-in', async () => {
+    const base = createFixtureBase();
+    const prev = process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK;
+    try {
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT);
+      writeFile(base, 'milestones/M001/slices/S01/S01-PLAN.md', PLAN_CONTENT);
+      writeFile(base, 'milestones/M001/slices/S01/tasks/.gitkeep', '');
+      writeFile(base, 'milestones/M001/slices/S01/tasks/T01-PLAN.md', '# T01 Plan');
+
+      process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK = '1';
+
+      assert.ok(!isDbAvailable(), 'fallback: DB is not available');
+      invalidateStateCache();
+      const state = await deriveState(base);
+
       assert.deepStrictEqual(state.phase, 'executing', 'fallback: phase is executing');
       assert.deepStrictEqual(state.activeMilestone?.id, 'M001', 'fallback: activeMilestone is M001');
       assert.deepStrictEqual(state.activeSlice?.id, 'S01', 'fallback: activeSlice is S01');
       assert.deepStrictEqual(state.activeTask?.id, 'T01', 'fallback: activeTask is T01');
     } finally {
+      if (prev === undefined) delete process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK;
+      else process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK = prev;
       cleanup(base);
     }
   });
@@ -395,8 +429,8 @@ describe('derive-state-db', async () => {
     assert.deepStrictEqual(state.registry, [], 'disk-import: registry remains DB-only');
   });
 
-  // ─── Test 5: Requirements counting from disk (DB no longer used for content) ─
-  test('derive-state-db: requirements from disk content', async () => {
+  // ─── Test 5: Legacy requirements counting from disk ────────────────────
+  test('derive-state-db: explicit legacy derivation counts requirements from disk content', async () => {
     const base = createFixtureBase();
     try {
       // Write minimal milestone dir (needed for milestone discovery)
@@ -405,9 +439,9 @@ describe('derive-state-db', async () => {
       writeFile(base, 'REQUIREMENTS.md', REQUIREMENTS_CONTENT);
 
       invalidateStateCache();
-      const state = await deriveState(base);
+      const state = await _deriveStateImpl(base);
 
-      // Requirements should come from disk
+      // Explicit legacy derivation still reads requirements from disk.
       assert.deepStrictEqual(state.requirements?.active, 2, 'req-from-disk: requirements.active = 2');
       assert.deepStrictEqual(state.requirements?.validated, 1, 'req-from-disk: requirements.validated = 1');
       assert.deepStrictEqual(state.requirements?.total, 3, 'req-from-disk: requirements.total = 3');

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -11,6 +11,7 @@ import {
   insertArtifact,
   isDbAvailable,
   insertMilestone,
+  insertRequirement,
   getAllMilestones,
   insertSlice,
   insertTask,
@@ -44,6 +45,23 @@ function insertArtifactRow(relativePath: string, content: string, opts?: {
     slice_id: opts?.slice_id ?? null,
     task_id: opts?.task_id ?? null,
     full_content: content,
+  });
+}
+
+function insertRequirementRow(id: string, status: string): void {
+  insertRequirement({
+    id,
+    class: 'functional',
+    status,
+    description: `${id} ${status}`,
+    why: 'test',
+    source: 'test',
+    primary_owner: '',
+    supporting_slices: '',
+    validation: '',
+    notes: '',
+    full_content: '',
+    superseded_by: null,
   });
 }
 
@@ -128,6 +146,9 @@ describe('derive-state-db', async () => {
       insertSlice({ id: 'S02', milestoneId: 'M001', title: 'Second Slice', status: 'pending', risk: 'low', depends: ['S01'] });
       insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'First Task', status: 'pending' });
       insertTask({ id: 'T02', sliceId: 'S01', milestoneId: 'M001', title: 'Done Task', status: 'complete' });
+      insertRequirementRow('R001', 'active');
+      insertRequirementRow('R002', 'active');
+      insertRequirementRow('R003', 'validated');
 
       insertArtifactRow('milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT, {
         artifact_type: 'roadmap',
@@ -197,8 +218,8 @@ describe('derive-state-db', async () => {
     }
   });
 
-  // ─── Test 3: Empty DB falls back to file reads ────────────────────────
-  test('derive-state-db: empty DB falls back to files', async () => {
+  // ─── Test 3: Empty DB remains authoritative ───────────────────────────
+  test('derive-state-db: empty DB does not import markdown milestones', async () => {
     const base = createFixtureBase();
     try {
       writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT);
@@ -206,21 +227,16 @@ describe('derive-state-db', async () => {
       writeFile(base, 'milestones/M001/slices/S01/tasks/.gitkeep', '');
       writeFile(base, 'milestones/M001/slices/S01/tasks/T01-PLAN.md', '# T01 Plan');
 
-      // Open DB but insert nothing — empty tables.
-      // With #2631 fix, deriveState will sync disk milestones into DB
-      // and then take the DB path. The result should still reflect the
-      // disk milestone correctly.
+      // Open DB but insert nothing — empty DB is authoritative at runtime.
       openDatabase(':memory:');
       assert.ok(isDbAvailable(), 'empty-db: DB is available');
 
       invalidateStateCache();
       const state = await deriveState(base);
 
-      // Milestone should be detected (synced from disk)
-      assert.deepStrictEqual(state.activeMilestone?.id, 'M001', 'empty-db: activeMilestone is M001');
-      // The DB path without explicit slice/task rows may derive a different
-      // phase than the filesystem path, but the milestone must be found.
-      assert.ok(state.activeMilestone !== null, 'empty-db: activeMilestone is not null');
+      assert.deepStrictEqual(getAllMilestones().length, 0, 'empty-db: markdown milestones are not imported');
+      assert.deepStrictEqual(state.activeMilestone, null, 'empty-db: no active milestone from disk');
+      assert.deepStrictEqual(state.registry, [], 'empty-db: registry remains empty');
 
       closeDatabase();
     } finally {
@@ -229,8 +245,8 @@ describe('derive-state-db', async () => {
     }
   });
 
-  // ─── Test 4: Partial DB content fills gaps from disk ──────────────────
-  test('derive-state-db: partial DB fills gaps from disk', async () => {
+  // ─── Test 4: Partial DB content does not fill gaps from disk ──────────
+  test('derive-state-db: partial DB does not fill requirements from disk', async () => {
     const base = createFixtureBase();
     try {
       // Write all files to disk
@@ -254,15 +270,14 @@ describe('derive-state-db', async () => {
       invalidateStateCache();
       const state = await deriveState(base);
 
-      // Should work: roadmap from DB, plan from disk fallback
+      // Should work from DB hierarchy, but requirements are DB-authoritative.
       assert.deepStrictEqual(state.phase, 'executing', 'partial-db: phase is executing');
       assert.deepStrictEqual(state.activeMilestone?.id, 'M001', 'partial-db: activeMilestone is M001');
       assert.deepStrictEqual(state.activeSlice?.id, 'S01', 'partial-db: activeSlice is S01');
       assert.deepStrictEqual(state.activeTask?.id, 'T01', 'partial-db: activeTask is T01');
-      // Requirements loaded from disk fallback
-      assert.deepStrictEqual(state.requirements?.active, 2, 'partial-db: requirements.active from disk');
-      assert.deepStrictEqual(state.requirements?.validated, 1, 'partial-db: requirements.validated from disk');
-      assert.deepStrictEqual(state.requirements?.total, 3, 'partial-db: requirements.total from disk');
+      assert.deepStrictEqual(state.requirements?.active, 0, 'partial-db: requirements.active not imported from disk');
+      assert.deepStrictEqual(state.requirements?.validated, 0, 'partial-db: requirements.validated not imported from disk');
+      assert.deepStrictEqual(state.requirements?.total, 0, 'partial-db: requirements.total not imported from disk');
 
       closeDatabase();
     } finally {
@@ -271,7 +286,7 @@ describe('derive-state-db', async () => {
     }
   });
 
-  test('derive-state-db: partial task rows reconcile missing plan tasks before summarizing', async (t) => {
+  test('derive-state-db: partial task rows do not import missing plan tasks', async (t) => {
     const base = createFixtureBase();
     t.after(() => {
       closeDatabase();
@@ -306,15 +321,39 @@ describe('derive-state-db', async () => {
     const state = await deriveState(base);
 
     const dbTasks = getSliceTasks('M001', 'S01');
-    assert.deepStrictEqual(dbTasks.length, 2, 'partial-task-db: missing T02 imported from plan');
+    assert.deepStrictEqual(dbTasks.length, 1, 'partial-task-db: missing T02 is not imported from plan');
     assert.deepStrictEqual(dbTasks.find(t => t.id === 'T01')?.status, 'complete', 'partial-task-db: existing complete T01 preserved');
-    assert.deepStrictEqual(dbTasks.find(t => t.id === 'T02')?.status, 'pending', 'partial-task-db: missing T02 inserted pending');
-    assert.deepStrictEqual(state.phase, 'executing', 'partial-task-db: phase remains executing, not summarizing');
-    assert.deepStrictEqual(state.activeTask?.id, 'T02', 'partial-task-db: activeTask is missing plan task T02');
-    assert.deepStrictEqual(state.progress?.tasks, { done: 1, total: 2 }, 'partial-task-db: task progress includes reconciled plan task');
+    assert.deepStrictEqual(dbTasks.find(t => t.id === 'T02'), undefined, 'partial-task-db: missing T02 absent from DB');
+    assert.deepStrictEqual(state.phase, 'summarizing', 'partial-task-db: phase follows DB tasks only');
+    assert.deepStrictEqual(state.activeTask, null, 'partial-task-db: no active task from disk-only plan row');
+    assert.deepStrictEqual(state.progress?.tasks, { done: 1, total: 1 }, 'partial-task-db: task progress is DB-only');
   });
 
-  test('derive-state-db: empty DB disk import preserves milestone completion and dependencies', async (t) => {
+  test('derive-state-db: disk SUMMARY does not complete a pending DB task', async (t) => {
+    const base = createFixtureBase();
+    t.after(() => {
+      closeDatabase();
+      cleanup(base);
+    });
+
+    writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT);
+    writeFile(base, 'milestones/M001/slices/S01/S01-PLAN.md', PLAN_CONTENT);
+    writeFile(base, 'milestones/M001/slices/S01/tasks/T01-SUMMARY.md', '# T01 Summary\n\nManual disk edit.');
+
+    openDatabase(':memory:');
+    insertMilestone({ id: 'M001', title: 'Test Milestone', status: 'active' });
+    insertSlice({ id: 'S01', milestoneId: 'M001', title: 'First Slice', status: 'active', risk: 'low', depends: [] });
+    insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'First Task', status: 'pending' });
+
+    invalidateStateCache();
+    const state = await deriveStateFromDb(base);
+
+    assert.deepStrictEqual(getSliceTasks('M001', 'S01').find(t => t.id === 'T01')?.status, 'pending');
+    assert.deepStrictEqual(state.phase, 'executing');
+    assert.deepStrictEqual(state.activeTask?.id, 'T01');
+  });
+
+  test('derive-state-db: empty DB does not import milestone completion and dependencies', async (t) => {
     const base = createFixtureBase();
     t.after(() => {
       closeDatabase();
@@ -350,12 +389,9 @@ describe('derive-state-db', async () => {
     const state = await deriveState(base);
 
     const milestones = getAllMilestones();
-    assert.deepStrictEqual(milestones.find(m => m.id === 'M001')?.status, 'complete', 'disk-import: terminal summary imports M001 as complete');
-    assert.deepStrictEqual(milestones.find(m => m.id === 'M002')?.depends_on, ['M001'], 'disk-import: M002 depends_on imported from CONTEXT');
-    assert.deepStrictEqual(milestones.find(m => m.id === 'M003')?.depends_on, ['M002'], 'disk-import: M003 depends_on imported from CONTEXT');
-    assert.deepStrictEqual(state.activeMilestone?.id, 'M002', 'disk-import: M002 is active because M001 completion satisfies dependency');
-    assert.deepStrictEqual(state.registry.find(e => e.id === 'M001')?.status, 'complete', 'disk-import: M001 registry status is complete');
-    assert.deepStrictEqual(state.registry.find(e => e.id === 'M003')?.status, 'pending', 'disk-import: M003 stays pending on unmet M002 dependency');
+    assert.deepStrictEqual(milestones.length, 0, 'disk-import: markdown milestones are not imported');
+    assert.deepStrictEqual(state.activeMilestone, null, 'disk-import: no active milestone from markdown');
+    assert.deepStrictEqual(state.registry, [], 'disk-import: registry remains DB-only');
   });
 
   // ─── Test 5: Requirements counting from disk (DB no longer used for content) ─
@@ -1127,7 +1163,7 @@ describe('derive-state-db', async () => {
   test('derive-state-db: disk-only milestone auto-synced into DB (#2416)', async () => {
     const base = createFixtureBase();
     try {
-      // M001 is complete and exists in DB. M002 was queued on disk only — no DB row.
+      // M001 is complete and exists in DB. M002 is disk-only — no DB row.
       writeFile(base, 'milestones/M001/M001-SUMMARY.md', '# M001 Summary\n\nDone.');
       writeFile(base, 'milestones/M002/M002-CONTEXT.md', '# M002: Queued\n\nQueued milestone.');
 
@@ -1138,16 +1174,12 @@ describe('derive-state-db', async () => {
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
-      // Before the fix, M002 was invisible: getAllMilestones() returned only M001
-      // (complete) → phase='complete' → auto-mode stopped.
-      // After the fix, deriveStateFromDb reconciles disk dirs and inserts M002.
-      assert.deepStrictEqual(state.phase, 'pre-planning', 'disk-sync-2416: phase is pre-planning, not complete');
-      assert.deepStrictEqual(state.registry.length, 2, 'disk-sync-2416: both milestones visible in registry');
+      assert.deepStrictEqual(state.phase, 'complete', 'disk-sync-2416: disk-only milestone is not imported');
+      assert.deepStrictEqual(state.registry.length, 1, 'disk-sync-2416: only DB milestones visible in registry');
       assert.deepStrictEqual(state.registry[0]?.id, 'M001', 'disk-sync-2416: registry[0] is M001');
       assert.deepStrictEqual(state.registry[0]?.status, 'complete', 'disk-sync-2416: M001 is complete');
-      assert.deepStrictEqual(state.registry[1]?.id, 'M002', 'disk-sync-2416: registry[1] is M002');
-      assert.deepStrictEqual(state.registry[1]?.status, 'active', 'disk-sync-2416: M002 is active');
-      assert.deepStrictEqual(state.activeMilestone?.id, 'M002', 'disk-sync-2416: activeMilestone is M002');
+      assert.deepStrictEqual(state.registry[1], undefined, 'disk-sync-2416: M002 remains absent without explicit import');
+      assert.deepStrictEqual(state.activeMilestone, null, 'disk-sync-2416: no active milestone from disk-only row');
 
       closeDatabase();
     } finally {
@@ -1208,12 +1240,11 @@ describe('derive-state-db', async () => {
       invalidateStateCache();
       const dbState = await deriveStateFromDb(base);
 
-      // M002 should be reconciled from disk (not skipped as ghost) and become active
+      // M002 is legitimate legacy disk state but is not authoritative without a DB row.
       const m002Entry = dbState.registry.find(e => e.id === 'M002');
-      assert.ok(m002Entry !== undefined, 'ghost-wt: M002 should be in registry');
-      assert.deepStrictEqual(dbState.activeMilestone?.id, 'M002', 'ghost-wt: M002 should be active');
-      // Should NOT be phase: complete
-      assert.notEqual(dbState.phase, 'complete', 'ghost-wt: phase should not be complete');
+      assert.equal(m002Entry, undefined, 'ghost-wt: M002 should not be imported into registry');
+      assert.deepStrictEqual(dbState.activeMilestone, null, 'ghost-wt: no active milestone from disk-only worktree');
+      assert.equal(dbState.phase, 'complete', 'ghost-wt: DB-only M001 completion drives state');
 
       closeDatabase();
     } finally {

--- a/src/resources/extensions/gsd/tests/derive-state-draft.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-draft.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from 'node:os';
 
 import { deriveState } from '../state.js';
 
+// This suite exercises the explicit legacy markdown derivation path.
+process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK = '1';
+
 let passed = 0;
 let failed = 0;
 

--- a/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
@@ -15,10 +15,12 @@ import { invalidateStateCache, deriveStateFromDb } from '../state.ts';
 import {
   openDatabase,
   closeDatabase,
+  insertAssessment,
   insertMilestone,
   insertRequirement,
   insertSlice,
   insertTask,
+  setMilestoneQueueOrder,
   updateTaskStatus,
 } from '../gsd-db.ts';
 
@@ -265,7 +267,8 @@ describe('derive-state-helpers', () => {
       writeFile(base, 'milestones/M001/slices/S01/S01-PLAN.md', PLAN_CONTENT);
       writeFile(base, 'milestones/M001/slices/S01/tasks/.gitkeep', '');
       writeFile(base, 'milestones/M001/slices/S01/tasks/T01-PLAN.md', '# T01 Plan');
-      // T02 completed with blocker discovered — written in summary frontmatter
+      // T02 completed with blocker discovered. The disk summary is a projection;
+      // only the DB blocker flag is authoritative for deriveStateFromDb().
       writeFile(base, 'milestones/M001/slices/S01/tasks/T02-SUMMARY.md',
         '---\nblocker_discovered: true\n---\n\n# T02 Summary\n\nFound a blocker.');
 
@@ -274,7 +277,7 @@ describe('derive-state-helpers', () => {
       insertSlice({ id: 'S01', milestoneId: 'M001', title: 'First', status: 'active', risk: 'low', depends: [] });
       insertSlice({ id: 'S02', milestoneId: 'M001', title: 'Second', status: 'pending', risk: 'low', depends: ['S01'] });
       insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'First Task', status: 'pending' });
-      insertTask({ id: 'T02', sliceId: 'S01', milestoneId: 'M001', title: 'Done Task', status: 'complete' });
+      insertTask({ id: 'T02', sliceId: 'S01', milestoneId: 'M001', title: 'Done Task', status: 'complete', blockerDiscovered: true });
 
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
@@ -287,8 +290,8 @@ describe('derive-state-helpers', () => {
     }
   });
 
-  // ─── checkInterruptedWork: continue.md triggers resume hint ─────────
-  test('checkInterruptedWork: continue.md present triggers resume nextAction', async () => {
+  // ─── CONTINUE.md projection is ignored by DB derive ─────────────────
+  test('deriveStateFromDb: continue.md projection does not trigger resume nextAction', async () => {
     const base = createFixtureBase();
     try {
       writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT);
@@ -308,8 +311,8 @@ describe('derive-state-helpers', () => {
       const state = await deriveStateFromDb(base);
 
       assert.equal(state.phase, 'executing', 'continue: phase is still executing');
-      assert.ok(state.nextAction.includes('Resume interrupted work'), 'continue: nextAction mentions resume');
-      assert.ok(state.nextAction.includes('continue.md'), 'continue: nextAction mentions continue.md');
+      assert.ok(!state.nextAction.includes('Resume interrupted work'), 'continue: nextAction does not mention resume');
+      assert.ok(!state.nextAction.includes('continue.md'), 'continue: nextAction does not mention continue.md');
     } finally {
       closeDatabase();
       cleanup(base);
@@ -389,6 +392,13 @@ describe('derive-state-helpers', () => {
       insertMilestone({ id: 'M001', title: 'First', status: 'active' });
       insertSlice({ id: 'S01', milestoneId: 'M001', title: 'First', status: 'complete', risk: 'low', depends: [] });
       insertSlice({ id: 'S02', milestoneId: 'M001', title: 'Second', status: 'complete', risk: 'low', depends: ['S01'] });
+      insertAssessment({
+        path: 'milestones/M001/M001-VALIDATION.md',
+        milestoneId: 'M001',
+        status: 'pass',
+        scope: 'milestone-validation',
+        fullContent: 'verdict: passed',
+      });
 
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
@@ -419,18 +429,18 @@ describe('derive-state-helpers', () => {
       assert.equal(state.activeMilestone?.id, 'M001', 'roadmap-projection: M001 is active');
       assert.equal(state.activeSlice, null, 'roadmap-projection: no active slice imported');
       assert.equal(state.phase, 'pre-planning', 'roadmap-projection: no DB slices routes to pre-planning');
-      assert.equal(state.progress?.slices?.total, 0, 'roadmap-projection: no slices imported');
+      assert.equal(state.progress?.slices, undefined, 'roadmap-projection: no slice progress from projection');
     } finally {
       closeDatabase();
       cleanup(base);
     }
   });
 
-  // ─── Queue order: milestones sorted by custom queue order ───────────
-  test('deriveStateFromDb respects custom queue order from QUEUE-ORDER.json', async () => {
+  // ─── Queue order: DB sequence is authoritative ─────────────────────
+  test('deriveStateFromDb ignores QUEUE-ORDER.json and uses DB sequence', async () => {
     const base = createFixtureBase();
     try {
-      // M003 should come first per queue order, M001 second
+      // QUEUE-ORDER.json is a projection and should not drive DB derivation.
       const queueOrder = JSON.stringify({ order: ['M003', 'M001', 'M002'], updatedAt: new Date().toISOString() });
       writeFileSync(join(base, '.gsd', 'QUEUE-ORDER.json'), queueOrder);
       writeFile(base, 'milestones/M001/M001-CONTEXT.md', '# M001\n\nContext.');
@@ -438,17 +448,17 @@ describe('derive-state-helpers', () => {
       writeFile(base, 'milestones/M003/M003-CONTEXT.md', '# M003\n\nContext.');
 
       openDatabase(':memory:');
-      // Insert in natural order — queue ordering should override
+      // Insert in natural order, then store the authoritative DB sequence.
       insertMilestone({ id: 'M001', title: 'First', status: 'active' });
       insertMilestone({ id: 'M002', title: 'Second', status: 'active' });
       insertMilestone({ id: 'M003', title: 'Third', status: 'active' });
+      setMilestoneQueueOrder(['M002', 'M001', 'M003']);
 
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
-      // M003 should be the active milestone (first in queue)
-      assert.equal(state.activeMilestone?.id, 'M003', 'queue-order: M003 is active (first in queue)');
-      assert.equal(state.registry[0]?.id, 'M003', 'queue-order: registry[0] is M003');
+      assert.equal(state.activeMilestone?.id, 'M002', 'queue-order: DB sequence chooses M002');
+      assert.equal(state.registry[0]?.id, 'M002', 'queue-order: registry[0] follows DB sequence');
     } finally {
       closeDatabase();
       cleanup(base);
@@ -467,6 +477,13 @@ describe('derive-state-helpers', () => {
       openDatabase(':memory:');
       insertMilestone({ id: 'M001', title: 'Remediation Test', status: 'active' });
       insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Done', status: 'complete', risk: 'low', depends: [] });
+      insertAssessment({
+        path: 'milestones/M001/M001-VALIDATION.md',
+        milestoneId: 'M001',
+        status: 'needs-remediation',
+        scope: 'milestone-validation',
+        fullContent: 'verdict: needs-remediation',
+      });
 
       invalidateStateCache();
       const state = await deriveStateFromDb(base);

--- a/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
@@ -11,7 +11,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { invalidateStateCache, deriveStateFromDb } from '../state.ts';
+import { invalidateStateCache, deriveStateFromDb, getActiveMilestoneId } from '../state.ts';
 import {
   openDatabase,
   closeDatabase,
@@ -140,10 +140,11 @@ describe('derive-state-helpers', () => {
   });
 
   // ─── resolveSliceDependencies: GSD_SLICE_LOCK with missing slice ────
-  test('resolveSliceDependencies: GSD_SLICE_LOCK pointing to non-existent slice returns blocked', async () => {
-    const base = createFixtureBase();
-    const origLock = process.env.GSD_SLICE_LOCK;
-    try {
+	  test('resolveSliceDependencies: GSD_SLICE_LOCK pointing to non-existent slice returns blocked', async () => {
+	    const base = createFixtureBase();
+	    const origLock = process.env.GSD_SLICE_LOCK;
+	    const origWorker = process.env.GSD_PARALLEL_WORKER;
+	    try {
       writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT);
       writeFile(base, 'milestones/M001/slices/S01/S01-PLAN.md', PLAN_CONTENT);
       writeFile(base, 'milestones/M001/slices/S01/tasks/.gitkeep', '');
@@ -154,26 +155,30 @@ describe('derive-state-helpers', () => {
       insertSlice({ id: 'S01', milestoneId: 'M001', title: 'First', status: 'active', risk: 'low', depends: [] });
       insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', title: 'First Task', status: 'pending' });
 
-      process.env.GSD_SLICE_LOCK = 'S99';
+	      process.env.GSD_SLICE_LOCK = 'S99';
+	      process.env.GSD_PARALLEL_WORKER = '1';
 
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
       assert.equal(state.phase, 'blocked', 'slice-lock-miss: phase is blocked');
       assert.ok(state.blockers.some(b => b.includes('GSD_SLICE_LOCK=S99')), 'slice-lock-miss: blocker mentions lock');
-    } finally {
-      if (origLock !== undefined) process.env.GSD_SLICE_LOCK = origLock;
-      else delete process.env.GSD_SLICE_LOCK;
-      closeDatabase();
+	    } finally {
+	      if (origLock !== undefined) process.env.GSD_SLICE_LOCK = origLock;
+	      else delete process.env.GSD_SLICE_LOCK;
+	      if (origWorker !== undefined) process.env.GSD_PARALLEL_WORKER = origWorker;
+	      else delete process.env.GSD_PARALLEL_WORKER;
+	      closeDatabase();
       cleanup(base);
     }
   });
 
   // ─── resolveSliceDependencies: GSD_SLICE_LOCK with valid slice ──────
-  test('resolveSliceDependencies: GSD_SLICE_LOCK targeting valid slice bypasses deps', async () => {
-    const base = createFixtureBase();
-    const origLock = process.env.GSD_SLICE_LOCK;
-    try {
+	  test('resolveSliceDependencies: GSD_SLICE_LOCK targeting valid slice bypasses deps', async () => {
+	    const base = createFixtureBase();
+	    const origLock = process.env.GSD_SLICE_LOCK;
+	    const origWorker = process.env.GSD_PARALLEL_WORKER;
+	    try {
       writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT);
       // S02 depends on S01 but we lock to S02 directly
       writeFile(base, 'milestones/M001/slices/S02/S02-PLAN.md', `# S02\n\n**Goal:** Test.\n**Demo:** Pass.\n\n## Tasks\n\n- [ ] **T01: Task** \`est:5m\`\n  Do thing.\n`);
@@ -186,17 +191,20 @@ describe('derive-state-helpers', () => {
       insertSlice({ id: 'S02', milestoneId: 'M001', title: 'Second', status: 'pending', risk: 'low', depends: ['S01'] });
       insertTask({ id: 'T01', sliceId: 'S02', milestoneId: 'M001', title: 'Task', status: 'pending' });
 
-      process.env.GSD_SLICE_LOCK = 'S02';
+	      process.env.GSD_SLICE_LOCK = 'S02';
+	      process.env.GSD_PARALLEL_WORKER = '1';
 
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
       assert.equal(state.activeSlice?.id, 'S02', 'slice-lock-valid: activeSlice is S02 (locked)');
       assert.equal(state.phase, 'executing', 'slice-lock-valid: phase is executing');
-    } finally {
-      if (origLock !== undefined) process.env.GSD_SLICE_LOCK = origLock;
-      else delete process.env.GSD_SLICE_LOCK;
-      closeDatabase();
+	    } finally {
+	      if (origLock !== undefined) process.env.GSD_SLICE_LOCK = origLock;
+	      else delete process.env.GSD_SLICE_LOCK;
+	      if (origWorker !== undefined) process.env.GSD_PARALLEL_WORKER = origWorker;
+	      else delete process.env.GSD_PARALLEL_WORKER;
+	      closeDatabase();
       cleanup(base);
     }
   });
@@ -461,6 +469,30 @@ describe('derive-state-helpers', () => {
       assert.equal(state.registry[0]?.id, 'M002', 'queue-order: registry[0] follows DB sequence');
     } finally {
       closeDatabase();
+      cleanup(base);
+    }
+  });
+
+	  test('getActiveMilestoneId: DB lock path ignores PARKED flag projection', async () => {
+	    const base = createFixtureBase();
+	    const previousLock = process.env.GSD_MILESTONE_LOCK;
+	    const previousWorker = process.env.GSD_PARALLEL_WORKER;
+	    try {
+	      process.env.GSD_MILESTONE_LOCK = 'M001';
+	      process.env.GSD_PARALLEL_WORKER = '1';
+      writeFile(base, 'milestones/M001/M001-PARKED.md', '# Parked on disk');
+
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'Active in DB', status: 'active' });
+
+      const id = await getActiveMilestoneId(base);
+      assert.equal(id, 'M001', 'DB status remains authoritative despite PARKED projection');
+	    } finally {
+	      if (previousLock === undefined) delete process.env.GSD_MILESTONE_LOCK;
+	      else process.env.GSD_MILESTONE_LOCK = previousLock;
+	      if (previousWorker === undefined) delete process.env.GSD_PARALLEL_WORKER;
+	      else process.env.GSD_PARALLEL_WORKER = previousWorker;
+	      closeDatabase();
       cleanup(base);
     }
   });

--- a/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
@@ -1,12 +1,9 @@
-// GSD Extension — Tests for extracted deriveStateFromDb helper functions
+// GSD Extension — Tests for DB-authoritative deriveStateFromDb behavior
 // Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 //
-// Tests the composable helpers extracted from deriveStateFromDb:
-//   reconcileDiskToDb, buildCompletenessSet, buildRegistryAndFindActive,
-//   handleNoActiveMilestone, resolveSliceDependencies, reconcileSliceTasks,
-//   detectBlockers, checkReplanTrigger, checkInterruptedWork
-//
-// Helpers are private — exercised through deriveStateFromDb integration.
+// Private helper behavior is exercised through deriveStateFromDb integration.
+// Markdown files in these tests are projections unless the DB row explicitly
+// makes them authoritative.
 
 import { describe, test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
@@ -19,6 +16,7 @@ import {
   openDatabase,
   closeDatabase,
   insertMilestone,
+  insertRequirement,
   insertSlice,
   insertTask,
   updateTaskStatus,
@@ -112,6 +110,20 @@ describe('derive-state-helpers', () => {
 
       openDatabase(':memory:');
       insertMilestone({ id: 'M001', title: 'First', status: 'complete' });
+      insertRequirement({
+        id: 'R001',
+        class: 'functional',
+        status: 'active',
+        description: 'Unmapped',
+        why: 'test',
+        source: 'test',
+        primary_owner: '',
+        supporting_slices: '',
+        validation: '',
+        notes: '',
+        full_content: '',
+        superseded_by: null,
+      });
 
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
@@ -187,8 +199,8 @@ describe('derive-state-helpers', () => {
     }
   });
 
-  // ─── reconcileSliceTasks: plan file imports tasks when DB empty ──────
-  test('reconcileSliceTasks: imports tasks from plan file when DB has zero tasks (#3600)', async () => {
+  // ─── DB-authoritative tasks: plan projection does not import tasks ──────
+  test('deriveStateFromDb: DB-empty task list does not import PLAN tasks', async () => {
     const base = createFixtureBase();
     try {
       writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT);
@@ -200,24 +212,23 @@ describe('derive-state-helpers', () => {
       insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
       insertSlice({ id: 'S01', milestoneId: 'M001', title: 'First', status: 'active', risk: 'low', depends: [] });
       insertSlice({ id: 'S02', milestoneId: 'M001', title: 'Second', status: 'pending', risk: 'low', depends: ['S01'] });
-      // No tasks inserted — reconcileSliceTasks should import from plan file
+      // No tasks inserted — PLAN.md is a projection and must not be imported.
 
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
-      // Plan has T01 (pending) and T02 (done) — reconciliation imports both
-      assert.equal(state.phase, 'executing', 'task-reconcile: phase is executing (tasks imported)');
-      assert.equal(state.activeTask?.id, 'T01', 'task-reconcile: activeTask is T01');
-      assert.equal(state.progress?.tasks?.total, 2, 'task-reconcile: total tasks = 2');
-      assert.equal(state.progress?.tasks?.done, 1, 'task-reconcile: done tasks = 1 (T02 was [x])');
+      assert.equal(state.phase, 'planning', 'db-empty-tasks: phase is planning');
+      assert.equal(state.activeTask, null, 'db-empty-tasks: no active task');
+      assert.equal(state.progress?.tasks?.total, 0, 'db-empty-tasks: no tasks imported');
+      assert.equal(state.progress?.tasks?.done, 0, 'db-empty-tasks: no completed tasks imported');
     } finally {
       closeDatabase();
       cleanup(base);
     }
   });
 
-  // ─── reconcileSliceTasks: stale task reconciled from disk summary ────
-  test('reconcileSliceTasks: stale pending task reconciled to complete when disk SUMMARY exists (#2514)', async () => {
+  // ─── DB-authoritative tasks: SUMMARY projection does not complete task ────
+  test('deriveStateFromDb: disk SUMMARY does not reconcile pending task', async () => {
     const base = createFixtureBase();
     try {
       writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT);
@@ -237,11 +248,9 @@ describe('derive-state-helpers', () => {
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
-      // T01 should have been reconciled to complete (SUMMARY exists on disk)
-      // Both tasks complete → phase should be summarizing
-      assert.equal(state.phase, 'summarizing', 'stale-task: phase is summarizing (T01 reconciled)');
-      assert.equal(state.activeTask, null, 'stale-task: no active task (all done)');
-      assert.equal(state.progress?.tasks?.done, 2, 'stale-task: tasks.done = 2');
+      assert.equal(state.phase, 'executing', 'disk-summary-ignored: phase is executing');
+      assert.equal(state.activeTask?.id, 'T01', 'disk-summary-ignored: T01 remains active');
+      assert.equal(state.progress?.tasks?.done, 1, 'disk-summary-ignored: only DB-complete task is done');
     } finally {
       closeDatabase();
       cleanup(base);
@@ -394,23 +403,23 @@ describe('derive-state-helpers', () => {
     }
   });
 
-  // ─── reconcileDiskToDb: disk slices synced into DB (#2533) ──────────
-  test('reconcileDiskToDb: slices in ROADMAP.md but missing from DB are auto-inserted (#2533)', async () => {
+  // ─── DB-authoritative slices: roadmap projection does not insert slices ───
+  test('deriveStateFromDb: ROADMAP slices missing from DB are not auto-inserted', async () => {
     const base = createFixtureBase();
     try {
       writeFile(base, 'milestones/M001/M001-ROADMAP.md', ROADMAP_CONTENT);
 
       openDatabase(':memory:');
       insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
-      // No slices inserted — reconcileDiskToDb should insert from roadmap
+      // No slices inserted — ROADMAP.md is a projection and must not be imported.
 
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
-      // Slices should have been reconciled from roadmap, S01 should be the active slice
-      assert.equal(state.activeMilestone?.id, 'M001', 'slice-reconcile: M001 is active');
-      assert.equal(state.activeSlice?.id, 'S01', 'slice-reconcile: S01 reconciled and active');
-      assert.ok((state.progress?.slices?.total ?? 0) >= 2, 'slice-reconcile: at least 2 slices reconciled');
+      assert.equal(state.activeMilestone?.id, 'M001', 'roadmap-projection: M001 is active');
+      assert.equal(state.activeSlice, null, 'roadmap-projection: no active slice imported');
+      assert.equal(state.phase, 'pre-planning', 'roadmap-projection: no DB slices routes to pre-planning');
+      assert.equal(state.progress?.slices?.total, 0, 'roadmap-projection: no slices imported');
     } finally {
       closeDatabase();
       cleanup(base);

--- a/src/resources/extensions/gsd/tests/derive-state.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state.test.ts
@@ -5,6 +5,10 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { deriveState, isSliceComplete, isMilestoneComplete, isGhostMilestone } from '../state.ts';
+
+// This suite exercises the explicit legacy markdown derivation path.
+process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK = '1';
+
 // ─── Fixture Helpers ───────────────────────────────────────────────────────
 
 function createFixtureBase(): string {

--- a/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
@@ -47,26 +47,12 @@ describe("completing-milestone dispatch guard (#4324)", () => {
     assert.ok(dispatchIdx > -1, "complete-milestone dispatch should exist after the skip guard");
   });
 
-  test("classifies SUMMARY outcome and conditionally reconciles DB (#4658)", () => {
+  test("does not reconcile DB from SUMMARY.md projection (#4658 superseded)", () => {
     const phaseCheck = source.indexOf('phase !== "completing-milestone"');
-    // The SUMMARY-exists reconciliation guard must appear in this rule
-    const summaryGuard = source.indexOf('resolveMilestoneFile(basePath, mid, "SUMMARY")', phaseCheck);
-    assert.ok(summaryGuard > -1, "SUMMARY file check should exist in the completing-milestone rule");
-
-    const classifyCall = source.indexOf("classifyMilestoneSummaryContent", summaryGuard);
-    assert.ok(classifyCall > -1, "SUMMARY mismatch handling should classify summary content");
-    const dbGateBeforeClassify = source.indexOf("existingSummary && isDbAvailable()", summaryGuard);
-    assert.ok(
-      dbGateBeforeClassify === -1 || dbGateBeforeClassify > classifyCall,
-      "SUMMARY classification must not be gated on DB availability",
-    );
-
-    const reconcileCall = source.indexOf('updateMilestoneStatus(mid, "complete"', summaryGuard);
-    assert.ok(reconcileCall > -1, "successful SUMMARY should reconcile DB to complete");
-
-    const stopAction = source.indexOf('action: "stop"', summaryGuard);
-    assert.ok(stopAction > -1, "SUMMARY mismatch should return stop action");
-    const warningLevel = source.indexOf('level: "warning"', summaryGuard);
-    assert.ok(warningLevel > -1, "SUMMARY mismatch should be warning-level stop (pauses auto-mode)");
+    assert.ok(phaseCheck > -1, "completing-milestone phase check should exist");
+    const ruleTail = source.slice(phaseCheck, source.indexOf('name:', phaseCheck + 1));
+    assert.doesNotMatch(ruleTail, /resolveMilestoneFile\(basePath,\s*mid,\s*"SUMMARY"\)/);
+    assert.doesNotMatch(ruleTail, /classifyMilestoneSummaryContent/);
+    assert.doesNotMatch(ruleTail, /updateMilestoneStatus\(mid,\s*"complete"/);
   });
 });

--- a/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
@@ -225,14 +225,14 @@ test("dispatch guard allows slice with all declared dependencies complete", (t) 
   );
 });
 
-test("dispatch guard skips completed milestone with SUMMARY even if it has unchecked remediation slices (#1716)", (t) => {
+test("dispatch guard does not skip prior milestone from SUMMARY projection when DB is not closed", (t) => {
   const repo = setupRepo();
   t.after(() => teardownRepo(repo));
 
   mkdirSync(join(repo, ".gsd", "milestones", "M001"), { recursive: true });
   mkdirSync(join(repo, ".gsd", "milestones", "M002"), { recursive: true });
 
-  // M001 is complete (has SUMMARY) but has unchecked remediation slices in DB
+  // M001 has a successful SUMMARY projection but is not closed in the DB.
   insertMilestone({ id: "M001", title: "Previous" });
   insertSlice({ id: "S01", milestoneId: "M001", title: "Core", status: "complete", depends: [], sequence: 1 });
   insertSlice({ id: "S02", milestoneId: "M001", title: "Tests", status: "complete", depends: ["S01"], sequence: 2 });
@@ -242,16 +242,15 @@ test("dispatch guard skips completed milestone with SUMMARY even if it has unche
   insertMilestone({ id: "M002", title: "Current" });
   insertSlice({ id: "S01", milestoneId: "M002", title: "Start", status: "pending", depends: [], sequence: 1 });
 
-  // M001 SUMMARY on disk triggers skip
+  // M001 SUMMARY on disk must not trigger skip while DB remains open/active.
   writeFileSync(join(repo, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# M001\n");
   writeFileSync(join(repo, ".gsd", "milestones", "M001", "M001-SUMMARY.md"),
     "---\nstatus: complete\n---\n# M001 Summary\nDone.\n");
   writeFileSync(join(repo, ".gsd", "milestones", "M002", "M002-ROADMAP.md"), "# M002\n");
 
-  // M001 has SUMMARY — should be skipped, not block M002/S01
   assert.equal(
     getPriorSliceCompletionBlocker(repo, "main", "plan-slice", "M002/S01"),
-    null,
+    "Cannot dispatch plan-slice M002/S01: earlier slice M001/S03-R is not complete.",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/dispatcher-stuck-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatcher-stuck-planning.test.ts
@@ -1,10 +1,9 @@
 /**
- * dispatcher-stuck-planning.test.ts — #3656
+ * dispatcher-stuck-planning.test.ts
  *
- * Verify that state.ts contains the disk-to-DB task reconciliation logic
- * that prevents the dispatcher from getting stuck in an infinite planning
- * loop when the planner writes a PLAN.md but never calls the persistence
- * tool, leaving the DB with zero or partial task rows.
+ * Verify that state.ts no longer imports disk PLAN.md tasks into the runtime
+ * DB. PLAN.md is a projection; task rows must be created through DB-backed
+ * planning/import APIs.
  */
 
 import { describe, test } from "node:test";
@@ -16,23 +15,23 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const sourceFile = join(__dirname, "..", "state.ts");
 
-describe("dispatcher stuck-planning reconciliation (#3656)", () => {
+describe("dispatcher DB-authoritative planning boundary", () => {
   const source = readFileSync(sourceFile, "utf-8");
 
-  test("imports insertTask from gsd-db", () => {
-    assert.match(source, /import\s*\{[^}]*insertTask[^}]*\}\s*from/);
+  test("does not import insertTask into state derivation", () => {
+    assert.doesNotMatch(source, /import\s*\{[^}]*insertTask[^}]*\}\s*from/);
   });
 
-  test("contains plan-file task reconciliation block", () => {
-    assert.match(source, /if\s*\(\s*planFile\s*\)/);
-    assert.match(source, /dbTaskIds\.has\(t\.id\)/);
+  test("does not contain plan-file task reconciliation block", () => {
+    assert.doesNotMatch(source, /dbTaskIds\.has\(t\.id\)/);
+    assert.match(source, /Slice \$\{activeSlice\.id\} has no DB tasks/);
   });
 
-  test("calls insertTask for each disk plan task", () => {
-    assert.match(source, /insertTask\(\{/);
+  test("does not call insertTask from state derivation", () => {
+    assert.doesNotMatch(source, /insertTask\(\{/);
   });
 
-  test("references issue #3600 in reconciliation comment", () => {
-    assert.match(source, /#3600/);
+  test("documents markdown projections as non-authoritative", () => {
+    assert.match(source, /Markdown files are projections only/);
   });
 });

--- a/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
@@ -11,7 +11,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
-import { closeDatabase, isDbAvailable, getDecisionById, _getAdapter } from '../gsd-db.ts';
+import { closeDatabase, isDbAvailable, getDecisionById, SCHEMA_VERSION, _getAdapter } from '../gsd-db.ts';
 
 const _require = createRequire(import.meta.url);
 
@@ -384,7 +384,7 @@ describe('ensure-db-open', () => {
       assert.ok(db, 'adapter should be available after ensureDbOpen');
       assert.equal(
         db.prepare('SELECT MAX(version) as version FROM schema_version').get()?.version,
-        22,
+        SCHEMA_VERSION,
         'legacy DB should migrate to current schema version',
       );
 

--- a/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-// ensureDbOpen — Tests that the lazy DB opener creates + migrates the database
-// when .gsd/ exists with Markdown content but no gsd.db file.
+// ensureDbOpen — Tests that the lazy DB opener creates/opens the authoritative
+// database without implicitly importing markdown projections.
 //
 // This covers the bug where interactive (non-auto) sessions got
 // "GSD database is not available" because ensureDbOpen only opened
@@ -284,11 +284,11 @@ function createLegacyV15Db(dbPath: string): void {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// ensureDbOpen creates DB + migrates when .gsd/ has Markdown
+// ensureDbOpen creates DB without implicit Markdown migration
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('ensure-db-open', () => {
-  test('ensureDbOpen: creates DB from Markdown', async () => {
+  test('ensureDbOpen: creates empty DB without importing Markdown', async () => {
     const tmpDir = makeTmpDir();
     const gsdDir = path.join(tmpDir, '.gsd');
     fs.mkdirSync(gsdDir, { recursive: true });
@@ -319,17 +319,12 @@ describe('ensure-db-open', () => {
 
       const result = await ensureDbOpen();
 
-      assert.ok(result === true, 'ensureDbOpen should return true when .gsd/ has Markdown');
+      assert.ok(result === true, 'ensureDbOpen should return true when .gsd/ exists');
       assert.ok(fs.existsSync(dbPath), 'DB file should be created after ensureDbOpen');
       assert.ok(isDbAvailable(), 'DB should be available after ensureDbOpen');
 
-      // Verify that Markdown migration actually ran
       const decision = getDecisionById('D001');
-      assert.ok(decision !== null, 'D001 should be migrated from DECISIONS.md');
-      if (decision) {
-        assert.deepStrictEqual(decision.scope, 'architecture', 'Migrated decision scope should match');
-        assert.deepStrictEqual(decision.choice, 'SQLite', 'Migrated decision choice should match');
-      }
+      assert.equal(decision, null, 'D001 should not be imported from DECISIONS.md without explicit migration');
     } finally {
       process.cwd = origCwd;
       closeDatabase();
@@ -360,7 +355,7 @@ describe('ensure-db-open', () => {
       assert.ok(result === true, 'ensureDbOpen should honor explicit basePath');
       assert.equal(process.cwd(), originalCwd, 'ensureDbOpen should not mutate process.cwd');
       assert.ok(isDbAvailable(), 'DB should be available after explicit open');
-      assert.ok(getDecisionById('D777') !== null, 'explicit basePath DB should be opened');
+      assert.equal(getDecisionById('D777'), null, 'explicit basePath should not import DECISIONS.md');
     } finally {
       closeDatabase();
       cleanupDir(tmpDir);
@@ -519,9 +514,9 @@ describe('ensure-db-open', () => {
     try {
       const { ensureDbOpen } = await import('../bootstrap/dynamic-tools.ts');
       assert.equal(await ensureDbOpen(firstDir), true);
-      assert.ok(getDecisionById('D101') !== null, 'first DB should be active');
+      assert.equal(getDecisionById('D101'), null, 'first DB should not import DECISIONS.md');
       assert.equal(await ensureDbOpen(secondDir), true);
-      assert.ok(getDecisionById('D202') !== null, 'second DB should be active after switch');
+      assert.equal(getDecisionById('D202'), null, 'second DB should not import DECISIONS.md');
       assert.equal(getDecisionById('D101'), null, 'first DB should no longer be active after switch');
     } finally {
       closeDatabase();

--- a/src/resources/extensions/gsd/tests/escalation.test.ts
+++ b/src/resources/extensions/gsd/tests/escalation.test.ts
@@ -19,6 +19,7 @@ import {
   claimEscalationOverride,
   findUnappliedEscalationOverride,
   listEscalationArtifacts,
+  SCHEMA_VERSION,
   _getAdapter,
 } from "../gsd-db.ts";
 import {
@@ -348,7 +349,7 @@ test("ADR-011 P2: schema v20 fresh DB has all escalation columns on tasks + sour
   assert.ok(decCols.includes("source"), "decisions table must have source column");
 
   const version = adapter.prepare("SELECT MAX(version) as v FROM schema_version").get();
-  assert.equal(version?.["v"], 22);
+  assert.equal(version?.["v"], SCHEMA_VERSION);
 });
 
 test("ADR-011 P2: findUnappliedEscalationOverride returns null when escalation_pending=1 (still pending)", (t) => {

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -11,6 +11,7 @@ import {
   wasDbOpenAttempted,
   getDbProvider,
   getDbStatus,
+  SCHEMA_VERSION,
   insertDecision,
   getDecisionById,
   insertRequirement,
@@ -101,7 +102,7 @@ describe('gsd-db', () => {
     // Check schema_version table
     const adapter = _getAdapter()!;
     const version = adapter.prepare('SELECT MAX(version) as version FROM schema_version').get();
-    assert.deepStrictEqual(version?.['version'], 22, 'schema version should be 22');
+    assert.deepStrictEqual(version?.['version'], SCHEMA_VERSION, `schema version should be ${SCHEMA_VERSION}`);
 
     // Check tables exist by querying them
     const dRows = adapter.prepare('SELECT count(*) as cnt FROM decisions').get();

--- a/src/resources/extensions/gsd/tests/gsdroot-worktree-detection.test.ts
+++ b/src/resources/extensions/gsd/tests/gsdroot-worktree-detection.test.ts
@@ -1,9 +1,10 @@
 /**
  * gsdroot-worktree-detection.test.ts — Regression test for #2594.
  *
- * gsdRoot() must return the worktree's own .gsd directory when the basePath
- * is inside a .gsd/worktrees/<name>/ structure, not walk up to the project
- * root's .gsd via the git-root probe.
+ * gsdRoot() must return the canonical project .gsd directory when basePath
+ * is inside a .gsd/worktrees/<name>/ structure. Worktree-local .gsd folders
+ * are legacy projection roots only; runtime state is DB-authoritative at the
+ * project .gsd.
  *
  * The bug: when a git worktree lives at /project/.gsd/worktrees/M008/,
  * probeGsdRoot() runs `git rev-parse --show-toplevel` which can return the
@@ -20,7 +21,7 @@ import { mkdtempSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 
-import { gsdRoot, _clearGsdRootCache } from "../paths.ts";
+import { gsdRoot, resolveGsdPathContract, _clearGsdRootCache } from "../paths.ts";
 
 describe("gsdRoot() worktree detection (#2594)", () => {
   let projectRoot: string;
@@ -61,7 +62,7 @@ describe("gsdRoot() worktree detection (#2594)", () => {
     rmSync(projectRoot, { recursive: true, force: true });
   });
 
-  test("returns worktree .gsd when basePath is a worktree with its own .gsd (fast path)", () => {
+  test("returns project .gsd when basePath is a worktree with its own .gsd", () => {
     // Simulates a worktree that already had copyPlanningArtifacts() run,
     // so it has its own .gsd/ directory.
     const worktreeBase = join(projectGsd, "worktrees", "M008");
@@ -71,41 +72,26 @@ describe("gsdRoot() worktree detection (#2594)", () => {
     const result = gsdRoot(worktreeBase);
     assert.equal(
       result,
-      worktreeGsd,
-      `Expected worktree .gsd (${worktreeGsd}), got ${result}. ` +
-        "gsdRoot() should use the fast path for an existing worktree .gsd.",
+      projectGsd,
+      `Expected canonical project .gsd (${projectGsd}), got ${result}.`,
     );
+    assert.equal(resolveGsdPathContract(worktreeBase).worktreeGsd, worktreeGsd);
   });
 
-  test("returns worktree .gsd path (not project root .gsd) when worktree .gsd does not exist yet", () => {
-    // This is the core #2594 bug: the worktree directory exists but its .gsd
-    // subdirectory hasn't been created yet. Without the fix, probeGsdRoot()
-    // walks up from the worktree path, finds /project/.gsd, and returns it.
-    // With the fix, it detects the .gsd/worktrees/<name>/ pattern and returns
-    // the worktree-local .gsd path as the creation fallback.
+  test("returns project .gsd when worktree .gsd does not exist yet", () => {
     const worktreeBase = join(projectGsd, "worktrees", "M008");
     mkdirSync(worktreeBase, { recursive: true });
     // NOTE: no .gsd/ inside worktreeBase
 
     const result = gsdRoot(worktreeBase);
-    const expected = join(worktreeBase, ".gsd");
-
-    // Without the fix, this returns projectGsd (/project/.gsd) because the
-    // walk-up from worktreeBase finds it. With the fix, it returns the
-    // worktree-local path.
-    assert.notEqual(
-      result,
-      projectGsd,
-      "gsdRoot() must NOT return the project root .gsd when basePath is inside .gsd/worktrees/",
-    );
     assert.equal(
       result,
-      expected,
-      `Expected worktree-local .gsd (${expected}), got ${result}.`,
+      projectGsd,
+      `Expected canonical project .gsd (${projectGsd}), got ${result}.`,
     );
   });
 
-  test("returns worktree .gsd when basePath is a real git worktree inside .gsd/worktrees/", () => {
+  test("returns project .gsd when basePath is a real git worktree inside .gsd/worktrees/", () => {
     // Create a real git worktree at .gsd/worktrees/M010
     const worktreeName = "M010";
     const worktreeBase = join(projectGsd, "worktrees", worktreeName);
@@ -125,17 +111,10 @@ describe("gsdRoot() worktree detection (#2594)", () => {
 
     // The real git worktree exists at worktreeBase but has NO .gsd/ subdir yet
     const gsdResult = gsdRoot(worktreeBase);
-    const expected = join(worktreeBase, ".gsd");
-
-    assert.notEqual(
-      gsdResult,
-      projectGsd,
-      "gsdRoot() must NOT escape to project root .gsd from inside a git worktree",
-    );
     assert.equal(
       gsdResult,
-      expected,
-      `Expected worktree-local .gsd (${expected}), got ${gsdResult}`,
+      projectGsd,
+      `Expected canonical project .gsd (${projectGsd}), got ${gsdResult}`,
     );
 
     // Cleanup worktree

--- a/src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts
@@ -473,26 +473,26 @@ test("mergeAllCompleted — by-completion order respects startedAt", async () =>
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Bug #2812 — determineMergeOrder should use worktree DB as source of truth
+// Bug #2812 — determineMergeOrder should use DB state as source of truth
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/** Set up a worktree DB with a milestone marked complete */
-function setupWorktreeDb(basePath: string, mid: string): void {
-  const wtGsdDir = join(basePath, ".gsd", "worktrees", mid, ".gsd");
-  mkdirSync(wtGsdDir, { recursive: true });
-  const dbPath = join(wtGsdDir, "gsd.db");
+/** Set up canonical DB with a milestone marked complete and a worktree marker dir */
+function setupCanonicalDbWithWorktree(basePath: string, mid: string): void {
+  mkdirSync(join(basePath, ".gsd", "worktrees", mid), { recursive: true });
+  mkdirSync(join(basePath, ".gsd"), { recursive: true });
+  const dbPath = join(basePath, ".gsd", "gsd.db");
   openDatabase(dbPath);
   insertMilestone({ id: mid, title: `Milestone ${mid}`, status: "complete" });
   updateMilestoneStatus(mid, "complete", new Date().toISOString());
   closeDatabase();
 }
 
-test("determineMergeOrder — finds milestones completed in worktree DB even when worker state is 'error' (#2812)", () => {
+test("determineMergeOrder — finds milestones completed in canonical DB even when worker state is 'error' (#2812)", () => {
   const base = realpathSync(mkdtempSync(join(tmpdir(), "merge-db-bug-")));
   try {
     // Simulate the bug scenario: orchestrator has stale "error" state
-    // but the worktree DB shows milestone is actually complete.
-    setupWorktreeDb(base, "M011");
+    // but the canonical DB shows milestone is actually complete.
+    setupCanonicalDbWithWorktree(base, "M011");
 
     const workers = [
       makeWorker({ milestoneId: "M010", state: "error" }),
@@ -502,12 +502,12 @@ test("determineMergeOrder — finds milestones completed in worktree DB even whe
 
     const order = determineMergeOrder(workers, "sequential", base);
 
-    // M011 should be included because its worktree DB says status='complete'
+    // M011 should be included because the canonical DB says status='complete'
     assert.ok(
       order.includes("M011"),
-      `Expected M011 in merge order (worktree DB says complete), got: [${order}]`,
+      `Expected M011 in merge order (canonical DB says complete), got: [${order}]`,
     );
-    // M010 and M012 should NOT be included (no worktree DB with complete status)
+    // M010 and M012 should NOT be included (no canonical complete status)
     assert.ok(!order.includes("M010"), "M010 should not be in merge order (error, no DB)");
     assert.ok(!order.includes("M012"), "M012 should not be in merge order (running, no DB)");
   } finally {
@@ -529,7 +529,7 @@ test("determineMergeOrder — combines stopped workers and DB-complete milestone
   const base = realpathSync(mkdtempSync(join(tmpdir(), "merge-dedup-")));
   try {
     // M001 is stopped in orchestrator AND complete in worktree DB
-    setupWorktreeDb(base, "M001");
+    setupCanonicalDbWithWorktree(base, "M001");
 
     const workers = [
       makeWorker({ milestoneId: "M001", state: "stopped" }),
@@ -555,8 +555,8 @@ test("mergeAllCompleted — discovers DB-complete milestones when workers show e
     ]);
     setupRoadmap(repo, "M011", "Feature System", ["S01: Feature module"]);
 
-    // Set up worktree DB showing M011 is complete
-    setupWorktreeDb(repo, "M011");
+    // Set up canonical DB showing M011 is complete
+    setupCanonicalDbWithWorktree(repo, "M011");
 
     // Orchestrator thinks M011 is in error (stale state)
     const workers = [

--- a/src/resources/extensions/gsd/tests/integration/state-machine-edge-cases.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/state-machine-edge-cases.test.ts
@@ -46,6 +46,7 @@ import {
   updateTaskStatus,
   updateSliceStatus,
   updateMilestoneStatus,
+  insertAssessment,
   insertReplanHistory,
   getReplanHistory,
   insertGateRow,
@@ -363,13 +364,13 @@ describe("state derivation failures", () => {
     const state2 = await deriveState(base);
     assert.equal(state2.phase, "executing", "cached result should still show executing");
 
-    // After explicit invalidation, should reflect the DB mutation and reconcile
-    // missing plan tasks instead of prematurely summarizing a partial DB row set.
+    // After explicit invalidation, DB rows remain authoritative; PLAN.md is a
+    // projection and must not import missing task rows.
     invalidateStateCache();
     const state3 = await deriveState(base);
-    assert.equal(state3.phase, "executing", "after cache invalidation should continue with the missing plan task");
-    assert.equal(state3.activeTask?.id, "T02", "missing plan task T02 should be imported and selected");
-    assert.deepEqual(state3.progress?.tasks, { done: 1, total: 2 });
+    assert.equal(state3.phase, "summarizing", "after cache invalidation should follow DB tasks only");
+    assert.equal(state3.activeTask, null, "disk-only plan task T02 should not be imported");
+    assert.deepEqual(state3.progress?.tasks, { done: 1, total: 1 });
   });
 
   test("corrupt ROADMAP: binary content does not crash deriveState", async () => {
@@ -486,12 +487,14 @@ describe("transition boundary failures", () => {
     writeFileSync(join(mDir, "M001-CONTEXT-DRAFT.md"), "# Draft\nSome draft.\n");
 
     openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Draft", status: "needs-discussion" });
     invalidateAllCaches();
     const state1 = await deriveState(base);
     assert.equal(state1.phase, "needs-discussion");
 
     // Now write the full CONTEXT (simulates discussion completion)
     writeFileSync(join(mDir, "M001-CONTEXT.md"), "# M001: Resolved\n\n## Purpose\nDone.\n");
+    updateMilestoneStatus("M001", "active");
 
     invalidateAllCaches();
     const state2 = await deriveState(base);
@@ -1148,6 +1151,13 @@ describe("completion and verification failures", () => {
     insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", status: "complete" });
     insertTask({ id: "T02", sliceId: "S01", milestoneId: "M001", status: "complete" });
     insertTask({ id: "T01", sliceId: "S02", milestoneId: "M001", status: "complete" });
+    insertAssessment({
+      path: "milestones/M001/M001-VALIDATION.md",
+      milestoneId: "M001",
+      status: "pass",
+      scope: "milestone-validation",
+      fullContent: "verdict: pass",
+    });
 
     invalidateAllCaches();
     const state = await deriveStateFromDb(base);

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -892,6 +892,11 @@ test('── markdown-renderer: missing artifact regenerates from DB without imp
     assert.ok(after !== null, 'artifact regenerated in DB');
     assert.ok(!after!.full_content.includes('DISK_ONLY_SENTINEL'), 'disk projection content was not imported');
     assert.ok(after!.full_content.includes('S01'), 'DB artifact reflects DB slice state');
+
+    assert.ok(fs.existsSync(roadmapPath), 'roadmap projection regenerated on disk');
+    const diskAfter = fs.readFileSync(roadmapPath, 'utf-8');
+    assert.ok(!diskAfter.includes('DISK_ONLY_SENTINEL'), 'disk projection was rewritten from DB');
+    assert.ok(diskAfter.includes('S01'), 'disk projection reflects DB slice state');
   } finally {
     closeDatabase();
     cleanupDir(tmpDir);

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -856,10 +856,10 @@ test('── markdown-renderer: renderAllFromDb produces all files ──', asyn
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Graceful Degradation (Disk Fallback)
+// DB-authoritative regeneration
 // ═══════════════════════════════════════════════════════════════════════════
 
-test('── markdown-renderer: graceful fallback reads from disk when artifact not in DB ──', async () => {
+test('── markdown-renderer: missing artifact regenerates from DB without importing disk projection ──', async () => {
   const tmpDir = makeTmpDir();
   const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
   openDatabase(dbPath);
@@ -874,7 +874,7 @@ test('── markdown-renderer: graceful fallback reads from disk when artifact 
     // Write roadmap to disk but NOT in artifacts DB
     const roadmapContent = makeRoadmapContent([
       { id: 'S01', title: 'Core', done: false },
-    ]);
+    ]) + '\n\nDISK_ONLY_SENTINEL';
     const roadmapPath = path.join(tmpDir, '.gsd', 'milestones', 'M001', 'M001-ROADMAP.md');
     fs.writeFileSync(roadmapPath, roadmapContent);
     clearAllCaches();
@@ -883,14 +883,15 @@ test('── markdown-renderer: graceful fallback reads from disk when artifact 
     const before = getArtifact('milestones/M001/M001-ROADMAP.md');
     assert.deepStrictEqual(before, null, 'artifact not in DB before render');
 
-    // Render — should read from disk, store in DB
+    // Render — should regenerate from DB rows, not import/patch disk content.
     const ok = await renderRoadmapCheckboxes(tmpDir, 'M001');
-    assert.ok(ok, 'render succeeds with disk fallback');
+    assert.ok(ok, 'render succeeds by regenerating from DB');
 
-    // Verify artifact now in DB (stored after reading from disk)
+    // Verify artifact now exists in DB but does not contain disk-only content.
     const after = getArtifact('milestones/M001/M001-ROADMAP.md');
-    assert.ok(after !== null, 'artifact stored in DB after disk fallback render');
-    assert.ok(after!.full_content.includes('[x] **S01:'), 'DB artifact reflects rendered state');
+    assert.ok(after !== null, 'artifact regenerated in DB');
+    assert.ok(!after!.full_content.includes('DISK_ONLY_SENTINEL'), 'disk projection content was not imported');
+    assert.ok(after!.full_content.includes('S01'), 'DB artifact reflects DB slice state');
   } finally {
     closeDatabase();
     cleanupDir(tmpDir);

--- a/src/resources/extensions/gsd/tests/md-importer.test.ts
+++ b/src/resources/extensions/gsd/tests/md-importer.test.ts
@@ -9,6 +9,7 @@ import {
   getRequirementById,
   getActiveRequirements,
   insertArtifact,
+  SCHEMA_VERSION,
   _getAdapter,
 } from '../gsd-db.ts';
 import {
@@ -363,7 +364,7 @@ test('md-importer: schema v1→v2 migration', () => {
   openDatabase(':memory:');
   const adapter = _getAdapter();
   const version = adapter?.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.v, 22, 'new DB should be at schema version 22');
+  assert.deepStrictEqual(version?.v, SCHEMA_VERSION, `new DB should be at schema version ${SCHEMA_VERSION}`);
 
   // Artifacts table should exist
   const tableCheck = adapter?.prepare("SELECT count(*) as c FROM sqlite_master WHERE type='table' AND name='artifacts'").get();

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -2,6 +2,7 @@ import {
   openDatabase,
   closeDatabase,
   isDbAvailable,
+  SCHEMA_VERSION,
   _getAdapter,
 } from '../gsd-db.ts';
 import {
@@ -328,9 +329,9 @@ test('memory-store: schema includes memories table', () => {
   const viewCount = adapter.prepare('SELECT count(*) as cnt FROM active_memories').get();
   assert.deepStrictEqual(viewCount?.['cnt'], 0, 'active_memories view should exist');
 
-  // Verify schema version is 22 (v22 quality_gates DDL fix included)
+  // Verify schema version is current (includes quality_gates DDL fix and later migrations)
   const version = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.["v"], 22, 'schema version should be 22');
+  assert.deepStrictEqual(version?.["v"], SCHEMA_VERSION, `schema version should be ${SCHEMA_VERSION}`);
 
   closeDatabase();
 });

--- a/src/resources/extensions/gsd/tests/park-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/park-milestone.test.ts
@@ -20,6 +20,8 @@ import {
 } from "../gsd-db.ts";
 import { createWorktree } from "../worktree-manager.ts";
 
+// This suite exercises the explicit legacy markdown derivation path.
+process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK = '1';
 
 
 // ─── Fixture Helpers ───────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/progressive-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/progressive-planning.test.ts
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { performance } from "node:perf_hooks";
 
 import {
   openDatabase,
@@ -99,21 +100,21 @@ test("ADR-011: sketch slice + progressive_planning ON → phase='refining'", asy
   assert.equal(state.phase, "refining", "sketch slice with flag ON must yield refining phase");
 });
 
-test("ADR-011: sketch slice + progressive_planning OFF → phase='planning' (backwards compat)", async (t) => {
+test("ADR-011: sketch slice + progressive_planning OFF → DB sketch metadata still yields refining", async (t) => {
   const originalCwd = process.cwd();
   const base = makeFixtureBase();
   t.after(() => cleanup(base, originalCwd));
 
   seedMilestoneWithSketchedS02(base);
   writeS01Artifacts(base);
-  // Write a PREFERENCES.md without the flag so loadEffectiveGSDPreferences finds
-  // a valid file but progressive_planning resolves to undefined.
+  // Write a PREFERENCES.md without the flag. DB slice metadata remains
+  // authoritative for whether this slice needs refinement.
   writePreferences(base, "phases:\n  skip_research: false");
   process.chdir(base);
 
   const state = await deriveStateFromDb(base);
   assert.equal(state.activeSlice?.id, "S02");
-  assert.equal(state.phase, "planning", "flag absent → must fall through to planning");
+  assert.equal(state.phase, "refining", "flag absent must not override DB sketch metadata");
 });
 
 test("ADR-011: dispatch rule maps refining → refine-slice unit", async (t) => {
@@ -516,24 +517,32 @@ test("ADR-011 P3 #26: refine-slice dispatch latency is bounded vs plan-slice bas
   await buildPlanSlicePrompt("M001", "Test", "S02", "Feature", base);
   await buildRefineSlicePrompt("M001", "Test", "S02", "Feature", base);
 
-  const planStart = Date.now();
-  await buildPlanSlicePrompt("M001", "Test", "S02", "Feature", base);
-  const planElapsed = Date.now() - planStart;
+  const measure = async (fn: () => Promise<string>): Promise<number> => {
+    const start = performance.now();
+    await fn();
+    return performance.now() - start;
+  };
 
-  const refineStart = Date.now();
-  await buildRefineSlicePrompt("M001", "Test", "S02", "Feature", base);
-  const refineElapsed = Date.now() - refineStart;
+  const planSamples: number[] = [];
+  const refineSamples: number[] = [];
+  for (let i = 0; i < 5; i++) {
+    planSamples.push(await measure(() => buildPlanSlicePrompt("M001", "Test", "S02", "Feature", base)));
+    refineSamples.push(await measure(() => buildRefineSlicePrompt("M001", "Test", "S02", "Feature", base)));
+  }
+  const bestPlan = Math.min(...planSamples);
+  const bestRefine = Math.min(...refineSamples);
 
   assert.ok(
-    refineElapsed < 500,
-    `refine-slice prompt build must complete under 500ms (took ${refineElapsed}ms)`,
+    bestRefine < 500,
+    `refine-slice prompt build must complete under 500ms (best=${bestRefine.toFixed(1)}ms, samples=${refineSamples.map(n => n.toFixed(1)).join(",")})`,
   );
   // Guard the ratio only when the baseline is large enough to be meaningful —
-  // if plan-slice measures 0-2ms the ratio is dominated by timer noise.
-  if (planElapsed >= 5) {
+  // if plan-slice measures in single-digit milliseconds, the ratio is dominated
+  // by scheduler and filesystem noise under the concurrent test runner.
+  if (bestPlan >= 20) {
     assert.ok(
-      refineElapsed < planElapsed * 3,
-      `refine-slice must not exceed 3x plan-slice baseline (refine=${refineElapsed}ms, plan=${planElapsed}ms)`,
+      bestRefine < bestPlan * 3,
+      `refine-slice must not exceed 3x plan-slice baseline (refine=${bestRefine.toFixed(1)}ms, plan=${bestPlan.toFixed(1)}ms)`,
     );
   }
 });

--- a/src/resources/extensions/gsd/tests/projection-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/projection-regression.test.ts
@@ -91,6 +91,7 @@ function makeMilestoneRow() {
     definition_of_done: [],
     requirement_coverage: '',
     boundary_map_markdown: '',
+    sequence: 0,
   };
 }
 

--- a/src/resources/extensions/gsd/tests/register-hooks-compaction-checkpoint.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-compaction-checkpoint.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 
 import { registerHooks } from "../bootstrap/register-hooks.ts";
 import { parseContinue } from "../files.ts";
-import { closeDatabase } from "../gsd-db.ts";
+import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
 import { deriveState, invalidateStateCache } from "../state.ts";
 
 function createPlanningFixtureBase(): string {
@@ -38,6 +38,11 @@ function createPlanningFixtureBase(): string {
 ## Tasks
 `,
   );
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Test Slice", status: "active", risk: "low", depends: [] });
+  closeDatabase();
 
   return base;
 }

--- a/src/resources/extensions/gsd/tests/replan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/replan-slice.test.ts
@@ -8,6 +8,9 @@ import { fileURLToPath } from 'node:url';
 import { parseSummary } from '../files.ts';
 import { deriveState } from '../state.ts';
 
+// This suite exercises the explicit legacy markdown derivation path.
+process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK = '1';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const worktreePromptsDir = join(__dirname, '..', 'prompts');
 

--- a/src/resources/extensions/gsd/tests/resolve-ts.mjs
+++ b/src/resources/extensions/gsd/tests/resolve-ts.mjs
@@ -1,5 +1,9 @@
 import { register } from 'node:module';
 import { pathToFileURL } from 'node:url';
 
+// Source legacy state tests exercise markdown derivation through deriveState().
+// Production/runtime keeps this fallback disabled unless explicitly requested.
+process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK ??= '1';
+
 // Register hook to redirect imports to the dist directory
 register(new URL('./dist-redirect.mjs', import.meta.url), pathToFileURL('./'));

--- a/src/resources/extensions/gsd/tests/rogue-file-detection.test.ts
+++ b/src/resources/extensions/gsd/tests/rogue-file-detection.test.ts
@@ -149,7 +149,7 @@ test("rogue detection: DB not available → returns empty array (graceful degrad
   }
 });
 
-test("rogue detection: slice summary on disk, no DB row → auto-remediated (not rogue)", () => {
+test("rogue detection: slice summary on disk, no DB completion → detected as rogue without DB import", () => {
   const basePath = createTmpBase();
   const dbPath = join(basePath, ".gsd", "gsd.db");
   mkdirSync(join(basePath, ".gsd"), { recursive: true });
@@ -160,10 +160,9 @@ test("rogue detection: slice summary on disk, no DB row → auto-remediated (not
     const summaryPath = createSliceSummaryOnDisk(basePath, "M001", "S01");
     assert.ok(existsSync(summaryPath), "Slice summary file should exist on disk");
 
-    // Fix #3633: stale slice DB status is auto-remediated via updateSliceStatus()
-    // instead of being reported as rogue, so rogues array should be empty.
     const rogues = detectRogueFileWrites("complete-slice", "M001/S01", basePath);
-    assert.equal(rogues.length, 0, "Should auto-remediate stale slice, not report as rogue");
+    assert.equal(rogues.length, 1, "Should report stale disk summary instead of mutating DB");
+    assert.equal(rogues[0]?.path, summaryPath);
   } finally {
     closeDatabase();
     rmSync(basePath, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/slice-disk-reconcile.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-disk-reconcile.test.ts
@@ -1,10 +1,8 @@
 /**
  * slice-disk-reconcile.test.ts — #2533
  *
- * Slices that exist on disk (in ROADMAP.md) but are missing from the SQLite
- * database cause permanent "No slice eligible — check dependency ordering"
- * blocks. deriveStateFromDb must reconcile disk slices into the DB, just as
- * it already does for milestones (#2416).
+ * DB-authoritative state: slices that exist only in ROADMAP.md are projections
+ * and must not be imported into the SQLite database by deriveStateFromDb().
  *
  * Scenario: M001 has a ROADMAP with S01-S04. S01 and S02 have SUMMARY files
  * (complete on disk). S03 depends on S01. Only S04 is in the DB (depends on
@@ -70,7 +68,7 @@ const ROADMAP_CONTENT = `# M001: Test Milestone
 `;
 
 async function testMissingSlicesCauseBlock(): Promise<void> {
-  console.log("\n--- Test: missing DB slices cause permanent block (pre-fix) ---");
+  console.log("\n--- Test: missing DB slices are not imported from ROADMAP.md ---");
 
   const base = createFixtureBase();
   const dbPath = join(base, ".gsd", "gsd.db");
@@ -96,51 +94,11 @@ async function testMissingSlicesCauseBlock(): Promise<void> {
     invalidateStateCache();
     const state = await deriveStateFromDb(base);
 
-    // After the fix, slices S01-S03 should be reconciled into DB
     const dbSlices = getMilestoneSlices("M001");
-    assertTrue(
-      dbSlices.length === 4,
-      `All 4 roadmap slices should be in DB after reconciliation, got ${dbSlices.length}`,
-    );
-
-    // S01 and S02 should be marked complete (have SUMMARY files)
-    const s01 = dbSlices.find(s => s.id === "S01");
-    assertTrue(s01 !== undefined, "S01 should exist in DB after reconciliation");
-    if (s01) {
-      assertEq(s01.status, "complete", "S01 should be 'complete' (has SUMMARY on disk)");
-    }
-
-    const s02 = dbSlices.find(s => s.id === "S02");
-    assertTrue(s02 !== undefined, "S02 should exist in DB after reconciliation");
-    if (s02) {
-      assertEq(s02.status, "complete", "S02 should be 'complete' (has SUMMARY on disk)");
-    }
-
-    // S03 should be pending (no SUMMARY)
-    const s03 = dbSlices.find(s => s.id === "S03");
-    assertTrue(s03 !== undefined, "S03 should exist in DB after reconciliation");
-    if (s03) {
-      assertEq(s03.status, "pending", "S03 should be 'pending' (no SUMMARY on disk)");
-    }
-
-    // The state should NOT be blocked — S03 should be eligible (S01 dep satisfied)
-    assertTrue(
-      state.phase !== "blocked",
-      `Phase should not be 'blocked' after reconciliation, got '${state.phase}'`,
-    );
-
-    // Active slice should be S03 (S01 dep met, S03 is first incomplete with satisfied deps)
-    assertTrue(
-      state.activeSlice !== null,
-      "There should be an active slice after reconciliation",
-    );
-    if (state.activeSlice) {
-      assertEq(
-        state.activeSlice.id,
-        "S03",
-        "Active slice should be S03 (its dependency S01 is complete) (#2533)",
-      );
-    }
+    assertEq(dbSlices.length, 1, `Only DB slice S04 should remain, got ${dbSlices.length}`);
+    assertEq(dbSlices[0]?.id, "S04", "Disk-only slices are not inserted");
+    assertEq(state.phase, "blocked", "DB-only S04 remains blocked on missing DB dependency S03");
+    assertEq(state.activeSlice, null, "No active slice is inferred from roadmap-only rows");
   } finally {
     closeDatabase();
     cleanup(base);
@@ -148,7 +106,7 @@ async function testMissingSlicesCauseBlock(): Promise<void> {
 }
 
 async function testSliceReconciliationIdempotent(): Promise<void> {
-  console.log("\n--- Test: slice reconciliation is idempotent ---");
+  console.log("\n--- Test: disk-only slices remain absent on repeated derives ---");
 
   const base = createFixtureBase();
   const dbPath = join(base, ".gsd", "gsd.db");
@@ -178,11 +136,7 @@ async function testSliceReconciliationIdempotent(): Promise<void> {
       assertEq(s01.status, "complete", "S01 status should remain 'complete' (not overwritten)");
     }
 
-    // S02-S04 should have been added
-    assertTrue(
-      dbSlices.length === 4,
-      `Should have 4 slices after reconciliation (existing + new), got ${dbSlices.length}`,
-    );
+    assertEq(dbSlices.length, 1, `Only existing DB slice should remain, got ${dbSlices.length}`);
   } finally {
     closeDatabase();
     cleanup(base);
@@ -218,7 +172,7 @@ async function testNoRoadmapSkipsReconciliation(): Promise<void> {
 }
 
 async function main(): Promise<void> {
-  console.log("\n=== #2533: deriveStateFromDb reconciles disk slices ===");
+  console.log("\n=== deriveStateFromDb does not reconcile disk slices ===");
 
   await testMissingSlicesCauseBlock();
   await testSliceReconciliationIdempotent();

--- a/src/resources/extensions/gsd/tests/stale-slice-rows.test.ts
+++ b/src/resources/extensions/gsd/tests/stale-slice-rows.test.ts
@@ -1,10 +1,9 @@
 /**
- * stale-slice-rows.test.ts — #3658
+ * stale-slice-rows.test.ts
  *
- * Verify that state.ts contains slice-level status reconciliation that
- * updates stale DB rows (status "pending") when disk artifacts (SUMMARY)
- * prove the slice is complete. Without this, the dependency resolver builds
- * doneSliceIds from stale DB rows and downstream slices stay blocked.
+ * Verify that state.ts no longer treats slice SUMMARY.md projections as
+ * authority for DB slice status. Slice rows must be updated through DB-backed
+ * completion/import APIs.
  */
 
 import { describe, test } from "node:test";
@@ -16,26 +15,26 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const sourceFile = join(__dirname, "..", "state.ts");
 
-describe("stale slice row reconciliation (#3658)", () => {
+describe("stale slice row DB-authoritative boundary", () => {
   const source = readFileSync(sourceFile, "utf-8");
 
-  test("imports updateSliceStatus from gsd-db", () => {
-    assert.match(source, /import\s*\{[^}]*updateSliceStatus[^}]*\}\s*from/);
+  test("does not import updateSliceStatus into state derivation", () => {
+    assert.doesNotMatch(source, /import\s*\{[^}]*updateSliceStatus[^}]*\}\s*from/);
   });
 
-  test("checks isStatusDone before reconciling slice rows", () => {
-    assert.match(source, /isStatusDone\(dbSlice\.status\)/);
+  test("does not scan DB slice rows for disk SUMMARY reconciliation", () => {
+    assert.doesNotMatch(source, /dbSlice/);
   });
 
-  test("resolves SUMMARY file to detect completed slices on disk", () => {
-    assert.match(source, /resolveSliceFile\(basePath,\s*mid,\s*dbSlice\.id,\s*["']SUMMARY["']\)/);
+  test("does not resolve slice SUMMARY to mutate DB state", () => {
+    assert.doesNotMatch(source, /resolveSliceFile\(basePath,\s*mid,\s*dbSlice\.id,\s*["']SUMMARY["']\)/);
   });
 
-  test("calls updateSliceStatus to reconcile stale rows", () => {
-    assert.match(source, /updateSliceStatus\(mid,\s*dbSlice\.id,\s*["']complete["']\)/);
+  test("does not call updateSliceStatus from state derivation", () => {
+    assert.doesNotMatch(source, /updateSliceStatus\(/);
   });
 
-  test("references issue #3599 in reconciliation comment", () => {
-    assert.match(source, /#3599/);
+  test("documents markdown projections as non-authoritative", () => {
+    assert.match(source, /Markdown files are projections only/);
   });
 });

--- a/src/resources/extensions/gsd/tests/state-corruption-2945.test.ts
+++ b/src/resources/extensions/gsd/tests/state-corruption-2945.test.ts
@@ -69,6 +69,7 @@ function makeMilestoneRow(overrides: Partial<MilestoneRow> = {}): MilestoneRow {
     definition_of_done: [],
     requirement_coverage: "",
     boundary_map_markdown: "",
+    sequence: 0,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/state-machine-full-walkthrough.test.ts
+++ b/src/resources/extensions/gsd/tests/state-machine-full-walkthrough.test.ts
@@ -858,11 +858,11 @@ describe("state-machine-full-walkthrough", () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // RECONCILIATION
+  // DB-AUTHORITATIVE DERIVATION
   // ═══════════════════════════════════════════════════════════════════════════
 
-  describe("Reconciliation", () => {
-    test("DB: task with SUMMARY on disk but DB says pending → reconciliation fixes status (#2514)", async () => {
+  describe("DB-authoritative derivation", () => {
+    test("DB: task with SUMMARY on disk but DB says pending → DB remains authoritative", async () => {
       const base = createFixtureBase();
       const dbPath = join(base, ".gsd", "gsd.db");
       openDatabase(dbPath);
@@ -875,19 +875,19 @@ describe("state-machine-full-walkthrough", () => {
       writeRoadmap(base, "M001", standardRoadmap());
       writePlan(base, "M001", "S01", standardPlan());
 
-      // Write SUMMARY files on disk for both tasks (simulating session disconnect)
+      // Write SUMMARY files on disk for both tasks. These are projections and
+      // must not complete pending DB tasks during runtime derivation.
       writeTaskSummary(base, "M001", "S01", "T01");
       writeTaskSummary(base, "M001", "S01", "T02");
 
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
-      // Reconciliation should detect SUMMARY→DB mismatch and update
-      // All tasks done → summarizing (not executing)
-      assert.equal(state.phase, "summarizing", "reconciliation should advance past pending tasks");
+      assert.equal(state.phase, "executing", "disk SUMMARY projections must not complete DB tasks");
+      assert.equal(state.activeTask?.id, "T01", "first pending DB task remains active");
     });
 
-    test("empty DB with disk milestones → disk-to-DB sync (#2631)", async () => {
+    test("empty DB with disk milestones → no runtime disk-to-DB sync", async () => {
       const base = createFixtureBase();
       writeContext(base, "M001", "# M001: Test\n\nContext.");
 
@@ -899,11 +899,10 @@ describe("state-machine-full-walkthrough", () => {
       invalidateStateCache();
       const state = await deriveState(base);
 
-      // After deriveState, DB should have the disk milestone
+      // Runtime derivation must not import disk milestones into the DB.
       const after = getAllMilestones();
-      assert.ok(after.length > 0, "DB should have milestones after reconciliation");
-      assert.equal(after[0]!.id, "M001");
-      assert.ok(state.activeMilestone !== null);
+      assert.equal(after.length, 0, "DB should remain empty without explicit migration");
+      assert.equal(state.activeMilestone, null, "disk milestone is ignored while DB is authoritative");
     });
 
     test("ghost milestone (empty dir) → NOT in registry", async () => {
@@ -1063,7 +1062,7 @@ describe("state-machine-full-walkthrough", () => {
   // ═══════════════════════════════════════════════════════════════════════════
 
   describe("Recovery: DB has slice but no task rows (partial migration)", () => {
-    test("DB tasks empty but PLAN on disk has tasks → reconciles to executing", async () => {
+    test("DB tasks empty but PLAN on disk has tasks → stays planning", async () => {
       const base = createFixtureBase();
       const dbPath = join(base, ".gsd", "gsd.db");
       openDatabase(dbPath);
@@ -1078,15 +1077,13 @@ describe("state-machine-full-walkthrough", () => {
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
-      // FIX (#3600): plan-file tasks are now reconciled into the DB,
-      // so the phase correctly advances to executing instead of planning.
-      assert.equal(state.phase, "executing",
-        "reconciled plan-file tasks → executing (not stuck in planning)");
+      assert.equal(state.phase, "planning",
+        "PLAN.md projection must not import DB tasks during runtime derivation");
     });
   });
 
   describe("Failure: partial SUMMARY reconciliation", () => {
-    test("only one task has SUMMARY, other still pending → executing next task", async () => {
+    test("only one task has SUMMARY, other still pending → executing first DB-pending task", async () => {
       const base = createFixtureBase();
       const dbPath = join(base, ".gsd", "gsd.db");
       openDatabase(dbPath);
@@ -1104,9 +1101,8 @@ describe("state-machine-full-walkthrough", () => {
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
-      // T01 reconciled to complete, T02 still pending → executing T02
       assert.equal(state.phase, "executing");
-      assert.equal(state.activeTask?.id, "T02", "should advance to next pending task");
+      assert.equal(state.activeTask?.id, "T01", "disk SUMMARY must not advance past pending DB task");
     });
   });
 
@@ -1255,7 +1251,7 @@ describe("state-machine-full-walkthrough", () => {
   });
 
   describe("Failure: missing task plan files in DB path", () => {
-    test("DB has tasks but no T##-PLAN.md files → planning phase", async () => {
+    test("DB has tasks but no T##-PLAN.md files → executing phase", async () => {
       const base = createFixtureBase();
       const dbPath = join(base, ".gsd", "gsd.db");
       openDatabase(dbPath);
@@ -1273,8 +1269,8 @@ describe("state-machine-full-walkthrough", () => {
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
-      assert.equal(state.phase, "planning",
-        "missing T##-PLAN.md files should keep state in planning");
+      assert.equal(state.phase, "executing",
+        "DB tasks are authoritative even when task plan projections are missing");
     });
   });
 
@@ -1591,7 +1587,7 @@ describe("state-machine-full-walkthrough", () => {
   });
 
   describe("Failure: multiple reconciliation in single derivation", () => {
-    test("DB has 3 stale tasks, all with SUMMARY on disk → all reconciled in one pass", async () => {
+    test("DB has 3 stale tasks, all with SUMMARY on disk → first DB-pending task remains active", async () => {
       const base = createFixtureBase();
       const dbPath = join(base, ".gsd", "gsd.db");
       openDatabase(dbPath);
@@ -1641,9 +1637,9 @@ describe("state-machine-full-walkthrough", () => {
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
-      // All 3 should be reconciled in one pass → summarizing
-      assert.equal(state.phase, "summarizing",
-        "all 3 stale tasks should be reconciled to complete in one derivation");
+      assert.equal(state.phase, "executing",
+        "disk SUMMARY projections must not reconcile DB task state");
+      assert.equal(state.activeTask?.id, "T01", "first non-closed DB task remains active");
     });
   });
 });

--- a/src/resources/extensions/gsd/tests/steer-worktree-path.test.ts
+++ b/src/resources/extensions/gsd/tests/steer-worktree-path.test.ts
@@ -1,6 +1,6 @@
 // GSD Extension - Steer Worktree Path Resolution Test
-// Regression test for #3476: /gsd steer must write overrides to the worktree .gsd/,
-// not the project root .gsd/, when a worktree is active.
+// Worktrees share the canonical project .gsd state root. /gsd steer writes
+// overrides to that canonical root even when invoked with a worktree path.
 
 import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
@@ -27,32 +27,31 @@ describe("steer worktree path resolution (#3476)", () => {
     rmSync(projectRoot, { recursive: true, force: true });
   });
 
-  test("appendOverride writes to worktree .gsd/ when worktree path is used", async () => {
+  test("appendOverride writes to canonical project .gsd/ when worktree path is used", async () => {
     await appendOverride(worktreePath, "Use Postgres instead of SQLite", "M001/S01/T01");
 
-    // Override should be in the worktree .gsd/
+    // Override should be in the canonical project .gsd/
     const wtOverrides = join(worktreePath, ".gsd", "OVERRIDES.md");
-    assert.ok(existsSync(wtOverrides), "override file exists in worktree .gsd/");
-
-    const content = readFileSync(wtOverrides, "utf-8");
-    assert.ok(content.includes("Use Postgres instead of SQLite"), "override content is correct");
-
-    // Override should NOT be in the project root .gsd/
     const rootOverrides = join(projectRoot, ".gsd", "OVERRIDES.md");
-    assert.ok(!existsSync(rootOverrides), "no override file in project root .gsd/");
+    assert.ok(!existsSync(wtOverrides), "no override file in worktree-local .gsd/");
+    assert.ok(existsSync(rootOverrides), "override file exists in project root .gsd/");
+
+    const content = readFileSync(rootOverrides, "utf-8");
+    assert.ok(content.includes("Use Postgres instead of SQLite"), "override content is correct");
   });
 
-  test("loadActiveOverrides reads from worktree .gsd/ when worktree path is used", async () => {
+  test("loadActiveOverrides reads canonical project .gsd/ when worktree path is used", async () => {
     await appendOverride(worktreePath, "Switch to JWT auth", "M001/S02/T01");
 
-    // Loading from worktree should find the override
+    // Loading from worktree resolves to the canonical project state root.
     const wtOverrides = await loadActiveOverrides(worktreePath);
     assert.equal(wtOverrides.length, 1, "one active override in worktree");
     assert.equal(wtOverrides[0].change, "Switch to JWT auth");
 
-    // Loading from project root should find nothing
+    // Loading from project root sees the same canonical override.
     const rootOverrides = await loadActiveOverrides(projectRoot);
-    assert.equal(rootOverrides.length, 0, "no overrides in project root");
+    assert.equal(rootOverrides.length, 1, "same override visible from project root");
+    assert.equal(rootOverrides[0].change, "Switch to JWT auth");
   });
 
   test("appendOverride falls back to project root when no worktree exists", async () => {

--- a/src/resources/extensions/gsd/tests/stop-auto-remote.test.ts
+++ b/src/resources/extensions/gsd/tests/stop-auto-remote.test.ts
@@ -135,7 +135,7 @@ test("stopAutoRemote sends SIGTERM to a live process and returns found:true", { 
 
 // ─── Lock path: original project root vs worktree ────────────────────────
 
-test("lock file should be discoverable at project root, not worktree path", () => {
+test("lock file should be discoverable from project root and worktree path", () => {
   const projectRoot = makeTmpBase();
   const worktreePath = join(projectRoot, ".gsd", "worktrees", "M001");
   mkdirSync(join(worktreePath, ".gsd"), { recursive: true });
@@ -149,9 +149,10 @@ test("lock file should be discoverable at project root, not worktree path", () =
     assert.ok(lock, "lock should be found at project root");
     assert.equal(lock!.unitType, "execute-task");
 
-    // Worktree path should NOT have a lock
+    // Worktree path resolves to the same canonical project .gsd lock.
     const worktreeLock = readCrashLock(worktreePath);
-    assert.equal(worktreeLock, null, "lock should NOT exist at worktree path");
+    assert.ok(worktreeLock, "lock should be discoverable via worktree path");
+    assert.equal(worktreeLock!.unitType, "execute-task");
   } finally {
     cleanup(projectRoot);
   }

--- a/src/resources/extensions/gsd/tests/sync-worktree-skip-current.test.ts
+++ b/src/resources/extensions/gsd/tests/sync-worktree-skip-current.test.ts
@@ -1,12 +1,9 @@
 /**
- * Regression test for #3641 — syncWorktreeStateBack skips current milestone
+ * Regression test for DB-authoritative syncWorktreeStateBack behavior.
  *
- * When syncing worktree state back to main, the current milestone being
- * merged should be skipped. Its files are already in the milestone branch
- * and copying them back would conflict with the squash merge.
- *
- * The fix adds a `mid === milestoneId` skip guard inside the milestone
- * iteration loop in syncWorktreeStateBack.
+ * Worktree milestone projections are not authoritative. syncWorktreeStateBack
+ * may reconcile a legacy worktree DB and copy diagnostics, but must not copy
+ * milestone markdown directories back into the project root.
  */
 
 import { describe, it } from 'node:test'
@@ -20,7 +17,7 @@ const src = readFileSync(
   'utf-8',
 )
 
-describe('syncWorktreeStateBack skips current milestone (#3641)', () => {
+describe('syncWorktreeStateBack does not copy worktree milestone projections', () => {
   it('syncWorktreeStateBack function exists', () => {
     assert.ok(
       src.includes('function syncWorktreeStateBack('),
@@ -28,7 +25,7 @@ describe('syncWorktreeStateBack skips current milestone (#3641)', () => {
     )
   })
 
-  it('mid === milestoneId skip guard exists in the milestone loop', () => {
+  it('does not iterate worktree milestones for copy-back', () => {
     // Find syncWorktreeStateBack
     const fnStart = src.indexOf('function syncWorktreeStateBack(')
     assert.ok(fnStart !== -1)
@@ -36,31 +33,11 @@ describe('syncWorktreeStateBack skips current milestone (#3641)', () => {
     // Get a reasonable portion of the function
     const fnBlock = extractSourceRegion(src, 'function syncWorktreeStateBack(', { fromIdx: fnStart })
 
-    // Find the for loop iterating milestones
-    const loopIdx = fnBlock.indexOf('for (const mid of wtMilestones)')
-    assert.ok(loopIdx !== -1, 'milestone iteration loop must exist')
-
-    // After the loop, there should be the skip guard
-    const loopBody = extractSourceRegion(fnBlock, 'for (const mid of wtMilestones)', { fromIdx: loopIdx })
-    assert.ok(
-      loopBody.includes('mid === milestoneId'),
-      'mid === milestoneId skip guard must exist inside the milestone loop',
-    )
-    assert.ok(
-      loopBody.includes('continue'),
-      'skip guard must use continue to skip the current milestone',
-    )
+    assert.ok(!fnBlock.includes('for (const mid of wtMilestones)'), 'must not iterate worktree milestones')
+    assert.ok(!fnBlock.includes('syncMilestoneDir('), 'must not copy milestone markdown projections')
   })
 
-  it('syncMilestoneDir is still called for non-current milestones', () => {
-    const fnStart = src.indexOf('function syncWorktreeStateBack(')
-    assert.ok(fnStart !== -1)
-
-    const fnBlock = extractSourceRegion(src, 'function syncWorktreeStateBack(', { fromIdx: fnStart })
-
-    assert.ok(
-      fnBlock.includes('syncMilestoneDir('),
-      'syncMilestoneDir must still be called for other milestones',
-    )
+  it('legacy milestone copy helper has been removed', () => {
+    assert.ok(!src.includes('function syncMilestoneDir('), 'syncMilestoneDir helper should not exist')
   })
 })

--- a/src/resources/extensions/gsd/tests/validate-milestone-write-order.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-write-order.test.ts
@@ -85,7 +85,7 @@ describe("handleValidateMilestone write ordering (#2725)", () => {
     assert.doesNotMatch(validationMd, /## Verification Class Compliance/);
   });
 
-  it("rolls back DB row when disk write fails", async () => {
+  it("keeps DB row and reports stale projection when disk write fails", async () => {
     base = makeTmpBase();
     const dbPath = join(base, ".gsd", "gsd.db");
     openDatabase(dbPath);
@@ -101,16 +101,15 @@ describe("handleValidateMilestone write ordering (#2725)", () => {
 
     const result = await handleValidateMilestone(VALID_PARAMS, base);
 
-    // Should return error
-    assert.ok("error" in result, "should return error when disk write fails");
-    assert.ok(result.error.includes("disk render failed"));
+    assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
+    assert.equal(result.stale, true, "result should report stale projection");
 
-    // DB row should have been rolled back (deleted)
     const adapter = _getAdapter()!;
     const row = adapter.prepare(
-      `SELECT * FROM assessments WHERE milestone_id = 'M001' AND scope = 'milestone-validation'`,
-    ).get();
-    assert.equal(row, undefined, "assessment row should be deleted after disk-write rollback");
+      `SELECT status FROM assessments WHERE milestone_id = 'M001' AND scope = 'milestone-validation'`,
+    ).get() as { status: string } | undefined;
+    assert.ok(row, "assessment row should remain committed");
+    assert.equal(row!.status, "pass");
   });
 
   it("persists milestone validation gate_runs rows when UOK gates are enabled", async () => {

--- a/src/resources/extensions/gsd/tests/validate-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone.test.ts
@@ -394,7 +394,7 @@ test("dispatch rule skips when skip_milestone_validation preference is set", asy
   }
 });
 
-test("dispatch rule fails closed for failure-path SUMMARY when DB milestone is not complete (#4658)", async () => {
+test("dispatch rule ignores failure-path SUMMARY projection when DB milestone is not complete (#4658 superseded)", async () => {
   const state: GSDState = {
     activeMilestone: { id: "M001", title: "Test" },
     activeSlice: null,
@@ -422,17 +422,14 @@ test("dispatch rule fails closed for failure-path SUMMARY when DB milestone is n
       prefs: undefined,
     };
     const result = await resolveDispatch(ctx);
-    assert.equal(result.action, "stop");
-    if (result.action === "stop") {
-      assert.equal(result.level, "warning");
-      assert.match(result.reason, /failure-path SUMMARY/i);
-    }
+    assert.equal(result.action, "dispatch");
+    assert.equal(getMilestone("M001")?.status, "active");
   } finally {
     cleanup(base);
   }
 });
 
-test("dispatch rule reconciles DB for successful stale SUMMARY (#4658)", async () => {
+test("dispatch rule does not reconcile DB from successful stale SUMMARY projection (#4658 superseded)", async () => {
   const state: GSDState = {
     activeMilestone: { id: "M001", title: "Test" },
     activeSlice: null,
@@ -473,15 +470,15 @@ test("dispatch rule reconciles DB for successful stale SUMMARY (#4658)", async (
       prefs: undefined,
     };
     const result = await resolveDispatch(ctx);
-    assert.equal(result.action, "skip");
+    assert.equal(result.action, "dispatch");
     const milestone = getMilestone("M001");
-    assert.equal(milestone?.status, "complete");
+    assert.equal(milestone?.status, "active");
   } finally {
     cleanup(base);
   }
 });
 
-test("dispatch rule fails closed for ambiguous stale SUMMARY (#4658)", async () => {
+test("dispatch rule ignores ambiguous stale SUMMARY projection (#4658 superseded)", async () => {
   const state: GSDState = {
     activeMilestone: { id: "M001", title: "Test" },
     activeSlice: null,
@@ -509,11 +506,8 @@ test("dispatch rule fails closed for ambiguous stale SUMMARY (#4658)", async () 
       prefs: undefined,
     };
     const result = await resolveDispatch(ctx);
-    assert.equal(result.action, "stop");
-    if (result.action === "stop") {
-      assert.equal(result.level, "warning");
-      assert.match(result.reason, /ambiguous SUMMARY/i);
-    }
+    assert.equal(result.action, "dispatch");
+    assert.equal(getMilestone("M001")?.status, "active");
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/workflow-logger-wiring.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-logger-wiring.test.ts
@@ -205,17 +205,22 @@ test("readTransaction logs ROLLBACK failures as split-brain signal", () => {
   );
 });
 
-// ─── Runtime: state.ts and workflow-projections.ts log silent bailouts ─────
+// ─── Runtime: startup/projection diagnostics stay explicit ─────────────────
 
-test("state.ts logs roadmap read failures instead of silently continuing", () => {
-  const stateSrc = readFileSync(
-    join(import.meta.dirname, "..", "state.ts"),
+test("auto-start initializes the DB without implicit markdown migration", () => {
+  const autoStartSrc = readFileSync(
+    join(import.meta.dirname, "..", "auto-start.ts"),
     "utf-8",
   );
+  assert.doesNotMatch(
+    autoStartSrc,
+    /migrateFromMarkdown|md-importer/,
+    "auto-start must not import markdown into the runtime DB implicitly",
+  );
   assert.match(
-    stateSrc,
-    /logWarning\("state",\s*"reconcileDiskToDb: roadmap read failed/,
-    "state.ts reconcileDiskToDb should log roadmap read failures",
+    autoStartSrc,
+    /failed to initialize project database/,
+    "DB initialization failures should still be logged",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp-auto-prep.test.ts
@@ -15,7 +15,7 @@ test("shouldAutoPrepareWorkflowMcp enables prep for externalCli local transport"
   assert.equal(result, true);
 });
 
-test("shouldAutoPrepareWorkflowMcp enables prep when claude-code provider is ready", () => {
+test("shouldAutoPrepareWorkflowMcp stays disabled for non-Claude active provider even when claude-code is ready", () => {
   const result = shouldAutoPrepareWorkflowMcp({
     model: { provider: "openai", baseUrl: "https://api.openai.com" },
     modelRegistry: {
@@ -24,10 +24,10 @@ test("shouldAutoPrepareWorkflowMcp enables prep when claude-code provider is rea
     },
   });
 
-  assert.equal(result, true);
+  assert.equal(result, false);
 });
 
-test("shouldAutoPrepareWorkflowMcp enables prep when claude-code provider is registered", () => {
+test("shouldAutoPrepareWorkflowMcp stays disabled for non-Claude active provider even when claude-code is registered", () => {
   const result = shouldAutoPrepareWorkflowMcp({
     model: { provider: "openai", baseUrl: "https://api.openai.com" },
     modelRegistry: {
@@ -36,7 +36,7 @@ test("shouldAutoPrepareWorkflowMcp enables prep when claude-code provider is reg
     },
   });
 
-  assert.equal(result, true);
+  assert.equal(result, false);
 });
 
 test("shouldAutoPrepareWorkflowMcp stays disabled when neither transport nor provider readiness match", () => {

--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -28,6 +28,17 @@ type ElicitPayload = {
 
 function readSrc(file: string): string {
   return readFileSync(join(gsdDir, file), "utf-8");
+}
+
+function listTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) out.push(...listTsFiles(full));
+    else if (entry.endsWith(".ts")) out.push(full);
+  }
+  return out;
 }
 
 function extractElicitPayload(request: unknown): ElicitPayload {
@@ -771,4 +782,16 @@ test("auto phases source enforces workflow compatibility preflight", () => {
 test("workflow transport error guidance includes /gsd mcp init hint", () => {
   const src = readSrc("workflow-mcp.ts");
   assert.match(src, /Please run \/gsd mcp init \./);
+});
+
+test("buildWorkflowMcpServers is only imported by tests or Claude Code MCP boundary code", () => {
+  const offenders: string[] = [];
+  for (const file of listTsFiles(gsdDir)) {
+    const rel = file.slice(gsdDir.length + 1).replace(/\\/g, "/");
+    if (rel === "workflow-mcp.ts" || rel.startsWith("tests/")) continue;
+    const src = readFileSync(file, "utf-8");
+    if (/\bimport\b[\s\S]*\bbuildWorkflowMcpServers\b/.test(src)) offenders.push(rel);
+  }
+
+  assert.deepEqual(offenders, []);
 });

--- a/src/resources/extensions/gsd/tests/worktree-db-same-file.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-db-same-file.test.ts
@@ -15,6 +15,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -155,6 +156,18 @@ describe("#2823: reconcileWorktreeDb same-file guard", () => {
       "should reconcile decisions from a genuinely different DB",
     );
   });
+});
+
+test("merge-time DB reconciliation only runs when legacy worktree DB exists", () => {
+  const src = readFileSync(join(import.meta.dirname, "..", "auto-worktree.ts"), "utf-8");
+  const reconcileIdx = src.indexOf("reconcileWorktreeDb(mainDbPath, worktreeDbPath)");
+  assert.ok(reconcileIdx !== -1, "merge-time reconcile call exists");
+  const guardWindow = src.slice(Math.max(0, reconcileIdx - 240), reconcileIdx);
+
+  assert.ok(
+    guardWindow.includes("existsSync(worktreeDbPath)") && guardWindow.includes("!isSamePath(worktreeDbPath, mainDbPath)"),
+    "merge-time reconcile requires a real legacy worktree DB and distinct DB paths",
+  );
 });
 
 // ─── Fix 3: infrastructure error classification ─────────────────────

--- a/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
@@ -5,8 +5,8 @@
  * from the main repo's .gsd/ into the worktree's .gsd/ for the
  * specified milestone, and deletes gsd.db so it rebuilds from fresh state.
  *
- * Also verifies that syncWorktreeStateBack recurses into tasks/ subdirectories
- * so task-level summaries are not dropped on milestone teardown (#1678).
+ * Also verifies that syncWorktreeStateBack does not import worktree markdown
+ * projections back into the project root.
  *
  * Covers:
  *   - Milestone directory synced from main to worktree
@@ -15,12 +15,12 @@
  *   - No-op when paths are equal
  *   - No-op when milestoneId is null
  *   - Non-existent directories handled gracefully
- *   - syncWorktreeStateBack recurses into tasks/ subdirectory (#1678)
- *   - syncWorktreeStateBack syncs root-level .gsd/ files (REQUIREMENTS, PROJECT, etc.)
- *   - syncWorktreeStateBack syncs ALL milestone directories, not just the current one
- *   - syncWorktreeStateBack handles next-milestone artifacts created during completion
+ *   - syncWorktreeStateBack skips milestone markdown projections
+ *   - syncWorktreeStateBack does not import root-level .gsd/ state projections
+ *   - syncWorktreeStateBack does not copy worktree milestone projections back
+ *   - syncWorktreeStateBack leaves next-milestone projections DB/project-root authoritative
  *   - syncGsdStateToWorktree syncs non-standard milestone dir names (#1547)
- *   - syncWorktreeStateBack syncs non-standard milestone dir names (#1547)
+ *   - syncWorktreeStateBack skips non-standard milestone projection dir names
  */
 
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
@@ -213,8 +213,8 @@ describe('worktree-sync-milestones', async () => {
     }
   }
 
-  // ─── 8. syncWorktreeStateBack recurses into tasks/ (#1678) ───────────
-  console.log('\n=== 8. syncWorktreeStateBack copies tasks/ subdirectory (#1678) ===');
+  // ─── 8. syncWorktreeStateBack does not copy task projections ───────────
+  console.log('\n=== 8. syncWorktreeStateBack leaves task projections in worktree ===');
   {
     const mainBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-main-'));
     const wtBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-wt-'));
@@ -232,27 +232,26 @@ describe('worktree-sync-milestones', async () => {
       // Main project root starts with only the milestone directory (no slices yet)
       mkdirSync(join(mainBase, '.gsd', 'milestones', 'M002'), { recursive: true });
 
-      // Pass M001 as milestoneId (the one being merged/skipped), M002 should still sync
       const { synced } = syncWorktreeStateBack(mainBase, wtBase, 'M001');
 
       const mainSliceDir = join(mainBase, '.gsd', 'milestones', 'M002', 'slices', 'S01');
       const mainTasksDir = join(mainSliceDir, 'tasks');
 
       assert.ok(
-        existsSync(join(mainSliceDir, 'S01-SUMMARY.md')),
-        '#1678: slice SUMMARY synced to project root',
+        !existsSync(join(mainSliceDir, 'S01-SUMMARY.md')),
+        'slice SUMMARY projection is not copied to project root',
       );
       assert.ok(
-        existsSync(join(mainTasksDir, 'T01-SUMMARY.md')),
-        '#1678: task T01-SUMMARY synced to project root',
+        !existsSync(join(mainTasksDir, 'T01-SUMMARY.md')),
+        'task T01-SUMMARY projection is not copied to project root',
       );
       assert.ok(
-        existsSync(join(mainTasksDir, 'T02-SUMMARY.md')),
-        '#1678: task T02-SUMMARY synced to project root',
+        !existsSync(join(mainTasksDir, 'T02-SUMMARY.md')),
+        'task T02-SUMMARY projection is not copied to project root',
       );
       assert.ok(
-        synced.some((p) => p.includes('tasks/T01-SUMMARY.md')),
-        '#1678: task summary appears in synced list',
+        !synced.some((p) => p.includes('tasks/T01-SUMMARY.md')),
+        'task summary does not appear in synced list',
       );
     } finally {
       rmSync(mainBase, { recursive: true, force: true });
@@ -260,8 +259,8 @@ describe('worktree-sync-milestones', async () => {
     }
   }
 
-  // ─── 9. syncWorktreeStateBack syncs root-level .gsd/ files ──────────
-  console.log('\n=== 9. syncWorktreeStateBack syncs root-level files (REQUIREMENTS, PROJECT) ===');
+  // ─── 9. syncWorktreeStateBack does not import root-level state projections ──────────
+  console.log('\n=== 9. syncWorktreeStateBack leaves root-level state projections authoritative ===');
   {
     const mainBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-root-main-'));
     const wtBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-root-wt-'));
@@ -281,31 +280,31 @@ describe('worktree-sync-milestones', async () => {
 
       const { synced } = syncWorktreeStateBack(mainBase, wtBase, 'M001');
 
-      // Root-level files should be overwritten with worktree versions
+      // Root-level state projections must not be overwritten with worktree versions.
       const reqContent = readFileSync(join(mainBase, '.gsd', 'REQUIREMENTS.md'), 'utf-8');
       assert.ok(
-        reqContent.includes('R002'),
-        'REQUIREMENTS.md updated with worktree content',
+        !reqContent.includes('R002'),
+        'REQUIREMENTS.md ignores worktree projection content',
       );
 
       const projContent = readFileSync(join(mainBase, '.gsd', 'PROJECT.md'), 'utf-8');
       assert.ok(
-        projContent.includes('M002'),
-        'PROJECT.md updated with worktree content',
+        !projContent.includes('M002'),
+        'PROJECT.md ignores worktree projection content',
       );
 
       assert.ok(
-        existsSync(join(mainBase, '.gsd', 'KNOWLEDGE.md')),
-        'KNOWLEDGE.md synced from worktree',
+        !existsSync(join(mainBase, '.gsd', 'KNOWLEDGE.md')),
+        'KNOWLEDGE.md is not copied back from worktree',
       );
 
       assert.ok(
-        synced.includes('REQUIREMENTS.md'),
-        'REQUIREMENTS.md appears in synced list',
+        !synced.includes('REQUIREMENTS.md'),
+        'REQUIREMENTS.md does not appear in synced list',
       );
       assert.ok(
-        synced.includes('PROJECT.md'),
-        'PROJECT.md appears in synced list',
+        !synced.includes('PROJECT.md'),
+        'PROJECT.md does not appear in synced list',
       );
     } finally {
       rmSync(mainBase, { recursive: true, force: true });
@@ -313,8 +312,8 @@ describe('worktree-sync-milestones', async () => {
     }
   }
 
-  // ─── 10. syncWorktreeStateBack syncs ALL milestone directories ─────
-  console.log('\n=== 10. syncWorktreeStateBack syncs all milestone dirs, not just current ===');
+  // ─── 10. syncWorktreeStateBack does not copy milestone directories ─────
+  console.log('\n=== 10. syncWorktreeStateBack does not copy milestone dirs ===');
   {
     const mainBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-all-main-'));
     const wtBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-all-wt-'));
@@ -352,19 +351,19 @@ describe('worktree-sync-milestones', async () => {
         'M001 SUMMARY NOT synced (current milestone skipped to prevent merge conflicts)',
       );
 
-      // M002 should be synced (other milestone — not skipped)
+      // M002 should not be synced either; worktree projections are not authoritative.
       assert.ok(
-        existsSync(join(mainBase, '.gsd', 'milestones', 'M002-abc123', 'M002-abc123-CONTEXT.md')),
-        'M002 CONTEXT synced to main (next-milestone fix)',
+        !existsSync(join(mainBase, '.gsd', 'milestones', 'M002-abc123', 'M002-abc123-CONTEXT.md')),
+        'M002 CONTEXT projection is not copied to main',
       );
       assert.ok(
-        existsSync(join(mainBase, '.gsd', 'milestones', 'M002-abc123', 'M002-abc123-ROADMAP.md')),
-        'M002 ROADMAP synced to main (next-milestone fix)',
+        !existsSync(join(mainBase, '.gsd', 'milestones', 'M002-abc123', 'M002-abc123-ROADMAP.md')),
+        'M002 ROADMAP projection is not copied to main',
       );
 
       assert.ok(
-        synced.some((p) => p.includes('M002-abc123')),
-        'M002 appears in synced list',
+        !synced.some((p) => p.includes('M002-abc123')),
+        'M002 does not appear in synced list',
       );
     } finally {
       rmSync(mainBase, { recursive: true, force: true });
@@ -373,7 +372,7 @@ describe('worktree-sync-milestones', async () => {
   }
 
   // ─── 11. Full M006→M007 transition scenario ───────────────────────────
-  console.log('\n=== 11. complete-milestone creates next-milestone artifacts that survive sync ===');
+  console.log('\n=== 11. complete-milestone worktree projections do not overwrite project root ===');
   {
     const mainBase = mkdtempSync(join(tmpdir(), 'gsd-wt-transition-main-'));
     const wtBase = mkdtempSync(join(tmpdir(), 'gsd-wt-transition-wt-'));
@@ -419,27 +418,27 @@ describe('worktree-sync-milestones', async () => {
         'M006 SUMMARY NOT synced (current milestone skipped)',
       );
 
-      // Verify M007 artifacts synced (the critical fix — other milestones still sync)
+      // Verify M007 worktree projections are not copied back.
       assert.ok(
-        existsSync(join(mainBase, '.gsd', 'milestones', 'M007-wortc8', 'M007-wortc8-CONTEXT.md')),
-        'M007 CONTEXT synced to main (next-milestone)',
+        !existsSync(join(mainBase, '.gsd', 'milestones', 'M007-wortc8', 'M007-wortc8-CONTEXT.md')),
+        'M007 CONTEXT projection is not copied to main',
       );
       assert.ok(
-        existsSync(join(mainBase, '.gsd', 'milestones', 'M007-wortc8', 'M007-wortc8-ROADMAP.md')),
-        'M007 ROADMAP synced to main (next-milestone)',
+        !existsSync(join(mainBase, '.gsd', 'milestones', 'M007-wortc8', 'M007-wortc8-ROADMAP.md')),
+        'M007 ROADMAP projection is not copied to main',
       );
 
-      // Verify root-level files updated
+      // Verify root-level projections remain project-root authoritative.
       const reqContent = readFileSync(join(mainBase, '.gsd', 'REQUIREMENTS.md'), 'utf-8');
       assert.ok(
-        reqContent.includes('R090'),
-        'REQUIREMENTS.md has R090 from worktree',
+        !reqContent.includes('R090'),
+        'REQUIREMENTS.md ignores worktree projection updates',
       );
 
       const projContent = readFileSync(join(mainBase, '.gsd', 'PROJECT.md'), 'utf-8');
       assert.ok(
-        projContent.includes('M007'),
-        'PROJECT.md has M007 from worktree',
+        !projContent.includes('M007'),
+        'PROJECT.md ignores worktree projection updates',
       );
     } finally {
       rmSync(mainBase, { recursive: true, force: true });
@@ -478,8 +477,8 @@ describe('worktree-sync-milestones', async () => {
     }
   }
 
-  // ─── 13. syncWorktreeStateBack syncs QUEUE.md and completed-units.json (#1787) ──
-  console.log('\n=== 13. QUEUE.md and completed-units.json synced from worktree (#1787) ===');
+  // ─── 13. syncWorktreeStateBack skips QUEUE.md but preserves completed-units diagnostics ──
+  console.log('\n=== 13. QUEUE.md skipped; completed-units.json diagnostic synced ===');
   {
     const mainBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-queue-main-'));
     const wtBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-queue-wt-'));
@@ -488,7 +487,7 @@ describe('worktree-sync-milestones', async () => {
       mkdirSync(join(mainBase, '.gsd', 'milestones', 'M001'), { recursive: true });
       mkdirSync(join(wtBase, '.gsd', 'milestones', 'M001'), { recursive: true });
 
-      // Worktree has QUEUE.md and completed-units.json written during milestone closeout
+      // Worktree has QUEUE.md projection and completed-units.json diagnostic.
       writeFileSync(join(wtBase, '.gsd', 'QUEUE.md'), '# Queue\n- M002 next');
       writeFileSync(
         join(wtBase, '.gsd', 'completed-units.json'),
@@ -507,22 +506,17 @@ describe('worktree-sync-milestones', async () => {
 
       const { synced } = syncWorktreeStateBack(mainBase, wtBase, 'M001');
 
-      // QUEUE.md should be synced
+      // QUEUE.md is state/projection content and should not be copied back.
       assert.ok(
-        existsSync(join(mainBase, '.gsd', 'QUEUE.md')),
-        '#1787: QUEUE.md synced from worktree to main',
-      );
-      const queueContent = readFileSync(join(mainBase, '.gsd', 'QUEUE.md'), 'utf-8');
-      assert.ok(
-        queueContent.includes('M002 next'),
-        '#1787: QUEUE.md has correct content',
+        !existsSync(join(mainBase, '.gsd', 'QUEUE.md')),
+        'QUEUE.md is not synced from worktree to main',
       );
       assert.ok(
-        synced.includes('QUEUE.md'),
-        '#1787: QUEUE.md appears in synced list',
+        !synced.includes('QUEUE.md'),
+        'QUEUE.md does not appear in synced list',
       );
 
-      // completed-units.json should be synced
+      // completed-units.json is diagnostic and may be copied for operator visibility.
       assert.ok(
         existsSync(join(mainBase, '.gsd', 'completed-units.json')),
         '#1787: completed-units.json synced from worktree to main',
@@ -578,8 +572,8 @@ describe('worktree-sync-milestones', async () => {
     }
   }
 
-  // ─── 15. syncWorktreeStateBack syncs non-standard milestone dir names (#1547) ──
-  console.log('\n=== 15. syncWorktreeStateBack syncs non-standard milestone dir names (#1547) ===');
+  // ─── 15. syncWorktreeStateBack skips non-standard milestone dir names ──
+  console.log('\n=== 15. syncWorktreeStateBack skips non-standard milestone dir names ===');
   {
     const mainBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-custom-main-'));
     const wtBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-custom-wt-'));
@@ -601,12 +595,12 @@ describe('worktree-sync-milestones', async () => {
       const { synced } = syncWorktreeStateBack(mainBase, wtBase, 'M001');
 
       assert.ok(
-        existsSync(join(mainBase, '.gsd', 'milestones', 'sprint-beta', 'SUMMARY.md')),
-        '#1547: non-standard milestone dir "sprint-beta" synced back to main',
+        !existsSync(join(mainBase, '.gsd', 'milestones', 'sprint-beta', 'SUMMARY.md')),
+        'non-standard milestone projection is not copied back to main',
       );
       assert.ok(
-        synced.some((p) => p.includes('sprint-beta')),
-        '#1547: sprint-beta appears in synced list',
+        !synced.some((p) => p.includes('sprint-beta')),
+        'sprint-beta does not appear in synced list',
       );
     } finally {
       rmSync(mainBase, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/worktree-sync-tasks.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-tasks.test.ts
@@ -1,8 +1,9 @@
 /**
- * worktree-sync-tasks.test.ts — Regression test for #1678.
+ * worktree-sync-tasks.test.ts
  *
- * Verifies that syncWorktreeStateBack() correctly syncs task summaries
- * from the tasks/ subdirectory within each slice, not just slice-level files.
+ * DB-authoritative worktree contract: task and milestone markdown under a
+ * worktree .gsd directory are legacy projections. syncWorktreeStateBack must
+ * not copy them into the canonical project .gsd tree.
  */
 
 import test from "node:test";
@@ -11,7 +12,6 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
-  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -20,19 +20,13 @@ import { tmpdir } from "node:os";
 
 import { syncWorktreeStateBack } from "../auto-worktree.ts";
 
-// ─── Helpers ─────────────────────────────────────────────────────────
-
 function makeTempDir(prefix: string): string {
   return mkdtempSync(join(tmpdir(), `gsd-sync-test-${prefix}-`));
 }
 
 function cleanup(...dirs: string[]): void {
   for (const dir of dirs) {
-    try {
-      rmSync(dir, { recursive: true, force: true });
-    } catch {
-      // ignore
-    }
+    rmSync(dir, { recursive: true, force: true });
   }
 }
 
@@ -42,168 +36,49 @@ function writeFile(dir: string, relativePath: string, content: string): void {
   writeFileSync(fullPath, content, "utf-8");
 }
 
-// ─── Tests ───────────────────────────────────────────────────────────
-
-test("syncWorktreeStateBack copies task summaries from tasks/ subdirectory (#1678)", () => {
+test("syncWorktreeStateBack does not copy task markdown projections from worktree", () => {
   const mainBase = makeTempDir("main");
   const wtBase = makeTempDir("wt");
-  const currentMid = "M000"; // milestone being merged (skipped by sync)
-  const mid = "M001";        // other milestone that should be synced
 
   try {
-    // Set up worktree with milestone, slice, and task files
-    writeFile(wtBase, `.gsd/milestones/${mid}/${mid}-ROADMAP.md`, "# Roadmap\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/${mid}-SUMMARY.md`, "# Summary\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/S01-PLAN.md`, "# Plan\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/S01-SUMMARY.md`, "# Slice Summary\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/S01-UAT.md`, "# UAT\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/tasks/T01-PLAN.md`, "# Task 1 Plan\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/tasks/T01-SUMMARY.md`, "# Task 1 Summary\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/tasks/T02-PLAN.md`, "# Task 2 Plan\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/tasks/T02-SUMMARY.md`, "# Task 2 Summary\n");
-
-    // Set up main with empty .gsd
+    writeFile(wtBase, ".gsd/milestones/M001/M001-ROADMAP.md", "# Roadmap\n");
+    writeFile(wtBase, ".gsd/milestones/M001/slices/S01/S01-PLAN.md", "# Plan\n");
+    writeFile(wtBase, ".gsd/milestones/M001/slices/S01/tasks/T01-SUMMARY.md", "# Task Summary\n");
     mkdirSync(join(mainBase, ".gsd"), { recursive: true });
 
-    // Run sync — currentMid is skipped, mid (M001) should be synced
-    const result = syncWorktreeStateBack(mainBase, wtBase, currentMid);
+    const result = syncWorktreeStateBack(mainBase, wtBase, "M000");
 
-    // Verify milestone-level files synced
-    assert.ok(
-      existsSync(join(mainBase, `.gsd/milestones/${mid}/${mid}-ROADMAP.md`)),
-      "ROADMAP should be synced",
-    );
-    assert.ok(
-      existsSync(join(mainBase, `.gsd/milestones/${mid}/${mid}-SUMMARY.md`)),
-      "SUMMARY should be synced",
-    );
-
-    // Verify slice-level files synced
-    assert.ok(
-      existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S01/S01-PLAN.md`)),
-      "S01-PLAN should be synced",
-    );
-    assert.ok(
-      existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S01/S01-SUMMARY.md`)),
-      "S01-SUMMARY should be synced",
-    );
-
-    // Verify task-level files synced (THE BUG FIX)
-    assert.ok(
-      existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S01/tasks/T01-PLAN.md`)),
-      "T01-PLAN should be synced (was dropped before fix)",
-    );
-    assert.ok(
-      existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S01/tasks/T01-SUMMARY.md`)),
-      "T01-SUMMARY should be synced (was dropped before fix)",
-    );
-    assert.ok(
-      existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S01/tasks/T02-PLAN.md`)),
-      "T02-PLAN should be synced (was dropped before fix)",
-    );
-    assert.ok(
-      existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S01/tasks/T02-SUMMARY.md`)),
-      "T02-SUMMARY should be synced (was dropped before fix)",
-    );
-
-    // Verify task files appear in synced list
-    const taskSynced = result.synced.filter(p => p.includes("/tasks/"));
-    assert.ok(
-      taskSynced.length >= 4,
-      `Expected at least 4 task files in synced list, got ${taskSynced.length}: ${taskSynced.join(", ")}`,
-    );
-
-    // Verify content integrity
-    const t1Summary = readFileSync(
-      join(mainBase, `.gsd/milestones/${mid}/slices/S01/tasks/T01-SUMMARY.md`),
-      "utf-8",
-    );
-    assert.equal(t1Summary, "# Task 1 Summary\n");
-  } finally {
-    cleanup(mainBase, wtBase);
-  }
-});
-
-test("syncWorktreeStateBack handles multiple slices with tasks (#1678)", () => {
-  const mainBase = makeTempDir("main");
-  const wtBase = makeTempDir("wt");
-  const currentMid = "M000"; // milestone being merged (skipped)
-  const mid = "M002";        // other milestone that should be synced
-
-  try {
-    // Set up two slices with tasks
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/S01-SUMMARY.md`, "# S01\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/tasks/T01-SUMMARY.md`, "# S01-T01\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S02/S02-SUMMARY.md`, "# S02\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S02/tasks/T01-SUMMARY.md`, "# S02-T01\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S02/tasks/T02-SUMMARY.md`, "# S02-T02\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S02/tasks/T03-SUMMARY.md`, "# S02-T03\n");
-
-    mkdirSync(join(mainBase, ".gsd"), { recursive: true });
-
-    const result = syncWorktreeStateBack(mainBase, wtBase, currentMid);
-
-    // All task summaries from both slices should be synced
-    assert.ok(existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S01/tasks/T01-SUMMARY.md`)));
-    assert.ok(existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S02/tasks/T01-SUMMARY.md`)));
-    assert.ok(existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S02/tasks/T02-SUMMARY.md`)));
-    assert.ok(existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S02/tasks/T03-SUMMARY.md`)));
-
-    // Verify content integrity across slices
+    assert.equal(result.synced.some((p) => p.includes("milestones/")), false);
     assert.equal(
-      readFileSync(join(mainBase, `.gsd/milestones/${mid}/slices/S02/tasks/T03-SUMMARY.md`), "utf-8"),
-      "# S02-T03\n",
+      existsSync(join(mainBase, ".gsd/milestones/M001/M001-ROADMAP.md")),
+      false,
+      "milestone markdown projection must not be copied",
+    );
+    assert.equal(
+      existsSync(join(mainBase, ".gsd/milestones/M001/slices/S01/tasks/T01-SUMMARY.md")),
+      false,
+      "task summary projection must not be copied",
     );
   } finally {
     cleanup(mainBase, wtBase);
   }
 });
 
-test("syncWorktreeStateBack handles slices without tasks/ directory", () => {
+test("syncWorktreeStateBack still copies diagnostic root files", () => {
   const mainBase = makeTempDir("main");
   const wtBase = makeTempDir("wt");
-  const currentMid = "M000"; // milestone being merged (skipped)
-  const mid = "M003";        // other milestone that should be synced
 
   try {
-    // Slice with no tasks/ subdirectory (legitimate case: pre-planning)
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/S01-RESEARCH.md`, "# Research\n");
-
+    writeFile(wtBase, ".gsd/completed-units.json", JSON.stringify({ units: ["M001/S01/T01"] }));
+    writeFile(wtBase, ".gsd/metrics.json", JSON.stringify({ version: 1, units: [] }));
     mkdirSync(join(mainBase, ".gsd"), { recursive: true });
 
-    const result = syncWorktreeStateBack(mainBase, wtBase, currentMid);
+    const result = syncWorktreeStateBack(mainBase, wtBase, "M001");
 
-    // Should sync the slice file without errors
-    assert.ok(existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S01/S01-RESEARCH.md`)));
-    // Should not have any task entries
-    const taskSynced = result.synced.filter(p => p.includes("/tasks/"));
-    assert.equal(taskSynced.length, 0);
-  } finally {
-    cleanup(mainBase, wtBase);
-  }
-});
-
-test("syncWorktreeStateBack ignores non-md files in tasks/", () => {
-  const mainBase = makeTempDir("main");
-  const wtBase = makeTempDir("wt");
-  const currentMid = "M000"; // milestone being merged (skipped)
-  const mid = "M004";        // other milestone that should be synced
-
-  try {
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/S01-PLAN.md`, "# Plan\n");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/tasks/T01-SUMMARY.md`, "# T01\n");
-    // Non-md file should be ignored
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/tasks/.DS_Store`, "junk");
-    writeFile(wtBase, `.gsd/milestones/${mid}/slices/S01/tasks/notes.txt`, "notes");
-
-    mkdirSync(join(mainBase, ".gsd"), { recursive: true });
-
-    const result = syncWorktreeStateBack(mainBase, wtBase, currentMid);
-
-    // Only .md files should be synced
-    assert.ok(existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S01/tasks/T01-SUMMARY.md`)));
-    assert.ok(!existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S01/tasks/.DS_Store`)));
-    assert.ok(!existsSync(join(mainBase, `.gsd/milestones/${mid}/slices/S01/tasks/notes.txt`)));
+    assert.ok(result.synced.includes("completed-units.json"));
+    assert.ok(result.synced.includes("metrics.json"));
+    assert.ok(existsSync(join(mainBase, ".gsd/completed-units.json")));
+    assert.ok(existsSync(join(mainBase, ".gsd/metrics.json")));
   } finally {
     cleanup(mainBase, wtBase);
   }

--- a/src/resources/extensions/gsd/tools/complete-milestone.ts
+++ b/src/resources/extensions/gsd/tools/complete-milestone.ts
@@ -56,6 +56,7 @@ export interface CompleteMilestoneParams {
 export interface CompleteMilestoneResult {
   milestoneId: string;
   summaryPath: string;
+  stale?: boolean;
 }
 
 function renderMilestoneSummaryMarkdown(params: CompleteMilestoneParams): string {
@@ -206,15 +207,15 @@ export async function handleCompleteMilestone(
   // This handles re-dispatch scenarios (DB/disk state divergence) where a prior
   // completion already wrote the file. Overwriting would silently destroy the
   // richer content the agent produced during the original completion run.
+  let projectionStale = false;
   if (!existsSync(summaryPath)) {
     try {
       await saveFile(summaryPath, summaryMd);
     } catch (renderErr) {
-      // Disk render failed — roll back DB status so state stays consistent
-      logWarning("tool", `complete_milestone — disk render failed, rolling back DB status: ${(renderErr as Error).message}`);
-      updateMilestoneStatus(params.milestoneId, 'active', null);
-      invalidateStateCache();
-      return { error: `disk render failed: ${(renderErr as Error).message}` };
+      projectionStale = true;
+      logWarning("projection", `complete_milestone projection write failed for ${params.milestoneId}; DB completion remains committed`, {
+        error: (renderErr as Error).message,
+      });
     }
   }
 
@@ -252,5 +253,6 @@ export async function handleCompleteMilestone(
   return {
     milestoneId: params.milestoneId,
     summaryPath,
+    ...(projectionStale ? { stale: true } : {}),
   };
 }

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -4,7 +4,8 @@
  * Validates inputs, checks all tasks are complete, writes slice row to DB in
  * a transaction, then (outside the transaction) renders SUMMARY.md + UAT.md
  * to disk, toggles the roadmap checkbox, stores rendered markdown in DB for
- * D004 recovery, and invalidates caches.
+ * D004 recovery, and invalidates caches. Projection write failures are stale
+ * projection diagnostics and do not roll back committed DB state.
  */
 
 import { join } from "node:path";
@@ -277,7 +278,6 @@ export async function handleCompleteSlice(
 
   // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───
   const completedAt = new Date().toISOString();
-  const originalSliceStatus = getSlice(params.milestoneId, params.sliceId)?.status ?? "pending";
   let guardError: string | null = null;
 
   transaction(() => {
@@ -349,10 +349,6 @@ export async function handleCompleteSlice(
     return { error: guardError };
   }
 
-  // ── Filesystem operations (outside transaction) ─────────────────────────
-  // If disk render fails, roll back the DB status so deriveState() and
-  // verifyExpectedArtifact() stay consistent (both say "not done").
-
   // Render summary markdown
   const summaryMd = renderSliceSummaryMarkdown(params);
 
@@ -371,6 +367,8 @@ export async function handleCompleteSlice(
 
   const uatMd = renderUatMarkdown(params);
   const uatPath = summaryPath.replace(/-SUMMARY\.md$/, "-UAT.md");
+  setSliceSummaryMd(params.milestoneId, params.sliceId, summaryMd, uatMd);
+  let projectionStale = false;
 
   try {
     await saveFile(summaryPath, summaryMd);
@@ -382,15 +380,9 @@ export async function handleCompleteSlice(
       logWarning("tool", `complete_slice — could not find roadmap for ${params.milestoneId}, skipping checkbox toggle`);
     }
   } catch (renderErr) {
-    // Disk render failed — roll back DB status so state stays consistent
-    logWarning("tool", `complete_slice — disk render failed for ${params.milestoneId}/${params.sliceId}, rolling back DB status`, { error: (renderErr as Error).message });
-    updateSliceStatus(params.milestoneId, params.sliceId, originalSliceStatus);
-    invalidateStateCache();
-    return { error: `disk render failed: ${(renderErr as Error).message}` };
+    projectionStale = true;
+    logWarning("projection", `complete_slice projection write failed for ${params.milestoneId}/${params.sliceId}; DB completion remains committed`, { error: (renderErr as Error).message });
   }
-
-  // Store rendered markdown in DB for D004 recovery
-  setSliceSummaryMd(params.milestoneId, params.sliceId, summaryMd, uatMd);
 
   // ── Close gates owned by complete-slice (Q8) ───────────────────────────
   // Each owned gate maps to a specific summary section via the registry.
@@ -493,5 +485,6 @@ export async function handleCompleteSlice(
     milestoneId: params.milestoneId,
     summaryPath,
     uatPath,
+    ...(projectionStale ? { stale: true } : {}),
   };
 }

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -1,11 +1,10 @@
 /**
  * complete-task handler — the core operation behind gsd_complete_task.
  *
- * Validates inputs, writes task row to DB in a transaction, then (outside
- * the transaction) renders SUMMARY.md to disk, toggles the plan checkbox,
- * stores the rendered markdown in the DB for D004 recovery, and invalidates
- * caches. Projection write failures are reported as stale projections and do
- * not roll back committed DB state.
+ * Validates inputs, writes task row and rendered SUMMARY.md to DB in a
+ * transaction, then renders projections to disk and invalidates caches.
+ * Projection write failures are reported as stale projections and do not roll
+ * back committed DB state.
  */
 
 import { join } from "node:path";
@@ -23,7 +22,6 @@ import {
   getSlice,
   getTask,
   updateTaskStatus,
-  setTaskSummaryMd,
   deleteVerificationEvidence,
   saveGateResult,
   getPendingGatesForTurn,
@@ -169,6 +167,7 @@ export async function handleCompleteTask(
   // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───
   const completedAt = new Date().toISOString();
   let guardError: string | null = null;
+  let summaryMd = "";
 
   // ── ADR-011 Phase 2: validate escalation payload BEFORE any side effects ─
   // Building the artifact runs the full shape validation (2-4 options, unique
@@ -238,6 +237,9 @@ export async function handleCompleteTask(
     }
 
     // All guards passed — perform writes
+    const taskRow = paramsToTaskRow(params, completedAt);
+    summaryMd = renderSummaryContent(taskRow, params.sliceId, params.milestoneId, params.verificationEvidence ?? []);
+
     insertMilestone({ id: params.milestoneId, title: params.milestoneId });
     insertSlice({ id: params.sliceId, milestoneId: params.milestoneId, title: params.sliceId });
     insertTask({
@@ -255,6 +257,7 @@ export async function handleCompleteTask(
       knownIssues: params.knownIssues ?? "None.",
       keyFiles: params.keyFiles ?? [],
       keyDecisions: params.keyDecisions ?? [],
+      fullSummaryMd: summaryMd,
     });
 
     for (const evidence of (params.verificationEvidence ?? [])) {
@@ -302,10 +305,6 @@ export async function handleCompleteTask(
     return { error: guardError };
   }
 
-  // Render summary markdown via the single source of truth (#2720)
-  const taskRow = paramsToTaskRow(params, completedAt);
-  const summaryMd = renderSummaryContent(taskRow, params.sliceId, params.milestoneId, params.verificationEvidence ?? []);
-  setTaskSummaryMd(params.milestoneId, params.sliceId, params.taskId, summaryMd);
   let projectionStale = false;
 
   // Resolve and write summary to disk

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -29,7 +29,7 @@ import {
   getPendingGatesForTurn,
 } from "../gsd-db.js";
 import { getGatesForTurn } from "../gate-registry.js";
-import { resolveSliceFile, resolveTasksDir, clearPathCache } from "../paths.js";
+import { resolveTasksDir, clearPathCache } from "../paths.js";
 import { checkOwnership, taskUnitKey } from "../unit-ownership.js";
 import { saveFile, clearParseCache } from "../files.js";
 import { invalidateStateCache } from "../state.js";
@@ -324,15 +324,9 @@ export async function handleCompleteTask(
   try {
     await saveFile(summaryPath, summaryMd);
 
-    // Toggle plan checkbox via renderer module
-    const planPath = resolveSliceFile(basePath, params.milestoneId, params.sliceId, "PLAN");
-    if (planPath) {
-      await renderPlanCheckboxes(basePath, params.milestoneId, params.sliceId);
-    } else {
-      process.stderr.write(
-        `gsd-db: complete_task — could not find plan file for ${params.sliceId}/${params.milestoneId}, skipping checkbox toggle\n`,
-      );
-    }
+    // Toggle or regenerate the plan projection from DB. Missing projection
+    // files are rebuilt by the renderer instead of being skipped.
+    await renderPlanCheckboxes(basePath, params.milestoneId, params.sliceId);
   } catch (renderErr) {
     projectionStale = true;
     logWarning("projection", `complete_task projection write failed for ${params.milestoneId}/${params.sliceId}/${params.taskId}; DB completion remains committed`, {

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -4,7 +4,8 @@
  * Validates inputs, writes task row to DB in a transaction, then (outside
  * the transaction) renders SUMMARY.md to disk, toggles the plan checkbox,
  * stores the rendered markdown in the DB for D004 recovery, and invalidates
- * caches.
+ * caches. Projection write failures are reported as stale projections and do
+ * not roll back committed DB state.
  */
 
 import { join } from "node:path";
@@ -301,13 +302,11 @@ export async function handleCompleteTask(
     return { error: guardError };
   }
 
-  // ── Filesystem operations (outside transaction) ─────────────────────────
-  // If disk render fails, roll back the DB status so deriveState() and
-  // verifyExpectedArtifact() stay consistent (both say "not done").
-
   // Render summary markdown via the single source of truth (#2720)
   const taskRow = paramsToTaskRow(params, completedAt);
   const summaryMd = renderSummaryContent(taskRow, params.sliceId, params.milestoneId, params.verificationEvidence ?? []);
+  setTaskSummaryMd(params.milestoneId, params.sliceId, params.taskId, summaryMd);
+  let projectionStale = false;
 
   // Resolve and write summary to disk
   let summaryPath: string;
@@ -335,19 +334,11 @@ export async function handleCompleteTask(
       );
     }
   } catch (renderErr) {
-    // Disk render failed — roll back DB status so state stays consistent
-    logWarning("tool", `complete_task — disk render failed, rolling back DB status: ${(renderErr as Error).message}`);
-    // Delete orphaned verification_evidence rows first (FK constraint
-    // references tasks, so evidence must go before status change).
-    // Without this, retries accumulate duplicate evidence rows (#2724).
-    deleteVerificationEvidence(params.milestoneId, params.sliceId, params.taskId);
-    updateTaskStatus(params.milestoneId, params.sliceId, params.taskId, 'pending');
-    invalidateStateCache();
-    return { error: `disk render failed: ${(renderErr as Error).message}` };
+    projectionStale = true;
+    logWarning("projection", `complete_task projection write failed for ${params.milestoneId}/${params.sliceId}/${params.taskId}; DB completion remains committed`, {
+      error: (renderErr as Error).message,
+    });
   }
-
-  // Store rendered markdown in DB for D004 recovery
-  setTaskSummaryMd(params.milestoneId, params.sliceId, params.taskId, summaryMd);
 
   // ── Close gates owned by execute-task (Q5/Q6/Q7) for this task ────────
   // Each gate id maps to a specific params field via taskGateFieldForId.
@@ -471,5 +462,6 @@ export async function handleCompleteTask(
     sliceId: params.sliceId,
     milestoneId: params.milestoneId,
     summaryPath,
+    ...(projectionStale ? { stale: true } : {}),
   };
 }

--- a/src/resources/extensions/gsd/tools/validate-milestone.ts
+++ b/src/resources/extensions/gsd/tools/validate-milestone.ts
@@ -14,7 +14,6 @@ import { join } from "node:path";
 import {
   transaction,
   insertAssessment,
-  deleteAssessmentByScope,
   getMilestoneSlices,
 } from "../gsd-db.js";
 import { resolveMilestonePath, clearPathCache } from "../paths.js";
@@ -45,6 +44,7 @@ export interface ValidateMilestoneResult {
   milestoneId: string;
   verdict: string;
   validationPath: string;
+  stale?: boolean;
 }
 
 export interface ValidateMilestoneOptions {
@@ -150,13 +150,14 @@ export async function handleValidateMilestone(
   });
 
   // ── Filesystem render (outside transaction) ────────────────────────────
-  // If disk render fails, roll back the DB row so state stays consistent.
+  let projectionStale = false;
   try {
     await saveFile(validationPath, validationMd);
   } catch (renderErr) {
-    logWarning("tool", `validate_milestone — disk render failed, rolling back DB row: ${(renderErr as Error).message}`);
-    deleteAssessmentByScope(params.milestoneId, 'milestone-validation');
-    return { error: `disk render failed: ${(renderErr as Error).message}` };
+    projectionStale = true;
+    logWarning("projection", `validate_milestone projection write failed for ${params.milestoneId}; DB validation remains committed`, {
+      error: (renderErr as Error).message,
+    });
   }
 
   invalidateStateCache();
@@ -202,5 +203,6 @@ export async function handleValidateMilestone(
     milestoneId: params.milestoneId,
     verdict: params.verdict,
     validationPath,
+    ...(projectionStale ? { stale: true } : {}),
   };
 }

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -76,7 +76,9 @@ export function snapshotState(): StateManifest {
   // Wrap all reads in a deferred transaction so the snapshot is consistent
   // (all SELECTs see the same DB state even if a concurrent write lands between them).
   return readTransaction(() => {
-  const rawMilestones = db.prepare("SELECT * FROM milestones ORDER BY id").all() as Record<string, unknown>[];
+  const rawMilestones = db.prepare(
+    "SELECT * FROM milestones ORDER BY CASE WHEN sequence > 0 THEN 0 ELSE 1 END, sequence, id",
+  ).all() as Record<string, unknown>[];
   const milestones: MilestoneRow[] = rawMilestones.map((r) => ({
     id: r["id"] as string,
     title: r["title"] as string,
@@ -95,6 +97,7 @@ export function snapshotState(): StateManifest {
     definition_of_done: JSON.parse((r["definition_of_done"] as string) || "[]"),
     requirement_coverage: (r["requirement_coverage"] as string) ?? "",
     boundary_map_markdown: (r["boundary_map_markdown"] as string) ?? "",
+    sequence: Number(r["sequence"] ?? 0),
   }));
 
   const rawSlices = db.prepare("SELECT * FROM slices ORDER BY milestone_id, sequence, id").all() as Record<string, unknown>[];

--- a/src/resources/extensions/gsd/workflow-mcp-auto-prep.ts
+++ b/src/resources/extensions/gsd/workflow-mcp-auto-prep.ts
@@ -29,29 +29,13 @@ function getAuthModeSafe(
   }
 }
 
-function hasClaudeCodeProvider(ctx: WorkflowMcpAutoPrepContext): boolean {
-  return getAuthModeSafe(ctx, "claude-code") === "externalCli";
-}
-
-function isClaudeCodeProviderReady(ctx: WorkflowMcpAutoPrepContext): boolean {
-  const readyCheck = ctx.modelRegistry?.isProviderRequestReady;
-  if (typeof readyCheck !== "function") return false;
-  try {
-    return readyCheck("claude-code");
-  } catch {
-    return false;
-  }
-}
-
 export function shouldAutoPrepareWorkflowMcp(ctx: WorkflowMcpAutoPrepContext): boolean {
   const provider = ctx.model?.provider;
   const baseUrl = ctx.model?.baseUrl;
   const authMode = getAuthModeSafe(ctx, provider);
 
-  if (usesWorkflowMcpTransport(authMode as any, baseUrl)) return true;
-  if (provider === "claude-code") return true;
-  if (hasClaudeCodeProvider(ctx)) return true;
-  return isClaudeCodeProviderReady(ctx);
+  if (provider !== "claude-code") return false;
+  return usesWorkflowMcpTransport(authMode as any, baseUrl) || authMode === "externalCli";
 }
 
 export function prepareWorkflowMcpForProject(

--- a/src/resources/extensions/gsd/workflow-reconcile.ts
+++ b/src/resources/extensions/gsd/workflow-reconcile.ts
@@ -20,7 +20,7 @@ import {
 } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
 import { invalidateStateCache } from "./state.js";
-import { clearPathCache } from "./paths.js";
+import { clearPathCache, resolveGsdPathContract } from "./paths.js";
 import { clearParseCache } from "./files.js";
 import { writeManifest } from "./workflow-manifest.js";
 import { atomicWriteSync } from "./atomic-write.js";
@@ -492,7 +492,7 @@ function _reconcileWorktreeLogsInner(
   atomicWriteSync(join(mainBasePath, ".gsd", "event-log.jsonl"), logContent);
 
   // Step 8: Replay into DB (wrapped in a transaction by replayEvents)
-  openDatabase(join(mainBasePath, ".gsd", "gsd.db"));
+  openDatabase(resolveGsdPathContract(mainBasePath).projectDb);
   replayEvents(merged);
 
   // Step 9: Write manifest
@@ -647,7 +647,7 @@ export function resolveConflict(
   writeEventLog(targetBasePath, targetBaseEvents.concat(rewrittenTargetEvents));
 
   // Replay resolved events through the DB (updates DB state)
-  openDatabase(join(basePath, ".gsd", "gsd.db"));
+  openDatabase(resolveGsdPathContract(basePath).projectDb);
   replayEvents(eventsToReplay);
   invalidateStateCache();
   clearPathCache();

--- a/src/resources/extensions/gsd/worktree-command.ts
+++ b/src/resources/extensions/gsd/worktree-command.ts
@@ -15,7 +15,7 @@ import { loadPrompt } from "./prompt-loader.js";
 import { autoCommitCurrentBranch, getMainBranch, resolveGitHeadPath, nudgeGitBranchCache } from "./worktree.js";
 import { runWorktreePostCreateHook } from "./auto-worktree.js";
 import { showConfirm } from "../shared/tui.js";
-import { gsdRoot, milestonesDir } from "./paths.js";
+import { gsdRoot, milestonesDir, resolveGsdPathContract } from "./paths.js";
 import {
   createWorktree,
   listWorktrees,
@@ -651,8 +651,9 @@ async function handleMerge(
     const commitMessage = `${commitType}: merge worktree ${name}\n\nGSD-Worktree: ${name}`;
 
     // Reconcile worktree DB into main DB before squash merge
-    const wtDbPath = join(worktreePath(basePath, name), ".gsd", "gsd.db");
-    const mainDbPath = join(basePath, ".gsd", "gsd.db");
+    const contract = resolveGsdPathContract(worktreePath(basePath, name), basePath);
+    const wtDbPath = join(contract.worktreeGsd ?? join(contract.workRoot, ".gsd"), "gsd.db");
+    const mainDbPath = contract.projectDb;
     if (existsSync(wtDbPath) && existsSync(mainDbPath)) {
       try {
         const { reconcileWorktreeDb } = await import("./gsd-db.js");


### PR DESCRIPTION
## TL;DR

**What:** Makes `gsd.db` the authoritative runtime state source for GSD workflows and treats markdown files as projections or explicit import inputs.
**Why:** Runtime disk-to-DB reconciliation created split-brain behavior between DB rows, markdown projections, and worktree-local `.gsd` folders.
**How:** Adds an explicit path contract, removes implicit markdown imports from runtime derive/bootstrap paths, makes projection failures non-rollback events, and updates tests around the DB-authoritative contract.

## What

This refactors the GSD extension state flow so runtime state is derived from `gsd.db` whenever the DB is open. It adds `resolveGsdPathContract()` to separate canonical project state from current worktree execution paths, routes worktree DB lookup through the canonical project DB, and updates projection/completion tools so DB mutations remain committed even if markdown projection writes fail.

The PR also updates the regression suite to assert that `ROADMAP.md`, `PLAN.md`, `SUMMARY.md`, `REQUIREMENTS.md`, and worktree-local `.gsd` files do not become implicit runtime authority. Explicit markdown migration/import support remains available through the migration/import APIs.

## Why

Closes #5205.

The previous runtime behavior allowed markdown projections to backfill DB state during derive/bootstrap paths. That made manually edited or stale files capable of changing runtime state, and it let worktree-local `.gsd` folders compete with the canonical project database. The result was a split-brain state model where the same project could behave differently depending on which projection files existed at the time of derivation.

## How

The core runtime path now treats an open DB as authoritative. `deriveStateFromDb()` reads DB milestone, slice, task, and requirement rows without importing missing rows from disk projections. `ensureDbOpen()` and auto-start initialize or open the canonical DB without calling markdown migration implicitly. Projection renderers regenerate missing markdown from DB content and no longer store disk fallback content into DB during normal runtime.

Worktree path resolution now returns an explicit contract with `projectRoot`, `workRoot`, `projectGsd`, `worktreeGsd`, `projectDb`, and `isWorktree`, so direct and external-state worktree layouts resolve to one canonical DB. Projection write failures in task/slice/milestone completion and validation handlers now log/report stale projection state while leaving committed DB changes intact.

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

This intentionally changes internal GSD runtime behavior: markdown projections are no longer imported into the runtime DB implicitly during normal derive/startup paths. Explicit migration/import/recovery commands remain the supported path for importing markdown into DB state.

## AI assistance

This PR is AI-assisted. The implementation was verified locally with the checks below.

## Verification

- `npm run verify:pr`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filesystem projection write failures no longer roll back DB commits; operations succeed, emit projection warnings, and may mark results as stale.
  * Startup no longer silently imports markdown during DB init; failure logs a general DB-init message.

* **New Features**
  * DB schema adds milestone sequencing plus APIs for ordering and requirement counts.
  * Canonical project-DB/worktree contract centralizes authoritative DB location.

* **Refactor**
  * Runtime is DB-authoritative; .gsd markdown is a rendered projection, not auto-reconciled.

* **Documentation**
  * Docs add /gsd recover, state-authority guidance, and a markdown-derive fallback flag.

* **Tests**
  * Broad test updates to reflect DB-first semantics and projection-stale behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->