### PR TITLE
fix(gsd): bound milestone memory dedupe queries

### DIFF
--- a/src/resources/extensions/gsd/commands-extract-learnings.ts
+++ b/src/resources/extensions/gsd/commands-extract-learnings.ts
@@ -222,14 +222,19 @@ Using the \`write\` tool, persist the full structured report to
 LEARNINGS.md is the full, cited audit trail. Write it first — subsequent steps
 feed from its content.
 
-### Step 3 — Optionally pre-query the memory store for semantic duplicates
+### Step 3 — Run one bounded duplicate check
 
-Before persisting any extracted item in Steps 4–6, you may call
-\`memory_query\` with 2–3 keywords from the item to check whether the
-memory store already holds a semantically equivalent entry at high
-confidence. Skip those items in their respective steps. The memory store
-is the single source of truth for cross-session durable knowledge — no
-other persistence call is part of this flow.
+Before persisting extracted items in Steps 4–6, do at most one duplicate-check
+pass for the durable Decisions, Lessons, and Patterns from this milestone. Use
+the already-written LEARNINGS.md content and call \`memory_query\` once with a
+compact keyword summary for the whole batch. If that result clearly shows a
+semantically equivalent high-confidence memory for an item, mark only that item
+as already captured and skip it in its respective persistence step.
+
+Do not re-read milestone artefacts or repeat memory queries category-by-category
+after this point. The memory store is the single source of truth for
+cross-session durable knowledge — no other persistence call is part of this
+flow.
 
 ### Step 4 — Persist Patterns via \`capture_thought\`
 
@@ -268,11 +273,11 @@ later projection back to a human-visible decisions register stays lossless
 
 ### Step 7 — Deduplication rule (applies to Steps 4, 5, 6)
 
-Before each \`capture_thought\` call, optionally call \`memory_query\` with 2–3
-keywords from the entry. If a semantically equivalent memory is returned at
-high confidence, skip the capture entirely. Prefer skipping a near-duplicate
-over creating a second slightly-different row — redundancy degrades the
-signal.
+Use only the duplicate-check result from Step 3. If that bounded check returned
+a semantically equivalent memory at high confidence for an extracted item, skip
+the capture entirely. Otherwise, persist the item once via \`capture_thought\`.
+Prefer skipping a near-duplicate over creating a second slightly-different row
+— redundancy degrades the signal.
 
 ### Step 8 — Surprises stay only in LEARNINGS.md
 

--- a/src/resources/extensions/gsd/tests/commands-extract-learnings.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-extract-learnings.test.ts
@@ -1,3 +1,4 @@
+// GSD2 commands-extract-learnings tests
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
@@ -482,6 +483,14 @@ describe("buildExtractionStepsBlock", () => {
     assert.ok(/deduplication/i.test(block) || /dedup/i.test(block));
     assert.ok(/semantically equivalent/i.test(block));
     assert.ok(/skip/i.test(block));
+  });
+
+  it("limits duplicate checks to one milestone-scoped memory query", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    const memoryQueryMatches = block.match(/memory_query/g) ?? [];
+    assert.equal(memoryQueryMatches.length, 1);
+    assert.ok(block.includes("Do not re-read milestone artefacts or repeat memory queries category-by-category"));
+    assert.ok(!block.includes("Before each `capture_thought` call, optionally call `memory_query`"));
   });
 
   it("instructs capture_thought as the sole persistence path for Patterns, Lessons, and Decisions (ADR-013 step 6 cutover)", () => {


### PR DESCRIPTION
## TL;DR

**What:** Bounds complete-milestone learnings duplicate checks to one milestone-scoped memory query.
**Why:** The prior prompt wording encouraged repeated memory queries over the same milestone files, wasting tokens during closeout.
**How:** Rewords the shared learnings extraction block and adds a regression test that rejects the old per-`capture_thought` query instruction.

## What

This updates the shared structured learnings extraction instructions used by `/gsd extract-learnings` and auto-mode `complete-milestone`.

- Step 3 now instructs one bounded duplicate-check pass for durable Decisions, Lessons, and Patterns.
- The prompt explicitly says not to re-read milestone artifacts or repeat memory queries category-by-category after that pass.
- Step 7 now reuses the Step 3 duplicate-check result instead of asking for `memory_query` before every capture.
- A regression test enforces a single `memory_query` mention and guards against reintroducing the old per-capture wording.

Closes #5384

## Why

During complete-milestone closeout, the prompt could lead agents to repeatedly verify the same extracted files and memory entries before final persistence. That adds token cost without improving milestone correctness.

## How

The change keeps the existing durability model intact: `LEARNINGS.md` remains the audit trail and `capture_thought` remains the persistence path for Patterns, Lessons, and Decisions. Only duplicate-check ordering changes, from repeated per-entry checks to one bounded milestone-scoped pass.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/commands-extract-learnings.test.ts` — passed, 49/49
- [x] `npm run typecheck:extensions` — passed
- [ ] `npm run verify:pr` — build and typecheck passed, then `test:unit` hit a timing failure in `metrics-lock-retry-sleep.test.js` (`child must have acquired the lock before we attempt`)
- [x] `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/metrics-lock-retry-sleep.test.js` — passed on targeted retry, 3/3

Opened as draft because the recorded full `verify:pr` run was not green even though the failing lock test passed on direct retry.

## Change Type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined learnings extraction by consolidating duplicate detection into a single comprehensive batch-level check against existing content, rather than performing redundant per-item verification. This improves overall efficiency and reduces unnecessary processing steps in the workflow.

* **Tests**
  * Added test assertions to validate the updated deduplication behavior and ensure the extraction process correctly identifies and handles duplicate learnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->