### PR TITLE
fix(gsd): mitigate ADR-013 decision double-injection during deprecation

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -815,6 +815,14 @@ export async function inlineDecisionsFromDb(
       // legacy table — that switch lands separately to handle superseded
       // history cleanly.
       const { queryDecisionsFromMemories, formatDecisionsForPrompt } = await import("./context-store.js");
+      const { getActiveMemoriesRanked } = await import("./memory-store.js");
+
+      // ADR-013 deprecation-window mitigation: once architecture memories exist,
+      // suppress decisions-table prompt injection to avoid duplicate semantics
+      // across memory auto-injection + inline decisions block.
+      const hasArchitectureCoverage = getActiveMemoriesRanked(80)
+        .some((m) => m.category === "architecture");
+      if (hasArchitectureCoverage) return null;
 
       // First query: try with both milestoneId and scope (if scope provided)
       let decisions = queryDecisionsFromMemories({ milestoneId, scope });

--- a/src/resources/extensions/gsd/tests/prompt-db.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-db.test.ts
@@ -22,6 +22,8 @@ import {
   formatDecisionsForPrompt,
   formatRequirementsForPrompt,
 } from '../context-store.ts';
+import { inlineDecisionsFromDb } from '../auto-prompts.ts';
+import { createMemory } from '../memory-store.ts';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // prompt-db: DB-aware decisions helper returns scoped content
@@ -148,6 +150,38 @@ console.log('\n=== prompt-db: project content from DB ===');
   assert.match(wrapped, /^### Project/, 'wrapped project starts with ### Project');
   assert.match(wrapped, /Source:.*PROJECT\.md/, 'wrapped project has source path');
   assert.match(wrapped, /# Test Project/, 'wrapped project includes content');
+
+  closeDatabase();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// prompt-db: suppress decisions inline when architecture memories are present
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== prompt-db: suppress decisions inline when architecture memories exist ===');
+{
+  openDatabase(':memory:');
+
+  insertDecision({
+    id: 'D001',
+    when_context: 'M001/S01',
+    scope: 'architecture',
+    decision: 'legacy decision row',
+    choice: 'A',
+    rationale: 'because',
+    revisable: 'yes',
+    made_by: 'agent',
+    superseded_by: null,
+  });
+
+  createMemory({
+    category: 'architecture',
+    content: 'memory-store architecture decision',
+    confidence: 0.9,
+  });
+
+  const inline = await inlineDecisionsFromDb(process.cwd(), 'M001');
+  assert.equal(inline, null, 'inline decisions should be suppressed when architecture memory coverage exists');
 
   closeDatabase();
 }


### PR DESCRIPTION
## Summary
Addresses the active ADR-013 deprecation-window duplication risk in #4512 by suppressing legacy decisions-table prompt injection once architecture memories are present.

## What changed
- `src/resources/extensions/gsd/auto-prompts.ts`
  - In `inlineDecisionsFromDb(...)`, added a guard:
    - if active memory-store coverage already includes `category === "architecture"`, return `null` and skip inline `### Decisions` injection.
  - This avoids double-injecting equivalent decision semantics through both:
    - system memory block (`loadMemoryBlock`), and
    - per-prompt decisions block (`inlineDecisionsFromDb`).

- `src/resources/extensions/gsd/tests/prompt-db.test.ts`
  - Added regression coverage proving decisions-inline is suppressed when architecture memories exist.

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/prompt-db.test.ts`

Closes #4512


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic decision prompt injection to suppress duplicate content when corresponding architecture memories already exist.

* **Tests**
  * Added test coverage verifying that decision prompts are properly suppressed when relevant architecture memories are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->