### PR TITLE
feat(tui): add adaptive style primitives

### DIFF
--- a/packages/pi-coding-agent/src/core/settings-manager.ts
+++ b/packages/pi-coding-agent/src/core/settings-manager.ts
@@ -32,6 +32,7 @@ export interface RetrySettings {
 export interface TerminalSettings {
 	showImages?: boolean; // default: true (only relevant if terminal supports images)
 	clearOnShrink?: boolean; // default: false (clear empty rows when content shrinks)
+	adaptiveMode?: AdaptiveTuiMode; // default: "auto"
 }
 
 export interface ImageSettings {
@@ -149,6 +150,7 @@ export interface HooksSettings {
 }
 
 export type TransportSetting = Transport;
+export type AdaptiveTuiMode = "auto" | "chat" | "workflow" | "validation" | "debug" | "compact";
 
 /**
  * Package source for npm/git packages.
@@ -976,6 +978,16 @@ export class SettingsManager {
 
 	setClearOnShrink(enabled: boolean): void {
 		this.setNestedGlobalSetting("terminal", "clearOnShrink", enabled);
+	}
+
+	getAdaptiveMode(): AdaptiveTuiMode {
+		const mode = this.settings.terminal?.adaptiveMode;
+		const valid: AdaptiveTuiMode[] = ["auto", "chat", "workflow", "validation", "debug", "compact"];
+		return mode && valid.includes(mode) ? mode : "auto";
+	}
+
+	setAdaptiveMode(mode: AdaptiveTuiMode): void {
+		this.setNestedGlobalSetting("terminal", "adaptiveMode", mode);
 	}
 
 	getImageAutoResize(): boolean {

--- a/packages/pi-coding-agent/src/core/slash-commands.ts
+++ b/packages/pi-coding-agent/src/core/slash-commands.ts
@@ -38,5 +38,6 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "thinking", description: "Set thinking level (off/minimal/low/medium/high/xhigh)" },
 	{ name: "edit-mode", description: "Toggle edit mode (standard/hashline)" },
 	{ name: "terminal", description: "Run a shell command directly (e.g. /terminal ping -c3 1.1.1.1)" },
+	{ name: "tui", description: "Configure TUI layout mode (e.g. /tui mode workflow)" },
 	{ name: "quit", description: "Quit pi" },
 ];

--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
@@ -55,6 +55,7 @@ describe("ToolExecutionComponent", () => {
 
 		assert.match(rendered, /Tool demo\u00b7do_thing/);
 		assert.match(rendered, /Running/);
+		assert.match(rendered, /Running · \d+(ms|s)/);
 	});
 
 	test("renders framed header with Error status for failed tool result", () => {
@@ -66,7 +67,20 @@ describe("ToolExecutionComponent", () => {
 
 		assert.match(rendered, /Tool demo\u00b7do_thing/);
 		assert.match(rendered, /Error/);
+		assert.match(rendered, /Error · \d+(ms|s)/);
 		assert.match(rendered, /boom/);
+	});
+
+	test("collapses successful low-signal tool cards by default", () => {
+		const rendered = renderToolCollapsed(
+			"mcp__demo__noop",
+			{ ok: true },
+			{ content: [], isError: false },
+		);
+
+		assert.match(rendered, /Done · \d+(ms|s)/);
+		assert.match(rendered, /Completed/);
+		assert.doesNotMatch(rendered, /ok=true/);
 	});
 
 	test("passes failed result status to custom result renderers", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.test.ts
@@ -1,0 +1,59 @@
+// GSD2 - Runtime tests for adaptive terminal layout rendering
+
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+import stripAnsi from "strip-ansi";
+import { AdaptiveLayoutComponent } from "./adaptive-layout.js";
+import { initTheme } from "../theme/theme.js";
+
+before(() => {
+	initTheme("dark", false);
+});
+
+function render(component: AdaptiveLayoutComponent, width: number): string {
+	return component.render(width).map(stripAnsi).join("\n");
+}
+
+describe("AdaptiveLayoutComponent", () => {
+	it("renders workflow command center and inspector on wide terminals", () => {
+		const component = new AdaptiveLayoutComponent(() => ({
+			override: "workflow",
+			activeToolCount: 2,
+			gsdPhase: "executing milestone M001",
+			sessionName: "demo",
+			cwd: "/tmp/demo",
+		}));
+
+		const output = render(component, 132);
+		assert.match(output, /GSD Command Center/);
+		assert.match(output, /signals/);
+		assert.match(output, /2 running/);
+	});
+
+	it("falls back to a single compact row for narrow workflow terminals", () => {
+		const component = new AdaptiveLayoutComponent(() => ({
+			override: "workflow",
+			activeToolCount: 1,
+			gsdPhase: "executing milestone M001",
+			cwd: "/tmp/demo",
+		}));
+
+		const output = render(component, 68);
+		assert.match(output, /GSD compact/);
+		assert.doesNotMatch(output, /signals/);
+	});
+
+	it("renders blocking failure context in debug mode", () => {
+		const component = new AdaptiveLayoutComponent(() => ({
+			override: "auto",
+			activeToolCount: 0,
+			lastError: "Cannot find module @gsd/native",
+			cwd: "/tmp/demo",
+		}));
+
+		const output = render(component, 120);
+		assert.match(output, /blocking failure/);
+		assert.match(output, /Cannot find module/);
+		assert.match(output, /inspect the failed output/);
+	});
+});

--- a/packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.ts
@@ -1,0 +1,160 @@
+// GSD2 - Adaptive terminal mode dashboard for the interactive TUI
+
+import { style, truncateToWidth, visibleWidth, type Component } from "@gsd/pi-tui";
+import type { TuiAdaptiveMode, TuiMode } from "../tui-mode.js";
+import { resolveTuiMode } from "../tui-mode.js";
+import { theme, type ThemeColor } from "../theme/theme.js";
+
+export interface AdaptiveLayoutState {
+	override: TuiAdaptiveMode;
+	activeToolCount: number;
+	gsdPhase?: string;
+	lastError?: string;
+	sessionName?: string;
+	cwd: string;
+}
+
+export class AdaptiveLayoutComponent implements Component {
+	constructor(private readonly getState: () => AdaptiveLayoutState) {}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const state = this.getState();
+		const mode = resolveTuiMode({
+			terminalWidth: width,
+			override: state.override,
+			activeToolCount: state.activeToolCount,
+			gsdPhase: state.gsdPhase,
+			hasBlockingError: !!state.lastError,
+		});
+
+		if (state.override === "auto" && mode === "chat" && !state.gsdPhase && !state.lastError && state.activeToolCount === 0) {
+			return [];
+		}
+
+		if (mode === "compact" || width < 72) return this.renderCompact(width, mode, state);
+		if (mode === "debug") return this.renderDebug(width, state);
+		if (mode === "validation") return this.renderValidation(width, state);
+		if (mode === "workflow") return this.renderWorkflow(width, state);
+		return this.renderChat(width, state);
+	}
+
+	private renderWorkflow(width: number, state: AdaptiveLayoutState): string[] {
+		if (width < 112) return this.renderCompact(width, "workflow", state);
+
+		const leftWidth = Math.max(44, Math.floor(width * 0.56));
+		const rightWidth = Math.max(32, width - leftWidth - 2);
+		const phase = state.gsdPhase ?? "Ready";
+		const left = this.frame(
+			[
+				this.metric("Active", phase, "modeWorkflow"),
+				this.metric("Tools", state.activeToolCount > 0 ? `${state.activeToolCount} running` : "idle", "toolRunning"),
+				this.metric("Mode", state.override === "auto" ? "auto workflow" : state.override, "modeWorkflow"),
+			],
+			leftWidth,
+			"GSD Command Center",
+			"workflow",
+			"modeWorkflow",
+		);
+		const right = this.frame(
+			[
+				`Session ${state.sessionName ?? "current"}`,
+				`Path ${this.basename(state.cwd)}`,
+				`Next ${state.activeToolCount > 0 ? "watch tool output" : "continue from prompt"}`,
+			],
+			rightWidth,
+			"signals",
+			"inspector",
+			"surfaceAccent",
+		);
+		return this.columns(left, right, leftWidth);
+	}
+
+	private renderValidation(width: number, state: AdaptiveLayoutState): string[] {
+		const phase = state.gsdPhase ?? "Validation pending";
+		return this.frame(
+			[
+				this.metric("Focus", phase, "modeValidation"),
+				this.metric("Checks", state.activeToolCount > 0 ? `${state.activeToolCount} active` : "waiting", "toolRunning"),
+				this.metric("Timeline", state.lastError ? "blocked" : "ready for completion evidence", state.lastError ? "toolError" : "toolSuccess"),
+			],
+			width,
+			"validation",
+			state.override === "auto" ? "auto" : state.override,
+			"modeValidation",
+		);
+	}
+
+	private renderDebug(width: number, state: AdaptiveLayoutState): string[] {
+		const error = state.lastError ?? "Blocking error detected";
+		return this.frame(
+			[
+				this.metric("Failure", truncateToWidth(error, Math.max(20, width - 20), ""), "toolError"),
+				this.metric("Tools", state.activeToolCount > 0 ? `${state.activeToolCount} still running` : "none running", "toolRunning"),
+				this.metric("Next", "inspect the failed output, then retry the smallest step", "modeDebug"),
+			],
+			width,
+			"blocking failure",
+			"debug",
+			"modeDebug",
+		);
+	}
+
+	private renderChat(width: number, state: AdaptiveLayoutState): string[] {
+		return this.frame(
+			[
+				this.metric("Mode", state.override === "auto" ? "auto chat" : state.override, "surfaceAccent"),
+				this.metric("Tools", state.activeToolCount > 0 ? `${state.activeToolCount} active` : "compact rows", "toolMuted"),
+			],
+			width,
+			"chat",
+			state.sessionName ?? "conversation",
+			"surfaceAccent",
+		);
+	}
+
+	private renderCompact(width: number, mode: TuiMode, state: AdaptiveLayoutState): string[] {
+		const phase = state.lastError ?? state.gsdPhase ?? (state.activeToolCount > 0 ? `${state.activeToolCount} tools` : "ready");
+		const line = `${theme.fg("modeCompact", "GSD compact")} ${theme.fg("surfaceMuted", `${mode} · ${phase}`)}`;
+		return style()
+			.border("minimal")
+			.borderColor((text) => theme.fg("surfaceBorder", text))
+			.bodyGutter(" ")
+			.render([line], width);
+	}
+
+	private frame(lines: string[], width: number, title: string, rightTitle: string, accent: ThemeColor): string[] {
+		return style()
+			.border("rounded")
+			.density("comfortable")
+			.toneColor((text) => theme.fg("surfaceMuted", text))
+			.borderColor((text) => theme.fg("surfaceBorder", text))
+			.title(theme.fg("surfaceTitle", title))
+			.rightTitle(theme.fg(accent, rightTitle))
+			.bodyGutter(theme.fg(accent, "│ "))
+			.render(lines, width);
+	}
+
+	private metric(label: string, value: string, color: ThemeColor): string {
+		return `${theme.fg("surfaceMuted", `${label.padEnd(8)} `)}${theme.fg(color, value)}`;
+	}
+
+	private columns(left: string[], right: string[], leftWidth: number): string[] {
+		const rows = Math.max(left.length, right.length);
+		const output: string[] = [];
+		for (let i = 0; i < rows; i++) {
+			const leftLine = left[i] ?? "";
+			const rightLine = right[i] ?? "";
+			const gap = " ".repeat(Math.max(2, leftWidth - visibleWidth(leftLine) + 2));
+			output.push(`${leftLine}${gap}${rightLine}`);
+		}
+		return output;
+	}
+
+	private basename(cwd: string): string {
+		const trimmed = cwd.replace(/\/+$/, "");
+		const slash = trimmed.lastIndexOf("/");
+		return slash === -1 ? trimmed : trimmed.slice(slash + 1);
+	}
+}

--- a/packages/pi-coding-agent/src/modes/interactive/components/chat-frame.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/chat-frame.ts
@@ -1,4 +1,4 @@
-import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+import { style, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 import { theme } from "../theme/theme.js";
 import { formatTimestamp, type TimestampFormat } from "./timestamp.js";
 
@@ -67,21 +67,21 @@ export function renderChatFrame(
 	const headerRow = `${leftStyled}${" ".repeat(gap)}${rightStyled}`;
 	const headerPad = Math.max(0, outerWidth - visibleWidth(headerRow));
 
-	const sourceLines = trimOuterBlankLines(contentLines);
 	const bodyColor =
 		opts.tone === "user"
 			? "userMessageText"
 			: isPurple
 				? "customMessageText"
 				: "assistantMessageText";
+	const sourceLines = trimOuterBlankLines(contentLines);
 	const bodyLines = (sourceLines.length > 0 ? sourceLines : [""]).map((line) => {
 		const clipped = truncateToWidth(line, contentWidth, "");
-		return border("│ ") + theme.fg(bodyColor, clipped);
+		return theme.fg(bodyColor, clipped);
 	});
 
-	return [
-		theme.fg(borderMuted, "─".repeat(outerWidth)),
-		headerRow + " ".repeat(headerPad),
-		...bodyLines,
-	];
+	return style()
+		.border("rule")
+		.borderColor((line) => (line.startsWith("─") ? theme.fg(borderMuted, line) : border(line)))
+		.title(headerRow + " ".repeat(headerPad))
+		.render(bodyLines, outerWidth);
 }

--- a/packages/pi-coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -1,5 +1,6 @@
 import type { ThinkingLevel } from "@gsd/pi-agent-core";
 import type { Transport } from "@gsd/pi-ai";
+import type { AdaptiveTuiMode } from "../../../core/settings-manager.js";
 import {
 	Container,
 	getCapabilities,
@@ -46,6 +47,7 @@ export interface SettingsConfig {
 	quietStartup: boolean;
 	clearOnShrink: boolean;
 	timestampFormat: "date-time-iso" | "date-time-us";
+	adaptiveMode: AdaptiveTuiMode;
 }
 
 export interface SettingsCallbacks {
@@ -71,6 +73,7 @@ export interface SettingsCallbacks {
 	onQuietStartupChange: (enabled: boolean) => void;
 	onClearOnShrinkChange: (enabled: boolean) => void;
 	onTimestampFormatChange: (format: "date-time-iso" | "date-time-us") => void;
+	onAdaptiveModeChange: (mode: AdaptiveTuiMode) => void;
 	onCancel: () => void;
 }
 
@@ -367,6 +370,15 @@ export class SettingsSelectorComponent extends Container {
 			values: ["date-time-iso", "date-time-us"],
 		});
 
+		const timestampIndex = items.findIndex((item) => item.id === "timestamp-format");
+		items.splice(timestampIndex + 1, 0, {
+			id: "adaptive-mode",
+			label: "TUI adaptive mode",
+			description: "Auto-select or force the terminal layout mode",
+			currentValue: config.adaptiveMode,
+			values: ["auto", "chat", "workflow", "validation", "debug", "compact"],
+		});
+
 		// Add borders
 		this.addChild(new DynamicBorder());
 
@@ -434,6 +446,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "timestamp-format":
 						callbacks.onTimestampFormatChange(newValue as "date-time-iso" | "date-time-us");
+						break;
+					case "adaptive-mode":
+						callbacks.onAdaptiveModeChange(newValue as AdaptiveTuiMode);
 						break;
 				}
 			},

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -104,10 +104,10 @@ function renderToolFrame(
 	const outerWidth = Math.max(20, width);
 	const contentWidth = Math.max(1, outerWidth - 2); // "│ " + content
 
-	const borderColor = opts.tone === "error" ? "error" : "toolTitle";
-	const topColor = opts.tone === "error" ? "error" : "toolTitle";
-	const labelColor = opts.tone === "error" ? "error" : "toolTitle";
-	const statusColor = opts.tone === "error" ? "error" : opts.tone === "pending" ? "warning" : "success";
+	const borderColor = opts.tone === "error" ? "toolError" : opts.tone === "pending" ? "toolRunning" : "toolSuccess";
+	const topColor = borderColor;
+	const labelColor = opts.tone === "error" ? "toolError" : "surfaceTitle";
+	const statusColor = opts.tone === "error" ? "toolError" : opts.tone === "pending" ? "toolRunning" : "toolSuccess";
 	const leftStyled = theme.fg(labelColor, theme.bold(`• ${opts.label}`));
 	const rightStyled = theme.fg(statusColor, opts.status);
 	const gap = Math.max(1, outerWidth - visibleWidth(leftStyled) - visibleWidth(rightStyled));
@@ -130,6 +130,11 @@ function renderToolFrame(
 const COMPACT_ARG_VALUE_LIMIT = 60;
 const GENERIC_OUTPUT_PREVIEW_LINES = 10;
 const GENERIC_ARGS_JSON_PREVIEW_LINES = 10;
+
+function formatElapsed(ms: number): string {
+	if (ms < 1000) return `${ms}ms`;
+	return `${Math.max(1, Math.round(ms / 1000))}s`;
+}
 
 /**
  * Format tool args for the generic-renderer fallback. Produces a one-line
@@ -199,6 +204,8 @@ export class ToolExecutionComponent extends Container {
 	private toolDefinition?: ToolDefinition;
 	private ui: TUI;
 	private cwd: string;
+	private readonly startedAt = Date.now();
+	private endedAt: number | undefined;
 	private result?: {
 		content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
 		isError: boolean;
@@ -433,6 +440,9 @@ export class ToolExecutionComponent extends Container {
 	): void {
 		this.result = result;
 		this.isPartial = isPartial;
+		if (!isPartial) {
+			this.endedAt = this.endedAt ?? Date.now();
+		}
 		if (this.normalizedToolName === "write" && !isPartial) {
 			const rawPath = str(this.args?.file_path ?? this.args?.path);
 			const fileContent = str(this.args?.content);
@@ -455,6 +465,7 @@ export class ToolExecutionComponent extends Container {
 	markHistoricalNoResult(): void {
 		if (this.result) return; // real result already set, nothing to do
 		this.isPartial = false;
+		this.endedAt = this.endedAt ?? Date.now();
 		this.result = {
 			content: [],
 			isError: false,
@@ -467,6 +478,7 @@ export class ToolExecutionComponent extends Container {
 	 */
 	completeWithError(message?: string): void {
 		this.isPartial = false;
+		this.endedAt = this.endedAt ?? Date.now();
 		if (this.result) {
 			let content = this.result.content;
 			if (message) {
@@ -537,20 +549,39 @@ export class ToolExecutionComponent extends Container {
 		}
 		const frameWidth = Math.max(20, width);
 		const contentWidth = Math.max(1, frameWidth - 4);
-		const lines = super.render(contentWidth);
 		const frameTone: ToolFrameTone =
 			this.result?.isError ? "error" : this.isPartial || !this.result ? "pending" : "success";
-		const frameStatus = this.isPartial || !this.result ? "Running" : this.result.isError ? "Error" : "Done";
+		const elapsed = formatElapsed((this.endedAt ?? Date.now()) - this.startedAt);
+		const frameStatus = `${this.isPartial || !this.result ? "Running" : this.result.isError ? "Error" : "Done"} · ${elapsed}`;
 		const parsed = parseMcpToolName(this.toolName);
 		const frameLabel = parsed
 			? `Tool ${parsed.server}·${parsed.tool}`
 			: `Tool ${prettifyToolName(this.toolName, this.toolDefinition?.label) || "unknown"}`;
+		if (this.shouldRenderCompactSuccess()) {
+			const availableWidth = Math.max(1, frameWidth - 2);
+			const summaryWidth = Math.max(1, availableWidth - visibleWidth(frameStatus) - 1);
+			const summary = truncateToWidth(this.getCompactSummary(frameLabel), summaryWidth, "");
+			const gap = Math.max(1, availableWidth - visibleWidth(summary) - visibleWidth(frameStatus));
+			const line = `${theme.fg("toolSuccess", summary)}${" ".repeat(gap)}${theme.fg("toolSuccess", frameStatus)}`;
+			return ["", ...style().border("minimal").borderColor((text) => theme.fg("toolSuccess", text)).render([line], frameWidth)];
+		}
+		const lines = super.render(contentWidth);
 		const framed = renderToolFrame(lines, frameWidth, {
 			label: frameLabel,
 			status: frameStatus,
 			tone: frameTone,
 		});
 		return framed.length > 0 ? ["", ...framed] : framed;
+	}
+
+	private shouldRenderCompactSuccess(): boolean {
+		if (this.expanded || this.isPartial || !this.result || this.result.isError) return false;
+		const hasImages = this.result.content?.some((block) => block.type === "image") ?? false;
+		return !hasImages && this.getTextOutput().trim().length === 0;
+	}
+
+	private getCompactSummary(frameLabel: string): string {
+		return `${frameLabel} Completed`;
 	}
 
 	private updateDisplay(): void {

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -6,6 +6,7 @@ import {
 	type ImageDimensions,
 	imageFallback,
 	Spacer,
+	style,
 	Text,
 	type TUI,
 	truncateToWidth,
@@ -107,8 +108,6 @@ function renderToolFrame(
 	const topColor = opts.tone === "error" ? "error" : "toolTitle";
 	const labelColor = opts.tone === "error" ? "error" : "toolTitle";
 	const statusColor = opts.tone === "error" ? "error" : opts.tone === "pending" ? "warning" : "success";
-	const border = (s: string) => theme.fg(borderColor, s);
-
 	const leftStyled = theme.fg(labelColor, theme.bold(`• ${opts.label}`));
 	const rightStyled = theme.fg(statusColor, opts.status);
 	const gap = Math.max(1, outerWidth - visibleWidth(leftStyled) - visibleWidth(rightStyled));
@@ -118,14 +117,14 @@ function renderToolFrame(
 	const sourceLines = trimOuterBlankLines(contentLines);
 	const bodyLines = (sourceLines.length > 0 ? sourceLines : [""]).map((line) => {
 		const clipped = truncateToWidth(line, contentWidth, "");
-		return border("│ ") + clipped;
+		return clipped;
 	});
 
-	return [
-		theme.fg(topColor, "─".repeat(outerWidth)),
-		headerRow + " ".repeat(headerPad),
-		...bodyLines,
-	];
+	return style()
+		.border("rule")
+		.borderColor((line) => theme.fg(line.startsWith("─") ? topColor : borderColor, line))
+		.title(headerRow + " ".repeat(headerPad))
+		.render(bodyLines, outerWidth);
 }
 
 const COMPACT_ARG_VALUE_LIMIT = 60;

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { findLatestPinnableText } from "./chat-controller.js";
+import { findLatestPinnableText, handleAgentEvent } from "./chat-controller.js";
+import { initTheme } from "../theme/theme.js";
 
 test("findLatestPinnableText: empty content returns empty string", () => {
 	assert.equal(findLatestPinnableText([]), "");
@@ -68,4 +69,45 @@ test("findLatestPinnableText: thinking blocks are not pinnable", () => {
 		{ type: "toolCall", id: "1", name: "Read" },
 	];
 	assert.equal(findLatestPinnableText(blocks), "");
+});
+
+test("handleAgentEvent: agent_start clears stale adaptive blocking error", async () => {
+	initTheme("dark", false);
+	let cleared = false;
+	let requestedRender = false;
+	const host = {
+		isInitialized: true,
+		clearBlockingError: () => {
+			cleared = true;
+		},
+		retryEscapeHandler: undefined,
+		retryLoader: undefined,
+		loadingAnimation: undefined,
+		statusContainer: {
+			clear() {},
+			addChild() {},
+		},
+		ui: {
+			requestRender() {
+				requestedRender = true;
+			},
+		},
+		defaultEditor: {},
+		footer: {
+			invalidate() {},
+		},
+		settingsManager: {
+			getTimestampFormat() {
+				return "date-time-iso";
+			},
+		},
+		defaultWorkingMessage: "Working...",
+		pendingWorkingMessage: undefined,
+	} as any;
+
+	await handleAgentEvent(host, { type: "agent_start" } as any);
+	host.loadingAnimation?.stop();
+
+	assert.equal(cleared, true);
+	assert.equal(requestedRender, true);
 });

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -177,6 +177,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					return;
 			}
 		case "agent_start":
+			host.clearBlockingError();
 			if (host.retryEscapeHandler) {
 				host.defaultEditor.onEscape = host.retryEscapeHandler;
 				host.retryEscapeHandler = undefined;

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode-state.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode-state.ts
@@ -20,6 +20,7 @@ export interface InteractiveModeStateHost {
 	isInitialized: boolean;
 	loadingAnimation?: any;
 	pendingWorkingMessage?: string;
+	clearBlockingError(): void;
 	defaultWorkingMessage: string;
 	streamingComponent?: any;
 	streamingMessage?: any;
@@ -37,4 +38,3 @@ export interface InteractiveModeStateHost {
 }
 
 export type InteractiveModeEvent = AgentSessionEvent;
-

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1233,6 +1233,7 @@ export class InteractiveMode {
 						this.streamingComponent = undefined;
 						this.streamingMessage = undefined;
 						this.pendingTools.clear();
+						this.clearBlockingError();
 
 						// Render any messages added via setup, or show empty session
 						this.renderInitialMessages();
@@ -2898,6 +2899,10 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
+	clearBlockingError(): void {
+		this.lastBlockingError = undefined;
+	}
+
 	showWarning(warningMessage: string): void {
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
@@ -3707,6 +3712,7 @@ export class InteractiveMode {
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
 		this.pendingTools.clear();
+		this.clearBlockingError();
 
 		// Switch session via AgentSession (emits extension session events)
 		await this.session.switchSession(sessionPath);
@@ -4028,6 +4034,7 @@ export class InteractiveMode {
 		this.streamingMessage = undefined;
 		this.pendingTools.clear();
 		this.pendingImages.length = 0;
+		this.clearBlockingError();
 
 		// Reset contextual tips for the new session
 		this.contextualTips.reset();

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -64,6 +64,7 @@ import { getChangelogPath, getNewEntries, parseChangelog } from "../../utils/cha
 import { readClipboardImage } from "../../utils/clipboard-image.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
+import { AdaptiveLayoutComponent } from "./components/adaptive-layout.js";
 import { BashExecutionComponent } from "./components/bash-execution.js";
 import { BorderedLoader } from "./components/bordered-loader.js";
 import { BranchSummaryMessageComponent } from "./components/branch-summary-message.js";
@@ -246,6 +247,7 @@ export class InteractiveMode {
 	private ui: TUI;
 	private chatContainer: Container;
 	private pendingMessagesContainer: Container;
+	private adaptiveLayout: AdaptiveLayoutComponent;
 	private statusContainer: Container;
 	private pinnedMessageContainer: Container;
 	private defaultEditor: CustomEditor;
@@ -261,6 +263,7 @@ export class InteractiveMode {
 	private loadingAnimation: Loader | undefined = undefined;
 	private pendingWorkingMessage: string | undefined = undefined;
 	private readonly defaultWorkingMessage = "Working...";
+	private lastBlockingError: string | undefined = undefined;
 
 	private lastSigintTime = 0;
 	private lastEscapeTime = 0;
@@ -367,6 +370,14 @@ export class InteractiveMode {
 		this.headerContainer = new Container();
 		this.chatContainer = new Container();
 		this.pendingMessagesContainer = new Container();
+		this.adaptiveLayout = new AdaptiveLayoutComponent(() => ({
+			override: this.settingsManager.getAdaptiveMode(),
+			activeToolCount: this.pendingTools.size,
+			gsdPhase: this.pendingWorkingMessage,
+			lastError: this.lastBlockingError,
+			sessionName: this.sessionManager.getSessionName(),
+			cwd: process.cwd(),
+		}));
 		this.statusContainer = new Container();
 		this.pinnedMessageContainer = new Container();
 		this.widgetContainerAbove = new Container();
@@ -571,6 +582,7 @@ export class InteractiveMode {
 			}
 		}
 
+		this.ui.addChild(this.adaptiveLayout);
 		this.ui.addChild(this.chatContainer);
 		this.ui.addChild(this.pendingMessagesContainer);
 		this.ui.addChild(this.statusContainer);
@@ -2880,6 +2892,7 @@ export class InteractiveMode {
 	}
 
 	showError(errorMessage: string): void {
+		this.lastBlockingError = errorMessage;
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new Text(theme.fg("error", `Error: ${errorMessage}`), 1, 0));
 		this.ui.requestRender();
@@ -3195,6 +3208,7 @@ export class InteractiveMode {
 					quietStartup: this.settingsManager.getQuietStartup(),
 					clearOnShrink: this.settingsManager.getClearOnShrink(),
 					timestampFormat: this.settingsManager.getTimestampFormat(),
+					adaptiveMode: this.settingsManager.getAdaptiveMode(),
 				},
 				{
 					onAutoCompactChange: (enabled) => {
@@ -3300,6 +3314,10 @@ export class InteractiveMode {
 					},
 					onTimestampFormatChange: (format) => {
 						this.settingsManager.setTimestampFormat(format);
+					},
+					onAdaptiveModeChange: (mode) => {
+						this.settingsManager.setAdaptiveMode(mode);
+						this.ui.requestRender();
 					},
 					onCancel: () => {
 						done();

--- a/packages/pi-coding-agent/src/modes/interactive/slash-command-handlers.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/slash-command-handlers.test.ts
@@ -1,0 +1,95 @@
+// GSD2 - Slash command tests for interactive TUI settings commands
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { Container } from "@gsd/pi-tui";
+import { SettingsManager } from "../../core/settings-manager.js";
+import { dispatchSlashCommand, type SlashCommandContext } from "./slash-command-handlers.js";
+
+function makeContext(settingsManager = SettingsManager.inMemory()): SlashCommandContext {
+	const statuses: string[] = [];
+	const warnings: string[] = [];
+	const renders: string[] = [];
+	return {
+		session: {} as never,
+		ui: {} as never,
+		keybindings: {} as never,
+		chatContainer: new Container(),
+		statusContainer: new Container(),
+		editorContainer: new Container(),
+		headerContainer: new Container(),
+		pendingMessagesContainer: new Container(),
+		editor: {} as never,
+		defaultEditor: {} as never,
+		sessionManager: {} as never,
+		settingsManager,
+		invalidateFooter() {},
+		showStatus(message: string) {
+			statuses.push(message);
+		},
+		showError(message: string) {
+			throw new Error(message);
+		},
+		showWarning(message: string) {
+			warnings.push(message);
+		},
+		showSelector() {},
+		updateEditorBorderColor() {},
+		getMarkdownThemeWithSettings: () => ({} as never),
+		requestRender() {
+			renders.push("render");
+		},
+		updateTerminalTitle() {},
+		showSettingsSelector() {},
+		showModelsSelector: async () => {},
+		handleModelCommand: async () => {},
+		showUserMessageSelector() {},
+		showTreeSelector() {},
+		showProviderManager() {},
+		showOAuthSelector: async () => {},
+		showSessionSelector() {},
+		handleClearCommand: async () => {},
+		handleReloadCommand: async () => {},
+		handleDebugCommand() {},
+		shutdown: async () => {},
+		executeCompaction: async () => undefined,
+		handleBashCommand: async () => {},
+		_testStatuses: statuses,
+		_testWarnings: warnings,
+		_testRenders: renders,
+	} as SlashCommandContext & {
+		_testStatuses: string[];
+		_testWarnings: string[];
+		_testRenders: string[];
+	};
+}
+
+describe("dispatchSlashCommand /tui", () => {
+	it("persists /tui mode validation to terminal adaptive mode", async () => {
+		const settingsManager = SettingsManager.inMemory();
+		const ctx = makeContext(settingsManager) as SlashCommandContext & {
+			_testStatuses: string[];
+			_testRenders: string[];
+		};
+
+		const handled = await dispatchSlashCommand("/tui mode validation", ctx);
+
+		assert.equal(handled, true);
+		assert.equal(settingsManager.getAdaptiveMode(), "validation");
+		assert.deepEqual(ctx._testStatuses, ["TUI mode: validation"]);
+		assert.equal(ctx._testRenders.length, 1);
+	});
+
+	it("rejects unknown TUI modes without changing settings", async () => {
+		const settingsManager = SettingsManager.inMemory({ terminal: { adaptiveMode: "workflow" } });
+		const ctx = makeContext(settingsManager) as SlashCommandContext & {
+			_testWarnings: string[];
+		};
+
+		const handled = await dispatchSlashCommand("/tui mode poster", ctx);
+
+		assert.equal(handled, true);
+		assert.equal(settingsManager.getAdaptiveMode(), "workflow");
+		assert.match(ctx._testWarnings[0], /Usage: \/tui mode/);
+	});
+});

--- a/packages/pi-coding-agent/src/modes/interactive/slash-command-handlers.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/slash-command-handlers.ts
@@ -31,7 +31,7 @@ import {
 import type { AgentSession } from "../../core/agent-session.js";
 import type { AppAction, KeybindingsManager } from "../../core/keybindings.js";
 import type { SessionManager } from "../../core/session-manager.js";
-import type { SettingsManager } from "../../core/settings-manager.js";
+import type { AdaptiveTuiMode, SettingsManager } from "../../core/settings-manager.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog.js";
 import { ArminComponent } from "./components/armin.js";
@@ -233,6 +233,10 @@ export async function dispatchSlashCommand(
 		// and env vars from shell profiles (.zprofile/.profile) are available.
 		// Note: shell aliases are not loaded (requires -i which has side effects).
 		await ctx.handleBashCommand(command, { loginShell: true });
+		return true;
+	}
+	if (text === "/tui" || text.startsWith("/tui ")) {
+		handleTuiCommand(text, ctx);
 		return true;
 	}
 
@@ -663,6 +667,25 @@ function handleEditModeCommand(arg: string | undefined, ctx: SlashCommandContext
 	const next = current === "standard" ? "hashline" : "standard";
 	ctx.session.setEditMode(next);
 	ctx.showStatus(`Edit mode: ${next}${next === "hashline" ? " (LINE#ID anchored edits)" : " (text-match edits)"}`);
+}
+
+function handleTuiCommand(text: string, ctx: SlashCommandContext): void {
+	const parts = text.trim().split(/\s+/);
+	const mode = parts[1] === "mode" ? parts[2] : parts[1];
+	const valid: AdaptiveTuiMode[] = ["auto", "chat", "workflow", "validation", "debug", "compact"];
+
+	if (!mode) {
+		ctx.showStatus(`TUI mode: ${ctx.settingsManager.getAdaptiveMode()}`);
+		return;
+	}
+	if (!valid.includes(mode as AdaptiveTuiMode)) {
+		ctx.showWarning(`Usage: /tui mode ${valid.join("|")}`);
+		return;
+	}
+
+	ctx.settingsManager.setAdaptiveMode(mode as AdaptiveTuiMode);
+	ctx.showStatus(`TUI mode: ${mode}`);
+	ctx.requestRender();
 }
 
 function handleArminSaysHi(ctx: SlashCommandContext): void {

--- a/packages/pi-coding-agent/src/modes/interactive/theme/theme-schema.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/theme/theme-schema.ts
@@ -70,6 +70,19 @@ export const ThemeJsonSchema = Type.Object({
     thinkingXhigh: ColorValueSchema,
     // Bash Mode (1 color)
     bashMode: ColorValueSchema,
+    // Adaptive TUI semantic tokens (optional; defaults are derived from core colors)
+    surfaceBorder: Type.Optional(ColorValueSchema),
+    surfaceMuted: Type.Optional(ColorValueSchema),
+    surfaceTitle: Type.Optional(ColorValueSchema),
+    surfaceAccent: Type.Optional(ColorValueSchema),
+    toolRunning: Type.Optional(ColorValueSchema),
+    toolSuccess: Type.Optional(ColorValueSchema),
+    toolError: Type.Optional(ColorValueSchema),
+    toolMuted: Type.Optional(ColorValueSchema),
+    modeWorkflow: Type.Optional(ColorValueSchema),
+    modeValidation: Type.Optional(ColorValueSchema),
+    modeDebug: Type.Optional(ColorValueSchema),
+    modeCompact: Type.Optional(ColorValueSchema),
   }),
   export: Type.Optional(
     Type.Object({

--- a/packages/pi-coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/theme/theme.ts
@@ -69,7 +69,19 @@ export type ThemeColor =
 	| "thinkingMedium"
 	| "thinkingHigh"
 	| "thinkingXhigh"
-	| "bashMode";
+	| "bashMode"
+	| "surfaceBorder"
+	| "surfaceMuted"
+	| "surfaceTitle"
+	| "surfaceAccent"
+	| "toolRunning"
+	| "toolSuccess"
+	| "toolError"
+	| "toolMuted"
+	| "modeWorkflow"
+	| "modeValidation"
+	| "modeDebug"
+	| "modeCompact";
 
 export type ThemeBg =
 	| "selectedBg"
@@ -374,6 +386,24 @@ function getBuiltinThemes(): Record<string, ThemeJson> {
 	return builtinThemes;
 }
 
+function withSemanticColorDefaults(colors: ThemeJson["colors"]): ThemeJson["colors"] {
+	return {
+		...colors,
+		surfaceBorder: colors.surfaceBorder ?? colors.border,
+		surfaceMuted: colors.surfaceMuted ?? colors.borderMuted,
+		surfaceTitle: colors.surfaceTitle ?? colors.toolTitle,
+		surfaceAccent: colors.surfaceAccent ?? colors.borderAccent,
+		toolRunning: colors.toolRunning ?? colors.warning,
+		toolSuccess: colors.toolSuccess ?? colors.success,
+		toolError: colors.toolError ?? colors.error,
+		toolMuted: colors.toolMuted ?? colors.muted,
+		modeWorkflow: colors.modeWorkflow ?? colors.accent,
+		modeValidation: colors.modeValidation ?? colors.warning,
+		modeDebug: colors.modeDebug ?? colors.error,
+		modeCompact: colors.modeCompact ?? colors.muted,
+	};
+}
+
 export function getAvailableThemes(): string[] {
 	const themes = new Set<string>(Object.keys(getBuiltinThemes()));
 	const customThemesDir = getCustomThemesDir();
@@ -493,7 +523,7 @@ function loadThemeJson(name: string): ThemeJson {
 
 function createTheme(themeJson: ThemeJson, mode?: ColorMode, sourcePath?: string): Theme {
 	const colorMode = mode ?? detectColorMode();
-	const resolvedColors = resolveThemeColors(themeJson.colors, themeJson.vars);
+	const resolvedColors = resolveThemeColors(withSemanticColorDefaults(themeJson.colors), themeJson.vars);
 	const fgColors: Record<ThemeColor, string | number> = {} as Record<ThemeColor, string | number>;
 	const bgColors: Record<ThemeBg, string | number> = {} as Record<ThemeBg, string | number>;
 	const bgColorKeys: Set<string> = new Set([

--- a/packages/pi-coding-agent/src/modes/interactive/tui-mode.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/tui-mode.test.ts
@@ -1,0 +1,33 @@
+// GSD2 - Tests for adaptive TUI mode selection
+
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { resolveTuiMode } from "./tui-mode.js";
+
+describe("resolveTuiMode", () => {
+	test("prioritizes compact layouts on narrow terminals", () => {
+		assert.equal(
+			resolveTuiMode({ terminalWidth: 60, hasBlockingError: true, gsdPhase: "validating-milestone" }),
+			"compact",
+		);
+	});
+
+	test("uses debug mode for blocking errors on roomy terminals", () => {
+		assert.equal(resolveTuiMode({ terminalWidth: 100, hasBlockingError: true }), "debug");
+	});
+
+	test("uses validation mode for validation and completion phases", () => {
+		assert.equal(resolveTuiMode({ terminalWidth: 100, gsdPhase: "validating-milestone" }), "validation");
+		assert.equal(resolveTuiMode({ terminalWidth: 100, gsdPhase: "complete-milestone" }), "validation");
+	});
+
+	test("uses workflow mode when tools or non-validation phases are active", () => {
+		assert.equal(resolveTuiMode({ terminalWidth: 100, activeToolCount: 1 }), "workflow");
+		assert.equal(resolveTuiMode({ terminalWidth: 100, gsdPhase: "execute-phase" }), "workflow");
+	});
+
+	test("falls back to chat mode for plain conversation", () => {
+		assert.equal(resolveTuiMode({ terminalWidth: 100 }), "chat");
+	});
+});

--- a/packages/pi-coding-agent/src/modes/interactive/tui-mode.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/tui-mode.test.ts
@@ -6,9 +6,16 @@ import { describe, test } from "node:test";
 import { resolveTuiMode } from "./tui-mode.js";
 
 describe("resolveTuiMode", () => {
+	test("explicit overrides beat auto selection", () => {
+		assert.equal(
+			resolveTuiMode({ terminalWidth: 60, override: "debug", gsdPhase: "validating-milestone" }),
+			"debug",
+		);
+	});
+
 	test("prioritizes compact layouts on narrow terminals", () => {
 		assert.equal(
-			resolveTuiMode({ terminalWidth: 60, hasBlockingError: true, gsdPhase: "validating-milestone" }),
+			resolveTuiMode({ terminalWidth: 60, override: "auto", hasBlockingError: true, gsdPhase: "validating-milestone" }),
 			"compact",
 		);
 	});

--- a/packages/pi-coding-agent/src/modes/interactive/tui-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/tui-mode.ts
@@ -1,0 +1,26 @@
+// GSD2 - Adaptive mode selection for the interactive terminal UI
+
+export type TuiMode = "chat" | "workflow" | "validation" | "debug" | "compact";
+
+export interface TuiModeContext {
+	terminalWidth: number;
+	gsdPhase?: string;
+	activeToolCount?: number;
+	hasBlockingError?: boolean;
+}
+
+export function resolveTuiMode(context: TuiModeContext): TuiMode {
+	if (context.terminalWidth < 72) return "compact";
+	if (context.hasBlockingError) return "debug";
+
+	const phase = context.gsdPhase?.toLowerCase() ?? "";
+	if (phase.includes("validat") || phase.includes("complete") || phase.includes("review")) {
+		return "validation";
+	}
+
+	if ((context.activeToolCount ?? 0) > 0 || phase.length > 0) {
+		return "workflow";
+	}
+
+	return "chat";
+}

--- a/packages/pi-coding-agent/src/modes/interactive/tui-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/tui-mode.ts
@@ -1,15 +1,18 @@
 // GSD2 - Adaptive mode selection for the interactive terminal UI
 
 export type TuiMode = "chat" | "workflow" | "validation" | "debug" | "compact";
+export type TuiAdaptiveMode = "auto" | TuiMode;
 
 export interface TuiModeContext {
 	terminalWidth: number;
+	override?: TuiAdaptiveMode;
 	gsdPhase?: string;
 	activeToolCount?: number;
 	hasBlockingError?: boolean;
 }
 
 export function resolveTuiMode(context: TuiModeContext): TuiMode {
+	if (context.override && context.override !== "auto") return context.override;
 	if (context.terminalWidth < 72) return "compact";
 	if (context.hasBlockingError) return "debug";
 

--- a/packages/pi-tui/src/__tests__/style.test.ts
+++ b/packages/pi-tui/src/__tests__/style.test.ts
@@ -1,0 +1,45 @@
+// GSD2 - Tests for terminal style primitives
+
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import stripAnsi from "strip-ansi";
+
+import { style, visibleWidth } from "../index.js";
+
+describe("style", () => {
+	test("renders rule frames with title, right title, and body gutter", () => {
+		const lines = style()
+			.border("rule")
+			.title("• Tool Bash")
+			.titleRight("Running")
+			.render(["$ npm test"], 40);
+
+		const plain = lines.map((line) => stripAnsi(line));
+		assert.match(plain[0], /^─+$/);
+		assert.equal(visibleWidth(plain[0]), 40);
+		assert.ok(plain[1].includes("• Tool Bash"));
+		assert.ok(plain[1].includes("Running"));
+		assert.equal(visibleWidth(plain[1]), 40);
+		assert.ok(plain[2].startsWith("│ "));
+		assert.ok(plain[2].includes("$ npm test"));
+	});
+
+	test("renders boxed rounded borders with padded content", () => {
+		const lines = style()
+			.border("rounded")
+			.paddingX(1)
+			.render(["Done"], 12)
+			.map((line) => stripAnsi(line));
+
+		assert.equal(lines[0], "╭──────────╮");
+		assert.equal(lines[1], "│ Done     │");
+		assert.equal(lines[2], "╰──────────╯");
+	});
+
+	test("truncates content to the available visible width", () => {
+		const plain = style().border("rule").render(["abcdefghij"], 7).map((line) => stripAnsi(line));
+
+		assert.equal(plain[1], "│ abcde");
+		assert.equal(visibleWidth(plain[1]), 7);
+	});
+});

--- a/packages/pi-tui/src/__tests__/style.test.ts
+++ b/packages/pi-tui/src/__tests__/style.test.ts
@@ -42,4 +42,35 @@ describe("style", () => {
 		assert.equal(plain[1], "│ abcde");
 		assert.equal(visibleWidth(plain[1]), 7);
 	});
+
+	test("renders minimal left-rule surfaces", () => {
+		const plain = style().border("minimal").title("note").render(["No full card"], 20).map((line) => stripAnsi(line));
+
+		assert.equal(plain[0], "│ note              ");
+		assert.equal(plain[1], "│ No full card      ");
+	});
+
+	test("applies dashboard density and body gutters", () => {
+		const plain = style()
+			.border("single")
+			.density("dashboard")
+			.bodyGutter("· ")
+			.render(["body"], 14)
+			.map((line) => stripAnsi(line));
+
+		assert.equal(plain[0], "┌────────────┐");
+		assert.equal(plain[1], "│            │");
+		assert.equal(plain[2], "│·  body     │");
+		assert.equal(plain[3], "│            │");
+		assert.equal(plain[4], "└────────────┘");
+	});
+
+	test("passes tone to toneColor when no explicit border color is set", () => {
+		const lines = style()
+			.border("minimal")
+			.tone("success", (tone, text) => `[${tone}]${text}`)
+			.render(["ok"], 8);
+
+		assert.equal(lines[0], "[success]│ ok    ");
+	});
 });

--- a/packages/pi-tui/src/index.ts
+++ b/packages/pi-tui/src/index.ts
@@ -5,7 +5,9 @@ export {
 	style,
 	TerminalStyle,
 	type TerminalBorderStyle,
+	type TerminalDensity,
 	type TerminalStyleSpec,
+	type TerminalTone,
 } from "./style.js";
 // Autocomplete support
 export {

--- a/packages/pi-tui/src/index.ts
+++ b/packages/pi-tui/src/index.ts
@@ -1,5 +1,12 @@
 // Core TUI interfaces and classes
 
+// Style primitives
+export {
+	style,
+	TerminalStyle,
+	type TerminalBorderStyle,
+	type TerminalStyleSpec,
+} from "./style.js";
 // Autocomplete support
 export {
 	type AutocompleteItem,

--- a/packages/pi-tui/src/style.ts
+++ b/packages/pi-tui/src/style.ts
@@ -2,19 +2,25 @@
 
 import { truncateToWidth, visibleWidth } from "./utils.js";
 
-export type TerminalBorderStyle = "none" | "rule" | "single" | "rounded" | "heavy";
+export type TerminalBorderStyle = "none" | "rule" | "single" | "rounded" | "heavy" | "minimal";
+export type TerminalDensity = "compact" | "comfortable" | "dashboard";
+export type TerminalTone = "default" | "muted" | "running" | "success" | "error" | "current";
 
 export interface TerminalStyleSpec {
 	width?: number;
 	paddingX?: number;
 	paddingY?: number;
 	border?: TerminalBorderStyle;
+	density?: TerminalDensity;
+	tone?: TerminalTone;
 	borderColor?: (text: string) => string;
 	foreground?: (text: string) => string;
+	toneColor?: (tone: TerminalTone, text: string) => string;
 	title?: string;
 	titleRight?: string;
 	titleColor?: (text: string) => string;
 	titleRightColor?: (text: string) => string;
+	bodyGutter?: string;
 }
 
 type BorderChars = {
@@ -26,7 +32,7 @@ type BorderChars = {
 	vertical: string;
 };
 
-const BORDER_CHARS: Record<Exclude<TerminalBorderStyle, "none" | "rule">, BorderChars> = {
+const BORDER_CHARS: Record<Exclude<TerminalBorderStyle, "none" | "rule" | "minimal">, BorderChars> = {
 	single: {
 		topLeft: "┌",
 		topRight: "┐",
@@ -51,6 +57,12 @@ const BORDER_CHARS: Record<Exclude<TerminalBorderStyle, "none" | "rule">, Border
 		horizontal: "━",
 		vertical: "┃",
 	},
+};
+
+const DENSITY_PADDING: Record<TerminalDensity, { x: number; y: number }> = {
+	compact: { x: 0, y: 0 },
+	comfortable: { x: 1, y: 0 },
+	dashboard: { x: 1, y: 1 },
 };
 
 function padVisible(line: string, width: number): string {
@@ -92,12 +104,24 @@ export class TerminalStyle {
 		return new TerminalStyle({ ...this.spec, border });
 	}
 
+	density(density: TerminalDensity): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, density });
+	}
+
+	tone(tone: TerminalTone, toneColor?: (tone: TerminalTone, text: string) => string): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, tone, toneColor });
+	}
+
 	borderColor(borderColor: (text: string) => string): TerminalStyle {
 		return new TerminalStyle({ ...this.spec, borderColor });
 	}
 
 	foreground(foreground: (text: string) => string): TerminalStyle {
 		return new TerminalStyle({ ...this.spec, foreground });
+	}
+
+	toneColor(toneColor: (tone: TerminalTone, text: string) => string): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, toneColor });
 	}
 
 	title(title: string, titleColor?: (text: string) => string): TerminalStyle {
@@ -108,12 +132,24 @@ export class TerminalStyle {
 		return new TerminalStyle({ ...this.spec, titleRight, titleRightColor });
 	}
 
+	rightTitle(titleRight: string, titleRightColor?: (text: string) => string): TerminalStyle {
+		return this.titleRight(titleRight, titleRightColor);
+	}
+
+	bodyGutter(bodyGutter: string): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, bodyGutter });
+	}
+
 	render(contentLines: string[], width?: number): string[] {
 		const outerWidth = normalizeWidth(this.spec, width);
 		const border = this.spec.border ?? "none";
-		const paddingX = Math.max(0, Math.floor(this.spec.paddingX ?? 0));
-		const paddingY = Math.max(0, Math.floor(this.spec.paddingY ?? 0));
-		const innerWidth = Math.max(1, outerWidth - (border === "none" ? 0 : 2) - paddingX * 2);
+		const densityPadding = DENSITY_PADDING[this.spec.density ?? "compact"];
+		const paddingX = Math.max(0, Math.floor(this.spec.paddingX ?? densityPadding.x));
+		const paddingY = Math.max(0, Math.floor(this.spec.paddingY ?? densityPadding.y));
+		const gutter = this.spec.bodyGutter ?? "";
+		const gutterWidth = visibleWidth(gutter);
+		const borderColumns = border === "none" ? 0 : 2;
+		const innerWidth = Math.max(1, outerWidth - borderColumns - paddingX * 2 - gutterWidth);
 		const emptyPaddedLine = " ".repeat(paddingX * 2 + innerWidth);
 		const sourceLines = contentLines.length > 0 ? contentLines : [""];
 		const paddedBody = [
@@ -121,10 +157,12 @@ export class TerminalStyle {
 			...sourceLines.map((line) => {
 				const clipped = truncateToWidth(line, innerWidth, "");
 				const styled = color(this.spec.foreground, clipped);
-				return `${" ".repeat(paddingX)}${padVisible(styled, innerWidth)}${" ".repeat(paddingX)}`;
+				return `${gutter}${" ".repeat(paddingX)}${padVisible(styled, innerWidth)}${" ".repeat(paddingX)}`;
 			}),
 			...Array.from({ length: paddingY }, () => emptyPaddedLine),
 		];
+		const borderColorFn = this.spec.borderColor ?? (this.spec.toneColor ? (value: string) => this.spec.toneColor?.(this.spec.tone ?? "default", value) ?? value : undefined);
+		const borderColor = (text: string) => color(borderColorFn, text);
 
 		if (border === "none") {
 			return paddedBody.map((line) => padVisible(line, outerWidth));
@@ -132,30 +170,36 @@ export class TerminalStyle {
 
 		if (border === "rule") {
 			return [
-				color(this.spec.borderColor, "─".repeat(outerWidth)),
+				borderColor("─".repeat(outerWidth)),
 				...this.renderTitleRows(outerWidth),
-				...paddedBody.map((line) => `${color(this.spec.borderColor, "│ ")}${truncateToWidth(line, Math.max(1, outerWidth - 2), "")}`),
+				...paddedBody.map((line) => `${borderColor("│ ")}${truncateToWidth(line, Math.max(1, outerWidth - 2), "")}`),
+			];
+		}
+
+		if (border === "minimal") {
+			const contentWidth = Math.max(1, outerWidth - 2);
+			return [
+				...this.renderTitleRows(contentWidth).map((line) => `${borderColor("│ ")}${padVisible(line, contentWidth)}`),
+				...paddedBody.map((line) => `${borderColor("│ ")}${padVisible(line, contentWidth)}`),
 			];
 		}
 
 		const chars = BORDER_CHARS[border];
 		const horizontalWidth = Math.max(0, outerWidth - 2);
-		const top = color(
-			this.spec.borderColor,
+		const top = borderColor(
 			`${chars.topLeft}${chars.horizontal.repeat(horizontalWidth)}${chars.topRight}`,
 		);
-		const bottom = color(
-			this.spec.borderColor,
+		const bottom = borderColor(
 			`${chars.bottomLeft}${chars.horizontal.repeat(horizontalWidth)}${chars.bottomRight}`,
 		);
 		const contentWidth = Math.max(1, outerWidth - 2);
 		return [
 			top,
 			...this.renderTitleRows(contentWidth).map((line) =>
-				`${color(this.spec.borderColor, chars.vertical)}${padVisible(line, contentWidth)}${color(this.spec.borderColor, chars.vertical)}`,
+				`${borderColor(chars.vertical)}${padVisible(line, contentWidth)}${borderColor(chars.vertical)}`,
 			),
 			...paddedBody.map((line) =>
-				`${color(this.spec.borderColor, chars.vertical)}${padVisible(line, contentWidth)}${color(this.spec.borderColor, chars.vertical)}`,
+				`${borderColor(chars.vertical)}${padVisible(line, contentWidth)}${borderColor(chars.vertical)}`,
 			),
 			bottom,
 		];

--- a/packages/pi-tui/src/style.ts
+++ b/packages/pi-tui/src/style.ts
@@ -1,0 +1,181 @@
+// GSD2 - Terminal style primitives for framed TUI surfaces
+
+import { truncateToWidth, visibleWidth } from "./utils.js";
+
+export type TerminalBorderStyle = "none" | "rule" | "single" | "rounded" | "heavy";
+
+export interface TerminalStyleSpec {
+	width?: number;
+	paddingX?: number;
+	paddingY?: number;
+	border?: TerminalBorderStyle;
+	borderColor?: (text: string) => string;
+	foreground?: (text: string) => string;
+	title?: string;
+	titleRight?: string;
+	titleColor?: (text: string) => string;
+	titleRightColor?: (text: string) => string;
+}
+
+type BorderChars = {
+	topLeft: string;
+	topRight: string;
+	bottomLeft: string;
+	bottomRight: string;
+	horizontal: string;
+	vertical: string;
+};
+
+const BORDER_CHARS: Record<Exclude<TerminalBorderStyle, "none" | "rule">, BorderChars> = {
+	single: {
+		topLeft: "┌",
+		topRight: "┐",
+		bottomLeft: "└",
+		bottomRight: "┘",
+		horizontal: "─",
+		vertical: "│",
+	},
+	rounded: {
+		topLeft: "╭",
+		topRight: "╮",
+		bottomLeft: "╰",
+		bottomRight: "╯",
+		horizontal: "─",
+		vertical: "│",
+	},
+	heavy: {
+		topLeft: "┏",
+		topRight: "┓",
+		bottomLeft: "┗",
+		bottomRight: "┛",
+		horizontal: "━",
+		vertical: "┃",
+	},
+};
+
+function padVisible(line: string, width: number): string {
+	return line + " ".repeat(Math.max(0, width - visibleWidth(line)));
+}
+
+function color(fn: ((text: string) => string) | undefined, text: string): string {
+	return fn ? fn(text) : text;
+}
+
+function normalizeWidth(spec: TerminalStyleSpec, width?: number): number {
+	return Math.max(1, Math.floor(width ?? spec.width ?? 80));
+}
+
+export class TerminalStyle {
+	private readonly spec: TerminalStyleSpec;
+
+	constructor(spec: TerminalStyleSpec = {}) {
+		this.spec = { ...spec };
+	}
+
+	width(width: number): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, width });
+	}
+
+	padding(x: number, y = x): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, paddingX: x, paddingY: y });
+	}
+
+	paddingX(paddingX: number): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, paddingX });
+	}
+
+	paddingY(paddingY: number): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, paddingY });
+	}
+
+	border(border: TerminalBorderStyle): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, border });
+	}
+
+	borderColor(borderColor: (text: string) => string): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, borderColor });
+	}
+
+	foreground(foreground: (text: string) => string): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, foreground });
+	}
+
+	title(title: string, titleColor?: (text: string) => string): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, title, titleColor });
+	}
+
+	titleRight(titleRight: string, titleRightColor?: (text: string) => string): TerminalStyle {
+		return new TerminalStyle({ ...this.spec, titleRight, titleRightColor });
+	}
+
+	render(contentLines: string[], width?: number): string[] {
+		const outerWidth = normalizeWidth(this.spec, width);
+		const border = this.spec.border ?? "none";
+		const paddingX = Math.max(0, Math.floor(this.spec.paddingX ?? 0));
+		const paddingY = Math.max(0, Math.floor(this.spec.paddingY ?? 0));
+		const innerWidth = Math.max(1, outerWidth - (border === "none" ? 0 : 2) - paddingX * 2);
+		const emptyPaddedLine = " ".repeat(paddingX * 2 + innerWidth);
+		const sourceLines = contentLines.length > 0 ? contentLines : [""];
+		const paddedBody = [
+			...Array.from({ length: paddingY }, () => emptyPaddedLine),
+			...sourceLines.map((line) => {
+				const clipped = truncateToWidth(line, innerWidth, "");
+				const styled = color(this.spec.foreground, clipped);
+				return `${" ".repeat(paddingX)}${padVisible(styled, innerWidth)}${" ".repeat(paddingX)}`;
+			}),
+			...Array.from({ length: paddingY }, () => emptyPaddedLine),
+		];
+
+		if (border === "none") {
+			return paddedBody.map((line) => padVisible(line, outerWidth));
+		}
+
+		if (border === "rule") {
+			return [
+				color(this.spec.borderColor, "─".repeat(outerWidth)),
+				...this.renderTitleRows(outerWidth),
+				...paddedBody.map((line) => `${color(this.spec.borderColor, "│ ")}${truncateToWidth(line, Math.max(1, outerWidth - 2), "")}`),
+			];
+		}
+
+		const chars = BORDER_CHARS[border];
+		const horizontalWidth = Math.max(0, outerWidth - 2);
+		const top = color(
+			this.spec.borderColor,
+			`${chars.topLeft}${chars.horizontal.repeat(horizontalWidth)}${chars.topRight}`,
+		);
+		const bottom = color(
+			this.spec.borderColor,
+			`${chars.bottomLeft}${chars.horizontal.repeat(horizontalWidth)}${chars.bottomRight}`,
+		);
+		const contentWidth = Math.max(1, outerWidth - 2);
+		return [
+			top,
+			...this.renderTitleRows(contentWidth).map((line) =>
+				`${color(this.spec.borderColor, chars.vertical)}${padVisible(line, contentWidth)}${color(this.spec.borderColor, chars.vertical)}`,
+			),
+			...paddedBody.map((line) =>
+				`${color(this.spec.borderColor, chars.vertical)}${padVisible(line, contentWidth)}${color(this.spec.borderColor, chars.vertical)}`,
+			),
+			bottom,
+		];
+	}
+
+	private renderTitleRows(width: number): string[] {
+		const leftRaw = this.spec.title ?? "";
+		const rightRaw = this.spec.titleRight ?? "";
+		if (!leftRaw && !rightRaw) return [];
+
+		const leftBudget = rightRaw ? Math.max(1, width - visibleWidth(rightRaw) - 1) : width;
+		const left = color(this.spec.titleColor, truncateToWidth(leftRaw, leftBudget, ""));
+		const right = color(this.spec.titleRightColor, rightRaw);
+		const gap = rightRaw
+			? Math.max(1, width - visibleWidth(left) - visibleWidth(right))
+			: Math.max(0, width - visibleWidth(left));
+		return [`${left}${" ".repeat(gap)}${right}`];
+	}
+}
+
+export function style(spec: TerminalStyleSpec = {}): TerminalStyle {
+	return new TerminalStyle(spec);
+}


### PR DESCRIPTION
## TL;DR

**What:** Turns the TUI refresher prototype into live terminal behavior with adaptive layouts, richer style primitives, semantic theme tokens, and stateful tool cards.
**Why:** The previous slice added foundations, but PR #5356 still needed visible prototype parity in the actual interactive TUI.
**How:** Expands `@gsd/pi-tui` style surfaces, persists `/tui mode`, renders adaptive dashboard/chat/validation/debug/compact layouts, and collapses low-signal successful tool cards while keeping running/error cards expanded.

## What

This PR now includes the full TUI refresher slice:

- Expanded `@gsd/pi-tui` style primitives:
  - `rule`, `single`, `rounded`, `heavy`, and `minimal` borders
  - `compact`, `comfortable`, and `dashboard` density presets
  - tone support, title/right-title helpers, ANSI-safe width handling, truncation, padding, and body gutters
- Live adaptive TUI layouts:
  - `workflow` command-center summary with a right-side inspector on wide terminals
  - `chat` compact conversation surface
  - `validation` status/check/timeline surface
  - `debug` blocking-failure panel with next-action context
  - `compact` single-column narrow-terminal fallback
- Persistent mode control:
  - `terminal.adaptiveMode?: "auto" | "chat" | "workflow" | "validation" | "debug" | "compact"`
  - `/tui mode <auto|chat|workflow|validation|debug|compact>`
  - `/settings` entry for the same mode override
- Tool card upgrade:
  - elapsed status labels for running/done/error cards
  - running/error cards stay detailed
  - successful low-signal cards collapse to a compact completion row
  - the existing expand-tools toggle still opens detailed cards
- Semantic theme tokens with fallbacks to existing colors:
  - surface/frame tokens
  - tool state tokens
  - mode tokens

Closes #5355

## Why

The HTML prototype was useful for evaluating the design direction, but the PR needed to deliver those concepts in the real terminal path. This makes the refresher testable in `gsd-dev` instead of remaining a separate browser mock.

The semantic theme work intentionally does not add new palettes. Existing themes remain valid, and missing semantic tokens resolve from the current core theme colors.

## How

The implementation keeps the shared `style()` API small and immutable, then uses it from live interactive components. Adaptive mode selection remains a pure resolver and the live `AdaptiveLayoutComponent` feeds it terminal width, active tool count, blocking error state, and available GSD status text.

Mode override persistence goes through `SettingsManager`, so `/tui mode ...` and `/settings` use the same `terminal.adaptiveMode` value. Tool cards track start/end timing and decide compact-vs-expanded rendering from runtime state rather than hardcoded tool names.

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-tui/src/__tests__/style.test.ts packages/pi-coding-agent/src/modes/interactive/tui-mode.test.ts packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.test.ts packages/pi-coding-agent/src/modes/interactive/slash-command-handlers.test.ts packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts`
- [x] `npm run build:native-pkg && npm run build:pi-tui`
- [x] `npm run build:pi-tui && npm run build --workspace @gsd/pi-coding-agent` confirms `@gsd/pi-tui` still builds before the coding-agent build reaches the known blocker
- [ ] `npm run build --workspace @gsd/pi-coding-agent` — blocked by pre-existing unrelated error: `src/cli.ts(11,10): error TS2305: Module '"@gsd/pi-ai/bedrock-provider"' has no exported member 'bedrockProviderModule'.`

## AI-assisted contribution

This PR is AI-assisted. The implementation was reviewed locally and tested with the commands listed above. No AI co-author trailer is included in the commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adaptive TUI layout that auto-selects modes (chat/workflow/validation/debug/compact)
  * /tui command and a new "TUI adaptive mode" setting (auto, chat, workflow, validation, debug, compact)
  * Compact rendering for successful tools with minimal output; tool cards now show elapsed time

* **Improvements**
  * New terminal styling primitives and semantic theme tokens for richer visuals

* **Bug Fixes**
  * Blocking error state is cleared when an agent starts, avoiding stale error displays
<!-- end of auto-generated comment: release notes by coderabbit.ai -->