### PR TITLE
chore(src): update remaining moved path references

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -8,7 +8,7 @@
  *
  * Uses dynamic imports for @modelcontextprotocol/sdk because TS Node16
  * cannot resolve the SDK's subpath exports statically (same pattern as
- * src/mcp-server.ts in the main package).
+ * src/mcp/mcp-server.ts in the main package).
  */
 
 import { readFile, readdir } from 'node:fs/promises';
@@ -873,7 +873,7 @@ export async function createMcpServer(
 ): Promise<{
   server: McpServerInstance;
 }> {
-  // Dynamic import — same workaround as src/mcp-server.ts
+  // Dynamic import — same workaround as src/mcp/mcp-server.ts
   const mcpMod = await import(`${MCP_PKG}/server/mcp.js`);
   const McpServer = mcpMod.McpServer as new (
     info: { name: string; version: string },

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -709,7 +709,7 @@ function adaptExecutorResult(result: unknown): unknown {
  * or arrays. Used to gate `structuredContent` forwarding so the MCP transport
  * receives only true JSON objects (the protocol contract).
  *
- * Mirrored in `src/mcp-server.ts` for the agent-tool registry path's
+ * Mirrored in `src/mcp/mcp-server.ts` for the agent-tool registry path's
  * structured-content gate. Keep both copies in sync if the contract definition
  * needs to evolve. See #4477 review.
  */

--- a/packages/pi-coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/pi-coding-agent/src/modes/rpc/rpc-client.ts
@@ -24,7 +24,7 @@ type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : n
 type RpcCommandBody = DistributiveOmit<RpcCommand, "id">;
 
 export interface RpcClientOptions {
-	/** Path to the CLI entry point (default: searches for dist/cli.js) */
+	/** Path to the CLI entry point (default: searches for dist/loader.js) */
 	cliPath?: string;
 	/** Working directory for the agent */
 	cwd?: string;
@@ -71,7 +71,7 @@ export class RpcClient {
 			throw new Error("Client already started");
 		}
 
-		const cliPath = this.options.cliPath ?? "dist/cli.js";
+		const cliPath = this.options.cliPath ?? "dist/loader.js";
 		const args = ["--mode", "rpc"];
 
 		if (this.options.provider) {

--- a/packages/rpc-client/src/rpc-client.ts
+++ b/packages/rpc-client/src/rpc-client.ts
@@ -36,7 +36,7 @@ type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : n
 type RpcCommandBody = DistributiveOmit<RpcCommand, "id">;
 
 export interface RpcClientOptions {
-	/** Path to the CLI entry point (default: searches for dist/cli.js) */
+	/** Path to the CLI entry point (default: searches for dist/loader.js) */
 	cliPath?: string;
 	/** Working directory for the agent */
 	cwd?: string;
@@ -79,7 +79,7 @@ export class RpcClient {
 
 		this._stopped = false;
 
-		const cliPath = this.options.cliPath ?? "dist/cli.js";
+		const cliPath = this.options.cliPath ?? "dist/loader.js";
 		const args = ["--mode", "rpc"];
 
 		if (this.options.provider) {

--- a/scripts/compile-tests.mjs
+++ b/scripts/compile-tests.mjs
@@ -315,7 +315,7 @@ async function main() {
 
   // Copy root dist/ into dist-test/dist/ — some tests compute projectRoot as
   // 3 levels up from dist-test/src/tests/ which lands at dist-test/, then
-  // import from dist/mcp-server.js etc.
+  // import from dist/mcp/mcp-server.js etc.
   const rootDistDir = join(ROOT, 'dist');
   const distTestDistDir = join(DIST_TEST_DIR, 'dist');
   await copyAssets(rootDistDir, distTestDistDir);

--- a/scripts/pr-risk-check.mjs
+++ b/scripts/pr-risk-check.mjs
@@ -7,7 +7,7 @@
  *   node scripts/pr-risk-check.mjs                      # auto-detect changed files vs main
  *   node scripts/pr-risk-check.mjs --base <branch>      # compare against a specific base
  *   node scripts/pr-risk-check.mjs --files a.ts,b.ts    # explicit file list
- *   echo "src/cli.ts" | node scripts/pr-risk-check.mjs  # pipe files via stdin
+ *   echo "src/cli/cli.ts" | node scripts/pr-risk-check.mjs  # pipe files via stdin
  *   node scripts/pr-risk-check.mjs --json               # JSON output
  *   node scripts/pr-risk-check.mjs --github             # GitHub Actions summary output
  */

--- a/scripts/refactor-baseline.mjs
+++ b/scripts/refactor-baseline.mjs
@@ -40,7 +40,7 @@ const CONTRACT_SURFACES = [
   },
   {
     surface: "web",
-    path: "src/web/bridge-service.ts",
+    path: "src/web-services/bridge-service.ts",
   },
   {
     surface: "webStore",

--- a/scripts/verify-s03.sh
+++ b/scripts/verify-s03.sh
@@ -30,12 +30,12 @@ echo ""
 # Check 1 — Build: dist outputs exist
 # ----------------------------------------------------------------
 echo "--- Build ---"
-if [ -f "dist/wizard.js" ] && [ -f "dist/cli.js" ] && [ -f "dist/loader.js" ]; then
-  pass "1 — dist/wizard.js, dist/cli.js, dist/loader.js exist"
+if [ -f "dist/onboarding/wizard.js" ] && [ -f "dist/cli/cli.js" ] && [ -f "dist/loader.js" ]; then
+  pass "1 — dist/onboarding/wizard.js, dist/cli/cli.js, dist/loader.js exist"
 else
   echo "  (building...)"
   npm run build --silent 2>&1
-  if [ -f "dist/wizard.js" ] && [ -f "dist/cli.js" ] && [ -f "dist/loader.js" ]; then
+  if [ -f "dist/onboarding/wizard.js" ] && [ -f "dist/cli/cli.js" ] && [ -f "dist/loader.js" ]; then
     pass "1 — build succeeded"
   else
     fail "1 — build failed or dist files missing"
@@ -110,12 +110,12 @@ echo ""
 echo "--- loadStoredEnvKeys hydration ---"
 
 # ----------------------------------------------------------------
-# Check 5 — Structural: env var names compiled into dist/wizard.js
+# Check 5 — Structural: env var names compiled into dist/onboarding/wizard.js
 # ----------------------------------------------------------------
-if grep -q "BRAVE_API_KEY" dist/wizard.js && grep -q "BRAVE_ANSWERS_KEY" dist/wizard.js && grep -q "CONTEXT7_API_KEY" dist/wizard.js && grep -q "JINA_API_KEY" dist/wizard.js; then
-  pass "5 — dist/wizard.js contains all four optional key env var names"
+if grep -q "BRAVE_API_KEY" dist/onboarding/wizard.js && grep -q "BRAVE_ANSWERS_KEY" dist/onboarding/wizard.js && grep -q "CONTEXT7_API_KEY" dist/onboarding/wizard.js && grep -q "JINA_API_KEY" dist/onboarding/wizard.js; then
+  pass "5 — dist/onboarding/wizard.js contains all four optional key env var names"
 else
-  fail "5 — dist/wizard.js missing one or more optional key env var names"
+  fail "5 — dist/onboarding/wizard.js missing one or more optional key env var names"
 fi
 
 # ----------------------------------------------------------------
@@ -133,10 +133,10 @@ tmp6=$(mktemp)
     ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
     GSD_TEST_AUTH_PATH="$tmp_auth" \
     node -e "
-      import('./dist/app-paths.js').then(async (paths) => {
+      import('./dist/app/app-paths.js').then(async (paths) => {
         // Override authFilePath for test
         const { AuthStorage } = await import('@mariozechner/pi-coding-agent');
-        const { loadStoredEnvKeys } = await import('./dist/wizard.js');
+        const { loadStoredEnvKeys } = await import('./dist/onboarding/wizard.js');
         const auth = AuthStorage.create('$tmp_auth');
         loadStoredEnvKeys(auth);
         const val = process.env.BRAVE_API_KEY;

--- a/src/cli/logo.ts
+++ b/src/cli/logo.ts
@@ -2,7 +2,7 @@
  * Shared GSD block-letter ASCII logo.
  *
  * Single source of truth — imported by:
- *   - scripts/postinstall.js (via dist/logo.js)
+ *   - scripts/postinstall.js (via dist/cli/logo.js)
  *   - src/loader.ts (via ./logo.js)
  */
 

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -31,7 +31,7 @@ const UPDATE_REGISTRY_URL = "https://registry.npmjs.org/gsd-pi/latest";
 const UPDATE_FETCH_TIMEOUT_MS = 5000;
 
 // Detects a bun-installed gsd via `process.argv[1]`. Mirrors isBunInstall in
-// src/update-check.ts — duplicated because tsconfig.resources.json rootDir
+// src/update/update-check.ts — duplicated because tsconfig.resources.json rootDir
 // prevents importing from src/. See #4145 for why the runtime-only check
 // (process.versions.bun) is insufficient: bun's global bin shims are plain
 // symlinks, so the target's #!/usr/bin/env node shebang runs the script under

--- a/src/resources/extensions/gsd/commands-worktree.ts
+++ b/src/resources/extensions/gsd/commands-worktree.ts
@@ -1,6 +1,6 @@
 // GSD-2 — In-TUI handler for /gsd worktree commands (list, merge, clean, remove).
 //
-// Mirrors the CLI subcommands in src/worktree-cli.ts but emits results via
+// Mirrors the CLI subcommands in src/worktrees/worktree-cli.ts but emits results via
 // ctx.ui.notify() instead of writing colored output to stderr. Reuses the
 // same extension modules (worktree-manager, native-git-bridge, etc.) so the
 // behavior is identical to the CLI surface.

--- a/src/resources/extensions/gsd/commands/handlers/onboarding.ts
+++ b/src/resources/extensions/gsd/commands/handlers/onboarding.ts
@@ -1,6 +1,6 @@
 // GSD — /gsd onboarding command handler (re-entry hub)
 //
-// The first-run wizard in src/onboarding.ts uses @clack/prompts and takes over
+// The first-run wizard in src/onboarding/onboarding.ts uses @clack/prompts and takes over
 // raw stdin. Running it from inside the pi-coding-agent TUI wedges the TUI
 // (clack leaves stdin paused + cooked, pi-tui's data handler then receives no
 // keypresses). So re-entry cannot replay the clack wizard — instead it routes

--- a/src/resources/extensions/gsd/onboarding-state.ts
+++ b/src/resources/extensions/gsd/onboarding-state.ts
@@ -17,7 +17,7 @@ import { gsdHome } from "./gsd-home.js";
 export const FLOW_VERSION = 1
 
 const RECORD_VERSION = 1
-// Inline agentDir computation (mirrors src/app-paths.ts) — keep this module
+// Inline agentDir computation (mirrors src/app/app-paths.ts) — keep this module
 // rootDir-clean for the resources tsconfig; importing from src/ pulls files
 // outside src/resources and breaks the build.
 const AGENT_DIR =

--- a/src/resources/extensions/gsd/setup-catalog.ts
+++ b/src/resources/extensions/gsd/setup-catalog.ts
@@ -35,7 +35,7 @@ export interface OnboardingStepDef {
  * To add a new step:
  *   1. Append here (or insert at the right position).
  *   2. Bump FLOW_VERSION in onboarding-state.ts so existing users get re-prompted.
- *   3. Wire its CLI runner in src/onboarding.ts (and handlers/onboarding.ts for --step).
+ *   3. Wire its CLI runner in src/onboarding/onboarding.ts (and handlers/onboarding.ts for --step).
  */
 export const ONBOARDING_STEPS: readonly OnboardingStepDef[] = [
   { id: "llm",       label: "LLM provider & auth",      required: true,  hint: "Sign in or paste an API key" },

--- a/src/resources/extensions/gsd/watch/header-renderer.ts
+++ b/src/resources/extensions/gsd/watch/header-renderer.ts
@@ -12,7 +12,7 @@ import { gsdHome } from "../gsd-home.js";
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /**
- * GSD ASCII logo — inlined here because the canonical src/logo.ts is outside
+ * GSD ASCII logo — inlined here because the canonical src/cli/logo.ts is outside
  * the resources rootDir and cannot be imported directly.
  */
 const GSD_LOGO: readonly string[] = [

--- a/src/resources/extensions/search-the-web/provider.ts
+++ b/src/resources/extensions/search-the-web/provider.ts
@@ -15,8 +15,8 @@ import { resolveSearchProviderFromPreferences } from '../gsd/preferences.js'
 import { gsdHome } from "../gsd/gsd-home.js";
 
 // Compute authFilePath lazily so GSD_HOME overrides (e.g. in tests) take effect.
-// Imported locally instead of from app-paths.ts because extensions are copied to
-// ~/.gsd/agent/extensions/ at runtime where '../../../app-paths.ts' doesn't resolve.
+// Imported locally instead of from src/app/app-paths.ts because extensions are
+// copied to ~/.gsd/agent/extensions/ at runtime where package-root imports do not resolve.
 function authFilePath(): string {
   return join(gsdHome(), 'agent', 'auth.json');
 }

--- a/src/tests/headless-recover.test.ts
+++ b/src/tests/headless-recover.test.ts
@@ -4,7 +4,7 @@
 // `gsd headless recover` available to non-TTY callers (CI, automation, the
 // live-regression suite). The headless dispatcher previously had no
 // `recover` case — the only path was the interactive slash-command
-// (`/gsd recover`), which is gated behind a TTY check (src/cli.ts
+// (`/gsd recover`), which is gated behind a TTY check (src/cli/cli.ts
 // printNonTtyErrorAndExit) and rejected piped invocations.
 //
 // The headless wiring composes ensureDbOpen + clearEngineHierarchy +

--- a/src/tests/pi-migration-exports.test.ts
+++ b/src/tests/pi-migration-exports.test.ts
@@ -1,7 +1,7 @@
 // GSD-2 — Regression test for pi-migration.ts public exports consumed by cli.ts
 //
 // Guards against the TS2304 regression introduced by 080c6ac1e where
-// src/cli.ts called `getPiDefaultModelAndProvider()` without importing it.
+// src/cli/cli.ts called `getPiDefaultModelAndProvider()` without importing it.
 // If the symbol is ever renamed or unexported, this test fails before the
 // root `tsc` build breaks every CI job on main.
 

--- a/src/tests/refactor-baseline.test.ts
+++ b/src/tests/refactor-baseline.test.ts
@@ -430,7 +430,7 @@ async function writeContractsSurfaceFixtures(root: string): Promise<void> {
     "packages/pi-coding-agent/src/modes/rpc/rpc-types.ts",
     "packages/rpc-client/src/rpc-types.ts",
     "packages/mcp-server/src/types.ts",
-    "src/web/bridge-service.ts",
+    "src/web-services/bridge-service.ts",
     "web/lib/gsd-workspace-store.tsx",
     "vscode-extension/src/gsd-client.ts",
   ];


### PR DESCRIPTION
## TL;DR

**What:** Updates the remaining stale references left after the src structure cleanup.
**Why:** Scripts, tests, comments, and default path hints should match the current grouped src/dist layout.
**How:** Replaces obsolete root-level src/dist path strings with their current grouped locations while leaving package-local CLI paths intact.

## What

This PR updates remaining moved-path references found during the final team review pass:

- updates refactor baseline fixture references from `src/web/*` to `src/web-services/*`
- updates verification script expectations for grouped dist output paths
- updates package RPC default CLI comments/paths to use the root loader entrypoint
- updates stale comments in GSD extension files and affected tests
- keeps package-local `packages/mcp-server/dist/cli.js` and daemon `dist/cli.js` references unchanged because those are not the root GSD CLI path

## Why

Closes #5332

The src cleanup moved files into clearer directories, but a final path audit found stale references that could mislead future contributors or make structure verification noisy.

## How

The changes are string/path reference updates only. The stale-path scan now only reports legitimate package-local MCP/daemon CLI paths and workflow-MCP fixture strings, not obsolete root `src/*.ts` or `src/web/*` references from the cleanup scope.

## Verification

- [x] `git diff --check`
- [x] Focused moved-path test set passed
- [x] `npm run build:core`
- [x] `npm run typecheck:extensions`
- [x] Direct rerun: `custom-engine-loop-integration.test.ts` passed, 8/8
- [x] Direct rerun: `context-store.test.ts` passed, 34/34
- [x] Direct rerun: `workflow-mcp.test.ts` passed, 31/31
- [ ] `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" npm run verify:pr` is not green yet. Latest full run reported `8931 passed, 4 failed, 9 skipped`; failures were timing-sensitive integration checks that passed on direct rerun.

## Change Type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Breaking Changes

No runtime behavior or public API changes are intended in this follow-up PR. This only updates references to the already-moved file layout.

## AI Assistance

This PR was AI-assisted. The changes were reviewed against the current source tree and verified with focused checks plus the documented local preflight status above.
