### PR TITLE
[codex] Prefer quick tasks in smart entry

### DIFF
--- a/src/resources/extensions/gsd/commands/dispatcher.ts
+++ b/src/resources/extensions/gsd/commands/dispatcher.ts
@@ -45,5 +45,11 @@ export async function handleGSDCommand(
 
   if (handled) return;
 
+  if (trimmed.includes(" ")) {
+    const { handleDo } = await import("../commands-do.js");
+    await handleDo(trimmed, ctx, pi);
+    return;
+  }
+
   ctx.ui.notify(`Unknown: /gsd ${trimmed}. Run /gsd help for available commands.`, "warning");
 }

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -2135,16 +2135,23 @@ export async function showSmartEntry(
         summary: ["No active milestone."],
         actions: [
           {
+            id: "quick_task",
+            label: "Quick task",
+            description: "For small bounded work, run /gsd quick <task> or /gsd do <task>.",
+            recommended: true,
+          },
+          {
             id: "new_milestone",
             label: "Create next milestone",
-            description: "Define what to build next.",
-            recommended: true,
+            description: "Define a larger body of work with planning artifacts.",
           },
         ],
         notYetMessage: "Run /gsd when ready.",
       });
 
-      if (choice === "new_milestone") {
+      if (choice === "quick_task") {
+        ctx.ui.notify("Run /gsd quick <task> for small bounded work, or /gsd do <task> for natural-language routing.", "info");
+      } else if (choice === "new_milestone") {
         setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId: nextId, step: stepMode });
         await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
           `New milestone ${nextId}.`,
@@ -2182,10 +2189,15 @@ export async function showSmartEntry(
       summary: ["All milestones complete."],
       actions: [
         {
+          id: "quick_task",
+          label: "Quick task",
+          description: "Do a small bounded task without opening a milestone.",
+          recommended: true,
+        },
+        {
           id: "new_milestone",
           label: "Start new milestone",
           description: "Define and plan the next milestone.",
-          recommended: true,
         },
         {
           id: "status",
@@ -2196,7 +2208,9 @@ export async function showSmartEntry(
       notYetMessage: "Run /gsd when ready.",
     });
 
-    if (choice === "new_milestone") {
+    if (choice === "quick_task") {
+      ctx.ui.notify("Run /gsd quick <task> for small bounded work, or /gsd do <task> for natural-language routing.", "info");
+    } else if (choice === "new_milestone") {
       const milestoneIds = findMilestoneIds(basePath);
       const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
       const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds, basePath);
@@ -2301,12 +2315,17 @@ export async function showSmartEntry(
 
       const actions = [
         {
+          id: "quick_task",
+          label: "Quick task instead",
+          description: "Use this when the work is small and should not become a milestone.",
+          recommended: true,
+        },
+        {
           id: "plan",
           label: "Create roadmap",
           description: hasContext
             ? "Context captured. Decompose into slices with a boundary map."
             : "Decompose the milestone into slices with a boundary map.",
-          recommended: true,
         },
         ...(!hasContext ? [{
           id: "discuss",
@@ -2332,7 +2351,9 @@ export async function showSmartEntry(
         notYetMessage: "Run /gsd when ready.",
       });
 
-      if (choice === "plan") {
+      if (choice === "quick_task") {
+        ctx.ui.notify("Run /gsd quick <task> for small bounded work, or /gsd do <task> for natural-language routing.", "info");
+      } else if (choice === "plan") {
         setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId, step: stepMode });
         await dispatchWorkflow(
           pi,

--- a/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
+++ b/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
@@ -47,6 +47,9 @@ test("guided-flow complete branch offers a chooser for next milestone or status"
   const branchChunk = guidedFlowSource.slice(branchIdx, nextBranchIdx === -1 ? branchIdx + 1600 : nextBranchIdx);
 
   assert.match(branchChunk, /showNextAction\(/, "complete branch should present a chooser");
+  assert.match(branchChunk, /id:\s*"quick_task"/, "complete branch should offer quick task before milestone planning");
+  assert.match(branchChunk, /Do a small bounded task without opening a milestone/, "quick task action should explain that it avoids milestones");
+  assert.match(branchChunk, /recommended:\s*true/, "quick task action should be the recommended complete-state action");
   assert.match(branchChunk, /findMilestoneIds\(basePath\)/, "complete branch should compute the next milestone id");
   assert.match(
     branchChunk,
@@ -54,6 +57,21 @@ test("guided-flow complete branch offers a chooser for next milestone or status"
     "complete branch should derive the next milestone id",
   );
   assert.match(branchChunk, /dispatchWorkflow\(pi, await prepareAndBuildDiscussPrompt\(/, "complete branch should dispatch the prepared discuss prompt");
+});
+
+test("dispatcher routes multi-word freeform /gsd input through /gsd do", () => {
+  const dispatcherSource = readFileSync(join(import.meta.dirname, "..", "commands", "dispatcher.ts"), "utf-8");
+
+  assert.match(
+    dispatcherSource,
+    /if\s*\(trimmed\.includes\(" "\)\)\s*\{[\s\S]*handleDo\(trimmed,\s*ctx,\s*pi\)/,
+    "dispatcher should treat multi-word unknown input as natural-language /gsd do work",
+  );
+  assert.match(
+    dispatcherSource,
+    /Unknown: \/gsd/,
+    "single-token unknown commands should still report the normal unknown-command warning",
+  );
 });
 
 test("guided-flow needs-discussion skip branch opens the project DB before reserving a new milestone", () => {


### PR DESCRIPTION
## Summary

Fixes #5429.

This changes the small-task path so bounded/freeform work is steered toward quick mode instead of milestone creation.

## What Changed

- Routes multi-word unknown `/gsd ...` input through `/gsd do`, which already falls back to `/gsd quick` for task-like input.
- Makes `Quick task` the recommended smart-entry action when no active milestone exists.
- Makes `Quick task` the recommended smart-entry action after all milestones are complete.
- Adds a `Quick task instead` option before `Create roadmap` when an active milestone has context but no roadmap.
- Adds regression coverage for the complete-state chooser and freeform dispatcher routing.

## Root Cause

Smart entry treated context-only milestone artifacts as active milestone state and made milestone planning the recommended continuation. That meant a small task could accidentally open M005, and a later `/gsd` run would try to finish that milestone with a full planning pass.

## Validation

- `git diff --check -- src/resources/extensions/gsd/commands/dispatcher.ts src/resources/extensions/gsd/guided-flow.ts src/resources/extensions/gsd/tests/smart-entry-complete.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/smart-entry-complete.test.ts`

Note: `npm run typecheck:extensions` currently fails in this local checkout before reaching this patch because workspace packages such as `@gsd/pi-coding-agent` and `@gsd/pi-tui` are not resolvable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Quick Task option to quickly complete small bounded tasks without opening a milestone
  * Improved command handling for more flexible workflow management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->