### PR TITLE
fix(gsd): surface memory_query degraded mode when FTS5 is unavailable

### DIFF
--- a/packages/pi-ai/src/providers/google-gemini-cli.test.ts
+++ b/packages/pi-ai/src/providers/google-gemini-cli.test.ts
@@ -1,0 +1,19 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildModelNotFoundErrorMessage } from "./google-gemini-cli.js";
+
+describe("buildModelNotFoundErrorMessage", () => {
+	it("returns antigravity-specific guidance for antigravity provider", () => {
+		const msg = buildModelNotFoundErrorMessage("claude-opus-4-5-thinking", true);
+		assert.match(msg, /Antigravity API error \(404\)/);
+		assert.match(msg, /removed or renamed in the Antigravity backend/);
+		assert.doesNotMatch(msg, /Try using the "google" provider with a GOOGLE_API_KEY/);
+	});
+
+	it("returns cloud-code-assist guidance for non-antigravity providers", () => {
+		const msg = buildModelNotFoundErrorMessage("gemini-2.0-pro", false);
+		assert.match(msg, /Cloud Code Assist API error \(404\)/);
+		assert.match(msg, /Try using the "google" provider with a GOOGLE_API_KEY/);
+	});
+});

--- a/packages/pi-ai/src/providers/google-gemini-cli.ts
+++ b/packages/pi-ai/src/providers/google-gemini-cli.ts
@@ -103,6 +103,22 @@ const MAX_EMPTY_STREAM_RETRIES = 2;
 const EMPTY_STREAM_BASE_DELAY_MS = 500;
 const CLAUDE_THINKING_BETA_HEADER = "interleaved-thinking-2025-05-14";
 
+export function buildModelNotFoundErrorMessage(modelId: string, isAntigravity: boolean): string {
+	if (isAntigravity) {
+		return (
+			`Antigravity API error (404): Model "${modelId}" was not found. ` +
+			`This model may have been removed or renamed in the Antigravity backend. ` +
+			`Please switch to a supported Antigravity model (e.g., claude-opus-4-6-thinking or gemini-3.1-pro-high).`
+		);
+	}
+	return (
+		`Cloud Code Assist API error (404): Model "${modelId}" was not found. ` +
+		`This model may not be available via Cloud Code Assist. ` +
+		`Try using the "google" provider with a GOOGLE_API_KEY instead, ` +
+		`or switch to a supported model (e.g., gemini-2.5-pro).`
+	);
+}
+
 /**
  * Extract retry delay from Gemini error response (in milliseconds).
  * Checks headers first (Retry-After, x-ratelimit-reset, x-ratelimit-reset-after),
@@ -447,12 +463,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 
 					// Not retryable or max retries exceeded
 					if (response.status === 404) {
-						throw new Error(
-							`Cloud Code Assist API error (404): Model "${model.id}" was not found. ` +
-							`This model may not be available via Cloud Code Assist. ` +
-							`Try using the "google" provider with a GOOGLE_API_KEY instead, ` +
-							`or switch to a supported model (e.g., gemini-2.5-pro).`,
-						);
+						throw new Error(buildModelNotFoundErrorMessage(model.id, isAntigravity));
 					}
 					throw new Error(`Cloud Code Assist API error (${response.status}): ${extractErrorMessage(errorText)}`);
 				} catch (error) {

--- a/src/resources/extensions/gsd/tests/memory-tools.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-tools.test.ts
@@ -253,6 +253,12 @@ test('memory-tools: memory_query surfaces degraded mode when FTS table is unavai
   assert.equal(result.details.degraded_fts, true);
   assert.match(result.content[0].text, /FTS5 unavailable/i);
 
+  const emptyQuery = executeMemoryQuery({ query: '' });
+  assert.ok(!emptyQuery.isError);
+  assert.equal(emptyQuery.details.keyword_backend, 'ranked');
+  assert.equal(emptyQuery.details.degraded_fts, false);
+  assert.doesNotMatch(emptyQuery.content[0].text, /FTS5 unavailable/i);
+
   closeDatabase();
 });
 

--- a/src/resources/extensions/gsd/tests/memory-tools.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-tools.test.ts
@@ -240,6 +240,22 @@ test('memory-tools: memory_query ignores superseded memories by default', () => 
   closeDatabase();
 });
 
+test('memory-tools: memory_query surfaces degraded mode when FTS table is unavailable', () => {
+  openDatabase(':memory:');
+  createMemory({ category: 'gotcha', content: 'credential rotation policy' });
+
+  const adapter = _getAdapter()!;
+  adapter.prepare('DROP TABLE IF EXISTS memories_fts').run();
+
+  const result = executeMemoryQuery({ query: 'credential' });
+  assert.ok(!result.isError);
+  assert.equal(result.details.keyword_backend, 'like-fallback');
+  assert.equal(result.details.degraded_fts, true);
+  assert.match(result.content[0].text, /FTS5 unavailable/i);
+
+  closeDatabase();
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // gsd_graph
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/resources/extensions/gsd/tools/memory-tools.ts
+++ b/src/resources/extensions/gsd/tools/memory-tools.ts
@@ -246,10 +246,11 @@ export function executeMemoryQuery(params: MemoryQueryParams): ToolExecutionResu
       ? "No matching memories."
       : hits.map((h) => `- [${h.id}] (${h.category}) ${h.content}`).join("\n");
 
-    const backend = ftsAvailable ? "fts5" : "like-fallback";
-    const text = ftsAvailable
-      ? summary
-      : `${summary}\n\n[degraded] FTS5 unavailable — memory query is using LIKE fallback (no stemming/BM25).`;
+    const usingLikeFallback = Boolean(query) && !ftsAvailable;
+    const backend = usingLikeFallback ? "like-fallback" : "ranked";
+    const text = usingLikeFallback
+      ? `${summary}\n\n[degraded] FTS5 unavailable — memory query is using LIKE fallback (no stemming/BM25).`
+      : summary;
 
     return {
       content: [{ type: "text", text }],
@@ -259,7 +260,7 @@ export function executeMemoryQuery(params: MemoryQueryParams): ToolExecutionResu
         k,
         returned: hits.length,
         keyword_backend: backend,
-        degraded_fts: !ftsAvailable,
+        degraded_fts: usingLikeFallback,
         hits,
       },
     };

--- a/src/resources/extensions/gsd/tools/memory-tools.ts
+++ b/src/resources/extensions/gsd/tools/memory-tools.ts
@@ -9,7 +9,7 @@
 //   - memory_query    → keyword-filtered, score-ranked listing of active memories
 //   - gsd_graph       → returns a memory and its supersedes edges only (Phase 4 adds memory_relations)
 
-import { _getAdapter, isDbAvailable } from "../gsd-db.js";
+import { _getAdapter, isDbAvailable, isMemoriesFtsAvailable } from "../gsd-db.js";
 import {
   createMemory,
   getActiveMemoriesRanked,
@@ -189,8 +189,11 @@ export function executeMemoryQuery(params: MemoryQueryParams): ToolExecutionResu
   const category = params.category?.trim().toLowerCase() || undefined;
   const scopeFilter = params.scope?.trim() || undefined;
   const tagFilter = params.tag?.trim().toLowerCase() || undefined;
+  const adapter = _getAdapter();
+  if (!adapter) return dbUnavailable("memory_query");
 
   try {
+    const ftsAvailable = isMemoriesFtsAvailable(adapter);
     let ranked: RankedMemory[] = [];
     if (query) {
       ranked = queryMemoriesRanked({
@@ -243,13 +246,20 @@ export function executeMemoryQuery(params: MemoryQueryParams): ToolExecutionResu
       ? "No matching memories."
       : hits.map((h) => `- [${h.id}] (${h.category}) ${h.content}`).join("\n");
 
+    const backend = ftsAvailable ? "fts5" : "like-fallback";
+    const text = ftsAvailable
+      ? summary
+      : `${summary}\n\n[degraded] FTS5 unavailable — memory query is using LIKE fallback (no stemming/BM25).`;
+
     return {
-      content: [{ type: "text", text: summary }],
+      content: [{ type: "text", text }],
       details: {
         operation: "memory_query",
         query,
         k,
         returned: hits.length,
+        keyword_backend: backend,
+        degraded_fts: !ftsAvailable,
         hits,
       },
     };


### PR DESCRIPTION
## Summary
Addresses the *silent degradation* portion of #4497 by surfacing when memory queries are running in LIKE fallback mode instead of FTS5.

### Changes
- `executeMemoryQuery(...)` now checks FTS availability via `isMemoriesFtsAvailable(adapter)`.
- Adds explicit query-time degradation signal when FTS is unavailable:
  - content includes: `[degraded] FTS5 unavailable — memory query is using LIKE fallback...`
  - details include:
    - `keyword_backend: "fts5" | "like-fallback"`
    - `degraded_fts: boolean`

### TDD
Added regression test:
- `memory-tools: memory_query surfaces degraded mode when FTS table is unavailable`

This keeps behavior backwards-compatible while making degraded retrieval visible to operators and agents.

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/memory-tools.test.ts`

Refs #4497


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved error messaging for missing models with provider-specific guidance.
  * Memory query now runs in degraded mode when full-text search is unavailable, using a fallback search and marking responses as degraded.

* **Tests**
  * Added tests for provider-specific error message generation.
  * Added tests verifying memory query degraded-mode behavior and fallback handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5312)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->