### PR TITLE
fix(gsd-extension): enforce worktree-isolation contract on write/edit

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -7,7 +7,7 @@ import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-exten
 import { updateSnapshot } from "../ecosystem/gsd-extension-api.js";
 
 import { buildMilestoneFileName, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "../paths.js";
-import { canonicalToolName, clearDiscussionFlowState, isDepthConfirmationAnswer, isQueuePhaseActive, markApprovalGateVerified, markDepthVerified, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, isGateQuestionId, setPendingGate, clearPendingGate, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
+import { canonicalToolName, clearDiscussionFlowState, isDepthConfirmationAnswer, isQueuePhaseActive, markApprovalGateVerified, markDepthVerified, resetWriteGateState, shouldBlockContextWrite, shouldBlockPlanningUnit, shouldBlockQueueExecution, shouldBlockWorktreeWrite, isGateQuestionId, setPendingGate, clearPendingGate, getPendingGate, shouldBlockPendingGate, shouldBlockPendingGateBash, extractDepthVerificationMilestoneId } from "./write-gate.js";
 import { resolveManifest } from "../unit-context-manifest.js";
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
@@ -480,6 +480,22 @@ export function registerHooks(
         );
         if (planningGuard.block) return planningGuard;
       }
+    }
+
+    // ── Worktree-isolation write gate (#5199) ────────────────────────────
+    // Block planning-write tools from landing code at the project root when
+    // git.isolation=worktree but auto-mode hasn't created the milestone
+    // worktree yet. Without this, writes silently orphan outside git history.
+    if (isToolCallEventType("write", event) || isToolCallEventType("edit", event)) {
+      const wtBasePath = resolveWorktreeProjectRoot(dash.basePath ?? discussionBasePath);
+      const wtGuard = shouldBlockWorktreeWrite(
+        event.toolName,
+        event.input.path,
+        wtBasePath,
+        isAutoActive(),
+        dash.currentUnit?.type,
+      );
+      if (wtGuard.block) return wtGuard;
     }
 
     // ── Single-writer engine: block direct writes to STATE.md ──────────

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -1,10 +1,12 @@
-import { copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import { minimatch } from "minimatch";
 
+import { getIsolationMode } from "../preferences.js";
 import type { ToolsPolicy } from "../unit-context-manifest.js";
 import { logWarning } from "../workflow-logger.js";
+import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "../worktree-root.js";
 
 /**
  * Regex matching milestone CONTEXT.md file names in both legacy M001
@@ -881,4 +883,136 @@ export function shouldBlockPlanningUnit(
   // CONTEXT.md write) catch known mutating shapes; defaulting to allow here
   // avoids breaking gsd_* MCP tools or future safe additions.
   return { block: false };
+}
+
+// ─── Worktree isolation write gate (#5199) ────────────────────────────────
+//
+// When `git.isolation: worktree` is configured, the per-unit commit pipeline
+// only runs inside the auto-mode loop (`auto-post-unit.ts`). If the LLM
+// authors code at the project root before auto-mode is started, those writes
+// land in the working tree but never reach a commit — they're silently
+// orphaned outside git history. This guard blocks those writes at the
+// tool_call seam so the agent receives a clear error instead.
+
+const WORKTREE_GATE_BOOTSTRAP_UNITS = new Set([
+  "discuss-milestone",
+  "plan-milestone",
+  "init",
+]);
+
+function realpathOrResolve(p: string): string {
+  const abs = resolve(p);
+  try {
+    return realpathSync(abs);
+  } catch {
+    // Path doesn't exist (yet) — realpath the deepest existing ancestor so
+    // platforms where /tmp -> /private/tmp don't break containment checks.
+    let dir = abs;
+    const tail: string[] = [];
+    while (dir && dir !== resolve(dir, "..")) {
+      try {
+        const real = realpathSync(dir);
+        return tail.length ? join(real, ...tail.reverse()) : real;
+      } catch {
+        const idx = dir.lastIndexOf(sep);
+        if (idx <= 0) break;
+        tail.push(dir.slice(idx + 1));
+        dir = dir.slice(0, idx) || sep;
+      }
+    }
+    return abs;
+  }
+}
+
+function isPathContained(target: string, container: string): boolean {
+  if (target === container) return true;
+  return target.startsWith(container.endsWith(sep) ? container : container + sep);
+}
+
+/**
+ * Block planning-write tool calls that would land code at the project root
+ * while `git.isolation: worktree` is in effect and auto-mode hasn't created
+ * (or flipped cwd into) the milestone worktree.
+ *
+ * Pure / unit-testable. Callers in `register-hooks.ts` supply the resolved
+ * project root and current auto liveness; this function does no I/O beyond
+ * realpath resolution.
+ *
+ * Allow rules (in order):
+ *   1. Tool isn't a planning-write (write/edit/multi_edit/notebook_edit).
+ *   2. `GSD_DISABLE_WORKTREE_WRITE_GUARD=1` self-hosting bypass.
+ *   3. Isolation mode is not "worktree".
+ *   4. Active unit is a bootstrap unit (discuss-milestone/plan-milestone/init).
+ *   5. Target is inside `<projectRoot>/.gsd/worktrees/` (a real worktree).
+ *   6. Target is inside `<projectRoot>/.gsd/` and isn't masquerading as a
+ *      worktrees sibling (rejects the `.gsd/worktrees-extra/…` prefix trick).
+ *   7. Auto is live AND `effectiveBasePath` is itself a `.gsd/worktrees/…` path.
+ *
+ * Otherwise: block with a message that points the agent at `/gsd` to start
+ * auto-mode.
+ */
+export function shouldBlockWorktreeWrite(
+  toolName: string,
+  targetPath: string,
+  effectiveBasePath: string,
+  isAutoLive: boolean,
+  currentUnitType?: string | null,
+): { block: boolean; reason?: string } {
+  const tool = canonicalToolName(toolName);
+  if (!PLANNING_WRITE_TOOLS.has(tool)) return { block: false };
+  if (process.env.GSD_DISABLE_WORKTREE_WRITE_GUARD === "1") return { block: false };
+  if (getIsolationMode(effectiveBasePath) !== "worktree") return { block: false };
+  if (currentUnitType && WORKTREE_GATE_BOOTSTRAP_UNITS.has(currentUnitType)) return { block: false };
+
+  if (!targetPath) {
+    return {
+      block: true,
+      reason: [
+        `HARD BLOCK: ${tool} called with empty path while \`git.isolation: worktree\` is configured`,
+        `and auto-mode is not active. Refusing to allow writes that cannot be located.`,
+      ].join(" "),
+    };
+  }
+
+  // Resolve the target relative to the project root, then realpath to defeat
+  // symlink-based escapes and prefix tricks (e.g. .gsd/worktrees-extra/).
+  const projectRoot = resolveWorktreeProjectRoot(effectiveBasePath);
+  const absTarget = isAbsolute(targetPath) ? targetPath : resolve(projectRoot, targetPath);
+  const realTarget = realpathOrResolve(absTarget);
+  const realRoot = realpathOrResolve(projectRoot);
+  const realGsd = realpathOrResolve(join(projectRoot, ".gsd"));
+  const realWorktreesDir = realpathOrResolve(join(projectRoot, ".gsd", "worktrees"));
+
+  // Allow writes inside the legitimate worktrees subtree.
+  if (isPathContained(realTarget, realWorktreesDir)) return { block: false };
+
+  // Allow writes to .gsd/ planning artifacts, but reject siblings whose name
+  // starts with "worktrees" (the worktrees-extra prefix trick — case 4).
+  if (isPathContained(realTarget, realGsd)) {
+    const rel = relative(realGsd, realTarget);
+    const firstSeg = rel.split(/[\/\\]/)[0] ?? "";
+    if (!firstSeg.startsWith("worktrees")) return { block: false };
+    // fall through: looks like worktrees<something> sibling — block
+  }
+
+  // Auto is live and the caller is operating inside a worktree path —
+  // host tool's write happens in worktree context; let it through.
+  if (isAutoLive && isGsdWorktreePath(effectiveBasePath)) return { block: false };
+
+  // Block. Provide enough context that the agent can self-correct.
+  const displayTarget = isPathContained(realTarget, realRoot)
+    ? relative(realRoot, realTarget) || "."
+    : realTarget;
+  return {
+    block: true,
+    reason: [
+      `HARD BLOCK: Worktree isolation is configured (\`git.isolation: worktree\`) but auto-mode is`,
+      `not running and the target "${displayTarget}" is not inside \`.gsd/worktrees/<MID>/\`.`,
+      `Code edits at the project root would be lost — only the auto-mode commit pipeline`,
+      `(auto-post-unit) commits work, and it never runs outside the loop.`,
+      `Required action: start auto-mode with \`/gsd\` so the milestone worktree is created,`,
+      `then write inside it. To disable this guard for self-hosting development, set`,
+      `GSD_DISABLE_WORKTREE_WRITE_GUARD=1.`,
+    ].join(" "),
+  };
 }

--- a/src/resources/extensions/gsd/tests/worktree-write-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-write-gate.test.ts
@@ -1,0 +1,179 @@
+// GSD-2 worktree-isolation write gate (#5199).
+//
+// Regression coverage for shouldBlockWorktreeWrite — the helper that prevents
+// the LLM from authoring code at the project root when `git.isolation: worktree`
+// is configured but auto-mode (and its post-unit commit pipeline) hasn't run.
+// Without this gate, writes silently orphan outside git history.
+//
+// Test setup creates a fresh temp project for each isolation case, writes a
+// `.gsd/PREFERENCES.md` with `isolation: "worktree"`, and exercises the helper
+// against the 9 scenarios listed in the issue. No source-grep tests — every
+// assertion exercises the real predicate.
+
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { shouldBlockWorktreeWrite } from "../bootstrap/write-gate.js";
+import { invalidateAllCaches } from "../cache.js";
+
+function makeProject(isolation: "none" | "worktree" | "branch" | null): string {
+  const root = mkdtempSync(join(tmpdir(), "wt-write-gate-"));
+  if (isolation !== null) {
+    mkdirSync(join(root, ".gsd"), { recursive: true });
+    writeFileSync(
+      join(root, ".gsd", "PREFERENCES.md"),
+      `---\ngit:\n  isolation: "${isolation}"\n---\n`,
+    );
+  }
+  invalidateAllCaches();
+  return root;
+}
+
+const PLANNING_WRITE_TOOLS = ["write", "edit", "multi_edit", "notebook_edit"];
+
+describe("shouldBlockWorktreeWrite (#5199)", () => {
+  let projectRoot: string;
+  let prevDisableEnv: string | undefined;
+
+  beforeEach(() => {
+    prevDisableEnv = process.env.GSD_DISABLE_WORKTREE_WRITE_GUARD;
+    delete process.env.GSD_DISABLE_WORKTREE_WRITE_GUARD;
+  });
+
+  afterEach(() => {
+    if (projectRoot) {
+      try { rmSync(projectRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+    if (prevDisableEnv === undefined) {
+      delete process.env.GSD_DISABLE_WORKTREE_WRITE_GUARD;
+    } else {
+      process.env.GSD_DISABLE_WORKTREE_WRITE_GUARD = prevDisableEnv;
+    }
+    invalidateAllCaches();
+  });
+
+  test("Case 1: every PLANNING_WRITE_TOOLS variant writing to <root>/app.js is blocked", () => {
+    projectRoot = makeProject("worktree");
+    for (const tool of PLANNING_WRITE_TOOLS) {
+      const result = shouldBlockWorktreeWrite(
+        tool,
+        join(projectRoot, "app.js"),
+        projectRoot,
+        /* isAutoLive */ false,
+        /* unitType */ null,
+      );
+      assert.equal(result.block, true, `tool ${tool} should be blocked`);
+      assert.match(result.reason ?? "", /HARD BLOCK/);
+    }
+  });
+
+  test("Case 2: write to <root>/.gsd/PROJECT.md is allowed", () => {
+    projectRoot = makeProject("worktree");
+    const result = shouldBlockWorktreeWrite(
+      "write",
+      join(projectRoot, ".gsd", "PROJECT.md"),
+      projectRoot,
+      false,
+      null,
+    );
+    assert.equal(result.block, false);
+  });
+
+  test("Case 3: write inside <root>/.gsd/worktrees/M001/ is allowed", () => {
+    projectRoot = makeProject("worktree");
+    const target = join(projectRoot, ".gsd", "worktrees", "M001", "src", "app.js");
+    const result = shouldBlockWorktreeWrite("edit", target, projectRoot, false, null);
+    assert.equal(result.block, false);
+  });
+
+  test("Case 4: write to <root>/.gsd/worktrees-extra/M001/app.js (prefix trick) is blocked", () => {
+    projectRoot = makeProject("worktree");
+    const target = join(projectRoot, ".gsd", "worktrees-extra", "M001", "app.js");
+    const result = shouldBlockWorktreeWrite("write", target, projectRoot, false, null);
+    assert.equal(result.block, true);
+    assert.match(result.reason ?? "", /HARD BLOCK/);
+  });
+
+  test("Case 5: isolation=none → allow", () => {
+    projectRoot = makeProject("none");
+    const result = shouldBlockWorktreeWrite(
+      "write",
+      join(projectRoot, "app.js"),
+      projectRoot,
+      false,
+      null,
+    );
+    assert.equal(result.block, false);
+  });
+
+  test("Case 6: isolation=worktree, auto active, effectiveBasePath inside worktree → allow", () => {
+    projectRoot = makeProject("worktree");
+    const inside = join(projectRoot, ".gsd", "worktrees", "M001");
+    mkdirSync(inside, { recursive: true });
+    const result = shouldBlockWorktreeWrite(
+      "write",
+      join(inside, "src", "app.js"),
+      inside,
+      /* isAutoLive */ true,
+      null,
+    );
+    assert.equal(result.block, false);
+  });
+
+  test("Case 7: isolation=worktree, auto active, effectiveBasePath is project root (cwd never flipped) → block", () => {
+    projectRoot = makeProject("worktree");
+    const result = shouldBlockWorktreeWrite(
+      "write",
+      join(projectRoot, "app.js"),
+      projectRoot,
+      /* isAutoLive */ true,
+      null,
+    );
+    assert.equal(result.block, true);
+    assert.match(result.reason ?? "", /HARD BLOCK/);
+  });
+
+  test("Case 8: bootstrap unit type active → allow", () => {
+    projectRoot = makeProject("worktree");
+    for (const unitType of ["discuss-milestone", "plan-milestone", "init"]) {
+      const result = shouldBlockWorktreeWrite(
+        "write",
+        join(projectRoot, "app.js"),
+        projectRoot,
+        false,
+        unitType,
+      );
+      assert.equal(result.block, false, `unit ${unitType} should bypass the guard`);
+    }
+  });
+
+  test("Case 9: GSD_DISABLE_WORKTREE_WRITE_GUARD=1 → allow", () => {
+    projectRoot = makeProject("worktree");
+    process.env.GSD_DISABLE_WORKTREE_WRITE_GUARD = "1";
+    const result = shouldBlockWorktreeWrite(
+      "write",
+      join(projectRoot, "app.js"),
+      projectRoot,
+      false,
+      null,
+    );
+    assert.equal(result.block, false);
+  });
+
+  test("non-planning tools (read/grep/bash) pass through unconditionally", () => {
+    projectRoot = makeProject("worktree");
+    for (const tool of ["read", "grep", "bash", "ls"]) {
+      const result = shouldBlockWorktreeWrite(
+        tool,
+        join(projectRoot, "app.js"),
+        projectRoot,
+        false,
+        null,
+      );
+      assert.equal(result.block, false, `tool ${tool} must not be gated`);
+    }
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Block planning-write tool calls (write/edit/multi_edit/notebook_edit) at the project root when `git.isolation: worktree` is configured but auto-mode hasn't started.
**Why:** Without auto-mode running, no commit pipeline executes — root-level writes silently orphan outside git history (#5199).
**How:** New `shouldBlockWorktreeWrite` helper in `bootstrap/write-gate.ts`, wired into the `tool_call` hook after the existing planning-unit guard.

## What

- **`src/resources/extensions/gsd/bootstrap/write-gate.ts`** — adds the pure, unit-testable predicate `shouldBlockWorktreeWrite(toolName, targetPath, effectiveBasePath, isAutoLive, currentUnitType)`. Reuses the existing `PLANNING_WRITE_TOOLS` set so `multi_edit`/`notebook_edit` are covered (the host's `isToolCallEventType` discriminators don't reach these). Realpath-aware containment via a deepest-existing-ancestor walk so the `.gsd/worktrees-extra/…` prefix trick can't defeat the gate, and macOS `/tmp → /private/tmp` symlink doesn't break the .gsd allowance.
- **`src/resources/extensions/gsd/bootstrap/register-hooks.ts`** — wires the guard into the `pi.on(\"tool_call\", …)` handler immediately after the planning-unit guard. Uses `resolveWorktreeProjectRoot(dash.basePath ?? discussionBasePath)` for `effectiveBasePath` per the issue spec. Twelve lines of net new code.
- **`src/resources/extensions/gsd/tests/worktree-write-gate.test.ts`** — 10 tests (the 9 scenarios listed in the issue plus a negative test for read/grep/bash). `node:test` + `node:assert/strict`, no source-grep assertions.

## Why

Closes #5199.

GSD-2's commit pipeline is gated on auto-mode being live. `runTurnGitAction` is invoked only from `auto-post-unit.ts` inside the auto-mode loop. When a user has `git.isolation: worktree` configured and walks `/gsd` planning manually without entering auto-mode, the LLM can author code at the project root with no path to a commit — `git status` shows untracked files indefinitely, `audit_events` and `turn_git_transactions` stay empty, and the run is unrecoverable without manual git surgery. This guard rejects those writes at the tool seam with a `HARD BLOCK` reason the agent can self-correct from.

## How

Allow rules, in order:

1. Tool isn't a planning-write — pass through.
2. `GSD_DISABLE_WORKTREE_WRITE_GUARD=1` — self-hosting bypass.
3. Isolation mode is not `worktree` — pass through.
4. Active unit is `discuss-milestone`, `plan-milestone`, or `init` — bootstrap carve-out.
5. Target is inside `<projectRoot>/.gsd/worktrees/` — legit worktree write.
6. Target is inside `<projectRoot>/.gsd/` and isn't masquerading as a `worktrees<…>` sibling — planning artifact.
7. Auto is live AND `effectiveBasePath` itself is a `.gsd/worktrees/…` path — auto-mode flipped cwd into the worktree.

Otherwise: block. The `isAutoActive()` probe is intentionally the only liveness signal — `isAutoPaused()` deliberately stays on the block side, since a paused session must still gate root writes.

### Acceptance

- [x] Helper lives in `write-gate.ts` as a pure, unit-testable function.
- [x] Hook integration is ≤ 15 lines (12 lines net).
- [x] All 9 issue test cases pass plus 1 additional negative case.
- [x] Reproduction path no longer reproducible — writes blocked, agent receives clear error, no untracked code at project root.
- [x] No regressions in existing guards: full `gsd/tests/` suite (6841 tests) passes.

## Test plan

- [x] `node --test \"dist-test/src/resources/extensions/gsd/tests/worktree-write-gate.test.js\"` → 10/10 green.
- [x] `node --test \"dist-test/src/resources/extensions/gsd/tests/write-gate*.test.js\"` (existing) → 103/103 green.
- [x] Full `gsd/tests/*` suite → 6841 pass / 0 fail / 7 skip.
- [x] `npx tsc --noEmit -p tsconfig.json` → clean.

AI-assisted PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a worktree write isolation guard that blocks writes in specific scenarios and directs users to use `/gsd` commands when operating under git worktree mode.

* **Tests**
  * Added comprehensive regression test coverage for the worktree isolation write guard, including environment variable overrides and multiple write scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->