### PR TITLE
fix(mcp): clear depth_verification gate when ask_user_questions answers via MCP

### DIFF
--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -948,6 +948,194 @@ describe('createMcpServer tool registration', () => {
     assert.equal(result.content[0]?.text, 'remote response');
   });
 
+  it('ask_user_questions surfaces remote success answers as structuredContent (regression #5267)', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue.' },
+          { label: 'Not quite', description: 'Clarify.' },
+        ],
+      },
+    ];
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        throw new Error('MCP host does not support elicitation');
+      },
+      isRemoteConfigured() {
+        return true;
+      },
+      async tryRemoteQuestions() {
+        return {
+          content: [{ type: 'text', text: '{"answers":{"depth_verification_M001":{"answers":["Yes, you got it (Recommended)"]}}}' }],
+          details: {
+            remote: true,
+            channel: 'discord',
+            timed_out: false,
+            promptId: 'p1',
+            threadUrl: null,
+            questions,
+            response: {
+              endInterview: false,
+              answers: {
+                depth_verification_M001: { selected: 'Yes, you got it (Recommended)', notes: '' },
+              },
+            },
+            status: 'answered',
+          },
+        };
+      },
+    });
+
+    assert.deepEqual(
+      (result as { structuredContent?: unknown }).structuredContent,
+      {
+        questions,
+        response: {
+          // endInterview mirrors the local RoundResult shape so register-hooks
+          // sees identical payloads on both code paths.
+          endInterview: false,
+          answers: {
+            depth_verification_M001: { selected: 'Yes, you got it (Recommended)', notes: '' },
+          },
+        },
+        cancelled: false,
+      },
+    );
+  });
+
+  it('ask_user_questions surfaces remote timeout as cancelled structuredContent (regression #5267)', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue.' },
+          { label: 'Not quite', description: 'Clarify.' },
+        ],
+      },
+    ];
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        throw new Error('MCP host does not support elicitation');
+      },
+      isRemoteConfigured() {
+        return true;
+      },
+      async tryRemoteQuestions() {
+        return {
+          content: [{ type: 'text', text: '{"timed_out":true,"channel":"discord","message":"User did not respond within 5 minutes."}' }],
+          details: { remote: true, channel: 'discord', timed_out: true, status: 'timed_out' },
+        };
+      },
+    });
+
+    assert.deepEqual(
+      (result as { structuredContent?: unknown }).structuredContent,
+      { questions, response: null, cancelled: true },
+    );
+  });
+
+  it('ask_user_questions returns cancelled structuredContent when remote is unconfigured and local declines (regression #5267)', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue.' },
+          { label: 'Not quite', description: 'Clarify.' },
+        ],
+      },
+    ];
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        return { action: 'decline' };
+      },
+      isRemoteConfigured() {
+        return false;
+      },
+      async tryRemoteQuestions() {
+        throw new Error('should not be called when remote is unconfigured');
+      },
+    });
+
+    assert.deepEqual(
+      (result as { structuredContent?: unknown }).structuredContent,
+      { questions, response: null, cancelled: true },
+    );
+    assert.equal(result.content[0]?.text, 'ask_user_questions was cancelled before receiving a response');
+  });
+
+  it('ask_user_questions returns cancelled structuredContent when configured remote returns null (regression #5267)', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue.' },
+          { label: 'Not quite', description: 'Clarify.' },
+        ],
+      },
+    ];
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        return { action: 'cancel' };
+      },
+      isRemoteConfigured() {
+        return true;
+      },
+      async tryRemoteQuestions() {
+        return null;
+      },
+    });
+
+    assert.deepEqual(
+      (result as { structuredContent?: unknown }).structuredContent,
+      { questions, response: null, cancelled: true },
+    );
+  });
+
+  it('ask_user_questions re-throws non-fallback local errors (regression #5267)', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue.' },
+          { label: 'Not quite', description: 'Clarify.' },
+        ],
+      },
+    ];
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        throw new TypeError('schema validation blew up');
+      },
+      isRemoteConfigured() {
+        return false;
+      },
+      async tryRemoteQuestions() {
+        throw new Error('should not be called');
+      },
+    });
+
+    // Non-fallback errors propagate to the outer try/catch and surface as an
+    // MCP `isError` result — no `structuredContent` is attached because the
+    // error path predates the structured success/cancel branches.
+    assert.equal('isError' in result && result.isError, true);
+    assert.match(result.content[0]?.text ?? '', /schema validation blew up/);
+  });
+
   it('ask_user_questions reports both local and remote errors when both paths fail', async () => {
     const questions = [
       {

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -1041,6 +1041,44 @@ describe('createMcpServer tool registration', () => {
     );
   });
 
+  it('ask_user_questions reports a malformed remote response as cancelled, not silent success (regression #5267)', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M001',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue.' },
+          { label: 'Not quite', description: 'Clarify.' },
+        ],
+      },
+    ];
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        throw new Error('MCP host does not support elicitation');
+      },
+      isRemoteConfigured() {
+        return true;
+      },
+      async tryRemoteQuestions() {
+        // Simulates a remote module returning a non-conforming `details.response`
+        // (e.g. a stale build, a wire mismatch). The handler must not surface
+        // this as `cancelled: false, response: null` — that would lie to any
+        // consumer reading `structuredContent.cancelled`.
+        return {
+          content: [{ type: 'text', text: '{}' }],
+          details: { remote: true, channel: 'discord', timed_out: false, response: 'not-an-object' },
+        };
+      },
+    });
+
+    assert.deepEqual(
+      (result as { structuredContent?: unknown }).structuredContent,
+      { questions, response: null, cancelled: true },
+    );
+  });
+
   it('ask_user_questions returns cancelled structuredContent when remote is unconfigured and local declines (regression #5267)', async () => {
     const questions = [
       {

--- a/packages/mcp-server/src/remote-questions.test.ts
+++ b/packages/mcp-server/src/remote-questions.test.ts
@@ -23,6 +23,7 @@ import { join } from 'node:path';
 // ask_user_questions handler integration test further below.
 import {
   isRemoteConfigured,
+  toRoundResultResponse,
   tryRemoteQuestions,
   type RemoteQuestion,
 } from './remote-questions.js';
@@ -46,6 +47,53 @@ const SAMPLE_QUESTIONS: RemoteQuestion[] = [
 function makePrefsFile(dir: string, content: string): void {
   writeFileSync(join(dir, 'PREFERENCES.md'), content, 'utf-8');
 }
+
+// ---------------------------------------------------------------------------
+// toRoundResultResponse — regression #5267
+// ---------------------------------------------------------------------------
+
+describe('toRoundResultResponse', () => {
+  it('normalizes a single-answer RemoteAnswer into RoundResult shape', () => {
+    const result = toRoundResultResponse({
+      answers: {
+        approach: { answers: ['Option A (Recommended)'] },
+      },
+    });
+    assert.deepEqual(result, {
+      endInterview: false,
+      answers: {
+        approach: { selected: 'Option A (Recommended)', notes: '' },
+      },
+    });
+  });
+
+  it('keeps multi-answer arrays intact for multi-select questions', () => {
+    const result = toRoundResultResponse({
+      answers: {
+        focus: { answers: ['Frontend', 'Backend'] },
+      },
+    });
+    assert.deepEqual(result.answers.focus, { selected: ['Frontend', 'Backend'], notes: '' });
+  });
+
+  it('lifts user_note into the notes field', () => {
+    const result = toRoundResultResponse({
+      answers: {
+        confirm: { answers: ['None of the above'], user_note: 'Need a hybrid path.' },
+      },
+    });
+    assert.deepEqual(result.answers.confirm, { selected: 'None of the above', notes: 'Need a hybrid path.' });
+  });
+
+  it('returns an empty selected string when the channel produced no answer', () => {
+    const result = toRoundResultResponse({
+      answers: {
+        approach: { answers: [] },
+      },
+    });
+    assert.deepEqual(result.answers.approach, { selected: '', notes: '' });
+  });
+});
 
 // ---------------------------------------------------------------------------
 // isRemoteConfigured — unit tests

--- a/packages/mcp-server/src/remote-questions.test.ts
+++ b/packages/mcp-server/src/remote-questions.test.ts
@@ -53,12 +53,42 @@ function makePrefsFile(dir: string, content: string): void {
 // ---------------------------------------------------------------------------
 
 describe('toRoundResultResponse', () => {
+  const singleSelectQuestion: RemoteQuestion = {
+    id: 'approach',
+    header: 'Approach',
+    question: 'Pick one',
+    options: [
+      { label: 'Option A (Recommended)', description: '' },
+      { label: 'Option B', description: '' },
+    ],
+  };
+
+  const multiSelectQuestion: RemoteQuestion = {
+    id: 'focus',
+    header: 'Focus',
+    question: 'Pick all',
+    options: [
+      { label: 'Frontend', description: '' },
+      { label: 'Backend', description: '' },
+    ],
+    allowMultiple: true,
+  };
+
+  const noteQuestion: RemoteQuestion = {
+    id: 'confirm',
+    header: 'Confirm',
+    question: 'Proceed?',
+    options: [
+      { label: 'Yes', description: '' },
+      { label: 'No', description: '' },
+    ],
+  };
+
   it('normalizes a single-answer RemoteAnswer into RoundResult shape', () => {
-    const result = toRoundResultResponse({
-      answers: {
-        approach: { answers: ['Option A (Recommended)'] },
-      },
-    });
+    const result = toRoundResultResponse(
+      { answers: { approach: { answers: ['Option A (Recommended)'] } } },
+      [singleSelectQuestion],
+    );
     assert.deepEqual(result, {
       endInterview: false,
       answers: {
@@ -68,30 +98,55 @@ describe('toRoundResultResponse', () => {
   });
 
   it('keeps multi-answer arrays intact for multi-select questions', () => {
-    const result = toRoundResultResponse({
-      answers: {
-        focus: { answers: ['Frontend', 'Backend'] },
-      },
-    });
+    const result = toRoundResultResponse(
+      { answers: { focus: { answers: ['Frontend', 'Backend'] } } },
+      [multiSelectQuestion],
+    );
     assert.deepEqual(result.answers.focus, { selected: ['Frontend', 'Backend'], notes: '' });
   });
 
+  it('preserves the array shape for a multi-select question with a single selection (regression #5267)', () => {
+    // Without consulting `allowMultiple`, the previous length-based inference
+    // collapsed `['Frontend']` into the string `'Frontend'`, breaking any
+    // consumer that does `selected.includes(...)` on a multi-select answer.
+    const result = toRoundResultResponse(
+      { answers: { focus: { answers: ['Frontend'] } } },
+      [multiSelectQuestion],
+    );
+    assert.deepEqual(result.answers.focus, { selected: ['Frontend'], notes: '' });
+  });
+
   it('lifts user_note into the notes field', () => {
-    const result = toRoundResultResponse({
-      answers: {
-        confirm: { answers: ['None of the above'], user_note: 'Need a hybrid path.' },
-      },
-    });
+    const result = toRoundResultResponse(
+      { answers: { confirm: { answers: ['None of the above'], user_note: 'Need a hybrid path.' } } },
+      [noteQuestion],
+    );
     assert.deepEqual(result.answers.confirm, { selected: 'None of the above', notes: 'Need a hybrid path.' });
   });
 
-  it('returns an empty selected string when the channel produced no answer', () => {
-    const result = toRoundResultResponse({
-      answers: {
-        approach: { answers: [] },
-      },
-    });
+  it('returns an empty selected string when the channel produced no answer for a single-select', () => {
+    const result = toRoundResultResponse(
+      { answers: { approach: { answers: [] } } },
+      [singleSelectQuestion],
+    );
     assert.deepEqual(result.answers.approach, { selected: '', notes: '' });
+  });
+
+  it('returns an empty array when the channel produced no answer for a multi-select', () => {
+    const result = toRoundResultResponse(
+      { answers: { focus: { answers: [] } } },
+      [multiSelectQuestion],
+    );
+    assert.deepEqual(result.answers.focus, { selected: [], notes: '' });
+  });
+
+  it('falls back to single-select shape when the answer id is not in the questions list', () => {
+    // Defensive: an unknown id (channel desync) should not wedge the helper.
+    const result = toRoundResultResponse(
+      { answers: { ghost: { answers: ['anything'] } } },
+      [singleSelectQuestion],
+    );
+    assert.deepEqual(result.answers.ghost, { selected: 'anything', notes: '' });
   });
 });
 

--- a/packages/mcp-server/src/remote-questions.ts
+++ b/packages/mcp-server/src/remote-questions.ts
@@ -833,6 +833,26 @@ function formatForTool(answer: RemoteAnswer): Record<string, { answers: string[]
 }
 
 /**
+ * Normalize a `RemoteAnswer` into the `RoundResult` shape the GSD
+ * discussion-gate hook reads from `tool_result` `details.response`. Mirrors
+ * `src/resources/extensions/remote-questions/manager.ts:toRoundResultResponse`.
+ * Without this, the remote channel (Discord / Slack / Telegram) would have
+ * the same gate-stuck problem as the local elicitation path. See #5267.
+ */
+export function toRoundResultResponse(answer: RemoteAnswer): {
+  endInterview: false;
+  answers: Record<string, { selected: string | string[]; notes: string }>;
+} {
+  const normalized: Record<string, { selected: string | string[]; notes: string }> = {};
+  for (const [id, data] of Object.entries(answer.answers)) {
+    const list = data.answers ?? [];
+    const selected: string | string[] = list.length <= 1 ? (list[0] ?? '') : list;
+    normalized[id] = { selected, notes: data.user_note ?? '' };
+  }
+  return { endInterview: false, answers: normalized };
+}
+
+/**
  * Dispatch questions to the configured remote channel and wait for a response.
  *
  * Returns null when no remote channel is configured.
@@ -926,6 +946,7 @@ export async function tryRemoteQuestions(
       promptId: prompt.id,
       threadUrl: ref.threadUrl ?? null,
       questions,
+      response: toRoundResultResponse(answer),
       status: 'answered',
     },
   };

--- a/packages/mcp-server/src/remote-questions.ts
+++ b/packages/mcp-server/src/remote-questions.ts
@@ -835,18 +835,32 @@ function formatForTool(answer: RemoteAnswer): Record<string, { answers: string[]
 /**
  * Normalize a `RemoteAnswer` into the `RoundResult` shape the GSD
  * discussion-gate hook reads from `tool_result` `details.response`. Mirrors
- * `src/resources/extensions/remote-questions/manager.ts:toRoundResultResponse`.
+ * `src/resources/extensions/remote-questions/manager.ts:toRoundResultResponse`
+ * and the local-path helper `buildAskUserQuestionsRoundResult` in server.ts.
  * Without this, the remote channel (Discord / Slack / Telegram) would have
  * the same gate-stuck problem as the local elicitation path. See #5267.
+ *
+ * `questions` is required so the multi-select contract is preserved: a
+ * `allowMultiple` question with a single selection must still surface
+ * `selected: [label]` so consumers reading `selected.includes(...)` keep
+ * working. Falling back to length-based inference (the previous behavior)
+ * silently demoted single-pick multi-select answers to strings.
  */
-export function toRoundResultResponse(answer: RemoteAnswer): {
+export function toRoundResultResponse(
+  answer: RemoteAnswer,
+  questions: RemoteQuestion[],
+): {
   endInterview: false;
   answers: Record<string, { selected: string | string[]; notes: string }>;
 } {
+  const allowMultipleById = new Map<string, boolean>();
+  for (const q of questions) allowMultipleById.set(q.id, q.allowMultiple ?? false);
+
   const normalized: Record<string, { selected: string | string[]; notes: string }> = {};
   for (const [id, data] of Object.entries(answer.answers)) {
     const list = data.answers ?? [];
-    const selected: string | string[] = list.length <= 1 ? (list[0] ?? '') : list;
+    const allowMultiple = allowMultipleById.get(id) ?? false;
+    const selected: string | string[] = allowMultiple ? list : (list[0] ?? '');
     normalized[id] = { selected, notes: data.user_note ?? '' };
   }
   return { endInterview: false, answers: normalized };
@@ -946,7 +960,7 @@ export async function tryRemoteQuestions(
       promptId: prompt.id,
       threadUrl: ref.threadUrl ?? null,
       questions,
-      response: toRoundResultResponse(answer),
+      response: toRoundResultResponse(answer, questions),
       status: 'answered',
     },
   };

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -329,6 +329,31 @@ interface AskUserQuestionsElicitRequest {
   };
 }
 
+/**
+ * Structured payload mirrored to the MCP `structuredContent` field on
+ * `ask_user_questions` results. Mirrors the `LocalResultDetails` shape that
+ * src/resources/extensions/ask-user-questions.ts already produces, so the
+ * GSD discussion-gate hook in register-hooks.ts can treat the MCP path
+ * identically to the in-process extension path. Without this, the bridge
+ * surfaces `details = undefined` and the gate hook's
+ * `if (details?.cancelled || !details?.response)` branch HARD-BLOCKs every
+ * user answer, including successful confirmations. See #5267.
+ */
+interface AskUserQuestionsRoundResultAnswer {
+  selected: string | string[];
+  notes: string;
+}
+
+interface AskUserQuestionsRoundResult {
+  answers: Record<string, AskUserQuestionsRoundResultAnswer>;
+}
+
+interface AskUserQuestionsStructuredContent {
+  questions: AskUserQuestion[];
+  response: AskUserQuestionsRoundResult | null;
+  cancelled: boolean;
+}
+
 const OTHER_OPTION_LABEL = 'None of the above';
 
 function normalizeAskUserQuestionsNote(value: AskUserQuestionsContentValue | undefined): string {
@@ -434,6 +459,38 @@ export function formatAskUserQuestionsElicitResult(
   return JSON.stringify({ answers });
 }
 
+/**
+ * Normalize an MCP elicitation form result into the `RoundResult` shape the
+ * GSD discussion-gate hook reads from `tool_result` `details.response`. The
+ * elicitation `content` map carries `{ [id]: label, [id]__note?: string }`;
+ * the hook expects `{ answers: { [id]: { selected, notes } } }`. Mirrored into
+ * `structuredContent` by `askUserQuestionsHandler`. See #5267.
+ */
+export function buildAskUserQuestionsRoundResult(
+  questions: AskUserQuestion[],
+  result: AskUserQuestionsElicitResult,
+): AskUserQuestionsRoundResult {
+  const answers: Record<string, AskUserQuestionsRoundResultAnswer> = {};
+  const content = result.content ?? {};
+
+  for (const question of questions) {
+    if (question.allowMultiple) {
+      const list = normalizeAskUserQuestionsAnswers(content[question.id], true);
+      answers[question.id] = { selected: list, notes: '' };
+      continue;
+    }
+
+    const list = normalizeAskUserQuestionsAnswers(content[question.id], false);
+    const selected = list[0] ?? '';
+    const notes = selected === OTHER_OPTION_LABEL
+      ? normalizeAskUserQuestionsNote(content[`${question.id}__note`])
+      : '';
+    answers[question.id] = { selected, notes };
+  }
+
+  return { answers };
+}
+
 interface AskUserQuestionsHandlerDeps {
   elicitInput(params: AskUserQuestionsElicitRequest): Promise<AskUserQuestionsElicitResult>;
   isRemoteConfigured(): boolean;
@@ -478,7 +535,15 @@ export async function askUserQuestionsHandler(
         'ask_user_questions',
       );
       if (elicitation.action === 'accept' && elicitation.content) {
-        return textContent(formatAskUserQuestionsElicitResult(questions, elicitation));
+        const structured: AskUserQuestionsStructuredContent = {
+          questions,
+          response: buildAskUserQuestionsRoundResult(questions, elicitation),
+          cancelled: false,
+        };
+        return {
+          content: [{ type: 'text' as const, text: formatAskUserQuestionsElicitResult(questions, elicitation) }],
+          structuredContent: structured as unknown as Record<string, unknown>,
+        };
       }
     } catch (err) {
       if (!isLocalElicitFallbackError(err)) throw err;
@@ -511,7 +576,15 @@ export async function askUserQuestionsHandler(
 
     if (localElicitError) throw localElicitError;
 
-    return textContent('ask_user_questions was cancelled before receiving a response');
+    const cancelledStructured: AskUserQuestionsStructuredContent = {
+      questions,
+      response: null,
+      cancelled: true,
+    };
+    return {
+      content: [{ type: 'text' as const, text: 'ask_user_questions was cancelled before receiving a response' }],
+      structuredContent: cancelledStructured as unknown as Record<string, unknown>,
+    };
   } catch (err) {
     return errorContent(err instanceof Error ? err.message : String(err));
   }
@@ -527,8 +600,8 @@ export type ElicitInputFn = (params: {
 }) => Promise<{ action: 'accept' | 'cancel' | 'decline'; content?: Record<string, unknown> }>;
 
 type ToolContent =
-  | { content: Array<{ type: 'text'; text: string }> }
-  | { isError: true; content: Array<{ type: 'text'; text: string }> };
+  | { content: Array<{ type: 'text'; text: string }>; structuredContent?: Record<string, unknown> }
+  | { isError: true; content: Array<{ type: 'text'; text: string }>; structuredContent?: Record<string, unknown> };
 
 export async function secureEnvCollectHandler(
   args: Record<string, unknown>,

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -345,6 +345,7 @@ interface AskUserQuestionsRoundResultAnswer {
 }
 
 interface AskUserQuestionsRoundResult {
+  endInterview: false;
   answers: Record<string, AskUserQuestionsRoundResultAnswer>;
 }
 
@@ -488,7 +489,10 @@ export function buildAskUserQuestionsRoundResult(
     answers[question.id] = { selected, notes };
   }
 
-  return { answers };
+  // `endInterview: false` mirrors the local extension's `RoundResult` shape and
+  // matches the remote path's `toRoundResultResponse` so register-hooks reads
+  // identical payloads regardless of channel. See peer review #5267-Q2.
+  return { endInterview: false, answers };
 }
 
 interface AskUserQuestionsHandlerDeps {
@@ -513,6 +517,18 @@ function isLocalElicitFallbackError(err: unknown): boolean {
 
 function formatErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Defensive guard for the `details.response` payload from `tryRemoteQuestions`.
+ * Accepts only an object with a plain `answers` map; anything else (null,
+ * stringified JSON, missing) falls back to `null` so the gate hook routes
+ * the cancel branch instead of crashing on `details.response.answers[id]`.
+ */
+function isRoundResultLike(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  const answers = (value as Record<string, unknown>)['answers'];
+  return !!answers && typeof answers === 'object' && !Array.isArray(answers);
 }
 
 export async function askUserQuestionsHandler(
@@ -568,9 +584,33 @@ export async function askUserQuestionsHandler(
       if (remoteResult) {
         const details = remoteResult.details as Record<string, unknown> | undefined;
         if (details?.['timed_out'] || details?.['error']) {
-          return textContent(remoteResult.content[0]?.text ?? 'Remote questions timed out or failed');
+          // Mirror the timeout/error into structuredContent so the gate hook's
+          // `details?.cancelled || !details?.response` branch fires correctly
+          // (gate stays pending, model re-asks) instead of silently dropping
+          // because no `details` made it across the MCP wire. See #5267.
+          const failedStructured: AskUserQuestionsStructuredContent = {
+            questions,
+            response: null,
+            cancelled: true,
+          };
+          return {
+            content: [{ type: 'text' as const, text: remoteResult.content[0]?.text ?? 'Remote questions timed out or failed' }],
+            structuredContent: failedStructured as unknown as Record<string, unknown>,
+          };
         }
-        return textContent(remoteResult.content[0]?.text ?? '');
+        // Successful remote answer — surface the normalized RoundResult that
+        // remote-questions.ts attached to `details.response` so the gate hook
+        // sees `details.response.answers[id].selected` on this path too.
+        const remoteResponse = isRoundResultLike(details?.['response']) ? details!['response'] as AskUserQuestionsRoundResult : null;
+        const acceptedStructured: AskUserQuestionsStructuredContent = {
+          questions,
+          response: remoteResponse,
+          cancelled: false,
+        };
+        return {
+          content: [{ type: 'text' as const, text: remoteResult.content[0]?.text ?? '' }],
+          structuredContent: acceptedStructured as unknown as Record<string, unknown>,
+        };
       }
     }
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -601,12 +601,22 @@ export async function askUserQuestionsHandler(
         // Successful remote answer — surface the normalized RoundResult that
         // remote-questions.ts attached to `details.response` so the gate hook
         // sees `details.response.answers[id].selected` on this path too.
-        const remoteResponse = isRoundResultLike(details?.['response']) ? details!['response'] as AskUserQuestionsRoundResult : null;
-        const acceptedStructured: AskUserQuestionsStructuredContent = {
-          questions,
-          response: remoteResponse,
-          cancelled: false,
-        };
+        // A malformed `response` (failing isRoundResultLike) is reported as
+        // an explicit cancellation rather than a silent `cancelled: false`
+        // with `response: null` — the latter would lie to any consumer that
+        // reads `structuredContent.cancelled` independently of `.response`.
+        const hasValidResponse = isRoundResultLike(details?.['response']);
+        const acceptedStructured: AskUserQuestionsStructuredContent = hasValidResponse
+          ? {
+              questions,
+              response: details!['response'] as AskUserQuestionsRoundResult,
+              cancelled: false,
+            }
+          : {
+              questions,
+              response: null,
+              cancelled: true,
+            };
         return {
           content: [{ type: 'text' as const, text: remoteResult.content[0]?.text ?? '' }],
           structuredContent: acceptedStructured as unknown as Record<string, unknown>,

--- a/src/tests/package-mcp-server-elicitation.test.ts
+++ b/src/tests/package-mcp-server-elicitation.test.ts
@@ -123,6 +123,123 @@ test('ask_user_questions returns the packaged answers JSON shape for form elicit
         },
       }),
     )
+
+    // Regression #5267: the gate hook reads `details.response.answers[id].selected`
+    // off the MCP `tool_result` event. The bridge maps `structuredContent`
+    // into `details`, so a missing `structuredContent` (or wrong inner shape)
+    // makes the discussion gate stay pending forever and HARD-BLOCKs every
+    // follow-up tool call.
+    assert.deepEqual(
+      (result as { structuredContent?: unknown }).structuredContent,
+      {
+        questions: [
+          {
+            id: 'deployment',
+            header: 'Deploy',
+            question: 'Where will this run?',
+            options: [
+              { label: 'Cloud', description: 'Managed hosting.' },
+              { label: 'On-prem', description: 'Runs in customer infrastructure.' },
+            ],
+          },
+        ],
+        response: {
+          answers: {
+            deployment: { selected: 'None of the above', notes: 'Need hybrid deployment.' },
+          },
+        },
+        cancelled: false,
+      },
+    )
+  } finally {
+    await close()
+  }
+})
+
+test('ask_user_questions structuredContent reflects an accepted single-select answer', async () => {
+  const { client, close } = await createConnectedClient({
+    onElicit: async () => ({
+      action: 'accept',
+      content: { confirm: 'Yes, you got it (Recommended)' },
+    }),
+  })
+
+  try {
+    const result = await client.callTool({
+      name: 'ask_user_questions',
+      arguments: {
+        questions: [
+          {
+            id: 'confirm',
+            header: 'Depth Check',
+            question: 'Did I capture the scope correctly?',
+            options: [
+              { label: 'Yes, you got it (Recommended)', description: 'Proceed.' },
+              { label: 'Not quite — let me clarify', description: 'Adjust.' },
+            ],
+          },
+        ],
+      },
+    })
+
+    assert.deepEqual(
+      (result as { structuredContent?: unknown }).structuredContent,
+      {
+        questions: [
+          {
+            id: 'confirm',
+            header: 'Depth Check',
+            question: 'Did I capture the scope correctly?',
+            options: [
+              { label: 'Yes, you got it (Recommended)', description: 'Proceed.' },
+              { label: 'Not quite — let me clarify', description: 'Adjust.' },
+            ],
+          },
+        ],
+        response: {
+          answers: {
+            confirm: { selected: 'Yes, you got it (Recommended)', notes: '' },
+          },
+        },
+        cancelled: false,
+      },
+    )
+  } finally {
+    await close()
+  }
+})
+
+test('ask_user_questions structuredContent reflects an accepted multi-select answer', async () => {
+  const { client, close } = await createConnectedClient({
+    onElicit: async () => ({
+      action: 'accept',
+      content: { focus: ['Frontend', 'Backend'] },
+    }),
+  })
+
+  try {
+    const result = await client.callTool({
+      name: 'ask_user_questions',
+      arguments: {
+        questions: [
+          {
+            id: 'focus',
+            header: 'Focus',
+            question: 'Which areas matter most?',
+            allowMultiple: true,
+            options: [
+              { label: 'Frontend', description: 'UI work.' },
+              { label: 'Backend', description: 'Server work.' },
+              { label: 'Infra', description: 'Ops work.' },
+            ],
+          },
+        ],
+      },
+    })
+
+    const structured = (result as { structuredContent?: { response?: { answers?: Record<string, { selected: unknown; notes: unknown }> } } }).structuredContent
+    assert.deepEqual(structured?.response?.answers?.focus, { selected: ['Frontend', 'Backend'], notes: '' })
+    assert.equal((result as { structuredContent?: { cancelled?: unknown } }).structuredContent?.cancelled, false)
   } finally {
     await close()
   }
@@ -183,9 +300,74 @@ test('ask_user_questions returns the cancellation message when elicitation is de
     const text = result.content.find(item => item.type === 'text')
     assert.ok(text && 'text' in text)
     assert.equal(text.text, 'ask_user_questions was cancelled before receiving a response')
+
+    // Regression #5267: the cancel/decline path must also surface a
+    // structuredContent payload so the gate hook routes the cancel branch
+    // (response: null, cancelled: true) instead of falling into the
+    // "missing details → HARD BLOCK with no recovery" path.
+    assert.deepEqual(
+      (result as { structuredContent?: unknown }).structuredContent,
+      {
+        questions: [
+          {
+            id: 'continue',
+            header: 'Continue',
+            question: 'Continue?',
+            options: [
+              { label: 'Yes', description: 'Proceed.' },
+              { label: 'No', description: 'Stop here.' },
+            ],
+          },
+        ],
+        response: null,
+        cancelled: true,
+      },
+    )
   } finally {
     await close()
   }
+})
+
+test('buildAskUserQuestionsRoundResult normalizes elicitation content into the gate-hook shape', async () => {
+  const mod = await import('../../packages/mcp-server/src/server.js') as {
+    buildAskUserQuestionsRoundResult: (questions: unknown[], result: { action: string; content?: Record<string, unknown> }) => { answers: Record<string, { selected: string | string[]; notes: string }> },
+  }
+  const buildAskUserQuestionsRoundResult = mod.buildAskUserQuestionsRoundResult
+  assert.equal(typeof buildAskUserQuestionsRoundResult, 'function', 'Helper buildAskUserQuestionsRoundResult must be exported from packages/mcp-server (regression #5267)')
+
+  const questions = [
+    { id: 'confirm', header: 'Confirm', question: 'Proceed?', options: [
+      { label: 'Yes', description: 'Go.' },
+      { label: 'No', description: 'Stop.' },
+    ] },
+    { id: 'focus', header: 'Focus', question: 'Which area?', allowMultiple: true, options: [
+      { label: 'Frontend', description: 'UI work.' },
+      { label: 'Backend', description: 'Server work.' },
+    ] },
+  ]
+
+  const accepted = buildAskUserQuestionsRoundResult(questions, {
+    action: 'accept',
+    content: {
+      confirm: 'Yes',
+      focus: ['Frontend', 'Backend'],
+    },
+  })
+  assert.deepEqual(accepted, {
+    answers: {
+      confirm: { selected: 'Yes', notes: '' },
+      focus: { selected: ['Frontend', 'Backend'], notes: '' },
+    },
+  })
+
+  const noteCarrying = buildAskUserQuestionsRoundResult([questions[0]], {
+    action: 'accept',
+    content: {
+      confirm: 'None of the above',
+      confirm__note: 'Want a hybrid path.',
+    },
+  })
+  assert.deepEqual(noteCarrying.answers.confirm, { selected: 'None of the above', notes: 'Want a hybrid path.' })
 })
 
 test('helper formatting stays aligned with the tool contract', () => {

--- a/src/tests/package-mcp-server-elicitation.test.ts
+++ b/src/tests/package-mcp-server-elicitation.test.ts
@@ -144,6 +144,7 @@ test('ask_user_questions returns the packaged answers JSON shape for form elicit
           },
         ],
         response: {
+          endInterview: false,
           answers: {
             deployment: { selected: 'None of the above', notes: 'Need hybrid deployment.' },
           },
@@ -197,6 +198,7 @@ test('ask_user_questions structuredContent reflects an accepted single-select an
           },
         ],
         response: {
+          endInterview: false,
           answers: {
             confirm: { selected: 'Yes, you got it (Recommended)', notes: '' },
           },
@@ -354,6 +356,7 @@ test('buildAskUserQuestionsRoundResult normalizes elicitation content into the g
     },
   })
   assert.deepEqual(accepted, {
+    endInterview: false,
     answers: {
       confirm: { selected: 'Yes', notes: '' },
       focus: { selected: ['Frontend', 'Backend'], notes: '' },


### PR DESCRIPTION
## TL;DR

**What:** Attach `structuredContent` to MCP `ask_user_questions` results so the GSD discussion-gate hook actually sees user answers on the Claude Code CLI path.
**Why:** Without it, every successful answer is treated as cancelled and HARD-BLOCKs the workflow — the depth_verification gate never clears.
**How:** Mirror the existing in-process `LocalResultDetails` shape (`{ questions, response: RoundResult|null, cancelled }`) into `structuredContent` on both the local-elicitation and remote (Discord/Slack/Telegram) success and cancel paths.

## What

`packages/mcp-server/src/server.ts`
- New `AskUserQuestionsStructuredContent` interface mirroring the `LocalResultDetails` shape used by `src/resources/extensions/ask-user-questions.ts`.
- New exported `buildAskUserQuestionsRoundResult(questions, elicitation)` normalizes the elicitation form `content` (`{ [id]: label, [id]__note?: string }`) into `{ endInterview: false, answers: { [id]: { selected, notes } } }`. Single-select returns `selected: string`; multi-select returns `selected: string[]`; `\"None of the above\"` carries the optional `__note` in `notes`.
- `askUserQuestionsHandler` now returns `structuredContent: { questions, response, cancelled }` on every terminal branch:
  - **local accept**: `response` = round result, `cancelled: false`
  - **remote success**: `response` = round result from remote (via `isRoundResultLike` guard), `cancelled: false`
  - **remote timeout/error**: `response: null`, `cancelled: true`
  - **fallthrough cancel** (local cancel/decline + remote not configured or returned null): `response: null`, `cancelled: true`
- `ToolContent` type widened to allow optional `structuredContent: Record<string, unknown>`.
- New defensive `isRoundResultLike` guard rejects malformed `details.response` payloads from the remote module so the gate hook can't crash on `response.answers[id]`.

`packages/mcp-server/src/remote-questions.ts`
- New exported `toRoundResultResponse(answer: RemoteAnswer)` returning the same `{ endInterview: false, answers }` shape. Mirrors the in-process implementation at `src/resources/extensions/remote-questions/manager.ts:178-186`.
- Success-path `details` now includes `response: toRoundResultResponse(answer)`.

## Why

Closes #5223.

The MCP-server `ask_user_questions` handler returned only text content. The Claude Code CLI bridge's `extractStructuredDetailsFromBlock` (stream-adapter.ts:1401-1425) populates the `tool_result` `details` field **exclusively** from `structuredContent`, so `details` was always `undefined` on the MCP path.

The GSD discussion-gate hook in `src/resources/extensions/gsd/bootstrap/register-hooks.ts:570-585` then evaluated `!details?.response` as `true` and HARD-BLOCKed every user answer, including correct depth_verification confirmations:

\`\`\`
HARD BLOCK: approval gate \"depth_verification_M001_confirm\" is still pending.
No user response was received for the confirmation question.
\`\`\`

The user then sees the model loop: re-ask → answer → blocked → re-ask → eventually a parallel tool batch tears down the second elicitation as `Cancelled`. This was almost certainly the same symptom #4614 (\"ask_user_questions selections trigger 'Cancelled' on Opus\") observed; the model-specific framing there was likely a red herring — Opus's longer turns just made the cycle more visible.

There was also a second shape mismatch: the MCP server's existing JSON serialized answers as `{ answers: { [id]: { answers: string[] } } }` while the hook reads `answer.selected`. Even if the existing JSON were promoted into `structuredContent`, the gate would not clear. The new `buildAskUserQuestionsRoundResult` and `toRoundResultResponse` helpers produce the correct `{ selected, notes }` shape on both paths.

## How

The fix lives entirely in `packages/mcp-server/`. No changes to the bridge, the hook, or any consumer downstream — both already handle the `LocalResultDetails`-shaped payload correctly via the in-process extension; the MCP path just needed to produce that same shape.

Local accept path (`server.ts:535-549`):
\`\`\`ts
const structured: AskUserQuestionsStructuredContent = {
  questions,
  response: buildAskUserQuestionsRoundResult(questions, elicitation),
  cancelled: false,
};
return { content: [...], structuredContent: structured as ... };
\`\`\`

Remote success path (`server.ts:582-609`) reads the normalized `response` already attached to `details` by the updated `tryRemoteQuestions` and forwards it as `structuredContent`.

Cancel/error paths return `{ questions, response: null, cancelled: true }` so the hook routes to its `details?.cancelled || !details?.response` branch instead of crashing on missing data.

### Peer review notes

Two rounds of `codex-peer-reviewer` validation:

- Round 1 confirmed root cause + caught the secondary shape mismatch (`{ answers: string[] }` vs `{ selected }`). Driven into the helper design.
- Round 2 (after remote-path fix) flagged: (a) `endInterview: false` shape divergence between local and remote — fixed by adding it to the local helper return value; (b) three missing test paths — added.

### Alternatives considered

1. **Patch the bridge** in `stream-adapter.ts` to also synthesize `details` from text content when no `structuredContent` is present. Rejected — would re-parse JSON ambiguously and apply to every MCP server, not just our own.
2. **Patch the gate hook** to accept the existing `{ answers: string[] }` JSON shape directly. Rejected — would split the consumer contract: in-process extension and remote module would still produce `{ selected }` while MCP would produce `{ answers }`. The hook is already the consumer; making the MCP path match the existing contract is the minimal change.

## Testing

Verified failing-before / passing-after on every regression assertion:

- `src/tests/package-mcp-server-elicitation.test.ts` — 8 tests (3 new + 2 augmented existing): structured payload on local accept (single-select, multi-select, None-of-the-above with note), local decline, helper unit test.
- `packages/mcp-server/src/mcp-server.test.ts` — 5 new tests: remote success, remote timeout, remote-unconfigured + local-decline cancel fallthrough, remote-configured + null cancel fallthrough, non-fallback local errors propagating as `isError`.
- `packages/mcp-server/src/remote-questions.test.ts` — 4 new tests for `toRoundResultResponse`: single-answer, multi-answer, user_note, empty-answers.

87/87 pass across `mcp-server` + `package-mcp-server-elicitation` + `remote-questions` + `register-hooks-depth-verification` (the consumer that was broken). 131/131 in adjacent suites (stream-adapter, in-process remote-questions/manager).

\`npm run verify:pr\` — re-run on CI, please.

### Test plan checklist

- [x] Build passes (`npx tsc --noEmit -p packages/mcp-server/tsconfig.json`)
- [x] `npm run test:compile` succeeds
- [x] Targeted suites pass (87/87 + 131/131 adjacent)
- [x] Manually verified failing assertions on `main` (5/8 elicitation tests fail without the fix)
- [ ] CI green
- [ ] Manual repro: claude-code-cli + GSD discuss-milestone, confirm depth_verification gate clears on accept

## Change type

- [x] `fix` — Bug fix
- [ ] `feat`
- [ ] `refactor`
- [ ] `test`
- [ ] `docs`
- [ ] `chore`

## Breaking changes

None. The `structuredContent` field is additive — clients that don't read it (any non-bridge consumer) get the same text payload as before. The text content of `ask_user_questions` is unchanged.

---

AI-assisted: drafted with Claude Code (Opus 4.7) and validated by two rounds of `codex-peer-reviewer` (independent context). All code understood and tested by the human author. No AI co-authorship credit on commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The ask_user_questions tool now always returns structured response data alongside text: normalized per-question answers, notes, endInterview flag, and a cancellation indicator for all outcomes.

* **Tests**
  * Expanded test coverage for local accept/decline paths, remote success/timeouts/malformed responses, non-fallbackable local errors, and normalization rules for single/multi-select, notes, and empty answers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->