### PR TITLE
fix(pi-ai): set neutral UA for kimi-coding anthropic adapter

### DIFF
--- a/packages/pi-ai/src/providers/anthropic-auth.test.ts
+++ b/packages/pi-ai/src/providers/anthropic-auth.test.ts
@@ -91,18 +91,44 @@ test("createClient uses resolveAnthropicBaseUrl for all auth paths (#4140)", () 
 	}
 });
 
-test("createClient applies provider-specific header override for kimi-coding UA (#4640)", () => {
-	const source = readFileSync(join(__dirname, "..", "..", "src", "providers", "anthropic.ts"), "utf-8");
-	assert.ok(
-		source.includes('if (provider === "kimi-coding")'),
-		"anthropic provider adapter should special-case kimi-coding",
-	);
-	assert.ok(
-		source.includes('{ "User-Agent": "gsd-pi" }'),
+test("buildAnthropicClientOptions applies neutral User-Agent for kimi-coding (#4640)", () => {
+	const kimiModel = {
+		id: "kimi-k2-instruct",
+		provider: "kimi-coding",
+		type: "anthropic-messages",
+	} as unknown as Model<"anthropic-messages">;
+	const opts = buildAnthropicClientOptions(kimiModel, "test-key", false);
+	assert.equal(
+		(opts.defaultHeaders as Record<string, string>)["User-Agent"],
+		"gsd-pi",
 		"kimi-coding should default to a neutral User-Agent",
 	);
-	assert.ok(
-		source.includes("defaultProviderHeaders(model.provider)"),
-		"provider-specific headers should be merged into defaultHeaders",
+});
+
+test("buildAnthropicClientOptions does not set User-Agent for non-kimi-coding providers (#4640)", () => {
+	const anthropicModel = {
+		id: "claude-opus-4-7",
+		provider: "anthropic",
+		type: "anthropic-messages",
+	} as unknown as Model<"anthropic-messages">;
+	const opts = buildAnthropicClientOptions(anthropicModel, "test-key", false);
+	assert.equal(
+		(opts.defaultHeaders as Record<string, string>)["User-Agent"],
+		undefined,
+		"non-kimi providers should not get the override",
+	);
+});
+
+test("kimi-coding User-Agent can be overridden by caller-supplied optionsHeaders (#4640)", () => {
+	const kimiModel = {
+		id: "kimi-k2-instruct",
+		provider: "kimi-coding",
+		type: "anthropic-messages",
+	} as unknown as Model<"anthropic-messages">;
+	const opts = buildAnthropicClientOptions(kimiModel, "test-key", false, { "User-Agent": "custom-agent" });
+	assert.equal(
+		(opts.defaultHeaders as Record<string, string>)["User-Agent"],
+		"custom-agent",
+		"explicit optionsHeaders should win over the default override",
 	);
 });

--- a/packages/pi-ai/src/providers/anthropic-auth.test.ts
+++ b/packages/pi-ai/src/providers/anthropic-auth.test.ts
@@ -90,3 +90,19 @@ test("createClient uses resolveAnthropicBaseUrl for all auth paths (#4140)", () 
 		else process.env.ANTHROPIC_BASE_URL = saved;
 	}
 });
+
+test("createClient applies provider-specific header override for kimi-coding UA (#4640)", () => {
+	const source = readFileSync(join(__dirname, "..", "..", "src", "providers", "anthropic.ts"), "utf-8");
+	assert.ok(
+		source.includes('if (provider === "kimi-coding")'),
+		"anthropic provider adapter should special-case kimi-coding",
+	);
+	assert.ok(
+		source.includes('{ "User-Agent": "gsd-pi" }'),
+		"kimi-coding should default to a neutral User-Agent",
+	);
+	assert.ok(
+		source.includes("defaultProviderHeaders(model.provider)"),
+		"provider-specific headers should be merged into defaultHeaders",
+	);
+});

--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -71,6 +71,15 @@ function hasBearerAuthorizationHeader(model: Model<"anthropic-messages">): boole
 	return typeof authHeader === "string" && authHeader.trim().toLowerCase().startsWith("bearer ");
 }
 
+function defaultProviderHeaders(provider: Model<"anthropic-messages">["provider"]): Record<string, string> | undefined {
+	// Kimi /coding rejects Anthropic SDK's stock User-Agent prefix with a
+	// misleading 429 "engine overloaded". Use a neutral UA by default.
+	if (provider === "kimi-coding") {
+		return { "User-Agent": "gsd-pi" };
+	}
+	return undefined;
+}
+
 export function buildAnthropicClientOptions(
 	model: Model<"anthropic-messages">,
 	apiKey: string,
@@ -134,6 +143,7 @@ export function buildAnthropicClientOptions(
 				"anthropic-dangerous-direct-browser-access": "true",
 				...(betaFeatures.length > 0 ? { "anthropic-beta": betaFeatures.join(",") } : {}),
 			},
+			defaultProviderHeaders(model.provider),
 			model.headers,
 			optionsHeaders,
 		),


### PR DESCRIPTION
## Summary
Fixes #4640 by setting a neutral default `User-Agent` for the `kimi-coding` Anthropic-compatible provider path.

## Changes
- `packages/pi-ai/src/providers/anthropic.ts`
  - Added `defaultProviderHeaders(provider)`.
  - For `provider === "kimi-coding"`, injects:
    - `User-Agent: gsd-pi`
  - Merged provider-specific headers into `defaultHeaders` before `model.headers`/`options.headers` so user overrides still win.

- `packages/pi-ai/src/providers/anthropic-auth.test.ts`
  - Added regression assertion that kimi-coding UA override exists and is merged.

## Why
Kimi `/coding` endpoint rejects Anthropic SDK default UA prefixes in this path; neutral UA avoids false 429 "engine overloaded" responses.

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-ai/src/providers/anthropic-auth.test.ts`

Closes #4640


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request header configuration for the kimi-coding provider to properly override unwanted default SDK behaviors, improving overall consistency and reliability of request processing across all Anthropic provider integration paths and supported services

* **Tests**
  * Added comprehensive test coverage verifying proper header configuration, header merging, and provider-specific behavior handling for Anthropic provider integrations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->