### PR TITLE
fix(claude-code): include symlinked .gsd target in SDK allowlist

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -22,7 +22,7 @@ import type {
 import type { ExtensionUIContext } from "@gsd/pi-coding-agent";
 import { EventStream } from "@gsd/pi-ai";
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
@@ -1351,12 +1351,23 @@ export function buildSdkOptions(
 			: { thinking: { type: "disabled" } }
 		: undefined;
 
+	const additionalDirectories: string[] = [];
+	try {
+		const gsdPath = join(sdkCwd, ".gsd");
+		if (lstatSync(gsdPath).isSymbolicLink()) {
+			additionalDirectories.push(realpathSync(gsdPath));
+		}
+	} catch {
+		// .gsd may not exist yet; ignore.
+	}
+
 	return {
 		pathToClaudeCodeExecutable: getClaudePath(),
 		model: modelId,
 		includePartialMessages: true,
 		persistSession: true,
 		cwd: sdkCwd,
+		...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
 		permissionMode,
 		allowDangerouslySkipPermissions: permissionMode === "bypassPermissions",
 		settingSources: ["project"],

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1,7 +1,7 @@
 // GSD2 - Claude Code stream adapter regression tests
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -710,6 +710,23 @@ describe("stream-adapter — session persistence (#2859)", () => {
 
 	test("resolveClaudeCodeCwd returns stream cwd when provided", () => {
 		assert.equal(resolveClaudeCodeCwd({ cwd: "/tmp/current-session" }), "/tmp/current-session");
+	});
+
+	test("buildSdkOptions includes .gsd symlink target in additionalDirectories (#4645)", () => {
+		if (process.platform === "win32") return;
+		const originalCwd = process.cwd();
+		const projectDir = mkdtempSync(join(tmpdir(), "claude-gsd-symlink-"));
+		const externalGsd = mkdtempSync(join(tmpdir(), "claude-gsd-target-"));
+		try {
+			symlinkSync(externalGsd, join(projectDir, ".gsd"));
+			process.chdir(projectDir);
+			const options = buildSdkOptions("claude-sonnet-4-20250514", "test");
+			assert.deepEqual((options as any).additionalDirectories, [realpathSync(externalGsd)]);
+		} finally {
+			process.chdir(originalCwd);
+			rmSync(projectDir, { recursive: true, force: true });
+			rmSync(externalGsd, { recursive: true, force: true });
+		}
 	});
 
 	test("buildSdkOptions enables betas for sonnet models", () => {


### PR DESCRIPTION
## Summary
Fixes #4645 by allowing Claude Code SDK sessions to write through a symlinked `.gsd` directory.

## Changes
- `src/resources/extensions/claude-code-cli/stream-adapter.ts`
  - In `buildSdkOptions(...)`:
    - detect `<cwd>/.gsd` symlink via `lstatSync`
    - resolve real target via `realpathSync`
    - pass target as `additionalDirectories` in SDK options
  - keeps behavior unchanged when `.gsd` is absent or not a symlink.

- `src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`
  - Added regression test:
    - creates temp project with `.gsd` symlink to external dir
    - asserts `buildSdkOptions(...)` includes resolved target in `additionalDirectories`

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`

Closes #4645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of symlinked directories in project configuration, ensuring they are properly resolved and recognized by the system.

* **Tests**
  * Added test coverage for symlink resolution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->