### PR TITLE
fix(gsd): bind task commits to milestone completion guard

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -308,7 +308,7 @@ function scanGsdTaggedCommits(
       if (!commitMessageHasGsdTrailer(message)) continue;
 
       const commitFiles = getChangedFilesForCommit(basePath, hash);
-      if (!commitMatchesMilestone(message, milestoneId, commitFiles)) continue;
+      if (!commitMatchesMilestone(basePath, message, milestoneId, commitFiles)) continue;
 
       matched = true;
       for (const file of commitFiles) {
@@ -336,20 +336,34 @@ function commitMessageHasGsdTrailer(message: string): boolean {
   return /^GSD-(?:Task|Unit):\s*\S+/m.test(message);
 }
 
-function commitMatchesMilestone(message: string, milestoneId: string, files: readonly string[]): boolean {
+function commitMatchesMilestone(basePath: string, message: string, milestoneId: string, files: readonly string[]): boolean {
   if (commitTrailerStartsWithMilestone(message, milestoneId)) return true;
 
   // Meaningful execute-task commits currently store task scope as Sxx/Tyy
   // rather than Mxx/Sxx/Tyy. Bind those commits back to the milestone when
   // either the commit touched this milestone's artifacts, or — for projects
   // where .gsd/ is gitignored/external (#5033) — the message explicitly
-  // names the milestone.
+  // names the milestone or local GSD state proves the task belongs here.
   if (/^GSD-Task:\s*S[^/\s]+\/T\S+/m.test(message)) {
     if (files.some((file) => isMilestoneArtifactPath(file, milestoneId))) return true;
     if (commitMessageMentionsMilestone(message, milestoneId)) return true;
+    if (commitTaskTrailerBelongsToMilestone(basePath, message, milestoneId)) return true;
   }
 
   return false;
+}
+
+function commitTaskTrailerBelongsToMilestone(basePath: string, message: string, milestoneId: string): boolean {
+  const match = message.match(/^GSD-Task:\s*(S[^/\s]+)\/(T[^\s]+)/m);
+  if (!match) return false;
+  const [, sliceId, taskId] = match;
+
+  if (getTask(milestoneId, sliceId, taskId)) return true;
+
+  const tasksDir = resolveTasksDir(basePath, milestoneId, sliceId);
+  if (!tasksDir) return false;
+  return existsSync(join(tasksDir, `${taskId}-PLAN.md`))
+    || existsSync(join(tasksDir, `${taskId}-SUMMARY.md`));
 }
 
 function commitMessageMentionsMilestone(message: string, milestoneId: string): boolean {

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -7,7 +7,7 @@ import { randomUUID } from "node:crypto";
 
 import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArtifactPath, diagnoseExpectedArtifact, buildLoopRemediationSteps, writeBlockerPlaceholder } from "../auto-recovery.ts";
 import { resolveMilestoneFile } from "../paths.ts";
-import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow } from "../gsd-db.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask } from "../gsd-db.ts";
 import { clearParseCache } from "../files.ts";
 import { parseRoadmap } from "../parsers-legacy.ts";
 import { invalidateAllCaches } from "../cache.ts";
@@ -758,6 +758,73 @@ test("hasImplementationArtifacts finds implementation commits when .gsd/ is giti
       result,
       "present",
       "milestone-tagged commit binding must work when .gsd/ is gitignored",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("hasImplementationArtifacts binds GSD-Task trailer to milestone via DB state when .gsd/ is gitignored", () => {
+  const base = makeGitBase();
+  try {
+    writeFileSync(join(base, ".git", "info", "exclude"), ".gsd/\n");
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      title: "Slice One",
+      status: "complete",
+      risk: "low",
+      depends: [],
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Task One",
+      status: "complete",
+    });
+
+    mkdirSync(join(base, "src"), { recursive: true });
+    writeFileSync(join(base, "src", "feature.ts"), "export function feature() {}\n");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync(
+      "git",
+      ["commit", "-m", "feat: add feature\n\nGSD-Task: S01/T01"],
+      { cwd: base, stdio: "ignore" },
+    );
+
+    const result = hasImplementationArtifacts(base, "M001");
+    assert.equal(
+      result,
+      "present",
+      "DB task ownership should bind S01/T01 implementation commits to M001 without explicit M001 text",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("hasImplementationArtifacts does not bind GSD-Task trailer without milestone ownership evidence", () => {
+  const base = makeGitBase();
+  try {
+    writeFileSync(join(base, ".git", "info", "exclude"), ".gsd/\n");
+    mkdirSync(join(base, "src"), { recursive: true });
+    writeFileSync(join(base, "src", "feature.ts"), "export function feature() {}\n");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync(
+      "git",
+      ["commit", "-m", "feat: add feature\n\nGSD-Task: S01/T01"],
+      { cwd: base, stdio: "ignore" },
+    );
+
+    const result = hasImplementationArtifacts(base, "M001");
+    assert.equal(
+      result,
+      "absent",
+      "S01/T01 shape alone must not bind an implementation commit to M001",
     );
   } finally {
     cleanup(base);


### PR DESCRIPTION
## TL;DR

**What:** Bind `GSD-Task: Sxx/Tyy` implementation commits back to their milestone using GSD state during completion-guard evidence checks.
**Why:** Auto-mode can falsely stop before `complete-milestone` when `.gsd/` is untracked and implementation commits do not mention the milestone ID.
**How:** The implementation-artifact detector now accepts DB/on-disk task ownership as milestone evidence while still requiring non-`.gsd/` changed files.

## What

This updates the completion guard evidence path in `auto-recovery.ts` so `GSD-Task: Sxx/Tyy` commits can be associated with `M001` when the GSD DB or task artifacts prove that `Sxx/Tyy` belongs to the milestone. It also adds regression coverage for the `.gsd/`-gitignored integration-branch topology and a negative case where trailer shape alone is not enough.

## Why

The existing guard correctly blocks milestones that only produced planning files, but it could not prove implementation evidence when `.gsd/` was excluded from git and task commits only carried slice/task trailers. That caused a false `no implementation files found outside .gsd/` stop even after validation passed.

Closes #5257

## How

The fix extends the milestone commit matcher with a local state ownership check. Matched commits still flow through the existing implementation-file classifier, so `.gsd/`-only histories remain blocked.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-recovery.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/skipped-validation-completion.test.ts src/resources/extensions/gsd/tests/remediation-completion-guard.test.ts`
- [x] `npm run typecheck:extensions`

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced commit-to-milestone matching logic to include fallback verification via database and filesystem artifacts, improving detection of task ownership even when directories are gitignored.

* **Tests**
  * Added test coverage verifying correct commit recognition for milestones, with and without task ownership metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->