### PR TITLE
fix(gsd): backfill milestone commit attribution

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -14,7 +14,7 @@ import { appendEvent } from "./workflow-events.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { clearParseCache } from "./files.js";
 import { parseRoadmap as parseLegacyRoadmap, parsePlan as parseLegacyPlan } from "./parsers-legacy.js";
-import { isDbAvailable, getTask, getSlice, getSliceTasks, getPendingGates, updateTaskStatus, updateSliceStatus, insertSlice, getMilestone, refreshOpenDatabaseFromDisk } from "./gsd-db.js";
+import { isDbAvailable, getTask, getSlice, getSliceTasks, getPendingGates, updateTaskStatus, updateSliceStatus, insertSlice, getMilestone, refreshOpenDatabaseFromDisk, getCompletedMilestoneTaskFileHints, getMilestoneCommitAttributionShas, recordMilestoneCommitAttribution } from "./gsd-db.js";
 import { isValidationTerminal } from "./state.js";
 import { getErrorMessage } from "./error-utils.js";
 import { logWarning, logError } from "./workflow-logger.js";
@@ -147,9 +147,9 @@ export function hasImplementationArtifacts(basePath: string, milestoneId?: strin
     // milestone commits instead of treating the self-diff as proof of no work.
     if (changedFiles.length === 0) {
       if (milestoneId && currentBranch === integrationBranch) {
-        const tagged = getChangedFilesFromMilestoneTaggedCommits(basePath, milestoneId);
-        if (!tagged.ok) return "unknown";
-        if (tagged.matched) return classifyImplementationFiles(tagged.files);
+        const milestoneEvidence = getChangedFilesFromMilestoneEvidence(basePath, milestoneId);
+        if (!milestoneEvidence.ok) return "unknown";
+        if (milestoneEvidence.matched) return classifyImplementationFiles(milestoneEvidence.files);
       }
       if (currentBranch && currentBranch !== "HEAD") return "absent";
       return "unknown";
@@ -164,9 +164,9 @@ export function hasImplementationArtifacts(basePath: string, milestoneId?: strin
     // insufficient; use the same milestone-tagged evidence fallback as the
     // self-diff retry path before declaring the milestone implementation-free.
     if (milestoneId) {
-      const tagged = getChangedFilesFromMilestoneTaggedCommits(basePath, milestoneId);
-      if (!tagged.ok) return "unknown";
-      if (tagged.matched) return classifyImplementationFiles(tagged.files);
+      const milestoneEvidence = getChangedFilesFromMilestoneEvidence(basePath, milestoneId);
+      if (!milestoneEvidence.ok) return "unknown";
+      if (milestoneEvidence.matched) return classifyImplementationFiles(milestoneEvidence.files);
     }
 
     return "absent";
@@ -197,6 +197,10 @@ function classifyImplementationFiles(files: readonly string[]): "present" | "abs
 
 function isImplementationPath(file: string): boolean {
   return !file.startsWith(".gsd/") && !file.startsWith(".gsd\\");
+}
+
+function normalizeRepoPath(file: string): string {
+  return file.trim().replace(/\\/g, "/").replace(/^\.\/+/, "");
 }
 
 /**
@@ -299,6 +303,126 @@ function getChangedFilesFromMilestoneTaggedCommits(
     matched: true,
     files: [...new Set([...scoped.files, ...unscoped.files])],
   };
+}
+
+function getChangedFilesFromMilestoneEvidence(
+  basePath: string,
+  milestoneId: string,
+): { ok: boolean; matched: boolean; files: string[] } {
+  const tagged = getChangedFilesFromMilestoneTaggedCommits(basePath, milestoneId);
+  if (!tagged.ok) return tagged;
+  if (tagged.matched && classifyImplementationFiles(tagged.files) === "present") return tagged;
+
+  const attributed = getChangedFilesFromAttributedMilestoneCommits(basePath, milestoneId);
+  if (!attributed.ok) return tagged.matched ? tagged : attributed;
+  if (attributed.matched && classifyImplementationFiles(attributed.files) === "present") return attributed;
+
+  const backfilled = backfillChangedFilesFromUntaggedMilestoneCommits(basePath, milestoneId);
+  if (!backfilled.ok) return tagged.matched ? tagged : attributed.matched ? attributed : backfilled;
+  if (!backfilled.matched) {
+    if (tagged.matched) return tagged;
+    return attributed.matched ? attributed : backfilled;
+  }
+
+  return {
+    ok: true,
+    matched: true,
+    files: [...new Set([...tagged.files, ...attributed.files, ...backfilled.files])],
+  };
+}
+
+function getChangedFilesFromAttributedMilestoneCommits(
+  basePath: string,
+  milestoneId: string,
+): { ok: boolean; matched: boolean; files: string[] } {
+  try {
+    const shas = getMilestoneCommitAttributionShas(milestoneId);
+    if (shas.length === 0) return { ok: true, matched: false, files: [] };
+
+    const files = new Set<string>();
+    let matched = false;
+    for (const sha of shas) {
+      if (!isFullCommitSha(sha)) continue;
+      const commitFiles = getChangedFilesForCommit(basePath, sha);
+      if (commitFiles.length === 0) continue;
+      matched = true;
+      for (const file of commitFiles) files.add(file);
+    }
+    return { ok: true, matched, files: [...files] };
+  } catch (e) {
+    logWarning("recovery", `milestone attribution scan failed: ${(e as Error).message}`);
+    return { ok: false, matched: false, files: [] };
+  }
+}
+
+function backfillChangedFilesFromUntaggedMilestoneCommits(
+  basePath: string,
+  milestoneId: string,
+): { ok: boolean; matched: boolean; files: string[] } {
+  try {
+    const milestone = getMilestone(milestoneId);
+    const milestoneStartedAt = milestone?.created_at ? Math.floor(Date.parse(milestone.created_at) / 1000) * 1000 : NaN;
+    if (!Number.isFinite(milestoneStartedAt)) return { ok: true, matched: false, files: [] };
+
+    const taskFileHints = getCompletedMilestoneTaskFileHints(milestoneId);
+    if (taskFileHints.length === 0) return { ok: true, matched: false, files: [] };
+
+    const hintSet = new Set(taskFileHints.map(normalizeRepoPath).filter(Boolean));
+    if (hintSet.size === 0) return { ok: true, matched: false, files: [] };
+
+    const records = getCommitRecords(basePath);
+    const files = new Set<string>();
+    let matched = false;
+    for (const record of records) {
+      if (!isFullCommitSha(record.hash)) continue;
+      if (Date.parse(record.committedAt) < milestoneStartedAt) continue;
+      if (record.parents.trim().split(/\s+/).filter(Boolean).length > 1) continue;
+      if (commitMessageHasGsdTrailer(record.message)) continue;
+
+      const commitFiles = getChangedFilesForCommit(basePath, record.hash);
+      const implementationFiles = commitFiles.map(normalizeRepoPath).filter(isImplementationPath);
+      if (implementationFiles.length === 0) continue;
+      if (!implementationFiles.some((file) => hintSet.has(file))) continue;
+
+      matched = true;
+      for (const file of implementationFiles) files.add(file);
+      recordMilestoneCommitAttribution({
+        commitSha: record.hash,
+        milestoneId,
+        source: "backfill",
+        confidence: 0.8,
+        files: implementationFiles,
+        createdAt: new Date().toISOString(),
+      });
+    }
+
+    return { ok: true, matched, files: [...files] };
+  } catch (e) {
+    logWarning("recovery", `milestone attribution backfill failed: ${(e as Error).message}`);
+    return { ok: false, matched: false, files: [] };
+  }
+}
+
+function getCommitRecords(basePath: string): Array<{ hash: string; parents: string; committedAt: string; message: string }> {
+  const logOutput = execFileSync("git", ["log", "--format=%H%x1f%P%x1f%cI%x1f%B%x1e", "HEAD"], {
+    cwd: basePath,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  });
+  return logOutput
+    .split("\x1e")
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .flatMap((record) => {
+      const parts = record.split("\x1f");
+      if (parts.length < 4) return [];
+      const [hash, parents, committedAt, ...messageParts] = parts;
+      return [{ hash: hash.trim(), parents: parents.trim(), committedAt: committedAt.trim(), message: messageParts.join("\x1f") }];
+    });
+}
+
+function isFullCommitSha(value: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(value);
 }
 
 function scanGsdTaggedCommits(

--- a/src/resources/extensions/gsd/db-base-schema.ts
+++ b/src/resources/extensions/gsd/db-base-schema.ts
@@ -324,6 +324,20 @@ export function createBaseSchemaObjects(db: DbAdapter, hooks: BaseSchemaHooks): 
   `);
 
   db.exec(`
+    CREATE TABLE IF NOT EXISTS milestone_commit_attributions (
+      commit_sha TEXT NOT NULL,
+      milestone_id TEXT NOT NULL,
+      slice_id TEXT DEFAULT NULL,
+      task_id TEXT DEFAULT NULL,
+      source TEXT NOT NULL DEFAULT 'recorded',
+      confidence REAL NOT NULL DEFAULT 1.0,
+      files_json TEXT NOT NULL DEFAULT '[]',
+      created_at TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (commit_sha, milestone_id)
+    )
+  `);
+
+  db.exec(`
     CREATE TABLE IF NOT EXISTS audit_events (
       event_id TEXT PRIMARY KEY,
       trace_id TEXT NOT NULL,
@@ -359,6 +373,7 @@ export function createBaseSchemaObjects(db: DbAdapter, hooks: BaseSchemaHooks): 
   db.exec("CREATE INDEX IF NOT EXISTS idx_gate_runs_turn ON gate_runs(trace_id, turn_id)");
   db.exec("CREATE INDEX IF NOT EXISTS idx_gate_runs_lookup ON gate_runs(milestone_id, slice_id, task_id, gate_id)");
   db.exec("CREATE INDEX IF NOT EXISTS idx_turn_git_tx_turn ON turn_git_transactions(trace_id, turn_id)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_milestone_commit_attr_milestone ON milestone_commit_attributions(milestone_id)");
   db.exec("CREATE INDEX IF NOT EXISTS idx_audit_events_trace ON audit_events(trace_id, ts)");
   db.exec("CREATE INDEX IF NOT EXISTS idx_audit_events_turn ON audit_events(trace_id, turn_id, ts)");
 

--- a/src/resources/extensions/gsd/db-migration-steps.ts
+++ b/src/resources/extensions/gsd/db-migration-steps.ts
@@ -399,6 +399,23 @@ export function applyMigrationV23MilestoneQueue(db: DbAdapter): void {
   ensureColumn(db, "milestones", "sequence", "ALTER TABLE milestones ADD COLUMN sequence INTEGER DEFAULT 0");
 }
 
+export function applyMigrationV26MilestoneCommitAttributions(db: DbAdapter): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS milestone_commit_attributions (
+      commit_sha TEXT NOT NULL,
+      milestone_id TEXT NOT NULL,
+      slice_id TEXT DEFAULT NULL,
+      task_id TEXT DEFAULT NULL,
+      source TEXT NOT NULL DEFAULT 'recorded',
+      confidence REAL NOT NULL DEFAULT 1.0,
+      files_json TEXT NOT NULL DEFAULT '[]',
+      created_at TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (commit_sha, milestone_id)
+    )
+  `);
+  db.exec("CREATE INDEX IF NOT EXISTS idx_milestone_commit_attr_milestone ON milestone_commit_attributions(milestone_id)");
+}
+
 export interface MigrationV22Hooks {
   copyQualityGateRowsToRepairedTable(db: DbAdapter): void;
 }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -77,6 +77,7 @@ import {
   applyMigrationV21StructuredMemories,
   applyMigrationV22QualityGateRepair,
   applyMigrationV23MilestoneQueue,
+  applyMigrationV26MilestoneCommitAttributions,
 } from "./db-migration-steps.js";
 import { isMemoriesFtsAvailableSchema, tryCreateMemoriesFtsSchema } from "./db-memory-fts-schema.js";
 import { createDbOpenState, type DbOpenPhase } from "./db-open-state.js";
@@ -105,7 +106,7 @@ const providerLoader = createSqliteProviderLoader({
   writeStderr: (message: string) => process.stderr.write(message),
 });
 
-export const SCHEMA_VERSION = 25;
+export const SCHEMA_VERSION = 26;
 
 function initSchema(db: DbAdapter, fileBacked: boolean): void {
   if (fileBacked) db.exec("PRAGMA journal_mode=WAL");
@@ -327,6 +328,11 @@ function migrateSchema(db: DbAdapter): void {
       // createRuntimeKvTableV25 for the full schema + invariants.
       createRuntimeKvTableV25(db);
       recordSchemaVersion(db, 25);
+    }
+
+    if (currentVersion < 26) {
+      applyMigrationV26MilestoneCommitAttributions(db);
+      recordSchemaVersion(db, 26);
     }
 
     db.exec("COMMIT");
@@ -1349,6 +1355,45 @@ export function getSliceTasks(milestoneId: string, sliceId: string): TaskRow[] {
   return rows.map(rowToTask);
 }
 
+export function getCompletedMilestoneTaskFileHints(milestoneId: string): string[] {
+  if (!currentDb) return [];
+  const rows = currentDb.prepare(
+    `SELECT files, key_files
+     FROM tasks
+     WHERE milestone_id = :mid AND status IN ('complete', 'done')`,
+  ).all({ ":mid": milestoneId }) as Array<Record<string, unknown>>;
+
+  const hints = new Set<string>();
+  for (const row of rows) {
+    for (const raw of [row["files"], row["key_files"]]) {
+      for (const file of parseStringArrayColumn(raw)) {
+        const normalized = normalizeRepoPath(file);
+        if (normalized) hints.add(normalized);
+      }
+    }
+  }
+  return [...hints];
+}
+
+function parseStringArrayColumn(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.filter((entry): entry is string => typeof entry === "string");
+  if (typeof raw !== "string") return [];
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) return parsed.filter((entry): entry is string => typeof entry === "string");
+    if (typeof parsed === "string") return [parsed];
+  } catch {
+    return trimmed.split(",");
+  }
+  return [];
+}
+
+function normalizeRepoPath(file: string): string {
+  return file.trim().replace(/\\/g, "/").replace(/^\.\/+/, "");
+}
+
 // ─── ADR-011 Phase 2 escalation helpers ──────────────────────────────────
 
 /** Set pause-on-escalation state on a completed task. Mutually exclusive with awaiting_review. */
@@ -2074,6 +2119,9 @@ export function deleteMilestone(milestoneId: string): void {
       `DELETE FROM artifacts WHERE milestone_id = :mid`,
     ).run({ ":mid": milestoneId });
     currentDb!.prepare(
+      `DELETE FROM milestone_commit_attributions WHERE milestone_id = :mid`,
+    ).run({ ":mid": milestoneId });
+    currentDb!.prepare(
       `DELETE FROM milestone_leases WHERE milestone_id = :mid`,
     ).run({ ":mid": milestoneId });
     currentDb!.prepare(
@@ -2391,6 +2439,75 @@ export function upsertTurnGitTransaction(entry: {
   });
 }
 
+export function getMilestoneCommitAttributionShas(milestoneId: string): string[] {
+  if (!currentDb) return [];
+  const rows = currentDb.prepare(
+    `SELECT commit_sha
+     FROM milestone_commit_attributions
+     WHERE milestone_id = :mid
+     ORDER BY created_at, commit_sha`,
+  ).all({ ":mid": milestoneId }) as Array<Record<string, unknown>>;
+  return rows
+    .map((row) => typeof row["commit_sha"] === "string" ? row["commit_sha"] : "")
+    .filter(Boolean);
+}
+
+export function recordMilestoneCommitAttribution(entry: {
+  commitSha: string;
+  milestoneId: string;
+  sliceId?: string;
+  taskId?: string;
+  source: "recorded" | "backfill";
+  confidence: number;
+  files: string[];
+  createdAt: string;
+}): void {
+  if (!currentDb) return;
+  transaction(() => {
+    currentDb!.prepare(
+      `INSERT OR REPLACE INTO milestone_commit_attributions (
+        commit_sha, milestone_id, slice_id, task_id, source, confidence, files_json, created_at
+      ) VALUES (
+        :commit_sha, :milestone_id, :slice_id, :task_id, :source, :confidence, :files_json, :created_at
+      )`,
+    ).run({
+      ":commit_sha": entry.commitSha,
+      ":milestone_id": entry.milestoneId,
+      ":slice_id": entry.sliceId ?? null,
+      ":task_id": entry.taskId ?? null,
+      ":source": entry.source,
+      ":confidence": entry.confidence,
+      ":files_json": JSON.stringify(entry.files),
+      ":created_at": entry.createdAt,
+    });
+
+    currentDb!.prepare(
+      `INSERT OR IGNORE INTO audit_events (
+        event_id, trace_id, turn_id, caused_by, category, type, ts, payload_json
+      ) VALUES (
+        :event_id, :trace_id, :turn_id, :caused_by, :category, :type, :ts, :payload_json
+      )`,
+    ).run({
+      ":event_id": `milestone-commit-attribution:${entry.milestoneId}:${entry.commitSha}`,
+      ":trace_id": "milestone-commit-attribution",
+      ":turn_id": null,
+      ":caused_by": null,
+      ":category": "git",
+      ":type": "milestone-commit-attribution-recorded",
+      ":ts": entry.createdAt,
+      ":payload_json": JSON.stringify({
+        commitSha: entry.commitSha,
+        milestoneId: entry.milestoneId,
+        sliceId: entry.sliceId ?? null,
+        taskId: entry.taskId ?? null,
+        source: entry.source,
+        confidence: entry.confidence,
+        files: entry.files,
+      }),
+    });
+  });
+}
+
 export function insertAuditEvent(entry: {
   eventId: string;
   traceId: string;
@@ -2494,6 +2611,7 @@ export function clearEngineHierarchy(): void {
     currentDb!.exec("DELETE FROM slice_dependencies");
     currentDb!.exec("DELETE FROM assessments");
     currentDb!.exec("DELETE FROM replan_history");
+    currentDb!.exec("DELETE FROM milestone_commit_attributions");
     currentDb!.exec("DELETE FROM tasks");
     currentDb!.exec("DELETE FROM slices");
     currentDb!.exec("DELETE FROM milestone_leases");

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -7,7 +7,7 @@ import { randomUUID } from "node:crypto";
 
 import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArtifactPath, diagnoseExpectedArtifact, buildLoopRemediationSteps, writeBlockerPlaceholder } from "../auto-recovery.ts";
 import { resolveMilestoneFile } from "../paths.ts";
-import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask } from "../gsd-db.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask, getMilestoneCommitAttributionShas } from "../gsd-db.ts";
 import { clearParseCache } from "../files.ts";
 import { parseRoadmap } from "../parsers-legacy.ts";
 import { invalidateAllCaches } from "../cache.ts";
@@ -775,6 +775,130 @@ test("hasImplementationArtifacts finds integration implementation-only commits w
       "present",
       ".gsd-only milestone closeout diffs should still honor implementation commits already on the integration branch",
     );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("hasImplementationArtifacts backfills untagged main implementation commits from completed task file hints", () => {
+  const base = makeGitBase();
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      title: "Slice One",
+      status: "complete",
+      risk: "low",
+      depends: [],
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Task One",
+      status: "complete",
+      keyFiles: ["index.html", "style.css", "app.js"],
+      planning: { files: ["index.html", "style.css", "app.js"] },
+    });
+
+    writeFileSync(join(base, "index.html"), "<main></main>\n");
+    writeFileSync(join(base, "style.css"), "main { display: block; }\n");
+    writeFileSync(join(base, "app.js"), "document.body.dataset.ready = 'true';\n");
+    execFileSync("git", ["add", "index.html", "style.css", "app.js"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feat: add to-do app with CRUD and localStorage persistence"], { cwd: base, stdio: "ignore" });
+    const commitSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: base, encoding: "utf-8" }).trim();
+
+    const result = hasImplementationArtifacts(base, "M001");
+    assert.equal(
+      result,
+      "present",
+      "completed task file hints should repair prior untagged implementation commits on main",
+    );
+    assert.deepEqual(getMilestoneCommitAttributionShas("M001"), [commitSha]);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("hasImplementationArtifacts does not backfill untagged commits before milestone creation", () => {
+  const base = makeGitBase();
+  try {
+    writeFileSync(join(base, "app.js"), "document.body.dataset.ready = 'old';\n");
+    execFileSync("git", ["add", "app.js"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feat: old app work"], {
+      cwd: base,
+      stdio: "ignore",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_DATE: "2020-01-01T00:00:00Z",
+        GIT_COMMITTER_DATE: "2020-01-01T00:00:00Z",
+      },
+    });
+
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      title: "Slice One",
+      status: "complete",
+      risk: "low",
+      depends: [],
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Task One",
+      status: "complete",
+      keyFiles: ["app.js"],
+      planning: { files: ["app.js"] },
+    });
+
+    const result = hasImplementationArtifacts(base, "M001");
+    assert.equal(result, "absent", "pre-milestone commits must not be attributed to the milestone");
+    assert.deepEqual(getMilestoneCommitAttributionShas("M001"), []);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("hasImplementationArtifacts does not backfill unrelated untagged implementation commits", () => {
+  const base = makeGitBase();
+  try {
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      title: "Slice One",
+      status: "complete",
+      risk: "low",
+      depends: [],
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Task One",
+      status: "complete",
+      keyFiles: ["src/expected.ts"],
+      planning: { files: ["src/expected.ts"] },
+    });
+
+    mkdirSync(join(base, "src"), { recursive: true });
+    writeFileSync(join(base, "src", "unrelated.ts"), "export const unrelated = true;\n");
+    execFileSync("git", ["add", "src/unrelated.ts"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feat: unrelated work"], { cwd: base, stdio: "ignore" });
+
+    const result = hasImplementationArtifacts(base, "M001");
+    assert.equal(result, "absent", "backfill must require overlap with completed task file hints");
+    assert.deepEqual(getMilestoneCommitAttributionShas("M001"), []);
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/db-schema-metadata.test.ts
+++ b/src/resources/extensions/gsd/tests/db-schema-metadata.test.ts
@@ -106,10 +106,10 @@ describe("db-schema-metadata", () => {
   test("records schema version rows with timestamps", () => {
     const db = new FakeAdapter();
 
-    recordSchemaVersion(db, 25);
+    recordSchemaVersion(db, 26);
 
     assert.equal(db.runCalls.length, 1);
-    assert.equal((db.runCalls[0][0] as Record<string, unknown>)[":version"], 25);
+    assert.equal((db.runCalls[0][0] as Record<string, unknown>)[":version"], 26);
     assert.equal(typeof (db.runCalls[0][0] as Record<string, unknown>)[":applied_at"], "string");
   });
 });

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -30,6 +30,10 @@ import {
   insertTask,
   getTask,
   getSliceTasks,
+  deleteMilestone,
+  clearEngineHierarchy,
+  recordMilestoneCommitAttribution,
+  getMilestoneCommitAttributionShas,
   checkpointDatabase,
   refreshOpenDatabaseFromDisk,
   tryCreateMemoriesFts,
@@ -1044,6 +1048,46 @@ describe('gsd-db', () => {
       closeDatabase();
       assert.equal(refreshOpenDatabaseFromDisk(), false);
       assert.equal(isDbAvailable(), false);
+    });
+  });
+
+  // ─── milestone_commit_attributions teardown ───────────────────────────────
+
+  describe('milestone commit attribution teardown', () => {
+    test('deleteMilestone removes persisted milestone commit attributions', () => {
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'Milestone', status: 'active' });
+      recordMilestoneCommitAttribution({
+        commitSha: '0123456789abcdef0123456789abcdef01234567',
+        milestoneId: 'M001',
+        source: 'backfill',
+        confidence: 0.8,
+        files: ['app.js'],
+        createdAt: '2026-05-05T00:00:00.000Z',
+      });
+
+      assert.deepEqual(getMilestoneCommitAttributionShas('M001'), ['0123456789abcdef0123456789abcdef01234567']);
+      deleteMilestone('M001');
+      assert.deepEqual(getMilestoneCommitAttributionShas('M001'), []);
+      closeDatabase();
+    });
+
+    test('clearEngineHierarchy removes persisted milestone commit attributions', () => {
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'Milestone', status: 'active' });
+      recordMilestoneCommitAttribution({
+        commitSha: 'fedcba9876543210fedcba9876543210fedcba98',
+        milestoneId: 'M001',
+        source: 'backfill',
+        confidence: 0.8,
+        files: ['app.js'],
+        createdAt: '2026-05-05T00:00:00.000Z',
+      });
+
+      assert.deepEqual(getMilestoneCommitAttributionShas('M001'), ['fedcba9876543210fedcba9876543210fedcba98']);
+      clearEngineHierarchy();
+      assert.deepEqual(getMilestoneCommitAttributionShas('M001'), []);
+      closeDatabase();
     });
   });
 


### PR DESCRIPTION
## TL;DR

**What:** Adds durable milestone commit attribution and conservative backfill for prior untagged implementation commits.
**Why:** `complete-milestone` can falsely reject real implementation work when the repo is already on the integration branch and the implementation commit lacks GSD trailers.
**How:** Persist milestone commit attributions, consult them after tagged history, and backfill untagged commits only when changed files overlap completed task file hints.

## What

This changes the GSD extension artifact guard and DB schema:

- adds `milestone_commit_attributions` with schema v26 migration
- adds DB helpers for completed task file hints and persisted commit attribution lookups
- teaches `hasImplementationArtifacts()` to check tagged commits, recorded attributions, then conservative backfill
- records an audit event when attribution is repaired
- adds regression coverage for untagged `main` self-diff implementation commits and the unrelated-commit negative case

## Why

Closes #5380.

The previous closeout fallback only handled commits with `GSD-Task` or `GSD-Unit` trailers. Older or manually-created auto-mode commits can have real implementation files and completed DB task rows but no trailer. When auto-mode resumes on the integration branch, branch diff is empty and tagged scan finds nothing, so the guard incorrectly concludes the milestone has only plan files.

## How

The fallback remains conservative:

1. Prefer explicit GSD-tagged commit evidence.
2. Use previously persisted milestone commit attributions when available.
3. Backfill only untagged, non-merge implementation commits whose changed files overlap completed task `files` / `key_files` hints for the milestone.
4. Persist the inferred attribution so future checks do not need to rediscover it.

This intentionally does not accept arbitrary recent implementation commits on `main`.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-recovery.test.ts` — 51/51 passed
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/db-schema-metadata.test.ts` — 5/5 passed
- [x] `npm run typecheck:extensions`
- [x] Manual source check against `/Users/jeremymcspadden/Github/test-apps/abcdeffedcba`: `hasImplementationArtifacts(base, "M001")` returned `present` and persisted commit `8a2ae371a2ae0ad2a056ef990a63e168614bfef9`
- [ ] `npm run verify:pr` — build and extension typecheck passed, unit suite remains red on unrelated ADR-012 allowlist failure in `src/providers/provider-migrations.ts`

## Change type checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None. This adds a DB migration/table and fallback behavior without changing public CLI/API contracts.

## AI-assisted contribution

This PR is AI-assisted. The commit does not credit an AI tool as author or co-author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced milestone artifact detection: now finds and attributes previously untagged implementation commits to milestones, improving recovery and attribution accuracy.
* **Database Migration**
  * Adds persistent tracking for milestone commit attributions to support improved detection and cleanup.
* **Tests**
  * New and expanded tests cover attribution backfill, detection cases, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->