### PR TITLE
fix(pi-coding-agent): persist sql.js snapshots atomically

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,10 @@
 - **Health adapter**: adapter behind the Health seam.
 - **Runtime persistence adapter**: adapter behind the Runtime persistence seam.
 - **Notification adapter**: adapter behind the Notification seam.
+- **State Reconciliation module**: module that reconciles DB-authoritative runtime state with durable disk projections before a Dispatch decision.
+- **Worktree Safety module**: module that validates project root, worktree registration, lease ownership, and git health before a source-writing Unit runs.
+- **Recovery Classification module**: module that maps provider, tool, policy, git, worktree, and runtime failures to a Recovery decision.
+- **Tool Contract module**: module that keeps Unit prompts, tool schemas, tool policy, and pre-dispatch validation aligned.
 
 ## Current decision in force
 
@@ -30,6 +34,19 @@
 
 See `docs/dev/ADR-014-auto-orchestration-deep-module.md`.
 
+- Runtime invariants should deepen into four first-class modules: State Reconciliation, Worktree Safety, Recovery Classification, and Tool Contract.
+
+See `docs/dev/ADR-015-runtime-invariant-modules.md`.
+
+- Auto Orchestration `advance()` should call invariant modules explicitly in sequence rather than hiding the pre-dispatch pipeline inside the Dispatch adapter:
+  - State Reconciliation
+  - Dispatch decision
+  - Tool Contract
+  - Worktree Safety
+  - Runtime persistence/journal
+
+Dispatch remains responsible for selecting the next Unit from reconciled state. It should not own DB/disk repair, tool-policy compilation, or worktree root preparation.
+
 ## Current implementation snapshot (phase 1)
 
 - `auto.ts` now wires a concrete Auto Orchestration module through `createWiredAutoOrchestrationModule(...)`.
@@ -37,3 +54,126 @@ See `docs/dev/ADR-014-auto-orchestration-deep-module.md`.
 - Runtime snapshot exports orchestration telemetry (`orchestrationPhase`, `orchestrationTransitionCount`, `orchestrationLastTransitionAt`).
 - Initial adapters are live for Dispatch, Health, and Runtime persistence seams.
 - Main auto-loop dispatch is still the existing path; orchestration seam is integrated incrementally for lifecycle and observability.
+
+## Triage synthesis (2026-05-05)
+
+Recent triage showed repeated failures concentrated in orchestration state coherence, worktree hygiene, and tool-surface contracts.
+
+### Common issue families
+
+- **State drift between DB, disk artifacts, and in-memory loop state**
+- Stale flags/rows repeatedly re-dispatch units (`is_sketch`, stale worker/lock, stale sequence/dependency rows)
+- Disk artifacts exist but DB status lags or never reconciles (`PROJECT.md` milestone registration, completion timestamps, roadmap divergence)
+- Recovery helpers exist but are not wired into dispatch/state derivation paths
+
+- **Worktree lifecycle and path-root ambiguity**
+- Units dispatch into ghost/invalid worktree roots (`.git` missing, fallback path-only creation, non-worktree git operations)
+- Health checks are unit-specific instead of lifecycle-wide, allowing earlier units to write in invalid roots
+- Worktree exit/merge decisions rely on brittle artifact signals instead of authoritative branch/commit state
+
+- **Auto-loop recovery policy gaps**
+- Deterministic and schema-validation failure modes are misclassified as generic provider failures
+- Retry counters and stuck-loop controls are inconsistently keyed or reset across pause/resume boundaries
+- Terminal guardrails are bypassed in side branches (e.g., complete-milestone placeholder behavior)
+
+- **Tool contract mismatches**
+- Prompt/tool/schema drift causes repeated invalid calls (`gsd_exec` runtime enums, closeout prompts vs policy constraints)
+- Tool availability/surface inconsistencies under session boot/registration timing
+- Validation happens too late (pre-exec catches issues that planner tools should reject upfront)
+
+- **Provider/platform integration edge cases**
+- Windows process/pipe semantics (`EOF`/abort timing) not normalized with POSIX assumptions
+- Provider-specific metadata/capabilities not fully surfaced (reasoning support, context budgeting semantics, model override behavior)
+
+- **Telemetry and diagnosis blind spots**
+- Exit reasons collapse into `other`, masking repeatable failure classes
+- Missing/imbalanced lifecycle events (`iteration-end`, dispatch/settlement gaps) weaken forensics and automated recovery decisions
+
+### Priority review focus areas
+
+- **Dispatch and state derivation invariants**
+- Verify every state gate has a deterministic DB+disk reconciliation path before dispatch
+- Ensure sketch/refine/plan transitions clear lifecycle flags atomically
+
+- **Recovery and error classification**
+- Add explicit classes for tool-schema overload, deterministic policy blocks, stale worker states, and worktree invalidity
+- Ensure each class maps to an intentional action (`retry`, `pause with remediation`, `self-heal`, `stop`)
+
+- **Worktree safety envelope**
+- Enforce root validity checks for all source-writing unit types, not only `execute-task`
+- Fail closed on worktree creation/registration errors; do not spawn workers into unresolved paths
+
+- **Prompt-policy-tool alignment**
+- Review every unit prompt against effective tools policy and schema enums
+- Remove contradictory instructions (e.g., “fix failures” where policy forbids writes)
+
+- **Migration and reconciliation**
+- Add startup and pre-dispatch reconciliation for PROJECT/ROADMAP/DB drift
+- Persist completion metadata consistently during recover/import flows
+
+- **Observability completeness**
+- Normalize exit reasons with dedicated buckets
+- Guarantee dispatch lifecycle event pairs and settlement records for each unit attempt
+
+### Deepening opportunities from triage
+
+#### State Reconciliation module
+
+- Files: `state.ts`, `gsd-db.ts`, `db-writer.ts`, `md-importer.ts`, `auto-recovery.ts`, PROJECT/ROADMAP parsers
+- Problem: DB rows, markdown projections, and cached state are reconciled opportunistically. Helpers such as sketch-flag repair exist but are not wired into the state path, so bugs reappear as wrong Dispatch decisions.
+- Refactor target: expose one pre-dispatch reconciliation Interface, e.g. `reconcileBeforeDispatch(basePath)`, that refreshes DB reads, repairs known projection drift, returns blocking inconsistencies, and invalidates derived-state caches.
+- Leverage: Dispatch and recovery callers stop needing to know each artifact-specific repair rule.
+- Locality: sketch flags, PROJECT milestone registration, ROADMAP sequence/dependency sync, completion timestamps, and artifact/DB mismatch handling move into one module.
+- Test focus: call the Interface with DB+disk fixture states and assert the resulting state changes or blockers.
+
+#### Worktree Safety module
+
+- Files: `worktree-resolver.ts`, `auto/phases.ts`, `auto-worktree.ts`, `worktree-manager.ts`, parallel and slice-parallel orchestrators, git helpers
+- Problem: worktree validity is checked in scattered, unit-specific places. Some paths build a worktree path string without proving it is registered, has `.git`, owns the lease, and matches `GSD_PROJECT_ROOT`.
+- Refactor target: expose one Interface for source-writing Units, e.g. `prepareUnitRoot(unitType, unitId)`, that returns a valid root or a typed `worktree-invalid` Recovery decision.
+- Leverage: every source-writing Unit receives the same root validation, lease fencing, and failure classification.
+- Locality: ghost worktree, missing `.git`, stale worktree, branch/HEAD mismatch, and worktree cleanup logic are reviewed in one module.
+- Test focus: invalid root, missing `.git`, stale path-only fallback, branch mismatch, and `GSD_PROJECT_ROOT` cases.
+
+#### Recovery Classification module
+
+- Files: `error-classifier.ts`, `bootstrap/agent-end-recovery.ts`, `auto-post-unit.ts`, `auto-timeout-recovery.ts`, `crash-recovery.ts`, `provider-error-pause.ts`
+- Problem: recovery behavior is distributed across provider handlers, post-unit verification, timeout recovery, and crash cleanup. New deterministic failures often fall through as generic provider errors or `other` exit reasons.
+- Refactor target: expose one failure taxonomy Interface, e.g. `classifyFailure(input) -> Recovery decision`, with explicit classes for tool schema, deterministic policy, stale worker, worktree invalid, provider quota, network, and verification drift.
+- Leverage: callers ask for a Recovery decision instead of re-implementing retry/pause/stop semantics.
+- Locality: bounded retries, pause messages, auto-resume behavior, exit reason normalization, and telemetry buckets are changed together.
+- Test focus: table-driven classification and action tests covering every known triage failure family.
+
+#### Tool Contract module
+
+- Files: `unit-context-manifest.ts`, prompts under `prompts/`, `bootstrap/write-gate.ts`, `bootstrap/exec-tools.ts`, `workflow-tool-executors.ts`, `pre-execution-checks.ts`, `tools/plan-slice.ts`
+- Problem: Unit prompts, tool schemas, and tool policy drift independently. The model can be instructed to do work the policy blocks, or call a schema value the tool rejects. Some validation waits until after planning artifacts are committed.
+- Refactor target: compile a Unit Tool Contract before dispatch that includes prompt obligations, allowed tools, schema enum values, validation requirements, and closeout tools.
+- Leverage: prompt authors and dispatch code get one reviewable contract per Unit type.
+- Locality: prompt wording, policy gates, schema descriptions, and planner-time validation stop drifting across files.
+- Test focus: prompt/policy/schema parity tests and planner tool validation tests for concrete task inputs.
+
+#### Auto Orchestration adapter depth pass
+
+- Files: `auto/orchestrator.ts`, `auto/contracts.ts`, `auto/phases.ts`, `auto.ts`, `auto-post-unit.ts`
+- Problem: ADR-014 introduced adapter seams, but adapter boundaries can become too shallow if Dispatch hides unrelated pre-dispatch invariants. That would make `advance()` look simple while preserving the same cross-cutting state repair, tool-contract, and worktree-safety coupling behind a larger Dispatch adapter.
+- Refactor target: keep `advance()` as the explicit lifecycle pipeline owner. It should call State Reconciliation before Dispatch, then call Tool Contract and Worktree Safety checks for the selected Unit before persisting/journaling the transition.
+- Leverage: reviewers can inspect orchestration ordering in one place, tests can assert the invariant sequence directly, and each adapter stays deep around one concern.
+- Locality: orchestration flow remains in Auto Orchestration; invariant modules own their own policy; Dispatch only selects the next Unit from reconciled state.
+- Test focus: contract tests for `advance()` ordering, short-circuit behavior, idempotency for the same reconciled snapshot, and typed failure handoff to Recovery Classification.
+
+### Refactor order
+
+- Start with the **Auto Orchestration adapter depth pass** so `advance()` has an explicit invariant pipeline before individual modules are extracted underneath it.
+- Then implement the **State Reconciliation module** and **Worktree Safety module**. They address the highest-cost loops and prevent invalid Dispatch decisions before a model turn is launched.
+- Follow with the **Recovery Classification module** to normalize outcomes once invalid runtime states are no longer the dominant source of noise.
+- Then add the **Tool Contract module** to prevent prompt/schema/policy drift from creating new recovery cases.
+
+### Standing review checklist for this context
+
+- Is DB state authoritative, and if yes, where is disk->DB reconciliation guaranteed?
+- Can this unit dispatch into an invalid basePath/worktree and still mutate artifacts?
+- Are retry/stuck-loop counters stable across pause/resume and keyed consistently by unit identity?
+- Do prompt instructions require tools or writes blocked by the current policy?
+- Can tool schema/documentation mismatch induce repeated invalid calls?
+- Does each abnormal stop path produce a distinct reason code and actionable remediation?

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,6 +8,7 @@
 - **Dispatch decision**: selection of the next Unit plus rationale and preconditions.
 - **Recovery decision**: retry/escalate/abort choice after runtime failure.
 - **Runtime persistence**: lock state, transition journal, and any persisted execution state required for safe resume.
+- **DB snapshot persistence**: crash-safe persistence of a full SQLite image exported from `sql.js`, written as a same-directory temporary file and atomically renamed over the live database path.
 
 ## Architecture terms adopted for this area
 
@@ -18,6 +19,7 @@
 - **Health adapter**: adapter behind the Health seam.
 - **Runtime persistence adapter**: adapter behind the Runtime persistence seam.
 - **Notification adapter**: adapter behind the Notification seam.
+- **DB snapshot persistence module**: the deep module that owns `sql.js` snapshot write semantics, including temp-file naming, fsync, cleanup, and rename ordering.
 - **State Reconciliation module**: module that reconciles DB-authoritative runtime state with durable disk projections before a Dispatch decision.
 - **Worktree Safety module**: module that validates project root, worktree registration, lease ownership, and git health before a source-writing Unit runs.
 - **Recovery Classification module**: module that maps provider, tool, policy, git, worktree, and runtime failures to a Recovery decision.

--- a/docs/dev/ADR-015-runtime-invariant-modules.md
+++ b/docs/dev/ADR-015-runtime-invariant-modules.md
@@ -1,0 +1,54 @@
+# ADR-015: Make Runtime Invariants First-Class Modules
+
+**Status:** Accepted
+**Date:** 2026-05-05
+**Author:** GSD architecture review
+**Related:** ADR-009 (unified orchestration kernel), ADR-014 (deep Auto Orchestration module), ADR-001 (worktree architecture)
+
+## Context
+
+The 2026-05-05 issue triage found repeated auto-mode failures where the same invariants were checked late, checked only for some Unit types, or repaired by helper code that was not wired into the main path. The recurring classes were DB/disk state drift, invalid worktree roots, generic recovery classification, prompt/tool/schema mismatch, and weak telemetry buckets.
+
+ADR-014 already accepts a deep Auto Orchestration module. The triage evidence shows that the current adapter shape is still too shallow for the invariants that cause the most expensive failures. More local guards would reduce one bug at a time, but the same complexity would keep reappearing across Dispatch decisions, Recovery decisions, worktree handling, and Unit tool setup.
+
+## Decision
+
+Deepen four runtime-invariant modules behind the Auto Orchestration module:
+
+1. **State Reconciliation module**
+2. **Worktree Safety module**
+3. **Recovery Classification module**
+4. **Tool Contract module**
+
+Each module must expose a small Interface that callers and tests can use directly. The implementation can keep internal seams, but Dispatch decisions and Recovery decisions should not know each repair rule, worktree validity check, provider/tool failure pattern, or prompt/schema pairing.
+
+The target Interfaces are:
+
+- `reconcileBeforeDispatch(basePath)` for DB/disk/cached-state repair and blocking inconsistencies
+- `prepareUnitRoot(unitType, unitId)` for worktree/root/lease/git validation before source-writing Units
+- `classifyFailure(input)` for failure taxonomy, Recovery decision, exit reason, and user-facing remediation
+- `compileUnitToolContract(unitType)` for prompt obligations, allowed tools, schema enums, validation rules, and closeout tools
+
+The Auto Orchestration module owns the explicit `advance()` pipeline. Dispatch must not hide the whole pre-dispatch sequence. The intended order is:
+
+1. State Reconciliation
+2. Dispatch decision
+3. Tool Contract
+4. Worktree Safety
+5. Runtime persistence/journal
+
+Dispatch receives reconciled state and selects the next Unit. Tool Contract and Worktree Safety validate the selected Unit before the transition is committed or a worker is launched. Failures from any step flow through Recovery Classification with typed reasons.
+
+## Why this decision
+
+This gives the Auto Orchestration module more depth without turning it into another large mixed-concern file. It also gives tests a better surface: each known triage failure family can be tested through one Interface instead of reproducing a full auto-loop session.
+
+The deletion test supports these modules. If any of them were deleted, their complexity would reappear across `state.ts`, dispatch rules, worktree orchestration, recovery handlers, prompts, write gates, and tool registrations. Keeping the behavior local gives maintainers higher leverage and better locality.
+
+## Consequences
+
+- Targeted bug fixes should prefer adding behavior to one of these modules over adding one-off guards at call sites.
+- Existing adapter contracts from ADR-014 can stay, but their Interfaces should become invariant-oriented rather than pass-through wrappers around existing helpers.
+- Tests should move toward table-driven contract coverage for reconciliation, worktree safety, recovery classification, and tool contract parity.
+- Auto Orchestration tests should assert the `advance()` sequencing and short-circuit behavior directly so adapter depth does not regress into hidden Dispatch coupling.
+- This extends ADR-014 and does not supersede it. The Auto Orchestration module remains the owner of lifecycle control-flow; these modules own the invariants it depends on.

--- a/packages/pi-coding-agent/src/core/db-snapshot.test.ts
+++ b/packages/pi-coding-agent/src/core/db-snapshot.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, it, afterEach } from "node:test";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { atomicWriteDbSnapshotSync } from "./db-snapshot.js";
+
+describe("atomicWriteDbSnapshotSync", () => {
+	let dir: string;
+
+	afterEach(() => {
+		if (dir) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("writes the full snapshot and leaves no temp file after success", () => {
+		dir = mkdtempSync(join(tmpdir(), "gsd-db-snapshot-test-"));
+		const dbPath = join(dir, "agent.db");
+		const snapshot = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+
+		atomicWriteDbSnapshotSync(dbPath, snapshot);
+
+		assert.deepEqual(readFileSync(dbPath), Buffer.from(snapshot));
+		assert.equal(existsSync(`${dbPath}.tmp`), false);
+		assert.deepEqual(
+			readdirSync(dir).filter((entry) => entry.includes("agent.db") && entry.includes(".tmp")),
+			[],
+		);
+	});
+});

--- a/packages/pi-coding-agent/src/core/db-snapshot.ts
+++ b/packages/pi-coding-agent/src/core/db-snapshot.ts
@@ -31,6 +31,11 @@ function fsyncDirectoryBestEffort(dirPath: string): void {
  * The snapshot is written to a unique temp file in the same directory, flushed,
  * then renamed over the target. A hard kill during the temp write leaves the
  * previous target intact; after rename, readers see the complete new snapshot.
+ *
+ * The rename replaces the target inode: existing file mode/ownership is not
+ * preserved, and a symlink at dbPath is replaced rather than written through.
+ * Agent DB snapshots are owned runtime files, so this trade-off favors a
+ * private 0600 replacement over retaining prior target metadata.
  */
 export function atomicWriteDbSnapshotSync(dbPath: string, snapshot: DbSnapshot): void {
 	const dirPath = dirname(dbPath);

--- a/packages/pi-coding-agent/src/core/db-snapshot.ts
+++ b/packages/pi-coding-agent/src/core/db-snapshot.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from "node:crypto";
+import { closeSync, fsyncSync, openSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+export type DbSnapshot = Buffer | Uint8Array;
+
+function closeBestEffort(fd: number | null): void {
+	if (fd === null) return;
+	try {
+		closeSync(fd);
+	} catch {
+		// Preserve the original write/rename failure when cleaning up.
+	}
+}
+
+function fsyncDirectoryBestEffort(dirPath: string): void {
+	let fd: number | null = null;
+	try {
+		fd = openSync(dirPath, "r");
+		fsyncSync(fd);
+	} catch {
+		// Directory fsync is unsupported on some platforms/filesystems.
+	} finally {
+		closeBestEffort(fd);
+	}
+}
+
+/**
+ * Persist a sql.js database export without exposing callers to a torn live file.
+ *
+ * The snapshot is written to a unique temp file in the same directory, flushed,
+ * then renamed over the target. A hard kill during the temp write leaves the
+ * previous target intact; after rename, readers see the complete new snapshot.
+ */
+export function atomicWriteDbSnapshotSync(dbPath: string, snapshot: DbSnapshot): void {
+	const dirPath = dirname(dbPath);
+	const tmpPath = join(dirPath, `.${basename(dbPath)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`);
+	let fd: number | null = null;
+	let renamed = false;
+
+	try {
+		fd = openSync(tmpPath, "wx", 0o600);
+		writeFileSync(fd, Buffer.from(snapshot));
+		fsyncSync(fd);
+		closeSync(fd);
+		fd = null;
+
+		renameSync(tmpPath, dbPath);
+		renamed = true;
+		fsyncDirectoryBestEffort(dirPath);
+	} finally {
+		closeBestEffort(fd);
+		if (!renamed) {
+			try {
+				unlinkSync(tmpPath);
+			} catch {
+				// The temp file may not have been created yet.
+			}
+		}
+	}
+}

--- a/packages/pi-coding-agent/src/resources/extensions/memory/storage-safety-guard.test.ts
+++ b/packages/pi-coding-agent/src/resources/extensions/memory/storage-safety-guard.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+test("MemoryStorage persists sql.js snapshots through the atomic DB snapshot writer", () => {
+	const src = readFileSync(
+		join(process.cwd(), "packages", "pi-coding-agent", "src", "resources", "extensions", "memory", "storage.ts"),
+		"utf-8",
+	);
+
+	assert.match(src, /atomicWriteDbSnapshotSync\(/, "storage must use atomic DB snapshot writes");
+	assert.doesNotMatch(src, /writeFileSync\(this\.dbPath/, "direct live DB overwrite is forbidden");
+});

--- a/packages/pi-coding-agent/src/resources/extensions/memory/storage.ts
+++ b/packages/pi-coding-agent/src/resources/extensions/memory/storage.ts
@@ -9,8 +9,9 @@
 
 import initSqlJs, { type Database as SqlJsDatabase } from "sql.js";
 import { randomUUID } from "crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync } from "fs";
 import { dirname } from "path";
+import { atomicWriteDbSnapshotSync } from "../../../core/db-snapshot.js";
 
 export interface ThreadRow {
 	thread_id: string;
@@ -74,7 +75,7 @@ export class MemoryStorage {
 
 	private persist(): void {
 		const data = this.db.export();
-		writeFileSync(this.dbPath, Buffer.from(data));
+		atomicWriteDbSnapshotSync(this.dbPath, data);
 	}
 
 	private schedulePersist(): void {


### PR DESCRIPTION
## Linked issue

Closes #5189

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Persist `sql.js` database snapshots through an atomic snapshot writer instead of directly overwriting the live DB file.
**Why:** A hard kill during `db.export()` persistence can leave the live SQLite image truncated or malformed.
**How:** Add a DB snapshot persistence module that writes a same-directory temp file, fsyncs it, renames it over the target, and guards `MemoryStorage` against direct live-file writes.

## What

This changes the memory extraction persistence path in `@gsd/pi-coding-agent`:

- Adds `packages/pi-coding-agent/src/core/db-snapshot.ts` with `atomicWriteDbSnapshotSync(...)`.
- Updates `packages/pi-coding-agent/src/resources/extensions/memory/storage.ts` to use the new DB snapshot persistence module.
- Adds behavior coverage for the snapshot writer.
- Adds a regression guard that prevents `MemoryStorage` from returning to direct `writeFileSync(this.dbPath, ...)` persistence.
- Adds `DB snapshot persistence` vocabulary to `CONTEXT.md` so future architecture reviews describe this seam consistently.

## Why

Issue #5189 identifies a real crash-safety bug in the `sql.js` memory extraction store. `sql.js` persists by exporting a full SQLite image. Directly writing that image to the live DB path creates a torn-write window: a hard kill can leave the target file partially written, causing `database disk image is malformed` on the next startup.

This PR scopes the fix to the confirmed `sql.js` snapshot persistence path. The GSD project DB path is a separate native SQLite/WAL stack and is not changed here.

## How

The new `atomicWriteDbSnapshotSync(...)` module is intentionally deep: callers only provide a target path and snapshot bytes. The implementation owns the crash-safety ordering:

1. Create a unique temp file in the same directory as the target.
2. Write the full snapshot to the temp file.
3. `fsync` the temp file before close.
4. Rename the temp file over the target.
5. Best-effort `fsync` the parent directory where supported.
6. Clean up the temp file if any pre-rename step fails.

This keeps temp-file naming, fsync behavior, cleanup, and rename ordering local to one module instead of spreading those rules into `MemoryStorage`.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Passed locally:

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/db-snapshot.test.ts packages/pi-coding-agent/src/resources/extensions/memory/storage-safety-guard.test.ts packages/pi-coding-agent/src/resources/extensions/memory/storage.test.ts
npm run test:compile
node --test dist-test/packages/pi-coding-agent/src/core/db-snapshot.test.js dist-test/packages/pi-coding-agent/src/resources/extensions/memory/storage-safety-guard.test.js dist-test/packages/pi-coding-agent/src/resources/extensions/memory/storage.test.js
```

Attempted broader local verification:

```bash
node scripts/run-package-tests.cjs
npm run build -w @gsd/pi-coding-agent
```

Those broader commands fail in this local worktree for pre-existing environment/baseline reasons unrelated to this change:

- Native clipboard tests fail because this headless environment reports the selected clipboard is unsupported.
- Several compiled `pi-coding-agent`/build checks fail because local workspace resolution points at a stale `@gsd/pi-tui` dist surface that does not expose `style`, while the source `packages/pi-tui/src/index.ts` does export it.

## AI disclosure

- [x] This PR includes AI-assisted code. The change was developed with test-first red/green cycles and verified with the targeted source and compiled tests listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Atomic database snapshot writes for safer, crash-resistant persistence.

* **Documentation**
  * New architectural docs describing runtime-invariant modules, orchestration flow, failure taxonomy, and a refactor/triage plan.

* **Tests**
  * Added tests validating atomic snapshot persistence and enforcing storage safety (preventing direct live DB overwrites).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->