### PR TITLE
fix(gsd): pause stale execute-task recovery

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -67,6 +67,60 @@ export {
 
 // ─── Artifact Resolution & Verification ───────────────────────────────────────
 
+export type ArtifactRecoveryDbRefreshResult =
+  | { ok: true }
+  | { ok: false; fatal: boolean; message: string; reason: string };
+
+export function refreshRecoveryDbForArtifact(
+  unitType: string,
+  unitId: string,
+): ArtifactRecoveryDbRefreshResult {
+  if (unitType !== "plan-slice" && unitType !== "execute-task") return { ok: true };
+  if (!isDbAvailable()) return { ok: true };
+
+  if (!refreshOpenDatabaseFromDisk()) {
+    return {
+      ok: false,
+      fatal: unitType === "execute-task",
+      reason: `${unitType}-db-refresh-failed`,
+      message: `Stuck recovery found ${unitType} ${unitId} artifacts, but the DB refresh failed.`,
+    };
+  }
+
+  if (unitType !== "execute-task") return { ok: true };
+
+  const { milestone: mid, slice: sid, task: tid } = parseUnitId(unitId);
+  if (!mid || !sid || !tid) {
+    return {
+      ok: false,
+      fatal: true,
+      reason: "execute-task-invalid-unit-id",
+      message: `Stuck recovery found execute-task ${unitId} artifacts, but the unit id could not be parsed for DB verification.`,
+    };
+  }
+
+  const task = getTask(mid, sid, tid);
+  if (!task) {
+    return {
+      ok: false,
+      fatal: true,
+      reason: "execute-task-artifact-db-missing",
+      message: `Stuck recovery found execute-task ${unitId} artifacts, but no matching DB task row exists after refresh.`,
+    };
+  }
+
+  if (!isClosedStatus(task.status)) {
+    return {
+      ok: false,
+      fatal: true,
+      reason: "execute-task-artifact-db-mismatch",
+      message: `Stuck recovery found execute-task ${unitId} artifacts, but the DB task status is still '${task.status}' after refresh.`,
+    };
+  }
+
+  return { ok: true };
+}
+
 function hasCapturedWorkflowPrefs(base: string): boolean {
   const prefsPath = resolveExpectedArtifactPath("workflow-preferences", "WORKFLOW-PREFS", base);
   if (!prefsPath || !existsSync(prefsPath)) return false;

--- a/src/resources/extensions/gsd/auto-timeout-recovery.ts
+++ b/src/resources/extensions/gsd/auto-timeout-recovery.ts
@@ -71,14 +71,14 @@ export async function recoverTimedOutUnit(
       recovery: status,
     });
 
-    const durableComplete = status.summaryExists && status.taskChecked && status.nextActionAdvanced;
+    const durableComplete = status.dbComplete || (status.summaryExists && status.taskChecked && status.nextActionAdvanced);
     if (durableComplete) {
       writeUnitRuntimeRecord(basePath, unitType, unitId, currentUnitStartedAt, {
         phase: "finalized",
         recovery: status,
       });
       ctx.ui.notify(
-        `${reason === "idle" ? "Idle" : "Timeout"} recovery: ${unitType} ${unitId} already completed on disk. Continuing auto-mode. (attempt ${attemptNumber})`,
+        `${reason === "idle" ? "Idle" : "Timeout"} recovery: ${unitType} ${unitId} already completed. Continuing auto-mode. (attempt ${attemptNumber})`,
         "info",
       );
       unitRecoveryCount.delete(recoveryKey);

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1094,10 +1094,6 @@ export async function runDispatch(
             level: 1,
             action: "artifact-found",
           });
-          ctx.ui.notify(
-            `Stuck recovery: artifact for ${unitType} ${unitId} found on disk. Invalidating caches.`,
-            "info",
-          );
           const recoveryDb = refreshRecoveryDbForArtifact(unitType, unitId);
           if (!recoveryDb.ok) {
             ctx.ui.notify(
@@ -1112,6 +1108,10 @@ export async function runDispatch(
             }
             return { action: "continue" };
           }
+          ctx.ui.notify(
+            `Stuck recovery: artifact for ${unitType} ${unitId} found on disk. Invalidating caches.`,
+            "info",
+          );
           deps.invalidateAllCaches();
           loopState.recentUnits.length = 0;
           loopState.stuckRecoveryAttempts = 0;
@@ -1149,7 +1149,7 @@ export async function runDispatch(
           ctx.ui.notify(
             recoveryDb.fatal
               ? `${recoveryDb.message} Pausing auto-mode for manual recovery.`
-              : `${recoveryDb.message} Keeping stuck state for retry.`,
+              : `${recoveryDb.message} Stopping for manual recovery.`,
             "warning",
           );
           if (recoveryDb.fatal) {

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -50,12 +50,12 @@ import {
 } from "../workflow-logger.js";
 import { gsdRoot } from "../paths.js";
 import { atomicWriteSync } from "../atomic-write.js";
-import { verifyExpectedArtifact, diagnoseExpectedArtifact, buildLoopRemediationSteps } from "../auto-recovery.js";
+import { verifyExpectedArtifact, diagnoseExpectedArtifact, buildLoopRemediationSteps, refreshRecoveryDbForArtifact } from "../auto-recovery.js";
 import { writeUnitRuntimeRecord } from "../unit-runtime.js";
 import { withTimeout, FINALIZE_PRE_TIMEOUT_MS, FINALIZE_POST_TIMEOUT_MS } from "./finalize-timeout.js";
 import { getEligibleSlices } from "../slice-parallel-eligibility.js";
 import { startSliceParallel } from "../slice-parallel-orchestrator.js";
-import { isDbAvailable, getMilestoneSlices, refreshOpenDatabaseFromDisk } from "../gsd-db.js";
+import { isDbAvailable, getMilestoneSlices } from "../gsd-db.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
 import { ensurePlanV2Graph, isEmptyPlanV2GraphResult, isMissingFinalizedContextResult } from "../uok/plan-v2.js";
 import { resolveUokFlags } from "../uok/flags.js";
@@ -74,12 +74,6 @@ import {
 /** Compare two paths for physical identity, tolerating trailing slashes and symlinks. */
 function isSamePathLocal(a: string, b: string): boolean {
   return normalizeWorktreePathForCompare(a) === normalizeWorktreePathForCompare(b);
-}
-
-function refreshPlanSliceRecoveryDbIfNeeded(unitType: string): boolean {
-  if (unitType !== "plan-slice") return true;
-  if (!isDbAvailable()) return true;
-  return refreshOpenDatabaseFromDisk();
 }
 
 // ─── Session timeout auto-resume state ────────────────────────────────────────
@@ -1104,11 +1098,18 @@ export async function runDispatch(
             `Stuck recovery: artifact for ${unitType} ${unitId} found on disk. Invalidating caches.`,
             "info",
           );
-          if (!refreshPlanSliceRecoveryDbIfNeeded(unitType)) {
+          const recoveryDb = refreshRecoveryDbForArtifact(unitType, unitId);
+          if (!recoveryDb.ok) {
             ctx.ui.notify(
-              `Stuck recovery found ${unitType} ${unitId} artifacts, but the DB refresh failed. Keeping stuck state for retry.`,
+              recoveryDb.fatal
+                ? `${recoveryDb.message} Pausing auto-mode for manual recovery.`
+                : `${recoveryDb.message} Keeping stuck state for retry.`,
               "warning",
             );
+            if (recoveryDb.fatal) {
+              await deps.pauseAuto(ctx, pi);
+              return { action: "break", reason: recoveryDb.reason };
+            }
             return { action: "continue" };
           }
           deps.invalidateAllCaches();
@@ -1135,19 +1136,26 @@ export async function runDispatch(
             level: 2,
             action: "artifact-found",
           });
-          ctx.ui.notify(
-            `Stuck recovery: artifact for ${unitType} ${unitId} found on disk after cache invalidation. Continuing.`,
-            "info",
-          );
-          if (refreshPlanSliceRecoveryDbIfNeeded(unitType)) {
+          const recoveryDb = refreshRecoveryDbForArtifact(unitType, unitId);
+          if (recoveryDb.ok) {
+            ctx.ui.notify(
+              `Stuck recovery: artifact for ${unitType} ${unitId} found on disk after cache invalidation. Continuing.`,
+              "info",
+            );
             loopState.recentUnits.length = 0;
             loopState.stuckRecoveryAttempts = 0;
             return { action: "continue" };
           }
           ctx.ui.notify(
-            `Stuck recovery found ${unitType} ${unitId} artifacts, but the DB refresh failed. Stopping for manual recovery.`,
+            recoveryDb.fatal
+              ? `${recoveryDb.message} Pausing auto-mode for manual recovery.`
+              : `${recoveryDb.message} Keeping stuck state for retry.`,
             "warning",
           );
+          if (recoveryDb.fatal) {
+            await deps.pauseAuto(ctx, pi);
+            return { action: "break", reason: recoveryDb.reason };
+          }
         }
         debugLog("autoLoop", {
           phase: "stuck-detected",

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
-import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArtifactPath, diagnoseExpectedArtifact, buildLoopRemediationSteps, writeBlockerPlaceholder } from "../auto-recovery.ts";
+import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArtifactPath, diagnoseExpectedArtifact, buildLoopRemediationSteps, writeBlockerPlaceholder, refreshRecoveryDbForArtifact } from "../auto-recovery.ts";
 import { resolveMilestoneFile } from "../paths.ts";
 import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask, getMilestoneCommitAttributionShas } from "../gsd-db.ts";
 import { clearParseCache } from "../files.ts";
@@ -173,6 +173,19 @@ test("resolveExpectedArtifactPath returns correct path for all slice-level types
   } finally {
     cleanup(base);
   }
+});
+
+test("refreshRecoveryDbForArtifact treats missing execute-task DB rows as fatal mismatches", () => {
+  makeTmpProject();
+
+  const result = refreshRecoveryDbForArtifact("execute-task", "M001/S01/T01");
+
+  assert.deepEqual(result, {
+    ok: false,
+    fatal: true,
+    reason: "execute-task-artifact-db-missing",
+    message: "Stuck recovery found execute-task M001/S01/T01 artifacts, but no matching DB task row exists after refresh.",
+  });
 });
 
 // ─── diagnoseExpectedArtifact ─────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -399,6 +399,240 @@ test("runDispatch pauses when complete-milestone summary exists on disk but the 
   assert.equal(stopCalls, 0, "mismatch pause should not hard-stop the loop");
 });
 
+test("runDispatch pauses when execute-task artifacts exist but DB status is still open", async (t) => {
+  const capture = createEventCapture();
+  let pauseCalls = 0;
+  let stopCalls = 0;
+  let invalidateCalls = 0;
+  const base = join(tmpdir(), `gsd-stuck-execute-task-${randomUUID()}`);
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  const tasksDir = join(sliceDir, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "in_progress" });
+  insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "First task", status: "pending" });
+  writeFileSync(
+    join(sliceDir, "S01-PLAN.md"),
+    [
+      "# S01",
+      "",
+      "## Tasks",
+      "",
+      "- [x] **T01: First task** `est:1h`",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan\n");
+  writeFileSync(join(tasksDir, "T01-SUMMARY.md"), "# T01 Summary\n\nDone on disk.\n");
+
+  const deps = makeMockDeps(capture, {
+    pauseAuto: async () => { pauseCalls++; },
+    stopAuto: async () => { stopCalls++; },
+    invalidateAllCaches: () => { invalidateCalls++; },
+    resolveDispatch: async () => ({
+      action: "dispatch" as const,
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      prompt: "execute the task",
+      matchedRule: "executing → execute-task",
+    }),
+  });
+  const ic = makeIC(deps, {
+    s: {
+      ...makeSession(),
+      basePath: base,
+      originalBasePath: base,
+    } as any,
+  });
+  const preData: PreDispatchData = {
+    state: {
+      phase: "executing",
+      activeMilestone: { id: "M001", title: "Test", status: "active" },
+      activeSlice: { id: "S01", title: "Slice" },
+      activeTask: { id: "T01", title: "First task" },
+      registry: [{ id: "M001", status: "active" }],
+      blockers: [],
+    } as any,
+    mid: "M001",
+    midTitle: "Test Milestone",
+  };
+  const loopState: LoopState = {
+    recentUnits: [
+      { key: "execute-task/M001/S01/T01" },
+      { key: "execute-task/M001/S01/T01" },
+    ],
+    stuckRecoveryAttempts: 0,
+    consecutiveFinalizeTimeouts: 0,
+  };
+
+  const result = await runDispatch(ic, preData, loopState);
+
+  assert.equal(result.action, "break");
+  assert.equal((result as any).reason, "execute-task-artifact-db-mismatch");
+  assert.equal(pauseCalls, 1, "execute-task disk/db mismatch should pause auto-mode");
+  assert.equal(stopCalls, 0, "execute-task disk/db mismatch should not hard-stop the loop");
+  assert.equal(invalidateCalls, 0, "mismatch should not clear caches and continue toward redispatch");
+  assert.equal(loopState.recentUnits.length, 3, "mismatch should keep the stuck window intact");
+  assert.equal(loopState.stuckRecoveryAttempts, 1, "mismatch should not reset the recovery counter");
+});
+
+test("runDispatch pauses at Level 2 when execute-task artifacts exist but DB status is still open", async (t) => {
+  const capture = createEventCapture();
+  let pauseCalls = 0;
+  let stopCalls = 0;
+  let invalidateCalls = 0;
+  const base = join(tmpdir(), `gsd-stuck-execute-task-l2-${randomUUID()}`);
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  const tasksDir = join(sliceDir, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "in_progress" });
+  insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "First task", status: "pending" });
+  writeFileSync(
+    join(sliceDir, "S01-PLAN.md"),
+    "# S01\n\n## Tasks\n\n- [x] **T01: First task** `est:1h`\n",
+  );
+  writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan\n");
+  writeFileSync(join(tasksDir, "T01-SUMMARY.md"), "# T01 Summary\n\nDone on disk.\n");
+
+  const deps = makeMockDeps(capture, {
+    pauseAuto: async () => { pauseCalls++; },
+    stopAuto: async () => { stopCalls++; },
+    invalidateAllCaches: () => { invalidateCalls++; },
+    resolveDispatch: async () => ({
+      action: "dispatch" as const,
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      prompt: "execute the task",
+      matchedRule: "executing execute-task",
+    }),
+  });
+  const ic = makeIC(deps, {
+    s: {
+      ...makeSession(),
+      basePath: base,
+      originalBasePath: base,
+    } as any,
+  });
+  const preData: PreDispatchData = {
+    state: {
+      phase: "executing",
+      activeMilestone: { id: "M001", title: "Test", status: "active" },
+      activeSlice: { id: "S01", title: "Slice" },
+      activeTask: { id: "T01", title: "First task" },
+      registry: [{ id: "M001", status: "active" }],
+      blockers: [],
+    } as any,
+    mid: "M001",
+    midTitle: "Test Milestone",
+  };
+  const loopState: LoopState = {
+    recentUnits: [
+      { key: "execute-task/M001/S01/T01" },
+      { key: "execute-task/M001/S01/T01" },
+    ],
+    stuckRecoveryAttempts: 1,
+    consecutiveFinalizeTimeouts: 0,
+  };
+
+  const result = await runDispatch(ic, preData, loopState);
+
+  assert.equal(result.action, "break");
+  assert.equal((result as any).reason, "execute-task-artifact-db-mismatch");
+  assert.equal(pauseCalls, 1, "Level 2 execute-task disk/db mismatch should pause auto-mode");
+  assert.equal(stopCalls, 0, "Level 2 execute-task disk/db mismatch should not hard-stop the loop");
+  assert.equal(invalidateCalls, 1, "Level 2 should invalidate caches before the final artifact recheck");
+  assert.equal(loopState.recentUnits.length, 3, "Level 2 mismatch should keep the stuck window intact");
+  assert.equal(loopState.stuckRecoveryAttempts, 1, "Level 2 mismatch should not reset the recovery counter");
+});
+
+test("runDispatch clears execute-task stuck state when artifacts and DB status are complete", async (t) => {
+  const capture = createEventCapture();
+  let pauseCalls = 0;
+  let stopCalls = 0;
+  let invalidateCalls = 0;
+  const base = join(tmpdir(), `gsd-stuck-execute-task-complete-${randomUUID()}`);
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  const tasksDir = join(sliceDir, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "in_progress" });
+  insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "First task", status: "complete" });
+  writeFileSync(
+    join(sliceDir, "S01-PLAN.md"),
+    "# S01\n\n## Tasks\n\n- [x] **T01: First task** `est:1h`\n",
+  );
+  writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan\n");
+  writeFileSync(join(tasksDir, "T01-SUMMARY.md"), "# T01 Summary\n\nDone on disk.\n");
+
+  const deps = makeMockDeps(capture, {
+    pauseAuto: async () => { pauseCalls++; },
+    stopAuto: async () => { stopCalls++; },
+    invalidateAllCaches: () => { invalidateCalls++; },
+    resolveDispatch: async () => ({
+      action: "dispatch" as const,
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      prompt: "execute the task",
+      matchedRule: "executing execute-task",
+    }),
+  });
+  const ic = makeIC(deps, {
+    s: {
+      ...makeSession(),
+      basePath: base,
+      originalBasePath: base,
+    } as any,
+  });
+  const preData: PreDispatchData = {
+    state: {
+      phase: "executing",
+      activeMilestone: { id: "M001", title: "Test", status: "active" },
+      activeSlice: { id: "S01", title: "Slice" },
+      activeTask: { id: "T01", title: "First task" },
+      registry: [{ id: "M001", status: "active" }],
+      blockers: [],
+    } as any,
+    mid: "M001",
+    midTitle: "Test Milestone",
+  };
+  const loopState: LoopState = {
+    recentUnits: [
+      { key: "execute-task/M001/S01/T01" },
+      { key: "execute-task/M001/S01/T01" },
+    ],
+    stuckRecoveryAttempts: 0,
+    consecutiveFinalizeTimeouts: 0,
+  };
+
+  const result = await runDispatch(ic, preData, loopState);
+
+  assert.equal(result.action, "continue");
+  assert.equal(pauseCalls, 0, "closed DB task should not pause auto-mode");
+  assert.equal(stopCalls, 0, "closed DB task should not hard-stop the loop");
+  assert.equal(invalidateCalls, 1, "closed DB task recovery should invalidate caches once");
+  assert.deepEqual(loopState.recentUnits, [], "closed DB task recovery should clear the stuck window");
+  assert.equal(loopState.stuckRecoveryAttempts, 0, "closed DB task recovery should reset the recovery counter");
+});
+
 test("runDispatch clears stuck state after Level 1 artifact recovery", async (t) => {
   const capture = createEventCapture();
   let invalidateCalls = 0;

--- a/src/resources/extensions/gsd/tests/stalled-tool-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/stalled-tool-recovery.test.ts
@@ -15,10 +15,11 @@
  * (the fix) and verifies it does not crash.
  */
 
-import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { recoverTimedOutUnit, type RecoveryContext } from "../auto-timeout-recovery.ts";
+import { closeDatabase, insertMilestone, insertSlice, insertTask, openDatabase } from "../gsd-db.ts";
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -36,6 +37,14 @@ function makeMockCtx() {
 function makeMockPi() {
   return {
     sendMessage: () => {},
+  } as any;
+}
+
+function makeRecordingPi() {
+  const messages: unknown[] = [];
+  return {
+    messages,
+    sendMessage: (message: unknown) => { messages.push(message); },
   } as any;
 }
 
@@ -61,6 +70,45 @@ function makeMockPi() {
     );
   }
   assert.ok(crashed, "should crash when basePath is undefined (reproduces #1855)");
+}
+
+// ═══ DB-complete execute-task recovery advances without steering ═════════════
+
+{
+  console.log("\n=== execute-task timeout recovery trusts closed DB status ===");
+  const base = mkdtempSync(join(tmpdir(), "gsd-timeout-db-complete-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "in_progress" });
+    insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "Task", status: "complete" });
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+      "# S01\n\n## Tasks\n\n- [ ] **T01: Task** `est:10m`\n",
+      "utf-8",
+    );
+    writeFileSync(join(base, ".gsd", "STATE.md"), "## Next Action\nExecute T01 for S01: Task\n", "utf-8");
+
+    const ctx = makeMockCtx();
+    const pi = makeRecordingPi();
+    const result = await recoverTimedOutUnit(ctx, pi, "execute-task", "M001/S01/T01", "idle", {
+      basePath: base,
+      verbose: false,
+      currentUnitStartedAt: Date.now(),
+      unitRecoveryCount: new Map(),
+    });
+
+    assert.equal(result, "recovered", "db-complete task should recover immediately");
+    assert.equal(pi.messages.length, 0, "db-complete task should not send steering recovery");
+    const runtime = JSON.parse(readFileSync(join(base, ".gsd", "runtime", "units", "execute-task-M001-S01-T01.json"), "utf-8"));
+    assert.equal(runtime.phase, "finalized", "db-complete task should be finalized");
+    assert.equal(runtime.recovery.dbComplete, true, "runtime recovery should record DB completion");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
 }
 
 // ═══ #1855: valid RecoveryContext does not crash ═════════════════════════════

--- a/src/resources/extensions/gsd/tests/unit-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-runtime.test.ts
@@ -9,6 +9,7 @@ import {
   readUnitRuntimeRecord,
   writeUnitRuntimeRecord,
 } from "../unit-runtime.ts";
+import { closeDatabase, insertMilestone, insertSlice, insertTask, openDatabase } from "../gsd-db.ts";
 import { clearPathCache } from '../paths.ts';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -70,6 +71,35 @@ console.log("\n=== runtime record cleanup ===");
   clearUnitRuntimeRecord(base, "execute-task", "M100/S02/T09");
   const loaded = readUnitRuntimeRecord(base, "execute-task", "M100/S02/T09");
   assert.deepStrictEqual(loaded, null, "record removed");
+}
+
+console.log("\n=== execute-task durability trusts closed DB task status ===");
+{
+  const dbBase = mkdtempSync(join(tmpdir(), "gsd-unit-runtime-db-test-"));
+  mkdirSync(join(dbBase, ".gsd", "milestones", "M300", "slices", "S01", "tasks"), { recursive: true });
+  try {
+    openDatabase(join(dbBase, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M300", title: "DB Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M300", title: "DB Slice", status: "in_progress" });
+    insertTask({ id: "T01", milestoneId: "M300", sliceId: "S01", title: "DB Task", status: "complete" });
+    writeFileSync(
+      join(dbBase, ".gsd", "milestones", "M300", "slices", "S01", "S01-PLAN.md"),
+      "# S01\n\n## Tasks\n\n- [ ] **T01: DB Task** `est:10m`\n",
+      "utf-8",
+    );
+    writeFileSync(join(dbBase, ".gsd", "STATE.md"), "## Next Action\nExecute T01 for S01: DB task\n", "utf-8");
+
+    const status = await inspectExecuteTaskDurability(dbBase, "M300/S01/T01");
+    assert.ok(status !== null, "db-complete: status exists");
+    assert.equal(status!.dbComplete, true, "db-complete: closed DB status is captured");
+    assert.equal(status!.summaryExists, false, "db-complete: summary can still be missing");
+    assert.equal(status!.taskChecked, false, "db-complete: checkbox can still be unchecked");
+    assert.equal(status!.nextActionAdvanced, false, "db-complete: next action can still point at task");
+    assert.equal(formatExecuteTaskRecoveryStatus(status!), "DB task status is closed");
+  } finally {
+    closeDatabase();
+    rmSync(dbBase, { recursive: true, force: true });
+  }
 }
 
 console.log("\n=== hook unit type sanitization (slash in unitType) ===");

--- a/src/resources/extensions/gsd/unit-runtime.ts
+++ b/src/resources/extensions/gsd/unit-runtime.ts
@@ -10,6 +10,8 @@ import {
 } from "./paths.js";
 import { loadFile, parseTaskPlanMustHaves, countMustHavesMentionedInSummary } from "./files.js";
 import { parseUnitId } from "./unit-id.js";
+import { getTask, isDbAvailable, refreshOpenDatabaseFromDisk } from "./gsd-db.js";
+import { isClosedStatus } from "./status-guards.js";
 
 // Per-record advisory lock — prevents read-modify-write races between
 // concurrent writers updating disjoint fields of the same runtime record.
@@ -92,6 +94,7 @@ export interface ExecuteTaskRecoveryStatus {
   summaryExists: boolean;
   taskChecked: boolean;
   nextActionAdvanced: boolean;
+  dbComplete: boolean;
   mustHaveCount: number;
   mustHavesMentionedInSummary: number;
 }
@@ -213,6 +216,12 @@ export async function inspectExecuteTaskDurability(
   const escapedTid = tid.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const taskChecked = !!planContent && new RegExp(`^- \\[[xX]\\] \\*\\*${escapedTid}:`, "m").test(planContent);
   const nextActionAdvanced = !new RegExp(`Execute ${tid}\\b`).test(stateContent);
+  let dbComplete = false;
+  if (isDbAvailable()) {
+    refreshOpenDatabaseFromDisk();
+    const task = getTask(mid, sid, tid);
+    dbComplete = !!task && isClosedStatus(task.status);
+  }
 
   // Must-have coverage: load task plan and count mentions in summary
   let mustHaveCount = 0;
@@ -239,12 +248,14 @@ export async function inspectExecuteTaskDurability(
     summaryExists,
     taskChecked,
     nextActionAdvanced,
+    dbComplete,
     mustHaveCount,
     mustHavesMentionedInSummary,
   };
 }
 
 export function formatExecuteTaskRecoveryStatus(status: ExecuteTaskRecoveryStatus): string {
+  if (status.dbComplete) return "DB task status is closed";
   const missing = [] as string[];
   if (!status.summaryExists) missing.push(`summary missing (${status.summaryPath})`);
   if (!status.taskChecked) missing.push(`task checkbox unchecked in ${status.planPath}`);


### PR DESCRIPTION
## TL;DR

**What:** Pauses auto-mode when execute-task stuck recovery finds disk artifacts but the DB task row is still open or missing, and makes idle/timeout recovery honor closed DB task status.
**Why:** Disk-only recovery can clear the stuck window, steer recovery, or redispatch the same task when DB state already says the task is incomplete or complete.
**How:** Refresh/check DB state during artifact recovery, classify execute-task DB mismatches as fatal dispatch recovery issues, add DB completion to timeout durability, and cover Level 1, Level 2, positive, missing-row, and timeout-recovery cases with tests.

## What

This updates the GSD auto-mode recovery paths for `execute-task` units:

- Adds `refreshRecoveryDbForArtifact()` in `auto-recovery.ts`.
- Keeps existing plan-slice DB refresh behavior.
- Requires execute-task DB rows to be closed after refresh before dispatch stuck recovery clears `recentUnits` and continues.
- Pauses auto-mode with an explicit reason when an execute-task artifact exists but the DB task row is missing or still open.
- Fixes dispatch recovery messages so they match the actual pause/continue/stop control flow.
- Adds `dbComplete` to execute-task timeout durability status.
- Lets idle/timeout recovery treat a closed DB task as already complete, without steering the agent to rewrite disk artifacts.

Closes #5490.
Related to #4649; this addresses the DB-authority recovery path called out there, but leaves any broader journal/finalize-event cleanup to a separate scoped change.

## Why

The reported loop repeatedly showed:

- `Verification gate: 2/2 checks passed`
- `Stuck recovery: artifact for execute-task M001/S01/T01 found on disk. Invalidating caches.`

For execute-task recovery, disk artifacts alone are not authoritative. If the task summary and checked task entry exist but the DB task status remains open, invalidating caches and clearing the stuck window can redispatch the same unit instead of surfacing the state mismatch.

A follow-up Auto Engine review found the same root-cause pattern in idle/timeout recovery: `inspectExecuteTaskDurability()` only considered summary, checkbox, and `STATE.md`. That meant a DB-complete task could still be treated as incomplete and get recovery steering. This PR now handles both recovery entry points.

## How

`runDispatch()` still owns dispatch control-flow policy, but artifact/DB classification now lives in `auto-recovery.ts` alongside existing artifact verification logic.

The dispatch recovery helper:

- no-ops for unrelated unit types;
- preserves plan-slice refresh behavior;
- refreshes the open DB before execute-task recovery;
- returns fatal mismatch reasons for invalid unit IDs, missing task rows, and open task statuses;
- allows normal recovery when the refreshed DB task status is closed.

The timeout recovery path now records `dbComplete` in `ExecuteTaskRecoveryStatus` and treats it as durable completion before sending recovery steering.

## Tests

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/journal-integration.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-recovery.test.ts src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/unit-runtime.test.ts src/resources/extensions/gsd/tests/stalled-tool-recovery.test.ts`
- [x] `git diff --check`
- [ ] `npm run verify:pr`

`npm run verify:pr` and `npm run build:core` are currently blocked before this patch's test phase by an upstream type error outside this change:

```text
src/resources/extensions/gsd/bootstrap/register-hooks.ts(82,9): error TS2339: Property 'setCompactionThresholdOverride' does not exist on type 'ExtensionContext'.
```

## Review Notes

Claude ultrareview found one messaging issue in the Level 2 branch. The warning/info messages now match the actual pause/continue control flow, and the focused tests were rerun after that fix.

A follow-up Auto Engine review found two risks:

- sibling idle/timeout recovery still ignored DB task status;
- dispatch recovery messages could still misstate whether recovery was pausing, retrying, stopping, or invalidating caches.

Both are addressed in the latest commit.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking Changes

None.

## AI Assistance

This PR is AI-assisted. The commits do not credit any AI tool as an author or co-author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved auto-recovery: artifact vs database verification now prevents false hard-stops, pauses auto-mode for manual intervention on fatal mismatches, and treats DB-completed tasks as durably finished.
* **Tests**
  * Added regression and integration tests covering stuck-state flows, DB vs disk mismatches, timeout recovery, and durability detection to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->