### PR TITLE
fix(gsd): avoid false stashPushed when no preflight stash entry exists

### DIFF
--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -178,9 +178,12 @@ function reconcileAlreadyPresentUntrackedStash(
   };
 }
 
-function findPreflightStashRef(basePath: string, milestoneId: string, stashMarker?: string): string | null {
-  const markerPrefix = `gsd-preflight-stash:${milestoneId}:`;
-  let fallbackRef: string | null = null;
+interface StashEntry {
+  ref: string;
+  subject: string;
+}
+
+function listStashEntries(basePath: string): StashEntry[] {
   try {
     const list = execFileSync("git", ["stash", "list", "--format=%gd%x00%s"], {
       cwd: basePath,
@@ -188,16 +191,34 @@ function findPreflightStashRef(basePath: string, milestoneId: string, stashMarke
       encoding: "utf-8",
       env: GIT_NO_PROMPT_ENV,
     });
+    const entries: StashEntry[] = [];
     for (const line of list.split("\n")) {
       const [ref, subject] = line.split("\x00");
       if (!ref || !subject) continue;
-      if (stashMarker && subject.includes(stashMarker)) return ref;
-      if (!fallbackRef && subject.includes(markerPrefix)) fallbackRef = ref;
+      entries.push({ ref, subject });
     }
+    return entries;
   } catch (err) {
-    logWarning("preflight", `stash list failed before restore: ${err instanceof Error ? err.message : String(err)}`);
+    logWarning("preflight", `stash list lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
   }
-  return fallbackRef;
+}
+
+function findStashRefByExactMarker(basePath: string, stashMarker: string): string | null {
+  const entry = listStashEntries(basePath).find((item) => item.subject.includes(stashMarker));
+  return entry?.ref ?? null;
+}
+
+function findPreflightStashRef(basePath: string, milestoneId: string, stashMarker?: string): string | null {
+  const markerPrefix = `gsd-preflight-stash:${milestoneId}:`;
+  const entries = listStashEntries(basePath);
+
+  if (stashMarker) {
+    const exactMatch = entries.find((entry) => entry.subject.includes(stashMarker));
+    if (exactMatch) return exactMatch.ref;
+  }
+
+  return entries.find((entry) => entry.subject.includes(markerPrefix))?.ref ?? null;
 }
 
 /**
@@ -244,6 +265,18 @@ export function preflightCleanRoot(
       encoding: "utf-8",
       env: GIT_NO_PROMPT_ENV,
     });
+
+    const createdStashRef = findStashRefByExactMarker(basePath, stashMarker);
+    if (!createdStashRef) {
+      const msg = `Auto-stash reported success but no stash entry was created before milestone ${milestoneId} merge. Continuing without postflight stash restore.`;
+      logWarning("preflight", msg);
+      notify(msg, "warning");
+      return {
+        stashPushed: false,
+        summary: `No stashable changes found before merge (milestone ${milestoneId}).`,
+      };
+    }
+
     return {
       stashPushed: true,
       stashMarker,

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 
 import { preflightCleanRoot, postflightPopStash } from "../clean-root-preflight.ts";
+import { _resetHasChangesCache, nativeHasChanges } from "../native-git-bridge.ts";
 
 function run(cmd: string, cwd: string): string {
   return execSync(cmd, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
@@ -381,6 +382,40 @@ test("postflightPopStash requires manual recovery when an untracked stash path i
     const stashList = run("git stash list", repo);
     assert.ok(preflight.stashMarker && stashList.includes(preflight.stashMarker), "stash must remain for manual recovery");
   } finally {
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});
+
+test("preflightCleanRoot does not claim stashPushed when cached dirty state is stale (#5424)", () => {
+  const repo = createTempRepo();
+  try {
+    _resetHasChangesCache();
+
+    // Seed the 10s hasChanges cache with a dirty=true result.
+    writeFileSync(join(repo, "README.md"), "# dirty then clean\n");
+    assert.equal(nativeHasChanges(repo), true, "cache seed should observe dirty tree");
+
+    // Immediately clean the tree before preflight runs. The cache remains true.
+    run("git checkout -- README.md", repo);
+    assert.equal(run("git status --porcelain", repo), "", "working tree should be clean before preflight");
+
+    const notifications: Array<{ msg: string; level: string }> = [];
+    const result = preflightCleanRoot(repo, "M5424", (msg, level) => {
+      notifications.push({ msg, level });
+    });
+
+    assert.equal(result.stashPushed, false, "must not claim stashPushed when no stash entry was created");
+    assert.equal(result.stashMarker, undefined, "stash marker should be absent when stash was not created");
+    assert.match(result.summary, /No stashable changes found/i);
+    assert.ok(
+      notifications.some((n) => n.level === "warning" && n.msg.includes("M5424")),
+      "warning should still be emitted when cached dirty state triggers preflight path",
+    );
+
+    const stashList = run("git stash list", repo);
+    assert.equal(stashList, "", "stash list must remain empty when git stash reports nothing to save");
+  } finally {
+    _resetHasChangesCache();
     try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
   }
 });


### PR DESCRIPTION
## Linked issue

Closes #5424

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Preflight stash now verifies that a real stash entry was created before setting `stashPushed=true`.
**Why:** `git stash push` can return exit 0 with no created entry (`No local changes to save`), which led to false postflight pop attempts.
**How:** Added post-push marker validation against `git stash list` and a regression test that reproduces stale-cache dirty detection.

## What

- Refactored stash-list parsing in `clean-root-preflight.ts` into small helpers.
- Added exact-marker lookup to validate stash side-effect after `git stash push`.
- Changed preflight behavior to fail-closed when no stash entry exists:
  - `stashPushed=false`
  - no `stashMarker`
  - summary reports no stashable changes
  - warning logged/notified for operator visibility
- Added regression test for #5424 using real repo behavior + `nativeHasChanges` 10s cache:
  - seed dirty cache
  - clean tree before preflight
  - assert preflight no longer claims stash created

## Why

Issue #5424 identifies the root cause: preflight previously treated `git stash push` exit success as proof of stash creation. That assumption is false for the "No local changes to save" path and caused postflight restore attempts against an empty stash list.

## How

- Red: Added failing test `preflightCleanRoot does not claim stashPushed when cached dirty state is stale (#5424)`.
- Green: Implemented exact marker existence check after stash push.
- Refactor: Consolidated stash-list lookup logic into typed helpers used by both preflight validation and postflight targeting.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [x] `refactor` — Code restructuring (no behavior change)

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Executed:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/clean-root-preflight.test.ts`

Notes:
- `src/resources/extensions/gsd/tests/integration/auto-preflight.test.ts` did not run in this isolated worktree due missing local package resolution (`ERR_MODULE_NOT_FOUND: yaml`) in this environment.

## AI disclosure

- [x] This PR includes AI-assisted code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regression where cached dirty state was not properly validated during preflight checks, preventing incorrect stash creation.

* **Improvements**
  * Enhanced stash management with more robust reference verification; merge operations now emit warnings instead of failing when stash operations encounter issues.

* **Tests**
  * Added regression test for stale cache handling in dirty state detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->