### PR TITLE
fix(gsd): ignore empty key file placeholders

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -136,6 +136,12 @@ export interface TaskCommitContext {
   issueNumber?: number;
 }
 
+function sanitizeTaskKeyFiles(keyFiles: readonly string[] | undefined): string[] {
+  return (keyFiles ?? [])
+    .map(file => file.trim())
+    .filter(file => file !== "" && file !== "(none)" && !file.includes("{{"));
+}
+
 /**
  * Build a meaningful conventional commit message from task execution context.
  * Format: `{type}: {description}` (clean conventional commit — no GSD IDs in subject).
@@ -161,8 +167,9 @@ export function buildTaskCommitMessage(ctx: TaskCommitContext): string {
   // Build body with key files if available
   const bodyParts: string[] = [];
 
-  if (ctx.keyFiles && ctx.keyFiles.length > 0) {
-    const fileLines = ctx.keyFiles
+  const keyFiles = sanitizeTaskKeyFiles(ctx.keyFiles);
+  if (keyFiles.length > 0) {
+    const fileLines = keyFiles
       .slice(0, 8) // cap at 8 files to keep commit concise
       .map(f => `- ${f}`)
       .join("\n");
@@ -718,7 +725,7 @@ export class GitServiceImpl {
     taskContext: TaskCommitContext,
     extraExclusions: readonly string[] = [],
   ): boolean {
-    const keyFiles = taskContext.keyFiles ?? [];
+    const keyFiles = sanitizeTaskKeyFiles(taskContext.keyFiles);
     if (keyFiles.length === 0) return false;
 
     const allExclusions = [...RUNTIME_EXCLUSION_PATHS, ...extraExclusions];

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -542,6 +542,30 @@ describe('git-service', async () => {
     rmSync(repo, { recursive: true, force: true });
   });
 
+  test('GitServiceImpl: ignores placeholder keyFiles from empty summaries', () => {
+    const repo = initTempRepo();
+    const svc = new GitServiceImpl(repo);
+
+    createFile(repo, "src/task.ts", "export const task = true;");
+
+    const msg = svc.autoCommit("execute-task", "M001/S01/T01", [], {
+      taskId: "S01/T01",
+      taskTitle: "implement task with empty key files",
+      oneLiner: "Added task implementation",
+      keyFiles: ["(none)"],
+    });
+    assert.ok(msg !== null, "placeholder keyFiles should fall back to normal staging");
+    assert.ok(!msg!.includes("(none)"), "placeholder keyFiles should not appear in commit message");
+
+    const committed = run("git show --name-only --format= HEAD", repo);
+    assert.ok(committed.includes("src/task.ts"), "dirty task file is committed");
+
+    const status = run("git status --porcelain", repo);
+    assert.equal(status, "", "working tree is clean after fallback staging");
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
   // ─── GitServiceImpl: empty-after-staging guard ─────────────────────────
 
   test('GitServiceImpl: empty-after-staging guard', () => {


### PR DESCRIPTION
## Linked issue

Closes #5298

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Treat empty key-file placeholders as no key files before auto-commit staging and commit-message rendering.
**Why:** Empty task summaries can carry a literal `(none)` placeholder that should never be passed to Git as a path.
**How:** Sanitize task `keyFiles` centrally in the Git service before scoped staging or commit body generation.

## What

This updates GSD workflow git commit handling so placeholder task summary entries such as `(none)` are ignored before building the task commit message or selecting scoped files to stage.

It also adds an integration regression test that exercises `GitServiceImpl.autoCommit()` with `keyFiles: ["(none)"]` and verifies the dirty task file is still committed through the normal fallback staging path.

## Why

When a task summary has no key files, summary frontmatter may contain a human-readable `(none)` placeholder. That placeholder is not a repo path. Passing it into scoped staging can make auto-commit fail with a Git pathspec error instead of committing the completed task.

## How

The Git service now normalizes task key files with a small sanitizer that drops empty strings, `(none)`, and unresolved template placeholders. The sanitized list is used both for the commit message file list and for scoped task staging.

If every key-file entry is filtered out, the existing fallback behavior remains: `autoCommit()` uses normal smart staging instead of scoped staging.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/git-service.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`

Manual smoke:

1. Ran the targeted git-service regression command above in the branch.
2. Confirmed placeholder `keyFiles: ["(none)"]` no longer appears in the commit message.
3. Confirmed the dirty task file is committed through fallback staging instead of trying to stage `(none)`.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ignore placeholder and template-like entries when determining changed files so commit messages and staged file selection exclude invalid placeholders.

* **Tests**
  * Added an integration test to verify placeholder/empty file entries are ignored and that auto-commit correctly stages and commits real changes, leaving a clean working tree.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->