### PR TITLE
fix(gsd): stop blocked custom workflow loops

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -378,6 +378,7 @@ export async function autoLoop(
         },
       });
       if (sessionLockOutcome.action === "stop" && sessionLockOutcome.reason === "session-lock-lost") {
+        finishTurn("stopped", "manual-attention", sessionLockOutcome.reason);
         break;
       }
 
@@ -427,6 +428,7 @@ export async function autoLoop(
           isComplete: engineState.isComplete,
         });
         if (engineState.isComplete) {
+          finishTurn("completed");
           await deps.stopAuto(ctx, pi, "Workflow complete");
           break;
         }
@@ -873,6 +875,7 @@ export async function autoLoop(
 
         if (cooldownDecision.action === "stop") {
           ctx.ui.notify(cooldownDecision.notifyMessage, "error");
+          finishTurn("stopped", "timeout", msg);
           await deps.stopAuto(ctx, pi, cooldownDecision.stopMessage);
           break;
         }

--- a/src/resources/extensions/gsd/custom-workflow-engine.ts
+++ b/src/resources/extensions/gsd/custom-workflow-engine.ts
@@ -29,6 +29,7 @@ import {
   markStepActive,
   markStepComplete,
   expandIteration,
+  isTerminalStepStatus,
   type WorkflowGraph,
 } from "./graph.js";
 import { injectContext } from "./context-injector.js";
@@ -39,6 +40,24 @@ import { withFileLock } from "./file-lock.js";
 
 // Re-export for downstream consumers
 export { readFrozenDefinition } from "./definition-io.js";
+
+function formatBlockedWorkflowReason(graph: WorkflowGraph): string {
+  const statusById = new Map(graph.steps.map((step) => [step.id, step.status]));
+  const blockedSteps = graph.steps
+    .filter((step) => step.status === "pending")
+    .map((step) => {
+      const blockers = step.dependsOn
+        .filter((depId) => !isTerminalStepStatus(statusById.get(depId)))
+        .map((depId) => `${depId} (${statusById.get(depId) ?? "missing"})`);
+      return blockers.length > 0
+        ? `${step.id} waiting on ${blockers.join(", ")}`
+        : `${step.id} has no runnable dependency path`;
+    });
+
+  return blockedSteps.length > 0
+    ? `Workflow blocked: no pending steps are ready. Blocked steps: ${blockedSteps.join("; ")}`
+    : "Workflow blocked: no pending steps are ready.";
+}
 
 export class CustomWorkflowEngine implements WorkflowEngine {
   readonly engineId = "custom";
@@ -114,7 +133,11 @@ export class CustomWorkflowEngine implements WorkflowEngine {
           (step) => step.status === "complete" || step.status === "expanded",
         );
         if (!allDone) {
-          return { action: "skip" };
+          return {
+            action: "stop",
+            reason: formatBlockedWorkflowReason(graph),
+            level: "error",
+          };
         }
         return {
           action: "stop",

--- a/src/resources/extensions/gsd/graph.ts
+++ b/src/resources/extensions/gsd/graph.ts
@@ -31,7 +31,7 @@ export interface GraphStep {
   status: "pending" | "active" | "complete" | "expanded";
   /** The prompt to dispatch for this step. */
   prompt: string;
-  /** IDs of steps that must be "complete" before this step can run. */
+  /** IDs of steps that must be terminal before this step can run. */
   dependsOn: string[];
   /** For iteration instances: ID of the parent step that was expanded. */
   parentStepId?: string;
@@ -152,10 +152,17 @@ export function writeGraph(runDir: string, graph: WorkflowGraph): void {
 }
 
 /**
- * Get the next pending step whose dependencies are all complete.
+ * Return whether a graph step status satisfies dependency edges.
+ */
+export function isTerminalStepStatus(status: GraphStep["status"] | undefined): boolean {
+  return status === "complete" || status === "expanded";
+}
+
+/**
+ * Get the next pending step whose dependencies are all terminal.
  *
  * Returns the first step (in array order) with status "pending" where
- * every step in its `dependsOn` list has status "complete".
+ * every step in its `dependsOn` list has status "complete" or "expanded".
  *
  * @param graph — the workflow graph to query
  * @returns The next dispatchable step, or null if none available
@@ -165,8 +172,8 @@ export function getNextPendingStep(graph: WorkflowGraph): GraphStep | null {
 
   for (const step of graph.steps) {
     if (step.status !== "pending") continue;
-    const depsComplete = step.dependsOn.every(
-      (depId) => statusMap.get(depId) === "complete",
+    const depsComplete = step.dependsOn.every((depId) =>
+      isTerminalStepStatus(statusMap.get(depId)),
     );
     if (depsComplete) return step;
   }

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -372,7 +372,56 @@ describe("Custom engine loop integration", () => {
     assert.ok(stopEntry?.includes("Workflow complete"), "Should stop with 'Workflow complete'");
   });
 
-  it("finishes custom-engine skip turns and clears current turn state", async () => {
+  it("finalizes custom-engine complete turns and clears current turn state", async () => {
+    _resetPendingResolve();
+
+    const runDir = makeTmpDir();
+    const graph = makeGraph([
+      makeStep({ id: "step-a", status: "complete" }),
+    ], "already-done");
+    writeGraph(runDir, graph);
+    writeDefinition(runDir, graph.steps, "already-done");
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const s = makeLoopSession({
+      activeEngineId: "custom",
+      activeRunDir: runDir,
+      basePath: runDir,
+    });
+    const turnResults: Array<{ status: string; failureClass: string; error?: string }> = [];
+    const deps = makeMockDeps({
+      stopAuto: async (_ctx, _pi, reason) => {
+        deps.callLog.push(`stopAuto:${reason ?? "no-reason"}`);
+        s.active = false;
+      },
+      uokObserver: {
+        onTurnStart: () => {},
+        onTurnResult: (result) => {
+          deps.callLog.push(`turnResult:${result.status}`);
+          turnResults.push({
+            status: result.status,
+            failureClass: result.failureClass,
+            error: result.error,
+          });
+        },
+        onPhaseResult: () => {},
+      },
+    });
+
+    await autoLoop(ctx, pi, s, deps);
+
+    assert.deepEqual(turnResults, [{ status: "completed", failureClass: "none", error: undefined }]);
+    assert.ok(
+      deps.callLog.indexOf("turnResult:completed") < deps.callLog.indexOf("stopAuto:Workflow complete"),
+      `turn should finalize before stopAuto; log=${deps.callLog.join(",")}`,
+    );
+    assert.equal(s.currentTraceId, null);
+    assert.equal(s.currentTurnId, null);
+    assert.equal(pi.calls.length, 0, "complete workflow should not dispatch work");
+  });
+
+  it("stops blocked custom workflows and clears current turn state", async () => {
     _resetPendingResolve();
 
     const runDir = makeTmpDir();
@@ -390,13 +439,20 @@ describe("Custom engine loop integration", () => {
       activeRunDir: runDir,
       basePath: runDir,
     });
-    const turnResults: Array<{ status: string }> = [];
+    const turnResults: Array<{ status: string; failureClass: string; error?: string }> = [];
     const deps = makeMockDeps({
+      stopAuto: async (_ctx, _pi, reason) => {
+        deps.callLog.push(`stopAuto:${reason ?? "no-reason"}`);
+        s.active = false;
+      },
       uokObserver: {
         onTurnStart: () => {},
         onTurnResult: (result) => {
-          turnResults.push({ status: result.status });
-          s.active = false;
+          turnResults.push({
+            status: result.status,
+            failureClass: result.failureClass,
+            error: result.error,
+          });
         },
         onPhaseResult: () => {},
       },
@@ -404,10 +460,60 @@ describe("Custom engine loop integration", () => {
 
     await autoLoop(ctx, pi, s, deps);
 
-    assert.deepEqual(turnResults, [{ status: "skipped" }]);
+    assert.equal(turnResults.length, 1);
+    assert.equal(turnResults[0].status, "stopped");
+    assert.equal(turnResults[0].failureClass, "manual-attention");
+    assert.match(turnResults[0].error ?? "", /custom-engine-dispatch-stop/);
     assert.equal(s.currentTraceId, null);
     assert.equal(s.currentTurnId, null);
-    assert.equal(pi.calls.length, 0, "skip should not dispatch a custom step");
+    assert.equal(pi.calls.length, 0, "blocked workflow should not dispatch a custom step");
+    assert.match(
+      deps.callLog.find((e: string) => e.startsWith("stopAuto:")) ?? "",
+      /Workflow blocked: no pending steps are ready/,
+    );
+  });
+
+  it("finalizes the active turn when the session lock is lost", async () => {
+    _resetPendingResolve();
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const s = makeLoopSession();
+    const turnResults: Array<{ status: string; failureClass: string; error?: string }> = [];
+    const deps = makeMockDeps({
+      validateSessionLock: () => ({
+        valid: false,
+        failureReason: "pid-mismatch",
+        expectedPid: 111,
+        existingPid: 222,
+      } as SessionLockStatus),
+      handleLostSessionLock: () => {
+        deps.callLog.push("handleLostSessionLock");
+      },
+      uokObserver: {
+        onTurnStart: () => {},
+        onTurnResult: (result) => {
+          turnResults.push({
+            status: result.status,
+            failureClass: result.failureClass,
+            error: result.error,
+          });
+        },
+        onPhaseResult: () => {},
+      },
+    });
+
+    await autoLoop(ctx, pi, s, deps);
+
+    assert.deepEqual(turnResults, [{
+      status: "stopped",
+      failureClass: "manual-attention",
+      error: "session-lock-lost",
+    }]);
+    assert.equal(s.currentTraceId, null);
+    assert.equal(s.currentTurnId, null);
+    assert.equal(pi.calls.length, 0, "lost session lock must not dispatch work");
+    assert.ok(deps.callLog.includes("handleLostSessionLock"));
   });
 
   it("does not call runPreDispatch or runFinalize on the custom path", async () => {

--- a/src/resources/extensions/gsd/tests/custom-workflow-engine.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-workflow-engine.test.ts
@@ -193,7 +193,7 @@ describe("CustomWorkflowEngine.resolveDispatch", () => {
     }
   });
 
-  it("returns skip when pending steps are blocked by incomplete dependencies", async () => {
+  it("returns stop with dependency details when pending steps are blocked", async () => {
     const { engine } = setupEngine([
       makeStep({ id: "a", dependsOn: ["b"] }),
       makeStep({ id: "b", dependsOn: ["a"] }),
@@ -202,7 +202,45 @@ describe("CustomWorkflowEngine.resolveDispatch", () => {
     const state = await engine.deriveState("/unused");
     const dispatch = await engine.resolveDispatch(state, { basePath: "/unused" });
 
-    assert.deepEqual(dispatch, { action: "skip" });
+    assert.equal(dispatch.action, "stop");
+    if (dispatch.action === "stop") {
+      assert.equal(dispatch.level, "error");
+      assert.match(dispatch.reason, /Workflow blocked/);
+      assert.match(dispatch.reason, /a waiting on b \(pending\)/);
+      assert.match(dispatch.reason, /b waiting on a \(pending\)/);
+    }
+  });
+
+  it("reports missing dependencies when no pending step can run", async () => {
+    const { engine } = setupEngine([
+      makeStep({ id: "a", dependsOn: ["missing-step"] }),
+    ]);
+
+    const state = await engine.deriveState("/unused");
+    const dispatch = await engine.resolveDispatch(state, { basePath: "/unused" });
+
+    assert.equal(dispatch.action, "stop");
+    if (dispatch.action === "stop") {
+      assert.equal(dispatch.level, "error");
+      assert.match(dispatch.reason, /a waiting on missing-step \(missing\)/);
+    }
+  });
+
+  it("does not report expanded dependencies as blockers", async () => {
+    const { engine } = setupEngine([
+      makeStep({ id: "iter", status: "expanded" }),
+      makeStep({ id: "after", dependsOn: ["iter", "missing-step"] }),
+    ]);
+
+    const state = await engine.deriveState("/unused");
+    const dispatch = await engine.resolveDispatch(state, { basePath: "/unused" });
+
+    assert.equal(dispatch.action, "stop");
+    if (dispatch.action === "stop") {
+      assert.equal(dispatch.level, "error");
+      assert.match(dispatch.reason, /after waiting on missing-step \(missing\)/);
+      assert.doesNotMatch(dispatch.reason, /iter \(expanded\)/);
+    }
   });
 
   it("respects dependency ordering", async () => {

--- a/src/resources/extensions/gsd/tests/graph-operations.test.ts
+++ b/src/resources/extensions/gsd/tests/graph-operations.test.ts
@@ -233,6 +233,16 @@ describe("getNextPendingStep", () => {
     const next = getNextPendingStep(graph);
     assert.equal(next?.id, "b");
   });
+
+  it("treats expanded dependencies as satisfied", (t) => {
+    const graph = makeGraph([
+      makeStep({ id: "iter", status: "expanded" }),
+      makeStep({ id: "after", dependsOn: ["iter"] }),
+    ]);
+
+    const next = getNextPendingStep(graph);
+    assert.equal(next?.id, "after");
+  });
 });
 
 // ─── markStepComplete ────────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Stops blocked custom workflows as terminal errors and finalizes auto-loop turn state on remaining direct exit paths.
**Why:** The #5308 refactor left blocked dependency graphs able to spin as skipped turns and left some UOK turns open on loop exits.
**How:** Custom workflow dispatch now reports blocked dependency details, and auto-loop lock-loss, complete-workflow, and cooldown-exhaustion exits call `finishTurn` before breaking.

## What

This PR fixes two follow-up P1 findings from the post-merge review of #5308:

- Custom workflows with pending steps but no runnable dependency path now return `stop` with dependency diagnostics instead of `skip`.
- Auto-loop terminal branches now finalize the active turn before breaking for session-lock loss, already-complete custom workflows, and credential cooldown retry exhaustion.
- Regression tests cover blocked/missing custom dependencies and UOK turn cleanup for blocked, complete, and lost-lock exits.

## Why

A blocked custom workflow graph should be surfaced as operator-visible blocked state, not a non-progressing skipped turn. Also, once `onTurnStart` has fired, every direct terminal path must emit `onTurnResult` and clear `currentTraceId`/`currentTurnId` so restart/recovery state remains consistent.

## How

`CustomWorkflowEngine.resolveDispatch()` now distinguishes complete graphs from blocked graphs when `getNextPendingStep()` returns null. Blocked graphs produce an error-level stop reason listing pending steps and their incomplete or missing dependencies.

`autoLoop()` now calls `finishTurn()` before direct breaks on session-lock loss, custom-engine complete, and cooldown retry exhaustion.

## Tests

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/custom-workflow-engine.test.ts src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts`
- [x] `npm run test:changed:src -- --since HEAD~1`
- [x] `npm run baseline:refactor:gate`

## Change type checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Breaking changes

None. Blocked custom workflow graphs now stop with a diagnostic instead of emitting skipped turns indefinitely.

## AI-assisted contribution

AI-assisted PR. The changes were verified with targeted regression tests, changed-source test verification, and the refactor baseline gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked workflows now stop with an explicit error and a detailed reason listing which steps/dependencies block progress.
  * Session-lock loss now records the turn as stopped (manual-attention) and clears turn state to avoid dangling state.
  * Transient credential cooldowns that stop now record the turn as stopped (timeout) before halting.
  * Already-complete workflows now record a completed turn before stopping auto.

* **Tests**
  * Integration and unit tests updated to validate these end-to-end behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->