### PR TITLE
fix(gsd): reacquire stale auto-mode leases

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -972,6 +972,8 @@ export async function stopAuto(
       if (s.workerId) {
         markWorkerStopping(s.workerId);
       }
+      s.workerId = null;
+      s.milestoneLeaseToken = null;
     } catch (e) {
       debugLog("stop-cleanup-coordination", { error: e instanceof Error ? e.message : String(e) });
     }

--- a/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: WorktreeResolver unit and regression tests.
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, mkdirSync, realpathSync } from "node:fs";
@@ -9,6 +11,17 @@ import {
   type NotifyCtx,
 } from "../worktree-resolver.js";
 import { AutoSession } from "../auto/session.js";
+import {
+  closeDatabase,
+  insertMilestone,
+  openDatabase,
+} from "../gsd-db.js";
+import { registerAutoWorker } from "../db/auto-workers.js";
+import {
+  claimMilestoneLease,
+  getMilestoneLease,
+  releaseMilestoneLease,
+} from "../db/milestone-leases.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -19,11 +32,12 @@ interface CallLog {
 }
 
 function makeSession(
-  overrides?: Partial<{ basePath: string; originalBasePath: string }>,
+  overrides?: Partial<AutoSession>,
 ): AutoSession {
   const s = new AutoSession();
   s.basePath = overrides?.basePath ?? "/project";
   s.originalBasePath = overrides?.originalBasePath ?? "/project";
+  Object.assign(s, overrides);
   return s;
 }
 
@@ -180,6 +194,17 @@ function makeNotifyCtx(): NotifyCtx & {
 
 function findCalls(calls: CallLog[], fn: string): CallLog[] {
   return calls.filter((c) => c.fn === fn);
+}
+
+function makeDbBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-worktree-resolver-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanupDbBase(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
 }
 
 // ─── Getter Tests ────────────────────────────────────────────────────────────
@@ -369,6 +394,43 @@ test("enterMilestone does not create double-nested worktree when originalBasePat
     !createdFromPath.includes("/.gsd/worktrees/"),
     `createAutoWorktree must be called with project root, got: "${createdFromPath}"`,
   );
+});
+
+test("enterMilestone reacquires a released same-milestone lease before worktree entry", (t) => {
+  const base = makeDbBase();
+  t.after(() => cleanupDbBase(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test milestone", status: "active" });
+
+  const workerId = registerAutoWorker({ projectRootRealpath: base });
+  const originalClaim = claimMilestoneLease(workerId, "M001");
+  assert.equal(originalClaim.ok, true);
+  if (!originalClaim.ok) throw new Error("expected test lease claim");
+  assert.equal(releaseMilestoneLease(workerId, "M001", originalClaim.token), true);
+
+  const s = makeSession({
+    basePath: base,
+    originalBasePath: base,
+    workerId,
+    currentMilestoneId: "M001",
+    milestoneLeaseToken: originalClaim.token,
+  });
+  const deps = makeDeps({
+    createAutoWorktree: (basePath: string, milestoneId: string) => join(basePath, ".gsd", "worktrees", milestoneId),
+  });
+  const ctx = makeNotifyCtx();
+  const resolver = new WorktreeResolver(s, deps);
+
+  resolver.enterMilestone("M001", ctx);
+
+  const row = getMilestoneLease("M001");
+  assert.ok(row);
+  assert.equal(row.worker_id, workerId);
+  assert.equal(row.status, "held");
+  assert.equal(row.fencing_token, originalClaim.token + 1);
+  assert.equal(s.milestoneLeaseToken, originalClaim.token + 1);
+  assert.equal(s.basePath, join(base, ".gsd", "worktrees", "M001"));
+  assert.equal(ctx.messages.some((m) => m.level === "error"), false);
 });
 
 // ─── enterMilestone Tests (branch mode) ──────────────────────────────────────

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -25,7 +25,7 @@ import { emitWorktreeCreated, emitWorktreeMerged } from "./worktree-telemetry.js
 import { getCollapseCadence, getMilestoneResquash, resquashMilestoneOnMain } from "./slice-cadence.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { resolveWorktreeProjectRoot, normalizeWorktreePathForCompare } from "./worktree-root.js";
-import { claimMilestoneLease, releaseMilestoneLease } from "./db/milestone-leases.js";
+import { claimMilestoneLease, refreshMilestoneLease, releaseMilestoneLease } from "./db/milestone-leases.js";
 
 // ─── Path Comparison Helper ────────────────────────────────────────────────
 /**
@@ -207,23 +207,44 @@ export class WorktreeResolver {
     // milestone (re-entry within the same session).
     if (this.s.workerId) {
       if (this.s.currentMilestoneId === milestoneId && this.s.milestoneLeaseToken !== null) {
-        // Already held — no-op, the heartbeat in loop.ts refreshes TTL.
-      } else {
-        // If we held a different milestone, release it first so other
-        // workers don't have to wait for TTL.
-        if (this.s.currentMilestoneId && this.s.currentMilestoneId !== milestoneId && this.s.milestoneLeaseToken !== null) {
-          try {
-            releaseMilestoneLease(this.s.workerId, this.s.currentMilestoneId, this.s.milestoneLeaseToken);
-          } catch (err) {
-            debugLog("WorktreeResolver", {
-              action: "enterMilestone",
-              milestoneId,
-              releasePriorLeaseError: err instanceof Error ? err.message : String(err),
-            });
-          }
+        const refreshed = refreshMilestoneLease(
+          this.s.workerId,
+          milestoneId,
+          this.s.milestoneLeaseToken,
+        );
+        if (refreshed) {
+          debugLog("WorktreeResolver", {
+            action: "enterMilestone",
+            milestoneId,
+            leaseRefreshed: true,
+            fencingToken: this.s.milestoneLeaseToken,
+          });
+        } else {
+          debugLog("WorktreeResolver", {
+            action: "enterMilestone",
+            milestoneId,
+            staleLeaseToken: this.s.milestoneLeaseToken,
+          });
           this.s.milestoneLeaseToken = null;
         }
+      }
 
+      // If we held a different milestone, release it first so other
+      // workers don't have to wait for TTL.
+      if (this.s.currentMilestoneId && this.s.currentMilestoneId !== milestoneId && this.s.milestoneLeaseToken !== null) {
+        try {
+          releaseMilestoneLease(this.s.workerId, this.s.currentMilestoneId, this.s.milestoneLeaseToken);
+        } catch (err) {
+          debugLog("WorktreeResolver", {
+            action: "enterMilestone",
+            milestoneId,
+            releasePriorLeaseError: err instanceof Error ? err.message : String(err),
+          });
+        }
+        this.s.milestoneLeaseToken = null;
+      }
+
+      if (this.s.milestoneLeaseToken === null) {
         try {
           const claim = claimMilestoneLease(this.s.workerId, milestoneId);
           if (claim.ok) {


### PR DESCRIPTION
## TL;DR

**What:** Reacquire stale auto-mode milestone leases before entering a milestone/worktree.
**Why:** A released in-memory lease token could make `execute-task` dispatch claims fail as `stale_lease`, causing auto-mode to loop until stuck without writing task summaries.
**How:** Refresh same-milestone lease tokens before reuse, clear stale tokens and reacquire them, and clear worker/lease state during stop cleanup.

## What

This updates the GSD auto-mode coordination path in `src/resources/extensions/gsd/`:

- `worktree-resolver.ts` now validates an existing same-milestone lease token with `refreshMilestoneLease()` before treating it as held.
- If the refresh fails, the resolver clears the stale token and calls `claimMilestoneLease()` to get a fresh fencing token before worktree entry continues.
- `auto.ts` clears `workerId` and `milestoneLeaseToken` after stop coordination cleanup so stopped worker state is not reused in-session.
- `worktree-resolver.test.ts` adds a DB-backed regression test for a released same-milestone token being reacquired before worktree entry.

Closes #5496

## Why

A reported auto-mode run planned `M001/S01`, then repeatedly derived `execute-task M001/S01/T01` without executing it. The stop reason was a missing `T01-SUMMARY.md`, but audit events showed the real failure: dispatch claims were skipped with `error:"stale-lease"`.

The bug was that `enterMilestone()` assumed `currentMilestoneId === milestoneId` plus a non-null `milestoneLeaseToken` meant the DB lease was still held. If that lease had already been released, every later unit dispatch using the stale token failed before task execution began.

## How

The resolver now uses the DB as authority for same-milestone tokens:

1. Refresh the existing token when re-entering the same milestone.
2. If refresh succeeds, keep using that token.
3. If refresh fails, clear the token and reacquire a new lease.
4. Preserve the existing held-by-other error path when another active worker owns the milestone.

This keeps the single-worker fallback behavior for DB-unavailable cases while preventing stale in-memory coordination state from blocking actual task execution.

## Change Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/worktree-resolver.test.ts`
- [ ] `npm run verify:pr`

`npm run verify:pr` ran through `build:core` and `typecheck:extensions`, then failed in compiled unit tests on an existing ADR-012 provider equality guard outside this PR:

```text
ADR-012: provider-equality checks are allowlisted or use isXxxApi helpers
New `model.provider === "<transport>"` check(s) detected in:
- src/providers/provider-migrations.ts
```

This PR is opened as draft because repo-wide preflight is not green.

## AI Assistance

This PR is AI-assisted. The fix was verified with a focused regression test, and the failing repo-wide preflight result is documented above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordination cleanup during worker shutdown to properly reset in-memory fields.
  * Enhanced lease management when entering milestones to handle same-milestone refresh attempts and properly release prior leases on switch.

* **Tests**
  * Added regression test to verify correct lease reacquisition and worktree path updates during milestone entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->