### PR TITLE
fix(gsd): make milestone completion idempotent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,10 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+          GSD_SKIP_RTK_INSTALL: '1'
         run: npm ci
 
       - name: Build core
@@ -362,6 +366,7 @@ jobs:
         env:
           ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+          GSD_SKIP_RTK_INSTALL: '1'
         run: npm ci
 
       - name: Validate managed RTK install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,9 @@ jobs:
           ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
           GSD_SKIP_RTK_INSTALL: '1'
-        run: npm ci
+        run: |
+          npm install --package-lock-only --ignore-scripts
+          npm ci
 
       - name: Build core
         run: npm run build:core
@@ -367,7 +369,9 @@ jobs:
           ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
           GSD_SKIP_RTK_INSTALL: '1'
-        run: npm ci
+        run: |
+          npm install --package-lock-only --ignore-scripts
+          npm ci
 
       - name: Validate managed RTK install
         run: >-

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -22,6 +22,10 @@ Plan (with integrated research) → Execute (per task) → Complete → Reassess
 - **Reassess** — checks if the roadmap still makes sense
 - **Validate Milestone** — reconciliation gate after all slices complete; compares roadmap success criteria against actual results, catches gaps before sealing the milestone
 
+### Idempotent Milestone Completion
+
+Milestone completion is safe to retry. If a `complete-milestone` unit is redispatched after the database already marks the milestone as closed, GSD treats the call as successful instead of returning an error. The existing summary projection is left intact, no duplicate completion event is appended, and the tool response includes `alreadyComplete: true` in its details so operators and integrations can distinguish a retry from the first completion.
+
 ### State Authority
 
 The SQLite database is the runtime source of truth for milestones, slices, tasks, requirements, decisions, summaries, and completion status. Markdown files in `.gsd/` are rendered projections for review, prompts, and git-friendly history; editing a projection does not override the database unless a command imports or saves that change through GSD.

--- a/docs/zh-CN/user-docs/auto-mode.md
+++ b/docs/zh-CN/user-docs/auto-mode.md
@@ -22,6 +22,10 @@ Plan (with integrated research) → Execute (per task) → Complete → Reassess
 - **Reassess**：检查 roadmap 是否仍然合理
 - **Validate Milestone**：在所有 slices 完成后做一致性校验，把 roadmap 的成功标准与实际结果对照，避免在封板前漏掉关键缺口
 
+### Milestone 完成的幂等行为
+
+Milestone completion 可以安全重试。如果 `complete-milestone` 单元在数据库已经把该 milestone 标记为关闭后再次派发，GSD 会把这次调用视为成功，而不是返回错误。已有的 summary projection 会保持不变，不会追加重复的 completion event，并且工具响应的 details 中会包含 `alreadyComplete: true`，方便 operator 和集成方区分重试与首次完成。
+
 ## 关键特性
 
 ### 每个单元都用全新会话

--- a/src/resources/extensions/gsd/tests/complete-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone.test.ts
@@ -432,10 +432,9 @@ describe("complete-milestone", () => {
     }
   });
 
-  test("handleCompleteMilestone does not overwrite existing SUMMARY.md on re-dispatch (#4598)", async () => {
+  test("handleCompleteMilestone treats already-complete milestone as idempotent re-dispatch (#4598)", async () => {
     // This test verifies that when SUMMARY.md already exists (from a prior completion),
     // re-calling handleCompleteMilestone does not overwrite it.
-    // Before the fix this test FAILS because the handler unconditionally writes SUMMARY.md.
     const { handleCompleteMilestone } = await import("../tools/complete-milestone.ts");
     const base = createFixtureBase();
     const mid = "M001";
@@ -443,7 +442,7 @@ describe("complete-milestone", () => {
     try {
       // Set up DB with milestone and a complete slice + task
       openDatabase(dbPath);
-      insertMilestone({ id: mid, title: "Test Milestone", status: "active" });
+      insertMilestone({ id: mid, title: "Test Milestone", status: "complete" });
       insertSlice({ id: "S01", milestoneId: mid, title: "Slice One", status: "complete" });
       insertTask({ id: "T01", sliceId: "S01", milestoneId: mid, title: "Task One", status: "complete" });
 
@@ -473,8 +472,9 @@ describe("complete-milestone", () => {
 
       const result = await handleCompleteMilestone(params, base);
 
-      // The call may return an error (milestone already complete) or success
-      // but in either case the SUMMARY.md must NOT be overwritten.
+      assert.ok(!("error" in result), `already-complete re-dispatch should succeed: ${JSON.stringify(result)}`);
+      assert.equal(result.alreadyComplete, true);
+
       const actualContent = readFileSync(summaryPath, "utf-8");
       assert.strictEqual(
         actualContent,

--- a/src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts
@@ -575,7 +575,7 @@ describe("state-machine-live-validation", () => {
       assert.match((result as any).error, /verification did not pass/);
     });
 
-    test("double milestone completion returns error", async () => {
+    test("double milestone completion is idempotent", async () => {
       base = createFullFixture();
       openDatabase(join(base, ".gsd", "gsd.db"));
       insertMilestone({ id: "M001", title: "Done", status: "complete" });
@@ -583,8 +583,9 @@ describe("state-machine-live-validation", () => {
       insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", status: "complete" });
 
       const result = await handleCompleteMilestone(makeMilestoneParams("M001") as any, base);
-      assert.ok("error" in result);
-      assert.match((result as any).error, /already complete/);
+      assert.ok(!("error" in result), `already-complete milestone should be accepted: ${JSON.stringify(result)}`);
+      assert.equal(result.alreadyComplete, true);
+      assert.ok(isClosedStatus(getMilestone("M001")!.status), "milestone remains closed");
     });
   });
 

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -391,6 +391,35 @@ test("executeCompleteMilestone sanitizes raw params and writes milestone summary
   }
 });
 
+test("executeCompleteMilestone returns success for already-complete milestones", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    seedMilestone("M003", "Milestone Three", "complete");
+    const milestoneDir = join(base, ".gsd", "milestones", "M003");
+    mkdirSync(milestoneDir, { recursive: true });
+    const summaryPath = join(milestoneDir, "M003-SUMMARY.md");
+    writeFileSync(summaryPath, "# Existing Summary\n");
+
+    const result = await inProjectDir(base, () => executeCompleteMilestone({
+      milestoneId: "M003",
+      title: "Milestone Three",
+      oneLiner: "Completed milestone",
+      narrative: "Everything shipped.",
+      verificationPassed: true,
+    }, base));
+
+    assert.equal(result.isError, undefined);
+    assert.equal(result.details.operation, "complete_milestone");
+    assert.equal(result.details.alreadyComplete, true);
+    assert.match(result.content[0].text, /already complete/);
+    assert.equal(readFileSync(summaryPath, "utf-8"), "# Existing Summary\n");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeReassessRoadmap writes assessment and updates roadmap projection", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tools/complete-milestone.ts
+++ b/src/resources/extensions/gsd/tools/complete-milestone.ts
@@ -57,6 +57,7 @@ export interface CompleteMilestoneResult {
   milestoneId: string;
   summaryPath: string;
   stale?: boolean;
+  alreadyComplete?: boolean;
 }
 
 function renderMilestoneSummaryMarkdown(params: CompleteMilestoneParams): string {
@@ -143,6 +144,7 @@ export async function handleCompleteMilestone(
   // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───
   const completedAt = new Date().toISOString();
   let guardError: string | null = null;
+  let alreadyComplete = false;
 
   transaction(() => {
     // State machine preconditions (inside txn for atomicity)
@@ -152,7 +154,7 @@ export async function handleCompleteMilestone(
       return;
     }
     if (isClosedStatus(milestone.status)) {
-      guardError = `milestone ${params.milestoneId} is already complete`;
+      alreadyComplete = true;
       return;
     }
 
@@ -238,14 +240,16 @@ export async function handleCompleteMilestone(
     logWarning("tool", `complete-milestone manifest warning: ${(mfErr as Error).message}`);
   }
   try {
-    appendEvent(basePath, {
-      cmd: "complete-milestone",
-      params: { milestoneId: params.milestoneId },
-      ts: new Date().toISOString(),
-      actor: "agent",
-      actor_name: params.actorName,
-      trigger_reason: params.triggerReason,
-    });
+    if (!alreadyComplete) {
+      appendEvent(basePath, {
+        cmd: "complete-milestone",
+        params: { milestoneId: params.milestoneId },
+        ts: new Date().toISOString(),
+        actor: "agent",
+        actor_name: params.actorName,
+        trigger_reason: params.triggerReason,
+      });
+    }
   } catch (eventErr) {
     logError("tool", `complete-milestone event log FAILED — completion invisible to reconciliation`, { error: (eventErr as Error).message });
   }
@@ -254,5 +258,6 @@ export async function handleCompleteMilestone(
     milestoneId: params.milestoneId,
     summaryPath,
     ...(projectionStale ? { stale: true } : {}),
+    ...(alreadyComplete ? { alreadyComplete: true } : {}),
   };
 }

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -477,12 +477,16 @@ export async function executeCompleteMilestone(
       isError: true,
       };
     }
+    const message = result.alreadyComplete
+      ? `Milestone ${result.milestoneId} is already complete. Summary available at ${result.summaryPath}`
+      : `Completed milestone ${result.milestoneId}. Summary written to ${result.summaryPath}`;
     return {
-      content: [{ type: "text", text: `Completed milestone ${result.milestoneId}. Summary written to ${result.summaryPath}` }],
+      content: [{ type: "text", text: message }],
       details: {
         operation: "complete_milestone",
         milestoneId: result.milestoneId,
         summaryPath: result.summaryPath,
+        ...(result.alreadyComplete ? { alreadyComplete: true } : {}),
       },
     };
   } catch (err) {


### PR DESCRIPTION
## Summary
- Treat duplicate `gsd_complete_milestone` calls for already-complete milestones as idempotent success instead of tool errors.
- Preserve existing milestone summaries on re-dispatch and report `alreadyComplete` through the executor.
- Add regression coverage for the handler, state-machine validation, and workflow executor path.

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/complete-milestone.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts`
- `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run verify:pr` (`8671 passed, 0 failed, 9 skipped`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Milestone completion is now idempotent: re-dispatch of an already-complete milestone returns success, includes an alreadyComplete indicator, avoids duplicate completion events, and preserves existing summary files.

* **Tests**
  * Added and updated tests to cover idempotent milestone completion and confirm summaries are not overwritten.

* **Documentation**
  * Added user-facing docs (English and Chinese) describing idempotent milestone completion behavior.

* **Chores**
  * CI install steps adjusted for improved portability on certain platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->