### PR TITLE
fix(gsd): quiet auto-mode warning noise

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
@@ -17,7 +17,7 @@ import { Container, Text } from "@gsd/pi-tui";
 import stripAnsi from "strip-ansi";
 
 import { initTheme, theme } from "../theme/theme.js";
-import { shouldRenderExtensionNotifyInChat } from "../interactive-mode.js";
+import { renderExtensionNotifyInChat, shouldRenderExtensionNotifyInChat } from "../interactive-mode.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { ToolExecutionComponent } from "./tool-execution.js";
 
@@ -34,6 +34,26 @@ describe("Extension warning notifications", () => {
 		assert.equal(shouldRenderExtensionNotifyInChat("success"), true);
 		assert.equal(shouldRenderExtensionNotifyInChat("info"), true);
 		assert.equal(shouldRenderExtensionNotifyInChat(undefined), true);
+
+		const warningChat = new Container();
+		const warningResult = renderExtensionNotifyInChat(warningChat, "extension warning", "warning");
+		assert.equal(warningResult.rendered, false);
+		assert.equal(
+			warningChat.render(80).map(stripAnsi).join("\n"),
+			"",
+			"warning notifications must not add chat output",
+		);
+
+		for (const type of ["error", "success", "info"] as const) {
+			const chat = new Container();
+			const result = renderExtensionNotifyInChat(chat, `${type} notification`, type);
+			assert.equal(result.rendered, true, `${type} notification should render`);
+			assert.match(
+				chat.render(80).map(stripAnsi).join("\n"),
+				new RegExp(`${type} notification`),
+				`${type} notification text should appear in chat output`,
+			);
+		}
 	});
 });
 

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
@@ -17,6 +17,7 @@ import { Container, Text } from "@gsd/pi-tui";
 import stripAnsi from "strip-ansi";
 
 import { initTheme, theme } from "../theme/theme.js";
+import { shouldRenderExtensionNotifyInChat } from "../interactive-mode.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { ToolExecutionComponent } from "./tool-execution.js";
 
@@ -24,6 +25,16 @@ import { ToolExecutionComponent } from "./tool-execution.js";
 // Initialize once before any test that exercises themed rendering.
 before(() => {
 	initTheme("dark");
+});
+
+describe("Extension warning notifications", () => {
+	it("do not render into chat output", () => {
+		assert.equal(shouldRenderExtensionNotifyInChat("warning"), false);
+		assert.equal(shouldRenderExtensionNotifyInChat("error"), true);
+		assert.equal(shouldRenderExtensionNotifyInChat("success"), true);
+		assert.equal(shouldRenderExtensionNotifyInChat("info"), true);
+		assert.equal(shouldRenderExtensionNotifyInChat(undefined), true);
+	});
 });
 
 interface MockTui {

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -170,6 +170,12 @@ type CompactionQueuedMessage = {
 	mode: "steer" | "followUp";
 };
 
+export type ExtensionNotifyType = "info" | "warning" | "error" | "success" | undefined;
+
+export function shouldRenderExtensionNotifyInChat(type: ExtensionNotifyType): boolean {
+	return type !== "warning";
+}
+
 /**
  * Options for InteractiveMode initialization.
  */
@@ -1834,10 +1840,11 @@ export class InteractiveMode {
 	 * Show a notification for extensions.
 	 */
 	private showExtensionNotify(message: string, type?: "info" | "warning" | "error" | "success"): void {
+		if (!shouldRenderExtensionNotifyInChat(type)) {
+			return;
+		}
 		if (type === "error") {
 			this.showError(message);
-		} else if (type === "warning") {
-			this.showWarning(message);
 		} else if (type === "success") {
 			this.showSuccess(message);
 		} else {

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -176,6 +176,41 @@ export function shouldRenderExtensionNotifyInChat(type: ExtensionNotifyType): bo
 	return type !== "warning";
 }
 
+export interface ExtensionNotifyRenderResult {
+	rendered: boolean;
+	statusSpacer?: Spacer;
+	statusText?: Text;
+}
+
+export function renderExtensionNotifyInChat(
+	chatContainer: Container,
+	message: string,
+	type?: ExtensionNotifyType,
+): ExtensionNotifyRenderResult {
+	if (!shouldRenderExtensionNotifyInChat(type)) {
+		return { rendered: false };
+	}
+
+	const spacer = new Spacer(1);
+	chatContainer.addChild(spacer);
+
+	if (type === "error") {
+		chatContainer.addChild(new Text(theme.fg("error", `Error: ${message}`), 1, 0));
+		return { rendered: true };
+	}
+	if (type === "success") {
+		chatContainer.addChild(new DynamicBorder((text) => theme.fg("success", text)));
+		chatContainer.addChild(new Text(theme.fg("success", message), 1, 0));
+		chatContainer.addChild(new DynamicBorder((text) => theme.fg("success", text)));
+		chatContainer.addChild(new Spacer(1));
+		return { rendered: true };
+	}
+
+	const statusText = new Text(theme.fg("dim", message), 1, 0);
+	chatContainer.addChild(statusText);
+	return { rendered: true, statusSpacer: spacer, statusText };
+}
+
 /**
  * Options for InteractiveMode initialization.
  */
@@ -1839,17 +1874,16 @@ export class InteractiveMode {
 	/**
 	 * Show a notification for extensions.
 	 */
-	private showExtensionNotify(message: string, type?: "info" | "warning" | "error" | "success"): void {
-		if (!shouldRenderExtensionNotifyInChat(type)) {
+	private showExtensionNotify(message: string, type?: ExtensionNotifyType): void {
+		const result = renderExtensionNotifyInChat(this.chatContainer, message, type);
+		if (!result.rendered) {
 			return;
 		}
-		if (type === "error") {
-			this.showError(message);
-		} else if (type === "success") {
-			this.showSuccess(message);
-		} else {
-			this.showStatus(message, { append: true });
+		if (result.statusSpacer && result.statusText) {
+			this.lastStatusSpacer = result.statusSpacer;
+			this.lastStatusText = result.statusText;
 		}
+		this.ui.requestRender();
 	}
 
 	/** Show a custom component with keyboard focus. Overlay mode renders on top of existing content. */

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -273,11 +273,13 @@ function gitPathspecForWorktreePath(basePath: string, targetPath: string): strin
     base = realpathSync.native(basePath);
   } catch {
     /* keep original */
+    void base;
   }
   try {
     target = realpathSync.native(targetPath);
   } catch {
     /* keep original */
+    void target;
   }
 
   const rel = relative(base, target);

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -18,7 +18,7 @@ import {
   statSync,
   lstatSync as lstatSyncFn,
 } from "node:fs";
-import { isAbsolute, join, sep as pathSep } from "node:path";
+import { isAbsolute, join, relative, sep as pathSep } from "node:path";
 import { GSDError, GSD_IO_ERROR, GSD_GIT_ERROR } from "./errors.js";
 import {
   reconcileWorktreeDb,
@@ -266,6 +266,38 @@ function getActiveWorkspace(): GsdWorkspace | null {
   return activeWorkspace;
 }
 
+function gitPathspecForWorktreePath(basePath: string, targetPath: string): string | null {
+  let base = basePath;
+  let target = targetPath;
+  try {
+    base = realpathSync.native(basePath);
+  } catch {
+    /* keep original */
+  }
+  try {
+    target = realpathSync.native(targetPath);
+  } catch {
+    /* keep original */
+  }
+
+  const rel = relative(base, target);
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) return null;
+  return rel.replaceAll("\\", "/");
+}
+
+function gitRemoteExists(basePath: string, remote: string): boolean {
+  try {
+    execFileSync("git", ["remote", "get-url", remote], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function clearProjectRootStateFiles(basePath: string, milestoneId: string): void {
   const gsdDir = gsdRoot(basePath);
   // Phase C pt 2: auto.lock removed from this list — the file is gone
@@ -301,11 +333,14 @@ function clearProjectRootStateFiles(basePath: string, milestoneId: string): void
   for (const dir of syncedDirs) {
     try {
       if (existsSync(dir)) {
+        const pathspec = gitPathspecForWorktreePath(basePath, dir);
+        if (!pathspec) continue;
+
         // Only remove files that are untracked by git — tracked files are
         // managed by the branch checkout and should not be deleted.
         const untrackedOutput = execFileSync(
           "git",
-          ["ls-files", "--others", "--exclude-standard", dir],
+          ["ls-files", "--others", "--exclude-standard", pathspec],
           { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
         ).trim();
         if (untrackedOutput) {
@@ -2187,16 +2222,18 @@ export function mergeMilestoneToMain(
   let pushed = false;
   if (prefs.auto_push === true && prefs.auto_pr !== true && !nothingToCommit) {
     const remote = prefs.remote ?? "origin";
-    try {
-      execFileSync("git", ["push", remote, mainBranch], {
-        cwd: originalBasePath_,
-        stdio: ["ignore", "pipe", "pipe"],
-        encoding: "utf-8",
-      });
-      pushed = true;
-    } catch (err) {
-      // Push failure is non-fatal
-      logWarning("worktree", `git push failed: ${err instanceof Error ? err.message : String(err)}`);
+    if (gitRemoteExists(originalBasePath_, remote)) {
+      try {
+        execFileSync("git", ["push", remote, mainBranch], {
+          cwd: originalBasePath_,
+          stdio: ["ignore", "pipe", "pipe"],
+          encoding: "utf-8",
+        });
+        pushed = true;
+      } catch (err) {
+        // Push failure is non-fatal
+        logWarning("worktree", `git push failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
   }
 

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -2244,29 +2244,31 @@ export function mergeMilestoneToMain(
   if (prefs.auto_pr === true && !nothingToCommit) {
     const remote = prefs.remote ?? "origin";
     const prTarget = prefs.pr_target_branch ?? mainBranch;
-    try {
-      // Push the milestone branch to remote first
-      execFileSync("git", ["push", remote, milestoneBranch], {
-        cwd: originalBasePath_,
-        stdio: ["ignore", "pipe", "pipe"],
-        encoding: "utf-8",
-      });
-      // Create PR via gh CLI with explicit --head and --base (#2302)
-      execFileSync("gh", [
-        "pr", "create", "--draft",
-        "--base", prTarget,
-        "--head", milestoneBranch,
-        "--title", `Milestone ${milestoneId} complete`,
-        "--body", "Auto-created by GSD on milestone completion.",
-      ], {
-        cwd: originalBasePath_,
-        stdio: ["ignore", "pipe", "pipe"],
-        encoding: "utf-8",
-      });
-      prCreated = true;
-    } catch (err) {
-      // PR creation failure is non-fatal — gh may not be installed or authenticated
-      logWarning("worktree", `PR creation failed: ${err instanceof Error ? err.message : String(err)}`);
+    if (gitRemoteExists(originalBasePath_, remote)) {
+      try {
+        // Push the milestone branch to remote first
+        execFileSync("git", ["push", remote, milestoneBranch], {
+          cwd: originalBasePath_,
+          stdio: ["ignore", "pipe", "pipe"],
+          encoding: "utf-8",
+        });
+        // Create PR via gh CLI with explicit --head and --base (#2302)
+        execFileSync("gh", [
+          "pr", "create", "--draft",
+          "--base", prTarget,
+          "--head", milestoneBranch,
+          "--title", `Milestone ${milestoneId} complete`,
+          "--body", "Auto-created by GSD on milestone completion.",
+        ], {
+          cwd: originalBasePath_,
+          stdio: ["ignore", "pipe", "pipe"],
+          encoding: "utf-8",
+        });
+        prCreated = true;
+      } catch (err) {
+        // PR creation failure is non-fatal — gh may not be installed or authenticated
+        logWarning("worktree", `PR creation failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
   }
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -22,6 +22,7 @@ import { logWarning as safetyLogWarning } from "../workflow-logger.js";
 import { installNotifyInterceptor } from "./notify-interceptor.js";
 import { initNotificationStore } from "../notification-store.js";
 import { initNotificationWidget } from "../notification-widget.js";
+import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { extractSubagentAgentClasses } from "./subagent-input.js";
 import { approvalGateIdForUnit, isExplicitApprovalResponse, shouldPauseForUserApprovalQuestion } from "../user-input-boundary.js";
 
@@ -64,6 +65,16 @@ async function applyDisabledModelProviderPolicy(ctx: ExtensionContext): Promise<
   }
 }
 
+export function resolveNotificationStoreBasePath(cwd: string = process.cwd()): string {
+  return resolveWorktreeProjectRoot(cwd);
+}
+
+function initSessionNotifications(ctx: ExtensionContext): void {
+  initNotificationStore(resolveNotificationStoreBasePath());
+  installNotifyInterceptor(ctx);
+  initNotificationWidget(ctx);
+}
+
 async function writeContextModeCompactionSnapshot(basePath: string): Promise<void> {
   try {
     const { loadEffectiveGSDPreferences } = await import("../preferences.js");
@@ -101,9 +112,7 @@ export function registerHooks(
   ecosystemHandlers: GSDEcosystemBeforeAgentStartHandler[],
 ): void {
   pi.on("session_start", async (_event, ctx) => {
-    initNotificationStore(process.cwd());
-    installNotifyInterceptor(ctx);
-    initNotificationWidget(ctx);
+    initSessionNotifications(ctx);
     if (!isAutoActive()) {
       const { initHealthWidget } = await import("../health-widget.js");
       initHealthWidget(ctx);
@@ -156,8 +165,7 @@ export function registerHooks(
   });
 
   pi.on("session_switch", async (_event, ctx) => {
-    initNotificationStore(process.cwd());
-    installNotifyInterceptor(ctx);
+    initSessionNotifications(ctx);
     resetWriteGateState(process.cwd());
     resetToolCallLoopGuard();
     await resetAskUserQuestionsTurnCache();

--- a/src/resources/extensions/gsd/notification-widget.ts
+++ b/src/resources/extensions/gsd/notification-widget.ts
@@ -27,9 +27,13 @@ export function buildNotificationWidgetLines(): string[] {
 }
 
 const REFRESH_INTERVAL_MS = 30_000;
+let notificationWidgetCleanup: (() => void) | undefined;
 
-export function initNotificationWidget(ctx: ExtensionContext): void {
-  if (!ctx.hasUI) return;
+export function initNotificationWidget(ctx: ExtensionContext): () => void {
+  notificationWidgetCleanup?.();
+  notificationWidgetCleanup = undefined;
+
+  if (!ctx.hasUI) return () => {};
 
   const push = () => {
     const chip = buildNotificationChip();
@@ -37,6 +41,23 @@ export function initNotificationWidget(ctx: ExtensionContext): void {
   };
   push();
 
-  onNotificationStoreChange(push);
-  setInterval(push, REFRESH_INTERVAL_MS).unref?.();
+  const unsubscribe = onNotificationStoreChange(push);
+  const interval = setInterval(push, REFRESH_INTERVAL_MS);
+  interval.unref?.();
+
+  const cleanup = () => {
+    unsubscribe();
+    clearInterval(interval);
+    ctx.ui.setStatus(STATUS_KEY, undefined);
+    if (notificationWidgetCleanup === cleanup) {
+      notificationWidgetCleanup = undefined;
+    }
+  };
+  notificationWidgetCleanup = cleanup;
+  return cleanup;
+}
+
+export function _resetNotificationWidgetForTests(): void {
+  notificationWidgetCleanup?.();
+  notificationWidgetCleanup = undefined;
 }

--- a/src/resources/extensions/gsd/notification-widget.ts
+++ b/src/resources/extensions/gsd/notification-widget.ts
@@ -48,8 +48,8 @@ export function initNotificationWidget(ctx: ExtensionContext): () => void {
   const cleanup = () => {
     unsubscribe();
     clearInterval(interval);
-    ctx.ui.setStatus(STATUS_KEY, undefined);
     if (notificationWidgetCleanup === cleanup) {
+      ctx.ui.setStatus(STATUS_KEY, undefined);
       notificationWidgetCleanup = undefined;
     }
   };

--- a/src/resources/extensions/gsd/prompts/complete-milestone.md
+++ b/src/resources/extensions/gsd/prompts/complete-milestone.md
@@ -14,7 +14,7 @@ Preloaded context below — the roadmap, compact slice-summary excerpts, require
 
 Start with what the excerpts give you. Read full files when the section heads signal richer context you need.
 
-**On-demand Read ordering:** Complete all slice SUMMARY Reads you need for cross-slice synthesis, the Decision Re-evaluation table, and LEARNINGS **before** calling `gsd_complete_milestone` (step 10). Once that tool runs, the milestone is marked complete in the DB — running out of tool budget between step 10 and the LEARNINGS write (step 12) leaves the milestone committed without its LEARNINGS artifact.
+**On-demand Read ordering:** Complete all slice SUMMARY Reads you need for cross-slice synthesis, the Decision Re-evaluation table, and LEARNINGS **before** calling `gsd_complete_milestone` (step 12). Once that tool runs, the milestone is marked complete in the DB, so it must be the final persistent milestone-closeout write.
 
 ### Delegate Review Work
 
@@ -54,7 +54,12 @@ Then:
 **Success path** (all verifications passed — continue with steps 9–13):
 
 9. For each requirement whose status changed in step 8, call `gsd_requirement_update` with the requirement ID and updated `status` and `validation` fields — the tool regenerates `.gsd/REQUIREMENTS.md` automatically. Do this BEFORE completing the milestone so requirement updates are persisted.
-10. **Persist completion through `gsd_complete_milestone`.** Call it with the parameters below. The tool updates the milestone status in the DB, renders `{{milestoneSummaryPath}}`, and validates all slices are complete before proceeding.
+10. Update `.gsd/PROJECT.md`: use the `write` tool with `path: ".gsd/PROJECT.md"` and `content` containing the full updated document reflecting milestone completion and current project state. Do NOT use the `edit` tool for this — PROJECT.md is a full-document refresh.
+11. Extract structured learnings from this milestone and persist them to the GSD memory store. Follow the procedure block immediately below — it writes `{{milestoneId}}-LEARNINGS.md` as the audit trail and persists Patterns, Lessons, and Decisions via `capture_thought` (categories: pattern, gotcha/convention, architecture). The memory store is the single source of truth for cross-session durable knowledge (ADR-013).
+
+{{extractLearningsSteps}}
+
+12. **Persist completion through `gsd_complete_milestone`.** Call it with the parameters below. This must be the final persistent write in the unit. The tool updates the milestone status in the DB, renders `{{milestoneSummaryPath}}`, and validates all slices are complete.
 
    **Required parameters:**
    - `milestoneId` (string) — Milestone ID (e.g. M001)
@@ -72,10 +77,6 @@ Then:
    **Optional parameters:**
    - `followUps` (string) — Follow-up items for future milestones
    - `deviations` (string) — Deviations from the original plan
-11. Update `.gsd/PROJECT.md`: use the `write` tool with `path: ".gsd/PROJECT.md"` and `content` containing the full updated document reflecting milestone completion and current project state. Do NOT use the `edit` tool for this — PROJECT.md is a full-document refresh.
-12. Extract structured learnings from this milestone and persist them to the GSD memory store. Follow the procedure block immediately below — it writes `{{milestoneId}}-LEARNINGS.md` as the audit trail and persists Patterns, Lessons, and Decisions via `capture_thought` (categories: pattern, gotcha/convention, architecture). The memory store is the single source of truth for cross-session durable knowledge (ADR-013).
-
-{{extractLearningsSteps}}
 
 13. Do not commit manually — the system auto-commits your changes after this unit completes.
 - Say: "Milestone {{milestoneId}} complete."

--- a/src/resources/extensions/gsd/prompts/complete-milestone.md
+++ b/src/resources/extensions/gsd/prompts/complete-milestone.md
@@ -42,7 +42,7 @@ Then:
 
 ### Verification Gate — STOP if verification failed
 
-**If ANY verification failure was recorded in steps 3, 4, or 5, you MUST follow the failure path below. Do NOT proceed to step 10.**
+**If ANY verification failure was recorded in steps 3, 4, or 5, you MUST follow the failure path below. Do NOT proceed with steps 9–13.**
 
 **Failure path** (verification failed):
 - Do NOT call `gsd_complete_milestone` — the milestone must not be marked as complete.

--- a/src/resources/extensions/gsd/tests/auto-pr-bugs.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-pr-bugs.test.ts
@@ -34,6 +34,25 @@ test("#2302 bug 1: auto_pr condition should not require pushed flag", () => {
   );
 });
 
+test("auto_pr skips milestone branch push when configured remote is absent", () => {
+  const autoPrIdx = autoWorktreeSrc.indexOf("prefs.auto_pr === true");
+  assert.ok(autoPrIdx !== -1, "auto_pr block exists in auto-worktree.ts");
+
+  const autoPrBlock = autoWorktreeSrc.slice(
+    autoPrIdx,
+    autoWorktreeSrc.indexOf("// 11. Guard removed", autoPrIdx),
+  );
+  const remoteExistsIdx = autoPrBlock.indexOf("gitRemoteExists(originalBasePath_, remote)");
+  const pushIdx = autoPrBlock.indexOf('execFileSync("git", ["push", remote, milestoneBranch]');
+
+  assert.ok(remoteExistsIdx !== -1, "auto_pr must check that the configured remote exists");
+  assert.ok(pushIdx !== -1, "auto_pr still pushes the milestone branch before creating the PR");
+  assert.ok(
+    remoteExistsIdx < pushIdx,
+    "auto_pr must check remote existence before pushing the milestone branch",
+  );
+});
+
 // ─── Bug 2: phases.ts should not duplicate PR creation ──────────────────────
 
 const phasesSrcPath = join(import.meta.dirname, "..", "auto", "phases.ts");

--- a/src/resources/extensions/gsd/tests/complete-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone.test.ts
@@ -1,3 +1,4 @@
+// GSD2 complete-milestone tests
 import { describe, test, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
@@ -471,7 +472,6 @@ describe("complete-milestone", () => {
       };
 
       const result = await handleCompleteMilestone(params, base);
-
       assert.ok(!("error" in result), `already-complete re-dispatch should succeed: ${JSON.stringify(result)}`);
       assert.equal(result.alreadyComplete, true);
 
@@ -480,6 +480,20 @@ describe("complete-milestone", () => {
         actualContent,
         originalContent,
         "existing SUMMARY.md must not be overwritten on re-dispatch (#4598)",
+      );
+
+      // Repeated re-dispatch should also be idempotent.
+      const repeatResult = await handleCompleteMilestone(params, base);
+      assert.ok(!("error" in repeatResult), "repeated re-dispatch should also succeed");
+      assert.strictEqual(repeatResult.alreadyComplete, true, "repeated re-dispatch is identified as already-complete");
+      assert.ok(
+        repeatResult.summaryPath.endsWith(join(".gsd", "milestones", mid, `${mid}-SUMMARY.md`)),
+        "repeated re-dispatch returns the existing summary path",
+      );
+      assert.strictEqual(
+        readFileSync(summaryPath, "utf-8"),
+        originalContent,
+        "repeated re-dispatch must not overwrite SUMMARY.md",
       );
     } finally {
       try { closeDatabase(); } catch { /* */ }

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../../auto-worktree.ts";
 import { getSliceBranchName } from "../../worktree.ts";
 import { nativeMergeSquash } from "../../native-git-bridge.ts";
+import { drainLogs, setStderrLoggingEnabled } from "../../workflow-logger.ts";
 
 function run(cmd: string, cwd: string): string {
   // Safe: all inputs are hardcoded test strings, not user input
@@ -249,6 +250,42 @@ describe("auto-worktree-milestone-merge", { timeout: 300_000 }, () => {
     assert.ok(remoteLog.includes("feat:"), "milestone commit reachable on remote after manual push");
 
     assert.strictEqual(typeof result.pushed, "boolean", "pushed flag remains boolean");
+  });
+
+  test("external .gsd and local-only auto_push closeout without cleanup or push warnings", () => {
+    const { repo, externalState } = freshRepoWithExternalGsd();
+    const previousStderr = setStderrLoggingEnabled(false);
+    drainLogs();
+
+    try {
+      writeFileSync(
+        join(externalState, "PREFERENCES.md"),
+        "---\nversion: 1\n---\n\ngit:\n  auto_push: true\n",
+      );
+      mkdirSync(join(externalState, "milestones", "M041"), { recursive: true });
+      mkdirSync(join(externalState, "runtime", "units"), { recursive: true });
+      writeFileSync(join(externalState, "runtime", "units", "leftover.json"), "{}\n");
+
+      const wtPath = createAutoWorktree(repo, "M041");
+      addSliceToMilestone(repo, wtPath, "M041", "S01", "Local-only push", [
+        { file: "local-only.ts", content: "export const localOnly = true;\n", message: "add local only file" },
+      ]);
+
+      const roadmap = makeRoadmap("M041", "Local-only closeout", [
+        { id: "S01", title: "Local-only push" },
+      ]);
+
+      const result = mergeMilestoneToMain(repo, "M041", roadmap);
+      const logs = drainLogs();
+      const messages = logs.map((entry) => entry.message).join("\n");
+
+      assert.equal(result.pushed, false, "local-only repo should not report pushed");
+      assert.ok(!messages.includes("untracked file cleanup failed"), "external .gsd cleanup should not call git on paths outside the repo");
+      assert.ok(!messages.includes("git push failed"), "missing origin should skip auto-push instead of running git push");
+    } finally {
+      drainLogs();
+      setStderrLoggingEnabled(previousStderr);
+    }
   });
 
   test("auto-resolve .gsd/ state file conflicts", () => {

--- a/src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts
@@ -585,6 +585,7 @@ describe("state-machine-live-validation", () => {
       const result = await handleCompleteMilestone(makeMilestoneParams("M001") as any, base);
       assert.ok(!("error" in result), `already-complete milestone should be accepted: ${JSON.stringify(result)}`);
       assert.equal(result.alreadyComplete, true);
+      assert.match(result.summaryPath, /M001-SUMMARY\.md$/);
       assert.ok(isClosedStatus(getMilestone("M001")!.status), "milestone remains closed");
     });
   });

--- a/src/resources/extensions/gsd/tests/notification-store.test.ts
+++ b/src/resources/extensions/gsd/tests/notification-store.test.ts
@@ -19,6 +19,7 @@ import {
   onNotificationStoreChange,
   _resetNotificationStore,
 } from "../notification-store.js";
+import { resolveNotificationStoreBasePath } from "../bootstrap/register-hooks.js";
 
 describe("notification-store", () => {
   let tmp: string;
@@ -241,6 +242,13 @@ describe("notification-store", () => {
     assert.equal(p1Entries[0].message, "project1");
 
     rmSync(tmp2, { recursive: true, force: true });
+  });
+
+  test("session notification base resolves auto-worktree paths to project root", () => {
+    const worktreePath = join(tmp, ".gsd", "worktrees", "M001");
+    mkdirSync(worktreePath, { recursive: true });
+
+    assert.equal(resolveNotificationStoreBasePath(worktreePath), tmp);
   });
 
   test("counters resync from disk after markAllRead", () => {

--- a/src/resources/extensions/gsd/tests/notification-widget.test.ts
+++ b/src/resources/extensions/gsd/tests/notification-widget.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { initNotificationStore, appendNotification, _resetNotificationStore } from "../notification-store.js";
-import { buildNotificationWidgetLines } from "../notification-widget.js";
+import { buildNotificationWidgetLines, initNotificationWidget, _resetNotificationWidgetForTests } from "../notification-widget.js";
 
 test("buildNotificationWidgetLines shows unread count with shortcut pair", () => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-notification-widget-"));
@@ -23,6 +23,41 @@ test("buildNotificationWidgetLines shows unread count with shortcut pair", () =>
     assert.match(combined, /🔔\s+1 unread/);
     assert.match(combined, /\(.+\/.+\)/);
   } finally {
+    _resetNotificationStore();
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("initNotificationWidget replaces prior interval and store subscription", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-notification-widget-"));
+  const firstStatuses: Array<string | undefined> = [];
+  const secondStatuses: Array<string | undefined> = [];
+  try {
+    mkdirSync(join(tmp, ".gsd"), { recursive: true });
+    _resetNotificationStore();
+    _resetNotificationWidgetForTests();
+    initNotificationStore(tmp);
+
+    initNotificationWidget({
+      hasUI: true,
+      ui: { setStatus: (_key: string, value: string | undefined) => firstStatuses.push(value) },
+    } as any);
+    initNotificationWidget({
+      hasUI: true,
+      ui: { setStatus: (_key: string, value: string | undefined) => secondStatuses.push(value) },
+    } as any);
+
+    const firstCountAfterReplace = firstStatuses.length;
+    appendNotification("Need attention", "warning");
+
+    assert.equal(
+      firstStatuses.length,
+      firstCountAfterReplace,
+      "replaced widget must not receive store-change refreshes",
+    );
+    assert.match(secondStatuses.at(-1) ?? "", /1 unread/);
+  } finally {
+    _resetNotificationWidgetForTests();
     _resetNotificationStore();
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/notification-widget.test.ts
+++ b/src/resources/extensions/gsd/tests/notification-widget.test.ts
@@ -37,8 +37,9 @@ test("initNotificationWidget replaces prior interval and store subscription", ()
     _resetNotificationStore();
     _resetNotificationWidgetForTests();
     initNotificationStore(tmp);
+    appendNotification("Need attention", "warning");
 
-    initNotificationWidget({
+    const firstCleanup = initNotificationWidget({
       hasUI: true,
       ui: { setStatus: (_key: string, value: string | undefined) => firstStatuses.push(value) },
     } as any);
@@ -48,14 +49,17 @@ test("initNotificationWidget replaces prior interval and store subscription", ()
     } as any);
 
     const firstCountAfterReplace = firstStatuses.length;
-    appendNotification("Need attention", "warning");
+    firstCleanup();
+    assert.equal(firstStatuses.length, firstCountAfterReplace, "stale cleanup must not clear the replaced status chip");
+
+    appendNotification("Need follow-up", "warning");
 
     assert.equal(
       firstStatuses.length,
       firstCountAfterReplace,
       "replaced widget must not receive store-change refreshes",
     );
-    assert.match(secondStatuses.at(-1) ?? "", /1 unread/);
+    assert.match(secondStatuses.at(-1) ?? "", /2 unread/);
   } finally {
     _resetNotificationWidgetForTests();
     _resetNotificationStore();

--- a/src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts
@@ -2,7 +2,7 @@
  * Regression test for #3696 — prompt step ordering and runtime fixes
  *
  * 1. complete-milestone.md: gsd_requirement_update (step 9) before
- *    gsd_complete_milestone (step 10)
+ *    gsd_complete_milestone, and completion remains the final durable write
  * 2. complete-slice.md: uses gsd_requirement_update
  * 3. register-extension.ts: _gsdEpipeGuard logs instead of re-throwing
  * 4. register-hooks.ts: session_before_compact only checks isAutoActive
@@ -48,6 +48,21 @@ describe('prompt step ordering (#3696)', () => {
       reqUpdateIdx < completeMilestoneIdx,
       'gsd_requirement_update step must come before gsd_complete_milestone step',
     );
+  });
+
+  test('project and learnings writes appear before gsd_complete_milestone', () => {
+    const projectMatch = completeMilestoneMd.match(/^\d+\.\s.*PROJECT\.md/m);
+    const learningsMatch = completeMilestoneMd.match(/^\d+\.\s.*Extract structured learnings/m);
+    const completeMilestoneMatch = completeMilestoneMd.match(/^\d+\.\s.*gsd_complete_milestone/m);
+    assert.ok(projectMatch, 'PROJECT.md update should appear in a numbered step');
+    assert.ok(learningsMatch, 'learnings extraction should appear in a numbered step');
+    assert.ok(completeMilestoneMatch, 'gsd_complete_milestone should appear in a numbered step');
+
+    const projectIdx = completeMilestoneMd.indexOf(projectMatch![0]);
+    const learningsIdx = completeMilestoneMd.indexOf(learningsMatch![0]);
+    const completeMilestoneIdx = completeMilestoneMd.indexOf(completeMilestoneMatch![0]);
+    assert.ok(projectIdx < completeMilestoneIdx, 'PROJECT.md update must happen before gsd_complete_milestone');
+    assert.ok(learningsIdx < completeMilestoneIdx, 'learnings extraction must happen before gsd_complete_milestone');
   });
 
   test('complete-slice.md uses gsd_requirement_update', () => {

--- a/src/resources/extensions/gsd/tests/workflow-logger.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-logger.test.ts
@@ -21,6 +21,11 @@ import {
   setStderrLoggingEnabled,
   _resetLogs,
 } from "../workflow-logger.ts";
+import {
+  initNotificationStore,
+  readNotifications,
+  _resetNotificationStore,
+} from "../notification-store.ts";
 
 const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
@@ -250,6 +255,7 @@ describe("workflow-logger", () => {
 
     afterEach(() => {
       setLogBasePath("");
+      _resetNotificationStore();
       cleanup(dir);
     });
 
@@ -343,16 +349,26 @@ describe("workflow-logger", () => {
   });
 
   describe("stderr output", () => {
-    test("writes WARN prefix to stderr for warnings", (t) => {
+    test("keeps warnings out of stderr but persists them to notifications", (t) => {
+      const dir = makeTempDir("wl-notify-");
       const written: string[] = [];
       const orig = process.stderr.write.bind(process.stderr);
       // @ts-ignore — patching for test
       process.stderr.write = (chunk: string) => { written.push(chunk); return true; };
-      t.after(() => { process.stderr.write = orig; });
+      t.after(() => {
+        process.stderr.write = orig;
+        _resetNotificationStore();
+        cleanup(dir);
+      });
 
+      initNotificationStore(dir);
       logWarning("engine", "test warn");
-      assert.equal(written.length, 1);
-      assert.ok(written[0].includes("[gsd:engine] WARN: test warn"));
+      assert.deepEqual(written, []);
+
+      const notifications = readNotifications(dir);
+      assert.equal(notifications.length, 1);
+      assert.equal(notifications[0].severity, "warning");
+      assert.equal(notifications[0].message, "[engine] test warn");
     });
 
     test("writes ERROR prefix to stderr for errors", (t) => {

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -391,11 +391,13 @@ test("executeCompleteMilestone sanitizes raw params and writes milestone summary
   }
 });
 
-test("executeCompleteMilestone returns success for already-complete milestones", async () => {
+test("executeCompleteMilestone returns success for already-complete milestones without overwriting the existing summary", async () => {
   const base = makeTmpBase();
   try {
     openTestDb(base);
     seedMilestone("M003", "Milestone Three", "complete");
+    seedSlice("M003", "S03", "complete");
+    writeRoadmap(base, "M003", ["S03"]);
     const milestoneDir = join(base, ".gsd", "milestones", "M003");
     mkdirSync(milestoneDir, { recursive: true });
     const summaryPath = join(milestoneDir, "M003-SUMMARY.md");
@@ -413,6 +415,7 @@ test("executeCompleteMilestone returns success for already-complete milestones",
     assert.equal(result.details.operation, "complete_milestone");
     assert.equal(result.details.alreadyComplete, true);
     assert.match(result.content[0].text, /already complete/);
+    assert.doesNotMatch(result.content[0].text, /Summary written to/);
     assert.equal(readFileSync(summaryPath, "utf-8"), "# Existing Summary\n");
   } finally {
     closeDatabase();

--- a/src/resources/extensions/gsd/tests/worktree-submodule-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-submodule-safety.test.ts
@@ -17,8 +17,8 @@
  *
  * This rewrite builds a real git parent repo + local submodule, creates
  * a worktree, dirties a tracked file inside the submodule, then invokes
- * `removeWorktree` and asserts observable behaviour on stderr (where
- * `logWarning` writes) and on the filesystem (the worktree is gone).
+ * `removeWorktree` and asserts observable behaviour through the workflow log
+ * buffer and on the filesystem (the worktree is gone).
  */
 
 import { describe, test, beforeEach, afterEach } from "node:test";
@@ -35,6 +35,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { createWorktree, removeWorktree } from "../worktree-manager.ts";
+import { _resetLogs, peekLogs } from "../workflow-logger.ts";
 
 interface Harness {
   parent: string;
@@ -112,53 +113,38 @@ function makeHarness(): Harness {
   };
 }
 
-/** Capture stderr writes during `fn`. `logWarning` writes to stderr, so
- * this reveals warnings emitted by the worktree-manager. */
-function captureStderr(fn: () => void): string {
-  const streamAny = process.stderr as unknown as {
-    write: (chunk: string | Uint8Array, ...rest: unknown[]) => boolean;
-  };
-  const original = streamAny.write.bind(streamAny);
-  const chunks: string[] = [];
-  streamAny.write = (chunk: string | Uint8Array): boolean => {
-    chunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  };
-  try {
-    fn();
-  } finally {
-    streamAny.write = original;
-  }
-  return chunks.join("");
+function workflowLogMessages(): string {
+  return peekLogs().map((entry) => entry.message).join("\n");
 }
 
 describe("removeWorktree preserves submodule uncommitted state (#2337)", () => {
   let h: Harness;
 
   beforeEach(() => {
+    _resetLogs();
     h = makeHarness();
   });
 
   afterEach(() => {
     h.cleanup();
+    _resetLogs();
   });
 
   test("clean submodules: worktree removes without stashing or submodule warnings", () => {
     const wt = createWorktree(h.parent, "cleanwt");
     runGit(wt.path, ["submodule", "update", "--init", "--recursive"]);
 
-    const stderr = captureStderr(() => {
-      removeWorktree(h.parent, "cleanwt");
-    });
+    removeWorktree(h.parent, "cleanwt");
+    const logs = workflowLogMessages();
 
     assert.ok(!existsSync(wt.path), "worktree directory should be gone");
     assert.doesNotMatch(
-      stderr,
+      logs,
       /Saved uncommitted submodule changes to rescue branch/,
       "clean submodule must not trigger rescue-branch creation",
     );
     assert.doesNotMatch(
-      stderr,
+      logs,
       /Submodule rescue branch creation failed/,
       "clean submodule must not trigger rescue-branch failure warning",
     );
@@ -191,9 +177,8 @@ describe("removeWorktree preserves submodule uncommitted state (#2337)", () => {
       `precondition: submodule must be diverged, got: "${subStatus}"`,
     );
 
-    const stderr = captureStderr(() => {
-      removeWorktree(h.parent, "dirtywt");
-    });
+    removeWorktree(h.parent, "dirtywt");
+    const logs = workflowLogMessages();
 
     // Worktree is gone: force fallback succeeded.
     assert.ok(!existsSync(wt.path), "worktree directory should be removed");
@@ -205,7 +190,7 @@ describe("removeWorktree preserves submodule uncommitted state (#2337)", () => {
     // removal. This is the assertion that #4823 demanded in place of
     // the tautological `src.includes("submodule") && src.includes("force")`.
     assert.match(
-      stderr,
+      logs,
       /Saved uncommitted submodule changes to rescue branch|Submodule rescue branch creation failed|Submodule changes detected/,
       "dirty submodule must trigger detection-and-warning path",
     );
@@ -231,12 +216,11 @@ describe("removeWorktree preserves submodule uncommitted state (#2337)", () => {
       renameSync(modPath, hiddenPath);
     }
 
-    const stderr = captureStderr(() => {
-      removeWorktree(h.parent, "no-gitmodules");
-    });
+    removeWorktree(h.parent, "no-gitmodules");
+    const logs = workflowLogMessages();
 
     assert.doesNotMatch(
-      stderr,
+      logs,
       /Saved uncommitted submodule changes to rescue branch/,
       "missing .gitmodules should skip submodule detection entirely",
     );

--- a/src/resources/extensions/gsd/tools/complete-milestone.ts
+++ b/src/resources/extensions/gsd/tools/complete-milestone.ts
@@ -1,3 +1,4 @@
+// GSD2 complete-milestone tool handler
 /**
  * complete-milestone handler — the core operation behind gsd_complete_milestone.
  *

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -487,6 +487,7 @@ export async function executeCompleteMilestone(
         milestoneId: result.milestoneId,
         summaryPath: result.summaryPath,
         ...(result.alreadyComplete ? { alreadyComplete: true } : {}),
+        ...(result.stale ? { stale: true } : {}),
       },
     };
   } catch (err) {

--- a/src/resources/extensions/gsd/workflow-logger.ts
+++ b/src/resources/extensions/gsd/workflow-logger.ts
@@ -3,13 +3,12 @@
 // Captures structured entries that the auto-loop can drain after each unit
 // to surface root causes for stuck loops, silent degradation, and blocked writes.
 // Error-severity entries are persisted to .gsd/audit-log.jsonl (sanitized) for
-// post-mortem analysis. Warnings are ephemeral (stderr + buffer only) to avoid
-// log amplification from expected-control-flow catch paths.
+// post-mortem analysis. Warnings persist to notifications and remain available
+// in the in-memory buffer, but are not printed to stderr.
 //
-// Stderr policy: every logWarning/logError call writes immediately to stderr
-// for terminal visibility. This is intentional — unlike debug-logger (which is
-// opt-in and zero-overhead when disabled), workflow-logger covers operational
-// warnings/errors that should always be visible. There is no disable flag.
+// Stderr policy: logError writes immediately to stderr for terminal visibility.
+// logWarning stays out of the TUI/stdout stream and is surfaced through the
+// notification store plus the auto-loop issue buffer.
 //
 // Singleton safety: _buffer is module-level and shared across all calls within
 // a process. The auto-loop must call _resetLogs() (or drainAndSummarize()) at
@@ -109,7 +108,8 @@ export function setStderrLoggingEnabled(enabled: boolean): boolean {
 // ─── Public API ─────────────────────────────────────────────────────────
 
 /**
- * Record a warning. Also writes to stderr for terminal visibility.
+ * Record a warning. Warnings are persisted to notifications and buffered for
+ * auto-loop issue summaries, but they are intentionally not written to stderr.
  */
 export function logWarning(
   component: LogComponent,
@@ -271,10 +271,10 @@ function _push(
     ...(context ? { context } : {}),
   };
 
-  // Always forward to stderr so terminal watchers see it (see module header for policy)
-  const prefix = severity === "error" ? "ERROR" : "WARN";
-  const ctxStr = context ? ` ${JSON.stringify(context)}` : "";
-  _writeStderr(`[gsd:${component}] ${prefix}: ${message}${ctxStr}\n`);
+  if (severity === "error") {
+    const ctxStr = context ? ` ${JSON.stringify(context)}` : "";
+    _writeStderr(`[gsd:${component}] ERROR: ${message}${ctxStr}\n`);
+  }
 
   // Persist to notification store (both warnings and errors)
   try {
@@ -317,8 +317,8 @@ function _push(
   }
 
   // Persist errors to .gsd/audit-log.jsonl so they survive context resets.
-  // Only error-severity entries are persisted — warnings are ephemeral (stderr + buffer)
-  // to avoid log amplification from expected-control-flow catch paths.
+  // Warnings are already persisted to notifications and buffered for the
+  // current auto-loop unit.
   if (_auditBasePath && severity === "error") {
     try {
       const auditDir = join(_auditBasePath, ".gsd");


### PR DESCRIPTION
## TL;DR
**What:** Quiet auto-mode warning noise, preserve notifications during context/session switches, and make milestone completion closeout idempotent.
**Why:** Auto-mode was surfacing warning notifications in chat/TUI output, losing notification history during context clears, and retrying completion after the DB already marked the milestone complete.
**How:** Hide warning extension notifications from chat while keeping them in the notification store, anchor notification storage to the project root, move `gsd_complete_milestone` to the final closeout step, make duplicate completion calls return non-mutating success, and skip invalid closeout cleanup/push operations.

Closes #5296

## What
- Suppresses warning extension notifications from chat/TUI rendering while preserving info/error/success rendering.
- Keeps warning records in the notification store and avoids stderr warning output from the GSD workflow logger.
- Resolves notification store initialization through the project root so auto-mode context clears do not appear to wipe notifications.
- Makes milestone completion the final durable closeout step and treats duplicate complete calls as idempotent success.
- Avoids closeout warnings for `.gsd` paths outside the git repo and missing push remotes.

## Why
Auto-mode should not spend extra context reacting to its own warning noise, and users still need the warnings retained in notifications for later inspection. Milestone closeout also needs to complete on the first attempt instead of marking the DB complete before remaining closeout work finishes.

## How
- Added a chat-rendering filter for extension notify events so warning events are ignored by the TUI message stream.
- Updated workflow logging so warnings are stored but not emitted as warning stderr lines.
- Reused project-root resolution for notification store setup during `session_start` and `session_switch`.
- Reordered the complete milestone prompt so summary/project updates and learnings happen before the completion tool call.
- Added pathspec/remote guards around worktree closeout cleanup and optional push.

## Change type checklist
- [x] fix - Bug fix
- [ ] feat - New feature
- [ ] docs - Documentation only
- [ ] refactor - Internal cleanup
- [ ] test - Tests only
- [ ] chore - Tooling or maintenance

## Tests
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/complete-milestone.test.ts src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts src/resources/extensions/gsd/tests/workflow-logger.test.ts src/resources/extensions/gsd/tests/notification-store.test.ts`
- [x] `npm run typecheck:extensions`

AI-assisted: Yes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate-complete detection now returns explicit duplicate/stale status and surfaces feedback.
  * Notification widget now returns a cleanup handle to support safe replacement and prevent stale updates.

* **Bug Fixes**
  * Warning notifications no longer render in chat or write to stderr; error/info/success continue to appear and persist.
  * Safer git/worktree handling: skip unsafe untracked-file cleanup and avoid pushes when the remote is absent.
  * Session notification wiring now consistent across session changes; notification store path resolution improved.

* **Tests**
  * Added/expanded tests for notification rendering, widget lifecycle, auto-worktree, prompt ordering, and milestone flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->