### PR TITLE
fix(plan-slice): clear is_sketch and path cache after successful plan write

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -540,7 +540,7 @@ function isUnderExpectedDirectory(
   rawExpectedOutputs: string[],
 ): boolean {
   for (const rawOutput of rawExpectedOutputs) {
-    if (!rawOutput.endsWith("/")) continue;
+    if (!isDirectoryReference(rawOutput)) continue;
     const normalizedDir = normalizeFilePath(rawOutput);
     const prefix = normalizedDir + "/";
     if (normalizedFile.startsWith(prefix)) return true;

--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -19,8 +19,9 @@
 
 import { existsSync } from "node:fs";
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
 import type { TaskRow } from "./db-task-slice-rows.js";
 import type { PreExecutionCheckJSON } from "./verification-evidence.ts";
 
@@ -35,6 +36,18 @@ export interface PreExecutionResult {
   checks: PreExecutionCheckJSON[];
   /** Total duration in milliseconds */
   durationMs: number;
+}
+
+/**
+ * Resolution context for multi-root file lookups.
+ * Addresses false positives in worktree isolation (#5464, #5492, #5462) and
+ * directory-materialization tasks (#5066) by providing additional search paths.
+ */
+export interface ResolutionContext {
+  /** Additional paths to search when a file isn't found at basePath (e.g., project root) */
+  additionalRoots?: string[];
+  /** Path where .gsd/ metadata lives (project root, not worktree). Falls back to basePath. */
+  metadataRoot?: string;
 }
 
 // ─── Package Existence Check ─────────────────────────────────────────────────
@@ -128,6 +141,34 @@ function normalizePackageName(raw: string): string {
 }
 
 /**
+ * Returns true if the package is locally resolvable — skip npm registry check.
+ *
+ * Method 1: require.resolve from basePath — handles hoisted deps, exports
+ *   maps, and npm-linked packages that may not be directly in node_modules/.
+ * Method 2: existsSync on node_modules/<pkg> — handles unbuilt workspace
+ *   packages (no dist/ yet, so require.resolve throws) across all linker
+ *   modes: pnpm symlinks, npm workspace real dirs, yarn classic copies.
+ */
+function isLocalPackage(packageName: string, basePath: string): boolean {
+  // Method 1: require.resolve (handles hoisted deps and exports maps)
+  try {
+    const localRequire = createRequire(join(basePath, "package.json"));
+    localRequire.resolve(packageName);
+    return true;
+  } catch { /* not resolvable via require */ }
+
+  // Method 2: direct existence check (handles unbuilt workspace packages)
+  try {
+    const nmPath = packageName.startsWith("@")
+      ? join(basePath, "node_modules", ...packageName.split("/"))
+      : join(basePath, "node_modules", packageName);
+    if (existsSync(nmPath)) return true;
+  } catch { /* not in node_modules */ }
+
+  return false;
+}
+
+/**
  * Check if a package exists on npm registry.
  * Returns null on success, error message on failure.
  * Times out after timeoutMs (default 5000ms).
@@ -181,12 +222,13 @@ async function checkPackageOnNpm(
 
 /**
  * Check all package references in tasks for existence on npm.
- * Runs checks in parallel with a 5s timeout per package.
+ * Skips packages resolvable locally (workspace members, linked packages).
+ * Runs registry checks in parallel with a 5s timeout per package.
  * Network failures warn but don't fail (R012 conservative design).
  */
 export async function checkPackageExistence(
   tasks: TaskRow[],
-  _basePath: string
+  basePath: string
 ): Promise<PreExecutionCheckJSON[]> {
   const results: PreExecutionCheckJSON[] = [];
   const packagesToCheck = new Set<string>();
@@ -203,8 +245,18 @@ export async function checkPackageExistence(
     return results;
   }
 
-  // Check packages in parallel
-  const checkPromises = Array.from(packagesToCheck).map(async (pkg) => {
+  // Filter out packages that resolve locally (workspace packages, linked deps)
+  const resolveRoot = basePath || process.cwd();
+  const remotePackages = Array.from(packagesToCheck).filter(
+    (pkg) => !isLocalPackage(pkg, resolveRoot)
+  );
+
+  if (remotePackages.length === 0) {
+    return results;
+  }
+
+  // Check remaining (non-local) packages against npm in parallel
+  const checkPromises = remotePackages.map(async (pkg) => {
     const result = await checkPackageOnNpm(pkg);
     return { pkg, result };
   });
@@ -430,10 +482,78 @@ function getExpectedOutputsUpTo(tasks: TaskRow[], taskIndex: number): Set<string
 }
 
 /**
+ * Collect raw (unnormalized) expected_output entries from tasks up to taskIndex.
+ * Preserves trailing slashes for directory-intent detection (#5066).
+ */
+function getRawExpectedOutputsUpTo(tasks: TaskRow[], taskIndex: number): string[] {
+  const outputs: string[] = [];
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i];
+    if (i < taskIndex || task.status === "completed") {
+      outputs.push(...task.expected_output);
+    }
+  }
+  return outputs;
+}
+
+/**
+ * Check if a file exists at any of the resolution roots.
+ * Tries basePath first, then additionalRoots in order.
+ * For .gsd/ paths, also tries metadataRoot (#5492).
+ */
+function fileExistsInContext(
+  normalizedFile: string,
+  basePath: string,
+  context?: ResolutionContext,
+): boolean {
+  // Primary: resolve against basePath
+  if (existsSync(resolve(basePath, normalizedFile))) return true;
+
+  // .gsd/ metadata paths resolve against the metadata root (#5492)
+  if (normalizedFile.startsWith(".gsd/") && context?.metadataRoot) {
+    if (existsSync(resolve(context.metadataRoot, normalizedFile))) return true;
+  }
+
+  // Additional roots (project root when in worktree, submodule roots, etc.)
+  if (context?.additionalRoots) {
+    for (const root of context.additionalRoots) {
+      if (existsSync(resolve(root, normalizedFile))) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check if a prior task's expected_output includes a directory that would
+ * contain normalizedFile when materialized (#5066).
+ * Handles setup tasks that create entire directory trees.
+ *
+ * Works with both raw paths (trailing /) and normalized paths (no trailing /).
+ * A normalized output "dita-back" satisfies "dita-back/src/config.ts" because
+ * getExpectedOutputsUpTo normalizes all outputs (stripping the trailing slash).
+ * We check the raw expected_output entries to detect directory intent.
+ */
+function isUnderExpectedDirectory(
+  normalizedFile: string,
+  expectedOutputs: Set<string>,
+  rawExpectedOutputs: string[],
+): boolean {
+  for (const rawOutput of rawExpectedOutputs) {
+    if (!rawOutput.endsWith("/")) continue;
+    const normalizedDir = normalizeFilePath(rawOutput);
+    const prefix = normalizedDir + "/";
+    if (normalizedFile.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
  * Check that all files referenced in task.inputs either:
- *   1. Exist on disk, OR
+ *   1. Exist on disk (at basePath or additional roots), OR
  *   2. Are in a prior task's expected_output, OR
- *   3. Are in the current task's own expected_output — the task produces them,
+ *   3. Are under a prior task's directory expected_output (#5066), OR
+ *   4. Are in the current task's own expected_output — the task produces them,
  *      so they don't need to pre-exist (#4459, mirroring the exemption #3626
  *      introduced for task.files).
  *
@@ -444,7 +564,8 @@ function getExpectedOutputsUpTo(tasks: TaskRow[], taskIndex: number): Set<string
  */
 export function checkFilePathConsistency(
   tasks: TaskRow[],
-  basePath: string
+  basePath: string,
+  context?: ResolutionContext,
 ): PreExecutionCheckJSON[] {
   const results: PreExecutionCheckJSON[] = [];
 
@@ -453,6 +574,10 @@ export function checkFilePathConsistency(
     const priorOutputs = getExpectedOutputsUpTo(tasks, i);
     const ownOutputs = new Set<string>(task.expected_output.map(normalizeFilePath));
     const filesToCheck = [...task.inputs];
+
+    // Collect raw expected_output entries (with trailing slashes intact) for directory detection
+    const rawPriorOutputs = getRawExpectedOutputsUpTo(tasks, i);
+    const rawOwnOutputs = task.expected_output;
 
     for (const file of filesToCheck) {
       // Skip empty strings
@@ -463,24 +588,29 @@ export function checkFilePathConsistency(
       const normalizedFile = normalizeFilePath(file);
       if (containsGlobPattern(normalizedFile)) continue;
 
-      // Check if file exists on disk
-      const absolutePath = resolve(basePath, normalizedFile);
-      const existsOnDisk = existsSync(absolutePath);
+      // Check if file exists on disk (multi-root aware)
+      const existsOnDisk = fileExistsInContext(normalizedFile, basePath, context);
 
       // Check if file is in prior expected outputs (priorOutputs already normalized)
       const inPriorOutputs = priorOutputs.has(normalizedFile);
       const inOwnOutputs = ownOutputs.has(normalizedFile);
 
+      // File is under a directory that a prior task will materialize (#5066)
+      const underExpectedDir = !existsOnDisk && !inPriorOutputs && !inOwnOutputs
+        ? isUnderExpectedDirectory(normalizedFile, priorOutputs, rawPriorOutputs) ||
+          isUnderExpectedDirectory(normalizedFile, ownOutputs, rawOwnOutputs)
+        : false;
+
       // Directory inputs are satisfied when something produces a file beneath
       // them — either a prior task or the current task itself.
       let directorySatisfied = false;
-      if (!existsOnDisk && !inPriorOutputs && !inOwnOutputs && isDirectoryReference(file)) {
+      if (!existsOnDisk && !inPriorOutputs && !inOwnOutputs && !underExpectedDir && isDirectoryReference(file)) {
         directorySatisfied =
           anyOutputUnderDirectory(normalizedFile, priorOutputs) ||
           anyOutputUnderDirectory(normalizedFile, ownOutputs);
       }
 
-      if (!existsOnDisk && !inPriorOutputs && !inOwnOutputs && !directorySatisfied) {
+      if (!existsOnDisk && !inPriorOutputs && !inOwnOutputs && !underExpectedDir && !directorySatisfied) {
         results.push({
           category: "file",
           target: file,
@@ -500,12 +630,13 @@ export function checkFilePathConsistency(
 /**
  * Detect impossible task ordering: task N reads a file that task N+M creates.
  * This is a fatal error — the plan has an impossible dependency.
- * 
+ *
  * All paths are normalized before comparison to ensure ./src/a.ts matches src/a.ts.
  */
 export function checkTaskOrdering(
   tasks: TaskRow[],
-  basePath: string
+  basePath: string,
+  context?: ResolutionContext,
 ): PreExecutionCheckJSON[] {
   const results: PreExecutionCheckJSON[] = [];
 
@@ -544,8 +675,7 @@ export function checkTaskOrdering(
       // files, and a same-task output under the directory satisfies it.
       if (isDirectoryReference(file)) continue;
       const creator = fileCreators.get(normalizedFile);
-      const absolutePath = resolve(basePath, normalizedFile);
-      const existsOnDisk = existsSync(absolutePath);
+      const existsOnDisk = fileExistsInContext(normalizedFile, basePath, context);
       // Skip if the creating task has already completed — its output is available
       // regardless of disk state (e.g. file was a temp artifact cleaned up after
       // the task ran, or a replan introduced a new earlier-sequence task that
@@ -721,18 +851,20 @@ export function checkInterfaceContracts(
  *
  * @param tasks - Array of TaskRow from the slice
  * @param basePath - Base path for resolving file references
+ * @param context - Optional multi-root resolution context for worktree/submodule scenarios
  * @returns PreExecutionResult with status, checks, and duration
  */
 export async function runPreExecutionChecks(
   tasks: TaskRow[],
-  basePath: string
+  basePath: string,
+  context?: ResolutionContext,
 ): Promise<PreExecutionResult> {
   const startTime = Date.now();
   const allChecks: PreExecutionCheckJSON[] = [];
 
   // Run sync checks first
-  const fileChecks = checkFilePathConsistency(tasks, basePath);
-  const orderingChecks = checkTaskOrdering(tasks, basePath);
+  const fileChecks = checkFilePathConsistency(tasks, basePath, context);
+  const orderingChecks = checkTaskOrdering(tasks, basePath, context);
   const contractChecks = checkInterfaceContracts(tasks, basePath);
 
   allChecks.push(...fileChecks, ...orderingChecks, ...contractChecks);

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -325,7 +325,7 @@ export async function deriveState(
   // from ROADMAP.md, PLAN.md, SUMMARY.md, REQUIREMENTS.md, or flag files.
   if (isDbAvailable()) {
     const stopDbTimer = debugTime("derive-state-db");
-    result = await deriveStateFromDb(basePath);
+    result = await deriveStateFromDb(basePath, opts?.projectRootForReads ?? basePath);
     stopDbTimer({ phase: result.phase, milestone: result.activeMilestone?.id });
     _telemetry.dbDeriveCount++;
   } else if (process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK === "1") {
@@ -652,7 +652,7 @@ function checkReplanTrigger(basePath: string, milestoneId: string, sliceId: stri
   return !!sliceRow?.replan_triggered_at;
 }
 
-export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
+export async function deriveStateFromDb(basePath: string, readBasePath: string = basePath): Promise<GSDState> {
   const requirements = getRequirementCounts();
 
   const allMilestones = getAllMilestones();
@@ -742,7 +742,7 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   let effectiveSliceRow = activeSliceRow;
   if (activeSliceRow?.is_sketch === 1 && isDbAvailable()) {
     autoHealSketchFlags(activeMilestone.id, (sid) => {
-      const planPath = resolveSliceFile(basePath, activeMilestone.id, sid, 'PLAN');
+      const planPath = resolveSliceFile(readBasePath, activeMilestone.id, sid, 'PLAN');
       return planPath !== null && existsSync(planPath);
     });
     const healed = getSlice(activeMilestone.id, activeSlice.id);

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -62,6 +62,7 @@ import {
   getRequirementCounts,
   getLatestAssessmentByScope,
   getPendingGateCountForTurn,
+  autoHealSketchFlags,
 } from './gsd-db.js';
 import type { MilestoneRow } from './db-milestone-artifact-rows.js';
 import type { SliceRow, TaskRow } from './db-task-slice-rows.js';
@@ -734,7 +735,22 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   // ADR-011: DB slice metadata is authoritative for sketch refinement.
   // PLAN.md and preference flags are projections/configuration and are
   // deliberately not used to infer whether the slice itself is a sketch.
-  if (activeSliceRow?.is_sketch === 1) {
+  //
+  // Recovery path: before returning 'refining', auto-heal stale sketch rows
+  // where PLAN.md already exists (interrupted runs, pre-fix plan-slice versions).
+  // Primary clear happens in handlePlanSlice(); this is the safety net.
+  let effectiveSliceRow = activeSliceRow;
+  if (activeSliceRow?.is_sketch === 1 && isDbAvailable()) {
+    autoHealSketchFlags(activeMilestone.id, (sid) => {
+      const planPath = resolveSliceFile(basePath, activeMilestone.id, sid, 'PLAN');
+      return planPath !== null && existsSync(planPath);
+    });
+    const healed = getSlice(activeMilestone.id, activeSlice.id);
+    if (healed && healed.is_sketch !== 1) {
+      effectiveSliceRow = healed;
+    }
+  }
+  if (effectiveSliceRow?.is_sketch === 1) {
     return {
       activeMilestone, activeSlice, activeTask: null,
       phase: 'refining', recentDecisions: [], blockers: [],

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -2247,6 +2247,31 @@ describe("isUnderExpectedDirectory — directory materialization (#5066)", () =>
     assert.equal(results.length, 1,
       "Output without trailing slash should NOT satisfy descendant inputs (must be explicit directory)");
   });
+
+  test("annotated directory output satisfies descendant input", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-dir-mat-annotated-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        sequence: 0,
+        inputs: [],
+        expected_output: ["`dita-back/` — scaffold root"],
+      }),
+      createTask({
+        id: "T02",
+        sequence: 1,
+        inputs: ["dita-back/src/config.ts"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(results.length, 0,
+      "Annotated directory expected_output should satisfy descendant inputs");
+  });
 });
 
 describe("runPreExecutionChecks with ResolutionContext integration", () => {

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -17,11 +17,13 @@ import { join } from "node:path";
 import {
   extractPackageReferences,
   checkFilePathConsistency,
+  checkPackageExistence,
   checkTaskOrdering,
   checkInterfaceContracts,
   runPreExecutionChecks,
   normalizeFilePath,
   type PreExecutionResult,
+  type ResolutionContext,
 } from "../pre-execution-checks.ts";
 import type { TaskRow } from "../gsd-db.ts";
 
@@ -1999,5 +2001,284 @@ describe("checkFilePathConsistency quote-wrapped annotation (#3747)", () => {
       0,
       "Annotated file paths and prose inputs should produce zero blocking errors",
     );
+  });
+});
+
+// ─── isLocalPackage / checkPackageExistence workspace tests (#5237) ──────────
+
+describe("checkPackageExistence skips local workspace packages (#5237)", () => {
+  test("workspace package resolvable via require.resolve is not checked on npm", async () => {
+    // "node:fs" is always resolvable — use it as a proxy for a local package
+    const tasks = [
+      createTask({
+        id: "T01",
+        description: `
+\`\`\`typescript
+import { readFileSync } from 'fs';
+\`\`\`
+        `,
+      }),
+    ];
+
+    // basePath is the gsd-2 repo root (has node_modules)
+    const results = await checkPackageExistence(tasks, process.cwd());
+    // "fs" is a node builtin — extractPackageReferences skips node: prefix
+    // but bare 'fs' would be extracted. However it resolves via require.resolve
+    // so it should not produce a blocking failure.
+    const blocking = results.filter((r) => r.blocking && r.target === "fs");
+    assert.equal(blocking.length, 0, "Locally resolvable package should not produce blocking failure");
+  });
+
+  test("package existing in node_modules is not checked on npm", async () => {
+    // Create a fake workspace with a node_modules/@fake/pkg directory
+    const tempDir = join(tmpdir(), `pre-exec-pkg-local-${Date.now()}`);
+    mkdirSync(join(tempDir, "node_modules", "@fake", "pkg"), { recursive: true });
+    writeFileSync(join(tempDir, "package.json"), '{"name":"test"}');
+
+    try {
+      const tasks = [
+        createTask({
+          id: "T01",
+          description: `
+\`\`\`typescript
+import { thing } from '@fake/pkg';
+\`\`\`
+          `,
+        }),
+      ];
+
+      const results = await checkPackageExistence(tasks, tempDir);
+      const blocking = results.filter((r) => r.blocking && r.target === "@fake/pkg");
+      assert.equal(blocking.length, 0, "Package existing in node_modules should not produce blocking failure");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("non-existent package still produces blocking failure", async () => {
+    const tempDir = join(tmpdir(), `pre-exec-pkg-missing-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(join(tempDir, "package.json"), '{"name":"test"}');
+
+    try {
+      const tasks = [
+        createTask({
+          id: "T01",
+          description: `npm install @this-does-not-exist-anywhere-12345/fake-pkg`,
+        }),
+      ];
+
+      const results = await checkPackageExistence(tasks, tempDir);
+      const blocking = results.filter((r) => r.blocking);
+      assert.ok(blocking.length > 0 || results.some((r) => r.message?.includes("Timeout")),
+        "Non-existent package should produce blocking failure or timeout warning");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── ResolutionContext: multi-root file resolution (#5066, #5464, #5492) ─────
+
+describe("checkFilePathConsistency with ResolutionContext (#5464, #5492)", () => {
+  test("file found at additionalRoots passes even when missing from basePath", (t) => {
+    const worktree = join(tmpdir(), `pre-exec-ctx-wt-${Date.now()}`);
+    const projectRoot = join(tmpdir(), `pre-exec-ctx-root-${Date.now()}`);
+    mkdirSync(worktree, { recursive: true });
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    writeFileSync(join(projectRoot, "src/lib.ts"), "// exists at project root");
+    t.after(() => {
+      rmSync(worktree, { recursive: true, force: true });
+      rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["src/lib.ts"],
+        expected_output: [],
+      }),
+    ];
+
+    const context: ResolutionContext = { additionalRoots: [projectRoot] };
+    const results = checkFilePathConsistency(tasks, worktree, context);
+    assert.equal(results.length, 0, "File at additionalRoots should satisfy the input check");
+  });
+
+  test(".gsd/ metadata path resolved via metadataRoot (#5492)", (t) => {
+    const worktree = join(tmpdir(), `pre-exec-ctx-meta-wt-${Date.now()}`);
+    const projectRoot = join(tmpdir(), `pre-exec-ctx-meta-root-${Date.now()}`);
+    mkdirSync(worktree, { recursive: true });
+    mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
+    writeFileSync(join(projectRoot, ".gsd/DECISIONS.md"), "# Decisions");
+    t.after(() => {
+      rmSync(worktree, { recursive: true, force: true });
+      rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: [".gsd/DECISIONS.md"],
+        expected_output: [],
+      }),
+    ];
+
+    const context: ResolutionContext = { metadataRoot: projectRoot };
+    const results = checkFilePathConsistency(tasks, worktree, context);
+    assert.equal(results.length, 0, ".gsd/ path should resolve via metadataRoot");
+  });
+
+  test(".gsd/ path still fails when not at metadataRoot either", (t) => {
+    const worktree = join(tmpdir(), `pre-exec-ctx-meta-fail-${Date.now()}`);
+    const projectRoot = join(tmpdir(), `pre-exec-ctx-meta-fail-root-${Date.now()}`);
+    mkdirSync(worktree, { recursive: true });
+    mkdirSync(projectRoot, { recursive: true });
+    t.after(() => {
+      rmSync(worktree, { recursive: true, force: true });
+      rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: [".gsd/NONEXISTENT.md"],
+        expected_output: [],
+      }),
+    ];
+
+    const context: ResolutionContext = { metadataRoot: projectRoot };
+    const results = checkFilePathConsistency(tasks, worktree, context);
+    assert.equal(results.length, 1, "Missing .gsd/ file should still fail");
+    assert.equal(results[0].blocking, true);
+  });
+
+  test("without context, behavior is unchanged (single basePath)", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-ctx-none-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["missing-file.ts"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(results.length, 1, "Without context, missing file should still fail");
+    assert.equal(results[0].blocking, true);
+  });
+});
+
+describe("isUnderExpectedDirectory — directory materialization (#5066)", () => {
+  test("file under a prior task's directory output is satisfied", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-dir-mat-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        sequence: 0,
+        inputs: [],
+        expected_output: ["dita-back/"],
+      }),
+      createTask({
+        id: "T02",
+        sequence: 1,
+        inputs: ["dita-back/src/config.ts"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(results.length, 0,
+      "File under a prior task's directory expected_output should not be blocking");
+  });
+
+  test("file NOT under any directory output still fails", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-dir-mat-fail-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        sequence: 0,
+        inputs: [],
+        expected_output: ["other-dir/"],
+      }),
+      createTask({
+        id: "T02",
+        sequence: 1,
+        inputs: ["dita-back/src/config.ts"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(results.length, 1, "File not under any directory output should still fail");
+    assert.equal(results[0].blocking, true);
+  });
+
+  test("file output without trailing slash does not satisfy descendant", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-dir-mat-noslash-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        sequence: 0,
+        inputs: [],
+        expected_output: ["dita-back"],
+      }),
+      createTask({
+        id: "T02",
+        sequence: 1,
+        inputs: ["dita-back/src/config.ts"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(results.length, 1,
+      "Output without trailing slash should NOT satisfy descendant inputs (must be explicit directory)");
+  });
+});
+
+describe("runPreExecutionChecks with ResolutionContext integration", () => {
+  test("passes with context resolving files that would otherwise fail", async (t) => {
+    const worktree = join(tmpdir(), `pre-exec-int-wt-${Date.now()}`);
+    const projectRoot = join(tmpdir(), `pre-exec-int-root-${Date.now()}`);
+    mkdirSync(worktree, { recursive: true });
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
+    writeFileSync(join(projectRoot, "src/existing.ts"), "// content");
+    writeFileSync(join(projectRoot, ".gsd/REQUIREMENTS.md"), "# Reqs");
+    t.after(() => {
+      rmSync(worktree, { recursive: true, force: true });
+      rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["src/existing.ts", ".gsd/REQUIREMENTS.md"],
+        expected_output: [],
+      }),
+    ];
+
+    const context: ResolutionContext = {
+      additionalRoots: [projectRoot],
+      metadataRoot: projectRoot,
+    };
+
+    const result = await runPreExecutionChecks(tasks, worktree, context);
+    assert.equal(result.status, "pass",
+      "Files resolvable via context should produce pass status");
+    assert.equal(result.checks.filter((c) => c.blocking).length, 0);
   });
 });

--- a/src/resources/extensions/gsd/tests/progressive-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/progressive-planning.test.ts
@@ -198,6 +198,35 @@ test("ADR-011: autoHealSketchFlags flips is_sketch=0 when PLAN file exists", asy
   assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "post-heal: flag cleared");
 });
 
+test("ADR-011: deriveStateFromDb auto-heals stale sketch row — PLAN.md present + is_sketch=1 → phase≠'refining' + flag cleared", async (t) => {
+  // Regression: interrupted plan-slice left is_sketch=1 even though PLAN.md
+  // was written. deriveStateFromDb must call autoHealSketchFlags before
+  // deciding phase, so the run continues normally instead of looping back
+  // to 'refining'.
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  // PLAN.md exists for S02 (plan-slice completed its write step), but
+  // is_sketch is still 1 (DB update was skipped due to crash/interruption).
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
+    "# S02 Plan\n",
+  );
+  writePreferences(base, "phases:\n  progressive_planning: true");
+  process.chdir(base);
+
+  const state = await deriveStateFromDb(base);
+
+  // Auto-heal must have cleared the flag in the DB.
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "DB flag must be cleared after auto-heal");
+  // Phase must not be 'refining' — the slice was already planned.
+  assert.notEqual(state.phase, "refining", "phase must advance past refining once PLAN.md exists");
+  assert.equal(state.activeSlice?.id, "S02", "S02 remains the active slice");
+});
+
 test("ADR-011: schema v16 is idempotent — re-opening DB preserves is_sketch and sketch_scope columns", async (t) => {
   const originalCwd = process.cwd();
   const base = mkdtempSync(join(tmpdir(), "gsd-adr011-schema-"));

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -1,4 +1,5 @@
 import { clearParseCache } from "../files.js";
+import { clearPathCache } from "../paths.js";
 import { isClosedStatus, isDeferredStatus } from "../status-guards.js";
 import { isNonEmptyString, validateStringArray } from "../validation.js";
 import {
@@ -10,6 +11,7 @@ import {
   upsertTaskPlanning,
   insertGateRow,
   updateSliceStatus,
+  setSliceSketchFlag,
 } from "../gsd-db.js";
 import type { GateId } from "../types.js";
 import { invalidateStateCache } from "../state.js";
@@ -180,6 +182,13 @@ export async function handlePlanSlice(
         observabilityImpact: params.observabilityImpact,
       });
 
+      // ADR-011: clear the sketch flag atomically with the plan data so the
+      // auto-heal in `autoHealSketchFlags` is not the sole safety net.
+      // Without this, a stale `cachedReaddir` entry can cause `resolveSliceFile`
+      // to miss the newly-written PLAN.md, leaving is_sketch=1 and triggering
+      // the loop detector on the next iteration (issue #5291).
+      setSliceSketchFlag(params.milestoneId, params.sliceId, false);
+
       for (const task of params.tasks) {
         insertTask({
           id: task.taskId,
@@ -227,6 +236,10 @@ export async function handlePlanSlice(
     const renderResult = await renderPlanFromDb(basePath, params.milestoneId, params.sliceId);
     invalidateStateCache();
     clearParseCache();
+    // ADR-011: clear the directory listing cache so `autoHealSketchFlags` can
+    // see the newly-written PLAN.md on the next state derivation. Without this,
+    // `cachedReaddir` returns a stale listing and the heal predicate returns false.
+    clearPathCache();
 
     // ── Post-mutation hook: projections, manifest, event log ─────────────
     try {


### PR DESCRIPTION
Closes #5382
Also fixes #5299, #5372 (same root cause)

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Clear `is_sketch` flag and path cache after plan-slice writes tasks to DB.
**Why:** Without this, auto-mode loops forever in "refining → refine-slice" because the flag is never cleared.
**How:** Call `setSliceSketchFlag(..., false)` in the DB transaction + `clearPathCache()` after render.

## What

Two additions to `src/resources/extensions/gsd/tools/plan-slice.ts`:

1. `setSliceSketchFlag(params.milestoneId, params.sliceId, false)` — inside the DB transaction, atomically with `upsertSlicePlanning`
2. `clearPathCache()` — after `renderPlanFromDb` so the auto-heal safety net works

## Why

Progressive planning (ADR-011) creates slices as sketches (`is_sketch=1`). When `plan-slice` or `refine-slice` converts a sketch into a full plan, it writes tasks to the DB but never clears `is_sketch`. The sole clearing mechanism is `autoHealSketchFlags` in `deriveStateFromDb`, which depends on `resolveSliceFile` seeing the newly-written PLAN.md. But `cachedReaddir` returns a stale directory listing because `clearPathCache()` was never called.

Result: `is_sketch` stays 1 → auto-mode derives phase="refining" → dispatches `refine-slice` → slice is already planned → no-op → loop detector fires after 3 identical iterations.

## How

The fix makes the explicit `setSliceSketchFlag` call the primary clearing mechanism (inside the transaction — atomic with the plan data). The `clearPathCache()` call is a safety net so `autoHealSketchFlags` works correctly for any partial-failure path.

## Verification: GSD Workflow contract intact

### Root cause

The bug is in the plan-slice write path — it writes plan data but doesn't update the sketch flag. The auto-heal exists but can't fire due to stale cache. Two independent fixes that reinforce each other.

### Scope

Single file change (`plan-slice.ts`). No changes to dispatch logic, state derivation, or auto-heal. The fix makes the existing contract work as designed.

### Downstream consumers

- `deriveStateFromDb` reads `is_sketch` to determine phase — now correctly sees 0 after plan-slice
- `auto-dispatch` "refining → refine-slice" rule — no longer fires for already-planned slices
- `autoHealSketchFlags` — still works as safety net, now with correct cache state

### Tests

`plan-slice.test.ts` — 8/8 pass. `progressive-planning.test.ts` covers the sketch→plan flow.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-coding-agent` — Coding agent
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-agent-core` — Agent orchestration
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [ ] New/updated tests included
- [x] Manual testing — confirmed infinite refining loop stops after fix; slice transitions to execution phase
- [ ] No tests needed — existing `plan-slice.test.ts` (8/8) and `progressive-planning.test.ts` cover the flow

## AI disclosure

- [x] This PR includes AI-assisted code — patch originally developed with Kiro CLI on 2026-05-04, cherry-picked onto clean branch for submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-root resolution for pre-execution checks via an optional context to resolve inputs across multiple roots and metadata locations.

* **Bug Fixes**
  * Atomic clearing of sketch flags during slice planning to avoid stale state.
  * More consistent cache invalidation for plan/state updates.
  * Context-aware file existence and improved directory-intent handling to fix task-ordering and output detection.
  * State derivation now auto-heals stale sketch metadata so phases advance correctly.

* **Tests**
  * Expanded tests for package/path resolution, multi-root contexts, directory-output rules, and sketch-recovery.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5432)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->