### PR TITLE
fix(pi-ai): truncate echoed args in tool validation errors

### DIFF
--- a/packages/pi-ai/src/utils/validation.test.ts
+++ b/packages/pi-ai/src/utils/validation.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Type } from "@sinclair/typebox";
+
+import { validateToolArguments } from "./validation.js";
+import type { Tool, ToolCall } from "../types.js";
+
+test("validation error summarizes large received arguments", () => {
+	const tool: Tool = {
+		name: "demo_tool",
+		description: "demo",
+		parameters: Type.Object({
+			requiredField: Type.String(),
+		}),
+	};
+
+	const big = "x".repeat(5000);
+	const toolCall: ToolCall = {
+		type: "toolCall",
+		id: "tc_1",
+		name: "demo_tool",
+		arguments: {
+			optionalBlob: big,
+		},
+	};
+
+	assert.throws(() => validateToolArguments(tool, toolCall), (err: unknown) => {
+		assert.ok(err instanceof Error);
+		assert.match(err.message, /Received arguments \(summarized\):/);
+		assert.match(err.message, /truncated, \d+ chars omitted/);
+		assert.ok(err.message.length < 2500, "error message should be capped and not echo full payload");
+		return true;
+	});
+});

--- a/packages/pi-ai/src/utils/validation.ts
+++ b/packages/pi-ai/src/utils/validation.ts
@@ -7,6 +7,15 @@ const addFormats = (addFormatsModule as any).default || addFormatsModule;
 
 import type { Tool, ToolCall } from "../types.js";
 
+const MAX_VALIDATION_ARGS_ECHO_CHARS = 1024;
+
+function summarizeArgumentsForError(args: unknown, maxChars = MAX_VALIDATION_ARGS_ECHO_CHARS): string {
+	const json = JSON.stringify(args, null, 2) ?? String(args);
+	if (json.length <= maxChars) return json;
+	const omitted = json.length - maxChars;
+	return `${json.slice(0, maxChars)}\n... [truncated, ${omitted} chars omitted]`;
+}
+
 // Detect if we're in a browser extension environment with strict CSP
 // Chrome extensions with Manifest V3 don't allow eval/Function constructor
 const isBrowserExtension = typeof globalThis !== "undefined" && (globalThis as any).chrome?.runtime?.id !== undefined;
@@ -63,7 +72,7 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): any {
 			})
 			.join("\n") || "Unknown validation error";
 
-	const errorMessage = `Validation failed for tool "${toolCall.name}":\n${errors}\n\nReceived arguments:\n${JSON.stringify(toolCall.arguments, null, 2)}`;
+	const errorMessage = `Validation failed for tool "${toolCall.name}":\n${errors}\n\nReceived arguments (summarized):\n${summarizeArgumentsForError(toolCall.arguments)}`;
 
 	throw new Error(errorMessage);
 }


### PR DESCRIPTION
## Summary
Fixes #4643 by preventing validation failures from echoing full oversized tool arguments back into the retry loop.

## Changes
- `packages/pi-ai/src/utils/validation.ts`
  - Added bounded argument summarization for validation error messages.
  - Replaced full `JSON.stringify(toolCall.arguments, null, 2)` echo with:
    - `Received arguments (summarized):`
    - capped payload (1024 chars)
    - explicit truncation suffix with omitted char count.

- `packages/pi-ai/src/utils/validation.test.ts`
  - New regression test verifies large argument payloads are summarized/truncated and message stays bounded.

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-ai/src/utils/validation.test.ts`

Closes #4643


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation error messages for tool arguments now show summarized, truncated argument content instead of echoing full payloads.
  * Error messages include a clear truncation notice indicating omitted content when arguments exceed the display limit.

* **Tests**
  * Added a test verifying validation errors summarize large argument payloads and enforce the message length cap.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5319)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->