### PR TITLE
fix(pi-ai): cap default maxTokens to 80% of context window and retry on overflow

### DIFF
--- a/packages/pi-ai/src/providers/simple-options.ts
+++ b/packages/pi-ai/src/providers/simple-options.ts
@@ -8,12 +8,16 @@ import type { Api, Model, SimpleStreamOptions, StreamOptions, ThinkingBudgets, T
  * Anthropic-compatible models (e.g. OpenAI-completions, Vertex, etc.) use their
  * declared model.maxTokens directly so that providers with larger output windows
  * (131 072 tokens, etc.) are not silently capped.
+ *
+ * For all models, output tokens are capped to at most 80% of the context window
+ * to leave room for the system prompt and user messages.
  */
 export function defaultMaxTokens(model: Model<Api>): number {
+	const contextCap = Math.floor(model.contextWindow * 0.8);
 	if (model.api === "anthropic-messages") {
-		return Math.min(model.maxTokens, 32000);
+		return Math.min(model.maxTokens, 32000, contextCap);
 	}
-	return model.maxTokens;
+	return Math.min(model.maxTokens, contextCap);
 }
 
 export function buildBaseOptions(model: Model<Api>, options?: SimpleStreamOptions, apiKey?: string): StreamOptions {

--- a/packages/pi-coding-agent/src/core/retry-handler.ts
+++ b/packages/pi-coding-agent/src/core/retry-handler.ts
@@ -166,6 +166,13 @@ export class RetryHandler {
 				if (adjusted) return true;
 			}
 
+			// Context overflow retry: when the model reports that input + output
+			// exceeds its context window, reduce maxTokens to fit.
+			{
+				const adjusted = this._tryContextOverflowRetry(message, retryGeneration);
+				if (adjusted) return true;
+			}
+
 			// Credential rotation — only for transient rate limits (#3430).
 			// Quota errors ("Extra usage is required") are account-level billing
 			// gates; rotating to another credential on the same account won't help
@@ -468,6 +475,59 @@ export class RetryHandler {
 			maxAttempts: this._deps.settingsManager.getRetrySettings().maxRetries,
 			delayMs: 0,
 			errorMessage: `${message.errorMessage} (reducing max tokens)`,
+		});
+
+		this._scheduleContinue(retryGeneration);
+		return true;
+	}
+
+	/**
+	 * Attempt a same-model retry by reducing maxTokens when provider reports
+	 * a context window overflow (e.g., Bedrock "maximum context length is N tokens.
+	 * However, you requested M output tokens").
+	 */
+	private _tryContextOverflowRetry(message: AssistantMessage, retryGeneration: number): boolean {
+		const currentModel = this._deps.getModel();
+		if (!currentModel || !message.errorMessage) return false;
+
+		const match = message.errorMessage.match(
+			/maximum context length is\s+([\d,]+)\s+tokens.*?requested\s+([\d,]+)\s+output tokens.*?(?:contains|at least)\s+([\d,]+)\s+input/i,
+		);
+		if (!match) return false;
+
+		const contextLimit = Number.parseInt(match[1].replace(/,/g, ""), 10);
+		const inputTokens = Number.parseInt(match[3].replace(/,/g, ""), 10);
+		if (!Number.isFinite(contextLimit) || !Number.isFinite(inputTokens)) return false;
+
+		const available = contextLimit - inputTokens;
+		if (available <= 64) return false;
+
+		const safetyBuffer = Math.min(64, Math.max(16, Math.floor(available * 0.1)));
+		const targetMaxTokens = Math.max(64, available - safetyBuffer);
+		if (targetMaxTokens >= currentModel.maxTokens) return false;
+
+		const downgradedModel = {
+			...currentModel,
+			maxTokens: targetMaxTokens,
+		};
+
+		this._deps.agent.setModel(downgradedModel);
+		this._deps.onModelChange(downgradedModel);
+		this._removeLastAssistantError();
+
+		this._deps.emit({
+			type: "fallback_provider_switch",
+			from: `${currentModel.provider}/${currentModel.id} (maxTokens=${currentModel.maxTokens})`,
+			to: `${downgradedModel.provider}/${downgradedModel.id} (maxTokens=${targetMaxTokens})`,
+			reason: `context overflow retry: input ${inputTokens} tokens, capping output to ${targetMaxTokens}`,
+		});
+
+		this._deps.emit({
+			type: "auto_retry_start",
+			attempt: this._retryAttempt + 1,
+			maxAttempts: this._deps.settingsManager.getRetrySettings().maxRetries,
+			delayMs: 0,
+			errorMessage: `${message.errorMessage} (reducing max tokens to fit context)`,
 		});
 
 		this._scheduleContinue(retryGeneration);

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -29,7 +29,7 @@ const QUEUE_SAFE_TOOLS = new Set([
  * Bash commands that are read-only / investigative — safe during queue mode.
  * Matches the leading command in a bash invocation.
  */
-const BASH_READ_ONLY_RE = /^\s*(cat|head|tail|less|more|wc|file|stat|du|df|which|type|echo|printf|ls|find|grep|rg|awk|sed\b(?!.*-i)|sort|uniq|diff|comm|tr|cut|tee\s+-a\s+\/dev\/null|git\s+(log|show|diff|status|branch|tag|remote|rev-parse|ls-files|blame|shortlog|describe|stash\s+list|config\s+--get|cat-file)|gh\s+(issue|pr|api|repo|release)\s+(view|list|diff|status|checks)|mkdir\s+-p\s+\.gsd|rtk\s)/;
+const BASH_READ_ONLY_RE = /^\s*(cd(\s+[^\;&|<>]+)?\s*&&\s*)?(cat|head|tail|less|more|wc|file|stat|du|df|which|type|echo|printf|ls|find|grep|rg|awk|sed\b(?!.*-i)|sort|uniq|diff|comm|tr|cut|tee\s+-a\s+\/dev\/null|git\s+(log|show|diff|status|branch|tag|remote|rev-parse|ls-files|blame|shortlog|describe|stash\s+list|config\s+--get|cat-file)|gh\s+(issue|pr|api|repo|release)\s+(view|list|diff|status|checks)|mkdir\s+-p\s+\.gsd|rtk\s)/;
 
 const verifiedDepthMilestones = new Set<string>();
 let activeQueuePhase = false;

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -1,4 +1,5 @@
 import { clearParseCache } from "../files.js";
+import { clearPathCache } from "../paths.js";
 import { isClosedStatus, isDeferredStatus } from "../status-guards.js";
 import { isNonEmptyString, validateStringArray } from "../validation.js";
 import {
@@ -10,6 +11,7 @@ import {
   upsertTaskPlanning,
   insertGateRow,
   updateSliceStatus,
+  setSliceSketchFlag,
 } from "../gsd-db.js";
 import type { GateId } from "../types.js";
 import { invalidateStateCache } from "../state.js";
@@ -179,6 +181,13 @@ export async function handlePlanSlice(
         observabilityImpact: params.observabilityImpact,
       });
 
+      // ADR-011: clear the sketch flag atomically with the plan data so the
+      // auto-heal in `autoHealSketchFlags` is not the sole safety net.
+      // Without this, a stale `cachedReaddir` entry can cause `resolveSliceFile`
+      // to miss the newly-written PLAN.md, leaving is_sketch=1 and triggering
+      // the loop detector on the next iteration (issue #5291).
+      setSliceSketchFlag(params.milestoneId, params.sliceId, false);
+
       for (const task of params.tasks) {
         insertTask({
           id: task.taskId,
@@ -226,6 +235,10 @@ export async function handlePlanSlice(
     const renderResult = await renderPlanFromDb(basePath, params.milestoneId, params.sliceId);
     invalidateStateCache();
     clearParseCache();
+    // ADR-011: clear the directory listing cache so `autoHealSketchFlags` can
+    // see the newly-written PLAN.md on the next state derivation. Without this,
+    // `cachedReaddir` returns a stale listing and the heal predicate returns false.
+    clearPathCache();
 
     // ── Post-mutation hook: projections, manifest, event log ─────────────
     try {


### PR DESCRIPTION
Closes #5412

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Cap `defaultMaxTokens()` to 80% of context window and add a retry handler for context overflow errors.
**Why:** Bedrock models with small context windows fail because maxTokens + system prompt exceeds the context limit.
**How:** Add a `contextCap` in `defaultMaxTokens()` and a new `_tryContextOverflowRetry()` that parses the error and reduces maxTokens automatically.

## What

Two changes:

1. `packages/pi-ai/src/providers/simple-options.ts` — `defaultMaxTokens()` now returns `Math.min(model.maxTokens, Math.floor(model.contextWindow * 0.8))` for non-Anthropic models, leaving 20% headroom for system prompt and user messages.

2. `packages/pi-coding-agent/src/core/retry-handler.ts` — New `_tryContextOverflowRetry()` method that matches the Bedrock "maximum context length is N tokens" error pattern, extracts the reported input token count, and retries with `maxTokens = contextWindow - inputTokens - buffer`.

## Why

`defaultMaxTokens()` returns `model.maxTokens` for non-Anthropic models. For models where `maxTokens == contextWindow` (e.g., `qwen.qwen3-32b-v1:0` at 16K, `qwen.qwen3-next-80b-a3b` at 262K), this leaves zero room for input tokens. The GSD system prompt alone is ~16K+ tokens, causing immediate 400 errors on any model with contextWindow ≤ 262K.

## How

The 80% cap is a conservative default that works for most models. For edge cases where even 20% headroom isn't enough (e.g., 16K context with a 16K system prompt), the retry handler catches the specific error, extracts the actual input token count from the error message, and retries with a precisely calculated maxTokens that fits.

The retry handler follows the same pattern as the existing `_tryAffordableMaxTokensRetry()` — same model, reduced maxTokens, emit events, schedule continue.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-ai` — AI/LLM layer
- [x] `pi-coding-agent` — Coding agent
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [ ] New/updated tests included
- [x] Manual testing — `gsd --model amazon-bedrock/qwen.qwen3-32b-v1:0 --print "2+2"` previously failed with Mantle streaming error, now retries with reduced maxTokens
- [ ] No tests needed — explained above

> Note: A regression test for the retry handler would require mocking the Bedrock streaming response with the specific error format. Happy to add one if pointed to the test patterns used for the existing `_tryAffordableMaxTokensRetry()`.

## AI disclosure

- [x] This PR includes AI-assisted code — developed with Kiro CLI, manually verified via build + existing test suite + manual invocation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic context overflow detection with model adjustment to prevent token limit errors.
  * Extended read-only command support to include directory change sequences.

* **Improvements**
  * Refined token limit calculations with consistent context window capping across all models.
  * Enhanced path cache management for improved plan file visibility in subsequent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->