### PR TITLE
fix(gsd): honor implementation commits during milestone closeout

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -155,7 +155,21 @@ export function hasImplementationArtifacts(basePath: string, milestoneId?: strin
       return "unknown";
     }
 
-    return classifyImplementationFiles(changedFiles);
+    const branchClassification = classifyImplementationFiles(changedFiles);
+    if (branchClassification === "present") return "present";
+
+    // A completing milestone branch can have a non-empty diff containing only
+    // .gsd/ closeout files after implementation commits already landed on the
+    // recorded integration branch. In that topology, the branch diff alone is
+    // insufficient; use the same milestone-tagged evidence fallback as the
+    // self-diff retry path before declaring the milestone implementation-free.
+    if (milestoneId) {
+      const tagged = getChangedFilesFromMilestoneTaggedCommits(basePath, milestoneId);
+      if (!tagged.ok) return "unknown";
+      if (tagged.matched) return classifyImplementationFiles(tagged.files);
+    }
+
+    return "absent";
   } catch (e) {
     // Non-fatal — if git operations fail, return unknown so callers can decide
     logWarning("recovery", `implementation artifact check failed: ${(e as Error).message}`);
@@ -263,7 +277,7 @@ function getChangedFilesFromMilestoneTaggedCommits(
     "log", "--format=%H%x1f%B%x1e", "HEAD", "--", `.gsd/milestones/${milestoneId}`,
   ]);
   if (!scoped.ok) return scoped;
-  if (scoped.matched) return scoped;
+  if (scoped.matched && classifyImplementationFiles(scoped.files) === "present") return scoped;
 
   // Fallback (#5033): when .gsd/ is gitignored / external / untracked, the
   // path-scoped scan matches no commits even though GSD-tagged commits
@@ -274,9 +288,17 @@ function getChangedFilesFromMilestoneTaggedCommits(
   // Intentionally unbounded — symmetric with the primary scan, and avoids
   // reintroducing the rolling-depth failure class removed in #4699 where
   // milestone evidence aged out behind unrelated activity.
-  return scanGsdTaggedCommits(basePath, milestoneId, [
+  const unscoped = scanGsdTaggedCommits(basePath, milestoneId, [
     "log", "--format=%H%x1f%B%x1e", "HEAD",
   ]);
+  if (!unscoped.ok) return scoped.matched ? scoped : unscoped;
+  if (!unscoped.matched) return scoped;
+
+  return {
+    ok: true,
+    matched: true,
+    files: [...new Set([...scoped.files, ...unscoped.files])],
+  };
 }
 
 function scanGsdTaggedCommits(

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -12,6 +12,7 @@ import { clearParseCache } from "../files.ts";
 import { parseRoadmap } from "../parsers-legacy.ts";
 import { invalidateAllCaches } from "../cache.ts";
 import { deriveState, invalidateStateCache } from "../state.ts";
+import { writeIntegrationBranch } from "../git-service.ts";
 
 const tmpDirs: string[] = [];
 
@@ -730,6 +731,50 @@ test("hasImplementationArtifacts rejects milestone-scoped main history with only
 
     const result = hasImplementationArtifacts(base, "M001");
     assert.equal(result, "absent", "milestone-scoped fallback must not treat .gsd-only commits as implementation");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("hasImplementationArtifacts finds integration implementation-only commits when milestone branch diff is .gsd-only", () => {
+  const base = makeGitBase();
+  try {
+    mkdirSync(join(base, "src"), { recursive: true });
+    writeFileSync(join(base, "src", "feature.ts"), "export function feature() {}\n");
+    execFileSync("git", ["add", "src/feature.ts"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feat: add milestone feature\n\nGSD-Task: S01/T01"], { cwd: base, stdio: "ignore" });
+
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      title: "Slice One",
+      status: "complete",
+      risk: "low",
+      depends: [],
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Task One",
+      status: "complete",
+    });
+
+    execFileSync("git", ["checkout", "-b", "milestone/M001"], { cwd: base, stdio: "ignore" });
+    writeIntegrationBranch(base, "M001", "main");
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-SUMMARY.md"), "# Milestone Summary\nDone.");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "chore: auto-commit after complete-milestone\n\nGSD-Unit: M001"], { cwd: base, stdio: "ignore" });
+
+    const result = hasImplementationArtifacts(base, "M001");
+    assert.equal(
+      result,
+      "present",
+      ".gsd-only milestone closeout diffs should still honor implementation commits already on the integration branch",
+    );
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## TL;DR

**What:** Fixes the complete-milestone implementation artifact guard when a milestone branch only contains `.gsd/` closeout files but implementation commits already exist on the integration branch.
**Why:** Auto-mode could falsely stop with "no implementation files found outside .gsd/" even though the milestone had real implementation-only `GSD-Task` commits.
**How:** Reuses milestone-tagged commit evidence when branch diffs are `.gsd/`-only, and keeps scanning unscoped history when path-scoped `.gsd/` matches do not include implementation files.

## What

This updates `hasImplementationArtifacts()` in the GSD auto-recovery path. The guard now:

- returns `present` immediately when the branch diff includes implementation files
- falls back to milestone-tagged commit evidence when the branch diff is non-empty but `.gsd/`-only
- keeps the unscoped commit scan available when path-scoped `.gsd/` history only proves closeout files, so implementation-only `GSD-Task: Sxx/Tyy` commits can still be associated via DB/task ownership evidence

The regression test covers the reported topology: implementation-only commit on `main`, milestone branch diff containing only `.gsd/` closeout state, and short `GSD-Task: S01/T01` attribution bound through DB state.

## Why

Closes #5171.

The complete-milestone dispatch guard stops when `hasImplementationArtifacts(basePath, mid)` returns `absent`. In this failure mode, the milestone branch diff was not empty, but it only contained `.gsd/` closeout files. That caused the detector to skip the integration-branch evidence that would have found real implementation commits already present in history.

## How

The implementation keeps the existing safety rule: matched milestone evidence still has to include at least one non-`.gsd/` file before the guard returns `present`.

The change is intentionally narrow. It does not relax the guard for `.gsd/`-only milestones; it only prevents `.gsd/` closeout commits from masking valid implementation commits that are already attributable to the milestone.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-recovery.test.ts` — passed, 49/49
- [x] `npm run typecheck:extensions` — passed
- [ ] `npm run verify:pr` — build and extension typecheck passed; unit suite failed on unrelated ADR-012 provider-equality allowlist check in `src/providers/provider-migrations.ts`

`npm run verify:pr` result after this commit:

- 8982 passed
- 1 failed
- 9 skipped
- failing test: `ADR-012: provider-equality checks are allowlisted or use isXxxApi helpers`
- unrelated file: `src/providers/provider-migrations.ts`

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

AI-assisted contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced auto-recovery artifact detection to more precisely identify implementation evidence, with improved handling of edge cases and refined fallback scanning mechanisms.

* **Tests**
  * Added test case to verify artifact detection correctly handles branch scenarios containing metadata-only changes alongside existing implementation artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->