### PR TITLE
fix(guided-flow): bust path cache before ready-signal validation

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -36,7 +36,7 @@ import { gsdHome } from "./gsd-home.js";
 import {
   gsdRoot, milestonesDir, resolveMilestoneFile, resolveMilestonePath,
   resolveSliceFile, resolveSlicePath, resolveGsdRootFile, relGsdRootFile,
-  relMilestoneFile, relSliceFile,
+  relMilestoneFile, relSliceFile, clearPathCache,
 } from "./paths.js";
 import { join } from "node:path";
 import { readFileSync, existsSync, mkdirSync, readdirSync, rmSync, unlinkSync } from "node:fs";
@@ -587,6 +587,13 @@ export function maybeHandleReadyPhraseWithoutFiles(event: { messages: any[] }): 
   const lastMsg = event.messages[event.messages.length - 1];
   const text = extractAssistantText(lastMsg);
   if (!READY_PHRASE_RE.test(text)) return false;
+
+  // Bust paths.ts cached dir listings before checking for fresh writes. The
+  // LLM's Write tool calls do not invalidate paths.ts caches, so a stale
+  // listing taken before the milestone dir or its CONTEXT/ROADMAP files
+  // existed would falsely report the artifacts as missing and trigger the
+  // 3-strike "ready without files" abort even though the writes succeeded.
+  clearPathCache();
 
   // Gate: artifacts must still be missing — if they exist, the happy path
   // already fired and we have nothing to do.

--- a/src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts
+++ b/src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts
@@ -22,6 +22,7 @@ import {
   resetEmptyTurnCounter,
 } from "../guided-flow.ts";
 import { drainLogs } from "../workflow-logger.ts";
+import { resolveMilestoneFile, clearPathCache } from "../paths.ts";
 
 // ─── Test harness ──────────────────────────────────────────────────────────
 
@@ -173,6 +174,79 @@ describe("#4573 maybeHandleReadyPhraseWithoutFiles", () => {
       });
       assert.equal(handled, false);
       assert.equal(cap.messages.length, 0);
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  test("stale path cache from a prior listing → fresh writes are detected (regression)", () => {
+    // Repro the live binary failure where:
+    //   1. paths.ts cached dir listings were populated when M001/ was empty
+    //      (or the milestone dir didn't yet exist).
+    //   2. The LLM then wrote M001-CONTEXT.md and M001-ROADMAP.md via the
+    //      standard Write tool — which has no awareness of paths.ts caches.
+    //   3. maybeHandleReadyPhraseWithoutFiles called resolveMilestoneFile,
+    //      which read the stale cache and reported the artifacts missing,
+    //      firing a false rejection nudge until MAX_READY_REJECTS aborted
+    //      the auto-start with `LLM signaled "ready" 3 times without
+    //      writing files`.
+    //
+    // The fix busts the path cache at the top of the validator before
+    // re-resolving. This test fails pre-fix (handled === true) because the
+    // cache returns the empty listing it captured in step (a).
+    const base = mkBase();
+    try {
+      const mDir = join(base, ".gsd", "milestones", "M001");
+
+      // (a) Prime the cache with a listing that DOES NOT include M001's
+      //     CONTEXT/ROADMAP files. mkBase() has already created the M001
+      //     directory but nothing inside it yet — so this readdir caches an
+      //     empty entry list keyed by the M001 dir path.
+      clearPathCache();
+      assert.equal(
+        resolveMilestoneFile(base, "M001", "CONTEXT"),
+        null,
+        "precondition: resolver must report missing before files are written",
+      );
+
+      // (b) Write the artifacts directly to disk (simulates the LLM Write
+      //     tool — no clearPathCache() call between the write and the
+      //     validator).
+      writeFileSync(join(mDir, "M001-CONTEXT.md"), "# ctx");
+      writeFileSync(join(mDir, "M001-ROADMAP.md"), "# roadmap");
+
+      // (c) Sanity: the cache is still stale. Without the fix, the
+      //     validator would still see the empty cached listing.
+      assert.equal(
+        resolveMilestoneFile(base, "M001", "CONTEXT"),
+        null,
+        "stale cache still reports missing pre-clearPathCache",
+      );
+
+      // (d) Run the validator. With the fix it busts the cache before
+      //     resolving and returns false (no nudge). Without the fix it
+      //     fires the nudge.
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleReadyPhraseWithoutFiles({
+        messages: [assistantMsg("Milestone M001 ready.")],
+      });
+      assert.equal(
+        handled,
+        false,
+        "fresh writes must not trigger the rejection nudge — cache must be busted before resolution",
+      );
+      assert.equal(cap.messages.length, 0, "no nudge sent");
+      assert.equal(
+        cap.notifies.length,
+        0,
+        "no rejection notify when files exist on disk",
+      );
     } finally {
       clearPendingAutoStart();
     }


### PR DESCRIPTION
## Summary

During `gsd new-milestone`, the auto-start loop rejected the LLM's "Milestone M001 ready." signal with `M001-CONTEXT.md and M001-ROADMAP.md are missing` even though the files were on disk and the LLM could read them back. After three rejections the loop aborted: `LLM signaled "ready" 3 times without writing files`.

Reproducible from the user's terminal output: the LLM ran `mkdir -p .gsd/milestones/M001/slices`, wrote both artifacts via the `Write` tool, called `gsd_plan_milestone`, then emitted the ready phrase — and was rejected. `ls` and `Read` confirmed the files existed.

## Root cause

`maybeHandleReadyPhraseWithoutFiles` (`src/resources/extensions/gsd/guided-flow.ts`) calls `resolveMilestoneFile` to verify the artifacts. That resolver chain (`resolveMilestoneFile` → `resolveMilestonePath` → `resolveDir` / `resolveFile`) reads through the dir-listing cache in `paths.ts` (`cachedReaddirWithTypes`, `cachedReaddir`). The cache has no TTL — only invalidated by explicit `clearPathCache()` calls.

The LLM writes files via the standard `Write` tool, which has no awareness of GSD's path cache. When the cache was populated earlier in the session — before the milestone dir existed or right after `mkdir -p` but before the writes — the validator saw the stale empty listing and rejected the ready signal as "files missing."

## Fix

Single-line: `clearPathCache()` at the top of `maybeHandleReadyPhraseWithoutFiles` so the validator always re-resolves against fresh disk state. Scoped to this call site (don't make every resolver call globally cache-busting). Cost is a handful of `readdirSync` calls on the next access; the cache repopulates lazily.

```ts
// Bust paths.ts cached dir listings before checking for fresh writes. The
// LLM's Write tool calls do not invalidate paths.ts caches, so a stale
// listing taken before the milestone dir or its CONTEXT/ROADMAP files
// existed would falsely report the artifacts as missing and trigger the
// 3-strike "ready without files" abort even though the writes succeeded.
clearPathCache();
```

## Regression test

Added to `src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts`:

1. Prime the cache with an empty M001 listing (`resolveMilestoneFile` returns null, caches empty entry list)
2. Write `M001-CONTEXT.md` and `M001-ROADMAP.md` directly to disk **without invalidating** the cache (simulates the LLM's `Write` tool path)
3. Assert the cache is still stale (`resolveMilestoneFile` still returns null pre-fix)
4. Call `maybeHandleReadyPhraseWithoutFiles`
5. Assert it returns `false` and emits no nudge / no notify

The test fails pre-fix with `true !== false` (the rejection nudge fires) and passes post-fix.

## Test plan

- [x] `node --test ready-phrase-no-files-4573.test.ts` — all 38 cases pass; new regression test fails pre-fix and passes post-fix
- [x] `npm run test:live-regression` (against locally-built `dist/loader.js`) — 9 pass / 0 fail
- [ ] CI on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of file detection in the guided recovery flow by ensuring fresh filesystem data is checked before evaluating artifact presence, preventing false rejection messages.

* **Tests**
  * Added regression test to verify file detection accuracy in recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->