### PR TITLE
fix(gsd): continue deep queued milestones

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -692,6 +692,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       const contextFile = resolveMilestoneFile(basePath, mid, "CONTEXT");
       const hasContext = !!(contextFile && (await loadFile(contextFile)));
       if (hasContext) return null; // fall through to next rule
+      if (prefs?.planning_depth === "deep") return null;
       // H6 fix (#4973): keep the non-deep auto-mode bypass, but do not
       // pre-verify deep planning's user-facing milestone approval gate.
       if (shouldBypassMilestoneDepthGateInAuto(prefs)) {

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -663,9 +663,10 @@ export async function bootstrapAutoSession(
       hasSurvivorBranch = false;
     }
 
+    const effectivePrefs = loadEffectiveGSDPreferences(base)?.preferences;
     const deepProjectStagePending = !hasSurvivorBranch
       ? (await import("./auto-dispatch.js")).hasPendingDeepStage(
-          loadEffectiveGSDPreferences(base)?.preferences,
+          effectivePrefs,
           base,
         )
       : false;
@@ -714,7 +715,7 @@ export async function bootstrapAutoSession(
         const mid = state.activeMilestone!.id;
         const contextFile = resolveMilestoneFile(base, mid, "CONTEXT");
         const hasContext = !!(contextFile && (await loadFile(contextFile)));
-        if (!hasContext) {
+        if (!hasContext && effectivePrefs?.planning_depth !== "deep") {
           const { showSmartEntry } = await import("./guided-flow.js");
           await showSmartEntry(ctx, pi, base, { step: requestedStepMode });
 

--- a/src/resources/extensions/gsd/tests/deep-planning-mode-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-planning-mode-dispatch.test.ts
@@ -14,6 +14,7 @@ import {
   DISPATCH_RULES,
   getDeepStageGate,
   hasPendingDeepStage,
+  resolveDispatch,
   setResearchProjectPromptBuilderForTest,
   type DispatchContext,
 } from "../auto-dispatch.ts";
@@ -246,6 +247,11 @@ function writeCapturedDeepPrefs(base: string): void {
     join(base, ".gsd", "PREFERENCES.md"),
     "---\nplanning_depth: deep\nworkflow_prefs_captured: true\n---\n",
   );
+}
+
+function writeSkippedProjectResearchDecision(base: string): void {
+  mkdirSync(join(base, ".gsd", "runtime"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "runtime", "research-decision.json"), JSON.stringify({ decision: "skip" }));
 }
 
 function makeCtx(
@@ -783,6 +789,42 @@ test("Deep mode: research-project DOES dispatch when only 3 of 4 research files 
   const prefs = { planning_depth: "deep" } as GSDPreferences;
   const result = await rule(RESEARCH_PROJECT_RULE_NAME).match(makeCtx(base, prefs));
   assert.ok(result && result.action === "dispatch", "any missing dimension must trigger re-run");
+});
+
+test("Deep mode: queued milestone without CONTEXT.md routes to milestone research after project setup", async (t) => {
+  const base = makeIsolatedBaseWithCleanup(t);
+
+  writeCapturedDeepPrefs(base);
+  writeValidProject(base);
+  writeValidRequirements(base);
+  writeSkippedProjectResearchDecision(base);
+
+  const prefs = { planning_depth: "deep" } as GSDPreferences;
+  const result = await resolveDispatch(makeCtx(base, prefs));
+
+  assert.equal(result.action, "dispatch");
+  if (result.action === "dispatch") {
+    assert.equal(result.unitType, "research-milestone");
+    assert.equal(result.unitId, "M001");
+  }
+});
+
+test("Deep mode: queued milestone without CONTEXT.md can route directly to milestone planning", async (t) => {
+  const base = makeIsolatedBaseWithCleanup(t);
+
+  writeCapturedDeepPrefs(base);
+  writeValidProject(base);
+  writeValidRequirements(base);
+  writeSkippedProjectResearchDecision(base);
+
+  const prefs = { planning_depth: "deep", phases: { skip_research: true } } as GSDPreferences;
+  const result = await resolveDispatch(makeCtx(base, prefs));
+
+  assert.equal(result.action, "dispatch");
+  if (result.action === "dispatch") {
+    assert.equal(result.unitType, "plan-milestone");
+    assert.equal(result.unitId, "M001");
+  }
 });
 
 // ─── centralized deep-stage gate ─────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -23,6 +23,11 @@ import {
   showSmartEntry,
   startDeepProjectSetupForeground,
 } from "../guided-flow.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  openDatabase,
+} from "../gsd-db.ts";
 import type { GSDPreferences } from "../preferences.ts";
 import type { GSDState } from "../types.ts";
 
@@ -338,6 +343,62 @@ test("deep project setup: pre-dispatch can run before the first milestone exists
       assert.equal(result.data.midTitle, "Project setup");
     }
   } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("deep project setup: bootstrap continues queued M002 without milestone context", async () => {
+  const base = makeRepo();
+  try {
+    writeCapturedDeepPrefs(base);
+    writeValidProjectAndRequirements(base);
+    mkdirSync(join(base, ".gsd", "runtime"), { recursive: true });
+    writeFileSync(join(base, ".gsd", "runtime", "research-decision.json"), '{"decision":"skip"}\n');
+
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "First milestone", status: "complete" });
+    insertMilestone({ id: "M002", title: "Second milestone", status: "queued" });
+    closeDatabase();
+
+    const messages: unknown[] = [];
+    const pi = {
+      ...makePi(messages),
+      getThinkingLevel: () => "medium",
+    };
+    const s = new AutoSession();
+    const ready = await bootstrapAutoSession(
+      s,
+      makeCtx(`queued-${randomUUID()}`) as any,
+      pi as any,
+      base,
+      false,
+      false,
+      {
+        shouldUseWorktreeIsolation: () => false,
+        registerSigtermHandler: () => {},
+        lockBase: () => base,
+        buildResolver: () => ({}) as any,
+      },
+      {
+        classification: "none",
+        lock: null,
+        pausedSession: null,
+        state: null,
+        recovery: null,
+        recoveryPrompt: null,
+        recoveryToolCallCount: 0,
+        artifactSatisfied: false,
+        hasResumableDiskState: false,
+        isBootstrapCrash: false,
+      },
+    );
+
+    assert.equal(ready, true);
+    assert.equal(s.active, true);
+    assert.equal(s.currentMilestoneId, "M002");
+    assert.equal(messages.length, 0, "queued deep milestone must not re-enter smart new-milestone discussion");
+  } finally {
+    try { closeDatabase(); } catch {}
     rmSync(base, { recursive: true, force: true });
   }
 });
@@ -1020,7 +1081,7 @@ test("deep project setup: research-project blocker placeholder is a file, not th
   const base = makeBase();
   try {
     const expectedPath = resolveExpectedArtifactPath("research-project", "PROJECT-RESEARCH", base);
-    assert.equal(expectedPath, join(base, ".gsd", "research", "PROJECT-RESEARCH-BLOCKER.md"));
+    assert.equal(expectedPath, join(realpathSync(base), ".gsd", "research", "PROJECT-RESEARCH-BLOCKER.md"));
 
     mkdirSync(join(base, ".gsd", "research"), { recursive: true });
     const diagnosis = writeBlockerPlaceholder(


### PR DESCRIPTION
## TL;DR

**What:** Continue deep-mode queued milestones into research/planning instead of restarting smart milestone discussion.
**Why:** `/gsd new-project --deep` can register M002, finish M001, then ask to start another milestone because M002 has no milestone `CONTEXT.md` yet.
**How:** In deep mode, bootstrap and dispatch no longer treat missing milestone context as a smart-entry discussion trigger once project-level deep setup gates are complete.

## What

This updates the GSD auto bootstrap and dispatch routing for deep project flows:

- `auto-start.ts` reuses effective preferences and skips smart-entry discussion for deep queued milestones missing `CONTEXT.md`.
- `auto-dispatch.ts` lets deep-mode pre-planning milestones without context fall through to milestone research/planning routes.
- Regression tests cover both dispatch and bootstrap paths for queued milestones prepared by deep project setup.

Closes #5264

## Why

Deep project setup can create multiple DB-backed milestone rows from `PROJECT.md`, with later milestones intentionally queued before they have milestone-level context. After M001 completes, M002 should become active and proceed toward planning. The old route interpreted missing `CONTEXT.md` as needing smart new-milestone discussion, which made the flow appear to forget that M002 was already queued.

## How

The fix keeps project-level deep setup gates authoritative: while those gates are pending, project setup still wins. Once they are complete, deep-mode queued milestones are allowed to use the existing research/planning dispatch rules even if milestone context has not been written yet. Light-mode behavior is unchanged.

## Change type checklist

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Tests

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/deep-planning-mode-dispatch.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts`
- [x] `npm run typecheck:extensions`
- [x] `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run verify:pr`

## Notes

AI-assisted change, reviewed and verified locally. No co-author metadata is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for milestone routing when project research is skipped and deep planning mode is active.
  * Enhanced integration tests to verify correct milestone sequencing in deep project workflows.

* **Bug Fixes**
  * Improved deep planning mode to prevent premature milestone dispatching when project context is incomplete.
  * Optimized preference loading to reduce redundant operations during planning initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->