### PR TITLE
fix(gsd): close Context Mode gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ The database is authoritative for milestones, slices, tasks, requirements, decis
 
 2. **Context pre-loading** — The dispatch prompt includes inlined task plans, slice plans, prior task summaries, dependency summaries, roadmap excerpts, and decisions register. The LLM starts with everything it needs instead of spending tool calls reading files.
 
-3. **Context Mode** — Context Mode is enabled by default and gives every auto-mode unit guidance for preserving context. Agents are steered toward `gsd_exec` for noisy scans, builds, tests, and diagnostics; full stdout/stderr is saved under `.gsd/exec/` while only a short digest enters the conversation. `gsd_exec_search` lets agents reuse prior runs instead of repeating expensive checks, and `gsd_resume` reads `.gsd/last-snapshot.md` after compaction or resume. Opt out with `context_mode.enabled: false`; tune sandbox timeout/output caps with `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, and `context_mode.exec_digest_chars`.
+3. **Context Mode** — Context Mode is enabled by default and gives eligible auto-mode units guidance for preserving context. Agents are steered toward `gsd_exec` for noisy scans, builds, tests, and diagnostics; capped stdout/stderr and metadata are saved under `.gsd/exec/` while only a short digest enters the conversation. `gsd_exec_search` lets agents reuse prior runs instead of repeating expensive checks, and `gsd_resume` reads a prior compaction snapshot from `.gsd/last-snapshot.md` when one exists. Opt out with `context_mode.enabled: false` to disable Context Mode guidance, snapshot injection, `gsd_exec`, `gsd_exec_search`, and `gsd_resume`; tune sandbox timeout/output caps and environment forwarding with `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, `context_mode.exec_digest_chars`, and `context_mode.exec_env_allowlist`.
 
 4. **Git isolation** — When `git.isolation` is set to `worktree` or `branch`, each milestone runs on its own `milestone/<MID>` branch (in a worktree or in-place). All slice work commits sequentially — no branch switching, no merge conflicts. When the milestone completes, it's squash-merged to main as one clean commit. The default is `none` (work on the current branch), configurable via preferences. If `worktree` is configured in a repo with no committed `HEAD`, GSD temporarily behaves as `none` until the first commit exists because git worktrees need a committed start point.
 
@@ -659,10 +659,11 @@ auto_report: true
 | `unique_milestone_ids`            | Uses unique milestone names to avoid clashes when working in teams of people                          |
 | `git.isolation`                   | `none` (default), `worktree`, or `branch` — enable worktree or branch isolation for milestone work. `worktree` requires a committed `HEAD`; zero-commit repos temporarily run as `none`    |
 | `git.manage_gitignore`            | Set `false` to prevent GSD from modifying `.gitignore`                                                |
-| `context_mode.enabled`            | Context Mode is default-on; set `false` to disable `gsd_exec`, exec history guidance, and resume snapshots |
+| `context_mode.enabled`            | Context Mode is default-on; set `false` to disable prompt guidance, snapshot injection, `gsd_exec`, `gsd_exec_search`, and `gsd_resume` |
 | `context_mode.exec_timeout_ms`    | Timeout for sandboxed `gsd_exec` runs (default: 30000)                                                |
 | `context_mode.exec_stdout_cap_bytes` | Persisted stdout cap for `gsd_exec` output (default: 1048576)                                      |
 | `context_mode.exec_digest_chars`  | Trailing stdout characters returned to the agent context (default: 300)                              |
+| `context_mode.exec_env_allowlist` | Environment variables forwarded to sandboxed `gsd_exec` runs in addition to `PATH` and `HOME`        |
 | `verification_commands`           | Array of shell commands to run after task execution (e.g., `["npm run lint", "npm run test"]`)        |
 | `verification_auto_fix`           | Auto-retry on verification failures (default: true)                                                   |
 | `verification_max_retries`        | Max retries for verification failures (default: 2)                                                    |

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -96,16 +96,16 @@ The amount of context inlined is controlled by your [token profile](./token-opti
 
 ### Context Mode
 
-Context Mode is enabled by default for auto-mode runs. Each unit receives manifest-driven guidance to preserve the conversation window: use `gsd_exec` for noisy codebase scans, builds, tests, and diagnostics; use `gsd_exec_search` before repeating a prior sandboxed run; and use `gsd_resume` after compaction or session resume to read `.gsd/last-snapshot.md`.
+Context Mode is enabled by default for auto-mode runs. Eligible auto-mode units receive manifest-driven guidance to preserve the conversation window: use `gsd_exec` for noisy codebase scans, builds, tests, and diagnostics; use `gsd_exec_search` before repeating a prior sandboxed run; and use `gsd_resume` after compaction or session resume to read a prior compaction snapshot from `.gsd/last-snapshot.md` when one exists.
 
-`gsd_exec` writes full stdout/stderr and metadata under `.gsd/exec/`, then returns only a short digest to the agent. This keeps large command output out of the LLM context while preserving exact evidence on disk. To opt out, set:
+`gsd_exec` writes capped stdout/stderr and metadata under `.gsd/exec/`; output may be truncated. It then returns only a short digest to the agent. This keeps large command output out of the LLM context while preserving exact evidence on disk. To opt out of Context Mode guidance, snapshot injection, `gsd_exec`, `gsd_exec_search`, and `gsd_resume`, set:
 
 ```yaml
 context_mode:
   enabled: false
 ```
 
-You can also tune sandbox behavior with `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, and `context_mode.exec_digest_chars`.
+You can also tune sandbox behavior with `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, `context_mode.exec_digest_chars`, and `context_mode.exec_env_allowlist`.
 
 ### Git Isolation
 

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -100,16 +100,16 @@ Every task gets a clean AI context window. No accumulated garbage, no quality de
 
 ## Context Mode
 
-Context Mode is enabled by default for auto-mode runs. Each unit receives manifest-driven guidance to preserve the conversation window: use `gsd_exec` for noisy codebase scans, builds, tests, and diagnostics; use `gsd_exec_search` before repeating a prior sandboxed run; and use `gsd_resume` after compaction or session resume to read `.gsd/last-snapshot.md`.
+Context Mode is enabled by default for auto-mode runs. Eligible auto-mode units receive manifest-driven guidance to preserve the conversation window: use `gsd_exec` for noisy codebase scans, builds, tests, and diagnostics; use `gsd_exec_search` before repeating a prior sandboxed run; and use `gsd_resume` after compaction or session resume to read a prior compaction snapshot from `.gsd/last-snapshot.md` when one exists.
 
-`gsd_exec` writes full stdout/stderr and metadata under `.gsd/exec/`, then returns only a short digest to the agent. This keeps large command output out of the LLM context while preserving exact evidence on disk. Opt out with:
+`gsd_exec` writes capped stdout/stderr and metadata under `.gsd/exec/`; output may be truncated. It then returns only a short digest to the agent. This keeps large command output out of the LLM context while preserving exact evidence on disk. Opt out of Context Mode guidance, snapshot injection, `gsd_exec`, `gsd_exec_search`, and `gsd_resume` with:
 
 ```yaml
 context_mode:
   enabled: false
 ```
 
-You can also tune sandbox behavior with `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, and `context_mode.exec_digest_chars`.
+You can also tune sandbox behavior with `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, `context_mode.exec_digest_chars`, and `context_mode.exec_env_allowlist`.
 
 ## Runtime Tool Policy
 

--- a/mintlify-docs/guides/auto-mode.mdx
+++ b/mintlify-docs/guides/auto-mode.mdx
@@ -51,16 +51,16 @@ Every task, research phase, and planning step gets a clean context window. The d
 
 ### Context Mode
 
-Context Mode is enabled by default for auto-mode runs. Each unit receives manifest-driven guidance to preserve the conversation window: use `gsd_exec` for noisy codebase scans, builds, tests, and diagnostics; use `gsd_exec_search` before repeating a prior sandboxed run; and use `gsd_resume` after compaction or session resume to read `.gsd/last-snapshot.md`.
+Context Mode is enabled by default for auto-mode runs. Eligible auto-mode units receive manifest-driven guidance to preserve the conversation window: use `gsd_exec` for noisy codebase scans, builds, tests, and diagnostics; use `gsd_exec_search` before repeating a prior sandboxed run; and use `gsd_resume` after compaction or session resume to read a prior compaction snapshot from `.gsd/last-snapshot.md` when one exists.
 
-`gsd_exec` writes full stdout/stderr and metadata under `.gsd/exec/`, then returns only a short digest to the agent. This keeps large command output out of the LLM context while preserving exact evidence on disk. Opt out with:
+`gsd_exec` writes capped stdout/stderr and metadata under `.gsd/exec/`; output may be truncated. It then returns only a short digest to the agent. This keeps large command output out of the LLM context while preserving exact evidence on disk. Opt out of Context Mode guidance, snapshot injection, `gsd_exec`, `gsd_exec_search`, and `gsd_resume` with:
 
 ```yaml
 context_mode:
   enabled: false
 ```
 
-You can also tune sandbox behavior with `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, and `context_mode.exec_digest_chars`.
+You can also tune sandbox behavior with `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, `context_mode.exec_digest_chars`, and `context_mode.exec_env_allowlist`.
 
 ### Runtime tool policy
 

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -191,6 +191,27 @@ describe("workflow MCP tools", () => {
     }
   });
 
+  it("gsd_exec is blocked by the MCP discussion-gate write gate", async () => {
+    const base = makeTmpBase();
+    try {
+      writeWriteGateSnapshot(base, { pendingGateId: "depth_verification_M001_confirm" });
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_exec");
+      assert.ok(tool, "exec tool should be registered");
+
+      const result = await tool!.handler({
+        projectDir: base,
+        runtime: "bash",
+        script: "echo should-not-run",
+      });
+
+      assertToolError(result, /Discussion gate .* has not been confirmed/);
+    } finally {
+      cleanup(base);
+    }
+  });
+
   it("gsd_exec_search finds a prior gsd_exec run", async () => {
     const base = makeTmpBase();
     try {
@@ -222,6 +243,28 @@ describe("workflow MCP tools", () => {
     }
   });
 
+  it("gsd_exec_search returns an MCP error when context mode is disabled", async () => {
+    const base = makeTmpBase();
+    try {
+      writeFileSync(
+        join(base, ".gsd", "PREFERENCES.md"),
+        "---\ncontext_mode:\n  enabled: false\n---\n",
+        "utf-8",
+      );
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_exec_search");
+      assert.ok(tool, "exec search tool should be registered");
+
+      const result = await tool!.handler({ projectDir: base, query: "anything" });
+
+      assertToolError(result, /context_mode\.enabled: false/);
+      assert.equal((result as any).structuredContent.error, "context_mode_disabled");
+    } finally {
+      cleanup(base);
+    }
+  });
+
   it("gsd_resume reads the context snapshot", async () => {
     const base = makeTmpBase();
     try {
@@ -243,6 +286,29 @@ describe("workflow MCP tools", () => {
         found: true,
         bytes: Buffer.byteLength("# GSD context snapshot\n\nResume from here.\n", "utf-8"),
       });
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("gsd_resume returns an MCP error when context mode is disabled", async () => {
+    const base = makeTmpBase();
+    try {
+      writeFileSync(
+        join(base, ".gsd", "PREFERENCES.md"),
+        "---\ncontext_mode:\n  enabled: false\n---\n",
+        "utf-8",
+      );
+      writeFileSync(join(base, ".gsd", "last-snapshot.md"), "# GSD context snapshot\n\nHidden.\n", "utf-8");
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const tool = server.tools.find((t) => t.name === "gsd_resume");
+      assert.ok(tool, "resume tool should be registered");
+
+      const result = await tool!.handler({ projectDir: base });
+
+      assertToolError(result, /context_mode\.enabled: false/);
+      assert.equal((result as any).structuredContent.error, "context_mode_disabled");
     } finally {
       cleanup(base);
     }

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -578,6 +578,17 @@ async function importLocalModule<T>(relativePath: string): Promise<T> {
   throw lastErr;
 }
 
+async function loadProjectPreferences(projectDir: string): Promise<unknown | null> {
+  const { loadEffectiveGSDPreferences } = await importLocalModule<any>(
+    "../../../src/resources/extensions/gsd/preferences.js",
+  );
+  try {
+    return loadEffectiveGSDPreferences(projectDir).preferences;
+  } catch {
+    return null;
+  }
+}
+
 function getWorkflowExecutorModuleCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
   const candidates: string[] = [];
   const explicitModule = env.GSD_WORKFLOW_EXECUTORS_MODULE?.trim();
@@ -1395,7 +1406,7 @@ const execRuntimeSchema = z.enum(["bash", "node", "python"]);
 const execParams = {
   projectDir: projectDirParam,
   runtime: execRuntimeSchema.describe("Interpreter: bash (-c), node (-e), or python3 (-c)."),
-  script: nonEmptyString("script").describe("Script body. Keep output small; full stdout/stderr are persisted under .gsd/exec."),
+  script: nonEmptyString("script").describe("Script body. Keep output small; capped stdout/stderr are persisted under .gsd/exec."),
   purpose: z.string().optional().describe("Short label recorded in meta.json for later review."),
   timeout_ms: z.number().int().min(1_000).max(600_000).optional().describe("Per-invocation timeout in milliseconds."),
 };
@@ -1873,26 +1884,19 @@ export function registerWorkflowTools(realServer: McpToolServer): void {
 
   server.tool(
     "gsd_exec",
-    "Run a short bash/node/python script in the project directory. Full stdout/stderr persist under .gsd/exec; only a digest returns to MCP.",
+    "Run a short bash/node/python script in the project directory. Capped stdout/stderr and metadata persist under .gsd/exec; only a digest returns to MCP.",
     execParams,
     async (args: Record<string, unknown>) => {
       const { projectDir, ...params } = parseWorkflowArgs(execSchema, args);
       await enforceWorkflowWriteGate("gsd_exec", projectDir);
-      const [{ executeGsdExec }, { loadEffectiveGSDPreferences }] = await Promise.all([
-        importLocalModule<any>("../../../src/resources/extensions/gsd/tools/exec-tool.js"),
-        importLocalModule<any>("../../../src/resources/extensions/gsd/preferences.js"),
-      ]);
-      let prefs: { preferences?: unknown } | null = null;
-      try {
-        prefs = loadEffectiveGSDPreferences(projectDir);
-      } catch {
-        prefs = null;
-      }
+      const { executeGsdExec } = await importLocalModule<any>(
+        "../../../src/resources/extensions/gsd/tools/exec-tool.js",
+      );
       return adaptExecutorResult(
-        await runSerializedWorkflowOperation(() =>
+        await runSerializedWorkflowOperation(async () =>
           executeGsdExec(params, {
             baseDir: projectDir,
-            preferences: (prefs?.preferences ?? null) as unknown,
+            preferences: await loadProjectPreferences(projectDir),
           }),
         ),
       );
@@ -1908,7 +1912,12 @@ export function registerWorkflowTools(realServer: McpToolServer): void {
       const { executeExecSearch } = await importLocalModule<any>(
         "../../../src/resources/extensions/gsd/tools/exec-search-tool.js",
       );
-      return adaptExecutorResult(executeExecSearch(params, { baseDir: projectDir }));
+      return adaptExecutorResult(
+        executeExecSearch(params, {
+          baseDir: projectDir,
+          preferences: await loadProjectPreferences(projectDir),
+        }),
+      );
     },
   );
 
@@ -1921,7 +1930,12 @@ export function registerWorkflowTools(realServer: McpToolServer): void {
       const { executeResume } = await importLocalModule<any>(
         "../../../src/resources/extensions/gsd/tools/resume-tool.js",
       );
-      return adaptExecutorResult(executeResume(params, { baseDir: projectDir }));
+      return adaptExecutorResult(
+        executeResume(params, {
+          baseDir: projectDir,
+          preferences: await loadProjectPreferences(projectDir),
+        }),
+      );
     },
   );
 

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -251,7 +251,7 @@ export class TUI extends Container {
 	public onDebug?: () => void;
 	private renderRequested = false;
 	private cursorRow = 0; // Logical cursor row (end of rendered content)
-	private hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
+	private hardwareCursorRow = 0; // Logical content row of the terminal cursor; physical screen row = hardwareCursorRow - previousViewportTop
 	private inputBuffer = ""; // Buffer for parsing terminal responses
 	private cellSizeQueryPending = false;
 	private showHardwareCursor = process.env.PI_HARDWARE_CURSOR === "1" || process.env.TERM_PROGRAM === "WarpTerminal";

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -35,6 +35,7 @@ import {
 import { formatDecisionsCompact, formatRequirementsCompact } from "./structured-data-formatter.js";
 import { readPhaseAnchor, formatAnchorForPrompt } from "./phase-anchor.js";
 import { composeContextModeInstructions, composeInlinedContext, type ArtifactResolver, type ContextModeRenderMode } from "./unit-context-composer.js";
+import { readCompactionSnapshot } from "./compaction-snapshot.js";
 import { logWarning } from "./workflow-logger.js";
 import { inlineGraphSubgraph } from "./graph-context.js";
 import { buildExtractionStepsBlock } from "./commands-extract-learnings.js";
@@ -102,13 +103,28 @@ function renderContextModeForPrompt(
   });
 }
 
+function renderContextModeBlockForPrompt(
+  unitType: string,
+  base: string,
+  renderMode: ContextModeRenderMode = "standalone",
+): string {
+  const contextMode = renderContextModeForPrompt(unitType, base, renderMode);
+  if (!contextMode) return "";
+  if (renderMode === "nested") return contextMode;
+
+  const snapshot = readCompactionSnapshot(base);
+  if (!snapshot?.trim()) return contextMode;
+
+  return `${contextMode}\n\n## Context Snapshot\nSource: \`.gsd/last-snapshot.md\`\n\n${snapshot.trimEnd()}`;
+}
+
 function prependContextModeToBlock(
   unitType: string,
   base: string,
   block: string,
   renderMode: ContextModeRenderMode = "standalone",
 ): string {
-  const contextMode = renderContextModeForPrompt(unitType, base, renderMode);
+  const contextMode = renderContextModeBlockForPrompt(unitType, base, renderMode);
   if (!contextMode) return block;
   if (!block.trim()) return contextMode;
   return `${contextMode}\n\n${block}`;

--- a/src/resources/extensions/gsd/bootstrap/exec-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/exec-tools.ts
@@ -6,23 +6,36 @@
 import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 
+async function loadContextModePreferences(baseDir: string) {
+  const [{ loadEffectiveGSDPreferences }, { logWarning }] = await Promise.all([
+    import("../preferences.js"),
+    import("../workflow-logger.js"),
+  ]);
+  try {
+    return loadEffectiveGSDPreferences(baseDir)?.preferences ?? null;
+  } catch (err) {
+    logWarning("tool", `Context Mode tool could not load preferences: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+}
+
 export function registerExecTools(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "gsd_exec",
     label: "Exec (Sandboxed)",
     description:
-      "Run a short script (bash/node/python) in a subprocess. Full stdout/stderr persist to " +
+      "Run a short script (bash/node/python) in a subprocess. Capped stdout/stderr and metadata persist to " +
       ".gsd/exec/<id>.{stdout,stderr,meta.json}; only a short digest returns in context. Use " +
       "this instead of reading many files or emitting large tool outputs — e.g. have the script " +
       "count/grep/summarize and log the finding. Enabled by default; opt out via " +
       "preferences.context_mode.enabled=false.",
     promptSnippet:
-      "Run a bash/node/python script in a sandbox; full output is saved to disk and only a digest returns",
+      "Run a bash/node/python script in a sandbox; capped output is saved to disk and only a digest returns",
     promptGuidelines: [
       "Prefer gsd_exec for analyses that would otherwise read >3 files or produce large tool output.",
       "Write scripts that log the finding (counts, matches, summaries) rather than raw dumps.",
       "The digest is the last ~300 chars of stdout — size your log output accordingly.",
-      "Need the full output? Read the stdout_path returned in details (file on local disk).",
+      "Need persisted output? Read the stdout_path returned in details (file on local disk).",
     ],
     parameters: Type.Object({
       runtime: Type.Union(
@@ -40,20 +53,11 @@ export function registerExecTools(pi: ExtensionAPI): void {
       ),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
-      const [{ executeGsdExec }, { loadEffectiveGSDPreferences }, { logWarning }] = await Promise.all([
-        import("../tools/exec-tool.js"),
-        import("../preferences.js"),
-        import("../workflow-logger.js"),
-      ]);
-      let prefs: ReturnType<typeof loadEffectiveGSDPreferences> | null = null;
-      try {
-        prefs = loadEffectiveGSDPreferences();
-      } catch (err) {
-        logWarning("tool", `gsd_exec could not load preferences: ${err instanceof Error ? err.message : String(err)}`);
-      }
+      const { executeGsdExec } = await import("../tools/exec-tool.js");
+      const baseDir = process.cwd();
       return executeGsdExec(params as Parameters<typeof executeGsdExec>[0], {
-        baseDir: process.cwd(),
-        preferences: prefs?.preferences ?? null,
+        baseDir,
+        preferences: await loadContextModePreferences(baseDir),
       });
     },
   });
@@ -67,7 +71,7 @@ export function registerExecTools(pi: ExtensionAPI): void {
     promptSnippet: "Search prior gsd_exec runs by substring, runtime, or failing-only filter",
     promptGuidelines: [
       "Use this before re-running an expensive analysis — the prior run's stdout file may still answer.",
-      "The preview shows the trailing ~300 chars of stdout; read stdout_path for the full transcript.",
+      "The preview shows the trailing ~300 chars of stdout; read stdout_path for persisted output.",
     ],
     parameters: Type.Object({
       query: Type.Optional(Type.String({ description: "Substring matched against id and purpose (case-insensitive)." })),
@@ -81,8 +85,10 @@ export function registerExecTools(pi: ExtensionAPI): void {
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
       const { executeExecSearch } = await import("../tools/exec-search-tool.js");
+      const baseDir = process.cwd();
       return executeExecSearch(params as Parameters<typeof executeExecSearch>[0], {
-        baseDir: process.cwd(),
+        baseDir,
+        preferences: await loadContextModePreferences(baseDir),
       });
     },
   });
@@ -102,8 +108,10 @@ export function registerExecTools(pi: ExtensionAPI): void {
     parameters: Type.Object({}),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
       const { executeResume } = await import("../tools/resume-tool.js");
+      const baseDir = process.cwd();
       return executeResume(params as Parameters<typeof executeResume>[0], {
-        baseDir: process.cwd(),
+        baseDir,
+        preferences: await loadContextModePreferences(baseDir),
       });
     },
   });

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -32,7 +32,7 @@ export interface ContextManagementConfig {
 /**
  * Opt-in tool-output sandboxing for sub-sessions. When enabled, the gsd_exec
  * MCP tool runs scripts in an isolated subprocess and returns only a short
- * digest to the calling agent's context window; full stdout/stderr persist
+ * digest to the calling agent's context window; capped stdout/stderr persist
  * in the project memory store and can be retrieved by id later.
  *
  * Inspired by mksglu/context-mode (Elastic License 2.0). This is an

--- a/src/resources/extensions/gsd/tests/compaction-snapshot.test.ts
+++ b/src/resources/extensions/gsd/tests/compaction-snapshot.test.ts
@@ -121,3 +121,14 @@ test('executeResume: reports friendly empty state when no snapshot exists', () =
     cleanup(base);
   }
 });
+
+test('executeResume: returns disabled error when context_mode.enabled=false', () => {
+  const base = freshBase();
+  try {
+    const result = executeResume({}, { baseDir: base, preferences: { context_mode: { enabled: false } } });
+    assert.equal(result.isError, true);
+    assert.equal((result.details as { error?: string }).error, 'context_mode_disabled');
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/exec-history.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-history.test.ts
@@ -108,6 +108,21 @@ test('executeExecSearch: returns helpful empty-state message when no matches', (
   }
 });
 
+test('executeExecSearch: returns disabled error when context_mode.enabled=false', () => {
+  const base = freshBase();
+  try {
+    writeRun(base, 'should-not-surface', { stdout: 'hidden\n' });
+    const result = executeExecSearch(
+      { query: 'hidden' },
+      { baseDir: base, preferences: { context_mode: { enabled: false } } },
+    );
+    assert.equal(result.isError, true);
+    assert.equal((result.details as { error?: string }).error, 'context_mode_disabled');
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('executeExecSearch: includes stdout_path and preview in details', () => {
   const base = freshBase();
   try {

--- a/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { EXEC_DEFAULTS, runExecSandbox, type ExecSandboxOptions } from '../exec-sandbox.ts';
 import { buildExecOptions, executeGsdExec } from '../tools/exec-tool.ts';
 import { isContextModeEnabled } from '../preferences-types.ts';
+import { validatePreferences } from '../preferences-validation.ts';
 
 function freshBase(): string {
   return mkdtempSync(join(tmpdir(), 'gsd-exec-test-'));
@@ -174,6 +175,52 @@ test('executeGsdExec: runs when enabled explicitly set to true', async () => {
   }
 });
 
+test('executeGsdExec: forwards custom exec_env_allowlist from preferences', async () => {
+  const base = freshBase();
+  try {
+    const result = await executeGsdExec(
+      {
+        runtime: 'bash',
+        script: 'printf "allowed=%s blocked=%s\\n" "$GSD_ALLOWED" "$GSD_BLOCKED"',
+      },
+      {
+        baseDir: base,
+        preferences: {
+          context_mode: {
+            enabled: true,
+            exec_env_allowlist: ['GSD_ALLOWED'],
+          },
+        },
+        env: {
+          PATH: '/usr/bin:/bin',
+          HOME: '/tmp',
+          GSD_ALLOWED: 'yes',
+          GSD_BLOCKED: 'no',
+        },
+      },
+    );
+    assert.ok(!result.isError);
+    assert.match(result.content[0].text, /allowed=yes blocked=/);
+    assert.doesNotMatch(result.content[0].text, /blocked=no/);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('executeGsdExec: enforces per-call timeout override end-to-end', async () => {
+  const base = freshBase();
+  try {
+    const result = await executeGsdExec(
+      { runtime: 'bash', script: 'sleep 2', timeout_ms: 1 },
+      { baseDir: base, preferences: { context_mode: { enabled: true, exec_timeout_ms: 10_000 } } },
+    );
+    assert.equal(result.details.timed_out, true);
+    assert.equal(result.isError, true);
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('executeGsdExec: rejects empty script', async () => {
   const base = freshBase();
   try {
@@ -186,6 +233,24 @@ test('executeGsdExec: rejects empty script', async () => {
   } finally {
     cleanup(base);
   }
+});
+
+test('validatePreferences: rejects invalid context_mode preference values', () => {
+  const result = validatePreferences({
+    context_mode: {
+      enabled: 'false',
+      exec_timeout_ms: 999,
+      exec_stdout_cap_bytes: 1,
+      exec_digest_chars: -1,
+      exec_env_allowlist: ['GOOD_NAME', 'bad-name'],
+    },
+  } as any);
+  assert.ok(result.errors.length > 0);
+  assert.ok(result.errors.includes('context_mode.enabled must be a boolean'));
+  assert.ok(result.errors.includes('context_mode.exec_timeout_ms must be a number between 1000 and 600000'));
+  assert.ok(result.errors.includes('context_mode.exec_stdout_cap_bytes must be a number between 4096 and 16777216'));
+  assert.ok(result.errors.includes('context_mode.exec_digest_chars must be a number between 0 and 4000'));
+  assert.ok(result.errors.includes('context_mode.exec_env_allowlist must be an array of valid env var names'));
 });
 
 test('isContextModeEnabled: defaults to true; only explicit false disables', () => {

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -21,12 +21,18 @@ import type {
   ComputedArtifactRegistry,
   UnitContextManifest,
 } from "../unit-context-manifest.ts";
-import { UNIT_MANIFESTS } from "../unit-context-manifest.ts";
-import { buildReassessRoadmapPrompt } from "../auto-prompts.ts";
+import { KNOWN_UNIT_TYPES, UNIT_MANIFESTS } from "../unit-context-manifest.ts";
+import {
+  buildExecuteTaskPrompt,
+  buildGateEvaluatePrompt,
+  buildReassessRoadmapPrompt,
+  buildWorkflowPreferencesPrompt,
+} from "../auto-prompts.ts";
 import { invalidateAllCaches } from "../cache.ts";
 import {
   openDatabase,
   closeDatabase,
+  insertGateRow,
   insertMilestone,
   upsertMilestonePlanning,
   insertSlice,
@@ -121,7 +127,7 @@ test("Context Mode composer: standalone output starts with heading and includes 
   assert.ok(out.startsWith("## Context Mode"));
   assert.match(out, /execution lane/i);
   assert.match(out, /`gsd_exec`/);
-  assert.match(out, /noisy commands/);
+  assert.match(out, /builds, tests, and diagnostics/);
   assert.match(out, /`gsd_exec_search`/);
   assert.match(out, /before reruns/);
   assert.match(out, /`gsd_resume`/);
@@ -136,7 +142,45 @@ test("Context Mode composer: nested output is compact single sentence", () => {
   assert.match(out, /`gsd_exec`/);
   assert.match(out, /`gsd_exec_search`/);
   assert.match(out, /`gsd_resume`/);
-  assert.ok(out.length < 180, `nested guidance should stay compact, got ${out.length} chars`);
+  assert.ok(out.length < 240, `nested guidance should stay compact, got ${out.length} chars`);
+});
+
+const laneLabelByMode: Record<string, string> = {
+  interview: "interview",
+  research: "research",
+  planning: "planning",
+  execution: "execution",
+  verification: "verification",
+  orchestration: "orchestration",
+  docs: "documentation",
+};
+
+test("Context Mode composer: every known eligible unit renders its configured lane and required tools", () => {
+  for (const unitType of KNOWN_UNIT_TYPES) {
+    const manifest = UNIT_MANIFESTS[unitType];
+    assert.ok(manifest, `missing manifest for ${unitType}`);
+    const out = composeContextModeInstructions(unitType, { enabled: true, renderMode: "standalone" });
+    if (manifest.contextMode === "none") {
+      assert.strictEqual(out, "", `${unitType} should not render Context Mode`);
+      continue;
+    }
+    assert.ok(out.startsWith("## Context Mode"), `${unitType} should render standalone Context Mode heading`);
+    assert.match(out, new RegExp(`Lane: \\*\\*${laneLabelByMode[manifest.contextMode]} lane\\*\\*\\.`, "i"));
+    assert.match(out, /`gsd_exec`/, `${unitType} should mention gsd_exec`);
+    assert.match(out, /`gsd_exec_search`/, `${unitType} should mention gsd_exec_search`);
+    assert.match(out, /`gsd_resume`/, `${unitType} should mention gsd_resume`);
+  }
+});
+
+test("Context Mode composer: workflow-preferences and research-decision render no Context Mode block", () => {
+  assert.strictEqual(
+    composeContextModeInstructions("workflow-preferences", { enabled: true, renderMode: "standalone" }),
+    "",
+  );
+  assert.strictEqual(
+    composeContextModeInstructions("research-decision", { enabled: true, renderMode: "standalone" }),
+    "",
+  );
 });
 
 // ─── Integration: migrated buildReassessRoadmapPrompt ─────────────────────
@@ -218,6 +262,94 @@ test("#4782 phase 2: buildReassessRoadmapPrompt emits composer-shaped context wi
   // Slice context is optional and not present in this fixture — must not
   // leave a stray empty section
   assert.ok(!prompt.includes("Slice Context (from discussion)"));
+});
+
+test("Context Mode resume injection: eligible prompts include one bounded snapshot block above inlined context", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  writeArtifacts(base);
+  writeFileSync(
+    join(base, ".gsd", "last-snapshot.md"),
+    "# GSD context snapshot\n\nResume evidence.\n",
+    "utf-8",
+  );
+
+  const prompt = await buildReassessRoadmapPrompt("M001", "Test", "S01", base);
+
+  assert.equal(prompt.match(/## Context Snapshot/g)?.length, 1);
+  assert.match(prompt, /Source: `\.gsd\/last-snapshot\.md`/);
+  assert.match(prompt, /Resume evidence/);
+  assert.ok(prompt.indexOf("## Context Mode") < prompt.indexOf("## Context Snapshot"));
+  assert.ok(prompt.indexOf("## Context Snapshot") < prompt.indexOf("## Inlined Context"));
+});
+
+test("Context Mode resume injection: missing snapshot does not add an empty block", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  writeArtifacts(base);
+
+  const prompt = await buildReassessRoadmapPrompt("M001", "Test", "S01", base);
+
+  assert.match(prompt, /## Context Mode/);
+  assert.doesNotMatch(prompt, /## Context Snapshot/);
+});
+
+test("Context Mode resume injection: disabled mode suppresses guidance and snapshot reads", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  writeArtifacts(base);
+  writeFileSync(join(base, ".gsd", "PREFERENCES.md"), "---\ncontext_mode:\n  enabled: false\n---\n", "utf-8");
+  writeFileSync(join(base, ".gsd", "last-snapshot.md"), "# GSD context snapshot\n\nDo not inject.\n", "utf-8");
+
+  const prompt = await buildReassessRoadmapPrompt("M001", "Test", "S01", base);
+
+  assert.doesNotMatch(prompt, /## Context Mode/);
+  assert.doesNotMatch(prompt, /## Context Snapshot/);
+  assert.doesNotMatch(prompt, /Do not inject/);
+});
+
+test("Context Mode resume injection: none-mode units do not inject snapshots", async () => {
+  const base = makeFixtureBase();
+  try {
+    writeFileSync(join(base, ".gsd", "last-snapshot.md"), "# GSD context snapshot\n\nNo lane.\n", "utf-8");
+    const prompt = await buildWorkflowPreferencesPrompt(base);
+    assert.doesNotMatch(prompt, /## Context Mode/);
+    assert.doesNotMatch(prompt, /## Context Snapshot/);
+    assert.doesNotMatch(prompt, /No lane/);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("Context Mode prompt suppression: disabled inlined, phase-anchor, and nested prompts omit Context Mode", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  writeArtifacts(base);
+  insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+  writeFileSync(join(base, ".gsd", "PREFERENCES.md"), "---\ncontext_mode:\n  enabled: false\n---\n", "utf-8");
+  writeFileSync(join(base, ".gsd", "last-snapshot.md"), "# GSD context snapshot\n\nDo not inject.\n", "utf-8");
+
+  const inlinedPrompt = await buildReassessRoadmapPrompt("M001", "Test", "S01", base);
+  assert.doesNotMatch(inlinedPrompt, /## Context Mode|Context Mode \(|## Context Snapshot/);
+
+  const phaseAnchorPrompt = await buildExecuteTaskPrompt("M001", "S01", "First", "T01", "Task", base);
+  assert.doesNotMatch(phaseAnchorPrompt, /## Context Mode|Context Mode \(|## Context Snapshot/);
+
+  const nestedPrompt = await buildGateEvaluatePrompt("M001", "Test", "S01", "First", base);
+  assert.match(nestedPrompt, /Use this as the prompt for a `subagent` call/);
+  assert.doesNotMatch(nestedPrompt, /## Context Mode|Context Mode \(|## Context Snapshot/);
 });
 
 // ─── v2 surface (#4924) ───────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tools/context-mode-tool-result.ts
+++ b/src/resources/extensions/gsd/tools/context-mode-tool-result.ts
@@ -1,0 +1,25 @@
+// Project/App: GSD-2
+// File Purpose: Shared Context Mode tool result helpers.
+
+export interface ToolExecutionResult {
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+  isError?: boolean;
+}
+
+export type ContextModeToolName = "gsd_exec" | "gsd_exec_search" | "gsd_resume";
+
+export function contextModeDisabledResult(operation: ContextModeToolName): ToolExecutionResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text:
+          `${operation} is disabled by \`context_mode.enabled: false\` in preferences. ` +
+          "Remove that override or set it to true to re-enable Context Mode tools.",
+      },
+    ],
+    details: { operation, error: "context_mode_disabled" },
+    isError: true,
+  };
+}

--- a/src/resources/extensions/gsd/tools/exec-search-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-search-tool.ts
@@ -4,6 +4,8 @@
 // re-discover past runs without re-executing. Read-only; no DB writes.
 
 import { searchExecHistory, type ExecSearchOptions } from "../exec-history.js";
+import { isContextModeEnabled, type ContextModeConfig } from "../preferences-types.js";
+import { contextModeDisabledResult, type ToolExecutionResult } from "./context-mode-tool-result.js";
 
 export interface ExecSearchToolParams {
   query?: string;
@@ -12,16 +14,14 @@ export interface ExecSearchToolParams {
   limit?: number;
 }
 
-export interface ToolExecutionResult {
-  content: Array<{ type: "text"; text: string }>;
-  details: Record<string, unknown>;
-  isError?: boolean;
-}
-
 export function executeExecSearch(
   params: ExecSearchToolParams,
-  opts: { baseDir: string },
+  opts: { baseDir: string; preferences?: { context_mode?: ContextModeConfig } | null },
 ): ToolExecutionResult {
+  if (!isContextModeEnabled(opts.preferences)) {
+    return contextModeDisabledResult("gsd_exec_search");
+  }
+
   const searchOpts: ExecSearchOptions = {
     query: typeof params.query === "string" ? params.query : undefined,
     runtime: params.runtime,

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -12,6 +12,7 @@ import {
   type ExecSandboxResult,
 } from "../exec-sandbox.js";
 import { isContextModeEnabled, type ContextModeConfig } from "../preferences-types.js";
+import { contextModeDisabledResult, type ToolExecutionResult } from "./context-mode-tool-result.js";
 
 export interface ExecToolParams {
   runtime: ExecSandboxRequest["runtime"];
@@ -20,17 +21,12 @@ export interface ExecToolParams {
   timeout_ms?: number;
 }
 
-export interface ToolExecutionResult {
-  content: Array<{ type: "text"; text: string }>;
-  details: Record<string, unknown>;
-  isError?: boolean;
-}
-
 export interface ExecToolDeps {
   baseDir: string;
   preferences: { context_mode?: ContextModeConfig } | null;
   /** Optional override for testing. */
   run?: (req: ExecSandboxRequest, opts: ExecSandboxOptions) => Promise<ExecSandboxResult>;
+  env?: NodeJS.ProcessEnv;
   now?: () => Date;
   generateId?: () => string;
 }
@@ -77,21 +73,6 @@ function isEnabled(prefs: ExecToolDeps["preferences"]): boolean {
   return isContextModeEnabled(prefs);
 }
 
-function disabledResult(): ToolExecutionResult {
-  return {
-    content: [
-      {
-        type: "text",
-        text:
-          "gsd_exec is disabled by `context_mode.enabled: false` in preferences. Remove that " +
-          "override (or set it to true) to re-enable sandboxed tool-output execution.",
-      },
-    ],
-    details: { operation: "gsd_exec", error: "context_mode_disabled" },
-    isError: true,
-  };
-}
-
 function paramError(message: string): ToolExecutionResult {
   return {
     content: [{ type: "text", text: `Error: ${message}` }],
@@ -104,7 +85,7 @@ export async function executeGsdExec(
   params: ExecToolParams,
   deps: ExecToolDeps,
 ): Promise<ToolExecutionResult> {
-  if (!isEnabled(deps.preferences)) return disabledResult();
+  if (!isEnabled(deps.preferences)) return contextModeDisabledResult("gsd_exec");
 
   const runtime = params.runtime;
   if (runtime !== "bash" && runtime !== "node" && runtime !== "python") {
@@ -121,7 +102,7 @@ export async function executeGsdExec(
   const opts = buildExecOptions(
     deps.baseDir,
     deps.preferences?.context_mode,
-    { now: deps.now, generateId: deps.generateId },
+    { env: deps.env, now: deps.now, generateId: deps.generateId },
   );
   const run = deps.run ?? runExecSandbox;
 

--- a/src/resources/extensions/gsd/tools/resume-tool.ts
+++ b/src/resources/extensions/gsd/tools/resume-tool.ts
@@ -3,22 +3,22 @@
 // re-deriving project memory state.
 
 import { readCompactionSnapshot } from "../compaction-snapshot.js";
+import { isContextModeEnabled, type ContextModeConfig } from "../preferences-types.js";
+import { contextModeDisabledResult, type ToolExecutionResult } from "./context-mode-tool-result.js";
 
 export interface ResumeToolParams {
   /** Ignored — reserved for future variant (e.g. dated snapshots). */
   _variant?: string;
 }
 
-export interface ToolExecutionResult {
-  content: Array<{ type: "text"; text: string }>;
-  details: Record<string, unknown>;
-  isError?: boolean;
-}
-
 export function executeResume(
   _params: ResumeToolParams,
-  opts: { baseDir: string },
+  opts: { baseDir: string; preferences?: { context_mode?: ContextModeConfig } | null },
 ): ToolExecutionResult {
+  if (!isContextModeEnabled(opts.preferences)) {
+    return contextModeDisabledResult("gsd_resume");
+  }
+
   const snapshot = readCompactionSnapshot(opts.baseDir);
   if (snapshot == null) {
     return {

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -112,8 +112,22 @@ const CONTEXT_MODE_LANE_LABELS: Record<Exclude<ContextModePolicy, "none">, strin
   docs: "documentation",
 };
 
-const CONTEXT_MODE_GUIDANCE =
-  "Use `gsd_exec` for noisy commands, `gsd_exec_search` before reruns, and `gsd_resume` after compaction or resume.";
+const CONTEXT_MODE_GUIDANCE_BY_LANE: Record<Exclude<ContextModePolicy, "none">, string> = {
+  interview:
+    "Use `gsd_resume` to restore prior discussion, `gsd_exec` for noisy discovery, and `gsd_exec_search` before repeating scans.",
+  research:
+    "Use `gsd_exec` for noisy research scans, `gsd_exec_search` before reruns, and `gsd_resume` to restore prior findings.",
+  planning:
+    "Use `gsd_resume` for planning continuity, `gsd_exec` for noisy checks, and `gsd_exec_search` before rerunning diagnostics.",
+  execution:
+    "Use `gsd_exec` for builds, tests, and diagnostics, `gsd_exec_search` before reruns, and `gsd_resume` after compaction or resume.",
+  verification:
+    "Use `gsd_exec` for verification commands, `gsd_exec_search` to reuse prior evidence, and `gsd_resume` after compaction or resume.",
+  orchestration:
+    "Use `gsd_resume` before resuming orchestration, `gsd_exec_search` to reuse prior runs, and `gsd_exec` for noisy coordination checks.",
+  docs:
+    "Use `gsd_resume` for prior context, `gsd_exec_search` for saved evidence, and `gsd_exec` for noisy doc validation commands.",
+};
 
 /**
  * Render the Context Mode instruction lane for a unit type. Unknown unit
@@ -129,15 +143,16 @@ export function composeContextModeInstructions(
   if (!manifest || manifest.contextMode === "none") return "";
 
   const lane = CONTEXT_MODE_LANE_LABELS[manifest.contextMode];
+  const guidance = CONTEXT_MODE_GUIDANCE_BY_LANE[manifest.contextMode];
   if (opts.renderMode === "nested") {
-    return `Context Mode (${lane} lane): ${CONTEXT_MODE_GUIDANCE}`;
+    return `Context Mode (${lane} lane): ${guidance}`;
   }
 
   return [
     "## Context Mode",
     "",
     `Lane: **${lane} lane**.`,
-    CONTEXT_MODE_GUIDANCE,
+    guidance,
   ].join("\n");
 }
 

--- a/src/tests/tui-pin-to-bottom-on-clear.test.ts
+++ b/src/tests/tui-pin-to-bottom-on-clear.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { TUI, type Component, type Terminal } from "@gsd/pi-tui";
+import { TUI, CURSOR_MARKER, type Component, type Terminal } from "@gsd/pi-tui";
 
 class ResizableMockTerminal implements Terminal {
   public writtenData: string[] = [];
@@ -159,6 +159,67 @@ describe("TUI pin-to-bottom on clear", () => {
     assert.ok(
       frame.includes("\x1b[2J\x1b[1;1H"),
       `expected clear + row-1 anchor for oversized block, got ${JSON.stringify(frame.slice(0, 120))}`,
+    );
+  });
+
+  it("uses differential render for same-line-count edit on short content", () => {
+    // Gap C: verify the negative-viewport coordinate math is correct when a
+    // same-length edit reaches the differential path (no line count change →
+    // early-exit doesn't fire).
+    const terminal = new ResizableMockTerminal(20);
+    const tui = new TUI(terminal, false);
+    const component = new StaticLinesComponent(["line 1", "line 2", "line 3"]);
+    tui.addChild(component);
+    (tui as any).doRender();
+
+    terminal.writtenData = [];
+    component.lines = ["line 1", "updated line 2", "line 3"];
+    (tui as any).doRender();
+
+    const frame = terminal.writtenData.join("");
+    // Same line count → must NOT clear the screen.
+    assert.ok(
+      !frame.includes("\x1b[2J"),
+      `expected differential render without full clear, got ${JSON.stringify(frame)}`,
+    );
+    // hardwareCursorRow=2, prevViewportTop=-17 → screen row=19.
+    // Target row=1, screen row=18. lineDiff = 18-19 = -1 → move up 1.
+    assert.ok(
+      frame.includes("\x1b[1A"),
+      `expected cursor to move up 1 row to the changed line, got ${JSON.stringify(frame)}`,
+    );
+    assert.ok(
+      frame.includes("updated line 2"),
+      `expected updated content in differential render, got ${JSON.stringify(frame)}`,
+    );
+  });
+
+  it("positions hardware cursor correctly within a short bottom-anchored block", () => {
+    // Gap B: verify positionHardwareCursor emits correct relative moves when
+    // content is short (negative previousViewportTop) and a CURSOR_MARKER is
+    // embedded in a non-final line.
+    const terminal = new ResizableMockTerminal(20);
+    const tui = new TUI(terminal, false);
+    // Marker on middle line; block is 3 lines on a 20-row terminal.
+    const component = new StaticLinesComponent([
+      "line 1",
+      `cursor${CURSOR_MARKER}`,
+      "line 3",
+    ]);
+    tui.addChild(component);
+    (tui as any).doRender();
+
+    const allWrites = terminal.writtenData.join("");
+    // Render frame must use bottom anchor (startRow = 20 - 3 + 1 = 18).
+    assert.ok(
+      allWrites.includes("\x1b[18;1H"),
+      `expected bottom anchor at row 18, got ${JSON.stringify(allWrites.slice(0, 160))}`,
+    );
+    // After writing 3 lines hardwareCursorRow=2. CURSOR_MARKER is at content
+    // row 1. positionHardwareCursor must move up 1 row (rowDelta = 1 - 2 = -1).
+    assert.ok(
+      allWrites.includes("\x1b[1A"),
+      `expected hardware cursor to move up 1 row to marker at content row 1, got ${JSON.stringify(allWrites)}`,
     );
   });
 });


### PR DESCRIPTION
## TL;DR

**What:** Closes Context Mode gaps across runtime tools, prompt resume injection, lane guidance, docs, and regression coverage.
**Why:** Context Mode opt-out and resume behavior were not consistently enforced across all eligible surfaces.
**How:** Centralizes disabled tool results, loads project preferences before all Context Mode tool executions, injects snapshots through the existing prompt prefix path, and adds targeted tests.

## What

This PR updates GSD2 Context Mode behavior so `context_mode.enabled: false` is a strict opt-out for:

- Context Mode prompt guidance
- automatic `.gsd/last-snapshot.md` prompt injection
- `gsd_exec`
- `gsd_exec_search`
- `gsd_resume`

It also adds eligible-prompt resume snapshot injection, replaces generic Context Mode guidance with lane-specific guidance, and aligns README/user/Mintlify/GitBook docs with capped stdout/stderr and `context_mode.exec_env_allowlist` behavior.

Closes #5483

## Why

Context Mode is meant to preserve useful working context while keeping noisy command output out of the model window. The previous behavior left gaps: search/resume tools could still be reachable when disabled, resume snapshots required explicit tool use instead of surfacing in eligible prompts, and docs overclaimed output persistence semantics.

## How

- Added a shared `contextModeDisabledResult()` helper for all Context Mode tools.
- Updated `gsd_exec_search` and `gsd_resume` to enforce `context_mode.enabled` like `gsd_exec`.
- Updated in-process and MCP wrappers to load project preferences before all three tool calls.
- Added Context Snapshot rendering under the existing `prependContextModeToBlock()` path, so disabled and `contextMode: "none"` units naturally omit it.
- Replaced generic guidance with compact lane-specific guidance while preserving mentions of `gsd_exec`, `gsd_exec_search`, and `gsd_resume` for every non-`none` lane.
- Added regression tests for disabled semantics, MCP behavior, prompt lanes, resume injection, preference validation, env allowlist forwarding, timeout enforcement, and MCP write-gate behavior.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/unit-context-composer.test.ts src/resources/extensions/gsd/tests/exec-sandbox.test.ts src/resources/extensions/gsd/tests/exec-history.test.ts src/resources/extensions/gsd/tests/compaction-snapshot.test.ts src/resources/extensions/gsd/tests/register-hooks-compaction-checkpoint.test.ts packages/mcp-server/src/workflow-tools.test.ts`
  - Result: 99 passed, 0 failed.
- `npm run verify:pr`
  - Result: 9021 passed, 0 failed, 9 skipped.

## Change Type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking Changes

No breaking public API or file-structure changes. This intentionally tightens documented opt-out behavior: `context_mode.enabled: false` now disables all Context Mode runtime tools and snapshot/prompt behavior.

## AI Assistance

This PR was AI-assisted. The implementation was verified locally with the targeted test suite and `npm run verify:pr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Context Mode behavior: stdout/stderr are now capped with metadata persisted, and only a digest is sent to the agent.
  * Expanded guidance on disabling Context Mode and related features.

* **New Features**
  * Added new Context Mode configuration options: `context_mode.enabled`, `context_mode.exec_timeout_ms`, `context_mode.exec_stdout_cap_bytes`, `context_mode.exec_digest_chars`, and `context_mode.exec_env_allowlist`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->