### PR TITLE
feat(context-mode): fully wire auto-run context mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,25 +361,27 @@ The database is authoritative for milestones, slices, tasks, requirements, decis
 
 2. **Context pre-loading** — The dispatch prompt includes inlined task plans, slice plans, prior task summaries, dependency summaries, roadmap excerpts, and decisions register. The LLM starts with everything it needs instead of spending tool calls reading files.
 
-3. **Git isolation** — When `git.isolation` is set to `worktree` or `branch`, each milestone runs on its own `milestone/<MID>` branch (in a worktree or in-place). All slice work commits sequentially — no branch switching, no merge conflicts. When the milestone completes, it's squash-merged to main as one clean commit. The default is `none` (work on the current branch), configurable via preferences. If `worktree` is configured in a repo with no committed `HEAD`, GSD temporarily behaves as `none` until the first commit exists because git worktrees need a committed start point.
+3. **Context Mode** — Context Mode is enabled by default and gives every auto-mode unit guidance for preserving context. Agents are steered toward `gsd_exec` for noisy scans, builds, tests, and diagnostics; full stdout/stderr is saved under `.gsd/exec/` while only a short digest enters the conversation. `gsd_exec_search` lets agents reuse prior runs instead of repeating expensive checks, and `gsd_resume` reads `.gsd/last-snapshot.md` after compaction or resume. Opt out with `context_mode.enabled: false`; tune sandbox timeout/output caps with `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, and `context_mode.exec_digest_chars`.
 
-4. **Crash recovery** — Auto mode persists worker state, unit-dispatch state, and paused-session metadata in the project-root SQLite database. If the session dies, the next `/gsd auto` reconstructs the interrupted unit from DB-backed runtime state, reads the surviving session file, synthesizes a recovery briefing from every tool call that made it to disk, and resumes with full context. Parallel orchestrator IPC still lives under `.gsd/parallel/`, so multi-worker sessions survive crashes too. In headless mode, crashes trigger automatic restart with exponential backoff (default 3 attempts).
+4. **Git isolation** — When `git.isolation` is set to `worktree` or `branch`, each milestone runs on its own `milestone/<MID>` branch (in a worktree or in-place). All slice work commits sequentially — no branch switching, no merge conflicts. When the milestone completes, it's squash-merged to main as one clean commit. The default is `none` (work on the current branch), configurable via preferences. If `worktree` is configured in a repo with no committed `HEAD`, GSD temporarily behaves as `none` until the first commit exists because git worktrees need a committed start point.
 
-5. **Provider error recovery** — Transient provider errors (rate limits, 500/503 server errors, overloaded) auto-resume after a delay. Permanent errors (auth, billing) pause for manual review. The model fallback chain retries transient network errors before switching models.
+5. **Crash recovery** — Auto mode persists worker state, unit-dispatch state, and paused-session metadata in the project-root SQLite database. If the session dies, the next `/gsd auto` reconstructs the interrupted unit from DB-backed runtime state, reads the surviving session file, synthesizes a recovery briefing from every tool call that made it to disk, and resumes with full context. Parallel orchestrator IPC still lives under `.gsd/parallel/`, so multi-worker sessions survive crashes too. In headless mode, crashes trigger automatic restart with exponential backoff (default 3 attempts).
 
-6. **Stuck and artifact detection** — A sliding-window detector identifies repeated dispatch patterns (including multi-unit cycles). Missing expected artifacts use a separate bounded path: GSD retries artifact verification up to 3 times with failure context, then pauses auto mode with the missing artifact error instead of looping indefinitely.
+6. **Provider error recovery** — Transient provider errors (rate limits, 500/503 server errors, overloaded) auto-resume after a delay. Permanent errors (auth, billing) pause for manual review. The model fallback chain retries transient network errors before switching models.
 
-7. **Timeout supervision** — Soft timeout warns the LLM to wrap up. Idle watchdog detects stalls. Hard timeout pauses auto mode. Recovery steering nudges the LLM to finish durable output before giving up.
+7. **Stuck and artifact detection** — A sliding-window detector identifies repeated dispatch patterns (including multi-unit cycles). Missing expected artifacts use a separate bounded path: GSD retries artifact verification up to 3 times with failure context, then pauses auto mode with the missing artifact error instead of looping indefinitely.
 
-8. **Cost tracking** — Every unit's token usage and cost is captured, broken down by phase, slice, and model. The dashboard shows running totals and projections. Budget ceilings can pause auto mode before overspending.
+8. **Timeout supervision** — Soft timeout warns the LLM to wrap up. Idle watchdog detects stalls. Hard timeout pauses auto mode. Recovery steering nudges the LLM to finish durable output before giving up.
 
-9. **Adaptive replanning** — After each slice completes, the roadmap is reassessed. If the work revealed new information that changes the plan, slices are reordered, added, or removed before continuing.
+9. **Cost tracking** — Every unit's token usage and cost is captured, broken down by phase, slice, and model. The dashboard shows running totals and projections. Budget ceilings can pause auto mode before overspending.
 
-10. **Verification enforcement** — Configure shell commands (`npm run lint`, `npm run test`, etc.) that run automatically after task execution. Failures trigger auto-fix retries before advancing. Auto-discovered checks from `package.json` run in advisory mode — they log warnings but don't block on pre-existing errors. Configurable via `verification_commands`, `verification_auto_fix`, and `verification_max_retries` preferences.
+10. **Adaptive replanning** — After each slice completes, the roadmap is reassessed. If the work revealed new information that changes the plan, slices are reordered, added, or removed before continuing.
 
-11. **Milestone validation** — After all slices complete, a `validate-milestone` gate compares roadmap success criteria against actual results before sealing the milestone.
+11. **Verification enforcement** — Configure shell commands (`npm run lint`, `npm run test`, etc.) that run automatically after task execution. Failures trigger auto-fix retries before advancing. Auto-discovered checks from `package.json` run in advisory mode — they log warnings but don't block on pre-existing errors. Configurable via `verification_commands`, `verification_auto_fix`, and `verification_max_retries` preferences.
 
-12. **Escape hatch** — Press Escape to pause. The conversation is preserved. Interact with the agent, inspect what happened, or just `/gsd auto` to resume from disk state.
+12. **Milestone validation** — After all slices complete, a `validate-milestone` gate compares roadmap success criteria against actual results before sealing the milestone.
+
+13. **Escape hatch** — Press Escape to pause. The conversation is preserved. Interact with the agent, inspect what happened, or just `/gsd auto` to resume from disk state.
 
 ### `/gsd` and `/gsd next` — Step Mode
 
@@ -657,6 +659,10 @@ auto_report: true
 | `unique_milestone_ids`            | Uses unique milestone names to avoid clashes when working in teams of people                          |
 | `git.isolation`                   | `none` (default), `worktree`, or `branch` — enable worktree or branch isolation for milestone work. `worktree` requires a committed `HEAD`; zero-commit repos temporarily run as `none`    |
 | `git.manage_gitignore`            | Set `false` to prevent GSD from modifying `.gitignore`                                                |
+| `context_mode.enabled`            | Context Mode is default-on; set `false` to disable `gsd_exec`, exec history guidance, and resume snapshots |
+| `context_mode.exec_timeout_ms`    | Timeout for sandboxed `gsd_exec` runs (default: 30000)                                                |
+| `context_mode.exec_stdout_cap_bytes` | Persisted stdout cap for `gsd_exec` output (default: 1048576)                                      |
+| `context_mode.exec_digest_chars`  | Trailing stdout characters returned to the agent context (default: 300)                              |
 | `verification_commands`           | Array of shell commands to run after task execution (e.g., `["npm run lint", "npm run test"]`)        |
 | `verification_auto_fix`           | Auto-retry on verification failures (default: true)                                                   |
 | `verification_max_retries`        | Max retries for verification failures (default: 2)                                                    |

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -90,6 +90,19 @@ The dispatch prompt is carefully constructed with:
 
 The amount of context inlined is controlled by your [token profile](./token-optimization.md). Budget mode inlines minimal context; quality mode inlines everything.
 
+### Context Mode
+
+Context Mode is enabled by default for auto-mode runs. Each unit receives manifest-driven guidance to preserve the conversation window: use `gsd_exec` for noisy codebase scans, builds, tests, and diagnostics; use `gsd_exec_search` before repeating a prior sandboxed run; and use `gsd_resume` after compaction or session resume to read `.gsd/last-snapshot.md`.
+
+`gsd_exec` writes full stdout/stderr and metadata under `.gsd/exec/`, then returns only a short digest to the agent. This keeps large command output out of the LLM context while preserving exact evidence on disk. To opt out, set:
+
+```yaml
+context_mode:
+  enabled: false
+```
+
+You can also tune sandbox behavior with `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, and `context_mode.exec_digest_chars`.
+
 ### Git Isolation
 
 GSD isolates milestone work using one of three modes (configured via `git.isolation` in preferences):

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -98,6 +98,19 @@ Fire-and-forget thought capture. Captures are triaged automatically between task
 
 Every task gets a clean AI context window. No accumulated garbage, no quality degradation from context bloat. The dispatch prompt includes everything needed — task plans, prior summaries, decisions, dependency context — so the AI starts oriented.
 
+## Context Mode
+
+Context Mode is enabled by default for auto-mode runs. Each unit receives manifest-driven guidance to preserve the conversation window: use `gsd_exec` for noisy codebase scans, builds, tests, and diagnostics; use `gsd_exec_search` before repeating a prior sandboxed run; and use `gsd_resume` after compaction or session resume to read `.gsd/last-snapshot.md`.
+
+`gsd_exec` writes full stdout/stderr and metadata under `.gsd/exec/`, then returns only a short digest to the agent. This keeps large command output out of the LLM context while preserving exact evidence on disk. Opt out with:
+
+```yaml
+context_mode:
+  enabled: false
+```
+
+You can also tune sandbox behavior with `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, and `context_mode.exec_digest_chars`.
+
 ## Runtime Tool Policy
 
 Every auto-mode unit declares a `ToolsPolicy` in its `UnitContextManifest`, and GSD enforces it before tool calls run. Execution units use `all` mode and can edit project files, run shell commands, and dispatch subagents. Most planning and discussion units use `planning` mode: read tools are allowed, writes are limited to `.gsd/`, bash must be read-only, and subagent dispatch is blocked. Selected planning and closeout units use `planning-dispatch` mode, which keeps the same source-write and bash restrictions but allows `subagent` dispatch for isolated recon, planning, or review work. Documentation units use `docs` mode, which also allows writes to the manifest's documentation globs such as `docs/**`, top-level `README*.md`, `CHANGELOG.md`, and top-level `*.md`.

--- a/mintlify-docs/guides/auto-mode.mdx
+++ b/mintlify-docs/guides/auto-mode.mdx
@@ -49,6 +49,19 @@ The research-decision unit only records the choice. If the decision is `research
 
 Every task, research phase, and planning step gets a clean context window. The dispatch prompt includes everything needed — task plans, prior summaries, dependency context, decisions register — so the LLM starts oriented.
 
+### Context Mode
+
+Context Mode is enabled by default for auto-mode runs. Each unit receives manifest-driven guidance to preserve the conversation window: use `gsd_exec` for noisy codebase scans, builds, tests, and diagnostics; use `gsd_exec_search` before repeating a prior sandboxed run; and use `gsd_resume` after compaction or session resume to read `.gsd/last-snapshot.md`.
+
+`gsd_exec` writes full stdout/stderr and metadata under `.gsd/exec/`, then returns only a short digest to the agent. This keeps large command output out of the LLM context while preserving exact evidence on disk. Opt out with:
+
+```yaml
+context_mode:
+  enabled: false
+```
+
+You can also tune sandbox behavior with `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, and `context_mode.exec_digest_chars`.
+
 ### Runtime tool policy
 
 Each auto-mode unit has a `UnitContextManifest` with an enforced `ToolsPolicy`. Execution units use `all` mode and can edit project files, run shell commands, and dispatch subagents. Most planning units use `planning` mode: they can write `.gsd/` planning artifacts and run read-only shell commands, but cannot dispatch subagents. Selected planning and closeout units use `planning-dispatch` mode, which keeps those source-write and bash restrictions while allowing `subagent` dispatch for isolated recon, planning, or review work.

--- a/package-lock.json
+++ b/package-lock.json
@@ -924,7 +924,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1412,6 +1411,16 @@
       },
       "optionalDependencies": {
         "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2672,6 +2681,7 @@
       "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -2766,6 +2776,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2783,6 +2794,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2800,6 +2812,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2817,6 +2830,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2834,6 +2848,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2851,6 +2866,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2868,6 +2884,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2885,6 +2902,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2902,6 +2920,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2919,6 +2938,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2936,6 +2956,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2953,6 +2974,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2967,6 +2989,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
@@ -2989,6 +3012,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3006,6 +3030,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3029,7 +3054,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.2",
@@ -3043,7 +3069,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.2",
@@ -3057,7 +3084,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.2",
@@ -3071,7 +3099,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.2",
@@ -3085,7 +3114,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.2",
@@ -3099,7 +3129,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.2",
@@ -3113,7 +3144,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.2",
@@ -3127,7 +3159,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.2",
@@ -3141,7 +3174,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.2",
@@ -3155,7 +3189,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.2",
@@ -3169,7 +3204,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.2",
@@ -3183,7 +3219,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.2",
@@ -3197,7 +3234,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.2",
@@ -3211,7 +3249,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.2",
@@ -3225,7 +3264,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.2",
@@ -3239,7 +3279,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.2",
@@ -3253,7 +3294,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
@@ -3267,7 +3309,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
@@ -3281,7 +3324,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.2",
@@ -3295,7 +3339,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.2",
@@ -3309,7 +3354,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.2",
@@ -3323,7 +3369,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.2",
@@ -3337,7 +3384,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
@@ -3351,7 +3399,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
@@ -3365,7 +3414,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
@@ -4450,7 +4500,8 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/hosted-git-info": {
       "version": "3.0.5",
@@ -4522,7 +4573,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4819,7 +4869,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5540,7 +5589,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5693,7 +5741,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5873,6 +5920,7 @@
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -6388,7 +6436,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7264,6 +7311,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7684,6 +7732,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7867,7 +7916,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7877,7 +7925,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7991,6 +8038,7 @@
       "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.127.0",
         "@rolldown/pluginutils": "1.0.0-rc.17"
@@ -8024,7 +8072,8 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/rollup": {
       "version": "4.60.2",
@@ -8032,6 +8081,7 @@
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8618,6 +8668,7 @@
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
@@ -8823,6 +8874,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8905,6 +8957,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8922,6 +8975,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8939,6 +8993,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8956,6 +9011,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8973,6 +9029,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8990,6 +9047,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9007,6 +9065,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9024,6 +9083,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9041,6 +9101,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9058,6 +9119,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9075,6 +9137,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9092,6 +9155,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9109,6 +9173,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9126,6 +9191,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9143,6 +9209,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9160,6 +9227,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9177,6 +9245,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9194,6 +9263,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9211,6 +9281,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9228,6 +9299,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9245,6 +9317,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9262,6 +9335,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9279,6 +9353,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9296,6 +9371,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9313,6 +9389,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9330,6 +9407,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9341,6 +9419,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9569,7 +9648,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9706,7 +9784,6 @@
     "packages/pi-coding-agent": {
       "name": "@gsd/pi-coding-agent",
       "version": "2.79.0",
-      "peer": true,
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
         "@silvia-odwyer/photon-node": "^0.3.4",
@@ -9735,7 +9812,6 @@
     "packages/pi-tui": {
       "name": "@gsd/pi-tui",
       "version": "2.79.0",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.6.2",
         "get-east-asian-width": "^1.3.0",
@@ -9800,7 +9876,6 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -132,6 +132,122 @@ describe("workflow MCP tools", () => {
     }
   });
 
+  it("gsd_exec runs by default, preserves cwd, and returns structured metadata", async () => {
+    const base = makeTmpBase();
+    const originalCwd = process.cwd();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_exec");
+      assert.ok(tool, "exec tool should be registered");
+
+      const result = await tool!.handler({
+        projectDir: base,
+        runtime: "node",
+        script: "console.log(process.cwd()); console.log('context mode default on');",
+        purpose: "default-on smoke",
+      });
+
+      const record = result as any;
+      assert.equal(record.isError, false);
+      assert.match(record.content[0].text as string, /context mode default on/);
+      assert.equal(record.structuredContent.operation, "gsd_exec");
+      assert.equal(record.structuredContent.runtime, "node");
+      assert.ok(existsSync(record.structuredContent.stdout_path), "stdout should be persisted");
+      assert.equal(process.cwd(), originalCwd, "gsd_exec must not mutate process.cwd");
+      assert.match(
+        readFileSync(record.structuredContent.stdout_path, "utf-8"),
+        new RegExp(base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+        "script should run relative to the requested projectDir",
+      );
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("gsd_exec returns an MCP error when context mode is disabled", async () => {
+    const base = makeTmpBase();
+    try {
+      writeFileSync(
+        join(base, ".gsd", "PREFERENCES.md"),
+        "---\ncontext_mode:\n  enabled: false\n---\n",
+        "utf-8",
+      );
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_exec");
+      assert.ok(tool, "exec tool should be registered");
+
+      const result = await tool!.handler({
+        projectDir: base,
+        runtime: "bash",
+        script: "echo should-not-run",
+      });
+
+      assertToolError(result, /context_mode\.enabled: false/);
+      assert.equal((result as any).structuredContent.error, "context_mode_disabled");
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("gsd_exec_search finds a prior gsd_exec run", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const execTool = server.tools.find((t) => t.name === "gsd_exec");
+      const searchTool = server.tools.find((t) => t.name === "gsd_exec_search");
+      assert.ok(execTool, "exec tool should be registered");
+      assert.ok(searchTool, "exec search tool should be registered");
+
+      await execTool!.handler({
+        projectDir: base,
+        runtime: "bash",
+        script: "printf 'needle-output\\n'",
+        purpose: "find-me-later",
+      });
+
+      const result = await searchTool!.handler({
+        projectDir: base,
+        query: "find-me",
+      });
+
+      assert.match((result as any).content[0].text as string, /find-me-later/);
+      assert.equal((result as any).structuredContent.operation, "gsd_exec_search");
+      assert.equal((result as any).structuredContent.matches, 1);
+      assert.match((result as any).structuredContent.results[0].stdout_path, /\.gsd\/exec\/.*\.stdout$/);
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("gsd_resume reads the context snapshot", async () => {
+    const base = makeTmpBase();
+    try {
+      writeFileSync(
+        join(base, ".gsd", "last-snapshot.md"),
+        "# GSD context snapshot\n\nResume from here.\n",
+        "utf-8",
+      );
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_resume");
+      assert.ok(tool, "resume tool should be registered");
+
+      const result = await tool!.handler({ projectDir: base });
+
+      assert.match((result as any).content[0].text as string, /Resume from here/);
+      assert.deepEqual((result as any).structuredContent, {
+        operation: "gsd_resume",
+        found: true,
+        bytes: Buffer.byteLength("# GSD context snapshot\n\nResume from here.\n", "utf-8"),
+      });
+    } finally {
+      cleanup(base);
+    }
+  });
+
   it("gsd_summary_save supports root-level PROJECT artifacts without milestone_id", async () => {
     const base = makeTmpBase();
     try {

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -216,7 +216,7 @@ describe("workflow MCP tools", () => {
       assert.match((result as any).content[0].text as string, /find-me-later/);
       assert.equal((result as any).structuredContent.operation, "gsd_exec_search");
       assert.equal((result as any).structuredContent.matches, 1);
-      assert.match((result as any).structuredContent.results[0].stdout_path, /\.gsd\/exec\/.*\.stdout$/);
+      assert.match((result as any).structuredContent.results[0].stdout_path, /\.gsd[\\/]exec[\\/].*\.stdout$/);
     } finally {
       cleanup(base);
     }

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -1915,6 +1915,7 @@ export function registerWorkflowTools(realServer: McpToolServer): void {
     execParams,
     async (args: Record<string, unknown>) => {
       const { projectDir, ...params } = parseWorkflowArgs(execSchema, args);
+      await enforceWorkflowWriteGate("gsd_exec", projectDir);
       const [{ executeGsdExec }, { loadEffectiveGSDPreferences }] = await Promise.all([
         importLocalModule<any>("../../../src/resources/extensions/gsd/tools/exec-tool.js"),
         importLocalModule<any>("../../../src/resources/extensions/gsd/preferences.js"),
@@ -1926,10 +1927,12 @@ export function registerWorkflowTools(realServer: McpToolServer): void {
         prefs = null;
       }
       return adaptExecutorResult(
-        await executeGsdExec(params, {
-          baseDir: projectDir,
-          preferences: (prefs?.preferences ?? null) as unknown,
-        }),
+        await runSerializedWorkflowOperation(() =>
+          executeGsdExec(params, {
+            baseDir: projectDir,
+            preferences: (prefs?.preferences ?? null) as unknown,
+          }),
+        ),
       );
     },
   );

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -692,6 +692,9 @@ export const WORKFLOW_TOOL_NAMES = [
   "gsd_complete_task",
   "gsd_milestone_status",
   "gsd_journal_query",
+  "gsd_exec",
+  "gsd_exec_search",
+  "gsd_resume",
   // ADR-013 step 3: memory-store tools exposed to external MCP clients.
   // gsd_memory_graph is namespaced to avoid collision with the existing
   // gsd_graph tool (project knowledge graph from .gsd/ artifacts).
@@ -1426,6 +1429,30 @@ const journalQueryParams = {
 };
 const journalQuerySchema = z.object(journalQueryParams);
 
+const execRuntimeSchema = z.enum(["bash", "node", "python"]);
+const execParams = {
+  projectDir: projectDirParam,
+  runtime: execRuntimeSchema.describe("Interpreter: bash (-c), node (-e), or python3 (-c)."),
+  script: nonEmptyString("script").describe("Script body. Keep output small; full stdout/stderr are persisted under .gsd/exec."),
+  purpose: z.string().optional().describe("Short label recorded in meta.json for later review."),
+  timeout_ms: z.number().int().min(1_000).max(600_000).optional().describe("Per-invocation timeout in milliseconds."),
+};
+const execSchema = z.object(execParams);
+
+const execSearchParams = {
+  projectDir: projectDirParam,
+  query: z.string().optional().describe("Substring matched against id and purpose, case-insensitive."),
+  runtime: execRuntimeSchema.optional().describe("Restrict to one runtime."),
+  failing_only: z.boolean().optional().describe("Only non-zero exit codes and timeouts."),
+  limit: z.number().int().min(1).max(200).optional().describe("Max results (default 20, cap 200)."),
+};
+const execSearchSchema = z.object(execSearchParams);
+
+const resumeParams = {
+  projectDir: projectDirParam,
+};
+const resumeSchema = z.object(resumeParams);
+
 /**
  * Wrap a real McpToolServer so every handler we register catches thrown
  * errors and returns a structured `{isError: true, content: [...]}` MCP
@@ -1879,6 +1906,57 @@ export function registerWorkflowTools(realServer: McpToolServer): void {
         return { content: [{ type: "text" as const, text: "No matching journal entries found." }] };
       }
       return { content: [{ type: "text" as const, text: JSON.stringify(entries, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "gsd_exec",
+    "Run a short bash/node/python script in the project directory. Full stdout/stderr persist under .gsd/exec; only a digest returns to MCP.",
+    execParams,
+    async (args: Record<string, unknown>) => {
+      const { projectDir, ...params } = parseWorkflowArgs(execSchema, args);
+      const [{ executeGsdExec }, { loadEffectiveGSDPreferences }] = await Promise.all([
+        importLocalModule<any>("../../../src/resources/extensions/gsd/tools/exec-tool.js"),
+        importLocalModule<any>("../../../src/resources/extensions/gsd/preferences.js"),
+      ]);
+      let prefs: { preferences?: unknown } | null = null;
+      try {
+        prefs = loadEffectiveGSDPreferences(projectDir);
+      } catch {
+        prefs = null;
+      }
+      return adaptExecutorResult(
+        await executeGsdExec(params, {
+          baseDir: projectDir,
+          preferences: (prefs?.preferences ?? null) as unknown,
+        }),
+      );
+    },
+  );
+
+  server.tool(
+    "gsd_exec_search",
+    "Search prior gsd_exec runs from .gsd/exec/*.meta.json without re-running them.",
+    execSearchParams,
+    async (args: Record<string, unknown>) => {
+      const { projectDir, ...params } = parseWorkflowArgs(execSearchSchema, args);
+      const { executeExecSearch } = await importLocalModule<any>(
+        "../../../src/resources/extensions/gsd/tools/exec-search-tool.js",
+      );
+      return adaptExecutorResult(executeExecSearch(params, { baseDir: projectDir }));
+    },
+  );
+
+  server.tool(
+    "gsd_resume",
+    "Read .gsd/last-snapshot.md so agents can re-orient after compaction or session resume.",
+    resumeParams,
+    async (args: Record<string, unknown>) => {
+      const { projectDir, ...params } = parseWorkflowArgs(resumeSchema, args);
+      const { executeResume } = await importLocalModule<any>(
+        "../../../src/resources/extensions/gsd/tools/resume-tool.js",
+      );
+      return adaptExecutorResult(executeResume(params, { baseDir: projectDir }));
     },
   );
 

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -17,6 +17,7 @@ import {
   resolveGsdRootFile, relGsdRootFile, resolveRuntimeFile,
 } from "./paths.js";
 import { resolveSkillDiscoveryMode, resolveInlineLevel, loadEffectiveGSDPreferences, resolveAllSkillReferences } from "./preferences.js";
+import { isContextModeEnabled } from "./preferences-types.js";
 import { parseRoadmap } from "./parsers-legacy.js";
 import type { GSDState, InlineLevel } from "./types.js";
 import type { GSDPreferences } from "./preferences.js";
@@ -33,7 +34,7 @@ import {
 } from "./gate-registry.js";
 import { formatDecisionsCompact, formatRequirementsCompact } from "./structured-data-formatter.js";
 import { readPhaseAnchor, formatAnchorForPrompt } from "./phase-anchor.js";
-import { composeInlinedContext, type ArtifactResolver } from "./unit-context-composer.js";
+import { composeContextModeInstructions, composeInlinedContext, type ArtifactResolver, type ContextModeRenderMode } from "./unit-context-composer.js";
 import { logWarning } from "./workflow-logger.js";
 import { inlineGraphSubgraph } from "./graph-context.js";
 import { buildExtractionStepsBlock } from "./commands-extract-learnings.js";
@@ -87,6 +88,30 @@ function capPreamble(preamble: string): string {
   const budget = Math.min(MAX_PREAMBLE_CHARS, resolvePromptBudgets().inlineContextBudgetChars);
   if (preamble.length <= budget) return preamble;
   return truncateAtSectionBoundary(preamble, budget).content;
+}
+
+function renderContextModeForPrompt(
+  unitType: string,
+  base: string,
+  renderMode: ContextModeRenderMode = "standalone",
+): string {
+  const effectivePrefs = loadEffectiveGSDPreferences(base)?.preferences;
+  return composeContextModeInstructions(unitType, {
+    enabled: isContextModeEnabled(effectivePrefs),
+    renderMode,
+  });
+}
+
+function prependContextModeToBlock(
+  unitType: string,
+  base: string,
+  block: string,
+  renderMode: ContextModeRenderMode = "standalone",
+): string {
+  const contextMode = renderContextModeForPrompt(unitType, base, renderMode);
+  if (!contextMode) return block;
+  if (!block.trim()) return contextMode;
+  return `${contextMode}\n\n${block}`;
 }
 
 // ─── Executor Constraints ─────────────────────────────────────────────────────
@@ -1266,6 +1291,7 @@ export async function buildDiscussMilestonePrompt(
   structuredQuestionsAvailable = "false",
 ): Promise<string> {
   const discussTemplates = inlineTemplate("context", "Context");
+  const contextModeInstructions = renderContextModeForPrompt("discuss-milestone", base);
 
   const basePrompt = loadPrompt("guided-discuss-milestone", {
     workingDirectory: base,
@@ -1276,16 +1302,17 @@ export async function buildDiscussMilestonePrompt(
     commitInstruction: "Do not commit planning artifacts — .gsd/ is managed externally.",
     fastPathInstruction: "",
   });
+  const promptWithContextMode = prependContextModeToBlock("discuss-milestone", base, basePrompt);
 
   // If a CONTEXT-DRAFT.md exists, append it as seed material
   const draftPath = resolveMilestoneFile(base, mid, "CONTEXT-DRAFT");
   const draftContent = draftPath ? await loadFile(draftPath) : null;
 
   if (draftContent) {
-    return `${basePrompt}\n\n## Prior Discussion (Draft Seed)\n\nThe following draft was captured from a prior multi-milestone discussion. Use it as seed material — the user has already provided this context. Start with a brief reflection on what the draft covers, then probe for any gaps or open questions before writing the full CONTEXT.md.\n\n${draftContent}`;
+    return `${promptWithContextMode}\n\n## Prior Discussion (Draft Seed)\n\nThe following draft was captured from a prior multi-milestone discussion. Use it as seed material — the user has already provided this context. Start with a brief reflection on what the draft covers, then probe for any gaps or open questions before writing the full CONTEXT.md.\n\n${draftContent}`;
   }
 
-  return basePrompt;
+  return contextModeInstructions ? promptWithContextMode : basePrompt;
 }
 
 /**
@@ -1298,10 +1325,10 @@ export async function buildWorkflowPreferencesPrompt(
   base: string,
   structuredQuestionsAvailable = "false",
 ): Promise<string> {
-  return loadPrompt("guided-workflow-preferences", {
+  return prependContextModeToBlock("workflow-preferences", base, loadPrompt("guided-workflow-preferences", {
     workingDirectory: base,
     structuredQuestionsAvailable,
-  });
+  }));
 }
 
 /**
@@ -1315,10 +1342,10 @@ export async function buildResearchProjectPrompt(
   base: string,
   structuredQuestionsAvailable = "false",
 ): Promise<string> {
-  return loadPrompt("guided-research-project", {
+  return prependContextModeToBlock("research-project", base, loadPrompt("guided-research-project", {
     workingDirectory: base,
     structuredQuestionsAvailable,
-  });
+  }));
 }
 
 /**
@@ -1331,10 +1358,10 @@ export async function buildResearchDecisionPrompt(
   base: string,
   structuredQuestionsAvailable = "false",
 ): Promise<string> {
-  return loadPrompt("guided-research-decision", {
+  return prependContextModeToBlock("research-decision", base, loadPrompt("guided-research-decision", {
     workingDirectory: base,
     structuredQuestionsAvailable,
-  });
+  }));
 }
 
 /**
@@ -1349,12 +1376,12 @@ export async function buildDiscussProjectPrompt(
 ): Promise<string> {
   const inlinedTemplates = inlineTemplate("project", "Project");
 
-  return loadPrompt("guided-discuss-project", {
+  return prependContextModeToBlock("discuss-project", base, loadPrompt("guided-discuss-project", {
     workingDirectory: base,
     inlinedTemplates,
     structuredQuestionsAvailable,
     commitInstruction: "Do not commit planning artifacts — .gsd/ is managed externally.",
-  });
+  }));
 }
 
 /**
@@ -1369,12 +1396,12 @@ export async function buildDiscussRequirementsPrompt(
 ): Promise<string> {
   const inlinedTemplates = inlineTemplate("requirements", "Requirements");
 
-  return loadPrompt("guided-discuss-requirements", {
+  return prependContextModeToBlock("discuss-requirements", base, loadPrompt("guided-discuss-requirements", {
     workingDirectory: base,
     inlinedTemplates,
     structuredQuestionsAvailable,
     commitInstruction: "Do not commit planning artifacts — .gsd/ is managed externally.",
-  });
+  }));
 }
 
 export async function buildResearchMilestonePrompt(mid: string, midTitle: string, base: string): Promise<string> {
@@ -1428,7 +1455,11 @@ export async function buildResearchMilestonePrompt(mid: string, midTitle: string
     if (knowledgeInlineRM) parts.push(knowledgeInlineRM);
   }
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`);
+  const inlinedContext = prependContextModeToBlock(
+    "research-milestone",
+    base,
+    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`),
+  );
 
   const outputRelPath = relMilestoneFile(base, mid, "RESEARCH");
   return loadPrompt("research-milestone", {
@@ -1501,7 +1532,11 @@ export async function buildPlanMilestonePrompt(mid: string, midTitle: string, ba
     inlined.push(inlineTemplate("task-plan", "Task Plan"));
   }
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const inlinedContext = prependContextModeToBlock(
+    "plan-milestone",
+    base,
+    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+  );
 
   const outputRelPath = relMilestoneFile(base, mid, "ROADMAP");
   const researchOutputPath = join(base, relMilestoneFile(base, mid, "RESEARCH"));
@@ -1530,6 +1565,7 @@ export async function buildPlanMilestonePrompt(mid: string, midTitle: string, ba
 
 export async function buildResearchSlicePrompt(
   mid: string, _midTitle: string, sid: string, sTitle: string, base: string,
+  options?: { contextModeRenderMode?: ContextModeRenderMode },
 ): Promise<string> {
   const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
   const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
@@ -1582,7 +1618,12 @@ export async function buildResearchSlicePrompt(
   const overridesInline = formatOverridesSection(activeOverrides);
   if (overridesInline) inlined.unshift(overridesInline);
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const inlinedContext = prependContextModeToBlock(
+    "research-slice",
+    base,
+    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+    options?.contextModeRenderMode,
+  );
 
   const outputRelPath = relSliceFile(base, mid, sid, "RESEARCH");
   return loadPrompt("research-slice", {
@@ -1629,6 +1670,7 @@ async function renderSlicePrompt(options: {
   sessionContextWindow?: number;
   modelRegistry?: MinimalModelRegistry;
   sessionProvider?: string;
+  contextModeRenderMode?: ContextModeRenderMode;
 }): Promise<string> {
   const {
     mid, sid, sTitle, base, level, promptTemplate, prependBlocks = [], extraVars = {},
@@ -1684,7 +1726,12 @@ async function renderSlicePrompt(options: {
   const overridesInline = formatOverridesSection(await loadActiveOverrides(base));
   if (overridesInline) inlined.unshift(overridesInline);
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const inlinedContext = prependContextModeToBlock(
+    promptTemplate,
+    base,
+    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+    options.contextModeRenderMode,
+  );
   const executorContextConstraints = formatExecutorConstraints(sessionContextWindow, modelRegistry, sessionProvider);
   const outputRelPath = relSliceFile(base, mid, sid, "PLAN");
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
@@ -1820,6 +1867,8 @@ export interface ExecuteTaskPromptOptions {
   modelRegistry?: MinimalModelRegistry;
   /** Session model provider, used for provider-specific effective context windows. */
   sessionProvider?: string;
+  /** Render compact Context Mode guidance when embedded inside another prompt. */
+  contextModeRenderMode?: ContextModeRenderMode;
 }
 
 export async function buildExecuteTaskPrompt(
@@ -1962,6 +2011,7 @@ export async function buildExecuteTaskPrompt(
     getGatesForTurn("execute-task"),
     { pending: new Set(etPending.map((g) => g.gate_id)), allowOmit: true },
   );
+  phaseAnchorSection = prependContextModeToBlock("execute-task", base, phaseAnchorSection, opts.contextModeRenderMode);
 
   return loadPrompt("execute-task", {
     overridesSection,
@@ -1990,6 +2040,7 @@ export async function buildExecuteTaskPrompt(
       taskTitle: tTitle,
       taskPlanContent,
       extraContext: [taskPlanInline, slicePlanExcerpt, finalCarryForward, resumeSection],
+      unitType: "execute-task",
     }),
   });
 }
@@ -2088,7 +2139,11 @@ export async function buildCompleteSlicePrompt(
     ? `${completeOverridesInline}\n\n---\n\n${body}`
     : body;
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${finalBody}`);
+  const inlinedContext = prependContextModeToBlock(
+    "complete-slice",
+    base,
+    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${finalBody}`),
+  );
   const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
 
   const sliceRel = relSlicePath(base, mid, sid);
@@ -2187,7 +2242,11 @@ export async function buildCompleteMilestonePrompt(
   if (contextInline) inlined.push(contextInline);
   inlined.push(inlineTemplate("milestone-summary", "Milestone Summary"));
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const inlinedContext = prependContextModeToBlock(
+    "complete-milestone",
+    base,
+    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+  );
 
   const milestoneSummaryPath = join(base, `${relMilestonePath(base, mid)}/${mid}-SUMMARY.md`);
 
@@ -2324,7 +2383,11 @@ export async function buildValidateMilestonePrompt(
   const contextInline = await inlineFileOptional(contextPath, contextRel, "Milestone Context");
   if (contextInline) inlined.push(contextInline);
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const inlinedContext = prependContextModeToBlock(
+    "validate-milestone",
+    base,
+    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+  );
 
   const validationOutputPath = join(base, `${relMilestonePath(base, mid)}/${mid}-VALIDATION.md`);
   const roadmapOutputPath = `${relMilestonePath(base, mid)}/${mid}-ROADMAP.md`;
@@ -2400,7 +2463,11 @@ export async function buildReplanSlicePrompt(
   const replanOverridesInline = formatOverridesSection(replanActiveOverrides);
   if (replanOverridesInline) inlined.unshift(replanOverridesInline);
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const inlinedContext = prependContextModeToBlock(
+    "replan-slice",
+    base,
+    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+  );
 
   const replanPath = join(base, `${relSlicePath(base, mid, sid)}/${sid}-REPLAN.md`);
 
@@ -2474,7 +2541,11 @@ export async function buildRunUatPrompt(
   };
 
   const composed = await composeInlinedContext("run-uat", resolveArtifact);
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${composed}`);
+  const inlinedContext = prependContextModeToBlock(
+    "run-uat",
+    base,
+    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${composed}`),
+  );
 
   const uatResultPath = join(base, relSliceFile(base, mid, sliceId, "ASSESSMENT"));
   const uatType = getUatType(uatContent);
@@ -2548,7 +2619,11 @@ export async function buildReassessRoadmapPrompt(
   const knowledgeInlineRA = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
   if (knowledgeInlineRA) parts.push(knowledgeInlineRA);
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`);
+  const inlinedContext = prependContextModeToBlock(
+    "reassess-roadmap",
+    base,
+    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`),
+  );
 
   const assessmentPath = join(base, relSliceFile(base, mid, completedSliceId, "ASSESSMENT"));
 
@@ -2641,6 +2716,7 @@ export async function buildReactiveExecutePrompt(
         sessionContextWindow: opts?.sessionContextWindow,
         modelRegistry: opts?.modelRegistry,
         sessionProvider: opts?.sessionProvider,
+        contextModeRenderMode: "nested",
       },
     );
 
@@ -2664,7 +2740,7 @@ export async function buildReactiveExecutePrompt(
     milestoneTitle: midTitle,
     sliceId: sid,
     sliceTitle: sTitle,
-    graphContext,
+    graphContext: prependContextModeToBlock("reactive-execute", base, graphContext),
     readyTaskCount: String(readyTaskIds.length),
     readyTaskList: readyTaskListLines.join("\n"),
     subagentPrompts: subagentSections.join("\n\n---\n\n"),
@@ -2730,7 +2806,7 @@ export async function buildParallelResearchSlicesPrompt(
   const subagentSections: string[] = [];
   const modelSuffix = subagentModel ? ` with model: "${subagentModel}"` : "";
   for (const slice of slices) {
-    const slicePrompt = await buildResearchSlicePrompt(mid, midTitle, slice.id, slice.title, basePath);
+    const slicePrompt = await buildResearchSlicePrompt(mid, midTitle, slice.id, slice.title, basePath, { contextModeRenderMode: "nested" });
     subagentSections.push([
       `### ${slice.id}: ${slice.title}`,
       "",
@@ -2786,6 +2862,8 @@ export async function buildGateEvaluatePrompt(
     gateListLines.push(`- **${def.id}**: ${def.question}`);
 
     const subPrompt = [
+      renderContextModeForPrompt("gate-evaluate", base, "nested"),
+      "",
       `You are evaluating quality gate **${def.id}** for slice ${sid} (${sTitle}).`,
       "",
       `**Working directory:** \`${normalizedBase}\`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT \`cd\` to any other directory.`,
@@ -2828,7 +2906,7 @@ export async function buildGateEvaluatePrompt(
     milestoneTitle: midTitle,
     sliceId: sid,
     sliceTitle: sTitle,
-    slicePlanContent: planContent,
+    slicePlanContent: prependContextModeToBlock("gate-evaluate", base, planContent),
     gateCount: String(pending.length),
     gateList: gateListLines.join("\n"),
     subagentPrompts: subagentSections.join("\n\n---\n\n"),
@@ -2905,7 +2983,7 @@ export async function buildRewriteDocsPrompt(
 
   const documentList = docList.length > 0 ? docList.join("\n") : "- No active plan documents found.";
 
-  return loadPrompt("rewrite-docs", {
+  return prependContextModeToBlock("rewrite-docs", base, loadPrompt("rewrite-docs", {
     workingDirectory: base,
     milestoneId: mid,
     milestoneTitle: midTitle,
@@ -2914,5 +2992,5 @@ export async function buildRewriteDocsPrompt(
     overrideContent,
     documentList,
     overridesPath: relGsdRootFile("OVERRIDES"),
-  });
+  }));
 }

--- a/src/resources/extensions/gsd/bootstrap/exec-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/exec-tools.ts
@@ -1,7 +1,7 @@
 // GSD2 — Exec (context-mode) tool registration.
 //
-// Exposes the `gsd_exec` tool over MCP. Opt-in: disabled unless
-// `context_mode.enabled: true` is set in preferences.
+// Exposes the Context Mode runtime tools in-process. Default-on; opt out with
+// `context_mode.enabled: false` in preferences.
 
 import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -64,6 +64,38 @@ async function applyDisabledModelProviderPolicy(ctx: ExtensionContext): Promise<
   }
 }
 
+async function writeContextModeCompactionSnapshot(basePath: string): Promise<void> {
+  try {
+    const { loadEffectiveGSDPreferences } = await import("../preferences.js");
+    const { isContextModeEnabled } = await import("../preferences-types.js");
+    const prefs = loadEffectiveGSDPreferences(basePath);
+    if (!isContextModeEnabled(prefs?.preferences)) return;
+
+    const { writeCompactionSnapshot } = await import("../compaction-snapshot.js");
+    const { ensureDbOpen } = await import("./dynamic-tools.js");
+    await ensureDbOpen(basePath);
+
+    let activeContext: string | null = null;
+    try {
+      const state = await deriveGsdState(basePath);
+      if (state.activeMilestone && state.activeSlice && state.activeTask) {
+        activeContext =
+          `Active: ${state.activeMilestone.id} / ${state.activeSlice.id} / ${state.activeTask.id}` +
+          (state.activeTask.title ? ` - ${state.activeTask.title}` : "");
+      }
+    } catch {
+      /* non-fatal */
+    }
+
+    writeCompactionSnapshot(basePath, { activeContext });
+  } catch (err) {
+    safetyLogWarning(
+      "context-mode",
+      `failed to write compaction snapshot: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 export function registerHooks(
   pi: ExtensionAPI,
   ecosystemHandlers: GSDEcosystemBeforeAgentStartHandler[],
@@ -229,15 +261,19 @@ export function registerHooks(
   });
 
   pi.on("session_before_compact", async () => {
+    const basePath = process.cwd();
+    // Context Mode is default-on. Write the resumable snapshot before any
+    // active-auto cancel return so auto sessions still leave re-entry context.
+    await writeContextModeCompactionSnapshot(basePath);
+
     // Only cancel compaction while auto-mode is actively running.
     // Paused auto-mode should allow compaction — the user may be doing
     // interactive work (#3165).
     if (isAutoActive()) {
       return { cancel: true };
     }
-    const basePath = process.cwd();
     const { ensureDbOpen } = await import("./dynamic-tools.js");
-    await ensureDbOpen();
+    await ensureDbOpen(basePath);
     const state = await deriveGsdState(basePath);
     if (!state.activeMilestone || !state.activeSlice) return;
     // Write checkpoint for ALL phases, not just "executing" — discuss, research,
@@ -280,42 +316,6 @@ export function registerHooks(
         ? `Resume task ${taskId}: ${taskTitle}.`
         : `Resume ${phaseLabel} work for slice ${state.activeSlice.id}.`,
     }));
-  });
-
-  // Context-mode snapshot: write .gsd/last-snapshot.md before compaction so
-  // agents can call gsd_resume (or Read the file) to re-orient. Opt-in via
-  // preferences.context_mode.enabled. Runs after the auto-cancel handler
-  // above — if that one returned cancel:true, pi still fires us but the
-  // compaction won't actually happen; the snapshot is still useful then,
-  // since auto may pause and resume later.
-  pi.on("session_before_compact", async () => {
-    try {
-      const { loadEffectiveGSDPreferences } = await import("../preferences.js");
-      const { isContextModeEnabled } = await import("../preferences-types.js");
-      const prefs = loadEffectiveGSDPreferences();
-      if (!isContextModeEnabled(prefs?.preferences)) return;
-      const { writeCompactionSnapshot } = await import("../compaction-snapshot.js");
-      const { ensureDbOpen } = await import("./dynamic-tools.js");
-      await ensureDbOpen();
-      const basePath = process.cwd();
-      let activeContext: string | null = null;
-      try {
-        const state = await deriveGsdState(basePath);
-        if (state.activeMilestone && state.activeSlice && state.activeTask) {
-          activeContext =
-            `Active: ${state.activeMilestone.id} / ${state.activeSlice.id} / ${state.activeTask.id}` +
-            (state.activeTask.title ? ` — ${state.activeTask.title}` : "");
-        }
-      } catch {
-        /* non-fatal */
-      }
-      writeCompactionSnapshot(basePath, { activeContext });
-    } catch (err) {
-      safetyLogWarning(
-        "context-mode",
-        `failed to write compaction snapshot: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
   });
 
   pi.on("message_update", async (event, ctx: ExtensionContext) => {

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -343,7 +343,8 @@ export interface GSDPreferences {
   /**
    * Tool-output sandboxing via gsd_exec. Keeps sub-session context windows
    * clean by running scripts in a subprocess and only surfacing a short
-   * digest. See `ContextModeConfig`. Default: disabled.
+   * digest. See `ContextModeConfig`. Default: enabled unless explicitly
+   * disabled with `context_mode.enabled: false`.
    */
   context_mode?: ContextModeConfig;
   token_profile?: TokenProfile;

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -154,8 +154,26 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "planning_depth",
 ]);
 
-/** Canonical list of all dispatch unit types. */
-export const KNOWN_UNIT_TYPES = [
+/**
+ * Broad union of every recognized unit-type *label* used across the codebase.
+ *
+ * This intentionally covers more than the manifest-tracked dispatch units in
+ * `unit-context-manifest.ts:KNOWN_UNIT_TYPES`. Examples that live here but not
+ * in the manifest:
+ * - `discuss-slice` — dispatched by `guided-flow.ts` rather than auto-mode;
+ *   composer falls through to default behavior via `resolveManifest()` null path.
+ * - `worktree-merge` — used as a model-routing case, prompt-template name, and
+ *   commit-message label, not as an LLM-dispatched unit.
+ *
+ * Used by `preferences-validation.ts` to validate user-provided unit-type
+ * references in preferences (model overrides, skill rules, etc.) — preferences
+ * may legitimately reference any label, including non-dispatched ones.
+ *
+ * The manifest-strict subset lives in `unit-context-manifest.ts:KNOWN_UNIT_TYPES`
+ * and is enforced 1:1 against `UNIT_MANIFESTS` by the parity test in
+ * `tests/unit-context-manifest.test.ts`.
+ */
+export const KNOWN_UNIT_LABELS = [
   "research-milestone", "plan-milestone", "research-slice", "plan-slice", "refine-slice",
   "execute-task", "reactive-execute", "gate-evaluate", "complete-slice", "replan-slice", "reassess-roadmap",
   "run-uat", "complete-milestone", "validate-milestone", "rewrite-docs",
@@ -164,7 +182,7 @@ export const KNOWN_UNIT_TYPES = [
   "workflow-preferences", "discuss-project", "discuss-requirements",
   "research-decision", "research-project",
 ] as const;
-export type UnitType = (typeof KNOWN_UNIT_TYPES)[number];
+export type UnitLabel = (typeof KNOWN_UNIT_LABELS)[number];
 
 
 export const SKILL_ACTIONS = new Set(["use", "prefer", "avoid"]);

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -14,7 +14,7 @@ import { normalizeStringArray } from "../shared/format-utils.js";
 
 import {
   KNOWN_PREFERENCE_KEYS,
-  KNOWN_UNIT_TYPES,
+  KNOWN_UNIT_LABELS,
 
   SKILL_ACTIONS,
   type WorkflowMode,
@@ -441,7 +441,7 @@ export function validatePreferences(preferences: GSDPreferences): {
   if (preferences.post_unit_hooks && Array.isArray(preferences.post_unit_hooks)) {
     const validHooks: PostUnitHookConfig[] = [];
     const seenNames = new Set<string>();
-    const knownUnitTypes = new Set<string>(KNOWN_UNIT_TYPES);
+    const knownUnitTypes = new Set<string>(KNOWN_UNIT_LABELS);
     for (const hook of preferences.post_unit_hooks) {
       if (!hook || typeof hook !== "object") {
         errors.push("post_unit_hooks entry must be an object");
@@ -503,7 +503,7 @@ export function validatePreferences(preferences: GSDPreferences): {
   if (preferences.pre_dispatch_hooks && Array.isArray(preferences.pre_dispatch_hooks)) {
     const validPreHooks: PreDispatchHookConfig[] = [];
     const seenPreNames = new Set<string>();
-    const knownUnitTypes = new Set<string>(KNOWN_UNIT_TYPES);
+    const knownUnitTypes = new Set<string>(KNOWN_UNIT_LABELS);
     const validActions = new Set(["modify", "skip", "replace"]);
     for (const hook of preferences.pre_dispatch_hooks) {
       if (!hook || typeof hook !== "object") {

--- a/src/resources/extensions/gsd/tests/bootstrap-derive-state-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/bootstrap-derive-state-db-open.test.ts
@@ -31,9 +31,9 @@ describe("bootstrap deriveState DB guards (#3844)", () => {
     const compactIdx = registerHooksSrc.indexOf('pi.on("session_before_compact"');
     assert.ok(compactIdx > -1, "register-hooks should define session_before_compact");
     const compactSection = extractSourceRegion(registerHooksSrc, 'pi.on("session_before_compact"');
-    const ensureIdx = compactSection.indexOf("ensureDbOpen()");
+    const ensureIdx = compactSection.indexOf("ensureDbOpen(basePath)");
     const deriveIdx = compactSection.indexOf("deriveGsdState(basePath)");
-    assert.ok(ensureIdx > -1, "session_before_compact should call ensureDbOpen()");
+    assert.ok(ensureIdx > -1, "session_before_compact should call ensureDbOpen(basePath)");
     assert.ok(deriveIdx > -1, "session_before_compact should derive state");
     assert.ok(ensureIdx < deriveIdx, "session_before_compact should open DB before deriveState");
   });

--- a/src/resources/extensions/gsd/tests/guided-flow-prompt-consolidation.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-flow-prompt-consolidation.test.ts
@@ -101,6 +101,20 @@ describe("guided-flow → auto-prompts consolidation (#5183)", () => {
       prompt.includes("Implement the thing"),
       "must include task plan body content from disk",
     );
+    assert.ok(prompt.includes("## Context Mode"), "execute-task should include standalone Context Mode guidance");
+    assert.ok(prompt.includes("execution lane"), "execute-task should render the execution lane");
+  });
+
+  test("buildExecuteTaskPrompt omits Context Mode when disabled", async () => {
+    writeFileSync(
+      join(base, ".gsd", "PREFERENCES.md"),
+      ["---", "context_mode:", "  enabled: false", "---", ""].join("\n"),
+    );
+
+    const prompt = await buildExecuteTaskPrompt(MID, SID, S_TITLE, TID, T_TITLE, base);
+
+    assert.ok(!prompt.includes("## Context Mode"));
+    assert.ok(!prompt.includes("Context Mode (execution lane)"));
   });
 
   test("buildCompleteSlicePrompt carries the complete-slice contract", async () => {

--- a/src/resources/extensions/gsd/tests/parallel-skill-prompt-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-skill-prompt-integration.test.ts
@@ -147,4 +147,12 @@ test("subagent dispatch prompt (buildParallelResearchSlicesPrompt) carries <skil
     prompt.includes(SKILL_ACTIVATION_SUBSTRING),
     `parallel-research-slices prompt should reference the always-used skill '${SKILL_NAME}'`,
   );
+  assert.ok(
+    prompt.includes("Context Mode (research lane):"),
+    "embedded parallel research subagent prompts should use nested Context Mode guidance",
+  );
+  assert.ok(
+    !prompt.includes("## Context Mode\n\nLane: **research lane**."),
+    "embedded parallel research subagent prompts should not use standalone Context Mode heading",
+  );
 });

--- a/src/resources/extensions/gsd/tests/pre-exec-gate-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-exec-gate-loop.test.ts
@@ -111,6 +111,9 @@ test("#4551: buildPlanSlicePrompt injects fix section when priorPreExecFailure p
     },
   );
 
+  assert.ok(prompt.includes("## Context Mode"), "plan-slice should include standalone Context Mode guidance");
+  assert.ok(prompt.includes("planning lane"), "plan-slice should render the planning lane");
+
   assert.ok(
     prompt.includes("Fix these specific issues from the prior pre-exec check"),
     "prompt must contain the fix section heading",

--- a/src/resources/extensions/gsd/tests/register-hooks-compaction-checkpoint.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-compaction-checkpoint.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { registerHooks } from "../bootstrap/register-hooks.ts";
+import { autoSession } from "../auto-runtime-state.ts";
 import { parseContinue } from "../files.ts";
 import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
 import { deriveState, invalidateStateCache } from "../state.ts";
@@ -95,4 +96,88 @@ test("register-hooks writes CONTINUE checkpoint during planning phase without ac
   assert.equal(parsed.frontmatter.status, "compacted");
   assert.match(parsed.completedWork, /planning phase/i, "completed-work should capture non-executing phase context");
   assert.match(parsed.nextAction, /slice S01/i, "next action should route resume to the active slice");
+});
+
+test("register-hooks writes Context Mode snapshot before active auto cancels compaction", async (t) => {
+  const base = createPlanningFixtureBase();
+  const originalCwd = process.cwd();
+  process.chdir(base);
+  invalidateStateCache();
+  closeDatabase();
+  autoSession.reset();
+  autoSession.active = true;
+
+  t.after(() => {
+    autoSession.reset();
+    invalidateStateCache();
+    closeDatabase();
+    process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>();
+  const pi = {
+    on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  } as any;
+
+  registerHooks(pi, []);
+
+  const compactHandlers = handlers.get("session_before_compact");
+  assert.ok(compactHandlers && compactHandlers.length > 0, "session_before_compact handler should be registered");
+
+  const result = await compactHandlers![0]({});
+
+  assert.deepEqual(result, { cancel: true }, "active auto should still cancel compaction");
+  const snapshotPath = join(base, ".gsd", "last-snapshot.md");
+  assert.ok(existsSync(snapshotPath), "active auto cancel should still leave a Context Mode snapshot");
+  assert.match(readFileSync(snapshotPath, "utf-8"), /GSD context snapshot/);
+});
+
+test("register-hooks does not write Context Mode snapshot when disabled", async (t) => {
+  const base = createPlanningFixtureBase();
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    "---\ncontext_mode:\n  enabled: false\n---\n",
+    "utf-8",
+  );
+  const originalCwd = process.cwd();
+  process.chdir(base);
+  invalidateStateCache();
+  closeDatabase();
+  autoSession.reset();
+
+  t.after(() => {
+    autoSession.reset();
+    invalidateStateCache();
+    closeDatabase();
+    process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>();
+  const pi = {
+    on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  } as any;
+
+  registerHooks(pi, []);
+
+  const compactHandlers = handlers.get("session_before_compact");
+  assert.ok(compactHandlers && compactHandlers.length > 0, "session_before_compact handler should be registered");
+
+  for (const handler of compactHandlers ?? []) {
+    await handler({});
+  }
+
+  assert.ok(
+    !existsSync(join(base, ".gsd", "last-snapshot.md")),
+    "disabled Context Mode should not write a snapshot",
+  );
 });

--- a/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
@@ -95,6 +95,8 @@ test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project
 
   // Context wrapper present
   assert.match(prompt, /## Inlined Context \(preloaded — do not re-read these files\)/);
+  assert.match(prompt, /## Context Mode/);
+  assert.match(prompt, /verification lane/);
 
   // Artifacts from the manifest inline list, in declared order:
   // slice-uat → slice-summary → project (#4925 review).

--- a/src/resources/extensions/gsd/tests/subagent-model-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/subagent-model-dispatch.test.ts
@@ -211,6 +211,14 @@ test("buildReactiveExecutePrompt: output contains model string when subagentMode
     prompt.includes('model: "claude-opus-4-6"'),
     `Prompt should contain model instruction. Got:\n${prompt.slice(0, 500)}`,
   );
+  assert.ok(
+    prompt.includes("Context Mode (execution lane):"),
+    "embedded reactive-execute task prompt should use nested Context Mode guidance",
+  );
+  assert.ok(
+    prompt.includes("## Context Mode"),
+    "reactive-execute parent prompt should include standalone Context Mode guidance",
+  );
 });
 
 test("buildReactiveExecutePrompt: no model instruction when subagentModel omitted", async (t) => {
@@ -265,4 +273,55 @@ test("buildReactiveExecutePrompt: no model instruction when subagentModel omitte
     !prompt.includes('with model:'),
     "Prompt should not contain model instruction when subagentModel is omitted",
   );
+});
+
+test("buildGateEvaluatePrompt: embedded gate prompts use nested Context Mode guidance", async (t) => {
+  const { buildGateEvaluatePrompt } = await import("../auto-prompts.ts");
+  const { closeDatabase, insertGateRow, insertMilestone, insertSlice, openDatabase } = await import("../gsd-db.ts");
+  const repo = mkdtempSync(join(tmpdir(), "gsd-subagent-model-gate-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  const sliceDir = join(repo, ".gsd", "milestones", "M001", "slices", "S01");
+  mkdirSync(sliceDir, { recursive: true });
+  writeFileSync(join(sliceDir, "S01-PLAN.md"), "# S01 Plan\n\n## Verification\n- Run checks.\n");
+  openDatabase(join(repo, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test Milestone", status: "active", depends_on: [] });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Test Slice",
+    status: "planned",
+    risk: "low",
+    depends: [],
+    demo: "",
+    sequence: 1,
+  });
+  insertGateRow({
+    milestoneId: "M001",
+    sliceId: "S01",
+    gateId: "Q3",
+    scope: "slice",
+  });
+
+  const prompt = await buildGateEvaluatePrompt(
+    "M001",
+    "Test Milestone",
+    "S01",
+    "Test Slice",
+    repo,
+    "claude-opus-4-6",
+  );
+
+  assert.ok(
+    prompt.includes("Context Mode (verification lane):"),
+    "embedded gate-evaluate prompt should use nested Context Mode guidance",
+  );
+  assert.ok(
+    prompt.includes("## Context Mode"),
+    "gate-evaluate parent prompt should include standalone Context Mode guidance",
+  );
+  assert.ok(prompt.includes('model: "claude-opus-4-6"'), "gate subagent prompt should preserve model instruction");
 });

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
+  composeContextModeInstructions,
   composeInlinedContext,
   composeUnitContext,
   manifestBudgetChars,
@@ -99,6 +100,43 @@ test("#4782 composer: manifestBudgetChars returns declared budget", () => {
   const small = manifestBudgetChars("reassess-roadmap");
   assert.ok(small !== null && small > 0);
   assert.strictEqual(manifestBudgetChars("never-dispatched"), null);
+});
+
+test("Context Mode composer: disabled, unknown, and none modes return empty string", () => {
+  assert.strictEqual(
+    composeContextModeInstructions("execute-task", { enabled: false, renderMode: "standalone" }),
+    "",
+  );
+  assert.strictEqual(
+    composeContextModeInstructions("never-dispatched", { enabled: true, renderMode: "standalone" }),
+    "",
+  );
+  assert.strictEqual(
+    composeContextModeInstructions("workflow-preferences", { enabled: true, renderMode: "standalone" }),
+    "",
+  );
+});
+
+test("Context Mode composer: standalone output starts with heading and includes required tools", () => {
+  const out = composeContextModeInstructions("execute-task", { enabled: true, renderMode: "standalone" });
+  assert.ok(out.startsWith("## Context Mode"));
+  assert.match(out, /execution lane/i);
+  assert.match(out, /`gsd_exec`/);
+  assert.match(out, /noisy scans, builds, and tests/);
+  assert.match(out, /`gsd_exec_search`/);
+  assert.match(out, /before repeating prior runs/);
+  assert.match(out, /`gsd_resume`/);
+  assert.match(out, /after compaction or resume/);
+});
+
+test("Context Mode composer: nested output is compact single sentence", () => {
+  const out = composeContextModeInstructions("gate-evaluate", { enabled: true, renderMode: "nested" });
+  assert.ok(!out.startsWith("## Context Mode"));
+  assert.match(out, /^Context Mode \(verification lane\): /);
+  assert.strictEqual(out.split(/\n/).length, 1);
+  assert.match(out, /`gsd_exec`/);
+  assert.match(out, /`gsd_exec_search`/);
+  assert.match(out, /`gsd_resume`/);
 });
 
 // ─── Integration: migrated buildReassessRoadmapPrompt ─────────────────────

--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -12,6 +12,7 @@ import {
   UNIT_MANIFESTS,
   resolveManifest,
   type ArtifactKey,
+  type ContextModePolicy,
   type SkillsPolicy,
   type UnitContextManifest,
 } from "../unit-context-manifest.ts";
@@ -102,6 +103,37 @@ test("#4782 phase 1: every manifest has a positive maxSystemPromptChars", () => 
       typeof manifest.maxSystemPromptChars === "number" && manifest.maxSystemPromptChars > 0,
       `manifest "${unitType}" has invalid maxSystemPromptChars: ${manifest.maxSystemPromptChars}`,
     );
+  }
+});
+
+test("Context Mode: every manifest declares the expected contextMode lane", () => {
+  const expected: Record<string, ContextModePolicy> = {
+    "workflow-preferences": "none",
+    "research-decision": "none",
+    "discuss-project": "interview",
+    "discuss-requirements": "interview",
+    "discuss-milestone": "interview",
+    "research-project": "research",
+    "research-milestone": "research",
+    "research-slice": "research",
+    "plan-milestone": "planning",
+    "plan-slice": "planning",
+    "refine-slice": "planning",
+    "replan-slice": "planning",
+    "reassess-roadmap": "planning",
+    "execute-task": "execution",
+    "reactive-execute": "execution",
+    "run-uat": "verification",
+    "gate-evaluate": "verification",
+    "validate-milestone": "verification",
+    "complete-slice": "verification",
+    "complete-milestone": "verification",
+    "rewrite-docs": "docs",
+  };
+
+  assert.deepEqual(Object.keys(expected).sort(), [...KNOWN_UNIT_TYPES].sort());
+  for (const unitType of KNOWN_UNIT_TYPES) {
+    assert.strictEqual(UNIT_MANIFESTS[unitType].contextMode, expected[unitType]);
   }
 });
 

--- a/src/resources/extensions/gsd/tests/worktree-path-injection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-path-injection.test.ts
@@ -229,6 +229,9 @@ test("worktree-aware prompt builders include the explicit working directory", as
     ),
   ]);
 
+  assert.ok(prompts[0].includes("## Context Mode"), "discuss-milestone should include standalone Context Mode guidance");
+  assert.ok(prompts[0].includes("interview lane"), "discuss-milestone should render the interview lane");
+
   for (const prompt of prompts) {
     assert.match(prompt, /working directory/i);
     assert.ok(prompt.includes(base), "prompt should include the provided working directory");

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -42,6 +42,7 @@ import {
   type BaseResolverContext,
   type ComputedArtifactId,
   type ComputedArtifactRegistry,
+  type ContextModePolicy,
   type UnitContextManifest,
 } from "./unit-context-manifest.js";
 
@@ -90,6 +91,54 @@ export async function composeInlinedContext(
 export function manifestBudgetChars(unitType: string): number | null {
   const manifest = resolveManifest(unitType);
   return manifest ? manifest.maxSystemPromptChars : null;
+}
+
+// ─── Context Mode lane guidance ──────────────────────────────────────────
+
+export type ContextModeRenderMode = "standalone" | "nested";
+
+export interface ComposeContextModeInstructionOptions {
+  readonly enabled: boolean;
+  readonly renderMode: ContextModeRenderMode;
+}
+
+const CONTEXT_MODE_LANE_LABELS: Record<Exclude<ContextModePolicy, "none">, string> = {
+  interview: "interview",
+  research: "research",
+  planning: "planning",
+  execution: "execution",
+  verification: "verification",
+  orchestration: "orchestration",
+  docs: "documentation",
+};
+
+const CONTEXT_MODE_GUIDANCE =
+  "Use `gsd_exec` for noisy scans, builds, and tests so full output stays out of prompt context; call `gsd_exec_search` before repeating prior runs; call `gsd_resume` after compaction or resume to recover stored execution context.";
+
+/**
+ * Render the Context Mode instruction lane for a unit type. Unknown unit
+ * types, disabled config, and explicit `contextMode: "none"` all omit the
+ * block so callers can prefix this safely without extra branching.
+ */
+export function composeContextModeInstructions(
+  unitType: string,
+  opts: ComposeContextModeInstructionOptions,
+): string {
+  if (!opts.enabled) return "";
+  const manifest = resolveManifest(unitType);
+  if (!manifest || manifest.contextMode === "none") return "";
+
+  const lane = CONTEXT_MODE_LANE_LABELS[manifest.contextMode];
+  if (opts.renderMode === "nested") {
+    return `Context Mode (${lane} lane): ${CONTEXT_MODE_GUIDANCE}`;
+  }
+
+  return [
+    "## Context Mode",
+    "",
+    `Lane: **${lane} lane**.`,
+    CONTEXT_MODE_GUIDANCE,
+  ].join("\n");
 }
 
 // ─── v2 surface (#4924) ───────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -90,6 +90,17 @@ export type MemoryPolicy = "none" | "critical-only" | "prompt-relevant";
 /** Preferences block policy. */
 export type PreferencesPolicy = "none" | "active-only" | "full";
 
+/** Context Mode lane guidance policy for each auto-mode unit. */
+export type ContextModePolicy =
+  | "none"
+  | "interview"
+  | "research"
+  | "planning"
+  | "execution"
+  | "verification"
+  | "orchestration"
+  | "docs";
+
 /**
  * Tool-access policy per unit type (#4934).
  *
@@ -220,6 +231,8 @@ export interface UnitContextManifest {
   readonly codebaseMap: boolean;
   /** Preferences block policy. */
   readonly preferences: PreferencesPolicy;
+  /** Context Mode guidance lane. */
+  readonly contextMode: ContextModePolicy;
   /**
    * Tool-access policy (#4934). Runtime enforcement covers path-scoped write
    * blocking, subagent denial, and bash allowlisting for active auto-mode
@@ -343,6 +356,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "research",
     tools: TOOLS_PLANNING,
     artifacts: {
       // Phase 3 migration (#4782): matches today's actual
@@ -359,6 +373,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "planning",
     tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["project", "requirements", "decisions", "milestone-research", "templates"],
@@ -373,6 +388,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "interview",
     tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["project", "requirements", "decisions", "milestone-context", "templates"],
@@ -387,6 +403,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: false,
     preferences: "active-only",
+    contextMode: "verification",
     // planning-dispatch: validation is a verification-fan-out unit. It reads
     // the milestone surface and dispatches reviewer/security/tester subagents
     // to report findings without touching user source. Mirrors
@@ -405,6 +422,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: false,
     preferences: "active-only",
+    contextMode: "verification",
     // planning-dispatch: completion is a high-leverage place to fan out to
     // reviewer / security / tester subagents. They read the diff and report
     // findings; they do not write user source. Write isolation to .gsd/ is
@@ -428,6 +446,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "research",
     tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["roadmap", "milestone-research", "dependency-summaries", "templates"],
@@ -442,6 +461,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "planning",
     // planning-dispatch: allows subagent dispatch so the planner can fan out
     // to scout for codebase recon and to planner/decompose-style specialists
     // for sub-decomposition. Write-isolation to .gsd/ is preserved.
@@ -459,6 +479,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "planning",
     // See plan-slice — same rationale: dispatch to scout/planner-style
     // specialists during refinement is materially better than re-doing recon
     // inline.
@@ -476,6 +497,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "planning",
     tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["slice-plan", "slice-research", "dependency-summaries", "prior-task-summaries", "templates"],
@@ -490,6 +512,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: false,
     preferences: "active-only",
+    contextMode: "verification",
     // See complete-milestone — same rationale: dispatch to reviewer / security /
     // tester subagents to fan out review work without bloating this unit's
     // context.
@@ -511,6 +534,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "critical-only",
     codebaseMap: false,
     preferences: "none",
+    contextMode: "planning",
     tools: TOOLS_PLANNING,
     artifacts: {
       // Phase 2 pilot (#4782): manifest now matches today's actual
@@ -530,6 +554,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "execution",
     tools: TOOLS_ALL,
     artifacts: {
       inline: ["task-plan", "slice-plan", "prior-task-summaries", "templates"],
@@ -544,6 +569,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "execution",
     tools: TOOLS_ALL,
     artifacts: {
       inline: ["slice-plan", "prior-task-summaries", "templates"],
@@ -560,6 +586,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "critical-only",
     codebaseMap: false,
     preferences: "active-only",
+    contextMode: "verification",
     tools: TOOLS_PLANNING,
     artifacts: {
       // Phase 3 migration (#4782): manifest matches today's actual
@@ -578,6 +605,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "critical-only",
     codebaseMap: false,
     preferences: "active-only",
+    contextMode: "verification",
     tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["slice-plan", "prior-task-summaries"],
@@ -592,6 +620,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "docs",
     tools: TOOLS_DOCS,
     artifacts: {
       inline: ["project", "requirements", "decisions", "templates"],
@@ -611,6 +640,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "none",
     codebaseMap: false,
     preferences: "none",
+    contextMode: "none",
     tools: TOOLS_PLANNING,
     artifacts: {
       inline: [],
@@ -628,6 +658,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "interview",
     tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["templates"],
@@ -644,6 +675,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "interview",
     tools: TOOLS_PLANNING,
     artifacts: {
       inline: ["project", "templates"],
@@ -660,6 +692,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "none",
     codebaseMap: false,
     preferences: "none",
+    contextMode: "none",
     tools: TOOLS_PLANNING,
     artifacts: {
       inline: [],
@@ -678,6 +711,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     memory: "prompt-relevant",
     codebaseMap: true,
     preferences: "active-only",
+    contextMode: "research",
     tools: { mode: "planning-dispatch", allowedSubagents: ["scout"] },
     artifacts: {
       inline: ["project", "requirements", "templates"],


### PR DESCRIPTION
## TL;DR

**What:** Fully wires Context Mode across auto-mode prompts, compaction snapshots, and workflow MCP.
**Why:** Context Mode was implemented in pieces but not consistently applied across an auto run or external MCP clients.
**How:** Adds manifest-driven Context Mode lanes, central composer guidance, prompt injection, MCP tool registration, snapshot-before-cancel behavior, tests, and docs.

## What

- Added `contextMode` lanes to the auto unit manifest and centralized rendering via `composeContextModeInstructions`.
- Injected standalone and nested Context Mode guidance into auto prompt builders, including generated subprompts.
- Registered `gsd_exec`, `gsd_exec_search`, and `gsd_resume` for workflow MCP clients.
- Ensured Context Mode snapshots are written before active auto-mode cancels compaction.
- Updated docs and comments to consistently describe default-on Context Mode and opt-out settings.
- Added behavior coverage for manifest lanes, composer rendering, prompt injection, MCP tools, and compaction snapshots.

## Why

Context Mode was advertised as default-on, but key runtime and dispatch paths were only partially connected. Agents were left relying on generic tool descriptions instead of unit-specific guidance, resume snapshots could be skipped during active auto-mode compaction cancellation, and external workflow MCP clients did not expose the Context Mode tools that compatibility checks advertised.

Closes #5255

## How

Context Mode remains guided rather than hard-enforced. The existing tool policy and write gate continue to enforce safety, while `UnitContextManifest` declares each unit's Context Mode lane. The composer renders concise guidance from that lane, prompt builders prepend it to relevant unit prompts, and MCP registration delegates to the existing shared exec/search/resume executors while adapting results to the workflow MCP response shape.

No breaking changes expected. `context_mode.enabled: false` remains the explicit opt-out.

## Verification

- [x] Targeted Context Mode suite via `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test ...` (`113/113` passing)
- [x] `npm run typecheck:extensions`
- [x] `npm run build:mcp-server`
- [ ] `npm run verify:pr` (build and typecheck passed; unit phase failed on unrelated existing `/var` vs `/private/var` temp-path expectations: `8601 passed, 5 failed, 9 skipped`)

## Change type checklist

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context Mode for managing conversation context in auto-mode (enabled by default)
  * New execution tools: run exec, search exec history, and resume from snapshots
  * Persistent execution evidence saved to the project’s .gsd exec store

* **Configuration**
  * Opt-out and tuning knobs for Context Mode and exec behavior

* **Documentation**
  * Updated user guides and README

* **Tests**
  * Expanded tests covering Context Mode and tool behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->