### PR TITLE
fix(gsd extension): preserve full task summary when commit subject truncates

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -164,11 +164,16 @@ export function buildTaskCommitMessage(ctx: TaskCommitContext): string {
   const truncated = description.length > maxDescLen
     ? description.slice(0, maxDescLen - 1).trimEnd() + "…"
     : description;
+  const wasTruncated = truncated !== description;
 
   const subject = `${type}: ${truncated}`;
 
   // Build body with key files if available
   const bodyParts: string[] = [];
+
+  if (wasTruncated) {
+    bodyParts.push(`Summary: ${description}`);
+  }
 
   if (ctx.keyFiles && ctx.keyFiles.length > 0) {
     const fileLines = ctx.keyFiles

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -225,6 +225,7 @@ describe('git-service', async () => {
     assert.ok(msg.startsWith("feat:"), "message starts with type: (no scope)");
     assert.ok(!msg.includes("(S01/T02)"), "no GSD ID in subject line");
     assert.ok(msg.includes("JWT-based auth"), "message includes one-liner content");
+    assert.ok(!msg.includes("Summary:"), "body omits summary when subject is not truncated");
     assert.ok(msg.includes("- src/auth.ts"), "message body includes key files");
     assert.ok(msg.includes("- src/middleware/jwt.ts"), "message body includes second key file");
     assert.ok(msg.includes("GSD context:"), "message includes human GSD context block");
@@ -245,6 +246,27 @@ describe('git-service', async () => {
     assert.ok(subject.includes("Added auth BREAKING: injected trailer"), "control characters are flattened");
     assert.equal(subject.includes("\r"), false, "subject does not include carriage returns");
     assert.equal(subject.includes("\u0007"), false, "subject does not include control characters");
+  });
+
+  test('buildTaskCommitMessage preserves full summary in body when subject truncates', () => {
+    const oneLiner = "Recorded S09 plugin-settings runtime evidence and bounded remaining WPF/SDK debt in the Avalonia migration checklist.";
+    const msg = buildTaskCommitMessage({
+      taskId: "S09/T03",
+      taskTitle: "record plugin settings evidence",
+      oneLiner,
+      keyFiles: ["AVALONIA_MIGRATION_CHECKLIST.md"],
+      issueNumber: 42,
+    });
+
+    const subject = msg.split("\n")[0];
+    assert.ok(subject.endsWith("…"), "subject remains truncated with ellipsis");
+    assert.ok(msg.includes(`Summary: ${oneLiner}`), "body preserves full one-liner when subject truncates");
+
+    const summaryIdx = msg.indexOf(`Summary: ${oneLiner}`);
+    const taskIdx = msg.indexOf("GSD-Task: S09/T03");
+    const resolvesIdx = msg.indexOf("Resolves #42");
+    assert.ok(summaryIdx < taskIdx, "summary appears before GSD-Task trailer");
+    assert.ok(taskIdx < resolvesIdx, "trailer order remains GSD-Task then Resolves");
   });
 
   {


### PR DESCRIPTION
## Linked issue

Closes #5134
Refs #5364

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Preserve the full task one-liner in commit bodies when `buildTaskCommitMessage` truncates the subject.
**Why:** Truncation currently causes information loss in Git history because only an ellipsized subject is retained.
**How:** Add a truncation-aware `Summary:` body line and lock behavior with integration tests for truncated and non-truncated cases.

## What

- Updated task commit message generation to detect subject truncation and include `Summary: <full sanitized description>` in the body only when truncation happens.
- Kept existing trailer behavior/order intact (`GSD-Task` then optional `Resolves #N`).
- Added regression coverage for:
  - summary preservation when truncation occurs
  - no redundant summary when truncation does not occur

## Why

Issue #5134 documents that long one-liners are cut in the subject and not preserved elsewhere in the commit message. This made task history harder to audit without reading external task artifacts.

## How

- Extend `buildTaskCommitMessage(ctx)` with a `wasTruncated` check.
- Prepend a summary line to body parts only when truncated.
- Validate the public behavior via `node:test` integration tests on the commit-message contract and trailer ordering.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Executed locally:

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/git-service.test.ts
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/github-sync/tests/commit-linking.test.ts
```

Note: full `npm run test:unit` in this environment still has unrelated pre-existing sandbox/setup failures (missing `~/.gsd` prompt assets and local permission/network constraints).

## AI disclosure

- [x] This PR includes AI-assisted code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commit messages now include a "Summary:" section in the body when the subject was truncated, preserving the full description while keeping subject brevity.

* **Tests**
  * Added tests verifying summary inclusion only on truncation and correct ordering of summary and trailer sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5365)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
