### PR TITLE
fix(gsd): keep detached auto-mode alive

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -420,6 +420,17 @@ export function _synthesizePausedSessionRecoveryForTest(
   return synthesizePausedSessionRecovery(basePath, unitType, unitId, sessionFile);
 }
 
+const DETACHED_AUTO_KEEPALIVE_INTERVAL_MS = 30_000;
+
+function withDetachedAutoKeepalive<T>(run: Promise<T>): Promise<T> {
+  const keepAlive = setInterval(() => {}, DETACHED_AUTO_KEEPALIVE_INTERVAL_MS);
+  return run.finally(() => {
+    clearInterval(keepAlive);
+  });
+}
+
+export const _withDetachedAutoKeepaliveForTest = withDetachedAutoKeepalive;
+
 export function startAutoDetached(
   ctx: ExtensionCommandContext,
   pi: ExtensionAPI,
@@ -431,7 +442,7 @@ export function startAutoDetached(
     milestoneLock?: string | null;
   },
 ): void {
-  void startAuto(ctx, pi, base, verboseMode, options).catch((err) => {
+  void withDetachedAutoKeepalive(startAuto(ctx, pi, base, verboseMode, options)).catch((err) => {
     const message = getErrorMessage(err);
     ctx.ui.notify(`Auto-start failed: ${message}`, "error");
     logWarning("engine", `auto start error: ${message}`, { file: "auto.ts" });

--- a/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
+++ b/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { _withDetachedAutoKeepaliveForTest } from "../auto.ts";
+
 const gsdDir = resolve(import.meta.dirname, "..");
 
 function readGsdFile(relativePath: string): string {
@@ -102,13 +104,55 @@ test("startAutoDetached reports failures asynchronously (#3733)", () => {
     "auto.ts should export startAutoDetached",
   );
   assert.ok(
-    autoSrc.includes("void startAuto(ctx, pi, base, verboseMode, options).catch"),
-    "startAutoDetached should launch startAuto without awaiting it",
+    autoSrc.includes("void withDetachedAutoKeepalive(startAuto(ctx, pi, base, verboseMode, options)).catch"),
+    "startAutoDetached should launch startAuto without awaiting it and keep the process alive",
   );
   assert.ok(
     autoSrc.includes("ctx.ui.notify(`Auto-start failed: ${message}`, \"error\")"),
     "startAutoDetached should surface async startup failures to the user",
   );
+});
+
+test("detached auto-start keeps a ref'ed handle until the run settles", async () => {
+  const originalSetInterval = globalThis.setInterval;
+  const originalClearInterval = globalThis.clearInterval;
+  let intervalCreated = false;
+  let intervalCleared = false;
+  let createdHandle: NodeJS.Timeout | undefined;
+  let resolveRun!: () => void;
+  const run = new Promise<void>((resolve) => {
+    resolveRun = resolve;
+  });
+
+  globalThis.setInterval = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+    intervalCreated = true;
+    assert.equal(timeout, 30_000);
+    void handler;
+    void args;
+    createdHandle = originalSetInterval(() => {}, 1_000_000);
+    assert.equal(createdHandle.hasRef(), true, "detached auto keepalive must be ref'ed");
+    return createdHandle;
+  }) as unknown as typeof setInterval;
+
+  globalThis.clearInterval = ((handle?: NodeJS.Timeout | number | string) => {
+    if (handle === createdHandle) intervalCleared = true;
+    return originalClearInterval(handle);
+  }) as unknown as typeof clearInterval;
+
+  try {
+    const heldRun = _withDetachedAutoKeepaliveForTest(run);
+    assert.equal(intervalCreated, true, "keepalive interval should start immediately");
+    assert.equal(intervalCleared, false, "keepalive should remain active while auto-mode is running");
+
+    resolveRun();
+    await heldRun;
+
+    assert.equal(intervalCleared, true, "keepalive interval should clear when auto-mode settles");
+  } finally {
+    if (createdHandle) originalClearInterval(createdHandle);
+    globalThis.setInterval = originalSetInterval;
+    globalThis.clearInterval = originalClearInterval;
+  }
 });
 
 test("detached auto-start preserves milestone lock across pause/stop cleanup (#3733)", () => {


### PR DESCRIPTION
## TL;DR

**What:** Keeps detached GSD auto-mode sessions alive until the auto loop settles.
**Why:** Detached auto-mode could return control to the shell while the TUI still showed an active provider wait state.
**How:** Wraps the detached `startAuto()` promise with a small ref'ed keepalive interval and clears it in `finally`.

## What

- Adds a lifecycle keepalive around `startAutoDetached()` in `src/resources/extensions/gsd/auto.ts`.
- Adds regression coverage proving the keepalive is ref'ed while the detached run is pending and cleared after it settles.

## Why

The TUI could appear to close during auto-mode research while background state still indicated active work. The detached async run did not by itself guarantee that the Node process stayed alive on every terminal/provider path.

## How

`startAutoDetached()` still launches without awaiting the active command turn, but the detached promise is now passed through `withDetachedAutoKeepalive()`. That helper starts a low-frequency interval to hold the process open and clears it when `startAuto()` resolves or rejects.

## Tests

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/start-auto-detached.test.ts`
- [x] `npm run typecheck:extensions`

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of detached auto-start functionality by implementing automatic cleanup of internal keepalive mechanisms.

* **Tests**
  * Added comprehensive test coverage for detached auto-start keepalive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->