### PR TITLE
fix(claude-code-cli): mark sensitive-path permission blocks as errors

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1477,7 +1477,8 @@ function stripStructuredContentPseudoBlocks(content: unknown): unknown {
 	return content.filter((item) => !isStructuredContentPseudoBlock(item));
 }
 
-const SENSITIVE_FILE_BLOCK_PATTERN = /requested permissions to (?:edit|write|create) .*sensitive file/i;
+const SENSITIVE_FILE_BLOCK_PATTERN =
+	/\bclaude requested permissions to (?:edit|write|create)\b[\s\S]*?\bwhich is a sensitive file\b/i;
 
 function isSensitiveFilePermissionBlock(content: ExternalToolResultContentBlock[]): boolean {
 	const text = content

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1477,6 +1477,22 @@ function stripStructuredContentPseudoBlocks(content: unknown): unknown {
 	return content.filter((item) => !isStructuredContentPseudoBlock(item));
 }
 
+const SENSITIVE_FILE_BLOCK_PATTERN = /requested permissions to (?:edit|write|create) .*sensitive file/i;
+
+function isSensitiveFilePermissionBlock(content: ExternalToolResultContentBlock[]): boolean {
+	const text = content
+		.filter((item) => item.type === "text" && typeof item.text === "string")
+		.map((item) => item.text)
+		.join("\n");
+	return SENSITIVE_FILE_BLOCK_PATTERN.test(text);
+}
+
+function normalizeExternalToolResult(result: ExternalToolResultPayload): ExternalToolResultPayload {
+	if (result.isError) return result;
+	if (!isSensitiveFilePermissionBlock(result.content)) return result;
+	return { ...result, isError: true };
+}
+
 /** Extract tool result payloads from an SDK synthetic user message, keyed by tool-use ID. */
 export function extractToolResultsFromSdkUserMessage(message: SDKUserMessage): Array<{
 	toolUseId: string;
@@ -1497,14 +1513,12 @@ export function extractToolResultsFromSdkUserMessage(message: SDKUserMessage): A
 		if (!toolUseId || seen.has(toolUseId)) continue;
 		seen.add(toolUseId);
 
-		extracted.push({
-			toolUseId,
-			result: {
-				content: normalizeToolResultContent(stripStructuredContentPseudoBlocks(block.content)),
-				details: extractStructuredDetailsFromBlock(block),
-				isError: block.is_error === true,
-			},
+		const result = normalizeExternalToolResult({
+			content: normalizeToolResultContent(stripStructuredContentPseudoBlocks(block.content)),
+			details: extractStructuredDetailsFromBlock(block),
+			isError: block.is_error === true,
 		});
+		extracted.push({ toolUseId, result });
 	}
 
 	if (extracted.length === 0) {
@@ -1513,14 +1527,12 @@ export function extractToolResultsFromSdkUserMessage(message: SDKUserMessage): A
 			const toolResult = fallback as Record<string, unknown>;
 			const toolUseId = typeof toolResult.tool_use_id === "string" ? toolResult.tool_use_id : "";
 			if (toolUseId) {
-				extracted.push({
-					toolUseId,
-					result: {
-						content: normalizeToolResultContent(stripStructuredContentPseudoBlocks(toolResult.content)),
-						details: extractStructuredDetailsFromBlock(toolResult),
-						isError: toolResult.is_error === true,
-					},
+				const result = normalizeExternalToolResult({
+					content: normalizeToolResultContent(stripStructuredContentPseudoBlocks(toolResult.content)),
+					details: extractStructuredDetailsFromBlock(toolResult),
+					isError: toolResult.is_error === true,
 				});
+				extracted.push({ toolUseId, result });
 			}
 		}
 	}

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -596,6 +596,29 @@ describe("stream-adapter — Claude Code external tool results", () => {
 		]);
 	});
 
+	test("extractToolResultsFromSdkUserMessage marks sensitive-file permission blocks as errors", () => {
+		const message: SDKUserMessage = {
+			type: "user",
+			session_id: "sess-1",
+			parent_tool_use_id: "tool-edit-1",
+			message: {
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool-edit-1",
+						content: "Claude requested permissions to edit .claude/mcp-tools/.env which is a sensitive file.",
+						is_error: false,
+					},
+				],
+			},
+		};
+
+		const results = extractToolResultsFromSdkUserMessage(message);
+		assert.equal(results.length, 1);
+		assert.equal(results[0].result.isError, true, "sensitive-path blocks must be treated as errors");
+	});
+
 	test("buildFinalAssistantContent preserves intermediate tool calls with attached external results", () => {
 		const finalContent = buildFinalAssistantContent({
 			intermediateToolBlocks: [


### PR DESCRIPTION
## Summary
Fixes #4605 by turning host sensitive-path permission blocks into explicit tool failures in Claude Code external-tool result mapping.

### What changed
- In `stream-adapter.ts`, detect Claude host block messages that match:
  - `Claude requested permissions to edit/write/create ... sensitive file`
- When detected, force `externalResult.isError = true` even if SDK marks `is_error: false`.
- Apply this normalization for both:
  - `tool_result`/`mcp_tool_result` blocks in `message.content`
  - fallback `tool_use_result`

### Why
The original symptom was silent continuation after sensitive-path gate failures. This change sharpens the failure signal at the adapter boundary so downstream agent logic sees these blocks as errors instead of soft-success text.

## TDD / diagnosis notes
- Reproduced at code seam: `extractToolResultsFromSdkUserMessage(...)` was passing through host sensitive-file block text without guaranteed error classification.
- Added regression test first:
  - `extractToolResultsFromSdkUserMessage marks sensitive-file permission blocks as errors`
- Implemented minimal normalization helper to classify this pattern.

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`

Closes #4605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Permission requests to edit/write/create sensitive files are now detected and surfaced as errors, preventing them from being treated as normal tool outputs.

* **Tests**
  * Added a regression test ensuring sensitive-file permission requests are classified as errors during result extraction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5310)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->