### PR TITLE
fix(shared): preserve submitted interview answers on abort

### DIFF
--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -1,3 +1,4 @@
+// GSD2 — Shared interview round UI widget
 /**
  * Shared interview round UI widget.
  *
@@ -224,12 +225,24 @@ export async function showInterviewRound(
 		let showingExitConfirm = false;
 		let exitCursor = 0; // 0 = keep going (default), 1 = end interview
 		let cachedLines: string[] | undefined;
+		let completed = false;
+		let removeAbortListener: (() => void) | undefined;
+
+		function finish(result: RoundResult) {
+			if (completed) return;
+			completed = true;
+			removeAbortListener?.();
+			done(result);
+		}
 
 		// External cancellation (e.g. remote channel won the race)
 		if (opts.signal) {
-			const onAbort = () => done({ endInterview: false, answers: {} });
+			const onAbort = () => finish({ endInterview: false, answers: {} });
 			if (opts.signal.aborted) { onAbort(); }
-			else { opts.signal.addEventListener("abort", onAbort, { once: true }); }
+			else {
+				opts.signal.addEventListener("abort", onAbort, { once: true });
+				removeAbortListener = () => opts.signal?.removeEventListener("abort", onAbort);
+			}
 		}
 
 		// Editor is created once; editorTheme comes from the design system
@@ -312,7 +325,7 @@ export async function showInterviewRound(
 
 		function submit() {
 			saveEditorToState();
-			done(buildResult());
+			finish(buildResult());
 		}
 
 		function goNextOrSubmit() {
@@ -355,10 +368,10 @@ export async function showInterviewRound(
 				if (matchesKey(data, Key.up) || matchesKey(data, Key.left)) { exitCursor = 0; refresh(); return; }
 				if (matchesKey(data, Key.down) || matchesKey(data, Key.right)) { exitCursor = 1; refresh(); return; }
 				if (data === "1") { showingExitConfirm = false; refresh(); return; }
-				if (data === "2") { done({ endInterview: false, answers: {} }); return; }
+				if (data === "2") { finish({ endInterview: false, answers: {} }); return; }
 				if (matchesKey(data, Key.enter) || matchesKey(data, Key.space)) {
 					if (exitCursor === 0) { showingExitConfirm = false; refresh(); }
-					else { done({ endInterview: false, answers: {} }); }
+					else { finish({ endInterview: false, answers: {} }); }
 					return;
 				}
 				if (matchesKey(data, Key.escape)) { showingExitConfirm = false; refresh(); return; }

--- a/src/resources/extensions/shared/tests/interview-notes-loop.test.ts
+++ b/src/resources/extensions/shared/tests/interview-notes-loop.test.ts
@@ -139,4 +139,45 @@ describe("interview-ui notes loop regression (#3502)", () => {
 		assert.ok(answer, "answer for q1 should exist");
 		assert.equal(answer.selected, "Web App");
 	});
+
+	it("ignores abort signals after a submitted answer", async () => {
+		const controller = new AbortController();
+		const doneCalls: RoundResult[] = [];
+		let widget: { handleInput(input: string): void } | undefined;
+
+		const resultPromise = showInterviewRound(questions, { signal: controller.signal }, {
+			ui: {
+				custom: (factory: any) => new Promise<RoundResult>((resolve) => {
+					const mockTui = { requestRender: () => {} };
+					const mockTheme = {
+						fg: (_c: string, t: string) => t,
+						bold: (t: string) => t,
+						dim: (t: string) => t,
+						italic: (t: string) => t,
+						strikethrough: (t: string) => t,
+						accent: (t: string) => t,
+						success: (t: string) => t,
+						warning: (t: string) => t,
+						error: (t: string) => t,
+						info: (t: string) => t,
+						muted: (t: string) => t,
+						dimmed: (t: string) => t,
+					};
+					widget = factory(mockTui, mockTheme, {}, (result: RoundResult) => {
+						doneCalls.push(result);
+						resolve(result);
+					});
+				}),
+			},
+		} as any);
+
+		assert.ok(widget, "widget should be created synchronously");
+		widget.handleInput(ENTER);
+		widget.handleInput(ENTER);
+		controller.abort();
+
+		const result = await resultPromise;
+		assert.equal(doneCalls.length, 1, "abort after submit must not emit a second empty result");
+		assert.deepEqual(result.answers.q1, { selected: "Web App", notes: "" });
+	});
 });


### PR DESCRIPTION
## TL;DR

**What:** Prevent the shared interview UI from overwriting a submitted answer with a later abort cancellation.
**Why:** A valid depth-check confirmation could render as `Cancelled`, leaving the GSD write gate pending and causing the agent to loop.
**How:** Make interview completion idempotent, remove the abort listener after completion, and cover the race with a regression test.

## What

This updates the shared interview round widget used by structured `ask_user_questions` elicitation. Once a user submits or exits, the widget now finishes exactly once and detaches its abort listener.

The PR also adds a regression test that submits an answer, fires the abort signal afterward, and verifies the submitted answer is preserved instead of replaced by an empty cancellation.

## Why

The depth verification UI could accept a user's recommended confirmation, then receive a late abort during teardown. That late abort resolved the interview with an empty answer set, which upstream treated as cancelled. The result was a stuck approval gate even though the user selected Yes.

## How

- Add a `finish()` helper in `showInterviewRound()` that guards duplicate completions.
- Remove the abort listener when the interview finishes normally.
- Route submit and explicit exit paths through the same one-shot completion helper.
- Add a `node:test` regression covering the late-abort-after-submit path.

AI-assisted: yes.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/shared/tests/interview-notes-loop.test.ts`
- [x] `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run verify:pr`

## Change type checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interview round completion handling to ensure consistent behavior across all exit scenarios and prevent unintended duplicate completions when an interview is cancelled after submission.

* **Tests**
  * Added regression test to verify that late cancellation signals don't trigger unwanted completion events after answers have already been submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->