### PR TITLE
fix(gsd): promote complete-slice tools policy from planning-dispatch to all

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -244,7 +244,7 @@ test("#4934: tools.mode is one of the declared policies", () => {
 });
 
 test('#4934: only execute-task and reactive-execute may use tools.mode "all" (full source-tree write access)', () => {
-  const allowedAllUnits = new Set(["execute-task", "reactive-execute"]);
+  const allowedAllUnits = new Set(["execute-task", "reactive-execute", "complete-slice"]);
   for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
     const mode = (manifest as { tools: { mode: string } }).tools.mode;
     if (mode === "all") {
@@ -262,7 +262,6 @@ test('planning-dispatch mode is reserved for slice-level decomposition and compl
   const allowedDispatchUnits = new Set([
     "plan-slice",
     "refine-slice",
-    "complete-slice",
     "complete-milestone",
     // Deep planning mode: research-project orchestrates 4 parallel research
     // subagents (stack/features/architecture/pitfalls). Subagent dispatch is

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -513,10 +513,12 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     codebaseMap: false,
     preferences: "active-only",
     contextMode: "verification",
-    // See complete-milestone — same rationale: dispatch to reviewer / security /
-    // tester subagents to fan out review work without bloating this unit's
-    // context.
-    tools: TOOLS_PLANNING_DISPATCH_REVIEW,
+    // complete-slice must run verification commands (tests, linters, type checks)
+    // and fix failures before marking done. planning-dispatch blocks bash/write,
+    // contradicting the prompt contract ("Run all slice-level verification checks
+    // from the slice plan. Fix failures before marking done"). Subagent dispatch
+    // for review/security/tester is still available under TOOLS_ALL.
+    tools: TOOLS_ALL,
     artifacts: {
       // Phase 3 migration (#4782): matches today's actual
       // buildCompleteSlicePrompt inlining order. Overrides prepend +


### PR DESCRIPTION
Closes #5291

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Change `complete-slice` tools policy from `TOOLS_PLANNING_DISPATCH_REVIEW` to `TOOLS_ALL`.
**Why:** The prompt says "run verification checks and fix failures" but the policy blocks bash and source writes.
**How:** One-line policy change + test allowlist updates.

## What

- `src/resources/extensions/gsd/unit-context-manifest.ts`: change `complete-slice` tools from `TOOLS_PLANNING_DISPATCH_REVIEW` to `TOOLS_ALL`
- `src/resources/extensions/gsd/tests/unit-context-manifest.test.ts`: add `complete-slice` to TOOLS_ALL allowlist, remove from planning-dispatch allowlist

## Why

The complete-slice prompt (Completion Rule #3) states:

> Run all slice-level verification checks from the slice plan. Fix failures before marking done; refresh current state if needed.

But `TOOLS_PLANNING_DISPATCH_REVIEW` (mode: `planning-dispatch`) blocks:
- `bash` execution (can't run tests/linters)
- Source file writes (can't fix failures)

This creates a hard contract violation — the prompt promises verification but the policy prevents it. Multiple reproductions attached to #5291 (Go, Rust, Node projects).

## How

`TOOLS_ALL` is the same policy used by `execute-task` and `reactive-execute`. It grants full tool access including bash, read, write, and subagent dispatch. The `complete-slice` unit needs this because:
1. It must run project-specific verification commands (test suites, type checkers, linters)
2. It must fix any failures found before calling `gsd_slice_complete`
3. Subagent dispatch (reviewer/security/tester) is still available under TOOLS_ALL

## Verification: GSD Workflow contract intact

### Scope

The write-gate (#4934) was introduced to prevent `discuss-milestone` from editing user source. That protection remains — discuss/plan/research units still use `TOOLS_PLANNING`. Only `complete-slice` is promoted, and it already operates on completed work (all tasks done, code written).

### Security model

`complete-slice` runs after all tasks are executed. It verifies and summarizes — promoting it to TOOLS_ALL doesn't expand the attack surface beyond what `execute-task` already has for the same slice.

### Tests

`unit-context-manifest.test.ts` — 20/20 pass after updating both allowlists.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-coding-agent` — Coding agent
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-agent-core` — Agent orchestration
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included — allowlist assertions updated in `unit-context-manifest.test.ts` (20/20 pass)
- [x] Manual testing — previously hit this bug during Rust project slice completion (cargo test blocked); fix allows verification to proceed
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code — developed with Kiro CLI, verified via test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the "complete-slice" unit's tool access policy to enable comprehensive permissions, allowing it to execute verification steps and fix issues before marking tasks complete.

* **Tests**
  * Updated unit context manifest tests to reflect revised tool access permissions for available units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->