### PR TITLE
ci: speed up merge workflow gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,16 @@ on:
       - '.github/workflows/build-native.yml'
       - '.github/workflows/cleanup-dev-versions.yml'
       - 'LICENSE'
+  workflow_dispatch:
+    inputs:
+      full_windows_e2e:
+        description: "Run the full Windows e2e suite"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -28,8 +38,10 @@ jobs:
     outputs:
       docs-only: ${{ steps.check.outputs.docs-only }}
       portability-changed: ${{ steps.check.outputs.portability-changed }}
+      windows-e2e-changed: ${{ steps.check.outputs.windows-e2e-changed }}
       docker-changed: ${{ steps.check.outputs.docker-changed }}
       studio-changed: ${{ steps.check.outputs.studio-changed }}
+      rtk-changed: ${{ steps.check.outputs.rtk-changed }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -69,6 +81,15 @@ jobs:
             echo "portability-changed=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No portability-relevant changes detected — skipping portability matrix jobs"
           fi
+          WINDOWS_E2E=$(echo "$NON_DOCS" | grep -E '^(tests/e2e/|src/(loader|rtk|rtk/|native|native/|resources/extensions/gsd/gsd-db|resources/extensions/gsd/extension-host|resources/extensions/gsd/auto-worktree|resources/extensions/gsd/workflow-mcp)|packages/(pi-coding-agent|pi-ai|pi-agent-core|native|mcp-server|rpc-client)/|native/|package\.json$|package-lock\.json$|tsconfig[^/]*\.json$|packages/.*/tsconfig\.json$)' || true)
+          if [ -n "$WINDOWS_E2E" ]; then
+            echo "windows-e2e-changed=true" >> "$GITHUB_OUTPUT"
+            echo "Windows e2e-relevant files changed:"
+            echo "$WINDOWS_E2E"
+          else
+            echo "windows-e2e-changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Windows e2e-relevant changes detected — skipping Windows e2e"
+          fi
           DOCKER=$(echo "$NON_DOCS" | grep -E '^(Dockerfile$|docker/|scripts/install\.js$|scripts/.*\.cjs$|scripts/.*\.mjs$|package\.json$|package-lock\.json$|src/|packages/|tests/e2e/docker/)' || true)
           if [ -n "$DOCKER" ]; then
             echo "docker-changed=true" >> "$GITHUB_OUTPUT"
@@ -86,6 +107,15 @@ jobs:
           else
             echo "studio-changed=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No Studio-relevant changes detected — skipping studio-e2e"
+          fi
+          RTK=$(echo "$NON_DOCS" | grep -E '^(src/rtk|src/rtk/|src/tests/rtk|src/tests/postinstall\.test\.ts|src/tests/app-smoke\.test\.ts|src/resources/extensions/gsd/tests/custom-verification\.test\.ts|src/resources/extensions/gsd/tests/verification-gate\.test\.ts|scripts/install\.js|package\.json$|package-lock\.json$)' || true)
+          if [ -n "$RTK" ]; then
+            echo "rtk-changed=true" >> "$GITHUB_OUTPUT"
+            echo "RTK-relevant files changed:"
+            echo "$RTK"
+          else
+            echo "rtk-changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No RTK-relevant changes detected — skipping RTK portability matrix"
           fi
 
   docs-check:
@@ -253,7 +283,9 @@ jobs:
         run: npm run verify:workspace-coverage
 
       - name: Run unit tests
-        run: npm run test:unit
+        run: |
+          npm run test:compile
+          npm run test:unit:compiled
 
       - name: Run package tests
         run: npm run test:packages
@@ -400,10 +432,11 @@ jobs:
     # tarball files. Gated by detect-changes so doc-only PRs skip it.
     # No untrusted GitHub event input is consumed in run: blocks.
     timeout-minutes: 20
-    needs: detect-changes
+    needs: [detect-changes, ci-circuit-breaker-fast, mergeability-gate]
     if: >-
       needs.detect-changes.outputs.docs-only != 'true' &&
-      needs.detect-changes.outputs.docker-changed == 'true'
+      needs.detect-changes.outputs.docker-changed == 'true' &&
+      needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -441,11 +474,12 @@ jobs:
     # continue-on-error.
     #
     # No untrusted GitHub event input is consumed in run: blocks.
-    timeout-minutes: 20
-    needs: detect-changes
+    timeout-minutes: 10
+    needs: [detect-changes, ci-circuit-breaker-fast, mergeability-gate]
     if: >-
       needs.detect-changes.outputs.docs-only != 'true' &&
-      needs.detect-changes.outputs.portability-changed == 'true'
+      needs.detect-changes.outputs.windows-e2e-changed == 'true' &&
+      needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-windows-2025
     continue-on-error: true
 
@@ -460,6 +494,10 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+          GSD_SKIP_RTK_INSTALL: '1'
         run: npm ci
 
       - name: Build core
@@ -469,13 +507,62 @@ jobs:
         shell: bash
         run: |
           export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
-          npm run test:e2e
+          npm run test:e2e:windows-smoke
 
       - name: Upload e2e artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-artifacts-windows
+          path: test-results/e2e
+          if-no-files-found: ignore
+          retention-days: 7
+
+  e2e-windows-full:
+    # Full Windows e2e is still exploratory. It has previously hung after
+    # fake-LLM failures while child services remained alive, so keep it
+    # manual until that suite is stable enough to promote.
+    timeout-minutes: 25
+    needs: [detect-changes, ci-circuit-breaker-fast, mergeability-gate]
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.full_windows_e2e == 'true' &&
+      needs.detect-changes.outputs.docs-only != 'true' &&
+      needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
+    runs-on: blacksmith-4vcpu-windows-2025
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+          GSD_SKIP_RTK_INSTALL: '1'
+        run: npm ci
+
+      - name: Build core
+        run: npm run build:core
+
+      - name: Run full e2e suite (against built binary)
+        shell: bash
+        run: |
+          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          npm run test:e2e
+
+      - name: Upload e2e artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-artifacts-windows-full
           path: test-results/e2e
           if-no-files-found: ignore
           retention-days: 7
@@ -489,10 +576,11 @@ jobs:
     #
     # No untrusted GitHub event input is consumed in run: blocks.
     timeout-minutes: 15
-    needs: detect-changes
+    needs: [detect-changes, ci-circuit-breaker-fast, mergeability-gate]
     if: >-
       needs.detect-changes.outputs.docs-only != 'true' &&
-      needs.detect-changes.outputs.studio-changed == 'true'
+      needs.detect-changes.outputs.studio-changed == 'true' &&
+      needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -567,7 +655,7 @@ jobs:
     needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
     if: >-
       needs.detect-changes.outputs.docs-only != 'true' &&
-      needs.detect-changes.outputs.portability-changed == 'true' &&
+      needs.detect-changes.outputs.rtk-changed == 'true' &&
       needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     strategy:
       fail-fast: false

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "baseline:refactor:phase0": "npm run baseline:refactor:gate && node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/derive-state-db.test.ts src/resources/extensions/gsd/tests/single-writer-invariant.test.ts src/resources/extensions/gsd/tests/auto-recovery.test.ts src/resources/extensions/gsd/tests/auto-worktree-registry.test.ts",
     "legacy:cleanup:gate": "node scripts/legacy-cleanup-gate.mjs",
     "legacy:cleanup:evidence": "node scripts/legacy-cleanup-evidence.mjs",
-    "test:unit": "npm run test:compile && node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test \"dist-test/src/tests/*.test.js\" \"dist-test/src/resources/extensions/gsd/tests/*.test.js\" \"dist-test/src/resources/extensions/gsd/tests/*.test.mjs\" \"dist-test/src/resources/extensions/shared/tests/*.test.js\" \"dist-test/src/resources/extensions/subagent/tests/*.test.js\" \"dist-test/src/resources/extensions/claude-code-cli/tests/*.test.js\" \"dist-test/src/resources/extensions/github-sync/tests/*.test.js\" \"dist-test/src/resources/extensions/universal-config/tests/*.test.js\" \"dist-test/src/resources/extensions/voice/tests/*.test.js\" \"dist-test/src/resources/extensions/mcp-client/tests/*.test.js\" \"dist-test/src/resources/extensions/remote-questions/tests/*.test.js\"",
+    "test:unit:compiled": "node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test \"dist-test/src/tests/*.test.js\" \"dist-test/src/resources/extensions/gsd/tests/*.test.js\" \"dist-test/src/resources/extensions/gsd/tests/*.test.mjs\" \"dist-test/src/resources/extensions/shared/tests/*.test.js\" \"dist-test/src/resources/extensions/subagent/tests/*.test.js\" \"dist-test/src/resources/extensions/claude-code-cli/tests/*.test.js\" \"dist-test/src/resources/extensions/github-sync/tests/*.test.js\" \"dist-test/src/resources/extensions/universal-config/tests/*.test.js\" \"dist-test/src/resources/extensions/voice/tests/*.test.js\" \"dist-test/src/resources/extensions/mcp-client/tests/*.test.js\" \"dist-test/src/resources/extensions/remote-questions/tests/*.test.js\"",
+    "test:unit": "npm run test:compile && npm run test:unit:compiled",
     "test:changed:src": "node scripts/verify-changed-src-tests.mjs",
     "test:packages": "npm run test:compile && node scripts/run-package-tests.cjs",
     "verify:workspace-coverage": "node scripts/verify-workspace-coverage.cjs",
@@ -107,6 +108,7 @@
     "prepublishOnly": "npm run sync-pkg-version && npm run sync-platform-versions && node scripts/prepublish-check.mjs && npm run build && npm run typecheck:extensions && npm run validate-pack",
     "test:live-regression": "node --experimental-strip-types tests/live-regression/run.ts",
     "test:e2e": "node --experimental-strip-types --test \"tests/e2e/*.e2e.test.ts\"",
+    "test:e2e:windows-smoke": "node --experimental-strip-types --test tests/e2e/sanity.e2e.test.ts tests/e2e/migration.e2e.test.ts tests/e2e/native-abi.e2e.test.ts",
     "test:e2e:docker": "node --experimental-strip-types --test \"tests/e2e/docker/**/*.e2e.test.ts\""
   },
   "dependencies": {


### PR DESCRIPTION
## TL;DR

**What:** Speeds up merge CI by narrowing slow optional gates and replacing PR-time Windows full e2e with a fast smoke path.
**Why:** `e2e-windows` can consume roughly 20 minutes while non-blocking, delaying merge/build feedback and wasting runner time.
**How:** Adds targeted change-detection outputs, gates optional slow jobs behind fast/mergeability checks, adds a manual full Windows e2e path, and introduces a compiled unit-test entrypoint for CI.

## What

- Adds `workflow_dispatch.full_windows_e2e` for manually running the full Windows e2e suite.
- Adds `windows-e2e-changed` and `rtk-changed` outputs to split broad portability detection.
- Changes PR-time `e2e-windows` to run `npm run test:e2e:windows-smoke` with install-time heavy downloads skipped.
- Keeps full Windows e2e available as `e2e-windows-full`, non-blocking and manual.
- Moves `docker-e2e` and `studio-e2e` behind fast gates and mergeability.
- Adds `test:unit:compiled` so CI can compile tests once before the unit test command.

## Why

The Windows e2e workflow was observed spending almost all of its runtime inside the full `npm run test:e2e` suite after a fake-LLM failure, eventually timing out/canceling around 20 minutes. Since that job is currently non-blocking, PR CI should keep the Windows smoke signal while moving the full exploratory suite out of the regular merge path.

Closes #5396

## How

The change keeps the existing Linux e2e gate untouched. Windows PR coverage now runs the e2e files that validate built-binary process basics, migration behavior, and native ABI behavior. The full fake-LLM suite remains available through manual workflow dispatch so it can still be exercised before promotion to required status.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

## Test plan

- [x] `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"`
- [x] `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'ci.yml ok'"`
- [x] `GSD_SMOKE_BINARY="$(pwd)/dist/loader.js" npm run test:e2e:windows-smoke` — 6 passed, 0 failed
- [ ] `npm run verify:pr` — not rerun to green for this PR; existing repo-wide unit preflight is red on an unrelated ADR-012 provider equality guard in `src/providers/provider-migrations.ts`.

AI-assisted contribution: yes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow with manual trigger support for extended Windows testing.
  * Optimized build process with compiled unit test execution.
  * Introduced Windows smoke tests as the default E2E test suite, with optional full test runs available.
  * Improved change detection to better gate heavy CI jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->