### PR TITLE
fix(gsd): register auto worker before bootstrap milestone entry

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -293,11 +293,15 @@ const STATE_REBUILD_MIN_INTERVAL_MS = 30_000;
  * the DB is unavailable (e.g. fresh project before init) we skip registration
  * silently rather than blocking session start.
  */
-function registerAutoWorkerForSession(session: AutoSession): void {
+function registerAutoWorkerForSession(
+  session: AutoSession,
+  projectRootOverride?: string,
+): void {
   if (session.workerId) return; // already registered (e.g. resume re-runs)
   try {
     const projectRootRealpath = normalizeRealPath(
       session.scope?.workspace.projectRoot
+        ?? projectRootOverride
         ?? (session.originalBasePath || session.basePath),
     );
     session.workerId = registerAutoWorker({ projectRootRealpath });
@@ -2056,6 +2060,11 @@ export async function startAuto(
     lockBase,
     buildResolver,
   };
+
+  // Register the worker before bootstrap enters a milestone worktree.
+  // This ensures enterMilestone can claim a lease and seed dispatch claims
+  // for crash-recovery fidelity (#5405).
+  registerAutoWorkerForSession(s, base);
 
   const ready = await bootstrapAutoSession(
     s,

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -300,8 +300,8 @@ function registerAutoWorkerForSession(
   if (session.workerId) return; // already registered (e.g. resume re-runs)
   try {
     const projectRootRealpath = normalizeRealPath(
-      session.scope?.workspace.projectRoot
-        ?? projectRootOverride
+      projectRootOverride
+        ?? session.scope?.workspace.projectRoot
         ?? (session.originalBasePath || session.basePath),
     );
     session.workerId = registerAutoWorker({ projectRootRealpath });

--- a/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
+++ b/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
@@ -96,6 +96,23 @@ test("auto bootstrap validates blocked directories before touching .gsd migratio
   );
 });
 
+test("fresh start registers the auto worker before bootstrap enters worktree flow (#5405)", () => {
+  const autoSrc = readGsdFile("auto.ts");
+  const startAutoIdx = autoSrc.indexOf("export async function startAuto(");
+  const startAutoBody = autoSrc.slice(startAutoIdx);
+
+  const preBootstrapRegisterIdx = startAutoBody.indexOf("registerAutoWorkerForSession(s, base);");
+  const bootstrapCallIdx = startAutoBody.indexOf("const ready = await bootstrapAutoSession(");
+
+  assert.ok(startAutoIdx > -1, "startAuto should exist");
+  assert.ok(preBootstrapRegisterIdx > -1, "startAuto should register worker before bootstrap");
+  assert.ok(bootstrapCallIdx > -1, "startAuto should call bootstrapAutoSession");
+  assert.ok(
+    preBootstrapRegisterIdx < bootstrapCallIdx,
+    "worker registration must happen before bootstrap so enterMilestone can claim milestone leases on first entry",
+  );
+});
+
 test("startAutoDetached reports failures asynchronously (#3733)", () => {
   const autoSrc = readGsdFile("auto.ts");
 


### PR DESCRIPTION
## Linked issue

Closes #5405

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Register the auto worker before fresh-start bootstrap enters milestone worktree flow.
**Why:** Entering a milestone before worker registration can skip lease acquisition, leaving `milestoneLeaseToken` null and degrading dispatch-claim/crash-lock fidelity.
**How:** Pre-bootstrap worker registration now runs in `startAuto` before `bootstrapAutoSession`, with a regression test enforcing call order.

## What

- Updated worker registration helper to accept a project-root override.
- On fresh start path, call `registerAutoWorkerForSession(s, base)` before `bootstrapAutoSession(...)`.
- Added a source-structure regression test verifying worker registration occurs before bootstrap for #5405.

## Why

Issue #5405 identifies startup ordering as the root cause:
- `enterMilestone` can run during bootstrap while `workerId` is still null.
- Lease acquisition is skipped, `milestoneLeaseToken` remains null.
- Dispatch claims degrade and crash lock fallback becomes misleading (`starting/bootstrap`).

Registering before bootstrap restores first-entry lease eligibility.

## How

- Red: added test `fresh start registers the auto worker before bootstrap enters worktree flow (#5405)`.
- Green: inserted pre-bootstrap registration call.
- Refactor: worker-registration helper now supports explicit project-root fallback.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Executed:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/start-auto-detached.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-dispatch-claim.test.ts`

## AI disclosure

- [x] This PR includes AI-assisted code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup sequencing to ensure crash-recovery wiring is established earlier, reducing startup failures and improving milestone handling.

* **Tests**
  * Added a test that verifies the worker registration occurs before bootstrap during fresh starts to prevent sequencing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->