### PR TITLE
fix(ollama): replace instant-dismiss overlays with keypress-dismiss pattern

### DIFF
--- a/src/resources/extensions/ollama/ollama-commands.ts
+++ b/src/resources/extensions/ollama/ollama-commands.ts
@@ -12,10 +12,35 @@
  */
 
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
-import { Text } from "@gsd/pi-tui";
 import * as client from "./ollama-client.js";
 import { discoverModels, formatModelForDisplay } from "./ollama-discovery.js";
 import { formatModelSize } from "./model-capabilities.js";
+
+type OverlayTheme = { fg(token: string, text: string): string };
+
+type DismissibleOverlay = {
+	render(width: number, theme: OverlayTheme): string[];
+	handleInput(data: string): void;
+	invalidate(): void;
+};
+
+export function createDismissibleOverlay(
+	lines: string[],
+	done: (r: undefined) => void,
+	options?: { includeDismissHint?: boolean },
+): DismissibleOverlay {
+	return {
+		render(_width: number, theme: OverlayTheme): string[] {
+			const base = lines.map((l) => theme.fg("text", l));
+			if (!options?.includeDismissHint) return base;
+			return [...base, "", theme.fg("dim", " Press any key to dismiss")];
+		},
+		handleInput(_data: string): void {
+			done(undefined);
+		},
+		invalidate(): void {},
+	};
+}
 
 export function registerOllamaCommands(pi: ExtensionAPI): void {
 	pi.registerCommand("ollama", {
@@ -100,11 +125,8 @@ async function handleStatus(ctx: any): Promise<void> {
 	}
 
 	await ctx.ui.custom(
-		(tui: any, theme: any, _kb: any, done: (r: undefined) => void) => {
-			const text = new Text(lines.map((l) => theme.fg("fg", l)).join("\n"), 0, 0);
-			setTimeout(() => done(undefined), 0);
-			return text;
-		},
+		(_tui: any, _theme: any, _kb: any, done: (r: undefined) => void) =>
+			createDismissibleOverlay(lines, done, { includeDismissHint: true }),
 	);
 }
 
@@ -127,11 +149,8 @@ async function handleList(ctx: any): Promise<void> {
 	}
 
 	await ctx.ui.custom(
-		(tui: any, theme: any, _kb: any, done: (r: undefined) => void) => {
-			const text = new Text(lines.map((l) => theme.fg("fg", l)).join("\n"), 0, 0);
-			setTimeout(() => done(undefined), 0);
-			return text;
-		},
+		(_tui: any, _theme: any, _kb: any, done: (r: undefined) => void) =>
+			createDismissibleOverlay(lines, done),
 	);
 }
 
@@ -233,11 +252,8 @@ async function handlePs(ctx: any): Promise<void> {
 		}
 
 		await ctx.ui.custom(
-			(tui: any, theme: any, _kb: any, done: (r: undefined) => void) => {
-				const text = new Text(lines.map((l) => theme.fg("fg", l)).join("\n"), 0, 0);
-				setTimeout(() => done(undefined), 0);
-				return text;
-			},
+			(_tui: any, _theme: any, _kb: any, done: (r: undefined) => void) =>
+				createDismissibleOverlay(lines, done),
 		);
 	} catch (err) {
 		ctx.ui.notify(

--- a/src/resources/extensions/ollama/ollama-commands.ts
+++ b/src/resources/extensions/ollama/ollama-commands.ts
@@ -19,18 +19,19 @@ import { formatModelSize } from "./model-capabilities.js";
 type OverlayTheme = { fg(token: string, text: string): string };
 
 type DismissibleOverlay = {
-	render(width: number, theme: OverlayTheme): string[];
+	render(width: number): string[];
 	handleInput(data: string): void;
 	invalidate(): void;
 };
 
 export function createDismissibleOverlay(
+	theme: OverlayTheme,
 	lines: string[],
 	done: (r: undefined) => void,
 	options?: { includeDismissHint?: boolean },
 ): DismissibleOverlay {
 	return {
-		render(_width: number, theme: OverlayTheme): string[] {
+		render(_width: number): string[] {
 			const base = lines.map((l) => theme.fg("text", l));
 			if (!options?.includeDismissHint) return base;
 			return [...base, "", theme.fg("dim", " Press any key to dismiss")];
@@ -125,8 +126,8 @@ async function handleStatus(ctx: any): Promise<void> {
 	}
 
 	await ctx.ui.custom(
-		(_tui: any, _theme: any, _kb: any, done: (r: undefined) => void) =>
-			createDismissibleOverlay(lines, done, { includeDismissHint: true }),
+		(_tui: any, theme: OverlayTheme, _kb: any, done: (r: undefined) => void) =>
+			createDismissibleOverlay(theme, lines, done, { includeDismissHint: true }),
 	);
 }
 
@@ -149,8 +150,8 @@ async function handleList(ctx: any): Promise<void> {
 	}
 
 	await ctx.ui.custom(
-		(_tui: any, _theme: any, _kb: any, done: (r: undefined) => void) =>
-			createDismissibleOverlay(lines, done),
+		(_tui: any, theme: OverlayTheme, _kb: any, done: (r: undefined) => void) =>
+			createDismissibleOverlay(theme, lines, done, { includeDismissHint: true }),
 	);
 }
 
@@ -252,8 +253,8 @@ async function handlePs(ctx: any): Promise<void> {
 		}
 
 		await ctx.ui.custom(
-			(_tui: any, _theme: any, _kb: any, done: (r: undefined) => void) =>
-				createDismissibleOverlay(lines, done),
+			(_tui: any, theme: OverlayTheme, _kb: any, done: (r: undefined) => void) =>
+				createDismissibleOverlay(theme, lines, done, { includeDismissHint: true }),
 		);
 	} catch (err) {
 		ctx.ui.notify(

--- a/src/resources/extensions/ollama/tests/ollama-commands-ui-behavior.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-commands-ui-behavior.test.ts
@@ -6,14 +6,13 @@ import { createDismissibleOverlay } from "../ollama-commands.js";
 test("createDismissibleOverlay renders with text token and dismiss hint", () => {
 	const doneCalls: unknown[] = [];
 	const overlay = createDismissibleOverlay(
+		{ fg: (token: string, text: string) => `[${token}]${text}` },
 		["line one", "line two"],
 		(value) => doneCalls.push(value),
 		{ includeDismissHint: true },
 	);
 
-	const themed = overlay.render(80, {
-		fg: (token: string, text: string) => `[${token}]${text}`,
-	});
+	const themed = overlay.render(80);
 
 	assert.deepEqual(themed, [
 		"[text]line one",
@@ -26,7 +25,11 @@ test("createDismissibleOverlay renders with text token and dismiss hint", () => 
 
 test("createDismissibleOverlay dismisses on key input", () => {
 	const doneCalls: unknown[] = [];
-	const overlay = createDismissibleOverlay(["line"], (value) => doneCalls.push(value));
+	const overlay = createDismissibleOverlay(
+		{ fg: (_token: string, text: string) => text },
+		["line"],
+		(value) => doneCalls.push(value),
+	);
 
 	overlay.handleInput("x");
 

--- a/src/resources/extensions/ollama/tests/ollama-commands-ui-behavior.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-commands-ui-behavior.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createDismissibleOverlay } from "../ollama-commands.js";
+
+test("createDismissibleOverlay renders with text token and dismiss hint", () => {
+	const doneCalls: unknown[] = [];
+	const overlay = createDismissibleOverlay(
+		["line one", "line two"],
+		(value) => doneCalls.push(value),
+		{ includeDismissHint: true },
+	);
+
+	const themed = overlay.render(80, {
+		fg: (token: string, text: string) => `[${token}]${text}`,
+	});
+
+	assert.deepEqual(themed, [
+		"[text]line one",
+		"[text]line two",
+		"",
+		"[dim] Press any key to dismiss",
+	]);
+	assert.equal(doneCalls.length, 0, "overlay should not auto-dismiss");
+});
+
+test("createDismissibleOverlay dismisses on key input", () => {
+	const doneCalls: unknown[] = [];
+	const overlay = createDismissibleOverlay(["line"], (value) => doneCalls.push(value));
+
+	overlay.handleInput("x");
+
+	assert.deepEqual(doneCalls, [undefined]);
+});


### PR DESCRIPTION
## Summary
Fixes stale issue #4564 on current `main`.

- replaces deprecated `theme.fg("fg", ...)` token usage with `text`
- removes `setTimeout(() => done(), 0)` instant-dismiss behavior
- adopts reusable overlay behavior: `{ render, handleInput, invalidate }`
- adds behavior test coverage for overlay rendering + dismissal

## TDD / Diagnosis notes (rubber-duck)
- Repro signal: `ollama-commands.ts` still used `fg` + instant timeout dismiss in status/list/ps overlays.
- Hypothesis: overlays were being dismissed immediately by timeout callback, not user input.
- Test-first: added `ollama-commands-ui-behavior.test.ts` for a reusable overlay helper.
- Minimal fix: introduced `createDismissibleOverlay(...)` and switched command overlays to use it.

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/ollama/tests/ollama-commands-ui-behavior.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/ollama/ollama-auth-mode.test.ts src/resources/extensions/ollama/ollama-status-indicator.test.ts`

Closes #4564


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Ollama command output display to use a reusable dismissible overlay component. Output from `/ollama status`, `/ollama list`, and `/ollama ps` commands now displays with keyboard dismissal support.

* **Tests**
  * Added test coverage for the overlay component's rendering and input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->