### PR TITLE
fix(gsd): wire /gsd graph build|status|query|diff into slash dispatcher

### DIFF
--- a/src/resources/extensions/gsd/commands-graph.ts
+++ b/src/resources/extensions/gsd/commands-graph.ts
@@ -1,0 +1,127 @@
+/**
+ * GSD Command — /gsd graph build|status|query|diff
+ *
+ * Slash-command surface that mirrors the `gsd graph` CLI subcommands in
+ * src/cli.ts. The underlying graph operations live in @gsd-build/mcp-server;
+ * we only translate user input/output for the interactive dispatcher.
+ *
+ * Issue #5148 — wires the missing dispatcher branch noted in PR #4212's gap.
+ */
+
+import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+
+type NotifyLevel = "info" | "warning" | "error" | "success";
+
+function notify(ctx: ExtensionCommandContext, message: string, level: NotifyLevel): void {
+  ctx.ui.notify(message, level);
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export async function handleGraph(
+  args: string,
+  ctx: ExtensionCommandContext,
+  projectDir: string,
+): Promise<void> {
+  const tokens = args.length > 0 ? args.split(/\s+/).filter(Boolean) : [];
+  const sub = tokens[0] ?? "build";
+
+  const { buildGraph, writeGraph, graphStatus, graphQuery, graphDiff, resolveGsdRoot } =
+    await import("@gsd-build/mcp-server");
+
+  if (sub === "build") {
+    try {
+      const gsdRoot = resolveGsdRoot(projectDir);
+      const graph = await buildGraph(projectDir);
+      await writeGraph(gsdRoot, graph);
+      notify(
+        ctx,
+        `Graph built: ${graph.nodes.length} nodes, ${graph.edges.length} edges`,
+        "success",
+      );
+    } catch (err) {
+      notify(ctx, `[gsd] graph build failed: ${errorMessage(err)}`, "error");
+    }
+    return;
+  }
+
+  if (sub === "status") {
+    try {
+      const result = await graphStatus(projectDir);
+      if (!result.exists) {
+        notify(ctx, "Graph: not built yet. Run: gsd graph build", "info");
+        return;
+      }
+      const ageDisplay =
+        result.ageHours !== undefined ? result.ageHours.toFixed(2) : "n/a";
+      notify(
+        ctx,
+        [
+          "Graph status:",
+          `  exists:    ${result.exists}`,
+          `  nodes:     ${result.nodeCount}`,
+          `  edges:     ${result.edgeCount}`,
+          `  stale:     ${result.stale}`,
+          `  ageHours:  ${ageDisplay}`,
+          `  lastBuild: ${result.lastBuild ?? "n/a"}`,
+        ].join("\n"),
+        "info",
+      );
+    } catch (err) {
+      notify(ctx, `[gsd] graph status failed: ${errorMessage(err)}`, "error");
+    }
+    return;
+  }
+
+  if (sub === "query") {
+    const term = tokens[1];
+    if (!term) {
+      notify(ctx, "Usage: /gsd graph query <term>", "warning");
+      return;
+    }
+    try {
+      const result = await graphQuery(projectDir, term);
+      if (result.nodes.length === 0) {
+        notify(ctx, `No nodes found for term: "${term}"`, "info");
+        return;
+      }
+      const header = `Query results for "${term}" (${result.nodes.length} nodes, ${result.edges.length} edges):`;
+      const lines = result.nodes.map(
+        (node) => `  [${node.type}] ${node.label} (${node.confidence})`,
+      );
+      notify(ctx, [header, ...lines].join("\n"), "info");
+    } catch (err) {
+      notify(ctx, `[gsd] graph query failed: ${errorMessage(err)}`, "error");
+    }
+    return;
+  }
+
+  if (sub === "diff") {
+    try {
+      const result = await graphDiff(projectDir);
+      notify(
+        ctx,
+        [
+          "Graph diff:",
+          `  nodes added:    ${result.nodes.added.length}`,
+          `  nodes removed:  ${result.nodes.removed.length}`,
+          `  nodes changed:  ${result.nodes.changed.length}`,
+          `  edges added:    ${result.edges.added.length}`,
+          `  edges removed:  ${result.edges.removed.length}`,
+        ].join("\n"),
+        "info",
+      );
+    } catch (err) {
+      notify(ctx, `[gsd] graph diff failed: ${errorMessage(err)}`, "error");
+    }
+    return;
+  }
+
+  notify(
+    ctx,
+    `Unknown graph command: ${sub}. Commands: build, status, query <term>, diff`,
+    "warning",
+  );
+}

--- a/src/resources/extensions/gsd/commands-graph.ts
+++ b/src/resources/extensions/gsd/commands-graph.ts
@@ -51,7 +51,7 @@ export async function handleGraph(
     try {
       const result = await graphStatus(projectDir);
       if (!result.exists) {
-        notify(ctx, "Graph: not built yet. Run: gsd graph build", "info");
+        notify(ctx, "Graph: not built yet. Run: /gsd graph build", "info");
         return;
       }
       const ageDisplay =
@@ -76,7 +76,7 @@ export async function handleGraph(
   }
 
   if (sub === "query") {
-    const term = tokens[1];
+    const term = tokens.slice(1).join(" ").trim();
     if (!term) {
       notify(ctx, "Usage: /gsd graph query <term>", "warning");
       return;

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -13,7 +13,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|fast|mcp|rethink|workflow|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
+  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|graph|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|fast|mcp|rethink|workflow|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -60,6 +60,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "steer", desc: "Hard-steer plan documents during execution" },
   { cmd: "inspect", desc: "Show SQLite DB diagnostics" },
   { cmd: "knowledge", desc: "Add persistent project knowledge (rule, pattern, or lesson)" },
+  { cmd: "graph", desc: "Build, inspect, query, or diff the knowledge graph (.gsd/graph.json)" },
   { cmd: "new-milestone", desc: "Create a milestone from a specification document (headless)" },
   { cmd: "new-project", desc: "Bootstrap a new project (use --deep for staged project-level discovery)" },
   { cmd: "parallel", desc: "Parallel milestone orchestration (start, status, stop, merge, watch)" },
@@ -193,6 +194,12 @@ const NESTED_COMPLETIONS: CompletionMap = {
     { cmd: "rule", desc: "Add a project rule (always/never do X)" },
     { cmd: "pattern", desc: "Add a code pattern to follow" },
     { cmd: "lesson", desc: "Record a lesson learned" },
+  ],
+  graph: [
+    { cmd: "build", desc: "Build the knowledge graph and write .gsd/graph.json" },
+    { cmd: "status", desc: "Show node/edge counts, age, and staleness for the cached graph" },
+    { cmd: "query", desc: "Query nodes/edges by term: /gsd graph query <term>" },
+    { cmd: "diff", desc: "Compare the on-disk graph with a freshly built one" },
   ],
   start: [
     { cmd: "bugfix", desc: "Triage, fix, test, and ship a bug fix" },

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -60,7 +60,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "steer", desc: "Hard-steer plan documents during execution" },
   { cmd: "inspect", desc: "Show SQLite DB diagnostics" },
   { cmd: "knowledge", desc: "Add persistent project knowledge (rule, pattern, or lesson)" },
-  { cmd: "graph", desc: "Build, inspect, query, or diff the knowledge graph (.gsd/graph.json)" },
+  { cmd: "graph", desc: "Build, inspect, query, or diff the knowledge graph (.gsd/graphs/graph.json)" },
   { cmd: "new-milestone", desc: "Create a milestone from a specification document (headless)" },
   { cmd: "new-project", desc: "Bootstrap a new project (use --deep for staged project-level discovery)" },
   { cmd: "parallel", desc: "Parallel milestone orchestration (start, status, stop, merge, watch)" },
@@ -196,7 +196,7 @@ const NESTED_COMPLETIONS: CompletionMap = {
     { cmd: "lesson", desc: "Record a lesson learned" },
   ],
   graph: [
-    { cmd: "build", desc: "Build the knowledge graph and write .gsd/graph.json" },
+    { cmd: "build", desc: "Build the knowledge graph and write .gsd/graphs/graph.json" },
     { cmd: "status", desc: "Show node/edge counts, age, and staleness for the cached graph" },
     { cmd: "query", desc: "Query nodes/edges by term: /gsd graph query <term>" },
     { cmd: "diff", desc: "Compare the on-disk graph with a freshly built one" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -97,6 +97,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "",
     "PROJECT KNOWLEDGE",
     "  /gsd knowledge <type> <text>   Add rule, pattern, or lesson to KNOWLEDGE.md",
+    "  /gsd graph [build|status|query <term>|diff]   Manage the .gsd/graph.json knowledge graph",
     "  /gsd codebase [generate|update|stats]   Manage the CODEBASE.md cache used in prompt context",
     "",
     "SHIPPING & BACKLOG",

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -97,7 +97,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "",
     "PROJECT KNOWLEDGE",
     "  /gsd knowledge <type> <text>   Add rule, pattern, or lesson to KNOWLEDGE.md",
-    "  /gsd graph [build|status|query <term>|diff]   Manage the .gsd/graph.json knowledge graph",
+    "  /gsd graph [build|status|query <term>|diff]   Manage the .gsd/graphs/graph.json knowledge graph",
     "  /gsd codebase [generate|update|stats]   Manage the CODEBASE.md cache used in prompt context",
     "",
     "SHIPPING & BACKLOG",

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -168,6 +168,11 @@ Examples:
     ctx.ui.notify("Usage: /gsd knowledge <rule|pattern|lesson> <description>. Example: /gsd knowledge rule Use real DB for integration tests", "warning");
     return true;
   }
+  if (trimmed === "graph" || trimmed.startsWith("graph ") || trimmed.startsWith("graph\t")) {
+    const { handleGraph } = await import("../../commands-graph.js");
+    await handleGraph(trimmed.replace(/^graph\s*/, "").trim(), ctx, projectRoot());
+    return true;
+  }
   if (trimmed === "migrate" || trimmed.startsWith("migrate ")) {
     const { handleMigrate } = await import("../../migrate/command.js");
     await handleMigrate(trimmed.replace(/^migrate\s*/, "").trim(), ctx, pi);

--- a/src/resources/extensions/gsd/tests/graph-slash-command-5148.test.ts
+++ b/src/resources/extensions/gsd/tests/graph-slash-command-5148.test.ts
@@ -1,0 +1,188 @@
+/**
+ * graph-slash-command-5148.test.ts
+ *
+ * Regression test for issue #5148: `/gsd graph build|status|query|diff`
+ * was not registered in the interactive command dispatcher even though
+ * the CLI subcommand existed.
+ *
+ * Verifies that the slash dispatcher:
+ *   1. Does not emit the "Unknown: /gsd graph …" fallback warning.
+ *   2. Routes each subcommand to a real handler producing the expected
+ *      user-facing output (mirroring `gsd graph` in src/cli.ts).
+ *   3. Surfaces argument-validation messages (e.g. missing query term).
+ *
+ * Also covers catalog wiring used by completions/help so the command is
+ * discoverable in the same way as its peers (e.g. `knowledge`).
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { handleGSDCommand } from "../commands/dispatcher.ts";
+import {
+  GSD_COMMAND_DESCRIPTION,
+  TOP_LEVEL_SUBCOMMANDS,
+  getGsdArgumentCompletions,
+} from "../commands/catalog.ts";
+
+interface Notification {
+  message: string;
+  level: string;
+}
+
+function createMockCtx() {
+  const notifications: Notification[] = [];
+  return {
+    notifications,
+    ctx: {
+      notifications,
+      ui: {
+        notify(message: string, level: string) {
+          notifications.push({ message, level });
+        },
+        custom: async () => {},
+      },
+      shutdown: async () => {},
+    },
+  };
+}
+
+function lastMessage(notifications: Notification[]): Notification {
+  assert.ok(notifications.length > 0, "expected at least one notification");
+  return notifications[notifications.length - 1];
+}
+
+describe("/gsd graph — issue #5148: wired into slash dispatcher", () => {
+  let base: string;
+  let saved: string;
+
+  beforeEach(() => {
+    base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-graph-5148-")));
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    saved = process.cwd();
+    process.chdir(base);
+  });
+
+  afterEach(() => {
+    process.chdir(saved);
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test("/gsd graph status (no graph yet) reports the not-built message", async () => {
+    const { notifications, ctx } = createMockCtx();
+    await handleGSDCommand("graph status", ctx as any, {} as any);
+
+    const last = lastMessage(notifications);
+    assert.doesNotMatch(last.message, /Unknown: \/gsd graph/);
+    assert.match(last.message, /not built yet/);
+    assert.match(last.message, /gsd graph build/);
+  });
+
+  test("/gsd graph build creates .gsd/graph.json and reports counts", async () => {
+    const { notifications, ctx } = createMockCtx();
+    await handleGSDCommand("graph build", ctx as any, {} as any);
+
+    const last = lastMessage(notifications);
+    assert.doesNotMatch(last.message, /Unknown: \/gsd graph/);
+    assert.match(last.message, /Graph built: \d+ nodes, \d+ edges/);
+    assert.ok(
+      existsSync(join(base, ".gsd", "graphs", "graph.json")),
+      "graph.json must be written under .gsd/graphs/",
+    );
+  });
+
+  test("/gsd graph status after build reports exists=true with counts", async () => {
+    const { notifications, ctx } = createMockCtx();
+    await handleGSDCommand("graph build", ctx as any, {} as any);
+    notifications.length = 0;
+
+    await handleGSDCommand("graph status", ctx as any, {} as any);
+    const last = lastMessage(notifications);
+    assert.match(last.message, /exists:\s+true/);
+    assert.match(last.message, /nodes:\s+\d+/);
+    assert.match(last.message, /edges:\s+\d+/);
+  });
+
+  test("/gsd graph query (no term) emits a usage warning", async () => {
+    const { notifications, ctx } = createMockCtx();
+    await handleGSDCommand("graph query", ctx as any, {} as any);
+
+    const last = lastMessage(notifications);
+    assert.doesNotMatch(last.message, /Unknown: \/gsd graph/);
+    assert.equal(last.level, "warning");
+    assert.match(last.message, /Usage: \/gsd graph query <term>/);
+  });
+
+  test("/gsd graph query <term> after build returns a result block", async () => {
+    const { notifications, ctx } = createMockCtx();
+    await handleGSDCommand("graph build", ctx as any, {} as any);
+    notifications.length = 0;
+
+    await handleGSDCommand("graph query nonexistent-term-xyz", ctx as any, {} as any);
+    const last = lastMessage(notifications);
+    assert.doesNotMatch(last.message, /Unknown: \/gsd graph/);
+    assert.match(last.message, /No nodes found|Query results/);
+  });
+
+  test("/gsd graph diff after build reports a structured diff summary", async () => {
+    const { notifications, ctx } = createMockCtx();
+    await handleGSDCommand("graph build", ctx as any, {} as any);
+    notifications.length = 0;
+
+    await handleGSDCommand("graph diff", ctx as any, {} as any);
+    const last = lastMessage(notifications);
+    assert.doesNotMatch(last.message, /Unknown: \/gsd graph/);
+    assert.match(last.message, /nodes added:\s+\d+/);
+    assert.match(last.message, /edges added:\s+\d+/);
+  });
+
+  test("/gsd graph (no subcommand) defaults to build, mirroring src/cli.ts", async () => {
+    const { notifications, ctx } = createMockCtx();
+    await handleGSDCommand("graph", ctx as any, {} as any);
+
+    const last = lastMessage(notifications);
+    assert.doesNotMatch(last.message, /Unknown: \/gsd graph/);
+    assert.match(last.message, /Graph built: \d+ nodes, \d+ edges/);
+  });
+
+  test("/gsd graph <unknown> reports a friendly usage error, not the fallback warning", async () => {
+    const { notifications, ctx } = createMockCtx();
+    await handleGSDCommand("graph banana", ctx as any, {} as any);
+
+    const last = lastMessage(notifications);
+    assert.doesNotMatch(last.message, /Unknown: \/gsd graph banana/);
+    assert.equal(last.level, "warning");
+    assert.match(last.message, /Unknown graph command/);
+    for (const sub of ["build", "status", "query", "diff"]) {
+      assert.match(last.message, new RegExp(sub), `usage hint should mention ${sub}`);
+    }
+  });
+});
+
+describe("/gsd graph — catalog & completion wiring", () => {
+  test("graph appears in TOP_LEVEL_SUBCOMMANDS", () => {
+    const entry = TOP_LEVEL_SUBCOMMANDS.find((c) => c.cmd === "graph");
+    assert.ok(entry, "graph must be present in TOP_LEVEL_SUBCOMMANDS");
+    assert.ok(entry!.desc.length > 0, "graph entry needs a description");
+  });
+
+  test("GSD_COMMAND_DESCRIPTION includes the graph token", () => {
+    assert.ok(
+      GSD_COMMAND_DESCRIPTION.includes("|graph"),
+      "GSD_COMMAND_DESCRIPTION must list `graph` so /gsd autocompletion surfaces it",
+    );
+  });
+
+  test("getGsdArgumentCompletions exposes graph subcommands", () => {
+    const completions = getGsdArgumentCompletions("graph ");
+    const labels = completions.map((c) => c.label);
+    assert.deepStrictEqual(
+      [...labels].sort(),
+      ["build", "diff", "query", "status"],
+      `expected build|status|query|diff completions, got: ${labels.join(", ")}`,
+    );
+  });
+});

--- a/src/resources/extensions/gsd/tests/graph-slash-command-5148.test.ts
+++ b/src/resources/extensions/gsd/tests/graph-slash-command-5148.test.ts
@@ -78,10 +78,10 @@ describe("/gsd graph — issue #5148: wired into slash dispatcher", () => {
     const last = lastMessage(notifications);
     assert.doesNotMatch(last.message, /Unknown: \/gsd graph/);
     assert.match(last.message, /not built yet/);
-    assert.match(last.message, /gsd graph build/);
+    assert.match(last.message, /\/gsd graph build/);
   });
 
-  test("/gsd graph build creates .gsd/graph.json and reports counts", async () => {
+  test("/gsd graph build creates .gsd/graphs/graph.json and reports counts", async () => {
     const { notifications, ctx } = createMockCtx();
     await handleGSDCommand("graph build", ctx as any, {} as any);
 
@@ -127,6 +127,21 @@ describe("/gsd graph — issue #5148: wired into slash dispatcher", () => {
     assert.match(last.message, /No nodes found|Query results/);
   });
 
+  test("/gsd graph query joins multi-word terms instead of truncating to the first token", async () => {
+    const { notifications, ctx } = createMockCtx();
+    await handleGSDCommand("graph build", ctx as any, {} as any);
+    notifications.length = 0;
+
+    await handleGSDCommand("graph query hello world", ctx as any, {} as any);
+    const last = lastMessage(notifications);
+    assert.doesNotMatch(last.message, /Unknown: \/gsd graph/);
+    assert.match(
+      last.message,
+      /hello world/,
+      "the joined multi-word term must reach the query handler / response",
+    );
+  });
+
   test("/gsd graph diff after build reports a structured diff summary", async () => {
     const { notifications, ctx } = createMockCtx();
     await handleGSDCommand("graph build", ctx as any, {} as any);
@@ -163,16 +178,44 @@ describe("/gsd graph — issue #5148: wired into slash dispatcher", () => {
 });
 
 describe("/gsd graph — catalog & completion wiring", () => {
-  test("graph appears in TOP_LEVEL_SUBCOMMANDS", () => {
+  test("graph appears in TOP_LEVEL_SUBCOMMANDS with the correct artifact path", () => {
     const entry = TOP_LEVEL_SUBCOMMANDS.find((c) => c.cmd === "graph");
     assert.ok(entry, "graph must be present in TOP_LEVEL_SUBCOMMANDS");
     assert.ok(entry!.desc.length > 0, "graph entry needs a description");
+    assert.match(
+      entry!.desc,
+      /\.gsd\/graphs\/graph\.json/,
+      "graph entry must reference the actual artifact path .gsd/graphs/graph.json",
+    );
+  });
+
+  test("graph build completion description references the correct artifact path", () => {
+    const completions = getGsdArgumentCompletions("graph ");
+    const build = completions.find((c) => c.label === "build");
+    assert.ok(build, "build completion must exist");
+    assert.match(
+      build!.description ?? "",
+      /\.gsd\/graphs\/graph\.json/,
+      "build completion must reference .gsd/graphs/graph.json",
+    );
   });
 
   test("GSD_COMMAND_DESCRIPTION includes the graph token", () => {
     assert.ok(
       GSD_COMMAND_DESCRIPTION.includes("|graph"),
       "GSD_COMMAND_DESCRIPTION must list `graph` so /gsd autocompletion surfaces it",
+    );
+  });
+
+  test("/gsd help full references the correct graph artifact path", async () => {
+    const { notifications, ctx } = createMockCtx();
+    await handleGSDCommand("help full", ctx as any, {} as any);
+    const combined = notifications.map((n) => n.message).join("\n");
+    assert.match(combined, /\/gsd graph/);
+    assert.match(
+      combined,
+      /\.gsd\/graphs\/graph\.json/,
+      "full help must reference the actual artifact path .gsd/graphs/graph.json",
     );
   });
 


### PR DESCRIPTION
## TL;DR

**What:** Register \`/gsd graph build|status|query|diff\` in the interactive command dispatcher so the slash command stops falling through to the "Unknown" warning.
**Why:** PR #4212 shipped \`gsd graph\` as a CLI subcommand but never wired it into the slash-command dispatcher, leaving the interactive surface unusable (issue #5148).
**How:** Add a \`graph\` branch in \`commands/handlers/ops.ts\` that delegates to a new \`commands-graph.ts\` mirroring the CLI's build/status/query/diff flow, plus catalog, nested-completion, and help-menu entries — same shape as the existing \`knowledge\` command.

## What

- \`src/resources/extensions/gsd/commands-graph.ts\` (new) — \`handleGraph(args, ctx, projectDir)\` translating each subcommand into \`buildGraph\`/\`writeGraph\`/\`graphStatus\`/\`graphQuery\`/\`graphDiff\` calls from \`@gsd-build/mcp-server\`, surfacing results via \`ctx.ui.notify\`. Output strings mirror the \`gsd graph …\` CLI output in \`src/cli.ts\`.
- \`src/resources/extensions/gsd/commands/handlers/ops.ts\` — dispatch branch for \`graph\` / \`graph <sub>\`, sitting next to \`knowledge\` to make the parallel obvious.
- \`src/resources/extensions/gsd/commands/catalog.ts\` — adds \`graph\` to \`GSD_COMMAND_DESCRIPTION\`, \`TOP_LEVEL_SUBCOMMANDS\`, and the \`NESTED_COMPLETIONS\` map (\`build\`/\`status\`/\`query\`/\`diff\`).
- \`src/resources/extensions/gsd/commands/handlers/core.ts\` — adds the \`/gsd graph\` line to the PROJECT KNOWLEDGE section of \`/gsd help full\` so the existing \`help-menu-coverage\` test stays green.
- \`src/resources/extensions/gsd/tests/graph-slash-command-5148.test.ts\` (new) — regression test covering the dispatcher-routing fix, status / build / query / diff output shapes, the missing-term usage warning, the no-subcommand default, and the catalog/completion wiring.

## Why

Closes #5148. The CLI subcommand has worked since PR #4212 (closed #4202), but \`/gsd graph build\` in the interactive dispatcher produced \`Unknown: /gsd graph build. Run /gsd help for available commands.\` because none of the three integration points (catalog, dispatcher, help) were updated. The fix follows the exact pattern established by \`/gsd knowledge\`.

## How

Tests were written first and confirmed to fail against \`main\` (TAP shows the dispatcher emitting the \"Unknown\" warning); they pass after the dispatcher branch is added. Verification:

- \`npm run build:core\` — green
- \`npm run typecheck:extensions\` — green
- New test file: 11/11 passing
- Adjacent suites (\`help-menu-coverage\`, \`commands-eval-review\`, \`knowledge\`) — 101/101 passing

The full \`npm run test:unit\` reports 7 unrelated pre-existing failures on the same \`main\` baseline (deep-project setup model-policy denials, Context Mode prompt assertions, guided-flow consolidation #5183, register-hooks compaction-checkpoint). Reproduced against unmodified \`main\` HEAD via \`git stash\` to confirm they are not introduced by this change.

## AI assistance

This change was AI-assisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/gsd graph` slash command to build, inspect, query, and diff the project knowledge graph (defaults to `build` when omitted).
  * Subcommands: `build`, `status`, `query <term>`, `diff`. Friendly warnings for missing query term and unknown subcommands; clear success/error notifications and formatted summaries.

* **Documentation**
  * Help text and CLI autocompletions updated so `graph` and its subcommands are discoverable.

* **Tests**
  * Added comprehensive tests covering wiring, outputs, and behaviors for all graph subcommands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->