### PR TITLE
fix(memory): make sql.js persistence crash-safe with atomic file replacement

### DIFF
--- a/packages/mcp-server/src/readers/graph.ts
+++ b/packages/mcp-server/src/readers/graph.ts
@@ -644,8 +644,29 @@ export async function writeSnapshot(gsdRoot: string): Promise<void> {
     return;
   }
   const snapshot = { ...graph, snapshotAt: new Date().toISOString() };
+  const final = snapshotPath(gsdRoot);
+  const tmp = final + '.tmp';
+  const content = Buffer.from(JSON.stringify(snapshot, null, 2), 'utf-8');
 
-  writeFileSync(snapshotPath(gsdRoot), JSON.stringify(snapshot, null, 2), 'utf-8');
+  const fd = openSync(tmp, 'w');
+  try {
+    let offset = 0;
+    while (offset < content.length) {
+      offset += writeSync(fd, content, offset, content.length - offset);
+    }
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+
+  renameSync(tmp, final);
+
+  const dirFd = openSync(dir, 'r');
+  try {
+    fsyncSync(dirFd);
+  } finally {
+    closeSync(dirFd);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp-server/src/readers/graph.ts
+++ b/packages/mcp-server/src/readers/graph.ts
@@ -661,11 +661,18 @@ export async function writeSnapshot(gsdRoot: string): Promise<void> {
 
   renameSync(tmp, final);
 
-  const dirFd = openSync(dir, 'r');
+  // Best-effort directory fsync: some platforms/filesystems (notably Windows)
+  // may reject directory descriptors. Data durability is still protected by
+  // the temp-file fsync + atomic rename above.
   try {
-    fsyncSync(dirFd);
-  } finally {
-    closeSync(dirFd);
+    const dirFd = openSync(dir, 'r');
+    try {
+      fsyncSync(dirFd);
+    } finally {
+      closeSync(dirFd);
+    }
+  } catch {
+    // Ignore platform/filesystem limitations for directory fsync.
   }
 }
 

--- a/packages/mcp-server/src/readers/graph.ts
+++ b/packages/mcp-server/src/readers/graph.ts
@@ -12,7 +12,7 @@
  * writeGraph() is atomic: writes to graph.tmp.json then renames to graph.json.
  */
 
-import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync } from 'node:fs';
+import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync, writeSync } from 'node:fs';
 import { basename, join, resolve } from 'node:path';
 import {
   resolveGsdRoot,
@@ -610,7 +610,14 @@ export async function writeGraph(gsdRoot: string, graph: KnowledgeGraph): Promis
   const tmp = graphTmpPath(gsdRoot);
   const final = graphJsonPath(gsdRoot);
 
-  writeFileSync(tmp, JSON.stringify(graph, null, 2), 'utf-8');
+  const content = Buffer.from(JSON.stringify(graph, null, 2), 'utf-8');
+  const fd = openSync(tmp, 'w');
+  try {
+    writeSync(fd, content);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
   renameSync(tmp, final);
 }
 

--- a/packages/pi-coding-agent/src/core/db-snapshot-write-guard.test.ts
+++ b/packages/pi-coding-agent/src/core/db-snapshot-write-guard.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+function collectTsFiles(dir: string, out: string[] = []): string[] {
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		const st = statSync(full);
+		if (st.isDirectory()) {
+			if (entry === "node_modules" || entry === "dist" || entry === "tests") continue;
+			collectTsFiles(full, out);
+			continue;
+		}
+		if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) out.push(full);
+	}
+	return out;
+}
+
+test("all sql.js db.export() persistence uses atomic snapshot helper", () => {
+	const srcRoot = join(process.cwd(), "packages", "pi-coding-agent", "src");
+	const files = collectTsFiles(srcRoot);
+
+	for (const file of files) {
+		const src = readFileSync(file, "utf-8");
+		if (!src.includes("db.export(")) continue;
+
+		assert.match(
+			src,
+			/atomicWriteDbSnapshotSync\(/,
+			`${file} uses db.export() but does not call atomicWriteDbSnapshotSync()`,
+		);
+		assert.doesNotMatch(
+			src,
+			/writeFileSync\([^\n]*dbPath/,
+			`${file} appears to write DB path directly; use atomicWriteDbSnapshotSync()`,
+		);
+	}
+});

--- a/packages/pi-coding-agent/src/core/db-snapshot-write-guard.test.ts
+++ b/packages/pi-coding-agent/src/core/db-snapshot-write-guard.test.ts
@@ -20,7 +20,7 @@ function collectTsFiles(dir: string, out: string[] = []): string[] {
 function stripComments(src: string): string {
 	return src
 		.replace(/\/\*[\s\S]*?\*\//g, "")
-		.replace(/^\s*\/\/.*$/gm, "");
+		.replace(/\/\/[^\n]*/g, "");
 }
 
 test("all sql.js db.export() persistence uses atomic snapshot helper", () => {
@@ -45,7 +45,7 @@ test("all sql.js db.export() persistence uses atomic snapshot helper", () => {
 			`${file} uses db.export() but does not call atomicWriteDbSnapshotSync()`,
 		);
 
-		const exportAssigned = /const\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*db\.export\(\s*\)\s*;/m;
+		const exportAssigned = /(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*db\.export\(\s*\)\s*;/m;
 		const match = code.match(exportAssigned);
 		if (match) {
 			const varName = match[1];

--- a/packages/pi-coding-agent/src/core/db-snapshot-write-guard.test.ts
+++ b/packages/pi-coding-agent/src/core/db-snapshot-write-guard.test.ts
@@ -17,23 +17,51 @@ function collectTsFiles(dir: string, out: string[] = []): string[] {
 	return out;
 }
 
+function stripComments(src: string): string {
+	return src
+		.replace(/\/\*[\s\S]*?\*\//g, "")
+		.replace(/^\s*\/\/.*$/gm, "");
+}
+
 test("all sql.js db.export() persistence uses atomic snapshot helper", () => {
 	const srcRoot = join(process.cwd(), "packages", "pi-coding-agent", "src");
 	const files = collectTsFiles(srcRoot);
 
 	for (const file of files) {
 		const src = readFileSync(file, "utf-8");
-		if (!src.includes("db.export(")) continue;
+		const code = stripComments(src);
+		if (!code.includes("db.export(")) continue;
+
+		const directExportWrite = /writeFileSync\([\s\S]{0,200}?db\.export\(/m;
+		assert.doesNotMatch(
+			code,
+			directExportWrite,
+			`${file} writes db.export() directly via writeFileSync(); use atomicWriteDbSnapshotSync()`,
+		);
 
 		assert.match(
-			src,
+			code,
 			/atomicWriteDbSnapshotSync\(/,
 			`${file} uses db.export() but does not call atomicWriteDbSnapshotSync()`,
 		);
-		assert.doesNotMatch(
-			src,
-			/writeFileSync\([^\n]*dbPath/,
-			`${file} appears to write DB path directly; use atomicWriteDbSnapshotSync()`,
-		);
+
+		const exportAssigned = /const\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*db\.export\(\s*\)\s*;/m;
+		const match = code.match(exportAssigned);
+		if (match) {
+			const varName = match[1];
+			const escape = varName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+			const badWrite = new RegExp(`writeFileSync\\([\\s\\S]{0,240}?\\b${escape}\\b`, "m");
+			assert.doesNotMatch(
+				code,
+				badWrite,
+				`${file} writes db.export() variable ${varName} via writeFileSync(); use atomicWriteDbSnapshotSync()`,
+			);
+			const goodWrite = new RegExp(`atomicWriteDbSnapshotSync\\([\\s\\S]{0,120}?\\b${escape}\\b`, "m");
+			assert.match(
+				code,
+				goodWrite,
+				`${file} must pass db.export() variable ${varName} to atomicWriteDbSnapshotSync()`,
+			);
+		}
 	}
 });

--- a/packages/pi-coding-agent/src/core/discovery-cache.ts
+++ b/packages/pi-coding-agent/src/core/discovery-cache.ts
@@ -3,8 +3,8 @@
  * Stores results at {agentDir}/discovery-cache.json with per-provider TTLs.
  */
 
-import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, writeSync } from "fs";
-import { dirname, join } from "path";
+import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, writeSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { getAgentDir } from "../config.js";
 import { type DiscoveredModel, getDefaultTTL } from "./model-discovery.js";
 

--- a/packages/pi-coding-agent/src/core/discovery-cache.ts
+++ b/packages/pi-coding-agent/src/core/discovery-cache.ts
@@ -3,7 +3,7 @@
  * Stores results at {agentDir}/discovery-cache.json with per-provider TTLs.
  */
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, writeSync } from "fs";
 import { dirname, join } from "path";
 import { getAgentDir } from "../config.js";
 import { type DiscoveredModel, getDefaultTTL } from "./model-discovery.js";
@@ -95,7 +95,14 @@ export class ModelDiscoveryCache {
 			}
 			// Atomic write: write to temp file then rename to avoid partial reads
 			const tmpPath = this.cachePath + ".tmp";
-			writeFileSync(tmpPath, JSON.stringify(this.data, null, 2), "utf-8");
+			const content = Buffer.from(JSON.stringify(this.data, null, 2), "utf-8");
+			const fd = openSync(tmpPath, "w");
+			try {
+				writeSync(fd, content);
+				fsyncSync(fd);
+			} finally {
+				closeSync(fd);
+			}
 			renameSync(tmpPath, this.cachePath);
 		} catch {
 			// Silently ignore write failures (read-only FS, permissions, etc.)

--- a/packages/pi-coding-agent/src/core/extensions/extension-registry.ts
+++ b/packages/pi-coding-agent/src/core/extensions/extension-registry.ts
@@ -6,7 +6,7 @@
  * The only way an extension stops loading is an explicit `gsd extensions disable <id>`.
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, writeSync } from "node:fs";
 import { getAgentDir } from "../../config.js";
 import { dirname, join } from "node:path";
 
@@ -95,7 +95,14 @@ export function saveRegistry(registry: ExtensionRegistry): void {
   try {
     mkdirSync(dirname(filePath), { recursive: true });
     const tmp = filePath + ".tmp";
-    writeFileSync(tmp, JSON.stringify(registry, null, 2), "utf-8");
+    const content = Buffer.from(JSON.stringify(registry, null, 2), "utf-8");
+    const fd = openSync(tmp, "w");
+    try {
+      writeSync(fd, content);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
     renameSync(tmp, filePath);
   } catch {
     // Non-fatal — don't let persistence failures break operation

--- a/packages/pi-coding-agent/src/core/fs-utils.test.ts
+++ b/packages/pi-coding-agent/src/core/fs-utils.test.ts
@@ -3,7 +3,7 @@ import { describe, it, afterEach } from "node:test";
 import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { atomicWriteFileSync } from "./fs-utils.js";
+import { atomicWriteDbSnapshotSync, atomicWriteFileSync } from "./fs-utils.js";
 
 describe("atomicWriteFileSync", () => {
 	let dir: string;
@@ -50,5 +50,24 @@ describe("atomicWriteFileSync", () => {
 		const filePath = join(dir, "test.txt");
 		atomicWriteFileSync(filePath, "utf8 content", "utf-8");
 		assert.equal(readFileSync(filePath, "utf-8"), "utf8 content");
+	});
+});
+
+describe("atomicWriteDbSnapshotSync", () => {
+	let dir: string;
+
+	afterEach(() => {
+		if (dir) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("writes snapshot bytes via atomic file replacement", () => {
+		dir = mkdtempSync(join(tmpdir(), "fs-utils-db-snapshot-test-"));
+		const dbPath = join(dir, "agent.db");
+		const snapshot = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+		atomicWriteDbSnapshotSync(dbPath, snapshot);
+		assert.deepEqual(readFileSync(dbPath), Buffer.from(snapshot));
+		assert.equal(existsSync(dbPath + ".tmp"), false);
 	});
 });

--- a/packages/pi-coding-agent/src/core/fs-utils.test.ts
+++ b/packages/pi-coding-agent/src/core/fs-utils.test.ts
@@ -53,7 +53,7 @@ describe("atomicWriteFileSync", () => {
 	});
 
 	it("fsyncs temp file before rename (durability guard)", () => {
-		const src = readFileSync(new URL("./fs-utils.ts", import.meta.url), "utf-8");
+		const src = readFileSync(join(process.cwd(), "packages", "pi-coding-agent", "src", "core", "fs-utils.ts"), "utf-8");
 		assert.match(src, /fsyncSync\(fd\)/);
 	});
 });

--- a/packages/pi-coding-agent/src/core/fs-utils.test.ts
+++ b/packages/pi-coding-agent/src/core/fs-utils.test.ts
@@ -51,6 +51,11 @@ describe("atomicWriteFileSync", () => {
 		atomicWriteFileSync(filePath, "utf8 content", "utf-8");
 		assert.equal(readFileSync(filePath, "utf-8"), "utf8 content");
 	});
+
+	it("fsyncs temp file before rename (durability guard)", () => {
+		const src = readFileSync(new URL("./fs-utils.ts", import.meta.url), "utf-8");
+		assert.match(src, /fsyncSync\(fd\)/);
+	});
 });
 
 describe("atomicWriteDbSnapshotSync", () => {

--- a/packages/pi-coding-agent/src/core/fs-utils.ts
+++ b/packages/pi-coding-agent/src/core/fs-utils.ts
@@ -1,4 +1,4 @@
-import { closeSync, fsyncSync, openSync, renameSync, writeFileSync } from "node:fs";
+import { closeSync, fsyncSync, openSync, renameSync, writeSync } from "node:fs";
 
 /**
  * Atomically write a file by writing to a temporary path then renaming.
@@ -7,15 +7,15 @@ import { closeSync, fsyncSync, openSync, renameSync, writeFileSync } from "node:
  */
 export function atomicWriteFileSync(filePath: string, content: string | Buffer, encoding?: BufferEncoding): void {
 	const tmpPath = filePath + ".tmp";
-	writeFileSync(tmpPath, content, encoding);
-
-	const fd = openSync(tmpPath, "r");
+	const buf = Buffer.isBuffer(content) ? content : Buffer.from(content, encoding ?? "utf8");
+	const fd = openSync(tmpPath, "w");
 	try {
+		writeSync(fd, buf);
 		fsyncSync(fd);
 	} finally {
 		closeSync(fd);
 	}
-
+	
 	renameSync(tmpPath, filePath);
 }
 

--- a/packages/pi-coding-agent/src/core/fs-utils.ts
+++ b/packages/pi-coding-agent/src/core/fs-utils.ts
@@ -10,3 +10,13 @@ export function atomicWriteFileSync(filePath: string, content: string | Buffer, 
 	writeFileSync(tmpPath, content, encoding);
 	renameSync(tmpPath, filePath);
 }
+
+/**
+ * Persist an in-memory DB snapshot atomically.
+ *
+ * Use this for sql.js `db.export()` buffers to avoid torn-write corruption
+ * on hard process death mid-write.
+ */
+export function atomicWriteDbSnapshotSync(dbPath: string, snapshot: Uint8Array): void {
+	atomicWriteFileSync(dbPath, Buffer.from(snapshot));
+}

--- a/packages/pi-coding-agent/src/core/fs-utils.ts
+++ b/packages/pi-coding-agent/src/core/fs-utils.ts
@@ -1,4 +1,4 @@
-import { renameSync, writeFileSync } from "node:fs";
+import { closeSync, fsyncSync, openSync, renameSync, writeFileSync } from "node:fs";
 
 /**
  * Atomically write a file by writing to a temporary path then renaming.
@@ -8,6 +8,14 @@ import { renameSync, writeFileSync } from "node:fs";
 export function atomicWriteFileSync(filePath: string, content: string | Buffer, encoding?: BufferEncoding): void {
 	const tmpPath = filePath + ".tmp";
 	writeFileSync(tmpPath, content, encoding);
+
+	const fd = openSync(tmpPath, "r");
+	try {
+		fsyncSync(fd);
+	} finally {
+		closeSync(fd);
+	}
+
 	renameSync(tmpPath, filePath);
 }
 

--- a/packages/pi-coding-agent/src/core/fs-utils.ts
+++ b/packages/pi-coding-agent/src/core/fs-utils.ts
@@ -10,7 +10,10 @@ export function atomicWriteFileSync(filePath: string, content: string | Buffer, 
 	const buf = Buffer.isBuffer(content) ? content : Buffer.from(content, encoding ?? "utf8");
 	const fd = openSync(tmpPath, "w");
 	try {
-		writeSync(fd, buf);
+		let offset = 0;
+		while (offset < buf.length) {
+			offset += writeSync(fd, buf, offset, buf.length - offset);
+		}
 		fsyncSync(fd);
 	} finally {
 		closeSync(fd);

--- a/packages/pi-coding-agent/src/resources/extensions/memory/storage.test.ts
+++ b/packages/pi-coding-agent/src/resources/extensions/memory/storage.test.ts
@@ -95,9 +95,9 @@ describe("MemoryStorage debounced persistence", () => {
 		reopened.close();
 	});
 
-	it("uses atomic write helper for db persistence (guard against torn-write regressions)", () => {
+	it("uses DB snapshot atomic helper for persistence (guard against torn-write regressions)", () => {
 		const src = readFileSync(new URL("./storage.ts", import.meta.url), "utf-8");
-		assert.match(src, /atomicWriteFileSync\(this\.dbPath,\s*Buffer\.from\(data\)\)/);
+		assert.match(src, /atomicWriteDbSnapshotSync\(this\.dbPath,\s*data\)/);
 		assert.doesNotMatch(src, /writeFileSync\(this\.dbPath/);
 	});
 });

--- a/packages/pi-coding-agent/src/resources/extensions/memory/storage.test.ts
+++ b/packages/pi-coding-agent/src/resources/extensions/memory/storage.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it, afterEach } from "node:test";
-import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -29,7 +29,6 @@ describe("MemoryStorage debounced persistence", () => {
 		const storage = await MemoryStorage.create(dbPath);
 
 		const initialStat = readFileSync(dbPath);
-		const initialMtime = initialStat.length;
 
 		storage.upsertThreads([
 			{ threadId: "t1", filePath: "/a.txt", fileSize: 100, fileMtime: 1000, cwd: "/proj" },
@@ -94,5 +93,11 @@ describe("MemoryStorage debounced persistence", () => {
 		const stats = reopened.getStats();
 		assert.equal(stats.totalThreads, 1, "Data should be persisted and readable after close");
 		reopened.close();
+	});
+
+	it("uses atomic write helper for db persistence (guard against torn-write regressions)", () => {
+		const src = readFileSync(new URL("./storage.ts", import.meta.url), "utf-8");
+		assert.match(src, /atomicWriteFileSync\(this\.dbPath,\s*Buffer\.from\(data\)\)/);
+		assert.doesNotMatch(src, /writeFileSync\(this\.dbPath/);
 	});
 });

--- a/packages/pi-coding-agent/src/resources/extensions/memory/storage.test.ts
+++ b/packages/pi-coding-agent/src/resources/extensions/memory/storage.test.ts
@@ -96,8 +96,11 @@ describe("MemoryStorage debounced persistence", () => {
 	});
 
 	it("uses DB snapshot atomic helper for persistence (guard against torn-write regressions)", () => {
-		const src = readFileSync(new URL("./storage.ts", import.meta.url), "utf-8");
-		assert.match(src, /atomicWriteDbSnapshotSync\(this\.dbPath,\s*data\)/);
+		const src = readFileSync(
+			join(process.cwd(), "packages", "pi-coding-agent", "src", "resources", "extensions", "memory", "storage.ts"),
+			"utf-8",
+		);
+		assert.match(src, /atomicWriteDbSnapshotSync\s*\(\s*this\.dbPath\s*,\s*[A-Za-z_$][A-Za-z0-9_$]*\s*\)/);
 		assert.doesNotMatch(src, /writeFileSync\(this\.dbPath/);
 	});
 });

--- a/src/extension-registry.ts
+++ b/src/extension-registry.ts
@@ -6,7 +6,7 @@
  * The only way an extension stops loading is an explicit `gsd extensions disable <id>`.
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, writeSync } from "node:fs";
 import { appRoot } from "./app-paths.js";
 import { dirname, join } from "node:path";
 
@@ -95,7 +95,14 @@ export function saveRegistry(registry: ExtensionRegistry): void {
   try {
     mkdirSync(dirname(filePath), { recursive: true });
     const tmp = filePath + ".tmp";
-    writeFileSync(tmp, JSON.stringify(registry, null, 2), "utf-8");
+    const content = Buffer.from(JSON.stringify(registry, null, 2), "utf-8");
+    const fd = openSync(tmp, "w");
+    try {
+      writeSync(fd, content);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
     renameSync(tmp, filePath);
   } catch {
     // Non-fatal — don't let persistence failures break operation

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { closeSync, cpSync, existsSync, fsyncSync, mkdirSync, mkdtempSync, openSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync, writeSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
@@ -123,7 +123,17 @@ function saveRegistry(registry: ExtensionRegistry): void {
   try {
     mkdirSync(dirname(filePath), { recursive: true });
     const tmp = filePath + ".tmp";
-    writeFileSync(tmp, JSON.stringify(registry, null, 2), "utf-8");
+    const content = Buffer.from(JSON.stringify(registry, null, 2), "utf-8");
+    const fd = openSync(tmp, "w");
+    try {
+      let offset = 0;
+      while (offset < content.length) {
+        offset += writeSync(fd, content, offset, content.length - offset);
+      }
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
     renameSync(tmp, filePath);
   } catch { /* non-fatal */ }
 }

--- a/src/resources/extensions/gsd/graph.ts
+++ b/src/resources/extensions/gsd/graph.ts
@@ -16,7 +16,7 @@
  */
 
 import { parse, stringify } from "yaml";
-import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync } from "node:fs";
+import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, writeSync } from "node:fs";
 import { join } from "node:path";
 import type { WorkflowDefinition } from "./definition-loader.js";
 
@@ -145,8 +145,14 @@ export function writeGraph(runDir: string, graph: WorkflowGraph): void {
 
   const filePath = join(runDir, GRAPH_FILENAME);
   const tmpPath = filePath + ".tmp";
-  const content = stringify(yamlData);
-  writeFileSync(tmpPath, content, "utf-8");
+  const content = Buffer.from(stringify(yamlData), "utf-8");
+  const fd = openSync(tmpPath, "w");
+  try {
+    writeSync(fd, content);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
   // Atomic rename for crash safety
   renameSync(tmpPath, filePath);
 }


### PR DESCRIPTION
Closes #5189

## Root cause
`MemoryStorage.persist()` wrote `db.export()` directly to the live DB path with `writeFileSync(dbPath, bytes)`.

For sql.js, the database is an in-memory image serialized as one full byte buffer. A direct overwrite violates crash-consistency: if the process is hard-killed mid-write, the file can be torn and later fail with `database disk image is malformed`.

Also, plain tmp+rename without flushing can still lose durability across OS/power crashes.

## Fix implemented
### 1) Crash-safe DB snapshot persistence
- Introduced `atomicWriteDbSnapshotSync(dbPath, snapshot)`.
- Switched memory storage persistence to this helper.

### 2) Durability hardening in atomic writer
- Upgraded `atomicWriteFileSync` to:
  1. `openSync(tmp, "w")`
  2. `writeSync(fd, buf)`
  3. `fsyncSync(fd)`
  4. `closeSync(fd)`
  5. `renameSync(tmp, file)`

This protects against both torn writes (process death) and missing flush before rename.

### 3) Follow-up refactor: apply same fsync+rename pattern to state/graph writers
Refactored additional non-DB state writers that used tmp+rename without fsync:
- `src/extension-runtime/extension-registry.ts`
- `packages/pi-coding-agent/src/core/extensions/extension-registry.ts`
- `packages/pi-coding-agent/src/core/discovery-cache.ts`
- `packages/mcp-server/src/readers/graph.ts` (`writeGraph`)
- `src/resources/extensions/gsd/graph.ts` (`writeGraph`)

## Regression guards added
- `packages/pi-coding-agent/src/core/db-snapshot-write-guard.test.ts` ensures all sql.js `db.export()` persistence in `pi-coding-agent/src` uses `atomicWriteDbSnapshotSync`.
- Memory storage source guard + fs-utils durability guard tests.

## Verification
### DB snapshot + atomic helper guards
```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test \
  packages/pi-coding-agent/src/core/db-snapshot-write-guard.test.ts \
  packages/pi-coding-agent/src/core/fs-utils.test.ts \
  packages/pi-coding-agent/src/resources/extensions/memory/storage.test.ts \
  packages/pi-coding-agent/src/resources/extensions/memory/storage-safety-guard.test.ts
```
Result: **12 passed, 0 failed**.

### Refactor validation for extension/discovery/graph writers
```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test \
  src/tests/extension-registry.test.ts \
  packages/pi-coding-agent/src/core/extensions/extension-registry.test.ts \
  packages/pi-coding-agent/src/core/discovery-cache.test.ts \
  packages/mcp-server/src/readers/graph.test.ts \
  src/resources/extensions/gsd/tests/graph-operations.test.ts
```
Result: **79 passed, 0 failed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence reliability to prevent partial or corrupted writes when saving on-disk data.

* **New Features**
  * Added an atomic snapshot write mechanism to make in-memory-to-disk saves more durable.

* **Tests**
  * Added tests ensuring atomic snapshot writes are used and preventing unsafe direct overwrites of live files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->