### PR TITLE
fix(post-exec): reduce import-check false positives for dotted stems and +types

### DIFF
--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -155,8 +155,19 @@ export function resolveImportPath(
       ".svg", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".ico", ".bmp",
       ".woff", ".woff2", ".ttf", ".otf", ".eot",
     ]);
+    const runtimeFallbackExtensions = new Set([".js", ".jsx", ".mjs", ".cjs"]);
+    const dottedStemFallbackExtensions = new Set([".server", ".client", ".webhook"]);
 
-    if (nonFallbackExtensions.has(explicitExt) && ![".js", ".jsx", ".mjs", ".cjs"].includes(explicitExt)) {
+    if (
+      explicitExt !== "" &&
+      !runtimeFallbackExtensions.has(explicitExt) &&
+      !nonFallbackExtensions.has(explicitExt) &&
+      !dottedStemFallbackExtensions.has(explicitExt)
+    ) {
+      return { exists: false, resolvedPath: null };
+    }
+
+    if (nonFallbackExtensions.has(explicitExt) && !runtimeFallbackExtensions.has(explicitExt)) {
       return { exists: false, resolvedPath: null };
     }
   }
@@ -232,7 +243,7 @@ export function checkImportResolution(
       // React Router generated +types modules may not exist on disk during
       // post-exec checks (generated during framework build). Don't block task
       // completion on these imports.
-      if (/^\.{1,2}\/\+types\//.test(importPath) || /\/\+types\//.test(importPath)) {
+      if (/^\.{1,2}\/\+types\//.test(importPath)) {
         continue;
       }
 

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -144,12 +144,19 @@ export function resolveImportPath(
     if (existsSync(directPath)) {
       return { exists: true, resolvedPath: directPath };
     }
-    // Only .js/.jsx/.mjs/.cjs imports legitimately fall through for the TS
-    // ESM convention (.js → .ts). Any other explicit extension (.css, .json,
-    // .svg, images, fonts, .ts, .tsx, …) must stay unresolved when the direct
-    // path is missing — otherwise a stray `./missing.css.ts` could shadow a
-    // genuinely missing `./missing.css` import.
-    if (![".js", ".jsx", ".mjs", ".cjs"].includes(explicitExt)) {
+
+    // Known concrete extensions that should NOT fall through to code-shadow
+    // probing when missing. This preserves the "missing.css must stay missing"
+    // guarantee while still allowing dotted module stems like ./route.server
+    // to resolve as ./route.server.ts.
+    const nonFallbackExtensions = new Set([
+      ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
+      ".json", ".css", ".scss", ".sass", ".less", ".styl",
+      ".svg", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".ico", ".bmp",
+      ".woff", ".woff2", ".ttf", ".otf", ".eot",
+    ]);
+
+    if (nonFallbackExtensions.has(explicitExt) && ![".js", ".jsx", ".mjs", ".cjs"].includes(explicitExt)) {
       return { exists: false, resolvedPath: null };
     }
   }
@@ -222,6 +229,13 @@ export function checkImportResolution(
     const imports = extractRelativeImports(source);
 
     for (const { importPath, lineNum } of imports) {
+      // React Router generated +types modules may not exist on disk during
+      // post-exec checks (generated during framework build). Don't block task
+      // completion on these imports.
+      if (/^\.{1,2}\/\+types\//.test(importPath) || /\/\+types\//.test(importPath)) {
+        continue;
+      }
+
       const resolution = resolveImportPath(importPath, file, basePath);
 
       if (!resolution.exists) {

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -316,6 +316,18 @@ describe("resolveImportPath", () => {
     assert.ok(result.exists);
     assert.ok(result.resolvedPath?.endsWith("route.server.ts"));
   });
+
+  test("missing unknown explicit extension does not match code-extension shadow", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-unknown-shadow-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "video.mp4.ts"), "export {};\n");
+    writeFileSync(join(dir, "src", "main.ts"), "");
+
+    const result = resolveImportPath("./video.mp4", "src/main.ts", dir);
+    assert.ok(!result.exists);
+    assert.equal(result.resolvedPath, null);
+  });
 });
 
 // ─── Import Resolution Check Tests ───────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -304,6 +304,18 @@ describe("resolveImportPath", () => {
     assert.ok(!result.exists);
     assert.equal(result.resolvedPath, null);
   });
+
+  test("resolves dotted TS module stem like .server via extension probing", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-server-dot-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "route.server.ts"), "export {};\n");
+    writeFileSync(join(dir, "src", "main.ts"), "");
+
+    const result = resolveImportPath("./route.server", "src/main.ts", dir);
+    assert.ok(result.exists);
+    assert.ok(result.resolvedPath?.endsWith("route.server.ts"));
+  });
 });
 
 // ─── Import Resolution Check Tests ───────────────────────────────────────────
@@ -325,6 +337,28 @@ describe("checkImportResolution", () => {
       const task = createTask({
         id: "T01",
         key_files: ["src/main.ts"],
+      });
+
+      const results = checkImportResolution(task, [], tempDir);
+      assert.deepEqual(results, []);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("ignores generated React Router +types imports", () => {
+    tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    mkdirSync(join(tempDir, "app", "routes"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "app", "routes", "root.tsx"),
+      "import type { Route } from './+types/root';\nexport default function Root() { return null; }"
+    );
+
+    try {
+      const task = createTask({
+        id: "T01",
+        key_files: ["app/routes/root.tsx"],
       });
 
       const results = checkImportResolution(task, [], tempDir);


### PR DESCRIPTION
## What
- allow dotted module stems (e.g. `./route.server`) to resolve via extension probing
- keep strict no-shadow behavior for concrete missing assets (e.g. `missing.css`)
- ignore generated React Router `./+types/*` imports in blocking post-exec checks
- add regression tests for both behaviors

## Why
Multiple open bugs report post-execution import resolver false positives blocking valid tasks (notably #5275, #5270).

## Verification
- Ran: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/post-execution-checks.test.ts`
- Result: 45 passed, 0 failed

Closes #5275
Refs #5270
Refs #5289


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import resolution for TypeScript modules with explicit file extensions, refining fallback behavior for dotted module names and preventing incorrect fallback matches
  * Fixed false-positive import validation errors for generated React Router type imports so they no longer trigger failures

* **Tests**
  * Added tests validating TypeScript extension resolution for dotted module stems
  * Added tests ensuring generated React Router type imports are ignored during validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->