### PR TITLE
Right-size tiny project workflows and de-duplicate milestone closeout

### DIFF
--- a/src/resources/GSD-WORKFLOW.md
+++ b/src/resources/GSD-WORKFLOW.md
@@ -28,7 +28,7 @@ Then do the thing `STATE.md` says to do next.
 ## The Hierarchy
 
 ```
-Milestone  →  a shippable version (4-10 slices)
+Milestone  →  a shippable version (1-10 slices, sized to the work)
   Slice    →  one demoable vertical capability (1-7 tasks)
     Task   →  one context-window-sized unit of work (fits in one session)
 ```
@@ -331,7 +331,7 @@ The **Don't Hand-Roll** and **Common Pitfalls** sections prevent the most expens
 
 **For a milestone (roadmap):**
 1. Read `M###-CONTEXT.md`, `M###-RESEARCH.md`, and `.gsd/DECISIONS.md` if they exist.
-2. Decompose the vision into 4-10 demoable vertical slices.
+2. Decompose the vision into 1-10 demoable vertical slices. Prefer one slice for tiny, single-file, or static work unless the request clearly spans independent capabilities.
 3. Order by risk (high-risk first to validate feasibility early).
 4. Write `M###-ROADMAP.md` with checkboxes, risk levels, dependencies, demo sentences.
 5. **Write the boundary map** — for each slice, specify what it produces (functions, types, interfaces, endpoints) and what it consumes from upstream slices. This forces interface thinking before implementation and enables deterministic verification that slices actually connect.

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -43,7 +43,7 @@ import {
 import { regenerateIfMissing } from "./workflow-projections.js";
 import { syncStateToProjectRoot } from "./auto-worktree.js";
 import { normalizeWorktreePathForCompare } from "./worktree-root.js";
-import { isDbAvailable, getTask, getSlice, getMilestone, updateTaskStatus, _getAdapter } from "./gsd-db.js";
+import { isDbAvailable, getTask, getSlice, getMilestone, updateTaskStatus, _getAdapter, getVerificationEvidence } from "./gsd-db.js";
 import { renderPlanCheckboxes } from "./markdown-renderer.js";
 import { consumeSignal } from "./session-status-io.js";
 import {
@@ -852,22 +852,22 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         }
 
         // Evidence cross-reference (execute-task only)
-        // Verification evidence is passed via the complete-task tool call and
-        // stored in the SUMMARY.md on disk — not available as structured data
-        // in the DB. The evidence collector tracks actual bash tool calls, so
-        // we can still detect units that claimed success but ran no commands.
+        // Only compare against concrete command evidence persisted by the task
+        // completion tool. A prose Verify field can be satisfied later by the
+        // host verification gate, so it is not enough to accuse the unit.
         if (safetyConfig.evidence_cross_reference && s.currentUnit.type === "execute-task") {
           try {
             const actual = getEvidence();
             const bashCalls = actual.filter(e => e.kind === "bash");
-            // If the task is marked complete but zero bash commands were run,
-            // it's suspicious — the LLM may have fabricated results.
             if (sMid && sSid && sTid && isDbAvailable()) {
               const taskRow = getTask(sMid, sSid, sTid);
-              if (taskRow?.status === "complete" && taskRow.verify && bashCalls.length === 0) {
-                logWarning("safety", "task marked complete with verification commands but no bash calls were executed");
+              const claimedCommands = getVerificationEvidence(sMid, sSid, sTid)
+                .map((row) => row.command)
+                .filter((command): command is string => typeof command === "string" && command.trim().length > 0);
+              if (taskRow?.status === "complete" && claimedCommands.length > 0 && bashCalls.length === 0) {
+                logWarning("safety", "task claimed verification command evidence but no execution tool calls were recorded");
                 ctx.ui.notify(
-                  `Safety: task ${sTid} has verification commands but no bash calls were recorded`,
+                  `Safety: task ${sTid} claimed command evidence but no execution tool calls were recorded`,
                   "warning",
                 );
               }

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -119,9 +119,17 @@ function formatProjectClassificationForPlanning(classification: ProjectClassific
   return lines.join("\n");
 }
 
+function isValidationFreshOrApplicable(validationContent: string | null, validationRel: string): boolean {
+  if (!validationContent) return false;
+  if (!/validation_metadata:/i.test(validationContent)) return false;
+  if (!/covered[_-]?artifacts:/i.test(validationContent)) return false;
+  return validationContent.includes(validationRel);
+}
+
 function formatCloseoutReviewInstructions(validationContent: string | null, validationRel: string): string {
   const verdict = validationContent ? extractVerdict(validationContent) : null;
-  if (verdict === "pass") {
+  const validationFresh = isValidationFreshOrApplicable(validationContent, validationRel);
+  if (verdict === "pass" && validationFresh) {
     return [
       "### Passing Validation Artifact",
       "",
@@ -135,7 +143,7 @@ function formatCloseoutReviewInstructions(validationContent: string | null, vali
     return [
       "### Validation Requires Attention",
       "",
-      `A validation artifact is present at \`${validationRel}\` with verdict \`${verdict}\`. Do not treat the milestone as complete unless the issues are resolved and evidence supports completion.`,
+      `A validation artifact is present at \`${validationRel}\` with verdict \`${verdict}\`, but it is missing freshness metadata or does not cover current milestone artifacts. Do not treat the milestone as complete unless the issues are resolved and evidence supports completion.`,
     ].join("\n");
   }
 

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -119,16 +119,45 @@ function formatProjectClassificationForPlanning(classification: ProjectClassific
   return lines.join("\n");
 }
 
-function isValidationFreshOrApplicable(validationContent: string | null, validationRel: string): boolean {
-  if (!validationContent) return false;
-  if (!/validation_metadata:/i.test(validationContent)) return false;
-  if (!/covered[_-]?artifacts:/i.test(validationContent)) return false;
-  return validationContent.includes(validationRel);
+function normalizeArtifactRef(value: string): string {
+  return value.trim().replace(/^[-\s]+/, "").replace(/^["'`]+|["'`]+$/g, "").replaceAll("\\", "/").replace(/^\.\//, "");
 }
 
-function formatCloseoutReviewInstructions(validationContent: string | null, validationRel: string): string {
+function parseCoveredArtifacts(validationContent: string): Set<string> {
+  const covered = new Set<string>();
+  const lines = validationContent.split(/\r?\n/);
+  let inCoveredArtifacts = false;
+  for (const line of lines) {
+    if (/^\s*covered[-_]?artifacts\s*:/i.test(line)) {
+      inCoveredArtifacts = true;
+      const inline = line.split(/covered[-_]?artifacts\s*:/i)[1]?.trim();
+      if (inline && inline !== "[]") {
+        inline.replace(/^\[|\]$/g, "").split(",").map(normalizeArtifactRef).filter(Boolean).forEach((item) => covered.add(item));
+      }
+      continue;
+    }
+    if (!inCoveredArtifacts) continue;
+    if (/^\S/.test(line) && !/^\s*-/.test(line)) break;
+    const item = line.match(/^\s*-\s*(.+)$/)?.[1];
+    if (item) covered.add(normalizeArtifactRef(item));
+  }
+  return covered;
+}
+
+function isValidationFreshOrApplicable(validationContent: string | null, currentArtifacts: string[]): boolean {
+  if (!validationContent) return false;
+  if (!/validation_metadata:/i.test(validationContent)) return false;
+  const coveredArtifacts = parseCoveredArtifacts(validationContent);
+  if (coveredArtifacts.size === 0) return false;
+  return currentArtifacts
+    .map(normalizeArtifactRef)
+    .filter(Boolean)
+    .every((artifact) => coveredArtifacts.has(artifact));
+}
+
+function formatCloseoutReviewInstructions(validationContent: string | null, validationRel: string, currentArtifacts: string[]): string {
   const verdict = validationContent ? extractVerdict(validationContent) : null;
-  const validationFresh = isValidationFreshOrApplicable(validationContent, validationRel);
+  const validationFresh = isValidationFreshOrApplicable(validationContent, currentArtifacts);
   if (verdict === "pass" && validationFresh) {
     return [
       "### Passing Validation Artifact",
@@ -2429,10 +2458,6 @@ export async function buildCompleteMilestonePrompt(
   const validationContent = validationPath ? await loadFile(validationPath) : null;
 
   const inlined: string[] = [];
-  inlined.push(formatCloseoutReviewInstructions(validationContent, validationRel));
-  if (validationContent) {
-    inlined.push(`### Milestone Validation\nSource: \`${validationRel}\`\n\n${validationContent.trim()}`);
-  }
   inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
 
   // Inline all slice summaries (deduplicated by slice ID)
@@ -2472,6 +2497,13 @@ export async function buildCompleteMilestonePrompt(
       `### On-demand Slice Summaries\n\nExcerpted above. Read the full file for any slice when the excerpt's section heads don't carry enough narrative for the milestone summary you're drafting:\n\n${pathList}`,
     );
   }
+  const validationContext = [
+    formatCloseoutReviewInstructions(validationContent, validationRel, [validationRel, roadmapRel, ...summaryRelPaths]),
+  ];
+  if (validationContent) {
+    validationContext.push(`### Milestone Validation\nSource: \`${validationRel}\`\n\n${validationContent.trim()}`);
+  }
+  inlined.unshift(...validationContext);
 
   // Inline root GSD files (skip for minimal — completion can read these if needed)
   if (inlineLevel !== "minimal") {

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -39,6 +39,7 @@ import { logWarning } from "./workflow-logger.js";
 import { inlineGraphSubgraph } from "./graph-context.js";
 import { buildExtractionStepsBlock } from "./commands-extract-learnings.js";
 import { resolveSkillManifest, warnIfManifestHasMissingSkills } from "./skill-manifest.js";
+import { classifyProject, type ProjectClassification } from "./detection.js";
 
 // ─── Preamble Cap ─────────────────────────────────────────────────────────────
 
@@ -78,6 +79,79 @@ function resolvePromptBudgets(): ReturnType<typeof computeBudgets> {
  */
 function resolveSummaryBudgetChars(): number {
   return resolvePromptBudgets().summaryBudgetChars;
+}
+
+function formatProjectClassificationForPlanning(classification: ProjectClassification): string {
+  const sampleFiles = classification.contentFiles.slice(0, 8);
+  const sample = sampleFiles.length > 0 ? sampleFiles.map((file) => `\`${file}\``).join(", ") : "(none)";
+  const lines = [
+    "### Project Classification",
+    "",
+    `- **Kind:** ${classification.kind}`,
+    `- **Content files:** ${classification.contentFiles.length}`,
+    `- **Sample files:** ${sample}`,
+    `- **Reason:** ${classification.reason}`,
+    "",
+  ];
+
+  if (classification.kind === "untyped-existing") {
+    if (classification.contentFiles.length <= 2) {
+      lines.push(
+        "**Workflow sizing:** This is a tiny existing untyped project. Prefer exactly one slice unless the milestone request clearly spans multiple independent user-visible capabilities.",
+      );
+    } else if (classification.contentFiles.length <= 5) {
+      lines.push(
+        "**Workflow sizing:** This is a small existing untyped project. Prefer 1-2 slices unless the milestone request clearly spans multiple independent user-visible capabilities.",
+      );
+    } else {
+      lines.push(
+        "**Workflow sizing:** Existing untyped project. Use generic file-level workflow guidance and size slices by real capability boundaries, not by missing tooling markers.",
+      );
+    }
+  } else if (classification.kind === "greenfield") {
+    lines.push("**Workflow sizing:** No project content exists yet. Use normal greenfield sizing for the requested scope.");
+  } else if (classification.kind === "typed-existing") {
+    lines.push("**Workflow sizing:** Known project markers exist. Use normal ecosystem-aware planning guidance.");
+  } else {
+    lines.push("**Workflow sizing:** Invalid repository state. Planning should surface this as a blocker rather than inventing project structure.");
+  }
+
+  return lines.join("\n");
+}
+
+function extractValidationVerdict(content: string | null): string | null {
+  if (!content) return null;
+  const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+  const source = frontmatter?.[1] ?? content;
+  const match = source.match(/^verdict:\s*["']?([a-zA-Z_-]+)["']?/m);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+function formatCloseoutReviewInstructions(validationContent: string | null, validationRel: string): string {
+  const verdict = extractValidationVerdict(validationContent);
+  if (verdict === "pass" || verdict === "passed") {
+    return [
+      "### Passing Validation Artifact",
+      "",
+      `A passing validation artifact is present at \`${validationRel}\`. Treat it as authoritative for success criteria, requirement coverage, verification classes, and cross-slice integration.`,
+      "",
+      "Do not delegate fresh reviewer/security/tester audits and do not redo the validation evidence review unless the artifact is internally inconsistent with the inlined summaries. Focus this unit on final milestone narrative, learnings, PROJECT/requirements updates, and `gsd_complete_milestone`.",
+    ].join("\n");
+  }
+
+  if (verdict) {
+    return [
+      "### Validation Requires Attention",
+      "",
+      `A validation artifact is present at \`${validationRel}\` with verdict \`${verdict}\`. Do not treat the milestone as complete unless the issues are resolved and evidence supports completion.`,
+    ].join("\n");
+  }
+
+  return [
+    "### No Passing Validation Artifact",
+    "",
+    `No passing validation artifact was found at \`${validationRel}\`. Use the full closeout review path before completion.`,
+  ].join("\n");
 }
 
 function capPreamble(preamble: string): string {
@@ -1658,6 +1732,8 @@ export async function buildPlanMilestonePrompt(mid: string, midTitle: string, ba
   const researchAnchor = readPhaseAnchor(base, mid, "research-milestone");
   if (researchAnchor) inlined.push(formatAnchorForPrompt(researchAnchor));
 
+  inlined.push(formatProjectClassificationForPlanning(classifyProject(base)));
+
   inlined.push(await inlineFile(contextPath, contextRel, "Milestone Context"));
   const researchInline = await inlineFileOptional(researchPath, researchRel, "Milestone Research");
   if (researchInline) inlined.push(researchInline);
@@ -2348,8 +2424,15 @@ export async function buildCompleteMilestonePrompt(
   const inlineLevel = level ?? resolveInlineLevel();
   const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
   const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
+  const validationPath = resolveMilestoneFile(base, mid, "VALIDATION");
+  const validationRel = relMilestoneFile(base, mid, "VALIDATION");
+  const validationContent = validationPath ? await loadFile(validationPath) : null;
 
   const inlined: string[] = [];
+  inlined.push(formatCloseoutReviewInstructions(validationContent, validationRel));
+  if (validationContent) {
+    inlined.push(`### Milestone Validation\nSource: \`${validationRel}\`\n\n${validationContent.trim()}`);
+  }
   inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
 
   // Inline all slice summaries (deduplicated by slice ID)

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -8,7 +8,7 @@
 
 import { loadFile, parseContinue, parseSummary, loadActiveOverrides, formatOverridesSection, parseTaskPlanFile } from "./files.js";
 import type { Override, UatType } from "./files.js";
-import { hasVerdict, getUatType } from "./verdict-parser.js";
+import { hasVerdict, getUatType, extractVerdict } from "./verdict-parser.js";
 import { loadPrompt, inlineTemplate } from "./prompt-loader.js";
 import {
   resolveMilestoneFile, resolveSliceFile, resolveSlicePath,
@@ -119,17 +119,9 @@ function formatProjectClassificationForPlanning(classification: ProjectClassific
   return lines.join("\n");
 }
 
-function extractValidationVerdict(content: string | null): string | null {
-  if (!content) return null;
-  const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
-  const source = frontmatter?.[1] ?? content;
-  const match = source.match(/^verdict:\s*["']?([a-zA-Z_-]+)["']?/m);
-  return match?.[1]?.toLowerCase() ?? null;
-}
-
 function formatCloseoutReviewInstructions(validationContent: string | null, validationRel: string): string {
-  const verdict = extractValidationVerdict(validationContent);
-  if (verdict === "pass" || verdict === "passed") {
+  const verdict = validationContent ? extractVerdict(validationContent) : null;
+  if (verdict === "pass") {
     return [
       "### Passing Validation Artifact",
       "",

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -139,6 +139,7 @@ export interface LoopDeps {
   postflightPopStash: (
     basePath: string,
     milestoneId: string,
+    stashMarker: string | undefined,
     notify: (message: string, level: "info" | "warning" | "error") => void,
   ) => void;
 

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -32,13 +32,13 @@ import { detectStuck } from "./detect-stuck.js";
 import { runUnit } from "./run-unit.js";
 import { debugLog } from "../debug-logger.js";
 import { resolveWorktreeProjectRoot, normalizeWorktreePathForCompare } from "../worktree-root.js";
-import { PROJECT_FILES, hasProjectFileInAncestor } from "../detection.js";
+import { classifyProject } from "../detection.js";
 import { MergeConflictError } from "../git-service.js";
 import { setCurrentPhase, clearCurrentPhase } from "../../shared/gsd-phase-state.js";
 import { pauseAutoForProviderError } from "../provider-error-pause.js";
 import { resumeAutoAfterProviderDelay } from "../bootstrap/provider-error-resume.js";
 import { join, basename } from "node:path";
-import { existsSync, cpSync, readdirSync } from "node:fs";
+import { existsSync, cpSync } from "node:fs";
 import {
   logWarning,
   logError,
@@ -1484,8 +1484,8 @@ export async function runUnitPhase(
   // Verify the working directory is a valid git checkout with project
   // files before dispatching work. A broken worktree causes agents to
   // hallucinate summaries since they cannot read or write any files.
-  // Uses the shared PROJECT_FILES list from detection.ts to support all
-  // ecosystems (Rust, Go, Python, Java, etc.), not just JS.
+  // Uses project classification so project presence is not conflated with
+  // ecosystem marker detection. Static/minimal repos become untyped-existing.
   if (s.basePath && unitType === "execute-task") {
     const gitMarker = join(s.basePath, ".git");
     const hasGit = deps.existsSync(gitMarker);
@@ -1496,30 +1496,16 @@ export async function runUnitPhase(
       await deps.stopAuto(ctx, pi, msg);
       return { action: "break", reason: "worktree-invalid" };
     }
-    const hasProjectFile = PROJECT_FILES.some((f) => deps.existsSync(join(s.basePath, f)));
-    const hasSrcDir = deps.existsSync(join(s.basePath, "src"));
-    // Xcode bundles have project-specific names (*.xcodeproj, *.xcworkspace)
-    // that cannot be matched by exact filename — scan the directory by suffix.
-    let hasXcodeBundle = false;
-    try {
-      const entries = deps.existsSync(s.basePath) ? readdirSync(s.basePath) : [];
-      hasXcodeBundle = entries.some((e: string) => e.endsWith(".xcodeproj") || e.endsWith(".xcworkspace"));
-    } catch (err) {
-      debugLog("runUnitPhase", { phase: "xcode-bundle-scan-failed", basePath: s.basePath, error: String(err) });
-    }
-    // Monorepo support (#2347): if no project files in the worktree directory,
-    // walk parent directories up to the filesystem root. In monorepos,
-    // package.json / Cargo.toml etc. live in a parent directory.
-    const hasProjectFileInParent =
-      !hasProjectFile && !hasSrcDir && !hasXcodeBundle
-        ? hasProjectFileInAncestor(s.basePath, deps.existsSync)
-        : false;
-    if (!hasProjectFile && !hasSrcDir && !hasXcodeBundle && !hasProjectFileInParent) {
-      // Greenfield projects won't have project files yet — the first task creates them.
-      // Log a warning but allow execution to proceed. The .git check above is sufficient
-      // to ensure we're in a valid working directory.
-      debugLog("runUnitPhase", { phase: "worktree-health-warn-greenfield", basePath: s.basePath, hasProjectFile, hasSrcDir, hasXcodeBundle });
-      ctx.ui.notify(`Warning: ${s.basePath} has no recognized project files — proceeding as greenfield project`, "warning");
+    const classification = classifyProject(s.basePath);
+    if (classification.kind === "greenfield" || classification.kind === "invalid-repo") {
+      debugLog("runUnitPhase", { phase: "worktree-health-greenfield", basePath: s.basePath, classification });
+      ctx.ui.notify(`Warning: ${s.basePath} has no project content yet — proceeding as greenfield project`, "warning");
+    } else if (classification.kind === "untyped-existing") {
+      debugLog("runUnitPhase", { phase: "worktree-health-untyped-existing", basePath: s.basePath, classification });
+      ctx.ui.notify(
+        `Notice: ${s.basePath} has existing project content but no recognized tooling markers — using generic file-level workflow guidance`,
+        "info",
+      );
     }
   }
 
@@ -1597,6 +1583,17 @@ export async function runUnitPhase(
 
   // Prompt injection
   let finalPrompt = prompt;
+
+  if (unitType === "execute-task") {
+    const projectClassification = classifyProject(s.basePath);
+    if (projectClassification.kind === "untyped-existing") {
+      const samples = projectClassification.contentFiles.slice(0, 8).join(", ") || "project files";
+      finalPrompt +=
+        "\n\n**Project classification:** Existing untyped project. No recognized build/tooling markers were detected, " +
+        "so use generic file-level workflow guidance. Task plans and completion summaries must list every concrete " +
+        `project file changed in \`files\` or \`expected_output\`. Detected content sample: ${samples}.`;
+    }
+  }
 
   if (s.pendingVerificationRetry) {
     const retryCtx = s.pendingVerificationRetry;

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1504,9 +1504,16 @@ export async function runUnitPhase(
     if (projectClassification.kind === "invalid-repo") {
       const msg = `Worktree health check failed: ${s.basePath} classified as invalid-repo (${projectClassification.reason}) — refusing to dispatch ${unitType} ${unitId}`;
       debugLog("runUnitPhase", { phase: "worktree-health-invalid-repo", basePath: s.basePath, classification: projectClassification });
-      ctx.ui.notify(msg, "error");
-      await deps.stopAuto(ctx, pi, msg);
-      return { action: "break", reason: "worktree-invalid" };
+      if (projectClassification.reason === "missing .git" && hasGit) {
+        ctx.ui.notify(
+          `Warning: ${s.basePath} project classification could not confirm .git; assuming it has no project content yet — proceeding as greenfield project because worktree health reported .git present`,
+          "warning",
+        );
+      } else {
+        ctx.ui.notify(msg, "error");
+        await deps.stopAuto(ctx, pi, msg);
+        return { action: "break", reason: "worktree-invalid" };
+      }
     } else if (projectClassification.kind === "greenfield") {
       debugLog("runUnitPhase", { phase: "worktree-health-greenfield", basePath: s.basePath, classification: projectClassification });
       ctx.ui.notify(`Warning: ${s.basePath} has no project content yet — proceeding as greenfield project`, "warning");

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1489,6 +1489,7 @@ export async function runUnitPhase(
   // hallucinate summaries since they cannot read or write any files.
   // Uses project classification so project presence is not conflated with
   // ecosystem marker detection. Static/minimal repos become untyped-existing.
+  let projectClassification: ReturnType<typeof classifyProject> | null = null;
   if (s.basePath && unitType === "execute-task") {
     const gitMarker = join(s.basePath, ".git");
     const hasGit = deps.existsSync(gitMarker);
@@ -1499,12 +1500,15 @@ export async function runUnitPhase(
       await deps.stopAuto(ctx, pi, msg);
       return { action: "break", reason: "worktree-invalid" };
     }
-    const classification = classifyProject(s.basePath);
-    if (classification.kind === "greenfield" || classification.kind === "invalid-repo") {
-      debugLog("runUnitPhase", { phase: "worktree-health-greenfield", basePath: s.basePath, classification });
+    projectClassification = classifyProject(s.basePath);
+    if (projectClassification.kind === "invalid-repo") {
+      debugLog("runUnitPhase", { phase: "worktree-health-invalid-repo", basePath: s.basePath, classification: projectClassification });
+      ctx.ui.notify(`Warning: ${s.basePath} is not a valid git repo for project classification — proceeding with caution`, "warning");
+    } else if (projectClassification.kind === "greenfield") {
+      debugLog("runUnitPhase", { phase: "worktree-health-greenfield", basePath: s.basePath, classification: projectClassification });
       ctx.ui.notify(`Warning: ${s.basePath} has no project content yet — proceeding as greenfield project`, "warning");
-    } else if (classification.kind === "untyped-existing") {
-      debugLog("runUnitPhase", { phase: "worktree-health-untyped-existing", basePath: s.basePath, classification });
+    } else if (projectClassification.kind === "untyped-existing") {
+      debugLog("runUnitPhase", { phase: "worktree-health-untyped-existing", basePath: s.basePath, classification: projectClassification });
       ctx.ui.notify(
         `Notice: ${s.basePath} has existing project content but no recognized tooling markers — using generic file-level workflow guidance`,
         "info",
@@ -1588,7 +1592,7 @@ export async function runUnitPhase(
   let finalPrompt = prompt;
 
   if (unitType === "execute-task") {
-    const projectClassification = classifyProject(s.basePath);
+    projectClassification ??= classifyProject(s.basePath);
     if (projectClassification.kind === "untyped-existing") {
       const samples = projectClassification.contentFiles.slice(0, 8).join(", ") || "project files";
       finalPrompt +=

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1502,8 +1502,11 @@ export async function runUnitPhase(
     }
     projectClassification = classifyProject(s.basePath);
     if (projectClassification.kind === "invalid-repo") {
+      const msg = `Worktree health check failed: ${s.basePath} classified as invalid-repo (${projectClassification.reason}) — refusing to dispatch ${unitType} ${unitId}`;
       debugLog("runUnitPhase", { phase: "worktree-health-invalid-repo", basePath: s.basePath, classification: projectClassification });
-      ctx.ui.notify(`Warning: ${s.basePath} is not a valid git repo for project classification — proceeding with caution`, "warning");
+      ctx.ui.notify(msg, "error");
+      await deps.stopAuto(ctx, pi, msg);
+      return { action: "break", reason: "worktree-invalid" };
     } else if (projectClassification.kind === "greenfield") {
       debugLog("runUnitPhase", { phase: "worktree-health-greenfield", basePath: s.basePath, classification: projectClassification });
       ctx.ui.notify(`Warning: ${s.basePath} has no project content yet — proceeding as greenfield project`, "warning");

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -684,6 +684,7 @@ export async function runPreDispatch(
       deps.postflightPopStash(
         s.originalBasePath || s.basePath,
         s.currentMilestoneId!,
+        preflightTransition.stashMarker,
         ctx.ui.notify.bind(ctx.ui),
       );
     }
@@ -797,6 +798,7 @@ export async function runPreDispatch(
           deps.postflightPopStash(
             s.originalBasePath || s.basePath,
             s.currentMilestoneId,
+            preflightAllComplete.stashMarker,
             ctx.ui.notify.bind(ctx.ui),
           );
         }
@@ -925,6 +927,7 @@ export async function runPreDispatch(
         deps.postflightPopStash(
           s.originalBasePath || s.basePath,
           s.currentMilestoneId,
+          preflightComplete.stashMarker,
           ctx.ui.notify.bind(ctx.ui),
         );
       }

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -120,8 +120,9 @@ export function postflightPopStash(
   stashMarker: string | undefined,
   notify: (message: string, level: "info" | "warning" | "error") => void,
 ): void {
+  let stashRef: string | null = null;
   try {
-    const stashRef = findPreflightStashRef(basePath, milestoneId, stashMarker);
+    stashRef = findPreflightStashRef(basePath, milestoneId, stashMarker);
     if (!stashRef) {
       const msg = `No matching GSD preflight stash found for milestone ${milestoneId}; leaving stash list untouched.`;
       logWarning("preflight", msg);
@@ -138,7 +139,10 @@ export function postflightPopStash(
   } catch (err) {
     // Pop conflicts mean the merged code collides with the stashed changes.
     // Log a warning — the user needs to resolve manually, but the merge succeeded.
-    const msg = `git stash pop failed after merge of milestone ${milestoneId}: ${err instanceof Error ? err.message : String(err)}. Run "git stash pop" manually to restore your changes.`;
+    const restoreHint = stashRef
+      ? `Run "git stash pop ${stashRef}" or "git stash apply ${stashRef}" manually to restore the correct stash.`
+      : `Run "git stash list" to find the matching GSD preflight stash before restoring manually.`;
+    const msg = `git stash pop ${stashRef ?? ""}`.trim() + ` failed after merge of milestone ${milestoneId}: ${err instanceof Error ? err.message : String(err)}. ${restoreHint}`;
     logWarning("preflight", msg);
     notify(msg, "warning");
   }

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -21,8 +21,29 @@ import { nativeHasChanges } from "./native-git-bridge.js";
 export interface PreflightResult {
   /** true when a stash was pushed and postflightPopStash should be called */
   stashPushed: boolean;
+  /** Unique marker embedded in the stash message for targeted restoration */
+  stashMarker?: string;
   /** human-readable summary of what happened (empty string for clean trees) */
   summary: string;
+}
+
+function findPreflightStashRef(basePath: string, milestoneId: string): string | null {
+  const markerPrefix = `gsd-preflight-stash:${milestoneId}:`;
+  try {
+    const list = execFileSync("git", ["stash", "list", "--format=%gd%x00%s"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      env: GIT_NO_PROMPT_ENV,
+    });
+    for (const line of list.split("\n")) {
+      const [ref, subject] = line.split("\x00");
+      if (ref && subject?.includes(markerPrefix)) return ref;
+    }
+  } catch (err) {
+    logWarning("preflight", `stash list failed before restore: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return null;
 }
 
 /**
@@ -62,7 +83,8 @@ export function preflightCleanRoot(
 
   // Push the stash
   try {
-    execFileSync("git", ["stash", "push", "--include-untracked", "-m", "gsd-preflight-stash"], {
+    const stashMarker = `gsd-preflight-stash:${milestoneId}:${process.pid}:${Date.now()}:${process.hrtime.bigint().toString(36)}`;
+    execFileSync("git", ["stash", "push", "--include-untracked", "-m", `gsd-preflight-stash [${stashMarker}]`], {
       cwd: basePath,
       stdio: ["ignore", "pipe", "pipe"],
       encoding: "utf-8",
@@ -70,6 +92,7 @@ export function preflightCleanRoot(
     });
     return {
       stashPushed: true,
+      stashMarker,
       summary: `Stashed uncommitted changes before merge (milestone ${milestoneId}).`,
     };
   } catch (err) {
@@ -94,7 +117,14 @@ export function postflightPopStash(
   notify: (message: string, level: "info" | "warning" | "error") => void,
 ): void {
   try {
-    execFileSync("git", ["stash", "pop"], {
+    const stashRef = findPreflightStashRef(basePath, milestoneId);
+    if (!stashRef) {
+      const msg = `No matching GSD preflight stash found for milestone ${milestoneId}; leaving stash list untouched.`;
+      logWarning("preflight", msg);
+      notify(msg, "warning");
+      return;
+    }
+    execFileSync("git", ["stash", "pop", stashRef], {
       cwd: basePath,
       stdio: ["ignore", "pipe", "pipe"],
       encoding: "utf-8",

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -27,7 +27,9 @@ export interface PreflightResult {
   summary: string;
 }
 
-function findPreflightStashRef(basePath: string, stashMarker: string): string | null {
+function findPreflightStashRef(basePath: string, milestoneId: string, stashMarker?: string): string | null {
+  const markerPrefix = `gsd-preflight-stash:${milestoneId}:`;
+  let fallbackRef: string | null = null;
   try {
     const list = execFileSync("git", ["stash", "list", "--format=%gd%x00%s"], {
       cwd: basePath,
@@ -37,12 +39,14 @@ function findPreflightStashRef(basePath: string, stashMarker: string): string | 
     });
     for (const line of list.split("\n")) {
       const [ref, subject] = line.split("\x00");
-      if (ref && subject?.includes(stashMarker)) return ref;
+      if (!ref || !subject) continue;
+      if (stashMarker && subject.includes(stashMarker)) return ref;
+      if (!fallbackRef && subject.includes(markerPrefix)) fallbackRef = ref;
     }
   } catch (err) {
     logWarning("preflight", `stash list failed before restore: ${err instanceof Error ? err.message : String(err)}`);
   }
-  return null;
+  return fallbackRef;
 }
 
 /**
@@ -117,7 +121,7 @@ export function postflightPopStash(
   notify: (message: string, level: "info" | "warning" | "error") => void,
 ): void {
   try {
-    const stashRef = stashMarker ? findPreflightStashRef(basePath, stashMarker) : null;
+    const stashRef = findPreflightStashRef(basePath, milestoneId, stashMarker);
     if (!stashRef) {
       const msg = `No matching GSD preflight stash found for milestone ${milestoneId}; leaving stash list untouched.`;
       logWarning("preflight", msg);

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -27,8 +27,7 @@ export interface PreflightResult {
   summary: string;
 }
 
-function findPreflightStashRef(basePath: string, milestoneId: string): string | null {
-  const markerPrefix = `gsd-preflight-stash:${milestoneId}:`;
+function findPreflightStashRef(basePath: string, stashMarker: string): string | null {
   try {
     const list = execFileSync("git", ["stash", "list", "--format=%gd%x00%s"], {
       cwd: basePath,
@@ -38,7 +37,7 @@ function findPreflightStashRef(basePath: string, milestoneId: string): string | 
     });
     for (const line of list.split("\n")) {
       const [ref, subject] = line.split("\x00");
-      if (ref && subject?.includes(markerPrefix)) return ref;
+      if (ref && subject?.includes(stashMarker)) return ref;
     }
   } catch (err) {
     logWarning("preflight", `stash list failed before restore: ${err instanceof Error ? err.message : String(err)}`);
@@ -114,10 +113,11 @@ export function preflightCleanRoot(
 export function postflightPopStash(
   basePath: string,
   milestoneId: string,
+  stashMarker: string | undefined,
   notify: (message: string, level: "info" | "warning" | "error") => void,
 ): void {
   try {
-    const stashRef = findPreflightStashRef(basePath, milestoneId);
+    const stashRef = stashMarker ? findPreflightStashRef(basePath, stashMarker) : null;
     if (!stashRef) {
       const msg = `No matching GSD preflight stash found for milestone ${milestoneId}; leaving stash list untouched.`;
       logWarning("preflight", msg);

--- a/src/resources/extensions/gsd/detection.ts
+++ b/src/resources/extensions/gsd/detection.ts
@@ -182,23 +182,6 @@ export const PROJECT_FILES = [
   "requirements.txt",
 ] as const;
 
-const PROJECT_CONTENT_EXCLUDE_DIRS = new Set([
-  ".git",
-  ".gsd",
-  ".bg-shell",
-  "node_modules",
-  "dist",
-  "build",
-  "coverage",
-  ".cache",
-  ".turbo",
-  "target",
-  "vendor",
-  ".gradle",
-  "DerivedData",
-  "out",
-]);
-
 /** File extensions that indicate SQLite databases in the project. */
 const SQLITE_EXTENSIONS = [".sqlite", ".sqlite3", ".db"] as const;
 
@@ -277,6 +260,7 @@ const TEST_MARKERS = [
 const RECURSIVE_SCAN_IGNORED_DIRS = new Set([
   ".git",
   ".gsd",
+  ".bg-shell",
   ".planning",
   ".plans",
   ".claude",
@@ -300,6 +284,8 @@ const RECURSIVE_SCAN_IGNORED_DIRS = new Set([
   "DerivedData",
   "out",
 ]) as ReadonlySet<string>;
+
+const PROJECT_CONTENT_EXCLUDE_DIRS = RECURSIVE_SCAN_IGNORED_DIRS;
 
 /** Project file markers safe to detect recursively via suffix matching. */
 const ROOT_ONLY_PROJECT_FILES = new Set<string>([
@@ -604,15 +590,13 @@ function listTrackedProjectFiles(basePath: string): string[] {
 }
 
 function listUntrackedProjectFiles(basePath: string): string[] {
-  return runGitLines(basePath, ["status", "--porcelain", "--untracked-files=normal"])
-    .filter((line) => line.startsWith("?? "))
-    .map((line) => normalizeGitPath(line.slice(3)))
+  return runGitLines(basePath, ["ls-files", "--others", "--exclude-standard"])
+    .map(normalizeGitPath)
     .filter(isProjectContentFile);
 }
 
 function hasKnownProjectMarkers(basePath: string, signals: ProjectSignals): boolean {
   if (signals.detectedFiles.length > 0) return true;
-  if (existsSync(join(basePath, "src"))) return true;
   if (signals.xcodePlatforms.length > 0) return true;
   if (hasProjectFileInAncestor(basePath)) return true;
   return false;

--- a/src/resources/extensions/gsd/detection.ts
+++ b/src/resources/extensions/gsd/detection.ts
@@ -598,7 +598,6 @@ function listUntrackedProjectFiles(basePath: string): string[] {
 function hasKnownProjectMarkers(basePath: string, signals: ProjectSignals): boolean {
   if (signals.detectedFiles.length > 0) return true;
   if (signals.xcodePlatforms.length > 0) return true;
-  if (hasProjectFileInAncestor(basePath)) return true;
   return false;
 }
 

--- a/src/resources/extensions/gsd/detection.ts
+++ b/src/resources/extensions/gsd/detection.ts
@@ -6,6 +6,7 @@
  * flow to show when entering a project directory.
  */
 
+import { execFileSync } from "node:child_process";
 import { existsSync, openSync, readSync, closeSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, parse as parsePath } from "node:path";
 import { homedir } from "node:os";
@@ -70,6 +71,22 @@ export interface ProjectSignals {
   packageManager?: string;
   /** Auto-detected verification commands */
   verificationCommands: string[];
+}
+
+export type ProjectClassificationKind =
+  | "invalid-repo"
+  | "greenfield"
+  | "untyped-existing"
+  | "typed-existing";
+
+export interface ProjectClassification {
+  kind: ProjectClassificationKind;
+  signals: ProjectSignals;
+  trackedFiles: string[];
+  untrackedFiles: string[];
+  contentFiles: string[];
+  markers: string[];
+  reason: string;
 }
 
 // ─── Project File Markers ───────────────────────────────────────────────────────
@@ -164,6 +181,23 @@ export const PROJECT_FILES = [
   "manage.py",
   "requirements.txt",
 ] as const;
+
+const PROJECT_CONTENT_EXCLUDE_DIRS = new Set([
+  ".git",
+  ".gsd",
+  ".bg-shell",
+  "node_modules",
+  "dist",
+  "build",
+  "coverage",
+  ".cache",
+  ".turbo",
+  "target",
+  "vendor",
+  ".gradle",
+  "DerivedData",
+  "out",
+]);
 
 /** File extensions that indicate SQLite databases in the project. */
 const SQLITE_EXTENSIONS = [".sqlite", ".sqlite3", ".db"] as const;
@@ -533,6 +567,117 @@ export function detectProjectSignals(basePath: string): ProjectSignals {
     hasTests,
     packageManager,
     verificationCommands,
+  };
+}
+
+function normalizeGitPath(file: string): string {
+  return file.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function isProjectContentFile(file: string): boolean {
+  const normalized = normalizeGitPath(file);
+  if (!normalized || normalized.endsWith("/")) return false;
+  if (normalized === ".gitignore" || normalized === ".gitattributes") return false;
+  const parts = normalized.split("/");
+  if (parts.some((part) => PROJECT_CONTENT_EXCLUDE_DIRS.has(part))) return false;
+  if (normalized.endsWith(".DS_Store")) return false;
+  return true;
+}
+
+function runGitLines(basePath: string, args: string[]): string[] {
+  try {
+    const output = execFileSync("git", args, {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf-8",
+    }).trim();
+    return output ? output.split("\n").map((line) => line.trim()).filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+function listTrackedProjectFiles(basePath: string): string[] {
+  return runGitLines(basePath, ["ls-files"])
+    .map(normalizeGitPath)
+    .filter(isProjectContentFile);
+}
+
+function listUntrackedProjectFiles(basePath: string): string[] {
+  return runGitLines(basePath, ["status", "--porcelain", "--untracked-files=normal"])
+    .filter((line) => line.startsWith("?? "))
+    .map((line) => normalizeGitPath(line.slice(3)))
+    .filter(isProjectContentFile);
+}
+
+function hasKnownProjectMarkers(basePath: string, signals: ProjectSignals): boolean {
+  if (signals.detectedFiles.length > 0) return true;
+  if (existsSync(join(basePath, "src"))) return true;
+  if (signals.xcodePlatforms.length > 0) return true;
+  if (hasProjectFileInAncestor(basePath)) return true;
+  return false;
+}
+
+/**
+ * Classify repo presence separately from ecosystem/tooling markers.
+ *
+ * Known project files identify tooling. Git-tracked/non-ignored content
+ * identifies whether this is an existing project at all. This keeps small
+ * static or documentation repos from being mislabeled as greenfield.
+ */
+export function classifyProject(basePath: string): ProjectClassification {
+  const signals = detectProjectSignals(basePath);
+  const markers = [...signals.detectedFiles];
+
+  if (!signals.isGitRepo) {
+    return {
+      kind: "invalid-repo",
+      signals,
+      trackedFiles: [],
+      untrackedFiles: [],
+      contentFiles: [],
+      markers,
+      reason: "missing .git",
+    };
+  }
+
+  const trackedFiles = listTrackedProjectFiles(basePath);
+  const untrackedFiles = listUntrackedProjectFiles(basePath);
+  const contentFiles = [...new Set([...trackedFiles, ...untrackedFiles])];
+  const hasMarkers = hasKnownProjectMarkers(basePath, signals);
+
+  if (hasMarkers) {
+    return {
+      kind: "typed-existing",
+      signals,
+      trackedFiles,
+      untrackedFiles,
+      contentFiles,
+      markers,
+      reason: markers.length > 0 ? `detected markers: ${markers.join(", ")}` : "detected project structure",
+    };
+  }
+
+  if (contentFiles.length > 0) {
+    return {
+      kind: "untyped-existing",
+      signals,
+      trackedFiles,
+      untrackedFiles,
+      contentFiles,
+      markers,
+      reason: "project content exists but no recognized tooling markers were found",
+    };
+  }
+
+  return {
+    kind: "greenfield",
+    signals,
+    trackedFiles,
+    untrackedFiles,
+    contentFiles,
+    markers,
+    reason: "no tracked or non-ignored project content",
   };
 }
 

--- a/src/resources/extensions/gsd/prompts/complete-milestone.md
+++ b/src/resources/extensions/gsd/prompts/complete-milestone.md
@@ -16,15 +16,14 @@ Start with what the excerpts give you. Read full files when the section heads si
 
 **On-demand Read ordering:** Complete all slice SUMMARY Reads you need for cross-slice synthesis, the Decision Re-evaluation table, and LEARNINGS **before** calling `gsd_complete_milestone` (step 12). Once that tool runs, the milestone is marked complete in the DB, so it must be the final persistent milestone-closeout write.
 
-### Delegate Review Work
+### Closeout Review Mode
 
-Use `subagent` for review work needing fresh context, before drafting LEARNINGS:
+The inlined context includes a validation status block.
 
-- Cross-slice integrations or new public APIs -> **reviewer** with milestone diff and roadmap.
-- Auth, network, parsing, file IO, shell exec, or crypto -> **security** audit.
-- Significant tests added or changed -> **tester** coverage check against success criteria.
+- If it says a passing validation artifact is present, treat that artifact as authoritative for success criteria, requirement coverage, verification classes, and cross-slice integration. Do not delegate fresh reviewer/security/tester audits unless the validation artifact is internally inconsistent with the inlined summaries.
+- If validation is missing, stale, non-pass, or internally inconsistent, use `subagent` for review work needing fresh context before drafting LEARNINGS: cross-slice integrations or new public APIs -> **reviewer**; auth, network, parsing, file IO, shell exec, or crypto -> **security**; significant tests added or changed -> **tester**.
 
-Subagents report only; they do not write user source. Fold findings into Decision Re-evaluation and LEARNINGS before completion.
+Subagents report only; they do not write user source. Fold any findings into Decision Re-evaluation and LEARNINGS before completion.
 
 {{inlinedContext}}
 
@@ -33,8 +32,8 @@ Subagents report only; they do not write user source. Fold findings into Decisio
 1. Use the **Milestone Summary** output template from the inlined context above
 2. {{skillActivation}}
 3. **Verify code changes exist.** Compare milestone work against the integration branch (`main`, `master`, or recorded branch), using merge-base as older revision and `HEAD` as newer. If the diff lists non-`.gsd/` files, pass. If `HEAD` equals the integration branch/merge-base, treat it as a self-diff retry: inspect milestone-scoped commit evidence (`GSD-Unit: {{milestoneId}}` or production `GSD-Task: Sxx/Tyy` trailers touching `.gsd/milestones/{{milestoneId}}/`) and verify those commits touched non-`.gsd/` files. Record **verification failure** only when neither source shows implementation files.
-4. Verify every **success criterion** from `{{roadmapPath}}` with evidence from summaries, tests, or observable behavior. Record unmet criteria as **verification failure**.
-5. Verify **definition of done**: all slices `[x]`, summaries exist, and integrations work. Record unmet items as **verification failure**.
+4. Verify every **success criterion** from `{{roadmapPath}}`. If passing validation is present, summarize the validation evidence instead of re-auditing it; otherwise verify with evidence from summaries, tests, or observable behavior. Record unmet criteria as **verification failure**.
+5. Verify **definition of done**: all slices `[x]`, summaries exist, and integrations work. If passing validation is present, trust its integration/verification verdict unless inconsistent with current artifacts. Record unmet items as **verification failure**.
 6. If the roadmap includes a **Horizontal Checklist**, verify each item and note unchecked items in the summary.
 7. Fill the **Decision Re-evaluation** table: compare each key `.gsd/DECISIONS.md` decision from this milestone with what shipped, and flag decisions to revisit.
 8. Validate **requirement status transitions**. For each changed requirement, confirm evidence supports the new status. Requirements may move between Active, Validated, Deferred, Blocked, or Out of Scope only with proof.

--- a/src/resources/extensions/gsd/prompts/plan-milestone.md
+++ b/src/resources/extensions/gsd/prompts/plan-milestone.md
@@ -48,7 +48,7 @@ Narrate decomposition reasoning in complete sentences: grouping, risk order, ver
 Then:
 1. Use the **Roadmap** output template from the inlined context above
 2. {{skillActivation}}
-3. Create only as many demoable vertical slices as the work genuinely needs.
+3. Create only as many demoable vertical slices as the work genuinely needs. Use 1-10 slices, sized to the work; tiny/single-file/static work should usually be one slice.
 4. Order by risk, high-risk first.
 5. Call `gsd_plan_milestone` to persist milestone fields, slice rows, and **Horizontal Checklist** through the DB-backed path. Fill checklist concerns considered during planning: requirements, decisions, shutdown, revenue, auth, shared resources, reconnection. Omit for trivial milestones. Do **not** write `{{outputPath}}`, `ROADMAP.md`, or other planning artifacts manually; the tool owns rendering and persistence.
 6. If planning produced structural decisions (slice ordering, technology choices, scope exclusions), call `gsd_decision_save` for each; the tool assigns IDs and regenerates `.gsd/DECISIONS.md`.
@@ -78,6 +78,8 @@ Apply these when decomposing and ordering slices:
 - Ship features, not proofs; use clearly marked realistic stubs only when necessary.
 - **Dependency format is comma-separated, never range syntax.** Write `depends:[S01,S02,S03]`, not `depends:[S01-S03]`.
 - Roadmap ambition must match the milestone; right-size decomposition.
+- Missing ecosystem markers are not a reason to over-plan. If Project Classification says `untyped-existing`, treat the listed content files as the project surface and use generic file-level workflow guidance.
+- For `untyped-existing` projects with 1-2 content files, prefer exactly one slice unless the request clearly spans multiple independent user-visible capabilities. For 3-5 content files, prefer 1-2 slices.
 
 ## Progressive Planning (ADR-011)
 

--- a/src/resources/extensions/gsd/safety/evidence-collector.ts
+++ b/src/resources/extensions/gsd/safety/evidence-collector.ts
@@ -50,6 +50,15 @@ export interface FileEditEvidence {
 
 export type EvidenceEntry = BashEvidence | FileWriteEvidence | FileEditEvidence;
 
+const EXECUTION_TOOL_NAMES = new Set([
+  "bash",
+  "Bash",
+  "gsd_exec",
+  "gsd_exec_search",
+  "mcp__gsd-workflow__gsd_exec",
+  "mcp__gsd-workflow__gsd_exec_search",
+]);
+
 // ─── Module State ───────────────────────────────────────────────────────────
 
 let unitEvidence: EvidenceEntry[] = [];
@@ -188,11 +197,11 @@ export function clearEvidenceFromDisk(
  * Exit codes and output are filled in by recordToolResult after execution.
  */
 export function recordToolCall(toolCallId: string, toolName: string, input: Record<string, unknown>): void {
-  if (toolName === "bash" || toolName === "Bash") {
+  if (EXECUTION_TOOL_NAMES.has(toolName)) {
     unitEvidence.push({
       kind: "bash",
       toolCallId,
-      command: String(input.command ?? ""),
+      command: String(input.command ?? input.cmd ?? input.query ?? ""),
       exitCode: -1,
       outputSnippet: "",
       timestamp: Date.now(),

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2556,7 +2556,7 @@ test("autoLoop warns but proceeds for greenfield project (no project files) (#18
     "should not stop with health check failure for greenfield project",
   );
   const greenfieldWarning = notifications.find(
-    (n) => n.includes("no recognized project files") && n.includes("greenfield"),
+    (n) => n.includes("no project content yet") && n.includes("greenfield"),
   );
   assert.ok(
     greenfieldWarning,

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -184,3 +184,25 @@ test("preflight + merge + postflight round-trip preserves uncommitted changes", 
     try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
   }
 });
+
+test("postflightPopStash restores the matching GSD stash, not stash@{0}", () => {
+  const repo = createTempRepo();
+  try {
+    writeFileSync(join(repo, "README.md"), "# target stash\n");
+    const preflight = preflightCleanRoot(repo, "M006", () => {});
+    assert.equal(preflight.stashPushed, true, "must have stashed target change");
+
+    writeFileSync(join(repo, "other.txt"), "other stash\n");
+    run('git stash push --include-untracked -m "unrelated newer stash"', repo);
+
+    postflightPopStash(repo, "M006", () => {});
+
+    const content = readFileSync(join(repo, "README.md"), "utf-8");
+    assert.equal(content.replace(/\r\n/g, "\n"), "# target stash\n");
+    const stashList = run("git stash list", repo);
+    assert.ok(stashList.includes("unrelated newer stash"), "unrelated newer stash must remain");
+    assert.ok(!stashList.includes("gsd-preflight-stash [gsd-preflight-stash:M006"), "target stash should be consumed");
+  } finally {
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -229,3 +229,20 @@ test("postflightPopStash restores the exact preflight marker when another same-m
     try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
   }
 });
+
+test("postflightPopStash falls back to milestone marker prefix when exact marker is unavailable", () => {
+  const repo = createTempRepo();
+  try {
+    writeFileSync(join(repo, "README.md"), "# fallback stash\n");
+    run('git stash push --include-untracked -m "gsd-preflight-stash [gsd-preflight-stash:M008:fallback]"', repo);
+
+    postflightPopStash(repo, "M008", undefined, () => {});
+
+    const content = readFileSync(join(repo, "README.md"), "utf-8");
+    assert.equal(content.replace(/\r\n/g, "\n"), "# fallback stash\n");
+    const stashList = run("git stash list", repo);
+    assert.ok(!stashList.includes("gsd-preflight-stash:M008:fallback"), "fallback stash should be consumed");
+  } finally {
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -185,6 +185,30 @@ test("preflight + merge + postflight round-trip preserves uncommitted changes", 
   }
 });
 
+test("postflightPopStash conflict warning names the exact stash ref", () => {
+  const repo = createTempRepo();
+  try {
+    writeFileSync(join(repo, "README.md"), "# local work\n");
+    const preflight = preflightCleanRoot(repo, "M005C", () => {});
+    assert.equal(preflight.stashPushed, true, "must have stashed");
+
+    writeFileSync(join(repo, "README.md"), "# merged work\n");
+    run("git add README.md", repo);
+    run('git commit -m "simulate conflicting merge"', repo);
+
+    const notifications: Array<{ msg: string; level: string }> = [];
+    postflightPopStash(repo, "M005C", preflight.stashMarker, (msg, level) => {
+      notifications.push({ msg, level });
+    });
+
+    const warning = notifications.find((n) => n.level === "warning")?.msg ?? "";
+    assert.match(warning, /git stash pop stash@\{\d+\}/);
+    assert.match(warning, /git stash apply stash@\{\d+\}/);
+  } finally {
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});
+
 test("postflightPopStash restores the matching GSD stash, not stash@{0}", () => {
   const repo = createTempRepo();
   try {

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -131,7 +131,7 @@ test("postflightPopStash — restores stashed changes and emits info notificatio
     run('git commit -m "simulate merge"', repo);
 
     const postNotifications: Array<{ msg: string; level: string }> = [];
-    postflightPopStash(repo, "M004", (msg, level) => {
+    postflightPopStash(repo, "M004", preflight.stashMarker, (msg, level) => {
       postNotifications.push({ msg, level });
     });
 
@@ -171,7 +171,7 @@ test("preflight + merge + postflight round-trip preserves uncommitted changes", 
     run('git commit -m "feat: add feature"', repo);
 
     // Postflight: pop stash
-    postflightPopStash(repo, "M005", () => {});
+    postflightPopStash(repo, "M005", preflight.stashMarker, () => {});
 
     // README.md must still have our local content
     const restored = readFileSync(join(repo, "README.md"), "utf-8");
@@ -195,13 +195,36 @@ test("postflightPopStash restores the matching GSD stash, not stash@{0}", () => 
     writeFileSync(join(repo, "other.txt"), "other stash\n");
     run('git stash push --include-untracked -m "unrelated newer stash"', repo);
 
-    postflightPopStash(repo, "M006", () => {});
+    postflightPopStash(repo, "M006", preflight.stashMarker, () => {});
 
     const content = readFileSync(join(repo, "README.md"), "utf-8");
     assert.equal(content.replace(/\r\n/g, "\n"), "# target stash\n");
     const stashList = run("git stash list", repo);
     assert.ok(stashList.includes("unrelated newer stash"), "unrelated newer stash must remain");
     assert.ok(!stashList.includes("gsd-preflight-stash [gsd-preflight-stash:M006"), "target stash should be consumed");
+  } finally {
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});
+
+test("postflightPopStash restores the exact preflight marker when another same-milestone stash exists", () => {
+  const repo = createTempRepo();
+  try {
+    writeFileSync(join(repo, "README.md"), "# target stash\n");
+    const preflight = preflightCleanRoot(repo, "M007", () => {});
+    assert.equal(preflight.stashPushed, true, "must have stashed target change");
+    assert.ok(preflight.stashMarker, "preflight must expose exact stash marker");
+
+    writeFileSync(join(repo, "same-milestone.txt"), "newer same milestone stash\n");
+    run('git stash push --include-untracked -m "gsd-preflight-stash [gsd-preflight-stash:M007:other]"', repo);
+
+    postflightPopStash(repo, "M007", preflight.stashMarker, () => {});
+
+    const content = readFileSync(join(repo, "README.md"), "utf-8");
+    assert.equal(content.replace(/\r\n/g, "\n"), "# target stash\n");
+    const stashList = run("git stash list", repo);
+    assert.ok(stashList.includes("gsd-preflight-stash:M007:other"), "newer same-milestone stash must remain");
+    assert.ok(!stashList.includes(preflight.stashMarker), "exact target stash should be consumed");
   } finally {
     try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
   }

--- a/src/resources/extensions/gsd/tests/detection.test.ts
+++ b/src/resources/extensions/gsd/tests/detection.test.ts
@@ -11,12 +11,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   detectProjectState,
   detectV1Planning,
   detectProjectSignals,
+  classifyProject,
   scanProjectFiles,
 } from "../detection.ts";
 
@@ -37,6 +39,18 @@ function cleanup(dir: string): void {
   }
 }
 
+function git(dir: string, args: string[]): void {
+  execFileSync("git", args, { cwd: dir, stdio: "ignore" });
+}
+
+function makeGitRepo(prefix: string): string {
+  const dir = makeTempDir(prefix);
+  git(dir, ["init"]);
+  git(dir, ["config", "user.email", "test@example.com"]);
+  git(dir, ["config", "user.name", "Test User"]);
+  return dir;
+}
+
 // ─── detectProjectState ─────────────────────────────────────────────────────────
 
 test("detectProjectState: empty directory returns state=none", (t) => {
@@ -47,6 +61,76 @@ test("detectProjectState: empty directory returns state=none", (t) => {
   assert.equal(result.state, "none");
   assert.equal(result.v1, undefined);
   assert.equal(result.v2, undefined);
+});
+
+test("classifyProject: no git repo is invalid", (t) => {
+  const dir = makeTempDir("classify-invalid");
+  t.after(() => cleanup(dir));
+
+  const classification = classifyProject(dir);
+  assert.equal(classification.kind, "invalid-repo");
+});
+
+test("classifyProject: empty git repo is greenfield", (t) => {
+  const dir = makeGitRepo("classify-greenfield");
+  t.after(() => cleanup(dir));
+
+  const classification = classifyProject(dir);
+  assert.equal(classification.kind, "greenfield");
+});
+
+test("classifyProject: tracked static HTML is existing untyped content", (t) => {
+  const dir = makeGitRepo("classify-index");
+  t.after(() => cleanup(dir));
+
+  writeFileSync(join(dir, "index.html"), "<main></main>\n", "utf-8");
+  git(dir, ["add", "index.html"]);
+  git(dir, ["commit", "-m", "add static page"]);
+
+  const classification = classifyProject(dir);
+  assert.equal(classification.kind, "untyped-existing");
+  assert.deepEqual(classification.contentFiles, ["index.html"]);
+});
+
+test("classifyProject: README-only repo is existing untyped content", (t) => {
+  const dir = makeGitRepo("classify-readme");
+  t.after(() => cleanup(dir));
+
+  writeFileSync(join(dir, "README.md"), "# docs\n", "utf-8");
+  git(dir, ["add", "README.md"]);
+  git(dir, ["commit", "-m", "add docs"]);
+
+  const classification = classifyProject(dir);
+  assert.equal(classification.kind, "untyped-existing");
+});
+
+test("classifyProject: known markers produce typed existing project", (t) => {
+  const dir = makeGitRepo("classify-typed");
+  t.after(() => cleanup(dir));
+
+  writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "typed" }), "utf-8");
+  git(dir, ["add", "package.json"]);
+  git(dir, ["commit", "-m", "add package"]);
+
+  const classification = classifyProject(dir);
+  assert.equal(classification.kind, "typed-existing");
+  assert.ok(classification.markers.includes("package.json"));
+});
+
+test("classifyProject: ignored build/cache-only files do not count as content", (t) => {
+  const dir = makeGitRepo("classify-ignored");
+  t.after(() => cleanup(dir));
+
+  writeFileSync(join(dir, ".gitignore"), "dist/\n.cache/\n", "utf-8");
+  git(dir, ["add", ".gitignore"]);
+  git(dir, ["commit", "-m", "ignore generated files"]);
+  mkdirSync(join(dir, "dist"), { recursive: true });
+  writeFileSync(join(dir, "dist", "bundle.js"), "generated\n", "utf-8");
+  mkdirSync(join(dir, ".cache"), { recursive: true });
+  writeFileSync(join(dir, ".cache", "x"), "cache\n", "utf-8");
+
+  const classification = classifyProject(dir);
+  assert.equal(classification.kind, "greenfield");
 });
 
 test("detectProjectState: directory with .gsd/milestones/M001 returns v2-gsd", (t) => {

--- a/src/resources/extensions/gsd/tests/detection.test.ts
+++ b/src/resources/extensions/gsd/tests/detection.test.ts
@@ -104,6 +104,32 @@ test("classifyProject: README-only repo is existing untyped content", (t) => {
   assert.equal(classification.kind, "untyped-existing");
 });
 
+test("classifyProject: src-only content is untyped existing, not typed marker", (t) => {
+  const dir = makeGitRepo("classify-src-only");
+  t.after(() => cleanup(dir));
+
+  mkdirSync(join(dir, "src"), { recursive: true });
+  writeFileSync(join(dir, "src", "index.txt"), "content\n", "utf-8");
+  git(dir, ["add", "src/index.txt"]);
+  git(dir, ["commit", "-m", "add source content"]);
+
+  const classification = classifyProject(dir);
+  assert.equal(classification.kind, "untyped-existing");
+  assert.deepEqual(classification.contentFiles, ["src/index.txt"]);
+});
+
+test("classifyProject: nested untracked files count as project content", (t) => {
+  const dir = makeGitRepo("classify-untracked-nested");
+  t.after(() => cleanup(dir));
+
+  mkdirSync(join(dir, "docs"), { recursive: true });
+  writeFileSync(join(dir, "docs", "index.html"), "<main></main>\n", "utf-8");
+
+  const classification = classifyProject(dir);
+  assert.equal(classification.kind, "untyped-existing");
+  assert.deepEqual(classification.untrackedFiles, ["docs/index.html"]);
+});
+
 test("classifyProject: known markers produce typed existing project", (t) => {
   const dir = makeGitRepo("classify-typed");
   t.after(() => cleanup(dir));
@@ -128,6 +154,19 @@ test("classifyProject: ignored build/cache-only files do not count as content", 
   writeFileSync(join(dir, "dist", "bundle.js"), "generated\n", "utf-8");
   mkdirSync(join(dir, ".cache"), { recursive: true });
   writeFileSync(join(dir, ".cache", "x"), "cache\n", "utf-8");
+
+  const classification = classifyProject(dir);
+  assert.equal(classification.kind, "greenfield");
+});
+
+test("classifyProject: generated framework/cache dirs do not count as content", (t) => {
+  const dir = makeGitRepo("classify-generated-dirs");
+  t.after(() => cleanup(dir));
+
+  mkdirSync(join(dir, ".next", "server"), { recursive: true });
+  writeFileSync(join(dir, ".next", "server", "page.js"), "generated\n", "utf-8");
+  mkdirSync(join(dir, ".venv", "lib"), { recursive: true });
+  writeFileSync(join(dir, ".venv", "lib", "site.py"), "generated\n", "utf-8");
 
   const classification = classifyProject(dir);
   assert.equal(classification.kind, "greenfield");

--- a/src/resources/extensions/gsd/tests/detection.test.ts
+++ b/src/resources/extensions/gsd/tests/detection.test.ts
@@ -79,6 +79,23 @@ test("classifyProject: empty git repo is greenfield", (t) => {
   assert.equal(classification.kind, "greenfield");
 });
 
+test("classifyProject: nested empty git repo does not inherit ancestor markers", (t) => {
+  const parent = makeGitRepo("classify-parent-marker");
+  t.after(() => cleanup(parent));
+
+  writeFileSync(join(parent, "package.json"), JSON.stringify({ name: "parent" }), "utf-8");
+  git(parent, ["add", "package.json"]);
+  git(parent, ["commit", "-m", "add parent marker"]);
+  const child = join(parent, "nested");
+  mkdirSync(child, { recursive: true });
+  git(child, ["init"]);
+  git(child, ["config", "user.email", "test@example.com"]);
+  git(child, ["config", "user.name", "Test User"]);
+
+  const classification = classifyProject(child);
+  assert.equal(classification.kind, "greenfield");
+});
+
 test("classifyProject: tracked static HTML is existing untyped content", (t) => {
   const dir = makeGitRepo("classify-index");
   t.after(() => cleanup(dir));

--- a/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
+++ b/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
@@ -152,6 +152,32 @@ test("complete-milestone prompt does not trust stale pass validation without met
   }
 });
 
+test("complete-milestone prompt does not trust pass validation missing current summary coverage", async () => {
+  const base = makeRepo({ "index.html": "<!doctype html>\n<title>Test</title>\n" });
+  try {
+    writeCompleteMilestoneFiles(base, [
+      "---",
+      "verdict: pass",
+      "remediation_round: 0",
+      "---",
+      "",
+      "# Validation",
+      "validation_metadata:",
+      "  covered_artifacts:",
+      "    - `.gsd/milestones/M001/M001-VALIDATION.md`",
+      "    - `.gsd/milestones/M001/M001-ROADMAP.md`",
+      "",
+      "All checks passed.",
+    ].join("\n"));
+    const prompt = await buildCompleteMilestonePrompt("M001", "Polish static page", base, "minimal");
+    assert.match(prompt, /Validation Requires Attention/);
+    assert.match(prompt, /does not cover current milestone artifacts/);
+    assert.doesNotMatch(prompt, /Passing Validation Artifact/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("complete-milestone prompt keeps deeper review path without passing validation", async () => {
   const base = makeRepo({ "index.html": "<!doctype html>\n<title>Test</title>\n" });
   try {

--- a/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
+++ b/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
@@ -39,6 +39,16 @@ function writeCompleteMilestoneFiles(base: string, validation: string): void {
   writeFileSync(join(dir, "slices", "S01", "S01-SUMMARY.md"), "# S01 Summary\n\n**Verification:** passed\n");
 }
 
+function validationMetadata(): string {
+  return [
+    "validation_metadata:",
+    "  covered_artifacts:",
+    "    - `.gsd/milestones/M001/M001-VALIDATION.md`",
+    "    - `.gsd/milestones/M001/M001-ROADMAP.md`",
+    "    - `.gsd/milestones/M001/slices/S01/S01-SUMMARY.md`",
+  ].join("\n");
+}
+
 test("plan-milestone prompt includes tiny untyped project classification and one-slice guidance", async () => {
   const base = makeRepo({ "index.html": "<!doctype html>\n<title>Test</title>\n" });
   try {
@@ -105,7 +115,7 @@ test("prompt templates carry right-sized planning and closeout mode guidance", (
 test("complete-milestone prompt trusts passing validation artifact", async () => {
   const base = makeRepo({ "index.html": "<!doctype html>\n<title>Test</title>\n" });
   try {
-    writeCompleteMilestoneFiles(base, "---\nverdict: pass\nremediation_round: 0\n---\n\n# Validation\nAll checks passed.");
+    writeCompleteMilestoneFiles(base, `---\nverdict: pass\nremediation_round: 0\n---\n\n# Validation\n${validationMetadata()}\n\nAll checks passed.`);
     const prompt = await buildCompleteMilestonePrompt("M001", "Polish static page", base, "minimal");
     assert.match(prompt, /Passing Validation Artifact/);
     assert.match(prompt, /Treat it as authoritative/);
@@ -119,11 +129,24 @@ test("complete-milestone prompt trusts passing validation artifact", async () =>
 test("complete-milestone prompt trusts centralized markdown body pass verdict", async () => {
   const base = makeRepo({ "index.html": "<!doctype html>\n<title>Test</title>\n" });
   try {
-    writeCompleteMilestoneFiles(base, "# Validation\n\n**Verdict:** PASS\n\nAll checks passed.");
+    writeCompleteMilestoneFiles(base, `# Validation\n\n**Verdict:** PASS\n\n${validationMetadata()}\n\nAll checks passed.`);
     const prompt = await buildCompleteMilestonePrompt("M001", "Polish static page", base, "minimal");
     assert.match(prompt, /Passing Validation Artifact/);
     assert.match(prompt, /Treat it as authoritative/);
     assert.match(prompt, /Do not delegate fresh reviewer\/security\/tester audits/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("complete-milestone prompt does not trust stale pass validation without metadata", async () => {
+  const base = makeRepo({ "index.html": "<!doctype html>\n<title>Test</title>\n" });
+  try {
+    writeCompleteMilestoneFiles(base, "---\nverdict: pass\nremediation_round: 0\n---\n\n# Validation\nAll checks passed.");
+    const prompt = await buildCompleteMilestonePrompt("M001", "Polish static page", base, "minimal");
+    assert.match(prompt, /Validation Requires Attention/);
+    assert.match(prompt, /missing freshness metadata/);
+    assert.doesNotMatch(prompt, /Passing Validation Artifact/);
   } finally {
     rmSync(base, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
+++ b/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { buildCompleteMilestonePrompt, buildPlanMilestonePrompt } from "../auto-prompts.ts";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+    env: { ...process.env, GIT_AUTHOR_NAME: "Test User", GIT_AUTHOR_EMAIL: "test@example.com", GIT_COMMITTER_NAME: "Test User", GIT_COMMITTER_EMAIL: "test@example.com" },
+  }).trim();
+}
+
+function makeRepo(files: Record<string, string>): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-right-size-"));
+  git(base, ["init", "-b", "main"]);
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# Context\n\nTest milestone.");
+  for (const [path, content] of Object.entries(files)) {
+    const abs = join(base, path);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  git(base, ["add", "."]);
+  git(base, ["commit", "-m", "init"]);
+  return base;
+}
+
+function writeCompleteMilestoneFiles(base: string, validation: string): void {
+  const dir = join(base, ".gsd", "milestones", "M001");
+  mkdirSync(join(dir, "slices", "S01"), { recursive: true });
+  writeFileSync(join(dir, "M001-ROADMAP.md"), "# M001\n\n## Slices\n- [x] **S01: One** `risk:low` `depends:[]`\n  > Done\n");
+  writeFileSync(join(dir, "M001-VALIDATION.md"), validation);
+  writeFileSync(join(dir, "slices", "S01", "S01-SUMMARY.md"), "# S01 Summary\n\n**Verification:** passed\n");
+}
+
+test("plan-milestone prompt includes tiny untyped project classification and one-slice guidance", async () => {
+  const base = makeRepo({ "index.html": "<!doctype html>\n<title>Test</title>\n" });
+  try {
+    const prompt = await buildPlanMilestonePrompt("M001", "Polish static page", base, "minimal");
+    assert.match(prompt, /\*\*Kind:\*\* untyped-existing/);
+    assert.match(prompt, /\*\*Content files:\*\* 1/);
+    assert.match(prompt, /`index\.html`/);
+    assert.match(prompt, /Prefer exactly one slice/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("plan-milestone prompt includes small untyped project 1-2 slice guidance", async () => {
+  const base = makeRepo({
+    "index.html": "html",
+    "README.md": "readme",
+    "styles.css": "body {}",
+  });
+  try {
+    const prompt = await buildPlanMilestonePrompt("M001", "Polish static files", base, "minimal");
+    assert.match(prompt, /\*\*Kind:\*\* untyped-existing/);
+    assert.match(prompt, /\*\*Content files:\*\* 3/);
+    assert.match(prompt, /Prefer 1-2 slices/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("plan-milestone prompt keeps normal guidance for typed projects", async () => {
+  const base = makeRepo({
+    "package.json": "{\"scripts\":{\"test\":\"node --test\"}}\n",
+    "src/index.js": "console.log('ok');\n",
+  });
+  try {
+    const prompt = await buildPlanMilestonePrompt("M001", "Update app", base, "minimal");
+    assert.match(prompt, /\*\*Kind:\*\* typed-existing/);
+    assert.match(prompt, /Use normal ecosystem-aware planning guidance/);
+    assert.doesNotMatch(prompt, /Prefer exactly one slice/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("workflow docs no longer contain blanket 4-10 slice guidance", () => {
+  const docs = readFileSync(join(process.cwd(), "src", "resources", "GSD-WORKFLOW.md"), "utf-8");
+  assert.doesNotMatch(docs, /4-10 slices/);
+  assert.match(docs, /1-10 slices/);
+  assert.match(docs, /single-file/);
+});
+
+test("prompt templates carry right-sized planning and closeout mode guidance", () => {
+  const planTemplate = readFileSync(join(process.cwd(), "src", "resources", "extensions", "gsd", "prompts", "plan-milestone.md"), "utf-8");
+  const completeTemplate = readFileSync(join(process.cwd(), "src", "resources", "extensions", "gsd", "prompts", "complete-milestone.md"), "utf-8");
+
+  assert.match(planTemplate, /Use 1-10 slices, sized to the work/);
+  assert.match(planTemplate, /tiny\/single-file\/static work should usually be one slice/);
+  assert.match(planTemplate, /untyped-existing/);
+  assert.match(completeTemplate, /Closeout Review Mode/);
+  assert.match(completeTemplate, /passing validation artifact is present/);
+  assert.doesNotMatch(completeTemplate, /^### Delegate Review Work/m);
+});
+
+test("complete-milestone prompt trusts passing validation artifact", async () => {
+  const base = makeRepo({ "index.html": "<!doctype html>\n<title>Test</title>\n" });
+  try {
+    writeCompleteMilestoneFiles(base, "---\nverdict: pass\nremediation_round: 0\n---\n\n# Validation\nAll checks passed.");
+    const prompt = await buildCompleteMilestonePrompt("M001", "Polish static page", base, "minimal");
+    assert.match(prompt, /Passing Validation Artifact/);
+    assert.match(prompt, /Treat it as authoritative/);
+    assert.match(prompt, /Do not delegate fresh reviewer\/security\/tester audits/);
+    assert.match(prompt, /All checks passed/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("complete-milestone prompt keeps deeper review path without passing validation", async () => {
+  const base = makeRepo({ "index.html": "<!doctype html>\n<title>Test</title>\n" });
+  try {
+    writeCompleteMilestoneFiles(base, "---\nverdict: needs-attention\nremediation_round: 0\n---\n\n# Validation\nFix gaps.");
+    const prompt = await buildCompleteMilestonePrompt("M001", "Polish static page", base, "minimal");
+    assert.match(prompt, /Validation Requires Attention/);
+    assert.match(prompt, /verdict `needs-attention`/);
+    assert.match(prompt, /Use `subagent` for review work needing fresh context/i);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
+++ b/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
@@ -116,6 +116,19 @@ test("complete-milestone prompt trusts passing validation artifact", async () =>
   }
 });
 
+test("complete-milestone prompt trusts centralized markdown body pass verdict", async () => {
+  const base = makeRepo({ "index.html": "<!doctype html>\n<title>Test</title>\n" });
+  try {
+    writeCompleteMilestoneFiles(base, "# Validation\n\n**Verdict:** PASS\n\nAll checks passed.");
+    const prompt = await buildCompleteMilestonePrompt("M001", "Polish static page", base, "minimal");
+    assert.match(prompt, /Passing Validation Artifact/);
+    assert.match(prompt, /Treat it as authoritative/);
+    assert.match(prompt, /Do not delegate fresh reviewer\/security\/tester audits/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("complete-milestone prompt keeps deeper review path without passing validation", async () => {
   const base = makeRepo({ "index.html": "<!doctype html>\n<title>Test</title>\n" });
   try {

--- a/src/resources/extensions/gsd/tests/safety-harness-false-positives.test.ts
+++ b/src/resources/extensions/gsd/tests/safety-harness-false-positives.test.ts
@@ -144,6 +144,18 @@ test("safety-harness-bug2-race: bash evidence survives mid-unit reset between to
   assert.ok(bash[0].outputSnippet.includes("found"), "output snippet captured");
 });
 
+test("safety-harness: gsd_exec counts as execution evidence", () => {
+  resetEvidence();
+
+  recordToolCall("tc-exec-1", "gsd_exec", { command: "grep -n render index.html" });
+  recordToolResult("tc-exec-1", "gsd_exec", "Command exited with code 0\n1:render\n", false);
+
+  const bash = getEvidence().filter((e): e is BashEvidence => e.kind === "bash");
+  assert.equal(bash.length, 1, "gsd_exec must be tracked as execution evidence");
+  assert.equal(bash[0].command, "grep -n render index.html");
+  assert.equal(bash[0].exitCode, 0);
+});
+
 // ─── Bug 3: git diff HEAD~1 scope check ─────────────────────────────────────
 
 test("safety-harness-bug3: validateFileChanges works on initial commit (no HEAD~1)", (t) => {
@@ -236,4 +248,21 @@ test("safety-harness-bug3: validateFileChanges works on merge commit", (t) => {
 
   // Must produce a valid result without throwing
   assert.ok(audit !== null, "audit must be produced for merge commit repo");
+});
+
+test("safety-harness: planned changed file avoids unexpected-file warning", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-planned-file-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  execFileSync("git", ["init"], { cwd: base });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: base });
+  execFileSync("git", ["config", "user.name", "Test User"], { cwd: base });
+  writeFileSync(join(base, "index.html"), "<main></main>\n");
+  execFileSync("git", ["add", "index.html"], { cwd: base });
+  execFileSync("git", ["commit", "-m", "add static app"], { cwd: base });
+
+  const audit = validateFileChanges(base, [], ["index.html"]);
+  assert.ok(audit !== null, "audit must be produced");
+  assert.deepEqual(audit!.unexpectedFiles, [], "planned index.html must not be unexpected");
+  assert.deepEqual(audit!.missingFiles, [], "planned index.html must not be missing");
 });

--- a/src/resources/extensions/gsd/tests/worktree-health-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-health-dispatch.test.ts
@@ -93,6 +93,8 @@ test("runUnitPhase fails closed when classification returns invalid-repo", () =>
     source.indexOf('projectClassification.kind === "greenfield"'),
   );
 
+  assert.match(invalidRepoBranch, /projectClassification\.reason === "missing \.git" && hasGit/);
+  assert.match(invalidRepoBranch, /project classification could not confirm \.git/);
   assert.match(invalidRepoBranch, /ctx\.ui\.notify\(msg,\s*"error"\)/);
   assert.match(invalidRepoBranch, /await deps\.stopAuto\(ctx,\s*pi,\s*msg\)/);
   assert.match(invalidRepoBranch, /return \{ action: "break", reason: "worktree-invalid" \}/);

--- a/src/resources/extensions/gsd/tests/worktree-health-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-health-dispatch.test.ts
@@ -14,7 +14,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 
-import { PROJECT_FILES } from "../detection.js";
+import { PROJECT_FILES, classifyProject } from "../detection.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -27,6 +27,14 @@ function createGitRepo(): string {
   execSync("git config user.name Test", { cwd: dir, stdio: "ignore" });
   writeFileSync(join(dir, "README.md"), "# test\n");
   execSync("git add . && git commit -m init", { cwd: dir, stdio: "ignore" });
+  return dir;
+}
+
+function createEmptyGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "wt-dispatch-test-empty-"));
+  execSync("git init", { cwd: dir, stdio: "ignore" });
+  execSync("git config user.email test@test.com", { cwd: dir, stdio: "ignore" });
+  execSync("git config user.name Test", { cwd: dir, stdio: "ignore" });
   return dir;
 }
 
@@ -132,8 +140,18 @@ describe("health check with git repo", () => {
   });
 
   test("health check passes for empty git repo (greenfield project)", () => {
-    assert.ok(wouldPassHealthCheck(dir, existsSync), "empty git repo should pass health check (greenfield)");
-    assert.ok(!hasRecognizedProjectFiles(dir, existsSync), "empty git repo has no recognized project files");
+    const empty = createEmptyGitRepo();
+    try {
+      assert.ok(wouldPassHealthCheck(empty, existsSync), "empty git repo should pass health check (greenfield)");
+      assert.equal(classifyProject(empty).kind, "greenfield");
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  test("health check classifies README-only repo as untyped existing, not greenfield", () => {
+    assert.ok(wouldPassHealthCheck(dir, existsSync), "README-only repo should pass health check");
+    assert.equal(classifyProject(dir).kind, "untyped-existing");
   });
 });
 

--- a/src/resources/extensions/gsd/tests/worktree-health-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-health-dispatch.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
@@ -72,8 +72,6 @@ function hasXcodeBundle(basePath: string): boolean {
   } catch { return false; }
 }
 
-import { existsSync } from "node:fs";
-
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 test("PROJECT_FILES is exported and contains expected multi-ecosystem entries", () => {
@@ -86,6 +84,19 @@ test("PROJECT_FILES is exported and contains expected multi-ecosystem entries", 
   assert.ok(PROJECT_FILES.includes("package.json"), "includes JS marker");
   assert.ok(PROJECT_FILES.includes("pom.xml"), "includes Java marker");
   assert.ok(PROJECT_FILES.includes("Package.swift"), "includes Swift marker");
+});
+
+test("runUnitPhase fails closed when classification returns invalid-repo", () => {
+  const source = readFileSync(join(process.cwd(), "src/resources/extensions/gsd/auto/phases.ts"), "utf-8");
+  const invalidRepoBranch = source.slice(
+    source.indexOf('projectClassification.kind === "invalid-repo"'),
+    source.indexOf('projectClassification.kind === "greenfield"'),
+  );
+
+  assert.match(invalidRepoBranch, /ctx\.ui\.notify\(msg,\s*"error"\)/);
+  assert.match(invalidRepoBranch, /await deps\.stopAuto\(ctx,\s*pi,\s*msg\)/);
+  assert.match(invalidRepoBranch, /return \{ action: "break", reason: "worktree-invalid" \}/);
+  assert.match(invalidRepoBranch, /classified as invalid-repo/);
 });
 
 describe("health check with git repo", () => {

--- a/src/resources/extensions/gsd/tests/worktree-manager.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-manager.test.ts
@@ -235,4 +235,11 @@ describe("removeWorktree — missing worktree", () => {
       "should not throw when worktree does not exist",
     );
   });
+
+  test("deleteBranch is quiet when the branch is already gone", () => {
+    assert.doesNotThrow(
+      () => removeWorktree(base, "nonexistent", { deleteBranch: true }),
+      "missing branch should be treated as already cleaned up",
+    );
+  });
 });

--- a/src/resources/extensions/gsd/tests/worktree-nested-git-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-nested-git-safety.test.ts
@@ -56,11 +56,11 @@ test("#2616: findNestedGitDirs ignores .git files (worktree pointers)", (t) => {
   );
 });
 
-test("#2616: findNestedGitDirs skips excluded directories (node_modules, .gsd, target)", (t) => {
+test("#2616: findNestedGitDirs skips excluded directories (node_modules, .gsd, .bg-shell, target)", (t) => {
   const root = makeRoot(t);
 
   // All three of these contain a .git *directory*, but the scan must skip them.
-  for (const excluded of ["node_modules", ".gsd", "target"]) {
+  for (const excluded of ["node_modules", ".gsd", ".bg-shell", "target"]) {
     const inside = join(root, excluded, "vendored-pkg");
     mkdirSync(join(inside, ".git"), { recursive: true });
   }
@@ -71,6 +71,13 @@ test("#2616: findNestedGitDirs skips excluded directories (node_modules, .gsd, t
     0,
     `excluded directories must be skipped, got ${JSON.stringify(found)}`,
   );
+});
+
+test("#2616: findNestedGitDirs ignores normal missing child .git probes", (t) => {
+  const root = makeRoot(t);
+  mkdirSync(join(root, "plain-dir"), { recursive: true });
+
+  assert.deepEqual(findNestedGitDirs(root), []);
 });
 
 test("#2616: findNestedGitDirs finds deeply nested repos", (t) => {

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -70,6 +70,15 @@ export interface WorktreeDiffSummary {
   removed: string[];
 }
 
+function deleteBranchIfPresent(basePath: string, branch: string, warningPrefix: string): void {
+  try {
+    if (!nativeBranchExists(basePath, branch)) return;
+    nativeBranchDelete(basePath, branch, true);
+  } catch (e) {
+    logWarning("worktree", `${warningPrefix}: ${(e as Error).message}`);
+  }
+}
+
 // ─── Path Helpers ──────────────────────────────────────────────────────────
 
 function normalizePathForComparison(path: string): string {
@@ -408,7 +417,7 @@ export function listWorktrees(basePath: string): WorktreeInfo[] {
 
 /** Directories to skip when scanning for nested .git dirs. */
 const NESTED_GIT_SKIP_DIRS = new Set([
-  ".git", ".gsd", "node_modules", ".next", ".nuxt", "dist", "build",
+  ".git", ".gsd", ".bg-shell", "node_modules", ".next", ".nuxt", "dist", "build",
   "__pycache__", ".tox", ".venv", "venv", "target", "vendor",
 ]);
 
@@ -462,7 +471,9 @@ export function findNestedGitDirs(rootPath: string): string[] {
           continue;
         }
       } catch (e) {
-        logWarning("worktree", `existsSync/.git check failed for ${fullPath}: ${(e as Error).message}`);
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          logWarning("worktree", `existsSync/.git check failed for ${fullPath}: ${(e as Error).message}`);
+        }
       }
 
       walk(fullPath, depth + 1);
@@ -535,7 +546,7 @@ export function removeWorktree(
   if (!existsSync(wtPath)) {
     nativeWorktreePrune(basePath);
     if (deleteBranch) {
-      try { nativeBranchDelete(basePath, branch, true); } catch (e) { logWarning("worktree", `nativeBranchDelete failed: ${(e as Error).message}`); }
+      deleteBranchIfPresent(basePath, branch, "nativeBranchDelete failed");
     }
     return;
   }
@@ -670,7 +681,7 @@ export function removeWorktree(
   nativeWorktreePrune(basePath);
 
   if (deleteBranch) {
-    try { nativeBranchDelete(basePath, branch, true); } catch (e) { logWarning("worktree", `final branch delete failed: ${(e as Error).message}`); }
+    deleteBranchIfPresent(basePath, branch, "final branch delete failed");
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #5407.

This PR addresses the M004-style long-running tiny/static project workflow problem in two layers:

- classify project presence separately from ecosystem/tooling markers, so static/minimal repos become `untyped-existing` instead of greenfield
- feed that classification into planning and completion prompts so tiny untyped work is right-sized and completion does not repeat validation work after a passing `VALIDATION.md`

It also includes the earlier M004 hardening stack for stash targeting, branch cleanup idempotency, `.bg-shell` scan suppression, and safety warning reductions.

## Changes

- Added `classifyProject()` over existing project signal detection with `invalid-repo`, `greenfield`, `untyped-existing`, and `typed-existing` outcomes.
- Detect project content using tracked plus filtered untracked files while excluding ignored/cache/build/GSD/bg-shell paths.
- Updated auto/worktree messaging for greenfield vs untyped existing vs typed existing repos.
- Added planning-time classification context: kind, content file count, sample files, and right-sized slice guidance.
- Replaced blanket `4-10 slices` guidance with `1-10 slices, sized to the work`.
- Updated milestone completion to trust passing validation artifacts and skip duplicate delegated review unless validation is missing, stale, non-pass, or inconsistent.
- Hardened M004 cleanup paths:
  - targeted stash restore with unique marker
  - quieter branch deletion when branch is already gone
  - nested `.git` scan ignores `.bg-shell` and normal `ENOENT`
  - safety warnings reduced for host/post-unit verification evidence

## Verification

Passed targeted suites:

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test \
  src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts \
  src/resources/extensions/gsd/tests/detection.test.ts \
  src/resources/extensions/gsd/tests/complete-milestone.test.ts \
  src/resources/extensions/gsd/tests/plan-milestone-rendering.test.ts \
  src/resources/extensions/gsd/tests/plan-slice-prompt.test.ts
```

Result: 132 passed, 0 failed.

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test \
  src/resources/extensions/gsd/tests/detection.test.ts \
  src/resources/extensions/gsd/tests/worktree-health-dispatch.test.ts \
  src/resources/extensions/gsd/tests/safety-harness-false-positives.test.ts \
  src/resources/extensions/gsd/tests/clean-root-preflight.test.ts \
  src/resources/extensions/gsd/tests/worktree-nested-git-safety.test.ts \
  src/resources/extensions/gsd/tests/worktree-manager.test.ts \
  src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
```

Result: 156 passed, 0 failed.

Attempted broader checks:

- `npm run typecheck:extensions` fails repo-wide due missing local package declarations/modules such as `@gsd/pi-coding-agent`, `@gsd/pi-tui`, `@gsd/native`.
- `npm run test:unit` compiles and runs, but fails broadly from the same local `dist-test` package/import setup plus pre-existing unrelated failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project classification that adapts planning and health checks for greenfield, untyped, and typed repos; planning prompts include classification and validation context.

* **Documentation**
  * Roadmap guidance updated to 1–10 demoable slices with special rules for tiny/untyped projects.
  * Closeout review mode adds conditional verification guidance based on validation evidence.

* **Bug Fixes**
  * More precise preflight stash tracking/restoration and non-fatal stash warnings.
  * Broader execution-evidence recognition and improved nested-repo/worktree error handling.

* **Tests**
  * Expanded coverage for classification, stash behavior, prompts, safety harness, and worktree scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->