### PR TITLE
ci: gate expensive PR jobs behind build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,7 @@ jobs:
     # ABI, migration chain, etc.) - see tests/e2e/README.md.
     # No untrusted GitHub event input is consumed in run: blocks.
     timeout-minutes: 15
-    needs: [detect-changes, mergeability-gate]
+    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
     if: needs.detect-changes.outputs.docs-only != 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
@@ -432,7 +432,7 @@ jobs:
     # tarball files. Gated by detect-changes so doc-only PRs skip it.
     # No untrusted GitHub event input is consumed in run: blocks.
     timeout-minutes: 20
-    needs: [detect-changes, ci-circuit-breaker-fast, mergeability-gate]
+    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
     if: >-
       needs.detect-changes.outputs.docs-only != 'true' &&
       needs.detect-changes.outputs.docker-changed == 'true' &&
@@ -462,68 +462,12 @@ jobs:
       - name: Run docker e2e suite
         run: npm run test:e2e:docker
 
-  e2e-windows:
-    # Runs the same `tests/e2e/` suite as the Linux `e2e` job, but on
-    # Windows. Catches Windows-specific regressions in path handling,
-    # temp-dir canonicalization, child-process env, and binary loader
-    # behavior that Linux/darwin runners miss.
-    #
-    # Non-blocking on purpose: continue-on-error is true while the
-    # surface stabilizes. Promotion criterion: 5 consecutive green runs
-    # on the same suite scope as the Linux `e2e` job, then drop the
-    # continue-on-error.
-    #
-    # No untrusted GitHub event input is consumed in run: blocks.
-    timeout-minutes: 10
-    needs: [detect-changes, ci-circuit-breaker-fast, mergeability-gate]
-    if: >-
-      needs.detect-changes.outputs.docs-only != 'true' &&
-      needs.detect-changes.outputs.windows-e2e-changed == 'true' &&
-      needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
-    runs-on: blacksmith-4vcpu-windows-2025
-    continue-on-error: true
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'npm'
-
-      - name: Install dependencies
-        env:
-          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
-          GSD_SKIP_RTK_INSTALL: '1'
-        run: npm ci
-
-      - name: Build core
-        run: npm run build:core
-
-      - name: Run e2e suite (against built binary)
-        shell: bash
-        run: |
-          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
-          npm run test:e2e:windows-smoke
-
-      - name: Upload e2e artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-artifacts-windows
-          path: test-results/e2e
-          if-no-files-found: ignore
-          retention-days: 7
-
   e2e-windows-full:
     # Full Windows e2e is still exploratory. It has previously hung after
     # fake-LLM failures while child services remained alive, so keep it
     # manual until that suite is stable enough to promote.
     timeout-minutes: 25
-    needs: [detect-changes, ci-circuit-breaker-fast, mergeability-gate]
+    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.event.inputs.full_windows_e2e == 'true' &&
@@ -576,7 +520,7 @@ jobs:
     #
     # No untrusted GitHub event input is consumed in run: blocks.
     timeout-minutes: 15
-    needs: [detect-changes, ci-circuit-breaker-fast, mergeability-gate]
+    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
     if: >-
       needs.detect-changes.outputs.docs-only != 'true' &&
       needs.detect-changes.outputs.studio-changed == 'true' &&
@@ -606,11 +550,15 @@ jobs:
         run: xvfb-run --auto-servernum npm run test:e2e -w @gsd/studio
 
   windows-portability:
+    # Consolidates the blocking Windows portability checks with the
+    # non-blocking Windows e2e smoke suite. When both path filters match, this
+    # avoids a second Windows runner, npm install, and build:core invocation.
     timeout-minutes: 25
     needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
     if: >-
       needs.detect-changes.outputs.docs-only != 'true' &&
-      needs.detect-changes.outputs.portability-changed == 'true' &&
+      (needs.detect-changes.outputs.portability-changed == 'true' ||
+       needs.detect-changes.outputs.windows-e2e-changed == 'true') &&
       needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-windows-2025
 
@@ -637,18 +585,56 @@ jobs:
         run: npm run build:core
 
       - name: Typecheck extensions
+        if: needs.detect-changes.outputs.portability-changed == 'true'
         run: npm run typecheck:extensions
 
       - name: Run package tests
+        if: needs.detect-changes.outputs.portability-changed == 'true'
         run: npm run test:packages
 
       - name: Run Windows portability tests
+        if: needs.detect-changes.outputs.portability-changed == 'true'
         run: >-
           node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs
           --experimental-strip-types --test
           src/tests/windows-portability.test.ts
           src/resources/extensions/gsd/tests/validate-directory.test.ts
           src/tests/integration/web-mode-windows-hide.test.ts
+
+      - name: Run Windows e2e smoke suite (non-blocking)
+        id: windows-smoke-e2e
+        if: needs.detect-changes.outputs.windows-e2e-changed == 'true'
+        timeout-minutes: 10
+        shell: bash
+        continue-on-error: true
+        run: |
+          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          npm run test:e2e:windows-smoke
+
+      - name: Upload Windows e2e artifacts on failure
+        if: steps.windows-smoke-e2e.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-artifacts-windows
+          path: test-results/e2e
+          if-no-files-found: ignore
+          retention-days: 7
+
+  e2e-windows:
+    # Compatibility/status shim to preserve the historical e2e-windows check
+    # name while the smoke suite runs in windows-portability.
+    timeout-minutes: 5
+    needs: [detect-changes, mergeability-gate, windows-portability]
+    if: >-
+      always() &&
+      needs.detect-changes.outputs.docs-only != 'true' &&
+      needs.detect-changes.outputs.windows-e2e-changed == 'true' &&
+      needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Windows smoke moved to windows-portability
+        run: echo "Windows e2e smoke now runs in windows-portability."
 
   rtk-portability:
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       docs-only: ${{ steps.check.outputs.docs-only }}
+      heavy-code-changed: ${{ steps.check.outputs.heavy-code-changed }}
       portability-changed: ${{ steps.check.outputs.portability-changed }}
       windows-e2e-changed: ${{ steps.check.outputs.windows-e2e-changed }}
       docker-changed: ${{ steps.check.outputs.docker-changed }}
@@ -71,6 +72,15 @@ jobs:
             echo "docs-only=false" >> "$GITHUB_OUTPUT"
             echo "Non-docs files changed:"
             echo "$NON_DOCS"
+          fi
+          HEAVY_CODE=$(echo "$NON_DOCS" | grep -E '^(src/|packages/|native/|scripts/|web/|studio/|extensions/|tests/|Dockerfile$|docker/|package\.json$|package-lock\.json$|tsconfig[^/]*\.json$|packages/.*/tsconfig\.json$)' || true)
+          if [ -n "$HEAVY_CODE" ]; then
+            echo "heavy-code-changed=true" >> "$GITHUB_OUTPUT"
+            echo "Build/runtime-relevant files changed:"
+            echo "$HEAVY_CODE"
+          else
+            echo "heavy-code-changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No build/runtime-relevant changes detected — skipping heavy build/test jobs"
           fi
           PORTABILITY=$(echo "$NON_DOCS" | grep -E '^(src/|packages/|native/|scripts/|web/|package\.json$|package-lock\.json$|web/package-lock\.json$|tsconfig[^/]*\.json$|packages/.*/tsconfig\.json$)' || true)
           if [ -n "$PORTABILITY" ]; then
@@ -239,7 +249,7 @@ jobs:
   build:
     timeout-minutes: 25
     needs: [detect-changes, ci-circuit-breaker-fast, mergeability-gate]
-    if: needs.detect-changes.outputs.docs-only != 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
+    if: needs.detect-changes.outputs.heavy-code-changed == 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -297,7 +307,7 @@ jobs:
     timeout-minutes: 2
     needs: [detect-changes, build, mergeability-gate]
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: always() && needs.detect-changes.outputs.docs-only != 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
+    if: always() && needs.detect-changes.outputs.heavy-code-changed == 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     steps:
       - name: Stop pipeline when build gate fails
         env:
@@ -311,7 +321,7 @@ jobs:
   integration-tests:
     timeout-minutes: 15
     needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
-    if: needs.detect-changes.outputs.docs-only != 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
+    if: needs.detect-changes.outputs.heavy-code-changed == 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -358,7 +368,7 @@ jobs:
     # No untrusted GitHub event input is consumed in run: blocks.
     timeout-minutes: 10
     needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
-    if: needs.detect-changes.outputs.docs-only != 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
+    if: needs.detect-changes.outputs.heavy-code-changed == 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -391,7 +401,7 @@ jobs:
     # No untrusted GitHub event input is consumed in run: blocks.
     timeout-minutes: 15
     needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
-    if: needs.detect-changes.outputs.docs-only != 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
+    if: needs.detect-changes.outputs.heavy-code-changed == 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -425,6 +435,32 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  ci-circuit-breaker-linux-runtime:
+    timeout-minutes: 2
+    needs: [detect-changes, mergeability-gate, integration-tests, live-regression, e2e]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: always() && needs.detect-changes.outputs.heavy-code-changed == 'true' && needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
+    steps:
+      - name: Stop expanded CI when Linux runtime fails
+        env:
+          INTEGRATION_TESTS: ${{ needs.integration-tests.result }}
+          LIVE_REGRESSION: ${{ needs.live-regression.result }}
+          E2E: ${{ needs.e2e.result }}
+        run: |
+          failed=0
+          for check in \
+            "integration-tests=$INTEGRATION_TESTS" \
+            "live-regression=$LIVE_REGRESSION" \
+            "e2e=$E2E"
+          do
+            result="${check#*=}"
+            if [ "$result" != "success" ]; then
+              echo "::error::Linux runtime gate failed ($check). Cancelling expanded CI jobs."
+              failed=1
+            fi
+          done
+          exit "$failed"
+
   docker-e2e:
     # Builds the runtime-local Dockerfile target from the current source
     # (npm pack + COPY into image) and runs `gsd --version` inside the
@@ -432,9 +468,9 @@ jobs:
     # tarball files. Gated by detect-changes so doc-only PRs skip it.
     # No untrusted GitHub event input is consumed in run: blocks.
     timeout-minutes: 20
-    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
+    needs: [detect-changes, ci-circuit-breaker-linux-runtime, mergeability-gate]
     if: >-
-      needs.detect-changes.outputs.docs-only != 'true' &&
+      needs.detect-changes.outputs.heavy-code-changed == 'true' &&
       needs.detect-changes.outputs.docker-changed == 'true' &&
       needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -467,11 +503,11 @@ jobs:
     # fake-LLM failures while child services remained alive, so keep it
     # manual until that suite is stable enough to promote.
     timeout-minutes: 25
-    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
+    needs: [detect-changes, ci-circuit-breaker-linux-runtime, mergeability-gate]
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.event.inputs.full_windows_e2e == 'true' &&
-      needs.detect-changes.outputs.docs-only != 'true' &&
+      needs.detect-changes.outputs.heavy-code-changed == 'true' &&
       needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-windows-2025
     continue-on-error: true
@@ -520,9 +556,9 @@ jobs:
     #
     # No untrusted GitHub event input is consumed in run: blocks.
     timeout-minutes: 15
-    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
+    needs: [detect-changes, ci-circuit-breaker-linux-runtime, mergeability-gate]
     if: >-
-      needs.detect-changes.outputs.docs-only != 'true' &&
+      needs.detect-changes.outputs.heavy-code-changed == 'true' &&
       needs.detect-changes.outputs.studio-changed == 'true' &&
       needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -554,9 +590,9 @@ jobs:
     # non-blocking Windows e2e smoke suite. When both path filters match, this
     # avoids a second Windows runner, npm install, and build:core invocation.
     timeout-minutes: 25
-    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
+    needs: [detect-changes, ci-circuit-breaker-linux-runtime, mergeability-gate]
     if: >-
-      needs.detect-changes.outputs.docs-only != 'true' &&
+      needs.detect-changes.outputs.heavy-code-changed == 'true' &&
       (needs.detect-changes.outputs.portability-changed == 'true' ||
        needs.detect-changes.outputs.windows-e2e-changed == 'true') &&
       needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
@@ -627,7 +663,7 @@ jobs:
     needs: [detect-changes, mergeability-gate, windows-portability]
     if: >-
       always() &&
-      needs.detect-changes.outputs.docs-only != 'true' &&
+      needs.detect-changes.outputs.heavy-code-changed == 'true' &&
       needs.detect-changes.outputs.windows-e2e-changed == 'true' &&
       needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -638,9 +674,9 @@ jobs:
 
   rtk-portability:
     timeout-minutes: 20
-    needs: [detect-changes, ci-circuit-breaker-build, mergeability-gate]
+    needs: [detect-changes, ci-circuit-breaker-linux-runtime, mergeability-gate]
     if: >-
-      needs.detect-changes.outputs.docs-only != 'true' &&
+      needs.detect-changes.outputs.heavy-code-changed == 'true' &&
       needs.detect-changes.outputs.rtk-changed == 'true' &&
       needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,12 +502,16 @@ jobs:
     # Full Windows e2e is still exploratory. It has previously hung after
     # fake-LLM failures while child services remained alive, so keep it
     # manual until that suite is stable enough to promote.
+    #
+    # ci-circuit-breaker-linux-runtime is intentionally excluded from needs:
+    # if it were included and got skipped (heavy-code-changed=false), this job
+    # would also be silently skipped even on explicit workflow_dispatch, breaking
+    # the "human override always runs" contract.
     timeout-minutes: 25
-    needs: [detect-changes, ci-circuit-breaker-linux-runtime, mergeability-gate]
+    needs: [detect-changes, mergeability-gate]
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.event.inputs.full_windows_e2e == 'true' &&
-      needs.detect-changes.outputs.heavy-code-changed == 'true' &&
       needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-windows-2025
     continue-on-error: true
@@ -677,11 +681,19 @@ jobs:
     steps:
       - name: Report Windows smoke outcome
         env:
-          SMOKE_RESULT: ${{ needs.windows-portability.result == 'skipped' && 'skipped' || (needs.windows-portability.outputs.smoke_result || 'skipped') }}
+          PORTABILITY_RESULT: ${{ needs.windows-portability.result }}
+          SMOKE_RESULT: ${{ needs.windows-portability.outputs.smoke_result }}
         run: |
           echo "Windows e2e smoke runs in windows-portability."
-          echo "Smoke step outcome: $SMOKE_RESULT"
-          case "$SMOKE_RESULT" in
+          echo "windows-portability result: $PORTABILITY_RESULT"
+          echo "Smoke step outcome: ${SMOKE_RESULT:-<unset>}"
+          # If the upstream job failed/cancelled before the smoke step ran,
+          # surface that instead of mis-reporting it as "did not run".
+          if [ -z "$SMOKE_RESULT" ] && [ "$PORTABILITY_RESULT" != "success" ] && [ "$PORTABILITY_RESULT" != "skipped" ]; then
+            echo "::warning::windows-portability ended in $PORTABILITY_RESULT before Windows e2e smoke ran (non-blocking). See windows-portability logs."
+            exit 1
+          fi
+          case "${SMOKE_RESULT:-skipped}" in
             success)
               echo "::notice::Windows e2e smoke succeeded."
               ;;
@@ -689,7 +701,7 @@ jobs:
               echo "::warning::Windows e2e smoke failed (non-blocking). See windows-portability artifacts."
               exit 1
               ;;
-            skipped|"")
+            skipped)
               echo "::notice::Windows e2e smoke did not run (no relevant changes)."
               ;;
             *)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,6 +597,8 @@ jobs:
        needs.detect-changes.outputs.windows-e2e-changed == 'true') &&
       needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-windows-2025
+    outputs:
+      smoke_result: ${{ steps.windows-smoke-e2e.outcome }}
 
     steps:
       - name: Checkout repository
@@ -658,7 +660,10 @@ jobs:
 
   e2e-windows:
     # Compatibility/status shim to preserve the historical e2e-windows check
-    # name while the smoke suite runs in windows-portability.
+    # name while the smoke suite runs in windows-portability. Reflects the
+    # smoke step outcome so the failure signal is not swallowed by the
+    # upstream job's continue-on-error step. The job itself remains
+    # non-blocking via continue-on-error.
     timeout-minutes: 5
     needs: [detect-changes, mergeability-gate, windows-portability]
     if: >-
@@ -667,10 +672,30 @@ jobs:
       needs.detect-changes.outputs.windows-e2e-changed == 'true' &&
       needs.mergeability-gate.outputs.skip-heavy-jobs != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    continue-on-error: true
 
     steps:
-      - name: Windows smoke moved to windows-portability
-        run: echo "Windows e2e smoke now runs in windows-portability."
+      - name: Report Windows smoke outcome
+        env:
+          SMOKE_RESULT: ${{ needs.windows-portability.result == 'skipped' && 'skipped' || (needs.windows-portability.outputs.smoke_result || 'skipped') }}
+        run: |
+          echo "Windows e2e smoke runs in windows-portability."
+          echo "Smoke step outcome: $SMOKE_RESULT"
+          case "$SMOKE_RESULT" in
+            success)
+              echo "::notice::Windows e2e smoke succeeded."
+              ;;
+            failure)
+              echo "::warning::Windows e2e smoke failed (non-blocking). See windows-portability artifacts."
+              exit 1
+              ;;
+            skipped|"")
+              echo "::notice::Windows e2e smoke did not run (no relevant changes)."
+              ;;
+            *)
+              echo "::notice::Windows e2e smoke outcome: $SMOKE_RESULT"
+              ;;
+          esac
 
   rtk-portability:
     timeout-minutes: 20


### PR DESCRIPTION
## Linked issue

Closes #5419

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Gates expensive PR CI by changed-file impact, build success, and Linux runtime success while consolidating duplicated Windows smoke work.
**Why:** PR CI was spending Linux, Docker, Studio, Windows, and macOS runner minutes on jobs that were unnecessary for docs/non-code chores or invalidated by earlier failures.
**How:** Adds `heavy-code-changed`, stages expanded CI behind circuit breakers, preserves existing check names, and runs Windows e2e smoke inside `windows-portability` instead of launching a second Windows runner.

## What

This changes the main CI workflow only:

- Adds a `heavy-code-changed` output in `detect-changes` for build/runtime-relevant paths.
- Skips `build` and downstream heavy jobs for docs-only and non-code chore changes such as workflow-only edits.
- Keeps source/runtime/build-input changes on the full build and test path.
- `e2e`, `docker-e2e`, `studio-e2e`, and manual full Windows e2e wait for circuit breakers instead of starting immediately after fast gates.
- Adds `ci-circuit-breaker-linux-runtime` so Docker, Studio, Windows, and RTK jobs wait for `integration-tests`, `live-regression`, and Linux `e2e`.
- `windows-portability` also runs the non-blocking Windows e2e smoke suite when Windows e2e-relevant paths change.
- The old separate Windows smoke job is replaced by an `e2e-windows` compatibility/status job so the PR check name remains present.
- The Windows smoke step keeps its 10-minute timeout and `continue-on-error` behavior.

## Why

Recent PR CI runs showed expensive jobs starting while the comprehensive `build` job was still running. When `build` later failed or the run was cancelled, those early e2e/Docker/Windows jobs had already consumed runner time.

The previous `docs-only` gate was also too coarse: `.github/workflows/ci.yml` is non-docs, so a CI-only chore triggered the full product build even when no product/runtime code changed.

This is particularly inefficient on Windows because `e2e-windows` and `windows-portability` could both perform checkout, Node setup, `npm ci`, and `build:core` for the same PR.

## How

The implementation keeps the change conservative:

- Classifies heavy CI by build/runtime-relevant paths instead of using only `docs-only`.
- Uses existing check names where practical to avoid branch-protection churn.
- Adds one internal circuit-breaker job after Linux runtime checks to stage optional expensive platforms and suites.
- Consolidates only the duplicated Windows smoke work that can share the existing Windows portability setup.
- Defers higher-risk optimizations, such as sharing build artifacts or splitting RTK matrix check names, to separate follow-up PRs after this topology change is observed in CI.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [x] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [x] No tests needed — explained above

Manual validation performed:

- `node -e "require('yaml').parse(require('fs').readFileSync('.github/workflows/ci.yml','utf8')); console.log('workflow yaml ok')"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'ruby yaml ok'"`
- `git diff --check`
- `node scripts/ci_monitor.cjs list-workflows --repo gsd-build/gsd-2`
- Static dependency assertions confirmed that `build` uses `heavy-code-changed`, the Linux runtime circuit breaker exists, and Docker/Windows/RTK jobs wait for `ci-circuit-breaker-linux-runtime`.
- Changed-file classifier assertions confirmed:
  - `.github/workflows/ci.yml` -> `heavy-code-changed=false`
  - docs-only changes -> `heavy-code-changed=false`
  - issue-template changes -> `heavy-code-changed=false`
  - `src/loader.ts` -> `heavy-code-changed=true`
  - `package-lock.json` -> `heavy-code-changed=true`
  - `scripts/install.js` -> `heavy-code-changed=true`
  - `tests/e2e/sanity.e2e.test.ts` -> `heavy-code-changed=true`
- Confirmed all `node-version` values in `ci.yml` remain `24`.

`node scripts/ci_monitor.cjs check-actions .github/workflows/ci.yml` was attempted but the script could not connect to `api.github.com` from this environment. This PR does not change action versions.

`npm run verify:pr` was attempted but fails in this local temp worktree while building `@gsd/native` because Node globals/types such as `Buffer`, `process`, and `node:path` are not resolving for that workspace. This PR only changes GitHub Actions YAML, and CI will run the authoritative environment after submission.

## AI disclosure

- [x] This PR includes AI-assisted code. The workflow topology was designed and edited with AI assistance, then validated with local workflow syntax, dependency, and changed-file classification checks described above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI gating reworked to run full suites only for substantial code changes, reducing unnecessary runs.
  * New Linux runtime fast-fail gate stops expanded CI when runtime checks fail.
  * Windows portability and non-blocking e2e smoke flows consolidated with improved outcome surfacing and artifact collection.
  * Studio and RTK test gating aligned with heavy-change signaling for more targeted test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
