### PR TITLE
fix(pi-tui): keep auto-mode tui anchored to bottom

### DIFF
--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -636,7 +636,8 @@ export class TUI extends Container {
 		if (this.stopped) return;
 		const width = this.terminal.columns;
 		const height = this.terminal.rows;
-		let viewportTop = Math.max(0, this.maxLinesRendered - height);
+		const getViewportTop = (lineCount: number): number => lineCount - height;
+		let viewportTop = getViewportTop(this.maxLinesRendered);
 		let prevViewportTop = this.previousViewportTop;
 		let hardwareCursorRow = this.hardwareCursorRow;
 		const computeLineDiff = (targetRow: number): number => {
@@ -673,14 +674,16 @@ export class TUI extends Container {
 		const fullRender = (clear: boolean): void => {
 			this.fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
+			const startRow = Math.max(1, height - Math.max(1, newLines.length) + 1);
 			if (clear) {
 				// Clear viewport (scrollback preserved) and anchor the rendered
 				// block to the terminal bottom so the editor / belowEditor
 				// widgets do not jump to row 1 after a chat clear. When the
 				// block is taller than the viewport, Math.max(1, …) falls back
 				// to row 1 — same as the prior `\x1b[H` behavior.
-				const startRow = Math.max(1, height - Math.max(1, newLines.length) + 1);
 				buffer += `\x1b[2J\x1b[${startRow};1H`;
+			} else if (startRow > 1) {
+				buffer += `\x1b[${startRow};1H`;
 			}
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
@@ -700,7 +703,7 @@ export class TUI extends Container {
 			} else {
 				this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
 			}
-			this.previousViewportTop = Math.max(0, this.maxLinesRendered - height);
+			this.previousViewportTop = getViewportTop(this.maxLinesRendered);
 			this.positionHardwareCursor(cursorPos, newLines.length);
 			this.previousLines = newLines;
 			this.previousWidth = width;
@@ -725,6 +728,15 @@ export class TUI extends Container {
 		// Width or height changed - full re-render
 		if (widthChanged || heightChanged) {
 			logRedraw(`terminal size changed (${this.previousWidth}x${this.previousHeight} -> ${width}x${height})`);
+			fullRender(true);
+			return;
+		}
+
+		if (
+			newLines.length !== this.previousLines.length &&
+			(newLines.length <= height || this.previousLines.length <= height)
+		) {
+			logRedraw(`bottom-anchored short block resized (${this.previousLines.length} -> ${newLines.length})`);
 			fullRender(true);
 			return;
 		}
@@ -781,7 +793,7 @@ export class TUI extends Container {
 		// No changes - but still need to update hardware cursor position if it moved
 		if (firstChanged === -1) {
 			this.positionHardwareCursor(cursorPos, newLines.length);
-			this.previousViewportTop = Math.max(0, this.maxLinesRendered - height);
+			this.previousViewportTop = getViewportTop(this.maxLinesRendered);
 			this.previousHeight = height;
 			return;
 		}
@@ -822,13 +834,13 @@ export class TUI extends Container {
 			this.previousLines = newLines;
 			this.previousWidth = width;
 			this.previousHeight = height;
-			this.previousViewportTop = Math.max(0, this.maxLinesRendered - height);
+			this.previousViewportTop = getViewportTop(this.maxLinesRendered);
 			return;
 		}
 
 		// Check if firstChanged is above what was previously visible
 		// Use previousLines.length (not maxLinesRendered) to avoid false positives after content shrinks
-		const previousContentViewportTop = Math.max(0, this.previousLines.length - height);
+		const previousContentViewportTop = getViewportTop(this.previousLines.length);
 		if (firstChanged < previousContentViewportTop) {
 			// First change is above previous viewport - need full re-render
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${previousContentViewportTop})`);
@@ -938,7 +950,7 @@ export class TUI extends Container {
 		this.hardwareCursorRow = finalCursorRow;
 		// Track terminal's working area (grows but doesn't shrink unless cleared)
 		this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
-		this.previousViewportTop = Math.max(0, this.maxLinesRendered - height);
+		this.previousViewportTop = getViewportTop(this.maxLinesRendered);
 
 		// Position hardware cursor for IME
 		this.positionHardwareCursor(cursorPos, newLines.length);

--- a/src/tests/tui-autocomplete-ghost-lines.test.ts
+++ b/src/tests/tui-autocomplete-ghost-lines.test.ts
@@ -79,13 +79,10 @@ describe("TUI autocomplete shrink clearing (#3721)", () => {
     (tui as any).doRender();
 
     assert.ok(terminal.writtenData.length >= 1, "shrink render should write a differential buffer");
-    // The real terminal cursor was positioned at the editor cursor row (row 1)
-    // for IME. Deleted autocomplete rows start after the new content bottom
-    // (row 3), so the first move must go down 2 rows from the actual cursor.
     const buffer = terminal.writtenData[0];
     assert.ok(
-      buffer.startsWith("\x1b[?2026h\x1b[2B\r"),
-      `expected shrink diff to move down from the hardware cursor row, got ${JSON.stringify(buffer)}`,
+      buffer.includes("\x1b[2J\x1b[21;1H"),
+      `expected short shrink to redraw at the bottom anchor, got ${JSON.stringify(buffer)}`,
     );
   });
 });

--- a/src/tests/tui-content-cursor-desync.test.ts
+++ b/src/tests/tui-content-cursor-desync.test.ts
@@ -312,8 +312,8 @@ describe("TUI cursor tracking regression (#3764)", () => {
 
     assert.ok(terminal.writtenData.length >= 1, "shrink render should produce a differential buffer");
     assert.ok(
-      terminal.writtenData[0].startsWith("\x1b[?2026h\x1b[1B\r"),
-      `shrink diff should move down from the actual hardware cursor row, got ${JSON.stringify(terminal.writtenData[0])}`,
+      terminal.writtenData[0].includes("\x1b[2J\x1b[22;1H"),
+      `short shrink should redraw at the bottom anchor, got ${JSON.stringify(terminal.writtenData[0])}`,
     );
 
     // After shrink, hardwareCursorRow should be at IME position again

--- a/src/tests/tui-pin-to-bottom-on-clear.test.ts
+++ b/src/tests/tui-pin-to-bottom-on-clear.test.ts
@@ -69,6 +69,44 @@ class StaticLinesComponent implements Component {
 }
 
 describe("TUI pin-to-bottom on clear", () => {
+  it("anchors short first renders to the terminal bottom", () => {
+    const terminal = new ResizableMockTerminal(20);
+    const tui = new TUI(terminal, false);
+    const component = new StaticLinesComponent(["line 1", "line 2", "line 3"]);
+    tui.addChild(component);
+
+    (tui as any).doRender();
+
+    const frame = terminal.writtenData.join("");
+    assert.ok(
+      frame.includes("\x1b[18;1Hline 1"),
+      `expected first render to start at bottom anchor row 18, got ${JSON.stringify(frame.slice(0, 120))}`,
+    );
+    assert.strictEqual(
+      (tui as any).previousViewportTop,
+      -17,
+      "short rendered blocks should use a bottom-anchored viewport baseline",
+    );
+  });
+
+  it("appends short auto-mode frames without feeding blank rows downward", () => {
+    const terminal = new ResizableMockTerminal(20);
+    const tui = new TUI(terminal, false);
+    const component = new StaticLinesComponent(["line 1", "line 2", "line 3"]);
+    tui.addChild(component);
+    (tui as any).doRender();
+
+    terminal.writtenData = [];
+    component.lines = ["line 1", "line 2", "line 3", "line 4"];
+    (tui as any).doRender();
+
+    const frame = terminal.writtenData.join("");
+    assert.ok(
+      frame.includes("\x1b[2J\x1b[17;1H"),
+      `expected append to redraw the resized bottom-anchored block at row 17, got ${JSON.stringify(frame)}`,
+    );
+  });
+
   it("anchors a short block to the terminal bottom when a height change triggers fullRender(clear)", () => {
     const terminal = new ResizableMockTerminal(24);
     const tui = new TUI(terminal, false);


### PR DESCRIPTION
## TL;DR

**What:** Keeps short TUI renders bottom-anchored while auto-mode output grows or shrinks.
**Why:** Auto-mode frames could scroll upward and then feed blank rows back down because short-content viewport math was still top-based.
**How:** Uses a bottom-anchored viewport baseline for short content and redraws resized short blocks as an anchored unit.

## What

This changes the `@gsd/pi-tui` renderer so short rendered blocks start at the terminal bottom and keep that baseline during subsequent renders. When short content changes line count, the renderer now redraws the block at its bottom anchor rather than treating it as a one-line append/delete from a top-anchored viewport.

The PR also adds regression coverage for short first renders and auto-style appended frames, and updates adjacent shrink tests to assert the new bottom-anchored redraw behavior.

## Why

During auto-mode, short TUI content could visibly climb upward and then backfeed downward as output streamed. The clear-render path already pinned short blocks to the bottom, but the first-render and differential paths still used a top-style viewport baseline for short content. That mismatch caused the visual instability.

Closes #5477

## How

The renderer now computes viewport baselines as `lineCount - height`, which represents the negative top offset needed for bottom-anchored short blocks. Full renders place short content at the terminal bottom even without a clear. When a short block changes height, the renderer performs an anchored full redraw so the whole block moves as one unit instead of scrolling blank space.

## Change type checklist

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Test plan

- [x] `npm run build --workspace @gsd/pi-tui`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/tui-pin-to-bottom-on-clear.test.ts src/tests/tui-content-cursor-desync.test.ts src/tests/tui-autocomplete-ghost-lines.test.ts`
- [x] `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test src/tests/tui-pin-to-bottom-on-clear.test.ts src/tests/tui-content-cursor-desync.test.ts src/tests/tui-autocomplete-ghost-lines.test.ts`
- [ ] `npm run verify:pr` — currently fails on unrelated ADR-012 provider-equality guard in `src/providers/provider-migrations.ts`.

AI-assisted: yes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cursor positioning reliability and viewport rendering for improved stability.
  * Enhanced handling of content resizing to prevent rendering artifacts.
  * Improved input method support for better IME compatibility.
  * Optimized rendering behavior for small content blocks.

* **Tests**
  * Added comprehensive tests for bottom-anchoring behavior during rendering.
  * Updated regression tests to validate rendering correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->