### PR TITLE
feat(headless): add `gsd headless recover` for non-TTY DB recovery

### DIFF
--- a/src/headless-recover.ts
+++ b/src/headless-recover.ts
@@ -1,0 +1,108 @@
+// gsd-pi — Headless Recover entrypoint
+/**
+ * Headless Recover — `gsd headless recover`
+ *
+ * Non-interactive parallel of the `/gsd recover` slash command. Clears the
+ * milestones / slices / tasks tables and re-imports them from the on-disk
+ * markdown projections (ROADMAP.md, PLAN.md, SUMMARY.md, …) via
+ * migrateHierarchyToDb. Mutating: this is the one headless subcommand that
+ * writes to the DB. Required for CI / automation flows that need to
+ * reconcile DB state from markdown without launching an LLM session or a
+ * TTY-bound interactive runtime.
+ *
+ * Output: `gsd-recover: recovered <N>M/<N>S/<N>T hierarchy\n` to stderr on
+ * success — same marker emitted by handleRecover (commands-maintenance.ts)
+ * so callers can distinguish the success path from a silent no-op.
+ *
+ * Exit codes:
+ *   0 — recovery succeeded
+ *   1 — `.gsd/` missing, DB could not be opened, or migration threw
+ */
+
+import { createJiti } from '@mariozechner/jiti'
+import { fileURLToPath } from 'node:url'
+import { resolveGsdAgentExtensionsDir, shouldUseAgentExtensionsDir } from './headless-query.js'
+import { resolveBundledGsdExtensionModule } from './bundled-resource-path.js'
+import { join } from 'node:path'
+import { existsSync } from 'node:fs'
+
+const jiti = createJiti(fileURLToPath(import.meta.url), { interopDefault: true, debug: false })
+
+const agentExtensionsDir = resolveGsdAgentExtensionsDir()
+const { useAgentDir } = shouldUseAgentExtensionsDir({ env: process.env })
+const gsdExtensionPath = (...segments: string[]) =>
+  useAgentDir
+    ? resolveAgentExtensionModule(agentExtensionsDir, segments)
+    : resolveBundledGsdExtensionModule(import.meta.url, segments.join('/'))
+
+function resolveAgentExtensionModule(agentDir: string, segments: string[]): string {
+  const requested = join(agentDir, ...segments)
+  if (existsSync(requested)) return requested
+  if (segments.length === 1 && segments[0].endsWith('.ts')) {
+    const jsPath = join(agentDir, segments[0].replace(/\.ts$/, '.js'))
+    if (existsSync(jsPath)) return jsPath
+  }
+  return requested
+}
+
+async function loadExtensionModules() {
+  const stateModule = await jiti.import(gsdExtensionPath('state.ts'), {}) as any
+  const dbModule = await jiti.import(gsdExtensionPath('gsd-db.ts'), {}) as any
+  const importerModule = await jiti.import(gsdExtensionPath('md-importer.ts'), {}) as any
+  const dynamicToolsModule = await jiti.import(gsdExtensionPath('bootstrap/dynamic-tools.ts'), {}) as any
+  return {
+    ensureDbOpen: dynamicToolsModule.ensureDbOpen as (basePath: string) => Promise<boolean>,
+    isDbAvailable: dbModule.isDbAvailable as () => boolean,
+    clearEngineHierarchy: dbModule.clearEngineHierarchy as () => void,
+    transaction: dbModule.transaction as <T>(fn: () => T) => T,
+    migrateHierarchyToDb: importerModule.migrateHierarchyToDb as (basePath: string) =>
+      { milestones: number; slices: number; tasks: number },
+    invalidateStateCache: stateModule.invalidateStateCache as () => void,
+  }
+}
+
+export interface RecoverResult {
+  exitCode: number
+}
+
+export async function handleRecover(basePath: string): Promise<RecoverResult> {
+  const gsdDir = join(basePath, '.gsd')
+  if (!existsSync(gsdDir)) {
+    process.stderr.write(`[headless] recover: no .gsd/ directory at ${basePath}\n`)
+    return { exitCode: 1 }
+  }
+
+  let modules: Awaited<ReturnType<typeof loadExtensionModules>>
+  try {
+    modules = await loadExtensionModules()
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    process.stderr.write(`[headless] recover: failed to load extension modules: ${msg}\n`)
+    return { exitCode: 1 }
+  }
+
+  const opened = await modules.ensureDbOpen(basePath)
+  if (!opened || !modules.isDbAvailable()) {
+    process.stderr.write(`[headless] recover: failed to open or create the GSD database at ${basePath}\n`)
+    return { exitCode: 1 }
+  }
+
+  let counts: { milestones: number; slices: number; tasks: number }
+  try {
+    counts = modules.transaction(() => {
+      modules.clearEngineHierarchy()
+      return modules.migrateHierarchyToDb(basePath)
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    process.stderr.write(`[headless] recover failed: ${msg}\n`)
+    return { exitCode: 1 }
+  }
+
+  modules.invalidateStateCache()
+
+  process.stderr.write(
+    `gsd-recover: recovered ${counts.milestones}M/${counts.slices}S/${counts.tasks}T hierarchy\n`,
+  )
+  return { exitCode: 0 }
+}

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -352,6 +352,16 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     return { exitCode: result.exitCode, interrupted: false }
   }
 
+  // Recover: rebuild DB hierarchy from on-disk markdown projections, no RPC
+  // child needed. This is the one mutating headless subcommand — required for
+  // CI / automation that needs to reconcile DB state from markdown without
+  // launching an interactive TTY-bound runtime.
+  if (options.command === 'recover') {
+    const { handleRecover } = await import('./headless-recover.js')
+    const result = await handleRecover(process.cwd())
+    process.exit(result.exitCode)
+  }
+
   // Doctor: read-only health check, no RPC child needed (#4904 live-regression).
   // The interactive `/gsd doctor` command lives in the GSD extension; this CLI
   // path lets non-interactive callers (CI, recovery scripts, the live-regression

--- a/src/help-text.ts
+++ b/src/help-text.ts
@@ -164,6 +164,7 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     '  gsd headless --answers answers.json auto              With pre-supplied answers',
     '  gsd headless --events agent_end,extension_ui_request auto   Filtered event stream',
     '  gsd headless query                              Instant JSON state snapshot',
+    '  gsd headless recover                            Rebuild DB hierarchy from markdown (mutating)',
     '',
     'Exit codes: 0 = success, 1 = error/timeout, 10 = blocked, 11 = cancelled',
   ].join('\n'),

--- a/src/tests/headless-recover.test.ts
+++ b/src/tests/headless-recover.test.ts
@@ -1,0 +1,140 @@
+// gsd-pi · headless recover wiring
+//
+// Regression test for the headless recover entrypoint introduced to make
+// `gsd headless recover` available to non-TTY callers (CI, automation, the
+// live-regression suite). The headless dispatcher previously had no
+// `recover` case — the only path was the interactive slash-command
+// (`/gsd recover`), which is gated behind a TTY check (src/cli.ts
+// printNonTtyErrorAndExit) and rejected piped invocations.
+//
+// The headless wiring composes ensureDbOpen + clearEngineHierarchy +
+// migrateHierarchyToDb + invalidateStateCache. This test exercises that
+// pipeline against a markdown-only fixture and verifies that:
+//   1. recovery succeeds against a fixture with only on-disk markdown,
+//   2. the DB is populated with the expected milestone/slice/task rows,
+//   3. running recovery a second time on an already-populated fixture is
+//      idempotent (the `clearEngineHierarchy` step makes this safe).
+//
+// The dispatcher branch itself (one if-block in headless.ts) is verified
+// by `npm run build:core`; the behavior-level guarantees live here.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { ensureDbOpen } from "../resources/extensions/gsd/bootstrap/dynamic-tools.ts";
+import {
+  isDbAvailable,
+  closeDatabase,
+  clearEngineHierarchy,
+  transaction,
+  getAllMilestones,
+  getMilestoneSlices,
+  getSliceTasks,
+} from "../resources/extensions/gsd/gsd-db.ts";
+import { migrateHierarchyToDb } from "../resources/extensions/gsd/md-importer.ts";
+import { invalidateStateCache } from "../resources/extensions/gsd/state.ts";
+
+function makeMarkdownFixture(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-headless-recover-"));
+  const mDir = join(base, ".gsd", "milestones", "M001");
+  const sDir = join(mDir, "slices", "S01");
+  mkdirSync(join(sDir, "tasks"), { recursive: true });
+
+  writeFileSync(
+    join(mDir, "M001-CONTEXT.md"),
+    "# M001: Recover Fixture\n\n## Purpose\nTest headless recover.\n",
+  );
+  writeFileSync(
+    join(mDir, "M001-ROADMAP.md"),
+    [
+      "# M001: Recover Fixture",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: First Slice** `risk:low` `depends:[]`",
+      "  > Demo for S01",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(sDir, "S01-PLAN.md"),
+    [
+      "# S01: First Slice",
+      "",
+      "**Goal:** test",
+      "",
+      "## Tasks",
+      "",
+      "- [ ] **T01: First Task** `est:5m`",
+    ].join("\n"),
+  );
+  return base;
+}
+
+test("headless recover: imports markdown hierarchy into authoritative DB", async (t) => {
+  const base = makeMarkdownFixture();
+  t.after(() => {
+    try { closeDatabase(); } catch { /* may not be open */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const opened = await ensureDbOpen(base);
+  assert.ok(opened, "ensureDbOpen should succeed when .gsd/ exists");
+  assert.ok(isDbAvailable(), "DB should be open after ensureDbOpen");
+
+  const counts = transaction(() => {
+    clearEngineHierarchy();
+    return migrateHierarchyToDb(base);
+  });
+  invalidateStateCache();
+
+  assert.equal(counts.milestones, 1, "one milestone imported");
+  assert.equal(counts.slices, 1, "one slice imported");
+  assert.equal(counts.tasks, 1, "one task imported");
+
+  const milestones = getAllMilestones();
+  assert.equal(milestones.length, 1, "DB has the imported milestone");
+  assert.equal(milestones[0]!.id, "M001");
+
+  const slices = getMilestoneSlices("M001");
+  assert.equal(slices.length, 1, "milestone has the imported slice");
+  assert.equal(slices[0]!.id, "S01");
+  assert.equal(slices[0]!.status, "pending");
+
+  const tasks = getSliceTasks("M001", "S01");
+  assert.equal(tasks.length, 1, "slice has the imported task");
+  assert.equal(tasks[0]!.id, "T01");
+});
+
+test("headless recover: idempotent when run twice on the same fixture", async (t) => {
+  const base = makeMarkdownFixture();
+  t.after(() => {
+    try { closeDatabase(); } catch { /* may not be open */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  await ensureDbOpen(base);
+
+  const first = transaction(() => {
+    clearEngineHierarchy();
+    return migrateHierarchyToDb(base);
+  });
+  invalidateStateCache();
+
+  const second = transaction(() => {
+    clearEngineHierarchy();
+    return migrateHierarchyToDb(base);
+  });
+  invalidateStateCache();
+
+  assert.deepEqual(
+    second,
+    first,
+    "second recovery must produce identical counts (clear-then-import is idempotent)",
+  );
+  assert.equal(getAllMilestones().length, 1, "DB has exactly one milestone after the second pass");
+  assert.equal(getSliceTasks("M001", "S01").length, 1, "DB has exactly one task after the second pass");
+});

--- a/tests/live-regression/run.ts
+++ b/tests/live-regression/run.ts
@@ -133,18 +133,18 @@ function buildTaskSummary(id: string): string {
 
 // Recover DB hierarchy from on-disk markdown projections. DB is authoritative
 // at runtime, so live-regression fixtures that exist only as markdown must be
-// imported via `gsd recover` before `headless query` can derive their state.
-// `handleRecover` exits 0 even when DB init silently fails, so also assert the
-// success-path marker on stderr (commands-maintenance.ts:535).
+// imported via `gsd headless recover` before `headless query` can derive
+// their state. The interactive `gsd recover` command requires a TTY; the
+// headless subcommand is the non-interactive parallel.
 function recover(dir: string): void {
-  const result = gsd(["recover"], dir);
+  const result = gsd(["headless", "recover"], dir);
   assert(
     result.code === 0,
-    `gsd recover should succeed for fixture, got ${result.code}: ${result.stderr}`,
+    `gsd headless recover should succeed for fixture, got ${result.code}: ${result.stderr}`,
   );
   assert(
     result.stderr.includes("gsd-recover: recovered"),
-    `gsd recover should reach success path, got stderr: ${result.stderr}`,
+    `gsd headless recover should reach success path, got stderr: ${result.stderr}`,
   );
 }
 


### PR DESCRIPTION
## Summary

PR #5211 added a `recover()` helper to the live-regression suite that runs `gsd recover` between fixture write and `gsd headless query`. That call fails in CI because the interactive `/gsd recover` slash command is gated behind a TTY check (`src/cli.ts` `printNonTtyErrorAndExit`):

```
gsd recover should succeed for fixture, got 1: [gsd] Error: Interactive mode requires a terminal (TTY) but stdin and stdout are not a TTY.
```

This adds `gsd headless recover` as the non-interactive parallel, mirroring the existing `gsd headless query` and `gsd headless doctor` shape (read/write, no RPC child, no TTY required). Switches the live-regression `recover()` helper to call the new subcommand.

## What's in the PR

- **`src/headless-recover.ts`** — new entrypoint that loads the GSD extension via jiti (same agent-dir-or-bundled fallback used by `headless-query.ts`) and orchestrates the same pipeline the interactive command runs:
  - `ensureDbOpen` → opens an existing DB or creates an empty authoritative one
  - `transaction(() => { clearEngineHierarchy(); migrateHierarchyToDb(basePath) })` → atomic clear + repopulate from `ROADMAP.md` / `PLAN.md` / `SUMMARY.md` projections
  - `invalidateStateCache()` → ensures the next derive uses fresh DB rows
  - emits `gsd-recover: recovered <m>M/<s>S/<t>T hierarchy` on stderr (matches the existing success-path marker at `commands-maintenance.ts:535`)
- **`src/headless.ts`** — wires `options.command === 'recover'` at the same level as `'query'` / `'doctor'`. Comment notes this is the one mutating headless subcommand.
- **`src/help-text.ts`** — adds the new subcommand to `gsd headless --help`.
- **`tests/live-regression/run.ts`** — switches the existing `recover(dir)` helper to call `gsd(["headless", "recover"], dir)`.
- **`src/tests/headless-recover.test.ts`** — new unit coverage:
  - success path (markdown fixture imported into milestone/slice/task rows; counts match)
  - idempotency (two consecutive recoveries produce identical counts; clear-then-import semantics)

## Why a separate PR

PR #5211 already merged with the old non-functional `gsd recover` call. Dev Verify on `main` is currently red. This PR closes that gap.

## Test plan

- [x] `npm run test:unit` — 8294 pass, 0 fail (added 2 cases for the new module)
- [x] `npm run typecheck:extensions`, `npm run build:core` — clean
- [ ] Dev Verify (installed package) on this PR — live-regression suite reports 9 passed / 0 failed
- [ ] CI: integration-tests, lint, build, rtk-portability all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `recover` command to `gsd headless` for rebuilding the database hierarchy from markdown projections.

* **Tests**
  * Added regression tests to verify recovery functionality and idempotency.

* **Chores**
  * Updated help text and test infrastructure for the recovery operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->