### PR TITLE
fix(gsd): restore completed_at during markdown recovery

### DIFF
--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -16,7 +16,9 @@ import {
   insertTask,
   openDatabase,
   transaction,
+  updateMilestoneStatus,
   updateSliceStatus,
+  updateTaskStatus,
   _getAdapter,
 } from './gsd-db.js';
 import {
@@ -31,7 +33,7 @@ import {
 } from './paths.js';
 import { findMilestoneIds } from './guided-flow.js';
 import { parseRoadmap, parsePlan } from './parsers-legacy.js';
-import { parseContextDependsOn } from './files.js';
+import { parseContextDependsOn, parseSummary } from './files.js';
 import { logWarning } from './workflow-logger.js';
 
 // ─── DECISIONS.md Parser ───────────────────────────────────────────────────
@@ -493,6 +495,12 @@ function findFileByPrefixAndSuffix(dir: string, idPrefix: string, suffix: string
 
 // ─── Hierarchy Migration (milestones/slices/tasks from roadmaps+plans) ────
 
+function readCompletedAtFromSummary(summaryPath: string | null): string | undefined {
+  if (!summaryPath || !existsSync(summaryPath)) return undefined;
+  const completedAt = parseSummary(readFileSync(summaryPath, 'utf-8')).frontmatter.completed_at?.trim();
+  return completedAt || undefined;
+}
+
 /**
  * Walk .gsd/milestones/ dirs, parse roadmaps and plans, and populate
  * the milestones/slices/tasks DB tables.
@@ -562,6 +570,7 @@ export function migrateHierarchyToDb(basePath: string): {
       const contextContent = readFileSync(contextPath!, 'utf-8');
       dependsOn = parseContextDependsOn(contextContent);
     }
+    const milestoneCompletedAt = readCompletedAtFromSummary(summaryPath);
 
     // Extract raw "## Boundary Map" section from roadmap markdown for planning column
     let boundaryMapSection = '';
@@ -587,6 +596,9 @@ export function migrateHierarchyToDb(basePath: string): {
         boundaryMapMarkdown: boundaryMapSection,
       },
     });
+    if (milestoneCompletedAt) {
+      updateMilestoneStatus(milestoneId, milestoneStatus, milestoneCompletedAt);
+    }
     counts.milestones++;
 
     // Parse roadmap for slices
@@ -596,6 +608,8 @@ export function migrateHierarchyToDb(basePath: string): {
       const sliceEntry = roadmap.slices[si]!;
       // Per K002: use 'complete' not 'done'
       const sliceStatus = sliceEntry.done ? 'complete' : 'pending';
+      const sliceSummaryPath = resolveSliceFile(basePath, milestoneId, sliceEntry.id, 'SUMMARY');
+      const sliceCompletedAt = readCompletedAtFromSummary(sliceSummaryPath);
 
       // Parse slice plan early so goal is available for insertSlice planning column
       const planPath = resolveSliceFile(basePath, milestoneId, sliceEntry.id, 'PLAN');
@@ -618,6 +632,9 @@ export function migrateHierarchyToDb(basePath: string): {
           goal: plan?.goal ?? '',
         },
       });
+      if (sliceStatus === 'complete' && sliceCompletedAt) {
+        updateSliceStatus(milestoneId, sliceEntry.id, sliceStatus, sliceCompletedAt);
+      }
       counts.slices++;
 
       // Insert tasks from parsed plan
@@ -626,14 +643,14 @@ export function migrateHierarchyToDb(basePath: string): {
       for (const taskEntry of plan.tasks) {
         // Per K002: use 'complete' not 'done'
         let taskStatus: string = taskEntry.done ? 'complete' : 'pending';
+        const tasksDir = resolveTasksDir(basePath, milestoneId, sliceEntry.id);
 
         // Pre-migration consistency: if task is marked done in the plan but has
         // no summary file on disk, import as 'pending' so it gets re-executed
         // rather than silently importing bad state as the new DB authority.
         if (taskStatus === 'complete') {
-          const tDir = resolveTasksDir(basePath, milestoneId, sliceEntry.id);
-          if (tDir) {
-            const summaryFile = join(tDir, `${taskEntry.id}-SUMMARY.md`);
+          if (tasksDir) {
+            const summaryFile = join(tasksDir, `${taskEntry.id}-SUMMARY.md`);
             if (!existsSync(summaryFile)) {
               taskStatus = 'pending';
               process.stderr.write(
@@ -642,6 +659,9 @@ export function migrateHierarchyToDb(basePath: string): {
             }
           }
         }
+        const taskCompletedAt = readCompletedAtFromSummary(
+          tasksDir ? join(tasksDir, `${taskEntry.id}-SUMMARY.md`) : null,
+        );
 
         insertTask({
           id: taskEntry.id,
@@ -654,6 +674,9 @@ export function migrateHierarchyToDb(basePath: string): {
             verify: taskEntry.verify ?? '',
           },
         });
+        if (taskStatus === 'complete' && taskCompletedAt) {
+          updateTaskStatus(milestoneId, sliceEntry.id, taskEntry.id, taskStatus, taskCompletedAt);
+        }
         counts.tasks++;
       }
 
@@ -664,7 +687,6 @@ export function migrateHierarchyToDb(basePath: string): {
       // doctor would have auto-fixed. Without a slice summary, the slice
       // is in the "summarizing" phase, not complete.
       if (!sliceEntry.done) {
-        const sliceSummaryPath = resolveSliceFile(basePath, milestoneId, sliceEntry.id, 'SUMMARY');
         const hasSliceSummary = sliceSummaryPath !== null && existsSync(sliceSummaryPath);
         const allTasksDone = plan.tasks.length > 0 && plan.tasks.every(t => {
           const tDir = resolveTasksDir(basePath, milestoneId, sliceEntry.id);
@@ -674,7 +696,7 @@ export function migrateHierarchyToDb(basePath: string): {
         });
         if (allTasksDone && hasSliceSummary) {
           if (_getAdapter()) {
-            updateSliceStatus(milestoneId, sliceEntry.id, 'complete');
+            updateSliceStatus(milestoneId, sliceEntry.id, 'complete', sliceCompletedAt);
             process.stderr.write(
               `gsd-migrate: ${milestoneId}/${sliceEntry.id} all tasks + slice summary complete — upgrading slice to complete\n`,
             );

--- a/src/resources/extensions/gsd/tests/md-importer.test.ts
+++ b/src/resources/extensions/gsd/tests/md-importer.test.ts
@@ -299,6 +299,97 @@ test('md-importer: migrateFromMarkdown orchestrator', () => {
   }
 });
 
+test('md-importer: recover completed_at from summary frontmatter', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-completed-at-import-'));
+  const m001 = path.join(tmpDir, '.gsd', 'milestones', 'M001');
+  const s01 = path.join(m001, 'slices', 'S01');
+  const tasks = path.join(s01, 'tasks');
+  const milestoneCompletedAt = '2026-04-01T10:00:00.000Z';
+  const sliceCompletedAt = '2026-04-01T11:00:00.000Z';
+  const taskCompletedAt = '2026-04-01T11:30:00.000Z';
+
+  fs.mkdirSync(tasks, { recursive: true });
+  fs.writeFileSync(
+    path.join(m001, 'M001-ROADMAP.md'),
+    `# M001: Import Milestone
+
+## Slices
+
+- [x] **S01: Completed Slice** \`risk:low\` \`depends:[]\`
+`,
+  );
+  fs.writeFileSync(
+    path.join(m001, 'M001-SUMMARY.md'),
+    `---
+id: M001
+completed_at: ${milestoneCompletedAt}
+---
+
+# M001 Summary
+`,
+  );
+  fs.writeFileSync(
+    path.join(s01, 'S01-PLAN.md'),
+    `# S01: Completed Slice
+
+## Tasks
+
+- [x] **T01: Completed Task** \`est:5m\`
+  - Files: src/task.ts
+  - Verify: npm test
+`,
+  );
+  fs.writeFileSync(
+    path.join(s01, 'S01-SUMMARY.md'),
+    `---
+id: S01
+parent: M001
+milestone: M001
+completed_at: ${sliceCompletedAt}
+---
+
+# S01 Summary
+`,
+  );
+  fs.writeFileSync(
+    path.join(tasks, 'T01-SUMMARY.md'),
+    `---
+id: T01
+parent: S01
+milestone: M001
+completed_at: ${taskCompletedAt}
+---
+
+# T01 Summary
+`,
+  );
+
+  try {
+    openDatabase(':memory:');
+    migrateFromMarkdown(tmpDir);
+
+    const adapter = _getAdapter();
+    const milestone = adapter?.prepare('SELECT completed_at FROM milestones WHERE id = :id').get({ ':id': 'M001' });
+    const slice = adapter?.prepare('SELECT completed_at FROM slices WHERE milestone_id = :mid AND id = :sid').get({
+      ':mid': 'M001',
+      ':sid': 'S01',
+    });
+    const task = adapter?.prepare('SELECT completed_at FROM tasks WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid').get({
+      ':mid': 'M001',
+      ':sid': 'S01',
+      ':tid': 'T01',
+    });
+
+    assert.equal(milestone?.completed_at, milestoneCompletedAt);
+    assert.equal(slice?.completed_at, sliceCompletedAt);
+    assert.equal(task?.completed_at, taskCompletedAt);
+
+    closeDatabase();
+  } finally {
+    cleanupDir(tmpDir);
+  }
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // md-importer: idempotent re-import
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Linked issue

Closes #5393

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Markdown recovery now preserves `completed_at` from milestone, slice, and task `SUMMARY.md` frontmatter.
**Why:** Headless recovery was restoring completed hierarchy state without the original completion timestamps.
**How:** The hierarchy importer parses summary frontmatter during recovery and applies the recovered timestamps after inserting/updating the DB rows.

## What

This updates the markdown hierarchy importer so completed milestone, slice, and task rows recover their `completed_at` values from existing summary artifacts. It also adds a regression test that imports a completed milestone tree and asserts exact timestamps for all three hierarchy levels.

## Why

Headless recovery should reconstruct the DB from the markdown artifacts as faithfully as possible. Before this change, recovered completed rows could have `completed_at` set to `NULL` or a new runtime timestamp instead of the timestamp already recorded in `SUMMARY.md`.

## How

The importer now reuses the existing summary parser to read `completed_at` from summary frontmatter and writes that value through the existing status update helpers after the row exists. This keeps the import path surgical and avoids changing the general insert helpers for non-recovery callers.

## Change type

- [ ] `feat` - New feature or capability
- [x] `fix` - Bug fix
- [ ] `refactor` - Code restructuring (no behavior change)
- [x] `test` - Adding or updating tests
- [ ] `docs` - Documentation only
- [ ] `chore` - Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` - Terminal UI
- [ ] `pi-ai` - AI/LLM layer
- [ ] `pi-agent-core` - Agent orchestration
- [ ] `pi-coding-agent` - Coding agent
- [x] `gsd extension` - GSD workflow
- [ ] `native` - Native bindings
- [ ] `ci/build` - Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes - described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing - steps described above
- [ ] No tests needed - explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/md-importer.test.ts`

Manual testing:

1. Ran the new regression test before the fix and observed the recovered milestone `completed_at` was `NULL` instead of the summary timestamp.
2. Re-ran the same test after the fix and confirmed milestone, slice, and task timestamps match the summary frontmatter exactly.

## AI disclosure

- [x] This PR includes AI-assisted code - prepared with Codex and verified as described in the test plan above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Completion timestamps are now preserved during Markdown migration, properly updating the status of milestones, slices, and tasks with their recorded completion times.

* **Tests**
  * Added test coverage for timestamp recovery during migration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->