### PR TITLE
fix(pi-coding-agent): retry on maxTokens context overflow instead of deferring to compaction

### DIFF
--- a/packages/pi-coding-agent/src/core/retry-handler.test.ts
+++ b/packages/pi-coding-agent/src/core/retry-handler.test.ts
@@ -516,3 +516,63 @@ describe("RetryHandler — long-context entitlement 429 (#2803)", () => {
 		});
 	});
 });
+
+// ─── maxTokens overflow retry (#5412) ───────────────────────────────────────
+
+describe("RetryHandler — maxTokens overflow retry (#5412)", () => {
+	it("classifies 'requested N output tokens' overflow as retryable", () => {
+		const model = createMockModel("amazon-bedrock", "qwen.qwen3-32b-v1:0");
+		(model as any).contextWindow = 32768;
+		(model as any).maxTokens = 16384;
+
+		const { deps } = createMockDeps({ model });
+		const handler = new RetryHandler(deps);
+
+		const msg = errorMessage(
+			"This model's maximum context length is 32768 tokens. However, you requested 16384 output tokens and your prompt contains at least 16385 input tokens, for a total of at least 32769 tokens.",
+		);
+
+		assert.equal(handler.isRetryableError(msg), true);
+	});
+
+	it("does NOT classify generic context overflow as retryable", () => {
+		const model = createMockModel("anthropic", "claude-sonnet-4-6");
+		(model as any).contextWindow = 200000;
+		(model as any).maxTokens = 32000;
+
+		const { deps } = createMockDeps({ model });
+		const handler = new RetryHandler(deps);
+
+		const msg = errorMessage("prompt is too long: 213462 tokens > 200000 maximum");
+
+		assert.equal(handler.isRetryableError(msg), false);
+	});
+
+	it("reduces maxTokens and retries on overflow", async () => {
+		const model = createMockModel("amazon-bedrock", "qwen.qwen3-32b-v1:0");
+		(model as any).contextWindow = 32768;
+		(model as any).maxTokens = 16384;
+		(model as any).api = "bedrock-converse-stream";
+
+		const { deps, emittedEvents, continueFn } = createMockDeps({ model });
+		const handler = new RetryHandler(deps);
+
+		const msg = errorMessage(
+			"This model's maximum context length is 32768 tokens. However, you requested 16384 output tokens and your prompt contains at least 16385 input tokens, for a total of at least 32769 tokens.",
+		);
+		deps.agent.state.messages.push(msg);
+
+		handler.createRetryPromiseForAgentEnd(deps.agent.state.messages);
+		const result = await handler.handleRetryableError(msg);
+
+		assert.equal(result, true, "should initiate retry");
+
+		// Verify maxTokens was reduced
+		const switchEvent = emittedEvents.find((e) => e.type === "fallback_provider_switch");
+		assert.ok(switchEvent, "should emit fallback_provider_switch");
+		assert.ok(switchEvent.reason.includes("context overflow"), "reason should mention context overflow");
+
+		// Available = 32768 - 16385 = 16383, target = floor(16383 * 0.9) = 14744
+		assert.ok(switchEvent.to.includes("14744"), `expected maxTokens=14744, got: ${switchEvent.to}`);
+	});
+});

--- a/packages/pi-coding-agent/src/core/retry-handler.ts
+++ b/packages/pi-coding-agent/src/core/retry-handler.ts
@@ -6,7 +6,8 @@
  * 2. Falling back to other providers via FallbackResolver
  * 3. Exponential backoff with configurable max retries
  *
- * Context overflow errors are NOT handled here (see compaction).
+ * Context overflow errors are generally handled by compaction, except when the
+ * overflow is caused by maxTokens being too high (retryable by reducing it).
  */
 
 import type { Agent } from "@gsd/pi-agent-core";
@@ -19,6 +20,27 @@ import type { SettingsManager } from "./settings-manager.js";
 import { sleep } from "../utils/sleep.js";
 import type { AgentSessionEvent } from "./agent-session.js";
 import { RETRYABLE_ERROR_RE } from "./retryable-error-regex.js";
+
+/**
+ * Detect context overflow errors caused specifically by maxTokens being too high.
+ * These mention "requested N output tokens" — distinguishing them from conversation-
+ * length overflows that compaction should handle.
+ */
+const MAX_TOKENS_OVERFLOW_RE =
+	/requested\s+([\d,]+)\s+output tokens.*(?:contains|at least)\s+([\d,]+)\s+input/i;
+
+function isMaxTokensOverflow(errorMessage: string): boolean {
+	return MAX_TOKENS_OVERFLOW_RE.test(errorMessage);
+}
+
+function parseMaxTokensOverflow(errorMessage: string): { inputTokens: number; requestedOutput: number } | null {
+	const match = errorMessage.match(MAX_TOKENS_OVERFLOW_RE);
+	if (!match) return null;
+	return {
+		requestedOutput: Number.parseInt(match[1].replace(/,/g, ""), 10),
+		inputTokens: Number.parseInt(match[2].replace(/,/g, ""), 10),
+	};
+}
 
 /** Dependencies injected from AgentSession into RetryHandler */
 export interface RetryHandlerDeps {
@@ -108,9 +130,13 @@ export class RetryHandler {
 	isRetryableError(message: AssistantMessage): boolean {
 		if (message.stopReason !== "error" || !message.errorMessage) return false;
 
-		// Context overflow is handled by compaction, not retry
+		// Context overflow is handled by compaction, not retry — UNLESS the error
+		// specifically mentions "requested N output tokens", which means maxTokens
+		// is too high and can be reduced without compaction.
 		const contextWindow = this._deps.getModel()?.contextWindow ?? 0;
-		if (isContextOverflow(message, contextWindow)) return false;
+		if (isContextOverflow(message, contextWindow)) {
+			return isMaxTokensOverflow(message.errorMessage);
+		}
 
 		return RETRYABLE_ERROR_RE.test(message.errorMessage);
 	}
@@ -157,6 +183,13 @@ export class RetryHandler {
 			// on the same model before rotating credentials/providers.
 			if (isQuotaError) {
 				const adjusted = this._tryAffordableMaxTokensRetry(message, retryGeneration);
+				if (adjusted) return true;
+			}
+
+			// MaxTokens overflow retry: when the provider reports that input + output
+			// exceeds context, reduce maxTokens to fit the available space.
+			if (message.errorMessage && isMaxTokensOverflow(message.errorMessage)) {
+				const adjusted = this._tryMaxTokensOverflowRetry(message, retryGeneration);
 				if (adjusted) return true;
 			}
 
@@ -462,6 +495,51 @@ export class RetryHandler {
 			maxAttempts: this._deps.settingsManager.getRetrySettings().maxRetries,
 			delayMs: 0,
 			errorMessage: `${message.errorMessage} (reducing max tokens)`,
+		});
+
+		this._scheduleContinue(retryGeneration);
+		return true;
+	}
+
+	/**
+	 * Attempt a same-model retry by reducing maxTokens when the provider reports
+	 * that input + requested output tokens exceed the context window.
+	 */
+	private _tryMaxTokensOverflowRetry(message: AssistantMessage, retryGeneration: number): boolean {
+		const currentModel = this._deps.getModel();
+		if (!currentModel || !message.errorMessage) return false;
+
+		const parsed = parseMaxTokensOverflow(message.errorMessage);
+		if (!parsed) return false;
+
+		const available = currentModel.contextWindow - parsed.inputTokens;
+		if (available <= 64) return false;
+
+		const targetMaxTokens = Math.max(64, Math.floor(available * 0.9));
+		if (targetMaxTokens >= currentModel.maxTokens) return false;
+
+		const downgradedModel = {
+			...currentModel,
+			maxTokens: targetMaxTokens,
+		};
+
+		this._deps.agent.setModel(downgradedModel);
+		this._deps.onModelChange(downgradedModel);
+		this._removeLastAssistantError();
+
+		this._deps.emit({
+			type: "fallback_provider_switch",
+			from: `${currentModel.provider}/${currentModel.id} (maxTokens=${currentModel.maxTokens})`,
+			to: `${downgradedModel.provider}/${downgradedModel.id} (maxTokens=${targetMaxTokens})`,
+			reason: `context overflow: input ${parsed.inputTokens} tokens, reducing output to ${targetMaxTokens}`,
+		});
+
+		this._deps.emit({
+			type: "auto_retry_start",
+			attempt: this._retryAttempt + 1,
+			maxAttempts: this._deps.settingsManager.getRetrySettings().maxRetries,
+			delayMs: 0,
+			errorMessage: `${message.errorMessage} (reducing max tokens to fit context)`,
 		});
 
 		this._scheduleContinue(retryGeneration);


### PR DESCRIPTION
Closes #5417

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Allow maxTokens-caused context overflow to be retried by reducing maxTokens.
**Why:** `isRetryableError()` excludes all context overflow, but maxTokens overflow is fixable without compaction.
**How:** Distinguish "requested N output tokens" errors from conversation-length overflow, then retry with reduced maxTokens.

## What

Changes to `packages/pi-coding-agent/src/core/retry-handler.ts`:

1. New `isMaxTokensOverflow()` helper — regex detects errors that specifically mention "requested N output tokens and your prompt contains M input tokens"
2. Modified `isRetryableError()` — context overflow is now retryable when `isMaxTokensOverflow` matches
3. New `_tryMaxTokensOverflowRetry()` — parses the error to extract input token count, computes `available = contextWindow - inputTokens`, sets `maxTokens = floor(available * 0.9)`, and retries

## Why

`isRetryableError()` returns false for all context overflow errors, deferring them to compaction. But when the error says "requested 16384 output tokens and your prompt contains 16385 input tokens", the problem is `maxTokens` — not conversation length. Compaction compresses message history; it cannot reduce the system prompt or maxTokens. The model appears permanently broken to the user.

## How

The fix distinguishes two types of context overflow:

| Error pattern | Cause | Fix |
|---|---|---|
| "prompt is too long: X tokens > Y maximum" | Conversation too long | Compaction (existing) |
| "requested N output tokens...contains M input tokens" | maxTokens too high | Reduce maxTokens and retry (this PR) |

The regex `/requested\s+[\d,]+\s+output tokens.*(?:contains|at least)\s+[\d,]+\s+input/i` matches only the second pattern. The retry follows the same structure as `_tryAffordableMaxTokensRetry()`.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-ai` — AI/LLM layer
- [x] `pi-coding-agent` — Coding agent
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included — 3 regression tests in `retry-handler.test.ts`:
  - `classifies 'requested N output tokens' overflow as retryable` — fails before fix, passes after
  - `does NOT classify generic context overflow as retryable` — ensures compaction path unchanged
  - `reduces maxTokens and retries on overflow` — verifies the full retry flow
- [x] Manual testing — `gsd --model amazon-bedrock/qwen.qwen3-32b-v1:0 --print "2+2"` now retries with reduced maxTokens instead of failing

## AI disclosure

- [x] This PR includes AI-assisted code — developed with Kiro CLI, verified via test suite (21/21 pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry mechanism now detects token-capacity overflow, automatically reduces requested token limits, and retries with a downgraded request to improve success rates when models reject large outputs.

* **Tests**
  * Added tests covering overflow detection, retry eligibility, automatic token-limit adjustment, and the fallback retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->