### PR TITLE
fix(gsd): close depth-verification gate workflow regressions

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -263,10 +263,21 @@ describe("workflow MCP tools", () => {
         "workflow MCP schema must advertise milestone_id as optional for root artifacts",
       );
 
+      const projectFixture = [
+        "# Project",
+        "",
+        "Root artifact",
+        "",
+        "## Milestone Sequence",
+        "",
+        "- [ ] M001: Foundation - Establish the first runnable slice.",
+        "",
+      ].join("\n");
+
       const result = await tool!.handler({
         projectDir: base,
         artifact_type: "PROJECT",
-        content: "# Project\n\nRoot artifact",
+        content: projectFixture,
       });
 
       const text = (result as any).content[0].text as string;
@@ -277,7 +288,7 @@ describe("workflow MCP tools", () => {
       );
       assert.equal(
         readFileSync(join(base, ".gsd", "PROJECT.md"), "utf-8"),
-        "# Project\n\nRoot artifact",
+        projectFixture,
       );
     } finally {
       cleanup(base);

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -426,7 +426,7 @@ export function registerHooks(
     // When /gsd queue is active, the agent should only create milestones,
     // not execute work. Block write/edit to non-.gsd/ paths and bash commands
     // that would modify files.
-    if (isQueuePhaseActive()) {
+    if (isQueuePhaseActive(discussionBasePath)) {
       let queueInput = "";
       if (isToolCallEventType("write", event)) {
         queueInput = event.input.path;
@@ -571,7 +571,7 @@ export function registerHooks(
     // If the user responded at all (even "needs adjustment"), clear the pending gate
     // because the user engaged — the prompt handles the re-ask-after-adjustment flow.
     const questions: any[] = (event.input as any)?.questions ?? [];
-    const currentPendingGate = getPendingGate();
+    const currentPendingGate = getPendingGate(basePath);
     if (currentPendingGate) {
       if (details?.cancelled || !details?.response) {
         // Gate stays pending. Direct the agent to the most reliable recovery

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -188,7 +188,7 @@ export function registerHooks(
     await getEcosystemReadyPromise();
 
     const beforeAgentBasePath = process.cwd();
-    const pendingApprovalGate = getPendingGate();
+    const pendingApprovalGate = getPendingGate(beforeAgentBasePath);
     if (pendingApprovalGate && isExplicitApprovalResponse(event.prompt, pendingApprovalGate)) {
       markApprovalGateVerified(pendingApprovalGate, beforeAgentBasePath);
       const milestoneId = extractDepthVerificationMilestoneId(pendingApprovalGate);
@@ -401,20 +401,22 @@ export function registerHooks(
     // ── Discussion gate enforcement: block tool calls while gate is pending ──
     // If ask_user_questions was called with a gate ID but hasn't been confirmed,
     // block all non-read-only tool calls to prevent the model from skipping gates.
-    if (getPendingGate()) {
+    if (getPendingGate(discussionBasePath)) {
       const milestoneId = await getDiscussionMilestoneIdFor(discussionBasePath);
       if (isToolCallEventType("bash", event)) {
         const bashGuard = shouldBlockPendingGateBash(
           event.input.command,
           milestoneId,
-          isQueuePhaseActive(),
+          isQueuePhaseActive(discussionBasePath),
+          discussionBasePath,
         );
         if (bashGuard.block) return bashGuard;
       } else {
         const gateGuard = shouldBlockPendingGate(
           toolName,
           milestoneId,
-          isQueuePhaseActive(),
+          isQueuePhaseActive(discussionBasePath),
+          discussionBasePath,
         );
         if (gateGuard.block) return gateGuard;
       }
@@ -498,7 +500,8 @@ export function registerHooks(
       event.toolName,
       event.input.path,
       await getDiscussionMilestoneIdFor(discussionBasePath),
-      isQueuePhaseActive(),
+      isQueuePhaseActive(discussionBasePath),
+      discussionBasePath,
     );
     if (result.block) return result;
   });
@@ -558,7 +561,7 @@ export function registerHooks(
     if (toolName !== "ask_user_questions") return;
     const basePath = process.cwd();
     const milestoneId = await getDiscussionMilestoneIdFor(basePath);
-    const queueActive = isQueuePhaseActive();
+    const queueActive = isQueuePhaseActive(basePath);
 
     const details = event.details as any;
 

--- a/src/resources/extensions/gsd/bootstrap/tests/write-gate-shouldblock-basepath.test.ts
+++ b/src/resources/extensions/gsd/bootstrap/tests/write-gate-shouldblock-basepath.test.ts
@@ -1,0 +1,97 @@
+// GSD-2 write-gate bootstrap — regression tests for basePath threading on
+// shouldBlockContextWrite / shouldBlockPendingGate (R1).
+//
+// The underlying bug: readers defaulted to process.cwd() and so missed the
+// per-basePath state Map entry written by markDepthVerified(..., baseDirA)
+// when cwd had drifted to baseDirB. With basePath threaded explicitly to
+// the readers, the depth-gate sees the verified state regardless of cwd.
+
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  markDepthVerified,
+  setPendingGate,
+  shouldBlockContextWrite,
+  shouldBlockPendingGate,
+  clearDiscussionFlowState,
+} from "../write-gate.js";
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "wg-shouldblock-basepath-"));
+}
+
+let originalCwd: string;
+before(() => {
+  originalCwd = process.cwd();
+});
+after(() => {
+  if (process.cwd() !== originalCwd) {
+    process.chdir(originalCwd);
+  }
+});
+
+describe("write-gate shouldBlock readers respect explicit basePath", () => {
+  let baseDirA: string;
+  let baseDirB: string;
+  let prevPersist: string | undefined;
+
+  before(() => {
+    baseDirA = makeTempDir();
+    baseDirB = makeTempDir();
+    prevPersist = process.env.GSD_PERSIST_WRITE_GATE_STATE;
+    process.env.GSD_PERSIST_WRITE_GATE_STATE = "1";
+  });
+
+  after(() => {
+    process.chdir(originalCwd);
+    if (prevPersist === undefined) {
+      delete process.env.GSD_PERSIST_WRITE_GATE_STATE;
+    } else {
+      process.env.GSD_PERSIST_WRITE_GATE_STATE = prevPersist;
+    }
+    rmSync(baseDirA, { recursive: true, force: true });
+    rmSync(baseDirB, { recursive: true, force: true });
+  });
+
+  test("shouldBlockContextWrite with explicit basePath sees verified state after cwd drift", () => {
+    clearDiscussionFlowState(baseDirA);
+    clearDiscussionFlowState(baseDirB);
+
+    markDepthVerified("M001", baseDirA);
+    process.chdir(baseDirB);
+
+    const contextPath = join(baseDirA, ".gsd", "milestones", "M001", "M001-CONTEXT.md");
+    const result = shouldBlockContextWrite("write", contextPath, "M001", undefined, baseDirA);
+
+    assert.equal(result.block, false, "explicit basePath should resolve to baseDirA's verified state");
+  });
+
+  test("shouldBlockContextWrite without basePath defaults to cwd and misses verified state (bug repro)", () => {
+    clearDiscussionFlowState(baseDirA);
+    clearDiscussionFlowState(baseDirB);
+
+    markDepthVerified("M001", baseDirA);
+    process.chdir(baseDirB);
+
+    const contextPath = join(baseDirA, ".gsd", "milestones", "M001", "M001-CONTEXT.md");
+    const result = shouldBlockContextWrite("write", contextPath, "M001");
+
+    assert.equal(result.block, true, "default-to-cwd path resolves to baseDirB and misses baseDirA state");
+  });
+
+  test("shouldBlockPendingGate with explicit basePath sees pending gate after cwd drift", () => {
+    clearDiscussionFlowState(baseDirA);
+    clearDiscussionFlowState(baseDirB);
+
+    setPendingGate("depth_verification_M001_confirm", baseDirA);
+    process.chdir(baseDirB);
+
+    const result = shouldBlockPendingGate("write", "M001", false, baseDirA);
+
+    assert.equal(result.block, true, "explicit basePath should resolve to baseDirA's pending gate state");
+  });
+});

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -351,8 +351,9 @@ export function shouldBlockPendingGate(
   toolName: string,
   milestoneId: string | null,
   queuePhaseActive?: boolean,
+  basePath: string = process.cwd(),
 ): { block: boolean; reason?: string } {
-  return shouldBlockPendingGateInSnapshot(currentWriteGateSnapshot(), toolName, milestoneId, queuePhaseActive);
+  return shouldBlockPendingGateInSnapshot(currentWriteGateSnapshot(basePath), toolName, milestoneId, queuePhaseActive);
 }
 
 export function shouldBlockPendingGateInSnapshot(
@@ -386,8 +387,9 @@ export function shouldBlockPendingGateBash(
   command: string,
   milestoneId: string | null,
   queuePhaseActive?: boolean,
+  basePath: string = process.cwd(),
 ): { block: boolean; reason?: string } {
-  return shouldBlockPendingGateBashInSnapshot(currentWriteGateSnapshot(), command, milestoneId, queuePhaseActive);
+  return shouldBlockPendingGateBashInSnapshot(currentWriteGateSnapshot(basePath), command, milestoneId, queuePhaseActive);
 }
 
 export function shouldBlockPendingGateBashInSnapshot(
@@ -444,6 +446,7 @@ export function shouldBlockContextWrite(
   inputPath: string,
   milestoneId: string | null,
   _queuePhaseActive?: boolean,
+  basePath: string = process.cwd(),
 ): { block: boolean; reason?: string } {
   if (toolName !== "write") return { block: false };
   if (!MILESTONE_CONTEXT_RE.test(inputPath)) return { block: false };
@@ -460,7 +463,7 @@ export function shouldBlockContextWrite(
     };
   }
 
-  if (isMilestoneDepthVerified(targetMilestoneId)) return { block: false };
+  if (isMilestoneDepthVerified(targetMilestoneId, basePath)) return { block: false };
 
   return {
     block: true,
@@ -483,8 +486,9 @@ export function shouldBlockContextArtifactSave(
   artifactType: string,
   milestoneId: string | null,
   sliceId?: string | null,
+  basePath: string = process.cwd(),
 ): { block: boolean; reason?: string } {
-  return shouldBlockContextArtifactSaveInSnapshot(currentWriteGateSnapshot(), artifactType, milestoneId, sliceId);
+  return shouldBlockContextArtifactSaveInSnapshot(currentWriteGateSnapshot(basePath), artifactType, milestoneId, sliceId);
 }
 
 export function shouldBlockContextArtifactSaveInSnapshot(

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -70,6 +70,7 @@ import {
 } from "./preparation.js";
 import { verifyExpectedArtifact } from "./auto-recovery.js";
 import { createWorkspace, scopeMilestone, type MilestoneScope } from "./workspace.js";
+import { getPendingGate, extractDepthVerificationMilestoneId } from "./bootstrap/write-gate.js";
 
 // ─── Re-exports (preserve public API for existing importers) ────────────────
 export {
@@ -410,6 +411,15 @@ export async function checkDeepProjectSetupAfterTurn(
     }
   }
 
+  // R2: a depth-verification gate is still pending — the LLM emitted the
+  // confirmation question (via ask_user_questions or plain chat) but the user
+  // has not approved yet. Returning false keeps the entry in the
+  // pendingDeepProjectSetupMap so the next user message can resume.
+  const pendingGateId = getPendingGate(entry.basePath);
+  if (pendingGateId) {
+    return false;
+  }
+
   return dispatchNextDeepProjectSetupStage(entry);
 }
 
@@ -493,6 +503,25 @@ export function checkAutoStartAfterDiscuss(): boolean {
   const contextFile = existsSync(contextFilePath) ? contextFilePath : null;
   const roadmapFile = existsSync(roadmapFilePath) ? roadmapFilePath : null;
   if (!contextFile && !roadmapFile) return false; // neither artifact yet — keep waiting
+
+  // Gate 1a: a depth-verification gate is still pending for THIS milestone — the
+  // LLM emitted the confirmation question (via ask_user_questions or plain chat)
+  // but the user has not answered yet. Advancing now would skip the gate and
+  // race ahead with unverified context.
+  const basePathForGate = entry.scope.workspace.projectRoot;
+  const pendingGateId = getPendingGate(basePathForGate);
+  if (pendingGateId) {
+    const pendingMilestoneId = extractDepthVerificationMilestoneId(pendingGateId);
+    // Block advancement if the gate is for THIS milestone, OR if it's a
+    // project/requirements gate (no milestone id encoded) for the deep setup flow.
+    const isProjectGate =
+      pendingGateId === "depth_verification_project_confirm" ||
+      pendingGateId === "depth_verification_requirements_confirm" ||
+      pendingGateId === "depth_verification_research_decision_confirm";
+    if (pendingMilestoneId === milestoneId || isProjectGate) {
+      return false;
+    }
+  }
 
   // Gate 1b: Discriminate plan-blocked from discuss-incomplete when the DB row is queued.
   // If the DB is available and the row is still "queued" but CONTEXT.md already exists on
@@ -626,6 +655,24 @@ export function checkAutoStartAfterDiscuss(): boolean {
   // Cleanup: remove discussion manifest after auto-start (only needed during discussion)
   if (existsSync(manifestPath)) {
     try { unlinkSync(manifestPath); } catch (e) { logWarning("guided", `manifest unlink failed: ${(e as Error).message}`); }
+  }
+
+  // R3b: belt-and-suspenders for silent registration failure. The discuss flow
+  // finished and STATE.md exists, but the milestone may never have landed in
+  // the DB. Without this guard, the user sees "Milestone M001 ready." and then
+  // /gsd reports "No Active Milestone".
+  if (isDbAvailable()) {
+    const milestoneRow = getMilestone(milestoneId);
+    if (!milestoneRow) {
+      ctx.ui.notify(
+        `Milestone ${milestoneId}: discuss artifacts on disk but no DB row exists. ` +
+        `PROJECT.md may have failed to register milestones. ` +
+        `Re-save PROJECT.md with canonical "- [ ] M001: Title — One-liner" lines, ` +
+        `then re-run /gsd to recover.`,
+        "error",
+      );
+      return false;
+    }
   }
 
   pendingAutoStartMap.delete(basePath);

--- a/src/resources/extensions/gsd/tests/check-auto-start-pending-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/check-auto-start-pending-gate.test.ts
@@ -1,0 +1,196 @@
+// GSD-2 + Regression tests for checkAutoStartAfterDiscuss Gate 1a (R2)
+//
+// When a depth-verification gate is still pending (the LLM emitted the
+// confirmation question via ask_user_questions or plain chat but the user has
+// not answered), checkAutoStartAfterDiscuss must NOT advance — even if
+// CONTEXT.md and STATE.md are present on disk. Otherwise the LLM can render
+// the question and the "Milestone M001 ready" phrase in the same turn and
+// race past the gate.
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  checkAutoStartAfterDiscuss,
+  setPendingAutoStart,
+  clearPendingAutoStart,
+} from "../guided-flow.ts";
+import { drainLogs } from "../workflow-logger.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+} from "../gsd-db.ts";
+import {
+  setPendingGate,
+  clearPendingGate,
+  clearDiscussionFlowState,
+} from "../bootstrap/write-gate.ts";
+
+interface MockCapture {
+  notifies: Array<{ msg: string; level: string }>;
+  messages: Array<{ payload: any; options: any }>;
+}
+
+function mkCapture(): MockCapture {
+  return { notifies: [], messages: [] };
+}
+
+function mkCtx(cap: MockCapture): any {
+  return {
+    ui: {
+      notify: (msg: string, level: string) => {
+        cap.notifies.push({ msg, level });
+      },
+    },
+  };
+}
+
+function mkPi(cap: MockCapture): any {
+  return {
+    sendMessage: (payload: any, options: any) => {
+      cap.messages.push({ payload, options });
+    },
+    setActiveTools: () => undefined,
+    getActiveTools: () => [],
+  };
+}
+
+function mkBase(): string {
+  // realpathSync to normalize the macOS /var → /private/var symlink so the
+  // basePath we pass to setPendingGate matches what the workspace's
+  // realpath-normalized projectRoot will resolve to.
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-gate1a-pending-")));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  // CONTEXT.md (Gate 1) and STATE.md (Gate 2) both present so the only
+  // possible blocker in these tests is the new Gate 1a.
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"),
+    "# M001: Pending Gate Test\n\nContext.\n",
+  );
+  writeFileSync(
+    join(base, ".gsd", "STATE.md"),
+    "# State\n\nactive: M001\n",
+  );
+  return base;
+}
+
+describe("checkAutoStartAfterDiscuss Gate 1a (pending depth-verification gate)", () => {
+  let base: string;
+  let cap: MockCapture;
+
+  beforeEach(() => {
+    clearPendingAutoStart();
+    drainLogs();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    clearPendingAutoStart();
+    if (base) {
+      try { clearDiscussionFlowState(base); } catch { /* */ }
+      try { clearPendingGate(base); } catch { /* */ }
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("returns false while a depth_verification gate is pending for the same milestone", () => {
+    base = mkBase();
+    openDatabase(":memory:");
+    // DB row present + active so Gate 1b is not the blocker
+    insertMilestone({ id: "M001", title: "Pending Gate Test", status: "active" });
+
+    cap = mkCapture();
+    setPendingAutoStart(base, {
+      basePath: base,
+      milestoneId: "M001",
+      ctx: mkCtx(cap),
+      pi: mkPi(cap),
+    });
+
+    // The depth-verification gate for THIS milestone is still pending.
+    setPendingGate("depth_verification_M001_confirm", base);
+
+    const result = checkAutoStartAfterDiscuss();
+    assert.equal(result, false, "must not advance while the milestone gate is pending");
+    // Must not have announced "ready" or kicked auto.
+    const readyNotify = cap.notifies.find((n) => /ready\.?$/i.test(n.msg) && n.level === "success");
+    assert.equal(readyNotify, undefined, "must not announce 'ready' while gate pending");
+  });
+
+  test("returns false while a depth_verification_project_confirm gate is pending (deep setup)", () => {
+    base = mkBase();
+    openDatabase(":memory:");
+    insertMilestone({ id: "M001", title: "Pending Gate Test", status: "active" });
+
+    cap = mkCapture();
+    setPendingAutoStart(base, {
+      basePath: base,
+      milestoneId: "M001",
+      ctx: mkCtx(cap),
+      pi: mkPi(cap),
+    });
+
+    // A project-level depth-verification gate (no milestone id encoded) is pending —
+    // deep-setup interview has not been confirmed yet.
+    setPendingGate("depth_verification_project_confirm", base);
+
+    const result = checkAutoStartAfterDiscuss();
+    assert.equal(result, false, "must not advance while a project-level gate is pending");
+  });
+
+  test("returns false while a depth_verification_requirements_confirm gate is pending", () => {
+    base = mkBase();
+    openDatabase(":memory:");
+    insertMilestone({ id: "M001", title: "Pending Gate Test", status: "active" });
+
+    cap = mkCapture();
+    setPendingAutoStart(base, {
+      basePath: base,
+      milestoneId: "M001",
+      ctx: mkCtx(cap),
+      pi: mkPi(cap),
+    });
+
+    setPendingGate("depth_verification_requirements_confirm", base);
+
+    const result = checkAutoStartAfterDiscuss();
+    assert.equal(result, false, "must not advance while the requirements gate is pending");
+  });
+
+  test("Gate 1a does NOT trip when the pending gate is for a DIFFERENT milestone", () => {
+    base = mkBase();
+    openDatabase(":memory:");
+    insertMilestone({ id: "M001", title: "Pending Gate Test", status: "active" });
+
+    cap = mkCapture();
+    setPendingAutoStart(base, {
+      basePath: base,
+      milestoneId: "M001",
+      ctx: mkCtx(cap),
+      pi: mkPi(cap),
+    });
+
+    // Pending gate is for a totally different milestone — Gate 1a must not block.
+    setPendingGate("depth_verification_M999_confirm", base);
+
+    // We do not assert true/false here — Gate 1b or downstream gates may still
+    // legitimately return false. The point is that Gate 1a alone must not trip,
+    // i.e. the pending-gate notification path is not entered. We assert this by
+    // confirming no Gate-1a related state was triggered: the test passes simply
+    // by virtue of checkAutoStartAfterDiscuss not throwing and the function
+    // proceeding past Gate 1a (verified by reaching Gate 1b which would
+    // normally emit a recovery message — but with status=active it does not).
+    // The pendingAutoStart entry will still be present (only the success path
+    // deletes it), and that is fine.
+    const result = checkAutoStartAfterDiscuss();
+    // Either result is acceptable; what we assert is that NO crash occurred and
+    // the function completed. We additionally assert that if false, it was not
+    // due to a "pending gate for M001" path — there is no observable error
+    // notify about M001 gate.
+    assert.equal(typeof result, "boolean", "function must return a boolean");
+  });
+});

--- a/src/resources/extensions/gsd/tests/check-auto-start-pending-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/check-auto-start-pending-gate.test.ts
@@ -164,7 +164,12 @@ describe("checkAutoStartAfterDiscuss Gate 1a (pending depth-verification gate)",
   test("Gate 1a does NOT trip when the pending gate is for a DIFFERENT milestone", () => {
     base = mkBase();
     openDatabase(":memory:");
-    insertMilestone({ id: "M001", title: "Pending Gate Test", status: "active" });
+    // status: "queued" so that Gate 1b downstream of Gate 1a fires its
+    // recovery notify ("context file exists but milestone is still queued") —
+    // observing that notify proves we advanced past Gate 1a. If Gate 1a
+    // wrongly tripped on the M999 gate it would `return false` immediately
+    // and Gate 1b would never run, so the notify would be absent.
+    insertMilestone({ id: "M001", title: "Pending Gate Test", status: "queued" });
 
     cap = mkCapture();
     setPendingAutoStart(base, {
@@ -174,23 +179,25 @@ describe("checkAutoStartAfterDiscuss Gate 1a (pending depth-verification gate)",
       pi: mkPi(cap),
     });
 
-    // Pending gate is for a totally different milestone — Gate 1a must not block.
     setPendingGate("depth_verification_M999_confirm", base);
 
-    // We do not assert true/false here — Gate 1b or downstream gates may still
-    // legitimately return false. The point is that Gate 1a alone must not trip,
-    // i.e. the pending-gate notification path is not entered. We assert this by
-    // confirming no Gate-1a related state was triggered: the test passes simply
-    // by virtue of checkAutoStartAfterDiscuss not throwing and the function
-    // proceeding past Gate 1a (verified by reaching Gate 1b which would
-    // normally emit a recovery message — but with status=active it does not).
-    // The pendingAutoStart entry will still be present (only the success path
-    // deletes it), and that is fine.
     const result = checkAutoStartAfterDiscuss();
-    // Either result is acceptable; what we assert is that NO crash occurred and
-    // the function completed. We additionally assert that if false, it was not
-    // due to a "pending gate for M001" path — there is no observable error
-    // notify about M001 gate.
-    assert.equal(typeof result, "boolean", "function must return a boolean");
+    assert.equal(result, false, "Gate 1b returns false (expected) — but only if Gate 1a let us through");
+
+    // Positive proof we passed Gate 1a: Gate 1b emitted its recovery notify
+    // about M001 (not M999 — the pending-gate milestone is irrelevant here).
+    const gate1bNotify = cap.notifies.find(n =>
+      n.level === "warning" && /M001.*context file exists but milestone is still queued/i.test(n.msg)
+    );
+    assert.ok(
+      gate1bNotify,
+      `expected Gate 1b warning notify about M001; got: ${JSON.stringify(cap.notifies)}`,
+    );
+
+    // Negative proof: no Gate 1a notification path exists in source today, but
+    // also assert no notify mentions M999 (the pending-gate milestone) — that
+    // would suggest Gate 1a is leaking the wrong milestone into messaging.
+    const m999Notify = cap.notifies.find(n => /M999/i.test(n.msg));
+    assert.equal(m999Notify, undefined, "no notify should reference M999 (the pending-gate milestone)");
   });
 });

--- a/src/resources/extensions/gsd/tests/check-auto-start-ready-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/check-auto-start-ready-guard.test.ts
@@ -1,0 +1,148 @@
+// GSD-2 + Regression tests for checkAutoStartAfterDiscuss "ready" notify guard (R3b)
+//
+// Belt-and-suspenders: even when CONTEXT.md and STATE.md exist on disk, the
+// "Milestone X ready." success notify must not fire when the milestone DB row
+// is absent. Otherwise the user sees "ready" and then /gsd reports
+// "No Active Milestone" because the milestone was never registered.
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  checkAutoStartAfterDiscuss,
+  setPendingAutoStart,
+  clearPendingAutoStart,
+} from "../guided-flow.ts";
+import { drainLogs } from "../workflow-logger.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+} from "../gsd-db.ts";
+import {
+  clearDiscussionFlowState,
+  clearPendingGate,
+} from "../bootstrap/write-gate.ts";
+
+interface MockCapture {
+  notifies: Array<{ msg: string; level: string }>;
+  messages: Array<{ payload: any; options: any }>;
+}
+
+function mkCapture(): MockCapture {
+  return { notifies: [], messages: [] };
+}
+
+function mkCtx(cap: MockCapture): any {
+  return {
+    ui: {
+      notify: (msg: string, level: string) => {
+        cap.notifies.push({ msg, level });
+      },
+    },
+  };
+}
+
+function mkPi(cap: MockCapture): any {
+  return {
+    sendMessage: (payload: any, options: any) => {
+      cap.messages.push({ payload, options });
+    },
+    setActiveTools: () => undefined,
+    getActiveTools: () => [],
+  };
+}
+
+function mkBase(): string {
+  // realpathSync to normalize the macOS /var → /private/var symlink so the
+  // basePath we pass matches what the workspace projectRoot resolves to.
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-ready-guard-")));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"),
+    "# M001: Ready Guard Test\n\nContext.\n",
+  );
+  writeFileSync(
+    join(base, ".gsd", "STATE.md"),
+    "# State\n\nactive: M001\n",
+  );
+  return base;
+}
+
+describe("checkAutoStartAfterDiscuss ready-notify DB guard (R3b)", () => {
+  let base: string;
+  let cap: MockCapture;
+
+  beforeEach(() => {
+    clearPendingAutoStart();
+    drainLogs();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    clearPendingAutoStart();
+    if (base) {
+      try { clearDiscussionFlowState(base); } catch { /* */ }
+      try { clearPendingGate(base); } catch { /* */ }
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("does not announce 'ready' when the milestone DB row is absent", () => {
+    base = mkBase();
+    // Open a fresh in-memory DB but DO NOT insertMilestone for M001.
+    openDatabase(":memory:");
+
+    cap = mkCapture();
+    setPendingAutoStart(base, {
+      basePath: base,
+      milestoneId: "M001",
+      ctx: mkCtx(cap),
+      pi: mkPi(cap),
+    });
+
+    const result = checkAutoStartAfterDiscuss();
+    assert.equal(result, false, "must return false when DB row missing");
+
+    // No success "ready" notify
+    const successReady = cap.notifies.find(
+      (n) => n.level === "success" && /ready\.?$/i.test(n.msg),
+    );
+    assert.equal(successReady, undefined, "must not announce 'ready' when DB row missing");
+
+    // An error notify must explain the missing DB row
+    const errorNotify = cap.notifies.find((n) => n.level === "error");
+    assert.ok(errorNotify, "must emit an error notify when the DB row is missing");
+    assert.match(
+      errorNotify!.msg,
+      /no DB row exists/i,
+      "error notify must mention the missing DB row",
+    );
+    assert.match(errorNotify!.msg, /M001/, "error notify must mention the milestone id");
+  });
+
+  test("announces 'ready' when DB row exists", () => {
+    base = mkBase();
+    openDatabase(":memory:");
+    insertMilestone({ id: "M001", title: "Ready Guard Test", status: "active" });
+
+    cap = mkCapture();
+    setPendingAutoStart(base, {
+      basePath: base,
+      milestoneId: "M001",
+      ctx: mkCtx(cap),
+      pi: mkPi(cap),
+    });
+
+    const result = checkAutoStartAfterDiscuss();
+    assert.equal(result, true, "must return true on the happy path");
+
+    const successReady = cap.notifies.find(
+      (n) => n.level === "success" && /Milestone\s+M001\s+ready/i.test(n.msg),
+    );
+    assert.ok(successReady, "must announce 'Milestone M001 ready.' on success");
+  });
+});

--- a/src/resources/extensions/gsd/tests/execute-summary-save-empty-project.test.ts
+++ b/src/resources/extensions/gsd/tests/execute-summary-save-empty-project.test.ts
@@ -1,0 +1,109 @@
+// gsd-2 / execute-summary-save PROJECT registration hard-fail tests
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { openDatabase, closeDatabase, getAllMilestones } from "../gsd-db.ts";
+import { markApprovalGateVerified, clearDiscussionFlowState } from "../bootstrap/write-gate.ts";
+import { executeSummarySave } from "../tools/workflow-tool-executors.ts";
+
+function makeTmpBase(): string {
+  const base = join(tmpdir(), `gsd-summary-save-empty-project-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* swallow */ }
+}
+
+function openTestDb(base: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+}
+
+async function inProjectDir<T>(dir: string, fn: () => Promise<T>): Promise<T> {
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(dir);
+    return await fn();
+  } finally {
+    process.chdir(originalCwd);
+  }
+}
+
+function setupBase(t: { after: (fn: () => void) => void }): string {
+  const base = makeTmpBase();
+  // Force deep planning so the root-artifact guard requires a verified approval gate,
+  // matching the production flow that surfaces the regression.
+  writeFileSync(join(base, ".gsd", "PREFERENCES.md"), "---\nplanning_depth: deep\n---\n");
+  openTestDb(base);
+  markApprovalGateVerified("depth_verification_project_confirm", base);
+  t.after(() => {
+    clearDiscussionFlowState(base);
+    closeDatabase();
+    cleanup(base);
+  });
+  return base;
+}
+
+test("executeSummarySave returns isError when PROJECT.md content has zero parseable milestone lines", async (t) => {
+  const base = setupBase(t);
+
+  const content = [
+    "# Project",
+    "",
+    "## What This Is",
+    "",
+    "Bad-separator regression fixture.",
+    "",
+    "## Milestone Sequence",
+    "",
+    // Wrong separator: " : " instead of em-dash / -- / -  → MILESTONE_LINE_RE matches zero lines.
+    "- [ ] M001: Foundation : Establish the first runnable slice.",
+    "",
+    "## Next Section",
+    "",
+    "Trailing prose with no list bullets so MILESTONE_LINE_RE cannot bridge across lines.",
+    "",
+  ].join("\n");
+
+  const result = await inProjectDir(base, () => executeSummarySave({
+    artifact_type: "PROJECT",
+    content,
+  }, base));
+
+  assert.equal(result.isError, true);
+  assert.equal(result.details.error, "milestone_registration_empty_parse");
+  assert.match(result.content[0].text, /zero parseable milestone lines/);
+  assert.equal(getAllMilestones().length, 0);
+});
+
+test("executeSummarySave registers milestones when PROJECT.md uses canonical em-dash format", async (t) => {
+  const base = setupBase(t);
+
+  const content = [
+    "# Project",
+    "",
+    "## What This Is",
+    "",
+    "Canonical milestone-sequence fixture.",
+    "",
+    "## Milestone Sequence",
+    "",
+    "- [ ] M001: Foo — bar",
+    "- [ ] M002: Baz — qux",
+    "",
+  ].join("\n");
+
+  const result = await inProjectDir(base, () => executeSummarySave({
+    artifact_type: "PROJECT",
+    content,
+  }, base));
+
+  assert.notEqual(result.isError, true);
+  assert.deepEqual(result.details.registeredMilestones, ["M001", "M002"]);
+  assert.equal(getAllMilestones().length, 2);
+});

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -692,7 +692,18 @@ test("executeSummarySave supports root-level deep planning artifacts", async () 
 
     const project = await inProjectDir(base, () => executeSummarySave({
       artifact_type: "PROJECT",
-      content: "# Project\n\n## What This Is\n\nA root project artifact.",
+      content: [
+        "# Project",
+        "",
+        "## What This Is",
+        "",
+        "A root project artifact.",
+        "",
+        "## Milestone Sequence",
+        "",
+        "- [ ] M001: Foundation - Establish the first runnable slice.",
+        "",
+      ].join("\n"),
     }, base));
     assert.equal(project.isError, undefined);
     assert.equal(project.details.path, "PROJECT.md");
@@ -794,7 +805,7 @@ test("executeSummarySave registers PROJECT milestone sequence for the next run",
   }
 });
 
-test("executeSummarySave keeps PROJECT artifact save successful if milestone registration fails", async () => {
+test("executeSummarySave hard-fails when milestone registration throws so silent No-Active-Milestone is impossible", async () => {
   const base = makeTmpBase();
   try {
     openTestDb(base);
@@ -824,10 +835,15 @@ test("executeSummarySave keeps PROJECT artifact save successful if milestone reg
       ].join("\n"),
     }, base));
 
-    assert.equal(result.isError, undefined);
+    // The artifact is persisted before registration runs, but registration must
+    // surface as isError so the LLM retries (INSERT OR IGNORE makes it idempotent)
+    // instead of announcing "ready" while the DB has zero milestone rows.
+    assert.equal(result.isError, true);
     assert.equal(result.details.path, "PROJECT.md");
-    assert.equal(result.details.registeredMilestones, undefined);
-    assert.match(String(result.details.warning), /milestone registration failed/);
+    assert.equal(result.details.error, "milestone_registration_threw");
+    assert.match(String(result.details.registration_error), /simulated milestone registration failure/);
+    assert.match(result.content[0].text, /milestone registration failed/);
+    assert.match(result.content[0].text, /idempotent/);
     assert.ok(existsSync(join(base, ".gsd", "PROJECT.md")));
     const artifact = originalPrepare("SELECT path FROM artifacts WHERE path = ?").get("PROJECT.md");
     assert.equal(artifact?.path, "PROJECT.md");
@@ -872,9 +888,22 @@ test("executeSummarySave requires verified root approval in deep mode", async ()
     writeFileSync(join(base, ".gsd", "PREFERENCES.md"), "---\nplanning_depth: deep\n---\n");
     openTestDb(base);
 
+    const projectFixture = [
+      "# Project",
+      "",
+      "## What This Is",
+      "",
+      "A root project artifact.",
+      "",
+      "## Milestone Sequence",
+      "",
+      "- [ ] M001: Foundation - Establish the first runnable slice.",
+      "",
+    ].join("\n");
+
     const blocked = await inProjectDir(base, () => executeSummarySave({
       artifact_type: "PROJECT",
-      content: "# Project\n\n## What This Is\n\nA root project artifact.",
+      content: projectFixture,
     }, base));
 
     assert.equal(blocked.isError, true);
@@ -886,7 +915,7 @@ test("executeSummarySave requires verified root approval in deep mode", async ()
 
     const unblocked = await inProjectDir(base, () => executeSummarySave({
       artifact_type: "PROJECT",
-      content: "# Project\n\n## What This Is\n\nA root project artifact.",
+      content: projectFixture,
     }, base));
 
     assert.equal(unblocked.isError, undefined);

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -201,6 +201,10 @@ export async function executeSummarySave(
           error: String(err),
           stack: err instanceof Error ? err.stack ?? "" : "",
         });
+        // PROJECT.md was persisted by saveArtifactToDb above; the artifacts row
+        // changed even though no milestones registered. Invalidate so subsequent
+        // /gsd reads see the persisted artifact instead of the pre-save cache.
+        invalidateStateCache();
         return {
           content: [{
             type: "text",
@@ -223,6 +227,9 @@ export async function executeSummarySave(
         logError("tool", `gsd_summary_save: PROJECT.md saved to ${relativePath} but parsed zero milestones — registration produced no DB rows`, {
           tool: "gsd_summary_save",
         });
+        // PROJECT.md was persisted; invalidate so subsequent reads see the new
+        // artifacts row even though no milestones registered.
+        invalidateStateCache();
         return {
           content: [{
             type: "text",

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -190,19 +190,56 @@ export async function executeSummarySave(
     );
 
     let registeredMilestones: string[] = [];
-    let registrationWarning: string | undefined;
     if (params.artifact_type === "PROJECT") {
       try {
         registeredMilestones = registerProjectMilestoneSequence(contentToSave);
         if (registeredMilestones.length > 0) invalidateStateCache();
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        registrationWarning = `PROJECT artifact saved, but milestone registration failed: ${msg}`;
-        logWarning("tool", registrationWarning, {
+        logError("tool", `gsd_summary_save: PROJECT artifact persisted but milestone registration threw: ${msg}`, {
           tool: "gsd_summary_save",
           error: String(err),
           stack: err instanceof Error ? err.stack ?? "" : "",
         });
+        return {
+          content: [{
+            type: "text",
+            text:
+              `Error: PROJECT.md was saved to ${relativePath} but milestone registration failed: ${msg}. ` +
+              `The DB has no milestone rows for this project, so /gsd will report "No Active Milestone". ` +
+              `Re-call gsd_summary_save(PROJECT) once the underlying error is resolved — INSERT OR IGNORE makes registration idempotent.`,
+          }],
+          details: {
+            operation: "save_summary",
+            path: relativePath,
+            artifact_type: params.artifact_type,
+            error: "milestone_registration_threw",
+            registration_error: msg,
+          },
+          isError: true,
+        };
+      }
+      if (registeredMilestones.length === 0) {
+        logError("tool", `gsd_summary_save: PROJECT.md saved to ${relativePath} but parsed zero milestones — registration produced no DB rows`, {
+          tool: "gsd_summary_save",
+        });
+        return {
+          content: [{
+            type: "text",
+            text:
+              `Error: PROJECT.md was saved to ${relativePath} but contains zero parseable milestone lines, ` +
+              `so no milestones were registered in the DB. /gsd will report "No Active Milestone". ` +
+              `Rewrite PROJECT.md so the "Milestone Sequence" section uses canonical lines: ` +
+              `\`- [ ] M001: <Title> — <One-liner>\` (em-dash, double-dash \`--\`, or single-dash \`-\` separator), then re-call gsd_summary_save(PROJECT).`,
+          }],
+          details: {
+            operation: "save_summary",
+            path: relativePath,
+            artifact_type: params.artifact_type,
+            error: "milestone_registration_empty_parse",
+          },
+          isError: true,
+        };
       }
     }
 
@@ -225,7 +262,6 @@ export async function executeSummarySave(
         artifact_type: params.artifact_type,
         content_source: contentSource,
         ...(registeredMilestones.length > 0 ? { registeredMilestones } : {}),
-        ...(registrationWarning ? { warning: registrationWarning } : {}),
       },
     };
   } catch (err) {


### PR DESCRIPTION
## TL;DR

**What:** Closes 3 stacked regressions in the depth-verification gate workflow that combine to break `/gsd new-project --deep` and `discuss-milestone` in worktree / multi-workspace / background-dispatch sessions.
**Why:** Symptoms compound — answers to the depth question are silently dropped (R1), the agent skips waiting and announces "ready" anyway (R2), and a failed milestone registration is reported as success (R3) so `/gsd` then says "No Active Milestone."
**How:** Thread `basePath` through write-gate readers (R1), guard advancement on `getPendingGate` (R2), hard-fail empty/throwing PROJECT registration (R3a), and re-check the DB row before announcing ready (R3b).

Closes #5278

## What

Five files changed; four new test files; three existing test cases updated for the inverted R3a contract.

| Area | File | Change |
|---|---|---|
| R1 | `src/resources/extensions/gsd/bootstrap/write-gate.ts` | Added optional `basePath: string = process.cwd()` to `shouldBlockContextWrite`, `shouldBlockPendingGate`, `shouldBlockPendingGateBash`, `shouldBlockContextArtifactSave`. Threaded into the underlying snapshot reader. |
| R1 | `src/resources/extensions/gsd/bootstrap/register-hooks.ts` | Pass `discussionBasePath` / `beforeAgentBasePath` / `basePath` to `getPendingGate`, `isQueuePhaseActive`, and the four readers above at every call site. |
| R2 | `src/resources/extensions/gsd/guided-flow.ts` | New "Gate 1a" in `checkAutoStartAfterDiscuss` returns `false` while `getPendingGate(basePath)` is set for this milestone or for a project-scope gate. Same guard added to `checkDeepProjectSetupAfterTurn`. |
| R3a | `src/resources/extensions/gsd/tools/workflow-tool-executors.ts` | `executeSummarySave` now returns `isError: true` with actionable text when `registerProjectMilestoneSequence` throws OR returns zero milestones. `INSERT OR IGNORE` makes retry idempotent. |
| R3b | `src/resources/extensions/gsd/guided-flow.ts` | "Milestone X ready." notify in `checkAutoStartAfterDiscuss` now calls `getMilestone(milestoneId)` first; on miss, emits a recovery error with PROJECT.md fix instructions. |

### Tests
- `src/resources/extensions/gsd/bootstrap/tests/write-gate-shouldblock-basepath.test.ts` — 3 cases (R1)
- `src/resources/extensions/gsd/tests/check-auto-start-pending-gate.test.ts` — 4 cases (R2)
- `src/resources/extensions/gsd/tests/check-auto-start-ready-guard.test.ts` — 2 cases (R3b)
- `src/resources/extensions/gsd/tests/execute-summary-save-empty-project.test.ts` — 2 cases (R3a)
- `src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts` — updated 3 existing cases whose fixtures and assertions covered the inverted R3a contract.

## Why

See [#5278](https://github.com/gsd-build/gsd-2/issues/5278) for the full root-cause analysis. Short version:

- **R1** — write-gate state Map is keyed per-basePath (introduced when state was bucketed for multi-workspace support). Writers always passed an explicit basePath; readers defaulted to `process.cwd()`. When cwd drifts at gate-read time the reader looks in an empty bucket → "not verified" → block. This is the "answers ignored" finickiness.
- **R2** — `checkAutoStartAfterDiscuss` and `checkDeepProjectSetupAfterTurn` only verified file existence. When the LLM emitted the depth question and the ready phrase in the same turn, advancement happened regardless of whether the user answered. `pendingGate` is set for both `ask_user_questions` (tool_call hook) and plain-chat approval text (message_update hook for `USER_APPROVAL_UNIT_TYPES`), so a single guard at the advancement check covers both paths.
- **R3a** — `executeSummarySave` swallowed registration failures into a file-only `logWarning` and returned success. The `parseProject` regex (em-dash separator required) returns an empty array on LLM format drift — also silent. Together: artifact persists, workflow announces success, DB has zero rows, `/gsd` says "No Active Milestone."
- **R3b** — Belt-and-suspenders for R3a at the announcement site.

## How

### R1: Optional `basePath` parameter, defaulted for backward compat

The 4 readers gain `basePath: string = process.cwd()` so existing callers (other modules, tests outside this branch) continue to work. Inside, the parameter is threaded into `currentWriteGateSnapshot(basePath)` / `isMilestoneDepthVerified(id, basePath)`. Every call site in `register-hooks.ts` is migrated to the explicit-basePath form using the basePath that's already in scope (`discussionBasePath = process.cwd()` captured at hook entry; `beforeAgentBasePath` for `before_agent_start`).

A future tightening — making `basePath` required so the type-checker surfaces remaining offenders — is deferred to keep the diff minimal and avoid a public API break. The new regression test exercises both the explicit-basePath path (works) and the default-cwd path (still has the bug, documenting the residual surface).

### R2: One guard, two advancement paths, both gate-set sources

```ts
// Gate 1a: a depth_verification_* gate is pending for this milestone or for
// the deep-setup project/requirements/research-decision approval. The LLM
// emitted the question (via ask_user_questions or plain chat) but the user
// has not answered yet. Advancing now would skip the gate.
const pendingGateId = getPendingGate(basePathForGate);
if (pendingGateId) { /* return false if it matches */ }
```

`pendingGate` is set by either the tool_call hook for `ask_user_questions` or the message_update hook for plain-chat approval questions, so the single check covers both. Mirror added to `checkDeepProjectSetupAfterTurn`.

### R3a: Hard-fail with retry guidance

When `registerProjectMilestoneSequence` throws or returns an empty array, `executeSummarySave` now returns:

```
{
  isError: true,
  details: { error: "milestone_registration_threw" | "milestone_registration_empty_parse", ... },
  content: [{ text: "...explain why + tell the LLM to retry; INSERT OR IGNORE makes it idempotent..." }]
}
```

Three existing test cases in `workflow-tool-executors.test.ts` had fixtures or assertions that covered the inverted contract; updated per CONTRIBUTING.md "Behavior changes — update or replace any existing tests that cover the changed behavior."

### R3b: Ready-notify guarded on `getMilestone()`

```ts
if (isDbAvailable()) {
  const milestoneRow = getMilestone(milestoneId);
  if (!milestoneRow) {
    ctx.ui.notify(`Milestone ${milestoneId}: discuss artifacts on disk but no DB row exists. ...`, "error");
    return false;
  }
}
ctx.ui.notify(`Milestone ${milestoneId} ready.`, "success");
```

## Test plan

- [x] `npm run verify:pr` locally — 8629 passed, 9 skipped. The 4 failing tests (`findEvalReviewFile` / `checkSliceEvalReview`) reproduce on `upstream/main` HEAD without my changes (macOS `/var → /private/var` realpath mismatch, unrelated).
- [x] All 11 new + adjacent regression tests pass together: 55/55.
- [ ] CI green on push.

## Notes

- AI-assisted: investigation, design, and implementation produced via Claude Code with human-in-the-loop review at each decision point. Per CONTRIBUTING.md no AI co-author is credited.
- One-concern PR is defensible because all three regressions converge on the same user-visible workflow (deep new-project / discuss-milestone). Maintainer authorized a single stacked PR over splitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blocks auto-start when depth‑verification gates are pending; notifies user when milestone DB row is missing.

* **Bug Fixes**
  * Gate enforcement now consistently respects workspace base paths to avoid cwd-related drift.
  * Milestone registration failures and empty-parsed milestone lists are treated as hard errors with clear user-facing feedback.

* **Tests**
  * Added regression suites covering workspace-scoped gates, auto-start pending/ready guards, and milestone registration behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->