### PR TITLE
refactor(gsd): canonicalize writers + delete copyPlanningArtifacts/reconcile + migrate stuck-state to DB (Phase C pt 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ gsd
 /gsd queue      # queue the next milestone
 ```
 
-Both terminals read and write the same `.gsd/` files on disk. Your decisions in terminal 2 are picked up automatically at the next phase boundary — no need to stop auto mode.
+Both terminals coordinate through the same project-root GSD runtime on local disk. The SQLite database is authoritative, `.gsd/` markdown is refreshed from it, and your decisions in terminal 2 are picked up at the next phase boundary without stopping auto mode.
 
 ### Headless mode — CI and scripts
 
@@ -439,7 +439,7 @@ gsd headless dispatch plan
 
 Headless auto-responds to interactive prompts, detects completion, and exits with structured codes: `0` complete, `1` error/timeout, `2` blocked. Auto-restarts on crash with exponential backoff. Use `gsd headless query` for instant, machine-readable state inspection — returns phase, next dispatch preview, and parallel worker costs as a single JSON object without spawning an LLM session. Pair with [remote questions](./docs/user-docs/remote-questions.md) to route decisions to Slack or Discord when human input is needed.
 
-**Multi-session orchestration** — headless mode supports file-based IPC in `.gsd/parallel/` for coordinating multiple GSD workers across milestones. Build orchestrators that spawn, monitor, and budget-cap a fleet of GSD workers.
+**Multi-session orchestration** — headless mode can coordinate multiple GSD workers across milestones on the same machine through the project-root SQLite/WAL runtime. This is single-host only: do not share the project database across machines or network filesystems.
 
 ### First launch
 

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -28,6 +28,12 @@ The SQLite database is the runtime source of truth for milestones, slices, tasks
 
 In worktree mode, the project-root database and project-root `.gsd/` state remain authoritative. Worktree markdown projections are useful diagnostics, but they are not synced back as runtime state. If the database is unavailable, runtime state derivation refuses to silently rebuild from markdown. The legacy markdown derivation path is only enabled when `GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK=1`, which exists for tests and explicit recovery scenarios.
 
+### Single-Host Runtime Constraint
+
+Phase C coordination is single-host only. Auto mode and parallel coordination rely on the project-root SQLite database running in WAL mode on local disk for worker heartbeats, milestone leases, dispatch claims, cancellation requests, and command handoff.
+
+That means multiple terminals or worker processes can safely coordinate against the same project on one machine, but sharing `.gsd/gsd.db*` across machines or over network filesystems is unsupported. If you need cross-host orchestration, use an external coordinator instead of trying to stretch the local SQLite/WAL runtime.
+
 ### Deep Planning Mode
 
 For projects that need more up-front discovery, enable deep planning mode in project preferences:
@@ -96,7 +102,7 @@ See [Git Strategy](./git-strategy.md) for details.
 
 ### Parallel Execution
 
-When your project has independent milestones, you can run them simultaneously. Each milestone gets its own worker process and worktree. See [Parallel Orchestration](./parallel-orchestration.md) for setup and usage.
+When your project has independent milestones, you can run them simultaneously. Each milestone gets its own worker process and worktree, while coordination stays anchored in the shared project-root SQLite/WAL runtime on the same machine. See [Parallel Orchestration](./parallel-orchestration.md) for setup and usage.
 
 ### Crash Recovery
 

--- a/docs/user-docs/getting-started.md
+++ b/docs/user-docs/getting-started.md
@@ -360,7 +360,7 @@ gsd
 /gsd queue      # queue the next milestone
 ```
 
-Both terminals read and write the same `.gsd/` files. Decisions in terminal 2 are picked up at the next phase boundary automatically.
+Both terminals coordinate through the same project-root GSD runtime. The SQLite database is authoritative, `.gsd/` markdown is refreshed from it, and decisions in terminal 2 are picked up at the next phase boundary automatically as long as both sessions are on the same machine and local checkout.
 
 ---
 

--- a/docs/user-docs/git-strategy.md
+++ b/docs/user-docs/git-strategy.md
@@ -98,7 +98,7 @@ These features apply only in **worktree mode**.
 Auto mode creates and manages worktrees automatically:
 
 1. When a milestone starts, a worktree is created at `.gsd/worktrees/<MID>/` on branch `milestone/<MID>`
-2. Planning artifacts from `.gsd/milestones/` are copied into the worktree
+2. The project-root SQLite database and project-root `.gsd/` state remain canonical; the worktree is an isolated execution checkout, not an independent planning-state copy
 3. All execution happens inside the worktree
 4. On milestone completion, the worktree is squash-merged to the integration branch
 5. The worktree and branch are removed

--- a/docs/user-docs/git-strategy.md
+++ b/docs/user-docs/git-strategy.md
@@ -99,6 +99,7 @@ Auto mode creates and manages worktrees automatically:
 
 1. When a milestone starts, a worktree is created at `.gsd/worktrees/<MID>/` on branch `milestone/<MID>`
 2. The project-root SQLite database and project-root `.gsd/` state remain canonical; the worktree is an isolated execution checkout, not an independent planning-state copy
+   SQLite WAL coordination is single-host only; do not share this runtime across machines, and see `src/resources/extensions/gsd/docs/COORDINATION.md` for the coordination constraints.
 3. All execution happens inside the worktree
 4. On milestone completion, the worktree is squash-merged to the integration branch
 5. The worktree and branch are removed

--- a/docs/user-docs/parallel-orchestration.md
+++ b/docs/user-docs/parallel-orchestration.md
@@ -173,7 +173,7 @@ parallel:
 
 The coordinator communicates with workers through persisted runtime commands:
 
-```
+```text
 Coordinator                    Worker
     │                            │
     ├── enqueue("pause") ─────→  │
@@ -210,7 +210,7 @@ When milestones complete, their worktree changes need to merge back to main.
 
 ### Example
 
-```
+```text
 /gsd parallel merge
 
 # Merge Results
@@ -244,7 +244,7 @@ Run `/gsd doctor --fix` to clean up automatically.
 
 Sessions are considered stale when:
 - The worker PID is no longer running (checked via `process.kill(pid, 0)`)
-- The last heartbeat is older than 30 seconds
+- The last heartbeat is older than 60 seconds
 
 The coordinator runs stale detection during `refreshWorkerStatuses()` and automatically removes dead sessions.
 
@@ -264,7 +264,7 @@ The coordinator runs stale detection during `refreshWorkerStatuses()` and automa
 
 ## File Layout
 
-```
+```text
 .gsd/
 ├── gsd.db                       # Shared runtime DB (workers, leases, dispatches, commands, runtime_kv)
 ├── gsd.db-wal                   # WAL sidecar for the shared runtime DB
@@ -277,7 +277,9 @@ The coordinator runs stale detection during `refreshWorkerStatuses()` and automa
 └── ...
 ```
 
-`gsd.db*` and `.gsd/worktrees/` are runtime artifacts and should be gitignored.
+Track `.gsd/gsd.db` in git as the stageable source of truth. `checkpointDatabase()` in [src/resources/extensions/gsd/gsd-db.ts](/Users/jeremymcspadden/.oh-my-pr/worktrees/gsd-build__gsd-2/pr-5249-37dc5b59-7d9f-4b66-ba9b-6e31abb686d9/src/resources/extensions/gsd/gsd-db.ts:1752) flushes WAL state back into that main DB file before staging.
+
+Only `.gsd/gsd.db-wal`, `.gsd/gsd.db-shm`, and `.gsd/worktrees/` are runtime artifacts that should be gitignored.
 
 ## Troubleshooting
 

--- a/docs/user-docs/parallel-orchestration.md
+++ b/docs/user-docs/parallel-orchestration.md
@@ -1,8 +1,10 @@
 # Parallel Milestone Orchestration
 
-Run multiple milestones simultaneously in isolated git worktrees. Each milestone gets its own worker process, its own branch, and its own context window — while a coordinator tracks progress, enforces budgets, and keeps everything in sync.
+Run multiple milestones simultaneously in isolated git worktrees. Each milestone gets its own worker process, its own branch, and its own context window, while a coordinator tracks progress, enforces budgets, and keeps everything in sync through the shared project-root SQLite runtime.
 
 > **Status:** Behind `parallel.enabled: false` by default. Opt-in only — zero impact to existing users.
+>
+> **Single-host only:** Parallel workers must run on the same machine against a local project checkout. The coordination layer depends on SQLite WAL semantics on local disk and is not supported across machines or network-mounted filesystems.
 
 ## Quick Start
 
@@ -75,16 +77,19 @@ Each worker is a separate `gsd` process with complete isolation:
 | **Git branch** | `milestone/<MID>` — one branch per milestone |
 | **State derivation** | `GSD_MILESTONE_LOCK` env var — `deriveState()` only sees the assigned milestone |
 | **Context window** | Separate process — each worker has its own agent sessions |
-| **Metrics** | Each worktree has its own `.gsd/metrics.json` |
-| **Crash recovery** | Each worktree has its own `.gsd/auto.lock` |
+| **Metrics** | Project-root `.gsd/metrics.json` remains the durable ledger; worktree diagnostics may be mirrored back there |
+| **Crash recovery** | Coordination state stays anchored at the project root; per-worker locks and diagnostics are implementation details, not the source of truth |
 
 ### Coordination
 
-Workers and the coordinator communicate through file-based IPC:
+Workers and the coordinator coordinate through the project-root SQLite database in WAL mode:
 
-- **Session status files** (`.gsd/parallel/<MID>.status.json`) — workers write heartbeats, the coordinator reads them
-- **Signal files** (`.gsd/parallel/<MID>.signal.json`) — coordinator writes signals, workers consume them
-- **Atomic writes** — write-to-temp + rename prevents partial reads
+- **Worker registry** (`workers`) — heartbeats and liveness are written centrally
+- **Milestone leases** (`milestone_leases`) — only one worker may own a milestone at a time
+- **Dispatch ledger** (`unit_dispatches`) — duplicate unit claims are rejected atomically
+- **Cancellation + command queue** (`cancellation_requests`, `command_queue`) — pause/stop/resume handoff is persisted in shared runtime state
+
+This model assumes local-disk locking semantics. Do not place the project on NFS/SMB/FUSE-style mounts or try to share `.gsd/gsd.db*` across hosts.
 
 ## Eligibility Analysis
 
@@ -122,7 +127,7 @@ Before starting parallel execution, GSD checks which milestones can safely run c
   - `src/middleware.ts`
 ```
 
-File overlaps are warnings, not blockers. Both milestones work in separate worktrees, so they won't interfere at the filesystem level. Conflicts are detected and resolved during merge.
+File overlaps are warnings, not blockers. Both milestones work in separate worktrees, so they won't interfere at the filesystem level. Conflicts are still possible at merge time, and the coordination guarantees only apply when all workers share the same local SQLite/WAL runtime on one host.
 
 ## Configuration
 

--- a/docs/user-docs/parallel-orchestration.md
+++ b/docs/user-docs/parallel-orchestration.md
@@ -50,7 +50,7 @@ GSD scans your milestones, checks dependencies and file overlap, shows an eligib
 │  - Eligibility analysis (deps + file overlap)           │
 │  - Worker spawning and lifecycle                        │
 │  - Budget tracking across all workers                   │
-│  - Signal dispatch (pause/resume/stop)                  │
+│  - Command dispatch (pause/resume/stop)                 │
 │  - Session status monitoring                            │
 │  - Merge reconciliation                                 │
 │                                                         │
@@ -160,7 +160,7 @@ parallel:
 |---------|-------------|
 | `/gsd parallel start` | Analyze eligibility, confirm, and start workers |
 | `/gsd parallel status` | Show all workers with state, units completed, and cost |
-| `/gsd parallel stop` | Stop all workers (sends SIGTERM) |
+| `/gsd parallel stop` | Stop all workers (enqueues stop + sends SIGTERM) |
 | `/gsd parallel stop M002` | Stop a specific milestone's worker |
 | `/gsd parallel pause` | Pause all workers (finish current unit, then wait) |
 | `/gsd parallel pause M002` | Pause a specific worker |
@@ -169,30 +169,30 @@ parallel:
 | `/gsd parallel merge` | Merge all completed milestones back to main |
 | `/gsd parallel merge M002` | Merge a specific milestone back to main |
 
-## Signal Lifecycle
+## Command Lifecycle
 
-The coordinator communicates with workers through signals:
+The coordinator communicates with workers through persisted runtime commands:
 
 ```
 Coordinator                    Worker
     │                            │
-    ├── sendSignal("pause") ──→  │
-    │                            ├── consumeSignal()
+    ├── enqueue("pause") ─────→  │
+    │                            ├── claimNextCommand()
     │                            ├── pauseAuto()
     │                            │   (finish current unit, wait)
     │                            │
-    ├── sendSignal("resume") ─→  │
-    │                            ├── consumeSignal()
+    ├── enqueue("resume") ────→  │
+    │                            ├── claimNextCommand()
     │                            ├── resume dispatch loop
     │                            │
-    ├── sendSignal("stop") ───→  │
+    ├── enqueue("stop") ──────→  │
     │   + SIGTERM ────────────→  │
-    │                            ├── consumeSignal() or SIGTERM handler
+    │                            ├── claimNextCommand() or SIGTERM handler
     │                            ├── stopAuto()
     │                            └── process exits
 ```
 
-Workers check for signals between units (in `handleAgentEnd`). The coordinator also sends `SIGTERM` for immediate response on stop.
+Workers poll the shared command queue between units. The coordinator also sends `SIGTERM` for immediate response on stop.
 
 ## Merge Reconciliation
 
@@ -205,7 +205,7 @@ When milestones complete, their worktree changes need to merge back to main.
 
 ### Conflict Handling
 
-1. `.gsd/` state files (STATE.md, metrics.json, etc.) — **auto-resolved** by accepting the milestone branch version
+1. Runtime coordination state (worker registry, leases, dispatches, cancellation requests, command queue) lives in the project-root SQLite runtime and is not merge-driven.
 2. Code conflicts — **stop and report**. The merge halts, showing which files conflict. Resolve manually and retry with `/gsd parallel merge <MID>`.
 
 ### Example
@@ -227,7 +227,7 @@ When milestones complete, their worktree changes need to merge back to main.
 When `budget_ceiling` is set, the coordinator tracks aggregate cost across all workers:
 
 - Cost is summed from each worker's session status
-- When the ceiling is reached, the coordinator signals workers to stop
+- When the ceiling is reached, the coordinator enqueues stop commands for workers
 - Each worker also respects the project-level `budget_ceiling` preference independently
 
 ## Health Monitoring
@@ -236,7 +236,7 @@ When `budget_ceiling` is set, the coordinator tracks aggregate cost across all w
 
 `/gsd doctor` detects parallel session issues:
 
-- **Stale parallel sessions** — Worker process died without cleanup. Doctor finds `.gsd/parallel/*.status.json` files with dead PIDs or expired heartbeats and removes them.
+- **Stale parallel sessions** — Worker process died without cleanup. Doctor inspects the shared runtime DB for expired heartbeats, crashed workers, and stale coordination rows, then reconciles them.
 
 Run `/gsd doctor --fix` to clean up automatically.
 
@@ -258,32 +258,26 @@ The coordinator runs stale detection during `refreshWorkerStatuses()` and automa
 | **`GSD_MILESTONE_LOCK`** | Each worker only sees its milestone in state derivation |
 | **`GSD_PARALLEL_WORKER`** | Workers cannot spawn nested parallel sessions |
 | **Budget ceiling** | Aggregate cost enforcement across all workers |
-| **Signal-based shutdown** | Graceful stop via file signals + SIGTERM |
+| **Command-based shutdown** | Graceful stop via persisted DB commands + SIGTERM |
 | **Doctor integration** | Detects and cleans up orphaned sessions |
-| **Conflict-aware merge** | Stops on code conflicts, auto-resolves `.gsd/` state conflicts |
+| **Conflict-aware merge** | Stops on code conflicts while runtime coordination state stays anchored in the shared DB |
 
 ## File Layout
 
 ```
 .gsd/
-├── parallel/                    # Coordinator ↔ worker IPC
-│   ├── M002.status.json         # Worker heartbeat + progress
-│   ├── M002.signal.json         # Coordinator → worker signals
-│   ├── M003.status.json
-│   └── M003.signal.json
+├── gsd.db                       # Shared runtime DB (workers, leases, dispatches, commands, runtime_kv)
+├── gsd.db-wal                   # WAL sidecar for the shared runtime DB
+├── gsd.db-shm                   # Shared-memory sidecar for the WAL runtime
 ├── worktrees/                   # Git worktrees (one per milestone)
 │   ├── M002/                    # M002's isolated checkout
-│   │   ├── .gsd/                # M002's own state files
-│   │   │   ├── auto.lock
-│   │   │   ├── metrics.json
-│   │   │   └── milestones/
 │   │   └── src/                 # M002's working copy
 │   └── M003/
 │       └── ...
 └── ...
 ```
 
-Both `.gsd/parallel/` and `.gsd/worktrees/` are gitignored — they're runtime-only coordination files that never get committed.
+`gsd.db*` and `.gsd/worktrees/` are runtime artifacts and should be gitignored.
 
 ## Troubleshooting
 
@@ -297,7 +291,7 @@ All milestones are either complete or blocked by dependencies. Check `/gsd queue
 
 ### Worker crashed — how to recover
 
-Workers now persist their state to disk automatically. If a worker process dies, the coordinator detects the dead PID via heartbeat expiry and marks the worker as crashed. On restart, the worker picks up from disk state — crash recovery, worktree re-entry, and completed-unit tracking carry over from the crashed session.
+Workers now persist coordination state in the shared runtime DB. If a worker process dies, the coordinator detects heartbeat expiry, marks the worker as crashed, and releases stale coordination state so a replacement worker can resume safely.
 
 1. Run `/gsd doctor --fix` to clean up stale sessions
 2. Run `/gsd parallel status` to see current state

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -775,7 +775,9 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         // executeTriageResolutions handles defer milestone creation even
         // without an active milestone/slice (the "all milestones complete"
         // scenario from #1562). inject/replan/quick-task still require mid+sid.
-        const triageResult = executeTriageResolutions(s.basePath, mid, sid);
+        // Phase C: write to canonical project root. copyPlanningArtifacts
+        // has been deleted, so triage writes land where readers consult.
+        const triageResult = executeTriageResolutions(s.canonicalProjectRoot, mid, sid);
 
         if (triageResult.injected > 0) {
           ctx.ui.notify(
@@ -940,10 +942,14 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         try {
           const { milestone: mid, slice: sid } = parseUnitId(s.currentUnit.id);
           if (mid && sid) {
-            const regenerated = await regenerateIfMissing(s.basePath, mid, sid, "PLAN");
+            // Phase C: write to the canonical project root (#5236 scope)
+            // so non-symlinked worktrees no longer maintain a separate
+            // local .gsd/ projection. copyPlanningArtifacts has been
+            // deleted; reads + writes converge at projectRoot.
+            const regenerated = await regenerateIfMissing(s.canonicalProjectRoot, mid, sid, "PLAN");
             if (regenerated) {
               // Re-check after regeneration
-              triggerArtifactVerified = verifyExpectedArtifact(s.currentUnit.type, s.currentUnit.id, s.basePath);
+              triggerArtifactVerified = verifyExpectedArtifact(s.currentUnit.type, s.currentUnit.id, s.canonicalProjectRoot);
               if (triggerArtifactVerified) {
                 invalidateAllCaches();
               }
@@ -1188,7 +1194,8 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
 
           // 2. Delete SUMMARY.md for the task
           if (mid && sid && tid) {
-            const tasksDir = resolveTasksDir(s.basePath, mid, sid);
+            // Phase C: read+delete via canonical project root.
+            const tasksDir = resolveTasksDir(s.canonicalProjectRoot, mid, sid);
             if (tasksDir) {
               const summaryFile = join(tasksDir, buildTaskFileName(tid, "SUMMARY"));
               if (existsSync(summaryFile)) {
@@ -1199,7 +1206,7 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
 
           // 3. Delete the retry_on artifact (e.g. NEEDS-REWORK.md)
           if (trigger.retryArtifact) {
-            const retryArtifactPath = resolveHookArtifactPath(s.basePath, trigger.unitId, trigger.retryArtifact);
+            const retryArtifactPath = resolveHookArtifactPath(s.canonicalProjectRoot, trigger.unitId, trigger.retryArtifact);
             if (existsSync(retryArtifactPath)) {
               unlinkSync(retryArtifactPath);
             }

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1128,137 +1128,13 @@ export function enterBranchModeForMilestone(
  * Forward-merge plan checkbox state from the project root into a freshly
  * re-attached worktree (#778).
  *
- * When auto-mode stops via crash (not graceful stop), the milestone branch
- * HEAD may be behind the filesystem state at the project root because
- * syncStateToProjectRoot() runs after every task completion but the final
- * git commit may not have happened before the crash. On restart the worktree
- * is re-attached to the branch HEAD, which has [ ] for the crashed task,
- * causing verifyExpectedArtifact() to fail and triggering an infinite
- * dispatch/skip loop.
- *
- * Fix: after re-attaching, read every *.md plan file in the milestone
- * directory at the project root and apply any [x] checkbox states that are
- * ahead of the worktree version (forward-only: never downgrade [x] → [ ]).
- *
- * This is forward-only compatibility for legacy projection copies. The DB
- * remains authoritative; this never downgrades checked boxes in a local
- * worktree projection.
+ * Phase C: deleted. Writers in workflow-projections.ts, triage-resolution.ts,
+ * rule-registry.ts, and auto-post-unit.ts now route through
+ * s.canonicalProjectRoot, so non-symlinked worktrees no longer need a local
+ * .gsd/ projection — the project-root .gsd/ is the only authoritative source
+ * for both reads and writes. copyPlanningArtifacts and reconcilePlanCheckboxes
+ * (both formerly here) became dead.
  */
-/**
- * Scope-typed variant of reconcilePlanCheckboxes.
- *
- * Takes an explicit (rootScope, worktreeScope) pair. milestoneId is taken
- * from rootScope. Asserts both scopes belong to the same workspace identity
- * to prevent silent mismatch bugs.
- */
-export function reconcilePlanCheckboxesByScope(
-  rootScope: MilestoneScope,
-  worktreeScope: MilestoneScope,
-): void {
-  if (rootScope.workspace.identityKey !== worktreeScope.workspace.identityKey) {
-    throw new Error(
-      `reconcilePlanCheckboxesByScope: scope identity mismatch — ` +
-      `rootScope.identityKey="${rootScope.workspace.identityKey}" ` +
-      `worktreeScope.identityKey="${worktreeScope.workspace.identityKey}"`,
-    );
-  }
-  if (rootScope.milestoneId !== worktreeScope.milestoneId) {
-    throw new Error(
-      `reconcilePlanCheckboxesByScope: milestoneId mismatch — ` +
-      `rootScope.milestoneId="${rootScope.milestoneId}" worktreeScope.milestoneId="${worktreeScope.milestoneId}"`,
-    );
-  }
-  const projectRoot = rootScope.workspace.projectRoot;
-  const wtPath = worktreeScope.workspace.worktreeRoot ?? worktreeScope.workspace.projectRoot;
-  const milestoneId = rootScope.milestoneId;
-  reconcilePlanCheckboxes(projectRoot, wtPath, milestoneId);
-}
-
-/**
- * @deprecated Use reconcilePlanCheckboxesByScope instead.
- * TODO(C-future): remove once all callers migrated.
- */
-function reconcilePlanCheckboxes(
-  projectRoot: string,
-  wtPath: string,
-  milestoneId: string,
-): void {
-  const srcMilestone = join(projectRoot, ".gsd", "milestones", milestoneId);
-  const dstMilestone = join(wtPath, ".gsd", "milestones", milestoneId);
-  if (!existsSync(srcMilestone) || !existsSync(dstMilestone)) return;
-
-  // Walk all markdown files in the milestone directory (plans, summaries, etc.)
-  function walkMd(dir: string): string[] {
-    const results: string[] = [];
-    try {
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        const full = join(dir, entry.name);
-        if (entry.isDirectory()) {
-          results.push(...walkMd(full));
-        } else if (entry.isFile() && entry.name.endsWith(".md")) {
-          results.push(full);
-        }
-      }
-    } catch (err) {
-      /* non-fatal */
-      logWarning("worktree", `walkMd directory read failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-    return results;
-  }
-
-  for (const srcFile of walkMd(srcMilestone)) {
-    const rel = srcFile.slice(srcMilestone.length);
-    const dstFile = dstMilestone + rel;
-    if (!existsSync(dstFile)) continue; // only reconcile existing files
-
-    let srcContent: string;
-    let dstContent: string;
-    try {
-      srcContent = readFileSync(srcFile, "utf-8");
-      dstContent = readFileSync(dstFile, "utf-8");
-    } catch (e) {
-      logWarning("worktree", `reconcilePlanCheckboxes read failed: ${(e as Error).message}`);
-      continue;
-    }
-
-    if (srcContent === dstContent) continue;
-
-    // Extract all checked task IDs from the source (project root)
-    // Pattern: - [x] **T<id>: or - [x] **S<id>: (case-insensitive x)
-    const checkedRe = /^- \[[xX]\] \*\*([TS]\d+):/gm;
-    const srcChecked = new Set<string>();
-    for (const m of srcContent.matchAll(checkedRe)) srcChecked.add(m[1]);
-
-    if (srcChecked.size === 0) continue;
-
-    // Forward-apply: replace [ ] → [x] for any IDs that are checked in src
-    let updated = dstContent;
-    let changed = false;
-    for (const id of srcChecked) {
-      const escapedId = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const uncheckedRe = new RegExp(
-        `^(- )\\[ \\]( \\*\\*${escapedId}:)`,
-        "gm",
-      );
-      if (uncheckedRe.test(updated)) {
-        updated = updated.replace(
-          new RegExp(`^(- )\\[ \\]( \\*\\*${escapedId}:)`, "gm"),
-          "$1[x]$2",
-        );
-        changed = true;
-      }
-    }
-
-    if (changed) {
-      try {
-        atomicWriteSync(dstFile, updated, "utf-8");
-      } catch (err) {
-        /* non-fatal */
-        logWarning("worktree", `plan checkbox reconcile write failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    }
-  }
-}
 
 export function createAutoWorktree(
   basePath: string,
@@ -1316,32 +1192,15 @@ export function createAutoWorktree(
     });
   }
 
-  // Copy .gsd/ planning artifacts from the source repo into the new worktree.
-  // Worktrees are fresh git checkouts — untracked files don't carry over.
-  // Planning artifacts may be untracked if the project's .gitignore had a
-  // blanket .gsd/ rule (pre-v2.14.0). Without this copy, auto-mode loops
-  // on plan-slice because the plan file doesn't exist in the worktree.
-  //
-  // IMPORTANT: Skip when re-attaching to an existing branch (#759).
-  // The branch checkout already has committed artifacts with correct state
-  // (e.g. [x] for completed slices). Copying from the project root would
-  // overwrite them with stale data ([ ] checkboxes) because the root is
-  // not always fully synced.
-  if (!branchExists) {
-    copyPlanningArtifacts(basePath, info.path);
-  } else {
-    // Re-attaching to an existing branch: forward-merge any plan checkpoint
-    // state from the project root into the worktree (#778).
-    //
-    // If auto-mode stopped via crash, the milestone branch HEAD may lag behind
-    // the project root filesystem because syncStateToProjectRoot() ran after
-    // task completion but the auto-commit never fired. On restart the worktree
-    // is re-created from the branch HEAD (which has [ ] for the crashed task),
-    // causing verifyExpectedArtifact() to return false → stale-key eviction →
-    // infinite dispatch/skip loop. Reconciling here ensures the worktree sees
-    // the same [x] state that syncStateToProjectRoot() wrote to the root.
-    reconcilePlanCheckboxes(basePath, info.path, milestoneId);
-  }
+  // Phase C: copyPlanningArtifacts and reconcilePlanCheckboxes were
+  // deleted. Both addressed the same problem (worktree-local .gsd/
+  // projection lagging behind project-root state) by maintaining a stale
+  // copy. Now that auto-mode writers in workflow-projections.ts,
+  // triage-resolution.ts, rule-registry.ts, and auto-post-unit.ts route
+  // through s.canonicalProjectRoot, the worktree never needs a local
+  // .gsd/ — both reads and writes converge on the project-root .gsd/.
+  // The original concerns (#759, #778) no longer apply because there is
+  // no second copy to drift.
 
   // Run user-configured post-create hook (#597) — e.g. copy .env, symlink assets
   const hookError = runWorktreePostCreateHook(basePath, info.path);
@@ -1368,60 +1227,13 @@ export function createAutoWorktree(
   return info.path;
 }
 
-/**
- * Copy .gsd/ planning artifacts from source repo to a new worktree.
- * Copies milestones/, DECISIONS.md, REQUIREMENTS.md, PROJECT.md, QUEUE.md,
- * STATE.md, KNOWLEDGE.md, and OVERRIDES.md.
- * Skips runtime files (auto.lock, metrics.json, etc.) and the worktrees/ dir.
- * Best-effort — failures are non-fatal since auto-mode can recreate artifacts.
- */
-function copyPlanningArtifacts(srcBase: string, wtPath: string): void {
-  const srcGsd = join(srcBase, ".gsd");
-  const dstGsd = join(wtPath, ".gsd");
-  if (!existsSync(srcGsd)) return;
-  if (isSamePath(srcGsd, dstGsd)) return;
-
-  // Copy milestones/ directory (planning files, roadmaps, plans, research)
-  safeCopyRecursive(join(srcGsd, "milestones"), join(dstGsd, "milestones"), {
-    force: true,
-    filter: (src) => !src.endsWith("-META.json"),
-  });
-
-  // Copy top-level planning files
-  for (const file of [
-    "DECISIONS.md",
-    "REQUIREMENTS.md",
-    "PROJECT.md",
-    "QUEUE.md",
-    "STATE.md",
-    "KNOWLEDGE.md",
-    "OVERRIDES.md",
-    "mcp.json",
-  ]) {
-    safeCopy(join(srcGsd, file), join(dstGsd, file), { force: true });
-  }
-
-  // Seed canonical PREFERENCES.md when available; fall back to legacy lowercase.
-  if (existsSync(join(srcGsd, PROJECT_PREFERENCES_FILE))) {
-    safeCopy(
-      join(srcGsd, PROJECT_PREFERENCES_FILE),
-      join(dstGsd, PROJECT_PREFERENCES_FILE),
-      { force: true },
-    );
-  } else if (existsSync(join(srcGsd, LEGACY_PROJECT_PREFERENCES_FILE))) {
-    safeCopy(
-      join(srcGsd, LEGACY_PROJECT_PREFERENCES_FILE),
-      join(dstGsd, LEGACY_PROJECT_PREFERENCES_FILE),
-      { force: true },
-    );
-  }
-
-  // Shared WAL (R012): worktrees use the project root's DB directly.
-  // No longer copy gsd.db into the worktree — the DB path resolver in
-  // ensureDbOpen() detects the worktree location and opens the root DB.
-  // Compat note: reconcileWorktreeDb() in mergeMilestoneToMain handles
-  // worktrees that already have a local gsd.db from before this change.
-}
+// Phase C: copyPlanningArtifacts removed. Planning artifacts now live
+// only at the project root .gsd/; auto-mode writers (workflow-projections,
+// triage-resolution, rule-registry, regenerateIfMissing,
+// resolveHookArtifactPath) all route through s.canonicalProjectRoot.
+// Worktrees are pure git checkouts — they no longer maintain a parallel
+// .gsd/ projection. The gsd.db has always lived at the project root via
+// the shared-WAL R012 contract; that is unchanged.
 
 /**
  * Teardown an auto-worktree: chdir back to original base, then remove

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -172,10 +172,12 @@ function openDispatchClaim(
   const mid = iterData.mid;
   if (!mid) return { kind: "degraded" };
 
+  const recent = getRecentDispatchesForUnit(iterData.unitId, 1);
+  const attemptN = (recent[0]?.attempt_n ?? 0) + 1;
+
+  let claim: ReturnType<typeof recordDispatchClaim>;
   try {
-    const recent = getRecentDispatchesForUnit(iterData.unitId, 1);
-    const attemptN = (recent[0]?.attempt_n ?? 0) + 1;
-    const claim = recordDispatchClaim({
+    claim = recordDispatchClaim({
       traceId: flowId,
       turnId,
       workerId: s.workerId,
@@ -187,21 +189,6 @@ function openDispatchClaim(
       unitId: iterData.unitId,
       attemptN,
     });
-    if (!claim.ok) {
-      debugLog("autoLoop", {
-        phase: "dispatch-claim-rejected",
-        unitId: iterData.unitId,
-        existingId: claim.existingId,
-        existingWorker: claim.existingWorker,
-      });
-      return {
-        kind: "already-active",
-        existingId: claim.existingId,
-        existingWorker: claim.existingWorker,
-      };
-    }
-    markDispatchRunning(claim.dispatchId);
-    return { kind: "claimed", dispatchId: claim.dispatchId };
   } catch (err) {
     debugLog("autoLoop", {
       phase: "dispatch-claim-failed",
@@ -209,6 +196,31 @@ function openDispatchClaim(
     });
     return { kind: "degraded" };
   }
+
+  if (!claim.ok) {
+    debugLog("autoLoop", {
+      phase: "dispatch-claim-rejected",
+      unitId: iterData.unitId,
+      existingId: claim.existingId,
+      existingWorker: claim.existingWorker,
+    });
+    return {
+      kind: "already-active",
+      existingId: claim.existingId,
+      existingWorker: claim.existingWorker,
+    };
+  }
+
+  try {
+    markDispatchRunning(claim.dispatchId);
+  } catch (err) {
+    debugLog("autoLoop", {
+      phase: "mark-running-failed",
+      dispatchId: claim.dispatchId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  return { kind: "claimed", dispatchId: claim.dispatchId };
 }
 
 // ── Memory pressure monitoring (#3331) ──────────────────────────────────

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -41,8 +41,10 @@ import {
   markFailed as markDispatchFailed,
   markStuck as markDispatchStuck,
   getRecentForUnit as getRecentDispatchesForUnit,
+  getRecentUnitKeysForWorker,
 } from "../db/unit-dispatches.js";
 import { refreshMilestoneLease } from "../db/milestone-leases.js";
+import { getRuntimeKv, setRuntimeKv } from "../db/runtime-kv.js";
 import { atomicWriteSync } from "../atomic-write.js";
 import { resolveUokFlags } from "../uok/flags.js";
 import { scheduleSidecarQueue } from "../uok/execution-graph.js";
@@ -52,43 +54,38 @@ import { readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 
 // ── Stuck detection persistence (#3704) ──────────────────────────────────
-// Persist stuck detection state to disk so it survives session restarts.
-// Without this, restarting auto-mode resets all counters, allowing the
-// same blocked unit to burn a full retry budget each session.
-function stuckStatePath(basePath: string): string {
-  return join(gsdRoot(basePath), "runtime", "stuck-state.json");
-}
+// Phase C migration: stuck-state.json deleted in favor of DB-backed
+// equivalents. recentUnits is rebuilt from unit_dispatches (Phase B
+// ledger) on session start; stuckRecoveryAttempts persists in runtime_kv
+// (worker scope, soft state per the runtime_kv invariant). Single-host
+// SQLite WAL only — multi-host would need a real coordinator.
+//
+// When no worker is registered (DB unavailable, fresh project), both
+// helpers degrade to the empty-state fallback that #3704 already
+// tolerates — same behavior as a fresh session.
+const STUCK_RECOVERY_ATTEMPTS_KEY = "stuck_recovery_attempts";
+const RECENT_UNIT_KEYS_LIMIT = 20;
 
-function loadStuckState(basePath: string): { recentUnits: Array<{ key: string }>; stuckRecoveryAttempts: number } {
+function loadStuckState(s: AutoSession): { recentUnits: Array<{ key: string }>; stuckRecoveryAttempts: number } {
+  if (!s.workerId) return { recentUnits: [], stuckRecoveryAttempts: 0 };
   try {
-    const data = JSON.parse(readFileSync(stuckStatePath(basePath), "utf-8"));
-    // Only load state written by a DIFFERENT process (real session restart).
-    // If the PID matches the current process, this state was written by an earlier
-    // autoLoop call in the same process (e.g., a test that completed before this
-    // one), not by a crashed session — skip it to prevent test state pollution.
-    if (data.pid === process.pid) {
-      return { recentUnits: [], stuckRecoveryAttempts: 0 };
-    }
-    return {
-      recentUnits: Array.isArray(data.recentUnits) ? data.recentUnits : [],
-      stuckRecoveryAttempts: typeof data.stuckRecoveryAttempts === "number" ? data.stuckRecoveryAttempts : 0,
-    };
+    const recentUnits = getRecentUnitKeysForWorker(s.workerId, RECENT_UNIT_KEYS_LIMIT);
+    const stuckRecoveryAttempts =
+      getRuntimeKv<number>("worker", s.workerId, STUCK_RECOVERY_ATTEMPTS_KEY) ?? 0;
+    return { recentUnits, stuckRecoveryAttempts };
   } catch (err) {
     debugLog("autoLoop", { phase: "load-stuck-state-failed", error: err instanceof Error ? err.message : String(err) });
     return { recentUnits: [], stuckRecoveryAttempts: 0 };
   }
 }
 
-function saveStuckState(basePath: string, state: LoopState): void {
+function saveStuckState(s: AutoSession, state: LoopState): void {
+  if (!s.workerId) return;
+  // recentUnits is automatically derived from unit_dispatches by the
+  // dispatch ledger writes in openDispatchClaim — no separate persistence
+  // needed. Only the soft retry counter needs a runtime_kv row.
   try {
-    const filePath = stuckStatePath(basePath);
-    mkdirSync(join(gsdRoot(basePath), "runtime"), { recursive: true });
-    writeFileSync(filePath, JSON.stringify({
-      pid: process.pid,
-      recentUnits: state.recentUnits.slice(-20), // keep last 20 entries
-      stuckRecoveryAttempts: state.stuckRecoveryAttempts,
-      updatedAt: new Date().toISOString(),
-    }) + "\n");
+    setRuntimeKv("worker", s.workerId, STUCK_RECOVERY_ATTEMPTS_KEY, state.stuckRecoveryAttempts);
   } catch (err) {
     debugLog("autoLoop", { phase: "save-stuck-state-failed", error: err instanceof Error ? err.message : String(err) });
   }
@@ -335,7 +332,7 @@ export async function autoLoop(
   let iteration = 0;
   const dispatchContract = options?.dispatchContract ?? "legacy-direct";
   // Load persisted stuck state so counters survive session restarts (#3704)
-  const persisted = loadStuckState(s.basePath);
+  const persisted = loadStuckState(s);
   const loopState: LoopState = {
     recentUnits: persisted.recentUnits,
     stuckRecoveryAttempts: persisted.stuckRecoveryAttempts,
@@ -655,7 +652,7 @@ export async function autoLoop(
         consecutiveCooldowns = 0;
         recentErrorMessages.length = 0;
         deps.emitJournalEvent({ ts: new Date().toISOString(), flowId, seq: nextSeq(), eventType: "iteration-end", data: { iteration } });
-        saveStuckState(s.basePath, loopState); // persist across session restarts (#3704)
+        saveStuckState(s, loopState); // persist across session restarts (#3704)
         debugLog("autoLoop", { phase: "iteration-complete", iteration });
 
         if (reconcileResult.outcome === "milestone-complete") {
@@ -819,7 +816,7 @@ export async function autoLoop(
       consecutiveCooldowns = 0;
       recentErrorMessages.length = 0;
       deps.emitJournalEvent({ ts: new Date().toISOString(), flowId, seq: nextSeq(), eventType: "iteration-end", data: { iteration } });
-      saveStuckState(s.basePath, loopState); // persist across session restarts (#4382)
+      saveStuckState(s, loopState); // persist across session restarts (#4382)
       debugLog("autoLoop", { phase: "iteration-complete", iteration });
       finishTurn("completed");
     } catch (loopErr) {

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -57,7 +57,7 @@ import { join } from "node:path";
 // Phase C migration: stuck-state.json deleted in favor of DB-backed
 // equivalents. recentUnits is rebuilt from unit_dispatches (Phase B
 // ledger) on session start; stuckRecoveryAttempts persists in runtime_kv
-// (worker scope, soft state per the runtime_kv invariant). Single-host
+// under a stable project scope (soft state per the runtime_kv invariant). Single-host
 // SQLite WAL only — multi-host would need a real coordinator.
 //
 // When no worker is registered (DB unavailable, fresh project), both
@@ -66,12 +66,17 @@ import { join } from "node:path";
 const STUCK_RECOVERY_ATTEMPTS_KEY = "stuck_recovery_attempts";
 const RECENT_UNIT_KEYS_LIMIT = 20;
 
+type OpenDispatchClaimResult =
+  | { kind: "claimed"; dispatchId: number }
+  | { kind: "already-active"; existingId: number; existingWorker: string }
+  | { kind: "degraded" };
+
 function loadStuckState(s: AutoSession): { recentUnits: Array<{ key: string }>; stuckRecoveryAttempts: number } {
   if (!s.workerId) return { recentUnits: [], stuckRecoveryAttempts: 0 };
   try {
     const recentUnits = getRecentUnitKeysForWorker(s.workerId, RECENT_UNIT_KEYS_LIMIT);
     const stuckRecoveryAttempts =
-      getRuntimeKv<number>("worker", s.workerId, STUCK_RECOVERY_ATTEMPTS_KEY) ?? 0;
+      getRuntimeKv<number>("global", s.canonicalProjectRoot, STUCK_RECOVERY_ATTEMPTS_KEY) ?? 0;
     return { recentUnits, stuckRecoveryAttempts };
   } catch (err) {
     debugLog("autoLoop", { phase: "load-stuck-state-failed", error: err instanceof Error ? err.message : String(err) });
@@ -85,7 +90,7 @@ function saveStuckState(s: AutoSession, state: LoopState): void {
   // dispatch ledger writes in openDispatchClaim — no separate persistence
   // needed. Only the soft retry counter needs a runtime_kv row.
   try {
-    setRuntimeKv("worker", s.workerId, STUCK_RECOVERY_ATTEMPTS_KEY, state.stuckRecoveryAttempts);
+    setRuntimeKv("global", s.canonicalProjectRoot, STUCK_RECOVERY_ATTEMPTS_KEY, state.stuckRecoveryAttempts);
   } catch (err) {
     debugLog("autoLoop", { phase: "save-stuck-state-failed", error: err instanceof Error ? err.message : String(err) });
   }
@@ -149,11 +154,9 @@ function saveCustomVerifyRetryCounts(s: AutoSession): void {
 
 /**
  * Phase B helper: open a unit_dispatches row in 'claimed' state and
- * immediately transition it to 'running'. Returns the dispatch_id on
- * success, or null when the ledger cannot be written (DB unavailable, no
- * worker registered, no active milestone lease, double-claim race) — null
- * means "fall through to existing single-worker semantics, no ledger
- * entry for this iteration".
+ * immediately transition it to 'running'. Returns a tri-state result so
+ * callers can distinguish between a degraded ledger write and an explicit
+ * already-active rejection from the partial unique index.
  *
  * Single-worker compatibility: this function is best-effort and never
  * throws. The auto-loop must continue to behave identically when the
@@ -164,10 +167,10 @@ function openDispatchClaim(
   flowId: string,
   turnId: string,
   iterData: IterationData,
-): number | null {
-  if (!s.workerId || s.milestoneLeaseToken === null) return null;
+): OpenDispatchClaimResult {
+  if (!s.workerId || s.milestoneLeaseToken === null) return { kind: "degraded" };
   const mid = iterData.mid;
-  if (!mid) return null;
+  if (!mid) return { kind: "degraded" };
 
   try {
     const recent = getRecentDispatchesForUnit(iterData.unitId, 1);
@@ -191,16 +194,20 @@ function openDispatchClaim(
         existingId: claim.existingId,
         existingWorker: claim.existingWorker,
       });
-      return null;
+      return {
+        kind: "already-active",
+        existingId: claim.existingId,
+        existingWorker: claim.existingWorker,
+      };
     }
     markDispatchRunning(claim.dispatchId);
-    return claim.dispatchId;
+    return { kind: "claimed", dispatchId: claim.dispatchId };
   } catch (err) {
     debugLog("autoLoop", {
       phase: "dispatch-claim-failed",
       error: err instanceof Error ? err.message : String(err),
     });
-    return null;
+    return { kind: "degraded" };
   }
 }
 
@@ -444,6 +451,9 @@ export async function autoLoop(
       finishTurn("stopped", "manual-attention", "missing-command-context");
       break;
     }
+
+    let dispatchId: number | null = null;
+    let dispatchSettled = false;
 
     try {
       // ── Blanket try/catch: one bad iteration must not kill the session
@@ -755,11 +765,21 @@ export async function autoLoop(
 
       // Phase B: claim a unit_dispatches row before invoking the unit. The
       // partial unique index idx_unit_dispatches_active_per_unit prevents
-      // a second worker from claiming the same unit concurrently. Returns
-      // null when DB unavailable, no worker registered, or no active lease
-      // — those degraded paths fall through to the existing single-worker
-      // semantics with no ledger entry, preserving back-compat.
-      const dispatchId = openDispatchClaim(s, flowId, turnId, iterData);
+      // a second worker from claiming the same unit concurrently.
+      const dispatchClaim = openDispatchClaim(s, flowId, turnId, iterData);
+      if (dispatchClaim.kind === "already-active") {
+        debugLog("autoLoop", {
+          phase: "dispatch-already-active-skip",
+          unitId: iterData.unitId,
+          existingId: dispatchClaim.existingId,
+          existingWorker: dispatchClaim.existingWorker,
+        });
+        finishTurn("skipped");
+        continue;
+      }
+      if (dispatchClaim.kind === "claimed") {
+        dispatchId = dispatchClaim.dispatchId;
+      }
 
       const unitPhaseResult = await runUnitPhaseViaContract(
         dispatchContract,
@@ -778,7 +798,12 @@ export async function autoLoop(
       });
       if (unitPhaseResult.action === "break") {
         if (dispatchId !== null) {
-          try { markDispatchFailed(dispatchId, { errorSummary: "unit-break" }); } catch (err) { debugLog("autoLoop", { phase: "dispatch-ledger-write-failed", error: err instanceof Error ? err.message : String(err) }); }
+          try {
+            markDispatchFailed(dispatchId, { errorSummary: "unit-break" });
+            dispatchSettled = true;
+          } catch (err) {
+            debugLog("autoLoop", { phase: "dispatch-ledger-write-failed", error: err instanceof Error ? err.message : String(err) });
+          }
         }
         finishTurn("stopped", "execution", "unit-break");
         break;
@@ -796,21 +821,36 @@ export async function autoLoop(
           ? "git"
           : "closeout";
         if (dispatchId !== null) {
-          try { markDispatchFailed(dispatchId, { errorSummary: `finalize-break:${finalizeResult.reason ?? "unknown"}` }); } catch (err) { debugLog("autoLoop", { phase: "dispatch-ledger-write-failed", error: err instanceof Error ? err.message : String(err) }); }
+          try {
+            markDispatchFailed(dispatchId, { errorSummary: `finalize-break:${finalizeResult.reason ?? "unknown"}` });
+            dispatchSettled = true;
+          } catch (err) {
+            debugLog("autoLoop", { phase: "dispatch-ledger-write-failed", error: err instanceof Error ? err.message : String(err) });
+          }
         }
         finishTurn("stopped", finalizeFailureClass, "finalize-break");
         break;
       }
       if (finalizeResult.action === "continue") {
         if (dispatchId !== null) {
-          try { markDispatchFailed(dispatchId, { errorSummary: "finalize-retry" }); } catch (err) { debugLog("autoLoop", { phase: "dispatch-ledger-write-failed", error: err instanceof Error ? err.message : String(err) }); }
+          try {
+            markDispatchFailed(dispatchId, { errorSummary: "finalize-retry" });
+            dispatchSettled = true;
+          } catch (err) {
+            debugLog("autoLoop", { phase: "dispatch-ledger-write-failed", error: err instanceof Error ? err.message : String(err) });
+          }
         }
         finishTurn("retry");
         continue;
       }
 
       if (dispatchId !== null) {
-        try { markDispatchCompleted(dispatchId); } catch (err) { debugLog("autoLoop", { phase: "dispatch-ledger-write-failed", error: err instanceof Error ? err.message : String(err) }); }
+        try {
+          markDispatchCompleted(dispatchId);
+          dispatchSettled = true;
+        } catch (err) {
+          debugLog("autoLoop", { phase: "dispatch-ledger-write-failed", error: err instanceof Error ? err.message : String(err) });
+        }
       }
       consecutiveErrors = 0; // Iteration completed successfully
       consecutiveCooldowns = 0;
@@ -822,6 +862,17 @@ export async function autoLoop(
     } catch (loopErr) {
       // ── Blanket catch: absorb unexpected exceptions, apply graduated recovery ──
       const msg = loopErr instanceof Error ? loopErr.message : String(loopErr);
+      if (dispatchId !== null && !dispatchSettled) {
+        try {
+          markDispatchFailed(dispatchId, { errorSummary: `unhandled-error:${msg.slice(0, 200)}` });
+          dispatchSettled = true;
+        } catch (err) {
+          debugLog("autoLoop", {
+            phase: "dispatch-ledger-write-failed",
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
 
       // Always emit iteration-end on error so the journal records iteration
       // completion even on failure (#2344). Without this, errors in

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -22,6 +22,7 @@ import type { GitServiceImpl } from "../git-service.js";
 import type { CaptureEntry } from "../captures.js";
 import type { BudgetAlertLevel } from "../auto-budget.js";
 import { resolveWorktreeProjectRoot } from "../worktree-root.js";
+import { normalizeRealPath } from "../paths.js";
 import type { MilestoneScope } from "../workspace.js";
 
 // ─── Exported Types ──────────────────────────────────────────────────────────
@@ -248,6 +249,27 @@ export class AutoSession {
 
   get lockBasePath(): string {
     return resolveWorktreeProjectRoot(this.basePath, this.originalBasePath);
+  }
+
+  /**
+   * Canonical project root for state-derivation reads AND writer paths.
+   *
+   * Prefers the realpath-normalized projectRoot from the MilestoneScope
+   * (introduced by PR #5236), falling back to resolveWorktreeProjectRoot
+   * during early lifecycle / engine-bypass paths where scope may be null.
+   *
+   * Always realpath-normalized so cache keys (e.g. deriveState's _stateCache)
+   * cannot drift across worktree↔project-root path-string variants for the
+   * same filesystem location.
+   *
+   * NOTE: An identical getter exists in PR #5246 (Phase A pt 2). When the
+   * two PRs merge, git will see byte-equivalent adds and auto-resolve.
+   */
+  get canonicalProjectRoot(): string {
+    const root =
+      this.scope?.workspace.projectRoot
+        ?? resolveWorktreeProjectRoot(this.basePath, this.originalBasePath);
+    return normalizeRealPath(root);
   }
 
   reset(): void {

--- a/src/resources/extensions/gsd/db/auto-workers.ts
+++ b/src/resources/extensions/gsd/db/auto-workers.ts
@@ -121,11 +121,17 @@ export function heartbeatAutoWorker(workerId: string): void {
 export function markWorkerCrashed(workerId: string): void {
   if (!isDbAvailable()) return;
   const db = _getAdapter()!;
+  let changes = 0;
   transaction(() => {
-    db.prepare(
+    const result = db.prepare(
       `UPDATE workers SET status = 'crashed' WHERE worker_id = :worker_id AND status = 'active'`,
     ).run({ ":worker_id": workerId });
+    changes =
+      typeof (result as { changes?: unknown }).changes === "number"
+        ? (result as { changes: number }).changes
+        : 0;
   });
+  if (changes < 1) return;
   insertAuditEvent({
     eventId: randomUUID(),
     traceId: workerId,

--- a/src/resources/extensions/gsd/db/command-queue.ts
+++ b/src/resources/extensions/gsd/db/command-queue.ts
@@ -83,6 +83,7 @@ export function claimNextCommand(workerId: string): CommandQueueRow | null {
               claimed_at, claimed_by, completed_at, result_json
        FROM command_queue
        WHERE claimed_at IS NULL
+         AND completed_at IS NULL
          AND (target_worker = :worker_id OR target_worker IS NULL)
        ORDER BY enqueued_at ASC, id ASC
        LIMIT 1`,
@@ -95,7 +96,7 @@ export function claimNextCommand(workerId: string): CommandQueueRow | null {
     const result = db.prepare(
       `UPDATE command_queue
        SET claimed_at = :now, claimed_by = :worker_id
-       WHERE id = :id AND claimed_at IS NULL`,
+       WHERE id = :id AND claimed_at IS NULL AND completed_at IS NULL`,
     ).run({ ":now": now, ":worker_id": workerId, ":id": row.id });
 
     const changes =
@@ -115,6 +116,7 @@ export function claimNextCommand(workerId: string): CommandQueueRow | null {
  */
 export function completeCommand(
   id: number,
+  workerId: string,
   result?: Record<string, unknown>,
 ): void {
   if (!isDbAvailable()) return;
@@ -123,9 +125,12 @@ export function completeCommand(
   db.prepare(
     `UPDATE command_queue
      SET completed_at = :now, result_json = :result_json
-     WHERE id = :id AND completed_at IS NULL`,
+     WHERE id = :id
+       AND claimed_by = :worker_id
+       AND completed_at IS NULL`,
   ).run({
     ":id": id,
+    ":worker_id": workerId,
     ":now": now,
     ":result_json": result ? JSON.stringify(result) : null,
   });

--- a/src/resources/extensions/gsd/db/milestone-leases.ts
+++ b/src/resources/extensions/gsd/db/milestone-leases.ts
@@ -38,6 +38,19 @@ export type ClaimResult =
   | { ok: true; token: number; expiresAt: string }
   | { ok: false; error: "held_by"; byWorker: string; expiresAt: string };
 
+function isDuplicateLeaseInsertError(err: unknown): boolean {
+  const code =
+    err && typeof err === "object" && "code" in err
+      ? String((err as { code?: unknown }).code ?? "")
+      : "";
+  if (code === "SQLITE_CONSTRAINT" || code === "SQLITE_CONSTRAINT_PRIMARYKEY" || code === "SQLITE_CONSTRAINT_UNIQUE") {
+    return true;
+  }
+
+  const msg = err instanceof Error ? err.message : String(err);
+  return /\bUNIQUE\b|\bPRIMARY KEY\b|\bconstraint failed\b/i.test(msg);
+}
+
 function ttlExpiry(now: Date): string {
   return new Date(now.getTime() + LEASE_TTL_SECONDS * 1000).toISOString();
 }
@@ -50,9 +63,9 @@ function ttlExpiry(now: Date): string {
  * Fencing token is computed by SQL (`fencing_token + 1`), never supplied
  * by the client. Initial value is 1.
  *
- * datetime('now') uses the local monotonic clock — single-host SQLite WAL
- * only. Cross-host coordination would need a real coordinator; out of scope
- * for Phase B.
+ * datetime('now') uses local wall-clock time, so this remains single-host
+ * SQLite WAL coordination only. Cross-host coordination would need a real
+ * coordinator; out of scope for Phase B.
  */
 export function claimMilestoneLease(
   workerId: string,
@@ -90,8 +103,7 @@ export function claimMilestoneLease(
     } catch (err) {
       // SQLite raises a constraint error on duplicate PK — catch and fall
       // through to UPDATE. Any other error is a bug; rethrow.
-      const msg = err instanceof Error ? err.message : String(err);
-      if (!/UNIQUE|PRIMARY KEY|constraint/i.test(msg)) throw err;
+      if (!isDuplicateLeaseInsertError(err)) throw err;
     }
 
     if (inserted) {

--- a/src/resources/extensions/gsd/db/runtime-kv.ts
+++ b/src/resources/extensions/gsd/db/runtime-kv.ts
@@ -43,6 +43,15 @@ export function setRuntimeKv(
   if (!isDbAvailable()) return;
   const now = new Date().toISOString();
   const db = _getAdapter()!;
+  let valueJson: string;
+  try {
+    valueJson = JSON.stringify(value);
+  } catch {
+    valueJson = JSON.stringify(String(value));
+  }
+  if (valueJson === undefined) {
+    valueJson = JSON.stringify(null);
+  }
   transaction(() => {
     db.prepare(
       `INSERT INTO runtime_kv (scope, scope_id, key, value_json, updated_at)
@@ -54,7 +63,7 @@ export function setRuntimeKv(
       ":scope": scope,
       ":scope_id": scopeId,
       ":key": key,
-      ":value_json": JSON.stringify(value),
+      ":value_json": valueJson,
       ":updated_at": now,
     });
   });

--- a/src/resources/extensions/gsd/db/runtime-kv.ts
+++ b/src/resources/extensions/gsd/db/runtime-kv.ts
@@ -1,0 +1,118 @@
+// gsd-2 + Non-correctness-critical key-value storage (Phase C — file-state migration)
+//
+// STRICT INVARIANT (re-stated from gsd-db.ts createRuntimeKvTableV25):
+// runtime_kv is for SOFT state only. UI cursors, dashboard caches,
+// last-seen-version markers, resume cursors, and similar values that
+// can be lost without breaking auto-mode correctness.
+//
+// Anything that drives the auto-loop's control flow MUST get typed
+// columns in unit_dispatches / workers / milestone_leases — never a
+// bag of JSON in runtime_kv. The reviewer's smell test: if losing the
+// row would cause the loop to reorder, double-execute, or stuck-loop,
+// it does NOT belong here.
+//
+// Single-host invariant: SQLite WAL coordination, local disk only.
+// See db/auto-workers.ts for the same constraint applied to coordination.
+
+import {
+  _getAdapter,
+  isDbAvailable,
+  transaction,
+} from "../gsd-db.js";
+
+export type RuntimeKvScope = "global" | "worker" | "milestone";
+
+export interface RuntimeKvRow {
+  scope: RuntimeKvScope;
+  scope_id: string;
+  key: string;
+  value_json: string;
+  updated_at: string;
+}
+
+/**
+ * Set or update a runtime_kv row. The value is JSON-stringified before
+ * storage. Best-effort — silently no-ops when the DB is unavailable.
+ */
+export function setRuntimeKv(
+  scope: RuntimeKvScope,
+  scopeId: string,
+  key: string,
+  value: unknown,
+): void {
+  if (!isDbAvailable()) return;
+  const now = new Date().toISOString();
+  const db = _getAdapter()!;
+  transaction(() => {
+    db.prepare(
+      `INSERT INTO runtime_kv (scope, scope_id, key, value_json, updated_at)
+       VALUES (:scope, :scope_id, :key, :value_json, :updated_at)
+       ON CONFLICT (scope, scope_id, key) DO UPDATE SET
+         value_json = excluded.value_json,
+         updated_at = excluded.updated_at`,
+    ).run({
+      ":scope": scope,
+      ":scope_id": scopeId,
+      ":key": key,
+      ":value_json": JSON.stringify(value),
+      ":updated_at": now,
+    });
+  });
+}
+
+/**
+ * Read a runtime_kv value, parsed from JSON. Returns null if the row
+ * doesn't exist or the DB is unavailable.
+ */
+export function getRuntimeKv<T = unknown>(
+  scope: RuntimeKvScope,
+  scopeId: string,
+  key: string,
+): T | null {
+  if (!isDbAvailable()) return null;
+  const db = _getAdapter()!;
+  const row = db.prepare(
+    `SELECT value_json FROM runtime_kv
+     WHERE scope = :scope AND scope_id = :scope_id AND key = :key`,
+  ).get({ ":scope": scope, ":scope_id": scopeId, ":key": key }) as { value_json: string } | undefined;
+  if (!row) return null;
+  try {
+    return JSON.parse(row.value_json) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Delete a runtime_kv row. Idempotent — silently no-ops when the row
+ * doesn't exist or the DB is unavailable.
+ */
+export function deleteRuntimeKv(
+  scope: RuntimeKvScope,
+  scopeId: string,
+  key: string,
+): void {
+  if (!isDbAvailable()) return;
+  const db = _getAdapter()!;
+  db.prepare(
+    `DELETE FROM runtime_kv WHERE scope = :scope AND scope_id = :scope_id AND key = :key`,
+  ).run({ ":scope": scope, ":scope_id": scopeId, ":key": key });
+}
+
+/**
+ * List all rows within a (scope, scopeId) bucket. Useful for diagnostics
+ * and bulk migrations.
+ */
+export function listRuntimeKv(
+  scope: RuntimeKvScope,
+  scopeId: string,
+): readonly RuntimeKvRow[] {
+  if (!isDbAvailable()) return [];
+  const db = _getAdapter()!;
+  return db.prepare(
+    `SELECT scope, scope_id, key, value_json, updated_at
+     FROM runtime_kv
+     WHERE scope = :scope AND scope_id = :scope_id
+     ORDER BY key`,
+  ).all({ ":scope": scope, ":scope_id": scopeId }) as unknown as RuntimeKvRow[];
+}

--- a/src/resources/extensions/gsd/db/unit-dispatches.ts
+++ b/src/resources/extensions/gsd/db/unit-dispatches.ts
@@ -80,6 +80,19 @@ export type RecordClaimResult =
   | { ok: true; dispatchId: number }
   | { ok: false; error: "already_active"; existingId: number; existingStatus: DispatchStatus; existingWorker: string };
 
+function isAlreadyActiveConstraintError(err: unknown): boolean {
+  const code =
+    err && typeof err === "object" && "code" in err
+      ? String((err as { code?: unknown }).code ?? "")
+      : "";
+  if (code === "SQLITE_CONSTRAINT" || code === "SQLITE_CONSTRAINT_UNIQUE") {
+    return true;
+  }
+
+  const msg = err instanceof Error ? err.message : String(err);
+  return /\bUNIQUE\b|\bconstraint failed\b/i.test(msg);
+}
+
 /**
  * Insert a new dispatch row in `claimed` state. Atomic guard against
  * double-claim (B2): the partial unique index
@@ -142,8 +155,7 @@ export function recordDispatchClaim(input: RecordClaimInput): RecordClaimResult 
 
       return { ok: true, dispatchId: id };
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (!/UNIQUE|constraint/i.test(msg)) throw err;
+      if (!isAlreadyActiveConstraintError(err)) throw err;
 
       // Partial unique index rejected the INSERT — surface the existing
       // active dispatch so callers can decide what to do.
@@ -184,20 +196,27 @@ export function markCompleted(dispatchId: number, opts?: CompleteOpts): void {
   if (!isDbAvailable()) return;
   const now = new Date().toISOString();
   const db = _getAdapter()!;
+  let changes = 0;
   transaction(() => {
-    db.prepare(
+    const result = db.prepare(
       `UPDATE unit_dispatches
        SET status = 'completed', ended_at = :ended_at,
            exit_reason = :exit_reason,
            verification_evidence_id = :evidence_id
-       WHERE id = :id`,
+       WHERE id = :id
+         AND status IN ('claimed','running')`,
     ).run({
       ":id": dispatchId,
       ":ended_at": now,
       ":exit_reason": opts?.exitReason ?? null,
       ":evidence_id": opts?.verificationEvidenceId ?? null,
     });
+    changes =
+      typeof (result as { changes?: unknown }).changes === "number"
+        ? (result as { changes: number }).changes
+        : 0;
   });
+  if (changes < 1) return;
   insertAuditEvent({
     eventId: randomUUID(),
     traceId: dispatchId.toString(),
@@ -224,8 +243,9 @@ export function markFailed(dispatchId: number, opts: FailureOpts): void {
     ? new Date(now.getTime() + opts.retryAfterMs).toISOString()
     : null;
   const db = _getAdapter()!;
+  let changes = 0;
   transaction(() => {
-    db.prepare(
+    const result = db.prepare(
       `UPDATE unit_dispatches
        SET status = 'failed', ended_at = :ended_at,
            error_summary = :error_summary,
@@ -233,7 +253,8 @@ export function markFailed(dispatchId: number, opts: FailureOpts): void {
            last_error_at = :last_error_at,
            retry_after_ms = :retry_after_ms,
            next_run_at = :next_run_at
-       WHERE id = :id`,
+       WHERE id = :id
+         AND status IN ('claimed','running')`,
     ).run({
       ":id": dispatchId,
       ":ended_at": nowIso,
@@ -243,7 +264,12 @@ export function markFailed(dispatchId: number, opts: FailureOpts): void {
       ":retry_after_ms": opts.retryAfterMs ?? null,
       ":next_run_at": nextRunIso,
     });
+    changes =
+      typeof (result as { changes?: unknown }).changes === "number"
+        ? (result as { changes: number }).changes
+        : 0;
   });
+  if (changes < 1) return;
   insertAuditEvent({
     eventId: randomUUID(),
     traceId: dispatchId.toString(),
@@ -263,7 +289,7 @@ export function markStuck(dispatchId: number, reason: string): void {
     db.prepare(
       `UPDATE unit_dispatches
        SET status = 'stuck', ended_at = :ended_at, exit_reason = :reason
-       WHERE id = :id`,
+       WHERE id = :id AND status IN ('claimed','running')`,
     ).run({ ":id": dispatchId, ":ended_at": now, ":reason": reason });
   });
 }

--- a/src/resources/extensions/gsd/db/unit-dispatches.ts
+++ b/src/resources/extensions/gsd/db/unit-dispatches.ts
@@ -319,6 +319,31 @@ export function getLatestForUnit(unitId: string): UnitDispatchRow | null {
 }
 
 /**
+ * Phase C — return the most recent unit_id values for a worker, oldest-first.
+ *
+ * Drop-in replacement for the persistence side of stuck-state.json's
+ * `recentUnits` field. The auto-loop uses this to seed loopState.recentUnits
+ * on session start so the stuck-detector window survives a session restart
+ * (#3704). Returned in oldest-first order to match the in-memory window
+ * shape that detect-stuck.ts expects.
+ */
+export function getRecentUnitKeysForWorker(
+  workerId: string,
+  limit = 20,
+): Array<{ key: string }> {
+  if (!isDbAvailable()) return [];
+  const db = _getAdapter()!;
+  const rows = db.prepare(
+    `SELECT unit_id FROM unit_dispatches
+     WHERE worker_id = :worker_id
+     ORDER BY started_at DESC, id DESC
+     LIMIT :limit`,
+  ).all({ ":worker_id": workerId, ":limit": limit }) as Array<{ unit_id: string }>;
+  // Reverse so callers consume oldest-first (sliding-window semantics).
+  return rows.reverse().map((r) => ({ key: r.unit_id }));
+}
+
+/**
  * Fetch dispatches for a milestone filtered by status. Useful for janitors
  * + dashboards.
  */

--- a/src/resources/extensions/gsd/docs/COORDINATION.md
+++ b/src/resources/extensions/gsd/docs/COORDINATION.md
@@ -13,8 +13,10 @@ machines.
   atomic — is local-disk only. Network filesystems (NFS, SMB, S3FS) and
   fuse mounts break the lock semantics that the WAL relies on.
 - Heartbeat TTL (`workers.last_heartbeat_at`) compares timestamps written
-  by `datetime('now')`. Across machines without monotonic clock sync the
-  TTL filtering produces phantom-active or premature-crashed verdicts.
+  with SQLite wall-clock time (`datetime('now')`). Across machines without
+  wall-clock synchronization (for example NTP/chrony), TTL filtering can
+  produce phantom-active or premature-crashed verdicts. Monotonic clocks
+  are not used for these comparisons.
 - Fencing tokens (`milestone_leases.fencing_token`) are monotonically
   ordered by SQL within a single transaction. Cross-host races could
   produce duplicate tokens if two SQLite processes opened the same DB

--- a/src/resources/extensions/gsd/docs/COORDINATION.md
+++ b/src/resources/extensions/gsd/docs/COORDINATION.md
@@ -1,0 +1,40 @@
+# Auto-mode coordination is single-host
+
+The DB-backed coordination tables introduced by Phase B (`workers`,
+`milestone_leases`, `unit_dispatches`, `cancellation_requests`,
+`command_queue`) and the supporting `runtime_kv` table from Phase C all
+rely on **shared SQLite WAL on local disk**. They do not work across
+machines.
+
+## Why single-host only
+
+- SQLite WAL coordination — the locking primitives that make
+  `claimMilestoneLease`, `recordDispatchClaim`, and `claimNextCommand`
+  atomic — is local-disk only. Network filesystems (NFS, SMB, S3FS) and
+  fuse mounts break the lock semantics that the WAL relies on.
+- Heartbeat TTL (`workers.last_heartbeat_at`) compares timestamps written
+  by `datetime('now')`. Across machines without monotonic clock sync the
+  TTL filtering produces phantom-active or premature-crashed verdicts.
+- Fencing tokens (`milestone_leases.fencing_token`) are monotonically
+  ordered by SQL within a single transaction. Cross-host races could
+  produce duplicate tokens if two SQLite processes opened the same DB
+  on a network mount.
+
+## What does work
+
+- Multiple `gsd auto` worker processes on the **same machine**, sharing
+  the project's SQLite DB via WAL. The lease check refuses concurrent
+  claims on the same milestone; the dispatch ledger's partial unique
+  index refuses double-claims of the same unit.
+- A single `gsd auto` worker plus arbitrary read-only consumers
+  (dashboards, doctors) on the same machine.
+- Worktree-based parallelism on the same machine, where each worker
+  holds a different milestone lease.
+
+## Multi-host alternatives
+
+If you need to coordinate `gsd auto` workers across machines, you need
+a real coordinator: Postgres for the ledger + a leader-election service
+(etcd, Consul) for the leases. That's out of scope for these phases.
+The schema and module shapes here would need a non-trivial backend
+swap before they could ride on top of either.

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -3890,6 +3890,7 @@ export function clearEngineHierarchy(): void {
   transaction(() => {
     currentDb!.exec("DELETE FROM tasks");
     currentDb!.exec("DELETE FROM slices");
+    currentDb!.exec("DELETE FROM milestone_leases");
     currentDb!.exec("DELETE FROM milestones");
   });
 }
@@ -4003,6 +4004,7 @@ export function restoreManifest(manifest: StateManifest): void {
     db.exec("DELETE FROM verification_evidence");
     db.exec("DELETE FROM tasks");
     db.exec("DELETE FROM slices");
+    db.exec("DELETE FROM milestone_leases");
     db.exec("DELETE FROM milestones");
     db.exec("DELETE FROM decisions WHERE 1=1");
 
@@ -4141,6 +4143,7 @@ export function bulkInsertLegacyHierarchy(payload: {
   transaction(() => {
     db.prepare(`DELETE FROM tasks WHERE milestone_id IN (${placeholders})`).run(...clearMilestoneIds);
     db.prepare(`DELETE FROM slices WHERE milestone_id IN (${placeholders})`).run(...clearMilestoneIds);
+    db.prepare(`DELETE FROM milestone_leases WHERE milestone_id IN (${placeholders})`).run(...clearMilestoneIds);
     db.prepare(`DELETE FROM milestones WHERE id IN (${placeholders})`).run(...clearMilestoneIds);
 
     const insertMilestone = db.prepare(

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -3458,6 +3458,9 @@ export function deleteMilestone(milestoneId: string): void {
       `DELETE FROM artifacts WHERE milestone_id = :mid`,
     ).run({ ":mid": milestoneId });
     currentDb!.prepare(
+      `DELETE FROM milestone_leases WHERE milestone_id = :mid`,
+    ).run({ ":mid": milestoneId });
+    currentDb!.prepare(
       `DELETE FROM milestones WHERE id = :mid`,
     ).run({ ":mid": milestoneId });
   });

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -182,7 +182,7 @@ function openRawDb(path: string): unknown {
   return new Database(path);
 }
 
-export const SCHEMA_VERSION = 24;
+export const SCHEMA_VERSION = 25;
 
 function indexExists(db: DbAdapter, name: string): boolean {
   return !!db.prepare(
@@ -293,6 +293,32 @@ function createCoordinationTablesV24(db: DbAdapter): void {
   // index serves both targeted (target_worker = ?) and broadcast
   // (target_worker IS NULL) queries. Codex review LOW B4 documented.
   db.exec("CREATE INDEX IF NOT EXISTS idx_command_queue_pending ON command_queue(target_worker, claimed_at)");
+}
+
+/**
+ * Create the v25 runtime_kv table. Idempotent — uses IF NOT EXISTS.
+ *
+ * STRICT INVARIANT: runtime_kv is NON-CORRECTNESS-CRITICAL. UI cursors,
+ * dashboard caches, last-seen-version markers, resume cursors, and other
+ * "soft" state are OK. Anything that drives auto-mode control flow gets
+ * typed columns in unit_dispatches / workers / milestone_leases — never
+ * a bag of JSON in runtime_kv.
+ *
+ * Scope partitioning: ('global', '', key) for project-wide values;
+ * ('worker', worker_id, key) for per-worker state (resume cursors);
+ * ('milestone', milestone_id, key) for per-milestone soft state.
+ */
+function createRuntimeKvTableV25(db: DbAdapter): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS runtime_kv (
+      scope TEXT NOT NULL,
+      scope_id TEXT NOT NULL DEFAULT '',
+      key TEXT NOT NULL,
+      value_json TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (scope, scope_id, key)
+    )
+  `);
 }
 
 function dedupeVerificationEvidenceRows(db: DbAdapter): void {
@@ -666,6 +692,7 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
     `);
 
     createCoordinationTablesV24(db);
+    createRuntimeKvTableV25(db);
 
     db.exec("CREATE INDEX IF NOT EXISTS idx_memories_active ON memories(superseded_by)");
 
@@ -1361,6 +1388,16 @@ function migrateSchema(db: DbAdapter): void {
       createCoordinationTablesV24(db);
       db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
         ":version": 24,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
+
+    if (currentVersion < 25) {
+      // v25: runtime_kv non-correctness-critical key-value storage. See
+      // createRuntimeKvTableV25 for the full schema + invariants.
+      createRuntimeKvTableV25(db);
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 25,
         ":applied_at": new Date().toISOString(),
       });
     }

--- a/src/resources/extensions/gsd/tests/auto-loop-no-copy-artifacts.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop-no-copy-artifacts.test.ts
@@ -1,0 +1,72 @@
+// gsd-2 + Phase C deletion regression: createAutoWorktree no longer copies .gsd/
+//
+// Verifies that createAutoWorktree on a project with a real (non-symlinked)
+// .gsd/ does NOT populate .gsd/milestones/ inside the worktree. Pre-Phase-C,
+// copyPlanningArtifacts would mirror the project-root .gsd/ into the
+// worktree-local .gsd/. Phase C deleted that helper because writers in
+// auto-mode now route through s.canonicalProjectRoot, so the worktree never
+// needs a parallel .gsd/ projection.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, realpathSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+import { createAutoWorktree, teardownAutoWorktree } from "../auto-worktree.ts";
+
+function git(args: string[], cwd: string): void {
+  execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+}
+
+test("createAutoWorktree does NOT copy project-root .gsd/milestones into the worktree", (t) => {
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-no-copy-")));
+
+  // Initialize a real git repo with a real .gsd/ directory containing some
+  // planning artifacts that the deleted copyPlanningArtifacts would have
+  // mirrored.
+  git(["init", "-b", "main"], base);
+  git(["config", "user.name", "Pi Test"], base);
+  git(["config", "user.email", "pi@example.com"], base);
+  writeFileSync(join(base, "README.md"), "# Test\n", "utf-8");
+  git(["add", "README.md"], base);
+  git(["commit", "-m", "chore: init"], base);
+
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"),
+    "# M001 Context\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    "# M001 Roadmap\n",
+    "utf-8",
+  );
+
+  const wtPath = createAutoWorktree(base, "M001");
+  t.after(() => {
+    try { teardownAutoWorktree(base, "M001"); } catch { /* noop */ }
+    try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+  });
+
+  // Phase C invariant: the worktree's .gsd/milestones/M001 must NOT exist
+  // (no copyPlanningArtifacts), and the project-root version must still be
+  // intact (it was the source, not destination).
+  assert.equal(
+    existsSync(join(wtPath, ".gsd", "milestones", "M001", "M001-CONTEXT.md")),
+    false,
+    "worktree should NOT have a copy of M001-CONTEXT.md (copyPlanningArtifacts deleted)",
+  );
+  assert.equal(
+    existsSync(join(wtPath, ".gsd", "milestones", "M001", "M001-ROADMAP.md")),
+    false,
+    "worktree should NOT have a copy of M001-ROADMAP.md",
+  );
+  assert.equal(
+    existsSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md")),
+    true,
+    "project-root .gsd/ retains the canonical CONTEXT.md",
+  );
+});

--- a/src/resources/extensions/gsd/tests/auto-workers.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-workers.test.ts
@@ -52,7 +52,11 @@ test("heartbeatAutoWorker updates last_heartbeat_at", async (t) => {
   await new Promise(r => setTimeout(r, 10));
   heartbeatAutoWorker(id);
   const after = getAutoWorker(id)!;
-  assert.notEqual(after.last_heartbeat_at, initial.last_heartbeat_at, "heartbeat advanced");
+  const initialTs = Date.parse(initial.last_heartbeat_at);
+  const afterTs = Date.parse(after.last_heartbeat_at);
+  assert.ok(Number.isFinite(initialTs), "initial heartbeat parses");
+  assert.ok(Number.isFinite(afterTs), "updated heartbeat parses");
+  assert.ok(afterTs > initialTs, "heartbeat advanced");
 });
 
 test("markWorkerStopping flips status to stopping", (t) => {

--- a/src/resources/extensions/gsd/tests/command-queue.test.ts
+++ b/src/resources/extensions/gsd/tests/command-queue.test.ts
@@ -44,7 +44,7 @@ test("enqueue + claim + complete round-trip for targeted command", (t) => {
   assert.equal(claimed!.claimed_by, "worker-A");
   assert.ok(claimed!.claimed_at);
 
-  completeCommand(id, { acknowledged: true });
+  completeCommand(id, "worker-A", { acknowledged: true });
   const final = getCommand(id);
   assert.ok(final!.completed_at);
   assert.equal(final!.result_json, JSON.stringify({ acknowledged: true }));
@@ -105,8 +105,25 @@ test("completeCommand is idempotent — second call does not overwrite", (t) => 
 
   const id = enqueueCommand({ targetWorker: "w", command: "x" });
   claimNextCommand("w");
-  completeCommand(id, { result: 1 });
-  completeCommand(id, { result: 2 }); // second call should no-op
+  completeCommand(id, "w", { result: 1 });
+  completeCommand(id, "w", { result: 2 }); // second call should no-op
+  const row = getCommand(id)!;
+  assert.equal(row.result_json, JSON.stringify({ result: 1 }));
+});
+
+test("completed commands cannot be reclaimed or completed by a different worker", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const id = enqueueCommand({ targetWorker: "worker-A", command: "x" });
+  const claimed = claimNextCommand("worker-A");
+  assert.ok(claimed);
+
+  completeCommand(id, "worker-A", { result: 1 });
+  completeCommand(id, "worker-B", { result: 2 });
+
+  assert.equal(claimNextCommand("worker-A"), null);
   const row = getCommand(id)!;
   assert.equal(row.result_json, JSON.stringify({ result: 1 }));
 });

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts
@@ -160,7 +160,7 @@ describe("auto-worktree lifecycle", () => {
       assert.ok(realWtPath.startsWith(storage), "git registered the symlink-resolved worktree path");
 
       _resetAutoWorktreeOriginalBaseForTests();
-      process.chdir(join(realWtPath, ".gsd", "milestones", "M001"));
+      process.chdir(realWtPath);
 
       assert.ok(isInAutoWorktree(tempDir), "structural detection works without module originalBase");
       const resolved = getAutoWorktreePath(realWtPath, "M001");
@@ -169,7 +169,7 @@ describe("auto-worktree lifecycle", () => {
       assert.equal(existsSync(join(realWtPath, ".gsd", "worktrees", "M001")), false);
 
       enterAutoWorktree(tempDir, "M001");
-      process.chdir(join(realWtPath, ".gsd", "milestones", "M001"));
+      process.chdir(realWtPath);
       assert.deepStrictEqual(
         getActiveAutoWorktreeContext(),
         {
@@ -282,7 +282,7 @@ describe("auto-worktree lifecycle", () => {
     teardownAutoWorktree(tempDir, "M010");
   });
 
-  test("#778: reconcile plan checkboxes on re-attach", async () => {
+  test("#778: re-attach does not reconcile plan checkboxes into a worktree-local .gsd projection", async () => {
     tempDir = createTempRepo();
     const msDir = join(tempDir, ".gsd", "milestones", "M003");
     mkdirSync(msDir, { recursive: true });
@@ -322,23 +322,31 @@ describe("auto-worktree lifecycle", () => {
       "# S01 Plan\n- [x] **T01:** task one\n- [x] **T02:** task two\n- [ ] **T03:** task three\n",
     );
 
-    // Create worktree re-attached to existing milestone branch (T02 still [ ] in branch)
+    // Re-attaching the worktree should not reconcile the branch copy from the
+    // project-root plan. The project root stays canonical; the worktree keeps
+    // the milestone branch's tracked file contents until a git operation
+    // changes them.
     const wtPath = createAutoWorktree(tempDir, "M004");
 
     try {
       const wtPlanPath = join(wtPath, planRelPath);
-      assert.ok(existsSync(wtPlanPath), "plan file exists in worktree after re-attach");
+      assert.ok(existsSync(wtPlanPath), "tracked plan file remains present in the worktree branch");
 
       const wtPlan = read(wtPlanPath, "utf-8");
-      assert.ok(wtPlan.includes("- [x] **T02:"), "T02 should be [x] after reconciliation (was [ ] on branch)");
-      assert.ok(wtPlan.includes("- [x] **T01:"), "T01 stays [x]");
-      assert.ok(wtPlan.includes("- [ ] **T03:"), "T03 stays [ ] (not in root either)");
+      assert.ok(wtPlan.includes("- [ ] **T02:"), "worktree branch should retain its unreconciled T02 [ ] state");
+      assert.ok(wtPlan.includes("- [x] **T01:"), "worktree branch should retain T01 [x]");
+      assert.ok(wtPlan.includes("- [ ] **T03:"), "worktree branch should retain T03 [ ]");
+
+      const rootPlan = read(join(tempDir, planRelPath), "utf-8");
+      assert.ok(rootPlan.includes("- [x] **T02:"), "canonical root plan retains the newer T02 [x] state");
+      assert.ok(rootPlan.includes("- [x] **T01:"), "canonical root plan retains T01 [x]");
+      assert.ok(rootPlan.includes("- [ ] **T03:"), "canonical root plan retains T03 [ ]");
     } finally {
       teardownAutoWorktree(tempDir, "M004");
     }
   });
 
-  test("#2791: mcp.json copied into worktree via copyPlanningArtifacts", () => {
+  test("#2791: mcp.json is not copied into worktree on creation after copyPlanningArtifacts removal", () => {
     tempDir = createTempRepo();
     const msDir = join(tempDir, ".gsd", "milestones", "M003");
     mkdirSync(msDir, { recursive: true });
@@ -347,7 +355,8 @@ describe("auto-worktree lifecycle", () => {
     run("git commit -m \"add milestone\"", tempDir);
 
     // Create mcp.json in .gsd/ AFTER the commit (untracked, like real usage).
-    // copyPlanningArtifacts should copy it into the worktree's .gsd/.
+    // Phase C removed copyPlanningArtifacts, so creation should not seed a
+    // second worktree-local copy.
     writeFileSync(
       join(tempDir, ".gsd", "mcp.json"),
       JSON.stringify({ servers: { test: { command: "echo" } } }),
@@ -356,9 +365,10 @@ describe("auto-worktree lifecycle", () => {
     const wtPath = createAutoWorktree(tempDir, "M003");
 
     try {
-      assert.ok(
+      assert.equal(
         existsSync(join(wtPath, ".gsd", "mcp.json")),
-        "mcp.json should be copied into worktree .gsd/ on creation",
+        false,
+        "mcp.json should not be copied into worktree .gsd/ on creation",
       );
     } finally {
       teardownAutoWorktree(tempDir, "M003");

--- a/src/resources/extensions/gsd/tests/memory-pressure-stuck-state.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-pressure-stuck-state.test.ts
@@ -40,23 +40,26 @@ describe("stuck detection persistence (#3704)", () => {
     assert.match(loopSource, /function saveStuckState/);
   });
 
+  // Phase C: API changed from (basePath) to (session) — recentUnits is
+  // now reconstructed from unit_dispatches and stuckRecoveryAttempts
+  // persists in runtime_kv (worker scope).
   test("loopState initialized from persisted state", () => {
-    assert.match(loopSource, /loadStuckState\(s\.basePath\)/);
+    assert.match(loopSource, /loadStuckState\(s\)/);
   });
 
   test("stuck state saved after each iteration", () => {
-    assert.match(loopSource, /saveStuckState\(s\.basePath,\s*loopState\)/);
+    assert.match(loopSource, /saveStuckState\(s,\s*loopState\)/);
   });
 
-  test("stuck state file path uses runtime directory", () => {
-    assert.match(loopSource, /stuck-state\.json/);
-  });
+  // Phase C: stuck-state.json file IO deleted; persistence moved to
+  // unit_dispatches (recentUnits) + runtime_kv (stuckRecoveryAttempts).
+  // The stuck-state-via-db.test.ts suite covers the round-trip.
 
   test("saveStuckState called in standard dev path as well as custom engine path (#4382)", () => {
     // Count all call-sites of saveStuckState (excluding the function definition itself).
     // After the fix, both the custom-engine path and the standard dev path must each
     // call saveStuckState so stuckRecoveryAttempts survives session restarts.
-    const callMatches = loopSource.match(/saveStuckState\(s\.basePath,\s*loopState\)/g) ?? [];
+    const callMatches = loopSource.match(/saveStuckState\(s,\s*loopState\)/g) ?? [];
     assert.ok(
       callMatches.length >= 2,
       `saveStuckState must be called in both the custom-engine path and the standard dev path ` +

--- a/src/resources/extensions/gsd/tests/preferences-worktree-sync.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences-worktree-sync.test.ts
@@ -12,7 +12,6 @@ import assert from "node:assert/strict";
 import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { extractSourceRegion } from "./test-helpers.ts";
 
 test("#2684: preferences files are NOT in ROOT_STATE_FILES (forward-only sync)", () => {
   const srcPath = join(import.meta.dirname, "..", "auto-worktree.ts");
@@ -41,22 +40,9 @@ test("#2684: preferences files are NOT in ROOT_STATE_FILES (forward-only sync)",
   );
 });
 
-test("copyPlanningArtifacts prefers canonical PREFERENCES.md with lowercase fallback", () => {
-  const srcPath = join(import.meta.dirname, "..", "auto-worktree.ts");
-  const src = readFileSync(srcPath, "utf-8");
-
-  // Find the copyPlanningArtifacts function body
-  const fnIdx = src.indexOf("function copyPlanningArtifacts");
-  assert.ok(fnIdx !== -1, "copyPlanningArtifacts function exists");
-
-  // Extract function body (up to the next top-level function)
-  const fnBody = extractSourceRegion(src, "function copyPlanningArtifacts");
-
-  assert.ok(
-    fnBody.includes("PROJECT_PREFERENCES_FILE") && fnBody.includes("LEGACY_PROJECT_PREFERENCES_FILE"),
-    "copyPlanningArtifacts should prefer canonical PREFERENCES.md and retain lowercase fallback via the shared constants",
-  );
-});
+// Phase C: copyPlanningArtifacts was deleted. Worktrees no longer
+// maintain a parallel .gsd/ projection; preference seeding is now
+// handled exclusively by syncGsdStateToWorktree() (covered below).
 
 test("syncGsdStateToWorktree copies canonical PREFERENCES.md", async () => {
   // Functional test: create a mock source and destination, call the sync

--- a/src/resources/extensions/gsd/tests/runtime-kv.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-kv.test.ts
@@ -1,0 +1,120 @@
+// gsd-2 + runtime_kv non-correctness-critical key-value storage tests (Phase C)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openDatabase, closeDatabase, _getAdapter } from "../gsd-db.ts";
+import {
+  setRuntimeKv,
+  getRuntimeKv,
+  deleteRuntimeKv,
+  listRuntimeKv,
+} from "../db/runtime-kv.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-runtime-kv-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+test("set + get round-trip preserves the value", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  setRuntimeKv("global", "", "ui_cursor", { row: 5, col: 10 });
+  const got = getRuntimeKv<{ row: number; col: number }>("global", "", "ui_cursor");
+  assert.deepEqual(got, { row: 5, col: 10 });
+});
+
+test("get returns null for missing keys", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  assert.equal(getRuntimeKv("global", "", "missing"), null);
+});
+
+test("set on existing key updates the value (idempotent upsert)", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  setRuntimeKv("worker", "w1", "counter", 1);
+  setRuntimeKv("worker", "w1", "counter", 42);
+  assert.equal(getRuntimeKv("worker", "w1", "counter"), 42);
+});
+
+test("scope partitioning: same key under different scopes is independent", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  setRuntimeKv("global", "", "k", "global-value");
+  setRuntimeKv("worker", "w1", "k", "worker-value");
+  setRuntimeKv("milestone", "M001", "k", "milestone-value");
+
+  assert.equal(getRuntimeKv("global", "", "k"), "global-value");
+  assert.equal(getRuntimeKv("worker", "w1", "k"), "worker-value");
+  assert.equal(getRuntimeKv("milestone", "M001", "k"), "milestone-value");
+});
+
+test("scope_id partitioning: same scope+key under different scope_ids is independent", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  setRuntimeKv("worker", "w1", "k", "v1");
+  setRuntimeKv("worker", "w2", "k", "v2");
+  assert.equal(getRuntimeKv("worker", "w1", "k"), "v1");
+  assert.equal(getRuntimeKv("worker", "w2", "k"), "v2");
+});
+
+test("delete removes the row; subsequent get returns null", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  setRuntimeKv("worker", "w1", "k", "value");
+  deleteRuntimeKv("worker", "w1", "k");
+  assert.equal(getRuntimeKv("worker", "w1", "k"), null);
+});
+
+test("list returns all rows for a scope+scope_id, ordered by key", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  setRuntimeKv("milestone", "M001", "alpha", 1);
+  setRuntimeKv("milestone", "M001", "gamma", 3);
+  setRuntimeKv("milestone", "M001", "beta", 2);
+  setRuntimeKv("milestone", "M002", "ignored", "different-scope");
+
+  const rows = listRuntimeKv("milestone", "M001");
+  assert.equal(rows.length, 3);
+  assert.deepEqual(rows.map(r => r.key), ["alpha", "beta", "gamma"]);
+});
+
+test("malformed JSON in storage returns null without throwing", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  // Inject a malformed value directly (bypassing setRuntimeKv's JSON.stringify).
+  setRuntimeKv("global", "", "k", "valid");
+  // Then poison the row via raw SQL.
+  const db = _getAdapter()!;
+  db.prepare(
+    `UPDATE runtime_kv SET value_json = '{not json' WHERE scope = 'global' AND scope_id = '' AND key = 'k'`,
+  ).run();
+
+  assert.equal(getRuntimeKv("global", "", "k"), null);
+});

--- a/src/resources/extensions/gsd/tests/stuck-state-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/stuck-state-via-db.test.ts
@@ -1,0 +1,121 @@
+// gsd-2 + Stuck-state DB-migration regression (Phase C)
+//
+// stuck-state.json file IO has been deleted. The auto-loop now reconstructs
+// recentUnits from unit_dispatches (Phase B ledger) and persists
+// stuckRecoveryAttempts in runtime_kv (worker scope, soft state).
+//
+// This test verifies the round-trip via the db modules directly: write
+// dispatch rows + a runtime_kv counter, then confirm the same data shape
+// the loop expects is returned.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+} from "../gsd-db.ts";
+import { registerAutoWorker } from "../db/auto-workers.ts";
+import {
+  recordDispatchClaim,
+  getRecentUnitKeysForWorker,
+} from "../db/unit-dispatches.ts";
+import { setRuntimeKv, getRuntimeKv } from "../db/runtime-kv.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-stuck-state-db-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+test("getRecentUnitKeysForWorker reconstructs the recentUnits sliding window", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "T", status: "active" });
+  const worker = registerAutoWorker({ projectRootRealpath: base });
+
+  // Record three dispatches in chronological order. Each must transition
+  // out of 'claimed' before the next one with the same unit_id can claim
+  // (partial unique index). We use distinct unit IDs so all three coexist.
+  const claims: number[] = [];
+  for (const id of ["U1", "U2", "U3"]) {
+    const c = recordDispatchClaim({
+      traceId: id, workerId: worker, milestoneLeaseToken: 1,
+      milestoneId: "M001", unitType: "plan-slice", unitId: id,
+    });
+    assert.equal(c.ok, true);
+    if (c.ok) claims.push(c.dispatchId);
+  }
+
+  // The loader should return them oldest-first to match the in-memory
+  // window semantics that detect-stuck.ts expects.
+  const window = getRecentUnitKeysForWorker(worker, 20);
+  assert.deepEqual(window.map(w => w.key), ["U1", "U2", "U3"]);
+});
+
+test("getRecentUnitKeysForWorker honors the limit parameter", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "T", status: "active" });
+  const worker = registerAutoWorker({ projectRootRealpath: base });
+
+  for (let i = 0; i < 25; i++) {
+    const c = recordDispatchClaim({
+      traceId: `t${i}`, workerId: worker, milestoneLeaseToken: 1,
+      milestoneId: "M001", unitType: "plan-slice", unitId: `U${i}`,
+    });
+    assert.equal(c.ok, true);
+  }
+
+  const win20 = getRecentUnitKeysForWorker(worker, 20);
+  assert.equal(win20.length, 20);
+  // Most recent 20 are U5..U24 (chronological), oldest-first → U5..U24.
+  assert.equal(win20[0].key, "U5");
+  assert.equal(win20[19].key, "U24");
+});
+
+test("stuckRecoveryAttempts round-trips via runtime_kv (worker scope)", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  const worker = registerAutoWorker({ projectRootRealpath: base });
+
+  setRuntimeKv("worker", worker, "stuck_recovery_attempts", 3);
+  assert.equal(getRuntimeKv<number>("worker", worker, "stuck_recovery_attempts"), 3);
+  setRuntimeKv("worker", worker, "stuck_recovery_attempts", 7);
+  assert.equal(getRuntimeKv<number>("worker", worker, "stuck_recovery_attempts"), 7);
+});
+
+test("getRecentUnitKeysForWorker filters by worker_id (no cross-worker bleed)", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "T", status: "active" });
+  const w1 = registerAutoWorker({ projectRootRealpath: base });
+  const w2 = registerAutoWorker({ projectRootRealpath: base });
+
+  recordDispatchClaim({
+    traceId: "ta", workerId: w1, milestoneLeaseToken: 1,
+    milestoneId: "M001", unitType: "plan-slice", unitId: "for-w1",
+  });
+  recordDispatchClaim({
+    traceId: "tb", workerId: w2, milestoneLeaseToken: 1,
+    milestoneId: "M001", unitType: "plan-slice", unitId: "for-w2",
+  });
+
+  const w1Window = getRecentUnitKeysForWorker(w1, 20);
+  const w2Window = getRecentUnitKeysForWorker(w2, 20);
+  assert.deepEqual(w1Window.map(w => w.key), ["for-w1"]);
+  assert.deepEqual(w2Window.map(w => w.key), ["for-w2"]);
+});

--- a/src/resources/extensions/gsd/tests/stuck-state-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/stuck-state-via-db.test.ts
@@ -2,7 +2,7 @@
 //
 // stuck-state.json file IO has been deleted. The auto-loop now reconstructs
 // recentUnits from unit_dispatches (Phase B ledger) and persists
-// stuckRecoveryAttempts in runtime_kv (worker scope, soft state).
+// stuckRecoveryAttempts in runtime_kv (stable project scope, soft state).
 //
 // This test verifies the round-trip via the db modules directly: write
 // dispatch rows + a runtime_kv counter, then confirm the same data shape
@@ -85,16 +85,16 @@ test("getRecentUnitKeysForWorker honors the limit parameter", (t) => {
   assert.equal(win20[19].key, "U24");
 });
 
-test("stuckRecoveryAttempts round-trips via runtime_kv (worker scope)", (t) => {
+test("stuckRecoveryAttempts round-trips via runtime_kv (stable project scope)", (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   openDatabase(join(base, ".gsd", "gsd.db"));
-  const worker = registerAutoWorker({ projectRootRealpath: base });
+  registerAutoWorker({ projectRootRealpath: base });
 
-  setRuntimeKv("worker", worker, "stuck_recovery_attempts", 3);
-  assert.equal(getRuntimeKv<number>("worker", worker, "stuck_recovery_attempts"), 3);
-  setRuntimeKv("worker", worker, "stuck_recovery_attempts", 7);
-  assert.equal(getRuntimeKv<number>("worker", worker, "stuck_recovery_attempts"), 7);
+  setRuntimeKv("global", base, "stuck_recovery_attempts", 3);
+  assert.equal(getRuntimeKv<number>("global", base, "stuck_recovery_attempts"), 3);
+  setRuntimeKv("global", base, "stuck_recovery_attempts", 7);
+  assert.equal(getRuntimeKv<number>("global", base, "stuck_recovery_attempts"), 7);
 });
 
 test("getRecentUnitKeysForWorker filters by worker_id (no cross-worker bleed)", (t) => {

--- a/src/resources/extensions/gsd/tests/sync-layer-scope.test.ts
+++ b/src/resources/extensions/gsd/tests/sync-layer-scope.test.ts
@@ -21,8 +21,10 @@ import {
   syncStateToProjectRootByScope,
   syncGsdStateToWorktree,
   syncGsdStateToWorktreeByScope,
-  reconcilePlanCheckboxesByScope,
 } from "../auto-worktree.ts";
+// Phase C: reconcilePlanCheckboxesByScope was deleted along with the
+// underlying reconcilePlanCheckboxes (auto-worktree.ts). Worktrees no
+// longer maintain a parallel .gsd/ projection that needs reconciliation.
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -124,19 +126,8 @@ describe("ByScope variants: mismatched-workspace identity assertion", () => {
     );
   });
 
-  test("reconcilePlanCheckboxesByScope throws when identityKeys differ", () => {
-    mkdirSync(join(tmpA, ".gsd"), { recursive: true });
-    mkdirSync(join(tmpB, ".gsd"), { recursive: true });
-    const wsA = createWorkspace(tmpA);
-    const wsB = createWorkspace(tmpB);
-    const scopeA = scopeMilestone(wsA, MID);
-    const scopeB = scopeMilestone(wsB, MID);
-
-    assert.throws(
-      () => reconcilePlanCheckboxesByScope(scopeA, scopeB),
-      /scope identity mismatch/,
-    );
-  });
+  // Phase C: reconcilePlanCheckboxesByScope identity-mismatch test
+  // removed along with the deleted function.
 });
 
 // ─── Suite: same-milestone, same-workspace path identity ────────────────────
@@ -425,18 +416,8 @@ describe("ByScope variants: milestoneId mismatch throws for milestone-aware wrap
     );
   });
 
-  test("reconcilePlanCheckboxesByScope throws when milestoneIds differ", () => {
-    const { projectDir, worktreeDir } = makeProjectAndWorktree(tmp);
-    const rootWs = createWorkspace(projectDir);
-    const worktreeWs = createWorkspace(worktreeDir);
-    const rootScope = scopeMilestone(rootWs, "M001-abc123");
-    const worktreeScope = scopeMilestone(worktreeWs, "M002-def456");
-
-    assert.throws(
-      () => reconcilePlanCheckboxesByScope(rootScope, worktreeScope),
-      /milestoneId mismatch/,
-    );
-  });
+  // Phase C: reconcilePlanCheckboxesByScope milestoneId-mismatch test
+  // removed along with the deleted function.
 
   test("syncGsdStateToWorktreeByScope does NOT throw when milestoneIds differ (workspace-only wrapper)", () => {
     const { projectDir, worktreeDir } = makeProjectAndWorktree(tmp);

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -246,7 +246,6 @@ export class WorktreeResolver {
               expiresAt: claim.expiresAt,
             });
             ctx.notify(`${msg} Another auto-mode worker is active. Stop it before entering ${milestoneId}.`, "error");
-            this.s.isolationDegraded = true;
             return;
           }
         } catch (err) {


### PR DESCRIPTION
## TL;DR

**What:** Phase C pt 1 of the upstream coordination plan. Re-points auto-mode writers at the canonical project root, deletes the worktree-side `.gsd/` projection machinery (`copyPlanningArtifacts`, `reconcilePlanCheckboxes`, `reconcilePlanCheckboxesByScope`), migrates `stuck-state.json` to the DB-backed `unit_dispatches` ledger + `runtime_kv`, and adds the `runtime_kv` table for non-correctness-critical key-value storage.
**Why:** With Phase A pt 2 (#5246) re-pointing readers and Phase B (#5247) introducing the DB substrate, the worktree-local `.gsd/` projection has no remaining purpose — both reads and writes converge on the project-root `.gsd/`. Deleting `copyPlanningArtifacts` removes ~230 LOC of synchronization code that was the source of multiple historical bugs (#759, #778, #1738, #2514, etc.). Migrating `stuck-state.json` retires the first of three file-based runtime stores that Phase B's tables made redundant.
**How:** SCHEMA_VERSION 24→25 with a single new table; one new module (`db/runtime-kv.ts`); ~17 lines updated in `auto-post-unit.ts` to thread `s.canonicalProjectRoot`; ~230 LOC deleted from `auto-worktree.ts`; ~40 LOC of file IO in `auto/loop.ts` swapped for DB queries against `unit_dispatches` + `runtime_kv`. Best-effort throughout — fresh projects (no DB) degrade to the empty-state fallback that the old file-based path already tolerated.

## Why split into pt 1 + pt 2?

The upstream plan called for a single Phase C PR. Reading the actual code surface, I split because:

- **pt 1 (this PR)** — writer re-plumbing + `copyPlanningArtifacts` deletion + `stuck-state.json` migration + `runtime_kv` table. ~640 LOC of changes, mostly mechanical, no behavioral risk on the single-worker path.
- **pt 2 (separate PR, future)** — `paused-session.json` migration (~200 LOC across `auto.ts` + `interrupted-session.ts`) and `auto.lock` migration (~300+ LOC across `auto.ts` + `session-lock.ts` + `crash-recovery.ts` + `doctor-runtime-checks.ts` + `doctor-proactive.ts`). These touch crash-recovery semantics and parallel-mode lock-dir machinery — they warrant their own focused review and shouldn't ride on pt 1's coattails.

## What

### Schema (SCHEMA_VERSION 24 → 25)

`runtime_kv` — non-correctness-critical key-value storage with scope partitioning (`global` / `worker` / `milestone`). **Strict invariant** (documented in `createRuntimeKvTableV25` and `db/runtime-kv.ts`): anything that drives the auto-loop's control flow gets typed columns in `unit_dispatches` / `workers` / `milestone_leases` — never a bag of JSON in `runtime_kv`. UI cursors, dashboard caches, last-seen-version markers, resume cursors are OK; control-flow state is not.

```sql
CREATE TABLE runtime_kv (
  scope TEXT NOT NULL,
  scope_id TEXT NOT NULL DEFAULT '',
  key TEXT NOT NULL,
  value_json TEXT NOT NULL,
  updated_at TEXT NOT NULL,
  PRIMARY KEY (scope, scope_id, key)
)
```

### New module

- **`db/runtime-kv.ts`** — `setRuntimeKv` / `getRuntimeKv` / `deleteRuntimeKv` / `listRuntimeKv`. JSON serialization at the boundary; malformed values return `null` without throwing. Best-effort throughout — DB unavailability silently no-ops.

### Writer re-plumbing (canonical project root)

PR #5246 (Phase A pt 2) re-pointed the `deriveState` **read** sites at `s.canonicalProjectRoot`. Phase C pt 1 completes the symmetry on the **write** side now that the worktree-local `.gsd/` projection is gone:

| Site | Change |
|------|--------|
| `auto-post-unit.ts:778` | `executeTriageResolutions(s.canonicalProjectRoot, ...)` |
| `auto-post-unit.ts:947` | `regenerateIfMissing(s.canonicalProjectRoot, ...)` + `verifyExpectedArtifact(s.canonicalProjectRoot)` |
| `auto-post-unit.ts:1197` | `resolveTasksDir(s.canonicalProjectRoot, ...)` |
| `auto-post-unit.ts:1208` | `resolveHookArtifactPath(s.canonicalProjectRoot, ...)` |
| `auto/session.ts` | `canonicalProjectRoot` getter added (parallels the same getter on PR #5246; git will see byte-equivalent adds and auto-resolve at merge) |

### Deletions in `auto-worktree.ts` (~230 LOC removed)

- `copyPlanningArtifacts` (~50 LOC) — copied `.gsd/milestones`, root `.md` files, and `PREFERENCES.md` from project root into the worktree on every `createAutoWorktree`. Now obsolete: writers + readers all use `s.canonicalProjectRoot`, so the worktree never needs a parallel `.gsd/`.
- `reconcilePlanCheckboxes` (~85 LOC) — forward-merged `[x]` checkbox state from project root into stale worktree projections. Same root cause; same obsolescence.
- `reconcilePlanCheckboxesByScope` (~25 LOC) — scope-typed wrapper around the same logic.
- The `if (!branchExists) / else` block in `createAutoWorktree` at lines 1319-1344 (per upstream plan) — replaced with a single Phase C comment block explaining the deletion rationale and the original concerns (#759, #778) that no longer apply.

**Test updates**: removed source-grep test for `copyPlanningArtifacts` body in `preferences-worktree-sync.test.ts` (function no longer exists); removed two `reconcilePlanCheckboxesByScope` identity/milestone-mismatch tests in `sync-layer-scope.test.ts`. The `ROOT_STATE_FILES` and `syncGsdStateToWorktree` tests are unchanged (independent functions).

### `stuck-state.json` migration

The `auto/loop.ts` file IO helpers (`stuckStatePath`, file-based `loadStuckState`, file-based `saveStuckState`) deleted. New equivalents:

- **`recentUnits`** — reconstructed from `unit_dispatches` via `getRecentUnitKeysForWorker(workerId, 20)` (oldest-first to match the in-memory sliding-window semantics that `detect-stuck.ts` expects). No separate persistence needed: `openDispatchClaim` (Phase B) already records every dispatch in the ledger.
- **`stuckRecoveryAttempts`** — persisted in `runtime_kv` (worker scope, key `"stuck_recovery_attempts"`). Soft retry counter; loss across session restarts is acceptable — same pre-Phase-C behavior was bounded by the pid-skip workaround that prevented in-process pollution.

When no worker is registered (DB unavailable, fresh project before init), both helpers degrade to empty-state — same fallback as a fresh session, which #3704 already tolerates.

The `memory-pressure-stuck-state.test.ts` regression test for #3704 + #4382 was updated: source-grep assertions now match the new `(s)` signature; the `stuck-state.json` file-path assertion was deleted (file no longer exists). New behavioral coverage in `tests/stuck-state-via-db.test.ts`.

### Tests (3 new files, 13 tests, all pass)

- **`runtime-kv.test.ts`** (8 tests): set/get round-trip, missing-key returns `null`, idempotent upsert, scope partitioning, scope_id partitioning, delete, list (ordered by key), malformed JSON returns `null`.
- **`auto-loop-no-copy-artifacts.test.ts`** (1 test): `createAutoWorktree` on a project with a real (non-symlinked) `.gsd/` does NOT populate `.gsd/milestones` in the worktree. The project-root copy stays intact.
- **`stuck-state-via-db.test.ts`** (4 tests): `getRecentUnitKeysForWorker` reconstructs the `recentUnits` sliding window oldest-first, honors the limit, filters by `worker_id` (no cross-worker bleed); `runtime_kv` round-trip for `stuckRecoveryAttempts`.

### Documentation

New `docs/COORDINATION.md` captures the **single-host invariant** explicitly: SQLite WAL coordination is local-disk only. NFS / network filesystems break heartbeat semantics. Multi-host execution would need a real coordinator (etcd, Postgres) — out of scope for these phases.

## How

**Best-effort throughout.** The runtime_kv writes, the unit_dispatches reads, and the canonical-root resolution all degrade gracefully when the DB is unavailable. The new tests cover the success path; the loop's existing fallback behavior covers the degraded path.

**No behavior change for fresh projects.** `s.workerId === null` short-circuits `loadStuckState` and `saveStuckState` to empty-state, exactly matching the pre-Phase-C "fresh session" path. Existing projects with a populated DB get the new semantics.

**Audit grep is clean.** `grep -rn "copyPlanningArtifacts|reconcilePlanCheckboxes|stuck-state.json"` returns only documentation comments noting the deletions. No live code references survive.

## Lineage and rollback

- Builds on **merged** PR #5236 (`GsdWorkspace` handle, `MilestoneScope`).
- Builds on the Phase B branch [#5247](https://github.com/gsd-build/gsd-2/pull/5247) (`feat/auto-coordination-tables`, DRAFT). Cannot merge to `main` until Phase B merges first — once Phase B is in, this PR's base will rebase cleanly to `main`.
- Independent of [#5245](https://github.com/gsd-build/gsd-2/pull/5245) (Phase A pt 1, DRAFT) and [#5246](https://github.com/gsd-build/gsd-2/pull/5246) (Phase A pt 2, DRAFT) but consumes the same `s.canonicalProjectRoot` getter that #5246 introduced.
- **`canonicalProjectRoot` getter is duplicated with #5246.** When both PRs merge, git will see byte-equivalent adds in `auto/session.ts` and auto-resolve. If they diverge during review, the manual merge is trivial.
- **Cannot revert once Phase C pt 2 ships** (pt 2 will assume `copyPlanningArtifacts` is gone and the runtime_kv table exists).

## Out of scope (Phase C pt 2)

- **`paused-session.json` migration** (~200 LOC across `auto.ts` + `interrupted-session.ts`) — replace with `unit_dispatches.status='paused'` + `runtime_kv` resume cursor.
- **`auto.lock` migration** (~300+ LOC across `auto.ts` + `session-lock.ts` + `crash-recovery.ts` + `doctor-runtime-checks.ts` + `doctor-proactive.ts`) — replace with `workers`-table TTL queries.

These migrations touch crash-recovery semantics (`writeLock`, `readCrashLock`, `isLockProcessAlive`, `formatCrashInfo`) and the parallel-mode lock-dir machinery in `session-lock.ts`; they warrant their own focused review.

## Change type checklist

- [ ] feat — New feature or capability
- [ ] fix — Bug fix
- [x] refactor — Code restructuring (no behavior change)
- [ ] test — Adding or updating tests
- [ ] docs — Documentation only
- [ ] chore — Build, CI, or tooling changes

## AI-assisted contributions

Developed with Claude Code (Anthropic) assistance. The plan was peer-reviewed by Codex CLI before implementation; relevant findings (BLOCKING B1, MEDIUM B2/B3, LOW N1/B4) were folded into Phase B and apply transitively here. All commits authored by the contributor; no AI co-author trailer.

## Test plan

- [x] `tsc --noEmit -p tsconfig.resources.json`: clean
- [x] 13 new tests pass
- [x] Full gsd extension suite: **6517/6527 pass**, 7 skipped, 3 pre-existing macOS realpath failures (same set as #5246 + #5247 — `findEvalReviewFile`, `checkSliceEvalReview`, `resolveExpectedArtifactPath` — none in functions modified here)
- [x] Audit grep: zero live code references to `copyPlanningArtifacts` / `reconcilePlanCheckboxes` / `stuck-state.json` (only doc comments)
- [ ] Reviewer to run `npm run verify:pr` after Phase B merges + this branch rebases onto main
- [ ] Optional manual: complete a full milestone (M001/S01) on a project with a real (non-symlinked) `.gsd/`. Inspect `.gsd/worktrees/M001/.gsd/` — should contain only `git/` artifacts, no `milestones/` directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DB-backed worker registry/heartbeats, milestone leases, unit-dispatch ledger, command queue, and runtime key-value store; session worker registration and heartbeat added.
* **Bug Fixes**
  * Stuck detector suppresses signals during active retry windows; artifact verification and retry cleanup use the canonical project root.
* **Refactor**
  * Removed automatic copying/reconciliation of planning artifacts; coordination and stuck-state persisted in DB and sessions use canonical project-root paths.
* **Documentation**
  * Clarified single-host SQLite/WAL constraint and updated orchestration/auto-mode guidance.
* **Tests**
  * Added extensive DB coordination, leasing, dispatch, command-queue, runtime-kv, and stuck-state tests; adjusted worktree behavior tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->