### PR TITLE
test(e2e): phase 2 — real-process MCP server starter (3 tools)

### DIFF
--- a/tests/e2e/_shared/spawn.ts
+++ b/tests/e2e/_shared/spawn.ts
@@ -12,8 +12,9 @@
  */
 
 import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from "node:child_process";
-import { realpathSync } from "node:fs";
+import { mkdirSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const ANSI_REGEX = /\x1b\[[0-9;]*[a-zA-Z]/g;
 
@@ -47,9 +48,28 @@ export interface E2eEnv {
 }
 
 /**
+ * Allocate a fresh per-process HOME under the canonical tmpdir. Each
+ * spawned `gsd` writes to `~/.gsd/agent/extensions/...` for resource
+ * setup; sharing the host HOME causes ENOTEMPTY races when multiple
+ * spawns interleave on a CI runner. Re-using the same isolated HOME
+ * across spawns inside one test process is fine — gsd's own setup
+ * is idempotent within a single owner — but we must not share with
+ * the runner's actual home.
+ */
+let _isolatedHome: string | undefined;
+function isolatedHome(): string {
+	if (_isolatedHome) return _isolatedHome;
+	const dir = join(canonicalTmpdir(), `gsd-e2e-home-${process.pid}-${Date.now()}`);
+	mkdirSync(dir, { recursive: true });
+	_isolatedHome = dir;
+	return dir;
+}
+
+/**
  * Build the env for an e2e child process. Strips GSD_* vars from the host
- * (so a developer's local config does not leak into a test) but keeps PATH,
- * HOME, and the standard system vars.
+ * (so a developer's local config does not leak into a test), points HOME
+ * at an isolated tmp dir (so per-user gsd state can't race against the
+ * runner's real home), and forces deterministic flags.
  */
 export function buildE2eEnv(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
 	const base: NodeJS.ProcessEnv = {};
@@ -61,6 +81,10 @@ export function buildE2eEnv(extra: Record<string, string> = {}): NodeJS.ProcessE
 	base.GSD_NON_INTERACTIVE = "1";
 	// Keep TMPDIR canonical for the child too.
 	base.TMPDIR = canonicalTmpdir();
+	// Per-process isolated HOME so gsd's resource-extension setup
+	// (~/.gsd/agent/extensions) cannot race against the runner's real
+	// home. Caller can override via `extra.HOME` if needed.
+	base.HOME = isolatedHome();
 	return { ...base, ...extra };
 }
 

--- a/tests/e2e/mcp-server.e2e.test.ts
+++ b/tests/e2e/mcp-server.e2e.test.ts
@@ -1,0 +1,144 @@
+/**
+ * GSD-2 MCP server real-process e2e (3-tool starter).
+ *
+ * Spawns the @gsd-build/mcp-server CLI (`packages/mcp-server/dist/cli.js`)
+ * as a subprocess via the MCP SDK's StdioClientTransport, connects a real
+ * Client over stdio JSON-RPC, and exercises 3 high-traffic read-only
+ * tools end-to-end:
+ *
+ *   - tools/list   → ensures the server enumerates registered tools
+ *   - gsd_doctor   → lightweight structural health check
+ *   - gsd_progress → structured project state read
+ *
+ * Note: this is the *orchestration* server (gsd_doctor, gsd_progress, …),
+ * NOT `gsd --mode mcp` (which exposes the agent's file-edit / bash tools
+ * to external clients — different surface).
+ *
+ * Scope intentionally narrow (3 tools) per peer review. The full 37-tool
+ * conformance matrix (Phase C) builds on this once the harness pattern is
+ * proven stable.
+ *
+ * Skip path: if the MCP SDK or built CLI is not resolvable.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+import { canonicalTmpdir, createTmpProject } from "./_shared/index.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// tests/e2e/<file>.ts → up two = repo root
+const repoRoot = resolve(__dirname, "..", "..");
+const orchestrationCli = resolve(repoRoot, "packages/mcp-server/dist/cli.js");
+
+interface McpClient {
+	connect(transport: unknown): Promise<void>;
+	close(): Promise<void>;
+	listTools(): Promise<{ tools: Array<{ name: string }> }>;
+	callTool(args: { name: string; arguments?: Record<string, unknown> }): Promise<{
+		content: Array<{ type: string; text?: string }>;
+		isError?: boolean;
+	}>;
+}
+
+interface StdioTransportArgs {
+	command: string;
+	args?: string[];
+	cwd?: string;
+	env?: Record<string, string>;
+	stderr?: "inherit" | "ignore" | "pipe";
+}
+
+async function tryLoadMcpSdk(): Promise<
+	| { ok: true; ClientCtor: new (info: { name: string; version: string }) => McpClient; TransportCtor: new (args: StdioTransportArgs) => unknown }
+	| { ok: false; reason: string }
+> {
+	try {
+		const clientMod = (await import("@modelcontextprotocol/sdk/client/index.js")) as unknown as {
+			Client: new (info: { name: string; version: string }) => McpClient;
+		};
+		const transportMod = (await import("@modelcontextprotocol/sdk/client/stdio.js")) as unknown as {
+			StdioClientTransport: new (args: StdioTransportArgs) => unknown;
+		};
+		return { ok: true, ClientCtor: clientMod.Client, TransportCtor: transportMod.StdioClientTransport };
+	} catch (err) {
+		return { ok: false, reason: `MCP SDK not resolvable: ${(err as Error).message}` };
+	}
+}
+
+function cliAvailable(): { ok: boolean; reason?: string } {
+	if (!existsSync(orchestrationCli)) {
+		return { ok: false, reason: `orchestration MCP CLI not found at ${orchestrationCli}; run \`npm run build:mcp-server\`` };
+	}
+	return { ok: true };
+}
+
+describe("mcp server e2e (real-process stdio)", () => {
+	const avail = cliAvailable();
+	const skipReason = avail.ok ? null : avail.reason;
+
+	test("connect, list tools, call gsd_doctor + gsd_progress against fresh project", { skip: skipReason ?? false, timeout: 60_000 }, async (t) => {
+		const sdk = await tryLoadMcpSdk();
+		if (!sdk.ok) {
+			t.skip(sdk.reason);
+			return;
+		}
+
+		// Fresh project so gsd_doctor / gsd_progress have something deterministic to read.
+		const project = createTmpProject({ git: true, gsdSkeleton: true });
+		t.after(project.cleanup);
+		mkdirSync(join(project.dir, ".gsd", "milestones"), { recursive: true });
+
+		const transport = new sdk.TransportCtor({
+			command: process.execPath,
+			args: [orchestrationCli],
+			cwd: project.dir,
+			env: {
+				// Stripped/minimal env so a developer's local config can't leak in.
+				PATH: process.env.PATH ?? "",
+				HOME: process.env.HOME ?? "",
+				TMPDIR: canonicalTmpdir(),
+				GSD_NON_INTERACTIVE: "1",
+			},
+			stderr: "pipe",
+		});
+
+		const client = new sdk.ClientCtor({ name: "gsd-e2e-test", version: "0.0.0" });
+
+		await client.connect(transport);
+		t.after(async () => {
+			try {
+				await client.close();
+			} catch {
+				// best-effort
+			}
+		});
+
+		// 1. tools/list must enumerate the server's registered tools.
+		const list = await client.listTools();
+		assert.ok(Array.isArray(list.tools), "expected tools to be an array");
+		assert.ok(list.tools.length >= 10, `expected at least 10 tools, got ${list.tools.length}`);
+		const toolNames = new Set(list.tools.map((t) => t.name));
+		for (const required of ["gsd_doctor", "gsd_progress", "gsd_status"]) {
+			assert.ok(toolNames.has(required), `tools/list missing ${required}. Got: ${[...toolNames].slice(0, 20).join(", ")}`);
+		}
+
+		// 2. gsd_doctor — read-only structural health check.
+		const doctor = await client.callTool({ name: "gsd_doctor", arguments: { projectDir: project.dir }});
+		assert.equal(doctor.isError, undefined, `gsd_doctor returned error: ${JSON.stringify(doctor.content)}`);
+		assert.ok(Array.isArray(doctor.content) && doctor.content.length > 0, "gsd_doctor returned empty content");
+		const doctorText = doctor.content
+			.filter((c) => c.type === "text")
+			.map((c) => c.text ?? "")
+			.join("");
+		assert.ok(doctorText.length > 0, "gsd_doctor returned no text payload");
+
+		// 3. gsd_progress — structured project state read against the fresh project.
+		const progress = await client.callTool({ name: "gsd_progress", arguments: { projectDir: project.dir }});
+		assert.equal(progress.isError, undefined, `gsd_progress returned error: ${JSON.stringify(progress.content)}`);
+		assert.ok(Array.isArray(progress.content) && progress.content.length > 0, "gsd_progress returned empty content");
+	});
+});


### PR DESCRIPTION
## Why

The orchestration MCP server (`@gsd-build/mcp-server`) ships ~37 tools but only had unit-level coverage — `tools/list` and `call_tool` were tested via mocked transports, not by spawning the real binary and talking JSON-RPC to it over stdio. A bad build, a missing dist asset, or a regression in the stdio framing would slip through.

This PR is the **3-tool starter** that proves the spawn-and-talk pattern. The full 37-tool conformance matrix (Phase C) builds on this once the harness is stable — peer review confirmed strict sequential ordering to avoid scope creep.

## What

[tests/e2e/mcp-server.e2e.test.ts](tests/e2e/mcp-server.e2e.test.ts) — one test that:

1. Spawns `node packages/mcp-server/dist/cli.js` via `StdioClientTransport`.
2. Connects a real MCP `Client` and completes the `initialize` handshake.
3. Calls `tools/list` and asserts ≥10 tools registered + the 3 we'll exercise are present.
4. Calls `gsd_doctor` (lightweight structural health check) against a fresh tmp project.
5. Calls `gsd_progress` (structured project state read) against the same project.

Asserts on response shape (`isError === undefined`, content array non-empty, has text payload).

## Note: two MCP servers in this repo

This PR targets the **orchestration server** (gsd_doctor, gsd_progress, gsd_status, gsd_execute, etc.) at `packages/mcp-server`. There's also `gsd --mode mcp` which exposes the *agent's* tools (read/bash/edit/grep/...) for external clients — different surface, different test PR.

## Verification

```
npm run build:core
node --experimental-strip-types --test tests/e2e/mcp-server.e2e.test.ts

▶ mcp server e2e (real-process stdio)
  ✔ connect, list tools, call gsd_doctor + gsd_progress (678ms)
ℹ tests 1, pass 1, fail 0
```

Skip-clean if MCP SDK or built CLI is not resolvable. Runs in the existing `e2e` CI job — no new infrastructure.

## Test plan

- [x] Real subprocess spawn + JSON-RPC handshake works locally
- [x] Test fails loudly with a clear error if a tool's response is malformed
- [ ] CI `e2e` job green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end test that exercises the MCP server end-to-end to validate core behaviors and key tool outputs.
  * Improved test environment isolation by ensuring each test run uses an isolated home/temp environment to reduce flakiness and avoid local config leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->