### PR TITLE
test(tui): cover browser parity for tui command

### DIFF
--- a/src/tests/integration/web-command-parity-contract.test.ts
+++ b/src/tests/integration/web-command-parity-contract.test.ts
@@ -40,11 +40,24 @@ const EXPECTED_BUILTIN_OUTCOMES = new Map<string, "rpc" | "surface" | "reject">(
   ["thinking", "surface"],
   ["edit-mode", "reject"],
   ["terminal", "reject"],
+  ["tui", "reject"],
   ["quit", "reject"],
 ])
 
 const BUILTIN_DESCRIPTIONS = new Map(BUILTIN_SLASH_COMMANDS.map((command) => [command.name, command.description]))
-const DEFERRED_BROWSER_REJECTS = ["share", "copy", "changelog", "hotkeys", "tree", "provider", "reload", "edit-mode", "terminal", "quit"] as const
+const DEFERRED_BROWSER_REJECTS = [
+  "share",
+  "copy",
+  "changelog",
+  "hotkeys",
+  "tree",
+  "provider",
+  "reload",
+  "edit-mode",
+  "terminal",
+  "tui",
+  "quit",
+] as const
 
 async function collectRegisteredGsdCommandRoots(): Promise<string[]> {
   const commands = new Map<string, unknown>()


### PR DESCRIPTION
## TL;DR

**What:** Adds `/tui` to the browser slash-command parity contract as an explicit deferred built-in reject.
**Why:** CI integration tests started failing after `/tui` was added to the authoritative built-in command list without a matching browser-mode expectation.
**How:** Updates `EXPECTED_BUILTIN_OUTCOMES` and `DEFERRED_BROWSER_REJECTS` so browser mode blocks `/tui` instead of allowing an implicit prompt/follow-up fallthrough.

## What

This PR updates `src/tests/integration/web-command-parity-contract.test.ts` to include `/tui` in the explicit built-in browser parity matrix.

## Why

The `integration-tests` CI job failed with:

```text
AssertionError [ERR_ASSERTION]: update EXPECTED_BUILTIN_OUTCOMES when slash-commands.ts changes so browser parity stays explicit
23 !== 24
```

The root cause was that PR #5356 added `/tui` to `BUILTIN_SLASH_COMMANDS`, but the browser parity contract still listed only 23 built-ins. Browser mode does not have a native `/tui` surface, so `/tui` should remain a deferred reject like `/terminal`.

## How

- Adds `/tui -> reject` to `EXPECTED_BUILTIN_OUTCOMES`.
- Adds `tui` to `DEFERRED_BROWSER_REJECTS` so the rejection reason/notice path is covered.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/integration/web-command-parity-contract.test.ts`
- [x] `npm run build:core`
- [ ] `npm run test:integration` locally reached and passed the previous `/tui` parity failure, but local macOS/web dependency setup still has unrelated blockers: `/private/var` vs `/var` temp path assertion and missing `web/node_modules/next` until `npm --prefix web ci` is run. CI installs web deps before integration.

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

## AI-assisted contribution

This PR was prepared with AI assistance and verified with the commands above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for browser-mode command validation to ensure proper handling of the `tui` command
  * Updated contract expectations to validate deferred rejection behavior in browser environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->