### PR TITLE
[codex] fix interactive tool rollup

### DIFF
--- a/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
+++ b/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
@@ -1080,7 +1080,9 @@ test("chat-controller rolls up low-signal direct tool execution events on agent_
 		} as any);
 	}
 
-	assert.equal(host.chatContainer.children.length, 3, "direct tool events render as individual rows while running");
+	assert.equal(host.chatContainer.children.length, 1, "direct tool events roll up as they finish");
+	assert.equal(host.chatContainer.children[0]?.constructor?.name, "ToolPhaseSummaryComponent");
+	assert.match(host.chatContainer.children[0].render(120).join("\n"), /Setup \/ shell 3 actions/);
 
 	await handleAgentEvent(host, { type: "agent_end" } as any);
 

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -1287,6 +1287,10 @@ export class ToolPhaseSummaryComponent extends Container {
 		super();
 	}
 
+	getPhases(): ToolExecutionPhase[] {
+		return this.phases.map((phase) => ({ ...phase }));
+	}
+
 	override render(width: number): string[] {
 		const frameWidth = Math.max(20, width);
 		const rows = this.phases.map((phase) => {

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Container } from "@gsd/pi-tui";
+import stripAnsi from "strip-ansi";
 
 import { findLatestPinnableText, handleAgentEvent } from "./chat-controller.js";
 import { initTheme } from "../theme/theme.js";
@@ -110,4 +112,58 @@ test("handleAgentEvent: agent_start clears stale adaptive blocking error", async
 
 	assert.equal(cleared, true);
 	assert.equal(requestedRender, true);
+});
+
+test("handleAgentEvent: standalone completed tool events roll up incrementally", async () => {
+	initTheme("dark", false);
+	const chatContainer = new Container();
+	let renderCount = 0;
+	const host = {
+		isInitialized: true,
+		footer: { invalidate() {} },
+		settingsManager: {
+			getTimestampFormat() {
+				return "date-time-iso";
+			},
+			getShowImages() {
+				return false;
+			},
+		},
+		getRegisteredToolDefinition() {
+			return undefined;
+		},
+		chatContainer,
+		pendingTools: new Map(),
+		ui: {
+			requestRender() {
+				renderCount++;
+			},
+		},
+	} as any;
+
+	for (const [toolCallId, toolName] of [
+		["read-1", "read"],
+		["read-2", "read"],
+		["edit-1", "edit"],
+	] as const) {
+		await handleAgentEvent(host, {
+			type: "tool_execution_start",
+			toolCallId,
+			toolName,
+			args: { path: `/tmp/${toolCallId}.txt` },
+		} as any);
+		await handleAgentEvent(host, {
+			type: "tool_execution_end",
+			toolCallId,
+			toolName,
+			result: { content: [], isError: false },
+			isError: false,
+		} as any);
+	}
+
+	const rendered = stripAnsi(chatContainer.render(100).join("\n"));
+	assert.match(rendered, /Context reads 2 actions\s+success · \d+(ms|s)/);
+	assert.match(rendered, /File changes 1 action\s+success · \d+(ms|s)/);
+	assert.doesNotMatch(rendered, /\bread\s+success ·/);
+	assert.ok(renderCount > 0);
 });

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -858,7 +858,6 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					host.streamingComponent.setShowMetadata(true);
 					host.streamingComponent.updateContent(host.streamingMessage);
 				}
-				replaceCompactToolRowsWithPhaseSummary(host);
 
 				if (host.streamingMessage.stopReason === "aborted" || host.streamingMessage.stopReason === "error") {
 					if (!errorMessage) {
@@ -877,6 +876,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					for (const [, component] of host.pendingTools.entries()) {
 						component.setArgsComplete();
 					}
+					replaceCompactToolRowsWithPhaseSummary(host);
 				}
 				host.streamingComponent = undefined;
 				host.streamingMessage = undefined;
@@ -927,7 +927,6 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 			const component = host.pendingTools.get(event.toolCallId);
 			if (component) {
 				component.updateResult({ ...event.result, isError: event.isError });
-				host.pendingTools.delete(event.toolCallId);
 				replaceCompactToolRowsWithPhaseSummary(host);
 				host.ui.requestRender();
 			}

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -28,7 +28,8 @@ type RenderedSegment =
 		contentType: "text" | "thinking";
 		component: AssistantMessageComponent;
 	}
-	| { kind: "tool"; contentIndex: number; component: ToolExecutionComponent };
+	| { kind: "tool"; contentIndex: number; component: ToolExecutionComponent }
+	| { kind: "tool-summary"; component: ToolPhaseSummaryComponent; phases: ToolExecutionPhase[] };
 
 let renderedSegments: RenderedSegment[] = [];
 // When providers reuse one assistant lifecycle across internal sub-turns,
@@ -124,17 +125,25 @@ function replaceCompactToolRowsWithPhaseSummary(
 ): void {
 	let changed = false;
 	const nextRenderedSegments: RenderedSegment[] = [];
-	let rollupRun: Array<{ seg: Extract<RenderedSegment, { kind: "tool" }>; phase: ToolExecutionPhase }> = [];
+	let rollupRun: Array<{
+		seg: Extract<RenderedSegment, { kind: "tool" | "tool-summary" }>;
+		phases: ToolExecutionPhase[];
+	}> = [];
 
 	const flushRollupRun = () => {
-		if (rollupRun.length < 2) {
+		const actionCount = rollupRun.reduce(
+			(total, item) => total + item.phases.reduce((sum, phase) => sum + phase.count, 0),
+			0,
+		);
+		if (actionCount < 2) {
 			nextRenderedSegments.push(...rollupRun.map((item) => item.seg));
 			rollupRun = [];
 			return;
 		}
 
 		const firstIndex = Math.max(0, host.chatContainer.children.indexOf(rollupRun[0].seg.component));
-		const summary = new ToolPhaseSummaryComponent(mergeToolPhases(rollupRun.map((item) => item.phase)));
+		const phases = mergeToolPhases(rollupRun.flatMap((item) => item.phases));
+		const summary = new ToolPhaseSummaryComponent(phases);
 
 		for (const { seg } of rollupRun) {
 			host.chatContainer.removeChild(seg.component);
@@ -149,13 +158,18 @@ function replaceCompactToolRowsWithPhaseSummary(
 		}
 
 		changed = true;
+		nextRenderedSegments.push({ kind: "tool-summary", component: summary, phases });
 		rollupRun = [];
 	};
 
 	for (const seg of renderedSegments) {
 		const phase = seg.kind === "tool" ? seg.component.getRollupPhase() : null;
 		if (seg.kind === "tool" && phase) {
-			rollupRun.push({ seg, phase });
+			rollupRun.push({ seg, phases: [phase] });
+			continue;
+		}
+		if (seg.kind === "tool-summary") {
+			rollupRun.push({ seg, phases: seg.component.getPhases() });
 			continue;
 		}
 
@@ -409,6 +423,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 							details: externalToolResult.details,
 							isError: externalToolResult.isError,
 						});
+						replaceCompactToolRowsWithPhaseSummary(host);
 					}
 				}
 
@@ -913,6 +928,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 			if (component) {
 				component.updateResult({ ...event.result, isError: event.isError });
 				host.pendingTools.delete(event.toolCallId);
+				replaceCompactToolRowsWithPhaseSummary(host);
 				host.ui.requestRender();
 			}
 			break;


### PR DESCRIPTION
## Summary

- Apply compact tool roll-up incrementally when standalone tool execution events finish.
- Allow existing roll-up summary components to merge with later completed tools instead of leaving new one-off rows behind.
- Add regression coverage for live standalone tool events rolling up into phase summaries.

## Why

The roll-up renderer already existed, but it only ran at assistant `message_end` / `agent_end`. Live standalone `tool_execution_*` events could therefore render long stacks of individual successful `read` / `edit` rows during active turns.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.test.ts packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts`
- `npm run build -w @gsd/pi-coding-agent -- --pretty false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now shows compacted phase summaries that merge phases across related tool executions for a clearer, single-row view.

* **Tests**
  * Added tests validating incremental roll-up of tool events and the rendered phase-summary output.

* **Refactor**
  * Rendering pipeline updated to consolidate multiple tool rows into unified phase summaries for cleaner chat presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->