### PR TITLE
fix(gsd): dispatch quick task menu selection

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -124,14 +124,14 @@ async function runQuickTaskChoice(ctx: ExtensionCommandContext, pi: ExtensionAPI
     return;
   }
 
-  const task = (await ctx.ui.input("Quick task", "Describe the task to run with /gsd do"))?.trim();
+  const task = (await ctx.ui.input("Quick task", "Describe the small task to run with /gsd quick"))?.trim();
   if (!task) {
     ctx.ui.notify("Quick task cancelled.", "info");
     return;
   }
 
-  const { handleDo } = await import("./commands-do.js");
-  await handleDo(task, ctx, pi);
+  const { handleQuick } = await import("./quick.js");
+  await handleQuick(task, ctx, pi);
 }
 
 /**

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -118,6 +118,22 @@ export function resolveExpectedArtifactPathForScope(
   return resolveExpectedArtifactPath(unitType, unitId, scope.workspace.projectRoot);
 }
 
+async function runQuickTaskChoice(ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {
+  if (!ctx.hasUI) {
+    ctx.ui.notify("Run /gsd quick <task> for small bounded work, or /gsd do <task> for natural-language routing.", "info");
+    return;
+  }
+
+  const task = (await ctx.ui.input("Quick task", "Describe the task to run with /gsd do"))?.trim();
+  if (!task) {
+    ctx.ui.notify("Quick task cancelled.", "info");
+    return;
+  }
+
+  const { handleDo } = await import("./commands-do.js");
+  await handleDo(task, ctx, pi);
+}
+
 /**
  * Scope-based overload of isGhostMilestone.
  * Binds basePath and milestoneId from the scope, ensuring path resolution
@@ -2150,7 +2166,7 @@ export async function showSmartEntry(
       });
 
       if (choice === "quick_task") {
-        ctx.ui.notify("Run /gsd quick <task> for small bounded work, or /gsd do <task> for natural-language routing.", "info");
+        await runQuickTaskChoice(ctx, pi);
       } else if (choice === "new_milestone") {
         setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId: nextId, step: stepMode });
         await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
@@ -2209,7 +2225,7 @@ export async function showSmartEntry(
     });
 
     if (choice === "quick_task") {
-      ctx.ui.notify("Run /gsd quick <task> for small bounded work, or /gsd do <task> for natural-language routing.", "info");
+      await runQuickTaskChoice(ctx, pi);
     } else if (choice === "new_milestone") {
       const milestoneIds = findMilestoneIds(basePath);
       const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
@@ -2352,7 +2368,7 @@ export async function showSmartEntry(
       });
 
       if (choice === "quick_task") {
-        ctx.ui.notify("Run /gsd quick <task> for small bounded work, or /gsd do <task> for natural-language routing.", "info");
+        await runQuickTaskChoice(ctx, pi);
       } else if (choice === "plan") {
         setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId, step: stepMode });
         await dispatchWorkflow(

--- a/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
+++ b/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
@@ -59,13 +59,13 @@ test("guided-flow complete branch offers a chooser for next milestone or status"
   assert.match(branchChunk, /dispatchWorkflow\(pi, await prepareAndBuildDiscussPrompt\(/, "complete branch should dispatch the prepared discuss prompt");
 });
 
-test("guided-flow quick task choices prompt for text and route through /gsd do", () => {
+test("guided-flow quick task choices prompt for text and route through /gsd quick", () => {
   const guidedFlowSource = readFileSync(join(import.meta.dirname, "..", "guided-flow.ts"), "utf-8");
 
   assert.match(
     guidedFlowSource,
-    /async function runQuickTaskChoice\([\s\S]*ctx\.ui\.input\("Quick task"[\s\S]*await import\("\.\/commands-do\.js"\)[\s\S]*await handleDo\(task,\s*ctx,\s*pi\)/,
-    "quick task chooser should prompt for task text and route through handleDo",
+    /async function runQuickTaskChoice\([\s\S]*ctx\.ui\.input\("Quick task"[\s\S]*await import\("\.\/quick\.js"\)[\s\S]*await handleQuick\(task,\s*ctx,\s*pi\)/,
+    "quick task chooser should prompt for task text and route through handleQuick",
   );
 
   const notifyOnlyPattern = /if \(choice === "quick_task"\) \{\s*ctx\.ui\.notify\("Run \/gsd quick <task>/;

--- a/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
+++ b/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
@@ -59,6 +59,26 @@ test("guided-flow complete branch offers a chooser for next milestone or status"
   assert.match(branchChunk, /dispatchWorkflow\(pi, await prepareAndBuildDiscussPrompt\(/, "complete branch should dispatch the prepared discuss prompt");
 });
 
+test("guided-flow quick task choices prompt for text and route through /gsd do", () => {
+  const guidedFlowSource = readFileSync(join(import.meta.dirname, "..", "guided-flow.ts"), "utf-8");
+
+  assert.match(
+    guidedFlowSource,
+    /async function runQuickTaskChoice\([\s\S]*ctx\.ui\.input\("Quick task"[\s\S]*await import\("\.\/commands-do\.js"\)[\s\S]*await handleDo\(task,\s*ctx,\s*pi\)/,
+    "quick task chooser should prompt for task text and route through handleDo",
+  );
+
+  const notifyOnlyPattern = /if \(choice === "quick_task"\) \{\s*ctx\.ui\.notify\("Run \/gsd quick <task>/;
+  assert.doesNotMatch(
+    guidedFlowSource,
+    notifyOnlyPattern,
+    "quick task chooser must not merely print instructions after selection",
+  );
+
+  const quickChoiceCalls = guidedFlowSource.match(/if \(choice === "quick_task"\) \{\s*await runQuickTaskChoice\(ctx,\s*pi\);/g) ?? [];
+  assert.equal(quickChoiceCalls.length, 3, "all guided-flow quick task choices should dispatch the helper");
+});
+
 test("dispatcher routes multi-word freeform /gsd input through /gsd do", () => {
   const dispatcherSource = readFileSync(join(import.meta.dirname, "..", "commands", "dispatcher.ts"), "utf-8");
 


### PR DESCRIPTION
## Linked issue

Closes #5437

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Selecting `Quick task` from the `/gsd` smart-entry menu now prompts for task text and dispatches through `/gsd do`.
**Why:** The menu looked actionable, but choosing `1` only posted instructional text into the TUI.
**How:** Added a small guided-flow helper that asks for the quick task and calls the existing `handleDo` routing path, with a regression guard in smart-entry tests.

## What

Updates the GSD smart-entry flow in `src/resources/extensions/gsd/guided-flow.ts` so all `quick_task` menu choices call `runQuickTaskChoice()`. The helper prompts for task text, handles cancellation, and routes the task through `commands-do.ts`.

Adds a regression test in `src/resources/extensions/gsd/tests/smart-entry-complete.test.ts` to ensure quick-task choices no longer just print instructions.

## Why

The `/gsd` menu showed `1. Quick task (recommended)`, but choosing it only emitted:

```
Run /gsd quick <task> for small bounded work, or /gsd do <task> for natural-language routing.
```

That forced the user to manually type another command after selecting an option. Selection should continue the flow.

## How

The quick-task option now reuses the existing natural-language routing instead of duplicating routing logic. If UI is unavailable it keeps the old informational fallback; otherwise it prompts for task text and calls `handleDo(task, ctx, pi)`.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Passing:

```bash
npm run test:changed:src -- --since HEAD~1
git diff --check
```

Attempted full preflight:

```bash
npm run verify:pr
```

Result: build and typecheck reached the unit suite, then `test:unit:compiled` failed with existing compiled-test import errors like `Unknown file extension ".ts" for .../dist-test/src/resources/extensions/gsd/prompt-loader.ts` and `Unknown file extension ".ts" for .../dist-test/src/resources/extensions/ask-user-questions.ts`. The failure is not in the changed smart-entry test, which passed in the targeted changed-source run.

## AI disclosure

- [x] This PR includes AI-assisted code. Codex implemented the small guided-flow fix and ran the tests listed above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced quick task selection with consistent flow across multiple scenarios, including cases with no active milestone, completed milestones, or no active slice.

* **Tests**
  * Added test coverage for quick task selection and routing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->