### PR TITLE
fix(gsd): prevent guided milestone prompt from triggering scout subagents

### DIFF
--- a/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
@@ -22,7 +22,7 @@ Before asking, read `.gsd/PROJECT.md` and find `## Project Shape` -> `**Complexi
 ### Before your first question round
 
 Do a lightweight targeted investigation so your questions are grounded in reality:
-- Scout the codebase using direct tools (`rg`, `find`, `read`) to understand what already exists that this milestone touches or builds on
+- Inspect the codebase using direct tools (`rg`, `find`, `read`) to understand what already exists that this milestone touches or builds on
 - Do **not** spawn agents/subagents for this pass (`scout`, `researcher`, `worker`) — keep it local, transparent, and fast
 - Check the roadmap context above (if present) to understand what surrounds this milestone
 - Use `resolve_library` / `get_library_docs` for unfamiliar libraries — prefer this over `search-the-web` for library documentation

--- a/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
@@ -21,13 +21,18 @@ Before asking, read `.gsd/PROJECT.md` and find `## Project Shape` -> `**Complexi
 
 ### Before your first question round
 
-Investigate enough to avoid assumption-driven questions:
-- Scout existing code with `rg`, `find`, or `scout`.
-- Check roadmap context above for surrounding scope.
-- Use `resolve_library` / `get_library_docs` for unfamiliar libraries; prefer them over web search.
-- Identify the 3-5 behavioral or architectural unknowns that materially change what gets built.
+Do a lightweight targeted investigation so your questions are grounded in reality:
+- Scout the codebase using direct tools (`rg`, `find`, `read`) to understand what already exists that this milestone touches or builds on
+- Do **not** spawn agents/subagents for this pass (`scout`, `researcher`, `worker`) — keep it local, transparent, and fast
+- Check the roadmap context above (if present) to understand what surrounds this milestone
+- Use `resolve_library` / `get_library_docs` for unfamiliar libraries — prefer this over `search-the-web` for library documentation
+- Identify the 3–5 biggest behavioural and architectural unknowns: things where the user's answer will materially change what gets built
 
-**Web search budget:** Limited per turn, typically 3-5. Prefer docs tools and `search_and_read`; use 2-3 searches in the first pass and save the rest.
+**Codebase investigation budget:** ≤5 tool calls and ≤2 minutes for this pass.
+
+**Web search budget:** You have a limited number of web searches per turn (typically 3-5). Prefer `resolve_library` / `get_library_docs` for library documentation and `search_and_read` for one-shot topic research — they are more budget-efficient. Target 2-3 web searches in the investigation pass. Distribute remaining searches across subsequent question rounds rather than clustering them.
+
+Do **not** go deep — just enough that your questions reflect what's actually true rather than what you assume.
 
 ### Question rounds
 

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -93,6 +93,14 @@ test("guided discussion prompts avoid wrap-up prompts after every round", () => 
   assert.match(slicePrompt, /Never fabricate or simulate user input/i);
 });
 
+test("guided milestone investigation uses direct tools and forbids subagent scout", () => {
+  const prompt = readPrompt("guided-discuss-milestone");
+  assert.match(prompt, /using direct tools \(`rg`, `find`, `read`\)/i);
+  assert.match(prompt, /Do \*\*not\*\* spawn agents\/subagents/i);
+  assert.match(prompt, /Codebase investigation budget:\*\*\s*≤5 tool calls and ≤2 minutes/i);
+  assert.doesNotMatch(prompt, /\(`rg`, `find`, or `scout`\)/i);
+});
+
 test("guided milestone discussion scopes depth verification to the milestone id", () => {
   const prompt = readPrompt("guided-discuss-milestone");
   assert.match(prompt, /depth_verification_\{\{milestoneId\}\}/, "depth verification id should include the milestone id");


### PR DESCRIPTION
## Summary
Fixes #4374 by making guided milestone investigation unambiguous and bounded so the model does not spawn expensive scout/research subagents for lightweight local discovery.

### Changes
- `guided-discuss-milestone.md`
  - Replace ambiguous `(... or scout)` wording with explicit direct-tool guidance: `rg`, `find`, `read`
  - Add explicit prohibition: do **not** spawn agents/subagents (`scout`, `researcher`, `worker`) for this pass
  - Add explicit budget: `≤5 tool calls`, `≤2 minutes`

- `prompt-contracts.test.ts`
  - Add regression test asserting:
    - direct-tool wording exists
    - subagent prohibition exists
    - budget constraint exists
    - legacy ambiguous `(rg, find, or scout)` phrasing is absent

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/prompt-contracts.test.ts`

Closes #4374


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Revised guided-discussion instructions to require a brief, targeted local codebase check using direct tools only (≤5 tool calls, ≤2 minutes) and to limit initial web searches (target 2–3), with remaining searches allocated to later rounds.

* **Tests**
  * Added tests ensuring direct-tool use only, forbidding spawned subagents/processes, and enforcing the investigation resource limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->