### PR TITLE
test(e2e): phase 8 — multi-iteration agent loop + safeguard pin

### DIFF
--- a/packages/pi-ai/src/models/fake-model.ts
+++ b/packages/pi-ai/src/models/fake-model.ts
@@ -1,0 +1,30 @@
+/**
+ * GSD-2 fake model — paired with the fake LLM provider for e2e tests.
+ *
+ * Only registered when `GSD_FAKE_LLM_TRANSCRIPT` env var is set, via the
+ * conditional branch in models/index.ts. The model is invisible to normal
+ * users; it shows up in `--list-models` only inside e2e test subprocesses.
+ */
+
+import type { Model } from "../types.js";
+
+export const FAKE_PROVIDER = "gsd-fake" as const;
+export const FAKE_MODEL_ID = "gsd-fake-model" as const;
+
+export const FAKE_MODEL: Model<"fake"> = {
+	id: FAKE_MODEL_ID,
+	name: "GSD Fake (e2e replay)",
+	api: "fake",
+	provider: FAKE_PROVIDER,
+	baseUrl: "https://fake.gsd.local/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+	},
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};

--- a/packages/pi-ai/src/models/index.ts
+++ b/packages/pi-ai/src/models/index.ts
@@ -1,6 +1,7 @@
 import { MODELS } from "./generated/index.js";
 import { CUSTOM_MODELS } from "./custom.js";
 import { CAPABILITY_PATCHES, applyCapabilityPatches } from "./capability-patches.js";
+import { FAKE_MODEL, FAKE_MODEL_ID, FAKE_PROVIDER } from "./fake-model.js";
 import type { Api, KnownProvider, Model, Usage } from "../types.js";
 
 const modelRegistry: Map<string, Map<string, Model<Api>>> = new Map();
@@ -27,6 +28,14 @@ for (const [provider, models] of Object.entries(CUSTOM_MODELS)) {
 			providerModels.set(id, model as Model<Api>);
 		}
 	}
+}
+
+// E2E-test-only: register the fake model when GSD_FAKE_LLM_TRANSCRIPT is set.
+// Env var must be set BEFORE this module is imported. See providers/fake.ts.
+if (process.env.GSD_FAKE_LLM_TRANSCRIPT) {
+	const providerModels = new Map<string, Model<Api>>();
+	providerModels.set(FAKE_MODEL_ID, FAKE_MODEL as Model<Api>);
+	modelRegistry.set(FAKE_PROVIDER, providerModels);
 }
 
 // Apply patches to the static registry at module load

--- a/packages/pi-ai/src/providers/fake.ts
+++ b/packages/pi-ai/src/providers/fake.ts
@@ -1,0 +1,376 @@
+/**
+ * GSD-2 fake LLM provider — deterministic JSONL replay for e2e tests.
+ *
+ * Activated only when `GSD_FAKE_LLM_TRANSCRIPT` env var is set. Reads a
+ * JSONL transcript file (one turn per line) and replays scripted responses
+ * sequentially. Each turn carries structural assertions about the incoming
+ * request — if the request shape drifts, the provider fails loudly so tests
+ * surface it instead of silently consuming wrong inputs.
+ *
+ * IMPORTANT: env var must be set BEFORE pi-ai is imported. Tests achieve
+ * this by setting it on the subprocess they spawn. In-process tests cannot
+ * mix fake and real providers in the same Node process.
+ *
+ * Transcript format (JSONL, one turn per line):
+ *   {
+ *     "turn": 1,
+ *     "expect": {
+ *       "modelId": "gsd-fake-model",
+ *       "messageCount": 2,            // optional, exact match
+ *       "lastUserText": "do X",       // optional, substring match
+ *       "systemContains": ["..."],    // optional, all must be present
+ *       "toolNames": ["read_file"],   // optional, exact set
+ *       "hasToolResultFor": "read_file" // optional, last message is a toolResult for this name
+ *     },
+ *     "emit": { "kind": "text", "text": "...", "stopReason": "stop" }
+ *       | { "kind": "tool_use", "calls": [...], "stopReason": "toolUse" }
+ *       | { "kind": "error_429", "message": "rate limited", "retryAfterMs": 1000 }
+ *       | { "kind": "malformed" }
+ *       | { "kind": "timeout", "delayMs": 60000 }
+ *   }
+ */
+
+import { readFileSync } from "node:fs";
+import type { ApiProvider } from "../api-registry.js";
+import type {
+	AssistantMessage,
+	Context,
+	Model,
+	SimpleStreamOptions,
+	StreamOptions,
+	ToolCall,
+	UserMessage,
+} from "../types.js";
+import { AssistantMessageEventStream } from "../utils/event-stream.js";
+
+export const FAKE_API = "fake" as const;
+
+interface ExpectFields {
+	modelId?: string;
+	messageCount?: number;
+	lastUserText?: string;
+	systemContains?: string[];
+	toolNames?: string[];
+	hasToolResultFor?: string;
+}
+
+type EmitSpec =
+	| { kind: "text"; text: string; stopReason?: "stop" | "length" }
+	| {
+			kind: "tool_use";
+			calls: { id?: string; name: string; input: Record<string, unknown> }[];
+			stopReason?: "toolUse";
+	  }
+	| { kind: "error_429"; message?: string; retryAfterMs?: number }
+	| { kind: "malformed"; message?: string }
+	| { kind: "timeout"; delayMs?: number };
+
+interface TranscriptTurn {
+	turn: number;
+	expect?: ExpectFields;
+	emit: EmitSpec;
+}
+
+function parseTranscript(path: string): TranscriptTurn[] {
+	const raw = readFileSync(path, "utf8");
+	const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+	const turns: TranscriptTurn[] = [];
+	for (const [i, line] of lines.entries()) {
+		try {
+			turns.push(JSON.parse(line));
+		} catch (err) {
+			throw new Error(
+				`fake-llm: failed to parse transcript ${path} line ${i + 1}: ${(err as Error).message}\n  line: ${line}`,
+			);
+		}
+	}
+	return turns;
+}
+
+function lastUserMessage(ctx: Context): UserMessage | undefined {
+	for (let i = ctx.messages.length - 1; i >= 0; i--) {
+		const m = ctx.messages[i];
+		if (m.role === "user") return m;
+	}
+	return undefined;
+}
+
+function userText(m: UserMessage): string {
+	if (typeof m.content === "string") return m.content;
+	return m.content
+		.filter((c): c is { type: "text"; text: string } => c.type === "text")
+		.map((c) => c.text)
+		.join("\n");
+}
+
+function checkExpectations(model: Model<typeof FAKE_API>, ctx: Context, turn: TranscriptTurn): void {
+	const e = turn.expect;
+	if (!e) return;
+	const fail = (msg: string): never => {
+		// Surface mismatch with enough context to debug, then throw.
+		const detail = {
+			turn: turn.turn,
+			modelId: model.id,
+			messageCount: ctx.messages.length,
+			lastUserText: lastUserMessage(ctx) ? userText(lastUserMessage(ctx)!).slice(0, 200) : null,
+			toolNames: ctx.tools?.map((t) => t.name) ?? [],
+		};
+		throw new Error(`fake-llm: turn ${turn.turn} expectation mismatch: ${msg}\n  actual: ${JSON.stringify(detail)}`);
+	};
+
+	if (e.modelId !== undefined && model.id !== e.modelId) {
+		fail(`expected modelId=${e.modelId}, got ${model.id}`);
+	}
+	if (e.messageCount !== undefined && ctx.messages.length !== e.messageCount) {
+		fail(`expected messageCount=${e.messageCount}, got ${ctx.messages.length}`);
+	}
+	if (e.lastUserText !== undefined) {
+		const last = lastUserMessage(ctx);
+		if (!last) fail(`expected lastUserText to contain "${e.lastUserText}", but no user messages found`);
+		const text = userText(last!);
+		if (!text.includes(e.lastUserText)) {
+			fail(`expected lastUserText to contain "${e.lastUserText}", got "${text.slice(0, 200)}"`);
+		}
+	}
+	if (e.systemContains && e.systemContains.length > 0) {
+		const sys = ctx.systemPrompt ?? "";
+		for (const needle of e.systemContains) {
+			if (!sys.includes(needle)) fail(`expected systemPrompt to contain "${needle}"`);
+		}
+	}
+	if (e.toolNames) {
+		const actual = (ctx.tools ?? []).map((t) => t.name).sort();
+		const expected = [...e.toolNames].sort();
+		if (actual.length !== expected.length || actual.some((n, i) => n !== expected[i])) {
+			fail(`expected toolNames=${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+		}
+	}
+	if (e.hasToolResultFor !== undefined) {
+		const last = ctx.messages[ctx.messages.length - 1];
+		if (!last || last.role !== "toolResult" || last.toolName !== e.hasToolResultFor) {
+			fail(`expected last message to be a toolResult for "${e.hasToolResultFor}"`);
+		}
+	}
+}
+
+function buildAssistantMessage(
+	model: Model<typeof FAKE_API>,
+	emit: EmitSpec,
+): AssistantMessage {
+	const content: AssistantMessage["content"] = [];
+	let stopReason: AssistantMessage["stopReason"] = "stop";
+
+	if (emit.kind === "text") {
+		content.push({ type: "text", text: emit.text });
+		stopReason = emit.stopReason ?? "stop";
+	} else if (emit.kind === "tool_use") {
+		for (const [i, call] of emit.calls.entries()) {
+			const tc: ToolCall = {
+				type: "toolCall",
+				id: call.id ?? `fake-tool-${Date.now()}-${i}`,
+				name: call.name,
+				arguments: call.input,
+			};
+			content.push(tc);
+		}
+		stopReason = "toolUse";
+	}
+
+	return {
+		role: "assistant",
+		content,
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+/**
+ * Create a fake provider bound to a transcript file. Each call to stream()
+ * advances the turn cursor by one. Caller is responsible for ensuring the
+ * transcript has enough turns.
+ */
+export function createFakeProvider(opts: { transcriptPath: string }): ApiProvider<typeof FAKE_API> {
+	const transcript = parseTranscript(opts.transcriptPath);
+	let cursor = 0;
+
+	function nextTurn(): TranscriptTurn {
+		if (cursor >= transcript.length) {
+			throw new Error(
+				`fake-llm: provider invoked ${cursor + 1} times but transcript only has ${transcript.length} turns. Add another turn to ${opts.transcriptPath}.`,
+			);
+		}
+		return transcript[cursor++];
+	}
+
+	function streamTurn(model: Model<typeof FAKE_API>, ctx: Context): AssistantMessageEventStream {
+		const stream = new AssistantMessageEventStream();
+		const turn = nextTurn();
+
+		// Synchronously validate expectations BEFORE doing any async work — this
+		// way drift mismatches are reported with the request that caused them.
+		checkExpectations(model, ctx, turn);
+
+		const emit = turn.emit;
+
+		queueMicrotask(async () => {
+			try {
+				if (emit.kind === "error_429") {
+					const errorMsg: AssistantMessage = {
+						role: "assistant",
+						content: [],
+						api: model.api,
+						provider: model.provider,
+						model: model.id,
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "error",
+						errorMessage: emit.message ?? "rate_limit_exceeded",
+						retryAfterMs: emit.retryAfterMs,
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "error", reason: "error", error: errorMsg });
+					stream.end(errorMsg);
+					return;
+				}
+
+				if (emit.kind === "malformed") {
+					// Simulate a provider that emits a corrupted/incomplete response.
+					// The agent loop converts this to stopReason: "error".
+					const errorMsg: AssistantMessage = {
+						role: "assistant",
+						content: [],
+						api: model.api,
+						provider: model.provider,
+						model: model.id,
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "error",
+						errorMessage: emit.message ?? "malformed_response",
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "error", reason: "error", error: errorMsg });
+					stream.end(errorMsg);
+					return;
+				}
+
+				if (emit.kind === "timeout") {
+					const delay = emit.delayMs ?? 60_000;
+					await new Promise((r) => setTimeout(r, delay));
+					// If the caller hasn't already aborted, emit a synthetic timeout error.
+					const errorMsg: AssistantMessage = {
+						role: "assistant",
+						content: [],
+						api: model.api,
+						provider: model.provider,
+						model: model.id,
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "error",
+						errorMessage: "timeout",
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "error", reason: "error", error: errorMsg });
+					stream.end(errorMsg);
+					return;
+				}
+
+				const message = buildAssistantMessage(model, emit);
+				stream.push({ type: "start", partial: { ...message, content: [] } });
+
+				if (emit.kind === "text") {
+					stream.push({ type: "text_start", contentIndex: 0, partial: message });
+					stream.push({
+						type: "text_delta",
+						contentIndex: 0,
+						delta: emit.text,
+						partial: message,
+					});
+					stream.push({
+						type: "text_end",
+						contentIndex: 0,
+						content: emit.text,
+						partial: message,
+					});
+				} else if (emit.kind === "tool_use") {
+					for (const [i, c] of message.content.entries()) {
+						if (c.type !== "toolCall") continue;
+						stream.push({ type: "toolcall_start", contentIndex: i, partial: message });
+						stream.push({
+							type: "toolcall_end",
+							contentIndex: i,
+							toolCall: c,
+							partial: message,
+						});
+					}
+				}
+
+				stream.push({
+					type: "done",
+					reason: message.stopReason as "stop" | "length" | "toolUse" | "pauseTurn",
+					message,
+				});
+				stream.end(message);
+			} catch (err) {
+				const errorMsg: AssistantMessage = {
+					role: "assistant",
+					content: [],
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "error",
+					errorMessage: (err as Error).message,
+					timestamp: Date.now(),
+				};
+				stream.push({ type: "error", reason: "error", error: errorMsg });
+				stream.end(errorMsg);
+			}
+		});
+
+		return stream;
+	}
+
+	return {
+		api: FAKE_API,
+		stream: ((model: Model<typeof FAKE_API>, ctx: Context, _opts?: StreamOptions) =>
+			streamTurn(model, ctx)) as ApiProvider<typeof FAKE_API>["stream"],
+		streamSimple: ((model: Model<typeof FAKE_API>, ctx: Context, _opts?: SimpleStreamOptions) =>
+			streamTurn(model, ctx)) as ApiProvider<typeof FAKE_API>["streamSimple"],
+	};
+}

--- a/packages/pi-ai/src/providers/register-builtins.ts
+++ b/packages/pi-ai/src/providers/register-builtins.ts
@@ -1,4 +1,5 @@
 import { clearApiProviders, registerApiProvider } from "../api-registry.js";
+import { createFakeProvider } from "./fake.js";
 import type { AssistantMessage, AssistantMessageEvent, Context, Model, SimpleStreamOptions } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import type { BedrockOptions } from "./amazon-bedrock.js";
@@ -188,6 +189,28 @@ function registerBuiltInApiProviders(): void {
 export function resetApiProviders(): void {
 	clearApiProviders();
 	registerBuiltInApiProviders();
+	registerFakeProviderIfEnabled();
+}
+
+/**
+ * E2E-test-only: when `GSD_FAKE_LLM_TRANSCRIPT` is set, register a
+ * deterministic JSONL-replay provider under api "fake". The env var must
+ * be set BEFORE this module is imported. Subprocess-spawned e2e tests do
+ * this by setting it on the spawn env.
+ *
+ * Synchronous registration: any failure throws here so the CLI startup
+ * fails loudly instead of silently falling through to a real provider.
+ */
+function registerFakeProviderIfEnabled(): void {
+	const transcriptPath = process.env.GSD_FAKE_LLM_TRANSCRIPT;
+	if (!transcriptPath) return;
+	try {
+		registerApiProvider(createFakeProvider({ transcriptPath }), "fake");
+	} catch (err) {
+		process.stderr.write(`fake-llm: failed to register: ${(err as Error).message}\n`);
+		throw err;
+	}
 }
 
 registerBuiltInApiProviders();
+registerFakeProviderIfEnabled();

--- a/packages/pi-coding-agent/src/core/model-registry.ts
+++ b/packages/pi-coding-agent/src/core/model-registry.ts
@@ -578,6 +578,10 @@ export class ModelRegistry {
 	 * Defaults to "apiKey" for built-ins and providers without explicit mode.
 	 */
 	getProviderAuthMode(provider: string): ProviderAuthMode {
+		// E2E-test-only: the fake provider is keyless. Sentinel is project-
+		// internal ("gsd-fake") so it cannot collide with a real provider.
+		// See packages/pi-ai/src/providers/fake.ts.
+		if (provider === "gsd-fake") return "none";
 		const config = this.registeredProviders.get(provider);
 		if (!config) return "apiKey";
 		if (config.authMode) return config.authMode;

--- a/tests/e2e/_shared/fake-llm.ts
+++ b/tests/e2e/_shared/fake-llm.ts
@@ -1,0 +1,144 @@
+/**
+ * GSD-2 e2e fake-LLM helpers.
+ *
+ * Compose a JSONL transcript and run `gsd --print` against it. The fake
+ * provider replays the transcript turn-by-turn (see
+ * packages/pi-ai/src/providers/fake.ts).
+ */
+
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { canonicalTmpdir, gsdSync, type SpawnSyncResult } from "./spawn.ts";
+
+export interface ExpectFields {
+	modelId?: string;
+	messageCount?: number;
+	lastUserText?: string;
+	systemContains?: string[];
+	toolNames?: string[];
+	hasToolResultFor?: string;
+}
+
+export type EmitSpec =
+	| { kind: "text"; text: string; stopReason?: "stop" | "length" }
+	| {
+			kind: "tool_use";
+			calls: { id?: string; name: string; input: Record<string, unknown> }[];
+			stopReason?: "toolUse";
+	  }
+	| { kind: "error_429"; message?: string; retryAfterMs?: number }
+	| { kind: "malformed"; message?: string }
+	| { kind: "timeout"; delayMs?: number };
+
+export interface TranscriptTurn {
+	turn: number;
+	expect?: ExpectFields;
+	emit: EmitSpec;
+}
+
+/**
+ * Write a JSONL transcript to a tmp file and return the absolute path.
+ * Caller does not need to clean it up — it lives under the canonical tmpdir
+ * and the OS will reclaim it.
+ */
+export function writeTranscript(turns: TranscriptTurn[]): string {
+	const path = join(canonicalTmpdir(), `gsd-fake-llm-${process.pid}-${Date.now()}.jsonl`);
+	const body = turns.map((t) => JSON.stringify(t)).join("\n") + "\n";
+	writeFileSync(path, body, "utf8");
+	return path;
+}
+
+export interface FakeRunOptions {
+	cwd: string;
+	prompt: string;
+	mode?: "text" | "json";
+	extraArgs?: string[];
+	extraEnv?: Record<string, string>;
+	timeoutMs?: number;
+}
+
+/**
+ * Run `gsd --print` against a fake-LLM transcript. Sets the env var the
+ * provider keys off, picks the fake model, and returns the spawn result.
+ */
+export function runWithFakeLlm(transcriptPath: string, opts: FakeRunOptions): SpawnSyncResult {
+	const args = [
+		"--print",
+		opts.prompt,
+		"--model",
+		"gsd-fake-model",
+		"--mode",
+		opts.mode ?? "text",
+		...(opts.extraArgs ?? []),
+	];
+	return gsdSync(args, {
+		cwd: opts.cwd,
+		timeoutMs: opts.timeoutMs ?? 30_000,
+		env: {
+			GSD_FAKE_LLM_TRANSCRIPT: transcriptPath,
+			...(opts.extraEnv ?? {}),
+		},
+	});
+}
+
+/**
+ * Parse JSON-mode stdout into the array of event objects. Skips blank
+ * lines and any pre-amble that isn't valid JSON (e.g. startup timing
+ * lines emitted to stdout). Throws if no events are found.
+ */
+export function parseJsonEvents(stdout: string): Array<Record<string, unknown>> {
+	const events: Array<Record<string, unknown>> = [];
+	for (const line of stdout.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			const parsed = JSON.parse(trimmed);
+			if (parsed && typeof parsed === "object" && "type" in parsed) {
+				events.push(parsed as Record<string, unknown>);
+			}
+		} catch {
+			// Not a JSON line — skip silently.
+		}
+	}
+	if (events.length === 0) {
+		throw new Error(`no JSON events found in stdout. Raw:\n${stdout}`);
+	}
+	return events;
+}
+
+/** Pull the final assistant message text out of a JSON event stream. */
+export function lastAssistantText(events: Array<Record<string, unknown>>): string {
+	for (let i = events.length - 1; i >= 0; i--) {
+		const ev = events[i];
+		if (ev.type === "agent_end") {
+			const messages = (ev as { messages?: Array<Record<string, unknown>> }).messages ?? [];
+			for (let j = messages.length - 1; j >= 0; j--) {
+				const m = messages[j];
+				if (m.role === "assistant") {
+					const content = (m as { content?: Array<{ type: string; text?: string }> }).content ?? [];
+					return content
+						.filter((c) => c.type === "text")
+						.map((c) => c.text ?? "")
+						.join("");
+				}
+			}
+		}
+	}
+	return "";
+}
+
+/** Pull the final assistant stopReason out of a JSON event stream. */
+export function lastAssistantStopReason(events: Array<Record<string, unknown>>): string | undefined {
+	for (let i = events.length - 1; i >= 0; i--) {
+		const ev = events[i];
+		if (ev.type === "agent_end") {
+			const messages = (ev as { messages?: Array<Record<string, unknown>> }).messages ?? [];
+			for (let j = messages.length - 1; j >= 0; j--) {
+				const m = messages[j];
+				if (m.role === "assistant") return (m as { stopReason?: string }).stopReason;
+			}
+		}
+	}
+	return undefined;
+}

--- a/tests/e2e/_shared/index.ts
+++ b/tests/e2e/_shared/index.ts
@@ -9,3 +9,4 @@
 export * from "./spawn.ts";
 export * from "./tmp-project.ts";
 export * from "./artifacts.ts";
+export * from "./fake-llm.ts";

--- a/tests/e2e/_shared/spawn.ts
+++ b/tests/e2e/_shared/spawn.ts
@@ -12,8 +12,9 @@
  */
 
 import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from "node:child_process";
-import { realpathSync } from "node:fs";
+import { mkdirSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const ANSI_REGEX = /\x1b\[[0-9;]*[a-zA-Z]/g;
 
@@ -47,9 +48,28 @@ export interface E2eEnv {
 }
 
 /**
+ * Allocate a fresh per-process HOME under the canonical tmpdir. Each
+ * spawned `gsd` writes to `~/.gsd/agent/extensions/...` for resource
+ * setup; sharing the host HOME causes ENOTEMPTY races when multiple
+ * spawns interleave on a CI runner. Re-using the same isolated HOME
+ * across spawns inside one test process is fine — gsd's own setup
+ * is idempotent within a single owner — but we must not share with
+ * the runner's actual home.
+ */
+let _isolatedHome: string | undefined;
+function isolatedHome(): string {
+	if (_isolatedHome) return _isolatedHome;
+	const dir = join(canonicalTmpdir(), `gsd-e2e-home-${process.pid}-${Date.now()}`);
+	mkdirSync(dir, { recursive: true });
+	_isolatedHome = dir;
+	return dir;
+}
+
+/**
  * Build the env for an e2e child process. Strips GSD_* vars from the host
- * (so a developer's local config does not leak into a test) but keeps PATH,
- * HOME, and the standard system vars.
+ * (so a developer's local config does not leak into a test), points HOME
+ * at an isolated tmp dir (so per-user gsd state can't race against the
+ * runner's real home), and forces deterministic flags.
  */
 export function buildE2eEnv(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
 	const base: NodeJS.ProcessEnv = {};
@@ -61,6 +81,10 @@ export function buildE2eEnv(extra: Record<string, string> = {}): NodeJS.ProcessE
 	base.GSD_NON_INTERACTIVE = "1";
 	// Keep TMPDIR canonical for the child too.
 	base.TMPDIR = canonicalTmpdir();
+	// Per-process isolated HOME so gsd's resource-extension setup
+	// (~/.gsd/agent/extensions) cannot race against the runner's real
+	// home. Caller can override via `extra.HOME` if needed.
+	base.HOME = isolatedHome();
 	return { ...base, ...extra };
 }
 

--- a/tests/e2e/agent-loop-multiturn.e2e.test.ts
+++ b/tests/e2e/agent-loop-multiturn.e2e.test.ts
@@ -1,0 +1,184 @@
+/**
+ * GSD-2 multi-iteration agent-loop e2e.
+ *
+ * Drives a 3-LLM-turn loop through the fake provider to prove the agent
+ * sustains repeated tool_use → tool_result → next-turn cycles. Phase 1b
+ * verified a *single* tool-use cycle works; this verifies the loop
+ * doesn't degrade or short-circuit across multiple iterations.
+ *
+ * Transcript shape:
+ *   turn 1: model emits tool_use #1
+ *   turn 2: after tool_result lands, model emits tool_use #2
+ *   turn 3: after tool_result lands, model emits final text
+ *
+ * Note: print mode does not register file-edit tools by default, so the
+ * scripted tool calls return "Tool not found" toolResults. That's exactly
+ * the value of this test at the e2e layer — we verify the agent loop
+ * dispatches and threads the failed-tool results through into subsequent
+ * turns regardless of tool implementation. The real product safeguard
+ * that halts the loop after 3 *consecutive* failed tool calls is
+ * intentionally NOT tripped here (we only emit 2 failed tool turns
+ * before the final text turn).
+ *
+ * Subagent / nested fake-LLM coverage is intentionally deferred: that
+ * would require either a multi-cursor transcript or per-call transcript
+ * targeting, which is more infrastructure than this PR justifies.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+
+import {
+	createTmpProject,
+	lastAssistantStopReason,
+	lastAssistantText,
+	parseJsonEvents,
+	runWithFakeLlm,
+	writeTranscript,
+} from "./_shared/index.ts";
+
+function binaryAvailable(): { ok: boolean; reason?: string } {
+	const bin = process.env.GSD_SMOKE_BINARY;
+	if (!bin) return { ok: false, reason: "GSD_SMOKE_BINARY not set; build with `npm run build:core`" };
+	if (!existsSync(bin)) return { ok: false, reason: `binary not found at ${bin}` };
+	return { ok: true };
+}
+
+describe("agent loop e2e — multi-iteration", () => {
+	const avail = binaryAvailable();
+	const skipReason = avail.ok ? null : avail.reason;
+
+	test("2 tool iterations + final text turn complete in order", { skip: skipReason ?? false, timeout: 60_000 }, (t) => {
+		const project = createTmpProject();
+		t.after(project.cleanup);
+
+		const transcript = writeTranscript([
+			// Iteration 1: agent calls a tool.
+			{
+				turn: 1,
+				expect: { modelId: "gsd-fake-model", lastUserText: "do two steps" },
+				emit: {
+					kind: "tool_use",
+					calls: [{ id: "step-1", name: "read_file", input: { file_path: "/dev/null" } }],
+				},
+			},
+			// Iteration 2: previous tool returned, agent calls another tool.
+			{
+				turn: 2,
+				expect: { hasToolResultFor: "read_file" },
+				emit: {
+					kind: "tool_use",
+					calls: [{ id: "step-2", name: "list_directory", input: { path: "/dev/null" } }],
+				},
+			},
+			// Final turn: text wrap-up. The fact that this turn fires (and
+			// fires with `hasToolResultFor` matching the prior iteration)
+			// proves the loop sustained both prior tool cycles.
+			{
+				turn: 3,
+				expect: { hasToolResultFor: "list_directory" },
+				emit: { kind: "text", text: "two steps done" },
+			},
+		]);
+
+		const result = runWithFakeLlm(transcript, {
+			cwd: project.dir,
+			prompt: "do two steps",
+			mode: "json",
+			timeoutMs: 45_000,
+			extraEnv: { GSD_TOOL_APPROVAL: "auto" },
+		});
+
+		const events = parseJsonEvents(result.stdoutClean);
+
+		// Two tool_execution_start events — one per iteration.
+		const toolStarts = events.filter((e) => e.type === "tool_execution_start");
+		assert.equal(
+			toolStarts.length,
+			2,
+			`expected 2 tool_execution_start events (one per iteration), got ${toolStarts.length}`,
+		);
+		const toolEnds = events.filter((e) => e.type === "tool_execution_end");
+		assert.equal(
+			toolEnds.length,
+			2,
+			`expected 2 tool_execution_end events, got ${toolEnds.length}`,
+		);
+
+		// The toolCallIds should map 1:1 with the scripted ids — proves the
+		// agent loop dispatched each call faithfully and didn't merge / dedupe.
+		const observedIds = toolStarts
+			.map((e) => (e as { toolCallId?: string }).toolCallId)
+			.filter(Boolean);
+		assert.deepEqual(
+			observedIds.sort(),
+			["step-1", "step-2"],
+			`expected scripted ids step-1/2, got ${JSON.stringify(observedIds)}`,
+		);
+
+		// Final assistant turn fired with the wrap-up text.
+		assert.equal(lastAssistantText(events), "two steps done");
+		assert.equal(lastAssistantStopReason(events), "stop");
+	});
+
+	test("3 consecutive failed tool calls trip the agent loop's safeguard", { skip: skipReason ?? false, timeout: 60_000 }, (t) => {
+		// This is a real production safeguard worth pinning: after 3 turns
+		// where every tool call fails (e.g. the model is hallucinating
+		// arguments), the agent halts with a clear message rather than
+		// looping forever. Surfaced organically while writing the
+		// multi-iteration test above.
+		const project = createTmpProject();
+		t.after(project.cleanup);
+
+		const transcript = writeTranscript([
+			{
+				turn: 1,
+				expect: { lastUserText: "loop forever" },
+				emit: { kind: "tool_use", calls: [{ id: "a", name: "NoSuchTool", input: {} }] },
+			},
+			{
+				turn: 2,
+				expect: { hasToolResultFor: "NoSuchTool" },
+				emit: { kind: "tool_use", calls: [{ id: "b", name: "NoSuchTool", input: {} }] },
+			},
+			{
+				turn: 3,
+				expect: { hasToolResultFor: "NoSuchTool" },
+				emit: { kind: "tool_use", calls: [{ id: "c", name: "NoSuchTool", input: {} }] },
+			},
+			// We also have a 4th turn so the fake provider doesn't run out
+			// if the safeguard fires on a different boundary than expected
+			// — but if the safeguard works, this turn never executes.
+			{
+				turn: 4,
+				expect: { hasToolResultFor: "NoSuchTool" },
+				emit: { kind: "text", text: "should not be reached" },
+			},
+		]);
+
+		const result = runWithFakeLlm(transcript, {
+			cwd: project.dir,
+			prompt: "loop forever",
+			mode: "json",
+			timeoutMs: 45_000,
+			extraEnv: { GSD_TOOL_APPROVAL: "auto" },
+		});
+
+		const events = parseJsonEvents(result.stdoutClean);
+		const finalText = lastAssistantText(events);
+
+		// Safeguard fired: must mention the consecutive-failure threshold.
+		assert.match(
+			finalText,
+			/consecutive turns with all tool calls failing|stopped/i,
+			`expected safeguard message in final assistant text, got: ${finalText.slice(0, 400)}`,
+		);
+		// Agent must NOT have reached the 4th scripted text turn.
+		assert.notEqual(
+			finalText,
+			"should not be reached",
+			"safeguard did not fire — agent ran past the 3-failure boundary",
+		);
+	});
+});

--- a/tests/e2e/agent-loop.e2e.test.ts
+++ b/tests/e2e/agent-loop.e2e.test.ts
@@ -1,0 +1,216 @@
+/**
+ * GSD-2 agent-loop e2e tests.
+ *
+ * Drives the real `gsd` binary through scripted prompt → tool → response
+ * cycles using the fake LLM provider (packages/pi-ai/src/providers/fake.ts).
+ * Three vertical slices in this first cut, per peer review:
+ *   T1 - simple text response (happy path)
+ *   T2 - tool-use cycle: model calls read_file, gets result, returns text
+ *   T3 - error path: provider emits a 429-shaped error, agent loop exits
+ *        cleanly with stopReason=error (NOT a retry — no retry loop exists)
+ *
+ * Failure modes "malformed" and "timeout" are deferred to a follow-up to
+ * keep the first PR scoped.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+
+import {
+	createTmpProject,
+	lastAssistantStopReason,
+	lastAssistantText,
+	parseJsonEvents,
+	runWithFakeLlm,
+	writeTranscript,
+} from "./_shared/index.ts";
+
+function binaryAvailable(): { ok: boolean; reason?: string } {
+	const bin = process.env.GSD_SMOKE_BINARY;
+	if (!bin) return { ok: false, reason: "GSD_SMOKE_BINARY not set; build with `npm run build:core` and re-export." };
+	if (!existsSync(bin)) return { ok: false, reason: `binary not found at ${bin}` };
+	return { ok: true };
+}
+
+describe("agent loop e2e (fake LLM)", () => {
+	const avail = binaryAvailable();
+	const skipReason = avail.ok ? null : avail.reason;
+
+	test("T1: 1-turn text response is replayed end-to-end", { skip: skipReason ?? false }, (t) => {
+		const project = createTmpProject();
+		t.after(project.cleanup);
+
+		const transcript = writeTranscript([
+			{
+				turn: 1,
+				expect: { modelId: "gsd-fake-model", lastUserText: "ping" },
+				emit: { kind: "text", text: "pong from fake" },
+			},
+		]);
+
+		const result = runWithFakeLlm(transcript, {
+			cwd: project.dir,
+			prompt: "ping",
+			mode: "json",
+			timeoutMs: 30_000,
+		});
+
+		assert.equal(
+			result.code,
+			0,
+			`expected exit 0, got ${result.code}. stderr=${result.stderrClean.slice(0, 800)}`,
+		);
+		const events = parseJsonEvents(result.stdoutClean);
+		assert.equal(lastAssistantText(events), "pong from fake");
+		assert.equal(lastAssistantStopReason(events), "stop");
+	});
+
+	test("T2: tool-use cycle traverses both turns with toolResult feedback", { skip: skipReason ?? false }, (t) => {
+		// Verifies the multi-turn agent loop:
+		//   1. Model emits tool_use
+		//   2. Agent loop dispatches tool execution
+		//   3. toolResult message lands back in context
+		//   4. Model receives the toolResult and produces final text
+		//
+		// We use a tool name (`read_file`) that is not registered in print
+		// mode — the loop still produces a toolResult (with an error
+		// payload), which is exactly what we need to verify the LOOP
+		// behavior. The fake provider's `hasToolResultFor` expectation on
+		// turn 2 fails loudly if the toolResult never arrives.
+		const project = createTmpProject();
+		t.after(project.cleanup);
+
+		const transcript = writeTranscript([
+			{
+				turn: 1,
+				expect: { modelId: "gsd-fake-model", lastUserText: "use a tool" },
+				emit: {
+					kind: "tool_use",
+					calls: [
+						{
+							id: "call-1",
+							name: "read_file",
+							input: { file_path: "/dev/null" },
+						},
+					],
+				},
+			},
+			{
+				turn: 2,
+				expect: { hasToolResultFor: "read_file" },
+				emit: { kind: "text", text: "tool cycle completed" },
+			},
+		]);
+
+		const result = runWithFakeLlm(transcript, {
+			cwd: project.dir,
+			prompt: "use a tool",
+			mode: "json",
+			timeoutMs: 60_000,
+			extraEnv: { GSD_TOOL_APPROVAL: "auto" },
+		});
+
+		const events = parseJsonEvents(result.stdoutClean);
+		// Tool execution lifecycle events both fire — proves the loop
+		// dispatched the tool call into the executor.
+		assert.ok(
+			events.some((e) => e.type === "tool_execution_start"),
+			"expected a tool_execution_start event (loop did not dispatch the tool)",
+		);
+		assert.ok(
+			events.some((e) => e.type === "tool_execution_end"),
+			"expected a tool_execution_end event (loop did not complete tool dispatch)",
+		);
+		// Final assistant text comes from turn 2 — proves the second turn
+		// fired with the toolResult in context (else the fake provider's
+		// `hasToolResultFor` expectation would have thrown).
+		assert.equal(lastAssistantText(events), "tool cycle completed");
+		assert.equal(lastAssistantStopReason(events), "stop");
+	});
+
+	test("T3: provider error_429 produces stopReason=error, no retry", { skip: skipReason ?? false }, (t) => {
+		const project = createTmpProject();
+		t.after(project.cleanup);
+
+		const transcript = writeTranscript([
+			{
+				turn: 1,
+				expect: { lastUserText: "trigger 429" },
+				emit: { kind: "error_429", message: "rate_limit_exceeded", retryAfterMs: 500 },
+			},
+		]);
+
+		const result = runWithFakeLlm(transcript, {
+			cwd: project.dir,
+			prompt: "trigger 429",
+			mode: "json",
+			// Print mode currently hangs after an error path instead of
+			// exiting (separate product issue worth a follow-up). The agent
+			// stream emits everything we need before that, so we cap the
+			// wait at 8s — enough for the loop to drain, fast enough that
+			// CI doesn't pay 30s per run.
+			timeoutMs: 8_000,
+		});
+
+		// Exit code may be non-zero on error path or null if we timed the
+		// hung process out — fine. We assert via the stream that the loop
+		// saw the error and reported stopReason=error.
+		const events = parseJsonEvents(result.stdoutClean);
+		assert.equal(
+			lastAssistantStopReason(events),
+			"error",
+			`expected stopReason=error, got ${lastAssistantStopReason(events)}. stderr=${result.stderrClean.slice(0, 800)}`,
+		);
+
+		// errorMessage should round-trip from the fake transcript so tests can
+		// verify that providers' rate-limit info is preserved through the loop.
+		const found = events.find(
+			(ev) =>
+				ev.type === "agent_end" &&
+				Array.isArray((ev as { messages?: Array<Record<string, unknown>> }).messages),
+		);
+		assert.ok(found, "expected an agent_end event");
+		const messages = (found as { messages: Array<Record<string, unknown>> }).messages;
+		const lastAssistant = [...messages]
+			.reverse()
+			.find((m) => (m as { role?: string }).role === "assistant") as
+			| { errorMessage?: string }
+			| undefined;
+		assert.equal(lastAssistant?.errorMessage, "rate_limit_exceeded");
+	});
+
+	test("transcript drift: mismatched expect{} fails loudly", { skip: skipReason ?? false }, (t) => {
+		// Sanity check: if the request shape doesn't match the transcript's
+		// expect{}, the fake provider must throw a clear error rather than
+		// silently consuming. This is what guards against prompt-template
+		// drift sneaking past structural assertions.
+		const project = createTmpProject();
+		t.after(project.cleanup);
+
+		const transcript = writeTranscript([
+			{
+				turn: 1,
+				expect: { lastUserText: "this will not match" },
+				emit: { kind: "text", text: "should never be emitted" },
+			},
+		]);
+
+		const result = runWithFakeLlm(transcript, {
+			cwd: project.dir,
+			prompt: "different prompt",
+			mode: "json",
+			// Same hang-after-error caveat as T3.
+			timeoutMs: 8_000,
+		});
+
+		// Expect a stopReason=error path because the fake provider threw
+		// during stream() — agent loop catches and reports the error.
+		const events = parseJsonEvents(result.stdoutClean);
+		assert.equal(
+			lastAssistantStopReason(events),
+			"error",
+			`expected stopReason=error from drift mismatch, got ${lastAssistantStopReason(events)}`,
+		);
+	});
+});


### PR DESCRIPTION
## Why

Stacks on #5348 (Phase 1b fake LLM). Phase 1b proved the *single* tool-use cycle replays. This PR proves the agent loop sustains *multiple* iterations without degrading or short-circuiting — the regression class peer review flagged: "an agent that runs one cycle and then quietly stops."

> **Note:** This PR includes the Phase 1b commit from #5348. When that lands, GitHub will resolve the duplicate. Net new in this PR: `tests/e2e/agent-loop-multiturn.e2e.test.ts` (the second commit).

## What

[tests/e2e/agent-loop-multiturn.e2e.test.ts](tests/e2e/agent-loop-multiturn.e2e.test.ts) — two tests:

### T1 — `2 tool iterations + final text turn complete in order`

3-LLM-turn transcript (tool_use → tool_use → text) through the real binary. Asserts:
- 2× `tool_execution_start` + 2× `tool_execution_end` events
- Scripted `toolCallIds` (step-1, step-2) flow through 1:1 (no merging/deduping)
- Final text turn fires with `hasToolResultFor` matching the prior iteration — proves the loop sustained both prior tool cycles

### T2 — `3 consecutive failed tool calls trip the agent loop's safeguard`

**Real bug-class pin surfaced organically while writing T1.** A model that emits unknown tools 3 times in a row gets halted by a built-in safeguard:

> `Agent stopped: 3 consecutive turns with all tool calls failing. This usually means the model is repeatedly sending arguments that do not match the tool schema.`

This is desirable production behavior. Pinning it prevents a silent regression where a refactor removes or weakens the circuit breaker, leading to runaway loops. The 4th scripted turn must NOT execute.

## Why "Tool not found" is okay here

Print mode does not register file-edit tools by default, so the scripted tool calls return `Tool not found` toolResults. That's **exactly the value at the e2e layer** — we verify the agent *loop* dispatches and threads results through subsequent turns regardless of tool implementation. The loop's behavior under failed tool calls IS the product behavior we want to validate.

## Out of scope (blocked, follow-ups spawned)

| Phase | Status |
|---|---|
| 9 — slash command e2e | Blocked on PTY harness (slash commands are TUI-only) |
| E — `gsd undo` e2e | Blocked on PTY harness (TUI-only invocation) |

Spawned a follow-up task to add `node-pty` support to the e2e harness; once that lands, both Phase 9 and E unblock.

Subagent / nested fake-LLM coverage is also deferred (needs multi-cursor transcript or per-call transcript targeting — more infrastructure than this PR justifies).

## Verification

```
GSD_SMOKE_BINARY=$(pwd)/dist/loader.js \
  node --experimental-strip-types --test tests/e2e/agent-loop-multiturn.e2e.test.ts

▶ agent loop e2e — multi-iteration
  ✔ 2 tool iterations + final text turn complete in order
  ✔ 3 consecutive failed tool calls trip the agent loop's safeguard
ℹ tests 2, pass 2, fail 0
```

## Test plan

- [x] Both tests pass against built binary locally
- [x] Multi-iteration verified via tool_execution event count + scripted ID round-trip
- [x] Safeguard verified by asserting the 4th scripted turn doesn't execute
- [ ] CI `e2e` job green (requires #5348 merged or this PR rebased onto main once it lands)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a deterministic, transcript-driven fake LLM for reproducible end-to-end agent testing.
  * New e2e suites validating multi-turn agent loops, tool-use sequencing, rate-limit/error handling, and safeguard behavior.
  * Helpers to write/parse transcripts, run the CLI with fake LLMs, and extract assistant text/stop reasons.
  * Spawn helpers now isolate HOME for each e2e run to avoid cross-test interference.

* **Chores**
  * Conditional test-only registration of the fake provider for e2e runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->