### PR TITLE
fix(gsd): viewport queue reorder list so cursor stays visible

### DIFF
--- a/src/resources/extensions/gsd/queue-reorder-ui.ts
+++ b/src/resources/extensions/gsd/queue-reorder-ui.ts
@@ -27,6 +27,20 @@ export interface ReorderResult {
   depsToRemove: Array<{ milestone: string; dep: string }>;
 }
 
+const MAX_VISIBLE_PENDING_ROWS = 12;
+
+export function computePendingViewport(cursor: number, total: number, maxVisible = MAX_VISIBLE_PENDING_ROWS): { start: number; end: number } {
+  if (total <= maxVisible) return { start: 0, end: total };
+  const half = Math.floor(maxVisible / 2);
+  let start = Math.max(0, cursor - half);
+  let end = start + maxVisible;
+  if (end > total) {
+    end = total;
+    start = end - maxVisible;
+  }
+  return { start, end };
+}
+
 /**
  * Show the queue reorder overlay.
  * Returns the new order + deps to remove, or null if cancelled.
@@ -181,7 +195,12 @@ export async function showQueueReorder(
         validation.redundant.map(r => `${r.milestone}:${r.dependsOn}`),
       );
 
-      for (let i = 0; i < items.length; i++) {
+      const viewport = computePendingViewport(cursor, items.length);
+      if (viewport.start > 0) {
+        lines.push(add(`    ${theme.fg("dim", `… ${viewport.start} above` )}`));
+      }
+
+      for (let i = viewport.start; i < viewport.end; i++) {
         const item = items[i];
         const isCursor = i === cursor;
         const num = i + 1;
@@ -213,6 +232,10 @@ export async function showQueueReorder(
         for (const v of validation.violations.filter(v => v.milestone === item.id && v.type === 'missing_dep')) {
           lines.push(add(`       ${theme.fg("error", `${GLYPH.statusWarning} depends_on: ${v.dependsOn} (does not exist)`)}`));
         }
+      }
+
+      if (viewport.end < items.length) {
+        lines.push(add(`    ${theme.fg("dim", `… ${items.length - viewport.end} below`)}`));
       }
 
       // Removed deps feedback

--- a/src/resources/extensions/gsd/tests/queue-reorder-viewport.test.ts
+++ b/src/resources/extensions/gsd/tests/queue-reorder-viewport.test.ts
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { computePendingViewport } from "../queue-reorder-ui.ts";
+
+test("queue reorder viewport keeps cursor visible in long lists (#4656)", () => {
+  const top = computePendingViewport(0, 30, 12);
+  assert.deepEqual(top, { start: 0, end: 12 });
+
+  const middle = computePendingViewport(15, 30, 12);
+  assert.equal(middle.start <= 15 && 15 < middle.end, true);
+  assert.equal(middle.end - middle.start, 12);
+
+  const bottom = computePendingViewport(29, 30, 12);
+  assert.deepEqual(bottom, { start: 18, end: 30 });
+});


### PR DESCRIPTION
## Summary
Fixes #4656 queue reorder overlay cursor loss in long lists by adding viewported rendering for pending milestones.

## Changes
- `src/resources/extensions/gsd/queue-reorder-ui.ts`
  - Added `computePendingViewport(...)` helper.
  - Queue render now shows a bounded pending window around the cursor (default 12 rows), instead of rendering the full list unbounded.
  - Adds dimmed overflow indicators (`… N above` / `… N below`).

- `src/resources/extensions/gsd/tests/queue-reorder-viewport.test.ts`
  - New regression test covering top/middle/bottom viewport behavior and cursor containment.

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/queue-reorder-viewport.test.ts`

Closes #4656


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue reorder UI now displays a limited viewport of pending items with indicators showing how many items exist above or below the visible window, improving usability for long queues.

* **Tests**
  * Added tests for queue reorder viewport functionality across various queue positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->