### PR TITLE
fix(gsd): use homedir() fallback in currentDirectoryRoot for cross-platform consistency

### DIFF
--- a/src/resources/extensions/gsd/commands/context.ts
+++ b/src/resources/extensions/gsd/commands/context.ts
@@ -65,7 +65,7 @@ export function currentDirectoryRoot(): string {
     try {
       cwd = process.cwd();
     } catch {
-      cwd = process.env.HOME ?? "/";
+      cwd = homedir();
     }
   }
   const result = validateDirectory(cwd);

--- a/src/resources/extensions/gsd/tests/current-directory-root-homedir-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/current-directory-root-homedir-fallback.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Regression test — currentDirectoryRoot() uses os.homedir() as fallback
+ * when process.cwd() throws (e.g. worktree teardown deletes the cwd).
+ *
+ * Before the fix, the catch block used `process.env.HOME ?? "/"`. On
+ * Windows, HOME is typically unset so this resolved to "/", an invalid
+ * path. After the fix, os.homedir() is used — it checks USERPROFILE,
+ * HOMEDRIVE+HOMEPATH, etc., returning a valid path on all platforms.
+ *
+ * The test monkey-patches process.cwd() to throw ENOENT, simulating a
+ * deleted cwd. currentDirectoryRoot() must NOT propagate the raw error;
+ * instead it falls back to homedir(), which validateDirectory correctly
+ * rejects as "blocked", yielding GSDNoProjectError — the same controlled
+ * error path handlers already know how to catch.
+ *
+ * The error message is also asserted to match validateDirectory(homedir()),
+ * confirming the fallback resolved to homedir() specifically (not "/" or
+ * any other path).
+ */
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+
+import { currentDirectoryRoot, GSDNoProjectError } from "../commands/context.ts";
+import { validateDirectory } from "../validate-directory.ts";
+
+describe("currentDirectoryRoot() homedir() fallback on deleted cwd", () => {
+  const originalCwd = process.cwd.bind(process);
+
+  beforeEach(() => {
+    process.cwd = () => {
+      const err = new Error("ENOENT: no such file or directory, uv_cwd");
+      (err as NodeJS.ErrnoException).code = "ENOENT";
+      throw err;
+    };
+  });
+
+  afterEach(() => {
+    process.cwd = originalCwd;
+  });
+
+  test("does not propagate ENOENT — throws GSDNoProjectError via homedir() fallback", () => {
+    const expected = validateDirectory(homedir());
+    assert.equal(expected.severity, "blocked", "homedir() itself should be blocked");
+
+    assert.throws(
+      () => currentDirectoryRoot(),
+      (err: unknown) => {
+        assert.ok(
+          err instanceof GSDNoProjectError,
+          `expected GSDNoProjectError, got: ${err}`,
+        );
+        assert.equal(
+          (err as Error).message,
+          expected.reason ?? "GSD must be run inside a project directory.",
+          "error message must match validateDirectory(homedir()), confirming homedir() was the fallback",
+        );
+        return true;
+      },
+      "should throw GSDNoProjectError (homedir fallback validated), not raw ENOENT",
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Replace `process.env.HOME ?? "/"` with `homedir()` in `currentDirectoryRoot()`.
**Why:** The "/" fallback is Unix-centric and meaningless on Windows where `HOME` may not be set.
**How:** One-line change aligning `currentDirectoryRoot()` with the identical fix already applied to `projectRoot()`.

## What

Single-line fix in `src/resources/extensions/gsd/commands/context.ts` line 68. The `currentDirectoryRoot()` function's catch block fell back to `process.env.HOME ?? "/"` when `process.cwd()` threw (deleted cwd). Changed to `homedir()`, matching the fix already in place in the sibling `projectRoot()` function on the same file.

## Why

PR #5169 (`fix(gsd): harden bare /gsd + deep auto-loop paths and runtime writes`) refactored both `projectRoot()` and `currentDirectoryRoot()` in `commands/context.ts` to add the `withCommandCwd` override mechanism. In `projectRoot()`, it correctly preserved the `homedir()` fallback that PR #5083 had already established. In `currentDirectoryRoot()`, however, the stale `process.env.HOME ?? "/"` pattern was left untouched -- a copy-paste oversight between two adjacent functions in the same diff.

On Windows, `HOME` is typically not set. The "/" fallback resolves to a path relative to the current drive root (e.g., `C:/`), which is not a valid user home directory. `os.homedir()` handles `USERPROFILE`, `HOMEDRIVE+HOMEPATH`, and POSIX `HOME` with appropriate platform fallbacks -- the correct cross-platform API.

## How

One-line change. No behavioral change on POSIX systems where `HOME` is always set. On Windows, the deleted-cwd fallback now correctly resolves to the user's home directory instead of the drive root.

Existing tests in `handler-worktree-write-isolation.test.ts` cover the observable contract: `currentDirectoryRoot()` rejects `homedir()` with `GSDNoProjectError`, confirming the catch path resolves to `homedir()`.

AI-assisted contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when the system working directory is unavailable by using a more reliable fallback to determine the project root, preventing raw system errors from surfacing.

* **Tests**
  * Added test coverage verifying the fallback behavior and that user-facing errors are reported consistently when the working directory cannot be accessed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->