### PR TITLE
ci: skip heavy CI jobs for merge-conflicted PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,10 +147,46 @@ jobs:
             exit 1
           fi
 
+  mergeability-gate:
+    timeout-minutes: 2
+    needs: [detect-changes, ci-circuit-breaker-fast]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      skip-heavy-jobs: ${{ steps.gate.outputs.skip-heavy-jobs }}
+    steps:
+      - name: Determine whether heavy CI should be skipped
+        id: gate
+        uses: actions/github-script@v8
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        with:
+          script: |
+            const eventName = process.env.EVENT_NAME;
+            let mergeableState = "unknown";
+
+            if (eventName === "pull_request") {
+              for (let i = 0; i < 6; i++) {
+                const { data } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.pull_request.number,
+                });
+
+                mergeableState = data.mergeable_state ?? "unknown";
+                if (mergeableState !== "unknown") break;
+                await new Promise(resolve => setTimeout(resolve, 1000));
+              }
+            }
+
+            const { shouldSkipHeavyJobs } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/ci/mergeability-gate.mjs`);
+            const skipHeavyJobs = shouldSkipHeavyJobs({ eventName, mergeableState });
+            core.info(`mergeable_state=${mergeableState}; skip-heavy-jobs=${skipHeavyJobs}`);
+            core.setOutput("skip-heavy-jobs", skipHeavyJobs ? "true" : "false");
+
   build:
     timeout-minutes: 25
-    needs: [detect-changes, ci-circuit-breaker-fast]
-    if: needs.detect-changes.outputs.docs-only != 'true'
+    needs: [detect-changes, ci-circuit-breaker-fast, mergeability-gate]
+    if: needs.detect-changes.outputs.docs-only != 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -204,9 +240,9 @@ jobs:
 
   ci-circuit-breaker-build:
     timeout-minutes: 2
-    needs: [detect-changes, build]
+    needs: [detect-changes, build, mergeability-gate]
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: always() && needs.detect-changes.outputs.docs-only != 'true'
+    if: always() && needs.detect-changes.outputs.docs-only != 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     steps:
       - name: Stop pipeline when build gate fails
         env:
@@ -219,8 +255,8 @@ jobs:
 
   integration-tests:
     timeout-minutes: 15
-    needs: [detect-changes, ci-circuit-breaker-build]
-    if: needs.detect-changes.outputs.docs-only != 'true'
+    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
+    if: needs.detect-changes.outputs.docs-only != 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -266,8 +302,8 @@ jobs:
     # workflow. Mirrors the Dev Publish smoke step at dev-publish.yml:84-88.
     # No untrusted GitHub event input is consumed in run: blocks.
     timeout-minutes: 10
-    needs: [detect-changes, ci-circuit-breaker-build]
-    if: needs.detect-changes.outputs.docs-only != 'true'
+    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
+    if: needs.detect-changes.outputs.docs-only != 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -299,8 +335,8 @@ jobs:
     # ABI, migration chain, etc.) - see tests/e2e/README.md.
     # No untrusted GitHub event input is consumed in run: blocks.
     timeout-minutes: 15
-    needs: detect-changes
-    if: needs.detect-changes.outputs.docs-only != 'true'
+    needs: [detect-changes, mergeability-gate]
+    if: needs.detect-changes.outputs.docs-only != 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -336,10 +372,11 @@ jobs:
 
   windows-portability:
     timeout-minutes: 25
-    needs: [detect-changes, ci-circuit-breaker-build]
+    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
     if: >-
       needs.detect-changes.outputs.docs-only != 'true' &&
-      needs.detect-changes.outputs.portability-changed == 'true'
+      needs.detect-changes.outputs.portability-changed == 'true' &&
+      needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-windows-2025
 
     steps:
@@ -380,10 +417,11 @@ jobs:
 
   rtk-portability:
     timeout-minutes: 20
-    needs: [detect-changes, ci-circuit-breaker-build]
+    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
     if: >-
       needs.detect-changes.outputs.docs-only != 'true' &&
-      needs.detect-changes.outputs.portability-changed == 'true'
+      needs.detect-changes.outputs.portability-changed == 'true' &&
+      needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/__tests__/mergeability-gate.test.mjs
+++ b/scripts/__tests__/mergeability-gate.test.mjs
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldSkipHeavyJobs } from "../ci/mergeability-gate.mjs";
+
+test("returns false for non-pull_request events", () => {
+  assert.equal(shouldSkipHeavyJobs({ eventName: "push", mergeableState: "dirty" }), false);
+});
+
+test("returns true for pull_request with dirty mergeable_state", () => {
+  assert.equal(shouldSkipHeavyJobs({ eventName: "pull_request", mergeableState: "dirty" }), true);
+});
+
+test("returns false for clean/unknown pull_request states", () => {
+  assert.equal(shouldSkipHeavyJobs({ eventName: "pull_request", mergeableState: "clean" }), false);
+  assert.equal(shouldSkipHeavyJobs({ eventName: "pull_request", mergeableState: "unknown" }), false);
+  assert.equal(shouldSkipHeavyJobs({ eventName: "pull_request", mergeableState: "unstable" }), false);
+});

--- a/scripts/ci/mergeability-gate.mjs
+++ b/scripts/ci/mergeability-gate.mjs
@@ -1,0 +1,19 @@
+export function shouldSkipHeavyJobs({ eventName, mergeableState }) {
+  if (eventName !== "pull_request") return false;
+  return mergeableState === "dirty";
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const eventName = process.env.GITHUB_EVENT_NAME ?? "";
+  const mergeableState = process.env.PR_MERGEABLE_STATE ?? "unknown";
+  const skip = shouldSkipHeavyJobs({ eventName, mergeableState });
+  const outputPath = process.env.GITHUB_OUTPUT;
+
+  if (!outputPath) {
+    console.error("GITHUB_OUTPUT is required");
+    process.exit(1);
+  }
+
+  const fs = await import("node:fs/promises");
+  await fs.appendFile(outputPath, `skip-heavy-jobs=${skip ? "true" : "false"}\n`, "utf-8");
+}


### PR DESCRIPTION
## TL;DR

**What:** Adds a mergeability gate in CI that skips heavy jobs when a PR has merge conflicts (`mergeable_state=dirty`).
**Why:** Running build/integration/portability/e2e on non-mergeable conflict states wastes CI resources.
**How:** Added a small tested gate helper + new `mergeability-gate` workflow job, then wired heavy jobs to skip when the gate says to skip.

## What

- Added `scripts/ci/mergeability-gate.mjs` with `shouldSkipHeavyJobs({ eventName, mergeableState })`.
- Added test coverage in `scripts/__tests__/mergeability-gate.test.mjs`.
- Added `mergeability-gate` job to `.github/workflows/ci.yml` that:
  - queries PR `mergeable_state` (with short retry while state is `unknown`),
  - computes `skip-heavy-jobs` output.
- Wired these heavy jobs to skip when `skip-heavy-jobs == 'true'`:
  - `build`
  - `ci-circuit-breaker-build`
  - `integration-tests`
  - `live-regression`
  - `e2e`
  - `windows-portability`
  - `rtk-portability`

Basic checks remain running (`detect-changes`, `docs-check`, `lint`, `ci-circuit-breaker-fast`).

## Why

Merge-conflicted PRs cannot merge until conflicts are resolved. Running expensive test/build matrices before that resolution is usually low-signal and high-cost. This change saves CI time and queue capacity without reducing fast feedback on basic checks.

Closes #5358

## How

TDD + rubber-duck flow used:
1. Wrote failing test first for gate behavior (`scripts/__tests__/mergeability-gate.test.mjs`).
2. Implemented minimal helper to satisfy behavior (`scripts/ci/mergeability-gate.mjs`).
3. Added workflow gate job and applied skip conditions only to heavy jobs.
4. Re-ran tests and validated outputs.

### Verification

```bash
node --test scripts/__tests__/mergeability-gate.test.mjs
```

Result: 3 passed, 0 failed.

---
AI-assisted: yes.

### Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow to conditionally skip heavy jobs based on PR mergeability status, improving build feedback time.

* **Tests**
  * Added tests for CI optimization logic to ensure correct behavior across different PR states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->