### PR TITLE
feat(models): support custom OpenAI model payload defaults

### DIFF
--- a/packages/pi-ai/src/providers/openai-completions.test.ts
+++ b/packages/pi-ai/src/providers/openai-completions.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { applyOpenAICompatibleProviderOptions } from "./openai-completions.js";
+import type { Model } from "../types.js";
+
+function makeModel(overrides: Partial<Model<"openai-completions">> = {}): Model<"openai-completions"> {
+	return {
+		id: "alias-model",
+		name: "Alias Model",
+		api: "openai-completions",
+		provider: "spark",
+		baseUrl: "http://127.0.0.1:18000/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 262144,
+		maxTokens: 32768,
+		...overrides,
+	};
+}
+
+describe("applyOpenAICompatibleProviderOptions", () => {
+	it("maps alias ids to the actual served model and applies payload defaults", () => {
+		const model = makeModel({
+			providerOptions: {
+				actualModelId: "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
+				payload: {
+					temperature: 1,
+					top_p: 0.95,
+					top_k: 20,
+					min_p: 0,
+					presence_penalty: 1.5,
+					repetition_penalty: 1,
+					chat_template_kwargs: {
+						enable_thinking: true,
+						preserve_thinking: true,
+					},
+				},
+			},
+		});
+
+		const params = applyOpenAICompatibleProviderOptions(model, {
+			model: model.id,
+			messages: [],
+			stream: true,
+		} as any);
+
+		assert.equal(params.model, "RedHatAI/Qwen3.6-35B-A3B-NVFP4");
+		assert.equal(params.temperature, 1);
+		assert.equal((params as any).top_p, 0.95);
+		assert.equal((params as any).top_k, 20);
+		assert.equal((params as any).min_p, 0);
+		assert.equal((params as any).presence_penalty, 1.5);
+		assert.equal((params as any).repetition_penalty, 1);
+		assert.deepEqual((params as any).chat_template_kwargs, {
+			enable_thinking: true,
+			preserve_thinking: true,
+		});
+	});
+
+	it("does not overwrite an explicit request temperature", () => {
+		const model = makeModel({
+			providerOptions: {
+				payload: {
+					temperature: 1,
+				},
+			},
+		});
+
+		const params = applyOpenAICompatibleProviderOptions(model, {
+			model: model.id,
+			messages: [],
+			stream: true,
+			temperature: 0.2,
+		} as any);
+
+		assert.equal(params.temperature, 0.2);
+	});
+});

--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -66,6 +66,67 @@ export interface OpenAICompletionsOptions extends StreamOptions {
 	reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
 }
 
+type OpenAICompatiblePayloadDefaults = {
+	chat_template_kwargs?: Record<string, unknown>;
+	temperature?: number;
+	top_p?: number;
+	top_k?: number;
+	min_p?: number;
+	presence_penalty?: number;
+	repetition_penalty?: number;
+};
+
+type OpenAICompatibleProviderOptions = {
+	actualModelId?: string;
+	payload?: OpenAICompatiblePayloadDefaults;
+};
+
+export function applyOpenAICompatibleProviderOptions(
+	model: Model<"openai-completions">,
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+): OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming {
+	const providerOptions = (model.providerOptions ?? {}) as OpenAICompatibleProviderOptions;
+	const defaultPayload = providerOptions.payload ?? {};
+	const targetModelId = providerOptions.actualModelId ?? model.id;
+	const nextParams = {
+		...params,
+		model: targetModelId,
+	} as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming;
+
+	if (defaultPayload.temperature !== undefined && nextParams.temperature === undefined) {
+		nextParams.temperature = defaultPayload.temperature;
+	}
+
+	if (defaultPayload.top_p !== undefined) {
+		(nextParams as typeof nextParams & { top_p: number }).top_p = defaultPayload.top_p;
+	}
+
+	if (defaultPayload.top_k !== undefined) {
+		(nextParams as typeof nextParams & { top_k: number }).top_k = defaultPayload.top_k;
+	}
+
+	if (defaultPayload.min_p !== undefined) {
+		(nextParams as typeof nextParams & { min_p: number }).min_p = defaultPayload.min_p;
+	}
+
+	if (defaultPayload.presence_penalty !== undefined) {
+		(nextParams as typeof nextParams & { presence_penalty: number }).presence_penalty =
+			defaultPayload.presence_penalty;
+	}
+
+	if (defaultPayload.repetition_penalty !== undefined) {
+		(nextParams as typeof nextParams & { repetition_penalty: number }).repetition_penalty =
+			defaultPayload.repetition_penalty;
+	}
+
+	if (defaultPayload.chat_template_kwargs !== undefined) {
+		(nextParams as typeof nextParams & { chat_template_kwargs: Record<string, unknown> }).chat_template_kwargs =
+			defaultPayload.chat_template_kwargs;
+	}
+
+	return nextParams;
+}
+
 export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenAICompletionsOptions> = (
 	model: Model<"openai-completions">,
 	context: Context,
@@ -356,7 +417,7 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 	const messages = convertMessages(model, context, compat);
 	maybeAddOpenRouterAnthropicCacheControl(model, messages);
 
-	const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
+	let params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
 		model: model.id,
 		messages,
 		stream: true,
@@ -418,7 +479,7 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 		}
 	}
 
-	return params;
+	return applyOpenAICompatibleProviderOptions(model, params);
 }
 
 function maybeAddOpenRouterAnthropicToolCacheControl(

--- a/packages/pi-coding-agent/src/core/model-registry-provider-options.test.ts
+++ b/packages/pi-coding-agent/src/core/model-registry-provider-options.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import { AuthStorage } from "./auth-storage.js";
+import { ModelRegistry } from "./model-registry.js";
+
+describe("ModelRegistry custom models providerOptions", () => {
+	it("preserves providerOptions from models.json custom models", () => {
+		const dir = mkdtempSync(join(tmpdir(), "gsd-provider-options-"));
+		const modelsPath = join(dir, "models.json");
+		writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					spark: {
+						apiKey: "dummy-key",
+						baseUrl: "http://127.0.0.1:18000/v1",
+						api: "openai-completions",
+						models: [
+							{
+								id: "qwen3.6-thinking",
+								name: "Qwen 3.6 Thinking",
+								reasoning: true,
+								contextWindow: 262144,
+								maxTokens: 32768,
+								providerOptions: {
+									actualModelId: "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
+									payload: {
+										chat_template_kwargs: { enable_thinking: true },
+									},
+								},
+							},
+						],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(AuthStorage.inMemory({}), modelsPath);
+		const model = registry.find("spark", "qwen3.6-thinking");
+
+		assert.ok(model);
+		assert.deepEqual(model.providerOptions, {
+			actualModelId: "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
+			payload: {
+				chat_template_kwargs: { enable_thinking: true },
+			},
+		});
+	});
+});

--- a/packages/pi-coding-agent/src/core/model-registry.ts
+++ b/packages/pi-coding-agent/src/core/model-registry.ts
@@ -100,6 +100,7 @@ const ModelDefinitionSchema = Type.Object({
 	headers: Type.Optional(Type.Record(Type.String(), Type.String())),
 	compat: Type.Optional(OpenAICompatSchema),
 	capabilities: Type.Optional(ModelCapabilitiesSchema),
+	providerOptions: Type.Optional(Type.Record(Type.String(), Type.Any())),
 });
 
 // Schema for per-model overrides (all fields optional, merged with built-in model)
@@ -531,6 +532,7 @@ export class ModelRegistry {
 					headers,
 					compat: modelDef.compat,
 					capabilities: modelDef.capabilities,
+					providerOptions: modelDef.providerOptions,
 				} as Model<Api>);
 			}
 		}


### PR DESCRIPTION
## TL;DR

**What:** Add `providerOptions` field to models.json for per-model customization of request payloads and model ID mapping on OpenAI-compatible servers.

**Why:** Local Qwen-compatible servers (like vLLM, SGLang, TGI) require specific parameters like `chat_template_kwargs.enable_thinking`, per-model temperature/presence_penalty defaults, and sometimes use a different model name than the user-facing alias. Users currently have no way to express these requirements in their config.

**How:** Added an optional `providerOptions` field to the model schema (preserved via TypeBox as `{ [key: string]: any }`). The `openai-completions` provider now reads `actualModelId` and `payload` from providerOptions and applies them during request building. Request-level values always override provider option defaults.

## What

Changes to two packages:

- **`packages/pi-ai/src/providers/openai-completions.ts`** — Extracted a new `applyOpenAICompatibleProviderOptions()` function that maps the configured `actualModelId` to the real model name and applies default values for temperature, top_p, top_k, min_p, presence_penalty, repetition_penalty, and chat_template_kwargs.

- **`packages/pi-coding-agent/src/core/model-registry.ts`** — Added `providerOptions` to the TypeBox model definition schema and passes it through during model construction.

## Why

When running local inference servers, users often need model ID mapping, thinking control flags (chat_template_kwargs), and consistent default sampling parameters. This enables configs like `qwen3.6-thinking → RedHatAI/Qwen3.6-35B-A3B-NVFP4`.

## How

Extended ModelDefinitionSchema with providerOptions, added applyOpenAICompatibleProviderOptions() to openai-completions.ts. Tests verify alias mapping, payload merging, and explicit-request precedence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for provider-specific options in custom model definitions
  * OpenAI-compatible providers can now apply default parameters (temperature, top_p, top_k, min_p, presence_penalty, repetition_penalty, and chat template settings) that apply to requests unless explicitly overridden

* **Tests**
  * Added comprehensive test coverage for provider options in model configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->