### PR TITLE
ci: run live-regression on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,39 @@ jobs:
       - name: Run integration tests
         run: npm run test:integration
 
+  live-regression:
+    # Runs the same tests/live-regression suite that Dev Verify runs
+    # post-publish, but pointed at the locally-built dist/loader.js so
+    # regressions surface on the PR instead of in the manual Dev Publish
+    # workflow. Mirrors the Dev Publish smoke step at dev-publish.yml:84-88.
+    # No untrusted GitHub event input is consumed in run: blocks.
+    timeout-minutes: 10
+    needs: detect-changes
+    if: needs.detect-changes.outputs.docs-only != 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build core
+        run: npm run build:core
+
+      - name: Run live regression (against built binary)
+        run: |
+          chmod +x dist/loader.js
+          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          npm run test:live-regression
+
   windows-portability:
     timeout-minutes: 25
     needs: detect-changes


### PR DESCRIPTION
## Summary

Live-regression tests previously ran only in the manual Dev Publish workflow against the freshly-published `gsd-pi@dev` npm package. That meant regressions in `gsd headless query` / state derivation were caught post-merge after a maintainer ran Dev Publish — not on the PR that introduced them.

PR #5206 (DB-authoritative state) and PR #5211 (initial live-regression fix) both shipped with regressions that only surfaced in Dev Verify hours later, each requiring a follow-up PR to heal `main`. PR #5215 fixes the symptom; this PR closes the discovery gap so the same class of bug fails the PR rather than `main`.

## What's in the PR

Add a parallel `live-regression` job to `.github/workflows/ci.yml`:

```yaml
- name: Build core
  run: npm run build:core
- name: Run live regression (against built binary)
  run: |
    chmod +x dist/loader.js
    export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
    npm run test:live-regression
```

Mirrors the Dev Publish smoke step (`.github/workflows/dev-publish.yml:84-88`) — same suite, same binary contract, just pointed at the locally-built `dist/loader.js` instead of the published npm package. Skipped on docs-only PRs via the existing `detect-changes` gate.

## Why a parallel job (not bolted onto integration-tests)

- Failure isolation: regressions in headless query / state derivation are categorically different from integration-test failures and should report independently.
- Wall-clock parallelism: the live-regression suite is fast (<5s locally, ~15s installed) but `npm ci` + `build:core` dominates — running it in parallel with `integration-tests` doesn't extend the critical path.
- Mirrors the precedent set by `pr-risk.yml` and `rtk-portability` — small, targeted gates over a single monolithic job.

## Test plan

- [ ] CI on this PR shows a new `live-regression` check (passing — this branch is on top of post-merge `main`)
- [ ] No effect on docs-only PRs (skipped via `detect-changes`)
- [ ] No effect on existing checks (`build`, `integration-tests`, `lint`, etc. unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline with automated regression testing on pull requests to ensure code stability and quality across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->