### PR TITLE
test(e2e): add real-process e2e harness foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,48 @@ jobs:
           export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
           npm run test:live-regression
 
+  e2e:
+    # Real-process e2e tests in tests/e2e/. Spawns the built dist/loader.js
+    # through the shared harness in tests/e2e/_shared/. This is where new
+    # cross-process flows land (fake-LLM agent loops, MCP server, native
+    # ABI, migration chain, etc.) - see tests/e2e/README.md.
+    # No untrusted GitHub event input is consumed in run: blocks.
+    timeout-minutes: 15
+    needs: detect-changes
+    if: needs.detect-changes.outputs.docs-only != 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build core
+        run: npm run build:core
+
+      - name: Run e2e suite (against built binary)
+        run: |
+          chmod +x dist/loader.js
+          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          npm run test:e2e
+
+      - name: Upload e2e artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-artifacts
+          path: test-results/e2e
+          if-no-files-found: ignore
+          retention-days: 7
+
   windows-portability:
     timeout-minutes: 25
     needs: detect-changes

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "docker:build-runtime": "docker build --target runtime -t ghcr.io/gsd-build/gsd-pi .",
     "docker:build-builder": "docker build --target builder -t ghcr.io/gsd-build/gsd-ci-builder .",
     "prepublishOnly": "npm run sync-pkg-version && npm run sync-platform-versions && node scripts/prepublish-check.mjs && npm run build && npm run typecheck:extensions && npm run validate-pack",
-    "test:live-regression": "node --experimental-strip-types tests/live-regression/run.ts"
+    "test:live-regression": "node --experimental-strip-types tests/live-regression/run.ts",
+    "test:e2e": "node --experimental-strip-types --test \"tests/e2e/**/*.e2e.test.ts\""
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,85 @@
+# GSD-2 e2e tests
+
+End-to-end tests that spawn the **real built** `gsd` binary as a child process
+and exercise it through realistic flows.
+
+These exist to catch regressions that mock-heavy unit/integration tests can't:
+real argv parsing, real env handling, real signal/exit behavior, real I/O.
+
+## Running locally
+
+```bash
+npm run build:core
+chmod +x dist/loader.js
+GSD_SMOKE_BINARY="$(pwd)/dist/loader.js" npm run test:e2e
+```
+
+If `GSD_SMOKE_BINARY` is not set, the suite falls back to whatever `gsd`
+resolves on PATH (matching the convention used by `tests/live-regression`).
+
+## Writing a new e2e test
+
+1. Create `tests/e2e/<feature>.e2e.test.ts`. The `.e2e.test.ts` suffix is
+   what `npm run test:e2e` globs.
+2. Use `node:test` + `node:assert/strict`. No Jest, no Vitest.
+3. Use `t.after()` for cleanup. Never `try`/`finally`.
+4. Import helpers from `./_shared/`:
+
+```ts
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { createTmpProject, gsdSync, gsdAsync } from "./_shared/index.ts";
+
+describe("my feature", () => {
+  test("does the thing", (t) => {
+    const project = createTmpProject({ git: true });
+    t.after(project.cleanup);
+
+    const result = gsdSync(["some-command"], { cwd: project.dir });
+
+    assert.equal(result.code, 0);
+    assert.match(result.stdoutClean, /expected output/);
+  });
+});
+```
+
+## Harness contracts (`_shared/`)
+
+- **`spawn.ts`** — `gsdSync` / `gsdAsync` wrappers. Both:
+  - Resolve `GSD_SMOKE_BINARY` → `node <path>` vs PATH `gsd` automatically.
+  - Strip every `GSD_*` env var inherited from the host (prevents local
+    config leaking into CI).
+  - Set `TMPDIR` to the canonical (realpath) tmpdir to avoid the macOS
+    `/var` vs `/private/var` symlink mismatch.
+  - Force `GSD_NON_INTERACTIVE=1`.
+  - Provide ANSI-stripped output via `result.stdoutClean` / `stderrClean`.
+- **`tmp-project.ts`** — `createTmpProject({ git, gsdSkeleton, files })`
+  returns `{ dir, cleanup, writeFile }`. Always wire `t.after(cleanup)`.
+  `git: true` initializes with `--initial-branch=main` for cross-platform
+  determinism.
+- **`artifacts.ts`** — `artifactsFor(testSlug)` returns `{ dir, write }`.
+  Use it to dump logs/screenshots/traces from a test that's about to fail
+  so CI can upload them.
+
+## Anti-patterns to avoid
+
+- ❌ Reading source files and grepping with regex — see "No source-grep
+  tests" in [CONTRIBUTING.md](../../CONTRIBUTING.md). E2e is the wrong layer
+  for that anyway.
+- ❌ Spawning `gsd` directly with `child_process.spawn` — bypasses the
+  env-stripping and TMPDIR fix. Always go through `gsdSync` / `gsdAsync`.
+- ❌ Asserting on raw ANSI-coded output. Use `result.stdoutClean`.
+- ❌ Calling real LLM/network APIs. Future phases land a fake-LLM provider
+  that replays scripted transcripts; until then, e2e tests must avoid any
+  flow that requires network.
+
+## Status
+
+- ✅ Phase 0 (shared harness)
+- ✅ Phase 1a (sanity: `--version`, `--help`, env isolation)
+- ⏳ Phase 1b (fake-LLM provider + agent loop test) — next PR
+- ⏳ Phase 2 (real-process MCP server e2e)
+- ⏳ Phase 6 (native TS↔Rust ABI smoke)
+- ⏳ Phase 7 (migration smoke)
+
+See the e2e remediation plan in the parent PR description for the full sequence.

--- a/tests/e2e/_shared/artifacts.ts
+++ b/tests/e2e/_shared/artifacts.ts
@@ -1,0 +1,40 @@
+/**
+ * GSD-2 e2e harness: artifact collection.
+ *
+ * Each e2e test gets a unique artifacts directory. Logs, screenshots, and
+ * traces written here are uploaded by CI on failure. Locally they help
+ * post-mortem a flake without re-running the test.
+ *
+ * Configure with E2E_ARTIFACTS_DIR (defaults to ./test-results/e2e under cwd).
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+function rootArtifactsDir(): string {
+	return resolve(process.env.E2E_ARTIFACTS_DIR ?? join(process.cwd(), "test-results", "e2e"));
+}
+
+export interface ArtifactSink {
+	dir: string;
+	write: (filename: string, content: string | Buffer) => string;
+}
+
+/**
+ * Create an artifacts directory for a single test. The slug is sanitized
+ * to be path-safe across platforms. Returns the dir + a writer.
+ */
+export function artifactsFor(testSlug: string): ArtifactSink {
+	const safe = testSlug.replace(/[^a-zA-Z0-9_.-]+/g, "_").slice(0, 80);
+	const dir = join(rootArtifactsDir(), `${Date.now()}_${safe}`);
+	mkdirSync(dir, { recursive: true });
+	return {
+		dir,
+		write: (filename, content) => {
+			const safeName = filename.replace(/[^a-zA-Z0-9_.-]+/g, "_");
+			const abs = join(dir, safeName);
+			writeFileSync(abs, content);
+			return abs;
+		},
+	};
+}

--- a/tests/e2e/_shared/index.ts
+++ b/tests/e2e/_shared/index.ts
@@ -1,0 +1,11 @@
+/**
+ * GSD-2 e2e harness barrel.
+ *
+ * Tests in tests/e2e/ should import from this single entry point so the
+ * harness surface stays small and stable. New helpers go in their own file
+ * here, then are re-exported from this barrel.
+ */
+
+export * from "./spawn.ts";
+export * from "./tmp-project.ts";
+export * from "./artifacts.ts";

--- a/tests/e2e/_shared/spawn.ts
+++ b/tests/e2e/_shared/spawn.ts
@@ -1,0 +1,192 @@
+/**
+ * GSD-2 e2e harness: process spawning.
+ *
+ * Wraps child_process.spawn with the conventions every e2e test needs:
+ * - canonical TMPDIR (resolves macOS /var vs /private/var symlink mismatch)
+ * - deterministic env (strips inherited GSD_* vars that leak from the host)
+ * - ANSI stripping
+ * - timeout + orphan kill
+ * - ready-signal helper for long-running processes
+ *
+ * Use this instead of calling spawn / spawnSync directly in e2e tests.
+ */
+
+import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+const ANSI_REGEX = /\x1b\[[0-9;]*[a-zA-Z]/g;
+
+/** Strip ANSI escape sequences. Use on stdout/stderr before assertions. */
+export function stripAnsi(s: string): string {
+	return s.replace(ANSI_REGEX, "");
+}
+
+/**
+ * Canonical OS tmpdir. macOS reports /var/folders/... but realpath gives
+ * /private/var/folders/... — child processes see the canonical form, and
+ * mismatched parents cause flaky path comparisons. Always use this.
+ */
+export function canonicalTmpdir(): string {
+	try {
+		return realpathSync(tmpdir());
+	} catch {
+		return tmpdir();
+	}
+}
+
+export interface E2eEnv {
+	/** Override binary path. Defaults to GSD_SMOKE_BINARY or "gsd". */
+	binary?: string;
+	/** Working directory for the spawned process. */
+	cwd: string;
+	/** Extra env vars merged on top of the cleaned base env. */
+	env?: Record<string, string>;
+	/** Timeout in ms. Default 30_000. */
+	timeoutMs?: number;
+}
+
+/**
+ * Build the env for an e2e child process. Strips GSD_* vars from the host
+ * (so a developer's local config does not leak into a test) but keeps PATH,
+ * HOME, and the standard system vars.
+ */
+export function buildE2eEnv(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
+	const base: NodeJS.ProcessEnv = {};
+	for (const [k, v] of Object.entries(process.env)) {
+		if (k.startsWith("GSD_")) continue;
+		base[k] = v;
+	}
+	// Force non-interactive — every e2e test runs in CI by default.
+	base.GSD_NON_INTERACTIVE = "1";
+	// Keep TMPDIR canonical for the child too.
+	base.TMPDIR = canonicalTmpdir();
+	return { ...base, ...extra };
+}
+
+export interface SpawnSyncResult {
+	stdout: string;
+	stderr: string;
+	stdoutClean: string;
+	stderrClean: string;
+	code: number | null;
+	signal: NodeJS.Signals | null;
+	timedOut: boolean;
+}
+
+/**
+ * Resolve the binary + argv for invoking the gsd CLI.
+ *
+ * GSD_SMOKE_BINARY=path/to/loader.js → spawn `node path/to/loader.js ...`
+ * (default "gsd")                    → spawn `gsd ...`
+ *
+ * Mirrors the convention used by tests/live-regression/run.ts.
+ */
+export function resolveGsdInvocation(args: string[], binaryOverride?: string): {
+	command: string;
+	argv: string[];
+} {
+	const binary = binaryOverride ?? process.env.GSD_SMOKE_BINARY ?? "gsd";
+	if (binary === "gsd") {
+		return { command: "gsd", argv: args };
+	}
+	return { command: process.execPath, argv: [binary, ...args] };
+}
+
+/** Synchronous spawn. Use for short, deterministic CLI calls (`--version`, etc). */
+export function gsdSync(args: string[], env: E2eEnv): SpawnSyncResult {
+	const { command, argv } = resolveGsdInvocation(args, env.binary);
+	const result = spawnSync(command, argv, {
+		cwd: env.cwd,
+		encoding: "utf8",
+		timeout: env.timeoutMs ?? 30_000,
+		stdio: ["pipe", "pipe", "pipe"],
+		env: buildE2eEnv(env.env),
+	});
+	const stdout = result.stdout ?? "";
+	const stderr = result.stderr ?? "";
+	return {
+		stdout,
+		stderr,
+		stdoutClean: stripAnsi(stdout),
+		stderrClean: stripAnsi(stderr),
+		code: result.status,
+		signal: result.signal,
+		timedOut: result.error?.code === "ETIMEDOUT" || (result.signal === "SIGTERM" && result.status === null),
+	};
+}
+
+export interface AsyncChild {
+	child: ChildProcess;
+	stdout: () => string;
+	stderr: () => string;
+	/** Resolves when stdout or stderr matches the predicate. Rejects on timeout. */
+	waitFor: (predicate: (out: { stdout: string; stderr: string }) => boolean, timeoutMs?: number) => Promise<void>;
+	/** Send SIGTERM, then SIGKILL after grace period. */
+	kill: (graceMs?: number) => Promise<void>;
+	/** Resolves when the process exits, returning its result. */
+	done: () => Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+}
+
+/**
+ * Spawn the gsd CLI as a long-running child. Caller is responsible for
+ * calling `.kill()` (typically via t.after).
+ */
+export function gsdAsync(args: string[], env: E2eEnv, opts: SpawnOptions = {}): AsyncChild {
+	const { command, argv } = resolveGsdInvocation(args, env.binary);
+	const child = spawn(command, argv, {
+		cwd: env.cwd,
+		stdio: ["pipe", "pipe", "pipe"],
+		env: buildE2eEnv(env.env),
+		...opts,
+	});
+
+	let stdoutBuf = "";
+	let stderrBuf = "";
+	child.stdout?.setEncoding("utf8");
+	child.stderr?.setEncoding("utf8");
+	child.stdout?.on("data", (chunk: string) => {
+		stdoutBuf += chunk;
+	});
+	child.stderr?.on("data", (chunk: string) => {
+		stderrBuf += chunk;
+	});
+
+	const exitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+		child.once("exit", (code, signal) => resolve({ code, signal }));
+	});
+
+	return {
+		child,
+		stdout: () => stdoutBuf,
+		stderr: () => stderrBuf,
+		async waitFor(predicate, timeoutMs = 30_000) {
+			const start = Date.now();
+			while (Date.now() - start < timeoutMs) {
+				if (predicate({ stdout: stdoutBuf, stderr: stderrBuf })) return;
+				if (child.exitCode !== null) {
+					throw new Error(
+						`process exited (code=${child.exitCode}) before predicate matched.\nstdout: ${stdoutBuf}\nstderr: ${stderrBuf}`,
+					);
+				}
+				await new Promise((r) => setTimeout(r, 50));
+			}
+			throw new Error(
+				`waitFor timed out after ${timeoutMs}ms.\nstdout: ${stdoutBuf}\nstderr: ${stderrBuf}`,
+			);
+		},
+		async kill(graceMs = 2000) {
+			if (child.exitCode !== null || child.signalCode !== null) return;
+			child.kill("SIGTERM");
+			const killed = await Promise.race([
+				exitPromise.then(() => true),
+				new Promise<boolean>((r) => setTimeout(() => r(false), graceMs)),
+			]);
+			if (!killed && child.exitCode === null) {
+				child.kill("SIGKILL");
+				await exitPromise;
+			}
+		},
+		done: () => exitPromise,
+	};
+}

--- a/tests/e2e/_shared/tmp-project.ts
+++ b/tests/e2e/_shared/tmp-project.ts
@@ -1,0 +1,68 @@
+/**
+ * GSD-2 e2e harness: temporary project scaffolding.
+ *
+ * Creates a fresh isolated tmp dir for an e2e test, optionally seeded
+ * with a git repo and/or a minimal `.gsd/` skeleton. Caller wires cleanup
+ * via t.after() per the project testing standards (no try/finally).
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { canonicalTmpdir } from "./spawn.ts";
+
+export interface TmpProjectOptions {
+	/** Run `git init` and create an initial empty commit. */
+	git?: boolean;
+	/** Create an empty `.gsd/` directory (does not create milestones). */
+	gsdSkeleton?: boolean;
+	/** Files to write into the project before any test action. */
+	files?: Record<string, string>;
+}
+
+export interface TmpProject {
+	dir: string;
+	cleanup: () => void;
+	writeFile: (relPath: string, content: string) => void;
+}
+
+/**
+ * Create an isolated tmp project. Returns the absolute path and a cleanup
+ * function. Always wrap with `t.after(project.cleanup)`.
+ */
+export function createTmpProject(opts: TmpProjectOptions = {}): TmpProject {
+	const dir = mkdtempSync(join(canonicalTmpdir(), "gsd-e2e-"));
+
+	if (opts.gsdSkeleton) {
+		mkdirSync(join(dir, ".gsd"), { recursive: true });
+	}
+
+	if (opts.files) {
+		for (const [rel, content] of Object.entries(opts.files)) {
+			const abs = join(dir, rel);
+			mkdirSync(join(abs, ".."), { recursive: true });
+			writeFileSync(abs, content);
+		}
+	}
+
+	if (opts.git) {
+		// --initial-branch is required on modern Git in CI; bare `git init`
+		// produces inconsistent default branch names across environments.
+		execFileSync("git", ["init", "--initial-branch=main"], { cwd: dir, stdio: "pipe" });
+		execFileSync("git", ["config", "user.email", "e2e@gsd.test"], { cwd: dir, stdio: "pipe" });
+		execFileSync("git", ["config", "user.name", "GSD E2E"], { cwd: dir, stdio: "pipe" });
+		execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: dir, stdio: "pipe" });
+	}
+
+	return {
+		dir,
+		cleanup: () => {
+			rmSync(dir, { recursive: true, force: true });
+		},
+		writeFile: (relPath, content) => {
+			const abs = join(dir, relPath);
+			mkdirSync(join(abs, ".."), { recursive: true });
+			writeFileSync(abs, content);
+		},
+	};
+}

--- a/tests/e2e/sanity.e2e.test.ts
+++ b/tests/e2e/sanity.e2e.test.ts
@@ -1,0 +1,77 @@
+/**
+ * GSD-2 e2e sanity tests.
+ *
+ * Smallest possible vertical slice that exercises the e2e harness through
+ * a real spawn of the built `gsd` binary. If this suite passes, the harness
+ * + CI wiring + binary build are working. Every later e2e suite builds on
+ * the same shared helpers in `_shared/`.
+ *
+ * Requires GSD_SMOKE_BINARY to point at the built loader (e.g. dist/loader.js)
+ * unless `gsd` is on PATH.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+
+import { createTmpProject, gsdSync } from "./_shared/index.ts";
+
+function binaryAvailable(): { ok: boolean; reason?: string } {
+	const bin = process.env.GSD_SMOKE_BINARY;
+	if (!bin) return { ok: false, reason: "GSD_SMOKE_BINARY not set; build with `npm run build:core` and re-export." };
+	if (!existsSync(bin)) return { ok: false, reason: `binary not found at ${bin}` };
+	return { ok: true };
+}
+
+describe("e2e sanity (real-process)", () => {
+	const avail = binaryAvailable();
+	const skipReason = avail.ok ? null : avail.reason;
+
+	test("gsd --version prints a semver and exits 0", { skip: skipReason ?? false }, (t) => {
+		const project = createTmpProject();
+		t.after(project.cleanup);
+
+		const result = gsdSync(["--version"], { cwd: project.dir, timeoutMs: 15_000 });
+
+		assert.equal(result.code, 0, `expected exit 0, got ${result.code}. stderr=${result.stderrClean}`);
+		assert.ok(!result.timedOut, "spawn timed out");
+		assert.match(
+			result.stdoutClean.trim(),
+			/\d+\.\d+\.\d+/,
+			`expected semver in stdout, got: ${result.stdoutClean.trim()}`,
+		);
+	});
+
+	test("gsd --help mentions usage and exits 0", { skip: skipReason ?? false }, (t) => {
+		const project = createTmpProject();
+		t.after(project.cleanup);
+
+		const result = gsdSync(["--help"], { cwd: project.dir, timeoutMs: 15_000 });
+
+		assert.equal(result.code, 0, `expected exit 0, got ${result.code}. stderr=${result.stderrClean}`);
+		const out = result.stdoutClean.toLowerCase();
+		assert.ok(
+			out.includes("usage") || out.includes("commands") || out.includes("options"),
+			`expected --help output to mention usage/commands/options, got: ${result.stdoutClean.slice(0, 400)}`,
+		);
+	});
+
+	test("inherited GSD_* env vars do not leak into the child", { skip: skipReason ?? false }, (t) => {
+		// Sanity check on the harness itself — buildE2eEnv() should strip GSD_* from the
+		// host. We verify by ensuring --version still succeeds even when a noisy GSD_*
+		// var is set in the parent that would, if leaked, break the child's startup.
+		// This protects against the harness regressing into a "leaks env" footgun.
+		const project = createTmpProject();
+		t.after(project.cleanup);
+
+		const previous = process.env.GSD_FORCE_BAD_CONFIG;
+		process.env.GSD_FORCE_BAD_CONFIG = "/nonexistent/path/that/should/never/be/read";
+		t.after(() => {
+			if (previous === undefined) delete process.env.GSD_FORCE_BAD_CONFIG;
+			else process.env.GSD_FORCE_BAD_CONFIG = previous;
+		});
+
+		const result = gsdSync(["--version"], { cwd: project.dir, timeoutMs: 15_000 });
+		assert.equal(result.code, 0, `expected child to ignore parent GSD_*; got code=${result.code} stderr=${result.stderrClean}`);
+	});
+});


### PR DESCRIPTION
## Why

A 7-agent audit + Codex peer review of e2e coverage across the repo found that the test suite is heavy on units/mocks and almost never crosses real process boundaries in PR CI. Playwright is installed but unused; VSCode and the standalone web-host build run zero runtime tests; subagent/auto-loop/MCP coverage is schema-only. The deeper smell: integration-layer tests use the same fast/isolated/mock-heavy patterns as units, producing false confidence.

This PR is **Wave 0 + Phase 1a** of the remediation plan — a shared real-process harness and one sanity slice that proves the pattern. Future PRs land on top of this foundation.

## What

### Wave 0 — shared harness (`tests/e2e/_shared/`)
- **`spawn.ts`** — `gsdSync` / `gsdAsync` that:
  - Resolve `GSD_SMOKE_BINARY` → `node <path>` vs PATH `gsd` (matches `tests/live-regression`).
  - Canonicalize `TMPDIR` via `realpath()` — fixes the macOS `/var` vs `/private/var` symlink flake before the first test hits it.
  - Strip every `GSD_*` env var inherited from the host so a developer's local config can't leak into CI.
  - Force `GSD_NON_INTERACTIVE=1` on every spawn.
  - Provide ANSI-stripped output (`stdoutClean` / `stderrClean`) and a `waitFor` predicate for long-running children.
- **`tmp-project.ts`** — `createTmpProject({ git, gsdSkeleton, files })`. `git: true` uses `--initial-branch=main` for cross-platform determinism (modern Git in CI defaults are inconsistent without it).
- **`artifacts.ts`** — per-test artifact dir under `test-results/e2e`. CI uploads on failure.

### Phase 1a — sanity slice (`tests/e2e/sanity.e2e.test.ts`)
Three node:test tests against the real built `dist/loader.js`:
1. `--version` exits 0 and prints semver.
2. `--help` exits 0 and mentions usage/commands/options.
3. A guard test: setting a hostile `GSD_*` env var in the parent must **not** leak into the child. Protects the harness itself from regressing.

### Wiring
- `npm run test:e2e` — globs `tests/e2e/**/*.e2e.test.ts` via `node:test`.
- New CI job `e2e` mirrors `live-regression`: builds core, exports `GSD_SMOKE_BINARY`, runs the suite, uploads `test-results/e2e` on failure.

## Conventions followed (per CONTRIBUTING.md)
- ✅ `node:test` + `node:assert/strict` (no Jest/Vitest).
- ✅ `t.after()` for cleanup, no `try`/`finally`.
- ✅ No source-grep tests — every assertion runs the real binary.
- ✅ Tests for both success path (`--version`, `--help`) and a failure-path guard (env leakage).
- ✅ Conventional commit subject (`test(e2e): ...`).

## Local verification

```
npm run build:core
chmod +x dist/loader.js
GSD_SMOKE_BINARY="$(pwd)/dist/loader.js" npm run test:e2e
```

Output:
```
▶ e2e sanity (real-process)
  ✔ gsd --version prints a semver and exits 0
  ✔ gsd --help mentions usage and exits 0
  ✔ inherited GSD_* env vars do not leak into the child
✔ e2e sanity (real-process)
ℹ tests 3, pass 3, fail 0
```

`npm run verify:pr` — 8591 passed. The 21 failures present are pre-existing template-loader errors on this branch (worktree was 239 commits behind main); none of my changes touch the template loader, the `dist-test/` build, or any source under `src/` or `packages/`.

## Roadmap (deferred to subsequent PRs)

Each phase is a separate PR built on this harness — no overlap with the foundation PR.

| Phase | Scope |
|---|---|
| 1b | Fake-LLM provider (deterministic JSONL replay; key on full request shape, not prompt hash) + first agent-loop test. Failure-mode fixtures (429, malformed JSON, timeout) included from day one. |
| 6  | Native TS↔Rust ABI smoke — load `packages/native` from a fresh process, exercise grep/AST/xxhash on linux-x64 + darwin-arm64. |
| 7  | Migration smoke — fixture DBs at v1/v5/v10/v15 → migrate to latest. (No rollback test; not a shipped feature.) |
| 2  | Real-process MCP server e2e — start narrow: `initialize` + `list_tools` + 3 high-risk tools. |
| 3  | VSCode extension — `@vscode/test-electron` activation only first; webview round-trips follow. |
| 4  | Web Playwright smoke — 3 flows (shell loads, auth-token rejection, terminal click round-trip). |
| 5  | github-sync sandbox — ephemeral `git init`, scriptable `gh` shim with PATH-isolation guard. |
| 8  | Subagent + auto-loop multi-iteration (depends on 1b). |
| 9  | Slash command / skill e2e (depends on 1b). |
| 10 | Release artifacts — `npm pack` install smoke, VSIX activation. |
| 11 | OAuth stub + telemetry redaction. |
| 12 | Incremental CI gate promotion (quarantine → required as suites stabilize). |

**Out of scope per peer review**: Studio/Electron (deferred until shipping), Docker runtime test, full 37-tool MCP matrix, Windows runner (linux + darwin first), broad rollback testing.

## Test plan

- [x] `npm run build:core` succeeds.
- [x] `GSD_SMOKE_BINARY=$(pwd)/dist/loader.js npm run test:e2e` — 3/3 pass locally.
- [x] `verify:pr` — only pre-existing failures present.
- [ ] CI `e2e` job green on this PR.
- [ ] CI `live-regression` still green (job is unchanged).
- [ ] On a deliberately failing test, confirm `test-results/e2e` artifacts upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced comprehensive end-to-end testing suite to validate real-world binary execution and cross-process scenarios
  * Integrated automated testing into CI/CD pipeline for continuous validation
  * Added initial sanity checks for binary version reporting, help command functionality, and environment isolation

* **Documentation**
  * Added comprehensive guide documenting e2e test authoring patterns, best practices, and anti-patterns to avoid

<!-- end of auto-generated comment: release notes by coderabbit.ai -->