### PR TITLE
feat(gsd): make UOK contracts DB-authoritative

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1472,7 +1472,7 @@ export async function runUnitPhase(
   s.lastUnitAgentEndMessages = null;
   setCurrentPhase(unitType, {
     basePath: s.basePath,
-    traceId: `phase:${ic.flowId}`,
+    traceId: ic.flowId,
     turnId: `iter-${ic.iteration}`,
     causedBy: "unit-start",
   });

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1470,7 +1470,12 @@ export async function runUnitPhase(
   s.lastGitActionFailure = null;
   s.lastGitActionStatus = null;
   s.lastUnitAgentEndMessages = null;
-  setCurrentPhase(unitType);
+  setCurrentPhase(unitType, {
+    basePath: s.basePath,
+    traceId: `phase:${ic.flowId}`,
+    turnId: `iter-${ic.iteration}`,
+    causedBy: "unit-start",
+  });
   s.lastToolInvocationError = null; // #2883: clear stale error from previous unit
   const unitStartSeq = ic.nextSeq();
   deps.emitJournalEvent({ ts: new Date().toISOString(), flowId: ic.flowId, seq: unitStartSeq, eventType: "unit-start", data: { unitType, unitId } });

--- a/src/resources/extensions/gsd/tests/uok-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-contracts.test.ts
@@ -1,5 +1,10 @@
+// GSD2 UOK Contract Versioning and DB Authority Tests
+
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import type {
   AuditEventEnvelope,
@@ -11,8 +16,17 @@ import type {
   WriteRecord,
   WriterToken,
 } from "../uok/contracts.ts";
-import { buildAuditEnvelope } from "../uok/audit.ts";
+import {
+  CURRENT_UOK_CONTRACT_VERSION,
+  normalizeAuditEvent,
+  validateAuditEvent,
+  validateDispatchEnvelope,
+  validateTurnResult,
+} from "../uok/contracts.ts";
+import { buildAuditEnvelope, emitUokAuditEvent } from "../uok/audit.ts";
 import { buildDispatchEnvelope, explainDispatch } from "../uok/dispatch-envelope.ts";
+import { buildTurnTimeline } from "../uok/timeline.ts";
+import { _getAdapter, closeDatabase, openDatabase } from "../gsd-db.ts";
 
 test("uok contracts serialize/deserialize turn envelopes", () => {
   const contract: TurnContract = {
@@ -37,6 +51,7 @@ test("uok contracts serialize/deserialize turn envelopes", () => {
   };
 
   const result: TurnResult = {
+    version: CURRENT_UOK_CONTRACT_VERSION,
     traceId: contract.traceId,
     turnId: contract.turnId,
     iteration: contract.iteration,
@@ -56,8 +71,10 @@ test("uok contracts serialize/deserialize turn envelopes", () => {
 
   const roundTrip = JSON.parse(JSON.stringify(result)) as TurnResult;
   assert.equal(roundTrip.turnId, "turn-1");
+  assert.equal(roundTrip.version, CURRENT_UOK_CONTRACT_VERSION);
   assert.equal(roundTrip.gateResults?.[0]?.gateId, "Q3");
   assert.equal(roundTrip.phaseResults.length, 3);
+  assert.equal(validateTurnResult(roundTrip).ok, true);
 });
 
 test("uok contracts include required DAG node kinds", () => {
@@ -84,9 +101,11 @@ test("uok audit envelope includes trace/turn/causality fields", () => {
   });
 
   assert.equal(event.traceId, "trace-xyz");
+  assert.equal(event.version, CURRENT_UOK_CONTRACT_VERSION);
   assert.equal(event.turnId, "turn-xyz");
   assert.equal(event.causedBy, "turn-start");
   assert.equal(event.payload.status, "completed");
+  assert.equal(validateAuditEvent(event).ok, true);
 });
 
 test("uok dispatch envelope carries scheduler reason and constraints", () => {
@@ -107,9 +126,98 @@ test("uok dispatch envelope carries scheduler reason and constraints", () => {
   });
 
   assert.equal(envelope.nodeKind, "unit");
+  assert.equal(envelope.version, CURRENT_UOK_CONTRACT_VERSION);
   assert.equal(envelope.reason.reasonCode, "dependency");
   assert.deepEqual(envelope.constraints?.dependsOn, ["plan-gate"]);
   assert.ok(explainDispatch(envelope).includes("execute-task M001/S01/T01"));
+  assert.equal(validateDispatchEnvelope(envelope).ok, true);
+});
+
+test("uok contracts normalize legacy records without losing payload fields", () => {
+  const legacy = {
+    eventId: "event-legacy",
+    traceId: "trace-legacy",
+    category: "orchestration",
+    type: "turn-result",
+    ts: new Date().toISOString(),
+    payload: { status: "completed", extra: "preserved" },
+  } as AuditEventEnvelope;
+
+  const normalized = normalizeAuditEvent(legacy);
+  assert.equal(normalized.version, "0");
+  assert.equal(normalized.payload.extra, "preserved");
+  assert.equal(validateAuditEvent(legacy).ok, true);
+});
+
+test("uok audit emission writes DB as authoritative before jsonl projection", (t) => {
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-uok-db-audit-"));
+  mkdirSync(join(basePath, ".gsd"), { recursive: true });
+  t.after(() => {
+    closeDatabase();
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  assert.equal(openDatabase(join(basePath, ".gsd", "gsd.db")), true);
+  emitUokAuditEvent(
+    basePath,
+    buildAuditEnvelope({
+      traceId: "trace-db",
+      turnId: "turn-db",
+      category: "orchestration",
+      type: "turn-start",
+      payload: { unitType: "execute-task" },
+    }),
+  );
+
+  const row = _getAdapter()!.prepare(
+    "SELECT payload_json FROM audit_events WHERE trace_id = 'trace-db' AND turn_id = 'turn-db'",
+  ).get() as { payload_json: string } | undefined;
+  assert.ok(row, "DB audit row should be written");
+  assert.equal(JSON.parse(row.payload_json).contractVersion, CURRENT_UOK_CONTRACT_VERSION);
+
+  const projection = readFileSync(join(basePath, ".gsd", "audit", "events.jsonl"), "utf-8");
+  assert.ok(projection.includes("trace-db"), "jsonl projection should still be written");
+});
+
+test("uok timeline prefers DB records over jsonl projection when DB is available", (t) => {
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-uok-timeline-"));
+  const auditDir = join(basePath, ".gsd", "audit");
+  mkdirSync(auditDir, { recursive: true });
+  writeFileSync(
+    join(auditDir, "events.jsonl"),
+    `${JSON.stringify({
+      version: CURRENT_UOK_CONTRACT_VERSION,
+      eventId: "jsonl-only",
+      traceId: "trace-timeline",
+      turnId: "turn-timeline",
+      category: "orchestration",
+      type: "jsonl-projection",
+      ts: "2026-01-01T00:00:00.000Z",
+      payload: {},
+    })}\n`,
+  );
+  t.after(() => {
+    closeDatabase();
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  assert.equal(openDatabase(join(basePath, ".gsd", "gsd.db")), true);
+  emitUokAuditEvent(
+    basePath,
+    buildAuditEnvelope({
+      traceId: "trace-timeline",
+      turnId: "turn-timeline",
+      category: "orchestration",
+      type: "db-authoritative",
+      payload: {},
+    }),
+  );
+
+  const timeline = buildTurnTimeline(basePath, { traceId: "trace-timeline", turnId: "turn-timeline" });
+  assert.equal(timeline.authoritative, "db");
+  assert.equal(timeline.degraded, false);
+  assert.ok(timeline.entries.some((entry) => entry.type === "db-authoritative"));
+  assert.equal(timeline.entries.some((entry) => entry.type === "jsonl-projection"), false);
 });
 
 test("uok writer records serialize sequence metadata", () => {

--- a/src/resources/extensions/gsd/tests/uok-loop-adapter-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-loop-adapter-writer.test.ts
@@ -112,3 +112,52 @@ test("uok turn observer releases writer token when validation throws", (t) => {
   // Cleanup must run in finally — token released, no leaked state.
   assert.equal(hasActiveWriterToken(basePath, "turn-throw"), false);
 });
+
+test("uok turn observer falls back to cached phaseResults when result.phaseResults is missing", (t) => {
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-uok-loop-writer-missing-"));
+  resetWriterTokensForTests();
+  t.after(() => {
+    resetWriterTokensForTests();
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  const observer = createTurnObserver({
+    basePath,
+    gitAction: "status-only",
+    gitPush: false,
+    enableAudit: false,
+    enableGitops: false,
+  });
+
+  observer.onTurnStart({
+    basePath,
+    traceId: "trace-missing",
+    turnId: "turn-missing",
+    iteration: 1,
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    startedAt: new Date().toISOString(),
+  });
+
+  // Without the Array.isArray guard, accessing result.phaseResults.length on a
+  // payload where phaseResults is undefined would throw TypeError before
+  // validateTurnResult could surface a structured error. The guard must defer
+  // to the cached phaseResults fallback so the turn completes cleanly.
+  assert.doesNotThrow(() => {
+    observer.onTurnResult({
+      traceId: "trace-missing",
+      turnId: "turn-missing",
+      iteration: 1,
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      status: "completed",
+      failureClass: "none",
+      // @ts-expect-error intentionally missing for test
+      phaseResults: undefined,
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+    });
+  });
+
+  assert.equal(hasActiveWriterToken(basePath, "turn-missing"), false);
+});

--- a/src/resources/extensions/gsd/tests/uok-loop-adapter-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-loop-adapter-writer.test.ts
@@ -63,3 +63,52 @@ test("uok turn observer adds writer sequence metadata to audit events", (t) => {
   assert.equal(payloads[1]?.writeSequence, 2);
   assert.equal(typeof payloads[0]?.writerTokenId, "string");
 });
+
+test("uok turn observer releases writer token when validation throws", (t) => {
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-uok-loop-writer-throw-"));
+  resetWriterTokensForTests();
+  t.after(() => {
+    resetWriterTokensForTests();
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  const observer = createTurnObserver({
+    basePath,
+    gitAction: "status-only",
+    gitPush: false,
+    enableAudit: false,
+    enableGitops: false,
+  });
+
+  observer.onTurnStart({
+    basePath,
+    traceId: "trace-throw",
+    turnId: "turn-throw",
+    iteration: 1,
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    startedAt: new Date().toISOString(),
+  });
+  assert.equal(hasActiveWriterToken(basePath, "turn-throw"), true);
+
+  // Invalid payload (missing required fields like status/finishedAt) should
+  // trigger validateTurnResult to fail and throw.
+  assert.throws(() => {
+    observer.onTurnResult({
+      traceId: "trace-throw",
+      turnId: "turn-throw",
+      // @ts-expect-error intentionally invalid for test
+      iteration: "not-a-number",
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      status: "completed",
+      failureClass: "none",
+      phaseResults: [],
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+    });
+  }, /Invalid UOK turn result/);
+
+  // Cleanup must run in finally — token released, no leaked state.
+  assert.equal(hasActiveWriterToken(basePath, "turn-throw"), false);
+});

--- a/src/resources/extensions/gsd/uok/audit.ts
+++ b/src/resources/extensions/gsd/uok/audit.ts
@@ -1,3 +1,5 @@
+// GSD2 UOK Audit Events and DB-First Projection Writes
+
 import { appendFileSync, closeSync, existsSync, mkdirSync, openSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
@@ -6,7 +8,7 @@ import { isStaleWrite } from "../auto/turn-epoch.js";
 import { withFileLockSync } from "../file-lock.js";
 import { gsdRoot } from "../paths.js";
 import { isDbAvailable, insertAuditEvent } from "../gsd-db.js";
-import type { AuditEventEnvelope } from "./contracts.js";
+import { CURRENT_UOK_CONTRACT_VERSION, validateAuditEvent, type AuditEventEnvelope } from "./contracts.js";
 
 function auditLogPath(basePath: string): string {
   return join(gsdRoot(basePath), "audit", "events.jsonl");
@@ -25,6 +27,7 @@ export function buildAuditEnvelope(args: {
   payload?: Record<string, unknown>;
 }): AuditEventEnvelope {
   return {
+    version: CURRENT_UOK_CONTRACT_VERSION,
     eventId: randomUUID(),
     traceId: args.traceId,
     turnId: args.turnId,
@@ -39,6 +42,26 @@ export function buildAuditEnvelope(args: {
 export function emitUokAuditEvent(basePath: string, event: AuditEventEnvelope): void {
   // Drop writes from a turn superseded by timeout recovery / cancellation.
   if (isStaleWrite("uok-audit")) return;
+  const validation = validateAuditEvent(event);
+  if (!validation.ok) {
+    throw new Error(`Invalid UOK audit event: ${validation.issues.map((issue) => `${issue.path}: ${issue.message}`).join("; ")}`);
+  }
+  const canonical = validation.value;
+
+  if (isDbAvailable()) {
+    try {
+      insertAuditEvent({
+        ...canonical,
+        payload: {
+          ...canonical.payload,
+          contractVersion: canonical.version ?? CURRENT_UOK_CONTRACT_VERSION,
+        },
+      });
+    } catch (err) {
+      throw new Error(`DB authoritative audit write failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   try {
     ensureAuditDir(basePath);
     const path = auditLogPath(basePath);
@@ -52,18 +75,11 @@ export function emitUokAuditEvent(basePath: string, event: AuditEventEnvelope): 
     withFileLockSync(
       path,
       () => {
-        appendFileSync(path, `${JSON.stringify(event)}\n`, "utf-8");
+        appendFileSync(path, `${JSON.stringify(canonical)}\n`, "utf-8");
       },
       { onLocked: "skip" },
     );
   } catch {
     // Best-effort: audit writes must never break orchestration.
-  }
-
-  if (!isDbAvailable()) return;
-  try {
-    insertAuditEvent(event);
-  } catch {
-    // Projection failures are non-fatal while legacy readers are still active.
   }
 }

--- a/src/resources/extensions/gsd/uok/contracts.ts
+++ b/src/resources/extensions/gsd/uok/contracts.ts
@@ -1,3 +1,9 @@
+// GSD2 UOK Contract Types and Versioning
+
+export const CURRENT_UOK_CONTRACT_VERSION = "1" as const;
+
+export type UokContractVersion = "0" | typeof CURRENT_UOK_CONTRACT_VERSION;
+
 export type FailureClass =
   | "none"
   | "policy"
@@ -77,6 +83,7 @@ export interface TurnCloseoutRecord {
 }
 
 export interface TurnResult {
+  version?: UokContractVersion;
   traceId: string;
   turnId: string;
   iteration: number;
@@ -109,6 +116,7 @@ export interface DispatchExplanation {
 }
 
 export interface UokDispatchEnvelope {
+  version?: UokContractVersion;
   action: "dispatch" | "stop" | "skip";
   nodeKind?: UokNodeKind;
   unitType?: string;
@@ -130,6 +138,7 @@ export interface UokDispatchEnvelope {
 }
 
 export interface AuditEventEnvelope {
+  version?: UokContractVersion;
   eventId: string;
   traceId: string;
   turnId?: string;
@@ -198,4 +207,100 @@ export interface UokTurnObserver {
     data?: Record<string, unknown>,
   ): void;
   onTurnResult(result: TurnResult): void;
+}
+
+export interface ContractValidationIssue {
+  path: string;
+  message: string;
+}
+
+export interface ContractValidationResult<T> {
+  ok: boolean;
+  value: T;
+  issues: ContractValidationIssue[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeVersion(value: unknown): UokContractVersion {
+  return value === CURRENT_UOK_CONTRACT_VERSION ? CURRENT_UOK_CONTRACT_VERSION : "0";
+}
+
+function requireString(
+  value: Record<string, unknown>,
+  key: string,
+  issues: ContractValidationIssue[],
+): void {
+  if (typeof value[key] !== "string" || value[key] === "") {
+    issues.push({ path: key, message: `${key} must be a non-empty string` });
+  }
+}
+
+function requireRecord(
+  value: Record<string, unknown>,
+  key: string,
+  issues: ContractValidationIssue[],
+): void {
+  if (!isRecord(value[key])) {
+    issues.push({ path: key, message: `${key} must be an object` });
+  }
+}
+
+export function normalizeTurnResult(value: TurnResult): TurnResult {
+  return { ...value, version: normalizeVersion(value.version) };
+}
+
+export function normalizeDispatchEnvelope(value: UokDispatchEnvelope): UokDispatchEnvelope {
+  return { ...value, version: normalizeVersion(value.version) };
+}
+
+export function normalizeAuditEvent(value: AuditEventEnvelope): AuditEventEnvelope {
+  return { ...value, version: normalizeVersion(value.version) };
+}
+
+export function validateTurnResult(value: TurnResult): ContractValidationResult<TurnResult> {
+  const normalized = normalizeTurnResult(value);
+  const record = normalized as unknown as Record<string, unknown>;
+  const issues: ContractValidationIssue[] = [];
+  requireString(record, "traceId", issues);
+  requireString(record, "turnId", issues);
+  if (!Number.isInteger(record.iteration)) {
+    issues.push({ path: "iteration", message: "iteration must be an integer" });
+  }
+  requireString(record, "status", issues);
+  requireString(record, "failureClass", issues);
+  if (!Array.isArray(record.phaseResults)) {
+    issues.push({ path: "phaseResults", message: "phaseResults must be an array" });
+  }
+  requireString(record, "startedAt", issues);
+  requireString(record, "finishedAt", issues);
+  return { ok: issues.length === 0, value: normalized, issues };
+}
+
+export function validateDispatchEnvelope(value: UokDispatchEnvelope): ContractValidationResult<UokDispatchEnvelope> {
+  const normalized = normalizeDispatchEnvelope(value);
+  const record = normalized as unknown as Record<string, unknown>;
+  const issues: ContractValidationIssue[] = [];
+  requireString(record, "action", issues);
+  requireRecord(record, "reason", issues);
+  if (isRecord(record.reason)) {
+    requireString(record.reason, "reasonCode", issues);
+    requireString(record.reason, "summary", issues);
+  }
+  return { ok: issues.length === 0, value: normalized, issues };
+}
+
+export function validateAuditEvent(value: AuditEventEnvelope): ContractValidationResult<AuditEventEnvelope> {
+  const normalized = normalizeAuditEvent(value);
+  const record = normalized as unknown as Record<string, unknown>;
+  const issues: ContractValidationIssue[] = [];
+  requireString(record, "eventId", issues);
+  requireString(record, "traceId", issues);
+  requireString(record, "category", issues);
+  requireString(record, "type", issues);
+  requireString(record, "ts", issues);
+  requireRecord(record, "payload", issues);
+  return { ok: issues.length === 0, value: normalized, issues };
 }

--- a/src/resources/extensions/gsd/uok/dispatch-envelope.ts
+++ b/src/resources/extensions/gsd/uok/dispatch-envelope.ts
@@ -1,3 +1,5 @@
+// GSD2 UOK Dispatch Envelope Builder
+
 import type {
   DispatchExplanation,
   DispatchReasonCode,
@@ -5,6 +7,7 @@ import type {
   UokDispatchEnvelope,
   UokGraphNode,
 } from "./contracts.js";
+import { CURRENT_UOK_CONTRACT_VERSION } from "./contracts.js";
 
 export interface BuildDispatchEnvelopeInput {
   action: UokDispatchEnvelope["action"];
@@ -22,6 +25,7 @@ export interface BuildDispatchEnvelopeInput {
 
 export function buildDispatchEnvelope(input: BuildDispatchEnvelopeInput): UokDispatchEnvelope {
   return {
+    version: CURRENT_UOK_CONTRACT_VERSION,
     action: input.action,
     nodeKind: input.node?.kind,
     unitType: input.unitType,

--- a/src/resources/extensions/gsd/uok/loop-adapter.ts
+++ b/src/resources/extensions/gsd/uok/loop-adapter.ts
@@ -158,7 +158,7 @@ export function createTurnObserver(options: CreateTurnObserverOptions): UokTurnO
         const merged: TurnResult = {
           ...result,
           version: CURRENT_UOK_CONTRACT_VERSION,
-          phaseResults: result.phaseResults.length > 0 ? result.phaseResults : [...phaseResults],
+          phaseResults: Array.isArray(result.phaseResults) && result.phaseResults.length > 0 ? result.phaseResults : [...phaseResults],
         };
         const validation = validateTurnResult(merged);
         if (!validation.ok) {

--- a/src/resources/extensions/gsd/uok/loop-adapter.ts
+++ b/src/resources/extensions/gsd/uok/loop-adapter.ts
@@ -145,62 +145,68 @@ export function createTurnObserver(options: CreateTurnObserverOptions): UokTurnO
     },
 
     onTurnResult(result): void {
-      const merged: TurnResult = {
-        ...result,
-        version: CURRENT_UOK_CONTRACT_VERSION,
-        phaseResults: result.phaseResults.length > 0 ? result.phaseResults : [...phaseResults],
+      const cleanup = (): void => {
+        if (writerToken) {
+          releaseWriterToken(options.basePath, writerToken);
+        }
+        writerToken = null;
+        current = null;
+        phaseResults.length = 0;
       };
-      const validation = validateTurnResult(merged);
-      if (!validation.ok) {
-        throw new Error(`Invalid UOK turn result: ${validation.issues.map((issue) => `${issue.path}: ${issue.message}`).join("; ")}`);
-      }
 
-      if (options.enableAudit) {
-        emitUokAuditEvent(
-          options.basePath,
-          buildAuditEnvelope({
-            traceId: validation.value.traceId,
-            turnId: validation.value.turnId,
-            category: "orchestration",
-            type: "turn-result",
-            payload: nextSequenceMetadata("audit", "append", {
-              contractVersion: validation.value.version,
-              unitType: validation.value.unitType,
-              unitId: validation.value.unitId,
-              status: validation.value.status,
-              failureClass: validation.value.failureClass,
-              error: validation.value.error,
-              phaseCount: validation.value.phaseResults.length,
-            }),
-          }),
-        );
-      }
-
-      if (options.enableGitops) {
-        const closeout: TurnCloseoutRecord = merged.closeout ?? {
-          traceId: merged.traceId,
-          turnId: merged.turnId,
-          unitType: merged.unitType,
-          unitId: merged.unitId,
-          status: merged.status,
-          failureClass: merged.failureClass,
-          gitAction: options.gitAction,
-          gitPushed: options.gitPush,
-          finishedAt: merged.finishedAt,
+      try {
+        const merged: TurnResult = {
+          ...result,
+          version: CURRENT_UOK_CONTRACT_VERSION,
+          phaseResults: result.phaseResults.length > 0 ? result.phaseResults : [...phaseResults],
         };
-        writeTurnCloseoutGitRecord(
-          options.basePath,
-          closeout,
-          nextSequenceMetadata("gitops", "update", { action: "record" }),
-        );
-      }
+        const validation = validateTurnResult(merged);
+        if (!validation.ok) {
+          throw new Error(`Invalid UOK turn result: ${validation.issues.map((issue) => `${issue.path}: ${issue.message}`).join("; ")}`);
+        }
 
-      if (writerToken) {
-        releaseWriterToken(options.basePath, writerToken);
+        if (options.enableAudit) {
+          emitUokAuditEvent(
+            options.basePath,
+            buildAuditEnvelope({
+              traceId: validation.value.traceId,
+              turnId: validation.value.turnId,
+              category: "orchestration",
+              type: "turn-result",
+              payload: nextSequenceMetadata("audit", "append", {
+                contractVersion: validation.value.version,
+                unitType: validation.value.unitType,
+                unitId: validation.value.unitId,
+                status: validation.value.status,
+                failureClass: validation.value.failureClass,
+                error: validation.value.error,
+                phaseCount: validation.value.phaseResults.length,
+              }),
+            }),
+          );
+        }
+
+        if (options.enableGitops) {
+          const closeout: TurnCloseoutRecord = merged.closeout ?? {
+            traceId: merged.traceId,
+            turnId: merged.turnId,
+            unitType: merged.unitType,
+            unitId: merged.unitId,
+            status: merged.status,
+            failureClass: merged.failureClass,
+            gitAction: options.gitAction,
+            gitPushed: options.gitPush,
+            finishedAt: merged.finishedAt,
+          };
+          writeTurnCloseoutGitRecord(
+            options.basePath,
+            closeout,
+            nextSequenceMetadata("gitops", "update", { action: "record" }),
+          );
+        }
+      } finally {
+        cleanup();
       }
-      writerToken = null;
-      current = null;
-      phaseResults.length = 0;
     },
   };
 }

--- a/src/resources/extensions/gsd/uok/loop-adapter.ts
+++ b/src/resources/extensions/gsd/uok/loop-adapter.ts
@@ -1,9 +1,12 @@
+// GSD2 UOK Turn Observer and DB-Backed Lifecycle Emission
+
 import type {
   TurnCloseoutRecord,
   TurnContract,
   TurnResult,
   UokTurnObserver,
 } from "./contracts.js";
+import { CURRENT_UOK_CONTRACT_VERSION, validateTurnResult } from "./contracts.js";
 import { buildAuditEnvelope, emitUokAuditEvent } from "./audit.js";
 import { writeTurnCloseoutGitRecord, writeTurnGitTransaction } from "./gitops.js";
 import { acquireWriterToken, nextWriteRecord, releaseWriterToken } from "./writer.js";
@@ -144,24 +147,30 @@ export function createTurnObserver(options: CreateTurnObserverOptions): UokTurnO
     onTurnResult(result): void {
       const merged: TurnResult = {
         ...result,
+        version: CURRENT_UOK_CONTRACT_VERSION,
         phaseResults: result.phaseResults.length > 0 ? result.phaseResults : [...phaseResults],
       };
+      const validation = validateTurnResult(merged);
+      if (!validation.ok) {
+        throw new Error(`Invalid UOK turn result: ${validation.issues.map((issue) => `${issue.path}: ${issue.message}`).join("; ")}`);
+      }
 
       if (options.enableAudit) {
         emitUokAuditEvent(
           options.basePath,
           buildAuditEnvelope({
-            traceId: merged.traceId,
-            turnId: merged.turnId,
+            traceId: validation.value.traceId,
+            turnId: validation.value.turnId,
             category: "orchestration",
             type: "turn-result",
             payload: nextSequenceMetadata("audit", "append", {
-              unitType: merged.unitType,
-              unitId: merged.unitId,
-              status: merged.status,
-              failureClass: merged.failureClass,
-              error: merged.error,
-              phaseCount: merged.phaseResults.length,
+              contractVersion: validation.value.version,
+              unitType: validation.value.unitType,
+              unitId: validation.value.unitId,
+              status: validation.value.status,
+              failureClass: validation.value.failureClass,
+              error: validation.value.error,
+              phaseCount: validation.value.phaseResults.length,
             }),
           }),
         );

--- a/src/resources/extensions/gsd/uok/timeline.ts
+++ b/src/resources/extensions/gsd/uok/timeline.ts
@@ -1,0 +1,158 @@
+// GSD2 UOK Timeline Reconstruction from Authoritative DB Records
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { _getAdapter, isDbAvailable } from "../gsd-db.js";
+import { gsdRoot } from "../paths.js";
+
+export interface TurnTimelineFilter {
+  traceId?: string;
+  turnId?: string;
+}
+
+export interface TurnTimelineEntry {
+  source: "audit_events" | "unit_dispatches" | "turn_git_transactions" | "audit_jsonl";
+  ts: string;
+  traceId?: string;
+  turnId?: string | null;
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+export interface TurnTimeline {
+  authoritative: "db" | "degraded-fallback";
+  degraded: boolean;
+  entries: TurnTimelineEntry[];
+}
+
+function parseJsonRecord(value: unknown): Record<string, unknown> {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value !== "string" || value.trim() === "") return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function matchesFilter(entry: Pick<TurnTimelineEntry, "traceId" | "turnId">, filter: TurnTimelineFilter): boolean {
+  if (filter.traceId && entry.traceId !== filter.traceId) return false;
+  if (filter.turnId && entry.turnId !== filter.turnId) return false;
+  return true;
+}
+
+function byTimestamp(a: TurnTimelineEntry, b: TurnTimelineEntry): number {
+  return a.ts.localeCompare(b.ts);
+}
+
+function readDbTimeline(filter: TurnTimelineFilter): TurnTimelineEntry[] {
+  const db = _getAdapter();
+  if (!db) return [];
+  const entries: TurnTimelineEntry[] = [];
+  const where: string[] = [];
+  const params: Record<string, string> = {};
+  if (filter.traceId) {
+    where.push("trace_id = :trace_id");
+    params[":trace_id"] = filter.traceId;
+  }
+  if (filter.turnId) {
+    where.push("turn_id = :turn_id");
+    params[":turn_id"] = filter.turnId;
+  }
+  const suffix = where.length > 0 ? ` WHERE ${where.join(" AND ")}` : "";
+
+  const auditRows = db.prepare(
+    `SELECT trace_id, turn_id, type, ts, payload_json FROM audit_events${suffix}`,
+  ).all(params) as Array<{ trace_id: string; turn_id: string | null; type: string; ts: string; payload_json: string }>;
+  for (const row of auditRows) {
+    entries.push({
+      source: "audit_events",
+      ts: row.ts,
+      traceId: row.trace_id,
+      turnId: row.turn_id,
+      type: row.type,
+      payload: parseJsonRecord(row.payload_json),
+    });
+  }
+
+  const dispatchRows = db.prepare(
+    `SELECT trace_id, turn_id, unit_type, unit_id, status, started_at, ended_at, exit_reason,
+            error_summary, retry_after_ms, attempt_n, max_attempts
+     FROM unit_dispatches${suffix}`,
+  ).all(params) as Array<Record<string, unknown>>;
+  for (const row of dispatchRows) {
+    entries.push({
+      source: "unit_dispatches",
+      ts: String(row.ended_at ?? row.started_at ?? ""),
+      traceId: String(row.trace_id ?? ""),
+      turnId: typeof row.turn_id === "string" ? row.turn_id : null,
+      type: `dispatch-${String(row.status ?? "unknown")}`,
+      payload: { ...row },
+    });
+  }
+
+  const gitRows = db.prepare(
+    `SELECT trace_id, turn_id, unit_type, unit_id, stage, action, push, status, error,
+            metadata_json, updated_at
+     FROM turn_git_transactions${suffix}`,
+  ).all(params) as Array<Record<string, unknown>>;
+  for (const row of gitRows) {
+    entries.push({
+      source: "turn_git_transactions",
+      ts: String(row.updated_at ?? ""),
+      traceId: String(row.trace_id ?? ""),
+      turnId: typeof row.turn_id === "string" ? row.turn_id : null,
+      type: `gitops-${String(row.stage ?? "unknown")}`,
+      payload: {
+        ...row,
+        metadata: parseJsonRecord(row.metadata_json),
+      },
+    });
+  }
+
+  return entries.filter((entry) => entry.ts !== "").sort(byTimestamp);
+}
+
+function readJsonlTimeline(basePath: string, filter: TurnTimelineFilter): TurnTimelineEntry[] {
+  const path = join(gsdRoot(basePath), "audit", "events.jsonl");
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf-8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line): TurnTimelineEntry | null => {
+      const event = parseJsonRecord(line);
+      const entry: TurnTimelineEntry = {
+        source: "audit_jsonl",
+        ts: String(event.ts ?? ""),
+        traceId: typeof event.traceId === "string" ? event.traceId : undefined,
+        turnId: typeof event.turnId === "string" ? event.turnId : null,
+        type: String(event.type ?? "audit"),
+        payload: parseJsonRecord(event.payload),
+      };
+      return entry.ts && matchesFilter(entry, filter) ? entry : null;
+    })
+    .filter((entry): entry is TurnTimelineEntry => entry !== null)
+    .sort(byTimestamp);
+}
+
+export function buildTurnTimeline(basePath: string, filter: TurnTimelineFilter = {}): TurnTimeline {
+  if (isDbAvailable()) {
+    return {
+      authoritative: "db",
+      degraded: false,
+      entries: readDbTimeline(filter),
+    };
+  }
+
+  return {
+    authoritative: "degraded-fallback",
+    degraded: true,
+    entries: readJsonlTimeline(basePath, filter),
+  };
+}

--- a/src/resources/extensions/shared/gsd-phase-state.ts
+++ b/src/resources/extensions/shared/gsd-phase-state.ts
@@ -59,6 +59,7 @@ export function deactivateGSD(): void {
 	_active = false;
 	_currentPhase = null;
 	emitPhaseChange("deactivate", previousPhase, _currentPhase);
+	_auditContext = null;
 }
 
 /** Set the currently dispatched GSD phase (e.g. "plan-milestone"). */

--- a/src/resources/extensions/shared/gsd-phase-state.ts
+++ b/src/resources/extensions/shared/gsd-phase-state.ts
@@ -1,5 +1,5 @@
 /**
- * GSD Phase State — cross-extension coordination
+ * GSD2 Phase State — cross-extension coordination
  * Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
  *
  * Lightweight module-level state that GSD auto-mode writes to and the
@@ -7,28 +7,80 @@
  * a module variable is sufficient — no file I/O needed.
  */
 
+import { buildAuditEnvelope, emitUokAuditEvent } from "../gsd/uok/audit.js";
+
 let _active = false;
 let _currentPhase: string | null = null;
 
+export interface GSDPhaseAuditContext {
+	basePath: string;
+	traceId: string;
+	turnId?: string;
+	causedBy?: string;
+}
+
+let _auditContext: GSDPhaseAuditContext | null = null;
+
+function emitPhaseChange(action: string, previousPhase: string | null, nextPhase: string | null): void {
+	if (!_auditContext) return;
+	emitUokAuditEvent(
+		_auditContext.basePath,
+		buildAuditEnvelope({
+			traceId: _auditContext.traceId,
+			turnId: _auditContext.turnId,
+			causedBy: _auditContext.causedBy,
+			category: "orchestration",
+			type: "phase_changed",
+			payload: {
+				action,
+				active: _active,
+				previousPhase,
+				nextPhase,
+			},
+		}),
+	);
+}
+
+export function configureGSDPhaseAudit(context: GSDPhaseAuditContext | null): void {
+	_auditContext = context;
+}
+
 /** Mark GSD auto-mode as active. */
-export function activateGSD(): void {
+export function activateGSD(context?: GSDPhaseAuditContext): void {
+	if (context) _auditContext = context;
+	const previousPhase = _currentPhase;
 	_active = true;
+	emitPhaseChange("activate", previousPhase, _currentPhase);
 }
 
 /** Mark GSD auto-mode as inactive and clear the current phase. */
 export function deactivateGSD(): void {
+	const previousPhase = _currentPhase;
 	_active = false;
 	_currentPhase = null;
+	emitPhaseChange("deactivate", previousPhase, _currentPhase);
 }
 
 /** Set the currently dispatched GSD phase (e.g. "plan-milestone"). */
-export function setCurrentPhase(phase: string): void {
+export function setCurrentPhase(phase: string, context?: GSDPhaseAuditContext): boolean {
+	if (context) _auditContext = context;
+	if (!_active) {
+		process.emitWarning(`Ignoring GSD phase "${phase}" while GSD auto-mode is inactive`, {
+			code: "GSD_PHASE_INACTIVE",
+		});
+		return false;
+	}
+	const previousPhase = _currentPhase;
 	_currentPhase = phase;
+	emitPhaseChange("set", previousPhase, _currentPhase);
+	return true;
 }
 
 /** Clear the current phase (unit completed or aborted). */
 export function clearCurrentPhase(): void {
+	const previousPhase = _currentPhase;
 	_currentPhase = null;
+	emitPhaseChange("clear", previousPhase, _currentPhase);
 }
 
 /** Returns true if GSD auto-mode is currently active. */

--- a/src/resources/extensions/shared/tests/gsd-phase-state.test.ts
+++ b/src/resources/extensions/shared/tests/gsd-phase-state.test.ts
@@ -2,8 +2,12 @@
 
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	activateGSD,
+	configureGSDPhaseAudit,
 	deactivateGSD,
 	setCurrentPhase,
 	clearCurrentPhase,
@@ -52,5 +56,35 @@ describe("gsd-phase-state", () => {
 		deactivateGSD();
 		activateGSD();
 		assert.equal(getCurrentPhase(), null);
+	});
+
+	it("deactivation clears the audit context so later events do not carry stale trace data", () => {
+		const basePath = mkdtempSync(join(tmpdir(), "gsd-phase-state-audit-"));
+		try {
+			activateGSD({ basePath, traceId: "stale-trace", causedBy: "test" });
+			setCurrentPhase("plan-milestone");
+			deactivateGSD();
+
+			// Re-activate WITHOUT a context. If deactivate did not clear the
+			// stored context, this setCurrentPhase would emit an audit event
+			// using "stale-trace".
+			activateGSD();
+			setCurrentPhase("execute-task");
+
+			const eventsPath = join(basePath, ".gsd", "audit", "events.jsonl");
+			if (existsSync(eventsPath)) {
+				const contents = readFileSync(eventsPath, "utf-8");
+				assert.equal(
+					contents.includes("stale-trace") &&
+						contents.split("\n").filter((line) => line.includes("stale-trace") && line.includes("execute-task")).length > 0,
+					false,
+					"execute-task phase change must not be emitted under the deactivated trace",
+				);
+			}
+		} finally {
+			configureGSDPhaseAudit(null);
+			deactivateGSD();
+			rmSync(basePath, { recursive: true, force: true });
+		}
 	});
 });

--- a/src/resources/extensions/shared/tests/gsd-phase-state.test.ts
+++ b/src/resources/extensions/shared/tests/gsd-phase-state.test.ts
@@ -1,3 +1,5 @@
+// GSD2 Shared Phase State Coordination Tests
+
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import {
@@ -25,9 +27,15 @@ describe("gsd-phase-state", () => {
 	it("tracks the current phase when active", () => {
 		activateGSD();
 		assert.equal(getCurrentPhase(), null);
-		setCurrentPhase("plan-milestone");
+		assert.equal(setCurrentPhase("plan-milestone"), true);
 		assert.equal(getCurrentPhase(), "plan-milestone");
 		clearCurrentPhase();
+		assert.equal(getCurrentPhase(), null);
+	});
+
+	it("rejects phase changes while inactive", () => {
+		assert.equal(setCurrentPhase("plan-milestone"), false);
+		activateGSD();
 		assert.equal(getCurrentPhase(), null);
 	});
 


### PR DESCRIPTION
## TL;DR

**What:** Adds versioned UOK contracts with DB-authoritative audit/timeline behavior.
**Why:** Contract state should be reconstructable from typed DB records, with jsonl/runtime files treated only as projections or degraded fallback.
**How:** Stamps UOK envelopes with version `1`, validates/normalizes records, writes audit events to DB before jsonl projection, adds DB-first timeline reads, and mirrors phase-state changes into audit events.

## What

This PR:

- Adds `CURRENT_UOK_CONTRACT_VERSION` and validation/normalization helpers for `TurnResult`, `UokDispatchEnvelope`, and `AuditEventEnvelope`.
- Updates UOK audit emission so DB writes are authoritative when the DB is available; jsonl remains a best-effort projection.
- Adds `buildTurnTimeline()` for DB-first timeline reconstruction across audit events, dispatch rows, and gitops rows, with jsonl fallback only when DB is unavailable.
- Hardens shared GSD phase state by rejecting phase changes while inactive and emitting phase-change audit events when audit context is provided.
- Wires auto unit dispatch to pass phase-state audit context.
- Adds tests for contract versioning, legacy normalization, DB authority, DB-preferred timelines, and inactive phase handling.

## Why

Closes #5265.

The contracts/gaps review called out replayability and mixed persistence risk. UOK audit and contract records need one canonical source of truth so incident reconstruction and future compatibility checks do not depend on best-effort jsonl files or soft runtime state.

## How

The implementation keeps the existing storage model and adds stricter semantics at the existing write/read seams:

- Builders emit versioned envelopes.
- Validators normalize missing legacy versions to `0` while preserving unknown payload fields.
- `emitUokAuditEvent()` validates records, writes the DB row first, and only then writes the jsonl projection.
- `buildTurnTimeline()` prefers DB tables and labels jsonl-only reads as degraded fallback.
- Shared phase-state remains memory-only for same-process coordination, while durable observability goes through DB-backed audit events.

## Change type checklist

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Testing

Passed:

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/uok-contracts.test.ts src/resources/extensions/gsd/tests/uok-loop-adapter-writer.test.ts src/resources/extensions/gsd/tests/uok-gate-runner.test.ts src/resources/extensions/shared/tests/gsd-phase-state.test.ts
npm run typecheck:extensions
git diff --check
```

`npm run verify:pr` status:

- Initial run failed because the fresh worktree had no `node_modules/esbuild`; fixed with `npm ci` per CONTRIBUTING.md setup guidance.
- Full preflight with canonical `TMPDIR` completed build and extension typecheck, then hit unrelated repo-wide flaky/timing failures:
  - `enhanced-verification-integration.test`: post-execution checks took `1016ms`, expected `<1000ms`.
  - Two workflow MCP stdio tests timed out with `MCP error -32001`.

## AI-assisted disclosure

This PR is AI-assisted. No AI tool is credited as an author or co-author in the commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Versioned audit/contracts with validation/normalization and a rebuilt turn timeline that prefers DB and falls back to JSONL.
  * Phase state now emits audit events and accepts optional audit context; setting a phase can be rejected when GSD is inactive.

* **Bug Fixes**
  * Audit events validated before persistence; DB writes are treated as authoritative and DB failures surface as errors.
  
* **Tests**
  * Expanded coverage for contract validation, timeline behavior, persistence, phase-audit flows, and cleanup on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->