### PR TITLE
fix(search): resolve project-scoped search credentials

### DIFF
--- a/src/resources/extensions/search-the-web/provider.test.ts
+++ b/src/resources/extensions/search-the-web/provider.test.ts
@@ -1,0 +1,69 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  getBraveApiKey,
+  getTavilyApiKey,
+  MISSING_SEARCH_API_KEY_MESSAGE,
+  resolveSearchProvider,
+} from './provider.ts';
+
+function withProjectEnv(
+  files: Record<string, string>,
+  run: () => void,
+): void {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'gsd-search-provider-'));
+  const tempHome = join(tempRoot, 'home');
+  const projectRoot = join(tempRoot, 'project');
+  const previousCwd = process.cwd();
+  const previousEnv = {
+    BRAVE_API_KEY: process.env.BRAVE_API_KEY,
+    TAVILY_API_KEY: process.env.TAVILY_API_KEY,
+    OLLAMA_API_KEY: process.env.OLLAMA_API_KEY,
+    GSD_HOME: process.env.GSD_HOME,
+  };
+
+  mkdirSync(projectRoot, { recursive: true });
+  mkdirSync(tempHome, { recursive: true });
+  for (const [file, content] of Object.entries(files)) {
+    writeFileSync(join(projectRoot, file), content);
+  }
+
+  try {
+    delete process.env.BRAVE_API_KEY;
+    delete process.env.TAVILY_API_KEY;
+    delete process.env.OLLAMA_API_KEY;
+    process.env.GSD_HOME = tempHome;
+    process.chdir(projectRoot);
+    run();
+  } finally {
+    process.chdir(previousCwd);
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+test('search provider resolves BRAVE_API_KEY from project .env', () => {
+  withProjectEnv({ '.env': 'BRAVE_API_KEY=project-brave-key\n' }, () => {
+    assert.equal(getBraveApiKey(), 'project-brave-key');
+    assert.equal(resolveSearchProvider(), 'brave');
+  });
+});
+
+test('search provider resolves TAVILY_API_KEY from project .env.local', () => {
+  withProjectEnv({ '.env.local': 'TAVILY_API_KEY=project-tavily-key\n' }, () => {
+    assert.equal(getTavilyApiKey(), 'project-tavily-key');
+    assert.equal(resolveSearchProvider(), 'tavily');
+  });
+});
+
+test('missing search key guidance avoids interactive-only recovery tools', () => {
+  assert.doesNotMatch(MISSING_SEARCH_API_KEY_MESSAGE, /secure_env_collect/);
+  assert.match(MISSING_SEARCH_API_KEY_MESSAGE, /\.env/);
+});

--- a/src/resources/extensions/search-the-web/provider.ts
+++ b/src/resources/extensions/search-the-web/provider.ts
@@ -10,7 +10,8 @@
  */
 
 import { AuthStorage } from '@gsd/pi-coding-agent'
-import { join } from 'path'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
 import { resolveSearchProviderFromPreferences } from '../gsd/preferences.js'
 import { gsdHome } from "../gsd/gsd-home.js";
 
@@ -26,15 +27,79 @@ export type SearchProviderPreference = SearchProvider | 'auto'
 
 const VALID_PREFERENCES = new Set<string>(['tavily', 'brave', 'ollama', 'auto'])
 const PREFERENCE_KEY = 'search_provider'
+export const MISSING_SEARCH_API_KEY_MESSAGE =
+  "No search API key is set. Configure TAVILY_API_KEY, BRAVE_API_KEY, or OLLAMA_API_KEY via live env, GSD keys, or project .env/.env.local, then retry."
 
-/** Returns the Tavily API key from the environment, or empty string if not set. */
-export function getTavilyApiKey(): string {
-  return process.env.TAVILY_API_KEY || ''
+function getStoredApiKey(providerId: SearchProvider): string {
+  try {
+    const auth = AuthStorage.create(authFilePath())
+    const cred = auth.getCredentialsForProvider(providerId).find(c => c.type === 'api_key' && c.key)
+    return cred?.type === 'api_key' ? cred.key : ''
+  } catch {
+    return ''
+  }
 }
 
-/** Returns the Brave API key from the environment, or empty string if not set. */
+function parseDotenvValue(content: string, key: string): string {
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/)
+    if (!match || match[1] !== key) continue
+    const value = match[2].trim()
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      return value.slice(1, -1)
+    }
+    return value.replace(/\s+#.*$/, '').trim()
+  }
+  return ''
+}
+
+function projectRootCandidates(): string[] {
+  const roots: string[] = []
+  const add = (dir: string | undefined): void => {
+    if (!dir) return
+    const resolved = resolve(dir)
+    if (!roots.includes(resolved)) roots.push(resolved)
+  }
+
+  add(process.env.GSD_PROJECT_ROOT)
+
+  let current = resolve(process.cwd())
+  while (true) {
+    add(current)
+    const parent = dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+
+  return roots
+}
+
+function readProjectDotenvKey(envVar: string): string {
+  for (const root of projectRootCandidates()) {
+    for (const fileName of ['.env', '.env.local']) {
+      const filePath = join(root, fileName)
+      if (!existsSync(filePath)) continue
+      const value = parseDotenvValue(readFileSync(filePath, 'utf-8'), envVar)
+      if (value) return value
+    }
+  }
+  return ''
+}
+
+function getToolApiKey(providerId: SearchProvider, envVar: string): string {
+  return process.env[envVar] || getStoredApiKey(providerId) || readProjectDotenvKey(envVar) || ''
+}
+
+/** Returns the Tavily API key from available configured sources, or empty string if not set. */
+export function getTavilyApiKey(): string {
+  return getToolApiKey('tavily', 'TAVILY_API_KEY')
+}
+
+/** Returns the Brave API key from available configured sources, or empty string if not set. */
 export function getBraveApiKey(): string {
-  return process.env.BRAVE_API_KEY || ''
+  return getToolApiKey('brave', 'BRAVE_API_KEY')
 }
 
 /** Standard headers for Brave Search API requests. */
@@ -46,9 +111,9 @@ export function braveHeaders(): Record<string, string> {
   }
 }
 
-/** Returns the Ollama API key from the environment, or empty string if not set. */
+/** Returns the Ollama API key from available configured sources, or empty string if not set. */
 export function getOllamaApiKey(): string {
-  return process.env.OLLAMA_API_KEY || ''
+  return getToolApiKey('ollama', 'OLLAMA_API_KEY')
 }
 
 /**

--- a/src/resources/extensions/search-the-web/tool-llm-context.ts
+++ b/src/resources/extensions/search-the-web/tool-llm-context.ts
@@ -27,7 +27,14 @@ import { normalizeQuery, extractDomain } from "./url-utils.js";
 import { formatLLMContext, type LLMContextSnippet, type LLMContextSource } from "./format.js";
 import type { TavilyResult, TavilySearchResponse } from "./tavily.js";
 import { publishedDateToAge } from "./tavily.js";
-import { getTavilyApiKey, getOllamaApiKey, getBraveApiKey, braveHeaders, resolveSearchProvider } from "./provider.js";
+import {
+  getTavilyApiKey,
+  getOllamaApiKey,
+  getBraveApiKey,
+  braveHeaders,
+  resolveSearchProvider,
+  MISSING_SEARCH_API_KEY_MESSAGE,
+} from "./provider.js";
 
 // =============================================================================
 // Types
@@ -334,7 +341,7 @@ export function registerLLMContextTool(pi: ExtensionAPI) {
       const provider = resolveSearchProvider();
       if (!provider) {
         return {
-          content: [{ type: "text", text: "search_and_read unavailable: No search API key is set. Use secure_env_collect to set TAVILY_API_KEY, BRAVE_API_KEY, or OLLAMA_API_KEY." }],
+          content: [{ type: "text", text: `search_and_read unavailable: ${MISSING_SEARCH_API_KEY_MESSAGE}` }],
           isError: true,
           details: { errorKind: "auth_error", error: "No search API key set" } satisfies Partial<LLMContextDetails>,
         };

--- a/src/resources/extensions/search-the-web/tool-search.ts
+++ b/src/resources/extensions/search-the-web/tool-search.ts
@@ -20,7 +20,14 @@ import { LRUTTLCache } from "./cache.js";
 import { fetchWithRetryTimed, fetchWithRetry, classifyError, type RateLimitInfo } from "./http.js";
 import { normalizeQuery, toDedupeKey, detectFreshness } from "./url-utils.js";
 import { formatSearchResults, type SearchResultFormatted, type FormatSearchOptions } from "./format.js";
-import { getTavilyApiKey, getOllamaApiKey, getBraveApiKey, braveHeaders, resolveSearchProvider } from "./provider.js";
+import {
+  getTavilyApiKey,
+  getOllamaApiKey,
+  getBraveApiKey,
+  braveHeaders,
+  resolveSearchProvider,
+  MISSING_SEARCH_API_KEY_MESSAGE,
+} from "./provider.js";
 import { normalizeTavilyResult, mapFreshnessToTavily, type TavilySearchResponse } from "./tavily.js";
 
 // =============================================================================
@@ -357,7 +364,7 @@ export function registerSearchTool(pi: ExtensionAPI) {
       const provider = resolveSearchProvider();
       if (!provider) {
         return {
-          content: [{ type: "text", text: "Web search unavailable: No search API key is set. Use secure_env_collect to set TAVILY_API_KEY, BRAVE_API_KEY, or OLLAMA_API_KEY." }],
+          content: [{ type: "text", text: `Web search unavailable: ${MISSING_SEARCH_API_KEY_MESSAGE}` }],
           isError: true,
           details: { errorKind: "auth_error", error: "No search API key set" } satisfies Partial<SearchDetails>,
         };


### PR DESCRIPTION
## Linked issue

Closes #5435

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** `search-the-web` now resolves search API keys from live env, GSD key storage, and project dotenv files.
**Why:** Auto/research flows could miss project-local `BRAVE_API_KEY` or `TAVILY_API_KEY` values and incorrectly report that no search key was set.
**How:** Search provider key lookup now uses one resolver path, and missing-key guidance points to reusable configuration sources instead of an interactive-only recovery tool.

## What

This updates the bundled search extension credential lookup for Tavily, Brave, and Ollama. Provider resolution now checks live environment variables, GSD key storage, and active project `.env` / `.env.local` files. It also updates the missing-key message used by both `search-the-web` and `search_and_read`.

## Why

A project can already contain a valid search key in dotenv files while the active Node process lacks that key in `process.env`. In that state, search tools treated every provider as unavailable and pushed auto/research flows away from live web search.

## How

The provider module now owns a small credential resolver that reads provider keys from the configured sources in order. The tests cover project-scoped Brave and Tavily keys and verify that missing-key guidance no longer points at an interactive-only recovery path.

## Change type

- [ ] `feat` - New feature or capability
- [x] `fix` - Bug fix
- [ ] `refactor` - Code restructuring (no behavior change)
- [x] `test` - Adding or updating tests
- [ ] `docs` - Documentation only
- [ ] `chore` - Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` - Terminal UI
- [ ] `pi-ai` - AI/LLM layer
- [ ] `pi-agent-core` - Agent orchestration
- [ ] `pi-coding-agent` - Coding agent
- [x] `gsd extension` - GSD workflow
- [ ] `native` - Native bindings
- [ ] `ci/build` - Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes - described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing - steps described above
- [ ] No tests needed - explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/search-the-web/provider.test.ts`

Manual testing:

1. Ran the new provider tests before the fix and observed project `.env` / `.env.local` keys were not detected.
2. Re-ran the same tests after the fix and confirmed project-scoped Brave and Tavily keys resolve the expected provider.

## AI disclosure

- [x] This PR includes AI-assisted code - prepared with Codex and verified as described in the test plan above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ollama API key configuration.
  * Expanded API key resolution to support multiple sources: environment variables, configuration files, and stored credentials.

* **Bug Fixes**
  * Standardized missing API key error messages across search tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->