### PR TITLE
fix(gsd): improve dynamic-routing disable and model fallback transparency

### DIFF
--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -475,7 +475,7 @@ export async function selectAndApplyModel(
       const model = resolveModelId(modelId, resolutionPool, ctx.model?.provider);
 
       if (!model) {
-        if (verbose) ctx.ui.notify(`Model ${modelId} not found, trying fallback.`, "info");
+        ctx.ui.notify(`Model ${modelId} not found, trying fallback.`, "warning");
         continue;
       }
 

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1381,8 +1381,17 @@ export async function bootstrapAutoSession(
         "info",
       );
     } else {
+      const suppressedByFlatRate = routingConfig.enabled
+        && !routingConfig.allow_flat_rate_providers
+        && !!effectiveProvider
+        && isFlatRateProvider(
+          effectiveProvider,
+          buildFlatRateContext(effectiveProvider, ctx, bannerPrefs),
+        );
       ctx.ui.notify(
-        `Dynamic routing: disabled — all tasks will use ${startModelLabel}`,
+        suppressedByFlatRate
+          ? `Dynamic routing: disabled (flat-rate provider: ${effectiveProvider}) — all tasks will use ${startModelLabel}`
+          : `Dynamic routing: disabled — all tasks will use ${startModelLabel}`,
         "info",
       );
     }

--- a/src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts
@@ -6,10 +6,13 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { buildFlatRateContext, isFlatRateProvider, resolvePreferredModelConfig } from "../auto-model-selection.ts";
+
+const __dirname_4386 = dirname(fileURLToPath(import.meta.url));
 
 describe("flat-rate provider routing guard (#3453)", () => {
 
@@ -300,6 +303,32 @@ describe("flat-rate routing opt-in (#4386)", () => {
         });
         assert.equal(result, undefined, "explicit opt-out behaves like default");
       },
+    );
+  });
+});
+
+// ─── Banner transparency: auto-start respects the opt-in (#4386) ────────────
+
+describe("auto-start banner respects allow_flat_rate_providers (#4386)", () => {
+  test("banner expression gates flat-rate disable on allow_flat_rate_providers", () => {
+    const src = readFileSync(
+      join(__dirname_4386, "..", "auto-start.ts"),
+      "utf-8",
+    );
+    assert.ok(
+      src.includes("routingConfig.allow_flat_rate_providers"),
+      "auto-start banner must read allow_flat_rate_providers so the banner reflects the opt-in",
+    );
+  });
+
+  test("banner explains when disable is due to flat-rate provider", () => {
+    const src = readFileSync(
+      join(__dirname_4386, "..", "auto-start.ts"),
+      "utf-8",
+    );
+    assert.ok(
+      src.includes("Dynamic routing: disabled (flat-rate provider:"),
+      "disabled banner should explicitly explain flat-rate suppression",
     );
   });
 });


### PR DESCRIPTION
## Summary
Fixes #4384 transparency gaps in dynamic routing and model fallback behavior.

### Changes
1. **Explicit flat-rate suppression reason in auto-start banner**
   - When routing is disabled because the provider is flat-rate and `allow_flat_rate_providers` is not enabled, banner now says:
   - `Dynamic routing: disabled (flat-rate provider: <provider>) ...`

2. **Always surface missing-model fallback**
   - In `selectAndApplyModel`, when a configured model id cannot be resolved, fallback warning is now always shown (warning severity), not verbose-only.

### Why
Users should not have to infer whether routing was disabled by config vs policy suppression, and they should always know when configured models were not used and fallback occurred.

## Tests
- Updated `flat-rate-routing-guard.test.ts` with banner transparency assertion.
- Verification:
  - `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts`

Closes #4384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model fallback notifications now consistently display at warning level
  * Dynamic routing disabled messages now include the specific flat-rate provider name for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->