### PR TITLE
fix(gsd): persist skip-validation state and clear gate rows on recover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,12 +337,12 @@ jobs:
         run: >-
           node --experimental-strip-types --input-type=module -e
           "const mod = await import('./src/rtk.ts');
-          const path = mod.getManagedRtkPath(process.platform);
-          if (!mod.validateRtkBinary(path)) {
-            console.error('Managed RTK validation failed:', path);
+          const result = await mod.ensureRtkAvailable();
+          if (!result.available || !result.binaryPath || !mod.validateRtkBinary(result.binaryPath)) {
+            console.error('Managed RTK validation failed:', result);
             process.exit(1);
           }
-          console.log('Managed RTK validated at', path);"
+          console.log('Managed RTK validated at', result.binaryPath, 'via', result.source);"
 
       - name: Run RTK-focused portability tests
         run: >-

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -60,7 +60,7 @@
 | `/gsd hooks` | Show configured post-unit and pre-dispatch hooks |
 | `/gsd run-hook` | Manually trigger a specific hook |
 | `/gsd migrate` | Migrate a v1 `.planning` directory to `.gsd` format |
-| `/gsd recover` | Explicitly reconstruct database hierarchy state from rendered markdown after database loss or corruption |
+| `/gsd recover` | Explicitly reset database hierarchy plus persisted validation and quality-gate state, then reconstruct from rendered markdown after database loss or corruption |
 
 ## Milestone Management
 

--- a/docs/user-docs/migration.md
+++ b/docs/user-docs/migration.md
@@ -54,4 +54,4 @@ If an existing project has markdown artifacts but a missing or damaged database,
 /gsd recover
 ```
 
-`/gsd recover` reconstructs the milestone, slice, and task hierarchy from the rendered markdown on disk. It is an explicit recovery/import operation; normal runtime does not silently derive state from markdown.
+`/gsd recover` clears the persisted hierarchy plus validation-related state, including quality-gate rows and skipped-validation assessments, then reconstructs the milestone, slice, and task hierarchy from the rendered markdown on disk. It is an explicit destructive recovery/import operation; normal runtime does not silently derive state from markdown.

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -322,7 +322,7 @@ Use this only when the database is missing, damaged, or known to be stale but th
 /gsd recover
 ```
 
-`/gsd recover` clears and reconstructs the database hierarchy tables from markdown, then derives state again to verify the result. Normal runtime does not silently import markdown projections, and worktree markdown is not synced back as authoritative state.
+`/gsd recover` clears the database hierarchy tables plus persisted validation/gate state from prior runs, including quality-gate rows and skipped-validation assessments, then reconstructs the hierarchy from markdown and derives state again to verify the result. Normal runtime does not silently import markdown projections, and worktree markdown is not synced back as authoritative state.
 
 ## Getting Help
 

--- a/src/help-text.ts
+++ b/src/help-text.ts
@@ -164,7 +164,7 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     '  gsd headless --answers answers.json auto              With pre-supplied answers',
     '  gsd headless --events agent_end,extension_ui_request auto   Filtered event stream',
     '  gsd headless query                              Instant JSON state snapshot',
-    '  gsd headless recover                            Rebuild DB hierarchy from markdown (mutating)',
+    '  gsd headless recover                            Reset hierarchy + validation/gates, then rebuild from markdown',
     '',
     'Exit codes: 0 = success, 1 = error/timeout, 10 = blocked, 11 = cancelled',
   ].join('\n'),

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1247,8 +1247,11 @@ export const DISPATCH_RULES: DispatchRule[] = [
           } catch (err) {
             try {
               unlinkSync(validationPath);
-            } catch {
-              // Preserve the original DB failure.
+            } catch (unlinkErr) {
+              logWarning(
+                "dispatch",
+                `failed to remove skipped validation file after DB write failure for ${mid}: ${unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr)}`,
+              );
             }
             throw err;
           }

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1205,9 +1205,12 @@ export const DISPATCH_RULES: DispatchRule[] = [
           const skipSource = trivialVariant
             ? "trivial-scope pipeline variant (#4781)"
             : "`skip_milestone_validation` preference";
+          const skipValidationReason = trivialVariant ? "trivial-scope" : "preference";
           const content = [
             "---",
             "verdict: pass",
+            "skip_validation: true",
+            `skip_validation_reason: ${skipValidationReason}`,
             "remediation_round: 0",
             "---",
             "",
@@ -1230,13 +1233,15 @@ export const DISPATCH_RULES: DispatchRule[] = [
               scope: "milestone-validation",
               fullContent: content,
             });
-            const gateSliceId = getMilestoneSlices(mid)[0]?.id ?? "_milestone";
-            insertMilestoneValidationGates(
-              mid,
-              gateSliceId,
-              "pass",
-              new Date().toISOString(),
-            );
+            const gateSliceId = getMilestoneSlices(mid)[0]?.id;
+            if (gateSliceId) {
+              insertMilestoneValidationGates(
+                mid,
+                gateSliceId,
+                "pass",
+                new Date().toISOString(),
+              );
+            }
           }
           invalidateAllCaches();
         }
@@ -1323,7 +1328,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
               if (validationContent) {
                 // Allow completion when validation was intentionally skipped by
                 // preference/budget profile (#3399, #3344).
+                const skippedByMarker = /^skip_validation:\s*true$/im.test(validationContent);
                 const skippedByPreference = /skip(?:ped)?[\s\-]+(?:by|per|due to)\s+(?:preference|budget|profile)/i.test(validationContent);
+                const skippedByTrivialVariant = /trivial-scope pipeline variant/i.test(validationContent);
 
                 // Accept either the structured template format (table with MET/N/A/SATISFIED)
                 // or prose evidence patterns the validation agent may emit.
@@ -1332,7 +1339,12 @@ export const DISPATCH_RULES: DispatchRule[] = [
                   (validationContent.includes("MET") || validationContent.includes("N/A") || validationContent.includes("SATISFIED"));
                 const proseMatch =
                   /[Oo]perational[\s\S]{0,500}?(?:✅|pass|verified|confirmed|met|complete|true|yes|addressed|covered|satisfied|partially|n\/a|not[\s-]+applicable)/i.test(validationContent);
-                const hasOperationalCheck = skippedByPreference || structuredMatch || proseMatch;
+                const hasOperationalCheck =
+                  skippedByMarker ||
+                  skippedByPreference ||
+                  skippedByTrivialVariant ||
+                  structuredMatch ||
+                  proseMatch;
                 if (!hasOperationalCheck) {
                   return {
                     action: "stop" as const,

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1219,29 +1219,38 @@ export const DISPATCH_RULES: DispatchRule[] = [
             `Milestone validation was skipped via ${skipSource}.`,
           ].join("\n");
           writeFileSync(validationPath, content, "utf-8");
-          // DB-backed state derivation keys off assessments, not only the file
-          // projection. Persist the skipped validation there too so the next
-          // loop iteration advances to completing-milestone instead of
-          // re-entering validating-milestone.
-          if (isDbAvailable()) {
-            insertAssessment({
-              path: validationPath,
-              milestoneId: mid,
-              sliceId: null,
-              taskId: null,
-              status: "pass",
-              scope: "milestone-validation",
-              fullContent: content,
-            });
-            const gateSliceId = getMilestoneSlices(mid)[0]?.id;
-            if (gateSliceId) {
-              insertMilestoneValidationGates(
-                mid,
-                gateSliceId,
-                "pass",
-                new Date().toISOString(),
-              );
+          try {
+            // DB-backed state derivation keys off assessments, not only the file
+            // projection. Persist the skipped validation there too so the next
+            // loop iteration advances to completing-milestone instead of
+            // re-entering validating-milestone.
+            if (isDbAvailable()) {
+              insertAssessment({
+                path: validationPath,
+                milestoneId: mid,
+                sliceId: null,
+                taskId: null,
+                status: "pass",
+                scope: "milestone-validation",
+                fullContent: content,
+              });
+              const gateSliceId = getMilestoneSlices(mid)[0]?.id;
+              if (gateSliceId) {
+                insertMilestoneValidationGates(
+                  mid,
+                  gateSliceId,
+                  "pass",
+                  new Date().toISOString(),
+                );
+              }
             }
+          } catch (err) {
+            try {
+              unlinkSync(validationPath);
+            } catch {
+              // Preserve the original DB failure.
+            }
+            throw err;
           }
           invalidateAllCaches();
         }

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -14,7 +14,7 @@ import type { GSDPreferences } from "./preferences.js";
 import type { UatType } from "./files.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
-import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, insertAssessment } from "./gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, insertAssessment, transaction } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 
@@ -1225,24 +1225,26 @@ export const DISPATCH_RULES: DispatchRule[] = [
             // loop iteration advances to completing-milestone instead of
             // re-entering validating-milestone.
             if (isDbAvailable()) {
-              insertAssessment({
-                path: validationPath,
-                milestoneId: mid,
-                sliceId: null,
-                taskId: null,
-                status: "pass",
-                scope: "milestone-validation",
-                fullContent: content,
+              transaction(() => {
+                insertAssessment({
+                  path: validationPath,
+                  milestoneId: mid,
+                  sliceId: null,
+                  taskId: null,
+                  status: "pass",
+                  scope: "milestone-validation",
+                  fullContent: content,
+                });
+                const gateSliceId = getMilestoneSlices(mid)[0]?.id;
+                if (gateSliceId) {
+                  insertMilestoneValidationGates(
+                    mid,
+                    gateSliceId,
+                    "pass",
+                    new Date().toISOString(),
+                  );
+                }
               });
-              const gateSliceId = getMilestoneSlices(mid)[0]?.id;
-              if (gateSliceId) {
-                insertMilestoneValidationGates(
-                  mid,
-                  gateSliceId,
-                  "pass",
-                  new Date().toISOString(),
-                );
-              }
             }
           } catch (err) {
             try {

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -14,7 +14,7 @@ import type { GSDPreferences } from "./preferences.js";
 import type { UatType } from "./files.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
-import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone } from "./gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, insertAssessment } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 
@@ -78,6 +78,8 @@ import {
   type DeepProjectSetupStage,
 } from "./deep-project-setup-policy.js";
 import { annotateBackgroundable } from "./delegation-policy.js";
+import { invalidateAllCaches } from "./cache.js";
+import { insertMilestoneValidationGates } from "./milestone-validation-gates.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -1214,6 +1216,29 @@ export const DISPATCH_RULES: DispatchRule[] = [
             `Milestone validation was skipped via ${skipSource}.`,
           ].join("\n");
           writeFileSync(validationPath, content, "utf-8");
+          // DB-backed state derivation keys off assessments, not only the file
+          // projection. Persist the skipped validation there too so the next
+          // loop iteration advances to completing-milestone instead of
+          // re-entering validating-milestone.
+          if (isDbAvailable()) {
+            insertAssessment({
+              path: validationPath,
+              milestoneId: mid,
+              sliceId: null,
+              taskId: null,
+              status: "pass",
+              scope: "milestone-validation",
+              fullContent: content,
+            });
+            const gateSliceId = getMilestoneSlices(mid)[0]?.id ?? "_milestone";
+            insertMilestoneValidationGates(
+              mid,
+              gateSliceId,
+              "pass",
+              new Date().toISOString(),
+            );
+          }
+          invalidateAllCaches();
         }
         return { action: "skip" };
       }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -3723,12 +3723,17 @@ export function deleteArtifactByPath(path: string): void {
 }
 
 /**
- * Drop all rows from tasks/slices/milestones in dependency order inside a
- * transaction. Used by `gsd recover` to rebuild engine state from markdown.
+ * Drop hierarchy rows in dependency order inside a transaction. Used by
+ * `gsd recover` to rebuild engine state from markdown.
  */
 export function clearEngineHierarchy(): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   transaction(() => {
+    currentDb!.exec("DELETE FROM verification_evidence");
+    currentDb!.exec("DELETE FROM quality_gates");
+    currentDb!.exec("DELETE FROM slice_dependencies");
+    currentDb!.exec("DELETE FROM assessments");
+    currentDb!.exec("DELETE FROM replan_history");
     currentDb!.exec("DELETE FROM tasks");
     currentDb!.exec("DELETE FROM slices");
     currentDb!.exec("DELETE FROM milestones");

--- a/src/resources/extensions/gsd/tests/pipeline-variant-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/pipeline-variant-dispatch.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 
 import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
 import {
+  _getAdapter,
   openDatabase,
   closeDatabase,
   insertMilestone,
@@ -241,7 +242,64 @@ test("#4781 phase 2: validate-milestone rule writes pass-through VALIDATION for 
   const { readFileSync } = await import("node:fs");
   const content = readFileSync(validationPath, "utf-8");
   assert.match(content, /verdict: pass/);
+  assert.match(content, /skip_validation: true/);
   assert.match(content, /trivial-scope pipeline variant \(#4781\)/);
+});
+
+test("#4781 phase 2: validate-milestone skip path does not persist gates without a real slice", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({
+    id: "M001",
+    title: TRIVIAL_INPUT.title,
+    status: "active",
+    depends_on: [],
+  });
+  upsertMilestonePlanning("M001", {
+    title: TRIVIAL_INPUT.title,
+    status: "active",
+    vision: TRIVIAL_INPUT.vision,
+    successCriteria: TRIVIAL_INPUT.successCriteria,
+    keyRisks: [],
+    proofStrategy: [],
+    verificationContract: "",
+    verificationIntegration: "",
+    verificationOperational: "",
+    verificationUat: "",
+    definitionOfDone: [],
+    requirementCoverage: "",
+    boundaryMapMarkdown: "",
+  });
+
+  const { writeFileSync, readFileSync } = await import("node:fs");
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    [
+      "# M001",
+      "## Slices",
+      "",
+      "_No slices required for this trivial milestone._",
+    ].join("\n"),
+  );
+
+  const ctx = makeCtx({ base, mid: "M001", phase: "validating-milestone" });
+  const result = await findRule(VALIDATE_RULE).match(ctx);
+
+  assert.ok(result, "rule must return a result, not null");
+  assert.strictEqual(result!.action, "skip", "trivial variant must still skip without slices");
+
+  const validationPath = join(base, ".gsd", "milestones", "M001", "M001-VALIDATION.md");
+  const content = readFileSync(validationPath, "utf-8");
+  assert.match(content, /skip_validation: true/);
+
+  const adapter = _getAdapter();
+  assert.ok(adapter, "test database should be open");
+  const gateCount = adapter.prepare(
+    "SELECT count(*) AS n FROM quality_gates WHERE milestone_id = 'M001'",
+  ).get() as { n: number };
+  assert.equal(gateCount.n, 0, "skip path must not persist milestone gates without a real slice id");
 });
 
 test("#4781 phase 2: validate-milestone rule dispatches normally for standard variant", async (t) => {

--- a/src/resources/extensions/gsd/tests/skipped-validation-completion.test.ts
+++ b/src/resources/extensions/gsd/tests/skipped-validation-completion.test.ts
@@ -22,6 +22,11 @@ const autoDispatchSrc = readFileSync(
 );
 
 describe('skipped validation completion (#3698)', () => {
+  test('skip_validation marker detection exists', () => {
+    assert.match(autoDispatchSrc, /skip_validation:\\s\*true/,
+      'skip_validation frontmatter marker should be recognized in auto-dispatch.ts');
+  });
+
   test('skippedByPreference regex detection exists', () => {
     assert.match(autoDispatchSrc, /skippedByPreference/,
       'skippedByPreference variable should exist in auto-dispatch.ts');
@@ -33,7 +38,7 @@ describe('skipped validation completion (#3698)', () => {
   });
 
   test('skippedByPreference feeds into operational check', () => {
-    assert.match(autoDispatchSrc, /hasOperationalCheck\s*=\s*skippedByPreference/,
+    assert.match(autoDispatchSrc, /hasOperationalCheck\s*=\s*[\s\S]*skippedByPreference/,
       'skippedByPreference should be part of hasOperationalCheck');
   });
 });

--- a/src/resources/extensions/gsd/tests/skipped-validation-completion.test.ts
+++ b/src/resources/extensions/gsd/tests/skipped-validation-completion.test.ts
@@ -1,44 +1,144 @@
 /**
  * Regression test for #3698 — allow milestone completion when validation
- * was skipped by preference
- *
- * When validation is skipped due to user preference (e.g. budget profile),
- * auto-dispatch should recognize the "skipped by preference" pattern and
- * allow completion instead of treating it as a missing validation.
+ * was skipped by preference.
  */
 
-import { describe, test } from 'node:test';
-import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  openDatabase,
+  upsertMilestonePlanning,
+} from "../gsd-db.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import type { GSDState } from "../types.ts";
 
-const autoDispatchSrc = readFileSync(
-  join(__dirname, '..', 'auto-dispatch.ts'),
-  'utf-8',
-);
+const COMPLETE_RULE = "completing-milestone → complete-milestone";
 
-describe('skipped validation completion (#3698)', () => {
-  test('skip_validation marker detection exists', () => {
-    assert.match(autoDispatchSrc, /skip_validation:\\s\*true/,
-      'skip_validation frontmatter marker should be recognized in auto-dispatch.ts');
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-skipped-validation-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  writeFileSync(join(base, "app.js"), "export const shipped = true;\n");
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  invalidateAllCaches();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function seedMilestone(base: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({
+    id: "M001",
+    title: "Preference-skipped validation milestone",
+    status: "active",
+    depends_on: [],
   });
-
-  test('skippedByPreference regex detection exists', () => {
-    assert.match(autoDispatchSrc, /skippedByPreference/,
-      'skippedByPreference variable should exist in auto-dispatch.ts');
+  upsertMilestonePlanning("M001", {
+    title: "Preference-skipped validation milestone",
+    status: "active",
+    vision: "Ship a small implementation with a documented validation skip.",
+    successCriteria: ["Completion remains unblocked when validation was intentionally skipped."],
+    keyRisks: [],
+    proofStrategy: [],
+    verificationContract: "",
+    verificationIntegration: "",
+    verificationOperational: "Smoke-test the shipped workflow before completion.",
+    verificationUat: "",
+    definitionOfDone: [],
+    requirementCoverage: "",
+    boundaryMapMarkdown: "",
   });
-
-  test('regex matches skip-by-preference patterns', () => {
-    assert.match(autoDispatchSrc, /skip\(\?:ped\)\?\[\\s\\-\]\+\(\?:by\|per\|due to\)/,
-      'should have regex matching "skipped by/per/due to" patterns');
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "First",
+    status: "done",
+    risk: "low",
+    depends: [],
+    demo: "",
+    sequence: 1,
   });
+}
 
-  test('skippedByPreference feeds into operational check', () => {
-    assert.match(autoDispatchSrc, /hasOperationalCheck\s*=\s*[\s\S]*skippedByPreference/,
-      'skippedByPreference should be part of hasOperationalCheck');
-  });
+function writeFixtureFiles(base: string): void {
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  writeFileSync(
+    join(milestoneDir, "M001-ROADMAP.md"),
+    [
+      "# M001",
+      "## Slices",
+      "- [x] **S01: First** `risk:low` `depends:[]`",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(milestoneDir, "slices", "S01", "S01-SUMMARY.md"),
+    "# S01\n\nImplemented the shipped workflow.\n",
+  );
+  writeFileSync(
+    join(milestoneDir, "M001-VALIDATION.md"),
+    [
+      "---",
+      "verdict: pass",
+      "skip_validation: true",
+      "skip_validation_reason: preference",
+      "remediation_round: 0",
+      "---",
+      "",
+      "# Milestone Validation (skipped)",
+      "",
+      "Milestone validation was skipped by preference.",
+    ].join("\n"),
+  );
+}
+
+function findRule(name: string) {
+  const rule = DISPATCH_RULES.find(candidate => candidate.name === name);
+  assert.ok(rule, `rule "${name}" must exist`);
+  return rule!;
+}
+
+function makeCtx(base: string): DispatchContext {
+  const state: GSDState = {
+    phase: "completing-milestone",
+    activeMilestone: { id: "M001", title: "Preference-skipped validation milestone" },
+    activeSlice: null,
+    activeTask: null,
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [{ id: "M001", title: "Preference-skipped validation milestone", status: "active" }],
+  };
+  return {
+    basePath: base,
+    mid: "M001",
+    midTitle: "Preference-skipped validation milestone",
+    state,
+    prefs: undefined,
+  };
+}
+
+test("#3698: completing-milestone dispatch accepts skipped validation fixture", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+
+  seedMilestone(base);
+  writeFixtureFiles(base);
+
+  const result = await findRule(COMPLETE_RULE).match(makeCtx(base));
+
+  assert.ok(result, "rule must return a result");
+  assert.strictEqual(result!.action, "dispatch", "skipped validation should still allow completion dispatch");
+  if (result!.action === "dispatch") {
+    assert.strictEqual(result.unitType, "complete-milestone");
+  }
 });

--- a/src/resources/extensions/gsd/tests/skipped-validation-db-atomicity.test.ts
+++ b/src/resources/extensions/gsd/tests/skipped-validation-db-atomicity.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test("skipped validation DB persistence stays atomic", () => {
+  const source = readFileSync(join(__dirname, "..", "auto-dispatch.ts"), "utf-8");
+
+  assert.match(
+    source,
+    /if \(isDbAvailable\(\)\) \{\s+transaction\(\(\) => \{\s+insertAssessment\([\s\S]*?insertMilestoneValidationGates\(/,
+    "skipped validation DB writes must remain inside a single transaction",
+  );
+});

--- a/src/resources/extensions/gsd/tests/validate-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
-import { deriveState, isValidationTerminal } from "../state.ts";
+import { deriveState, invalidateStateCache, isValidationTerminal } from "../state.ts";
 import { resolveExpectedArtifactPath, diagnoseExpectedArtifact } from "../auto-artifact-paths.ts";
 import { verifyExpectedArtifact, buildLoopRemediationSteps } from "../auto-recovery.ts";
 import { resolveDispatch, type DispatchContext } from "../auto-dispatch.ts";
@@ -24,6 +24,7 @@ function makeTmpBase(): string {
 }
 
 function cleanup(base: string): void {
+  invalidateStateCache();
   clearPathCache();
   clearParseCache();
   closeDatabase();
@@ -389,6 +390,45 @@ test("dispatch rule skips when skip_milestone_validation preference is set", asy
     // Verify the VALIDATION file was written
     const validationPath = join(base, ".gsd", "milestones", "M001", "M001-VALIDATION.md");
     assert.ok(existsSync(validationPath), "VALIDATION file should be written on skip");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("skip write immediately advances deriveState out of validating-milestone", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    insertMilestone({ id: "M001", title: "Test", status: "active" } as any);
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice 1", status: "complete" } as any);
+
+    writeContext(base, "M001");
+    writeRoadmap(base, "M001", ALL_DONE_ROADMAP);
+    writeSliceSummary(base, "M001", "S01", "# S01 Summary\nDone.");
+
+    invalidateStateCache();
+    clearPathCache();
+    clearParseCache();
+
+    const before = await deriveState(base);
+    assert.equal(before.phase, "validating-milestone", "precondition: missing VALIDATION keeps phase in validation");
+
+    const ctx: DispatchContext = {
+      basePath: base,
+      mid: "M001",
+      midTitle: "Test",
+      state: before,
+      prefs: { phases: { skip_milestone_validation: true } },
+    };
+    const result = await resolveDispatch(ctx);
+    assert.equal(result.action, "skip");
+
+    const after = await deriveState(base);
+    assert.equal(
+      after.phase,
+      "completing-milestone",
+      "post-skip deriveState should see the new VALIDATION file without manual cache invalidation",
+    );
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/write-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate.test.ts
@@ -299,31 +299,39 @@ test('write-gate: deep root PROJECT/REQUIREMENTS final saves require verified ap
 });
 
 test('write-gate: reopening a gate revokes its previous verified approval', () => {
-  clearDiscussionFlowState(process.cwd());
+  const base = join(tmpdir(), `gsd-write-gate-reopen-${randomUUID()}`);
+  mkdirSync(base, { recursive: true });
 
-  markApprovalGateVerified('depth_verification_project_confirm');
-  assert.strictEqual(
-    shouldBlockRootArtifactSaveInSnapshot(
-      loadWriteGateSnapshot(process.cwd()),
-      'PROJECT',
-      { requireVerifiedApproval: true },
-    ).block,
-    false,
-    'precondition: verified approval unlocks the final project artifact',
-  );
+  try {
+    clearDiscussionFlowState(base);
 
-  setPendingGate('depth_verification_project_confirm', process.cwd());
-  clearPendingGate(process.cwd());
+    markApprovalGateVerified('depth_verification_project_confirm', base);
+    assert.strictEqual(
+      shouldBlockRootArtifactSaveInSnapshot(
+        loadWriteGateSnapshot(base),
+        'PROJECT',
+        { requireVerifiedApproval: true },
+      ).block,
+      false,
+      'precondition: verified approval unlocks the final project artifact',
+    );
 
-  assert.strictEqual(
-    shouldBlockRootArtifactSaveInSnapshot(
-      loadWriteGateSnapshot(process.cwd()),
-      'PROJECT',
-      { requireVerifiedApproval: true },
-    ).block,
-    true,
-    'a re-asked gate must require a fresh approval',
-  );
+    setPendingGate('depth_verification_project_confirm', base);
+    clearPendingGate(base);
+
+    assert.strictEqual(
+      shouldBlockRootArtifactSaveInSnapshot(
+        loadWriteGateSnapshot(base),
+        'PROJECT',
+        { requireVerifiedApproval: true },
+      ).block,
+      true,
+      'a re-asked gate must require a fresh approval',
+    );
+  } finally {
+    clearDiscussionFlowState(base);
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/src/tests/headless-recover.test.ts
+++ b/src/tests/headless-recover.test.ts
@@ -33,6 +33,7 @@ import {
   getAllMilestones,
   getMilestoneSlices,
   getSliceTasks,
+  insertGateRow,
 } from "../resources/extensions/gsd/gsd-db.ts";
 import { migrateHierarchyToDb } from "../resources/extensions/gsd/md-importer.ts";
 import { invalidateStateCache } from "../resources/extensions/gsd/state.ts";
@@ -137,4 +138,32 @@ test("headless recover: idempotent when run twice on the same fixture", async (t
   );
   assert.equal(getAllMilestones().length, 1, "DB has exactly one milestone after the second pass");
   assert.equal(getSliceTasks("M001", "S01").length, 1, "DB has exactly one task after the second pass");
+});
+
+test("headless recover: clears gate rows before rebuilding hierarchy", async (t) => {
+  const base = makeMarkdownFixture();
+  t.after(() => {
+    try { closeDatabase(); } catch { /* may not be open */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  await ensureDbOpen(base);
+
+  transaction(() => {
+    clearEngineHierarchy();
+    return migrateHierarchyToDb(base);
+  });
+  invalidateStateCache();
+
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q5", scope: "task", taskId: "T01" });
+
+  const recovered = transaction(() => {
+    clearEngineHierarchy();
+    return migrateHierarchyToDb(base);
+  });
+  invalidateStateCache();
+
+  assert.deepEqual(recovered, { milestones: 1, slices: 1, tasks: 1 });
+  assert.equal(getSliceTasks("M001", "S01").length, 1, "DB has the imported task after gate-backed recovery");
 });


### PR DESCRIPTION
## TL;DR

Fixes two independent DB-vs-file projection drift bugs that cause auto-mode to either loop on `validating-milestone` (skip-pref ignored on next tick) or crash `gsd recover` (orphan FK-referencing rows). Both paths land regression tests via `node:test` + `node:assert/strict`.

## What

- `auto-dispatch.ts`: when `skip_milestone_validation` writes the marker file, also `insertAssessment` (`scope: \"milestone-validation\"`, `status: \"pass\"`) + `insertMilestoneValidationGates(mid, sliceId, \"pass\", now)` + `invalidateAllCaches()`.
- `gsd-db.ts`: `clearEngineHierarchy()` now drops `verification_evidence`, `quality_gates`, `slice_dependencies`, `assessments`, and `replan_history` inside the same transaction, in dependency order, before `tasks`/`slices`/`milestones`.
- New regression tests:
  - `tests/validate-milestone.test.ts`: \"skip write immediately advances deriveState out of validating-milestone\"
  - `src/tests/headless-recover.test.ts`: \"headless recover: clears gate rows before rebuilding hierarchy\"

## Why

**Bug 1 (skip-validation infinite loop):** \`deriveState\` is DB-first per \`state.ts:281-324\`. When the dispatch rule wrote the skip-marker file but didn't update DB assessments/gates, the next loop tick saw \"no pass assessment\" and re-entered \`validating-milestone\` indefinitely — tripping the stuck-detector at \`auto/detect-stuck.ts:62-69\` rule 2b.

**Bug 2 (recover crash):** \`clearEngineHierarchy()\` only deleted \`tasks\`/\`slices\`/\`milestones\`, leaving rows in five FK-referencing tables (\`verification_evidence\`, \`quality_gates\`, \`slice_dependencies\`, \`assessments\`, \`replan_history\`). On the next \`migrateHierarchyToDb\` cycle these either FK-violated or polluted the rebuild.

Both fixes converge on the same invariant: **DB and file projections of milestone state must not diverge across writes**.

## How

Both regression tests fail on \`main\` without the source changes (each isolates the exact failure mode), pass with them. \`npx tsx --test --test-name-pattern\` confirms green:

\`\`\`
✔ skip write immediately advances deriveState out of validating-milestone
✔ headless recover: clears gate rows before rebuilding hierarchy
\`\`\`

## Scope note (Phase A part 1 of approved plan)

This PR is the first commit of a 3-phase coordination overhaul plan. Pending follow-ups (in order):

1. **Phase A pt 2** — path threading through 8 production files (\`auto/loop.ts\`, \`auto/phases.ts\`, \`state.ts\`, \`escalation.ts\`, \`auto-post-unit.ts\`, \`rule-registry.ts\`, \`workflow-projections.ts\`, \`triage-resolution.ts\`) so reads consult the canonical project root regardless of \`s.basePath\` mutation, plus a symlinked-worktree reproduction test. Specced; ready to execute next session.
2. **Phase B** — DB-backed coordination tables (workers, milestone_leases, unit_dispatches, cancellation_requests, command_queue) under SCHEMA_VERSION 23 → 24.
3. **Phase C** — file-state migration (paused-session.json, stuck-state.json, auto.lock → DB) + delete \`copyPlanningArtifacts\` / \`reconcilePlanCheckboxes\`.

Splitting Phase A across two PRs keeps blast radius small and gets the immediate user-facing fixes in fast. Plan reviewed by Codex CLI; BLOCKING/HIGH findings folded in.

## AI assistance disclosure

The two source fixes were originally drafted in a \`claude.ai/code\` cloud session that couldn't submit a PR. Rescued and validated locally; tests run via \`npx tsx --test\` against the committed code.

## Test plan

- [x] \`tests/validate-milestone.test.ts\` — new test passes
- [x] \`tests/headless-recover.test.ts\` — new test passes
- [ ] CI green (will check once posted)
- [ ] Reviewer to confirm no regression in DB-backed projects already running auto-mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust managed-tool validation with clearer failure/success logging
  * Skipped milestone validations now write a VALIDATION record (with reason), persist pass/gates, and invalidate caches so state advances correctly
  * Clearing engine hierarchy now removes additional engine tables for consistent resets

* **Tests**
  * New and strengthened regression tests for recovery, skipped-validation flows, gate behavior, and DB atomicity
  * Improved test isolation (temp workspaces) and cache invalidation between tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->