### PR TITLE
fix(gsd): recover planned slices after artifact writes

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -14,7 +14,7 @@ import { appendEvent } from "./workflow-events.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { clearParseCache } from "./files.js";
 import { parseRoadmap as parseLegacyRoadmap, parsePlan as parseLegacyPlan } from "./parsers-legacy.js";
-import { isDbAvailable, getTask, getSlice, getSliceTasks, getPendingGates, updateTaskStatus, updateSliceStatus, insertSlice, getMilestone } from "./gsd-db.js";
+import { isDbAvailable, getTask, getSlice, getSliceTasks, getPendingGates, updateTaskStatus, updateSliceStatus, insertSlice, getMilestone, refreshOpenDatabaseFromDisk } from "./gsd-db.js";
 import { isValidationTerminal } from "./state.js";
 import { getErrorMessage } from "./error-utils.js";
 import { logWarning, logError } from "./workflow-logger.js";
@@ -588,19 +588,54 @@ export function verifyExpectedArtifact(
     }
   }
 
-  // plan-slice must produce a plan with actual task entries, not just a scaffold.
-  // The plan file may exist from a prior discussion/context step with only headings
-  // but no tasks. Without this check the artifact is considered "complete" and the
-  // unit gets skipped — but deriveState still returns phase:"planning" because the
-  // plan has no tasks, creating an infinite skip loop (#699).
+  // plan-slice verification is DB-primary. The slice plan is a projection, so
+  // DB task rows prove the slice was planned even if the rendered markdown no
+  // longer uses legacy checkbox/heading syntax.
   if (unitType === "plan-slice") {
-    const planContent = readFileSync(absPath, "utf-8");
-    // Accept checkbox-style (- [x] **T01: ...) or heading-style (### T01 -- / ### T01: / ### T01 —)
-    const hasCheckboxTask = /^- \[[xX ]\] \*\*T\d+:/m.test(planContent);
-    const hasHeadingTask = /^#{2,4}\s+T\d+\s*(?:--|—|:)/m.test(planContent);
-    if (!hasCheckboxTask && !hasHeadingTask) {
-      logWarning("recovery", `verify-fail ${unitType} ${unitId}: plan has no task checkbox/heading (len=${planContent.length}) at ${absPath}`);
-      return false;
+    const { milestone: mid, slice: sid } = parseUnitId(unitId);
+    if (mid && sid) {
+      try {
+        let taskIds: string[] | null = null;
+        if (isDbAvailable()) {
+          const refreshed = refreshOpenDatabaseFromDisk();
+          if (refreshed) {
+            const tasks = getSliceTasks(mid, sid);
+            if (tasks.length > 0) taskIds = tasks.map(t => t.id);
+          }
+        }
+
+        if (!taskIds) {
+          // LEGACY: DB unavailable or no tasks in DB. Require actual task
+          // entries so an empty scaffold cannot advance the pipeline (#699).
+          const planContent = readFileSync(absPath, "utf-8");
+          const hasCheckboxTask = /^\s*- \[[xX ]\] \*\*T\d+:/m.test(planContent);
+          const hasHeadingTask = /^\s*#{2,4}\s+T\d+\s*(?:--|—|:)/m.test(planContent);
+          if (!hasCheckboxTask && !hasHeadingTask) {
+            logWarning("recovery", `verify-fail ${unitType} ${unitId}: plan has no task checkbox/heading (len=${planContent.length}) at ${absPath}`);
+            return false;
+          }
+          const plan = parseLegacyPlan(planContent);
+          if (plan.tasks.length > 0) taskIds = plan.tasks.map((t: { id: string }) => t.id);
+        }
+
+        if (taskIds && taskIds.length > 0) {
+          const tasksDir = resolveTasksDir(base, mid, sid);
+          if (!tasksDir) {
+            logWarning("recovery", `verify-fail ${unitType} ${unitId}: resolveTasksDir returned null for ${mid}/${sid}`);
+            return false;
+          }
+          for (const tid of taskIds) {
+            const taskPlanFile = join(tasksDir, `${tid}-PLAN.md`);
+            if (!existsSync(taskPlanFile)) {
+              logWarning("recovery", `verify-fail ${unitType} ${unitId}: task plan missing ${taskPlanFile}`);
+              return false;
+            }
+          }
+        }
+      } catch (err) {
+        // Parse failure — don't block; slice plan may have non-standard format
+        logWarning("recovery", `plan-slice task plan verification failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
   }
 
@@ -625,49 +660,6 @@ export function verifyExpectedArtifact(
       } else {
         // DB available but task row not found — completion tool never ran (#3607)
         return false;
-      }
-    }
-  }
-
-  // plan-slice must also produce individual task plan files for every task listed
-  // in the slice plan. Without this check, a plan-slice that wrote S{sid}-PLAN.md
-  // but omitted T{tid}-PLAN.md files would be marked complete, causing execute-task
-  // to dispatch with a missing task plan (see issue #739).
-  if (unitType === "plan-slice") {
-    const { milestone: mid, slice: sid } = parseUnitId(unitId);
-    if (mid && sid) {
-      try {
-        // DB primary path — get task IDs to verify task plan files exist
-        let taskIds: string[] | null = null;
-        if (isDbAvailable()) {
-          const tasks = getSliceTasks(mid, sid);
-          if (tasks.length > 0) taskIds = tasks.map(t => t.id);
-        }
-
-        if (!taskIds) {
-          // LEGACY: DB unavailable or no tasks in DB — parse plan file for task IDs
-          const planContent = readFileSync(absPath, "utf-8");
-          const plan = parseLegacyPlan(planContent);
-          if (plan.tasks.length > 0) taskIds = plan.tasks.map((t: { id: string }) => t.id);
-        }
-
-        if (taskIds && taskIds.length > 0) {
-          const tasksDir = resolveTasksDir(base, mid, sid);
-          if (!tasksDir) {
-            logWarning("recovery", `verify-fail ${unitType} ${unitId}: resolveTasksDir returned null for ${mid}/${sid}`);
-            return false;
-          }
-          for (const tid of taskIds) {
-            const taskPlanFile = join(tasksDir, `${tid}-PLAN.md`);
-            if (!existsSync(taskPlanFile)) {
-              logWarning("recovery", `verify-fail ${unitType} ${unitId}: task plan missing ${taskPlanFile}`);
-              return false;
-            }
-          }
-        }
-      } catch (err) {
-        // Parse failure — don't block; slice plan may have non-standard format
-        logWarning("recovery", `plan-slice task plan verification failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   }

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -55,7 +55,7 @@ import { writeUnitRuntimeRecord } from "../unit-runtime.js";
 import { withTimeout, FINALIZE_PRE_TIMEOUT_MS, FINALIZE_POST_TIMEOUT_MS } from "./finalize-timeout.js";
 import { getEligibleSlices } from "../slice-parallel-eligibility.js";
 import { startSliceParallel } from "../slice-parallel-orchestrator.js";
-import { isDbAvailable, getMilestoneSlices } from "../gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, refreshOpenDatabaseFromDisk } from "../gsd-db.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
 import { ensurePlanV2Graph, isEmptyPlanV2GraphResult, isMissingFinalizedContextResult } from "../uok/plan-v2.js";
 import { resolveUokFlags } from "../uok/flags.js";
@@ -74,6 +74,12 @@ import {
 /** Compare two paths for physical identity, tolerating trailing slashes and symlinks. */
 function isSamePathLocal(a: string, b: string): boolean {
   return normalizeWorktreePathForCompare(a) === normalizeWorktreePathForCompare(b);
+}
+
+function refreshPlanSliceRecoveryDbIfNeeded(unitType: string): boolean {
+  if (unitType !== "plan-slice") return true;
+  if (!isDbAvailable()) return true;
+  return refreshOpenDatabaseFromDisk();
 }
 
 // ─── Session timeout auto-resume state ────────────────────────────────────────
@@ -1065,7 +1071,16 @@ export async function runDispatch(
             `Stuck recovery: artifact for ${unitType} ${unitId} found on disk. Invalidating caches.`,
             "info",
           );
+          if (!refreshPlanSliceRecoveryDbIfNeeded(unitType)) {
+            ctx.ui.notify(
+              `Stuck recovery found ${unitType} ${unitId} artifacts, but the DB refresh failed. Keeping stuck state for retry.`,
+              "warning",
+            );
+            return { action: "continue" };
+          }
           deps.invalidateAllCaches();
+          loopState.recentUnits.length = 0;
+          loopState.stuckRecoveryAttempts = 0;
           return { action: "continue" };
         }
         ctx.ui.notify(
@@ -1075,6 +1090,32 @@ export async function runDispatch(
         deps.invalidateAllCaches();
       } else {
         // Level 2: hard stop — genuinely stuck
+        deps.invalidateAllCaches();
+        const artifactExists = verifyExpectedArtifact(
+          unitType,
+          unitId,
+          s.basePath,
+        );
+        if (artifactExists && unitType !== "complete-milestone") {
+          debugLog("autoLoop", {
+            phase: "stuck-recovery",
+            level: 2,
+            action: "artifact-found",
+          });
+          ctx.ui.notify(
+            `Stuck recovery: artifact for ${unitType} ${unitId} found on disk after cache invalidation. Continuing.`,
+            "info",
+          );
+          if (refreshPlanSliceRecoveryDbIfNeeded(unitType)) {
+            loopState.recentUnits.length = 0;
+            loopState.stuckRecoveryAttempts = 0;
+            return { action: "continue" };
+          }
+          ctx.ui.notify(
+            `Stuck recovery found ${unitType} ${unitId} artifacts, but the DB refresh failed. Stopping for manual recovery.`,
+            "warning",
+          );
+        }
         debugLog("autoLoop", {
           phase: "stuck-detected",
           unitType,

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -753,6 +753,11 @@ function columnExists(db: DbAdapter, table: string, column: string): boolean {
   return rows.some((row) => row["name"] === column);
 }
 
+function formatFtsUnavailableError(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.replace(/\bmoduel\s*:\s*/gi, "module: ");
+}
+
 /**
  * Create the FTS5 virtual table for memories plus the triggers that keep it
  * in sync with the base table. FTS5 may be unavailable on stripped-down
@@ -787,7 +792,7 @@ export function tryCreateMemoriesFts(db: DbAdapter): boolean {
     `);
     return true;
   } catch (err) {
-    logWarning("db", `FTS5 unavailable — memory queries will use LIKE fallback: ${(err as Error).message}`);
+    logWarning("db", `FTS5 unavailable — memory queries will use LIKE fallback: ${formatFtsUnavailableError(err)}`);
     return false;
   }
 }
@@ -1738,6 +1743,35 @@ export function closeDatabase(): void {
   _dbOpenAttempted = false;
   _lastDbError = null;
   _lastDbPhase = null;
+}
+
+/**
+ * Re-open the active database connection from disk.
+ *
+ * Auto-mode can observe artifacts written by a workflow server running in a
+ * different process before its long-lived singleton has re-synchronized. The
+ * recovery path uses this to force the next state derivation to read from the
+ * current on-disk database instead of continuing with a possibly stale handle.
+ */
+export function refreshOpenDatabaseFromDisk(): boolean {
+  if (!currentDb || !currentPath) return false;
+  if (currentPath === ":memory:") return false;
+
+  const dbPath = currentPath;
+  const identityKey = _currentIdentityKey;
+
+  try {
+    closeDatabase();
+    const opened = openDatabase(dbPath);
+    if (opened && identityKey && currentDb) {
+      _dbCache.set(identityKey, { dbPath, db: currentDb });
+      _currentIdentityKey = identityKey;
+    }
+    return opened;
+  } catch (e) {
+    logWarning("db", `database refresh failed: ${(e as Error).message}`);
+    return false;
+  }
 }
 
 /** Run a full VACUUM — call sparingly (e.g. after milestone completion). */

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -1,3 +1,5 @@
+// GSD Extension - Database regression tests.
+
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
@@ -29,7 +31,10 @@ import {
   getTask,
   getSliceTasks,
   checkpointDatabase,
+  refreshOpenDatabaseFromDisk,
+  tryCreateMemoriesFts,
 } from '../gsd-db.ts';
+import { _resetLogs, peekLogs, setStderrLoggingEnabled } from '../workflow-logger.ts';
 
 const _require = createRequire(import.meta.url);
 
@@ -910,6 +915,31 @@ describe('gsd-db', () => {
     closeDatabase();
   });
 
+  test('gsd-db: FTS5 unavailable warning normalizes provider typo', () => {
+    const previousStderr = setStderrLoggingEnabled(false);
+    _resetLogs();
+    try {
+      const ok = tryCreateMemoriesFts({
+        exec(): void {
+          throw new Error('no such moduel : fts5');
+        },
+        prepare(): never {
+          throw new Error('prepare should not be called');
+        },
+        close(): void {},
+      });
+
+      assert.equal(ok, false, 'FTS5 creation should report fallback');
+      const warning = peekLogs().find((entry) => entry.component === 'db' && entry.message.includes('FTS5 unavailable'));
+      assert.ok(warning, 'FTS5 fallback warning should be logged');
+      assert.match(warning!.message, /no such module: fts5/);
+      assert.doesNotMatch(warning!.message, /moduel/);
+    } finally {
+      _resetLogs();
+      setStderrLoggingEnabled(previousStderr);
+    }
+  });
+
   // ─── checkpointDatabase ────────────────────────────────────────────────────
 
   describe('checkpointDatabase', () => {
@@ -949,6 +979,71 @@ describe('gsd-db', () => {
       closeDatabase();
       // Must not throw
       assert.doesNotThrow(() => checkpointDatabase());
+    });
+  });
+
+  // ─── refreshOpenDatabaseFromDisk ───────────────────────────────────────────
+
+  describe('refreshOpenDatabaseFromDisk', () => {
+    test('refreshOpenDatabaseFromDisk: reopens the active file-backed database and sees external writes', (t) => {
+      const dbPath = tempDbPath();
+      t.after(() => cleanup(dbPath));
+
+      openDatabase(dbPath);
+      insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
+      insertSlice({
+        id: 'S01',
+        milestoneId: 'M001',
+        title: 'Slice 1',
+        status: 'pending',
+        sequence: 1,
+      });
+      insertTask({
+        id: 'T01',
+        milestoneId: 'M001',
+        sliceId: 'S01',
+        title: 'Task 1',
+        status: 'pending',
+        sequence: 1,
+      });
+
+      const adapterBefore = _getAdapter()!;
+
+      const externalDb = openRawSqliteForTest(dbPath);
+      try {
+        externalDb.exec(`
+          INSERT INTO tasks (milestone_id, slice_id, id, title, status, sequence)
+          VALUES ('M001', 'S01', 'T02', 'Task 2', 'pending', 2)
+        `);
+      } finally {
+        externalDb.close();
+      }
+
+      const visibleBeforeRefresh = getSliceTasks('M001', 'S01').map(task => task.id);
+      assert.ok(visibleBeforeRefresh.includes('T01'));
+
+      assert.equal(refreshOpenDatabaseFromDisk(), true);
+      assert.notEqual(_getAdapter(), adapterBefore, 'refresh must replace the active adapter rather than becoming a no-op');
+      const sliceTaskIds = getSliceTasks('M001', 'S01').map(task => task.id);
+      assert.deepEqual(sliceTaskIds, ['T01', 'T02']);
+      assert.equal(isDbAvailable(), true);
+    });
+
+    test('refreshOpenDatabaseFromDisk: refuses in-memory databases without closing them', () => {
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'Test', status: 'active' });
+
+      assert.equal(refreshOpenDatabaseFromDisk(), false);
+      assert.equal(isDbAvailable(), true);
+      assert.ok(_getAdapter()!.prepare("SELECT 1 FROM milestones WHERE id = 'M001'").get());
+
+      closeDatabase();
+    });
+
+    test('refreshOpenDatabaseFromDisk: is a no-op when no database is open', () => {
+      closeDatabase();
+      assert.equal(refreshOpenDatabaseFromDisk(), false);
+      assert.equal(isDbAvailable(), false);
     });
   });
 

--- a/src/resources/extensions/gsd/tests/integration/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-recovery.test.ts
@@ -1,3 +1,5 @@
+// GSD Extension — Auto recovery integration tests.
+
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync, chmodSync } from "node:fs";
@@ -401,6 +403,57 @@ test("verifyExpectedArtifact plan-slice fails for plan with no tasks (#699)", (t
   assert.equal(result, false, "should fail when plan has no task entries (empty scaffold, #699)");
 });
 
+test("verifyExpectedArtifact plan-slice trusts DB tasks over legacy plan syntax", (t) => {
+  const base = makeTmpBase();
+  t.after(() => {
+    closeDatabase();
+    cleanup(base);
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending" });
+  insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "First task", status: "pending" });
+  insertTask({ id: "T02", milestoneId: "M001", sliceId: "S01", title: "Second task", status: "pending" });
+
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  const tasksDir = join(sliceDir, "tasks");
+  writeFileSync(
+    join(sliceDir, "S01-PLAN.md"),
+    "# S01: Slice\n\n## Tasks\n\nTask rows live in the DB; this projection intentionally has no legacy task syntax.\n",
+  );
+  writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan\n");
+  writeFileSync(join(tasksDir, "T02-PLAN.md"), "# T02 Plan\n");
+
+  const result = verifyExpectedArtifact("plan-slice", "M001/S01", base);
+  assert.equal(result, true, "DB task rows plus task plan files should verify plan-slice");
+});
+
+test("verifyExpectedArtifact plan-slice still fails when a DB-backed task plan file is missing", (t) => {
+  const base = makeTmpBase();
+  t.after(() => {
+    closeDatabase();
+    cleanup(base);
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending" });
+  insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "First task", status: "pending" });
+  insertTask({ id: "T02", milestoneId: "M001", sliceId: "S01", title: "Second task", status: "pending" });
+
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  const tasksDir = join(sliceDir, "tasks");
+  writeFileSync(
+    join(sliceDir, "S01-PLAN.md"),
+    "# S01: Slice\n\n## Tasks\n\nTask rows live in the DB; this projection intentionally has no legacy task syntax.\n",
+  );
+  writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan\n");
+
+  const result = verifyExpectedArtifact("plan-slice", "M001/S01", base);
+  assert.equal(result, false, "DB task rows must still require matching task plan files");
+});
+
 // ─── verifyExpectedArtifact: heading-style plan tasks (#1691) ─────────────
 
 test("verifyExpectedArtifact accepts plan-slice with heading-style tasks (### T01 --)", (t) => {
@@ -453,6 +506,32 @@ test("verifyExpectedArtifact accepts plan-slice with colon-style heading tasks (
     verifyExpectedArtifact("plan-slice", "M001/S01", base),
     true,
     "Colon heading-style plan should be treated as completed artifact",
+  );
+});
+
+test("verifyExpectedArtifact accepts indented legacy plan-slice task markers", (t) => {
+  const base = makeTmpBase();
+  t.after(() => cleanup(base));
+
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  const tasksDir = join(sliceDir, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  writeFileSync(join(sliceDir, "S01-PLAN.md"), [
+    "# S01: Test Slice",
+    "",
+    "## Tasks",
+    "",
+    "  - [ ] **T01: Implement feature** `est:1h`",
+    "",
+    "  ### T02 -- Write tests",
+  ].join("\n"));
+  writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan");
+  writeFileSync(join(tasksDir, "T02-PLAN.md"), "# T02 Plan");
+
+  assert.strictEqual(
+    verifyExpectedArtifact("plan-slice", "M001/S01", base),
+    true,
+    "Indented legacy task markers should be treated as completed plan-slice artifacts",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -399,6 +399,140 @@ test("runDispatch pauses when complete-milestone summary exists on disk but the 
   assert.equal(stopCalls, 0, "mismatch pause should not hard-stop the loop");
 });
 
+test("runDispatch clears stuck state after Level 1 artifact recovery", async (t) => {
+  const capture = createEventCapture();
+  let invalidateCalls = 0;
+  let stopCalls = 0;
+  const base = join(tmpdir(), `gsd-stuck-plan-${randomUUID()}`);
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  const tasksDir = join(sliceDir, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending" });
+  insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "First task", status: "pending" });
+  writeFileSync(join(sliceDir, "S01-PLAN.md"), "# S01\n\n## Tasks\n\n- [ ] **T01: First task** `est:1h`\n");
+  writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan\n");
+
+  const deps = makeMockDeps(capture, {
+    invalidateAllCaches: () => { invalidateCalls++; },
+    stopAuto: async () => { stopCalls++; },
+    resolveDispatch: async () => ({
+      action: "dispatch" as const,
+      unitType: "plan-slice",
+      unitId: "M001/S01",
+      prompt: "plan the slice",
+      matchedRule: "planning → plan-slice",
+    }),
+  });
+  const ic = makeIC(deps, {
+    s: {
+      ...makeSession(),
+      basePath: base,
+      originalBasePath: base,
+    } as any,
+  });
+  const preData: PreDispatchData = {
+    state: {
+      phase: "planning",
+      activeMilestone: { id: "M001", title: "Test", status: "active" },
+      activeSlice: { id: "S01", title: "Slice" },
+      registry: [{ id: "M001", status: "active" }],
+      blockers: [],
+    } as any,
+    mid: "M001",
+    midTitle: "Test Milestone",
+  };
+  const loopState: LoopState = {
+    recentUnits: [
+      { key: "plan-slice/M001/S01" },
+      { key: "plan-slice/M001/S01" },
+    ],
+    stuckRecoveryAttempts: 0,
+    consecutiveFinalizeTimeouts: 0,
+  };
+
+  const result = await runDispatch(ic, preData, loopState);
+
+  assert.equal(result.action, "continue");
+  assert.equal(invalidateCalls, 1, "Level 1 artifact recovery should invalidate caches");
+  assert.equal(stopCalls, 0, "Level 1 artifact recovery should not hard-stop");
+  assert.deepEqual(loopState.recentUnits, [], "Level 1 artifact recovery should clear the stuck window");
+  assert.equal(loopState.stuckRecoveryAttempts, 0, "Level 1 artifact recovery should reset the recovery counter");
+});
+
+test("runDispatch escapes Level 2 stuck stop when artifact verifies after cache invalidation", async (t) => {
+  const capture = createEventCapture();
+  let invalidateCalls = 0;
+  let stopCalls = 0;
+  const base = join(tmpdir(), `gsd-stuck-plan-l2-${randomUUID()}`);
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  const tasksDir = join(sliceDir, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending" });
+  insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "First task", status: "pending" });
+  writeFileSync(join(sliceDir, "S01-PLAN.md"), "# S01\n\n## Tasks\n\n- [ ] **T01: First task** `est:1h`\n");
+  writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan\n");
+
+  const deps = makeMockDeps(capture, {
+    invalidateAllCaches: () => { invalidateCalls++; },
+    stopAuto: async () => { stopCalls++; },
+    resolveDispatch: async () => ({
+      action: "dispatch" as const,
+      unitType: "plan-slice",
+      unitId: "M001/S01",
+      prompt: "plan the slice",
+      matchedRule: "planning → plan-slice",
+    }),
+  });
+  const ic = makeIC(deps, {
+    s: {
+      ...makeSession(),
+      basePath: base,
+      originalBasePath: base,
+    } as any,
+  });
+  const preData: PreDispatchData = {
+    state: {
+      phase: "planning",
+      activeMilestone: { id: "M001", title: "Test", status: "active" },
+      activeSlice: { id: "S01", title: "Slice" },
+      registry: [{ id: "M001", status: "active" }],
+      blockers: [],
+    } as any,
+    mid: "M001",
+    midTitle: "Test Milestone",
+  };
+  const loopState: LoopState = {
+    recentUnits: [
+      { key: "plan-slice/M001/S01" },
+      { key: "plan-slice/M001/S01" },
+    ],
+    stuckRecoveryAttempts: 1,
+    consecutiveFinalizeTimeouts: 0,
+  };
+
+  const result = await runDispatch(ic, preData, loopState);
+
+  assert.equal(result.action, "continue");
+  assert.equal(invalidateCalls, 1, "Level 2 escape should invalidate caches before rechecking artifacts");
+  assert.equal(stopCalls, 0, "verified artifacts should escape Level 2 hard stop");
+  assert.deepEqual(loopState.recentUnits, [], "Level 2 artifact escape should clear the stuck window");
+  assert.equal(loopState.stuckRecoveryAttempts, 0, "Level 2 artifact escape should reset the recovery counter");
+});
+
 test("runUnitPhase emits unit-start and unit-end with causedBy reference", async () => {
   const capture = createEventCapture();
 

--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -1,3 +1,5 @@
+// GSD Extension — Plan-slice tool integration tests.
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync, writeFileSync } from 'node:fs';
@@ -8,6 +10,7 @@ import { openDatabase, closeDatabase, insertMilestone, insertSlice, getSlice, ge
 import { handlePlanSlice } from '../tools/plan-slice.ts';
 import { parsePlan } from '../parsers-legacy.ts';
 import { parseTaskPlanFile } from '../files.ts';
+import { deriveState, invalidateStateCache } from '../state.ts';
 
 function makeTmpBase(): string {
   const base = mkdtempSync(join(tmpdir(), 'gsd-plan-slice-'));
@@ -93,6 +96,30 @@ test('handlePlanSlice writes slice/task planning state and renders plan artifact
     assert.ok(existsSync(taskPlanPath), 'task plan should be rendered to disk');
     const taskPlan = parseTaskPlanFile(readFileSync(taskPlanPath, 'utf-8'));
     assert.deepEqual(taskPlan.frontmatter.skills_used, []);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('handlePlanSlice advances DB-derived state out of planning immediately', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+
+    invalidateStateCache();
+    const before = await deriveState(base);
+    assert.equal(before.phase, 'planning');
+    assert.equal(before.progress?.tasks?.total, 0);
+
+    const result = await handlePlanSlice(validParams(), base);
+    assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+
+    invalidateStateCache();
+    const after = await deriveState(base);
+    assert.notEqual(after.phase, 'planning');
+    assert.equal(after.progress?.tasks?.total, 2);
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## TL;DR

**What:** Fixes plan-slice recovery so auto-mode can continue after planned slice artifacts are already written.
**Why:** Auto-mode could repeatedly derive `plan-slice/M001/S01` after the tool wrote `S01-PLAN.md` and task plans, then hard-stop as stuck.
**How:** Make plan-slice artifact verification DB-primary, refresh the open DB handle during artifact recovery, and clear the stuck window when recovery succeeds.

## What

This updates GSD auto-mode recovery for plan-slice units:

- Verifies plan-slice artifacts using DB task rows first, while preserving legacy markdown parsing when the DB is unavailable.
- Requires every planned DB task to have its matching `tasks/T##-PLAN.md` artifact.
- Refreshes the active DB connection during plan-slice stuck recovery before the next state derivation.
- Clears the stuck detection window after Level 1 and Level 2 artifact recovery so a recovered unit does not immediately hard-stop again.
- Adds regression coverage for DB-backed plan-slice verification, dispatch stuck recovery, DB refresh, and immediate post-plan state advancement.

## Why

The failure mode from the report was: `gsd_plan_slice` wrote the slice plan and task plan files, but auto-mode still derived the same `plan-slice/M001/S01` unit. Recovery noticed the artifact existed, invalidated caches, then the same sliding stuck window caused a hard stop instead of letting derivation advance.

Rendered plan files are projections of the DB-backed plan. Treating legacy checkbox/heading syntax as the only proof made DB-backed plans fragile, and cache invalidation alone was not enough when the workflow server and auto-mode process were not perfectly synchronized.

## How

`verifyExpectedArtifact("plan-slice", ...)` now reads task IDs from the DB when available and verifies each corresponding task plan file. If the DB has no tasks or is unavailable, it falls back to the old markdown task syntax checks so unmigrated projects continue to work.

The stuck recovery branch now refreshes the active DB connection for recovered plan-slice artifacts and resets `recentUnits` plus `stuckRecoveryAttempts` before continuing. Level 2 recovery also rechecks artifacts after invalidation and escapes the hard stop when the artifact is valid.

AI-assisted contribution. No co-authored-by trailer.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/gsd-db.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/journal-integration.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/plan-slice.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/auto-recovery.test.ts`
- `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run verify:pr` — 8621 passed, 0 failed, 9 skipped

## Checklist

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plan-slice verification now uses on-disk database state first with a legacy file-based fallback.
  * Stuck-recovery logic refreshes the database when needed, avoiding unnecessary hard-stops and allowing execution to continue.

* **Chores / Tests**
  * Added tests covering database refresh behavior, FTS5 error message sanitization, and several recovery/integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->