### PR TITLE
feat(gsd): per-tool delegation policy + dispatch backgroundable annotation

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -80,34 +80,25 @@ Add to `.cursor/mcp.json`:
 The workflow MCP surface includes:
 
 - `gsd_decision_save`
-- `gsd_save_decision`
 - `gsd_requirement_update`
-- `gsd_update_requirement`
 - `gsd_requirement_save`
-- `gsd_save_requirement`
 - `gsd_milestone_generate_id`
-- `gsd_generate_milestone_id`
 - `gsd_plan_milestone`
 - `gsd_plan_slice`
 - `gsd_plan_task`
-- `gsd_task_plan`
 - `gsd_replan_slice`
-- `gsd_slice_replan`
 - `gsd_task_complete`
-- `gsd_complete_task`
 - `gsd_slice_complete`
-- `gsd_complete_slice`
 - `gsd_skip_slice`
 - `gsd_validate_milestone`
-- `gsd_milestone_validate`
 - `gsd_complete_milestone`
-- `gsd_milestone_complete`
 - `gsd_reassess_roadmap`
-- `gsd_roadmap_reassess`
 - `gsd_save_gate_result`
 - `gsd_summary_save`
 - `gsd_milestone_status`
 - `gsd_journal_query`
+
+**Aliases (kept for backwards compatibility — prefer the canonical name above):** `gsd_save_decision`, `gsd_update_requirement`, `gsd_save_requirement`, `gsd_generate_milestone_id`, `gsd_task_plan`, `gsd_slice_replan`, `gsd_complete_task`, `gsd_complete_slice`, `gsd_milestone_validate`, `gsd_milestone_complete`, `gsd_roadmap_reassess`.
 
 These tools use the same GSD workflow handlers as the native in-process tool path wherever a shared handler exists.
 

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -77,6 +77,7 @@ import {
   resolveDeepProjectSetupState,
   type DeepProjectSetupStage,
 } from "./deep-project-setup-policy.js";
+import { annotateBackgroundable } from "./delegation-policy.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -89,6 +90,12 @@ export type DispatchAction =
       pauseAfterDispatch?: boolean;
       /** Name of the matched dispatch rule from the unified registry (journal provenance). */
       matchedRule?: string;
+      /**
+       * True when the matched unit type has a `good` verdict in delegation-policy.ts.
+       * Annotated in `resolveDispatch`. Consumers may use this to fork the prompt
+       * to a background sub-agent; default behavior is unchanged (synchronous).
+       */
+      backgroundable?: boolean;
     }
   | { action: "stop"; reason: string; level: "info" | "warning" | "error"; matchedRule?: string }
   | { action: "skip"; matchedRule?: string };
@@ -1366,7 +1373,7 @@ export async function resolveDispatch(
   // Delegate to registry when available
   try {
     const registry = getRegistry();
-    return await registry.evaluateDispatch(ctx);
+    return annotateBackgroundable(await registry.evaluateDispatch(ctx));
   } catch (err) {
     // Registry not initialized — fall back to inline loop
     logWarning("dispatch", `registry dispatch failed, falling back to inline rules: ${err instanceof Error ? err.message : String(err)}`);
@@ -1376,7 +1383,7 @@ export async function resolveDispatch(
     const result = await rule.match(ctx);
     if (result) {
       if (result.action !== "skip") result.matchedRule = rule.name;
-      return result;
+      return annotateBackgroundable(result);
     }
   }
 
@@ -1391,6 +1398,7 @@ export async function resolveDispatch(
     matchedRule: "<no-match>",
   };
 }
+
 
 /** Exposed for testing — returns the rule names in evaluation order. */
 export function getDispatchRuleNames(): string[] {

--- a/src/resources/extensions/gsd/delegation-policy.ts
+++ b/src/resources/extensions/gsd/delegation-policy.ts
@@ -1,0 +1,126 @@
+// Delegation policy — codifies which GSD MCP tools are safe to run as
+// background sub-agents while the foreground /gsd flow continues. Verdicts
+// are derived from the round-1 and round-2 evaluations recorded in this
+// branch's PR description; the rationale field on each entry preserves
+// the reason so future changes have to revisit the analysis explicitly.
+//
+// Default-deny: unknown tools are never backgroundable.
+
+export type BackgroundabilityVerdict = "good" | "risky" | "no";
+
+export interface DelegationPolicyEntry {
+  /** Canonical MCP tool name (the verb_object form, e.g. `gsd_plan_slice`). */
+  toolName: string;
+  /** Workflow unit type from auto-dispatch.ts, when one exists. */
+  unitType?: string;
+  verdict: BackgroundabilityVerdict;
+  /** One-line justification grounded in the evaluation findings. */
+  rationale: string;
+  /**
+   * Constraints the caller MUST satisfy when dispatching this unit in the
+   * background. Only populated for `good` and conditional `risky` entries.
+   */
+  constraints?: string[];
+}
+
+const POLICY: Record<string, DelegationPolicyEntry> = {
+  gsd_plan_slice: {
+    toolName: "gsd_plan_slice",
+    unitType: "plan-slice",
+    verdict: "good",
+    rationale:
+      "Self-contained, no user prompts, atomic DB tx; existing slice-parallel-orchestrator pattern transfers cleanly.",
+    constraints: [
+      "Lock the slice from further user discussion once dispatched (context is frozen at dispatch time).",
+      "Foreground must not derive state for that slice while the transaction is in flight.",
+      "Foreground must await background completion before any tool reads the planned tasks/gates.",
+    ],
+  },
+  gsd_execute: {
+    toolName: "gsd_execute",
+    verdict: "good",
+    rationale:
+      "No DB writes; UUID-isolated stdout/stderr/meta files; existing reactive-execute parallel-subagent precedent.",
+  },
+  gsd_validate_milestone: {
+    toolName: "gsd_validate_milestone",
+    unitType: "validate-milestone",
+    verdict: "good",
+    rationale:
+      "Verdict pre-computed by parallel reviewers; atomic DB tx plus isolated VALIDATION.md write; no user interaction.",
+  },
+  gsd_reassess_roadmap: {
+    toolName: "gsd_reassess_roadmap",
+    unitType: "reassess-roadmap",
+    verdict: "good",
+    rationale:
+      "Narrower mutation scope than plan_milestone; structural guards prevent modification of completed slices.",
+  },
+  gsd_doctor: {
+    toolName: "gsd_doctor",
+    verdict: "risky",
+    rationale:
+      "Diagnostic-only mode (fix=false) is safe to background; fix=true writes STATE.md/ROADMAP.md without session-lock coordination and can race the foreground flow.",
+    constraints: [
+      "Background only with fix=false (diagnostic-only).",
+      "Apply fixes synchronously, only when no foreground unit is dispatched.",
+    ],
+  },
+  gsd_plan_milestone: {
+    toolName: "gsd_plan_milestone",
+    unitType: "plan-milestone",
+    verdict: "risky",
+    rationale:
+      "Inputs require CONTEXT.md from discuss-milestone, so initial questioning is already done by the time it can start; TOCTOU guards and projection coherence make concurrency unsafe.",
+  },
+  gsd_replan_slice: {
+    toolName: "gsd_replan_slice",
+    unitType: "replan-slice",
+    verdict: "risky",
+    rationale:
+      "Blocks the replanning→executing state transition on a gate that waits for S##-REPLAN.md; background failure leaves the flow stuck.",
+  },
+  gsd_plan_task: {
+    toolName: "gsd_plan_task",
+    verdict: "no",
+    rationale:
+      "plan-slice prompt explicitly forbids calling gsd_plan_task separately; per-task granularity multiplies manifest writes and projection re-renders with no payoff.",
+  },
+};
+
+// Alias map keyed on the secondary name; resolves to the canonical entry above.
+// Sourced from packages/mcp-server/src/workflow-tools.ts alias registrations
+// (gsd_milestone_validate, gsd_roadmap_reassess, gsd_slice_replan, gsd_task_plan).
+const ALIASES: Record<string, string> = {
+  gsd_milestone_validate: "gsd_validate_milestone",
+  gsd_roadmap_reassess: "gsd_reassess_roadmap",
+  gsd_slice_replan: "gsd_replan_slice",
+  gsd_task_plan: "gsd_plan_task",
+};
+
+function resolveCanonical(name: string): string {
+  return ALIASES[name] ?? name;
+}
+
+export function getDelegationVerdict(toolName: string): DelegationPolicyEntry | null {
+  return POLICY[resolveCanonical(toolName)] ?? null;
+}
+
+export function isBackgroundable(toolName: string): boolean {
+  const entry = getDelegationVerdict(toolName);
+  return entry?.verdict === "good";
+}
+
+export function listBackgroundableTools(): string[] {
+  return Object.values(POLICY)
+    .filter((entry) => entry.verdict === "good")
+    .map((entry) => entry.toolName)
+    .sort();
+}
+
+export function getVerdictByUnitType(unitType: string): DelegationPolicyEntry | null {
+  for (const entry of Object.values(POLICY)) {
+    if (entry.unitType === unitType) return entry;
+  }
+  return null;
+}

--- a/src/resources/extensions/gsd/delegation-policy.ts
+++ b/src/resources/extensions/gsd/delegation-policy.ts
@@ -5,6 +5,35 @@
 // the reason so future changes have to revisit the analysis explicitly.
 //
 // Default-deny: unknown tools are never backgroundable.
+//
+// ─── Tool-name vs unit-type namespaces ───────────────────────────────────
+// Entries are keyed by canonical MCP tool name (`gsd_*`). The optional
+// `unitType` field is a *secondary* index for the dispatcher's convenience
+// — it bridges this policy to `auto-dispatch.ts`' `DispatchAction.unitType`
+// values. The two namespaces are not 1:1:
+//
+//   - Some tools have no corresponding unit type (e.g. `gsd_doctor`,
+//     `gsd_plan_task`) and intentionally omit `unitType`.
+//   - Some unit types share a tool — e.g. `execute-task`, `execute-task-simple`,
+//     and `reactive-execute` all invoke `gsd_execute`. The current shape
+//     allows only one `unitType` per entry, so those units fall through to
+//     `getVerdictByUnitType() === null` (→ `backgroundable: false`) even
+//     though `gsd_execute` itself is GOOD. This is the intended default-deny
+//     posture until a future PR wires actual background dispatch and
+//     decides whether each unit-level orchestration is safe — the unit
+//     wraps a prompt, harness setup, and post-processing on top of the
+//     tool, and the tool's safety doesn't transfer automatically.
+//
+// Auto-dispatch produces 20 distinct unit types; only 5 are explicitly
+// classified here. The other 15 default-deny:
+//   complete-milestone, complete-slice, discuss-milestone, discuss-project,
+//   discuss-requirements, execute-task, execute-task-simple, gate-evaluate,
+//   reactive-execute, refine-slice, research-decision, research-milestone,
+//   research-project, research-slice, rewrite-docs, run-uat
+//
+// Adding a `unitType` mapping (or a future `unitTypes: string[]`) to an
+// existing entry is the place to lift any of these out of default-deny
+// when the analysis has been done.
 
 export type BackgroundabilityVerdict = "good" | "risky" | "no";
 
@@ -38,6 +67,12 @@ const POLICY: Record<string, DelegationPolicyEntry> = {
   },
   gsd_execute: {
     toolName: "gsd_execute",
+    // No `unitType` set on purpose — the underlying tool is safe, but the
+    // unit-level orchestrations that invoke it (`execute-task`,
+    // `execute-task-simple`, `reactive-execute`) wrap additional prompt and
+    // harness work whose safety is a separate analysis. Default-deny those
+    // units until that analysis is recorded; adding `unitType` here would
+    // promote them silently.
     verdict: "good",
     rationale:
       "No DB writes; UUID-isolated stdout/stderr/meta files; existing reactive-execute parallel-subagent precedent.",
@@ -140,6 +175,19 @@ export type AnnotatableDispatchAction =
  * Annotates a dispatch action in place with `backgroundable: true` when its
  * unitType has a `good` verdict in the policy. Stop/skip actions pass through
  * unchanged. Default-deny: unknown unit types resolve to `false`.
+ *
+ * **Mutation contract.** The `backgroundable` field is written directly onto
+ * the passed action object. This is intentional — every dispatch path in
+ * `auto-dispatch.ts` constructs a fresh action object per `where(ctx)` /
+ * `evaluateDispatch(ctx)` invocation, so in-place mutation cannot leak across
+ * dispatch cycles. Future dispatch rules MUST follow that convention: never
+ * cache or share `DispatchAction` objects across calls. If you need to cache,
+ * either freeze the cached object (`Object.freeze`) and clone on read, or
+ * stop calling `annotateBackgroundable` on the shared instance. The annotator
+ * always recomputes from the policy on every call (no internal cache), so
+ * repeated invocations on the same object will overwrite stale values
+ * deterministically — see the `annotateBackgroundable recomputes on each call`
+ * test for the contract pin.
  */
 export function annotateBackgroundable<T extends AnnotatableDispatchAction>(action: T): T {
   if (action.action !== "dispatch") return action;

--- a/src/resources/extensions/gsd/delegation-policy.ts
+++ b/src/resources/extensions/gsd/delegation-policy.ts
@@ -124,3 +124,26 @@ export function getVerdictByUnitType(unitType: string): DelegationPolicyEntry | 
   }
   return null;
 }
+
+/**
+ * Minimal shape of a dispatch action that the annotator needs to operate on.
+ * Matches the `dispatch` and non-dispatch variants of auto-dispatch.ts'
+ * DispatchAction without depending on it (so this module stays free of
+ * workspace-package transitive imports).
+ */
+export type AnnotatableDispatchAction =
+  | { action: "dispatch"; unitType: string; backgroundable?: boolean; [k: string]: unknown }
+  | { action: "stop"; [k: string]: unknown }
+  | { action: "skip"; [k: string]: unknown };
+
+/**
+ * Annotates a dispatch action in place with `backgroundable: true` when its
+ * unitType has a `good` verdict in the policy. Stop/skip actions pass through
+ * unchanged. Default-deny: unknown unit types resolve to `false`.
+ */
+export function annotateBackgroundable<T extends AnnotatableDispatchAction>(action: T): T {
+  if (action.action !== "dispatch") return action;
+  const verdict = getVerdictByUnitType(action.unitType);
+  action.backgroundable = verdict?.verdict === "good";
+  return action;
+}

--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -28,7 +28,7 @@ This unit runs under the `planning-dispatch` tools-policy: you may use the `suba
 - **Touched auth, network, parsing, file IO, shell exec, or crypto** → dispatch the **security** agent for an OWASP-style audit.
 - **Added or modified tests** → dispatch the **tester** agent to assess coverage gaps relative to the slice plan.
 
-Subagents read the diff and report findings — they do **not** write user source. You remain responsible for acting on their feedback before calling `gsd_complete_slice` with `milestoneId` and `sliceId`.
+Subagents read the diff and report findings — they do **not** write user source. You remain responsible for acting on their feedback before calling `gsd_slice_complete` with `milestoneId` and `sliceId`.
 
 Then:
 1. Use the **Slice Summary** and **UAT** output templates from the inlined context above
@@ -37,11 +37,11 @@ Then:
 4. If the slice plan includes observability/diagnostic surfaces, confirm they work. Skip this for simple slices that don't have observability sections.
 5. Address every gate listed in the **Gates to Close** section above — each gate maps to a specific slice-summary section the handler inspects (for example, Q8 maps to **Operational Readiness**: health signal, failure signal, recovery procedure, and monitoring gaps). Leaving a section empty records the gate as `omitted`.
 6. If this slice produced evidence that a requirement changed status (Active → Validated, Active → Deferred, etc.), call `gsd_requirement_update` with the requirement ID, updated `status`, and `validation` evidence. Do NOT write `.gsd/REQUIREMENTS.md` directly — the engine renders it from the database.
-7. Prepare the slice completion content you will pass to `gsd_complete_slice` using the camelCase fields `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, and `uatContent`. Do **not** manually write `{{sliceSummaryPath}}`. Do **not** manually write `{{sliceUatPath}}` — the DB-backed tool is the canonical write path for both artifacts.
+7. Prepare the slice completion content you will pass to `gsd_slice_complete` using the camelCase fields `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, and `uatContent`. Do **not** manually write `{{sliceSummaryPath}}`. Do **not** manually write `{{sliceUatPath}}` — the DB-backed tool is the canonical write path for both artifacts.
 8. Draft the UAT content you will pass as `uatContent` — a concrete UAT script with real test cases derived from the slice plan and task summaries. Include preconditions, numbered steps with expected outcomes, and edge cases. This must NOT be a placeholder or generic template — tailor every test case to what this slice actually built. Fill the `UAT Type` and `Not Proven By This UAT` sections explicitly so the artifact states what class of acceptance it covers and what still remains unproven (e.g. live integration paths, performance under load, scenarios deferred to a later slice).
 9. Review task summaries for `key_decisions`. For each significant decision, call `capture_thought` with `category: "architecture"` (or `"pattern"`) and a `structuredFields` payload of `{ scope, decision, choice, rationale, made_by: "agent", revisable }`.
 10. Review task summaries for patterns, gotchas, or non-obvious lessons learned. For each one that would save future agents from repeating investigation, call `capture_thought` with the matching category (`gotcha`, `convention`, `pattern`, `environment`). The memory store is the single source of truth (ADR-013); do not append to `.gsd/DECISIONS.md` or `.gsd/KNOWLEDGE.md` directly.
-11. Call `gsd_complete_slice` with the camelCase fields `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, and `uatContent`, plus any optional enrichment fields you have. Do NOT manually mark the roadmap checkbox — the tool writes to the DB, renders `{{sliceSummaryPath}}` and `{{sliceUatPath}}`, and updates the ROADMAP.md projection automatically.
+11. Call `gsd_slice_complete` with the camelCase fields `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, and `uatContent`, plus any optional enrichment fields you have. Do NOT manually mark the roadmap checkbox — the tool writes to the DB, renders `{{sliceSummaryPath}}` and `{{sliceUatPath}}`, and updates the ROADMAP.md projection automatically.
 12. Do not run git commands — the system commits your changes and handles any merge after this unit succeeds.
 13. Update `.gsd/PROJECT.md` if it exists — refresh current state if needed: use the `write` tool with `path: ".gsd/PROJECT.md"` and `content` containing the full updated document reflecting current project state. Do NOT use the `edit` tool for this — PROJECT.md is a full-document refresh.
 
@@ -49,6 +49,6 @@ Then:
 
 **File system safety:** Task summaries are preloaded in the inlined context above. Task artifacts use a **flat file layout** — files such as `T01-SUMMARY.md` and `T02-SUMMARY.md` live directly inside the `tasks/` directory, not inside per-task subdirectories like `tasks/T01/SUMMARY.md`. If you need to re-read any of them, use `find .gsd/milestones/{{milestoneId}}/slices/{{sliceId}}/tasks -name "*-SUMMARY.md"` to list file paths first. Never use `tasks/*/SUMMARY.md`, and never pass `{{slicePath}}` or any other directory path directly to the `read` tool. The `read` tool only accepts file paths, not directories.
 
-**You MUST call `gsd_complete_slice` with the slice summary and UAT content before finishing. The tool persists to both DB and disk and renders `{{sliceSummaryPath}}` and `{{sliceUatPath}}` automatically.**
+**You MUST call `gsd_slice_complete` with the slice summary and UAT content before finishing. The tool persists to both DB and disk and renders `{{sliceSummaryPath}}` and `{{sliceUatPath}}` automatically.**
 
 When done, say: "Slice {{sliceId}} complete."

--- a/src/resources/extensions/gsd/prompts/execute-task.md
+++ b/src/resources/extensions/gsd/prompts/execute-task.md
@@ -85,14 +85,14 @@ Then:
 17. If you made an architectural, pattern, library, or observability decision during this task that downstream work should know about, call `capture_thought` with `category: "architecture"` (or `"pattern"`). For decisions, populate `structuredFields` with `{ scope, decision, choice, rationale, made_by: "agent", revisable }` so future projection back to a human-visible decisions register stays lossless. Not every task produces decisions — only capture when a meaningful choice was made.
 18. If you discover a non-obvious rule, recurring gotcha, or useful pattern during execution, call `capture_thought` with `category: "gotcha"`, `"convention"`, `"pattern"`, or `"environment"` as appropriate. Only capture entries that would save future agents from repeating your investigation — don't capture obvious things. The memory store is the single source of truth for cross-session knowledge (ADR-013); do not append to `.gsd/DECISIONS.md` or `.gsd/KNOWLEDGE.md` directly.
 19. Read the template at `~/.gsd/agent/extensions/gsd/templates/task-summary.md`
-20. Use that template to prepare the completion content you will pass to `gsd_complete_task` using the camelCase fields `milestoneId`, `sliceId`, `taskId`, `oneLiner`, `narrative`, `verification`, and `verificationEvidence`. Do **not** manually write `{{taskSummaryPath}}` — the DB-backed tool is the canonical write path and renders the summary file for you.
-21. Call `gsd_complete_task` with milestoneId, sliceId, taskId, and the completion fields derived from the template. This is your final required step — do NOT manually edit PLAN.md checkboxes. The tool marks the task complete, updates the DB, renders `{{taskSummaryPath}}`, and updates PLAN.md automatically.
+20. Use that template to prepare the completion content you will pass to `gsd_task_complete` using the camelCase fields `milestoneId`, `sliceId`, `taskId`, `oneLiner`, `narrative`, `verification`, and `verificationEvidence`. Do **not** manually write `{{taskSummaryPath}}` — the DB-backed tool is the canonical write path and renders the summary file for you.
+21. Call `gsd_task_complete` with milestoneId, sliceId, taskId, and the completion fields derived from the template. This is your final required step — do NOT manually edit PLAN.md checkboxes. The tool marks the task complete, updates the DB, renders `{{taskSummaryPath}}`, and updates PLAN.md automatically.
 22. Do not run git commands — the system reads your task summary after completion and creates a meaningful commit from it (type inferred from title, message from your one-liner, key files from frontmatter). Write a clear, specific one-liner in the summary — it becomes the commit message.
 
 All work stays in your working directory: `{{workingDirectory}}`.
 
 **Autonomous execution:** Do not call `ask_user_questions` or `secure_env_collect`. You are running in auto-mode — there is no human available to answer questions. Make reasonable assumptions and document them in the task summary. If a decision genuinely requires human input, note it in the summary and proceed with the best available option.
 
-**You MUST call `gsd_complete_task` before finishing. Do not manually write `{{taskSummaryPath}}`.**
+**You MUST call `gsd_task_complete` before finishing. Do not manually write `{{taskSummaryPath}}`.**
 
 When done, say: "Task {{taskId}} complete."

--- a/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
@@ -12,6 +12,13 @@ Discuss milestone {{milestoneId}} ("{{milestoneTitle}}"). Identify gray areas, a
 
 {{fastPathInstruction}}
 
+### Read project shape
+
+Before your first question round, read `.gsd/PROJECT.md` and look for `## Project Shape` → `**Complexity:**`. The verdict is either **`simple`** or **`complex`** (default to `complex` if PROJECT.md is missing the section, predates this convention, or the value is unclear). The verdict scales the rest of this stage:
+
+- **`simple`** — favor 1–2 plain-text question rounds. Skip the parallel-research investigation. Skip `ask_user_questions` unless presenting concrete alternatives.
+- **`complex`** — full investigation, 3–4-option structured questions, multi-round.
+
 ### Before your first question round
 
 Do a lightweight targeted investigation so your questions are grounded in reality:
@@ -36,7 +43,7 @@ Ask **1–3 questions per round**. Keep each question focused on one of:
 
 **Never fabricate or simulate user input.** Never generate fake transcript markers like `[User]`, `[Human]`, or `User:`. Ask one question round, then wait for the user's actual response before continuing.
 
-**If `{{structuredQuestionsAvailable}}` is `true`:** use `ask_user_questions` for each round. 1–3 questions per call, each as a separate question object. Keep option labels short (3–5 words). Always include a freeform "Other / let me explain" option. When the user picks that option or writes a long freeform answer, switch to plain text follow-up for that thread before resuming structured questions. **IMPORTANT: Call `ask_user_questions` exactly once per turn. Never make multiple calls with the same or overlapping questions — wait for the user's response before asking the next round.**
+**If `{{structuredQuestionsAvailable}}` is `true`:** use `ask_user_questions` for each round. 1–3 questions per call, each as a separate question object. Keep option labels short (3–5 words). In **`complex`** mode, each multi-choice question MUST present **3 or 4 concrete, researched options** plus a final **"Other — let me discuss"** option; options must be grounded in the investigation above (codebase signals, library docs, prior `.gsd/` artifacts), not generic placeholders. In **`simple`** mode, 2 options is fine when alternatives are genuinely binary. Binary depth-check / wrap-up gates are exempt from the 3-or-4 rule. When the user picks "Other — let me discuss" or writes a long freeform answer, switch to plain text follow-up for that thread before resuming structured questions. **IMPORTANT: Call `ask_user_questions` exactly once per turn. Never make multiple calls with the same or overlapping questions — wait for the user's response before asking the next round.**
 
 **If `{{structuredQuestionsAvailable}}` is `false`:** ask questions in plain text. Keep each round to 1–3 focused questions. Wait for answers before asking the next round.
 

--- a/src/resources/extensions/gsd/prompts/guided-discuss-project.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-project.md
@@ -26,6 +26,18 @@ Ask the user a single freeform question in plain text, not structured: **"What d
 
 Wait for their response. This grounds every follow-up in their own terminology.
 
+### Classify project shape
+
+After the opening answer, classify the project as **`simple`** or **`complex`** before continuing. Print the verdict in chat as one line: `Project shape: simple` or `Project shape: complex` followed by a one-line rationale.
+
+**`simple`** — most of these apply: single primary user (the user themselves or one immediate team), no external integrations beyond well-known SDKs/libs, greenfield or self-contained, scope describable in 1–2 sentences without ambiguity, no compliance/regulatory needs, ≤5 distinct capabilities.
+
+**`complex`** — any of these apply: multi-user with roles/permissions, non-trivial brownfield codebase, external integrations with auth/data exchange, compliance/security/regulated domain (PII, payments, healthcare), >5 capabilities or unclear scope, cross-team/cross-org coordination, novel domain where assumptions need validation.
+
+**Default to `complex` when uncertain.** The user can override the verdict in plain text; if they do, accept it and proceed.
+
+The verdict drives the rest of this stage and gets persisted to PROJECT.md → `## Project Shape`. Downstream stages (`discuss-requirements`, `discuss-milestone`, `discuss-slice`) read it from there.
+
 ### Before deeper rounds
 
 Do a lightweight targeted investigation so your questions are grounded in reality:
@@ -50,9 +62,11 @@ Ask **1–3 questions per round**. Each round targets one of:
 
 **Never fabricate or simulate user input.** Never generate fake transcript markers like `[User]`, `[Human]`, or `User:`. Ask one question round, then wait for the user's actual response before continuing.
 
-**Plain-text default:** Project discovery is open-ended. Ask question rounds in plain text unless you are presenting 2–3 concrete alternatives with clear tradeoffs.
+**Cadence is shape-dependent:**
+- **`simple`** — favor 1–2 plain-text rounds. Skip `ask_user_questions` unless you are presenting concrete alternatives. Get to the depth checklist fast.
+- **`complex`** — full investigation, multiple rounds, structured questions when meaningful alternatives exist.
 
-**If `{{structuredQuestionsAvailable}}` is `true` and you use `ask_user_questions`:** ask 1–3 questions per call. Every question object MUST include a stable lowercase `id`. Keep option labels short (3–5 words). Do not add a separate "Other" option; the question UI provides a freeform path automatically. Wait for each tool result before asking the next round.
+**If `{{structuredQuestionsAvailable}}` is `true` and you use `ask_user_questions`:** ask 1–3 questions per call. Every question object MUST include a stable lowercase `id`. Keep option labels short (3–5 words). In **`complex`** mode, each multi-choice question MUST present **3 or 4 concrete, researched options** plus a final **"Other — let me discuss"** option; options must be grounded in your investigation (codebase signals, library docs, prior `.gsd/` artifacts), not generic placeholders. In **`simple`** mode, 2 options is fine. Binary depth-check / wrap-up gates are exempt from the 3-or-4 rule. Wait for each tool result before asking the next round.
 
 **If `{{structuredQuestionsAvailable}}` is `false`:** ask questions in plain text. Keep each round to 1–3 focused questions.
 
@@ -126,8 +140,9 @@ Once the user confirms depth:
 
 1. Use the **Project** output template (inlined above).
 2. Call `gsd_summary_save` with `artifact_type: "PROJECT"` and the full project markdown as `content`; omit `milestone_id`. The tool writes `.gsd/PROJECT.md` to disk and persists to DB. Preserve the user's exact terminology, emphasis, and framing.
-3. The `## Capability Contract` section MUST reference `.gsd/REQUIREMENTS.md` — that file does not yet exist; the next stage (`discuss-requirements`) will produce it.
-4. The `## Milestone Sequence` MUST list at least M001 with title and one-liner. Subsequent milestones may be listed as known intents; they will be elaborated in their own discuss-milestone stages.
-5. Do NOT use `artifact_type: "CONTEXT"` and do NOT pass `milestone_id: "PROJECT"`; that creates a fake milestone named PROJECT.
-6. {{commitInstruction}}
-7. Say exactly: `"Project context written."` — nothing else.
+3. The `## Project Shape` section MUST contain `**Complexity:** simple` or `**Complexity:** complex` (matching the verdict you announced) plus a one-line `**Why:**` rationale. Downstream stages read this line.
+4. The `## Capability Contract` section MUST reference `.gsd/REQUIREMENTS.md` — that file does not yet exist; the next stage (`discuss-requirements`) will produce it.
+5. The `## Milestone Sequence` MUST list at least M001 with title and one-liner. Subsequent milestones may be listed as known intents; they will be elaborated in their own discuss-milestone stages.
+6. Do NOT use `artifact_type: "CONTEXT"` and do NOT pass `milestone_id: "PROJECT"`; that creates a fake milestone named PROJECT.
+7. {{commitInstruction}}
+8. Say exactly: `"Project context written."` — nothing else.

--- a/src/resources/extensions/gsd/prompts/guided-discuss-requirements.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-requirements.md
@@ -21,7 +21,7 @@ Before your first action, print this banner verbatim in chat:
 ## Pre-flight
 
 1. Read `.gsd/PROJECT.md` end-to-end. If it does not exist, STOP and emit: `"PROJECT.md missing — run discuss-project first."`
-2. Extract: Core Value, Anti-goals, Constraints, Milestone Sequence, **Project Shape → Complexity** (verdict is either `simple` or `complex`; default to `complex` if the section is missing or unclear).
+2. Extract: Core Value, Anti-goals, Constraints, Milestone Sequence, and the project shape verdict — read the `## Project Shape` section and look for `**Complexity:**` (verdict is either `simple` or `complex`; default to `complex` if the section is missing or unclear).
 3. Check for existing `.gsd/REQUIREMENTS.md` — if present, this is a refinement pass, not a fresh write. Read existing requirements and treat them as the working set.
 
 **Shape-dependent cadence:**

--- a/src/resources/extensions/gsd/prompts/guided-discuss-requirements.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-requirements.md
@@ -21,8 +21,12 @@ Before your first action, print this banner verbatim in chat:
 ## Pre-flight
 
 1. Read `.gsd/PROJECT.md` end-to-end. If it does not exist, STOP and emit: `"PROJECT.md missing — run discuss-project first."`
-2. Extract: Core Value, Anti-goals, Constraints, Milestone Sequence.
+2. Extract: Core Value, Anti-goals, Constraints, Milestone Sequence, **Project Shape → Complexity** (verdict is either `simple` or `complex`; default to `complex` if the section is missing or unclear).
 3. Check for existing `.gsd/REQUIREMENTS.md` — if present, this is a refinement pass, not a fresh write. Read existing requirements and treat them as the working set.
+
+**Shape-dependent cadence:**
+- **`simple`** — favor a single fast pass: extract requirements directly from PROJECT.md, ask 1–2 plain-text clarifying questions only if a class or status assignment is genuinely ambiguous, then write REQUIREMENTS.md.
+- **`complex`** — full multi-round questioning with structured 3–4-option questions where alternatives matter.
 
 ---
 
@@ -51,7 +55,7 @@ Ask **1–3 questions per round**. Each round targets one dimension:
 
 **Never fabricate or simulate user input.** Wait for actual responses.
 
-**If `{{structuredQuestionsAvailable}}` is `true`:** use `ask_user_questions`. Every question object MUST include a stable lowercase `id`. For class assignments, present the allowed classes as multi-select options. For status, present the four statuses as exclusive options. Ask 1–3 questions per call. Wait for each tool result before asking the next round.
+**If `{{structuredQuestionsAvailable}}` is `true`:** use `ask_user_questions`. Every question object MUST include a stable lowercase `id`. For class assignments, present the allowed classes as multi-select options. For status, present the four statuses as exclusive options. In **`complex`** mode, any free-form question MUST present **3 or 4 concrete, researched options** plus a final **"Other — let me discuss"** option grounded in the investigation above. The class-assignment and status questions are exempt — they have fixed enumerations. Ask 1–3 questions per call. Wait for each tool result before asking the next round.
 
 **If `{{structuredQuestionsAvailable}}` is `false`:** ask in plain text. Keep each round to 1–3 questions.
 

--- a/src/resources/extensions/gsd/prompts/guided-discuss-slice.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-slice.md
@@ -8,6 +8,13 @@ Your goal is **not** to center the discussion on tech stack trivia, naming conve
 
 ## Interview Protocol
 
+### Read project shape
+
+Before your first question round, read `.gsd/PROJECT.md` and look for `## Project Shape` → `**Complexity:**`. The verdict is either **`simple`** or **`complex`** (default to `complex` if the section is missing or unclear).
+
+- **`simple`** — favor 1–2 plain-text rounds, write the slice context fast. Skip parallel-research investigation.
+- **`complex`** — full investigation with structured 3–4-option questions.
+
 ### Before your first question round
 
 Do a lightweight targeted investigation so your questions are grounded in reality:
@@ -24,7 +31,7 @@ Do **not** go deep — just enough that your questions reflect what's actually t
 
 **Never fabricate or simulate user input.** Never generate fake transcript markers like `[User]`, `[Human]`, or `User:`. Ask one question round, then wait for the user's actual response before continuing.
 
-**If `{{structuredQuestionsAvailable}}` is `true`:** Ask **1–3 questions per round** using `ask_user_questions`. **Call `ask_user_questions` exactly once per turn — never make multiple calls with the same or overlapping questions. Wait for the user's response before asking the next round.**
+**If `{{structuredQuestionsAvailable}}` is `true`:** Ask **1–3 questions per round** using `ask_user_questions`. In **`complex`** mode, each multi-choice question MUST present **3 or 4 concrete, researched options** plus a final **"Other — let me discuss"** option; options must be grounded in the investigation above (codebase signals, library docs, prior `.gsd/` artifacts), not generic placeholders. In **`simple`** mode, 2 options is fine. Binary wrap-up gates are exempt from the 3-or-4 rule. **Call `ask_user_questions` exactly once per turn — never make multiple calls with the same or overlapping questions. Wait for the user's response before asking the next round.**
 **If `{{structuredQuestionsAvailable}}` is `false`:** Ask **1–3 questions per round** in plain text. Number them and wait for the user's response before asking the next round.
 Keep each question focused on one of:
 - **UX and user-facing behaviour** — what does the user see, click, trigger, or experience?

--- a/src/resources/extensions/gsd/templates/project.md
+++ b/src/resources/extensions/gsd/templates/project.md
@@ -11,6 +11,16 @@
 
 {{theOneThingThatMustWorkEvenIfEverythingElseIsCut}}
 
+## Project Shape
+
+<!-- Drives questioning depth in downstream stages. `simple` → short plain-text
+     rounds, fast PROJECT/CONTEXT/REQUIREMENTS writes. `complex` → researched
+     3–4-option questions with an "Other — let me discuss" hatch.
+     Default to `complex` when uncertain. -->
+
+- **Complexity:** {{simple | complex}}
+- **Why:** {{one-line rationale citing the signals that decided it}}
+
 ## Current State
 
 {{whatHasBeenBuiltSoFar — what works, what exists, what's deployed}}

--- a/src/resources/extensions/gsd/tests/delegation-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/delegation-policy.test.ts
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  getDelegationVerdict,
+  getVerdictByUnitType,
+  isBackgroundable,
+  listBackgroundableTools,
+} from "../delegation-policy.js";
+
+// Pin the GOOD set: changes here must come with explicit re-evaluation.
+const EXPECTED_BACKGROUNDABLE = [
+  "gsd_execute",
+  "gsd_plan_slice",
+  "gsd_reassess_roadmap",
+  "gsd_validate_milestone",
+];
+
+test("isBackgroundable returns true for the four GOOD-verdict tools", () => {
+  for (const name of EXPECTED_BACKGROUNDABLE) {
+    assert.equal(isBackgroundable(name), true, `${name} should be backgroundable`);
+  }
+});
+
+test("isBackgroundable returns false for RISKY-verdict tools", () => {
+  for (const name of ["gsd_doctor", "gsd_plan_milestone", "gsd_replan_slice"]) {
+    assert.equal(isBackgroundable(name), false, `${name} should not be backgroundable`);
+  }
+});
+
+test("isBackgroundable returns false for NO-verdict tools", () => {
+  assert.equal(isBackgroundable("gsd_plan_task"), false);
+});
+
+test("isBackgroundable defaults to false for unknown tools (default-deny)", () => {
+  assert.equal(isBackgroundable("gsd_nonexistent_tool"), false);
+  assert.equal(isBackgroundable(""), false);
+});
+
+test("listBackgroundableTools returns exactly the four GOOD tools, sorted", () => {
+  assert.deepEqual(listBackgroundableTools(), EXPECTED_BACKGROUNDABLE);
+});
+
+test("getDelegationVerdict resolves alias names to canonical entries", () => {
+  for (const [alias, canonical] of [
+    ["gsd_milestone_validate", "gsd_validate_milestone"],
+    ["gsd_roadmap_reassess", "gsd_reassess_roadmap"],
+    ["gsd_slice_replan", "gsd_replan_slice"],
+    ["gsd_task_plan", "gsd_plan_task"],
+  ] as const) {
+    const entry = getDelegationVerdict(alias);
+    assert.ok(entry, `alias ${alias} should resolve`);
+    assert.equal(entry.toolName, canonical, `${alias} should resolve to ${canonical}`);
+  }
+});
+
+test("plan_slice carries the slice-lock + await constraints", () => {
+  const entry = getDelegationVerdict("gsd_plan_slice");
+  assert.ok(entry);
+  assert.ok(entry.constraints && entry.constraints.length >= 3);
+  assert.ok(
+    entry.constraints!.some((c) => /lock the slice/i.test(c)),
+    "plan_slice must carry the slice-lock constraint",
+  );
+  assert.ok(
+    entry.constraints!.some((c) => /await background completion/i.test(c)),
+    "plan_slice must require await before downstream reads",
+  );
+});
+
+test("doctor carries fix-mode safety constraints", () => {
+  const entry = getDelegationVerdict("gsd_doctor");
+  assert.ok(entry);
+  assert.equal(entry.verdict, "risky");
+  assert.ok(
+    entry.constraints && entry.constraints.some((c) => /fix=false/.test(c)),
+    "doctor must restrict background runs to fix=false",
+  );
+});
+
+test("getVerdictByUnitType maps dispatcher unit types back to the policy", () => {
+  assert.equal(getVerdictByUnitType("plan-slice")?.toolName, "gsd_plan_slice");
+  assert.equal(getVerdictByUnitType("validate-milestone")?.toolName, "gsd_validate_milestone");
+  assert.equal(getVerdictByUnitType("reassess-roadmap")?.toolName, "gsd_reassess_roadmap");
+  assert.equal(getVerdictByUnitType("plan-milestone")?.toolName, "gsd_plan_milestone");
+  assert.equal(getVerdictByUnitType("replan-slice")?.toolName, "gsd_replan_slice");
+  assert.equal(getVerdictByUnitType("nonexistent-unit"), null);
+});
+
+test("every entry carries a non-empty rationale so the verdict is auditable", () => {
+  for (const name of [...EXPECTED_BACKGROUNDABLE, "gsd_doctor", "gsd_plan_milestone", "gsd_replan_slice", "gsd_plan_task"]) {
+    const entry = getDelegationVerdict(name);
+    assert.ok(entry, `${name} should be in the policy`);
+    assert.ok(entry.rationale.length > 20, `${name} rationale must be substantive`);
+  }
+});

--- a/src/resources/extensions/gsd/tests/delegation-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/delegation-policy.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  annotateBackgroundable,
   getDelegationVerdict,
   getVerdictByUnitType,
   isBackgroundable,
@@ -91,5 +92,60 @@ test("every entry carries a non-empty rationale so the verdict is auditable", ()
     const entry = getDelegationVerdict(name);
     assert.ok(entry, `${name} should be in the policy`);
     assert.ok(entry.rationale.length > 20, `${name} rationale must be substantive`);
+  }
+});
+
+// ─── annotateBackgroundable contract pins ────────────────────────────────
+
+test("annotateBackgroundable recomputes the verdict on every call (no internal cache)", () => {
+  // The annotator mutates in place. Repeated calls on the same object with
+  // different unit types must always reflect the latest unitType — never a
+  // stale cached value. This pins the contract documented in the JSDoc so a
+  // future "optimization" that adds memoization keyed on object identity
+  // breaks the suite instead of silently leaking a stale flag.
+  const action: { action: "dispatch"; unitType: string; backgroundable?: boolean } = {
+    action: "dispatch",
+    unitType: "plan-slice",
+  };
+  annotateBackgroundable(action);
+  assert.equal(action.backgroundable, true, "plan-slice should annotate true");
+
+  action.unitType = "plan-milestone";
+  annotateBackgroundable(action);
+  assert.equal(action.backgroundable, false, "plan-milestone (risky) should re-annotate false");
+
+  action.unitType = "validate-milestone";
+  annotateBackgroundable(action);
+  assert.equal(action.backgroundable, true, "validate-milestone should re-annotate true");
+
+  action.unitType = "complete-slice";
+  annotateBackgroundable(action);
+  assert.equal(action.backgroundable, false, "uncovered unit type should re-annotate false (default-deny)");
+});
+
+test("annotateBackgroundable passes stop/skip actions through unchanged", () => {
+  const stop = { action: "stop" as const, reason: "x", level: "info" as const };
+  const skip = { action: "skip" as const };
+  assert.equal(annotateBackgroundable(stop), stop);
+  assert.equal(annotateBackgroundable(skip), skip);
+  assert.equal((stop as Record<string, unknown>).backgroundable, undefined);
+  assert.equal((skip as Record<string, unknown>).backgroundable, undefined);
+});
+
+// ─── F4 latent gap pin: silent default-deny on unit types invoking GOOD tools ──
+
+test("execute-task / reactive-execute / execute-task-simple intentionally default-deny despite gsd_execute being GOOD", () => {
+  // gsd_execute carries a GOOD verdict but no `unitType`, by design — the
+  // unit-level orchestrations wrap prompt and harness work whose safety is
+  // a separate analysis. Lifting these out of default-deny must be an
+  // explicit, audited change. This test pins the current behavior; if the
+  // policy entry gains a unitType mapping (or a unitTypes array), update
+  // both the entry and this test together.
+  for (const unitType of ["execute-task", "execute-task-simple", "reactive-execute"]) {
+    assert.equal(
+      getVerdictByUnitType(unitType),
+      null,
+      `${unitType} must remain unmapped until per-unit analysis is recorded`,
+    );
   }
 });

--- a/src/resources/extensions/gsd/tests/dispatch-backgroundable-annotation.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-backgroundable-annotation.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  annotateBackgroundable,
+  type AnnotatableDispatchAction,
+} from "../delegation-policy.js";
+
+function dispatchAction(unitType: string): AnnotatableDispatchAction {
+  return {
+    action: "dispatch",
+    unitType,
+    unitId: `M001/${unitType}`,
+    prompt: "(test prompt)",
+  };
+}
+
+test("annotateBackgroundable marks plan-slice as backgroundable", () => {
+  const annotated = annotateBackgroundable(dispatchAction("plan-slice"));
+  assert.equal(annotated.action, "dispatch");
+  if (annotated.action !== "dispatch") return;
+  assert.equal(annotated.backgroundable, true);
+  assert.equal(annotated.unitType, "plan-slice");
+});
+
+test("annotateBackgroundable marks validate-milestone and reassess-roadmap as backgroundable", () => {
+  for (const unitType of ["validate-milestone", "reassess-roadmap"]) {
+    const annotated = annotateBackgroundable(dispatchAction(unitType));
+    assert.equal(annotated.action, "dispatch");
+    if (annotated.action !== "dispatch") continue;
+    assert.equal(annotated.backgroundable, true, `${unitType} should be backgroundable`);
+  }
+});
+
+test("annotateBackgroundable marks plan-milestone and replan-slice as NOT backgroundable", () => {
+  for (const unitType of ["plan-milestone", "replan-slice"]) {
+    const annotated = annotateBackgroundable(dispatchAction(unitType));
+    assert.equal(annotated.action, "dispatch");
+    if (annotated.action !== "dispatch") continue;
+    assert.equal(annotated.backgroundable, false, `${unitType} should not be backgroundable`);
+  }
+});
+
+test("annotateBackgroundable defaults unknown unit types to false (default-deny)", () => {
+  const annotated = annotateBackgroundable(dispatchAction("execute-task"));
+  assert.equal(annotated.action, "dispatch");
+  if (annotated.action !== "dispatch") return;
+  assert.equal(annotated.backgroundable, false);
+});
+
+test("annotateBackgroundable leaves stop and skip actions untouched", () => {
+  const stop: AnnotatableDispatchAction = { action: "stop", reason: "test", level: "info" };
+  const skip: AnnotatableDispatchAction = { action: "skip" };
+  assert.deepEqual(annotateBackgroundable(stop), stop);
+  assert.deepEqual(annotateBackgroundable(skip), skip);
+});

--- a/src/resources/extensions/gsd/tests/guided-flow-prompt-consolidation.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-flow-prompt-consolidation.test.ts
@@ -86,8 +86,8 @@ describe("guided-flow → auto-prompts consolidation (#5183)", () => {
     assert.ok(prompt.includes(TID), "must mention task id");
     assert.ok(prompt.includes(T_TITLE), "must mention task title");
     assert.ok(
-      prompt.includes("gsd_complete_task"),
-      "must instruct calling the canonical gsd_complete_task tool",
+      prompt.includes("gsd_task_complete"),
+      "must instruct calling the canonical gsd_task_complete tool",
     );
     assert.ok(
       prompt.includes(base),
@@ -110,8 +110,8 @@ describe("guided-flow → auto-prompts consolidation (#5183)", () => {
     assert.ok(prompt.includes(SID), "must mention slice id");
     assert.ok(prompt.includes(S_TITLE), "must mention slice title");
     assert.ok(
-      prompt.includes("gsd_complete_slice"),
-      "must instruct calling gsd_complete_slice (was in guided-complete-slice.md)",
+      prompt.includes("gsd_slice_complete"),
+      "must instruct calling gsd_slice_complete (was in guided-complete-slice.md)",
     );
     assert.ok(
       prompt.includes(base),

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -4,9 +4,14 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const promptsDir = join(process.cwd(), "src/resources/extensions/gsd/prompts");
+const templatesDir = join(process.cwd(), "src/resources/extensions/gsd/templates");
 
 function readPrompt(name: string): string {
   return readFileSync(join(promptsDir, `${name}.md`), "utf-8");
+}
+
+function readTemplate(name: string): string {
+  return readFileSync(join(templatesDir, `${name}.md`), "utf-8");
 }
 
 test("reactive-execute prompt keeps task summaries with subagents and avoids batch commits", () => {
@@ -466,10 +471,73 @@ test("downstream discuss prompts read project shape verdict from PROJECT.md", ()
 });
 
 test("project template includes the Project Shape section so the verdict has a home", () => {
-  const template = readFileSync(
-    join(process.cwd(), "src/resources/extensions/gsd/templates/project.md"),
-    "utf-8",
-  );
+  const template = readTemplate("project");
   assert.match(template, /## Project Shape/);
   assert.match(template, /\*\*Complexity:\*\*/);
+});
+
+// ─── Project shape verdict — end-to-end propagation contract (F7 / #5267) ──
+// The verdict is propagated from discuss-project to downstream stages via
+// PROJECT.md text only, with no parser. These tests pin the round-trip:
+// the format the upstream stage is told to write must be discoverable by
+// the regex pattern the downstream stage is told to look for.
+
+/**
+ * Render the project.md template with a concrete complexity verdict so we
+ * can assert on a realistic PROJECT.md (the placeholder is filled the way
+ * an LLM following the prompt would fill it).
+ */
+function renderProjectMd(verdict: "simple" | "complex"): string {
+  return readTemplate("project")
+    .replace("{{simple | complex}}", verdict)
+    .replace("{{one-line rationale citing the signals that decided it}}", "Test fixture rationale.");
+}
+
+test("project shape verdict survives the discuss-project → discuss-milestone round trip", () => {
+  for (const verdict of ["simple", "complex"] as const) {
+    const projectMd = renderProjectMd(verdict);
+
+    // Upstream contract: the PROJECT.md the discuss-project prompt writes
+    // must contain the section header and the bolded `**Complexity:** <verdict>`
+    // marker that downstream stages are told to grep for.
+    assert.match(projectMd, /## Project Shape/, `rendered ${verdict} PROJECT.md must keep the section header`);
+    const complexityMarker = new RegExp(`\\*\\*Complexity:\\*\\*\\s*${verdict}\\b`);
+    assert.match(
+      projectMd,
+      complexityMarker,
+      `rendered ${verdict} PROJECT.md must expose the bolded Complexity marker the downstream regex looks for`,
+    );
+
+    // Downstream contract: discuss-milestone, discuss-requirements, and
+    // discuss-slice must each instruct the LLM to look at the same section
+    // header AND the same `**Complexity:**` marker the template writes.
+    // Without this, the upstream verdict is silently dropped.
+    for (const downstream of ["guided-discuss-milestone", "guided-discuss-requirements", "guided-discuss-slice"]) {
+      const prompt = readPrompt(downstream);
+      assert.match(
+        prompt,
+        /## Project Shape/,
+        `${downstream} must direct the LLM to the same section header the template writes`,
+      );
+      assert.match(
+        prompt,
+        /\*\*Complexity:\*\*/,
+        `${downstream} must direct the LLM to the same **Complexity:** marker the template writes`,
+      );
+    }
+  }
+});
+
+test("downstream discuss prompts default to complex when PROJECT.md lacks the verdict", () => {
+  // Safe-by-default: if upstream omits the section (existing projects, LLM
+  // drift, future template change), each downstream stage must explicitly
+  // fall back to complex so behavior is conservative rather than stuck.
+  for (const downstream of ["guided-discuss-milestone", "guided-discuss-requirements", "guided-discuss-slice"]) {
+    const prompt = readPrompt(downstream);
+    assert.match(
+      prompt,
+      /default to `complex`/i,
+      `${downstream} must default to complex when the upstream verdict is missing`,
+    );
+  }
 });

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -174,15 +174,15 @@ test("guided-resume-task prompt preserves recovery state until work is supersede
 
 // ─── Prompt migration: execute-task → gsd_complete_task ───────────────
 
-test("execute-task prompt references gsd_complete_task tool", () => {
+test("execute-task prompt references gsd_task_complete tool", () => {
   const prompt = readPrompt("execute-task");
-  assert.match(prompt, /gsd_complete_task/);
+  assert.match(prompt, /gsd_task_complete/);
 });
 
-test("execute-task prompt uses gsd_complete_task as canonical summary write path", () => {
+test("execute-task prompt uses gsd_task_complete as canonical summary write path", () => {
   const prompt = readPrompt("execute-task");
   assert.match(prompt, /\{\{taskSummaryPath\}\}/);
-  assert.match(prompt, /gsd_complete_task/);
+  assert.match(prompt, /gsd_task_complete/);
   assert.match(prompt, /DB-backed tool is the canonical write path/i);
   assert.match(prompt, /Do \*\*not\*\* manually write `?\{\{taskSummaryPath\}\}`?/i);
   assert.doesNotMatch(prompt, /^\d+\.\s+Write `?\{\{taskSummaryPath\}\}`?\s*$/m);
@@ -202,9 +202,9 @@ test("execute-task prompt still contains template variables for context", () => 
 
 // ─── Prompt migration: complete-slice → gsd_complete_slice ────────────
 
-test("complete-slice prompt references gsd_complete_slice tool", () => {
+test("complete-slice prompt references gsd_slice_complete tool", () => {
   const prompt = readPrompt("complete-slice");
-  assert.match(prompt, /gsd_complete_slice/);
+  assert.match(prompt, /gsd_slice_complete/);
 });
 
 test("complete-slice prompt does not instruct LLM to toggle checkboxes manually", () => {
@@ -216,7 +216,7 @@ test("complete-slice prompt instructs writing summary and UAT files before tool 
   const prompt = readPrompt("complete-slice");
   assert.match(prompt, /\{\{sliceSummaryPath\}\}/);
   assert.match(prompt, /\{\{sliceUatPath\}\}/);
-  assert.match(prompt, /gsd_complete_slice/);
+  assert.match(prompt, /gsd_slice_complete/);
   assert.match(prompt, /DB-backed tool is the canonical write path/i);
   assert.match(prompt, /Do \*\*not\*\* manually write `?\{\{sliceSummaryPath\}\}`?/i);
   assert.match(prompt, /Do \*\*not\*\* manually write `?\{\{sliceUatPath\}\}`?/i);

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -398,3 +398,78 @@ test("reactive-execute prompt references tool calls instead of checkbox updates"
   assert.doesNotMatch(prompt, /checkbox edits/);
   assert.match(prompt, /completion tool calls/);
 });
+
+// ─── Project-shape classifier + 3-or-4-options-with-Other-hatch contract ──
+
+test("guided-discuss-project classifies project shape and persists the verdict to PROJECT.md", () => {
+  const prompt = readPrompt("guided-discuss-project");
+  assert.match(prompt, /Classify project shape/i, "must include the classifier section");
+  assert.match(prompt, /`simple`/);
+  assert.match(prompt, /`complex`/);
+  assert.match(prompt, /Default to `complex` when uncertain/i);
+  assert.match(prompt, /## Project Shape/, "must reference the persisted PROJECT.md section");
+  assert.match(prompt, /\*\*Complexity:\*\*\s*simple/);
+  assert.match(prompt, /\*\*Complexity:\*\*\s*complex/);
+});
+
+test("guided-discuss prompts require 3-or-4 options plus Other-let-me-discuss in complex mode", () => {
+  for (const name of [
+    "guided-discuss-project",
+    "guided-discuss-milestone",
+    "guided-discuss-slice",
+  ]) {
+    const prompt = readPrompt(name);
+    assert.match(
+      prompt,
+      /3 or 4 concrete, researched options/i,
+      `${name} must require 3 or 4 grounded options in complex mode`,
+    );
+    assert.match(
+      prompt,
+      /"Other — let me discuss"/,
+      `${name} must include the "Other — let me discuss" escape hatch`,
+    );
+    assert.match(
+      prompt,
+      /grounded in (the |your |)investigation/i,
+      `${name} must require options grounded in prior investigation`,
+    );
+  }
+});
+
+test("guided-discuss-requirements scopes the 3-or-4-options rule to free-form questions only", () => {
+  const prompt = readPrompt("guided-discuss-requirements");
+  assert.match(prompt, /3 or 4 concrete, researched options/i);
+  assert.match(prompt, /"Other — let me discuss"/);
+  // Class-assignment and status questions have fixed enumerations, so the rule must exempt them.
+  assert.match(prompt, /class-assignment.*status.*exempt/i);
+});
+
+test("downstream discuss prompts read project shape verdict from PROJECT.md", () => {
+  for (const name of [
+    "guided-discuss-milestone",
+    "guided-discuss-requirements",
+    "guided-discuss-slice",
+  ]) {
+    const prompt = readPrompt(name);
+    assert.match(
+      prompt,
+      /Project Shape/,
+      `${name} must reference Project Shape from PROJECT.md`,
+    );
+    assert.match(
+      prompt,
+      /default to `complex`/i,
+      `${name} must default to complex when the verdict is missing`,
+    );
+  }
+});
+
+test("project template includes the Project Shape section so the verdict has a home", () => {
+  const template = readFileSync(
+    join(process.cwd(), "src/resources/extensions/gsd/templates/project.md"),
+    "utf-8",
+  );
+  assert.match(template, /## Project Shape/);
+  assert.match(template, /\*\*Complexity:\*\*/);
+});

--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -50,8 +50,8 @@ test("guided execute-task requires canonical task completion tool", () => {
   assert.deepEqual(getRequiredWorkflowToolsForGuidedUnit("execute-task"), ["gsd_task_complete"]);
 });
 
-test("auto execute-task requires legacy completion alias until prompt contract is aligned", () => {
-  assert.deepEqual(getRequiredWorkflowToolsForAutoUnit("execute-task"), ["gsd_complete_task"]);
+test("auto execute-task requires canonical task completion tool", () => {
+  assert.deepEqual(getRequiredWorkflowToolsForAutoUnit("execute-task"), ["gsd_task_complete"]);
 });
 
 test("deep project setup units declare required workflow MCP tools", () => {

--- a/src/resources/extensions/gsd/tests/write-intercept.test.ts
+++ b/src/resources/extensions/gsd/tests/write-intercept.test.ts
@@ -71,6 +71,6 @@ test('write-intercept: BLOCKED_WRITE_ERROR is a non-empty string', () => {
 });
 
 test('write-intercept: BLOCKED_WRITE_ERROR mentions engine tool calls', () => {
-  assert.ok(BLOCKED_WRITE_ERROR.includes('gsd_complete_task'), 'should mention gsd_complete_task');
+  assert.ok(BLOCKED_WRITE_ERROR.includes('gsd_task_complete'), 'should mention gsd_task_complete');
   assert.ok(BLOCKED_WRITE_ERROR.includes('engine tool calls'), 'should mention engine tool calls');
 });

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -349,9 +349,9 @@ export function getRequiredWorkflowToolsForAutoUnit(unitType: string): string[] 
     case "execute-task":
     case "execute-task-simple":
     case "reactive-execute":
-      return ["gsd_complete_task"];
+      return ["gsd_task_complete"];
     case "complete-slice":
-      return ["gsd_complete_slice"];
+      return ["gsd_slice_complete"];
     case "replan-slice":
       return ["gsd_replan_slice"];
     case "reassess-roadmap":

--- a/src/resources/extensions/gsd/write-intercept.ts
+++ b/src/resources/extensions/gsd/write-intercept.ts
@@ -91,9 +91,9 @@ function matchesBlockedPattern(path: string): boolean {
  * Directs the agent to use engine tool calls instead.
  */
 export const BLOCKED_WRITE_ERROR = `Direct writes to .gsd/STATE.md and .gsd/gsd.db are blocked. Use engine tool calls instead:
-- To complete a task: call gsd_complete_task(milestone_id, slice_id, task_id, summary)
-- To complete a slice: call gsd_complete_slice(milestone_id, slice_id, summary, uat_result)
-- To save a decision: call gsd_save_decision(scope, decision, choice, rationale)
+- To complete a task: call gsd_task_complete(milestone_id, slice_id, task_id, summary)
+- To complete a slice: call gsd_slice_complete(milestone_id, slice_id, summary, uat_result)
+- To save a decision: call gsd_decision_save(scope, decision, choice, rationale)
 - To start a task: call gsd_start_task(milestone_id, slice_id, task_id)
 - To record verification: call gsd_record_verification(milestone_id, slice_id, task_id, evidence)
 - To report a blocker: call gsd_report_blocker(milestone_id, slice_id, task_id, description)`;


### PR DESCRIPTION
## Linked issue

Closes #5226

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Codify which GSD MCP tools are safe to run as background sub-agents and annotate every dispatched unit with a `backgroundable: boolean` verdict from that policy.
**Why:** Without a single source of truth, future background-dispatch wiring (parallel milestone validation, opportunistic reassess_roadmap, soft-pre-fetched plan_slice) has to reinvent concurrency reasoning at every call site, and any new dispatch path can silently background a tool that mutates shared state.
**How:** New `src/resources/extensions/gsd/delegation-policy.ts` keyed by canonical tool name, with verdicts (`good`/`risky`/`no`), one-line rationale, and per-tool constraint lists. `auto-dispatch.ts` calls `annotateBackgroundable` on every dispatch action so the field flows through unchanged at runtime — pure instrumentation until a future PR wires actual background dispatch.

## What

**Primary change — delegation infrastructure (commits 92509758, 221c3631):**

- New `src/resources/extensions/gsd/delegation-policy.ts` (149 lines) — centralized policy module, zero workspace-package dependencies (so it can be unit-tested without pulling the auto-prompts.ts import chain). Exports:
  - `getDelegationVerdict(toolName)` — canonical-name lookup with alias resolution
  - `isBackgroundable(toolName)` — boolean shorthand for the `good` verdict
  - `listBackgroundableTools()` — the GOOD set, sorted
  - `getVerdictByUnitType(unitType)` — bridges dispatcher unit types to the policy
  - `annotateBackgroundable(action)` — in-place annotator for `DispatchAction` shapes
- `src/resources/extensions/gsd/auto-dispatch.ts` (+10/-2) — wires every `dispatch` action through `annotateBackgroundable` before returning; stop/skip actions pass through unchanged.
- New tests (`delegation-policy.test.ts` 95 lines, `dispatch-backgroundable-annotation.test.ts` 55 lines) pin the GOOD set, alias resolution (`gsd_milestone_validate` → `gsd_validate_milestone`, etc.), and the constraint contracts so any future change has to revisit the analysis.

Initial classification:
- **good** (4): `gsd_plan_slice`, `gsd_execute`, `gsd_validate_milestone`, `gsd_reassess_roadmap`
- **risky** (3): `gsd_doctor` (only `fix=false` is safe), `gsd_plan_milestone`, `gsd_replan_slice`
- **no** (1): `gsd_plan_task` (plan-slice forbids per-task granularity)

**Bundled adjacent changes** — flagged for maintainer review under "Scope" below:

- *Discuss complexity classifier (commit 91deb109):* Adds a `simple | complex` verdict emitted during discuss-project and persisted to a new `## Project Shape` section in PROJECT.md. Downstream stages (discuss-milestone, -requirements, -slice) read the verdict and adapt cadence — `simple` favors 1–2 plain-text rounds and skips the deep investigation; `complex` runs the full treatment. Structured questions in complex mode now require 3–4 concrete researched options plus an explicit "Other — let me discuss" escape hatch.
- *Canonical tool names (commit 485ec3a9):* Internal prose, prescriptive tool returns, and live prompts now use canonical names (`gsd_task_complete`, `gsd_slice_complete`, `gsd_decision_save`) instead of the alias forms. The 11 alias registrations in `workflow-tools.ts` and `bootstrap/db-tools.ts` stay in place — they exist precisely so external callers can use either name — but the codebase no longer recommends two names for the same handler.

## Why

Closes #5226.

GSD already runs some operations in parallel (slice-parallel-orchestrator for `plan_slice`, reactive-execute parallel sub-agents) but the rules for "is this tool safe to background?" live in scattered comments and prompt prose. New dispatch sites can't consult a single source of truth, so:

- Any future PR that adds a background-dispatch path has to re-derive the safety analysis from scratch (or skip it).
- A typo in a unit type silently default-allows backgrounding instead of failing loud.
- Maintainers reviewing dispatch changes have no machine-readable contract to cite.

This PR is the foundation: a declarative, default-deny policy with rationale and constraints, plus the dispatcher annotation. The runtime field is currently just instrumentation — the actual background-dispatch wiring is intentionally a separate follow-up so this PR stays focused on the policy contract.

## How

The policy lives as a flat `Record<string, DelegationPolicyEntry>` keyed by canonical tool name. Each entry carries a `verdict`, a one-line `rationale` grounded in the existing dispatch / DB / prompt code, and (for `good` and conditional `risky` entries) a `constraints` list describing what callers must guarantee — e.g. for `gsd_plan_slice`:

> Lock the slice from further user discussion once dispatched (context is frozen at dispatch time). Foreground must not derive state for that slice while the transaction is in flight. Foreground must await background completion before any tool reads the planned tasks/gates.

Aliases are resolved through a separate `ALIASES` map sourced from `packages/mcp-server/src/workflow-tools.ts` so the policy doesn't have to duplicate alternate names. Default-deny: unknown tools resolve to `null` from `getDelegationVerdict` and `false` from `isBackgroundable`.

The auto-dispatch wiring is a one-line annotation call; the field is added to the returned action object in place, so existing consumers that don't read `backgroundable` are unaffected.

### Alternatives considered

1. **Inline the policy in `auto-dispatch.ts`.** Rejected — couples the policy to the dispatcher, makes testing pull in the full auto-prompts import chain, and prevents non-dispatch consumers (e.g. a future `/gsd doctor` check) from reading the verdict.
2. **Boolean-only verdict (`backgroundable: true|false`).** Rejected — losing the `risky` middle tier and the constraint list throws away the most useful part of the analysis. Future PRs that want to background a `risky` tool need the constraints to do it safely.
3. **Drive everything off the unit type instead of the tool name.** Rejected — some MCP tools (e.g. `gsd_doctor`, `gsd_plan_task`) have no corresponding unit type; the canonical tool name is the more general key. The unit-type lookup is an explicit secondary index for the dispatcher's convenience.

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — `chore: prefer canonical tool names` commit (bundled, see Scope note)

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow (delegation policy, auto-dispatch annotation, discuss prompts)
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

> **Note for maintainers — bundled scope.** Per CONTRIBUTING.md "One concern per PR." This branch ships three logically distinct concerns:
> 1. Delegation policy + dispatch annotation (commits 92509758 + 221c3631) — the umbrella issue #5226.
> 2. Discuss complexity classifier (commit 91deb109) — could land independently.
> 3. Canonicalize tool names in prompts (commit 485ec3a9) — chore, could land independently.
>
> Happy to split into 3 PRs on request — let me know if a maintainer prefers that before review.

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

The 11 alias registrations stay in place; only internal prose and prescriptive tool returns change to recommend canonicals. External callers using either form are unaffected.

The `backgroundable` field on dispatch actions is additive — consumers that don't read it see no behavioral change. No background dispatch is wired in this PR.

## Test plan

- [x] CI passes
- [x] New/updated tests included — 5 prompt-contract tests for the discuss complexity work; 95 LOC of policy tests pinning the GOOD set, alias resolution, and constraints; 55 LOC for the dispatch annotation. Existing prompt-contract tests updated to assert canonical names.
- [ ] Manual testing — not performed; the runtime change is instrumentation only.
- [ ] No tests needed — N/A.

## AI disclosure

- [x] This PR includes AI-assisted code. The delegation verdicts were derived from a two-round evaluation of each tool's DB-write surface, user-prompt requirements, and concurrency safety; the rationale and constraint fields preserve the analysis so future changes have to revisit it explicitly. Commit history was rebased to remove AI co-author attribution per CONTRIBUTING.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project-shape classification (simple vs. complex) to tailor questioning depth/cadence.
  * Background-execution annotation for select workflow dispatches so eligible actions may run asynchronously.

* **Documentation**
  * Canonical tool names adopted with backwards-compatible aliases; README, prompts, templates, and error text updated to reflect renamed tools.

* **Tests**
  * New and updated suites covering delegation/backgroundability logic, annotation behavior, and prompt/tool-contract expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->