### PR TITLE
feat(tui): summarize low-signal tool output by phase

### DIFF
--- a/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
+++ b/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
@@ -1002,6 +1002,57 @@ test("chat-controller does not pin when there are no tool calls", async () => {
 	assert.equal(host.pinnedMessageContainer.children.length, 0, "pinned zone should stay empty without tool calls");
 });
 
+test("chat-controller rolls up only contiguous low-signal tool runs on message_end", async () => {
+	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
+		fg: (_key: string, text: string) => text,
+		bg: (_key: string, text: string) => text,
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		truncate: (text: string) => text,
+	};
+
+	const host = createHost();
+	host.getMarkdownThemeWithSettings = () => ({});
+
+	const t1 = { type: "toolCall", id: "t1", name: "bash", arguments: { command: "true" } };
+	const t2 = { type: "toolCall", id: "t2", name: "bash", arguments: { command: "true" } };
+	const text = { type: "text", text: "middle output" };
+	const t3 = { type: "toolCall", id: "t3", name: "read", arguments: { path: "/tmp/a" } };
+	const t4 = { type: "toolCall", id: "t4", name: "read", arguments: { path: "/tmp/b" } };
+	const content = [t1, t2, text, t3, t4];
+
+	await handleAgentEvent(host, { type: "message_start", message: makeAssistant([]) } as any);
+	await handleAgentEvent(host, {
+		type: "message_update",
+		message: makeAssistant(content),
+		assistantMessageEvent: {
+			type: "text_delta",
+			contentIndex: 2,
+			delta: text.text,
+			partial: makeAssistant(content),
+		},
+	} as any);
+
+	for (const tool of [t1, t2, t3, t4]) {
+		await handleAgentEvent(host, {
+			type: "tool_execution_end",
+			toolCallId: tool.id,
+			isError: false,
+			result: { content: [], details: {} },
+		} as any);
+	}
+
+	await handleAgentEvent(host, { type: "message_end", message: makeAssistant(content) } as any);
+
+	assert.equal(host.chatContainer.children.length, 3, "two separated tool runs should become two summaries around text");
+	assert.equal(host.chatContainer.children[0]?.constructor?.name, "ToolPhaseSummaryComponent");
+	assert.equal(host.chatContainer.children[1]?.constructor?.name, "AssistantMessageComponent");
+	assert.equal(host.chatContainer.children[2]?.constructor?.name, "ToolPhaseSummaryComponent");
+	assert.match(host.chatContainer.children[0].render(120).join("\n"), /Setup \/ shell 2 actions/);
+	assert.match(host.chatContainer.children[2].render(120).join("\n"), /Context reads 2 actions/);
+	assert.equal(host.chatContainer._prevRender, null, "summary reposition must invalidate the chat container render cache");
+});
+
 // Regression test for issue #4144: interleaved text/tool content must render in content[] index order.
 // Stream: [text "A", toolCall T1, text "B", toolCall T2, text "C"]
 // Expected chatContainer order: textRun(A), toolExec(T1), textRun(B), toolExec(T2), textRun(C)

--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
@@ -1,7 +1,8 @@
+// GSD-2 Interactive Tool Execution Rendering Tests
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import stripAnsi from "strip-ansi";
-import { ToolExecutionComponent } from "../tool-execution.js";
+import { ToolExecutionComponent, ToolPhaseSummaryComponent, type ToolExecutionPhase } from "../tool-execution.js";
 import { initTheme } from "../../theme/theme.js";
 
 initTheme("dark", false);
@@ -81,6 +82,49 @@ describe("ToolExecutionComponent", () => {
 		assert.match(rendered, /Done · \d+(ms|s)/);
 		assert.match(rendered, /Completed/);
 		assert.doesNotMatch(rendered, /ok=true/);
+	});
+
+	test("exposes phase metadata for successful low-signal tool rows", () => {
+		const component = new ToolExecutionComponent(
+			"gsd_requirement_update",
+			{ id: "R001" },
+			{},
+			{ label: "Update Requirement" } as any,
+			{ requestRender() {} } as any,
+		);
+		component.updateResult({ content: [], isError: false });
+
+		assert.deepEqual(component.getRollupPhase()?.label, "Requirement writes");
+	});
+
+	test("does not expose phase metadata for output-bearing tools", () => {
+		const component = new ToolExecutionComponent(
+			"mcp__demo__do_thing",
+			{ ok: true },
+			{},
+			undefined,
+			{ requestRender() {} } as any,
+		);
+		component.updateResult({ content: [{ type: "text", text: "important output" }], isError: false });
+
+		assert.equal(component.getRollupPhase(), null);
+	});
+
+	test("renders phase-based summaries for rolled-up tool executions", () => {
+		const phases: ToolExecutionPhase[] = [
+			{ label: "Setup / shell", count: 6, durationMs: 12 },
+			{ label: "Context reads", count: 4, durationMs: 6 },
+			{ label: "Requirement writes", count: 4, durationMs: 4 },
+			{ label: "Memory lookups", count: 4, durationMs: 4 },
+			{ label: "Finalization", count: 1, durationMs: 1 },
+		];
+		const rendered = stripAnsi(new ToolPhaseSummaryComponent(phases).render(120).join("\n"));
+
+		assert.match(rendered, /Setup \/ shell 6 actions\s+success · 12ms/);
+		assert.match(rendered, /Context reads 4 actions\s+success · 6ms/);
+		assert.match(rendered, /Requirement writes 4 actions\s+success · 4ms/);
+		assert.match(rendered, /Memory lookups 4 actions\s+success · 4ms/);
+		assert.match(rendered, /Finalization 1 action\s+success · 1ms/);
 	});
 
 	test("passes failed result status to custom result renderers", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -1,3 +1,4 @@
+// GSD-2 Interactive Tool Execution Rendering
 import {
 	Box,
 	Container,
@@ -130,6 +131,12 @@ function renderToolFrame(
 const COMPACT_ARG_VALUE_LIMIT = 60;
 const GENERIC_OUTPUT_PREVIEW_LINES = 10;
 const GENERIC_ARGS_JSON_PREVIEW_LINES = 10;
+
+export type ToolExecutionPhase = {
+	label: string;
+	count: number;
+	durationMs: number;
+};
 
 function formatElapsed(ms: number): string {
 	if (ms < 1000) return `${ms}ms`;
@@ -578,6 +585,33 @@ export class ToolExecutionComponent extends Container {
 		if (this.expanded || this.isPartial || !this.result || this.result.isError) return false;
 		const hasImages = this.result.content?.some((block) => block.type === "image") ?? false;
 		return !hasImages && this.getTextOutput().trim().length === 0;
+	}
+
+	getRollupPhase(): ToolExecutionPhase | null {
+		if (!this.shouldRenderCompactSuccess()) return null;
+		const label = this.getPhaseLabel();
+		const endedAt = this.endedAt ?? Date.now();
+		return {
+			label,
+			count: 1,
+			durationMs: Math.max(0, endedAt - this.startedAt),
+		};
+	}
+
+	private getPhaseLabel(): string {
+		const name = this.normalizedToolName;
+		const displayName = prettifyToolName(this.toolName, this.toolDefinition?.label);
+
+		if (name === "bash") return "Setup / shell";
+		if (name === "read" || name === "ls" || name === "find" || name === "grep") return "Context reads";
+		if (name === "write" || name === "edit") return "File changes";
+		if (name === "web_search" || displayName === "ToolSearch") return "Discovery";
+		if (displayName === "Memory Query" || displayName === "Memory Capture" || displayName === "Gsd Graph") {
+			return "Memory lookups";
+		}
+		if (displayName === "Update Requirement" || displayName === "Save Requirement") return "Requirement writes";
+		if (displayName.startsWith("Complete ")) return "Finalization";
+		return "Other tool actions";
 	}
 
 	private getCompactSummary(frameLabel: string): string {
@@ -1229,5 +1263,26 @@ export class ToolExecutionComponent extends Container {
 		}
 
 		return text;
+	}
+}
+
+export class ToolPhaseSummaryComponent extends Container {
+	constructor(private readonly phases: ToolExecutionPhase[]) {
+		super();
+	}
+
+	override render(width: number): string[] {
+		const frameWidth = Math.max(20, width);
+		const rows = this.phases.map((phase) => {
+			const left = `${phase.label} ${phase.count} ${phase.count === 1 ? "action" : "actions"}`;
+			const right = `success · ${formatElapsed(phase.durationMs)}`;
+			const contentWidth = Math.max(1, frameWidth - 2);
+			const leftWidth = Math.max(1, contentWidth - visibleWidth(right) - 1);
+			const leftText = truncateToWidth(left, leftWidth, "");
+			const gap = Math.max(1, contentWidth - visibleWidth(leftText) - visibleWidth(right));
+			return `${theme.fg("toolSuccess", leftText)}${" ".repeat(gap)}${theme.fg("toolSuccess", right)}`;
+		});
+
+		return ["", ...style().border("minimal").borderColor((text) => theme.fg("toolSuccess", text)).render(rows, frameWidth)];
 	}
 }

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -1,9 +1,14 @@
+// GSD-2 Interactive Chat Controller
 import { Loader, Markdown, Spacer, Text } from "@gsd/pi-tui";
 
 import type { InteractiveModeEvent, InteractiveModeStateHost } from "../interactive-mode-state.js";
 import { theme } from "../theme/theme.js";
 import { AssistantMessageComponent } from "../components/assistant-message.js";
-import { ToolExecutionComponent } from "../components/tool-execution.js";
+import {
+	ToolExecutionComponent,
+	ToolPhaseSummaryComponent,
+	type ToolExecutionPhase,
+} from "../components/tool-execution.js";
 import { DynamicBorder } from "../components/dynamic-border.js";
 import { appKey } from "../components/keybinding-hints.js";
 
@@ -99,6 +104,71 @@ let hasToolsInTurn = false;
 let pinnedBorder: DynamicBorder | undefined;
 // Reference to the pinned markdown component below the border
 let pinnedTextComponent: Markdown | undefined;
+
+function mergeToolPhases(phases: ToolExecutionPhase[]): ToolExecutionPhase[] {
+	const merged: ToolExecutionPhase[] = [];
+	for (const phase of phases) {
+		const previous = merged[merged.length - 1];
+		if (previous?.label === phase.label) {
+			previous.count += phase.count;
+			previous.durationMs += phase.durationMs;
+		} else {
+			merged.push({ ...phase });
+		}
+	}
+	return merged;
+}
+
+function replaceCompactToolRowsWithPhaseSummary(
+	host: InteractiveModeStateHost & { ui: { requestRender: () => void } },
+): void {
+	let changed = false;
+	const nextRenderedSegments: RenderedSegment[] = [];
+	let rollupRun: Array<{ seg: Extract<RenderedSegment, { kind: "tool" }>; phase: ToolExecutionPhase }> = [];
+
+	const flushRollupRun = () => {
+		if (rollupRun.length < 2) {
+			nextRenderedSegments.push(...rollupRun.map((item) => item.seg));
+			rollupRun = [];
+			return;
+		}
+
+		const firstIndex = Math.max(0, host.chatContainer.children.indexOf(rollupRun[0].seg.component));
+		const summary = new ToolPhaseSummaryComponent(mergeToolPhases(rollupRun.map((item) => item.phase)));
+
+		for (const { seg } of rollupRun) {
+			host.chatContainer.removeChild(seg.component);
+		}
+
+		host.chatContainer.addChild(summary);
+		const summaryIndex = host.chatContainer.children.indexOf(summary);
+		if (summaryIndex !== -1 && summaryIndex !== firstIndex) {
+			host.chatContainer.children.splice(summaryIndex, 1);
+			host.chatContainer.children.splice(firstIndex, 0, summary);
+			(host.chatContainer as unknown as { _prevRender: string[] | null })._prevRender = null;
+		}
+
+		changed = true;
+		rollupRun = [];
+	};
+
+	for (const seg of renderedSegments) {
+		const phase = seg.kind === "tool" ? seg.component.getRollupPhase() : null;
+		if (seg.kind === "tool" && phase) {
+			rollupRun.push({ seg, phase });
+			continue;
+		}
+
+		flushRollupRun();
+		nextRenderedSegments.push(seg);
+	}
+	flushRollupRun();
+
+	if (changed) {
+		renderedSegments = nextRenderedSegments;
+		host.ui.requestRender();
+	}
+}
 
 export async function handleAgentEvent(host: InteractiveModeStateHost & {
 	init: () => Promise<void>;
@@ -773,6 +843,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					host.streamingComponent.setShowMetadata(true);
 					host.streamingComponent.updateContent(host.streamingMessage);
 				}
+				replaceCompactToolRowsWithPhaseSummary(host);
 
 				if (host.streamingMessage.stopReason === "aborted" || host.streamingMessage.stopReason === "error") {
 					if (!errorMessage) {


### PR DESCRIPTION
## TL;DR

**What:** Adds a phase-based summary for successful empty-output tool rows in the interactive TUI.
**Why:** Repeated low-signal tool rows make completed GSD runs hard to scan.
**How:** Exposes roll-up metadata from tool execution components and replaces eligible completed rows with a phase summary at turn finalization.

## What

This updates the interactive TUI tool rendering path to roll up successful low-signal tool executions into phase summaries such as setup/shell, context reads, requirement writes, memory lookups, and finalization.

Changed files:

- `packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts`
- `packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts`
- `packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts`

The roll-up only applies to completed successful tools with no text output and no images. Errors, running tools, output-bearing tools, and image results remain visible individually.

Closes #5386

## Why

Completed GSD workflows can produce long runs of repeated compact tool rows, especially for shell, read, requirement update, memory query, and finalization calls. The repeated rows add noise without improving auditability for normal scanning.

## How

- Adds `getRollupPhase()` to `ToolExecutionComponent` so eligible low-signal tools can provide phase metadata.
- Adds `ToolPhaseSummaryComponent` to render grouped phase rows with action counts and total durations.
- Updates the chat controller to replace eligible completed tool rows after assistant turn finalization, preserving the first tool row position and leaving important tool rows untouched.
- Adds node:test coverage for phase eligibility, output-bearing exclusion, and summary rendering.

## Change Type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Tests

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts`
- [x] `npm run typecheck:extensions`
- [x] `npm run build -w @gsd/pi-coding-agent`
- [x] `npm run verify:pr` — `8982 passed, 0 failed, 9 skipped`

## AI Assistance

This PR was AI-assisted. The implementation was verified with the commands listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool execution phases now roll up contiguous, compact successful tool runs into a single compact summary showing phase label, action count, and elapsed time, replacing multiple tool rows while preserving chat order.
  * Adjacent phases with the same label are merged into aggregated counts and durations for clearer timelines.

* **Tests**
  * Added coverage verifying roll-up behavior, summary rendering, and correct placement during message completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->