### PR TITLE
[codex] Harden auto crash recovery

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -68,6 +68,8 @@ import {
   settleDispatchCompleted,
   settleDispatchFailed,
 } from "./workflow-dispatch-ledger.js";
+import { emitOpenUnitEndForUnit } from "../crash-recovery.js";
+import { writeUnitRuntimeRecord } from "../unit-runtime.js";
 import { openDispatchClaim } from "./workflow-dispatch-claim.js";
 import { completeWorkflowIteration } from "./workflow-iteration-completion.js";
 import { createWorkflowJournalReporter } from "./workflow-journal-reporter.js";
@@ -699,6 +701,32 @@ export async function autoLoop(
       } catch (err) {
         if (err instanceof ModelPolicyDispatchBlockedError) {
           throw err;
+        }
+        try {
+          emitOpenUnitEndForUnit(
+            s.basePath,
+            iterData.unitType,
+            iterData.unitId,
+            "cancelled",
+            {
+              message: formatDispatchExceptionSummary({ error: err }),
+              category: "unit-exception",
+              isTransient: false,
+            },
+          );
+          writeUnitRuntimeRecord(
+            s.basePath,
+            iterData.unitType,
+            iterData.unitId,
+            s.currentUnit?.startedAt ?? Date.now(),
+            {
+              phase: "crashed",
+              lastProgressAt: Date.now(),
+              lastProgressKind: "unit-exception",
+            },
+          );
+        } catch {
+          // Best-effort observability: the original exception still controls flow.
         }
         dispatchSettled = settleDispatchFailed(
           dispatchId,

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -203,6 +203,36 @@ async function enforceMinRequestInterval(s: AutoSession, prefs: IterationContext
   }
 }
 
+function closeOutCrashedUnit(s: AutoSession, iterData: IterationData, err: unknown): void {
+  const summary = formatDispatchExceptionSummary({ error: err });
+  try {
+    emitOpenUnitEndForUnit(
+      s.basePath,
+      iterData.unitType,
+      iterData.unitId,
+      "cancelled",
+      {
+        message: summary,
+        category: "unit-exception",
+        isTransient: false,
+      },
+    );
+    writeUnitRuntimeRecord(
+      s.basePath,
+      iterData.unitType,
+      iterData.unitId,
+      s.currentUnit?.startedAt ?? Date.now(),
+      {
+        phase: "crashed",
+        lastProgressAt: Date.now(),
+        lastProgressKind: "unit-exception",
+      },
+    );
+  } catch (closeoutErr) {
+    logWarning("dispatch", `unit crash closeout failed: ${closeoutErr instanceof Error ? closeoutErr.message : String(closeoutErr)}`);
+  }
+}
+
 /**
  * Main auto-mode execution loop. Iterates: derive → dispatch → guards →
  * runUnit → finalize → repeat. Exits when s.active becomes false or a
@@ -495,14 +525,23 @@ export async function autoLoop(
 
         // ── Unit execution (shared with dev path) ──
         await enforceMinRequestInterval(s, prefs);
-        const unitPhaseResult = await runUnitPhaseViaContract(
-          dispatchContract,
-          ic,
-          iterData,
-          loopState,
-          undefined,
-          unitDispatchDeps,
-        );
+        let unitPhaseResult: Awaited<ReturnType<typeof runUnitPhaseViaContract>>;
+        try {
+          unitPhaseResult = await runUnitPhaseViaContract(
+            dispatchContract,
+            ic,
+            iterData,
+            loopState,
+            undefined,
+            unitDispatchDeps,
+          );
+        } catch (err) {
+          if (err instanceof ModelPolicyDispatchBlockedError) {
+            throw err;
+          }
+          closeOutCrashedUnit(s, iterData, err);
+          throw err;
+        }
         if (unitPhaseResult.action === "next") {
           const requestTimestamp = resolveUnitRequestTimestamp(unitPhaseResult.data);
           if (requestTimestamp !== undefined) s.lastRequestTimestamp = requestTimestamp;
@@ -702,32 +741,7 @@ export async function autoLoop(
         if (err instanceof ModelPolicyDispatchBlockedError) {
           throw err;
         }
-        try {
-          emitOpenUnitEndForUnit(
-            s.basePath,
-            iterData.unitType,
-            iterData.unitId,
-            "cancelled",
-            {
-              message: formatDispatchExceptionSummary({ error: err }),
-              category: "unit-exception",
-              isTransient: false,
-            },
-          );
-          writeUnitRuntimeRecord(
-            s.basePath,
-            iterData.unitType,
-            iterData.unitId,
-            s.currentUnit?.startedAt ?? Date.now(),
-            {
-              phase: "crashed",
-              lastProgressAt: Date.now(),
-              lastProgressKind: "unit-exception",
-            },
-          );
-        } catch {
-          // Best-effort observability: the original exception still controls flow.
-        }
+        closeOutCrashedUnit(s, iterData, err);
         dispatchSettled = settleDispatchFailed(
           dispatchId,
           formatDispatchExceptionSummary({ error: err }),

--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -38,6 +38,7 @@ import { _getAdapter, isDbAvailable } from "./gsd-db.js";
 import { gsdRoot, normalizeRealPath } from "./paths.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { effectiveLockFile } from "./session-lock.js";
+import { listUnitRuntimeRecords, type AutoUnitRuntimeRecord } from "./unit-runtime.js";
 
 export interface LockData {
   pid: number;
@@ -50,6 +51,14 @@ export interface LockData {
 }
 
 const SESSION_FILE_KV_KEY = "session_file";
+const IN_FLIGHT_RUNTIME_PHASES = new Set([
+  "dispatched",
+  "wrapup-warning-sent",
+  "timeout",
+  "finalize-timeout",
+  "crashed",
+  "paused",
+]);
 
 function lockPath(basePath: string): string {
   return join(gsdRoot(basePath), effectiveLockFile());
@@ -103,10 +112,40 @@ function getLatestDispatchForWorker(workerId: string):
   return row ?? null;
 }
 
-function workerToLockData(worker: AutoWorkerRow): LockData {
+function latestInFlightRuntimeRecord(basePath: string): AutoUnitRuntimeRecord | null {
+  const records = listUnitRuntimeRecords(basePath).filter((record) =>
+    IN_FLIGHT_RUNTIME_PHASES.has(record.phase),
+  );
+  if (records.length === 0) return null;
+  return records.sort((a, b) => {
+    const bTime = b.updatedAt || b.startedAt || 0;
+    const aTime = a.updatedAt || a.startedAt || 0;
+    return bTime - aTime;
+  })[0] ?? null;
+}
+
+function runtimeRecordToLockData(worker: AutoWorkerRow, record: AutoUnitRuntimeRecord, sessionFile?: string): LockData {
+  const startedAt = Number.isFinite(record.startedAt)
+    ? new Date(record.startedAt).toISOString()
+    : worker.started_at;
+  return {
+    pid: worker.pid,
+    startedAt: worker.started_at,
+    unitType: record.unitType,
+    unitId: record.unitId,
+    unitStartedAt: startedAt,
+    sessionFile,
+  };
+}
+
+function workerToLockData(basePath: string, worker: AutoWorkerRow): LockData {
   const dispatch = getLatestDispatchForWorker(worker.worker_id);
   const sessionFile =
     getRuntimeKv<string>("worker", worker.worker_id, SESSION_FILE_KV_KEY) ?? undefined;
+  if (!dispatch) {
+    const runtimeRecord = latestInFlightRuntimeRecord(basePath);
+    if (runtimeRecord) return runtimeRecordToLockData(worker, runtimeRecord, sessionFile);
+  }
   return {
     pid: worker.pid,
     startedAt: worker.started_at,
@@ -204,7 +243,7 @@ export function readCrashLock(basePath: string): LockData | null {
     try {
       const projectRoot = normalizeRealPath(basePath);
       const stale = findStaleWorkerForProject(projectRoot);
-      if (stale) return workerToLockData(stale);
+      if (stale) return workerToLockData(basePath, stale);
     } catch {
       // Fall through to the legacy lock-file compatibility path.
     }
@@ -260,25 +299,48 @@ export function formatCrashInfo(lock: LockData): string {
  */
 export function emitCrashRecoveredUnitEnd(basePath: string, lock: LockData): void {
   if (!lock.unitType || !lock.unitId || lock.unitType === "starting") return;
+  emitOpenUnitEndForUnit(basePath, lock.unitType, lock.unitId, "crash-recovered");
+}
 
+export function emitOpenUnitEndForUnit(
+  basePath: string,
+  unitType: string,
+  unitId: string,
+  status: string,
+  errorContext?: { message: string; category: string; stopReason?: string; isTransient?: boolean; retryAfterMs?: number },
+): boolean {
   try {
     const all = queryJournal(basePath);
 
     const starts = all.filter(
-      (e) => e.eventType === "unit-start" && e.data?.unitId === lock.unitId,
+      (e) =>
+        e.eventType === "unit-start" &&
+        e.data?.unitType === unitType &&
+        e.data?.unitId === unitId,
     );
-    if (starts.length === 0) return;
+    if (starts.length === 0) return false;
 
-    const lastStart = starts[starts.length - 1];
+    const lastStart = [...starts].reverse().find((start) => {
+      return !all.some(
+        (e) =>
+          e.eventType === "unit-end" &&
+          e.data?.unitType === unitType &&
+          e.data?.unitId === unitId &&
+          e.causedBy?.flowId === start.flowId &&
+          e.causedBy?.seq === start.seq,
+      );
+    });
+    if (!lastStart) return false;
 
     const alreadyClosed = all.some(
       (e) =>
         e.eventType === "unit-end" &&
-        e.data?.unitId === lock.unitId &&
+        e.data?.unitType === unitType &&
+        e.data?.unitId === unitId &&
         e.causedBy?.flowId === lastStart.flowId &&
         e.causedBy?.seq === lastStart.seq,
     );
-    if (alreadyClosed) return;
+    if (alreadyClosed) return false;
 
     const maxSeq = all
       .filter((e) => e.flowId === lastStart.flowId)
@@ -290,15 +352,18 @@ export function emitCrashRecoveredUnitEnd(basePath: string, lock: LockData): voi
       seq: maxSeq + 1,
       eventType: "unit-end",
       data: {
-        unitType: lock.unitType,
-        unitId: lock.unitId,
-        status: "crash-recovered",
+        unitType,
+        unitId,
+        status,
         artifactVerified: false,
+        ...(errorContext ? { errorContext } : {}),
       },
       causedBy: { flowId: lastStart.flowId, seq: lastStart.seq },
     });
+    return true;
   } catch {
     // Never throw from crash recovery path.
+    return false;
   }
 }
 

--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -38,7 +38,7 @@ import { _getAdapter, isDbAvailable } from "./gsd-db.js";
 import { gsdRoot, normalizeRealPath } from "./paths.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { effectiveLockFile } from "./session-lock.js";
-import { listUnitRuntimeRecords, type AutoUnitRuntimeRecord } from "./unit-runtime.js";
+import { isInFlightRuntimePhase, listUnitRuntimeRecords, type AutoUnitRuntimeRecord } from "./unit-runtime.js";
 
 export interface LockData {
   pid: number;
@@ -51,14 +51,6 @@ export interface LockData {
 }
 
 const SESSION_FILE_KV_KEY = "session_file";
-const IN_FLIGHT_RUNTIME_PHASES = new Set([
-  "dispatched",
-  "wrapup-warning-sent",
-  "timeout",
-  "finalize-timeout",
-  "crashed",
-  "paused",
-]);
 
 function lockPath(basePath: string): string {
   return join(gsdRoot(basePath), effectiveLockFile());
@@ -114,7 +106,7 @@ function getLatestDispatchForWorker(workerId: string):
 
 function latestInFlightRuntimeRecord(basePath: string): AutoUnitRuntimeRecord | null {
   const records = listUnitRuntimeRecords(basePath).filter((record) =>
-    IN_FLIGHT_RUNTIME_PHASES.has(record.phase),
+    isInFlightRuntimePhase(record.phase),
   );
   if (records.length === 0) return null;
   return records.sort((a, b) => {

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -30,7 +30,7 @@ import {
   formatInterruptedSessionRunningMessage,
   formatInterruptedSessionSummary,
 } from "./interrupted-session.js";
-import { listUnitRuntimeRecords, clearUnitRuntimeRecord } from "./unit-runtime.js";
+import { listUnitRuntimeRecords, clearUnitRuntimeRecord, isInFlightRuntimePhase } from "./unit-runtime.js";
 import { resolveExpectedArtifactPath } from "./auto.js";
 import { gsdHome } from "./gsd-home.js";
 import {
@@ -1802,8 +1802,8 @@ function selfHealRuntimeRecords(basePath: string, ctx: ExtensionContext): { clea
         cleared++;
         continue;
       }
-      // Clear records stuck in dispatched or timeout phase (process died mid-unit)
-      if (phase === "dispatched" || phase === "timeout") {
+      // Clear records stuck in an in-flight phase (process died mid-unit).
+      if (isInFlightRuntimePhase(phase)) {
         clearUnitRuntimeRecord(basePath, unitType, unitId);
         cleared++;
       }

--- a/src/resources/extensions/gsd/tests/crash-handler-secondary.test.ts
+++ b/src/resources/extensions/gsd/tests/crash-handler-secondary.test.ts
@@ -232,4 +232,59 @@ describe('emitCrashRecoveredUnitEnd (#3348)', () => {
       rmSync(base, { recursive: true, force: true });
     }
   });
+
+  test('emitOpenUnitEndForUnit closes the latest open start with error context', async () => {
+    const base = makeTmpBase();
+    try {
+      const { emitJournalEvent, queryJournal } = await import('../journal.ts');
+      const { emitOpenUnitEndForUnit } = await import('../crash-recovery.ts');
+
+      const firstFlowId = randomUUID();
+      const secondFlowId = randomUUID();
+      emitJournalEvent(base, {
+        ts: new Date().toISOString(),
+        flowId: firstFlowId,
+        seq: 1,
+        eventType: 'unit-start',
+        data: { unitType: 'execute-task', unitId: 'M008/S04/T02' },
+      });
+      emitJournalEvent(base, {
+        ts: new Date().toISOString(),
+        flowId: firstFlowId,
+        seq: 2,
+        eventType: 'unit-end',
+        data: { unitType: 'execute-task', unitId: 'M008/S04/T02', status: 'completed' },
+        causedBy: { flowId: firstFlowId, seq: 1 },
+      });
+      emitJournalEvent(base, {
+        ts: new Date().toISOString(),
+        flowId: secondFlowId,
+        seq: 3,
+        eventType: 'unit-start',
+        data: { unitType: 'execute-task', unitId: 'M008/S04/T02' },
+      });
+
+      const emitted = emitOpenUnitEndForUnit(
+        base,
+        'execute-task',
+        'M008/S04/T02',
+        'cancelled',
+        { message: 'runUnitPhase exploded', category: 'unit-exception', isTransient: false },
+      );
+
+      assert.equal(emitted, true, 'open unit should be closed');
+      const ends = queryJournal(base).filter((e) => e.eventType === 'unit-end');
+      assert.equal(ends.length, 2, 'should preserve existing end and add one new end');
+      const newEnd = ends.find((e) => e.causedBy?.flowId === secondFlowId);
+      assert.ok(newEnd, 'new end should close the latest open start');
+      assert.equal(newEnd!.data?.status, 'cancelled');
+      assert.deepEqual(newEnd!.data?.errorContext, {
+        message: 'runUnitPhase exploded',
+        category: 'unit-exception',
+        isTransient: false,
+      });
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
@@ -30,6 +30,7 @@ import {
   isLockProcessAlive,
 } from "../crash-recovery.ts";
 import { normalizeRealPath } from "../paths.ts";
+import { writeUnitRuntimeRecord } from "../unit-runtime.ts";
 
 function makeBase(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-crash-recovery-"));
@@ -100,6 +101,27 @@ test("readCrashLock synthesizes LockData from a stale dead worker (no dispatches
   assert.equal(lock!.unitType, "starting");
   assert.equal(lock!.unitId, "bootstrap");
   assert.ok(lock!.startedAt, "startedAt populated from workers.started_at");
+});
+
+test("readCrashLock falls back to latest in-flight runtime record when dispatch claim is missing", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  const projectRoot = normalizeRealPath(base);
+  const workerId = registerAutoWorker({ projectRootRealpath: projectRoot });
+  writeUnitRuntimeRecord(base, "execute-task", "M008/S04/T02", 1778069087937, {
+    phase: "dispatched",
+    lastProgressAt: 1778069087937,
+    lastProgressKind: "dispatch",
+  });
+  setWorkerPid(workerId, 99999);
+  expireWorker(workerId);
+
+  const lock = readCrashLock(base);
+  assert.ok(lock, "stale worker surfaced as a crash lock");
+  assert.equal(lock!.unitType, "execute-task");
+  assert.equal(lock!.unitId, "M008/S04/T02");
+  assert.equal(lock!.unitStartedAt, new Date(1778069087937).toISOString());
 });
 
 test("readCrashLock includes the most recent dispatch as unitType/unitId", (t) => {

--- a/src/resources/extensions/gsd/tests/unit-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-runtime.test.ts
@@ -5,6 +5,7 @@ import {
   clearUnitRuntimeRecord,
   formatExecuteTaskRecoveryStatus,
   inspectExecuteTaskDurability,
+  isInFlightRuntimePhase,
   readUnitRuntimeRecord,
   writeUnitRuntimeRecord,
 } from "../unit-runtime.ts";
@@ -21,6 +22,12 @@ writeFileSync(
   "# S02: Test Slice\n\n## Tasks\n\n- [ ] **T09: Do the thing** `est:10m`\n  Description.\n",
   "utf-8",
 );
+
+console.log("\n=== in-flight runtime phases ===");
+{
+  assert.equal(isInFlightRuntimePhase("crashed"), true, "crashed records remain recoverable");
+  assert.equal(isInFlightRuntimePhase("finalized"), false, "finalized records are terminal");
+}
 
 console.log("\n=== runtime record write/read/update ===");
 {

--- a/src/resources/extensions/gsd/unit-runtime.ts
+++ b/src/resources/extensions/gsd/unit-runtime.ts
@@ -67,6 +67,7 @@ export type UnitRuntimePhase =
   | "wrapup-warning-sent"
   | "timeout"
   | "finalize-timeout"
+  | "crashed"
   | "recovered"
   | "finalized"
   | "paused"

--- a/src/resources/extensions/gsd/unit-runtime.ts
+++ b/src/resources/extensions/gsd/unit-runtime.ts
@@ -73,6 +73,19 @@ export type UnitRuntimePhase =
   | "paused"
   | "skipped";
 
+export const IN_FLIGHT_RUNTIME_PHASES: ReadonlySet<UnitRuntimePhase> = new Set([
+  "dispatched",
+  "wrapup-warning-sent",
+  "timeout",
+  "finalize-timeout",
+  "crashed",
+  "paused",
+]);
+
+export function isInFlightRuntimePhase(phase: UnitRuntimePhase): boolean {
+  return IN_FLIGHT_RUNTIME_PHASES.has(phase);
+}
+
 export interface ExecuteTaskRecoveryStatus {
   planPath: string;
   summaryPath: string;


### PR DESCRIPTION
## TL;DR

**What:** Hardens GSD auto-mode crash recovery when a unit dies after `unit-start` but before an activity log or DB dispatch row is available.
**Why:** A release-blocking TUI dropout left `M008/S04/T02` stuck at `phase: dispatched` with no `unit-end`, making recovery and forensics lose the real unit context.
**How:** Falls back to runtime unit records for stale-worker recovery and emits a cancelled journal `unit-end` plus `crashed` runtime phase when `runUnitPhase` throws.

## What

This PR updates the GSD workflow recovery path:

- Adds a `crashed` runtime phase for auto unit records.
- Teaches DB-backed crash recovery to fall back to the latest in-flight `.gsd/runtime/units/*.json` record when a stale worker has no `unit_dispatches` row.
- Adds `emitOpenUnitEndForUnit()` so the orchestrator can close the latest open journal `unit-start` with structured error context.
- Marks runtime records as `crashed` when `runUnitPhase` throws inside the auto loop.
- Adds regression coverage for the missing-dispatch-claim recovery case and the open-unit journal closeout helper.

## Why

We saw a real auto-mode dropout where the journal contained `unit-start` for `execute-task M008/S04/T02`, but there was no matching `unit-end`, no activity log for T02, and no current-worker row in `unit_dispatches`. The runtime record still knew the exact unit, but crash recovery did not use that evidence.

That made the system harder to resume and much harder to debug during release work.

## How

The fix treats runtime unit records as the durable fallback evidence source for this narrow crash window. If the DB has a stale worker but no dispatch row, recovery now chooses the newest in-flight runtime record (`dispatched`, `wrapup-warning-sent`, `timeout`, `finalize-timeout`, `crashed`, or `paused`) instead of falling back to `starting/bootstrap`.

For caught orchestrator exceptions, the auto loop now best-effort closes the open journal unit with `status: cancelled` and writes `phase: crashed` to the runtime record before preserving the original exception flow.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts src/resources/extensions/gsd/tests/crash-handler-secondary.test.ts src/resources/extensions/gsd/tests/unit-runtime.test.ts`
- `npm run typecheck:extensions`
- `git diff --check`
- `npm run verify:pr` was attempted from a clean sibling worktree. Build and extension typecheck completed, then `test:unit:compiled` hung with no failure output while child tests `park-milestone.test.js`, `paused-session-via-db.test.js`, and `pending-autostart-scope.test.js` remained running for several minutes, so the suite was stopped to avoid an indefinite local run.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

## AI-assisted contribution

This PR is AI-assisted. The implementation was validated with focused regression tests and typecheck as listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash recovery by synthesizing crash state from persistent runtime records and falling back to legacy file-based locks.

* **New Features**
  * Automatic crash observability: unit-end events and runtime records are emitted for crashed units.
  * Added a distinct "crashed" runtime phase for clearer state handling.

* **Tests**
  * New tests covering crash recovery via DB, synthetic unit-end emission, and in-flight phase handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->