### PR TITLE
fix(gsd): block complete-milestone when needs-attention has unchecked criteria

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1346,6 +1346,25 @@ export const DISPATCH_RULES: DispatchRule[] = [
               level: "warning",
             };
           }
+
+          // Safety guard (#4361): "needs-attention" can be terminal at the
+          // state layer, but completion must stop when success criteria are
+          // still unchecked to prevent retry loops until MAX_VERIFICATION_RETRIES.
+          if (verdict === "needs-attention") {
+            const checklistMatch = validationContent.match(
+              /##\s*Success Criteria(?:\s+Checklist)?[\s\S]*?(?=\n##\s|\n---|$)/i,
+            );
+            const unchecked = checklistMatch
+              ? (checklistMatch[0].match(/^-\s+\[\s\]/gm) ?? []).length
+              : 0;
+            if (unchecked > 0) {
+              return {
+                action: "stop",
+                reason: `Cannot complete milestone ${mid}: VALIDATION verdict is "needs-attention" but ${unchecked} Success Criteria item(s) are unchecked. Resolve blockers and re-run validation, or update the verdict to "needs-remediation" to trigger remediation.`,
+                level: "warning",
+              };
+            }
+          }
         }
       }
 

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1359,10 +1359,12 @@ export const DISPATCH_RULES: DispatchRule[] = [
             }
           }
 
-          if (verdict === "needs-remediation" || verdict === "needs-attention") {
+          // needs-remediation always blocks; needs-attention is handled above
+          // (only blocks when checklist items remain unchecked).
+          if (verdict === "needs-remediation") {
             return {
               action: "stop",
-              reason: `Cannot complete milestone ${mid}: VALIDATION verdict is "${verdict}". Address the validation findings and re-run validation, or update the verdict manually.`,
+              reason: `Cannot complete milestone ${mid}: VALIDATION verdict is "needs-remediation". Address the validation findings and re-run validation, or update the verdict manually.`,
               level: "warning",
             };
           }

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1339,17 +1339,10 @@ export const DISPATCH_RULES: DispatchRule[] = [
         const validationContent = await loadFile(validationFile);
         if (validationContent) {
           const verdict = extractVerdict(validationContent);
-          if (verdict === "needs-remediation" || verdict === "needs-attention") {
-            return {
-              action: "stop",
-              reason: `Cannot complete milestone ${mid}: VALIDATION verdict is "${verdict}". Address the validation findings and re-run validation, or update the verdict manually.`,
-              level: "warning",
-            };
-          }
 
-          // Safety guard (#4361): "needs-attention" can be terminal at the
-          // state layer, but completion must stop when success criteria are
-          // still unchecked to prevent retry loops until MAX_VERIFICATION_RETRIES.
+          // Safety guard (#4361): when verdict is "needs-attention", surface
+          // the specific unchecked-criteria count first so the operator sees
+          // an actionable message instead of the generic verdict warning.
           if (verdict === "needs-attention") {
             const checklistMatch = validationContent.match(
               /##\s*Success Criteria(?:\s+Checklist)?[\s\S]*?(?=\n##\s|\n---|$)/i,
@@ -1364,6 +1357,14 @@ export const DISPATCH_RULES: DispatchRule[] = [
                 level: "warning",
               };
             }
+          }
+
+          if (verdict === "needs-remediation" || verdict === "needs-attention") {
+            return {
+              action: "stop",
+              reason: `Cannot complete milestone ${mid}: VALIDATION verdict is "${verdict}". Address the validation findings and re-run validation, or update the verdict manually.`,
+              level: "warning",
+            };
           }
         }
       }

--- a/src/resources/extensions/gsd/tests/completing-milestone-needs-attention-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/completing-milestone-needs-attention-guard.test.ts
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-4361-"));
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  mkdirSync(join(milestoneDir, "slices", "S01"), { recursive: true });
+  writeFileSync(join(milestoneDir, "M001-ROADMAP.md"), "# M001\n## Slices\n- [x] **S01: Slice** `risk:low` `depends:[]`\n");
+  writeFileSync(join(milestoneDir, "slices", "S01", "S01-SUMMARY.md"), "# S01\n");
+  writeFileSync(join(base, "impl.txt"), "implementation artifact");
+  return base;
+}
+
+function cleanup(base: string): void {
+  rmSync(base, { recursive: true, force: true });
+}
+
+function completingRule() {
+  const rule = DISPATCH_RULES.find((r) => r.name === "completing-milestone → complete-milestone");
+  assert.ok(rule, "completing-milestone rule must exist");
+  return rule!;
+}
+
+function makeCtx(basePath: string): DispatchContext {
+  return {
+    basePath,
+    mid: "M001",
+    midTitle: "Test",
+    state: { phase: "completing-milestone" } as any,
+    prefs: undefined,
+  };
+}
+
+test("#4361: stops completion on needs-attention with unchecked success criteria", async () => {
+  const base = makeBase();
+  try {
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-VALIDATION.md"),
+      [
+        "---",
+        "verdict: needs-attention",
+        "---",
+        "",
+        "## Success Criteria Checklist",
+        "- [x] S01 done",
+        "- [ ] S02 blocked",
+        "- [ ] S03 blocked",
+      ].join("\n"),
+    );
+
+    const result = await completingRule().match(makeCtx(base));
+    assert.ok(result);
+    assert.equal(result.action, "stop");
+    if (result.action === "stop") {
+      assert.match(result.reason, /needs-attention/i);
+      assert.match(result.reason, /2 Success Criteria item\(s\) are unchecked/i);
+    }
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("#4361: allows completion dispatch when needs-attention has no unchecked criteria", async () => {
+  const base = makeBase();
+  try {
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-VALIDATION.md"),
+      [
+        "---",
+        "verdict: needs-attention",
+        "---",
+        "",
+        "## Success Criteria Checklist",
+        "- [x] S01 done",
+        "- [x] S02 documented",
+      ].join("\n"),
+    );
+
+    const result = await completingRule().match(makeCtx(base));
+    assert.ok(result);
+    assert.equal(result.action, "dispatch");
+    if (result.action === "dispatch") {
+      assert.equal(result.unitType, "complete-milestone");
+    }
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## Summary
Fixes #4361 by adding a completing-milestone dispatch guard for contradictory validation output:
- `verdict: needs-attention`
- plus unchecked items in `## Success Criteria Checklist`

Without this guard, auto-mode can re-dispatch `complete-milestone` until retry exhaustion.

## Changes
- `src/resources/extensions/gsd/auto-dispatch.ts`
  - In `completing-milestone → complete-milestone`, after the existing `needs-remediation` stop guard:
    - parse Success Criteria section
    - count unchecked checklist items (`- [ ]`)
    - if verdict is `needs-attention` and unchecked > 0, return `action: "stop"` with warning

- `src/resources/extensions/gsd/tests/completing-milestone-needs-attention-guard.test.ts`
  - behavior test: stops when needs-attention has unchecked criteria
  - behavior test: still dispatches when needs-attention has no unchecked criteria

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/completing-milestone-needs-attention-guard.test.ts`

Closes #4361


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Milestone completion now halts when a validation verdict of "needs-attention" contains unchecked Success Criteria checklist items, returning a warning to resolve blockers, re-run validation, or update the verdict.

* **Tests**
  * Added tests verifying behavior when "needs-attention" validations have unresolved and resolved Success Criteria checklist items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5316)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->