### PR TITLE
fix(tui): roll up direct tool execution rows

### DIFF
--- a/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
+++ b/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
@@ -1053,6 +1053,42 @@ test("chat-controller rolls up only contiguous low-signal tool runs on message_e
 	assert.equal(host.chatContainer._prevRender, null, "summary reposition must invalidate the chat container render cache");
 });
 
+test("chat-controller rolls up low-signal direct tool execution events on agent_end", async () => {
+	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
+		fg: (_key: string, text: string) => text,
+		bg: (_key: string, text: string) => text,
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		truncate: (text: string) => text,
+	};
+
+	const host = createHost();
+	host.getMarkdownThemeWithSettings = () => ({});
+
+	for (const toolCallId of ["bash-1", "bash-2", "bash-3"]) {
+		await handleAgentEvent(host, {
+			type: "tool_execution_start",
+			toolCallId,
+			toolName: "bash",
+			args: { command: "true" },
+		} as any);
+		await handleAgentEvent(host, {
+			type: "tool_execution_end",
+			toolCallId,
+			isError: false,
+			result: { content: [], details: {} },
+		} as any);
+	}
+
+	assert.equal(host.chatContainer.children.length, 3, "direct tool events render as individual rows while running");
+
+	await handleAgentEvent(host, { type: "agent_end" } as any);
+
+	assert.equal(host.chatContainer.children.length, 1, "direct low-signal tool rows should roll up on agent_end");
+	assert.equal(host.chatContainer.children[0]?.constructor?.name, "ToolPhaseSummaryComponent");
+	assert.match(host.chatContainer.children[0].render(120).join("\n"), /Setup \/ shell 3 actions/);
+});
+
 // Regression test for issue #4144: interleaved text/tool content must render in content[] index order.
 // Stream: [text "A", toolCall T1, text "B", toolCall T2, text "C"]
 // Expected chatContainer order: textRun(A), toolExec(T1), textRun(B), toolExec(T2), textRun(C)

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -894,6 +894,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				component.setExpanded(host.toolOutputExpanded);
 				host.chatContainer.addChild(component);
 				host.pendingTools.set(event.toolCallId, component);
+				renderedSegments.push({ kind: "tool", contentIndex: Number.MAX_SAFE_INTEGER, component });
 				host.ui.requestRender();
 			}
 			break;
@@ -927,6 +928,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				host.streamingComponent.setShowMetadata(true);
 				host.streamingComponent.updateContent(host.streamingMessage);
 			}
+			replaceCompactToolRowsWithPhaseSummary(host);
 			host.streamingComponent = undefined;
 			host.streamingMessage = undefined;
 			renderedSegments = [];


### PR DESCRIPTION
## TL;DR

**What:** Fixes remaining unrolled low-signal tool rows emitted through direct tool execution events.
**Why:** The merged phase summary only scanned `renderedSegments` populated by assistant content rendering, so direct tool events could remain as repeated rows.
**How:** Registers direct `tool_execution_start` components in `renderedSegments`, runs the phase summary pass on `agent_end`, and adds regression coverage.

## What

This follow-up keeps the existing phase-summary behavior and extends it to direct `tool_execution_start` / `tool_execution_end` rows.

Changed files:

- `packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts`
- `packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts`

Closes #5400

## Why

Some assistant output still showed repeated low-signal tool rows after #5387 because direct tool execution components were added to `chatContainer` but not to the segment list used by the roll-up pass.

## How

- Tracks direct tool execution components in `renderedSegments` when they start.
- Invokes `replaceCompactToolRowsWithPhaseSummary()` during `agent_end` before clearing segment state.
- Adds a regression test proving three direct successful `bash` tool events roll up into one `Setup / shell` summary.

## Change Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Tests

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts` — `21 passed`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts` — `17 passed`
- [x] `npm run typecheck:extensions`
- [x] `npm run build -w @gsd/pi-coding-agent`
- [x] `npm run verify:pr` — `9004 passed, 0 failed, 9 skipped`

## AI Assistance

This PR was AI-assisted. The implementation was verified with the commands listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of multiple sequential tool executions to display each individually during processing, then consolidate them into a single summary view at completion
  * Improved the lifecycle point at which tool execution rows are compacted to ensure proper grouping of related actions throughout the execution flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->