### PR TITLE
chore(triage): enforce needs-triage label at issue intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,7 @@ description: Report crashes, regressions, incorrect behavior, or broken workflow
 title: "[Bug]: "
 labels:
   - bug
+  - needs-triage
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,6 +3,7 @@ description: Propose a new capability or improvement for GSD.
 title: "[Feature]: "
 labels:
   - enhancement
+  - needs-triage
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -37,7 +37,20 @@ jobs:
             const title = item.title;
             const body = item.body || '';
             const type = isIssue ? 'issue' : 'pull_request';
-            const existingLabels = (item.labels || []).map(l => l.name);
+            let existingLabels = (item.labels || []).map(l => l.name);
+
+            // Ensure all newly opened issues enter the canonical triage queue,
+            // even when they bypass issue templates (API/import/manual labeling).
+            if (isIssue && !existingLabels.includes('needs-triage')) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                labels: ['needs-triage']
+              });
+              existingLabels.push('needs-triage');
+              core.info('Added default label: needs-triage');
+            }
 
             const prompt = `You are a GitHub issue/PR triage bot for the GSD-2 project. Your job is to:
             1. Classify the ${type} with appropriate labels


### PR DESCRIPTION
## TL;DR

**What:** Adds `needs-triage` to issue intake defaults and workflow fallback labeling.
**Why:** New issues were not consistently entering the canonical triage queue.
**How:** Updated issue templates and added an `issues.opened` workflow guard that adds `needs-triage` when missing.

## What

This PR updates issue-intake automation:

- Adds `needs-triage` to:
  - `.github/ISSUE_TEMPLATE/bug_report.yml`
  - `.github/ISSUE_TEMPLATE/feature_request.yml`
- Updates `.github/workflows/ai-triage.yml` so that on issue open, if `needs-triage` is absent, it is added before AI classification continues.

## Why

Issue queue operations and triage reports expect new issues to start in `needs-triage`. In current behavior, issues were often labeled by type/priority but skipped `needs-triage`, creating inconsistency in triage workflows.

Closes #5368.

## How

- Template-level default ensures UI-created issues are pre-labeled.
- Workflow-level fallback ensures API/import/manual issue creation paths also receive `needs-triage`.
- The workflow mutates `existingLabels` after adding `needs-triage`, preventing duplicate label operations later in the same run.

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## AI-assisted disclosure

This PR was prepared with AI assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated issue templates to support the `needs-triage` label option for bug reports and feature requests.
  * Automated issue triage workflow now applies the `needs-triage` label to newly opened issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->