### PR TITLE
refactor(gsd-extension): deepen auto orchestration behind explicit seams

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,39 @@
+# CONTEXT
+
+## Domain glossary
+
+- **Auto Orchestration**: runtime coordination of GSD auto-mode units from start to completion, including dispatch, recovery, and stop/resume behavior.
+- **Unit**: the smallest executable workflow step (e.g., plan slice, execute task, complete slice).
+- **Unit progression**: movement from one Unit to the next under orchestration rules.
+- **Dispatch decision**: selection of the next Unit plus rationale and preconditions.
+- **Recovery decision**: retry/escalate/abort choice after runtime failure.
+- **Runtime persistence**: lock state, transition journal, and any persisted execution state required for safe resume.
+
+## Architecture terms adopted for this area
+
+- **Auto Orchestration module**: the module that owns unit lifecycle control-flow.
+- **Dispatch adapter**: adapter behind the Dispatch seam.
+- **Recovery adapter**: adapter behind the Recovery seam.
+- **Worktree adapter**: adapter behind the Worktree seam.
+- **Health adapter**: adapter behind the Health seam.
+- **Runtime persistence adapter**: adapter behind the Runtime persistence seam.
+- **Notification adapter**: adapter behind the Notification seam.
+
+## Current decision in force
+
+- Auto-mode architecture should deepen around a single Auto Orchestration module with interface:
+  - `start(sessionContext)`
+  - `advance()`
+  - `resume()`
+  - `stop(reason)`
+  - `getStatus()`
+
+See `docs/dev/ADR-014-auto-orchestration-deep-module.md`.
+
+## Current implementation snapshot (phase 1)
+
+- `auto.ts` now wires a concrete Auto Orchestration module through `createWiredAutoOrchestrationModule(...)`.
+- Session state now carries orchestration status via `AutoSession.orchestration`.
+- Runtime snapshot exports orchestration telemetry (`orchestrationPhase`, `orchestrationTransitionCount`, `orchestrationLastTransitionAt`).
+- Initial adapters are live for Dispatch, Health, and Runtime persistence seams.
+- Main auto-loop dispatch is still the existing path; orchestration seam is integrated incrementally for lifecycle and observability.

--- a/docs/dev/ADR-014-auto-orchestration-deep-module.md
+++ b/docs/dev/ADR-014-auto-orchestration-deep-module.md
@@ -1,0 +1,73 @@
+# ADR-014: Deepen Auto Orchestration Behind Explicit Seams
+
+**Status:** Accepted
+**Date:** 2026-05-03
+**Author:** GSD architecture review
+**Related:** ADR-009 (orchestration kernel refactor), ADR-010 (clean seam architecture)
+
+## Context
+
+`src/resources/extensions/gsd/auto.ts` currently carries multiple concerns in one place (dispatch, recovery, worktree coordination, health/escalation, locks/journaling, notifications). The module’s interface is broad relative to its implementation details, reducing locality and making failure diagnosis (especially wrong-dispatch and stuck-loop behavior) expensive.
+
+## Decision
+
+Introduce a deep **Auto Orchestration module** with a small interface:
+
+- `start(sessionContext)`
+- `advance()`
+- `resume()`
+- `stop(reason)`
+- `getStatus()`
+
+Keep orchestration control-flow in this module, and move concern-specific behavior behind explicit seams with adapters:
+
+1. Dispatch seam
+2. Recovery seam
+3. Worktree seam
+4. Health seam
+5. Runtime persistence seam (locks + journal)
+6. Notification seam
+
+`auto.ts` becomes wiring/entry glue, not the orchestration implementation.
+
+## Why this decision
+
+- Increases depth: callers drive one orchestration interface instead of coordinating internals.
+- Increases locality: transition logic and invariants are concentrated in one place.
+- Improves testability: contract tests can target orchestration behavior across adapters.
+- Aligns with ADR-010’s seam discipline (package/module structure should enforce, not imply, architecture).
+
+## Invariants
+
+- Exactly one active unit at a time.
+- `advance()` is idempotent for the same state snapshot.
+- Lock ownership is validated before mutating runtime state.
+- Recovery cannot skip required verification transitions.
+- Every state transition is journaled.
+
+## Implementation status (2026-05-03)
+
+Phase 1 landed in-tree with no behavior switch of the primary auto loop yet:
+
+- Added orchestration contracts: `src/resources/extensions/gsd/auto/contracts.ts`
+- Added orchestration implementation: `src/resources/extensions/gsd/auto/orchestrator.ts`
+- Added thin wiring in `auto.ts`: `createWiredAutoOrchestrationModule(...)` and lifecycle integration points (`start`, `resume`, `pause`, `stop` hooks)
+- Added runtime observability surfaces:
+  - `AutoSession.orchestration`
+  - `getAutoRuntimeSnapshot()` fields: `orchestrationPhase`, `orchestrationTransitionCount`, `orchestrationLastTransitionAt`
+- Wired initial real adapters behind seams:
+  - Dispatch adapter uses `deriveState(...)` + `resolveDispatch(...)`
+  - Health adapter uses `preDispatchHealthGate(...)` and records orchestration snapshots via `recordHealthSnapshot(...)`
+  - Runtime persistence adapter validates session lock status and journals transitions
+
+Contract and invariants are covered by dedicated tests:
+
+- `src/resources/extensions/gsd/tests/auto-orchestrator.test.ts`
+- `src/resources/extensions/gsd/tests/auto-runtime-state.test.ts`
+- `src/resources/extensions/gsd/tests/auto-session-encapsulation.test.ts`
+
+## Consequences
+
+- Short-term migration cost (extracting logic and introducing adapter contracts).
+- Long-term leverage via clearer failure handling and safer refactors.
+- Existing helpers that are now pass-through should be removed after contract tests are green (deletion test).

--- a/src/resources/extensions/gsd/auto-runtime-state.ts
+++ b/src/resources/extensions/gsd/auto-runtime-state.ts
@@ -16,14 +16,21 @@ export type AutoRuntimeSnapshot = {
   paused: boolean;
   currentUnit: CurrentUnit | null;
   basePath: string;
+  orchestrationPhase?: "idle" | "running" | "paused" | "stopped" | "error";
+  orchestrationTransitionCount?: number;
+  orchestrationLastTransitionAt?: number;
 };
 
 export function getAutoRuntimeSnapshot(): AutoRuntimeSnapshot {
+  const orchestrationStatus = autoSession.orchestration?.getStatus();
   return {
     active: autoSession.active,
     paused: autoSession.paused,
     currentUnit: autoSession.currentUnit ? { ...autoSession.currentUnit } : null,
     basePath: autoSession.basePath,
+    orchestrationPhase: orchestrationStatus?.phase,
+    orchestrationTransitionCount: orchestrationStatus?.transitionCount,
+    orchestrationLastTransitionAt: orchestrationStatus?.lastTransitionAt,
   };
 }
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1459,7 +1459,7 @@ export function createWiredAutoOrchestrationModule(
     runtime: {
       async ensureLockOwnership() {
         const status = getSessionLockStatus(runtimeBasePath);
-        if (status === "in_use_by_other") {
+        if (!status.valid || status.failureReason === "pid-mismatch") {
           throw new Error("session lock held by another process");
         }
       },
@@ -1903,7 +1903,6 @@ export async function startAuto(
     }
     // Rebuild scope now that s.basePath reflects the actual worktree (or project root).
     rebuildScope(s.basePath, s.currentMilestoneId);
-    ensureOrchestrationModule(ctx, pi, s.basePath || base);
     // Ensure the workflow-logger audit log is pinned to the project root
     // even when auto-mode is entered via a path that bypasses the
     // bootstrap/dynamic-tools ensureDbOpen() → setLogBasePath() chain
@@ -1936,6 +1935,7 @@ export async function startAuto(
       rebuildScope(s.basePath, s.currentMilestoneId);
     }
 
+    ensureOrchestrationModule(ctx, pi, s.basePath || base);
     registerSigtermHandler(lockBase());
 
     ctx.ui.setStatus("gsd-auto", s.stepMode ? "next" : "auto");

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -231,6 +231,8 @@ import type { ErrorContext } from "./auto/types.js";
 import { runAutoLoopWithUok } from "./uok/kernel.js";
 import { resolveUokFlags } from "./uok/flags.js";
 import { validateDirectory } from "./validate-directory.js";
+import { createAutoOrchestrator } from "./auto/orchestrator.js";
+import type { AutoOrchestrationModule, AutoOrchestratorDeps } from "./auto/contracts.js";
 // Slice-level parallelism (#2340)
 import { getEligibleSlices } from "./slice-parallel-eligibility.js";
 import { startSliceParallel } from "./slice-parallel-orchestrator.js";
@@ -1208,6 +1210,12 @@ export async function stopAuto(
     // changes the user made between sessions (#4959 / CodeRabbit).
     if (pi) clearToolBaseline(pi);
 
+    try {
+      await s.orchestration?.stop(reason ?? "stop");
+    } catch (err) {
+      debugLog("stop-orchestration-stop", { error: err instanceof Error ? err.message : String(err) });
+    }
+
     // Reset all session state in one call
     s.reset();
   }
@@ -1306,6 +1314,12 @@ export async function pauseAuto(
   resolveAgentEnd({ messages: [] });
   _resetPendingResolve();
 
+  try {
+    await s.orchestration?.stop("pause");
+  } catch (err) {
+    debugLog("pause-orchestration-stop", { error: err instanceof Error ? err.message : String(err) });
+  }
+
   s.active = false;
   s.paused = true;
   deactivateGSD();
@@ -1361,6 +1375,140 @@ function buildResolverDeps(): WorktreeResolverDeps {
  */
 function buildResolver(): WorktreeResolver {
   return new WorktreeResolver(s, buildResolverDeps());
+}
+
+/**
+ * Thin entry glue for the new Auto Orchestration module.
+ *
+ * This intentionally wires only dispatch + error notification today, with
+ * no behavior changes to the existing auto loop. It provides a concrete seam
+ * the next refactor steps can adopt incrementally.
+ */
+export function createWiredAutoOrchestrationModule(
+  ctx: ExtensionContext,
+  _pi: ExtensionAPI,
+  basePath: string,
+): AutoOrchestrationModule {
+  const flowId = `auto-orchestrator-${Date.now()}`;
+  let seq = 0;
+
+  const deps: AutoOrchestratorDeps = {
+    dispatch: {
+      async decideNextUnit() {
+        const state = await deriveState(basePath);
+        const active = state.activeMilestone;
+        if (!active) return null;
+
+        const prefs = loadEffectiveGSDPreferences(basePath)?.preferences;
+        const action = await resolveDispatch({
+          basePath,
+          mid: active.id,
+          midTitle: active.title,
+          state,
+          prefs,
+        });
+
+        if (action.action !== "dispatch") return null;
+        return {
+          unitType: action.unitType,
+          unitId: action.unitId,
+          reason: action.matchedRule ?? "dispatch",
+          preconditions: [],
+        };
+      },
+    },
+    recovery: {
+      async classifyAndRecover(input) {
+        const reason = input.error instanceof Error ? input.error.message : String(input.error ?? "unknown auto error");
+        return { action: "escalate" as const, reason };
+      },
+    },
+    worktree: {
+      async prepareForUnit() {},
+      async syncAfterUnit() {},
+      async cleanupOnStop() {},
+    },
+    health: {
+      async preAdvanceGate() {
+        const gate = await preDispatchHealthGate(basePath);
+        return {
+          allow: gate.proceed,
+          reason: gate.reason,
+        };
+      },
+      async postAdvanceRecord(result) {
+        if (result.kind === "error") {
+          recordHealthSnapshot(1, 0, 0, [{
+            code: "orchestration-error",
+            message: result.reason ?? "orchestration error",
+            severity: "error",
+            unitId: "orchestration",
+          }], [], "orchestration");
+        } else if (result.kind === "blocked") {
+          recordHealthSnapshot(0, 1, 0, [{
+            code: "orchestration-blocked",
+            message: result.reason ?? "orchestration blocked",
+            severity: "warning",
+            unitId: "orchestration",
+          }], [], "orchestration");
+        }
+      },
+    },
+    runtime: {
+      async ensureLockOwnership() {
+        const status = getSessionLockStatus(basePath);
+        if (status === "in_use_by_other") {
+          throw new Error("session lock held by another process");
+        }
+      },
+      async journalTransition(event) {
+        const eventType = event.name === "start"
+          ? "iteration-start"
+          : event.name === "resume"
+            ? "iteration-start"
+            : event.name === "advance"
+              ? "dispatch-match"
+              : event.name === "advance-blocked"
+                ? "guard-block"
+                : event.name === "advance-stopped"
+                  ? "dispatch-stop"
+                  : event.name === "advance-error"
+                    ? "iteration-end"
+                    : event.name === "advance-retry"
+                      ? "guard-block"
+                      : event.name === "stop"
+                      ? "terminal"
+                      : "iteration-end";
+
+        _emitJournalEvent(basePath, {
+          ts: new Date().toISOString(),
+          flowId,
+          seq: ++seq,
+          eventType,
+          data: {
+            source: "auto-orchestrator",
+            name: event.name,
+            reason: event.reason,
+            unitType: event.unitType,
+            unitId: event.unitId,
+          },
+        });
+      },
+    },
+    notifications: {
+      async notifyLifecycle(event) {
+        if (event.name === "error") {
+          ctx.ui.notify(event.detail ?? "auto orchestration error", "error");
+        }
+      },
+    },
+  };
+
+  return createAutoOrchestrator(deps);
+}
+
+function ensureOrchestrationModule(ctx: ExtensionContext, pi: ExtensionAPI, basePath: string): void {
+  s.orchestration = createWiredAutoOrchestrationModule(ctx, pi, basePath);
 }
 
 /**
@@ -1753,6 +1901,7 @@ export async function startAuto(
     }
     // Rebuild scope now that s.basePath reflects the actual worktree (or project root).
     rebuildScope(s.basePath, s.currentMilestoneId);
+    ensureOrchestrationModule(ctx, pi, s.basePath || base);
     // Ensure the workflow-logger audit log is pinned to the project root
     // even when auto-mode is entered via a path that bypasses the
     // bootstrap/dynamic-tools ensureDbOpen() → setLogBasePath() chain
@@ -1868,6 +2017,11 @@ export async function startAuto(
     }
     pi.events.emit(CMUX_CHANNELS.LOG, { preferences: loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, message: s.stepMode ? "Step-mode resumed." : "Auto-mode resumed.", level: "progress" });
 
+    try {
+      await s.orchestration?.resume();
+    } catch (err) {
+      debugLog("resume-orchestration-resume", { error: err instanceof Error ? err.message : String(err) });
+    }
     startAutoCommandPolling(s.basePath);
     await runAutoLoopWithUok({
       ctx,
@@ -1904,7 +2058,7 @@ export async function startAuto(
   // Build scope after bootstrap has populated s.basePath / s.originalBasePath /
   // s.currentMilestoneId (including worktree setup inside bootstrapAutoSession).
   rebuildScope(s.basePath, s.currentMilestoneId);
-
+  ensureOrchestrationModule(ctx, pi, s.basePath || base);
   captureProjectRootEnv(s.originalBasePath || s.basePath);
   registerAutoWorkerForSession(s);
   try {
@@ -1914,6 +2068,12 @@ export async function startAuto(
     logWarning("engine", `cmux sync failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
   }
   pi.events.emit(CMUX_CHANNELS.LOG, { preferences: loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, message: requestedStepMode ? "Step-mode started." : "Auto-mode started.", level: "progress" });
+
+  try {
+    await s.orchestration?.start({ basePath: s.basePath, trigger: "auto-loop" });
+  } catch (err) {
+    debugLog("start-orchestration-start", { error: err instanceof Error ? err.message : String(err) });
+  }
 
   startAutoCommandPolling(s.basePath);
 
@@ -2037,6 +2197,7 @@ export async function dispatchHookUnit(
   }
 
   s.basePath = targetBasePath;
+  ensureOrchestrationModule(ctx, pi, s.basePath);
 
   const hookUnitType = `hook/${hookName}`;
   const hookStartedAt = Date.now();

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -147,6 +147,7 @@ import {
   MergeConflictError,
   parseSliceBranch,
   setActiveMilestoneId,
+  resolveProjectRoot,
 } from "./worktree.js";
 import { GitServiceImpl } from "./git-service.js";
 import { getPriorSliceCompletionBlocker } from "./dispatch-guard.js";
@@ -1387,7 +1388,8 @@ function buildResolver(): WorktreeResolver {
 export function createWiredAutoOrchestrationModule(
   ctx: ExtensionContext,
   _pi: ExtensionAPI,
-  basePath: string,
+  dispatchBasePath: string,
+  runtimeBasePath = resolveProjectRoot(dispatchBasePath),
 ): AutoOrchestrationModule {
   const flowId = `auto-orchestrator-${Date.now()}`;
   let seq = 0;
@@ -1395,13 +1397,13 @@ export function createWiredAutoOrchestrationModule(
   const deps: AutoOrchestratorDeps = {
     dispatch: {
       async decideNextUnit() {
-        const state = await deriveState(basePath);
+        const state = await deriveState(dispatchBasePath);
         const active = state.activeMilestone;
         if (!active) return null;
 
-        const prefs = loadEffectiveGSDPreferences(basePath)?.preferences;
+        const prefs = loadEffectiveGSDPreferences(dispatchBasePath)?.preferences;
         const action = await resolveDispatch({
-          basePath,
+          basePath: dispatchBasePath,
           mid: active.id,
           midTitle: active.title,
           state,
@@ -1430,7 +1432,7 @@ export function createWiredAutoOrchestrationModule(
     },
     health: {
       async preAdvanceGate() {
-        const gate = await preDispatchHealthGate(basePath);
+        const gate = await preDispatchHealthGate(dispatchBasePath);
         return {
           allow: gate.proceed,
           reason: gate.reason,
@@ -1456,7 +1458,7 @@ export function createWiredAutoOrchestrationModule(
     },
     runtime: {
       async ensureLockOwnership() {
-        const status = getSessionLockStatus(basePath);
+        const status = getSessionLockStatus(runtimeBasePath);
         if (status === "in_use_by_other") {
           throw new Error("session lock held by another process");
         }
@@ -1474,13 +1476,13 @@ export function createWiredAutoOrchestrationModule(
                   ? "dispatch-stop"
                   : event.name === "advance-error"
                     ? "iteration-end"
-                    : event.name === "advance-retry"
+                    : event.name === "advance-paused" || event.name === "advance-retry"
                       ? "guard-block"
                       : event.name === "stop"
                       ? "terminal"
                       : "iteration-end";
 
-        _emitJournalEvent(basePath, {
+        _emitJournalEvent(runtimeBasePath, {
           ts: new Date().toISOString(),
           flowId,
           seq: ++seq,
@@ -1508,7 +1510,7 @@ export function createWiredAutoOrchestrationModule(
 }
 
 function ensureOrchestrationModule(ctx: ExtensionContext, pi: ExtensionAPI, basePath: string): void {
-  s.orchestration = createWiredAutoOrchestrationModule(ctx, pi, basePath);
+  s.orchestration = createWiredAutoOrchestrationModule(ctx, pi, basePath, lockBase());
 }
 
 /**
@@ -2197,7 +2199,9 @@ export async function dispatchHookUnit(
   }
 
   s.basePath = targetBasePath;
-  ensureOrchestrationModule(ctx, pi, s.basePath);
+  if (!s.orchestration) {
+    ensureOrchestrationModule(ctx, pi, s.basePath);
+  }
 
   const hookUnitType = `hook/${hookName}`;
   const hookStartedAt = Date.now();

--- a/src/resources/extensions/gsd/auto/contracts.ts
+++ b/src/resources/extensions/gsd/auto/contracts.ts
@@ -1,0 +1,87 @@
+import type { GSDState } from "../types.js";
+
+export interface AutoSessionContext {
+  basePath: string;
+  trigger: "guided-flow" | "resume" | "auto-loop" | "manual";
+}
+
+export interface AutoStatus {
+  phase: "idle" | "running" | "paused" | "stopped" | "error";
+  activeUnit?: {
+    unitType: string;
+    unitId: string;
+  };
+  lastTransitionAt?: number;
+  transitionCount: number;
+}
+
+export interface AutoAdvanceResult {
+  kind: "advanced" | "blocked" | "paused" | "stopped" | "error";
+  reason?: string;
+  stateSnapshot?: GSDState;
+}
+
+export interface AutoOrchestrationModule {
+  start(sessionContext: AutoSessionContext): Promise<AutoAdvanceResult>;
+  advance(): Promise<AutoAdvanceResult>;
+  resume(): Promise<AutoAdvanceResult>;
+  stop(reason: string): Promise<AutoAdvanceResult>;
+  getStatus(): AutoStatus;
+}
+
+export interface DispatchAdapter {
+  decideNextUnit(): Promise<{
+    unitType: string;
+    unitId: string;
+    reason: string;
+    preconditions: string[];
+  } | null>;
+}
+
+export interface RecoveryAdapter {
+  classifyAndRecover(input: {
+    error: unknown;
+    unitType?: string;
+    unitId?: string;
+  }): Promise<{
+    action: "retry" | "escalate" | "stop";
+    reason: string;
+  }>;
+}
+
+export interface WorktreeAdapter {
+  prepareForUnit(unitType: string, unitId: string): Promise<void>;
+  syncAfterUnit(unitType: string, unitId: string): Promise<void>;
+  cleanupOnStop(reason: string): Promise<void>;
+}
+
+export interface HealthAdapter {
+  preAdvanceGate(): Promise<{ allow: boolean; reason?: string }>;
+  postAdvanceRecord(result: AutoAdvanceResult): Promise<void>;
+}
+
+export interface RuntimePersistenceAdapter {
+  ensureLockOwnership(): Promise<void>;
+  journalTransition(event: {
+    name: string;
+    reason?: string;
+    unitType?: string;
+    unitId?: string;
+  }): Promise<void>;
+}
+
+export interface NotificationAdapter {
+  notifyLifecycle(event: {
+    name: string;
+    detail?: string;
+  }): Promise<void>;
+}
+
+export interface AutoOrchestratorDeps {
+  dispatch: DispatchAdapter;
+  recovery: RecoveryAdapter;
+  worktree: WorktreeAdapter;
+  health: HealthAdapter;
+  runtime: RuntimePersistenceAdapter;
+  notifications: NotificationAdapter;
+}

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -7,6 +7,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 
 import type { AutoSession } from "./session.js";
+import type { ErrorContext } from "./types.js";
 import type { GSDPreferences } from "../preferences.js";
 import type { GSDState } from "../types.js";
 import type { SessionLockStatus } from "../session-lock.js";
@@ -39,7 +40,11 @@ export interface LoopDeps {
     pi?: ExtensionAPI,
     reason?: string,
   ) => Promise<void>;
-  pauseAuto: (ctx?: ExtensionContext, pi?: ExtensionAPI) => Promise<void>;
+  pauseAuto: (
+    ctx?: ExtensionContext,
+    pi?: ExtensionAPI,
+    errorContext?: ErrorContext,
+  ) => Promise<void>;
   clearUnitTimeout: () => void;
   updateProgressWidget: (
     ctx: ExtensionContext,
@@ -245,7 +250,11 @@ export interface LoopDeps {
     prefs: GSDPreferences | undefined;
     buildSnapshotOpts: () => CloseoutOptions & Record<string, unknown>;
     buildRecoveryContext: () => unknown;
-    pauseAuto: (ctx?: ExtensionContext, pi?: ExtensionAPI) => Promise<void>;
+    pauseAuto: (
+      ctx?: ExtensionContext,
+      pi?: ExtensionAPI,
+      errorContext?: ErrorContext,
+    ) => Promise<void>;
   }) => void;
 
   // Prompt helpers
@@ -271,7 +280,11 @@ export interface LoopDeps {
   ) => Promise<"dispatched" | "continue" | "retry">;
   runPostUnitVerification: (
     vctx: VerificationContext,
-    pauseAuto: (ctx?: ExtensionContext, pi?: ExtensionAPI) => Promise<void>,
+    pauseAuto: (
+      ctx?: ExtensionContext,
+      pi?: ExtensionAPI,
+      errorContext?: ErrorContext,
+    ) => Promise<void>,
   ) => Promise<VerificationResult>;
   postUnitPostVerification: (
     pctx: PostUnitContext,

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -106,13 +106,16 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
 
       const journalName = result.kind === "paused"
         ? "advance-paused"
-        : "advance-error";
+        : result.kind === "stopped"
+          ? "advance-stopped"
+          : "advance-error";
       await this.deps.runtime.journalTransition({ name: journalName, reason: recovery.reason });
 
-      const notificationName = result.kind === "paused"
-        ? "pause"
-        : "error";
-      await this.deps.notifications.notifyLifecycle({ name: notificationName, detail: recovery.reason });
+      if (result.kind === "paused") {
+        await this.deps.notifications.notifyLifecycle({ name: "pause", detail: recovery.reason });
+      } else if (result.kind === "error") {
+        await this.deps.notifications.notifyLifecycle({ name: "error", detail: recovery.reason });
+      }
       await this.deps.health.postAdvanceRecord(result);
       return result;
     }

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -1,0 +1,153 @@
+import type { AutoAdvanceResult, AutoOrchestrationModule, AutoOrchestratorDeps, AutoSessionContext, AutoStatus } from "./contracts.js";
+
+function now(): number {
+  return Date.now();
+}
+
+export class AutoOrchestrator implements AutoOrchestrationModule {
+  private status: AutoStatus = {
+    phase: "idle",
+    transitionCount: 0,
+  };
+  private readonly deps: AutoOrchestratorDeps;
+  private lastAdvanceKey: string | null = null;
+
+  public constructor(deps: AutoOrchestratorDeps) {
+    this.deps = deps;
+  }
+
+  public async start(_sessionContext: AutoSessionContext): Promise<AutoAdvanceResult> {
+    this.lastAdvanceKey = null;
+    this.status.phase = "running";
+    this.bumpTransition();
+    await this.deps.runtime.journalTransition({ name: "start" });
+    await this.deps.notifications.notifyLifecycle({ name: "start" });
+    return this.advance();
+  }
+
+  public async advance(): Promise<AutoAdvanceResult> {
+    try {
+      await this.deps.runtime.ensureLockOwnership();
+      const gate = await this.deps.health.preAdvanceGate();
+      if (!gate.allow) {
+        const blocked: AutoAdvanceResult = { kind: "blocked", reason: gate.reason ?? "health gate blocked" };
+        await this.deps.runtime.journalTransition({ name: "advance-blocked", reason: blocked.reason });
+        await this.deps.health.postAdvanceRecord(blocked);
+        return blocked;
+      }
+
+      const decision = await this.deps.dispatch.decideNextUnit();
+      if (!decision) {
+        const stopped: AutoAdvanceResult = { kind: "stopped", reason: "no remaining units" };
+        this.status.phase = "stopped";
+        this.status.activeUnit = undefined;
+        this.lastAdvanceKey = null;
+        this.bumpTransition();
+        await this.deps.runtime.journalTransition({ name: "advance-stopped", reason: stopped.reason });
+        await this.deps.health.postAdvanceRecord(stopped);
+        return stopped;
+      }
+
+      const nextKey = `${decision.unitType}:${decision.unitId}`;
+      if (this.lastAdvanceKey === nextKey) {
+        const blocked: AutoAdvanceResult = { kind: "blocked", reason: "idempotent advance: unit already active" };
+        await this.deps.runtime.journalTransition({
+          name: "advance-blocked",
+          reason: blocked.reason,
+          unitType: decision.unitType,
+          unitId: decision.unitId,
+        });
+        await this.deps.health.postAdvanceRecord(blocked);
+        return blocked;
+      }
+
+      this.status.activeUnit = { unitType: decision.unitType, unitId: decision.unitId };
+      this.status.phase = "running";
+      this.lastAdvanceKey = nextKey;
+      this.bumpTransition();
+
+      await this.deps.runtime.journalTransition({
+        name: "advance",
+        reason: decision.reason,
+        unitType: decision.unitType,
+        unitId: decision.unitId,
+      });
+      await this.deps.worktree.prepareForUnit(decision.unitType, decision.unitId);
+      await this.deps.worktree.syncAfterUnit(decision.unitType, decision.unitId);
+
+      const advanced: AutoAdvanceResult = { kind: "advanced" };
+      await this.deps.health.postAdvanceRecord(advanced);
+      return advanced;
+    } catch (error) {
+      const recovery = await this.deps.recovery.classifyAndRecover({
+        error,
+        unitType: this.status.activeUnit?.unitType,
+        unitId: this.status.activeUnit?.unitId,
+      });
+      const result: AutoAdvanceResult = recovery.action === "retry"
+        ? { kind: "paused", reason: recovery.reason }
+        : recovery.action === "escalate"
+          ? { kind: "error", reason: recovery.reason }
+          : { kind: "stopped", reason: recovery.reason };
+
+      if (result.kind === "paused") {
+        this.status.phase = "paused";
+      } else if (result.kind === "stopped") {
+        this.status.phase = "stopped";
+      } else {
+        this.status.phase = "error";
+      }
+
+      if (result.kind === "stopped") {
+        this.lastAdvanceKey = null;
+        this.status.activeUnit = undefined;
+      }
+      this.bumpTransition();
+
+      const journalName = result.kind === "paused"
+        ? "advance-retry"
+        : "advance-error";
+      await this.deps.runtime.journalTransition({ name: journalName, reason: recovery.reason });
+
+      const notificationName = result.kind === "paused"
+        ? "pause"
+        : "error";
+      await this.deps.notifications.notifyLifecycle({ name: notificationName, detail: recovery.reason });
+      await this.deps.health.postAdvanceRecord(result);
+      return result;
+    }
+  }
+
+  public async resume(): Promise<AutoAdvanceResult> {
+    this.lastAdvanceKey = null;
+    this.status.phase = "running";
+    this.bumpTransition();
+    await this.deps.runtime.journalTransition({ name: "resume" });
+    await this.deps.notifications.notifyLifecycle({ name: "resume" });
+    return this.advance();
+  }
+
+  public async stop(reason: string): Promise<AutoAdvanceResult> {
+    await this.deps.worktree.cleanupOnStop(reason);
+    this.status.phase = "stopped";
+    this.status.activeUnit = undefined;
+    this.lastAdvanceKey = null;
+    this.bumpTransition();
+    await this.deps.runtime.journalTransition({ name: "stop", reason });
+    await this.deps.notifications.notifyLifecycle({ name: "stop", detail: reason });
+    return { kind: "stopped", reason };
+  }
+
+  public getStatus(): AutoStatus {
+    return { ...this.status, activeUnit: this.status.activeUnit ? { ...this.status.activeUnit } : undefined };
+  }
+
+  private bumpTransition(): void {
+    this.status.transitionCount += 1;
+    this.status.lastTransitionAt = now();
+  }
+}
+
+export function createAutoOrchestrator(deps: AutoOrchestratorDeps): AutoOrchestrationModule {
+  return new AutoOrchestrator(deps);
+}

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -113,6 +113,8 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
 
       if (result.kind === "paused") {
         await this.deps.notifications.notifyLifecycle({ name: "pause", detail: recovery.reason });
+      } else if (result.kind === "stopped") {
+        await this.deps.notifications.notifyLifecycle({ name: "stopped", detail: recovery.reason });
       } else if (result.kind === "error") {
         await this.deps.notifications.notifyLifecycle({ name: "error", detail: recovery.reason });
       }

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -105,7 +105,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       this.bumpTransition();
 
       const journalName = result.kind === "paused"
-        ? "advance-retry"
+        ? "advance-paused"
         : "advance-error";
       await this.deps.runtime.journalTransition({ name: journalName, reason: recovery.reason });
 
@@ -128,6 +128,9 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   }
 
   public async stop(reason: string): Promise<AutoAdvanceResult> {
+    if (this.status.phase === "stopped") {
+      return { kind: "stopped", reason };
+    }
     await this.deps.worktree.cleanupOnStop(reason);
     this.status.phase = "stopped";
     this.status.activeUnit = undefined;

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -21,6 +21,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent
 import type { GitServiceImpl } from "../git-service.js";
 import type { CaptureEntry } from "../captures.js";
 import type { BudgetAlertLevel } from "../auto-budget.js";
+import type { AutoOrchestrationModule } from "./contracts.js";
 import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { normalizeRealPath } from "../paths.js";
 import type { MilestoneScope } from "../workspace.js";
@@ -229,6 +230,9 @@ export class AutoSession {
   /** Cleanup function returned by startCommandPolling(); null when not running. */
   commandPollingCleanup: (() => void) | null = null;
 
+  // ── Orchestration seam ───────────────────────────────────────────────────
+  orchestration: AutoOrchestrationModule | null = null;
+
   // ── Loop promise state ──────────────────────────────────────────────────
   // Per-unit resolve function and session-switch guard live at module level
   // in auto-loop.ts (_currentResolve, _sessionSwitchInFlight).
@@ -354,10 +358,14 @@ export class AutoSession {
     // Remote command polling — cleanup must be called before reset (auto.ts stopAuto)
     this.commandPollingCleanup = null;
 
+    // Orchestration seam
+    this.orchestration = null;
+
     // Loop promise state lives in auto-loop.ts module scope
   }
 
   toJSON(): Record<string, unknown> {
+    const orchestrationStatus = this.orchestration?.getStatus();
     return {
       active: this.active,
       paused: this.paused,
@@ -367,6 +375,9 @@ export class AutoSession {
       activeRunDir: this.activeRunDir,
       currentMilestoneId: this.currentMilestoneId,
       currentUnit: this.currentUnit,
+      orchestrationPhase: orchestrationStatus?.phase,
+      orchestrationTransitionCount: orchestrationStatus?.transitionCount,
+      orchestrationLastTransitionAt: orchestrationStatus?.lastTransitionAt,
       unitDispatchCount: Object.fromEntries(this.unitDispatchCount),
     };
   }

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -212,8 +212,8 @@ test("recovery stop clears activeUnit", async () => {
 
   assert.equal(result.kind, "stopped");
   assert.equal(orchestrator.getStatus().activeUnit, undefined);
-  assert.ok(calls.includes("journal:advance-error"));
-  assert.ok(calls.includes("notify:error"));
+  assert.ok(calls.includes("journal:advance-stopped"));
+  assert.ok(!calls.includes("notify:error"));
 });
 
 test("recovery retry maps to paused result", async () => {

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1,0 +1,352 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createAutoOrchestrator } from "../auto/orchestrator.js";
+import type { AutoOrchestratorDeps } from "../auto/contracts.js";
+
+function makeDeps(overrides: Partial<AutoOrchestratorDeps> = {}): { deps: AutoOrchestratorDeps; calls: string[] } {
+  const calls: string[] = [];
+
+  const deps: AutoOrchestratorDeps = {
+    dispatch: {
+      async decideNextUnit() {
+        calls.push("dispatch.decide");
+        return { unitType: "execute-task", unitId: "T01", reason: "ready", preconditions: [] };
+      },
+    },
+    recovery: {
+      async classifyAndRecover() {
+        calls.push("recovery.classify");
+        return { action: "stop", reason: "fatal" };
+      },
+    },
+    worktree: {
+      async prepareForUnit() { calls.push("worktree.prepare"); },
+      async syncAfterUnit() { calls.push("worktree.sync"); },
+      async cleanupOnStop() { calls.push("worktree.cleanup"); },
+    },
+    health: {
+      async preAdvanceGate() {
+        calls.push("health.pre");
+        return { allow: true };
+      },
+      async postAdvanceRecord() { calls.push("health.post"); },
+    },
+    runtime: {
+      async ensureLockOwnership() { calls.push("runtime.lock"); },
+      async journalTransition(event) { calls.push(`journal:${event.name}`); },
+    },
+    notifications: {
+      async notifyLifecycle(event) { calls.push(`notify:${event.name}`); },
+    },
+  };
+
+  return { deps: { ...deps, ...overrides }, calls };
+}
+
+test("start() advances and records active unit", async () => {
+  const { deps, calls } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.start({ basePath: "/tmp/project", trigger: "manual" });
+
+  assert.equal(result.kind, "advanced");
+  const status = orchestrator.getStatus();
+  assert.equal(status.phase, "running");
+  assert.deepEqual(status.activeUnit, { unitType: "execute-task", unitId: "T01" });
+  assert.ok(calls.includes("journal:start"));
+  assert.ok(calls.includes("journal:advance"));
+});
+
+test("advance() returns blocked when health gate denies", async () => {
+  const { deps } = makeDeps({
+    health: {
+      async preAdvanceGate() { return { allow: false, reason: "doctor-block" }; },
+      async postAdvanceRecord() {},
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.advance();
+
+  assert.equal(result.kind, "blocked");
+  assert.equal(result.reason, "doctor-block");
+});
+
+test("advance() stops when dispatch has no next unit", async () => {
+  const { deps } = makeDeps({
+    dispatch: {
+      async decideNextUnit() { return null; },
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.advance();
+
+  assert.equal(result.kind, "stopped");
+  assert.equal(orchestrator.getStatus().phase, "stopped");
+});
+
+test("advance() uses recovery on error", async () => {
+  const { deps, calls } = makeDeps({
+    runtime: {
+      async ensureLockOwnership() { throw new Error("lock lost"); },
+      async journalTransition(event) { calls.push(`journal:${event.name}`); },
+    },
+    recovery: {
+      async classifyAndRecover() { return { action: "escalate", reason: "needs manual" }; },
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.advance();
+
+  assert.equal(result.kind, "error");
+  assert.equal(result.reason, "needs manual");
+  assert.equal(orchestrator.getStatus().phase, "error");
+  assert.ok(calls.includes("journal:advance-error"));
+});
+
+test("advance() is idempotent for the same active unit", async () => {
+  const { deps, calls } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const first = await orchestrator.advance();
+  const second = await orchestrator.advance();
+
+  assert.equal(first.kind, "advanced");
+  assert.equal(second.kind, "blocked");
+  assert.equal(second.reason, "idempotent advance: unit already active");
+
+  const prepareCalls = calls.filter((c) => c === "worktree.prepare").length;
+  assert.equal(prepareCalls, 1);
+});
+
+test("resume() re-enters running flow via advance", async () => {
+  const { deps } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.resume();
+
+  assert.equal(result.kind, "advanced");
+  assert.equal(orchestrator.getStatus().phase, "running");
+});
+
+test("resume() clears idempotent lock and allows re-advance", async () => {
+  const { deps } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const first = await orchestrator.advance();
+  const blocked = await orchestrator.advance();
+  const resumed = await orchestrator.resume();
+
+  assert.equal(first.kind, "advanced");
+  assert.equal(blocked.kind, "blocked");
+  assert.equal(resumed.kind, "advanced");
+});
+
+test("transitionCount increases across lifecycle transitions", async () => {
+  const { deps } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const before = orchestrator.getStatus().transitionCount;
+  await orchestrator.start({ basePath: "/tmp/project", trigger: "manual" });
+  const afterStart = orchestrator.getStatus().transitionCount;
+  await orchestrator.stop("done");
+  const afterStop = orchestrator.getStatus().transitionCount;
+
+  assert.ok(afterStart > before);
+  assert.ok(afterStop > afterStart);
+});
+
+test("stop() clears idempotent unit lock so advance can run again", async () => {
+  const { deps } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const first = await orchestrator.advance();
+  const blocked = await orchestrator.advance();
+  const stopped = await orchestrator.stop("reset");
+  const second = await orchestrator.advance();
+
+  assert.equal(first.kind, "advanced");
+  assert.equal(blocked.kind, "blocked");
+  assert.equal(stopped.kind, "stopped");
+  assert.equal(second.kind, "advanced");
+});
+
+test("advance() stopped clears previous activeUnit", async () => {
+  let first = true;
+  const { deps } = makeDeps({
+    dispatch: {
+      async decideNextUnit() {
+        if (first) {
+          first = false;
+          return { unitType: "execute-task", unitId: "T01", reason: "ready", preconditions: [] };
+        }
+        return null;
+      },
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  await orchestrator.advance();
+  const stopped = await orchestrator.advance();
+
+  assert.equal(stopped.kind, "stopped");
+  assert.equal(orchestrator.getStatus().activeUnit, undefined);
+});
+
+test("recovery stop clears activeUnit", async () => {
+  const { deps, calls } = makeDeps({
+    runtime: {
+      async ensureLockOwnership() { throw new Error("boom"); },
+      async journalTransition(event) { calls.push(`journal:${event.name}`); },
+    },
+    recovery: {
+      async classifyAndRecover() { return { action: "stop", reason: "fatal" }; },
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.advance();
+
+  assert.equal(result.kind, "stopped");
+  assert.equal(orchestrator.getStatus().activeUnit, undefined);
+  assert.ok(calls.includes("journal:advance-error"));
+  assert.ok(calls.includes("notify:error"));
+});
+
+test("recovery retry maps to paused result", async () => {
+  const { deps, calls } = makeDeps({
+    runtime: {
+      async ensureLockOwnership() { throw new Error("boom"); },
+      async journalTransition(event) { calls.push(`journal:${event.name}`); },
+    },
+    recovery: {
+      async classifyAndRecover() { return { action: "retry", reason: "transient" }; },
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.advance();
+
+  assert.equal(result.kind, "paused");
+  assert.equal(result.reason, "transient");
+  assert.equal(orchestrator.getStatus().phase, "paused");
+  assert.ok(calls.includes("journal:advance-retry"));
+  assert.ok(calls.includes("notify:pause"));
+});
+
+test("getStatus() returns defensive copy of activeUnit", async () => {
+  const { deps } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  await orchestrator.advance();
+  const snap1 = orchestrator.getStatus();
+  if (snap1.activeUnit) snap1.activeUnit.unitId = "MUTATED";
+  const snap2 = orchestrator.getStatus();
+
+  assert.equal(snap2.activeUnit?.unitId, "T01");
+});
+
+test("start() clears prior idempotent lock", async () => {
+  const { deps } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  await orchestrator.advance();
+  const blocked = await orchestrator.advance();
+  const restarted = await orchestrator.start({ basePath: "/tmp/project", trigger: "manual" });
+
+  assert.equal(blocked.kind, "blocked");
+  assert.equal(restarted.kind, "advanced");
+});
+
+test("error path emits error notification", async () => {
+  const { deps, calls } = makeDeps({
+    runtime: {
+      async ensureLockOwnership() { throw new Error("boom"); },
+      async journalTransition(event) { calls.push(`journal:${event.name}`); },
+    },
+    recovery: {
+      async classifyAndRecover() { return { action: "escalate", reason: "needs manual" }; },
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  await orchestrator.advance();
+
+  assert.ok(calls.includes("notify:error"));
+});
+
+test("blocked path journals advance-blocked", async () => {
+  const { deps, calls } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  await orchestrator.advance();
+  await orchestrator.advance();
+
+  assert.ok(calls.includes("journal:advance-blocked"));
+});
+
+test("health post hook runs on blocked result", async () => {
+  const { deps, calls } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  await orchestrator.advance();
+  await orchestrator.advance();
+
+  assert.ok(calls.includes("health.post"));
+});
+
+test("start() emits start notification", async () => {
+  const { deps, calls } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  await orchestrator.start({ basePath: "/tmp/project", trigger: "manual" });
+
+  assert.ok(calls.includes("notify:start"));
+});
+
+test("resume() emits resume notification", async () => {
+  const { deps, calls } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  await orchestrator.resume();
+
+  assert.ok(calls.includes("notify:resume"));
+});
+
+test("stopped with no remaining units clears idempotent lock for next advance", async () => {
+  let callCount = 0;
+  const { deps } = makeDeps({
+    dispatch: {
+      async decideNextUnit() {
+        callCount += 1;
+        if (callCount === 2) return null;
+        return { unitType: "execute-task", unitId: "T01", reason: "ready", preconditions: [] };
+      },
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const first = await orchestrator.advance();
+  const stopped = await orchestrator.advance();
+  const after = await orchestrator.advance();
+
+  assert.equal(first.kind, "advanced");
+  assert.equal(stopped.kind, "stopped");
+  assert.equal(after.kind, "advanced");
+});
+
+test("stop() cleans up worktree and transitions to stopped", async () => {
+  const { deps, calls } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.stop("user-request");
+
+  assert.equal(result.kind, "stopped");
+  assert.equal(orchestrator.getStatus().phase, "stopped");
+  assert.ok(calls.includes("worktree.cleanup"));
+  assert.ok(calls.includes("journal:stop"));
+  assert.ok(calls.includes("notify:stop"));
+});

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -213,6 +213,7 @@ test("recovery stop clears activeUnit", async () => {
   assert.equal(result.kind, "stopped");
   assert.equal(orchestrator.getStatus().activeUnit, undefined);
   assert.ok(calls.includes("journal:advance-stopped"));
+  assert.ok(calls.includes("notify:stopped"));
   assert.ok(!calls.includes("notify:error"));
 });
 

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -233,7 +233,7 @@ test("recovery retry maps to paused result", async () => {
   assert.equal(result.kind, "paused");
   assert.equal(result.reason, "transient");
   assert.equal(orchestrator.getStatus().phase, "paused");
-  assert.ok(calls.includes("journal:advance-retry"));
+  assert.ok(calls.includes("journal:advance-paused"));
   assert.ok(calls.includes("notify:pause"));
 });
 

--- a/src/resources/extensions/gsd/tests/auto-runtime-state.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-runtime-state.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { autoSession, getAutoRuntimeSnapshot } from "../auto-runtime-state.ts";
+
+test("getAutoRuntimeSnapshot includes orchestration phase when available", () => {
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.basePath = "/tmp/project";
+  autoSession.orchestration = {
+    async start() { return { kind: "advanced" as const }; },
+    async advance() { return { kind: "advanced" as const }; },
+    async resume() { return { kind: "advanced" as const }; },
+    async stop() { return { kind: "stopped" as const }; },
+    getStatus() {
+      return { phase: "running" as const, transitionCount: 3, lastTransitionAt: 123 };
+    },
+  };
+
+  const snap = getAutoRuntimeSnapshot();
+
+  assert.equal(snap.active, true);
+  assert.equal(snap.basePath, "/tmp/project");
+  assert.equal(snap.orchestrationPhase, "running");
+  assert.equal(snap.orchestrationTransitionCount, 3);
+  assert.equal(snap.orchestrationLastTransitionAt, 123);
+
+  autoSession.reset();
+});
+
+test("getAutoRuntimeSnapshot omits orchestration phase when seam not wired", () => {
+  autoSession.reset();
+
+  const snap = getAutoRuntimeSnapshot();
+
+  assert.equal(snap.orchestrationPhase, undefined);
+  assert.equal(snap.orchestrationTransitionCount, undefined);
+  assert.equal(snap.orchestrationLastTransitionAt, undefined);
+});

--- a/src/resources/extensions/gsd/tests/auto-session-encapsulation.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-session-encapsulation.test.ts
@@ -201,6 +201,9 @@ test("AutoSession.toJSON() includes key diagnostic properties", () => {
     "basePath",
     "currentMilestoneId",
     "currentUnit",
+    "orchestrationPhase",
+    "orchestrationTransitionCount",
+    "orchestrationLastTransitionAt",
   ];
 
   const missing = requiredDiagnostics.filter(prop => !toJSONBody.includes(prop));


### PR DESCRIPTION
## Linked issue

Closes #5281

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Introduces a new Auto Orchestration module with explicit seam contracts, lifecycle wiring, and contract tests, while keeping the existing auto loop behavior intact.
**Why:** `auto.ts` was carrying too many concerns; this deepens the orchestration module for locality, testability, and safer evolution.
**How:** Added `contracts.ts` + `orchestrator.ts`, wired adapters in `auto.ts` (dispatch/health/runtime persistence/notifications), integrated orchestration lifecycle into start/resume/pause/stop paths, and added focused tests.

## What

- Added new architecture docs:
  - `docs/dev/ADR-014-auto-orchestration-deep-module.md`
  - `CONTEXT.md`
- Added new orchestration module and seam contracts:
  - `src/resources/extensions/gsd/auto/contracts.ts`
  - `src/resources/extensions/gsd/auto/orchestrator.ts`
- Integrated lifecycle wiring in existing auto runtime:
  - `src/resources/extensions/gsd/auto.ts`
  - `src/resources/extensions/gsd/auto/session.ts`
  - `src/resources/extensions/gsd/auto-runtime-state.ts`
- Added and expanded tests:
  - `src/resources/extensions/gsd/tests/auto-orchestrator.test.ts`
  - `src/resources/extensions/gsd/tests/auto-runtime-state.test.ts`
  - `src/resources/extensions/gsd/tests/auto-session-encapsulation.test.ts`

## Why

The auto-mode orchestration surface had low locality and high coupling across dispatch, recovery, health, lock/journal, and lifecycle concerns. This change establishes a deep orchestration module and stable seam contracts before switching the primary loop logic, reducing regression risk and improving diagnosability.

## How

- New orchestration interface:
  - `start(sessionContext)`
  - `advance()`
  - `resume()`
  - `stop(reason)`
  - `getStatus()`
- Adapters wired initially for:
  - Dispatch (`deriveState` + `resolveDispatch`)
  - Health (`preDispatchHealthGate` + `recordHealthSnapshot`)
  - Runtime persistence (session lock check + journal transition emission)
  - Notifications
- Lifecycle hooks now call orchestration lifecycle methods from auto start/resume/pause/stop paths (best-effort, non-breaking).
- Added contract coverage for:
  - idempotent advance behavior
  - retry/escalate/stop recovery mapping
  - transition bookkeeping and defensive status snapshots
  - runtime snapshot orchestration fields

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual/targeted test run:

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test \
  src/resources/extensions/gsd/tests/auto-runtime-state.test.ts \
  src/resources/extensions/gsd/tests/auto-orchestrator.test.ts \
  src/resources/extensions/gsd/tests/auto-session-encapsulation.test.ts
```

Observed: `33 passed, 0 failed`.

## AI disclosure

- [x] This PR includes AI-assisted code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-mode now exposes orchestration observability metrics including phase status (idle/running/paused/stopped/error), transition count, and last transition timestamp in runtime snapshots for improved visibility into unit progression.

* **Documentation**
  * Added architecture documentation outlining auto-orchestration module design, adapter patterns, and phase 1 implementation snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->