### PR TITLE
fix(gsd): use DB-complete signal in execute-task timeout recovery

### DIFF
--- a/src/resources/extensions/gsd/tests/auto-timeout-recovery-db-complete.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-timeout-recovery-db-complete.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { recoverTimedOutUnit, type RecoveryContext } from "../auto-timeout-recovery.ts";
+import { closeDatabase, openDatabase, insertMilestone, insertSlice, insertTask } from "../gsd-db.ts";
+
+test("#4649: timeout recovery treats DB-complete execute-task as recovered", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-recovery-db-complete-"));
+  try {
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+    writeFileSync(join(base, ".gsd", "STATE.md"), "## Next Action\nExecute T01 for S01: stale\n", "utf-8");
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"), "# S01\n\n## Tasks\n- [ ] **T01: Task**\n", "utf-8");
+
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "M1", status: "active", depends_on: [] });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "S1", status: "active", risk: "low", depends: [], demo: "", sequence: 1 });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Task",
+      status: "complete",
+      planning: { description: "", estimate: "", files: [], verify: "", inputs: [], expectedOutput: [], observabilityImpact: "" },
+      sequence: 1,
+    });
+
+    const ctx = { ui: { notify: () => {} } } as any;
+    const pi = { sendMessage: () => {} } as any;
+    const rctx: RecoveryContext = {
+      basePath: base,
+      verbose: false,
+      currentUnitStartedAt: Date.now(),
+      unitRecoveryCount: new Map(),
+    };
+
+    const outcome = await recoverTimedOutUnit(ctx, pi, "execute-task", "M001/S01/T01", "idle", rctx);
+    assert.equal(outcome, "recovered");
+  } finally {
+    try { closeDatabase(); } catch {}
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/auto-timeout-recovery-db-complete.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-timeout-recovery-db-complete.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { recoverTimedOutUnit, type RecoveryContext } from "../auto-timeout-recovery.ts";
+import { readUnitRuntimeRecord } from "../unit-runtime.ts";
 import { closeDatabase, openDatabase, insertMilestone, insertSlice, insertTask } from "../gsd-db.ts";
 
 test("#4649: timeout recovery treats DB-complete execute-task as recovered", async () => {
@@ -27,17 +28,29 @@ test("#4649: timeout recovery treats DB-complete execute-task as recovered", asy
       sequence: 1,
     });
 
-    const ctx = { ui: { notify: () => {} } } as any;
-    const pi = { sendMessage: () => {} } as any;
+    const notifications: string[] = [];
+    const ctx = { ui: { notify: (msg: string) => notifications.push(msg) } } as any;
+    let sendMessageCalls = 0;
+    const pi = { sendMessage: () => { sendMessageCalls += 1; } } as any;
+    const unitRecoveryCount = new Map<string, number>();
     const rctx: RecoveryContext = {
       basePath: base,
       verbose: false,
       currentUnitStartedAt: Date.now(),
-      unitRecoveryCount: new Map(),
+      unitRecoveryCount,
     };
 
     const outcome = await recoverTimedOutUnit(ctx, pi, "execute-task", "M001/S01/T01", "idle", rctx);
     assert.equal(outcome, "recovered");
+    assert.equal(sendMessageCalls, 0, "DB-complete fast-path must not redispatch steering");
+    assert.equal(unitRecoveryCount.has("execute-task/M001/S01/T01"), false, "DB-complete fast path should clear retry counter");
+    const runtime = readUnitRuntimeRecord(base, "execute-task", "M001/S01/T01");
+    assert.equal(runtime?.phase, "finalized", "DB-complete fast-path should finalize the unit");
+    assert.equal(
+      notifications.some(m => m.includes("already completed")),
+      true,
+      "should finalize via completion path, not steering retry",
+    );
   } finally {
     try { closeDatabase(); } catch {}
     rmSync(base, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/unit-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-runtime.test.ts
@@ -13,6 +13,7 @@ import { closeDatabase, insertMilestone, insertSlice, insertTask, openDatabase }
 import { clearPathCache } from '../paths.ts';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { closeDatabase, openDatabase, insertMilestone, insertSlice, insertTask } from "../gsd-db.ts";
 
 const base = mkdtempSync(join(tmpdir(), "gsd-unit-runtime-test-"));
 const tasksDir = join(base, ".gsd", "milestones", "M100", "slices", "S02", "tasks");
@@ -48,6 +49,7 @@ console.log("\n=== execute-task durability inspection ===");
   assert.deepStrictEqual(status!.summaryExists, false, "summary initially missing");
   assert.deepStrictEqual(status!.taskChecked, false, "task initially unchecked");
   assert.deepStrictEqual(status!.nextActionAdvanced, false, "next action initially stale");
+  assert.deepStrictEqual(status!.dbComplete, false, "dbComplete false when DB unavailable or task incomplete");
   assert.ok(/summary missing/i.test(formatExecuteTaskRecoveryStatus(status!)), "diagnostic mentions summary");
 
   writeFileSync(join(tasksDir, "T09-SUMMARY.md"), "# done\n", "utf-8");
@@ -328,6 +330,40 @@ console.log("\n=== per-record lock: stale .lock is reclaimed, list ignores .lock
     assert.equal(records[0].unitId, "M002/S01/T01");
   } finally {
     rmSync(listBase, { recursive: true, force: true });
+  }
+}
+
+console.log("\n=== db-complete signal: execute-task durability reads DB status ===");
+{
+  const dbBase = mkdtempSync(join(tmpdir(), "gsd-unit-runtime-db-test-"));
+  try {
+    mkdirSync(join(dbBase, ".gsd", "milestones", "M300", "slices", "S01", "tasks"), { recursive: true });
+    writeFileSync(join(dbBase, ".gsd", "STATE.md"), "## Next Action\nExecute T02 for S01: next\n", "utf-8");
+    writeFileSync(
+      join(dbBase, ".gsd", "milestones", "M300", "slices", "S01", "S01-PLAN.md"),
+      "# S01\n\n## Tasks\n\n- [ ] **T01: Work** `est:10m`\n",
+      "utf-8",
+    );
+
+    openDatabase(join(dbBase, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M300", title: "Test", status: "active", depends_on: [] });
+    insertSlice({ id: "S01", milestoneId: "M300", title: "Slice", status: "active", risk: "low", depends: [], demo: "", sequence: 1 });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M300",
+      title: "Work",
+      status: "complete",
+      planning: { description: "", estimate: "", files: [], verify: "", inputs: [], expectedOutput: [], observabilityImpact: "" },
+      sequence: 1,
+    });
+
+    const status = await inspectExecuteTaskDurability(dbBase, "M300/S01/T01");
+    assert.ok(status);
+    assert.equal(status!.dbComplete, true, "dbComplete should be true when DB task status is complete");
+  } finally {
+    try { closeDatabase(); } catch {}
+    rmSync(dbBase, { recursive: true, force: true });
   }
 }
 

--- a/src/resources/extensions/gsd/unit-runtime.ts
+++ b/src/resources/extensions/gsd/unit-runtime.ts
@@ -223,12 +223,6 @@ export async function inspectExecuteTaskDurability(
     dbComplete = !!task && isClosedStatus(task.status);
   }
 
-  let dbComplete = false;
-  if (isDbAvailable()) {
-    const dbTask = getTask(mid, sid, tid);
-    dbComplete = dbTask?.status === "complete" || dbTask?.status === "done";
-  }
-
   // Must-have coverage: load task plan and count mentions in summary
   let mustHaveCount = 0;
   let mustHavesMentionedInSummary = 0;

--- a/src/resources/extensions/gsd/unit-runtime.ts
+++ b/src/resources/extensions/gsd/unit-runtime.ts
@@ -223,6 +223,12 @@ export async function inspectExecuteTaskDurability(
     dbComplete = !!task && isClosedStatus(task.status);
   }
 
+  let dbComplete = false;
+  if (isDbAvailable()) {
+    const dbTask = getTask(mid, sid, tid);
+    dbComplete = dbTask?.status === "complete" || dbTask?.status === "done";
+  }
+
   // Must-have coverage: load task plan and count mentions in summary
   let mustHaveCount = 0;
   let mustHavesMentionedInSummary = 0;


### PR DESCRIPTION
## Summary
Fixes #4649 by aligning timeout recovery durability checks with DB-authoritative execute-task completion state.

## Changes
- `src/resources/extensions/gsd/unit-runtime.ts`
  - `inspectExecuteTaskDurability(...)` now includes `dbComplete` for execute-task units
  - derives `dbComplete` from task status (`complete`/`done`) when DB is available

- `src/resources/extensions/gsd/auto-timeout-recovery.ts`
  - recovery now treats either condition as complete:
    - filesystem durable triplet (`summaryExists && taskChecked && nextActionAdvanced`)
    - **or** `dbComplete` true
  - prevents false redispatch of already-completed tasks

- Tests:
  - `src/resources/extensions/gsd/tests/unit-runtime.test.ts` updated with dbComplete assertions
  - new `src/resources/extensions/gsd/tests/auto-timeout-recovery-db-complete.test.ts`

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/unit-runtime.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-timeout-recovery-db-complete.test.ts`

Closes #4649


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery now treats tasks marked complete in the database as already finished, allowing proper finalization, notifications, and retry-state cleanup.

* **Tests**
  * Added tests confirming recovery behavior when DB indicates completion.
  * Extended durability inspection tests to cover DB-present and DB-unavailable cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->