### PR TITLE
fix(gsd): detect markdown bold verdicts

### DIFF
--- a/src/resources/extensions/gsd/tests/verdict-parser.test.ts
+++ b/src/resources/extensions/gsd/tests/verdict-parser.test.ts
@@ -106,6 +106,12 @@ describe("hasVerdict", () => {
     assert.equal(hasVerdict("verdict: pass"), true);
   });
 
+  it("returns true for markdown bold verdicts that extractVerdict parses (#5240)", () => {
+    assert.equal(hasVerdict("# Assessment\n\n**Verdict:** PASS"), true);
+    assert.equal(hasVerdict("# Assessment\n\n**Verdict:** ✅ PASS"), true);
+    assert.equal(hasVerdict("# Assessment\n\n**Verdict** needs-remediation"), true);
+  });
+
   it("returns false when no verdict field exists", () => {
     assert.equal(hasVerdict("# Just a heading"), false);
   });

--- a/src/resources/extensions/gsd/verdict-parser.ts
+++ b/src/resources/extensions/gsd/verdict-parser.ts
@@ -45,10 +45,11 @@ export function extractVerdict(content: string): string | undefined {
 }
 
 /**
- * Returns `true` when the content's frontmatter contains a `verdict` field.
+ * Returns `true` when the content contains any verdict format we can extract,
+ * while preserving the legacy bare `verdict: pass` body check.
  */
 export function hasVerdict(content: string): boolean {
-  return /verdict:\s*[\w-]+/i.test(content);
+  return extractVerdict(content) !== undefined || /verdict:\s*[\w-]+/i.test(content);
 }
 
 // ── UAT verdict schema ──────────────────────────────────────────────────


### PR DESCRIPTION
## Linked issue

Closes #5240

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Make `hasVerdict()` recognize markdown bold verdicts such as `**Verdict:** PASS`.
**Why:** The UAT dispatch guard could miss verdicts that `extractVerdict()` already understands, causing unnecessary repeated `run-uat` dispatches.
**How:** Check `extractVerdict()` from `hasVerdict()` while preserving the existing bare `verdict: pass` behavior.

## What

This updates the centralized verdict parser so `hasVerdict()` recognizes the same markdown body verdict formats already supported by `extractVerdict()`.

It adds regression coverage for markdown bold verdict lines with a colon, an emoji prefix, and the no-colon bold form.

## Why

`extractVerdict()` can parse common assessment output such as `**Verdict:** PASS`, but `hasVerdict()` only checked a narrow `verdict: pass`-style pattern. That mismatch can make dispatch logic think an ASSESSMENT file has no verdict even when the parser can extract one.

## How

`hasVerdict()` now returns true when `extractVerdict()` finds a verdict, and keeps the legacy bare `verdict: pass` regex as a compatibility fallback.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/verdict-parser.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`

Manual smoke:

1. Ran the targeted verdict-parser regression command above in the branch.
2. Confirmed `hasVerdict()` returns true for markdown bold verdicts that `extractVerdict()` can parse.
3. Confirmed the existing bare `verdict: pass` behavior still passes.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verdict detection to recognize markdown-bold patterns (e.g., **Verdict:** PASS), normalized verdict variants, and legacy formats to reduce missed detections.

* **Tests**
  * Added regression tests validating verdict recognition across several formatting styles (bold, emoji-prefixed, and hyphenated labels) to prevent future regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->