### PR TITLE
fix(gsd): resolve plan-slice artifacts case-insensitively

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -159,9 +159,9 @@ export function diagnoseExpectedArtifact(
       }
       return `${relSliceFile(base, mid, sid!, "RESEARCH")} (slice research)`;
     case "plan-slice":
-      return `${relSliceFile(base, mid, sid!, "PLAN")} (slice plan)`;
+      return `${relSliceFile(base, mid, sid!, "PLAN")} plus tasks/T##-PLAN.md files (slice plan and task plans)`;
     case "refine-slice":
-      return `${relSliceFile(base, mid, sid!, "PLAN")} (refined slice plan from sketch)`;
+      return `${relSliceFile(base, mid, sid!, "PLAN")} plus tasks/T##-PLAN.md files (refined slice plan and task plans)`;
     case "execute-task": {
       return `Task ${tid} marked [x] in ${relSliceFile(base, mid, sid!, "PLAN")} + summary written`;
     }

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -188,9 +188,14 @@ export function resolveDir(parentDir: string, idPrefix: string): string | null {
     // Exact match first (current convention: bare ID)
     const exact = entries.find(e => e.isDirectory() && e.name === idPrefix);
     if (exact) return exact.name;
+    const idLower = idPrefix.toLowerCase();
+    const exactCaseInsensitive = entries.find(
+      e => e.isDirectory() && e.name.toLowerCase() === idLower
+    );
+    if (exactCaseInsensitive) return exactCaseInsensitive.name;
     // Prefix match for legacy descriptor dirs: M001-SOMETHING
     const prefixed = entries.find(
-      e => e.isDirectory() && e.name.startsWith(idPrefix + "-")
+      e => e.isDirectory() && e.name.toLowerCase().startsWith(idLower + "-")
     );
     return prefixed ? prefixed.name : null;
   } catch {

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -90,6 +90,46 @@ test("resolveExpectedArtifactPath returns correct path for plan-slice", () => {
   }
 });
 
+test("plan-slice artifact resolution handles lowercase unit IDs against uppercase paths", () => {
+  const base = makeTmpBase();
+  try {
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    const tasksDir = join(sliceDir, "tasks");
+    writeFileSync(join(sliceDir, "S01-PLAN.md"), [
+      "# S01: Test Slice",
+      "",
+      "## Tasks",
+      "",
+      "- [ ] **T01: Implement feature** `est:1h`",
+    ].join("\n"));
+    writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan");
+
+    const artifactPath = resolveExpectedArtifactPath("plan-slice", "m001/s01", base);
+    assert.ok(
+      artifactPath?.endsWith(".gsd/milestones/M001/slices/S01/S01-PLAN.md"),
+      "lowercase unit IDs should resolve to the existing uppercase artifact path",
+    );
+
+    const diagnostic = diagnoseExpectedArtifact("plan-slice", "m001/s01", base);
+    assert.ok(
+      diagnostic?.includes(".gsd/milestones/M001/slices/S01/S01-PLAN.md"),
+      "diagnostic should report the existing uppercase artifact path",
+    );
+    assert.ok(
+      diagnostic?.includes("task plans"),
+      "diagnostic should mention task plans because slice plan alone is insufficient",
+    );
+
+    assert.equal(
+      verifyExpectedArtifact("plan-slice", "m001/s01", base),
+      true,
+      "verification should pass when the uppercase slice plan and task plans exist",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("resolveExpectedArtifactPath returns null for unknown type", () => {
   const base = makeTmpBase();
   try {


### PR DESCRIPTION
## TL;DR

**What:** Resolve GSD artifact directories case-insensitively and clarify plan-slice artifact diagnostics.
**Why:** Lowercase unit IDs can leave auto-mode stuck even when the canonical uppercase slice plan exists, and the old diagnostic omitted required task plan files.
**How:** Directory lookup now preserves actual on-disk casing after case-insensitive matching, and plan-slice/refine-slice diagnostics mention `tasks/T##-PLAN.md` requirements.

## What

This updates GSD artifact path resolution for milestone and slice directories so inputs like `m001/s01` can resolve existing canonical paths such as `.gsd/milestones/M001/slices/S01/S01-PLAN.md`.

It also updates expected-artifact messaging for `plan-slice` and `refine-slice` to say that verification requires the slice plan plus generated task plan files.

## Why

A stuck-loop error can point at an uppercase slice plan that already exists, while the real verification requirement also includes task plan files. That made recovery misleading and allowed casing differences in unit IDs to interfere with artifact resolution.

Closes #5271

## How

`resolveDir` now checks exact casing first, then performs case-insensitive exact and legacy-prefix directory matches while returning the actual directory name from disk.

The regression test covers lowercase `m001/s01` resolving to uppercase GSD artifacts, confirms the diagnostic uses the canonical uppercase path, and verifies that task plans are part of the expected artifact contract.

## Test plan

- [x] `npm run test:compile`
- [x] `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/auto-recovery.test.js`
- [x] `npm run typecheck:extensions`

## Change type checklist

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted: Yes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Directory path resolution now handles case-insensitive matching, ensuring consistent behavior regardless of identifier casing.
  * Diagnostic output now provides more detailed information about artifact locations and dependencies.

* **Tests**
  * Added coverage for case-insensitive identifier handling with uppercase and lowercase path combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->