### PR TITLE
fix(gsd): persist gate confirmations from mcp questions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2455,7 +2455,14 @@
       }
     },
     "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
-      "optional": true
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@img/sharp-win32-arm64": {
       "version": "0.34.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -924,7 +924,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2455,6 +2454,9 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+      "optional": true
+    },
     "node_modules/@img/sharp-win32-arm64": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
@@ -2672,6 +2674,7 @@
       "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -2766,6 +2769,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2783,6 +2787,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2800,6 +2805,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2817,6 +2823,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2834,6 +2841,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2851,6 +2859,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2868,6 +2877,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2885,6 +2895,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2902,6 +2913,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2919,6 +2931,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2936,6 +2949,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2953,6 +2967,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2967,6 +2982,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
@@ -2989,6 +3005,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3006,6 +3023,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3029,7 +3047,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.2",
@@ -3043,7 +3062,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.2",
@@ -3057,7 +3077,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.2",
@@ -3071,7 +3092,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.2",
@@ -3085,7 +3107,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.2",
@@ -3099,7 +3122,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.2",
@@ -3113,7 +3137,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.2",
@@ -3127,7 +3152,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.2",
@@ -3141,7 +3167,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.2",
@@ -3155,7 +3182,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.2",
@@ -3169,7 +3197,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.2",
@@ -3183,7 +3212,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.2",
@@ -3197,7 +3227,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.2",
@@ -3211,7 +3242,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.2",
@@ -3225,7 +3257,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.2",
@@ -3239,7 +3272,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.2",
@@ -3253,7 +3287,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
@@ -3267,7 +3302,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
@@ -3281,7 +3317,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.2",
@@ -3295,7 +3332,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.2",
@@ -3309,7 +3347,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.2",
@@ -3323,7 +3362,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.2",
@@ -3337,7 +3377,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
@@ -3351,7 +3392,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
@@ -3365,7 +3407,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
@@ -4450,7 +4493,8 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/hosted-git-info": {
       "version": "3.0.5",
@@ -4522,7 +4566,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4819,7 +4862,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5540,7 +5582,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5693,7 +5734,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5873,6 +5913,7 @@
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -6388,7 +6429,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7264,6 +7304,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7684,6 +7725,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7867,7 +7909,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7877,7 +7918,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7991,6 +8031,7 @@
       "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.127.0",
         "@rolldown/pluginutils": "1.0.0-rc.17"
@@ -8024,7 +8065,8 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/rollup": {
       "version": "4.60.2",
@@ -8032,6 +8074,7 @@
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8618,6 +8661,7 @@
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
@@ -8823,6 +8867,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8905,6 +8950,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8922,6 +8968,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8939,6 +8986,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8956,6 +9004,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8973,6 +9022,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8990,6 +9040,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9007,6 +9058,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9024,6 +9076,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9041,6 +9094,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9058,6 +9112,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9075,6 +9130,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9092,6 +9148,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9109,6 +9166,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9126,6 +9184,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9143,6 +9202,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9160,6 +9220,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9177,6 +9238,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9194,6 +9256,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9211,6 +9274,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9228,6 +9292,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9245,6 +9310,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9262,6 +9328,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9279,6 +9346,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9296,6 +9364,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9313,6 +9382,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9330,6 +9400,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9341,6 +9412,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9569,7 +9641,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9706,7 +9777,6 @@
     "packages/pi-coding-agent": {
       "name": "@gsd/pi-coding-agent",
       "version": "2.80.0",
-      "peer": true,
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
         "@silvia-odwyer/photon-node": "^0.3.4",
@@ -9735,7 +9805,6 @@
     "packages/pi-tui": {
       "name": "@gsd/pi-tui",
       "version": "2.80.0",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.6.2",
         "get-east-asian-width": "^1.3.0",
@@ -9800,7 +9869,6 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -882,6 +882,71 @@ describe('createMcpServer tool registration', () => {
     );
   });
 
+  it('ask_user_questions persists confirmed depth gates for local answers', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M003_confirm',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue with the current summary.' },
+          { label: 'Not quite', description: 'I need to clarify the depth further.' },
+        ],
+      },
+    ];
+    const calls: string[] = [];
+    const writeGate = {
+      isGateQuestionId(questionId: string) {
+        return questionId.startsWith('depth_verification_');
+      },
+      isDepthConfirmationAnswer(selected: unknown, options?: Array<{ label?: string }>) {
+        return selected === options?.[0]?.label;
+      },
+      setPendingGate(gateId: string, basePath: string) {
+        calls.push(`pending:${gateId}:${basePath}`);
+      },
+      markApprovalGateVerified(gateId?: string | null, basePath?: string) {
+        calls.push(`approval:${gateId}:${basePath}`);
+      },
+      markDepthVerified(milestoneId?: string | null, basePath?: string) {
+        calls.push(`depth:${milestoneId}:${basePath}`);
+      },
+      clearPendingGate(basePath: string) {
+        calls.push(`clear:${basePath}`);
+      },
+      extractDepthVerificationMilestoneId(questionId: string) {
+        return questionId.match(/_(M\d+)_/)?.[1] ?? null;
+      },
+    };
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        return {
+          action: 'accept',
+          content: {
+            depth_verification_M003_confirm: 'Yes, you got it (Recommended)',
+          },
+        };
+      },
+      isRemoteConfigured() {
+        return false;
+      },
+      async tryRemoteQuestions() {
+        throw new Error('should not be called');
+      },
+      writeGate,
+      writeGateBasePath: '/tmp/gsd-project',
+    });
+
+    assert.equal('isError' in result && result.isError, false);
+    assert.deepEqual(calls, [
+      'pending:depth_verification_M003_confirm:/tmp/gsd-project',
+      'approval:depth_verification_M003_confirm:/tmp/gsd-project',
+      'depth:M003:/tmp/gsd-project',
+      'clear:/tmp/gsd-project',
+    ]);
+  });
+
   it('ask_user_questions falls back to remote when local elicitation is cancelled', async () => {
     const questions = [
       {

--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -947,6 +947,79 @@ describe('createMcpServer tool registration', () => {
     ]);
   });
 
+  it('ask_user_questions persists confirmed depth gates for remote answers', async () => {
+    const questions = [
+      {
+        id: 'depth_verification_M003_confirm',
+        header: 'Depth Check',
+        question: 'Did I capture the depth right?',
+        options: [
+          { label: 'Yes, you got it (Recommended)', description: 'Continue with the current summary.' },
+          { label: 'Not quite', description: 'I need to clarify the depth further.' },
+        ],
+      },
+    ];
+    const calls: string[] = [];
+    const writeGate = {
+      isGateQuestionId(questionId: string) {
+        return questionId.startsWith('depth_verification_');
+      },
+      isDepthConfirmationAnswer(selected: unknown, options?: Array<{ label?: string }>) {
+        return selected === options?.[0]?.label;
+      },
+      setPendingGate(gateId: string, basePath: string) {
+        calls.push(`pending:${gateId}:${basePath}`);
+      },
+      markApprovalGateVerified(gateId?: string | null, basePath?: string) {
+        calls.push(`approval:${gateId}:${basePath}`);
+      },
+      markDepthVerified(milestoneId?: string | null, basePath?: string) {
+        calls.push(`depth:${milestoneId}:${basePath}`);
+      },
+      clearPendingGate(basePath: string) {
+        calls.push(`clear:${basePath}`);
+      },
+      extractDepthVerificationMilestoneId(questionId: string) {
+        return questionId.match(/_(M\d+)_/)?.[1] ?? null;
+      },
+    };
+
+    const result = await askUserQuestionsHandler(questions, undefined, {
+      async elicitInput() {
+        return { action: 'cancel' };
+      },
+      isRemoteConfigured() {
+        return true;
+      },
+      async tryRemoteQuestions() {
+        return {
+          content: [{ type: 'text', text: 'remote response' }],
+          details: {
+            response: {
+              endInterview: false,
+              answers: {
+                depth_verification_M003_confirm: {
+                  selected: 'Yes, you got it (Recommended)',
+                  notes: '',
+                },
+              },
+            },
+          },
+        };
+      },
+      writeGate,
+      writeGateBasePath: '/tmp/gsd-project',
+    });
+
+    assert.equal('isError' in result && result.isError, false);
+    assert.deepEqual(calls, [
+      'pending:depth_verification_M003_confirm:/tmp/gsd-project',
+      'approval:depth_verification_M003_confirm:/tmp/gsd-project',
+      'depth:M003:/tmp/gsd-project',
+      'clear:/tmp/gsd-project',
+    ]);
+  });
+
   it('ask_user_questions falls back to remote when local elicitation is cancelled', async () => {
     const questions = [
       {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -15,6 +15,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
 import { z } from 'zod';
 import type { SessionManager } from './session-manager.js';
 import { isRemoteConfigured, tryRemoteQuestions } from './remote-questions.js';
@@ -355,6 +356,16 @@ interface AskUserQuestionsStructuredContent {
   cancelled: boolean;
 }
 
+interface AskUserQuestionsWriteGateModule {
+  isGateQuestionId(questionId: string): boolean;
+  isDepthConfirmationAnswer(selected: unknown, options?: Array<{ label?: string }>): boolean;
+  setPendingGate(gateId: string, basePath: string): void;
+  markApprovalGateVerified(gateId?: string | null, basePath?: string): void;
+  markDepthVerified(milestoneId?: string | null, basePath?: string): void;
+  clearPendingGate(basePath: string): void;
+  extractDepthVerificationMilestoneId(questionId: string): string | null;
+}
+
 const OTHER_OPTION_LABEL = 'None of the above';
 
 function normalizeAskUserQuestionsNote(value: AskUserQuestionsContentValue | undefined): string {
@@ -499,6 +510,89 @@ interface AskUserQuestionsHandlerDeps {
   elicitInput(params: AskUserQuestionsElicitRequest): Promise<AskUserQuestionsElicitResult>;
   isRemoteConfigured(): boolean;
   tryRemoteQuestions(questions: AskUserQuestion[], signal?: AbortSignal): Promise<RemoteToolResult | null>;
+  writeGate?: AskUserQuestionsWriteGateModule | null;
+  writeGateBasePath?: string;
+}
+
+let askUserQuestionsWriteGateModulePromise: Promise<AskUserQuestionsWriteGateModule | null> | null = null;
+
+function isAskUserQuestionsWriteGateModule(value: unknown): value is AskUserQuestionsWriteGateModule {
+  if (!value || typeof value !== 'object') return false;
+  const module = value as Record<string, unknown>;
+  return (
+    typeof module['isGateQuestionId'] === 'function' &&
+    typeof module['isDepthConfirmationAnswer'] === 'function' &&
+    typeof module['setPendingGate'] === 'function' &&
+    typeof module['markApprovalGateVerified'] === 'function' &&
+    typeof module['markDepthVerified'] === 'function' &&
+    typeof module['clearPendingGate'] === 'function' &&
+    typeof module['extractDepthVerificationMilestoneId'] === 'function'
+  );
+}
+
+async function loadAskUserQuestionsWriteGateModule(): Promise<AskUserQuestionsWriteGateModule | null> {
+  if (!askUserQuestionsWriteGateModulePromise) {
+    askUserQuestionsWriteGateModulePromise = (async () => {
+      const modulePath = process.env.GSD_WORKFLOW_WRITE_GATE_MODULE?.trim();
+      if (!modulePath) return null;
+      try {
+        if (/^[a-z]{2,}:/i.test(modulePath) && !modulePath.startsWith('file:')) {
+          throw new Error('GSD_WORKFLOW_WRITE_GATE_MODULE only supports file: URLs or filesystem paths.');
+        }
+        const specifier = modulePath.startsWith('file:') ? modulePath : pathToFileURL(resolve(modulePath)).href;
+        const loaded = await import(specifier);
+        return isAskUserQuestionsWriteGateModule(loaded) ? loaded : null;
+      } catch (err) {
+        console.warn(`[gsd:mcp] ask_user_questions write-gate integration unavailable: ${formatErrorMessage(err)}`);
+        return null;
+      }
+    })();
+  }
+  return askUserQuestionsWriteGateModulePromise;
+}
+
+function askUserQuestionsWriteGateBasePath(deps: AskUserQuestionsHandlerDeps): string {
+  return deps.writeGateBasePath ?? process.env.GSD_WORKFLOW_PROJECT_ROOT?.trim() ?? process.cwd();
+}
+
+async function resolveAskUserQuestionsWriteGate(deps: AskUserQuestionsHandlerDeps): Promise<AskUserQuestionsWriteGateModule | null> {
+  if (deps.writeGate !== undefined) return deps.writeGate;
+  return loadAskUserQuestionsWriteGateModule();
+}
+
+async function recordAskUserQuestionsPendingGate(
+  questions: AskUserQuestion[],
+  deps: AskUserQuestionsHandlerDeps,
+): Promise<void> {
+  const writeGate = await resolveAskUserQuestionsWriteGate(deps);
+  if (!writeGate) return;
+
+  const basePath = askUserQuestionsWriteGateBasePath(deps);
+  for (const question of questions) {
+    if (writeGate.isGateQuestionId(question.id)) {
+      writeGate.setPendingGate(question.id, basePath);
+    }
+  }
+}
+
+async function recordAskUserQuestionsGateResult(
+  structured: AskUserQuestionsStructuredContent,
+  deps: AskUserQuestionsHandlerDeps,
+): Promise<void> {
+  if (structured.cancelled || !structured.response) return;
+  const writeGate = await resolveAskUserQuestionsWriteGate(deps);
+  if (!writeGate) return;
+
+  const basePath = askUserQuestionsWriteGateBasePath(deps);
+  for (const question of structured.questions) {
+    if (!writeGate.isGateQuestionId(question.id)) continue;
+    const selected = structured.response.answers[question.id]?.selected;
+    if (!writeGate.isDepthConfirmationAnswer(selected, question.options)) continue;
+
+    writeGate.markApprovalGateVerified(question.id, basePath);
+    writeGate.markDepthVerified(writeGate.extractDepthVerificationMilestoneId(question.id), basePath);
+    writeGate.clearPendingGate(basePath);
+  }
 }
 
 function isLocalElicitFallbackError(err: unknown): boolean {
@@ -539,6 +633,7 @@ export async function askUserQuestionsHandler(
   try {
     const validationError = validateAskUserQuestionsPayload(questions);
     if (validationError) return errorContent(validationError);
+    await recordAskUserQuestionsPendingGate(questions, deps);
 
     // Local-first: try the MCP host's elicitation channel (Claude Code,
     // Cursor, etc.) before any configured remote channel. A misconfigured
@@ -556,6 +651,7 @@ export async function askUserQuestionsHandler(
           response: buildAskUserQuestionsRoundResult(questions, elicitation),
           cancelled: false,
         };
+        await recordAskUserQuestionsGateResult(structured, deps);
         return {
           content: [{ type: 'text' as const, text: formatAskUserQuestionsElicitResult(questions, elicitation) }],
           structuredContent: structured as unknown as Record<string, unknown>,
@@ -612,11 +708,12 @@ export async function askUserQuestionsHandler(
               response: details!['response'] as AskUserQuestionsRoundResult,
               cancelled: false,
             }
-          : {
+            : {
               questions,
               response: null,
               cancelled: true,
             };
+        await recordAskUserQuestionsGateResult(acceptedStructured, deps);
         return {
           content: [{ type: 'text' as const, text: remoteResult.content[0]?.text ?? '' }],
           structuredContent: acceptedStructured as unknown as Record<string, unknown>,

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -539,7 +539,8 @@ async function loadAskUserQuestionsWriteGateModule(): Promise<AskUserQuestionsWr
         if (/^[a-z]{2,}:/i.test(modulePath) && !modulePath.startsWith('file:')) {
           throw new Error('GSD_WORKFLOW_WRITE_GATE_MODULE only supports file: URLs or filesystem paths.');
         }
-        const specifier = modulePath.startsWith('file:') ? modulePath : pathToFileURL(resolve(modulePath)).href;
+        const baseRoot = process.env.GSD_WORKFLOW_PROJECT_ROOT?.trim() || process.cwd();
+        const specifier = modulePath.startsWith('file:') ? modulePath : pathToFileURL(resolve(baseRoot, modulePath)).href;
         const loaded = await import(specifier);
         return isAskUserQuestionsWriteGateModule(loaded) ? loaded : null;
       } catch (err) {

--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
@@ -14,7 +14,7 @@ function renderTool(
 		isError: boolean;
 		details?: Record<string, unknown>;
 	},
-	toolDefinition?: { label?: string },
+	toolDefinition?: { label?: string; renderCall?: (...args: any[]) => any; renderResult?: (...args: any[]) => any },
 ): string {
 	const component = new ToolExecutionComponent(
 		toolName,
@@ -36,7 +36,7 @@ function renderToolCollapsed(
 		isError: boolean;
 		details?: Record<string, unknown>;
 	},
-	toolDefinition?: { label?: string },
+	toolDefinition?: { label?: string; renderCall?: (...args: any[]) => any; renderResult?: (...args: any[]) => any },
 ): string {
 	const component = new ToolExecutionComponent(
 		toolName,
@@ -67,6 +67,27 @@ describe("ToolExecutionComponent", () => {
 		assert.match(rendered, /Tool demo\u00b7do_thing/);
 		assert.match(rendered, /Error/);
 		assert.match(rendered, /boom/);
+	});
+
+	test("passes failed result status to custom result renderers", () => {
+		const rendered = renderTool(
+			"gsd_requirement_save",
+			{ id: "R001" },
+			{ content: [{ type: "text", text: "saved" }], isError: true },
+			{
+				label: "Save Requirement",
+				renderResult(result: { isError?: boolean }) {
+					return {
+						render: () => [result.isError ? "custom saw error" : "custom saw success"],
+						invalidate() {},
+					};
+				},
+			},
+		);
+
+		assert.match(rendered, /Error/);
+		assert.match(rendered, /custom saw error/);
+		assert.doesNotMatch(rendered, /custom saw success/);
 	});
 
 	test("renders capitalized Claude Code Bash tool names with bash output instead of generic args JSON", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -619,8 +619,13 @@ export class ToolExecutionComponent extends Container {
 			// Render result component if we have a result
 			if (this.result && this.toolDefinition.renderResult) {
 				try {
+					const rendererResult = {
+						content: this.result.content as any,
+						details: this.result.details,
+						isError: this.result.isError,
+					};
 					const resultComponent = this.toolDefinition.renderResult(
-						{ content: this.result.content as any, details: this.result.details },
+						rendererResult,
 						{ expanded: this.expanded, isPartial: this.isPartial },
 						theme,
 					);

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -583,6 +583,10 @@ export function updateProgressWidget(
     : state.activeSlice;
   const task = state.activeTask;
 
+  if (mid) {
+    updateSliceProgressCache(accessors.getBasePath(), mid.id, slice?.id);
+  }
+
   // Cache git branch at widget creation time (not per render)
   let cachedBranch: string | null = null;
   try { cachedBranch = getCurrentBranch(accessors.getBasePath()); } catch (err) { /* not in git repo */

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -273,7 +273,8 @@ test("updateProgressWidget refreshes slice progress cache immediately", (t) => {
   );
 
   const progress = getRoadmapSlicesSync();
-  assert.deepEqual(progress && {
+  assert.ok(progress, "progress cache should be populated immediately after updateProgressWidget");
+  assert.deepEqual({
     done: progress.done,
     total: progress.total,
     activeSliceTasks: progress.activeSliceTasks,

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -13,6 +13,9 @@ import {
   formatWidgetTokens,
   estimateTimeRemaining,
   extractUatSliceId,
+  updateProgressWidget,
+  getRoadmapSlicesSync,
+  clearSliceProgressCache,
   getWidgetMode,
   cycleWidgetMode,
   _resetWidgetModeForTests,
@@ -21,6 +24,13 @@ import {
   _getLastCommitForTests,
   _getLastCommitFetchedAtForTests,
 } from "../auto-dashboard.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+} from "../gsd-db.ts";
 
 const autoSource = readFileSync(join(process.cwd(), "src", "resources", "extensions", "gsd", "auto.ts"), "utf-8");
 const dashboardSource = readFileSync(join(process.cwd(), "src", "resources", "extensions", "gsd", "auto-dashboard.ts"), "utf-8");
@@ -218,6 +228,59 @@ test("auto progress widget renders RTK savings under the footer stats line", () 
   assert.match(dashboardSource, /formatRtkSavingsLabel/);
   assert.match(dashboardSource, /getRtkSessionSavings\(accessors\.getBasePath\(\), sessionId\)/);
   assert.match(dashboardSource, /lines\.push\(rightAlign\("", theme\.fg\("dim", cachedRtkLabel\), width\)\);/);
+});
+
+test("updateProgressWidget refreshes slice progress cache immediately", (t) => {
+  const dir = makeTempDir("progress-cache");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  openDatabase(join(dir, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete", sequence: 1 });
+  insertSlice({ milestoneId: "M001", id: "S02", title: "Active", status: "pending", sequence: 2 });
+  insertSlice({ milestoneId: "M001", id: "S03", title: "Pending", status: "pending", sequence: 3 });
+  insertTask({ milestoneId: "M001", sliceId: "S02", id: "T01", title: "Task", status: "complete" });
+
+  t.after(() => {
+    closeDatabase();
+    clearSliceProgressCache();
+    cleanup(dir);
+  });
+
+  clearSliceProgressCache();
+  updateProgressWidget(
+    {
+      hasUI: true,
+      ui: { setWidget() {} },
+    } as any,
+    "complete-slice",
+    "M001/S02",
+    {
+      phase: "summarizing",
+      activeMilestone: { id: "M001", title: "Milestone" },
+      activeSlice: { id: "S02", title: "Active" },
+      activeTask: null,
+    } as any,
+    {
+      getAutoStartTime: () => 0,
+      isStepMode: () => false,
+      getCmdCtx: () => null,
+      getBasePath: () => dir,
+      isVerbose: () => false,
+      isSessionSwitching: () => false,
+      getCurrentDispatchedModelId: () => null,
+    },
+  );
+
+  const progress = getRoadmapSlicesSync();
+  assert.deepEqual(progress && {
+    done: progress.done,
+    total: progress.total,
+    activeSliceTasks: progress.activeSliceTasks,
+  }, {
+    done: 1,
+    total: 3,
+    activeSliceTasks: { done: 1, total: 1 },
+  });
 });
 
 test("last commit refresh backs off cleanly when base path is not a git repo", (t) => {

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -233,18 +233,19 @@ test("auto progress widget renders RTK savings under the footer stats line", () 
 test("updateProgressWidget refreshes slice progress cache immediately", (t) => {
   const dir = makeTempDir("progress-cache");
   mkdirSync(join(dir, ".gsd"), { recursive: true });
-  openDatabase(join(dir, ".gsd", "gsd.db"));
-  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
-  insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete", sequence: 1 });
-  insertSlice({ milestoneId: "M001", id: "S02", title: "Active", status: "pending", sequence: 2 });
-  insertSlice({ milestoneId: "M001", id: "S03", title: "Pending", status: "pending", sequence: 3 });
-  insertTask({ milestoneId: "M001", sliceId: "S02", id: "T01", title: "Task", status: "complete" });
 
   t.after(() => {
     closeDatabase();
     clearSliceProgressCache();
     cleanup(dir);
   });
+
+  openDatabase(join(dir, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+  insertSlice({ milestoneId: "M001", id: "S01", title: "Done", status: "complete", sequence: 1 });
+  insertSlice({ milestoneId: "M001", id: "S02", title: "Active", status: "pending", sequence: 2 });
+  insertSlice({ milestoneId: "M001", id: "S03", title: "Pending", status: "pending", sequence: 3 });
+  insertTask({ milestoneId: "M001", sliceId: "S02", id: "T01", title: "Task", status: "complete" });
 
   clearSliceProgressCache();
   updateProgressWidget(


### PR DESCRIPTION
## TL;DR

**What:** Persist GSD depth-gate confirmations from MCP `ask_user_questions`, align custom tool rendering with actual tool error state, and refresh dashboard slice progress immediately.
**Why:** Accepted depth confirmations could remain pending on disk, successful-looking tool bodies could appear inside red Error frames, and the auto dashboard could show stale slice progress after completion.
**How:** The MCP question handler now records pending and confirmed gate state through the write-gate module, custom renderers receive `isError`, and `updateProgressWidget` refreshes the slice progress cache before rendering.

## What

- Added write-gate persistence around accepted MCP `ask_user_questions` depth confirmations.
- Passed tool `isError` into custom result renderers so tool card body and frame status agree.
- Refreshed auto-dashboard slice/task progress cache when the progress widget is set, instead of waiting for the 15s timer.
- Added regression coverage for all three behaviors.

## Why

This fixes the failure mode where the user selected the recommended Yes confirmation but `.gsd/runtime/write-gate-state.json` still showed a pending depth gate, causing the workflow to loop and attempt manual recovery. It also addresses the confusing red Error frame with a success body and stale progress display after slice completion.

## How

`askUserQuestionsHandler` now optionally loads the workflow write-gate module from `GSD_WORKFLOW_WRITE_GATE_MODULE` and uses `GSD_WORKFLOW_PROJECT_ROOT` as the canonical project root when available, so worktree cwd drift does not write gate state to the wrong checkout. The UI renderer change is scoped to the object passed into existing custom renderers. The dashboard change reuses the existing `updateSliceProgressCache` path.

AI-assisted PR.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/mcp-server/src/mcp-server.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-dashboard.test.ts`
- [x] `git diff --check`
- [ ] `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run verify:pr` — build and extension typecheck passed; unit preflight failed in existing TUI cursor/autocomplete tests unrelated to this diff (`tui-autocomplete-ghost-lines`, `tui-content-cursor-desync`). Re-running those focused tests reproduced the same failures.

## Change type checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Progress widget now updates immediately when a milestone is active, eliminating stale progress displays.

* **Improvements**
  * Tool execution failures are propagated to custom result renderers so errors display correctly.
  * Server-side question handling now optionally integrates a write-gate flow and reliably records, verifies, and clears confirmation gates for depth checks.

* **Tests**
  * Added tests for gate verification workflows and slice progress reporting with cached state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->