### PR TITLE
fix(gsd): avoid hard-stop on pause-originated cancelled units

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -548,6 +548,13 @@ async function emitCancelledUnitEnd(
   });
 }
 
+export function _isPauseOriginatedCancellation(
+  paused: boolean,
+  errorContext?: { message: string; category: string; stopReason?: string; isTransient?: boolean; retryAfterMs?: number },
+): boolean {
+  return paused && !errorContext;
+}
+
 export function _buildCancelledUnitStopReason(
   unitType: string,
   unitId: string,
@@ -2139,6 +2146,12 @@ export async function runUnitPhase(
   }
 
   if (unitResult.status === "cancelled") {
+    if (_isPauseOriginatedCancellation(s.paused, unitResult.errorContext)) {
+      await emitCancelledUnitEnd(ic, unitType, unitId, unitStartSeq);
+      debugLog("autoLoop", { phase: "exit", reason: "paused-cancelled" });
+      return { action: "break", reason: "paused" };
+    }
+
     const errorCategory = unitResult.errorContext?.category;
     // Provider-error pause: agent_end recovery normally pauses before this
     // branch. Provider readiness failures happen before dispatch, so pause here

--- a/src/resources/extensions/gsd/tests/auto-abort-pause-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-abort-pause-regression.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { _buildAbortedPauseContext, isUserInitiatedAbortMessage } from "../bootstrap/agent-end-recovery.js";
-import { _buildCancelledUnitStopReason } from "../auto/phases.js";
+import { _buildCancelledUnitStopReason, _isPauseOriginatedCancellation } from "../auto/phases.js";
 
 test("aborted agent_end maps errorMessage into structured aborted pause context", () => {
   const withMessage = _buildAbortedPauseContext({ errorMessage: "provider aborted request" });
@@ -18,6 +18,12 @@ test("aborted agent_end maps errorMessage into structured aborted pause context"
     category: "aborted",
     isTransient: true,
   });
+});
+
+test("pause-originated cancellations are detected and do not hard-stop", () => {
+  assert.equal(_isPauseOriginatedCancellation(true, undefined), true);
+  assert.equal(_isPauseOriginatedCancellation(false, undefined), false);
+  assert.equal(_isPauseOriginatedCancellation(true, { category: "aborted", message: "x" }), false);
 });
 
 test("cancelled non-session failures are labeled as unit aborts (not session-creation failures)", () => {


### PR DESCRIPTION
## Summary
Fixes #4646 by preventing pause-originated cancelled unit results from falling through to hard-stop cleanup.

## Changes
- `src/resources/extensions/gsd/auto/phases.ts`
  - Added `_isPauseOriginatedCancellation(paused, errorContext)` helper.
  - In cancelled-unit handling, if cancellation came from an already-paused state with no `errorContext`, we now:
    - emit `unit-end` (cancelled)
    - break with `reason: "paused"`
    - **skip** hard-stop path (`stopAuto`) to avoid double/extra cleanup.

- `src/resources/extensions/gsd/tests/auto-abort-pause-regression.test.ts`
  - Added regression test for `_isPauseOriginatedCancellation` semantics.

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-abort-pause-regression.test.ts`

Closes #4646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cancellation handling to properly process pause-initiated cancellations, preventing unexpected interruptions.

* **Tests**
  * Added test coverage validating correct detection of pause-originated cancellations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->