### PR TITLE
[codex] fix migrated planning db carry-forward

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -2058,6 +2058,23 @@ export async function showSmartEntry(
     }
   }
 
+  if (interrupted.classification !== "recoverable") {
+    try {
+      const { autoImportMarkdownHierarchyIfDbMismatch } = await import("./migration-auto-check.js");
+      const result = await autoImportMarkdownHierarchyIfDbMismatch(basePath);
+      if (result.action === "imported") {
+        ctx.ui.notify(
+          `Recovered migrated planning state into gsd.db (${result.reason}): ${result.afterDb.milestones} milestone(s), ${result.afterDb.slices} slice(s), ${result.afterDb.tasks} task(s).`,
+          "info",
+        );
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.ui.notify(`GSD could not auto-import existing planning state into gsd.db: ${message}`, "warning");
+      logWarning("guided", `planning state auto-import failed: ${message}`, { file: "guided-flow.ts" });
+    }
+  }
+
   // Always derive from the project root — the assessment may have derived
   // state from a worktree path that was cleaned up in the stale branch above.
   const state = await deriveState(basePath);

--- a/src/resources/extensions/gsd/migrate/command.ts
+++ b/src/resources/extensions/gsd/migrate/command.ts
@@ -25,6 +25,50 @@ import {
 
 import type { MigrationPreview } from "./writer.js";
 import { homedir } from "node:os";
+import { ensureDbOpen } from "../bootstrap/dynamic-tools.js";
+import { clearEngineHierarchy, transaction } from "../gsd-db.js";
+import { migrateFromMarkdown } from "../md-importer.js";
+import { invalidateStateCache } from "../state.js";
+
+export type MigrationImportCounts = ReturnType<typeof migrateFromMarkdown>;
+
+function assertMigrationImportMatchesPreview(imported: MigrationImportCounts, preview: MigrationPreview): void {
+  const mismatches: string[] = [];
+  if (imported.hierarchy.milestones !== preview.milestoneCount) {
+    mismatches.push(`milestones ${imported.hierarchy.milestones}/${preview.milestoneCount}`);
+  }
+  if (imported.hierarchy.slices !== preview.totalSlices) {
+    mismatches.push(`slices ${imported.hierarchy.slices}/${preview.totalSlices}`);
+  }
+  if (imported.hierarchy.tasks !== preview.totalTasks) {
+    mismatches.push(`tasks ${imported.hierarchy.tasks}/${preview.totalTasks}`);
+  }
+  if (imported.requirements !== preview.requirements.total) {
+    mismatches.push(`requirements ${imported.requirements}/${preview.requirements.total}`);
+  }
+  if (mismatches.length > 0) {
+    throw new Error(`migration DB import verification failed: ${mismatches.join(", ")}`);
+  }
+}
+
+export async function importWrittenMigrationToDb(
+  basePath: string,
+  preview?: MigrationPreview,
+): Promise<MigrationImportCounts> {
+  const opened = await ensureDbOpen(basePath);
+  if (!opened) {
+    throw new Error(`failed to open or create the GSD database at ${basePath}`);
+  }
+
+  const counts = transaction(() => {
+    clearEngineHierarchy();
+    const imported = migrateFromMarkdown(basePath);
+    if (preview) assertMigrationImportMatchesPreview(imported, preview);
+    return imported;
+  });
+  invalidateStateCache();
+  return counts;
+}
 
 /** Format preview stats for embedding in the review prompt. */
 function formatPreviewStats(preview: MigrationPreview): string {
@@ -182,9 +226,10 @@ export async function handleMigrate(
 
   const result = await writeGSDDirectory(project, process.cwd());
   const gsdPath = gsdRoot(process.cwd());
+  const imported = await importWrittenMigrationToDb(process.cwd(), preview);
 
   ctx.ui.notify(
-    `✓ Migration complete — ${result.paths.length} file(s) written to .gsd/`,
+    `✓ Migration complete — ${result.paths.length} file(s) written to .gsd/ and ${imported.hierarchy.milestones}M/${imported.hierarchy.slices}S/${imported.hierarchy.tasks}T imported to the database`,
     "info",
   );
 
@@ -193,6 +238,7 @@ export async function handleMigrate(
     title: "Migration written",
     summary: [
       `${result.paths.length} files written to .gsd/`,
+      `${imported.hierarchy.milestones} milestone(s), ${imported.hierarchy.slices} slice(s), and ${imported.hierarchy.tasks} task(s) imported to gsd.db`,
       "",
       "The agent can now review the migrated output against GSD-2 standards —",
       "checking structure, content quality, deriveState() round-trip, and",

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -1,0 +1,129 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+
+import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
+import {
+  clearEngineHierarchy,
+  getAllMilestones,
+  getMilestoneSlices,
+  getSliceTasks,
+  isDbAvailable,
+  transaction,
+} from "./gsd-db.js";
+import { migrateHierarchyToDb } from "./md-importer.js";
+import { parsePlan, parseRoadmap } from "./parsers-legacy.js";
+import {
+  milestonesDir,
+  resolveMilestoneFile,
+  resolveSliceFile,
+} from "./paths.js";
+import { invalidateStateCache } from "./state.js";
+
+export interface HierarchyCounts {
+  milestones: number;
+  slices: number;
+  tasks: number;
+}
+
+export interface MigrationAutoCheckResult {
+  action: "none" | "imported";
+  reason: "no-markdown" | "in-sync" | "db-empty" | "count-mismatch";
+  markdown: HierarchyCounts;
+  beforeDb: HierarchyCounts;
+  afterDb: HierarchyCounts;
+}
+
+function zeroCounts(): HierarchyCounts {
+  return { milestones: 0, slices: 0, tasks: 0 };
+}
+
+function sameCounts(a: HierarchyCounts, b: HierarchyCounts): boolean {
+  return a.milestones === b.milestones && a.slices === b.slices && a.tasks === b.tasks;
+}
+
+export function countMarkdownHierarchy(basePath: string): HierarchyCounts {
+  const root = milestonesDir(basePath);
+  if (!existsSync(root)) return zeroCounts();
+
+  const counts = zeroCounts();
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !/^M\d+/.test(entry.name)) continue;
+    counts.milestones++;
+
+    const roadmapPath = resolveMilestoneFile(basePath, entry.name, "ROADMAP");
+    if (!roadmapPath || !existsSync(roadmapPath)) continue;
+
+    const roadmap = parseRoadmap(readFileSync(roadmapPath, "utf-8"));
+    counts.slices += roadmap.slices.length;
+
+    for (const slice of roadmap.slices) {
+      const planPath = resolveSliceFile(basePath, entry.name, slice.id, "PLAN");
+      if (!planPath || !existsSync(planPath)) continue;
+      const plan = parsePlan(readFileSync(planPath, "utf-8"));
+      counts.tasks += plan.tasks.length;
+    }
+  }
+
+  return counts;
+}
+
+export function countDbHierarchy(): HierarchyCounts {
+  if (!isDbAvailable()) return zeroCounts();
+  const counts = zeroCounts();
+  const milestones = getAllMilestones();
+  counts.milestones = milestones.length;
+
+  for (const milestone of milestones) {
+    const slices = getMilestoneSlices(milestone.id);
+    counts.slices += slices.length;
+    for (const slice of slices) {
+      counts.tasks += getSliceTasks(milestone.id, slice.id).length;
+    }
+  }
+
+  return counts;
+}
+
+export async function autoImportMarkdownHierarchyIfDbMismatch(
+  basePath: string,
+): Promise<MigrationAutoCheckResult> {
+  const markdown = countMarkdownHierarchy(basePath);
+  if (sameCounts(markdown, zeroCounts())) {
+    return {
+      action: "none",
+      reason: "no-markdown",
+      markdown,
+      beforeDb: zeroCounts(),
+      afterDb: zeroCounts(),
+    };
+  }
+
+  const opened = await ensureDbOpen(basePath);
+  if (!opened || !isDbAvailable()) {
+    throw new Error(`failed to open or create the GSD database at ${basePath}`);
+  }
+
+  const beforeDb = countDbHierarchy();
+  if (sameCounts(markdown, beforeDb)) {
+    return { action: "none", reason: "in-sync", markdown, beforeDb, afterDb: beforeDb };
+  }
+
+  const reason = sameCounts(beforeDb, zeroCounts()) ? "db-empty" : "count-mismatch";
+  const imported = transaction(() => {
+    clearEngineHierarchy();
+    return migrateHierarchyToDb(basePath);
+  });
+  invalidateStateCache();
+
+  const afterDb = {
+    milestones: imported.milestones,
+    slices: imported.slices,
+    tasks: imported.tasks,
+  };
+  if (!sameCounts(markdown, afterDb)) {
+    throw new Error(
+      `migration auto-import verification failed: markdown ${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T, db ${afterDb.milestones}M/${afterDb.slices}S/${afterDb.tasks}T`,
+    );
+  }
+
+  return { action: "imported", reason, markdown, beforeDb, afterDb };
+}

--- a/src/resources/extensions/gsd/tests/migrate-writer-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-writer-integration.test.ts
@@ -13,6 +13,9 @@ import { parseRoadmap, parsePlan } from '../parsers-legacy.ts';
 import { parseSummary } from '../files.ts';
 import { deriveState } from '../state.ts';
 import { invalidateAllCaches } from '../cache.ts';
+import { ensureDbOpen } from '../bootstrap/dynamic-tools.ts';
+import { closeDatabase, getAllMilestones } from '../gsd-db.ts';
+import { importWrittenMigrationToDb } from '../migrate/command.ts';
 import type {
   GSDProject,
   GSDMilestone,
@@ -246,6 +249,51 @@ test('Scenario 1: Incomplete project — write, parse, deriveState', async () =>
       assert.deepStrictEqual(preview.requirements.total, 4, 'incomplete: preview requirements total');
 
     } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+});
+
+test('Scenario 1b: written migration imports into authoritative DB state', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-writer-db-import-'));
+    try {
+      const project = buildIncompleteProject();
+      await writeGSDDirectory(project, base);
+
+      assert.equal(await ensureDbOpen(base), true, 'db import: ensureDbOpen creates authoritative DB');
+
+      invalidateAllCaches();
+      const before = await deriveState(base);
+      assert.equal(before.activeMilestone, null, 'db import: markdown-only migration is invisible before DB import');
+
+      const imported = await importWrittenMigrationToDb(base);
+      assert.deepStrictEqual(imported.hierarchy, { milestones: 1, slices: 2, tasks: 3 }, 'db import: hierarchy counts');
+
+      invalidateAllCaches();
+      const after = await deriveState(base);
+      assert.deepStrictEqual(after.phase, 'executing', 'db import: deriveState sees imported DB hierarchy');
+      assert.deepStrictEqual(after.activeMilestone?.id, 'M001', 'db import: active milestone');
+      assert.deepStrictEqual(after.activeSlice?.id, 'S02', 'db import: active slice');
+      assert.deepStrictEqual(after.activeTask?.id, 'T03', 'db import: active task');
+    } finally {
+      closeDatabase();
+      rmSync(base, { recursive: true, force: true });
+    }
+});
+
+test('Scenario 1c: DB import verification fails when preview counts do not match', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-writer-db-check-'));
+    try {
+      const project = buildIncompleteProject();
+      await writeGSDDirectory(project, base);
+
+      const preview = generatePreview(project);
+      await assert.rejects(
+        () => importWrittenMigrationToDb(base, { ...preview, totalTasks: preview.totalTasks + 1 }),
+        /migration DB import verification failed: tasks 3\/4/,
+      );
+      assert.deepStrictEqual(getAllMilestones(), [], 'db import: failed verification rolls back hierarchy rewrite');
+    } finally {
+      closeDatabase();
       rmSync(base, { recursive: true, force: true });
     }
 });

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+
+import { ensureDbOpen } from "../bootstrap/dynamic-tools.ts";
+import {
+  _getAdapter,
+  closeDatabase,
+  getAllMilestones,
+  getSliceTasks,
+} from "../gsd-db.ts";
+import {
+  autoImportMarkdownHierarchyIfDbMismatch,
+  countMarkdownHierarchy,
+} from "../migration-auto-check.ts";
+import { writeGSDDirectory } from "../migrate/writer.ts";
+import type { GSDProject } from "../migrate/types.ts";
+
+function makeBase(): string {
+  return mkdtempSync(join(tmpdir(), "gsd-migration-auto-check-"));
+}
+
+function cleanup(base: string): void {
+  closeDatabase();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function projectFixture(): GSDProject {
+  return {
+    projectContent: "# Legacy Project\n",
+    decisionsContent: "",
+    requirements: [],
+    milestones: [
+      {
+        id: "M001",
+        title: "Legacy Milestone",
+        vision: "Carry forward previous work",
+        successCriteria: ["Existing task is visible"],
+        research: null,
+        boundaryMap: [],
+        slices: [
+          {
+            id: "S01",
+            title: "Legacy Slice",
+            risk: "medium",
+            depends: [],
+            done: false,
+            demo: "Legacy slice demo",
+            goal: "Legacy slice demo",
+            research: null,
+            summary: null,
+            tasks: [
+              {
+                id: "T01",
+                title: "Legacy Task",
+                description: "Task carried from markdown",
+                done: false,
+                estimate: "",
+                files: ["src/index.ts"],
+                mustHaves: [],
+                summary: null,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test("migration auto-check imports markdown hierarchy when DB is empty", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory(projectFixture(), base);
+    assert.deepEqual(countMarkdownHierarchy(base), { milestones: 1, slices: 1, tasks: 1 });
+
+    assert.equal(await ensureDbOpen(base), true);
+    assert.equal(getAllMilestones().length, 0, "fresh authoritative DB starts empty");
+
+    const result = await autoImportMarkdownHierarchyIfDbMismatch(base);
+    assert.equal(result.action, "imported");
+    assert.equal(result.reason, "db-empty");
+    assert.deepEqual(result.afterDb, { milestones: 1, slices: 1, tasks: 1 });
+    assert.equal(getAllMilestones().length, 1);
+    assert.equal(getSliceTasks("M001", "S01").length, 1);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("migration auto-check repairs DB hierarchy count mismatch", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory(projectFixture(), base);
+    await autoImportMarkdownHierarchyIfDbMismatch(base);
+
+    _getAdapter()!.prepare("DELETE FROM tasks WHERE milestone_id = ? AND slice_id = ? AND id = ?").run("M001", "S01", "T01");
+    assert.equal(getSliceTasks("M001", "S01").length, 0, "test fixture simulates stale DB task count");
+
+    const result = await autoImportMarkdownHierarchyIfDbMismatch(base);
+    assert.equal(result.action, "imported");
+    assert.equal(result.reason, "count-mismatch");
+    assert.deepEqual(result.beforeDb, { milestones: 1, slices: 1, tasks: 0 });
+    assert.deepEqual(result.afterDb, { milestones: 1, slices: 1, tasks: 1 });
+    assert.equal(getSliceTasks("M001", "S01").length, 1);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("migration auto-check leaves matching DB hierarchy alone", async () => {
+  const base = makeBase();
+  try {
+    await writeGSDDirectory(projectFixture(), base);
+    await autoImportMarkdownHierarchyIfDbMismatch(base);
+
+    const result = await autoImportMarkdownHierarchyIfDbMismatch(base);
+    assert.equal(result.action, "none");
+    assert.equal(result.reason, "in-sync");
+    assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });
+    assert.deepEqual(result.afterDb, { milestones: 1, slices: 1, tasks: 1 });
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** Import migrated `.gsd` planning hierarchy into `gsd.db` and auto-repair markdown/DB mismatches at runtime.
**Why:** Users migrating 2.75-era work into 2.80 could have valid `.gsd` markdown but an empty or stale DB, making prior work look missing or broken.
**How:** `/gsd migrate` now imports written hierarchy into DB with count verification, and guided flow runs a startup auto-check that repairs empty/mismatched DB hierarchy with a notice UI.

## What

- Adds `importWrittenMigrationToDb` after migration writes `.gsd` files.
- Adds `migration-auto-check` to compare markdown counts against DB counts and repair mismatches transactionally.
- Shows a recovery notice when migrated planning state is reloaded into `gsd.db`.
- Adds regression tests for migration visibility, preview mismatch verification, empty DB repair, mismatch repair, and no-op matching DB.

## Why

This protects the 2.75 > 2.80 migration path where `.planning` / `.gsd` content can exist on disk while the DB-backed runtime sees no matching hierarchy. The patch carries the markdown hierarchy forward into the database and makes the runtime self-heal if the two drift.

## How

The migrate command opens the DB, clears existing engine hierarchy, imports markdown hierarchy, invalidates cached state, and verifies imported counts against the migration preview. Guided flow performs a lightweight count comparison after DB open; if counts are empty or mismatched, it reimports markdown hierarchy inside a transaction and surfaces the result in the UI.

## Validation

- PASS: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/migrate-writer-integration.test.ts`
- PASS: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/migration-auto-check.test.ts src/resources/extensions/gsd/tests/migrate-writer-integration.test.ts`
- PASS: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/migrate-validator-parsers.test.ts src/resources/extensions/gsd/tests/migrate-transformer.test.ts src/resources/extensions/gsd/tests/migrate-writer.test.ts src/resources/extensions/gsd/tests/migrate-writer-integration.test.ts src/tests/headless-recover.test.ts`
- PASS: `npm run typecheck:extensions`
- PASS: `git diff --check`
- FAIL: `npm run verify:pr` completed build/typecheck but failed in the broader compiled unit suite on pre-existing/unrelated issues: dist-test `.ts` import extension errors, `auto/loop.ts:728` empty catch in an unstaged dirty file, one workflow MCP timeout, and workflow-logger coverage.

## Change type checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New user-visible functionality
- [ ] `docs` — Documentation-only change
- [ ] `refactor` — Code restructuring without behavior change
- [ ] `chore` — Tooling, build, or repo maintenance

## AI assistance

AI-assisted via Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic migration import during guided setup with success notifications.
  * Auto-detection and repair when Markdown hierarchy diverges from the database.
  * Validation that import results match preview counts, surfaced in user messages.

* **Bug Fixes**
  * Improved error reporting when import/verification fails to prevent silent mismatches.

* **Tests**
  * Added integration and unit tests covering import, repair, and no-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->