### PR TITLE
[codex] fix auto-mode session handoff exits

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
@@ -120,6 +120,7 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 
 	it("newSession() invokes abort() before _disconnectFromAgent()", async () => {
 		const session = await createSession();
+		(session as any).agent.state.isStreaming = true;
 		const order = recordCallOrder(session as any, ["abort", "_disconnectFromAgent"]);
 
 		const ok = await session.newSession();
@@ -136,6 +137,40 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 			abortIdx < disconnectIdx,
 			`abort() must run before _disconnectFromAgent(); order=${order.join(",")}`,
 		);
+	});
+
+	it("newSession() waits instead of aborting when the prior turn is idle but not settled", async () => {
+		const session = await createSession();
+		const order: string[] = [];
+		let releaseIdle!: () => void;
+		const idle = new Promise<void>((resolve) => {
+			releaseIdle = resolve;
+		});
+
+		(session as any).agent.state.isStreaming = false;
+		(session as any).agent.waitForIdle = () => {
+			order.push("waitForIdle");
+			return idle;
+		};
+		(session as any).abort = async () => {
+			order.push("abort");
+		};
+		const originalDisconnect = (session as any)._disconnectFromAgent.bind(session);
+		(session as any)._disconnectFromAgent = () => {
+			order.push("_disconnectFromAgent");
+			originalDisconnect();
+		};
+
+		const pendingNewSession = session.newSession();
+		await Promise.resolve();
+		assert.deepEqual(order, ["waitForIdle"]);
+		assert.equal(order.includes("abort"), false);
+
+		releaseIdle();
+		const ok = await pendingNewSession;
+		assert.equal(ok, true);
+		assert.deepEqual(order, ["waitForIdle", "_disconnectFromAgent"]);
+		assert.equal(order.includes("abort"), false);
 	});
 
 	it("newSession() waits instead of aborting while agent_end processing is still streaming", async () => {
@@ -432,6 +467,7 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 		const sessionFile = session.sessionFile;
 		assert.ok(typeof sessionFile === "string" && sessionFile.length > 0, "need a session file to switch to");
 
+		(session as any).agent.state.isStreaming = true;
 		const order = recordCallOrder(session as any, ["abort", "_disconnectFromAgent"]);
 
 		const ok = await session.switchSession(sessionFile);

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1626,6 +1626,11 @@ export class AgentSession {
 		// message_end/agent_end events fire while listeners are still connected.
 		// During agent_end handling the turn is already ending; aborting there can
 		// convert a successful auto-mode handoff into an aborted provider message.
+		if (!this.agent.state.isStreaming) {
+			this._retryHandler.abortRetry();
+			await this.agent.waitForIdle();
+			return;
+		}
 		await this.abort();
 	}
 

--- a/src/resources/extensions/gsd/auto-supervisor.ts
+++ b/src/resources/extensions/gsd/auto-supervisor.ts
@@ -32,6 +32,7 @@ let _currentSigtermHandler: (() => void) | null = null;
 export function registerSigtermHandler(
   currentBasePath: string,
   previousHandler: (() => void) | null,
+  onSignalCleanup?: () => void,
 ): () => void {
   // Remove the explicitly-passed previous handler
   if (previousHandler) {
@@ -43,6 +44,12 @@ export function registerSigtermHandler(
     for (const sig of CLEANUP_SIGNALS) process.off(sig, _currentSigtermHandler);
   }
   const handler = () => {
+    try {
+      onSignalCleanup?.();
+    } catch {
+      void 0;
+      // Signal cleanup is best-effort; lock cleanup and process exit still run.
+    }
     clearLock(currentBasePath);
     releaseSessionLock(currentBasePath);
     process.exit(0);

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -59,6 +59,7 @@ import {
   isLockProcessAlive,
   formatCrashInfo,
   emitCrashRecoveredUnitEnd,
+  emitOpenUnitEndForUnit,
 } from "./crash-recovery.js";
 import {
   acquireSessionLock,
@@ -200,6 +201,8 @@ import {
   detectWorkingTreeActivity,
 } from "./auto-supervisor.js";
 import { isDbAvailable, getMilestone } from "./gsd-db.js";
+import { markLatestActiveForWorkerCanceled } from "./db/unit-dispatches.js";
+import { writeUnitRuntimeRecord } from "./unit-runtime.js";
 import { countPendingCaptures } from "./captures.js";
 import { CMUX_CHANNELS, type CmuxLogLevel } from "../shared/cmux-events.js";
 import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
@@ -505,9 +508,54 @@ export {
   getBudgetEnforcementAction,
 } from "./auto-budget.js";
 
+function closeOutSignalInterruptedUnit(currentBasePath: string): void {
+  const currentUnit = s.currentUnit;
+  if (!currentUnit) return;
+
+  const reason = "Auto-mode process received a termination signal";
+  const errorContext: ErrorContext = {
+    message: reason,
+    category: "aborted",
+    isTransient: false,
+  };
+  const basePath = s.basePath || currentBasePath;
+
+  try {
+    emitOpenUnitEndForUnit(basePath, currentUnit.type, currentUnit.id, "cancelled", errorContext);
+  } catch (err) {
+    logWarning("engine", `signal unit-end cleanup failed: ${getErrorMessage(err)}`, { file: "auto.ts" });
+  }
+
+  try {
+    writeUnitRuntimeRecord(basePath, currentUnit.type, currentUnit.id, currentUnit.startedAt, {
+      phase: "crashed",
+      lastProgressAt: Date.now(),
+      lastProgressKind: "signal",
+    });
+  } catch (err) {
+    logWarning("engine", `signal runtime cleanup failed: ${getErrorMessage(err)}`, { file: "auto.ts" });
+  }
+
+  try {
+    if (s.workerId) markLatestActiveForWorkerCanceled(s.workerId, "signal-exit");
+  } catch (err) {
+    logWarning("engine", `signal dispatch cleanup failed: ${getErrorMessage(err)}`, { file: "auto.ts" });
+  }
+
+  try {
+    resolveAgentEndCancelled(errorContext);
+  } catch (err) {
+    logWarning("engine", `signal resolve cleanup failed: ${getErrorMessage(err)}`, { file: "auto.ts" });
+  }
+}
+
 /** Wrapper: register SIGTERM handler and store reference. */
 function registerSigtermHandler(currentBasePath: string): void {
-  s.sigtermHandler = _registerSigtermHandler(currentBasePath, s.sigtermHandler);
+  s.sigtermHandler = _registerSigtermHandler(
+    currentBasePath,
+    s.sigtermHandler,
+    () => closeOutSignalInterruptedUnit(currentBasePath),
+  );
 }
 
 /** Wrapper: deregister SIGTERM handler and clear reference. */

--- a/src/resources/extensions/gsd/auto/resolve.ts
+++ b/src/resources/extensions/gsd/auto/resolve.ts
@@ -22,6 +22,7 @@ import { bumpTurnGeneration } from "./turn-epoch.js";
 
 let _currentResolve: ((result: UnitResult) => void) | null = null;
 let _sessionSwitchInFlight = false;
+let _pendingSwitchCancellation: { errorContext?: ErrorContext } | null = null;
 
 // ─── Setters (needed for cross-module mutation) ─────────────────────────────
 
@@ -35,6 +36,12 @@ export function _setSessionSwitchInFlight(v: boolean): void {
 
 export function _clearCurrentResolve(): void {
   _currentResolve = null;
+}
+
+export function _consumePendingSwitchCancellation(): { errorContext?: ErrorContext } | null {
+  const pending = _pendingSwitchCancellation;
+  _pendingSwitchCancellation = null;
+  return pending;
 }
 
 // ─── resolveAgentEnd ─────────────────────────────────────────────────────────
@@ -96,7 +103,7 @@ export function bumpAndResolveSynthetic(reason: string): void {
  * blocks to ensure the autoLoop is never stuck awaiting a promise that
  * will never resolve. Safe to call when no resolver is pending (no-op).
  */
-export function resolveAgentEndCancelled(errorContext?: ErrorContext): void {
+export function resolveAgentEndCancelled(errorContext?: ErrorContext): boolean {
   if (_currentResolve) {
     // Cancellation supersedes the in-flight turn the same way timeout
     // recovery does — bump the turn epoch so any lingering writes from the
@@ -107,8 +114,22 @@ export function resolveAgentEndCancelled(errorContext?: ErrorContext): void {
     debugLog("resolveAgentEndCancelled", { status: "resolving-cancelled" });
     const r = _currentResolve;
     _currentResolve = null;
+    _pendingSwitchCancellation = null;
     r({ status: "cancelled", ...(errorContext ? { errorContext } : {}) });
+    return true;
   }
+
+  if (_sessionSwitchInFlight) {
+    bumpTurnGeneration(
+      `cancelled-during-switch:${errorContext?.category ?? "unknown"}`,
+    );
+    _pendingSwitchCancellation = errorContext ? { errorContext } : {};
+    debugLog("resolveAgentEndCancelled", { status: "queued-during-switch" });
+    return false;
+  }
+
+  debugLog("resolveAgentEndCancelled", { status: "no-pending-resolve" });
+  return false;
 }
 
 // ─── resetPendingResolve (test helper) ───────────────────────────────────────
@@ -120,6 +141,7 @@ export function resolveAgentEndCancelled(errorContext?: ErrorContext): void {
 export function _resetPendingResolve(): void {
   _currentResolve = null;
   _sessionSwitchInFlight = false;
+  _pendingSwitchCancellation = null;
 }
 
 export function _hasPendingResolveForTest(): boolean {

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -11,7 +11,12 @@ import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 import type { AutoSession } from "./session.js";
 import { NEW_SESSION_TIMEOUT_MS } from "./session.js";
 import type { UnitResult } from "./types.js";
-import { _clearCurrentResolve, _setCurrentResolve, _setSessionSwitchInFlight } from "./resolve.js";
+import {
+  _clearCurrentResolve,
+  _consumePendingSwitchCancellation,
+  _setCurrentResolve,
+  _setSessionSwitchInFlight,
+} from "./resolve.js";
 import {
   getCurrentTurnGeneration,
   runWithTurnGeneration,
@@ -97,6 +102,7 @@ export async function runUnit(
     sessionResult = await Promise.race([sessionPromise, timeoutPromise]);
   } catch (sessionErr) {
     if (sessionTimeoutHandle) clearTimeout(sessionTimeoutHandle);
+    _consumePendingSwitchCancellation();
     const msg =
       sessionErr instanceof Error ? sessionErr.message : String(sessionErr);
     debugLog("runUnit", {
@@ -110,17 +116,20 @@ export async function runUnit(
   if (sessionTimeoutHandle) clearTimeout(sessionTimeoutHandle);
 
   if (sessionResult.cancelled) {
+    _consumePendingSwitchCancellation();
     debugLog("runUnit-session-timeout", { unitType, unitId });
     return { status: "cancelled", errorContext: { message: "Session creation timed out", category: "timeout", isTransient: true } };
   }
 
   if (!s.active) {
+    _consumePendingSwitchCancellation();
     return { status: "cancelled" };
   }
 
   if (s.currentUnitModel && typeof pi.setModel === "function") {
     const restored = await pi.setModel(s.currentUnitModel, { persist: false });
     if (!restored) {
+      _consumePendingSwitchCancellation();
       const message =
         `Failed to restore configured model ${s.currentUnitModel.provider}/${s.currentUnitModel.id} after session creation`;
       ctx.ui.notify(
@@ -145,6 +154,14 @@ export async function runUnit(
   const unitPromise = new Promise<UnitResult>((resolve) => {
     _setCurrentResolve(resolve);
   });
+  const pendingSwitchCancellation = _consumePendingSwitchCancellation();
+  if (pendingSwitchCancellation) {
+    _clearCurrentResolve();
+    return {
+      status: "cancelled",
+      ...(pendingSwitchCancellation.errorContext ? { errorContext: pendingSwitchCancellation.errorContext } : {}),
+    };
+  }
 
   // ── Provider request-readiness pre-check (#4555) ──
   // Verify the provider can accept requests before dispatching. If the token

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -153,9 +153,29 @@ export async function handleAgentEnd(
   if (maybeHandleEmptyIntentTurn(event, isAutoActive())) return;
 
   if (!isAutoActive()) return;
-  if (isSessionSwitchInFlight()) return;
 
   const lastMsg = event.messages[event.messages.length - 1];
+  if (isSessionSwitchInFlight()) {
+    if (lastMsg && "stopReason" in lastMsg && lastMsg.stopReason === "error") {
+      const rawErrorMsg = ("errorMessage" in lastMsg && lastMsg.errorMessage) ? String(lastMsg.errorMessage) : "";
+      if (isUserInitiatedAbortMessage(rawErrorMsg)) {
+        resolveAgentEndCancelled({
+          message: rawErrorMsg,
+          category: "aborted",
+          isTransient: false,
+        });
+      }
+    } else if (lastMsg && "stopReason" in lastMsg && lastMsg.stopReason === "aborted") {
+      const content = "content" in lastMsg ? lastMsg.content : undefined;
+      const hasEmptyContent = Array.isArray(content) && content.length === 0;
+      const hasErrorMessage = "errorMessage" in lastMsg && !!lastMsg.errorMessage;
+      if (!hasEmptyContent || hasErrorMessage) {
+        resolveAgentEndCancelled(_buildAbortedPauseContext(lastMsg as { errorMessage?: unknown }));
+      }
+    }
+    return;
+  }
+
   if (lastMsg && "stopReason" in lastMsg && lastMsg.stopReason === "aborted") {
     // Empty content with aborted stopReason is a non-fatal agent stop (the LLM
     // chose to end without producing output). Only pause on genuine fatal aborts

--- a/src/resources/extensions/gsd/db/unit-dispatches.ts
+++ b/src/resources/extensions/gsd/db/unit-dispatches.ts
@@ -360,6 +360,47 @@ export function markCanceled(dispatchId: number, reason: string): void {
 }
 
 /**
+ * Best-effort signal/crash cleanup: cancel the latest active dispatch owned by
+ * a worker when the process is exiting before the normal loop can settle it.
+ */
+export function markLatestActiveForWorkerCanceled(workerId: string, reason: string): boolean {
+  if (!isDbAvailable()) return false;
+  const now = new Date().toISOString();
+  const db = _getAdapter()!;
+  const result = transaction(() => {
+    return db.prepare(
+      `UPDATE unit_dispatches
+       SET status = 'canceled', ended_at = :ended_at, exit_reason = :reason
+       WHERE id = (
+         SELECT id FROM unit_dispatches
+         WHERE worker_id = :worker_id
+           AND status IN ('pending','claimed','running')
+         ORDER BY id DESC
+         LIMIT 1
+       )`,
+    ).run({
+      ":ended_at": now,
+      ":reason": reason,
+      ":worker_id": workerId,
+    });
+  });
+  const changes =
+    typeof (result as { changes?: unknown }).changes === "number"
+      ? (result as { changes: number }).changes
+      : 0;
+  if (changes <= 0) return false;
+  insertAuditEvent({
+    eventId: randomUUID(),
+    traceId: workerId,
+    category: "orchestration",
+    type: "dispatch-canceled",
+    ts: now,
+    payload: { workerId, reason },
+  });
+  return true;
+}
+
+/**
  * Fetch the most recent N dispatches for a unit. Used by recordDispatchClaim
  * callers to compute attempt_n and by detect-stuck.ts (B3) to consult
  * retry budget before tripping the stuck verdict.

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -87,6 +87,34 @@ import { logWarning } from "./workflow-logger.js";
 import { deleteRuntimeKv } from "./db/runtime-kv.js";
 import { PAUSED_SESSION_KV_KEY } from "./interrupted-session.js";
 
+type AutoStartOptions = Parameters<typeof startAutoDetached>[4];
+type AutoStartLauncher = typeof startAutoDetached;
+
+function scheduleAutoStartAfterIdle(
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+  basePath: string,
+  verboseMode: boolean,
+  options?: AutoStartOptions,
+  launch: AutoStartLauncher = startAutoDetached,
+): void {
+  const waitForIdle =
+    typeof (ctx as { waitForIdle?: unknown }).waitForIdle === "function"
+      ? ctx.waitForIdle.bind(ctx)
+      : async () => {};
+  void waitForIdle()
+    .then(() => {
+      setTimeout(() => launch(ctx, pi, basePath, verboseMode, options), 0);
+    })
+    .catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.ui.notify(`Auto-start failed while waiting for the prior turn to settle: ${message}`, "error");
+      logWarning("guided", `auto-start idle wait failed: ${message}`);
+    });
+}
+
+export const _scheduleAutoStartAfterIdleForTest = scheduleAutoStartAfterIdle;
+
 // ─── Scope-based validator wrappers ──────────────────────────────────────────
 // These thin wrappers accept a MilestoneScope so callers that already hold a
 // pinned scope never have to re-derive (basePath, milestoneId) separately.
@@ -446,7 +474,7 @@ async function dispatchNextDeepProjectSetupStage(entry: PendingDeepProjectSetupE
 
   if (!hasPendingDeepStage(prefs, entry.basePath)) {
     pendingDeepProjectSetupMap.delete(entry.basePath);
-    startAutoDetached(entry.ctx, entry.pi, entry.basePath, false, { step: entry.step });
+    scheduleAutoStartAfterIdle(entry.ctx, entry.pi, entry.basePath, false, { step: entry.step });
     return true;
   }
 
@@ -479,7 +507,7 @@ async function dispatchNextDeepProjectSetupStage(entry: PendingDeepProjectSetupE
       entry.ctx.ui.notify(result.reason, result.level);
     } else if (hasPendingDeepStage(prefs, entry.basePath)) {
       pendingDeepProjectSetupMap.delete(entry.basePath);
-      startAutoDetached(entry.ctx, entry.pi, entry.basePath, false, { step: entry.step });
+      scheduleAutoStartAfterIdle(entry.ctx, entry.pi, entry.basePath, false, { step: entry.step });
       return true;
     }
     return false;
@@ -487,7 +515,7 @@ async function dispatchNextDeepProjectSetupStage(entry: PendingDeepProjectSetupE
 
   if (!USER_DRIVEN_DEEP_SETUP_UNITS.has(result.unitType)) {
     pendingDeepProjectSetupMap.delete(entry.basePath);
-    startAutoDetached(entry.ctx, entry.pi, entry.basePath, false, { step: entry.step });
+    scheduleAutoStartAfterIdle(entry.ctx, entry.pi, entry.basePath, false, { step: entry.step });
     return true;
   }
 
@@ -693,7 +721,7 @@ export function checkAutoStartAfterDiscuss(): boolean {
 
   pendingAutoStartMap.delete(basePath);
   ctx.ui.notify(`Milestone ${milestoneId} ready.`, "success");
-  startAutoDetached(ctx, pi, basePath, false, { step });
+  scheduleAutoStartAfterIdle(ctx, pi, basePath, false, { step });
   return true;
 }
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -10,6 +10,8 @@ import {
   _resetPendingResolve,
   _hasPendingResolveForTest,
   _setActiveSession,
+  _setSessionSwitchInFlight,
+  _consumePendingSwitchCancellation,
   isSessionSwitchInFlight,
 } from "../auto/resolve.js";
 import { runUnit } from "../auto/run-unit.js";
@@ -206,6 +208,28 @@ test("runUnit returns cancelled when session creation fails", async () => {
   assert.equal(pi.calls.length, 0);
 });
 
+test("runUnit clears queued switch cancellation when session creation fails", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  const pi = makeMockPi();
+  const s = makeMockSession({
+    newSessionThrows: "connection refused",
+    onNewSessionStart: () => {
+      resolveAgentEndCancelled({
+        message: "Claude Code process aborted by user",
+        category: "aborted",
+        isTransient: false,
+      });
+    },
+  });
+
+  const result = await runUnit(ctx, pi, s, "task", "T01", "prompt");
+
+  assert.equal(result.status, "cancelled");
+  assert.equal(_consumePendingSwitchCancellation(), null);
+});
+
 test("runUnit returns cancelled when session creation times out", async () => {
   _resetPendingResolve();
 
@@ -219,6 +243,34 @@ test("runUnit returns cancelled when session creation times out", async () => {
   assert.equal(result.status, "cancelled");
   assert.equal(result.event, undefined);
   assert.equal(pi.calls.length, 0);
+});
+
+test("runUnit consumes a cancellation queued during session switch before dispatch", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  const pi = makeMockPi();
+  let cancellationQueued = false;
+  const s = makeMockSession({
+    newSessionDelayMs: 10,
+    onNewSessionStart: () => {
+      setTimeout(() => {
+        cancellationQueued = !resolveAgentEndCancelled({
+          message: "Claude Code process aborted by user",
+          category: "aborted",
+          isTransient: false,
+        });
+      }, 0);
+    },
+  });
+
+  const result = await runUnit(ctx, pi, s, "plan-slice", "M009/S01", "prompt");
+
+  assert.equal(cancellationQueued, true);
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.errorContext?.category, "aborted");
+  assert.equal(result.errorContext?.message, "Claude Code process aborted by user");
+  assert.equal(pi.calls.length, 0, "queued switch cancellation must prevent prompt dispatch");
 });
 
 test("runUnit keeps the session-switch guard across a late newSession settlement", async () => {
@@ -2087,6 +2139,25 @@ test("resolveAgentEndCancelled without args produces no errorContext field", asy
   const resolved = await p;
   assert.equal(resolved.status, "cancelled");
   assert.equal(resolved.errorContext, undefined, "errorContext must not be present when no args passed");
+});
+
+test("resolveAgentEndCancelled queues cancellation that arrives during session switch", () => {
+  _resetPendingResolve();
+
+  _setSessionSwitchInFlight(true);
+  const resolved = resolveAgentEndCancelled({
+    message: "Claude Code process aborted by user",
+    category: "aborted",
+    isTransient: false,
+  });
+
+  assert.equal(resolved, false);
+  const pending = _consumePendingSwitchCancellation();
+  assert.ok(pending?.errorContext, "queued cancellation should preserve errorContext");
+  assert.equal(pending.errorContext.category, "aborted");
+  assert.equal(pending.errorContext.message, "Claude Code process aborted by user");
+  assert.equal(_consumePendingSwitchCancellation(), null);
+  _resetPendingResolve();
 });
 
 // ─── #1571: artifact verification retry ──────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/signal-handlers.test.ts
+++ b/src/resources/extensions/gsd/tests/signal-handlers.test.ts
@@ -101,3 +101,30 @@ test("registerSigtermHandler deregisters previous handler from all signals", () 
   // Clean up
   deregisterSigtermHandler(handler2);
 });
+
+test("registered signal handler runs best-effort cleanup before exiting", () => {
+  let cleanupCalled = false;
+  let exitCode: number | string | null | undefined;
+  const originalExit = process.exit;
+  const handler = registerSigtermHandler(
+    "/tmp/test-signal-cleanup",
+    null,
+    () => {
+      cleanupCalled = true;
+    },
+  );
+
+  (process as any).exit = ((code?: number | string | null) => {
+    exitCode = code;
+    throw new Error("process.exit intercepted");
+  }) as never;
+
+  try {
+    assert.throws(() => handler(), /process\.exit intercepted/);
+    assert.equal(cleanupCalled, true);
+    assert.equal(exitCode, 0);
+  } finally {
+    (process as any).exit = originalExit;
+    deregisterSigtermHandler(handler);
+  }
+});

--- a/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
+++ b/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { _withDetachedAutoKeepaliveForTest } from "../auto.ts";
+import { _scheduleAutoStartAfterIdleForTest } from "../guided-flow.ts";
 
 const gsdDir = resolve(import.meta.dirname, "..");
 
@@ -201,4 +202,41 @@ test("detached auto-start preserves milestone lock across pause/stop cleanup (#3
     sessionSrc.includes("sessionMilestoneLock: string | null = null;"),
     "AutoSession should track the detached milestone lock explicitly",
   );
+});
+
+test("discussion auto-start waits for the current command context to become idle", async () => {
+  let releaseIdle!: () => void;
+  const idle = new Promise<void>((resolveIdle) => {
+    releaseIdle = resolveIdle;
+  });
+  const launches: unknown[][] = [];
+  const ctx = {
+    waitForIdle: () => idle,
+    ui: {
+      notify: () => {},
+    },
+  } as any;
+
+  _scheduleAutoStartAfterIdleForTest(
+    ctx,
+    {} as any,
+    "/tmp/gsd-auto-start-idle-test",
+    false,
+    { step: true },
+    (...args: unknown[]) => {
+      launches.push(args);
+    },
+  );
+
+  await Promise.resolve();
+  assert.equal(launches.length, 0, "auto-start must not launch before waitForIdle resolves");
+
+  releaseIdle();
+  await Promise.resolve();
+  assert.equal(launches.length, 0, "auto-start should defer launch to the next timer turn");
+
+  await new Promise((resolveTimer) => setTimeout(resolveTimer, 0));
+  assert.equal(launches.length, 1);
+  assert.equal(launches[0][2], "/tmp/gsd-auto-start-idle-test");
+  assert.deepEqual(launches[0][4], { step: true });
 });

--- a/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
@@ -21,6 +21,7 @@ import {
   markFailed,
   markStuck,
   markCanceled,
+  markLatestActiveForWorkerCanceled,
   getRecentForUnit,
   getLatestForUnit,
 } from "../db/unit-dispatches.ts";
@@ -194,6 +195,35 @@ test("markStuck and markCanceled set their respective statuses", (t) => {
   if (!b.ok) return;
   markCanceled(b.dispatchId, "user-cancel");
   assert.equal(getLatestForUnit("M001/S01/T01")!.status, "canceled");
+});
+
+test("markLatestActiveForWorkerCanceled cancels only the latest active dispatch for a worker", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  const { workerId, leaseToken } = setup(base);
+
+  const first = recordDispatchClaim({
+    traceId: "tc-1", workerId, milestoneLeaseToken: leaseToken,
+    milestoneId: "M001", unitType: "plan-slice", unitId: "M001/S01",
+  });
+  assert.equal(first.ok, true);
+  if (!first.ok) return;
+  markCompleted(first.dispatchId);
+
+  const second = recordDispatchClaim({
+    traceId: "tc-2", workerId, milestoneLeaseToken: leaseToken,
+    milestoneId: "M001", unitType: "run-task", unitId: "M001/S01/T01",
+  });
+  assert.equal(second.ok, true);
+  if (!second.ok) return;
+  markRunning(second.dispatchId);
+
+  assert.equal(markLatestActiveForWorkerCanceled(workerId, "signal-exit"), true);
+  assert.equal(getLatestForUnit("M001/S01")!.status, "completed");
+  const latest = getLatestForUnit("M001/S01/T01")!;
+  assert.equal(latest.status, "canceled");
+  assert.equal(latest.exit_reason, "signal-exit");
+  assert.equal(markLatestActiveForWorkerCanceled(workerId, "signal-exit"), false);
 });
 
 test("terminal transitions do not overwrite an already terminal dispatch", (t) => {


### PR DESCRIPTION
## TL;DR

**What:** Prevent GSD auto-mode from exiting or orphaning a running unit during provider/session handoff races.
**Why:** A real run left `M009/S01` stuck in `dispatched`/`running` after an immediate `Claude Code process aborted by user` error during auto-start.
**How:** Wait instead of aborting already-idle session transitions, defer auto-start until the prior turn is idle, queue cancellation events that arrive during session switching, and close active unit/dispatch state on process signals.

Closes #5487

## What

This changes the GSD auto-mode handoff path across:

- `AgentSession` session transitions
- guided-flow discussion/deep-project auto-start
- auto-mode per-unit resolver/session-switch cancellation handling
- signal cleanup for active runtime records and `unit_dispatches` rows
- focused regression tests for the handoff, resolver, signal, and dispatch cleanup paths

## Why

The observed workflow started `plan-slice` for `M009/S01`, then the session recorded `Claude Code process aborted by user` immediately after switching provider/session state. The unit never emitted `unit-end`, its runtime record stayed `dispatched`, and the DB dispatch row stayed `running` for a dead worker PID.

The root race had a few edges: `newSession()` could abort a turn that was already idle but still settling, guided-flow could start auto-mode inside the prior `agent_end` teardown window, and terminal abort events during session switching were ignored before a per-unit resolver existed.

## How

- `AgentSession._settleCurrentTurnForSessionTransition()` now waits for idle when the provider is no longer streaming instead of force-aborting.
- Guided-flow auto-start sites schedule detached auto-mode after `ctx.waitForIdle()` with a fallback for test/minimal contexts.
- `resolveAgentEndCancelled()` queues cancellation context while session switching is in flight; `runUnit()` consumes that queued cancellation before sending the prompt.
- Signal handlers now best-effort close the active journal/runtime state and cancel the latest active dispatch for the worker before lock cleanup/exit.

## Validation

- [x] `npm run build -w @gsd/pi-coding-agent`
- [x] `npm run typecheck:extensions`
- [x] `npm run test:compile`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/start-auto-detached.test.ts src/resources/extensions/gsd/tests/signal-handlers.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern "runUnit consumes|runUnit clears|resolveAgentEndCancelled" src/resources/extensions/gsd/tests/auto-loop.test.ts`
- [x] `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/check-auto-start-ready-guard.test.js dist-test/src/resources/extensions/gsd/tests/guided-flow-session-isolation.test.js dist-test/src/resources/extensions/gsd/tests/silent-catch-diagnostics.test.js dist-test/src/resources/extensions/gsd/tests/auto-supervisor.test.mjs` confirmed the patch-related guard tests pass; `auto-supervisor.test.mjs` still hits the existing compiled `.ts` loader issue.
- [ ] `npm run verify:pr` reached `test:unit`; `build:core` and `typecheck:extensions` passed, but `test:unit` failed with existing compiled `.ts` loader/import failures. Patch-caused `waitForIdle`/empty-catch failures were fixed and rerun above.

## Change Type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## AI Assistance

This PR is AI-assisted. The changes were investigated against runtime artifacts and validated with targeted tests plus repository build/typecheck/test compilation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signal handler cleanup callback support for graceful termination.
  * Introduced idle-based auto-start deferral to improve session stability.
  * Added worker dispatch cancellation capability.

* **Bug Fixes**
  * Improved session transition handling to prevent premature abort operations.
  * Enhanced cancellation state management during session switches.

* **Tests**
  * Added comprehensive test coverage for signal handlers, session transitions, and dispatch cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->