### PR TITLE
fix(gsd-extension): preserve auto-mode cancellation context and pause diagnostics

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1264,6 +1264,7 @@ export async function pauseAuto(
       activeRunDir: s.activeRunDir,
       autoStartTime: s.autoStartTime,
       milestoneLock: s.sessionMilestoneLock ?? undefined,
+      pauseReason: _errorContext?.message,
     };
     setRuntimeKv("global", "", PAUSED_SESSION_KV_KEY, pausedMeta);
   } catch (err) {

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -7,6 +7,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 
 import type { AutoSession } from "./session.js";
+import type { ErrorContext } from "./types.js";
 import type { GSDPreferences } from "../preferences.js";
 import type { GSDState } from "../types.js";
 import type { SessionLockStatus } from "../session-lock.js";
@@ -39,7 +40,11 @@ export interface LoopDeps {
     pi?: ExtensionAPI,
     reason?: string,
   ) => Promise<void>;
-  pauseAuto: (ctx?: ExtensionContext, pi?: ExtensionAPI) => Promise<void>;
+  pauseAuto: (
+    ctx?: ExtensionContext,
+    pi?: ExtensionAPI,
+    errorContext?: ErrorContext,
+  ) => Promise<void>;
   clearUnitTimeout: () => void;
   updateProgressWidget: (
     ctx: ExtensionContext,
@@ -245,7 +250,11 @@ export interface LoopDeps {
     prefs: GSDPreferences | undefined;
     buildSnapshotOpts: () => CloseoutOptions & Record<string, unknown>;
     buildRecoveryContext: () => unknown;
-    pauseAuto: (ctx?: ExtensionContext, pi?: ExtensionAPI) => Promise<void>;
+    pauseAuto: (
+      ctx?: ExtensionContext,
+      pi?: ExtensionAPI,
+      errorContext?: ErrorContext,
+    ) => Promise<void>;
   }) => void;
 
   // Prompt helpers
@@ -271,7 +280,11 @@ export interface LoopDeps {
   ) => Promise<"dispatched" | "continue" | "retry">;
   runPostUnitVerification: (
     vctx: VerificationContext,
-    pauseAuto: (ctx?: ExtensionContext, pi?: ExtensionAPI) => Promise<void>,
+    pauseAuto: (
+      ctx?: ExtensionContext,
+      pi?: ExtensionAPI,
+      errorContext?: ErrorContext,
+    ) => Promise<void>,
   ) => Promise<VerificationResult>;
   postUnitPostVerification: (
     pctx: PostUnitContext,

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -25,6 +25,12 @@ import type { MergeReconcileResult } from "../auto-recovery.js";
 import type { UokTurnObserver } from "../uok/contracts.js";
 import type { PreflightResult } from "../clean-root-preflight.js";
 
+type PauseAutoFn = (
+  ctx?: ExtensionContext,
+  pi?: ExtensionAPI,
+  errorContext?: ErrorContext,
+) => Promise<void>;
+
 /**
  * Dependencies injected by the caller (auto.ts startAuto) so autoLoop
  * can access private functions from auto.ts without exporting them.
@@ -40,11 +46,7 @@ export interface LoopDeps {
     pi?: ExtensionAPI,
     reason?: string,
   ) => Promise<void>;
-  pauseAuto: (
-    ctx?: ExtensionContext,
-    pi?: ExtensionAPI,
-    errorContext?: ErrorContext,
-  ) => Promise<void>;
+  pauseAuto: PauseAutoFn;
   clearUnitTimeout: () => void;
   updateProgressWidget: (
     ctx: ExtensionContext,
@@ -250,11 +252,7 @@ export interface LoopDeps {
     prefs: GSDPreferences | undefined;
     buildSnapshotOpts: () => CloseoutOptions & Record<string, unknown>;
     buildRecoveryContext: () => unknown;
-    pauseAuto: (
-      ctx?: ExtensionContext,
-      pi?: ExtensionAPI,
-      errorContext?: ErrorContext,
-    ) => Promise<void>;
+    pauseAuto: PauseAutoFn;
   }) => void;
 
   // Prompt helpers
@@ -280,11 +278,7 @@ export interface LoopDeps {
   ) => Promise<"dispatched" | "continue" | "retry">;
   runPostUnitVerification: (
     vctx: VerificationContext,
-    pauseAuto: (
-      ctx?: ExtensionContext,
-      pi?: ExtensionAPI,
-      errorContext?: ErrorContext,
-    ) => Promise<void>,
+    pauseAuto: PauseAutoFn,
   ) => Promise<VerificationResult>;
   postUnitPostVerification: (
     pctx: PostUnitContext,

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -232,6 +232,33 @@ async function emitCancelledUnitEnd(
   });
 }
 
+export function _buildCancelledUnitStopReason(
+  unitType: string,
+  unitId: string,
+  errorContext?: { message: string; category: string },
+): {
+  notifyMessage: string;
+  stopReason: string;
+  loopReason: "session-failed" | "unit-aborted";
+} {
+  const cancellationMessage = errorContext?.message ?? "unknown";
+  const isSessionCreationFailure = errorContext?.category === "session-failed";
+
+  if (isSessionCreationFailure) {
+    return {
+      notifyMessage: `Session creation failed for ${unitType} ${unitId}: ${cancellationMessage}. Stopping auto-mode.`,
+      stopReason: `Session creation failed: ${cancellationMessage}`,
+      loopReason: "session-failed",
+    };
+  }
+
+  return {
+    notifyMessage: `Unit ${unitType} ${unitId} aborted after dispatch: ${cancellationMessage}. Stopping auto-mode.`,
+    stopReason: `Unit aborted: ${cancellationMessage}`,
+    loopReason: "unit-aborted",
+  };
+}
+
 async function failClosedOnFinalizeTimeout(
   ic: IterationContext,
   iterData: IterationData,
@@ -1875,26 +1902,15 @@ export async function runUnitPhase(
     await deps.autoCommitUnit?.(s.basePath, unitType, unitId, ctx);
     await emitCancelledUnitEnd(ic, unitType, unitId, unitStartSeq, unitResult.errorContext);
 
-    const cancellationMessage = unitResult.errorContext?.message ?? "unknown";
-    const isSessionCreationFailure = errorCategory === "session-failed";
-
-    if (isSessionCreationFailure) {
-      ctx.ui.notify(
-        `Session creation failed for ${unitType} ${unitId}: ${cancellationMessage}. Stopping auto-mode.`,
-        "warning",
-      );
-      await deps.stopAuto(ctx, pi, `Session creation failed: ${cancellationMessage}`);
-      debugLog("autoLoop", { phase: "exit", reason: "session-failed" });
-      return { action: "break", reason: "session-failed" };
-    }
-
-    ctx.ui.notify(
-      `Unit ${unitType} ${unitId} aborted after dispatch: ${cancellationMessage}. Stopping auto-mode.`,
-      "warning",
+    const cancelledStop = _buildCancelledUnitStopReason(
+      unitType,
+      unitId,
+      unitResult.errorContext,
     );
-    await deps.stopAuto(ctx, pi, `Unit aborted: ${cancellationMessage}`);
-    debugLog("autoLoop", { phase: "exit", reason: "unit-aborted" });
-    return { action: "break", reason: "unit-aborted" };
+    ctx.ui.notify(cancelledStop.notifyMessage, "warning");
+    await deps.stopAuto(ctx, pi, cancelledStop.stopReason);
+    debugLog("autoLoop", { phase: "exit", reason: cancelledStop.loopReason });
+    return { action: "break", reason: cancelledStop.loopReason };
   }
 
   // ── Immediate unit closeout (metrics, activity log, memory) ────────

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -994,7 +994,10 @@ export async function runDispatch(
     // See: https://github.com/gsd-build/gsd-2/issues/2474
     if (dispatchResult.level === "warning") {
       ctx.ui.notify(dispatchResult.reason, "warning");
-      await deps.pauseAuto(ctx, pi);
+      await deps.pauseAuto(ctx, pi, {
+        message: dispatchResult.reason,
+        category: "unknown",
+      });
     } else {
       await closeoutAndStop(ctx, pi, s, deps, dispatchResult.reason);
     }
@@ -1871,13 +1874,27 @@ export async function runUnitPhase(
     }
     await deps.autoCommitUnit?.(s.basePath, unitType, unitId, ctx);
     await emitCancelledUnitEnd(ic, unitType, unitId, unitStartSeq, unitResult.errorContext);
+
+    const cancellationMessage = unitResult.errorContext?.message ?? "unknown";
+    const isSessionCreationFailure = errorCategory === "session-failed";
+
+    if (isSessionCreationFailure) {
+      ctx.ui.notify(
+        `Session creation failed for ${unitType} ${unitId}: ${cancellationMessage}. Stopping auto-mode.`,
+        "warning",
+      );
+      await deps.stopAuto(ctx, pi, `Session creation failed: ${cancellationMessage}`);
+      debugLog("autoLoop", { phase: "exit", reason: "session-failed" });
+      return { action: "break", reason: "session-failed" };
+    }
+
     ctx.ui.notify(
-      `Session creation failed for ${unitType} ${unitId}: ${unitResult.errorContext?.message ?? "unknown"}. Stopping auto-mode.`,
+      `Unit ${unitType} ${unitId} aborted after dispatch: ${cancellationMessage}. Stopping auto-mode.`,
       "warning",
     );
-    await deps.stopAuto(ctx, pi, `Session creation failed: ${unitResult.errorContext?.message ?? "unknown"}`);
-    debugLog("autoLoop", { phase: "exit", reason: "session-failed" });
-    return { action: "break", reason: "session-failed" };
+    await deps.stopAuto(ctx, pi, `Unit aborted: ${cancellationMessage}`);
+    debugLog("autoLoop", { phase: "exit", reason: "unit-aborted" });
+    return { action: "break", reason: "unit-aborted" };
   }
 
   // ── Immediate unit closeout (metrics, activity log, memory) ────────

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -56,6 +56,19 @@ function resolveAgentEndBasePath(): string | undefined {
   }
 }
 
+export function _buildAbortedPauseContext(lastMsg: { errorMessage?: unknown }): {
+  message: string;
+  category: "aborted";
+  isTransient: true;
+} {
+  const hasErrorMessage = Object.prototype.hasOwnProperty.call(lastMsg, "errorMessage") && !!lastMsg.errorMessage;
+  return {
+    message: hasErrorMessage ? String(lastMsg.errorMessage) : "Operation aborted",
+    category: "aborted",
+    isTransient: true,
+  };
+}
+
 async function pauseTransientWithBackoff(
   cls: ErrorClass,
   pi: ExtensionAPI,
@@ -159,11 +172,7 @@ export async function handleAgentEnd(
       return;
     }
 
-    await pauseAuto(ctx, pi, {
-      message: hasErrorMessage ? String(lastMsg.errorMessage) : "Operation aborted",
-      category: "aborted",
-      isTransient: true,
-    });
+    await pauseAuto(ctx, pi, _buildAbortedPauseContext(lastMsg as { errorMessage?: unknown }));
     return;
   }
   if (lastMsg && "stopReason" in lastMsg && lastMsg.stopReason === "error") {

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -159,7 +159,11 @@ export async function handleAgentEnd(
       return;
     }
 
-    await pauseAuto(ctx, pi);
+    await pauseAuto(ctx, pi, {
+      message: hasErrorMessage ? String(lastMsg.errorMessage) : "Operation aborted",
+      category: "aborted",
+      isTransient: true,
+    });
     return;
   }
   if (lastMsg && "stopReason" in lastMsg && lastMsg.stopReason === "error") {

--- a/src/resources/extensions/gsd/interrupted-session.ts
+++ b/src/resources/extensions/gsd/interrupted-session.ts
@@ -37,6 +37,7 @@ export interface PausedSessionMetadata {
   activeRunDir?: string | null;
   autoStartTime?: number;
   milestoneLock?: string | null;
+  pauseReason?: string;
 }
 
 export interface InterruptedSessionAssessment {

--- a/src/resources/extensions/gsd/tests/auto-abort-pause-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-abort-pause-regression.test.ts
@@ -1,33 +1,32 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const AGENT_END_RECOVERY_TS = join(__dirname, "..", "bootstrap", "agent-end-recovery.ts");
-const AUTO_PHASES_TS = join(__dirname, "..", "auto", "phases.ts");
-const AUTO_TS = join(__dirname, "..", "auto.ts");
+import { _buildAbortedPauseContext } from "../bootstrap/agent-end-recovery.js";
+import { _buildCancelledUnitStopReason } from "../auto/phases.js";
 
-test("aborted agent_end with errorMessage propagates structured pause context", () => {
-  // allow-source-grep: regression guard for aborted-turn error-context propagation wiring.
-  const source = readFileSync(AGENT_END_RECOVERY_TS, "utf-8");
+test("aborted agent_end maps errorMessage into structured aborted pause context", () => {
+  const withMessage = _buildAbortedPauseContext({ errorMessage: "provider aborted request" });
+  assert.deepEqual(withMessage, {
+    message: "provider aborted request",
+    category: "aborted",
+    isTransient: true,
+  });
 
-  assert.ok(source.includes("category: \"aborted\""));
-  assert.ok(source.includes("message: hasErrorMessage ? String(lastMsg.errorMessage) : \"Operation aborted\""));
+  const withoutMessage = _buildAbortedPauseContext({});
+  assert.deepEqual(withoutMessage, {
+    message: "Operation aborted",
+    category: "aborted",
+    isTransient: true,
+  });
 });
 
-test("cancelled non-session failures are not labeled as session-creation failures", () => {
-  // allow-source-grep: regression guard for cancellation-message branch wording.
-  const source = readFileSync(AUTO_PHASES_TS, "utf-8");
+test("cancelled non-session failures are labeled as unit aborts (not session-creation failures)", () => {
+  const cancelled = _buildCancelledUnitStopReason("execute-task", "M001-S001-T001", {
+    category: "aborted",
+    message: "tool invocation cancelled",
+  });
 
-  assert.ok(source.includes("const isSessionCreationFailure = errorCategory === \"session-failed\""));
-  assert.ok(source.includes("Unit ${unitType} ${unitId} aborted after dispatch"));
-});
-
-test("pause metadata persists pauseReason for resumable diagnostics", () => {
-  // allow-source-grep: regression guard for persisted pause reason field.
-  const source = readFileSync(AUTO_TS, "utf-8");
-
-  assert.ok(source.includes("pauseReason: _errorContext?.message"));
+  assert.match(cancelled.notifyMessage, /aborted after dispatch/);
+  assert.equal(cancelled.stopReason, "Unit aborted: tool invocation cancelled");
+  assert.equal(cancelled.loopReason, "unit-aborted");
 });

--- a/src/resources/extensions/gsd/tests/auto-abort-pause-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-abort-pause-regression.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const AGENT_END_RECOVERY_TS = join(__dirname, "..", "bootstrap", "agent-end-recovery.ts");
+const AUTO_PHASES_TS = join(__dirname, "..", "auto", "phases.ts");
+const AUTO_TS = join(__dirname, "..", "auto.ts");
+
+test("aborted agent_end with errorMessage propagates structured pause context", () => {
+  // allow-source-grep: regression guard for aborted-turn error-context propagation wiring.
+  const source = readFileSync(AGENT_END_RECOVERY_TS, "utf-8");
+
+  assert.ok(source.includes("category: \"aborted\""));
+  assert.ok(source.includes("message: hasErrorMessage ? String(lastMsg.errorMessage) : \"Operation aborted\""));
+});
+
+test("cancelled non-session failures are not labeled as session-creation failures", () => {
+  // allow-source-grep: regression guard for cancellation-message branch wording.
+  const source = readFileSync(AUTO_PHASES_TS, "utf-8");
+
+  assert.ok(source.includes("const isSessionCreationFailure = errorCategory === \"session-failed\""));
+  assert.ok(source.includes("Unit ${unitType} ${unitId} aborted after dispatch"));
+});
+
+test("pause metadata persists pauseReason for resumable diagnostics", () => {
+  // allow-source-grep: regression guard for persisted pause reason field.
+  const source = readFileSync(AUTO_TS, "utf-8");
+
+  assert.ok(source.includes("pauseReason: _errorContext?.message"));
+});

--- a/src/resources/extensions/gsd/tests/paused-session-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/paused-session-via-db.test.ts
@@ -64,6 +64,7 @@ test("readPausedSessionMetadata round-trips a real PausedSessionMetadata payload
     activeRunDir: null,
     autoStartTime: Date.now(),
     milestoneLock: null,
+    pauseReason: "Blocked: waiting for UAT",
   };
   setRuntimeKv("global", "", PAUSED_SESSION_KV_KEY, meta);
 
@@ -73,6 +74,7 @@ test("readPausedSessionMetadata round-trips a real PausedSessionMetadata payload
   assert.equal(loaded!.unitType, "plan-slice");
   assert.equal(loaded!.unitId, "M001/S01");
   assert.equal(loaded!.sessionFile, "/tmp/session.jsonl");
+  assert.equal(loaded!.pauseReason, "Blocked: waiting for UAT");
 });
 
 test("readPausedSessionMetadata auto-deletes stale pseudo-milestone pause rows", (t) => {


### PR DESCRIPTION
## Linked issue

Closes #5262
Relates #5231

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Preserves structured cancellation context through auto-mode pause/stop paths and persists pause reason in paused-session metadata.
**Why:** Aborted turns were being misreported as session-creation failures (`unknown`) and warning-level pauses lost their reason across resume.
**How:** Propagate aborted-turn context from agent_end recovery, branch cancelled-unit messaging by category in phases, and store `pauseReason` in paused-session metadata.

## What

- `src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts`
  - For aborted assistant turns with error message, call `pauseAuto` with structured context:
    - `category: "aborted"`
    - `message: <errorMessage or Operation aborted>`
    - `isTransient: true`
- `src/resources/extensions/gsd/auto/phases.ts`
  - Warning-level dispatch stop now passes explicit pause context to `pauseAuto`.
  - Cancelled-unit hard-stop branch now distinguishes:
    - `session-failed` -> existing session-creation failure wording
    - non-session cancellations (e.g. aborted) -> `Unit ... aborted after dispatch` wording
- `src/resources/extensions/gsd/auto.ts`
  - Persist `pauseReason` into paused-session metadata.
- `src/resources/extensions/gsd/interrupted-session.ts`
  - Extend `PausedSessionMetadata` with optional `pauseReason`.
- Tests:
  - Added `src/resources/extensions/gsd/tests/auto-abort-pause-regression.test.ts`.

## Why

Consolidated issue scan of open auto-mode failures shows a repeated root-cause family: **error context is dropped between recovery layers**. Symptoms vary (misleading stop reasons, resumability confusion, forensic ambiguity), but the common fault is the same seam:

1. `agent_end` recovery classifies cancellation
2. pause/resolve bridges carry (or drop) context
3. phase-level cancellation branch formats stop semantics

This PR addresses that common seam by preserving context end-to-end for aborted turns and warning pauses.

## How

Rubber-duck summary of the fix:
1. Aborted turn has signal (`stopReason=aborted`, `errorMessage`) but we dropped it.
2. Dropped context becomes generic cancelled result.
3. Generic cancelled branch used session-creation language by default.
4. User sees wrong failure subsystem (`Session creation failed: unknown`).
5. Fix is to preserve context at the source and branch messaging by category at the sink.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Executed:

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test \
  src/resources/extensions/gsd/tests/auto-abort-pause-regression.test.ts
```

Result: `3 passed, 0 failed`.

## AI disclosure

- [x] This PR includes AI-assisted code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Session pause tracking now persists a user-facing pauseReason and explicit categories for warnings, cancellations, and aborted agent ends, producing clearer, more specific UI notifications and consistent persisted pause metadata.

* **Tests**
  * Added regression tests verifying pause metadata (pauseReason, category, and structured abort context) is created, persisted, and surfaced for warning, cancellation, and abort scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->