### PR TITLE
fix(compaction): apply compaction_threshold_percent from GSD prefs (#5475)

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -2211,6 +2211,9 @@ export class AgentSession {
 					})();
 				},
 				getSystemPrompt: () => this.systemPrompt,
+				setCompactionThresholdOverride: (percent) => {
+					this.settingsManager.setCompactionThresholdOverride(percent);
+				},
 			},
 		);
 	}

--- a/packages/pi-coding-agent/src/core/compaction-threshold.test.ts
+++ b/packages/pi-coding-agent/src/core/compaction-threshold.test.ts
@@ -1,0 +1,121 @@
+// pi-coding-agent / Regression tests for compaction threshold percent (#5475)
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { shouldCompact, type CompactionSettings } from "./compaction/compaction.js";
+import { SettingsManager } from "./settings-manager.js";
+
+const REGISTRY_DEFAULTS: CompactionSettings = {
+	enabled: true,
+	reserveTokens: 16_384,
+	keepRecentTokens: 20_000,
+};
+
+describe("shouldCompact — thresholdPercent (#5475)", () => {
+	it("uses absolute reserveTokens when thresholdPercent is unset (legacy behavior)", () => {
+		// 200K window, 16384 reserve → fires at 183_617 tokens
+		assert.equal(shouldCompact(183_616, 200_000, REGISTRY_DEFAULTS), false);
+		assert.equal(shouldCompact(183_617, 200_000, REGISTRY_DEFAULTS), true);
+	});
+
+	it("uses thresholdPercent when set, ignoring reserveTokens", () => {
+		const settings: CompactionSettings = { ...REGISTRY_DEFAULTS, thresholdPercent: 0.7 };
+		// 200K * 0.7 = 140_000 → fires above that
+		assert.equal(shouldCompact(140_000, 200_000, settings), false);
+		assert.equal(shouldCompact(140_001, 200_000, settings), true);
+		// reserveTokens-based math would have said false at 183_616 — the percent override changes that
+		assert.equal(shouldCompact(150_000, 200_000, settings), true);
+	});
+
+	it("falls back to reserveTokens when thresholdPercent is out of range", () => {
+		// Defense in depth: reject 0, 1, negative, NaN, Infinity
+		for (const bad of [0, 1, -0.1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+			const settings: CompactionSettings = { ...REGISTRY_DEFAULTS, thresholdPercent: bad };
+			assert.equal(
+				shouldCompact(183_616, 200_000, settings),
+				false,
+				`bad=${bad} should fall back to reserveTokens math`,
+			);
+			assert.equal(shouldCompact(183_617, 200_000, settings), true, `bad=${bad}`);
+		}
+	});
+
+	it("respects enabled=false regardless of thresholdPercent", () => {
+		const settings: CompactionSettings = {
+			...REGISTRY_DEFAULTS,
+			enabled: false,
+			thresholdPercent: 0.5,
+		};
+		assert.equal(shouldCompact(199_999, 200_000, settings), false);
+	});
+
+	it("scales with contextWindow — same percent, different windows", () => {
+		const settings: CompactionSettings = { ...REGISTRY_DEFAULTS, thresholdPercent: 0.8 };
+		// 100K window: fires above 80_000
+		assert.equal(shouldCompact(80_000, 100_000, settings), false);
+		assert.equal(shouldCompact(80_001, 100_000, settings), true);
+		// 1M window: fires above 800_000
+		assert.equal(shouldCompact(800_000, 1_000_000, settings), false);
+		assert.equal(shouldCompact(800_001, 1_000_000, settings), true);
+	});
+});
+
+describe("SettingsManager — compaction threshold override (#5475)", () => {
+	it("getCompactionThresholdPercent returns undefined by default", () => {
+		const sm = SettingsManager.inMemory({});
+		assert.equal(sm.getCompactionThresholdPercent(), undefined);
+		assert.equal(sm.getCompactionSettings().thresholdPercent, undefined);
+	});
+
+	it("setCompactionThresholdOverride applies in-memory and is exposed via getCompactionSettings", () => {
+		const sm = SettingsManager.inMemory({});
+		sm.setCompactionThresholdOverride(0.7);
+		assert.equal(sm.getCompactionThresholdPercent(), 0.7);
+		assert.equal(sm.getCompactionSettings().thresholdPercent, 0.7);
+	});
+
+	it("setCompactionThresholdOverride(undefined) clears a prior override", () => {
+		const sm = SettingsManager.inMemory({});
+		sm.setCompactionThresholdOverride(0.7);
+		sm.setCompactionThresholdOverride(undefined);
+		assert.equal(sm.getCompactionThresholdPercent(), undefined);
+		assert.equal(sm.getCompactionSettings().thresholdPercent, undefined);
+	});
+
+	it("setCompactionThresholdOverride preserves other compaction fields (enabled, reserveTokens)", () => {
+		const sm = SettingsManager.inMemory({
+			compaction: { enabled: true, reserveTokens: 30_000, keepRecentTokens: 25_000 },
+		});
+		sm.setCompactionThresholdOverride(0.6);
+		const settings = sm.getCompactionSettings();
+		assert.equal(settings.enabled, true);
+		assert.equal(settings.reserveTokens, 30_000);
+		assert.equal(settings.keepRecentTokens, 25_000);
+		assert.equal(settings.thresholdPercent, 0.6);
+	});
+
+	it("setCompactionThresholdOverride works when no compaction config exists yet", () => {
+		const sm = SettingsManager.inMemory({});
+		sm.setCompactionThresholdOverride(0.85);
+		assert.equal(sm.getCompactionThresholdPercent(), 0.85);
+		// Other compaction fields fall back to their defaults
+		const settings = sm.getCompactionSettings();
+		assert.equal(settings.enabled, true);
+		assert.equal(typeof settings.reserveTokens, "number");
+		assert.equal(typeof settings.keepRecentTokens, "number");
+	});
+});
+
+describe("end-to-end — getCompactionSettings + shouldCompact (#5475)", () => {
+	it("70% threshold on a 200K window fires at the documented bug-report value (140_001 not 183_617)", () => {
+		const sm = SettingsManager.inMemory({});
+		sm.setCompactionThresholdOverride(0.7);
+		const settings = sm.getCompactionSettings();
+
+		assert.equal(shouldCompact(140_000, 200_000, settings), false);
+		assert.equal(shouldCompact(140_001, 200_000, settings), true);
+		// Pre-fix behavior would have required 183_617 — verify we no longer wait that long
+		assert.equal(shouldCompact(150_000, 200_000, settings), true);
+	});
+});

--- a/packages/pi-coding-agent/src/core/compaction/compaction.ts
+++ b/packages/pi-coding-agent/src/core/compaction/compaction.ts
@@ -86,6 +86,13 @@ export interface CompactionSettings {
 	enabled: boolean;
 	reserveTokens: number;
 	keepRecentTokens: number;
+	/**
+	 * Optional percent-of-context-window threshold (0 < value < 1). When set,
+	 * `shouldCompact()` fires once `contextTokens > contextWindow * thresholdPercent`,
+	 * overriding the absolute `reserveTokens` calculation. Lets host integrations
+	 * (e.g. GSD) express compaction policy as a fraction independent of model size.
+	 */
+	thresholdPercent?: number;
 }
 
 export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
@@ -185,9 +192,20 @@ export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEst
 
 /**
  * Check if compaction should trigger based on context usage.
+ *
+ * When `thresholdPercent` is set (and within (0, 1)), it overrides the absolute
+ * `reserveTokens` calculation: compaction fires at `contextWindow * thresholdPercent`.
+ * Otherwise the legacy `contextWindow - reserveTokens` headroom is used.
  */
 export function shouldCompact(contextTokens: number, contextWindow: number, settings: CompactionSettings): boolean {
 	if (!settings.enabled) return false;
+	if (
+		settings.thresholdPercent !== undefined &&
+		settings.thresholdPercent > 0 &&
+		settings.thresholdPercent < 1
+	) {
+		return contextTokens > contextWindow * settings.thresholdPercent;
+	}
 	return contextTokens > contextWindow - settings.reserveTokens;
 }
 

--- a/packages/pi-coding-agent/src/core/extensions/runner.test.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.test.ts
@@ -141,6 +141,7 @@ describe("ExtensionRunner.emitToolCall", () => {
 			getContextUsage: () => undefined,
 			compact: () => {},
 			getSystemPrompt: () => "",
+			setCompactionThresholdOverride: () => {},
 		});
 
 		const errors: any[] = [];
@@ -220,6 +221,7 @@ describe("ExtensionRunner.createContext", () => {
 			getContextUsage: () => undefined,
 			compact: () => {},
 			getSystemPrompt: () => "",
+			setCompactionThresholdOverride: () => {},
 		});
 
 		const errors: any[] = [];

--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -235,6 +235,7 @@ export class ExtensionRunner {
 	private getContextUsageFn: () => ContextUsage | undefined = () => undefined;
 	private compactFn: (options?: CompactOptions) => void = () => {};
 	private getSystemPromptFn: () => string = () => "";
+	private setCompactionThresholdOverrideFn: (percent: number | undefined) => void = () => {};
 	private newSessionHandler: NewSessionHandler = async () => {
 		throw new Error("Command context not yet bound: newSession is unavailable during early lifecycle");
 	};
@@ -428,6 +429,7 @@ export class ExtensionRunner {
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.compactFn = contextActions.compact;
 		this.getSystemPromptFn = contextActions.getSystemPrompt;
+		this.setCompactionThresholdOverrideFn = contextActions.setCompactionThresholdOverride;
 
 		// Flush provider registrations queued during extension loading
 		for (const { name, config } of this.runtime.pendingProviderRegistrations) {
@@ -714,6 +716,7 @@ export class ExtensionRunner {
 			getContextUsage: () => this.getContextUsageFn(),
 			compact: (options) => this.compactFn(options),
 			getSystemPrompt: () => this.getSystemPromptFn(),
+			setCompactionThresholdOverride: (percent) => this.setCompactionThresholdOverrideFn(percent),
 		};
 	}
 

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -289,6 +289,12 @@ export interface ExtensionContext {
 	compact(options?: CompactOptions): void;
 	/** Get the current effective system prompt. */
 	getSystemPrompt(): string;
+	/**
+	 * Set or clear an in-memory compaction threshold-percent override (0 < value < 1).
+	 * Pass `undefined` to clear. The override is not persisted; host integrations
+	 * are expected to re-apply on each session_start.
+	 */
+	setCompactionThresholdOverride(percent: number | undefined): void;
 }
 
 /**
@@ -1741,6 +1747,7 @@ export interface ExtensionContextActions {
 	getContextUsage: () => ContextUsage | undefined;
 	compact: (options?: CompactOptions) => void;
 	getSystemPrompt: () => string;
+	setCompactionThresholdOverride: (percent: number | undefined) => void;
 }
 
 /**

--- a/packages/pi-coding-agent/src/core/settings-manager.ts
+++ b/packages/pi-coding-agent/src/core/settings-manager.ts
@@ -15,6 +15,13 @@ export interface CompactionSettings {
 	enabled?: boolean; // default: true
 	reserveTokens?: number; // default: 16384
 	keepRecentTokens?: number; // default: 20000
+	/**
+	 * Optional percent-of-context-window trigger (0 < value < 1). When set,
+	 * compaction fires at `contextWindow * thresholdPercent` and overrides
+	 * `reserveTokens`. Typically set as a runtime override by host integrations
+	 * (see `setCompactionThresholdOverride`) and not persisted by users directly.
+	 */
+	thresholdPercent?: number;
 }
 
 export interface BranchSummarySettings {
@@ -812,11 +819,42 @@ export class SettingsManager {
 		return this.settings.compaction?.keepRecentTokens ?? COMPACTION_KEEP_RECENT_TOKENS;
 	}
 
-	getCompactionSettings(): { enabled: boolean; reserveTokens: number; keepRecentTokens: number } {
+	getCompactionThresholdPercent(): number | undefined {
+		return this.settings.compaction?.thresholdPercent;
+	}
+
+	/**
+	 * Set or clear an in-memory compaction threshold-percent override.
+	 *
+	 * Applied to `this.settings` only; never persisted to disk. Pass `undefined`
+	 * to clear a previously set override (necessary for idempotent re-sync from
+	 * host integrations whose preference may have been removed).
+	 *
+	 * Direct mutation is used instead of `applyOverrides()` because deep-merge
+	 * semantics skip `undefined` values, which would prevent clearing.
+	 */
+	setCompactionThresholdOverride(percent: number | undefined): void {
+		if (!this.settings.compaction) {
+			this.settings.compaction = {};
+		}
+		if (percent === undefined) {
+			delete this.settings.compaction.thresholdPercent;
+		} else {
+			this.settings.compaction.thresholdPercent = percent;
+		}
+	}
+
+	getCompactionSettings(): {
+		enabled: boolean;
+		reserveTokens: number;
+		keepRecentTokens: number;
+		thresholdPercent?: number;
+	} {
 		return {
 			enabled: this.getCompactionEnabled(),
 			reserveTokens: this.getCompactionReserveTokens(),
 			keepRecentTokens: this.getCompactionKeepRecentTokens(),
+			thresholdPercent: this.getCompactionThresholdPercent(),
 		};
 	}
 

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1378,6 +1378,9 @@ export class InteractiveMode {
 				})();
 			},
 			getSystemPrompt: () => this.session.systemPrompt,
+			setCompactionThresholdOverride: (percent) => {
+				this.session.settingsManager.setCompactionThresholdOverride(percent);
+			},
 		});
 
 		// Set up the extension shortcut handler on the default editor

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -65,6 +65,26 @@ async function applyDisabledModelProviderPolicy(ctx: ExtensionContext): Promise<
   }
 }
 
+/**
+ * Bridge `context_management.compaction_threshold_percent` from GSD preferences
+ * into the agent's runtime compaction settings (#5475). The preference is
+ * validated to (0.5, 0.95) at load time, but defense-in-depth normalization
+ * here protects against a stale or hand-edited prefs file. Calling with
+ * `undefined` clears any prior override so a removed preference does not leak.
+ */
+async function applyCompactionThresholdOverride(ctx: ExtensionContext): Promise<void> {
+  try {
+    const { loadEffectiveGSDPreferences } = await import("../preferences.js");
+    const prefs = loadEffectiveGSDPreferences();
+    const raw = prefs?.preferences.context_management?.compaction_threshold_percent;
+    const value =
+      typeof raw === "number" && Number.isFinite(raw) && raw > 0 && raw < 1 ? raw : undefined;
+    ctx.setCompactionThresholdOverride(value);
+  } catch {
+    // Non-fatal: leave any existing override in place.
+  }
+}
+
 export function resolveNotificationStoreBasePath(cwd: string = process.cwd()): string {
   return resolveWorktreeProjectRoot(cwd);
 }
@@ -123,6 +143,7 @@ export function registerHooks(
     await resetAskUserQuestionsTurnCache();
     await syncServiceTierStatus(ctx);
     await applyDisabledModelProviderPolicy(ctx);
+    await applyCompactionThresholdOverride(ctx);
     // Skip MCP auto-prep when running inside an auto-worktree (see session_switch below).
     const { isInAutoWorktree } = await import("../auto-worktree.js");
     if (!isInAutoWorktree(process.cwd())) {
@@ -172,6 +193,7 @@ export function registerHooks(
     clearDiscussionFlowState(process.cwd());
     await syncServiceTierStatus(ctx);
     await applyDisabledModelProviderPolicy(ctx);
+    await applyCompactionThresholdOverride(ctx);
     // Skip MCP auto-prep when running inside an auto-worktree. The worktree
     // already has .mcp.json from createAutoWorktree, and re-running the writer
     // post-chdir rewrites the file mid-run (non-idempotent due to cwd-relative


### PR DESCRIPTION
## TL;DR

**What:** Wires `context_management.compaction_threshold_percent` (already in GSD prefs) into pi-coding-agent's `shouldCompact()` so the user-configured percent actually triggers compaction.
**Why:** The preference was validated and stored but never read by any compaction code, so users setting 70% on a 200K window still saw compaction at ~91.8% (the hardcoded 16,384-token reserve).
**How:** Add a generic `thresholdPercent` field to pi-coding-agent's `CompactionSettings`; expose a narrow in-memory `setCompactionThresholdOverride` action on `ExtensionContext`; have GSD's `register-hooks` push the preference value into pi via that action on `session_start` / `session_switch`.

Closes #5475

## What

Nine files changed across pi-coding-agent and the GSD extension layer:

**pi-coding-agent (generic, model-agnostic improvement):**
- `core/compaction/compaction.ts` — added `thresholdPercent?: number` to `CompactionSettings`; `shouldCompact()` now fires above `contextWindow * thresholdPercent` when the value is set and within `(0, 1)`, otherwise falls back to the legacy `contextWindow - reserveTokens` math.
- `core/settings-manager.ts` — added `getCompactionThresholdPercent()` and `setCompactionThresholdOverride(percent | undefined)`. The setter mutates `this.settings` in-memory only — it does **not** persist, so it can never overwrite a user's explicit pi-side compaction config. `undefined` clears any prior override (necessary because deep-merge skips `undefined` values).
- `core/extensions/types.ts`, `core/extensions/runner.ts`, `core/agent-session.ts`, `modes/interactive/interactive-mode.ts` — narrow `setCompactionThresholdOverride` action threaded through `ExtensionContext` and `ExtensionContextActions`.
- `core/extensions/runner.test.ts` — added the new action to existing `bindCore` mocks.
- `core/compaction-threshold.test.ts` — new file, 11 regression tests.

**GSD bridge:**
- `src/resources/extensions/gsd/bootstrap/register-hooks.ts` — new `applyCompactionThresholdOverride()` helper, called from `session_start` and `session_switch` after `applyDisabledModelProviderPolicy`. Reads `context_management.compaction_threshold_percent`, applies a defense-in-depth range guard (already validated to 0.5–0.95 upstream), and pushes the value via `ctx.setCompactionThresholdOverride(...)`. Wrapped in try/catch — non-fatal if prefs cannot be loaded.

## Why

Per the issue, the bug is structural: `compaction_threshold_percent` is defined and validated in `preferences-types.ts:28` and `preferences-validation.ts:658-661`, but `grep` finds zero references in any compaction trigger path. pi-coding-agent's `shouldCompact()` (`compaction.ts:189-192`) only consulted `reserveTokens`, so the user's percent setting was silently ignored.

The architectural complication: pi-coding-agent is a standalone package and must not depend on GSD-specific preferences. So the fix is layered — pi-coding-agent gets a generic, agnostic `thresholdPercent` primitive, and GSD bridges its preference into pi via the extension hook system.

## How

**Design decisions:**

1. **Layered separation.** pi-coding-agent owns the generic feature (any host integration can use percent-based thresholds); GSD owns the policy mapping from its preference key. Avoids layering violations.

2. **In-memory override (not persistence).** `setCompactionThresholdOverride` mutates `this.settings` but never writes to the settings file. A separate `SettingsManager.create()` call from GSD would not share state with pi's running instance, and persisting could overwrite a user's explicit pi-side config. In-memory override sidesteps both problems and is re-applied on every `session_start`.

3. **Direct mutation, not `applyOverrides()`.** Codex peer review caught that `deepMergeSettings` skips `undefined` values, so `applyOverrides({compaction: {thresholdPercent: undefined}})` would silently fail to clear a prior override. Using direct mutation with explicit `delete` lets the bridge be idempotent when the preference is removed.

4. **Defense-in-depth range guard.** Even though `preferences-validation.ts` already enforces 0.5–0.95, the bridge re-checks `0 < value < 1` before calling the override. Protects against stale or hand-edited `PREFERENCES.md` files where a future author might store an integer percent (e.g. `70`), which would otherwise compute `contextWindow * 70` → runaway compaction.

5. **Both `session_start` and `session_switch` hooks.** Ensures the override is re-applied when the user navigates between sessions, not only at startup.

**Blast radius (verified):**
- `shouldCompact()` behavior is unchanged when `thresholdPercent` is undefined → no impact on non-GSD users.
- Manual `compact()` and `prepareCompaction()` use `keepRecentTokens`, not `reserveTokens` → unaffected.
- `branchSummary.reserveTokens` is a separate field → unaffected.
- All 3 `getCompactionSettings()` call sites in `compaction-orchestrator.ts` benefit transparently.

**Peer review:** Design was peer-reviewed via codex-peer-reviewer before implementation. Three concerns surfaced and addressed (bindCore-vs-session_start ordering, undefined-clearing semantics, range guard).

## Test plan

- [x] `npm run build` — green
- [x] New regression tests: 11/11 pass (`packages/pi-coding-agent/src/core/compaction-threshold.test.ts`)
  - `shouldCompact()` percent-path firing, scaling with contextWindow, range fallback (0, 1, NaN, Infinity, negative), `enabled=false` short-circuit
  - `setCompactionThresholdOverride()` set / clear / preserves other compaction fields / works with empty initial config
  - End-to-end: 70% on 200K window fires at 140,001 (the bug-report value) instead of the pre-fix 183,617
- [x] Affected existing tests: 24/24 pass (runner, compaction-orchestrator, compaction)
- [x] Full suite: 1139/1140 pass — the single failure (`commands-eval-review.integration.test.ts`) is a pre-existing macOS `/private/var` realpath flake, confirmed unrelated by reproducing on `main`

## Disclosure

AI-assisted (Claude Code, with codex-peer-review validation on the design). All code reviewed and tested manually before commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added runtime control for context compaction thresholds, allowing dynamic adjustment during agent sessions
* Compaction behavior is now configurable and integrated with preferences for fine-grained context management

**Tests**
* Comprehensive test coverage added for compaction threshold override functionality, including validation scenarios and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->