### PR TITLE
fix(tui): keep pinned output until trailing tool completion

### DIFF
--- a/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
+++ b/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
@@ -965,10 +965,87 @@ test("chat-controller clears pinned zone when assistant message ends", async () 
 
 	assert.ok(host.pinnedMessageContainer.children.length > 0, "pinned zone should be populated during streaming");
 
+	// Simulate the tool completing before message_end (e.g. form elicitation path).
+	await handleAgentEvent(
+		host,
+		{
+			type: "tool_execution_end",
+			toolCallId: toolCall.id,
+			result: { content: [{ type: "text", text: "ok" }], details: {} },
+			isError: false,
+		} as any,
+	);
+	assert.equal(host.pendingTools.size, 0, "no pending tools should remain before message_end");
+
 	// End the assistant message (e.g. before form elicitation) — pinned zone should clear
 	await handleAgentEvent(host, { type: "message_end", message: makeAssistant(msgContent) } as any);
 
 	assert.equal(host.pinnedMessageContainer.children.length, 0, "pinned zone should clear on message_end to prevent duplicate display");
+});
+
+test("chat-controller keeps pinned zone until trailing tool_execution_end after message_end (#4346)", async () => {
+	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
+		fg: (_key: string, text: string) => text,
+		bg: (_key: string, text: string) => text,
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		truncate: (text: string) => text,
+	};
+
+	const host = createHost();
+	const toolCall = {
+		type: "toolCall",
+		id: "tool-msg-end-order-1",
+		name: "exec_command",
+		arguments: { cmd: "echo hi" },
+	};
+
+	await handleAgentEvent(host, { type: "message_start", message: makeAssistant([]) } as any);
+
+	host.getMarkdownThemeWithSettings = () => ({});
+	const msgContent = [{ type: "text", text: "Summary after tools." }, toolCall];
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant(msgContent),
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 1,
+				toolCall: {
+					...toolCall,
+					externalResult: {
+						content: [{ type: "text", text: "ok" }],
+						details: {},
+						isError: false,
+					},
+				},
+				partial: makeAssistant(msgContent),
+			},
+		} as any,
+	);
+
+	assert.ok(host.pinnedMessageContainer.children.length > 0, "pinned zone should be populated during streaming");
+	assert.ok(host.pendingTools.size > 0, "tool should still be pending before message_end");
+
+	await handleAgentEvent(host, { type: "message_end", message: makeAssistant(msgContent) } as any);
+	assert.ok(
+		host.pinnedMessageContainer.children.length > 0,
+		"pinned zone should remain visible after message_end while tools are still pending",
+	);
+
+	await handleAgentEvent(
+		host,
+		{
+			type: "tool_execution_end",
+			toolCallId: toolCall.id,
+			result: { content: [{ type: "text", text: "ok" }], details: {} },
+			isError: false,
+		} as any,
+	);
+
+	assert.equal(host.pendingTools.size, 0, "tool should be removed from pending map when it completes");
+	assert.equal(host.pinnedMessageContainer.children.length, 0, "pinned zone should clear when last pending tool completes");
 });
 
 test("chat-controller does not pin when there are no tool calls", async () => {

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -105,6 +105,19 @@ let hasToolsInTurn = false;
 let pinnedBorder: DynamicBorder | undefined;
 // Reference to the pinned markdown component below the border
 let pinnedTextComponent: Markdown | undefined;
+// True after assistant message_end when we still have pending tool executions.
+// Once the pending map drains, pinned output can be torn down safely.
+let deferPinnedCleanupUntilToolsComplete = false;
+
+function clearPinnedOutput(host: InteractiveModeStateHost): void {
+	if (pinnedBorder) pinnedBorder.stopSpinner();
+	host.pinnedMessageContainer.clear();
+	lastPinnedText = "";
+	hasToolsInTurn = false;
+	pinnedBorder = undefined;
+	pinnedTextComponent = undefined;
+	deferPinnedCleanupUntilToolsComplete = false;
+}
 
 function mergeToolPhases(phases: ToolExecutionPhase[]): ToolExecutionPhase[] {
 	const merged: ToolExecutionPhase[] = [];
@@ -229,12 +242,10 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 		lastContentLength = 0;
 		lastPinnedText = "";
 		hasToolsInTurn = false;
+		deferPinnedCleanupUntilToolsComplete = false;
 		renderedSegments = [];
 		orphanedSegments = [];
-		if (pinnedBorder) pinnedBorder.stopSpinner();
-		pinnedBorder = undefined;
-		pinnedTextComponent = undefined;
-		host.pinnedMessageContainer.clear();
+		clearPinnedOutput(host);
 	}
 
 	switch (event.type) {
@@ -247,15 +258,10 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					host.streamingMessage = undefined;
 					host.pendingTools.clear();
 					host.pendingMessagesContainer.clear();
-					host.pinnedMessageContainer.clear();
-					lastPinnedText = "";
-					hasToolsInTurn = false;
+					clearPinnedOutput(host);
 					renderedSegments = [];
 					orphanedSegments = [];
 					lastContentLength = 0;
-					if (pinnedBorder) pinnedBorder.stopSpinner();
-					pinnedBorder = undefined;
-					pinnedTextComponent = undefined;
 					host.compactionQueuedMessages = [];
 					host.rebuildChatFromMessages();
 					host.updatePendingMessagesDisplay();
@@ -902,12 +908,11 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				// Clear pinned output once the message is finalized in the chat
 				// container — prevents duplicate display when the agent continues
 				// (e.g. form elicitation) after the assistant message ends.
-				if (pinnedBorder) pinnedBorder.stopSpinner();
-				host.pinnedMessageContainer.clear();
-				lastPinnedText = "";
-				hasToolsInTurn = false;
-				pinnedBorder = undefined;
-				pinnedTextComponent = undefined;
+				if (host.pendingTools.size === 0) {
+					clearPinnedOutput(host);
+				} else {
+					deferPinnedCleanupUntilToolsComplete = true;
+				}
 				host.footer.invalidate();
 			}
 			host.ui.requestRender();
@@ -943,7 +948,11 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 			const component = host.pendingTools.get(event.toolCallId);
 			if (component) {
 				component.updateResult({ ...event.result, isError: event.isError });
+				host.pendingTools.delete(event.toolCallId);
 				replaceCompactToolRowsWithPhaseSummary(host);
+				if (deferPinnedCleanupUntilToolsComplete && host.pendingTools.size === 0) {
+					clearPinnedOutput(host);
+				}
 				host.ui.requestRender();
 			}
 			break;
@@ -968,14 +977,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 			host.pendingTools.clear();
 			// Pinned output is only useful while work is actively streaming.
 			// Keep chat history as the single source after completion.
-			if (pinnedBorder) {
-				pinnedBorder.stopSpinner();
-			}
-			host.pinnedMessageContainer.clear();
-			lastPinnedText = "";
-			hasToolsInTurn = false;
-			pinnedBorder = undefined;
-			pinnedTextComponent = undefined;
+			clearPinnedOutput(host);
 			await host.checkShutdownRequested();
 			host.ui.requestRender();
 			break;


### PR DESCRIPTION
## TL;DR

**What:** Defers TUI pinned-output teardown when `message_end` arrives before the final tool completion event.
**Why:** Assistant prose could be pushed off-screen by trailing tool cards because pinned output was cleared too early.
**How:** Gate `message_end` teardown on `pendingTools`, defer cleanup until the last `tool_execution_end`, and add regression coverage for the event-order case.

## What

This PR updates interactive chat event handling so pinned assistant output is not cleared prematurely when tool execution finishes after `message_end`.

- Added deferred cleanup state in `chat-controller` for `message_end` with in-flight tools.
- Added a shared pinned-output cleanup helper and reused it across turn/session cleanup paths.
- Added regression test for the ordering path: `message_update` (tool context) -> `message_end` -> trailing `tool_execution_end`.
- Updated existing `message_end` test to explicitly cover the no-pending-tools (form-elicitation-safe) path.

## Why

Issue #4346 reports a reproducible ordering bug: when `message_end` fires before pending tools complete, tool result rendering can push the assistant text out of view after the pinned mirror has already been removed.

Closes #4346.

## How

- At `message_end`, pinned output now clears immediately only when `pendingTools.size === 0`.
- If tools are still pending at `message_end`, cleanup is deferred.
- At `tool_execution_end`, when deferred cleanup is active and the pending tool map drains to zero, pinned output is cleared exactly once.
- Existing behavior for no-tool/no-pending message completion remains unchanged.

## Testing

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts`
- `npm run verify:pr` (fails in this environment due unrelated sandbox/user-home constraints: missing `~/.gsd/agent/extensions/gsd/prompts/*.md`, EPERM on `~/.agents/skills/*`, loopback listen EPERM, and unrelated guided-flow prompt assertions)

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## AI-assisted disclosure

This PR was prepared with AI assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the pinned output zone (Latest Output) to remain visible while tool execution is pending and clear properly once all tools complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->