### PR TITLE
fix(gsd): bind short-trailer impl commits to milestone via DB

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -241,15 +241,20 @@ function scanGsdTaggedCommits(
         const hash = record.slice(0, sep).trim();
         const message = record.slice(sep + 1);
         return [{ hash, message }];
-      });
+      })
+      .reverse();
 
     const files = new Set<string>();
     let matched = false;
+    let activeMilestone: string | null = null;
     for (const { hash, message } of records) {
       if (!commitMessageHasGsdTrailer(message)) continue;
 
+      const longTrailerMid = extractLongTrailerMilestone(message);
+      if (longTrailerMid) activeMilestone = longTrailerMid;
+
       const commitFiles = getChangedFilesForCommit(basePath, hash);
-      if (!commitMatchesMilestone(message, milestoneId, commitFiles)) continue;
+      if (!commitMatchesMilestone(message, milestoneId, commitFiles, activeMilestone)) continue;
 
       matched = true;
       for (const file of commitFiles) {
@@ -277,22 +282,28 @@ function commitMessageHasGsdTrailer(message: string): boolean {
   return /^GSD-(?:Task|Unit):\s*\S+/m.test(message);
 }
 
-function commitMatchesMilestone(message: string, milestoneId: string, files: readonly string[]): boolean {
+function commitMatchesMilestone(
+  message: string,
+  milestoneId: string,
+  files: readonly string[],
+  activeMilestone: string | null,
+): boolean {
   if (commitTrailerStartsWithMilestone(message, milestoneId)) return true;
 
-  // Meaningful execute-task commits currently store task scope as Sxx/Tyy
-  // rather than Mxx/Sxx/Tyy. Bind those commits back to the milestone when
-  // either the commit touched this milestone's artifacts, or — for projects
-  // where .gsd/ is gitignored/external (#5033) — the message explicitly
-  // names the milestone.
   const shortTrailer = message.match(/^GSD-Task:\s*(S[^/\s]+)\/T\S+/m);
   if (shortTrailer) {
     if (files.some((file) => isMilestoneArtifactPath(file, milestoneId))) return true;
     if (commitMessageMentionsMilestone(message, milestoneId)) return true;
-    if (isDbAvailable() && getSlice(milestoneId, shortTrailer[1]!) != null) return true;
+    if (activeMilestone === milestoneId) return true;
+    if (activeMilestone === null && isDbAvailable() && getSlice(milestoneId, shortTrailer[1]!) != null) return true;
   }
 
   return false;
+}
+
+function extractLongTrailerMilestone(message: string): string | null {
+  const match = message.match(/^GSD-(?:Task|Unit):\s*(M\d{3}(?:-[a-z0-9]{6})?)(?:$|[\s/])/m);
+  return match ? match[1]! : null;
 }
 
 function commitMessageMentionsMilestone(message: string, milestoneId: string): boolean {

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -295,7 +295,13 @@ function commitMatchesMilestone(
     if (files.some((file) => isMilestoneArtifactPath(file, milestoneId))) return true;
     if (commitMessageMentionsMilestone(message, milestoneId)) return true;
     if (activeMilestone === milestoneId) return true;
-    if (activeMilestone === null && isDbAvailable() && getSlice(milestoneId, shortTrailer[1]!) != null) return true;
+
+    if (isDbAvailable()) {
+      const sliceId = shortTrailer[1]!;
+      if (getSlice(milestoneId, sliceId) == null) return false;
+      if (activeMilestone === null) return true;
+      return getSlice(activeMilestone, sliceId) == null;
+    }
   }
 
   return false;

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -301,8 +301,14 @@ function commitMatchesMilestone(
   return false;
 }
 
+const MILESTONE_ID_BODY = MILESTONE_ID_RE.source.replace(/^\^|\$$/g, "");
+const LONG_TRAILER_RE = new RegExp(
+  `^GSD-(?:Task|Unit):\\s*(${MILESTONE_ID_BODY})(?:$|[\\s/])`,
+  "m",
+);
+
 function extractLongTrailerMilestone(message: string): string | null {
-  const match = message.match(/^GSD-(?:Task|Unit):\s*(M\d{3}(?:-[a-z0-9]{6})?)(?:$|[\s/])/m);
+  const match = message.match(LONG_TRAILER_RE);
   return match ? match[1]! : null;
 }
 

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -9,7 +9,7 @@
 
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 import { parseUnitId } from "./unit-id.js";
-import { MILESTONE_ID_RE } from "./milestone-ids.js";
+import { MILESTONE_ID_RE, MILESTONE_ID_BODY } from "./milestone-ids.js";
 import { appendEvent } from "./workflow-events.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { clearParseCache } from "./files.js";
@@ -310,7 +310,6 @@ function commitMatchesMilestone(
   return false;
 }
 
-const MILESTONE_ID_BODY = MILESTONE_ID_RE.source.replace(/^\^|\$$/g, "");
 const LONG_TRAILER_RE = new RegExp(
   `^GSD-(?:Task|Unit):\\s*(${MILESTONE_ID_BODY})(?:$|[\\s/])`,
   "m",

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -215,23 +215,6 @@ function getChangedFilesFromMilestoneTaggedCommits(
   basePath: string,
   milestoneId: string,
 ): { ok: boolean; matched: boolean; files: string[] } {
-  // Primary: path-scoped log against .gsd/milestones/<id>. Fast and unbounded
-  // by depth when .gsd/ is tracked in git.
-  const scoped = scanGsdTaggedCommits(basePath, milestoneId, [
-    "log", "--format=%H%x1f%B%x1e", "HEAD", "--", `.gsd/milestones/${milestoneId}`,
-  ]);
-  if (!scoped.ok) return scoped;
-  if (scoped.matched) return scoped;
-
-  // Fallback (#5033): when .gsd/ is gitignored / external / untracked, the
-  // path-scoped scan matches no commits even though GSD-tagged commits
-  // referencing the milestone exist on the integration branch. Re-scan all
-  // of HEAD's history and rely on commitMatchesMilestone to bind by
-  // explicit milestone mention in the message body.
-  //
-  // Intentionally unbounded — symmetric with the primary scan, and avoids
-  // reintroducing the rolling-depth failure class removed in #4699 where
-  // milestone evidence aged out behind unrelated activity.
   return scanGsdTaggedCommits(basePath, milestoneId, [
     "log", "--format=%H%x1f%B%x1e", "HEAD",
   ]);
@@ -302,9 +285,11 @@ function commitMatchesMilestone(message: string, milestoneId: string, files: rea
   // either the commit touched this milestone's artifacts, or — for projects
   // where .gsd/ is gitignored/external (#5033) — the message explicitly
   // names the milestone.
-  if (/^GSD-Task:\s*S[^/\s]+\/T\S+/m.test(message)) {
+  const shortTrailer = message.match(/^GSD-Task:\s*(S[^/\s]+)\/T\S+/m);
+  if (shortTrailer) {
     if (files.some((file) => isMilestoneArtifactPath(file, milestoneId))) return true;
     if (commitMessageMentionsMilestone(message, milestoneId)) return true;
+    if (isDbAvailable() && getSlice(milestoneId, shortTrailer[1]!) != null) return true;
   }
 
   return false;

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -14,7 +14,7 @@ import { appendEvent } from "./workflow-events.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { clearParseCache } from "./files.js";
 import { parseRoadmap as parseLegacyRoadmap, parsePlan as parseLegacyPlan } from "./parsers-legacy.js";
-import { isDbAvailable, getTask, getSlice, getSliceTasks, getPendingGates, updateTaskStatus, updateSliceStatus, insertSlice, getMilestone } from "./gsd-db.js";
+import { isDbAvailable, getTask, getSlice, getSliceTasks, getPendingGates, updateTaskStatus, updateSliceStatus, insertSlice, getMilestone, listMilestonesOwningSlice } from "./gsd-db.js";
 import { isValidationTerminal } from "./state.js";
 import { getErrorMessage } from "./error-utils.js";
 import { logWarning, logError } from "./workflow-logger.js";
@@ -299,7 +299,10 @@ function commitMatchesMilestone(
     if (isDbAvailable()) {
       const sliceId = shortTrailer[1]!;
       if (getSlice(milestoneId, sliceId) == null) return false;
-      if (activeMilestone === null) return true;
+      if (activeMilestone === null) {
+        const owners = listMilestonesOwningSlice(sliceId);
+        return owners.length === 1 && owners[0] === milestoneId;
+      }
       return getSlice(activeMilestone, sliceId) == null;
     }
   }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -2132,6 +2132,12 @@ export function getSlice(milestoneId: string, sliceId: string): SliceRow | null 
   return rowToSlice(row);
 }
 
+export function listMilestonesOwningSlice(sliceId: string): string[] {
+  if (!currentDb) return [];
+  const rows = currentDb.prepare("SELECT milestone_id FROM slices WHERE id = :sid").all({ ":sid": sliceId }) as Array<{ milestone_id: string }>;
+  return rows.map((r) => r.milestone_id);
+}
+
 export function updateSliceStatus(milestoneId: string, sliceId: string, status: string, completedAt?: string): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   currentDb.prepare(

--- a/src/resources/extensions/gsd/milestone-ids.ts
+++ b/src/resources/extensions/gsd/milestone-ids.ts
@@ -14,8 +14,11 @@ import { getErrorMessage } from "./error-utils.js";
 
 // ─── Regex ──────────────────────────────────────────────────────────────────
 
+/** Body of a milestone ID — `M001` or `M001-abc123`, without anchors. */
+export const MILESTONE_ID_BODY = "M\\d{3}(?:-[a-z0-9]{6})?";
+
 /** Matches both classic `M001` and unique `M001-abc123` formats (anchored). */
-export const MILESTONE_ID_RE = /^M\d{3}(?:-[a-z0-9]{6})?$/;
+export const MILESTONE_ID_RE = new RegExp(`^${MILESTONE_ID_BODY}$`);
 
 // ─── Parsing & Extraction ───────────────────────────────────────────────────
 

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -815,6 +815,43 @@ test("hasImplementationArtifacts binds short-trailer impl commits via DB on inte
   }
 });
 
+test("hasImplementationArtifacts attributes reused slice IDs to the milestone they belong to", () => {
+  const base = makeGitBase();
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "First", status: "complete" });
+    insertSlice({ milestoneId: "M001", id: "S01", title: "S", status: "complete", risk: "low", depends: [] });
+    insertMilestone({ id: "M002", title: "Second", status: "active" });
+    insertSlice({ milestoneId: "M002", id: "S01", title: "S", status: "pending", risk: "low", depends: [] });
+
+    mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# M001");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "chore: plan\n\nGSD-Unit: M001"], { cwd: base, stdio: "ignore" });
+
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-SUMMARY.md"), "# done");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "chore: complete\n\nGSD-Unit: M001"], { cwd: base, stdio: "ignore" });
+
+    mkdirSync(join(base, ".gsd", "milestones", "M002"), { recursive: true });
+    writeFileSync(join(base, ".gsd", "milestones", "M002", "M002-ROADMAP.md"), "# M002");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "chore: plan\n\nGSD-Unit: M002"], { cwd: base, stdio: "ignore" });
+
+    mkdirSync(join(base, "src"), { recursive: true });
+    writeFileSync(join(base, "src", "m2.ts"), "export const y = 2;\n");
+    execFileSync("git", ["add", "src"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feat: m2 impl\n\nGSD-Task: S01/T01"], { cwd: base, stdio: "ignore" });
+
+    assert.equal(hasImplementationArtifacts(base, "M001"), "absent");
+    assert.equal(hasImplementationArtifacts(base, "M002"), "present");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("hasImplementationArtifacts returns true on non-git directory (fail-open)", () => {
   const base = join(tmpdir(), `gsd-test-nogit-${randomUUID()}`);
   mkdirSync(base, { recursive: true });

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -852,6 +852,37 @@ test("hasImplementationArtifacts attributes reused slice IDs to the milestone th
   }
 });
 
+test("hasImplementationArtifacts binds short-trailer commit when an unrelated prior milestone set the active context", () => {
+  const base = makeGitBase();
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "First", status: "complete" });
+    insertSlice({ milestoneId: "M001", id: "S01", title: "S1", status: "complete", risk: "low", depends: [] });
+    insertMilestone({ id: "M002", title: "Second", status: "active" });
+    insertSlice({ milestoneId: "M002", id: "S02", title: "S2", status: "pending", risk: "low", depends: [] });
+
+    mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# M001");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "chore: plan M001\n\nGSD-Unit: M001"], { cwd: base, stdio: "ignore" });
+
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-SUMMARY.md"), "# done");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "chore: complete M001\n\nGSD-Unit: M001"], { cwd: base, stdio: "ignore" });
+
+    mkdirSync(join(base, "src"), { recursive: true });
+    writeFileSync(join(base, "src", "m2.ts"), "export const z = 3;\n");
+    execFileSync("git", ["add", "src"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feat: m2 impl\n\nGSD-Task: S02/T01"], { cwd: base, stdio: "ignore" });
+
+    assert.equal(hasImplementationArtifacts(base, "M002"), "present");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("hasImplementationArtifacts returns true on non-git directory (fail-open)", () => {
   const base = join(tmpdir(), `gsd-test-nogit-${randomUUID()}`);
   mkdirSync(base, { recursive: true });

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -789,6 +789,32 @@ test("hasImplementationArtifacts ignores malformed milestone IDs in commit-messa
   }
 });
 
+test("hasImplementationArtifacts binds short-trailer impl commits via DB on integration branch", () => {
+  const base = makeGitBase();
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "M", status: "active" });
+    insertSlice({ milestoneId: "M001", id: "S13", title: "S", status: "pending", risk: "low", depends: [] });
+
+    mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# Roadmap");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "chore: plan\n\nGSD-Unit: M001"], { cwd: base, stdio: "ignore" });
+
+    mkdirSync(join(base, "src"), { recursive: true });
+    writeFileSync(join(base, "src", "feature.ts"), "export const x = 1;\n");
+    execFileSync("git", ["add", "src"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feat: impl\n\nGSD-Task: S13/T05"], { cwd: base, stdio: "ignore" });
+
+    const result = hasImplementationArtifacts(base, "M001");
+    assert.equal(result, "present");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("hasImplementationArtifacts returns true on non-git directory (fail-open)", () => {
   const base = join(tmpdir(), `gsd-test-nogit-${randomUUID()}`);
   mkdirSync(base, { recursive: true });

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -883,6 +883,30 @@ test("hasImplementationArtifacts binds short-trailer commit when an unrelated pr
   }
 });
 
+test("hasImplementationArtifacts does not over-attribute ambiguous slice IDs when DB is the only signal", () => {
+  const base = makeGitBase();
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "First", status: "complete" });
+    insertSlice({ milestoneId: "M001", id: "S01", title: "S", status: "complete", risk: "low", depends: [] });
+    insertMilestone({ id: "M002", title: "Second", status: "active" });
+    insertSlice({ milestoneId: "M002", id: "S01", title: "S", status: "pending", risk: "low", depends: [] });
+
+    writeFileSync(join(base, ".git", "info", "exclude"), ".gsd/\n");
+    mkdirSync(join(base, "src"), { recursive: true });
+    writeFileSync(join(base, "src", "feature.ts"), "export const x = 1;\n");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feat: impl\n\nGSD-Task: S01/T01"], { cwd: base, stdio: "ignore" });
+
+    assert.notEqual(hasImplementationArtifacts(base, "M001"), "present");
+    assert.notEqual(hasImplementationArtifacts(base, "M002"), "present");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("hasImplementationArtifacts returns true on non-git directory (fail-open)", () => {
   const base = join(tmpdir(), `gsd-test-nogit-${randomUUID()}`);
   mkdirSync(base, { recursive: true });


### PR DESCRIPTION
## TL;DR

**What:** Stop `complete-milestone` from blocking forever when implementation commits use short `GSD-Task: Sxx/Tyy` trailers and don't co-touch `.gsd/milestones/<MID>/`.
**Why:** `hasImplementationArtifacts()` falsely returned `"absent"` on the integration branch (isolation `none`), causing an infinite `dispatch-stop → auto-exit` loop.
**How:** Drop the path-scoped optimization in the milestone-tagged commit scan and bind short trailers via `getSlice()` when the DB is available.

## What

- `src/resources/extensions/gsd/auto-recovery.ts`
  - `getChangedFilesFromMilestoneTaggedCommits()`: removed the path-scoped primary scan (`-- .gsd/milestones/<id>`); always scan unscoped HEAD history with `commitMatchesMilestone()` deciding attribution.
  - `commitMatchesMilestone()`: for short trailers `GSD-Task: Sxx/Tyy`, also bind via DB (`getSlice(milestoneId, sliceId) != null`) when `isDbAvailable()`.
- `src/resources/extensions/gsd/tests/auto-recovery.test.ts`
  - Regression test: short-trailer impl commit on `main` with milestone/slice in DB → asserts `"present"`. Fails on `main` (returns `"absent"`), passes after the fix.

## Why

Reported in #5071 with two duplicate forensic reports (#5035, #5171). When auto-mode runs without worktree isolation, milestone work lands directly on `main`. Real implementation commits carry `GSD-Task: S13/T05`-style trailers and touch only `src/` / `cmd/` etc.

The path-scoped scan in `getChangedFilesFromMilestoneTaggedCommits()` only saw commits that *also* modified `.gsd/milestones/<MID>/`. It matched the `.gsd`-only plan commit (`GSD-Unit: M001`), classified the changed-files set as `"absent"`, and never reached the existing unscoped fallback. The dispatch guard then emitted `dispatch-stop` for `completing-milestone → complete-milestone` on every iteration; users had to manually run `gsd_complete_milestone` to recover.

Closes #5071
Closes #5035
Closes #5171

## How

Two minimal changes, both in `auto-recovery.ts`:

1. **Always scan unscoped.** The path-scoped scan was a perf optimization that hid implementation-only commits. Dropping it makes `commitMatchesMilestone()` the single source of attribution truth. The unscoped scan path was already present (added in #5033 for gitignored `.gsd/`); we now use it unconditionally.

2. **DB binding for short trailers.** When a commit's only milestone evidence is `GSD-Task: Sxx/Tyy` and neither `.gsd` co-touch nor message mention applies, look up the slice in the DB. If the slice belongs to the milestone, the commit binds. Falls back gracefully when the DB is unavailable (legacy projects keep prior behavior).

The previous false-negative case (#4699 — `.gsd`-only main history with `GSD-Unit: M001`) still returns `"absent"` because the `.gsd` files classify that way after attribution; covered by existing test.

## Test plan

- [x] `npm run verify:pr` — 8061 passed, 0 failed, 9 skipped
- [x] New regression test fails on baseline (`expected: 'present', actual: 'absent'`), passes with fix
- [x] All 46 unit tests in `auto-recovery.test.ts` pass
- [x] All 38 integration tests in `tests/integration/auto-recovery.test.ts` pass

## AI assistance

This PR was AI-assisted (Claude Opus 4.7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved milestone attribution for implementation commits by tracking an active milestone from long-form trailers during history scans and consulting persisted slice ownership to disambiguate reused slice IDs; also considers message body and touched artifact paths to reduce incorrect attributions.

* **Tests**
  * Added integration tests validating milestone-to-commit binding, detection of implementation artifacts, and handling of reused or ambiguous slice IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->