### PR TITLE
Fix/remote questions discord

### DIFF
--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -236,9 +236,9 @@ export interface AutoSupervisorConfig {
 
 export interface RemoteQuestionsConfig {
   channel: "slack" | "discord" | "telegram";
-  channel_id: string | number;
-  timeout_minutes?: number;        // clamped to 1-30
-  poll_interval_seconds?: number;  // clamped to 2-30
+  channel_id: string;
+  timeout_minutes?: number;
+  poll_interval_seconds?: number;
 }
 
 export interface CmuxPreferences {

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -431,7 +431,16 @@ export function validatePreferences(preferences: GSDPreferences): {
   // ─── Remote Questions ───────────────────────────────────────────────
   if (preferences.remote_questions !== undefined) {
     if (preferences.remote_questions && typeof preferences.remote_questions === "object") {
-      validated.remote_questions = preferences.remote_questions;
+      const rq = preferences.remote_questions as unknown as Record<string, unknown>;
+      if (typeof rq.channel_id === "number") {
+        errors.push(
+          `remote_questions.channel_id must be quoted as a string in PREFERENCES.md ` +
+            `(got number ${rq.channel_id} — IDs above 2^53 lose precision when parsed as numbers). ` +
+            `Fix: change \`channel_id: ${rq.channel_id}\` to \`channel_id: "${rq.channel_id}"\`.`,
+        );
+      } else {
+        validated.remote_questions = preferences.remote_questions;
+      }
     } else {
       errors.push("remote_questions must be an object");
     }

--- a/src/resources/extensions/gsd/tests/preferences-channel-id-snowflake.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences-channel-id-snowflake.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression test for the remote_questions.channel_id snowflake-precision bug:
+ * Discord/Telegram IDs can exceed 2^53, so YAML parsers that coerce them to
+ * JS numbers silently corrupt the value (e.g. 1234567890123456789 →
+ * 1234567890123456800). validatePreferences must reject numeric channel_id
+ * with a clear error pointing the user at the fix (quote the value).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { validatePreferences } from "../preferences.ts";
+
+test("remote_questions.channel_id as number is rejected with a precision-loss error", () => {
+  const { errors } = validatePreferences({
+    remote_questions: {
+      channel: "discord",
+      channel_id: 1234567890123456789 as unknown as string,
+    },
+  } as any);
+
+  assert.ok(errors.length > 0, "must produce at least one error");
+  const msg = errors.join("\n");
+  assert.match(msg, /channel_id/);
+  assert.match(msg, /string|quoted/i);
+  assert.match(msg, /2\^53|precision/i);
+});
+
+test("remote_questions.channel_id as quoted string passes validation", () => {
+  const { errors, preferences } = validatePreferences({
+    remote_questions: {
+      channel: "discord",
+      channel_id: "1234567890123456789",
+    },
+  } as any);
+
+  assert.equal(errors.length, 0, `expected no errors, got: ${errors.join(", ")}`);
+  assert.equal(preferences.remote_questions?.channel_id, "1234567890123456789");
+});
+
+test("remote_questions.channel_id error suggests the exact quoted replacement", () => {
+  const { errors } = validatePreferences({
+    remote_questions: {
+      channel: "discord",
+      channel_id: 999999999999999999 as unknown as string,
+    },
+  } as any);
+
+  // The message should point at the offending value so the user can fix it
+  // without parsing a generic "must be a string" complaint.
+  const msg = errors.join("\n");
+  assert.match(msg, /channel_id/);
+});
+
+test("remote_questions as non-object is rejected", () => {
+  const { errors } = validatePreferences({
+    remote_questions: "discord" as unknown as object,
+  } as any);
+  assert.ok(errors.some((e) => /remote_questions must be an object/.test(e)));
+});

--- a/src/resources/extensions/remote-questions/config.ts
+++ b/src/resources/extensions/remote-questions/config.ts
@@ -58,10 +58,15 @@ function hydrateRemoteTokensFromAuth(): void {
 
     for (const [providerId, envVar] of needed) {
       try {
-        const creds = auth.getCredentialsForProvider(providerId);
-        const apiKeyCred = creds.find((c: { type: string; key?: string }) => c.type === "api_key" && !!c.key) as
-          | { type: "api_key"; key: string }
-          | undefined;
+        const creds = auth.getCredentialsForProvider(providerId) as Array<{ type: string; key?: string }>;
+        let apiKeyCred: { type: string; key?: string } | undefined;
+        for (let i = creds.length - 1; i >= 0; i--) {
+          const c = creds[i];
+          if (c.type === "api_key" && !!c.key) {
+            apiKeyCred = c;
+            break;
+          }
+        }
         if (apiKeyCred?.key) {
           process.env[envVar] = apiKeyCred.key;
         }

--- a/src/resources/extensions/remote-questions/config.ts
+++ b/src/resources/extensions/remote-questions/config.ts
@@ -86,7 +86,7 @@ export function resolveRemoteConfig(): ResolvedConfig | null {
   if (!rq || !rq.channel || !rq.channel_id) return null;
   if (rq.channel !== "slack" && rq.channel !== "discord" && rq.channel !== "telegram") return null;
 
-  const channelId = String(rq.channel_id);
+  const channelId = rq.channel_id;
   if (!CHANNEL_ID_PATTERNS[rq.channel].test(channelId)) return null;
 
   const token = process.env[ENV_KEYS[rq.channel]];
@@ -110,7 +110,7 @@ export function getRemoteConfigStatus(): string {
   const rq: RemoteQuestionsConfig | undefined = prefs?.preferences.remote_questions;
   if (!rq || !rq.channel || !rq.channel_id) return "Remote questions: not configured";
   if (rq.channel !== "slack" && rq.channel !== "discord" && rq.channel !== "telegram") return `Remote questions: unknown channel type \"${rq.channel}\"`;
-  const channelId = String(rq.channel_id);
+  const channelId = rq.channel_id;
   if (!CHANNEL_ID_PATTERNS[rq.channel].test(channelId)) return `Remote questions: invalid ${rq.channel} channel ID format`;
   const envVar = ENV_KEYS[rq.channel];
   if (!process.env[envVar]) return `Remote questions: ${envVar} not set — remote questions disabled`;

--- a/src/resources/extensions/remote-questions/config.ts
+++ b/src/resources/extensions/remote-questions/config.ts
@@ -59,14 +59,7 @@ function hydrateRemoteTokensFromAuth(): void {
     for (const [providerId, envVar] of needed) {
       try {
         const creds = auth.getCredentialsForProvider(providerId) as Array<{ type: string; key?: string }>;
-        let apiKeyCred: { type: string; key?: string } | undefined;
-        for (let i = creds.length - 1; i >= 0; i--) {
-          const c = creds[i];
-          if (c.type === "api_key" && !!c.key) {
-            apiKeyCred = c;
-            break;
-          }
-        }
+        const apiKeyCred = pickLastApiKeyCredential(creds);
         if (apiKeyCred?.key) {
           process.env[envVar] = apiKeyCred.key;
         }
@@ -122,6 +115,16 @@ export function getRemoteConfigStatus(): string {
 
 export function isValidChannelId(channel: RemoteChannel, id: string): boolean {
   return CHANNEL_ID_PATTERNS[channel].test(id);
+}
+
+export function pickLastApiKeyCredential<T extends { type: string; key?: string }>(
+  creds: ReadonlyArray<T>,
+): T | undefined {
+  for (let i = creds.length - 1; i >= 0; i--) {
+    const c = creds[i];
+    if (c.type === "api_key" && !!c.key) return c;
+  }
+  return undefined;
 }
 
 function clampNumber(value: unknown, fallback: number, min: number, max: number): number {

--- a/src/resources/extensions/remote-questions/tests/config-api-key-last.test.ts
+++ b/src/resources/extensions/remote-questions/tests/config-api-key-last.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression test for the remote-questions token rotation bug:
+ * when multiple `api_key` credentials are present in auth.json for the same
+ * provider, hydrateRemoteTokensFromAuth must use the LAST one (newest token
+ * after rotation), not the first. The earlier implementation used `find`,
+ * which returned the stale token and silently disabled remote questions
+ * after a rotation.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { pickLastApiKeyCredential } from "../config.ts";
+
+test("pickLastApiKeyCredential returns the last api_key credential with a key", () => {
+  const creds = [
+    { type: "api_key", key: "old-token" },
+    { type: "oauth", key: "irrelevant" },
+    { type: "api_key", key: "new-token" },
+  ];
+  assert.equal(pickLastApiKeyCredential(creds)?.key, "new-token");
+});
+
+test("pickLastApiKeyCredential skips api_key entries without a key", () => {
+  const creds = [
+    { type: "api_key", key: "valid-token" },
+    { type: "api_key" }, // rotated out, no key set
+    { type: "api_key", key: "" }, // empty
+  ];
+  assert.equal(pickLastApiKeyCredential(creds)?.key, "valid-token");
+});
+
+test("pickLastApiKeyCredential returns undefined when no api_key has a key", () => {
+  const creds = [
+    { type: "oauth", key: "x" },
+    { type: "api_key" },
+  ];
+  assert.equal(pickLastApiKeyCredential(creds), undefined);
+});
+
+test("pickLastApiKeyCredential returns undefined for empty input", () => {
+  assert.equal(pickLastApiKeyCredential([]), undefined);
+});
+
+test("pickLastApiKeyCredential differs from Array.prototype.find on rotation case", () => {
+  // This guards against a regression where someone "simplifies" the helper
+  // back to `creds.find(c => c.type === "api_key" && !!c.key)`, which would
+  // return the FIRST (stale) token after a key rotation appends a new entry.
+  const creds = [
+    { type: "api_key", key: "stale" },
+    { type: "api_key", key: "fresh" },
+  ];
+  const findResult = creds.find((c) => c.type === "api_key" && !!c.key);
+  assert.equal(findResult?.key, "stale", "sanity: find returns the first match");
+  assert.equal(pickLastApiKeyCredential(creds)?.key, "fresh", "helper must return the last match");
+});


### PR DESCRIPTION
## Linked issue

<!--
PRs without a linked issue will be closed.
Open or find an issue first: https://github.com/gsd-build/gsd-2/issues
-->

Closes #5212
Closes #5213

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Fix two Discord remote-questions bugs: stale token reuse after rotation and snowflake precision loss for unquoted `channel_id`.
**Why:** `ask_user_questions` was returning `401 Unauthorized` after token rotation and `404 Unknown Channel` for valid IDs written as numbers in `PREFERENCES.md`.
**How:** Pick the most recently added `api_key` credential instead of the first; reject numeric `channel_id` at validation time with an actionable error.

## What

Two focused fixes in the GSD remote-questions path:

- `src/resources/extensions/remote-questions/config.ts` — token hydration now selects the **last** `api_key` credential for the provider instead of the first.
- `src/resources/extensions/gsd/preferences-types.ts` — narrow `RemoteQuestionsConfig.channel_id` from `string | number` to `string`.
- `src/resources/extensions/gsd/preferences-validation.ts` — reject `typeof channel_id === "number"` with an error that quotes the offending value and shows the corrected form.
- Remove the misleading `String(rq.channel_id)` coercions from `resolveRemoteConfig` and `getRemoteConfigStatus`; the value is guaranteed to be a string by the time it reaches those sites.

## Why

**Bug 1 — Stale token wins after `/gsd keys add`.** `AuthStorage.set()` appends new credentials of type `api_key` instead of replacing them. The hydration helper used `Array.prototype.find`, which returns the first match — i.e. the revoked token. Users who rotated a Discord bot token kept hitting `401 Unauthorized` with no obvious cause.

**Bug 2 — Snowflake precision loss.** Discord snowflakes (and large Telegram chat IDs) are 64-bit integers. JavaScript numbers are IEEE-754 doubles, so any integer above `Number.MAX_SAFE_INTEGER` (`2^53 − 1`) loses precision the moment the YAML parser reads it as a number:

```
1493867473030746174  → number → 1493867473030746000  (truncated, invalid ID)
"1493867473030746174" → string → precision preserved
```

The pre-existing `String(rq.channel_id)` coercion ran *after* the truncation, so it only stringified the already-broken value. The regex `^\d{17,20}$` happily accepted the truncated 19-digit ID, and Discord returned `404 Unknown Channel` (`10003`) on `GET /channels/{id}`.

## How

**Fix 1 — last-wins credential lookup.** Replaced `find` with a reverse loop. Equivalent to `findLast`, written manually to avoid requiring `lib: es2023` in the project's TS config.

```ts
const creds = auth.getCredentialsForProvider(providerId) as Array<{ type: string; key?: string }>;
let apiKeyCred: { type: string; key?: string } | undefined;
for (let i = creds.length - 1; i >= 0; i--) {
  const c = creds[i];
  if (c.type === "api_key" && !!c.key) {
    apiKeyCred = c;
    break;
  }
}
```

The deeper root cause (append-vs-replace in `AuthStorage.set`) lives in another package and is more invasive — out of scope here. The consumer-side fix is minimal, reversible, and matches the user's mental model: the latest token wins.

**Fix 2 — fail fast on numeric `channel_id`.** Validation now produces:

```
remote_questions.channel_id must be quoted as a string in PREFERENCES.md
(got number 1493867473030746000 — IDs above 2^53 lose precision when parsed
as numbers). Fix: change `channel_id: 1493867473030746000` to
`channel_id: "1493867473030746000"`.
```

This tells the user exactly what to change instead of letting them debug a silent Discord `404`.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

The `channel_id` type narrows from `string | number` to `string`, but this is internal to the preferences module. Users who already quote `channel_id` (the documented form) see no change.

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described below
- [ ] No tests needed — explained above

Automated tests added (commit `ecbed878`):

- `src/resources/extensions/remote-questions/tests/config-api-key-last.test.ts` — 5 tests covering `pickLastApiKeyCredential()`, including an explicit regression guard that compares against `Array.prototype.find` to prevent anyone from "simplifying" the helper back to first-wins.
- `src/resources/extensions/gsd/tests/preferences-channel-id-snowflake.test.ts` — 4 tests covering numeric `channel_id` rejection, string acceptance, the actionable error message content, and non-object `remote_questions`.

All 9 tests green; `npx tsc --noEmit` clean.

Manual verification:

1. `npx tsc --noEmit` passes (verified locally — no new errors).
2. With two `discord_bot` `api_key` credentials in `~/.gsd/auth.json` (old token first, new token second), confirm `ask_user_questions` authenticates with the second token and no longer returns `401`.
3. Set `channel_id: 1493867473030746174` (unquoted) in `PREFERENCES.md` and confirm preferences validation now reports the actionable error instead of silently truncating.
4. Set `channel_id: "1493867473030746174"` (quoted) and confirm `ask_user_questions` reaches the channel without `404 Unknown Channel`.

## AI disclosure

- [x] This PR includes AI-assisted code <!-- Authored with Claude Code (Opus 4.7); manually verified with `npx tsc --noEmit` and the steps above. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API credential selection to prioritize the most recent valid key instead of the first match, preventing stale credentials from being used.
  * Enhanced channel ID validation with stricter type checking to prevent numeric precision loss issues.
  * Improved error messages for remote questions configuration to provide clearer guidance when validation issues occur.

* **Tests**
  * Added comprehensive validation tests for channel ID handling.
  * Added test suite for API credential selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->