### PR TITLE
feat(gsd): DB-backed auto-mode coordination tables (workers, leases, dispatches, command queue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ gsd headless dispatch plan
 
 Headless auto-responds to interactive prompts, detects completion, and exits with structured codes: `0` complete, `1` error/timeout, `2` blocked. Auto-restarts on crash with exponential backoff. Use `gsd headless query` for instant, machine-readable state inspection — returns phase, next dispatch preview, and parallel worker costs as a single JSON object without spawning an LLM session. Pair with [remote questions](./docs/user-docs/remote-questions.md) to route decisions to Slack or Discord when human input is needed.
 
-**Multi-session orchestration** — headless mode supports file-based IPC in `.gsd/parallel/` for coordinating multiple GSD workers across milestones. Build orchestrators that spawn, monitor, and budget-cap a fleet of GSD workers.
+**Multi-session orchestration** — headless mode supports DB-backed coordination across multiple GSD workers. Worker registration, milestone leases, unit dispatch tracking, and command delivery live in `.gsd/gsd.db`, while `.gsd/parallel/` remains a local runtime area for per-milestone locks and isolation artifacts.
 
 ### First launch
 
@@ -721,7 +721,7 @@ The best practice for working in teams is to ensure unique milestone names acros
 .gsd/runtime/
 # Git worktree working copies
 .gsd/worktrees/
-# Parallel orchestration IPC and worker status
+# Parallel runtime locks and per-milestone isolation artifacts
 .gsd/parallel/
 # SQLite database and WAL sidecars — authoritative runtime state, local only
 .gsd/gsd.db*

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -96,7 +96,7 @@ See [Git Strategy](./git-strategy.md) for details.
 
 ### Parallel Execution
 
-When your project has independent milestones, you can run them simultaneously. Each milestone gets its own worker process and worktree. See [Parallel Orchestration](./parallel-orchestration.md) for setup and usage.
+When your project has independent milestones, you can run them simultaneously. Each milestone gets its own worker process and worktree, and the shared project database coordinates worker heartbeats, milestone leases, dispatch ownership, retry windows, and control commands. See [Parallel Orchestration](./parallel-orchestration.md) for setup and usage.
 
 ### Crash Recovery
 

--- a/docs/user-docs/parallel-orchestration.md
+++ b/docs/user-docs/parallel-orchestration.md
@@ -263,7 +263,7 @@ The coordinator runs stale detection during status refresh and either marks the 
 
 ## File Layout
 
-```
+```text
 .gsd/
 ├── gsd.db                       # Shared runtime database
 ├── gsd.db-wal / gsd.db-shm      # SQLite WAL sidecars while workers are active

--- a/docs/user-docs/parallel-orchestration.md
+++ b/docs/user-docs/parallel-orchestration.md
@@ -1,6 +1,6 @@
 # Parallel Milestone Orchestration
 
-Run multiple milestones simultaneously in isolated git worktrees. Each milestone gets its own worker process, its own branch, and its own context window — while a coordinator tracks progress, enforces budgets, and keeps everything in sync.
+Run multiple milestones simultaneously in isolated git worktrees. Each milestone gets its own worker process, its own branch, and its own context window, while the shared GSD database tracks worker liveness, milestone ownership, dispatch status, retry windows, and control commands.
 
 > **Status:** Behind `parallel.enabled: false` by default. Opt-in only — zero impact to existing users.
 
@@ -80,11 +80,14 @@ Each worker is a separate `gsd` process with complete isolation:
 
 ### Coordination
 
-Workers and the coordinator communicate through file-based IPC:
+Workers and the coordinator communicate through DB-backed coordination tables in `.gsd/gsd.db`:
 
-- **Session status files** (`.gsd/parallel/<MID>.status.json`) — workers write heartbeats, the coordinator reads them
-- **Signal files** (`.gsd/parallel/<MID>.signal.json`) — coordinator writes signals, workers consume them
-- **Atomic writes** — write-to-temp + rename prevents partial reads
+- **`workers`** — registry of active auto-mode workers with heartbeat TTL and shutdown/crash status
+- **`milestone_leases`** — one-worker-at-a-time milestone ownership with fencing tokens for safe takeover after expiry or release
+- **`unit_dispatches`** — dispatch ledger that records claim, running, completed, failed, stuck, canceled, and retry timing state per unit
+- **`command_queue`** — targeted or broadcast control commands claimed atomically by workers
+
+If a worker stops heartbeating, its lease can expire and another worker can safely take over the milestone. Retry-aware stuck detection also consults the dispatch ledger so a unit waiting for `next_run_at` is not misclassified as stuck.
 
 ## Eligibility Analysis
 
@@ -187,7 +190,7 @@ Coordinator                    Worker
     │                            └── process exits
 ```
 
-Workers check for signals between units (in `handleAgentEnd`). The coordinator also sends `SIGTERM` for immediate response on stop.
+Workers poll the command queue between units and the coordinator also sends `SIGTERM` for immediate response on stop. Heartbeats and lease refreshes happen continuously during the loop, so `parallel status` reflects DB state rather than sidecar JSON files.
 
 ## Merge Reconciliation
 
@@ -231,17 +234,18 @@ When `budget_ceiling` is set, the coordinator tracks aggregate cost across all w
 
 `/gsd doctor` detects parallel session issues:
 
-- **Stale parallel sessions** — Worker process died without cleanup. Doctor finds `.gsd/parallel/*.status.json` files with dead PIDs or expired heartbeats and removes them.
+- **Stale workers or leases** — Worker process died without cleanup. Doctor inspects worker heartbeats and expired milestone leases in the database, then clears the stale coordination state.
 
 Run `/gsd doctor --fix` to clean up automatically.
 
 ### Stale Detection
 
 Sessions are considered stale when:
-- The worker PID is no longer running (checked via `process.kill(pid, 0)`)
-- The last heartbeat is older than 30 seconds
+- The worker PID is no longer running
+- The last heartbeat is older than the worker TTL
+- A milestone lease is released or expires without a matching active heartbeat
 
-The coordinator runs stale detection during `refreshWorkerStatuses()` and automatically removes dead sessions.
+The coordinator runs stale detection during status refresh and either marks the worker crashed or allows the lease to be taken over on the next claim.
 
 ## Safety Model
 
@@ -253,7 +257,7 @@ The coordinator runs stale detection during `refreshWorkerStatuses()` and automa
 | **`GSD_MILESTONE_LOCK`** | Each worker only sees its milestone in state derivation |
 | **`GSD_PARALLEL_WORKER`** | Workers cannot spawn nested parallel sessions |
 | **Budget ceiling** | Aggregate cost enforcement across all workers |
-| **Signal-based shutdown** | Graceful stop via file signals + SIGTERM |
+| **Command queue + SIGTERM** | Graceful stop/pause/resume via DB-backed commands plus process signals |
 | **Doctor integration** | Detects and cleans up orphaned sessions |
 | **Conflict-aware merge** | Stops on code conflicts, auto-resolves `.gsd/` state conflicts |
 
@@ -261,11 +265,11 @@ The coordinator runs stale detection during `refreshWorkerStatuses()` and automa
 
 ```
 .gsd/
-├── parallel/                    # Coordinator ↔ worker IPC
-│   ├── M002.status.json         # Worker heartbeat + progress
-│   ├── M002.signal.json         # Coordinator → worker signals
-│   ├── M003.status.json
-│   └── M003.signal.json
+├── gsd.db                       # Shared runtime database
+├── gsd.db-wal / gsd.db-shm      # SQLite WAL sidecars while workers are active
+├── parallel/                    # Per-milestone runtime lock / isolation dirs
+│   ├── M002/
+│   └── M003/
 ├── worktrees/                   # Git worktrees (one per milestone)
 │   ├── M002/                    # M002's isolated checkout
 │   │   ├── .gsd/                # M002's own state files
@@ -278,7 +282,7 @@ The coordinator runs stale detection during `refreshWorkerStatuses()` and automa
 └── ...
 ```
 
-Both `.gsd/parallel/` and `.gsd/worktrees/` are gitignored — they're runtime-only coordination files that never get committed.
+`.gsd/gsd.db*`, `.gsd/parallel/`, and `.gsd/worktrees/` are all local runtime artifacts and should remain gitignored.
 
 ## Troubleshooting
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -244,6 +244,7 @@ import type {
   CurrentUnit,
   UnitRouting,
   StartModel,
+  AutoSession,
 } from "./auto/session.js";
 export {
   STUB_RECOVERY_THRESHOLD,
@@ -257,6 +258,9 @@ export type {
 import { autoSession as s } from "./auto-runtime-state.js";
 import { gsdHome } from "./gsd-home.js";
 import { createWorkspace, scopeMilestone } from "./workspace.js";
+import { registerAutoWorker, markWorkerStopping } from "./db/auto-workers.js";
+import { releaseMilestoneLease } from "./db/milestone-leases.js";
+import { normalizeRealPath } from "./paths.js";
 
 // ── ENCAPSULATION INVARIANT ─────────────────────────────────────────────────
 // ALL mutable auto-mode state lives in the AutoSession class (auto/session.ts).
@@ -273,6 +277,28 @@ import { createWorkspace, scopeMilestone } from "./workspace.js";
 
 /** Throttle STATE.md rebuilds — at most once per 30 seconds */
 const STATE_REBUILD_MIN_INTERVAL_MS = 30_000;
+
+/**
+ * Phase B — register this auto-mode process in the workers table so other
+ * workers and janitors can detect liveness via heartbeat. Best-effort: if
+ * the DB is unavailable (e.g. fresh project before init) we skip registration
+ * silently rather than blocking session start.
+ */
+function registerAutoWorkerForSession(session: AutoSession): void {
+  if (session.workerId) return; // already registered (e.g. resume re-runs)
+  try {
+    const projectRootRealpath = normalizeRealPath(
+      session.scope?.workspace.projectRoot
+        ?? (session.originalBasePath || session.basePath),
+    );
+    session.workerId = registerAutoWorker({ projectRootRealpath });
+  } catch (err) {
+    debugLog("autoLoop", {
+      phase: "register-worker-failed",
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
 
 function captureProjectRootEnv(projectRoot: string): void {
   if (!s.projectRootEnvCaptured) {
@@ -909,6 +935,21 @@ export async function stopAuto(
       if (lockBase()) releaseSessionLock(lockBase());
     } catch (e) {
       debugLog("stop-cleanup-locks", { error: e instanceof Error ? e.message : String(e) });
+    }
+
+    // ── Step 1b: Coordination cleanup (Phase B) ──
+    // Release any active milestone lease so other workers don't have to
+    // wait for TTL expiry, then mark this worker as stopping. Best-effort:
+    // DB unavailability or stale state must not block shutdown.
+    try {
+      if (s.workerId && s.currentMilestoneId && s.milestoneLeaseToken) {
+        releaseMilestoneLease(s.workerId, s.currentMilestoneId, s.milestoneLeaseToken);
+      }
+      if (s.workerId) {
+        markWorkerStopping(s.workerId);
+      }
+    } catch (e) {
+      debugLog("stop-cleanup-coordination", { error: e instanceof Error ? e.message : String(e) });
     }
 
     // ── Step 1b: Flush queued follow-up messages (#3512) ──
@@ -1824,6 +1865,7 @@ export async function startAuto(
     pi.events.emit(CMUX_CHANNELS.LOG, { preferences: loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, message: s.stepMode ? "Step-mode resumed." : "Auto-mode resumed.", level: "progress" });
 
     captureProjectRootEnv(s.originalBasePath || s.basePath);
+    registerAutoWorkerForSession(s);
     startAutoCommandPolling(s.basePath);
     await runAutoLoopWithUok({
       ctx,
@@ -1862,6 +1904,7 @@ export async function startAuto(
   rebuildScope(s.basePath, s.currentMilestoneId);
 
   captureProjectRootEnv(s.originalBasePath || s.basePath);
+  registerAutoWorkerForSession(s);
   try {
     pi.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "sync" as const, preferences: loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, state: await deriveState(s.basePath) });
   } catch (err) {

--- a/src/resources/extensions/gsd/auto/detect-stuck.ts
+++ b/src/resources/extensions/gsd/auto/detect-stuck.ts
@@ -6,6 +6,7 @@
 
 import type { WindowEntry } from "./types.js";
 import { summarizeLogs } from "../workflow-logger.js";
+import { getLatestForUnit } from "../db/unit-dispatches.js";
 
 /**
  * Pattern matching ENOENT errors with a file path.
@@ -15,12 +16,41 @@ import { summarizeLogs } from "../workflow-logger.js";
 const ENOENT_PATH_RE = /ENOENT[^']*'([^']+)'/;
 
 /**
+ * Phase B / codex review MEDIUM B3 — retry coupling.
+ *
+ * If unit_dispatches has a recent failed dispatch for `unitKey` whose
+ * retry budget is not yet exhausted (attempt_n < max_attempts) AND whose
+ * scheduled next_run_at is still in the future, the loop is legitimately
+ * waiting on its own backoff. Suppress the stuck verdict in that case so
+ * the retry budget can fully drain before we declare stuck.
+ *
+ * Returns true if the dispatch ledger says we should suppress the stuck
+ * signal; false (no suppression) when the ledger is unavailable or has
+ * no opinion.
+ */
+function retryBudgetSuppresses(unitKey: string): boolean {
+  try {
+    const latest = getLatestForUnit(unitKey);
+    if (!latest) return false;
+    if (latest.attempt_n >= latest.max_attempts) return false;
+    if (!latest.next_run_at) return false;
+    const nextRun = Date.parse(latest.next_run_at);
+    if (!Number.isFinite(nextRun)) return false;
+    return nextRun > Date.now();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Analyze a sliding window of recent unit dispatches for stuck patterns.
  * Returns a signal with reason if stuck, null otherwise.
  *
  * Rule 1: Same error string twice in a row → stuck immediately.
  * Rule 2: Same unit key 3+ consecutive times → stuck (preserves prior behavior).
- * Rule 2b: Same unit key appears 3+ times anywhere in the active window → stuck.
+ * Rule 2b: Same unit key appears 3+ times anywhere in the active window → stuck,
+ *          UNLESS unit_dispatches says we're inside the retry-backoff window
+ *          (codex review MEDIUM B3 — Phase B retry coupling).
  * Rule 3: Oscillation A→B→A→B in last 4 entries → stuck.
  * Rule 4: Same ENOENT path in any 2 entries within the window → stuck (#3575).
  *         Missing files don't self-heal between retries — retrying wastes budget.
@@ -48,10 +78,11 @@ export function detectStuck(
     };
   }
 
-  // Rule 2: Same unit 3+ consecutive times
+  // Rule 2: Same unit 3+ consecutive times — suppressed if unit_dispatches
+  // says we're inside the retry-backoff window (codex MEDIUM B3).
   if (window.length >= 3) {
     const lastThree = window.slice(-3);
-    if (lastThree.every((u) => u.key === last.key)) {
+    if (lastThree.every((u) => u.key === last.key) && !retryBudgetSuppresses(last.key)) {
       return {
         stuck: true,
         reason: `${last.key} derived 3 consecutive times without progress${suffix}`,
@@ -59,9 +90,10 @@ export function detectStuck(
     }
   }
 
-  // Rule 2b: Same unit key 3+ times anywhere in the active window
+  // Rule 2b: Same unit key 3+ times anywhere in the active window — same
+  // retry-budget suppression as Rule 2.
   const countInWindow = window.filter((entry) => entry.key === last.key).length;
-  if (countInWindow >= 3) {
+  if (countInWindow >= 3 && !retryBudgetSuppresses(last.key)) {
     return {
       stuck: true,
       reason: `${last.key} derived ${countInWindow} times in last ${window.length} attempts without progress${suffix}`,

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -33,6 +33,16 @@ import { ModelPolicyDispatchBlockedError } from "../auto-model-selection.js";
 import { resolveEngine } from "../engine-resolver.js";
 import { logWarning } from "../workflow-logger.js";
 import { gsdRoot } from "../paths.js";
+import { heartbeatAutoWorker } from "../db/auto-workers.js";
+import {
+  recordDispatchClaim,
+  markRunning as markDispatchRunning,
+  markCompleted as markDispatchCompleted,
+  markFailed as markDispatchFailed,
+  markStuck as markDispatchStuck,
+  getRecentForUnit as getRecentDispatchesForUnit,
+} from "../db/unit-dispatches.js";
+import { refreshMilestoneLease } from "../db/milestone-leases.js";
 import { atomicWriteSync } from "../atomic-write.js";
 import { resolveUokFlags } from "../uok/flags.js";
 import { scheduleSidecarQueue } from "../uok/execution-graph.js";
@@ -137,6 +147,63 @@ function saveCustomVerifyRetryCounts(s: AutoSession): void {
     if (code !== "ENOENT") {
       debugLog("autoLoop", { phase: "save-custom-verify-retries-failed", error: err instanceof Error ? err.message : String(err) });
     }
+  }
+}
+
+/**
+ * Phase B helper: open a unit_dispatches row in 'claimed' state and
+ * immediately transition it to 'running'. Returns the dispatch_id on
+ * success, or null when the ledger cannot be written (DB unavailable, no
+ * worker registered, no active milestone lease, double-claim race) — null
+ * means "fall through to existing single-worker semantics, no ledger
+ * entry for this iteration".
+ *
+ * Single-worker compatibility: this function is best-effort and never
+ * throws. The auto-loop must continue to behave identically when the
+ * ledger is degraded.
+ */
+function openDispatchClaim(
+  s: AutoSession,
+  flowId: string,
+  turnId: string,
+  iterData: IterationData,
+): number | null {
+  if (!s.workerId || s.milestoneLeaseToken === null) return null;
+  const mid = iterData.mid;
+  if (!mid) return null;
+
+  try {
+    const recent = getRecentDispatchesForUnit(iterData.unitId, 1);
+    const attemptN = (recent[0]?.attempt_n ?? 0) + 1;
+    const claim = recordDispatchClaim({
+      traceId: flowId,
+      turnId,
+      workerId: s.workerId,
+      milestoneLeaseToken: s.milestoneLeaseToken,
+      milestoneId: mid,
+      sliceId: iterData.state.activeSlice?.id ?? null,
+      taskId: iterData.state.activeTask?.id ?? null,
+      unitType: iterData.unitType,
+      unitId: iterData.unitId,
+      attemptN,
+    });
+    if (!claim.ok) {
+      debugLog("autoLoop", {
+        phase: "dispatch-claim-rejected",
+        unitId: iterData.unitId,
+        existingId: claim.existingId,
+        existingWorker: claim.existingWorker,
+      });
+      return null;
+    }
+    markDispatchRunning(claim.dispatchId);
+    return claim.dispatchId;
+  } catch (err) {
+    debugLog("autoLoop", {
+      phase: "dispatch-claim-failed",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
   }
 }
 
@@ -281,6 +348,23 @@ export async function autoLoop(
   while (s.active) {
     iteration++;
     debugLog("autoLoop", { phase: "loop-top", iteration });
+
+    // Phase B: heartbeat the worker registry + active milestone lease so
+    // janitors and concurrent workers see a live process. Best-effort —
+    // DB unavailability or stale state must not stop the loop.
+    if (s.workerId) {
+      try {
+        heartbeatAutoWorker(s.workerId);
+        if (s.currentMilestoneId && s.milestoneLeaseToken) {
+          refreshMilestoneLease(s.workerId, s.currentMilestoneId, s.milestoneLeaseToken);
+        }
+      } catch (err) {
+        debugLog("autoLoop", {
+          phase: "heartbeat-failed",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
 
     // ── Journal: per-iteration flow grouping ──
     const flowId = randomUUID();
@@ -671,6 +755,15 @@ export async function autoLoop(
       }
 
       await enforceMinRequestInterval(s, prefs);
+
+      // Phase B: claim a unit_dispatches row before invoking the unit. The
+      // partial unique index idx_unit_dispatches_active_per_unit prevents
+      // a second worker from claiming the same unit concurrently. Returns
+      // null when DB unavailable, no worker registered, or no active lease
+      // — those degraded paths fall through to the existing single-worker
+      // semantics with no ledger entry, preserving back-compat.
+      const dispatchId = openDispatchClaim(s, flowId, turnId, iterData);
+
       const unitPhaseResult = await runUnitPhaseViaContract(
         dispatchContract,
         ic,
@@ -687,6 +780,9 @@ export async function autoLoop(
         unitId: iterData.unitId,
       });
       if (unitPhaseResult.action === "break") {
+        if (dispatchId !== null) {
+          try { markDispatchFailed(dispatchId, { errorSummary: "unit-break" }); } catch (err) { debugLog("autoLoop", { phase: "dispatch-ledger-write-failed", error: err instanceof Error ? err.message : String(err) }); }
+        }
         finishTurn("stopped", "execution", "unit-break");
         break;
       }
@@ -702,14 +798,23 @@ export async function autoLoop(
         const finalizeFailureClass = finalizeResult.reason === "git-closeout-failure"
           ? "git"
           : "closeout";
+        if (dispatchId !== null) {
+          try { markDispatchFailed(dispatchId, { errorSummary: `finalize-break:${finalizeResult.reason ?? "unknown"}` }); } catch (err) { debugLog("autoLoop", { phase: "dispatch-ledger-write-failed", error: err instanceof Error ? err.message : String(err) }); }
+        }
         finishTurn("stopped", finalizeFailureClass, "finalize-break");
         break;
       }
       if (finalizeResult.action === "continue") {
+        if (dispatchId !== null) {
+          try { markDispatchFailed(dispatchId, { errorSummary: "finalize-retry" }); } catch (err) { debugLog("autoLoop", { phase: "dispatch-ledger-write-failed", error: err instanceof Error ? err.message : String(err) }); }
+        }
         finishTurn("retry");
         continue;
       }
 
+      if (dispatchId !== null) {
+        try { markDispatchCompleted(dispatchId); } catch (err) { debugLog("autoLoop", { phase: "dispatch-ledger-write-failed", error: err instanceof Error ? err.message : String(err) }); }
+      }
       consecutiveErrors = 0; // Iteration completed successfully
       consecutiveCooldowns = 0;
       recentErrorMessages.length = 0;

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -97,6 +97,21 @@ export class AutoSession {
   originalBasePath = "";
   // TODO(C8): remove basePath/originalBasePath once all readers use s.scope
   scope: MilestoneScope | null = null;
+
+  // ── Coordination identity (Phase B — DB-backed coordination) ────────────
+  /**
+   * Worker registry ID set by registerAutoWorker() at session start. Used by
+   * heartbeatAutoWorker() each loop iteration and by recordDispatchClaim()
+   * to fence dispatch ledger writes against stale workers.
+   */
+  workerId: string | null = null;
+  /**
+   * Active milestone lease fencing token, set by claimMilestoneLease() inside
+   * worktree-resolver.enterMilestone(). Threaded into recordDispatchClaim()
+   * as milestone_lease_token so out-of-band dispatches by a stale worker
+   * are detectable.
+   */
+  milestoneLeaseToken: number | null = null;
   previousProjectRootEnv: string | null = null;
   hadProjectRootEnv = false;
   projectRootEnvCaptured = false;
@@ -251,6 +266,8 @@ export class AutoSession {
     this.basePath = "";
     this.originalBasePath = "";
     this.scope = null;
+    this.workerId = null;
+    this.milestoneLeaseToken = null;
     this.previousProjectRootEnv = null;
     this.hadProjectRootEnv = false;
     this.projectRootEnvCaptured = false;

--- a/src/resources/extensions/gsd/db/auto-workers.ts
+++ b/src/resources/extensions/gsd/db/auto-workers.ts
@@ -1,0 +1,191 @@
+// gsd-2 + Auto-mode worker process registry (DB-backed coordination, Phase B)
+//
+// IMPORTANT — naming clarification (codex review LOW N1):
+// This module is the AUTO-MODE PROCESS REGISTRY. It tracks long-running
+// `gsd auto` worker processes for cross-process coordination via the shared
+// SQLite WAL. It is NOT the in-process subagent registry, which lives at
+// `src/resources/extensions/subagent/worker-registry.ts` and tracks dispatched
+// subagent threads within a single process.
+//
+// Both modules use the word "worker" but they are unrelated:
+//   - subagent/worker-registry.ts → ephemeral in-process subagent threads
+//   - db/auto-workers.ts          → durable cross-process auto-mode sessions
+//
+// Single-host invariant: SQLite WAL coordination only works on local disk.
+// NFS / network filesystems break heartbeat semantics. Multi-host execution
+// needs a real coordinator (etcd, Postgres) — out of scope for Phase B.
+
+import { randomUUID } from "node:crypto";
+import { hostname } from "node:os";
+
+import {
+  _getAdapter,
+  isDbAvailable,
+  transaction,
+  insertAuditEvent,
+} from "../gsd-db.js";
+
+const HEARTBEAT_TTL_SECONDS = 60;
+// Version label is for diagnostics only — embedded in audit_events and
+// workers.version. Bumping this manually on protocol changes is fine; we
+// don't pull it from package.json to avoid module-load filesystem I/O.
+const WORKER_REGISTRY_VERSION = "1";
+
+export type WorkerStatus = "active" | "stopping" | "crashed";
+
+export interface AutoWorkerRow {
+  worker_id: string;
+  host: string;
+  pid: number;
+  started_at: string;
+  version: string;
+  last_heartbeat_at: string;
+  status: WorkerStatus;
+  project_root_realpath: string;
+}
+
+/**
+ * Register a new auto-mode worker process. Returns the generated worker_id
+ * for the session to store on its AutoSession.
+ *
+ * The worker is created with `status='active'` and an initial heartbeat
+ * stamp; callers must invoke heartbeatAutoWorker() periodically (e.g. once
+ * per loop iteration) to refresh the TTL.
+ */
+export function registerAutoWorker(opts: {
+  projectRootRealpath: string;
+}): string {
+  if (!isDbAvailable()) {
+    throw new Error("registerAutoWorker: DB unavailable");
+  }
+  const workerId = `auto-${hostname()}-${process.pid}-${randomUUID().slice(0, 8)}`;
+  const now = new Date().toISOString();
+
+  transaction(() => {
+    const db = _getAdapter()!;
+    db.prepare(
+      `INSERT INTO workers (
+        worker_id, host, pid, started_at, version,
+        last_heartbeat_at, status, project_root_realpath
+      ) VALUES (
+        :worker_id, :host, :pid, :started_at, :version,
+        :last_heartbeat_at, 'active', :project_root_realpath
+      )`,
+    ).run({
+      ":worker_id": workerId,
+      ":host": hostname(),
+      ":pid": process.pid,
+      ":started_at": now,
+      ":version": WORKER_REGISTRY_VERSION,
+      ":last_heartbeat_at": now,
+      ":project_root_realpath": opts.projectRootRealpath,
+    });
+  });
+
+  insertAuditEvent({
+    eventId: randomUUID(),
+    traceId: workerId,
+    category: "orchestration",
+    type: "worker-registered",
+    ts: now,
+    payload: {
+      workerId,
+      host: hostname(),
+      pid: process.pid,
+      version: WORKER_REGISTRY_VERSION,
+      projectRootRealpath: opts.projectRootRealpath,
+    },
+  });
+
+  return workerId;
+}
+
+/**
+ * Refresh the worker's heartbeat. Call once per auto-loop iteration.
+ * Idempotent — silently no-ops if the worker no longer exists (e.g. row was
+ * cleaned up by a janitor).
+ */
+export function heartbeatAutoWorker(workerId: string): void {
+  if (!isDbAvailable()) return;
+  const now = new Date().toISOString();
+  const db = _getAdapter()!;
+  db.prepare(
+    `UPDATE workers SET last_heartbeat_at = :now WHERE worker_id = :worker_id AND status = 'active'`,
+  ).run({ ":now": now, ":worker_id": workerId });
+}
+
+/**
+ * Mark the worker as crashed. Used by janitors / doctor commands when a
+ * worker's heartbeat has expired beyond the TTL window.
+ */
+export function markWorkerCrashed(workerId: string): void {
+  if (!isDbAvailable()) return;
+  const db = _getAdapter()!;
+  transaction(() => {
+    db.prepare(
+      `UPDATE workers SET status = 'crashed' WHERE worker_id = :worker_id AND status = 'active'`,
+    ).run({ ":worker_id": workerId });
+  });
+  insertAuditEvent({
+    eventId: randomUUID(),
+    traceId: workerId,
+    category: "orchestration",
+    type: "worker-crashed",
+    ts: new Date().toISOString(),
+    payload: { workerId },
+  });
+}
+
+/**
+ * Mark the worker as stopping. Called from the stopAuto path when the user
+ * cleanly shuts down auto-mode.
+ */
+export function markWorkerStopping(workerId: string): void {
+  if (!isDbAvailable()) return;
+  const db = _getAdapter()!;
+  transaction(() => {
+    db.prepare(
+      `UPDATE workers SET status = 'stopping' WHERE worker_id = :worker_id`,
+    ).run({ ":worker_id": workerId });
+  });
+}
+
+/**
+ * Return all workers whose status is 'active' AND whose heartbeat is within
+ * the TTL window. Workers older than the TTL are NOT auto-marked crashed
+ * here — that's a separate janitor responsibility — but they are filtered
+ * out of the active set so callers see a fresh view.
+ */
+export function getActiveAutoWorkers(): readonly AutoWorkerRow[] {
+  if (!isDbAvailable()) return [];
+  const db = _getAdapter()!;
+  const cutoffMs = Date.now() - HEARTBEAT_TTL_SECONDS * 1000;
+  const cutoffIso = new Date(cutoffMs).toISOString();
+  const rows = db.prepare(
+    `SELECT worker_id, host, pid, started_at, version,
+            last_heartbeat_at, status, project_root_realpath
+     FROM workers
+     WHERE status = 'active' AND last_heartbeat_at >= :cutoff
+     ORDER BY started_at`,
+  ).all({ ":cutoff": cutoffIso }) as unknown as AutoWorkerRow[];
+  return rows;
+}
+
+/**
+ * Look up a single worker row. Returns null if no row exists.
+ */
+export function getAutoWorker(workerId: string): AutoWorkerRow | null {
+  if (!isDbAvailable()) return null;
+  const db = _getAdapter()!;
+  const row = db.prepare(
+    `SELECT worker_id, host, pid, started_at, version,
+            last_heartbeat_at, status, project_root_realpath
+     FROM workers WHERE worker_id = :worker_id`,
+  ).get({ ":worker_id": workerId }) as AutoWorkerRow | undefined;
+  return row ?? null;
+}
+
+/** Test/janitor helper: TTL constant exported for callers to compute expirations. */
+export function autoWorkerHeartbeatTtlSeconds(): number {
+  return HEARTBEAT_TTL_SECONDS;
+}

--- a/src/resources/extensions/gsd/db/command-queue.ts
+++ b/src/resources/extensions/gsd/db/command-queue.ts
@@ -1,0 +1,144 @@
+// gsd-2 + Worker IPC command queue (DB-backed coordination, Phase B)
+//
+// New infrastructure for dispatcher-to-worker IPC (cancel signals, pause
+// requests, etc.). NOT a replacement for any existing on-disk queue and
+// NOT related to startAutoCommandPolling() in auto.ts (which polls a
+// remote channel like Telegram, not a local file queue).
+//
+// Broadcast semantics (codex review LOW B4):
+// SQLite indexes NULLs in B-trees, so the single index
+// idx_command_queue_pending(target_worker, claimed_at) serves both:
+//   - targeted queries: WHERE target_worker = ?
+//   - broadcast queries: WHERE target_worker IS NULL
+// Workers should poll for both forms (their own ID + broadcasts) on each
+// claim cycle.
+
+import {
+  _getAdapter,
+  isDbAvailable,
+  transaction,
+} from "../gsd-db.js";
+
+export interface CommandQueueRow {
+  id: number;
+  target_worker: string | null;
+  command: string;
+  args_json: string;
+  enqueued_at: string;
+  claimed_at: string | null;
+  claimed_by: string | null;
+  completed_at: string | null;
+  result_json: string | null;
+}
+
+export interface EnqueueInput {
+  /** null = broadcast to all workers; string = target a specific worker_id */
+  targetWorker: string | null;
+  command: string;
+  args?: Record<string, unknown>;
+}
+
+/**
+ * Enqueue a command. Returns the new row id. Broadcast commands
+ * (targetWorker=null) will be claimed by exactly one worker — the IPC
+ * model is "single delivery to whoever claims first", not pub-sub.
+ */
+export function enqueueCommand(input: EnqueueInput): number {
+  if (!isDbAvailable()) {
+    throw new Error("enqueueCommand: DB unavailable");
+  }
+  const now = new Date().toISOString();
+  const db = _getAdapter()!;
+  const result = transaction(() => {
+    return db.prepare(
+      `INSERT INTO command_queue (target_worker, command, args_json, enqueued_at)
+       VALUES (:target_worker, :command, :args_json, :enqueued_at)`,
+    ).run({
+      ":target_worker": input.targetWorker,
+      ":command": input.command,
+      ":args_json": JSON.stringify(input.args ?? {}),
+      ":enqueued_at": now,
+    });
+  });
+  return Number((result as { lastInsertRowid?: number | bigint }).lastInsertRowid ?? 0);
+}
+
+/**
+ * Atomically claim the next pending command for the given worker. Returns
+ * the claimed row, or null if nothing to claim.
+ *
+ * Polls both targeted (target_worker = workerId) and broadcast
+ * (target_worker IS NULL) queues, oldest-first.
+ */
+export function claimNextCommand(workerId: string): CommandQueueRow | null {
+  if (!isDbAvailable()) return null;
+  const now = new Date().toISOString();
+  const db = _getAdapter()!;
+
+  return transaction((): CommandQueueRow | null => {
+    // Find the oldest unclaimed command targeted at this worker OR
+    // broadcast. The partial index covers both via NULL-in-B-tree.
+    const row = db.prepare(
+      `SELECT id, target_worker, command, args_json, enqueued_at,
+              claimed_at, claimed_by, completed_at, result_json
+       FROM command_queue
+       WHERE claimed_at IS NULL
+         AND (target_worker = :worker_id OR target_worker IS NULL)
+       ORDER BY enqueued_at ASC, id ASC
+       LIMIT 1`,
+    ).get({ ":worker_id": workerId }) as CommandQueueRow | undefined;
+
+    if (!row) return null;
+
+    // Conditional UPDATE — only succeeds if still unclaimed (guards against
+    // races between two workers polling simultaneously).
+    const result = db.prepare(
+      `UPDATE command_queue
+       SET claimed_at = :now, claimed_by = :worker_id
+       WHERE id = :id AND claimed_at IS NULL`,
+    ).run({ ":now": now, ":worker_id": workerId, ":id": row.id });
+
+    const changes =
+      typeof (result as { changes?: unknown }).changes === "number"
+        ? (result as { changes: number }).changes
+        : 0;
+
+    if (changes !== 1) return null; // lost the race
+
+    return { ...row, claimed_at: now, claimed_by: workerId };
+  });
+}
+
+/**
+ * Mark a command complete with optional result payload. Idempotent — if
+ * the command is already completed, the second call is a no-op.
+ */
+export function completeCommand(
+  id: number,
+  result?: Record<string, unknown>,
+): void {
+  if (!isDbAvailable()) return;
+  const now = new Date().toISOString();
+  const db = _getAdapter()!;
+  db.prepare(
+    `UPDATE command_queue
+     SET completed_at = :now, result_json = :result_json
+     WHERE id = :id AND completed_at IS NULL`,
+  ).run({
+    ":id": id,
+    ":now": now,
+    ":result_json": result ? JSON.stringify(result) : null,
+  });
+}
+
+/** Diagnostic helper: read a single row by id. */
+export function getCommand(id: number): CommandQueueRow | null {
+  if (!isDbAvailable()) return null;
+  const db = _getAdapter()!;
+  const row = db.prepare(
+    `SELECT id, target_worker, command, args_json, enqueued_at,
+            claimed_at, claimed_by, completed_at, result_json
+     FROM command_queue WHERE id = :id`,
+  ).get({ ":id": id }) as CommandQueueRow | undefined;
+  return row ?? null;
+}

--- a/src/resources/extensions/gsd/db/milestone-leases.ts
+++ b/src/resources/extensions/gsd/db/milestone-leases.ts
@@ -210,8 +210,8 @@ export function releaseMilestoneLease(
 ): boolean {
   if (!isDbAvailable()) return false;
   const db = _getAdapter()!;
-  const result = transaction(() => {
-    return db.prepare(
+  return transaction(() => {
+    const result = db.prepare(
       `UPDATE milestone_leases
        SET status = 'released'
        WHERE milestone_id = :milestone_id
@@ -223,22 +223,22 @@ export function releaseMilestoneLease(
       ":worker_id": workerId,
       ":token": fencingToken,
     });
+    const changes =
+      typeof (result as { changes?: unknown }).changes === "number"
+        ? (result as { changes: number }).changes
+        : 0;
+    if (changes === 1) {
+      insertAuditEvent({
+        eventId: randomUUID(),
+        traceId: workerId,
+        category: "orchestration",
+        type: "lease-released",
+        ts: new Date().toISOString(),
+        payload: { workerId, milestoneId, token: fencingToken },
+      });
+    }
+    return changes === 1;
   });
-  const changes =
-    typeof (result as { changes?: unknown }).changes === "number"
-      ? (result as { changes: number }).changes
-      : 0;
-  if (changes === 1) {
-    insertAuditEvent({
-      eventId: randomUUID(),
-      traceId: workerId,
-      category: "orchestration",
-      type: "lease-released",
-      ts: new Date().toISOString(),
-      payload: { workerId, milestoneId, token: fencingToken },
-    });
-  }
-  return changes === 1;
 }
 
 /**

--- a/src/resources/extensions/gsd/db/milestone-leases.ts
+++ b/src/resources/extensions/gsd/db/milestone-leases.ts
@@ -1,0 +1,258 @@
+// gsd-2 + Milestone leases with fencing tokens (DB-backed coordination, Phase B)
+//
+// One worker at a time may hold a lease on a given milestone. Leases carry a
+// monotonic fencing token that increments on every successful takeover, so
+// stale workers can be cheaply detected and rejected at write time
+// (unit_dispatches.milestone_lease_token).
+//
+// Codex review BLOCKING B1: claim semantics must atomically handle two
+// distinct cases inside one transaction:
+//   1. First claim (no row exists)         → INSERT with fencing_token=1
+//   2. Takeover (row exists, expired/released) → UPDATE w/ fencing_token+1
+// `INSERT OR ABORT` alone is wrong because the row already exists for any
+// takeover and a plain INSERT cannot succeed.
+
+import { randomUUID } from "node:crypto";
+
+import {
+  _getAdapter,
+  isDbAvailable,
+  transaction,
+  insertAuditEvent,
+} from "../gsd-db.js";
+
+const LEASE_TTL_SECONDS = 60;
+
+export type LeaseStatus = "held" | "released" | "expired";
+
+export interface MilestoneLeaseRow {
+  milestone_id: string;
+  worker_id: string;
+  fencing_token: number;
+  acquired_at: string;
+  expires_at: string;
+  status: LeaseStatus;
+}
+
+export type ClaimResult =
+  | { ok: true; token: number; expiresAt: string }
+  | { ok: false; error: "held_by"; byWorker: string; expiresAt: string };
+
+function ttlExpiry(now: Date): string {
+  return new Date(now.getTime() + LEASE_TTL_SECONDS * 1000).toISOString();
+}
+
+/**
+ * Acquire (or take over an expired) milestone lease for the given worker.
+ *
+ * Atomicity: the entire claim runs inside a single transaction so the
+ * INSERT-vs-UPDATE branch decision can never tear under concurrent claims.
+ * Fencing token is computed by SQL (`fencing_token + 1`), never supplied
+ * by the client. Initial value is 1.
+ *
+ * datetime('now') uses the local monotonic clock — single-host SQLite WAL
+ * only. Cross-host coordination would need a real coordinator; out of scope
+ * for Phase B.
+ */
+export function claimMilestoneLease(
+  workerId: string,
+  milestoneId: string,
+): ClaimResult {
+  if (!isDbAvailable()) {
+    throw new Error("claimMilestoneLease: DB unavailable");
+  }
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const expiresIso = ttlExpiry(now);
+
+  return transaction((): ClaimResult => {
+    const db = _getAdapter()!;
+
+    // Step 1: try a fresh INSERT. If it fails because the row already
+    // exists, fall through to the takeover branch below.
+    let inserted = false;
+    try {
+      db.prepare(
+        `INSERT INTO milestone_leases (
+          milestone_id, worker_id, fencing_token,
+          acquired_at, expires_at, status
+        ) VALUES (
+          :milestone_id, :worker_id, 1,
+          :acquired_at, :expires_at, 'held'
+        )`,
+      ).run({
+        ":milestone_id": milestoneId,
+        ":worker_id": workerId,
+        ":acquired_at": nowIso,
+        ":expires_at": expiresIso,
+      });
+      inserted = true;
+    } catch (err) {
+      // SQLite raises a constraint error on duplicate PK — catch and fall
+      // through to UPDATE. Any other error is a bug; rethrow.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/UNIQUE|PRIMARY KEY|constraint/i.test(msg)) throw err;
+    }
+
+    if (inserted) {
+      insertAuditEvent({
+        eventId: randomUUID(),
+        traceId: workerId,
+        category: "orchestration",
+        type: "lease-acquired",
+        ts: nowIso,
+        payload: { workerId, milestoneId, token: 1, mode: "fresh" },
+      });
+      return { ok: true, token: 1, expiresAt: expiresIso };
+    }
+
+    // Step 2: takeover. Conditional UPDATE — only succeeds if the existing
+    // lease is expired or explicitly released. Fencing token is incremented
+    // by SQL (`fencing_token + 1`) so the new holder's token monotonically
+    // exceeds the prior holder's. db.changes() === 1 confirms the takeover
+    // actually happened (vs. losing the race to another worker).
+    const updateResult = db.prepare(
+      `UPDATE milestone_leases
+       SET worker_id = :worker_id,
+           fencing_token = fencing_token + 1,
+           acquired_at = :acquired_at,
+           expires_at = :expires_at,
+           status = 'held'
+       WHERE milestone_id = :milestone_id
+         AND (status IN ('expired','released')
+              OR datetime(expires_at) < datetime('now'))`,
+    ).run({
+      ":milestone_id": milestoneId,
+      ":worker_id": workerId,
+      ":acquired_at": nowIso,
+      ":expires_at": expiresIso,
+    });
+
+    const changes =
+      typeof (updateResult as { changes?: unknown }).changes === "number"
+        ? (updateResult as { changes: number }).changes
+        : 0;
+
+    if (changes === 1) {
+      // Read back to obtain the new token value.
+      const row = db.prepare(
+        `SELECT worker_id, fencing_token, expires_at FROM milestone_leases WHERE milestone_id = :milestone_id`,
+      ).get({ ":milestone_id": milestoneId }) as Pick<MilestoneLeaseRow, "worker_id" | "fencing_token" | "expires_at"> | undefined;
+      const token = row?.fencing_token ?? 1;
+      insertAuditEvent({
+        eventId: randomUUID(),
+        traceId: workerId,
+        category: "orchestration",
+        type: "lease-acquired",
+        ts: nowIso,
+        payload: { workerId, milestoneId, token, mode: "takeover" },
+      });
+      return { ok: true, token, expiresAt: expiresIso };
+    }
+
+    // Lease still held by someone else — read current holder for the error.
+    const holder = db.prepare(
+      `SELECT worker_id, expires_at FROM milestone_leases WHERE milestone_id = :milestone_id`,
+    ).get({ ":milestone_id": milestoneId }) as { worker_id: string; expires_at: string } | undefined;
+
+    return {
+      ok: false,
+      error: "held_by",
+      byWorker: holder?.worker_id ?? "unknown",
+      expiresAt: holder?.expires_at ?? "",
+    };
+  });
+}
+
+/**
+ * Refresh the lease's expires_at when the worker heartbeats. Idempotent —
+ * silently no-ops if the lease was already taken over or released.
+ */
+export function refreshMilestoneLease(
+  workerId: string,
+  milestoneId: string,
+  fencingToken: number,
+): boolean {
+  if (!isDbAvailable()) return false;
+  const now = new Date();
+  const expiresIso = ttlExpiry(now);
+  const db = _getAdapter()!;
+  const result = db.prepare(
+    `UPDATE milestone_leases
+     SET expires_at = :expires_at
+     WHERE milestone_id = :milestone_id
+       AND worker_id = :worker_id
+       AND fencing_token = :token
+       AND status = 'held'`,
+  ).run({
+    ":expires_at": expiresIso,
+    ":milestone_id": milestoneId,
+    ":worker_id": workerId,
+    ":token": fencingToken,
+  });
+  const changes =
+    typeof (result as { changes?: unknown }).changes === "number"
+      ? (result as { changes: number }).changes
+      : 0;
+  return changes === 1;
+}
+
+/**
+ * Voluntarily release the lease (e.g. clean shutdown). Future claims may
+ * proceed without waiting for TTL expiry.
+ */
+export function releaseMilestoneLease(
+  workerId: string,
+  milestoneId: string,
+  fencingToken: number,
+): boolean {
+  if (!isDbAvailable()) return false;
+  const db = _getAdapter()!;
+  const result = transaction(() => {
+    return db.prepare(
+      `UPDATE milestone_leases
+       SET status = 'released'
+       WHERE milestone_id = :milestone_id
+         AND worker_id = :worker_id
+         AND fencing_token = :token
+         AND status = 'held'`,
+    ).run({
+      ":milestone_id": milestoneId,
+      ":worker_id": workerId,
+      ":token": fencingToken,
+    });
+  });
+  const changes =
+    typeof (result as { changes?: unknown }).changes === "number"
+      ? (result as { changes: number }).changes
+      : 0;
+  if (changes === 1) {
+    insertAuditEvent({
+      eventId: randomUUID(),
+      traceId: workerId,
+      category: "orchestration",
+      type: "lease-released",
+      ts: new Date().toISOString(),
+      payload: { workerId, milestoneId, token: fencingToken },
+    });
+  }
+  return changes === 1;
+}
+
+/**
+ * Read current lease row for diagnostics. Returns null if no row exists.
+ */
+export function getMilestoneLease(milestoneId: string): MilestoneLeaseRow | null {
+  if (!isDbAvailable()) return null;
+  const db = _getAdapter()!;
+  const row = db.prepare(
+    `SELECT milestone_id, worker_id, fencing_token, acquired_at, expires_at, status
+     FROM milestone_leases WHERE milestone_id = :milestone_id`,
+  ).get({ ":milestone_id": milestoneId }) as MilestoneLeaseRow | undefined;
+  return row ?? null;
+}
+
+/** TTL exported so callers (e.g. tests / janitors) can compute expirations. */
+export function milestoneLeaseTtlSeconds(): number {
+  return LEASE_TTL_SECONDS;
+}

--- a/src/resources/extensions/gsd/db/milestone-leases.ts
+++ b/src/resources/extensions/gsd/db/milestone-leases.ts
@@ -91,7 +91,9 @@ export function claimMilestoneLease(
       // SQLite raises a constraint error on duplicate PK — catch and fall
       // through to UPDATE. Any other error is a bug; rethrow.
       const msg = err instanceof Error ? err.message : String(err);
-      if (!/UNIQUE|PRIMARY KEY|constraint/i.test(msg)) throw err;
+      const isUniqueConflict = /UNIQUE|PRIMARY KEY/i.test(msg);
+      const isForeignKeyFailure = /FOREIGN KEY/i.test(msg);
+      if (!isUniqueConflict || isForeignKeyFailure) throw err;
     }
 
     if (inserted) {

--- a/src/resources/extensions/gsd/db/unit-dispatches.ts
+++ b/src/resources/extensions/gsd/db/unit-dispatches.ts
@@ -1,0 +1,334 @@
+// gsd-2 + Unit dispatch ledger (DB-backed coordination, Phase B)
+//
+// Records every auto-mode unit dispatch (plan-slice, run-task, summarize, …)
+// with worker_id, fencing token, status lifecycle, and retry metadata. The
+// ledger is the substrate Phase C will consume to migrate stuck-state.json
+// and paused-session.json out of the runtime/ directory.
+//
+// Codex review MEDIUM B2: partial unique index
+//   idx_unit_dispatches_active_per_unit ON unit_dispatches(unit_id)
+//   WHERE status IN ('claimed','running')
+// enforces that two workers cannot simultaneously claim the same unit.
+// recordDispatchClaim relies on the index to fail fast at INSERT time
+// rather than racing in application code.
+
+import { randomUUID } from "node:crypto";
+
+import {
+  _getAdapter,
+  isDbAvailable,
+  transaction,
+  insertAuditEvent,
+} from "../gsd-db.js";
+
+export type DispatchStatus =
+  | "pending"
+  | "claimed"
+  | "running"
+  | "completed"
+  | "failed"
+  | "stuck"
+  | "canceled"
+  | "paused";
+
+export interface UnitDispatchRow {
+  id: number;
+  trace_id: string;
+  turn_id: string | null;
+  worker_id: string;
+  milestone_lease_token: number;
+  milestone_id: string;
+  slice_id: string | null;
+  task_id: string | null;
+  unit_type: string;
+  unit_id: string;
+  status: DispatchStatus;
+  attempt_n: number;
+  started_at: string;
+  ended_at: string | null;
+  exit_reason: string | null;
+  error_summary: string | null;
+  verification_evidence_id: number | null;
+  next_run_at: string | null;
+  retry_after_ms: number | null;
+  max_attempts: number;
+  last_error_code: string | null;
+  last_error_at: string | null;
+}
+
+export interface RecordClaimInput {
+  traceId: string;
+  turnId?: string | null;
+  workerId: string;
+  milestoneLeaseToken: number;
+  milestoneId: string;
+  sliceId?: string | null;
+  taskId?: string | null;
+  unitType: string;
+  unitId: string;
+  /**
+   * Attempt number for this unit. Callers should compute this from the
+   * most recent prior dispatch for the same unit_id (use
+   * getRecentForUnit() then add 1). Defaults to 1 for fresh claims.
+   */
+  attemptN?: number;
+  /** Per-attempt cap; defaults to 3. */
+  maxAttempts?: number;
+}
+
+export type RecordClaimResult =
+  | { ok: true; dispatchId: number }
+  | { ok: false; error: "already_active"; existingId: number; existingStatus: DispatchStatus; existingWorker: string };
+
+/**
+ * Insert a new dispatch row in `claimed` state. Atomic guard against
+ * double-claim (B2): the partial unique index
+ * idx_unit_dispatches_active_per_unit refuses the INSERT if any row for
+ * the same unit_id already has status IN ('claimed','running').
+ */
+export function recordDispatchClaim(input: RecordClaimInput): RecordClaimResult {
+  if (!isDbAvailable()) {
+    throw new Error("recordDispatchClaim: DB unavailable");
+  }
+  const now = new Date().toISOString();
+
+  return transaction((): RecordClaimResult => {
+    const db = _getAdapter()!;
+
+    try {
+      const result = db.prepare(
+        `INSERT INTO unit_dispatches (
+          trace_id, turn_id, worker_id, milestone_lease_token,
+          milestone_id, slice_id, task_id,
+          unit_type, unit_id, status, attempt_n,
+          started_at, max_attempts
+        ) VALUES (
+          :trace_id, :turn_id, :worker_id, :milestone_lease_token,
+          :milestone_id, :slice_id, :task_id,
+          :unit_type, :unit_id, 'claimed', :attempt_n,
+          :started_at, :max_attempts
+        )`,
+      ).run({
+        ":trace_id": input.traceId,
+        ":turn_id": input.turnId ?? null,
+        ":worker_id": input.workerId,
+        ":milestone_lease_token": input.milestoneLeaseToken,
+        ":milestone_id": input.milestoneId,
+        ":slice_id": input.sliceId ?? null,
+        ":task_id": input.taskId ?? null,
+        ":unit_type": input.unitType,
+        ":unit_id": input.unitId,
+        ":attempt_n": input.attemptN ?? 1,
+        ":started_at": now,
+        ":max_attempts": input.maxAttempts ?? 3,
+      });
+      const id = Number((result as { lastInsertRowid?: number | bigint }).lastInsertRowid ?? 0);
+
+      insertAuditEvent({
+        eventId: randomUUID(),
+        traceId: input.traceId,
+        turnId: input.turnId ?? undefined,
+        category: "orchestration",
+        type: "dispatch-claimed",
+        ts: now,
+        payload: {
+          dispatchId: id,
+          unitId: input.unitId,
+          unitType: input.unitType,
+          workerId: input.workerId,
+          attemptN: input.attemptN ?? 1,
+        },
+      });
+
+      return { ok: true, dispatchId: id };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/UNIQUE|constraint/i.test(msg)) throw err;
+
+      // Partial unique index rejected the INSERT — surface the existing
+      // active dispatch so callers can decide what to do.
+      const existing = db.prepare(
+        `SELECT id, status, worker_id FROM unit_dispatches
+         WHERE unit_id = :unit_id AND status IN ('claimed','running')
+         ORDER BY id DESC LIMIT 1`,
+      ).get({ ":unit_id": input.unitId }) as { id: number; status: DispatchStatus; worker_id: string } | undefined;
+
+      return {
+        ok: false,
+        error: "already_active",
+        existingId: existing?.id ?? 0,
+        existingStatus: existing?.status ?? "claimed",
+        existingWorker: existing?.worker_id ?? "unknown",
+      };
+    }
+  });
+}
+
+/** Transition a `claimed` dispatch into `running`. */
+export function markRunning(dispatchId: number): void {
+  if (!isDbAvailable()) return;
+  const db = _getAdapter()!;
+  db.prepare(
+    `UPDATE unit_dispatches SET status = 'running'
+     WHERE id = :id AND status = 'claimed'`,
+  ).run({ ":id": dispatchId });
+}
+
+export interface CompleteOpts {
+  verificationEvidenceId?: number | null;
+  exitReason?: string;
+}
+
+/** Transition a dispatch into `completed`. */
+export function markCompleted(dispatchId: number, opts?: CompleteOpts): void {
+  if (!isDbAvailable()) return;
+  const now = new Date().toISOString();
+  const db = _getAdapter()!;
+  transaction(() => {
+    db.prepare(
+      `UPDATE unit_dispatches
+       SET status = 'completed', ended_at = :ended_at,
+           exit_reason = :exit_reason,
+           verification_evidence_id = :evidence_id
+       WHERE id = :id`,
+    ).run({
+      ":id": dispatchId,
+      ":ended_at": now,
+      ":exit_reason": opts?.exitReason ?? null,
+      ":evidence_id": opts?.verificationEvidenceId ?? null,
+    });
+  });
+  insertAuditEvent({
+    eventId: randomUUID(),
+    traceId: dispatchId.toString(),
+    category: "orchestration",
+    type: "dispatch-completed",
+    ts: now,
+    payload: { dispatchId },
+  });
+}
+
+export interface FailureOpts {
+  errorSummary: string;
+  errorCode?: string;
+  /** Backoff before next attempt (used by stuck-detector retry suppression). */
+  retryAfterMs?: number;
+}
+
+/** Transition a dispatch into `failed`, optionally scheduling a retry. */
+export function markFailed(dispatchId: number, opts: FailureOpts): void {
+  if (!isDbAvailable()) return;
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const nextRunIso = opts.retryAfterMs
+    ? new Date(now.getTime() + opts.retryAfterMs).toISOString()
+    : null;
+  const db = _getAdapter()!;
+  transaction(() => {
+    db.prepare(
+      `UPDATE unit_dispatches
+       SET status = 'failed', ended_at = :ended_at,
+           error_summary = :error_summary,
+           last_error_code = :last_error_code,
+           last_error_at = :last_error_at,
+           retry_after_ms = :retry_after_ms,
+           next_run_at = :next_run_at
+       WHERE id = :id`,
+    ).run({
+      ":id": dispatchId,
+      ":ended_at": nowIso,
+      ":error_summary": opts.errorSummary,
+      ":last_error_code": opts.errorCode ?? null,
+      ":last_error_at": nowIso,
+      ":retry_after_ms": opts.retryAfterMs ?? null,
+      ":next_run_at": nextRunIso,
+    });
+  });
+  insertAuditEvent({
+    eventId: randomUUID(),
+    traceId: dispatchId.toString(),
+    category: "orchestration",
+    type: "dispatch-failed",
+    ts: nowIso,
+    payload: { dispatchId, errorSummary: opts.errorSummary, retryAfterMs: opts.retryAfterMs ?? null },
+  });
+}
+
+/** Transition a dispatch into `stuck`. */
+export function markStuck(dispatchId: number, reason: string): void {
+  if (!isDbAvailable()) return;
+  const now = new Date().toISOString();
+  const db = _getAdapter()!;
+  transaction(() => {
+    db.prepare(
+      `UPDATE unit_dispatches
+       SET status = 'stuck', ended_at = :ended_at, exit_reason = :reason
+       WHERE id = :id`,
+    ).run({ ":id": dispatchId, ":ended_at": now, ":reason": reason });
+  });
+}
+
+/** Transition a dispatch into `paused`. */
+export function markPaused(dispatchId: number): void {
+  if (!isDbAvailable()) return;
+  const now = new Date().toISOString();
+  const db = _getAdapter()!;
+  db.prepare(
+    `UPDATE unit_dispatches
+     SET status = 'paused', ended_at = :ended_at
+     WHERE id = :id AND status IN ('claimed','running')`,
+  ).run({ ":id": dispatchId, ":ended_at": now });
+}
+
+/** Transition a dispatch into `canceled`. */
+export function markCanceled(dispatchId: number, reason: string): void {
+  if (!isDbAvailable()) return;
+  const now = new Date().toISOString();
+  const db = _getAdapter()!;
+  db.prepare(
+    `UPDATE unit_dispatches
+     SET status = 'canceled', ended_at = :ended_at, exit_reason = :reason
+     WHERE id = :id AND status IN ('pending','claimed','running')`,
+  ).run({ ":id": dispatchId, ":ended_at": now, ":reason": reason });
+}
+
+/**
+ * Fetch the most recent N dispatches for a unit. Used by recordDispatchClaim
+ * callers to compute attempt_n and by detect-stuck.ts (B3) to consult
+ * retry budget before tripping the stuck verdict.
+ */
+export function getRecentForUnit(unitId: string, limit = 10): UnitDispatchRow[] {
+  if (!isDbAvailable()) return [];
+  const db = _getAdapter()!;
+  return db.prepare(
+    `SELECT * FROM unit_dispatches WHERE unit_id = :unit_id ORDER BY id DESC LIMIT :limit`,
+  ).all({ ":unit_id": unitId, ":limit": limit }) as unknown as UnitDispatchRow[];
+}
+
+/**
+ * Fetch the latest dispatch for a unit, regardless of status. Returns null
+ * if the unit has never been dispatched.
+ */
+export function getLatestForUnit(unitId: string): UnitDispatchRow | null {
+  if (!isDbAvailable()) return null;
+  const db = _getAdapter()!;
+  const row = db.prepare(
+    `SELECT * FROM unit_dispatches WHERE unit_id = :unit_id ORDER BY id DESC LIMIT 1`,
+  ).get({ ":unit_id": unitId }) as UnitDispatchRow | undefined;
+  return row ?? null;
+}
+
+/**
+ * Fetch dispatches for a milestone filtered by status. Useful for janitors
+ * + dashboards.
+ */
+export function getDispatchesByStatus(
+  milestoneId: string,
+  status: DispatchStatus,
+): UnitDispatchRow[] {
+  if (!isDbAvailable()) return [];
+  const db = _getAdapter()!;
+  return db.prepare(
+    `SELECT * FROM unit_dispatches WHERE milestone_id = :mid AND status = :status ORDER BY id`,
+  ).all({ ":mid": milestoneId, ":status": status }) as unknown as UnitDispatchRow[];
+}

--- a/src/resources/extensions/gsd/db/unit-dispatches.ts
+++ b/src/resources/extensions/gsd/db/unit-dispatches.ts
@@ -143,7 +143,9 @@ export function recordDispatchClaim(input: RecordClaimInput): RecordClaimResult 
       return { ok: true, dispatchId: id };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (!/UNIQUE|constraint/i.test(msg)) throw err;
+      const isUniqueConflict = /UNIQUE/i.test(msg);
+      const isForeignKeyFailure = /FOREIGN KEY/i.test(msg);
+      if (!isUniqueConflict || isForeignKeyFailure) throw err;
 
       // Partial unique index rejected the INSERT — surface the existing
       // active dispatch so callers can decide what to do.

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -182,12 +182,117 @@ function openRawDb(path: string): unknown {
   return new Database(path);
 }
 
-export const SCHEMA_VERSION = 23;
+export const SCHEMA_VERSION = 24;
 
 function indexExists(db: DbAdapter, name: string): boolean {
   return !!db.prepare(
     "SELECT 1 as present FROM sqlite_master WHERE type = 'index' AND name = ?",
   ).get(name);
+}
+
+/**
+ * Create the v24 coordination tables (workers, milestone_leases,
+ * unit_dispatches, cancellation_requests, command_queue) and their indexes.
+ *
+ * Idempotent — uses IF NOT EXISTS throughout. Called from both the
+ * fresh-install path and the v24 migration block in migrateSchema().
+ *
+ * Single-host invariant: these tables coordinate concurrent auto-mode
+ * workers via shared SQLite WAL on local disk only. NFS / network
+ * filesystems break the coordination semantics — multi-host execution
+ * needs a real coordinator (etcd, Postgres) and is out of scope.
+ */
+function createCoordinationTablesV24(db: DbAdapter): void {
+  const ddl = [
+    `CREATE TABLE IF NOT EXISTS workers (
+      worker_id TEXT PRIMARY KEY,
+      host TEXT NOT NULL,
+      pid INTEGER NOT NULL,
+      started_at TEXT NOT NULL,
+      version TEXT NOT NULL,
+      last_heartbeat_at TEXT NOT NULL,
+      status TEXT NOT NULL,
+      project_root_realpath TEXT NOT NULL
+    )`,
+    `CREATE TABLE IF NOT EXISTS milestone_leases (
+      milestone_id TEXT PRIMARY KEY,
+      worker_id TEXT NOT NULL,
+      fencing_token INTEGER NOT NULL,
+      acquired_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      status TEXT NOT NULL,
+      FOREIGN KEY (worker_id) REFERENCES workers(worker_id),
+      FOREIGN KEY (milestone_id) REFERENCES milestones(id)
+    )`,
+    `CREATE TABLE IF NOT EXISTS unit_dispatches (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      trace_id TEXT NOT NULL,
+      turn_id TEXT,
+      worker_id TEXT NOT NULL,
+      milestone_lease_token INTEGER NOT NULL,
+      milestone_id TEXT NOT NULL,
+      slice_id TEXT,
+      task_id TEXT,
+      unit_type TEXT NOT NULL,
+      unit_id TEXT NOT NULL,
+      status TEXT NOT NULL,
+      attempt_n INTEGER NOT NULL DEFAULT 1,
+      started_at TEXT NOT NULL,
+      ended_at TEXT,
+      exit_reason TEXT,
+      error_summary TEXT,
+      verification_evidence_id INTEGER,
+      next_run_at TEXT,
+      retry_after_ms INTEGER,
+      max_attempts INTEGER NOT NULL DEFAULT 3,
+      last_error_code TEXT,
+      last_error_at TEXT,
+      FOREIGN KEY (worker_id) REFERENCES workers(worker_id),
+      FOREIGN KEY (verification_evidence_id) REFERENCES verification_evidence(id)
+    )`,
+    `CREATE TABLE IF NOT EXISTS cancellation_requests (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      requested_at TEXT NOT NULL,
+      requested_by TEXT NOT NULL,
+      scope TEXT NOT NULL,
+      scope_id TEXT NOT NULL,
+      dispatch_id INTEGER,
+      reason TEXT NOT NULL,
+      status TEXT NOT NULL,
+      acked_at TEXT,
+      acked_worker_id TEXT,
+      FOREIGN KEY (dispatch_id) REFERENCES unit_dispatches(id),
+      FOREIGN KEY (acked_worker_id) REFERENCES workers(worker_id)
+    )`,
+    `CREATE TABLE IF NOT EXISTS command_queue (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      target_worker TEXT,
+      command TEXT NOT NULL,
+      args_json TEXT NOT NULL DEFAULT '{}',
+      enqueued_at TEXT NOT NULL,
+      claimed_at TEXT,
+      claimed_by TEXT,
+      completed_at TEXT,
+      result_json TEXT
+    )`,
+  ];
+  for (const stmt of ddl) db.exec(stmt);
+
+  // Indexes — created here so both fresh-install and v24-migration paths
+  // produce identical structure.
+  db.exec("CREATE INDEX IF NOT EXISTS idx_unit_dispatches_active ON unit_dispatches(milestone_id, status)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_unit_dispatches_trace ON unit_dispatches(trace_id, turn_id)");
+  // Partial unique index — prevents two workers from claiming the same
+  // unit concurrently. Codex review MEDIUM B2: enforces double-claim guard
+  // at the DB level.
+  db.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_unit_dispatches_active_per_unit "
+    + "ON unit_dispatches(unit_id) WHERE status IN ('claimed','running')",
+  );
+  // command_queue index — SQLite indexes NULLs in B-trees, so this single
+  // index serves both targeted (target_worker = ?) and broadcast
+  // (target_worker IS NULL) queries. Codex review LOW B4 documented.
+  db.exec("CREATE INDEX IF NOT EXISTS idx_command_queue_pending ON command_queue(target_worker, claimed_at)");
 }
 
 function dedupeVerificationEvidenceRows(db: DbAdapter): void {
@@ -559,6 +664,8 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
         PRIMARY KEY (trace_id, turn_id)
       )
     `);
+
+    createCoordinationTablesV24(db);
 
     db.exec("CREATE INDEX IF NOT EXISTS idx_memories_active ON memories(superseded_by)");
 
@@ -1242,6 +1349,18 @@ function migrateSchema(db: DbAdapter): void {
       ensureColumn(db, "milestones", "sequence", "ALTER TABLE milestones ADD COLUMN sequence INTEGER DEFAULT 0");
       db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
         ":version": 23,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
+
+    if (currentVersion < 24) {
+      // v24: auto-mode coordination tables. See createCoordinationTablesV24
+      // for full schema + invariants. No-op for fresh installs (the same
+      // helper runs in the fresh-install path); for upgraded DBs this is
+      // the only place these tables get created.
+      createCoordinationTablesV24(db);
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 24,
         ":applied_at": new Date().toISOString(),
       });
     }

--- a/src/resources/extensions/gsd/tests/auto-workers.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-workers.test.ts
@@ -1,0 +1,98 @@
+// gsd-2 + Auto-mode worker registry tests (Phase B coordination)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openDatabase, closeDatabase } from "../gsd-db.ts";
+import {
+  registerAutoWorker,
+  heartbeatAutoWorker,
+  markWorkerCrashed,
+  markWorkerStopping,
+  getActiveAutoWorkers,
+  getAutoWorker,
+} from "../db/auto-workers.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-auto-workers-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+test("registerAutoWorker creates a row with active status and heartbeat", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const id = registerAutoWorker({ projectRootRealpath: base });
+  assert.match(id, /^auto-/, "worker_id has expected prefix");
+
+  const row = getAutoWorker(id);
+  assert.ok(row, "row exists");
+  assert.equal(row!.status, "active");
+  assert.equal(row!.project_root_realpath, base);
+  assert.equal(row!.pid, process.pid);
+});
+
+test("heartbeatAutoWorker updates last_heartbeat_at", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const id = registerAutoWorker({ projectRootRealpath: base });
+  const initial = getAutoWorker(id)!;
+  await new Promise(r => setTimeout(r, 10));
+  heartbeatAutoWorker(id);
+  const after = getAutoWorker(id)!;
+  assert.notEqual(after.last_heartbeat_at, initial.last_heartbeat_at, "heartbeat advanced");
+});
+
+test("markWorkerStopping flips status to stopping", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const id = registerAutoWorker({ projectRootRealpath: base });
+  markWorkerStopping(id);
+  const row = getAutoWorker(id)!;
+  assert.equal(row.status, "stopping");
+});
+
+test("markWorkerCrashed flips status to crashed", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const id = registerAutoWorker({ projectRootRealpath: base });
+  markWorkerCrashed(id);
+  const row = getAutoWorker(id)!;
+  assert.equal(row.status, "crashed");
+});
+
+test("getActiveAutoWorkers filters by status and TTL", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const a = registerAutoWorker({ projectRootRealpath: base });
+  const b = registerAutoWorker({ projectRootRealpath: base });
+
+  const active = getActiveAutoWorkers();
+  assert.equal(active.length, 2);
+  assert.ok(active.find(w => w.worker_id === a));
+  assert.ok(active.find(w => w.worker_id === b));
+
+  // Mark one crashed → should disappear from active set
+  markWorkerCrashed(a);
+  const after = getActiveAutoWorkers();
+  assert.equal(after.length, 1);
+  assert.equal(after[0].worker_id, b);
+});

--- a/src/resources/extensions/gsd/tests/command-queue.test.ts
+++ b/src/resources/extensions/gsd/tests/command-queue.test.ts
@@ -1,0 +1,112 @@
+// gsd-2 + Command queue tests (Phase B coordination — IPC inbox + broadcast NULL semantics)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openDatabase, closeDatabase } from "../gsd-db.ts";
+import {
+  enqueueCommand,
+  claimNextCommand,
+  completeCommand,
+  getCommand,
+} from "../db/command-queue.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-cmd-q-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+test("enqueue + claim + complete round-trip for targeted command", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const id = enqueueCommand({
+    targetWorker: "worker-A",
+    command: "cancel",
+    args: { reason: "user-request" },
+  });
+  assert.ok(id > 0);
+
+  const claimed = claimNextCommand("worker-A");
+  assert.ok(claimed);
+  assert.equal(claimed!.id, id);
+  assert.equal(claimed!.command, "cancel");
+  assert.equal(claimed!.claimed_by, "worker-A");
+  assert.ok(claimed!.claimed_at);
+
+  completeCommand(id, { acknowledged: true });
+  const final = getCommand(id);
+  assert.ok(final!.completed_at);
+  assert.equal(final!.result_json, JSON.stringify({ acknowledged: true }));
+});
+
+test("targeted command is invisible to other workers", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  enqueueCommand({ targetWorker: "worker-A", command: "for-A" });
+  const wrong = claimNextCommand("worker-B");
+  assert.equal(wrong, null, "worker-B sees nothing for worker-A");
+
+  const right = claimNextCommand("worker-A");
+  assert.ok(right);
+  assert.equal(right!.command, "for-A");
+});
+
+test("broadcast command (target=null) is visible to ANY worker, claimed exactly once", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  enqueueCommand({ targetWorker: null, command: "broadcast-cancel" });
+
+  const a = claimNextCommand("worker-A");
+  assert.ok(a, "first poller wins");
+  assert.equal(a!.command, "broadcast-cancel");
+
+  // Second poller (different worker) sees nothing — broadcast is single-delivery
+  const b = claimNextCommand("worker-B");
+  assert.equal(b, null);
+});
+
+test("oldest-first ordering across mixed targeted + broadcast queue", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  enqueueCommand({ targetWorker: null, command: "first" });
+  enqueueCommand({ targetWorker: "worker-A", command: "second" });
+  enqueueCommand({ targetWorker: null, command: "third" });
+
+  const c1 = claimNextCommand("worker-A")!;
+  const c2 = claimNextCommand("worker-A")!;
+  const c3 = claimNextCommand("worker-A")!;
+  assert.equal(c1.command, "first");
+  assert.equal(c2.command, "second");
+  assert.equal(c3.command, "third");
+  assert.equal(claimNextCommand("worker-A"), null);
+});
+
+test("completeCommand is idempotent — second call does not overwrite", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const id = enqueueCommand({ targetWorker: "w", command: "x" });
+  claimNextCommand("w");
+  completeCommand(id, { result: 1 });
+  completeCommand(id, { result: 2 }); // second call should no-op
+  const row = getCommand(id)!;
+  assert.equal(row.result_json, JSON.stringify({ result: 1 }));
+});

--- a/src/resources/extensions/gsd/tests/detect-stuck-respects-retry.test.ts
+++ b/src/resources/extensions/gsd/tests/detect-stuck-respects-retry.test.ts
@@ -1,0 +1,131 @@
+// gsd-2 + Stuck-detector retry coupling regression (Phase B / codex MEDIUM B3)
+//
+// Rule 2b previously tripped on 3 same-unit appearances regardless of
+// retry budget. With unit_dispatches.attempt_n + next_run_at driving in-DB
+// backoff, a unit that fails 3× under retry would trip the stuck-detector
+// before its retry budget exhausted. This test verifies suppression while
+// the retry window is open and re-engagement once the window passes or
+// budget exhausts.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  _getAdapter,
+} from "../gsd-db.ts";
+import { registerAutoWorker } from "../db/auto-workers.ts";
+import {
+  recordDispatchClaim,
+  markFailed,
+  getLatestForUnit,
+} from "../db/unit-dispatches.ts";
+import { detectStuck } from "../auto/detect-stuck.ts";
+import type { WindowEntry } from "../auto/types.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-detect-stuck-retry-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+function windowOf(unitKey: string, n: number): WindowEntry[] {
+  return Array.from({ length: n }, () => ({ key: unitKey }));
+}
+
+test("rule 2b trips with no DB context (legacy behavior preserved)", () => {
+  // No DB open — getLatestForUnit returns null, suppression cannot fire,
+  // pre-Phase-B behavior is intact.
+  const result = detectStuck(windowOf("plan-slice:M001/S01", 3));
+  assert.ok(result, "stuck signal returned");
+  assert.equal(result!.stuck, true);
+});
+
+test("rule 2b SUPPRESSED while retry budget remains and next_run_at is in the future", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "T", status: "active" });
+  const w = registerAutoWorker({ projectRootRealpath: base });
+
+  // Record a failed dispatch with attempt_n=1, max_attempts=3, retry_after
+  // pushing next_run_at into the future.
+  const claim = recordDispatchClaim({
+    traceId: "t1", workerId: w, milestoneLeaseToken: 1,
+    milestoneId: "M001", unitType: "plan-slice", unitId: "plan-slice:M001/S01",
+    attemptN: 1, maxAttempts: 3,
+  });
+  assert.equal(claim.ok, true);
+  if (!claim.ok) return;
+  markFailed(claim.dispatchId, { errorSummary: "transient", retryAfterMs: 60_000 });
+
+  const latest = getLatestForUnit("plan-slice:M001/S01")!;
+  assert.equal(latest.attempt_n, 1);
+  assert.ok(latest.next_run_at);
+
+  const result = detectStuck(windowOf("plan-slice:M001/S01", 3));
+  assert.equal(result, null, "rule 2b suppressed while retry window is active");
+});
+
+test("rule 2b RE-ENGAGES once attempt_n reaches max_attempts", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "T", status: "active" });
+  const w = registerAutoWorker({ projectRootRealpath: base });
+
+  // Burn through attempts up to the cap — last attempt = max_attempts.
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    const claim = recordDispatchClaim({
+      traceId: `t${attempt}`, workerId: w, milestoneLeaseToken: 1,
+      milestoneId: "M001", unitType: "plan-slice", unitId: "plan-slice:M001/S01",
+      attemptN: attempt, maxAttempts: 3,
+    });
+    assert.equal(claim.ok, true);
+    if (!claim.ok) return;
+    markFailed(claim.dispatchId, { errorSummary: "transient", retryAfterMs: 60_000 });
+  }
+
+  const latest = getLatestForUnit("plan-slice:M001/S01")!;
+  assert.equal(latest.attempt_n, 3);
+  assert.equal(latest.max_attempts, 3);
+
+  const result = detectStuck(windowOf("plan-slice:M001/S01", 3));
+  assert.ok(result, "stuck signal returned once retry budget is exhausted");
+});
+
+test("rule 2b RE-ENGAGES once next_run_at is in the past", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "T", status: "active" });
+  const w = registerAutoWorker({ projectRootRealpath: base });
+
+  const claim = recordDispatchClaim({
+    traceId: "t", workerId: w, milestoneLeaseToken: 1,
+    milestoneId: "M001", unitType: "plan-slice", unitId: "plan-slice:M001/S01",
+    attemptN: 1, maxAttempts: 3,
+  });
+  assert.equal(claim.ok, true);
+  if (!claim.ok) return;
+  markFailed(claim.dispatchId, { errorSummary: "transient", retryAfterMs: 60_000 });
+
+  // Force next_run_at into the past — retry window has already lapsed.
+  const db = _getAdapter()!;
+  db.prepare(
+    `UPDATE unit_dispatches SET next_run_at = '1970-01-01T00:00:00.000Z' WHERE id = :id`,
+  ).run({ ":id": claim.dispatchId });
+
+  const result = detectStuck(windowOf("plan-slice:M001/S01", 3));
+  assert.ok(result, "stuck re-engages once retry window has passed");
+});

--- a/src/resources/extensions/gsd/tests/milestone-leases.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-leases.test.ts
@@ -138,3 +138,15 @@ test("refreshMilestoneLease only succeeds with the matching fencing token", (t) 
   // Stale token (e.g. claim.token - 1) refuses
   assert.equal(refreshMilestoneLease(w1, "M001", claim.token - 1), false);
 });
+
+test("claimMilestoneLease rethrows foreign-key failures instead of treating them as lease contention", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  assert.throws(
+    () => claimMilestoneLease("missing-worker", "M001"),
+    /FOREIGN KEY constraint failed/,
+  );
+});

--- a/src/resources/extensions/gsd/tests/milestone-leases.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-leases.test.ts
@@ -1,0 +1,140 @@
+// gsd-2 + Milestone leases tests (Phase B coordination — fencing semantics)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  _getAdapter,
+} from "../gsd-db.ts";
+import { registerAutoWorker } from "../db/auto-workers.ts";
+import {
+  claimMilestoneLease,
+  releaseMilestoneLease,
+  refreshMilestoneLease,
+  getMilestoneLease,
+} from "../db/milestone-leases.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-leases-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+test("first claim returns ok=true with token=1", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  const w1 = registerAutoWorker({ projectRootRealpath: base });
+  const claim = claimMilestoneLease(w1, "M001");
+  assert.equal(claim.ok, true);
+  if (claim.ok) {
+    assert.equal(claim.token, 1, "fresh claim starts fencing token at 1");
+  }
+
+  const row = getMilestoneLease("M001");
+  assert.ok(row);
+  assert.equal(row!.worker_id, w1);
+  assert.equal(row!.fencing_token, 1);
+  assert.equal(row!.status, "held");
+});
+
+test("second claim by different worker is rejected while lease is held", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  const w1 = registerAutoWorker({ projectRootRealpath: base });
+  const w2 = registerAutoWorker({ projectRootRealpath: base });
+  const first = claimMilestoneLease(w1, "M001");
+  assert.equal(first.ok, true);
+
+  const second = claimMilestoneLease(w2, "M001");
+  assert.equal(second.ok, false);
+  if (!second.ok) {
+    assert.equal(second.error, "held_by");
+    assert.equal(second.byWorker, w1);
+  }
+});
+
+test("releaseMilestoneLease frees the lease for takeover", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  const w1 = registerAutoWorker({ projectRootRealpath: base });
+  const w2 = registerAutoWorker({ projectRootRealpath: base });
+  const first = claimMilestoneLease(w1, "M001");
+  assert.equal(first.ok, true);
+
+  if (first.ok) {
+    const released = releaseMilestoneLease(w1, "M001", first.token);
+    assert.equal(released, true);
+  }
+
+  // After release, w2 may take over with monotonically larger token
+  const second = claimMilestoneLease(w2, "M001");
+  assert.equal(second.ok, true);
+  if (second.ok) {
+    assert.equal(second.token, 2, "takeover increments fencing token monotonically");
+  }
+});
+
+test("expired lease (TTL passed) allows takeover with token+1", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  const w1 = registerAutoWorker({ projectRootRealpath: base });
+  const w2 = registerAutoWorker({ projectRootRealpath: base });
+  const first = claimMilestoneLease(w1, "M001");
+  assert.equal(first.ok, true);
+
+  // Force expiration by patching the row's expires_at into the past.
+  const db = _getAdapter()!;
+  db.prepare(
+    `UPDATE milestone_leases SET expires_at = '1970-01-01T00:00:00.000Z' WHERE milestone_id = 'M001'`,
+  ).run();
+
+  const takeover = claimMilestoneLease(w2, "M001");
+  assert.equal(takeover.ok, true);
+  if (takeover.ok) {
+    assert.equal(takeover.token, 2);
+  }
+  const row = getMilestoneLease("M001");
+  assert.equal(row!.worker_id, w2);
+  assert.equal(row!.fencing_token, 2);
+});
+
+test("refreshMilestoneLease only succeeds with the matching fencing token", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  const w1 = registerAutoWorker({ projectRootRealpath: base });
+  const claim = claimMilestoneLease(w1, "M001");
+  assert.equal(claim.ok, true);
+  if (!claim.ok) return;
+
+  // Correct token refreshes
+  assert.equal(refreshMilestoneLease(w1, "M001", claim.token), true);
+
+  // Stale token (e.g. claim.token - 1) refuses
+  assert.equal(refreshMilestoneLease(w1, "M001", claim.token - 1), false);
+});

--- a/src/resources/extensions/gsd/tests/parallel-milestone-isolation.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-milestone-isolation.test.ts
@@ -1,0 +1,104 @@
+// gsd-2 + Parallel-worker isolation regression (Phase B coordination)
+//
+// Two simulated workers attempt to claim leases on the same project. The
+// lease infrastructure must guarantee:
+//   - On the same milestone: only one wins; the loser sees held_by error
+//   - On different milestones: both succeed independently
+//
+// This is the integration check that ties registerAutoWorker +
+// claimMilestoneLease + recordDispatchClaim together end-to-end.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+} from "../gsd-db.ts";
+import { registerAutoWorker } from "../db/auto-workers.ts";
+import { claimMilestoneLease } from "../db/milestone-leases.ts";
+import { recordDispatchClaim } from "../db/unit-dispatches.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-parallel-iso-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+test("two workers contesting the same milestone: only one wins the lease", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Contested", status: "active" });
+
+  const w1 = registerAutoWorker({ projectRootRealpath: base });
+  const w2 = registerAutoWorker({ projectRootRealpath: base });
+
+  const r1 = claimMilestoneLease(w1, "M001");
+  const r2 = claimMilestoneLease(w2, "M001");
+
+  assert.equal(r1.ok, true, "first claim wins");
+  assert.equal(r2.ok, false, "second claim is rejected");
+  if (!r2.ok) {
+    assert.equal(r2.error, "held_by");
+    assert.equal(r2.byWorker, w1);
+  }
+});
+
+test("two workers on different milestones can both proceed independently", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "First", status: "active" });
+  insertMilestone({ id: "M002", title: "Second", status: "active" });
+
+  const w1 = registerAutoWorker({ projectRootRealpath: base });
+  const w2 = registerAutoWorker({ projectRootRealpath: base });
+
+  const r1 = claimMilestoneLease(w1, "M001");
+  const r2 = claimMilestoneLease(w2, "M002");
+
+  assert.equal(r1.ok, true);
+  assert.equal(r2.ok, true);
+  if (r1.ok && r2.ok) {
+    assert.equal(r1.token, 1);
+    assert.equal(r2.token, 1);
+  }
+});
+
+test("dispatch ledger ties unit_id uniqueness to active status", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "T", status: "active" });
+
+  const w1 = registerAutoWorker({ projectRootRealpath: base });
+  const w2 = registerAutoWorker({ projectRootRealpath: base });
+
+  // Both workers somehow attempt to claim the same unit (e.g. lease drift).
+  // The partial unique index on unit_dispatches.unit_id WHERE status IN
+  // ('claimed','running') must serialize the writes regardless of lease state.
+  const claim1 = recordDispatchClaim({
+    traceId: "t1", workerId: w1, milestoneLeaseToken: 1,
+    milestoneId: "M001", unitType: "plan-slice", unitId: "M001/S01",
+  });
+  const claim2 = recordDispatchClaim({
+    traceId: "t2", workerId: w2, milestoneLeaseToken: 1,
+    milestoneId: "M001", unitType: "plan-slice", unitId: "M001/S01",
+  });
+
+  assert.equal(claim1.ok, true);
+  assert.equal(claim2.ok, false);
+  if (!claim2.ok) {
+    assert.equal(claim2.error, "already_active");
+  }
+});

--- a/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
@@ -1,0 +1,194 @@
+// gsd-2 + Unit dispatch ledger tests (Phase B coordination — partial unique index, retry metadata)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+} from "../gsd-db.ts";
+import { registerAutoWorker } from "../db/auto-workers.ts";
+import {
+  recordDispatchClaim,
+  markRunning,
+  markCompleted,
+  markFailed,
+  markStuck,
+  markCanceled,
+  getRecentForUnit,
+  getLatestForUnit,
+} from "../db/unit-dispatches.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-dispatches-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+function setup(base: string): { workerId: string } {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice" });
+  const workerId = registerAutoWorker({ projectRootRealpath: base });
+  return { workerId };
+}
+
+test("recordDispatchClaim creates a claimed row", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  const { workerId } = setup(base);
+
+  const claim = recordDispatchClaim({
+    traceId: "trace-1",
+    turnId: "turn-1",
+    workerId,
+    milestoneLeaseToken: 1,
+    milestoneId: "M001",
+    sliceId: "S01",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+  });
+  assert.equal(claim.ok, true);
+  if (claim.ok) {
+    const row = getLatestForUnit("M001/S01");
+    assert.ok(row);
+    assert.equal(row!.id, claim.dispatchId);
+    assert.equal(row!.status, "claimed");
+    assert.equal(row!.worker_id, workerId);
+    assert.equal(row!.attempt_n, 1);
+  }
+});
+
+test("partial unique index rejects double-claim of the same active unit", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  const { workerId } = setup(base);
+  const w2 = registerAutoWorker({ projectRootRealpath: base });
+
+  const first = recordDispatchClaim({
+    traceId: "t-a",
+    workerId,
+    milestoneLeaseToken: 1,
+    milestoneId: "M001",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+  });
+  assert.equal(first.ok, true);
+
+  // Second worker tries to claim the same unit while first is still claimed
+  const second = recordDispatchClaim({
+    traceId: "t-b",
+    workerId: w2,
+    milestoneLeaseToken: 1,
+    milestoneId: "M001",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+  });
+  assert.equal(second.ok, false);
+  if (!second.ok) {
+    assert.equal(second.error, "already_active");
+    assert.equal(second.existingWorker, workerId);
+  }
+});
+
+test("after markCompleted, a fresh claim for the same unit succeeds", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  const { workerId } = setup(base);
+
+  const first = recordDispatchClaim({
+    traceId: "t-1",
+    workerId,
+    milestoneLeaseToken: 1,
+    milestoneId: "M001",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+  });
+  assert.equal(first.ok, true);
+  if (!first.ok) return;
+  markRunning(first.dispatchId);
+  markCompleted(first.dispatchId);
+
+  // Re-dispatch
+  const second = recordDispatchClaim({
+    traceId: "t-2",
+    workerId,
+    milestoneLeaseToken: 1,
+    milestoneId: "M001",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+    attemptN: 2,
+  });
+  assert.equal(second.ok, true);
+  if (second.ok) {
+    const recent = getRecentForUnit("M001/S01", 5);
+    assert.equal(recent.length, 2);
+    assert.equal(recent[0].status, "claimed");
+    assert.equal(recent[0].attempt_n, 2);
+    assert.equal(recent[1].status, "completed");
+  }
+});
+
+test("markFailed records error_summary and retry metadata", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  const { workerId } = setup(base);
+
+  const claim = recordDispatchClaim({
+    traceId: "t-1",
+    workerId,
+    milestoneLeaseToken: 1,
+    milestoneId: "M001",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+  });
+  assert.equal(claim.ok, true);
+  if (!claim.ok) return;
+  markRunning(claim.dispatchId);
+  markFailed(claim.dispatchId, {
+    errorSummary: "boom",
+    errorCode: "test-fail",
+    retryAfterMs: 5000,
+  });
+
+  const row = getLatestForUnit("M001/S01")!;
+  assert.equal(row.status, "failed");
+  assert.equal(row.error_summary, "boom");
+  assert.equal(row.last_error_code, "test-fail");
+  assert.equal(row.retry_after_ms, 5000);
+  assert.ok(row.next_run_at, "next_run_at scheduled");
+});
+
+test("markStuck and markCanceled set their respective statuses", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  const { workerId } = setup(base);
+
+  const a = recordDispatchClaim({
+    traceId: "ta", workerId, milestoneLeaseToken: 1,
+    milestoneId: "M001", unitType: "plan-slice", unitId: "M001/S01",
+  });
+  assert.equal(a.ok, true);
+  if (!a.ok) return;
+  markStuck(a.dispatchId, "test-stuck");
+  assert.equal(getLatestForUnit("M001/S01")!.status, "stuck");
+
+  const b = recordDispatchClaim({
+    traceId: "tb", workerId, milestoneLeaseToken: 1,
+    milestoneId: "M001", unitType: "run-task", unitId: "M001/S01/T01",
+  });
+  assert.equal(b.ok, true);
+  if (!b.ok) return;
+  markCanceled(b.dispatchId, "user-cancel");
+  assert.equal(getLatestForUnit("M001/S01/T01")!.status, "canceled");
+});

--- a/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
@@ -192,3 +192,21 @@ test("markStuck and markCanceled set their respective statuses", (t) => {
   markCanceled(b.dispatchId, "user-cancel");
   assert.equal(getLatestForUnit("M001/S01/T01")!.status, "canceled");
 });
+
+test("recordDispatchClaim rethrows foreign-key failures instead of mapping them to already_active", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  setup(base);
+
+  assert.throws(
+    () => recordDispatchClaim({
+      traceId: "t-fk",
+      workerId: "missing-worker",
+      milestoneLeaseToken: 1,
+      milestoneId: "M001",
+      unitType: "plan-slice",
+      unitId: "M001/S01",
+    }),
+    /FOREIGN KEY constraint failed/,
+  );
+});

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -25,6 +25,7 @@ import { emitWorktreeCreated, emitWorktreeMerged } from "./worktree-telemetry.js
 import { getCollapseCadence, getMilestoneResquash, resquashMilestoneOnMain } from "./slice-cadence.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { resolveWorktreeProjectRoot, normalizeWorktreePathForCompare } from "./worktree-root.js";
+import { claimMilestoneLease, releaseMilestoneLease } from "./db/milestone-leases.js";
 
 // ─── Path Comparison Helper ────────────────────────────────────────────────
 /**
@@ -197,6 +198,68 @@ export class WorktreeResolver {
         reason: "isolation-degraded",
       });
       return;
+    }
+
+    // Phase B: claim a milestone lease before any worktree mutation. Two
+    // workers cannot enter the same milestone concurrently. Best-effort:
+    // skip if no worker registered (single-worker fallback) or DB
+    // unavailable; reuse existing lease if we already hold it on this
+    // milestone (re-entry within the same session).
+    if (this.s.workerId) {
+      if (this.s.currentMilestoneId === milestoneId && this.s.milestoneLeaseToken !== null) {
+        // Already held — no-op, the heartbeat in loop.ts refreshes TTL.
+      } else {
+        // If we held a different milestone, release it first so other
+        // workers don't have to wait for TTL.
+        if (this.s.currentMilestoneId && this.s.currentMilestoneId !== milestoneId && this.s.milestoneLeaseToken !== null) {
+          try {
+            releaseMilestoneLease(this.s.workerId, this.s.currentMilestoneId, this.s.milestoneLeaseToken);
+          } catch (err) {
+            debugLog("WorktreeResolver", {
+              action: "enterMilestone",
+              milestoneId,
+              releasePriorLeaseError: err instanceof Error ? err.message : String(err),
+            });
+          }
+          this.s.milestoneLeaseToken = null;
+        }
+
+        try {
+          const claim = claimMilestoneLease(this.s.workerId, milestoneId);
+          if (claim.ok) {
+            this.s.milestoneLeaseToken = claim.token;
+            debugLog("WorktreeResolver", {
+              action: "enterMilestone",
+              milestoneId,
+              leaseAcquired: true,
+              fencingToken: claim.token,
+              expiresAt: claim.expiresAt,
+            });
+          } else {
+            // Lease held by another worker — fail loud so the user can
+            // see the conflict instead of silently double-running.
+            const msg = `Milestone ${milestoneId} is held by worker ${claim.byWorker} until ${claim.expiresAt}.`;
+            debugLog("WorktreeResolver", {
+              action: "enterMilestone",
+              milestoneId,
+              leaseHeldByOther: claim.byWorker,
+              expiresAt: claim.expiresAt,
+            });
+            ctx.notify(`${msg} Another auto-mode worker is active. Stop it before entering ${milestoneId}.`, "error");
+            this.s.isolationDegraded = true;
+            return;
+          }
+        } catch (err) {
+          // DB unavailable or other error — log and fall through to the
+          // pre-Phase-B single-worker behavior so a fresh project before
+          // DB init still works.
+          debugLog("WorktreeResolver", {
+            action: "enterMilestone",
+            milestoneId,
+            leaseError: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
     }
 
     // Resolve the project root for worktree operations via shared helper.


### PR DESCRIPTION
## TL;DR

**What:** Phase B of the upstream coordination plan — adds five SQLite-WAL-backed coordination tables (workers, milestone_leases, unit_dispatches, cancellation_requests, command_queue) plus four new modules under `db/` and wires worker registration, milestone leasing, dispatch ledger writes, and stuck-detector retry coupling into the auto-mode loop.
**Why:** Lay the substrate for cross-process auto-mode coordination. Currently single-worker auto-mode coordinates via filesystem files (`auto.lock`, `stuck-state.json`, `paused-session.json`); concurrent workers on the same project can step on each other. This PR introduces fenced leases and a dispatch ledger so two workers can safely operate against the same project DB.
**How:** SCHEMA_VERSION 23→24 with idempotent table creation in both fresh-install and migration paths. New `db/` modules wrap each table with the codex-reviewed atomic semantics. Wire-up in `auto.ts`, `auto/loop.ts`, `worktree-resolver.ts`, and `auto/detect-stuck.ts` is best-effort throughout — single-worker semantics preserved when DB is unavailable or no worker is registered.

## What

### Schema (SCHEMA_VERSION 23 → 24)

Five new tables, created idempotently in both the fresh-install path and a v24 migration block. New helper `createCoordinationTablesV24()` keeps the two paths byte-equivalent.

- `workers` — auto-mode process registry with heartbeat TTL (60s)
- `milestone_leases` — fenced one-worker-per-milestone leases (60s TTL)
- `unit_dispatches` — per-unit dispatch ledger (claim → running → completed/failed/stuck), plus `attempt_n` / `next_run_at` for retry-budget tracking
- `cancellation_requests` — IPC for milestone/slice/task/dispatch cancels
- `command_queue` — broadcast-or-targeted dispatcher→worker IPC

Indexes:
- `idx_unit_dispatches_active(milestone_id, status)` — hot-path
- `idx_unit_dispatches_trace(trace_id, turn_id)` — observability joins
- `idx_unit_dispatches_active_per_unit` — **PARTIAL UNIQUE on `unit_id` WHERE `status IN ('claimed','running')`** — codex MEDIUM B2: enforces double-claim guard at DB level
- `idx_command_queue_pending(target_worker, claimed_at)` — SQLite indexes NULL in B-trees so this single index serves both targeted and broadcast queries (codex LOW B4 documented inline)

### New modules under `src/resources/extensions/gsd/db/`

- **`db/auto-workers.ts`** — `registerAutoWorker`, `heartbeatAutoWorker`, `markWorkerCrashed`, `markWorkerStopping`, `getActiveAutoWorkers`, `getAutoWorker`. Top-of-file comment explicitly contrasts this **cross-process** registry with the in-process `subagent/worker-registry.ts` (codex LOW N1).
- **`db/milestone-leases.ts`** — `claimMilestoneLease` implements the BLOCKING B1 atomic INSERT-then-conditional-UPDATE pattern: try INSERT (catches PK constraint violation), then conditional UPDATE WHERE `status IN ('expired','released') OR expires_at < now`, then check `db.changes() === 1`. Fencing token computed by SQL (`fencing_token + 1`), never client-supplied.
- **`db/unit-dispatches.ts`** — `recordDispatchClaim` relies on the partial unique index for atomic double-claim rejection. `markRunning`, `markCompleted`, `markFailed` (with retry metadata), `markStuck`, `markCanceled`, `markPaused`, `getRecentForUnit`, `getLatestForUnit`, `getDispatchesByStatus`.
- **`db/command-queue.ts`** — `enqueueCommand`, `claimNextCommand`, `completeCommand`, `getCommand`. Conditional UPDATE pattern guards against poll-races between concurrent workers.

### Wire-up

- **`auto/session.ts`** — new `workerId` and `milestoneLeaseToken` fields, cleared on `reset()`.
- **`auto.ts`** — `registerAutoWorker` called at session start (both fresh and resume paths). `markWorkerStopping` + `releaseMilestoneLease` in `stopAuto` cleanup. Best-effort: DB unavailability does not block startup or shutdown.
- **`auto/loop.ts`** — heartbeat at loop top (refreshes worker + active lease TTL). New `openDispatchClaim` helper opens claimed→running ledger row before `runUnitPhaseViaContract`; `markCompleted` on success; `markFailed` on `unit-break`, `finalize-break`, `finalize-retry`. Best-effort: ledger writes never throw upward, single-worker semantics preserved.
- **`worktree-resolver.ts`** — `claimMilestoneLease` before any worktree mutation in `enterMilestone`. If another worker holds the lease, fail loud with `notify("error")` naming the holder. Re-entry on same milestone is a no-op; switching milestones releases the prior lease before claiming the new one.
- **`auto/detect-stuck.ts`** — rules 2 and 2b consult `getLatestForUnit` and suppress the stuck verdict while `attempt_n < max_attempts` AND `next_run_at` is in the future (codex MEDIUM B3 — retry coupling).

### Tests (6 new files, 27 tests, all pass)

| File | Coverage |
|------|----------|
| `auto-workers.test.ts` | register / heartbeat / markCrashed / markStopping; TTL filtering |
| `milestone-leases.test.ts` | fresh claim, contested claim, release, TTL takeover with token+1 monotonicity, refresh-token validation |
| `unit-dispatches.test.ts` | claim/running/completed; partial-unique-index rejection; re-claim after completion; markFailed with retry metadata; markStuck; markCanceled |
| `command-queue.test.ts` | targeted round-trip; broadcast single-delivery; oldest-first ordering with id tiebreaker; idempotent completion |
| `parallel-milestone-isolation.test.ts` | two-worker contested lease; independent milestones; dispatch-ledger uniqueness |
| `detect-stuck-respects-retry.test.ts` | legacy behavior preserved when DB unavailable; suppression while retry window active; re-engagement at attempt_n cap; re-engagement when next_run_at lapses |

## Why

The auto-mode coordination story today is filesystem-based: `auto.lock`, `stuck-state.json`, `paused-session.json`, in-memory `originalBase` singletons. This works for the single-worker case but cannot detect or prevent two workers from operating on the same project (or the same milestone) concurrently. The visible failure modes — partial state writes, cross-worker state contamination, missing crash detection — are systemic and well-documented (#3704, #4382, #2645, etc.).

PR #5236 introduced `GsdWorkspace` / `MilestoneScope` and unified path resolution. PR #5246 (Draft) extended that to the readers and fixed the deriveState cache key. This PR builds on both: it gives the system a way to identify itself (worker registry), claim exclusive use of a milestone (fenced lease), record what it dispatched (ledger), and accept signals from siblings or dispatchers (command queue).

The single-worker default path is unchanged — Phase B is purely additive infrastructure. Phase C will then **migrate the file-based runtime state out** (replacing `stuck-state.json` / `paused-session.json` / `auto.lock` reads with queries against these tables) and **delete `copyPlanningArtifacts` / `reconcilePlanCheckboxes`**, which become unnecessary once non-symlinked worktrees safely consult the project-root `.gsd/` (Phase A pt 2's read-side guarantee).

## How

**Best-effort throughout.** Every wire-up site is wrapped in try/catch that logs to `debugLog` rather than throwing. If the DB is unavailable (e.g. fresh project before init), the auto-loop falls through to the existing single-worker semantics with no ledger entry. The test `silent-catch-diagnostics` is satisfied — every catch logs.

**BLOCKING B1 lease semantics.** `claimMilestoneLease` runs both branches inside a single `transaction()`:
1. Try INSERT with `fencing_token = 1`. If it raises a PK constraint violation, fall through.
2. Conditional UPDATE: `SET worker_id = :new, fencing_token = fencing_token + 1, ... WHERE milestone_id = :mid AND (status IN ('expired','released') OR datetime(expires_at) < datetime('now'))`.
3. Check `db.changes() === 1`. If 0, the lease is still held — read the holder and return `{ ok: false, error: 'held_by', byWorker, expiresAt }`.

**MEDIUM B2 double-claim guard.** Partial unique index on `unit_dispatches(unit_id) WHERE status IN ('claimed','running')`. `recordDispatchClaim` catches the constraint violation, looks up the existing active row, and returns `{ ok: false, error: 'already_active', existingId, existingStatus, existingWorker }`.

**MEDIUM B3 retry coupling.** `detect-stuck.ts` rules 2 and 2b (both "same unit repeated") consult `getLatestForUnit(unitKey)`. If `attempt_n < max_attempts` AND `next_run_at` is in the future, the stuck verdict is suppressed — the loop is legitimately waiting on its own backoff.

**Custom-engine path NOT instrumented.** The `auto/loop.ts:511` `runUnitPhaseViaContract` call (custom-engine path) is left alone; the dispatch ledger only wraps the dev path at `auto/loop.ts:701`. Custom engines have their own state machine and contract — instrumenting them is out of scope.

## Single-host invariant

SQLite WAL coordination only works on local disk. NFS / network filesystems break heartbeat semantics. Multi-host execution would need a real coordinator (etcd, Postgres) and is out of scope. Documented at the top of `db/auto-workers.ts` and reiterated in `createCoordinationTablesV24`.

## Out of scope (deferred)

- **Phase C** — file-state migration (`paused-session.json`, `stuck-state.json`, `auto.lock` → DB), delete `copyPlanningArtifacts` / `reconcilePlanCheckboxes`, `runtime_kv` table.
- **Janitor / doctor work** — auto-promote `active` workers to `crashed` when heartbeat lapses; expire stuck leases. Current implementation: workers/leases auto-filter via TTL on read; no background sweep.
- **Cross-host coordination** — explicitly out per single-host invariant.
- **Custom-engine ledger instrumentation** — separate effort if/when needed.

## Lineage and rollback

- Builds on **merged** [PR #5236](https://github.com/gsd-build/gsd-2/pull/5236) (GsdWorkspace handle, MilestoneScope) which established `s.scope`.
- Independent of [PR #5245](https://github.com/gsd-build/gsd-2/pull/5245) (Phase A pt 1 — DB-projection consistency, DRAFT) and [PR #5246](https://github.com/gsd-build/gsd-2/pull/5246) (Phase A pt 2 — reader-side path threading + cache-key fix, DRAFT). Phase A and Phase B can merge in either order.
- **Forward-revertable on its own.** The new tables are additive and the wire-up degrades to single-worker semantics if the DB doesn't have them. **Do NOT revert once Phase C ships** — Phase C's removal of `paused-session.json` / `stuck-state.json` / `auto.lock` will assume these tables exist.

## Change type checklist

- [x] feat — New feature or capability
- [ ] fix — Bug fix
- [ ] refactor — Code restructuring (no behavior change)
- [ ] test — Adding or updating tests
- [ ] docs — Documentation only
- [ ] chore — Build, CI, or tooling changes

## AI-assisted contributions

Developed with Claude Code (Anthropic) assistance. The plan was peer-reviewed by Codex CLI before implementation; all BLOCKING (B1 lease semantics) and MEDIUM (B2 double-claim guard, B3 retry coupling) findings were folded in before code was written. All commits authored by the contributor; no AI co-author trailer.

## Test plan

- [x] `tsc --noEmit -p tsconfig.resources.json`: clean
- [x] 27 new tests pass: `npx tsx --test src/resources/extensions/gsd/tests/{auto-workers,milestone-leases,unit-dispatches,command-queue,parallel-milestone-isolation,detect-stuck-respects-retry}.test.ts`
- [x] Full gsd extension suite: **6508/6518 pass**, 7 skipped, 3 pre-existing macOS realpath failures (same set as #5246 — `findEvalReviewFile`, `checkSliceEvalReview`, `resolveExpectedArtifactPath` — none in functions modified by this PR)
- [x] `silent-catch-diagnostics` test passes (best-effort wire-up sites use `debugLog` rather than empty catches)
- [ ] Reviewer to run `npm run verify:pr` and confirm no regression beyond the documented pre-existing macOS failures
- [ ] Optional manual: open two `gsd auto` processes against the same project on the same milestone — second one must fail loud naming the first as the holder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DB-backed multi-worker coordination: worker registry, heartbeats, milestone leases (fencing), unit dispatch ledger, and command queue; schema bumped for v24.
  * Auto-mode: worker registration on start/resume, heartbeat/lease refresh, dispatch claiming, ledger-backed state transitions, and improved shutdown coordination.

* **Bug Fixes**
  * Detect-stuck now respects retry-backoff windows to avoid premature stuck signals.

* **Documentation**
  * Updated parallel/multi-session docs and README to describe DB-based orchestration.

* **Tests**
  * Added end-to-end tests for workers, leases, dispatch ledger, and command queue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->