### PR TITLE
docs: document stale PR closure policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,6 +239,14 @@ PRs go through automated review first, then human review. To help us review effi
 - Respond to review comments. If you disagree, explain why — discussion is welcome.
 - If your PR has been open for a while without review, ping in Discord. We're a small team and things slip.
 
+### Stale or unreviewable PRs
+
+Keep open PRs in a reviewable, merge-ready state. For PR authors below maintainer level, PRs that remain blocked by failing CI, merge conflicts, or requested follow-up for more than 3 days may be closed without merge. Prior contributor status is not an exemption; the exemption is maintainer-level repository access.
+
+If your PR is closed for staleness, you are welcome to resubmit when you are ready to bring it back in an issue-free, reviewable state. Closing stale PRs is queue management, not a rejection of future work on the same idea.
+
+Maintainer-level PRs are not auto-closed under this policy, but they may receive a reminder comment asking the author to finish the PR or close it if it is no longer moving.
+
 ### 72-hour response policy
 
 Once a maintainer leaves review feedback, you have **72 hours** to respond — either with a code update, a question, or a comment explaining your timeline. We reserve the right to close PRs that go silent past 72 hours. Closed PRs can be reopened once you're ready to engage; we're not trying to throw away your work, we're trying to keep the review queue honest about what's actually moving.


### PR DESCRIPTION
## Linked issue

Closes #5422

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Documents the stale/unreviewable PR policy in `CONTRIBUTING.md`.
**Why:** Contributors need clear expectations for PRs that remain blocked by CI failures, merge conflicts, or missing follow-up.
**How:** Adds a review-process section covering the 3-day non-maintainer auto-close rule, maintainer-level reminder behavior, and resubmission path.

## What

Adds a `Stale or unreviewable PRs` section to `CONTRIBUTING.md`.

The policy states that:

- PRs from authors below maintainer level may be closed if they stay blocked for more than 3 days.
- Prior contributor status is not an exemption; maintainer-level repository access is the exemption.
- Maintainer-level stale PRs are not auto-closed, but may receive a reminder to finish or close.
- Closed stale PRs can be resubmitted when ready for review.

## Why

This makes review-queue management explicit and gives contributors a published expectation before stale PRs are closed.

## How

This is documentation-only. No runtime behavior changes.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [ ] Manual testing — steps described above
- [x] No tests needed — documentation-only change

Validation performed:

- `git diff --check`

## AI disclosure

- [x] This PR includes AI-assisted documentation. The policy wording was edited with AI assistance and reviewed against the maintainer's requested behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with new policy guidance on closing stale or unreviewable pull requests, including specific closure conditions and resubmission procedures for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->