### PR TITLE
fix(gsd): allow ask_user_questions re-ask without strict loop block

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
+++ b/src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts
@@ -16,8 +16,8 @@ import { createHash } from "node:crypto";
 
 const MAX_CONSECUTIVE_IDENTICAL_CALLS = 4;
 
-/** Interactive/user-facing tools where even 1 duplicate is confusing. */
-const STRICT_LOOP_TOOLS = new Set(["ask_user_questions"]);
+/** Tools with stricter duplicate limits than the global threshold. */
+const STRICT_LOOP_TOOLS = new Set<string>();
 const MAX_CONSECUTIVE_STRICT = 1;
 
 let consecutiveCount = 0;

--- a/src/resources/extensions/gsd/tests/ask-user-questions-dedup.test.ts
+++ b/src/resources/extensions/gsd/tests/ask-user-questions-dedup.test.ts
@@ -21,7 +21,7 @@ import {
 } from "../../ask-user-questions.ts";
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Strict loop guard: ask_user_questions blocks on 2nd identical call
+// Loop guard: ask_user_questions uses normal threshold (re-ask safe)
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe("ask_user_questions dedup", () => {
@@ -30,15 +30,16 @@ describe("ask_user_questions dedup", () => {
     resetAskUserQuestionsCache();
   });
 
-  test("loop guard blocks 2nd identical ask_user_questions call", () => {
+  test("loop guard allows repeated ask_user_questions up to normal threshold", () => {
     const args = { questions: [{ id: "app_coverage", question: "Which apps?" }] };
 
-    const first = checkToolCallLoop("ask_user_questions", args);
-    assert.equal(first.block, false, "First call should be allowed");
+    for (let i = 1; i <= 4; i++) {
+      const result = checkToolCallLoop("ask_user_questions", args);
+      assert.equal(result.block, false, `ask_user_questions call ${i} should be allowed`);
+    }
 
-    const second = checkToolCallLoop("ask_user_questions", args);
-    assert.equal(second.block, true, "2nd identical call should be blocked");
-    assert.ok(second.reason!.includes("ask_user_questions"), "Reason should name the tool");
+    const fifth = checkToolCallLoop("ask_user_questions", args);
+    assert.equal(fifth.block, true, "5th identical ask_user_questions call should be blocked");
   });
 
   test("loop guard allows different ask_user_questions calls", () => {

--- a/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts
@@ -136,17 +136,18 @@ console.log('\n── Loop guard: nested args are not stripped ──');
     assert.deepStrictEqual(getToolCallLoopCount(), 1, `Each unique nested call should reset count to 1`);
   }
 
-  // Truly identical nested calls should still be detected.
-  // ask_user_questions has a strict threshold of 1, so the 2nd identical call is blocked.
+  // Truly identical nested calls are still detected (normal threshold).
   resetToolCallLoopGuard();
-  const first = checkToolCallLoop('ask_user_questions', {
-    questions: [{ id: 'same', question: 'Same?' }],
-  });
-  assert.ok(first.block === false, 'First ask_user_questions call should be allowed');
+  for (let i = 1; i <= 4; i++) {
+    const r = checkToolCallLoop('ask_user_questions', {
+      questions: [{ id: 'same', question: 'Same?' }],
+    });
+    assert.ok(r.block === false, `ask_user_questions call ${i} should be allowed`);
+  }
   const blocked = checkToolCallLoop('ask_user_questions', {
     questions: [{ id: 'same', question: 'Same?' }],
   });
-  assert.ok(blocked.block === true, '2nd identical ask_user_questions call should be blocked (strict threshold)');
+  assert.ok(blocked.block === true, '5th identical ask_user_questions call should be blocked');
 
   // Non-strict tools still allow up to 4 identical calls
   resetToolCallLoopGuard();


### PR DESCRIPTION
## Summary
Fixes #4674 by removing the strict duplicate threshold for `ask_user_questions` in the tool-call loop guard.

## Changes
- `src/resources/extensions/gsd/bootstrap/tool-call-loop-guard.ts`
  - Removed `ask_user_questions` from `STRICT_LOOP_TOOLS`.
  - `ask_user_questions` now follows the normal identical-call threshold like other tools.

- Tests updated:
  - `src/resources/extensions/gsd/tests/ask-user-questions-dedup.test.ts`
  - `src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts`
  - Both now assert `ask_user_questions` is allowed through 4 identical calls and blocks on 5th.

## Why
Depth-verification and write-gate flows can legitimately require a re-ask after cancelled/aborted interactive turns. Strict 2nd-call blocking created a deadlock with gate enforcement.

## Verification
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/ask-user-questions-dedup.test.ts src/resources/extensions/gsd/tests/tool-call-loop-guard.test.ts`

Closes #4674


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the loop guard behavior for the `ask_user_questions` feature to use standard thresholds, allowing up to 4 identical consecutive calls before blocking instead of the previous stricter limit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5326)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->