### PR TITLE
fix(gsd): stop stale milestone completion replay

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -2265,6 +2265,13 @@ export async function runFinalize(
 
   // Both pre and post verification completed without timeout — reset counter
   loopState.consecutiveFinalizeTimeouts = 0;
+  if (preUnitSnapshot) {
+    writeUnitRuntimeRecord(s.basePath, preUnitSnapshot.type, preUnitSnapshot.id, preUnitSnapshot.startedAt, {
+      phase: "finalized",
+      lastProgressAt: Date.now(),
+      lastProgressKind: "finalize-success",
+    });
+  }
   s.currentUnit = null;
   clearCurrentPhase();
 

--- a/src/resources/extensions/gsd/prompts/complete-milestone.md
+++ b/src/resources/extensions/gsd/prompts/complete-milestone.md
@@ -29,14 +29,15 @@ Subagents report only; they do not write user source. Fold any findings into Dec
 
 ## Steps
 
-1. Use the **Milestone Summary** output template from the inlined context above
-2. {{skillActivation}}
-3. **Verify code changes exist.** Compare milestone work against the integration branch (`main`, `master`, or recorded branch), using merge-base as older revision and `HEAD` as newer. If the diff lists non-`.gsd/` files, pass. If `HEAD` equals the integration branch/merge-base, treat it as a self-diff retry: inspect milestone-scoped commit evidence (`GSD-Unit: {{milestoneId}}` or production `GSD-Task: Sxx/Tyy` trailers touching `.gsd/milestones/{{milestoneId}}/`) and verify those commits touched non-`.gsd/` files. Record **verification failure** only when neither source shows implementation files.
-4. Verify every **success criterion** from `{{roadmapPath}}`. If passing validation is present, summarize the validation evidence instead of re-auditing it; otherwise verify with evidence from summaries, tests, or observable behavior. Record unmet criteria as **verification failure**.
-5. Verify **definition of done**: all slices `[x]`, summaries exist, and integrations work. If passing validation is present, trust its integration/verification verdict unless inconsistent with current artifacts. Record unmet items as **verification failure**.
-6. If the roadmap includes a **Horizontal Checklist**, verify each item and note unchecked items in the summary.
-7. Fill the **Decision Re-evaluation** table: compare each key `.gsd/DECISIONS.md` decision from this milestone with what shipped, and flag decisions to revisit.
-8. Validate **requirement status transitions**. For each changed requirement, confirm evidence supports the new status. Requirements may move between Active, Validated, Deferred, Blocked, or Out of Scope only with proof.
+1. **Duplicate completion guard:** Call `gsd_milestone_status` for `{{milestoneId}}` before any durable writes. If the returned milestone **status is `complete`**, this is a stale or duplicate closeout turn: do NOT mutate requirements, do NOT refresh the project document, do NOT write LEARNINGS, and do NOT persist milestone completion again. Say: "Milestone {{milestoneId}} is already complete." and stop.
+2. Use the **Milestone Summary** output template from the inlined context above
+3. {{skillActivation}}
+4. **Verify code changes exist.** Compare milestone work against the integration branch (`main`, `master`, or recorded branch), using merge-base as older revision and `HEAD` as newer. If the diff lists non-`.gsd/` files, pass. If `HEAD` equals the integration branch/merge-base, treat it as a self-diff retry: inspect milestone-scoped commit evidence (`GSD-Unit: {{milestoneId}}` or production `GSD-Task: Sxx/Tyy` trailers touching `.gsd/milestones/{{milestoneId}}/`) and verify those commits touched non-`.gsd/` files. Record **verification failure** only when neither source shows implementation files.
+5. Verify every **success criterion** from `{{roadmapPath}}`. If passing validation is present, summarize the validation evidence instead of re-auditing it; otherwise verify with evidence from summaries, tests, or observable behavior. Record unmet criteria as **verification failure**.
+6. Verify **definition of done**: all slices `[x]`, summaries exist, and integrations work. If passing validation is present, trust its integration/verification verdict unless inconsistent with current artifacts. Record unmet items as **verification failure**.
+7. If the roadmap includes a **Horizontal Checklist**, verify each item and note unchecked items in the summary.
+8. Fill the **Decision Re-evaluation** table: compare each key `.gsd/DECISIONS.md` decision from this milestone with what shipped, and flag decisions to revisit.
+9. Validate **requirement status transitions**. For each changed requirement, confirm evidence supports the new status. Requirements may move between Active, Validated, Deferred, Blocked, or Out of Scope only with proof.
 
 **DB access safety:** Do NOT query `.gsd/gsd.db` directly via `sqlite3` or `node -e require('better-sqlite3')`; the engine owns the WAL connection. Use `gsd_milestone_status`, inlined context, or `gsd_*` tools; never direct SQL.
 
@@ -53,13 +54,13 @@ Subagents report only; they do not write user source. Fold any findings into Dec
 
 **Success path** (all verifications passed):
 
-9. For each requirement whose status changed in step 8, call `gsd_requirement_update` with the requirement ID and updated `status` and `validation` fields — the tool regenerates `.gsd/REQUIREMENTS.md` automatically. Do this BEFORE completing the milestone so requirement updates are persisted.
-10. Update `.gsd/PROJECT.md`: use the `write` tool with `path: ".gsd/PROJECT.md"` and `content` containing the full updated document reflecting milestone completion and current project state. Do NOT use the `edit` tool for this — PROJECT.md is a full-document refresh.
-11. Extract structured learnings from this milestone and persist them to the GSD memory store. Follow the procedure block immediately below — it writes `{{milestoneId}}-LEARNINGS.md` as the audit trail and persists Patterns, Lessons, and Decisions via `capture_thought` (categories: pattern, gotcha/convention, architecture). The memory store is the single source of truth for cross-session durable knowledge (ADR-013).
+10. For each requirement whose status changed in step 9, call `gsd_requirement_update` with the requirement ID and updated `status` and `validation` fields — the tool regenerates `.gsd/REQUIREMENTS.md` automatically. Do this BEFORE completing the milestone so requirement updates are persisted.
+11. Update `.gsd/PROJECT.md`: use the `write` tool with `path: ".gsd/PROJECT.md"` and `content` containing the full updated document reflecting milestone completion and current project state. Do NOT use the `edit` tool for this — PROJECT.md is a full-document refresh.
+12. Extract structured learnings from this milestone and persist them to the GSD memory store. Follow the procedure block immediately below — it writes `{{milestoneId}}-LEARNINGS.md` as the audit trail and persists Patterns, Lessons, and Decisions via `capture_thought` (categories: pattern, gotcha/convention, architecture). The memory store is the single source of truth for cross-session durable knowledge (ADR-013).
 
 {{extractLearningsSteps}}
 
-12. **Persist completion through `gsd_complete_milestone`.** Call it with the parameters below. This must be the final persistent write in the unit. The tool updates the milestone status in the DB, renders `{{milestoneSummaryPath}}`, and validates all slices are complete.
+13. **Persist completion through `gsd_complete_milestone`.** Call it with the parameters below. This must be the final persistent write in the unit. The tool updates the milestone status in the DB, renders `{{milestoneSummaryPath}}`, and validates all slices are complete.
 
    **Required parameters:**
    - `milestoneId` (string) — Milestone ID (e.g. M001)
@@ -78,7 +79,7 @@ Subagents report only; they do not write user source. Fold any findings into Dec
    - `followUps` (string) — Follow-up items for future milestones
    - `deviations` (string) — Deviations from the original plan
 
-13. Do not commit manually — the system auto-commits your changes after this unit completes.
+14. Do not commit manually — the system auto-commits your changes after this unit completes.
 - Say: "Milestone {{milestoneId}} complete."
 
 **Important:** Do NOT skip code-change, success-criteria, or definition-of-done verification (steps 3-5). The summary must reflect verified outcomes. Verification failures block completion; there is no override. If a verification tool fails, errors, or returns unexpected output, treat it as failure.

--- a/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
@@ -1,17 +1,20 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 import { runFinalize } from "../auto/phases.ts";
 import { AutoSession } from "../auto/session.ts";
+import { readUnitRuntimeRecord, writeUnitRuntimeRecord } from "../unit-runtime.ts";
 
-test("runFinalize clears currentUnit after successful finalize", async () => {
-  const s = new AutoSession();
-  s.basePath = "/tmp/gsd-finalize-current-unit";
-  s.currentUnit = {
-    type: "execute-task",
-    id: "M001/S01/T01",
-    startedAt: Date.now(),
-  };
+async function runSuccessfulFinalize(s: AutoSession) {
+  const unit = s.currentUnit;
+  assert.ok(unit, "test setup must provide currentUnit");
+
+  writeUnitRuntimeRecord(s.basePath, unit.type, unit.id, unit.startedAt, {
+    phase: "dispatched",
+  });
 
   const deps = {
     clearUnitTimeout() {},
@@ -26,7 +29,7 @@ test("runFinalize clears currentUnit after successful finalize", async () => {
     postUnitPostVerification: async () => "continue",
   };
 
-  const result = await runFinalize(
+  return runFinalize(
     {
       ctx: { ui: { notify() {} } },
       pi: {},
@@ -38,8 +41,8 @@ test("runFinalize clears currentUnit after successful finalize", async () => {
       nextSeq: () => 1,
     } as any,
     {
-      unitType: "execute-task",
-      unitId: "M001/S01/T01",
+      unitType: unit.type,
+      unitId: unit.id,
       prompt: "",
       finalPrompt: "",
       pauseAfterUatDispatch: false,
@@ -55,7 +58,47 @@ test("runFinalize clears currentUnit after successful finalize", async () => {
       consecutiveFinalizeTimeouts: 0,
     },
   );
+}
 
-  assert.equal(result.action, "next");
-  assert.equal(s.currentUnit, null);
+test("runFinalize clears currentUnit after successful finalize", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-finalize-current-unit-"));
+  const s = new AutoSession();
+  s.basePath = base;
+  s.currentUnit = {
+    type: "execute-task",
+    id: "M001/S01/T01",
+    startedAt: Date.now(),
+  };
+
+  try {
+    const result = await runSuccessfulFinalize(s);
+
+    assert.equal(result.action, "next");
+    assert.equal(s.currentUnit, null);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("runFinalize marks unit runtime finalized after successful finalize", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-finalize-runtime-"));
+  const s = new AutoSession();
+  const startedAt = Date.now();
+  s.basePath = base;
+  s.currentUnit = {
+    type: "complete-milestone",
+    id: "M001",
+    startedAt,
+  };
+
+  try {
+    const result = await runSuccessfulFinalize(s);
+    const runtime = readUnitRuntimeRecord(base, "complete-milestone", "M001");
+
+    assert.equal(result.action, "next");
+    assert.equal(runtime?.phase, "finalized");
+    assert.equal(runtime?.lastProgressKind, "finalize-success");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
 });

--- a/src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts
@@ -65,6 +65,25 @@ describe('prompt step ordering (#3696)', () => {
     assert.ok(learningsIdx < completeMilestoneIdx, 'learnings extraction must happen before gsd_complete_milestone');
   });
 
+  test('complete-milestone duplicate guard checks milestone status before durable writes', () => {
+    const guardMatch = completeMilestoneMd.match(/^\d+\.\s.*gsd_milestone_status/m);
+    const reqUpdateMatch = completeMilestoneMd.match(/^\d+\.\s.*gsd_requirement_update/m);
+    assert.ok(guardMatch, 'complete-milestone must start with a gsd_milestone_status duplicate guard');
+    assert.ok(reqUpdateMatch, 'gsd_requirement_update should appear in a numbered step');
+
+    const guardIdx = completeMilestoneMd.indexOf(guardMatch![0]);
+    const reqUpdateIdx = completeMilestoneMd.indexOf(reqUpdateMatch![0]);
+    assert.ok(
+      guardIdx < reqUpdateIdx,
+      'duplicate guard must run before requirement/project/learnings writes',
+    );
+    assert.match(
+      completeMilestoneMd,
+      /status(?:`|\*\*)?\s+(?:is\s+)?(?:`complete`|"complete")/i,
+      'duplicate guard must tell the agent to stop when status is complete',
+    );
+  });
+
   test('complete-slice.md uses gsd_requirement_update', () => {
     assert.match(completeSliceMd, /gsd_requirement_update/,
       'complete-slice.md should reference gsd_requirement_update');

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -165,6 +165,9 @@ test("executeMilestoneStatus returns milestone metadata and slice counts", async
     assert.equal(parsed.sliceCount, 1);
     assert.equal(parsed.slices[0].id, "S01");
     assert.equal(parsed.slices[0].taskCounts.pending, 1);
+    assert.equal(result.details.status, "active");
+    assert.equal(result.details.title, "Milestone One");
+    assert.deepEqual(result.details.slices, parsed.slices);
   } finally {
     closeDatabase();
     cleanup(base);

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -813,7 +813,7 @@ export async function executeMilestoneStatus(
 
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        details: { operation: "milestone_status", milestoneId: milestone.id, sliceCount: slices.length },
+        details: { operation: "milestone_status", ...result },
       };
     });
   } catch (err) {


### PR DESCRIPTION
## TL;DR

**What:** Prevent stale auto-mode milestone completion turns from replaying closeout after the milestone is already complete.
**Why:** A queued `complete-milestone` turn can restart verification after auto-mode has completed, merged, and stopped.
**How:** Finalize unit runtime records, expose machine-readable milestone status details, and add a duplicate-completion guard before durable closeout writes.

## What

This PR updates the GSD auto-mode closeout path:

- Marks successful auto-mode units as `finalized` in `.gsd/runtime/units` instead of leaving them `dispatched`.
- Returns full structured milestone status details from `gsd_milestone_status`, including `status`, `title`, and `slices`.
- Adds an early duplicate guard to `complete-milestone.md` so stale closeout turns stop before requirement, project, learnings, or completion writes when the milestone is already complete.
- Adds regression tests for the runtime finalization, structured status details, and prompt guard ordering.

## Why

Closes #5493.

A completed milestone run can finish successfully, merge back to `main`, stop because all milestones are complete, and still have a stale queued closeout turn replay the milestone completion verification flow. The closeout flow needs a durable runtime finalization signal and a machine-readable status guard so duplicate turns stop cleanly.

## How

The implementation keeps the fix narrow:

- `runFinalize` writes a final unit runtime record on the success path.
- `executeMilestoneStatus` uses the same result object for structured details that it already emits in text content.
- `complete-milestone.md` checks `gsd_milestone_status` before any durable writes and exits immediately when status is `complete`.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts` — 34 passed, 0 failed
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test --test-name-pattern "workflow MCP launch config reaches mutation tools over stdio|workflow MCP ask_user_questions uses stdio elicitation round-trip" dist-test/src/resources/extensions/gsd/tests/workflow-mcp.test.js` — 2 passed, 0 failed
- `npm run verify:pr` — 9070 passed, 0 failed, 9 skipped
- `git diff --check`

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

## AI assistance

This PR was AI-assisted. The changes were verified with focused regression tests and the repo preflight before opening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added duplicate-completion guard for milestone closeouts to prevent reprocessing.
  * Unit finalization now records runtime phase information upon successful completion.
  * Enhanced verification workflow with explicit success/failure paths during milestone completion.

* **Tests**
  * Updated test suite to validate finalization runtime tracking and duplicate-guard functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->