### PR TITLE
fix: design hardening — memory scan cap, template cache, token counter, dispatch tests, artifact hash, memory decay

### DIFF
--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -50,7 +50,7 @@ After commit: regenerate markdown artifacts → write to disk → invalidate cac
 
 ## 2. Schema Version History
 
-Current version: **V26**
+Current version: **V28**
 
 | Version | What Changed |
 |---------|-------------|
@@ -80,6 +80,8 @@ Current version: **V26**
 | V24 | **Auto-mode coordination**: workers, milestone_leases, unit_dispatches, cancellation_requests, command_queue |
 | V25 | runtime_kv (soft state KV with global/worker/milestone scope) |
 | V26 | milestone_commit_attributions |
+| V27 | artifacts.content_hash (SHA-256 of full_content, computed on every insertArtifact) |
+| V28 | memories.last_hit_at; incrementMemoryHitCount sets it; queryMemoriesRanked applies time-decay (1.0 → 0.7 floor over 90 days) |
 
 ---
 
@@ -143,8 +145,10 @@ slice_id      TEXT DEFAULT NULL
 task_id       TEXT DEFAULT NULL
 full_content  TEXT NOT NULL DEFAULT ''
 imported_at   TEXT NOT NULL DEFAULT ''
+content_hash  TEXT DEFAULT NULL                  ← V27, SHA-256 of full_content
 ```
 Stores markdown artifact content (PROJECT, REQUIREMENTS, SUMMARY, RESEARCH, CONTEXT, etc.).
+V27: `content_hash` is computed and stored on every `insertArtifact` for integrity fingerprinting.
 
 ---
 
@@ -428,10 +432,12 @@ hit_count         INTEGER NOT NULL DEFAULT 0
 scope             TEXT NOT NULL DEFAULT 'project'   ← V18
 tags              TEXT NOT NULL DEFAULT '[]'         ← V18, JSON
 structured_fields TEXT DEFAULT NULL                  ← V21, JSON
+last_hit_at       TEXT DEFAULT NULL                  ← V28, set by incrementMemoryHitCount
 ```
 - Index: `idx_memories_active` (superseded_by), `idx_memories_scope` (scope)
 - View: `active_memories` WHERE superseded_by IS NULL
 - FTS: `memories_fts` virtual table (V19)
+- V28: `queryMemoriesRanked` applies `memoryDecayFactor(last_hit_at)` — linear decay from 1.0 (≤0 days) to 0.7 floor (≥90 days)
 
 ---
 

--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -1,0 +1,727 @@
+# GSD-2 Database Map
+
+> Complete schema, access layer, migration history, and cross-reference to the prompt system.
+
+---
+
+## 1. Database Infrastructure Stack
+
+```
+gsd_* tool call (from LLM)
+       │
+       ▼
+bootstrap/db-tools.ts          ← tool registration + input parsing
+       │
+       ▼
+tools/workflow-tool-executors.ts  ← business logic
+       │
+       ├── validation reads (milestones, slices, tasks)
+       │
+       ▼
+gsd-db.ts  ← typed write API, transaction wrapper
+       │
+       ├── transaction()  (db-transaction.ts — depth counter, no nested BEGIN)
+       │
+       ▼
+db-adapter.ts  ← normalized prepared-statement cache
+       │
+       ▼
+db-provider.ts  ← node:sqlite (primary) or better-sqlite3 (fallback)
+       │
+       ▼
+SQLite WAL  (.gsd/gsd.db)
+       │
+       ▼
+After commit: regenerate markdown artifacts → write to disk → invalidate cache
+```
+
+**Connection scoping (db-connection-cache.ts):**
+- Keyed by workspace `identityKey` (realpath of project root)
+- Sibling worktrees share the same `.gsd/gsd.db` via SQLite WAL
+- Only one connection is "active" at a time; others cached for fast re-activation
+- On process exit: checkpoint WAL → vacuum → close
+
+**Provider fallback chain:**
+1. `node:sqlite` (Node ≥ 22 built-in) — preferred
+2. `better-sqlite3` (npm) — fallback if node:sqlite unavailable
+3. null → DB unavailable (non-fatal; GSD degrades gracefully)
+
+---
+
+## 2. Schema Version History
+
+Current version: **V26**
+
+| Version | What Changed |
+|---------|-------------|
+| V1 | schema_version + decisions + requirements tables |
+| V2 | artifacts table |
+| V3 | memories + memory_processed_units; FTS3 |
+| V4 | decisions.made_by column |
+| V5 | **Core hierarchy**: milestones, slices, tasks, verification_evidence |
+| V6 | slices.full_summary_md, full_uat_md |
+| V7 | slices.depends, demo; milestones.depends_on |
+| V8 | Deep planning fields on milestones/slices/tasks; replan_history; assessments |
+| V9 | sequence ordering on slices + tasks |
+| V10 | slices.replan_triggered_at |
+| V11 | tasks.full_plan_md; replan_history unique index |
+| V12 | quality_gates table (broken DDL, fixed in V22) |
+| V13 | Hot-path indexes; verification_evidence dedup index |
+| V14 | slice_dependencies table |
+| V15 | gate_runs, turn_git_transactions, audit_events, audit_turn_index |
+| V16 | slices.is_sketch, sketch_scope (ADR-011); decisions.source |
+| V17 | tasks escalation columns (blocker_source, escalation_*) |
+| V18 | memory_sources; memories.scope + tags |
+| V19 | memory_embeddings; memories_fts (FTS5 virtual table + triggers) |
+| V20 | memory_relations |
+| V21 | memories.structured_fields |
+| V22 | quality_gates table repair (task_id constraint); scope column |
+| V23 | milestones.sequence |
+| V24 | **Auto-mode coordination**: workers, milestone_leases, unit_dispatches, cancellation_requests, command_queue |
+| V25 | runtime_kv (soft state KV with global/worker/milestone scope) |
+| V26 | milestone_commit_attributions |
+
+---
+
+## 3. Complete Table Inventory
+
+### 3a. Core Hierarchy (V1, V5–V11)
+
+#### `schema_version`
+```
+version    INTEGER NOT NULL
+applied_at TEXT NOT NULL
+```
+Tracks which migrations have run.
+
+---
+
+#### `decisions`
+```
+seq            INTEGER PRIMARY KEY AUTOINCREMENT
+id             TEXT NOT NULL UNIQUE
+when_context   TEXT NOT NULL DEFAULT ''
+scope          TEXT NOT NULL DEFAULT ''
+decision       TEXT NOT NULL DEFAULT ''
+choice         TEXT NOT NULL DEFAULT ''
+rationale      TEXT NOT NULL DEFAULT ''
+revisable      TEXT NOT NULL DEFAULT ''
+made_by        TEXT NOT NULL DEFAULT 'agent'     ← V4
+source         TEXT NOT NULL DEFAULT 'discussion' ← V16
+superseded_by  TEXT DEFAULT NULL
+```
+- Index: `idx_memories_active` (superseded_by)
+- View: `active_decisions` WHERE superseded_by IS NULL
+
+---
+
+#### `requirements`
+```
+id                TEXT PRIMARY KEY
+class             TEXT NOT NULL DEFAULT ''
+status            TEXT NOT NULL DEFAULT ''
+description       TEXT NOT NULL DEFAULT ''
+why               TEXT NOT NULL DEFAULT ''
+source            TEXT NOT NULL DEFAULT ''
+primary_owner     TEXT NOT NULL DEFAULT ''
+supporting_slices TEXT NOT NULL DEFAULT ''
+validation        TEXT NOT NULL DEFAULT ''
+notes             TEXT NOT NULL DEFAULT ''
+full_content      TEXT NOT NULL DEFAULT ''
+superseded_by     TEXT DEFAULT NULL
+```
+- View: `active_requirements` WHERE superseded_by IS NULL
+
+---
+
+#### `artifacts` (V2)
+```
+path          TEXT PRIMARY KEY
+artifact_type TEXT NOT NULL DEFAULT ''
+milestone_id  TEXT DEFAULT NULL
+slice_id      TEXT DEFAULT NULL
+task_id       TEXT DEFAULT NULL
+full_content  TEXT NOT NULL DEFAULT ''
+imported_at   TEXT NOT NULL DEFAULT ''
+```
+Stores markdown artifact content (PROJECT, REQUIREMENTS, SUMMARY, RESEARCH, CONTEXT, etc.).
+
+---
+
+#### `milestones` (V5)
+```
+id                      TEXT PRIMARY KEY
+title                   TEXT NOT NULL DEFAULT ''
+status                  TEXT NOT NULL DEFAULT 'active'
+depends_on              TEXT NOT NULL DEFAULT '[]'   ← JSON array, V7
+created_at              TEXT NOT NULL DEFAULT ''
+completed_at            TEXT DEFAULT NULL
+vision                  TEXT NOT NULL DEFAULT ''           ← V8
+success_criteria        TEXT NOT NULL DEFAULT '[]'         ← V8, JSON
+key_risks               TEXT NOT NULL DEFAULT '[]'         ← V8, JSON
+proof_strategy          TEXT NOT NULL DEFAULT '[]'         ← V8, JSON
+verification_contract   TEXT NOT NULL DEFAULT ''           ← V8
+verification_integration TEXT NOT NULL DEFAULT ''          ← V8
+verification_operational TEXT NOT NULL DEFAULT ''          ← V8
+verification_uat        TEXT NOT NULL DEFAULT ''           ← V8
+definition_of_done      TEXT NOT NULL DEFAULT '[]'         ← V8, JSON
+requirement_coverage    TEXT NOT NULL DEFAULT ''           ← V8
+boundary_map_markdown   TEXT NOT NULL DEFAULT ''           ← V8
+sequence                INTEGER DEFAULT 0                  ← V23
+```
+- Index: `idx_milestones_status` (status)
+- Status values: `active`, `closed`, `queued`
+
+---
+
+#### `slices` (V5)
+```
+milestone_id         TEXT NOT NULL
+id                   TEXT NOT NULL
+title                TEXT NOT NULL DEFAULT ''
+status               TEXT NOT NULL DEFAULT 'pending'
+risk                 TEXT NOT NULL DEFAULT 'medium'
+depends              TEXT NOT NULL DEFAULT '[]'         ← V7, JSON
+demo                 TEXT NOT NULL DEFAULT ''           ← V7
+created_at           TEXT NOT NULL DEFAULT ''
+completed_at         TEXT DEFAULT NULL
+full_summary_md      TEXT NOT NULL DEFAULT ''           ← V6
+full_uat_md          TEXT NOT NULL DEFAULT ''           ← V6
+goal                 TEXT NOT NULL DEFAULT ''           ← V8
+success_criteria     TEXT NOT NULL DEFAULT ''           ← V8
+proof_level          TEXT NOT NULL DEFAULT ''           ← V8
+integration_closure  TEXT NOT NULL DEFAULT ''           ← V8
+observability_impact TEXT NOT NULL DEFAULT ''           ← V8
+sequence             INTEGER DEFAULT 0                  ← V9
+replan_triggered_at  TEXT DEFAULT NULL                  ← V10
+is_sketch            INTEGER NOT NULL DEFAULT 0         ← V16
+sketch_scope         TEXT NOT NULL DEFAULT ''           ← V16
+PRIMARY KEY (milestone_id, id)
+FOREIGN KEY milestone_id → milestones(id)
+```
+- Index: `idx_slices_active` (milestone_id, status)
+- Status values: `pending`, `in_progress`, `complete`, `skipped`
+
+---
+
+#### `tasks` (V5)
+```
+milestone_id                TEXT NOT NULL
+slice_id                    TEXT NOT NULL
+id                          TEXT NOT NULL
+title                       TEXT NOT NULL DEFAULT ''
+status                      TEXT NOT NULL DEFAULT 'pending'
+one_liner                   TEXT NOT NULL DEFAULT ''
+narrative                   TEXT NOT NULL DEFAULT ''
+verification_result         TEXT NOT NULL DEFAULT ''
+duration                    TEXT NOT NULL DEFAULT ''
+completed_at                TEXT DEFAULT NULL
+blocker_discovered          INTEGER DEFAULT 0
+blocker_source              TEXT NOT NULL DEFAULT ''           ← V17
+escalation_pending          INTEGER NOT NULL DEFAULT 0         ← V17
+escalation_awaiting_review  INTEGER NOT NULL DEFAULT 0         ← V17
+escalation_artifact_path    TEXT DEFAULT NULL                  ← V17
+escalation_override_applied_at TEXT DEFAULT NULL              ← V17
+deviations                  TEXT NOT NULL DEFAULT ''
+known_issues                TEXT NOT NULL DEFAULT ''
+key_files                   TEXT NOT NULL DEFAULT '[]'         ← JSON
+key_decisions               TEXT NOT NULL DEFAULT '[]'         ← JSON
+full_summary_md             TEXT NOT NULL DEFAULT ''
+description                 TEXT NOT NULL DEFAULT ''           ← V8
+estimate                    TEXT NOT NULL DEFAULT ''           ← V8
+files                       TEXT NOT NULL DEFAULT '[]'         ← V8, JSON
+verify                      TEXT NOT NULL DEFAULT ''           ← V8
+inputs                      TEXT NOT NULL DEFAULT '[]'         ← V8, JSON
+expected_output             TEXT NOT NULL DEFAULT '[]'         ← V8, JSON
+observability_impact        TEXT NOT NULL DEFAULT ''           ← V8
+full_plan_md                TEXT NOT NULL DEFAULT ''           ← V11
+sequence                    INTEGER DEFAULT 0                  ← V9
+PRIMARY KEY (milestone_id, slice_id, id)
+FOREIGN KEY (milestone_id, slice_id) → slices(milestone_id, id)
+```
+- Indexes: `idx_tasks_active` (milestone_id, slice_id, status), `idx_tasks_escalation_pending`
+- Status values: `pending`, `in_progress`, `complete`, `skipped`, `blocked`
+
+---
+
+#### `verification_evidence` (V5)
+```
+id           INTEGER PRIMARY KEY AUTOINCREMENT
+task_id      TEXT NOT NULL DEFAULT ''
+slice_id     TEXT NOT NULL DEFAULT ''
+milestone_id TEXT NOT NULL DEFAULT ''
+command      TEXT NOT NULL DEFAULT ''
+exit_code    INTEGER DEFAULT 0
+verdict      TEXT NOT NULL DEFAULT ''
+duration_ms  INTEGER DEFAULT 0
+created_at   TEXT NOT NULL DEFAULT ''
+FOREIGN KEY (milestone_id, slice_id, task_id) → tasks
+```
+- Indexes: `idx_verification_evidence_task`, unique dedup index (V13)
+
+---
+
+#### `replan_history` (V8)
+```
+id                       INTEGER PRIMARY KEY AUTOINCREMENT
+milestone_id             TEXT NOT NULL
+slice_id                 TEXT DEFAULT NULL
+task_id                  TEXT DEFAULT NULL
+summary                  TEXT NOT NULL DEFAULT ''
+previous_artifact_path   TEXT DEFAULT NULL
+replacement_artifact_path TEXT DEFAULT NULL
+created_at               TEXT NOT NULL DEFAULT ''
+FOREIGN KEY milestone_id → milestones(id)
+```
+
+---
+
+#### `assessments` (V8)
+```
+path         TEXT PRIMARY KEY
+milestone_id TEXT NOT NULL DEFAULT ''
+slice_id     TEXT DEFAULT NULL
+task_id      TEXT DEFAULT NULL
+status       TEXT NOT NULL DEFAULT ''
+scope        TEXT NOT NULL DEFAULT ''
+full_content TEXT NOT NULL DEFAULT ''
+created_at   TEXT NOT NULL DEFAULT ''
+FOREIGN KEY milestone_id → milestones(id)
+```
+
+---
+
+#### `quality_gates` (V12, repaired V22)
+```
+milestone_id TEXT NOT NULL
+slice_id     TEXT NOT NULL
+gate_id      TEXT NOT NULL
+scope        TEXT NOT NULL DEFAULT 'slice'   ← V22
+task_id      TEXT NOT NULL DEFAULT ''        ← V22 (was broken)
+status       TEXT NOT NULL DEFAULT 'pending'
+verdict      TEXT NOT NULL DEFAULT ''
+rationale    TEXT NOT NULL DEFAULT ''
+findings     TEXT NOT NULL DEFAULT ''
+evaluated_at TEXT DEFAULT NULL
+PRIMARY KEY (milestone_id, slice_id, gate_id, task_id)
+FOREIGN KEY (milestone_id, slice_id) → slices
+```
+- Index: `idx_quality_gates_pending`
+
+---
+
+#### `slice_dependencies` (V14)
+```
+milestone_id        TEXT NOT NULL
+slice_id            TEXT NOT NULL
+depends_on_slice_id TEXT NOT NULL
+PRIMARY KEY (milestone_id, slice_id, depends_on_slice_id)
+FOREIGN KEY (milestone_id, slice_id) → slices
+FOREIGN KEY (milestone_id, depends_on_slice_id) → slices
+```
+- Index: `idx_slice_deps_target`
+
+---
+
+#### `gate_runs` (V15)
+```
+id            INTEGER PRIMARY KEY AUTOINCREMENT
+trace_id      TEXT NOT NULL
+turn_id       TEXT NOT NULL
+gate_id       TEXT NOT NULL
+gate_type     TEXT NOT NULL DEFAULT ''
+unit_type     TEXT DEFAULT NULL
+unit_id       TEXT DEFAULT NULL
+milestone_id  TEXT DEFAULT NULL
+slice_id      TEXT DEFAULT NULL
+task_id       TEXT DEFAULT NULL
+outcome       TEXT NOT NULL DEFAULT 'pass'
+failure_class TEXT NOT NULL DEFAULT 'none'
+rationale     TEXT NOT NULL DEFAULT ''
+findings      TEXT NOT NULL DEFAULT ''
+attempt       INTEGER NOT NULL DEFAULT 1
+max_attempts  INTEGER NOT NULL DEFAULT 1
+retryable     INTEGER NOT NULL DEFAULT 0
+evaluated_at  TEXT NOT NULL DEFAULT ''
+```
+- Indexes: `idx_gate_runs_turn`, `idx_gate_runs_lookup`
+
+---
+
+#### `turn_git_transactions` (V15)
+```
+trace_id      TEXT NOT NULL
+turn_id       TEXT NOT NULL
+unit_type     TEXT DEFAULT NULL
+unit_id       TEXT DEFAULT NULL
+stage         TEXT NOT NULL DEFAULT 'turn-start'
+action        TEXT NOT NULL DEFAULT 'status-only'
+push          INTEGER NOT NULL DEFAULT 0
+status        TEXT NOT NULL DEFAULT 'ok'
+error         TEXT DEFAULT NULL
+metadata_json TEXT NOT NULL DEFAULT '{}'
+updated_at    TEXT NOT NULL DEFAULT ''
+PRIMARY KEY (trace_id, turn_id, stage)
+```
+- Index: `idx_turn_git_tx_turn`
+
+---
+
+#### `audit_events` (V15)
+```
+event_id     TEXT PRIMARY KEY
+trace_id     TEXT NOT NULL
+turn_id      TEXT DEFAULT NULL
+caused_by    TEXT DEFAULT NULL
+category     TEXT NOT NULL
+type         TEXT NOT NULL
+ts           TEXT NOT NULL
+payload_json TEXT NOT NULL DEFAULT '{}'
+```
+- Indexes: `idx_audit_events_trace`, `idx_audit_events_turn`
+
+---
+
+#### `audit_turn_index` (V15)
+```
+trace_id    TEXT NOT NULL
+turn_id     TEXT NOT NULL
+first_ts    TEXT NOT NULL
+last_ts     TEXT NOT NULL
+event_count INTEGER NOT NULL DEFAULT 0
+PRIMARY KEY (trace_id, turn_id)
+```
+
+---
+
+#### `milestone_commit_attributions` (V26)
+```
+commit_sha   TEXT NOT NULL
+milestone_id TEXT NOT NULL
+slice_id     TEXT DEFAULT NULL
+task_id      TEXT DEFAULT NULL
+source       TEXT NOT NULL DEFAULT 'recorded'
+confidence   REAL NOT NULL DEFAULT 1.0
+files_json   TEXT NOT NULL DEFAULT '[]'
+created_at   TEXT NOT NULL DEFAULT ''
+PRIMARY KEY (commit_sha, milestone_id)
+```
+- Index: `idx_milestone_commit_attr_milestone`
+
+---
+
+### 3b. Memory & Knowledge Layer (V3, V18–V21)
+
+#### `memories` (V3)
+```
+seq               INTEGER PRIMARY KEY AUTOINCREMENT
+id                TEXT NOT NULL UNIQUE
+category          TEXT NOT NULL
+content           TEXT NOT NULL
+confidence        REAL NOT NULL DEFAULT 0.8
+source_unit_type  TEXT
+source_unit_id    TEXT
+created_at        TEXT NOT NULL
+updated_at        TEXT NOT NULL
+superseded_by     TEXT DEFAULT NULL
+hit_count         INTEGER NOT NULL DEFAULT 0
+scope             TEXT NOT NULL DEFAULT 'project'   ← V18
+tags              TEXT NOT NULL DEFAULT '[]'         ← V18, JSON
+structured_fields TEXT DEFAULT NULL                  ← V21, JSON
+```
+- Index: `idx_memories_active` (superseded_by), `idx_memories_scope` (scope)
+- View: `active_memories` WHERE superseded_by IS NULL
+- FTS: `memories_fts` virtual table (V19)
+
+---
+
+#### `memory_processed_units` (V3)
+```
+unit_key     TEXT PRIMARY KEY
+activity_file TEXT
+processed_at TEXT NOT NULL
+```
+
+---
+
+#### `memory_sources` (V18)
+```
+id           TEXT PRIMARY KEY
+kind         TEXT NOT NULL
+uri          TEXT
+title        TEXT
+content      TEXT NOT NULL
+content_hash TEXT NOT NULL UNIQUE
+imported_at  TEXT NOT NULL
+scope        TEXT NOT NULL DEFAULT 'project'
+tags         TEXT NOT NULL DEFAULT '[]'
+```
+- Indexes: `idx_memory_sources_kind`, `idx_memory_sources_scope`
+
+---
+
+#### `memory_embeddings` (V19)
+```
+memory_id  TEXT PRIMARY KEY
+model      TEXT NOT NULL
+dim        INTEGER NOT NULL
+vector     BLOB NOT NULL
+updated_at TEXT NOT NULL
+```
+
+---
+
+#### `memory_relations` (V20)
+```
+from_id    TEXT NOT NULL
+to_id      TEXT NOT NULL
+rel        TEXT NOT NULL
+confidence REAL NOT NULL DEFAULT 0.8
+created_at TEXT NOT NULL
+PRIMARY KEY (from_id, to_id, rel)
+```
+- Indexes: `idx_memory_relations_from`, `idx_memory_relations_to`
+
+---
+
+#### `memories_fts` (V19, Virtual)
+```
+FTS5 virtual table
+Content: memories.content
+Tokenizer: porter unicode61
+Triggers: memories_ai, memories_ad, memories_au (keep in sync)
+Fallback: LIKE scan if FTS5 unavailable
+```
+
+---
+
+### 3c. Auto-Mode Coordination (V24)
+
+#### `workers`
+```
+worker_id              TEXT PRIMARY KEY
+host                   TEXT NOT NULL
+pid                    INTEGER NOT NULL
+started_at             TEXT NOT NULL
+version                TEXT NOT NULL
+last_heartbeat_at      TEXT NOT NULL
+status                 TEXT NOT NULL
+project_root_realpath  TEXT NOT NULL
+```
+
+---
+
+#### `milestone_leases`
+```
+milestone_id   TEXT PRIMARY KEY
+worker_id      TEXT NOT NULL
+fencing_token  INTEGER NOT NULL
+acquired_at    TEXT NOT NULL
+expires_at     TEXT NOT NULL
+status         TEXT NOT NULL
+FOREIGN KEY worker_id → workers(worker_id)
+FOREIGN KEY milestone_id → milestones(id)
+```
+
+---
+
+#### `unit_dispatches`
+```
+id                      INTEGER PRIMARY KEY AUTOINCREMENT
+trace_id                TEXT NOT NULL
+turn_id                 TEXT
+worker_id               TEXT NOT NULL
+milestone_lease_token   INTEGER NOT NULL
+milestone_id            TEXT NOT NULL
+slice_id                TEXT
+task_id                 TEXT
+unit_type               TEXT NOT NULL
+unit_id                 TEXT NOT NULL
+status                  TEXT NOT NULL
+attempt_n               INTEGER NOT NULL DEFAULT 1
+started_at              TEXT NOT NULL
+ended_at                TEXT
+exit_reason             TEXT
+error_summary           TEXT
+verification_evidence_id INTEGER
+next_run_at             TEXT
+retry_after_ms          INTEGER
+max_attempts            INTEGER NOT NULL DEFAULT 3
+last_error_code         TEXT
+last_error_at           TEXT
+FOREIGN KEY worker_id → workers
+FOREIGN KEY verification_evidence_id → verification_evidence(id)
+```
+- Indexes: `idx_unit_dispatches_active`, `idx_unit_dispatches_trace`
+- Unique partial index: `idx_unit_dispatches_active_per_unit` ON unit_id WHERE status IN ('claimed','running') — prevents double-claim
+
+---
+
+#### `cancellation_requests`
+```
+id              INTEGER PRIMARY KEY AUTOINCREMENT
+requested_at    TEXT NOT NULL
+requested_by    TEXT NOT NULL
+scope           TEXT NOT NULL
+scope_id        TEXT NOT NULL
+dispatch_id     INTEGER
+reason          TEXT NOT NULL
+status          TEXT NOT NULL
+acked_at        TEXT
+acked_worker_id TEXT
+FOREIGN KEY dispatch_id → unit_dispatches(id)
+FOREIGN KEY acked_worker_id → workers(worker_id)
+```
+
+---
+
+#### `command_queue`
+```
+id           INTEGER PRIMARY KEY AUTOINCREMENT
+target_worker TEXT     ← NULL = broadcast to all workers
+command      TEXT NOT NULL
+args_json    TEXT NOT NULL DEFAULT '{}'
+enqueued_at  TEXT NOT NULL
+claimed_at   TEXT
+claimed_by   TEXT
+completed_at TEXT
+result_json  TEXT
+```
+- Index: `idx_command_queue_pending` (target_worker, claimed_at)
+
+---
+
+### 3d. Soft State (V25)
+
+#### `runtime_kv`
+```
+scope      TEXT NOT NULL    ← 'global' | 'worker' | 'milestone'
+scope_id   TEXT NOT NULL DEFAULT ''
+key        TEXT NOT NULL
+value_json TEXT NOT NULL
+updated_at TEXT NOT NULL
+PRIMARY KEY (scope, scope_id, key)
+```
+Non-correctness-critical state: UI cursors, dashboard caches, resume pointers. Safe to lose.
+
+---
+
+## 4. Entity Relationship Diagram
+
+```
+milestones ──┐
+  │ id        │ (depends_on → milestones.id, via JSON)
+  │           │
+  ▼           │
+slices ───────┘
+  │ (milestone_id, id) PRIMARY KEY
+  │
+  ├──► slice_dependencies (milestone_id, slice_id, depends_on_slice_id)
+  │
+  ▼
+tasks
+  │ (milestone_id, slice_id, id) PRIMARY KEY
+  │
+  ├──► verification_evidence (milestone_id, slice_id, task_id)
+  ├──► quality_gates (milestone_id, slice_id, gate_id, task_id)
+  └──► unit_dispatches.task_id (via coordination layer)
+
+milestones ──► replan_history (milestone_id)
+milestones ──► assessments (milestone_id)
+milestones ──► milestone_leases (milestone_id) ◄── workers
+milestones ──► unit_dispatches (milestone_id) ◄── workers
+milestones ──► milestone_commit_attributions (milestone_id)
+
+memories ──► memories_fts (FTS5 virtual, via triggers)
+memories ──► memory_embeddings (memory_id)
+memories ──► memory_relations (from_id, to_id)
+memory_sources ──► (imported content, feeds memories)
+
+unit_dispatches ──► cancellation_requests (dispatch_id)
+unit_dispatches ──► verification_evidence (verification_evidence_id)
+
+decisions  (independent, supersedable)
+requirements  (independent, supersedable)
+artifacts  (independent, keyed by path)
+gate_runs  (audit, keyed by trace_id + turn_id + gate_id)
+turn_git_transactions  (audit, keyed by trace_id + turn_id + stage)
+audit_events  (append-only audit log)
+audit_turn_index  (turn-level index into audit_events)
+runtime_kv  (soft state KV)
+```
+
+---
+
+## 5. Complete gsd_* Tool → Table Map
+
+| Tool | Tables READ | Tables WRITTEN | Disk Artifacts |
+|------|------------|----------------|----------------|
+| `gsd_decision_save` | decisions | decisions | DECISIONS.md (regenerated) |
+| `gsd_requirement_save` | requirements | requirements | REQUIREMENTS.md |
+| `gsd_requirement_update` | requirements | requirements | REQUIREMENTS.md |
+| `gsd_summary_save` | milestones, slices, tasks | artifacts | M##/S##/T## artifact files |
+| `gsd_milestone_generate_id` | milestones | milestones (INSERT OR IGNORE, queued) | — |
+| `gsd_plan_milestone` | milestones, slices | milestones, slices, tasks, replan_history | ROADMAP.md |
+| `gsd_plan_slice` | slices, tasks | slices, tasks | S##-PLAN.md |
+| `gsd_plan_task` | slices, tasks | tasks | T##-PLAN.md |
+| `gsd_task_complete` | tasks, slices | tasks, verification_evidence | T##-SUMMARY.md; toggles checkbox in S##-PLAN.md |
+| `gsd_slice_complete` | tasks, slices | slices, tasks (cascade skipped) | S##-SUMMARY.md, S##-UAT.md; toggles checkpoint in ROADMAP.md |
+| `gsd_complete_milestone` | milestones, slices, tasks | milestones | M##-SUMMARY.md |
+| `gsd_validate_milestone` | milestones, slices, tasks | assessments | VALIDATION.md |
+| `gsd_reassess_roadmap` | milestones, slices | milestones, slices, assessments | ROADMAP.md, ASSESSMENT.md |
+| `gsd_replan_slice` | slices, tasks | slices, tasks, replan_history, quality_gates | S##-PLAN.md, S##-REPLAN.md |
+| `gsd_skip_slice` | slices, tasks | slices, tasks | STATE.md (via rebuildState) |
+| `gsd_task_reopen` | tasks, slices, milestones | tasks | deletes T##-SUMMARY.md |
+| `gsd_slice_reopen` | slices, tasks, milestones | slices, tasks | deletes S##-SUMMARY.md, UAT, all T##-SUMMARY.md |
+| `gsd_milestone_reopen` | milestones, slices, tasks | milestones, slices, tasks | deletes all summaries |
+| `gsd_save_gate_result` | quality_gates | quality_gates, gate_runs | — |
+| `capture_thought` | memories | memories | KNOWLEDGE.md |
+| `memory_query` | memories, memories_fts, memory_embeddings | memories (hit_count++) | — |
+
+---
+
+## 6. DB State → Dispatch Rule Mapping
+
+`auto-dispatch.ts` reads DB state to decide which prompt to run. Here's exactly which tables each dispatch rule queries:
+
+| Dispatch Rule | Tables Queried | Condition |
+|--------------|----------------|-----------|
+| `workflow-preferences` | — | PREFERENCES.md file missing |
+| `discuss-project` | artifacts | PROJECT artifact absent |
+| `discuss-requirements` | artifacts | REQUIREMENTS artifact absent |
+| `research-decision` | runtime_kv | research-decision key absent/unresolved |
+| `research-project` | artifacts, milestones | deep mode ON + RESEARCH absent |
+| `discuss-milestone` | milestones, artifacts | active milestone + CONTEXT absent |
+| `research-milestone` | milestones, artifacts | CONTEXT present + RESEARCH absent (if needed) |
+| `plan-milestone` | milestones, slices | CONTEXT present + no slices exist |
+| `parallel-research-slices` | slices, artifacts | slices exist + RESEARCH artifacts missing |
+| `guided-discuss-slice` | slices, artifacts | slice CONTEXT absent |
+| `plan-slice` | slices, tasks | CONTEXT present + no tasks |
+| `refine-slice` | slices | `is_sketch = 1` |
+| `reactive-execute` | tasks | ≥ 3 tasks WHERE status = 'pending' |
+| `execute-task` | tasks | 1–2 tasks WHERE status = 'pending' |
+| `gate-evaluate` | quality_gates | status = 'pending' |
+| `run-uat` | slices, assessments | tasks all done + UAT absent |
+| `complete-slice` | tasks, slices | all tasks complete + slice status ≠ 'complete' |
+| `reassess-roadmap` | slices, milestones | slice just completed + roadmap needs update |
+| `validate-milestone` | slices, milestones, assessments | all slices complete + VALIDATION absent |
+| `complete-milestone` | milestones, assessments | VALIDATION present + milestone status ≠ 'closed' |
+
+---
+
+## 7. Write Path Invariants
+
+1. **Single-writer rule**: all writes go through typed wrappers in `gsd-db.ts`. No raw SQL escapes to the adapter from outside this file. Enforced by structural test.
+
+2. **Transaction wrapping**: every multi-table write uses `transaction()`. Rollback on any error. Re-entrant: nested calls increment depth counter; no nested BEGIN.
+
+3. **Cascade semantics**:
+   - `gsd_slice_complete` cascades `pending` tasks → `skipped`
+   - `gsd_skip_slice` cascades `pending`/`active` tasks → `skipped`, preserves `complete`
+   - `gsd_milestone_reopen` cascades all slices → `in_progress`, all tasks → `pending`
+
+4. **Conflict guards**: `insertSlice`, `insertTask` use `ON CONFLICT` to preserve existing completed status and non-empty fields. Fresh INSERT of an already-complete row is a no-op.
+
+5. **FTS fallback**: if FTS5 unavailable, `memory_query` falls back to LIKE scan on `memories.content`.
+
+6. **Workspace isolation**: same `.gsd/gsd.db` for all worktrees of one project; separate `.gsd/gsd.db` per project root. Coordination tables assume single-host shared WAL. Multi-host needs external coordinator.

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -20,7 +20,7 @@ See also:
                        │  reads
                        ▼
               auto-dispatch.ts
-            (DISPATCH_RULES, 25 rules,
+            (DISPATCH_RULES, 29 rules,
              first match → prompt + builder)
                        │
                        ▼
@@ -262,10 +262,30 @@ execute-task / debug-diagnose / complete-milestone prompts
 later execute-task / plan-slice / research-slice prompts
   └─► memory_query(keywords)
         └─► SELECT FROM memories_fts WHERE content MATCH keywords  (FTS5)
-             OR  SELECT FROM memories WHERE content LIKE '%keywords%'  (fallback)
-        └─► UPDATE memories SET hit_count = hit_count + 1
+             OR  SELECT FROM memories WHERE content LIKE '%keywords%' LIMIT cap  (fallback)
+        └─► incrementMemoryHitCount(id, now):
+            UPDATE memories SET hit_count = hit_count + 1, last_hit_at = now  ← V28
+        └─► queryMemoriesRanked applies memoryDecayFactor(last_hit_at):
+            score *= max(0.7, 1.0 - 0.3 * min(1.0, daysAgo/90))               ← V28
         └─► Returns ranked memory rows → inlined into {{inlinedContext}}
 ```
+
+### Artifact Integrity Fingerprint (V27)
+
+Every prompt that writes an artifact (e.g. `guided-discuss-project` writing
+`artifacts (PROJECT)`, `complete-slice` writing the slice summary) flows through
+`insertArtifact` in `gsd-db.ts`, which now computes and persists a SHA-256 of
+`full_content` alongside the row:
+
+```
+prompt → gsd_summary_save tool → insertArtifact({...})
+  └─► content_hash = createHash('sha256').update(full_content).digest('hex')   ← V27
+  └─► INSERT OR REPLACE INTO artifacts (..., content_hash) VALUES (..., :hash)
+```
+
+The hash is read-only metadata for now (no consumers verify it yet); the column
+exists so future integrity-check tooling can detect manual edits or truncated
+writes without breaking older binaries (column is nullable).
 
 ---
 

--- a/docs/prompt-db-combined-map.md
+++ b/docs/prompt-db-combined-map.md
@@ -1,0 +1,343 @@
+# GSD-2 Prompt ↔ Database Combined Map
+
+> How each prompt in the pipeline reads and writes the database, and which DB state drives which prompt to fire.
+
+See also:
+- [prompt-map.md](./prompt-map.md) — full prompt system detail
+- [db-map.md](./db-map.md) — full database schema detail
+
+---
+
+## 1. Master Flow: State Machine
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         gsd.db (SQLite WAL)                         │
+│                                                                     │
+│  milestones  slices  tasks  quality_gates  workers  unit_dispatches │
+│  memories  artifacts  decisions  requirements  runtime_kv  ...      │
+└──────────────────────┬──────────────────────────────────────────────┘
+                       │  reads
+                       ▼
+              auto-dispatch.ts
+            (DISPATCH_RULES, 25 rules,
+             first match → prompt + builder)
+                       │
+                       ▼
+              auto-prompts.ts
+           (buildXxxPrompt — inlines
+            context from DB + disk files)
+                       │
+                       ▼
+              Pi SDK session.run(prompt)
+                       │
+                       ▼
+                   LLM runs
+                       │
+                       ▼ calls gsd_* tools
+              bootstrap/db-tools.ts
+                       │
+                       ▼
+              gsd-db.ts  (typed write API)
+                       │
+                 transaction()
+                       │
+                       ▼
+               SQLite writes
+                       │
+         ┌─────────────┴──────────────┐
+         │                            │
+         ▼                            ▼
+   DB tables updated          Markdown artifacts
+   (canonical source)         regenerated + written to disk
+         │
+         ▼
+   auto.ts loop ──► back to auto-dispatch.ts
+```
+
+---
+
+## 2. Prompt → DB Read/Write Reference
+
+Each row = one prompt file. Columns show which DB tables it touches and how.
+
+### Setup Phase
+
+| Prompt | DB Reads | DB Writes | Disk Artifact Written |
+|--------|----------|-----------|----------------------|
+| `guided-workflow-preferences` | — | runtime_kv (research-decision seed) | PREFERENCES.md |
+| `guided-discuss-project` | — | artifacts (PROJECT) | PROJECT.md |
+| `guided-discuss-requirements` | requirements | requirements (INSERT), artifacts (REQUIREMENTS) | REQUIREMENTS.md |
+| `guided-research-decision` | runtime_kv | runtime_kv (research-decision.json key) | — |
+| `guided-research-project` | milestones, artifacts | artifacts (RESEARCH × 4 aspects) | M##-RESEARCH.md |
+
+### Milestone Planning Phase
+
+| Prompt | DB Reads | DB Writes | Disk Artifact Written |
+|--------|----------|-----------|----------------------|
+| `discuss` / `guided-discuss-milestone` | milestones, artifacts | artifacts (CONTEXT) | M##-CONTEXT.md |
+| `discuss-headless` | milestones, artifacts | milestones, slices, decisions, artifacts | M##-CONTEXT.md, DECISIONS.md |
+| `research-milestone` | milestones, artifacts | artifacts (RESEARCH) | M##-RESEARCH.md |
+| `plan-milestone` | milestones, slices | milestones (UPDATE planning), slices (INSERT), tasks (INSERT), decisions | ROADMAP.md, S##-PLAN.md sketches |
+| `queue` | milestones | milestones (INSERT queued), artifacts (CONTEXT) | PROJECT.md, QUEUE.md |
+
+### Slice Planning Phase
+
+| Prompt | DB Reads | DB Writes | Disk Artifact Written |
+|--------|----------|-----------|----------------------|
+| `parallel-research-slices` | slices, artifacts | artifacts (RESEARCH per slice) | S##-RESEARCH.md × N |
+| `guided-discuss-slice` | slices, artifacts | artifacts (CONTEXT) | S##-CONTEXT.md |
+| `research-slice` / `guided-research-slice` | slices, memories | artifacts (RESEARCH), memories (hit_count++) | S##-RESEARCH.md |
+| `plan-slice` | slices, tasks, memories | slices (UPDATE planning), tasks (INSERT), memories (hit_count++) | S##-PLAN.md, T##-PLAN.md |
+| `refine-slice` | slices (is_sketch=1), tasks | slices (UPDATE is_sketch=0), tasks (INSERT/UPDATE) | S##-PLAN.md |
+
+### Execution Phase
+
+| Prompt | DB Reads | DB Writes | Disk Artifact Written |
+|--------|----------|-----------|----------------------|
+| `execute-task` | tasks, slices, milestones, memories, quality_gates | tasks (UPDATE status, narrative, summary), verification_evidence (INSERT), memories (hit_count++) | T##-SUMMARY.md; S##-PLAN.md checkbox |
+| `guided-resume-task` | tasks, slices | tasks (UPDATE status, summary), verification_evidence (INSERT) | T##-SUMMARY.md |
+| `reactive-execute` | tasks | tasks (via N× execute-task subagents) | T##-SUMMARY.md × N |
+| `quick-task` | — | — (no DB; writes summaryPath directly) | {{summaryPath}} |
+
+### Quality Gate Phase
+
+| Prompt | DB Reads | DB Writes | Disk Artifact Written |
+|--------|----------|-----------|----------------------|
+| `gate-evaluate` | quality_gates | quality_gates (UPDATE), gate_runs (INSERT) | gate result per subagent |
+| `validate-milestone` | milestones, slices, tasks, quality_gates | assessments (INSERT VALIDATION) | VALIDATION.md |
+| `run-uat` | slices, assessments | assessments (INSERT ASSESSMENT) | S##-ASSESSMENT.md |
+
+### Completion Phase
+
+| Prompt | DB Reads | DB Writes | Disk Artifact Written |
+|--------|----------|-----------|----------------------|
+| `complete-slice` | tasks, slices | slices (UPDATE status+summary), tasks (cascade skipped) | S##-SUMMARY.md, S##-UAT.md; ROADMAP.md checkpoint |
+| `reassess-roadmap` | milestones, slices | milestones (UPDATE), slices (INSERT/UPDATE/DELETE), assessments | ROADMAP.md, ASSESSMENT.md |
+| `complete-milestone` | milestones, slices, tasks | milestones (UPDATE status=closed, completed_at) | M##-SUMMARY.md |
+
+### Maintenance Phase
+
+| Prompt | DB Reads | DB Writes | Disk Artifact Written |
+|--------|----------|-----------|----------------------|
+| `replan-slice` | slices, tasks | slices, tasks, replan_history, quality_gates | S##-PLAN.md, S##-REPLAN.md |
+| `rethink` | milestones, slices, artifacts | slices (UPDATE status=skipped), milestones (UPDATE sequence) | QUEUE-ORDER.json, PARKED.md |
+| `rewrite-docs` | decisions, requirements, artifacts | decisions, requirements, artifacts | DECISIONS.md, REQUIREMENTS.md, task/slice plans |
+| `doctor-heal` | slices, tasks, artifacts | artifacts (repair CONTEXT/SUMMARY/UAT) | repairs existing artifacts |
+| `review-migration` | milestones, slices, tasks, artifacts, decisions, requirements | — (read-only audit) | — |
+| `scan` | — | — | STACK.md, INTEGRATIONS.md, ARCHITECTURE.md |
+| `debug-diagnose` | memories | memories (INSERT pattern/gotcha), memories (hit_count++) | — |
+| `forensics` | audit_events, gate_runs, turn_git_transactions | — (read-only) | — |
+| `triage-captures` | artifacts (CAPTURES) | artifacts (CAPTURES, updated classifications) | CAPTURES.md |
+| `add-tests` | tasks, slices | — | test files (via code execution) |
+| `heal-skill` | — | — | skill-review-queue.md |
+
+---
+
+## 3. DB State → Which Prompt Fires
+
+The dispatch loop reads DB state to determine which prompt to issue next. This is the precise join between DB and prompt layer:
+
+```
+DB State                                           → Prompt Dispatched
+───────────────────────────────────────────────────────────────────────
+PREFERENCES.md missing                             → guided-workflow-preferences
+
+artifacts WHERE artifact_type='PROJECT' missing    → guided-discuss-project
+
+requirements table empty                           → guided-discuss-requirements
+
+runtime_kv[scope='global', key='research-decision']
+  absent or value='pending'                        → guided-research-decision
+
+runtime_kv[research-decision]='deep' AND
+  M##-RESEARCH artifacts missing                   → guided-research-project × 4 subagents
+
+milestones.status='active' AND
+  artifacts WHERE artifact_type='CONTEXT' missing  → discuss / guided-discuss-milestone
+
+CONTEXT present AND
+  M##-RESEARCH missing AND complexity='high'       → research-milestone
+
+CONTEXT present AND
+  slices WHERE milestone_id=M## count = 0          → plan-milestone
+
+slices exist AND
+  S##-RESEARCH artifacts missing                   → parallel-research-slices × N subagents
+
+slices WHERE slice_id=S## AND
+  S##-CONTEXT artifact missing                     → guided-discuss-slice
+
+S##-CONTEXT present AND
+  tasks WHERE slice_id=S## count = 0               → plan-slice
+
+slices WHERE is_sketch = 1                         → refine-slice
+
+tasks WHERE status='pending' AND count ≥ 3         → reactive-execute (parallel)
+
+tasks WHERE status='pending' AND count < 3         → execute-task (sequential)
+
+quality_gates WHERE status='pending'               → gate-evaluate
+
+tasks all status='complete' AND
+  S##-ASSESSMENT artifact missing                  → run-uat
+
+tasks all complete AND
+  slices.status ≠ 'complete'                       → complete-slice
+
+slice just completed AND
+  roadmap requires update                          → reassess-roadmap
+
+slices all complete AND
+  VALIDATION artifact missing                      → validate-milestone
+
+VALIDATION present AND
+  milestones.status ≠ 'closed'                     → complete-milestone
+
+milestones.status = 'closed' AND
+  next milestone in queue                          → loop: next milestone
+
+nothing matches                                    → stop
+```
+
+---
+
+## 4. Full Data Lineage: Task Completion
+
+One task's full DB journey from creation to completion:
+
+```
+plan-milestone prompt fires
+  └─► gsd_plan_milestone tool
+        └─► INSERT INTO slices (milestone_id, id, title, status='pending', is_sketch=1, sequence)
+        └─► INSERT INTO tasks (milestone_id, slice_id, id, title, status='pending', description, sequence)
+
+refine-slice prompt fires (if is_sketch=1)
+  └─► gsd_plan_slice tool
+        └─► UPDATE slices SET is_sketch=0, goal, success_criteria, proof_level, ...
+        └─► INSERT INTO tasks (full task plans for this slice)
+        └─► UPDATE tasks SET full_plan_md, description, estimate, files, verify, ...
+
+execute-task prompt fires
+  └─► (reads) tasks WHERE id=T## → full_plan_md, description, estimate, files, verify
+  └─► (reads) slices WHERE id=S## → goal, success_criteria
+  └─► (reads) memories FTS → relevant knowledge
+  └─► (reads) quality_gates WHERE status='pending' → gates to close
+  └─► LLM executes the task
+  └─► gsd_task_complete tool
+        └─► UPDATE tasks SET
+              status='complete',
+              one_liner, narrative, verification_result,
+              full_summary_md, key_files, key_decisions,
+              completed_at, blocker_discovered
+        └─► INSERT INTO verification_evidence (command, exit_code, verdict, duration_ms)
+        └─► UPDATE quality_gates SET status='evaluated', verdict (if gate was open)
+        └─► INSERT INTO gate_runs (audit)
+        └─► Write T##-SUMMARY.md to disk
+        └─► Toggle checkbox in S##-PLAN.md
+
+complete-slice prompt fires (after all tasks complete)
+  └─► gsd_slice_complete tool
+        └─► UPDATE slices SET status='complete', full_summary_md, full_uat_md, completed_at
+        └─► UPDATE tasks SET status='skipped' WHERE status='pending' (cascade)
+        └─► Write S##-SUMMARY.md, S##-UAT.md to disk
+        └─► Toggle checkpoint in ROADMAP.md
+
+complete-milestone prompt fires (after all slices complete)
+  └─► gsd_complete_milestone tool
+        └─► UPDATE milestones SET status='closed', completed_at
+        └─► Write M##-SUMMARY.md to disk
+```
+
+---
+
+## 5. Memory System: capture_thought → memory_query
+
+```
+execute-task / debug-diagnose / complete-milestone prompts
+  └─► capture_thought(category, content)
+        └─► INSERT INTO memories (id, category, content, confidence, source_unit_type, created_at)
+        └─► FTS triggers fire: INSERT INTO memories_fts
+
+later execute-task / plan-slice / research-slice prompts
+  └─► memory_query(keywords)
+        └─► SELECT FROM memories_fts WHERE content MATCH keywords  (FTS5)
+             OR  SELECT FROM memories WHERE content LIKE '%keywords%'  (fallback)
+        └─► UPDATE memories SET hit_count = hit_count + 1
+        └─► Returns ranked memory rows → inlined into {{inlinedContext}}
+```
+
+---
+
+## 6. Coordination: Auto-Mode Multi-Worker DB Interactions
+
+```
+worker process starts
+  └─► INSERT INTO workers (worker_id, host, pid, started_at, version, status)
+
+worker claims a milestone
+  └─► INSERT INTO milestone_leases (milestone_id, worker_id, fencing_token, expires_at, status='active')
+  └─► (unique PK on milestone_id prevents two workers claiming same milestone)
+
+worker dispatches a unit
+  └─► INSERT INTO unit_dispatches (trace_id, turn_id, worker_id, milestone_lease_token,
+                                   milestone_id, slice_id, task_id, unit_type, unit_id,
+                                   status='claimed', attempt_n, started_at)
+  └─► unique partial index: only one row with status IN ('claimed','running') per unit_id
+
+user cancels
+  └─► INSERT INTO cancellation_requests (scope, scope_id, dispatch_id, reason, status='pending')
+  └─► worker polls: SELECT FROM cancellation_requests WHERE status='pending'
+  └─► UPDATE cancellation_requests SET status='acked', acked_worker_id, acked_at
+
+command broadcast
+  └─► INSERT INTO command_queue (target_worker=NULL, command, args_json)  ← NULL = all workers
+  └─► INSERT INTO command_queue (target_worker='w-123', command, args_json) ← targeted
+
+unit completes
+  └─► UPDATE unit_dispatches SET status='done'|'failed', ended_at, exit_reason, error_summary
+  └─► (all further state from gsd_task_complete, gsd_slice_complete, etc.)
+```
+
+---
+
+## 7. Schema File → Tables Defined
+
+| Source File | Tables |
+|------------|--------|
+| `db-base-schema.ts` | schema_version, decisions, requirements, artifacts, memories, memory_processed_units, memory_sources, memory_embeddings, memory_relations, milestones, slices, tasks, verification_evidence, replan_history, assessments, quality_gates, slice_dependencies, gate_runs, turn_git_transactions, milestone_commit_attributions, audit_events, audit_turn_index + all indexes + active_decisions/active_requirements/active_memories views |
+| `db-coordination-schema.ts` | workers, milestone_leases, unit_dispatches, cancellation_requests, command_queue |
+| `db-memory-fts-schema.ts` | memories_fts (FTS5 virtual table), memories_ai/ad/au triggers |
+| `db-runtime-kv-schema.ts` | runtime_kv |
+| `db-verification-evidence-schema.ts` | verification_evidence dedup index (helper for V13 migration) |
+| `eval-review-schema.ts` | eval_reviews (EVAL-REVIEW status tracking, separate from milestone validation) |
+
+---
+
+## 8. Accessor Layer → Tables
+
+| Row Accessor File | Tables It Accesses |
+|------------------|--------------------|
+| `db-task-slice-rows.ts` | slices, tasks (row → typed struct parsers) |
+| `db-milestone-artifact-rows.ts` | milestones, artifacts (row → typed struct parsers) |
+| `db-decision-requirement-rows.ts` | decisions, requirements (row → typed struct parsers) |
+| `db-gate-rows.ts` | quality_gates (row → GateRow) |
+| `db-verification-evidence-rows.ts` | verification_evidence (row → VerificationEvidenceRow) |
+| `db-lightweight-query-rows.ts` | tasks (IdStatusSummary, ActiveTaskSummary, TaskStatusCounts aggregates) |
+
+---
+
+## 9. Key Invariants (Cross-Cutting)
+
+| Invariant | Where Enforced |
+|-----------|---------------|
+| Single-writer: all DB writes through `gsd-db.ts` typed API | structural test `single-writer-invariant.test.ts` |
+| Cascade on slice complete: pending tasks → skipped | `gsd_slice_complete` transaction |
+| Cascade on milestone reopen: all slices → in_progress, tasks → pending | `gsd_milestone_reopen` transaction |
+| No nested transactions | `db-transaction.ts` depth counter |
+| Workspace isolation: one DB per project root, shared across worktrees via WAL | `db-connection-cache.ts` identityKey |
+| Coordination: one active dispatch per unit_id at a time | `idx_unit_dispatches_active_per_unit` unique partial index |
+| Memory FTS fallback: LIKE scan if FTS5 unavailable | `tryCreateMemoriesFtsSchema` onUnavailable callback |
+| Pre-migration backup: .db.bak-vN before any migration run | `db-migration-backup.ts` |
+| Prompt template vars: all `{{vars}}` must be provided before substitution | `prompt-loader.ts` pre-substitution validation |
+| Prompt cache stability: static sections always before dynamic | `prompt-ordering.ts` reorderForCaching |

--- a/docs/prompt-map.md
+++ b/docs/prompt-map.md
@@ -429,36 +429,42 @@ LLM sees: "load these skill files and follow their rules for this unit"
 
 ## 10. Dispatch Rule Priority Order
 
-`auto-dispatch.ts` evaluates rules top-to-bottom, first match wins:
+`auto-dispatch.ts` evaluates 29 rules top-to-bottom, first match wins. Source of
+truth is the `DISPATCH_RULES` array in `auto-dispatch.ts`; the canary test
+`tests/dispatch-rule-coverage.test.ts` pins the count at 29.
 
 ```
-Priority  Rule                          Fires When
-────────  ────────────────────────────  ─────────────────────────────────────
-1         workflow-preferences          PREFERENCES.md missing
-2         discuss-project              PROJECT.md missing
-3         discuss-requirements         REQUIREMENTS.md missing
-4         research-decision            deep-mode flag not resolved
-5         research-project             deep mode ON + research not done
-6         discuss-milestone            active milestone, CONTEXT missing
-7         research-milestone           CONTEXT done, RESEARCH missing (if needed)
-8         plan-milestone               CONTEXT done, ROADMAP missing
-9         parallel-research-slices     ROADMAP done, slice RESEARCH missing
-10        guided-discuss-slice         slice CONTEXT missing
-11        plan-slice                   slice CONTEXT done, PLAN missing
-12        refine-slice                 slice is sketch, needs expansion
-13        reactive-execute             ≥3 tasks ready (parallel mode)
-14        execute-task                 1–2 tasks ready (sequential mode)
-15        gate-evaluate                gates pending
-16        run-uat                      tasks done, UAT pending
-17        complete-slice               UAT passed, slice not closed
-18        reassess-roadmap             slice closed, roadmap needs update
-19        validate-milestone           all slices closed, not yet validated
-20        complete-milestone           validated, not yet completed
-21        rethink                      user-triggered reorganization
-22        rewrite-docs                 OVERRIDES.md present and unprocessed
-23        triage-captures              captures pending triage
-24        doctor-heal                  doctor report present
-25        stop                         nothing left to do
+Priority  Rule                                          Fires When
+────────  ────────────────────────────────────────────  ─────────────────────────
+ 1        escalating-task → pause-for-escalation        a task escalation is awaiting user review
+ 2        rewrite-docs (override gate)                  OVERRIDES.md present and unprocessed
+ 3        execution-entry phase (no context) → discuss  re-entry into a milestone with no CONTEXT
+ 4        summarizing → complete-slice                  slice in 'summarizing' phase
+ 5        run-uat (post-completion)                     tasks done, UAT pending
+ 6        uat-verdict-gate (non-PASS blocks)            UAT non-PASS — block until resolved
+ 7        reassess-roadmap (post-completion)            slice closed, roadmap needs update
+ 8        needs-discussion → discuss-milestone          milestone explicitly flagged for discussion
+ 9        deep: workflow-preferences                    deep mode + PREFERENCES.md missing
+10        deep: discuss-project                         deep mode + PROJECT artifact missing
+11        deep: discuss-requirements                    deep mode + REQUIREMENTS missing
+12        deep: research-decision                       deep mode + research decision not made
+13        deep: research-project                        deep mode + research approved, files missing
+14        pre-planning (no context) → discuss-milestone active milestone, CONTEXT missing
+15        pre-planning (no research) → research-mile…   CONTEXT done, RESEARCH missing
+16        pre-planning (has research) → plan-milestone  CONTEXT + RESEARCH done, ROADMAP missing
+17        planning (require_slice_discussion) → pause   slice flagged for discussion (#3454)
+18        planning (multi slices need research) → par…  ROADMAP done, slice RESEARCH missing × ≥2
+19        planning (no research, not S01) → research…   single slice needs RESEARCH
+20        refining → refine-slice                       slice is sketch, needs expansion
+21        planning → plan-slice                         slice CONTEXT done, PLAN missing
+22        evaluating-gates → gate-evaluate              gates pending evaluation
+23        replanning-slice → replan-slice               slice in 'replanning' phase
+24        executing → reactive-execute (parallel)       ≥3 tasks ready (parallel mode)
+25        executing → execute-task (recover plan)       task plan missing — recover via plan-slice
+26        executing → execute-task                      1–2 tasks ready (sequential mode)
+27        validating-milestone → validate-milestone     all slices closed, not yet validated
+28        completing-milestone → complete-milestone     validated, not yet completed
+29        complete → stop                               nothing left to do
 ```
 
 ---

--- a/docs/prompt-map.md
+++ b/docs/prompt-map.md
@@ -1,0 +1,474 @@
+# GSD-2 Prompt System Map
+
+> Complete dependency graph of all prompts, how they're loaded, assembled, dispatched, and how they chain into each other.
+
+---
+
+## 1. Pipeline Overview
+
+```
+User / gsd auto
+      │
+      ▼
+ auto.ts  ──── reads STATE.md ──► GSDState
+      │
+      ▼
+ auto-dispatch.ts
+   DISPATCH_RULES[]  (first match wins)
+      │
+      ├── resolves → unitType + promptBuilder + backgroundable flag
+      │
+      ▼
+ auto-prompts.ts
+   buildXxxPrompt()
+      │
+      ├── loadPrompt(name, vars)          ← prompt-loader.ts (template cache)
+      ├── composeInlinedContext()         ← unit-context-composer.ts
+      ├── reorderForCaching()             ← prompt-ordering.ts
+      └── filterSkillsByManifest()        ← skill-manifest.ts
+      │
+      ▼
+ Pi SDK session.run(prompt)
+      │
+      ▼
+ LLM executes → calls gsd_* tools → writes artifacts → STATE.md updated
+      │
+      ▼
+ Loop back to auto.ts
+```
+
+---
+
+## 2. Prompt Loading Infrastructure
+
+| File | Role |
+|------|------|
+| `prompt-loader.ts` | Reads all `prompts/*.md` at startup into `templateCache`. Substitutes `{{varName}}` placeholders. Falls back to lazy read if cache misses. Preloads `templatesDir`, `taskSummaryTemplatePath`, `skillActivation` as defaults. |
+| `prompt-ordering.ts` | Splits assembled prompt into `## sections`, classifies each as `static / semi-static / dynamic`, reorders to maximize LLM cache prefix stability. |
+| `prompt-validation.ts` | Validates that all `{{vars}}` declared in a template have values provided before substitution fires. |
+| `prompt-cache-optimizer.ts` | Tracks cache hit/miss rates per prompt; adjusts section ordering hints over time. |
+
+**Template resolution priority** (highest wins):
+1. `~/.agents/gsd/prompts/` (user-local, written by `initResources()`)
+2. Module-relative `prompts/` (npm package fallback)
+
+---
+
+## 3. Shared Injected Variables (every prompt gets these for free)
+
+```
+{{templatesDir}}              path to templates/ dir
+{{planTemplatePath}}          templates/plan.md
+{{taskPlanTemplatePath}}      templates/task-plan.md
+{{taskSummaryTemplatePath}}   templates/task-summary.md
+{{skillActivation}}           standard skill-loading instruction block
+```
+
+---
+
+## 4. Context Composition Stack
+
+Every `buildXxxPrompt()` call assembles context via these layers (in order):
+
+```
+Preamble  (system.md rules, skill activation block)
+    │
+Static section
+    ├── PROJECT.md
+    ├── REQUIREMENTS.md
+    └── DECISIONS.md
+
+Semi-static section
+    ├── KNOWLEDGE.md  (patterns, gotchas)
+    ├── PREFERENCES.md
+    └── Prior slice/milestone RESEARCH.md
+
+Dynamic section
+    ├── Active M##-CONTEXT.md
+    ├── Active S##-PLAN.md
+    ├── Active T##-PLAN.md
+    ├── Task summary from prior run (resume)
+    ├── Carry-forward captures
+    └── Gate list to close
+```
+
+Budget enforcement: `context-budget.ts` computes `preambleBudgetChars`, `summaryBudgetChars`, `verificationBudgetChars` from the model's context window. Sections are truncated at markdown section boundaries, not mid-sentence.
+
+---
+
+## 5. The 44 Prompt Files — Full Inventory
+
+### 5a. System & Foundation
+
+| Prompt | Purpose | Reads | Writes |
+|--------|---------|-------|--------|
+| `system.md` | Hard rules, isolation model, naming conventions, skills table, execution heuristics. Bundled into every prompt as preamble. | — | — |
+| `heal-skill.md` | Post-unit skill drift analysis. Never edits skill files directly. | Skill activation block | `.gsd/skill-review-queue.md` |
+
+### 5b. Project Setup Flow (runs once, sequentially)
+
+```
+guided-workflow-preferences
+         │
+         ▼
+guided-discuss-project
+         │
+         ▼
+guided-discuss-requirements
+         │
+         ▼
+research-decision  (gate: deep mode opt-in)
+         │
+         ▼
+guided-research-project  (deep mode only — 4 parallel subagents)
+```
+
+| Prompt | Purpose | Key Tools Called |
+|--------|---------|-----------------|
+| `guided-workflow-preferences.md` | Write `.gsd/PREFERENCES.md` with defaults; pre-seeds `research-decision.json`. No user questions. | — |
+| `guided-discuss-project.md` | Interview-style project scoping. Classifies project shape (tiny/small/medium/large). | `ask_user_questions`, `gsd_summary_save(PROJECT)` |
+| `guided-discuss-requirements.md` | Interview-style requirements capture. | `ask_user_questions`, `gsd_requirement_save`, `gsd_summary_save(REQUIREMENTS)` |
+| `guided-research-decision.md` | Single fixed-question gate: opt into deep research or proceed lean. | `ask_user_questions` → writes `runtime/research-decision.json` |
+| `guided-research-project.md` | Spawns 4 parallel scout subagents (stack, features, architecture, pitfalls). Headless. | `subagent` × 4 |
+
+### 5c. Milestone Planning Flow
+
+```
+discuss-milestone  OR  discuss-headless  (headless = no questions)
+         │
+         ▼
+research-milestone  (optional, based on complexity)
+         │
+         ▼
+plan-milestone
+         │
+         ▼
+parallel-research-slices  (all slices at once)
+         │
+         ▼
+plan-slice  (per slice, sequential)
+```
+
+| Prompt | Purpose | Key Tools Called |
+|--------|---------|-----------------|
+| `discuss.md` | Interactive milestone discussion. Layered Q&A: Scope → Architecture → Error States → Quality Bar. | `ask_user_questions`, `gsd_summary_save(CONTEXT)` |
+| `guided-discuss-milestone.md` | Same as discuss.md but interview-driven, with draft saves. | `ask_user_questions`, `gsd_summary_save(CONTEXT)` |
+| `discuss-headless.md` | Create milestone CONTEXT from spec with no user interaction. | `gsd_plan_milestone`, `gsd_decision_save` |
+| `research-milestone.md` | Strategic research before planning. Narrates findings. | `gsd_summary_save(RESEARCH)` |
+| `plan-milestone.md` | Decompose milestone into slices. Plans first slice inline if single-slice. | `gsd_plan_milestone`, `gsd_decision_save` |
+| `parallel-research-slices.md` | Spawn one scout subagent per slice simultaneously. Retries once on failure. | `subagent` × N |
+| `plan-slice.md` | Decompose single slice into tasks. Progressive planning: sketches for S02+. | `memory_query`, `gsd_plan_slice` |
+| `refine-slice.md` | Expand sketched slice plan into full task breakdown. | `gsd_plan_slice` |
+| `guided-discuss-slice.md` | Interview-driven slice scoping. | `ask_user_questions`, `gsd_summary_save(CONTEXT)` |
+| `guided-research-slice.md` | Scout a slice. | `memory_query`, `gsd_summary_save(RESEARCH)` |
+| `research-slice.md` | Research a slice (non-guided, auto-mode). | `memory_query`, `gsd_summary_save(RESEARCH)` |
+
+### 5d. Execution Flow
+
+```
+reactive-execute  (≥3 ready tasks → parallel)
+    OR
+execute-task  (single task → sequential)
+         │
+         ▼
+guided-resume-task  (if task was interrupted)
+```
+
+| Prompt | Purpose | Key Tools Called |
+|--------|---------|-----------------|
+| `execute-task.md` | Execute a single task. Inlines full context stack. | `memory_query`, `gsd_task_complete` |
+| `reactive-execute.md` | Dispatch all ready tasks in parallel subagents. Records failures only when no summary left. | `subagent` × N |
+| `guided-resume-task.md` | Resume interrupted task. Reads `{{sliceId}}-CONTINUE.md` for continuation context. | `gsd_task_complete` |
+| `quick-task.md` | Lightweight task outside milestone structure. No DB tools. | writes `{{summaryPath}}` directly |
+
+### 5e. Quality Gates
+
+```
+gate-evaluate  (parallel gate subagents)
+         │
+         ▼
+validate-milestone  (3 parallel reviewers)
+         │
+         ▼
+run-uat  (user acceptance tests)
+```
+
+| Prompt | Purpose | Key Tools Called |
+|--------|---------|-----------------|
+| `gate-evaluate.md` | Spawn one subagent per quality gate in parallel. Verifies `gsd_save_gate_result` called. | `subagent` × N |
+| `validate-milestone.md` | 3 parallel reviewers: (A) requirements, (B) integration, (C) acceptance. | `subagent` × 3, `gsd_validate_milestone` |
+| `run-uat.md` | Execute UAT. Modes: artifact-driven, runtime, browser, human-experience. | `gsd_summary_save(ASSESSMENT)` |
+
+### 5f. Completion Flow
+
+```
+complete-slice
+         │
+         ▼
+reassess-roadmap  (after each slice)
+         │
+         ▼
+complete-milestone
+```
+
+| Prompt | Purpose | Key Tools Called |
+|--------|---------|-----------------|
+| `complete-slice.md` | Close slice after tasks pass. Compress summary. | `gsd_slice_complete`, `gsd_requirement_update` |
+| `reassess-roadmap.md` | Review roadmap post-slice. Validates success-criterion coverage. | `gsd_reassess_roadmap`, `gsd_requirement_update` |
+| `complete-milestone.md` | Close milestone. Persist to DB. | `gsd_complete_milestone`, `gsd_requirement_update`, `capture_thought` |
+
+### 5g. Maintenance & Repair
+
+| Prompt | Purpose | Key Tools Called |
+|--------|---------|-----------------|
+| `replan-slice.md` | Replan after blocker discovered mid-slice. Preserves completed tasks. | `gsd_replan_slice` |
+| `rethink.md` | Reorder, park, unpark, skip, or discard milestones. | `gsd_skip_slice`, writes `QUEUE-ORDER.json` |
+| `reassess-roadmap.md` | *(see Completion Flow above)* | — |
+| `rewrite-docs.md` | Apply OVERRIDES.md changes across all planning docs. | — |
+| `review-migration.md` | Audit `.planning → .gsd` migration correctness. | `deriveState` |
+| `doctor-heal.md` | Repair broken GSD artifacts (summaries, UAT, CONTEXT). | — |
+| `scan.md` | Codebase scan → STACK.md, INTEGRATIONS.md, ARCHITECTURE.md. No tool calls. | writes `{{outputDir}}` |
+| `forensics.md` | Debug GSD engine failures. Map failures to source files. | reads activity logs, journal, metrics |
+| `debug-diagnose.md` | Root-cause analysis for reported bugs. | `capture_thought`, `memory_query` |
+| `debug-session-manager.md` | Manage debug session with checkpoint protocol. Structured return headers. | — |
+| `add-tests.md` | Generate tests for completed slices. | skill activation |
+| `triage-captures.md` | Classify user thoughts captured with `capture_thought`. | `ask_user_questions`, updates `CAPTURES.md` |
+| `queue.md` | Add future milestones to queue. | `gsd_milestone_generate_id`, `gsd_summary_save(CONTEXT)`, updates `QUEUE.md` |
+
+### 5h. Workflow Execution (one-off workflows, not milestone-driven)
+
+| Prompt | Purpose | Notes |
+|--------|---------|-------|
+| `workflow-start.md` | Execute a templated workflow (phases, complexity gates, artifact directory). | Follows phases in order, writes artifacts, atomic commits |
+| `workflow-oneshot.md` | Execute a oneshot workflow (no STATE.json). | prompt-only, no scaffolding |
+
+---
+
+## 6. Full Dependency Graph
+
+### 6a. Sequential Chains
+
+```
+STATE.md
+  └─► auto.ts
+        └─► auto-dispatch.ts (DISPATCH_RULES, first match)
+              │
+              ├── [setup] guided-workflow-preferences
+              │              │ writes PREFERENCES.md
+              │              │
+              ├── [setup] guided-discuss-project
+              │              │ writes PROJECT.md
+              │              │
+              ├── [setup] guided-discuss-requirements
+              │              │ writes REQUIREMENTS.md
+              │              │
+              ├── [gate]  guided-research-decision
+              │              │ writes research-decision.json
+              │              │
+              ├── [deep]  guided-research-project ──► 4× subagent
+              │              │ writes RESEARCH artifacts
+              │              │
+              ├── [ms]    discuss / guided-discuss-milestone / discuss-headless
+              │              │ writes M##-CONTEXT.md
+              │              │
+              ├── [ms]    research-milestone
+              │              │ writes M##-RESEARCH.md
+              │              │
+              ├── [ms]    plan-milestone
+              │              │ writes M##-ROADMAP.md + S##-PLAN sketches
+              │              │
+              ├── [sl]    parallel-research-slices ──► N× subagent (research-slice)
+              │              │ writes S##-RESEARCH.md
+              │              │
+              ├── [sl]    guided-discuss-slice
+              │              │ writes S##-CONTEXT.md
+              │              │
+              ├── [sl]    plan-slice / refine-slice
+              │              │ writes S##-PLAN.md + T##-PLAN.md
+              │              │
+              ├── [task]  reactive-execute ──────────► N× subagent (execute-task)
+              │    OR                                     │ writes T##-SUMMARY.md
+              ├── [task]  execute-task                    │
+              │              │ reads T##-PLAN.md, S##-PLAN.md excerpt
+              │              │ writes T##-SUMMARY.md
+              │              │
+              ├── [gate]  gate-evaluate ────────────► N× subagent
+              │              │ writes gate results
+              │              │
+              ├── [sl]    run-uat
+              │              │ writes S##-ASSESSMENT.md
+              │              │
+              ├── [sl]    complete-slice
+              │              │ writes S##-SUMMARY.md
+              │              │
+              ├── [ms]    reassess-roadmap
+              │              │ updates M##-ROADMAP.md
+              │              │
+              ├── [ms]    validate-milestone ────────► 3× subagent
+              │              │ writes validation verdict
+              │              │
+              └── [ms]    complete-milestone
+                             │ writes M##-SUMMARY.md
+                             └─► loop back to next milestone
+```
+
+### 6b. Parallel Dispatch Map
+
+| Orchestrator Prompt | Subagents Spawned | How Many |
+|--------------------|-------------------|---------|
+| `guided-research-project.md` | stack scout, features scout, architecture scout, pitfalls scout | 4 (fixed) |
+| `parallel-research-slices.md` | `research-slice` (one per slice) | N slices |
+| `reactive-execute.md` | `execute-task` (one per ready task) | N ready tasks |
+| `gate-evaluate.md` | one gate evaluator per gate | N gates |
+| `validate-milestone.md` | reviewer-A (requirements), reviewer-B (integration), reviewer-C (acceptance) | 3 (fixed) |
+
+### 6c. Recovery / Detour Chains
+
+```
+execute-task  ──[interrupted]──► guided-resume-task
+                                    reads {{sliceId}}-CONTINUE.md
+
+execute-task  ──[blocker]──────► replan-slice
+                                    rewrites incomplete tasks only
+
+plan-milestone ──[any]─────────► rethink
+                                    reorders / parks / discards milestones
+
+auto.ts ────────[drift]────────► heal-skill
+                                    writes skill-review-queue.md
+
+auto.ts ────────[doctor]───────► doctor-heal
+                                    repairs CONTEXT, UAT, SUMMARY artifacts
+
+any prompt ─────[failure]──────► forensics / debug-diagnose / debug-session-manager
+```
+
+---
+
+## 7. Artifact Flow (What Each Phase Writes)
+
+```
+Phase                   Artifact Written
+─────────────────────────────────────────────────────
+guided-workflow-preferences  →  .gsd/PREFERENCES.md
+guided-discuss-project       →  .gsd/PROJECT.md
+guided-discuss-requirements  →  .gsd/REQUIREMENTS.md
+guided-research-decision     →  .gsd/runtime/research-decision.json
+guided-research-project      →  .gsd/milestones/M##/M##-RESEARCH.md (×4 aspects)
+
+discuss / guided-discuss-milestone  →  .gsd/milestones/M##/M##-CONTEXT.md
+research-milestone           →  .gsd/milestones/M##/M##-RESEARCH.md
+plan-milestone               →  .gsd/milestones/M##/M##-ROADMAP.md
+                                 .gsd/milestones/M##/slices/S##/S##-PLAN.md (sketches)
+
+research-slice               →  .gsd/milestones/M##/slices/S##/S##-RESEARCH.md
+guided-discuss-slice         →  .gsd/milestones/M##/slices/S##/S##-CONTEXT.md
+plan-slice / refine-slice    →  .gsd/milestones/M##/slices/S##/S##-PLAN.md
+                                 .gsd/milestones/M##/slices/S##/tasks/T##-PLAN.md
+
+execute-task                 →  .gsd/milestones/M##/slices/S##/tasks/T##-SUMMARY.md
+gate-evaluate                →  gate results (DB + artifact)
+run-uat                      →  .gsd/milestones/M##/slices/S##/S##-ASSESSMENT.md
+complete-slice               →  .gsd/milestones/M##/slices/S##/S##-SUMMARY.md
+reassess-roadmap             →  updates M##-ROADMAP.md (slice statuses)
+validate-milestone           →  validation verdict (DB)
+complete-milestone           →  .gsd/milestones/M##/M##-SUMMARY.md
+
+triage-captures              →  .gsd/CAPTURES.md (classification metadata)
+queue                        →  .gsd/QUEUE.md, updates PROJECT.md
+scan                         →  {{outputDir}}/STACK.md, INTEGRATIONS.md, ARCHITECTURE.md
+rewrite-docs                 →  DECISIONS.md, task plans, REQUIREMENTS.md, PROJECT.md
+```
+
+---
+
+## 8. Skill System Dependency
+
+```
+skill-catalog.ts   (tech-stack → repo + skill names)
+       │
+       ▼
+skill-discovery.ts (resolves installed skills for current project)
+       │
+       ▼
+skill-manifest.ts  (allowlist per unit type)
+       │             e.g. plan-milestone → [decompose-into-slices, api-design, tdd, ...]
+       │             e.g. execute-task   → wildcard (all skills eligible)
+       ▼
+{{skillActivation}} placeholder in every prompt
+       │
+       ▼
+LLM sees: "load these skill files and follow their rules for this unit"
+```
+
+---
+
+## 9. Tool → DB Write Map
+
+| Tool | Persists To |
+|------|------------|
+| `gsd_plan_milestone` | milestones table, slices table |
+| `gsd_plan_slice` | slices table, tasks table |
+| `gsd_task_complete` | tasks table, T##-SUMMARY.md |
+| `gsd_slice_complete` | slices table, S##-SUMMARY.md |
+| `gsd_complete_milestone` | milestones table, M##-SUMMARY.md |
+| `gsd_validate_milestone` | milestones table (validation verdict) |
+| `gsd_reassess_roadmap` | slices table (reorder, add, remove) |
+| `gsd_replan_slice` | tasks table (replace incomplete tasks) |
+| `gsd_skip_slice` | slices table (status = skipped) |
+| `gsd_requirement_save` | requirements table |
+| `gsd_requirement_update` | requirements table |
+| `gsd_summary_save` | artifact files + DB reference |
+| `gsd_decision_save` | DECISIONS.md + DB |
+| `capture_thought` | KNOWLEDGE.md (patterns, gotchas, arch) |
+| `memory_query` | READ — queries KNOWLEDGE.md + summaries |
+| `ask_user_questions` | blocks until user responds; no DB write |
+| `subagent` | spins up child Pi session with given prompt |
+
+---
+
+## 10. Dispatch Rule Priority Order
+
+`auto-dispatch.ts` evaluates rules top-to-bottom, first match wins:
+
+```
+Priority  Rule                          Fires When
+────────  ────────────────────────────  ─────────────────────────────────────
+1         workflow-preferences          PREFERENCES.md missing
+2         discuss-project              PROJECT.md missing
+3         discuss-requirements         REQUIREMENTS.md missing
+4         research-decision            deep-mode flag not resolved
+5         research-project             deep mode ON + research not done
+6         discuss-milestone            active milestone, CONTEXT missing
+7         research-milestone           CONTEXT done, RESEARCH missing (if needed)
+8         plan-milestone               CONTEXT done, ROADMAP missing
+9         parallel-research-slices     ROADMAP done, slice RESEARCH missing
+10        guided-discuss-slice         slice CONTEXT missing
+11        plan-slice                   slice CONTEXT done, PLAN missing
+12        refine-slice                 slice is sketch, needs expansion
+13        reactive-execute             ≥3 tasks ready (parallel mode)
+14        execute-task                 1–2 tasks ready (sequential mode)
+15        gate-evaluate                gates pending
+16        run-uat                      tasks done, UAT pending
+17        complete-slice               UAT passed, slice not closed
+18        reassess-roadmap             slice closed, roadmap needs update
+19        validate-milestone           all slices closed, not yet validated
+20        complete-milestone           validated, not yet completed
+21        rethink                      user-triggered reorganization
+22        rewrite-docs                 OVERRIDES.md present and unprocessed
+23        triage-captures              captures pending triage
+24        doctor-heal                  doctor report present
+25        stop                         nothing left to do
+```
+
+---
+
+## 11. How to Read the Map
+
+- **Box** = a prompt file (`prompts/X.md`)
+- **Arrow →** = "produces" or "writes"
+- **Dashed →** = "reads from" 
+- **×N** = spawns N parallel subagents each running that prompt
+- **[gate]** = requires explicit user confirmation before proceeding
+- **DB** = persists to `gsd.db` via a `gsd_*` tool call
+- **Headless** = no `ask_user_questions` calls; autonomous judgment

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -248,7 +248,14 @@ import { initTokenCounter } from "./token-counter.js";
 // can use accurate token counts via countTokensSync without paying the load
 // cost mid-prompt-build. Fire-and-forget — failure falls back to the
 // provider-aware char-ratio estimator already used by getCharsPerToken().
-void initTokenCounter();
+// Catch rejections explicitly: an unhandled rejection at module-import time
+// can destabilize startup before the engine logger is configured.
+void initTokenCounter().catch((err) => {
+  logWarning(
+    "engine",
+    `token counter warm-up failed: ${err instanceof Error ? err.message : String(err)}`,
+  );
+});
 
 // ─── Session State ─────────────────────────────────────────────────────────
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1975,6 +1975,10 @@ export async function startAuto(
       : new URL("../../../resource-loader.js", import.meta.url).href;
     const { initResources } = await import(resourceLoaderPath);
     initResources(agentDir);
+    // initResources() uses synchronous fs APIs, so the prompt-template cache
+    // can be primed immediately — no need for the legacy 1s setTimeout deferral.
+    const { primeCache } = await import("./prompt-loader.js");
+    primeCache();
     // Open the project DB before rebuild/derive so resume uses DB-backed
     // state instead of falling back to stale markdown parsing (#2940).
     await openProjectDbIfPresent(s.basePath);

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -242,6 +242,13 @@ import {
   type WorktreeResolverDeps,
 } from "./worktree-resolver.js";
 import { reorderForCaching } from "./prompt-ordering.js";
+import { initTokenCounter } from "./token-counter.js";
+
+// Warm the tiktoken encoder at extension startup so context-budget computations
+// can use accurate token counts via countTokensSync without paying the load
+// cost mid-prompt-build. Fire-and-forget — failure falls back to the
+// provider-aware char-ratio estimator already used by getCharsPerToken().
+void initTokenCounter();
 
 // ─── Session State ─────────────────────────────────────────────────────────
 

--- a/src/resources/extensions/gsd/context-budget.ts
+++ b/src/resources/extensions/gsd/context-budget.ts
@@ -38,12 +38,22 @@ const DEFAULT_CONTEXT_WINDOW = 200_000;
 const CLAUDE_CODE_EFFECTIVE_CONTEXT_WINDOW = 200_000;
 
 /**
- * Cached empirical chars-per-token from a tiktoken probe. Computed lazily on
- * first computeBudgets() call after the encoder warms; the cl100k_base encoder
- * gives a stable ratio for ASCII English so a single probe is sufficient.
- * NULL means "not yet probed" or "encoder unavailable".
+ * Cached empirical chars-per-token from a tiktoken probe, keyed by provider.
+ * countTokensSync's fallback path is provider-aware, so we cache per-provider
+ * to preserve that distinction once the encoder warms. The cl100k_base encoder
+ * itself gives a stable ratio for ASCII English so a single probe per provider
+ * key is sufficient. Empty map means "not yet probed" or "encoder unavailable".
  */
-let _cachedEmpiricalCharsPerToken: number | null = null;
+const _empiricalCharsPerTokenByProvider = new Map<string, number>();
+
+/**
+ * Test hook — clears the empirical chars-per-token cache so test cases that
+ * assert against the static char-ratio fallback aren't polluted by a prior
+ * tiktoken-warmed run in the same process. Production code must not call this.
+ */
+export function _resetEmpiricalCacheForTest(): void {
+  _empiricalCharsPerTokenByProvider.clear();
+}
 
 /** Percentage of context consumed before suggesting a continue-here checkpoint */
 const CONTINUE_THRESHOLD_PERCENT = 70;
@@ -117,16 +127,20 @@ export function computeBudgets(contextWindow: number, provider?: TokenProvider):
 
   // Prefer the tiktoken encoder for total-char estimation when it has been
   // warmed (initTokenCounter resolved). The cl100k_base ratio is stable for
-  // ASCII English, so probe once and cache — computeBudgets is called multiple
-  // times per prompt build and the probe encode is otherwise wasted work.
+  // ASCII English, so probe once per provider and cache — computeBudgets is
+  // called multiple times per prompt build and the probe encode is otherwise
+  // wasted work.
   let totalChars: number;
   if (isAccurateCountingAvailable()) {
-    if (_cachedEmpiricalCharsPerToken === null) {
+    const providerKey = provider ?? "__default__";
+    let empirical = _empiricalCharsPerTokenByProvider.get(providerKey);
+    if (empirical === undefined) {
       const probe = "the quick brown fox jumps over the lazy dog ".repeat(64);
       const probeTokens = countTokensSync(probe, provider);
-      _cachedEmpiricalCharsPerToken = probeTokens > 0 ? probe.length / probeTokens : charsPerToken;
+      empirical = probeTokens > 0 ? probe.length / probeTokens : charsPerToken;
+      _empiricalCharsPerTokenByProvider.set(providerKey, empirical);
     }
-    totalChars = effectiveWindow * _cachedEmpiricalCharsPerToken;
+    totalChars = effectiveWindow * empirical;
   } else {
     totalChars = effectiveWindow * charsPerToken;
   }

--- a/src/resources/extensions/gsd/context-budget.ts
+++ b/src/resources/extensions/gsd/context-budget.ts
@@ -37,6 +37,14 @@ const DEFAULT_CONTEXT_WINDOW = 200_000;
 /** Conservative effective context for Claude Code subscription routing (#4676) */
 const CLAUDE_CODE_EFFECTIVE_CONTEXT_WINDOW = 200_000;
 
+/**
+ * Cached empirical chars-per-token from a tiktoken probe. Computed lazily on
+ * first computeBudgets() call after the encoder warms; the cl100k_base encoder
+ * gives a stable ratio for ASCII English so a single probe is sufficient.
+ * NULL means "not yet probed" or "encoder unavailable".
+ */
+let _cachedEmpiricalCharsPerToken: number | null = null;
+
 /** Percentage of context consumed before suggesting a continue-here checkpoint */
 const CONTINUE_THRESHOLD_PERCENT = 70;
 
@@ -108,15 +116,17 @@ export function computeBudgets(contextWindow: number, provider?: TokenProvider):
   const charsPerToken = provider ? getCharsPerToken(provider) : CHARS_PER_TOKEN;
 
   // Prefer the tiktoken encoder for total-char estimation when it has been
-  // warmed (initTokenCounter resolved). countTokensSync(probe) gives an
-  // empirical chars-per-token for a representative ASCII probe, which is more
-  // accurate than the static provider table for English-heavy prompts.
+  // warmed (initTokenCounter resolved). The cl100k_base ratio is stable for
+  // ASCII English, so probe once and cache — computeBudgets is called multiple
+  // times per prompt build and the probe encode is otherwise wasted work.
   let totalChars: number;
   if (isAccurateCountingAvailable()) {
-    const probe = "the quick brown fox jumps over the lazy dog ".repeat(64);
-    const probeTokens = countTokensSync(probe, provider);
-    const empiricalCharsPerToken = probeTokens > 0 ? probe.length / probeTokens : charsPerToken;
-    totalChars = effectiveWindow * empiricalCharsPerToken;
+    if (_cachedEmpiricalCharsPerToken === null) {
+      const probe = "the quick brown fox jumps over the lazy dog ".repeat(64);
+      const probeTokens = countTokensSync(probe, provider);
+      _cachedEmpiricalCharsPerToken = probeTokens > 0 ? probe.length / probeTokens : charsPerToken;
+    }
+    totalChars = effectiveWindow * _cachedEmpiricalCharsPerToken;
   } else {
     totalChars = effectiveWindow * charsPerToken;
   }

--- a/src/resources/extensions/gsd/context-budget.ts
+++ b/src/resources/extensions/gsd/context-budget.ts
@@ -8,7 +8,12 @@
  * @see D001 (module location), D002 (200K fallback), D003 (section-boundary truncation)
  */
 
-import { type TokenProvider, getCharsPerToken } from "./token-counter.js";
+import {
+  type TokenProvider,
+  getCharsPerToken,
+  isAccurateCountingAvailable,
+  countTokensSync,
+} from "./token-counter.js";
 
 // ─── Budget ratio constants ──────────────────────────────────────────────────
 // Percentages of total context window allocated to each budget category.
@@ -101,7 +106,20 @@ export interface MinimalPreferences {
 export function computeBudgets(contextWindow: number, provider?: TokenProvider): BudgetAllocation {
   const effectiveWindow = contextWindow > 0 ? contextWindow : DEFAULT_CONTEXT_WINDOW;
   const charsPerToken = provider ? getCharsPerToken(provider) : CHARS_PER_TOKEN;
-  const totalChars = effectiveWindow * charsPerToken;
+
+  // Prefer the tiktoken encoder for total-char estimation when it has been
+  // warmed (initTokenCounter resolved). countTokensSync(probe) gives an
+  // empirical chars-per-token for a representative ASCII probe, which is more
+  // accurate than the static provider table for English-heavy prompts.
+  let totalChars: number;
+  if (isAccurateCountingAvailable()) {
+    const probe = "the quick brown fox jumps over the lazy dog ".repeat(64);
+    const probeTokens = countTokensSync(probe, provider);
+    const empiricalCharsPerToken = probeTokens > 0 ? probe.length / probeTokens : charsPerToken;
+    totalChars = effectiveWindow * empiricalCharsPerToken;
+  } else {
+    totalChars = effectiveWindow * charsPerToken;
+  }
 
   return {
     summaryBudgetChars: Math.floor(totalChars * SUMMARY_RATIO),

--- a/src/resources/extensions/gsd/db-base-schema.ts
+++ b/src/resources/extensions/gsd/db-base-schema.ts
@@ -57,7 +57,8 @@ export function createBaseSchemaObjects(db: DbAdapter, hooks: BaseSchemaHooks): 
       slice_id TEXT DEFAULT NULL,
       task_id TEXT DEFAULT NULL,
       full_content TEXT NOT NULL DEFAULT '',
-      imported_at TEXT NOT NULL DEFAULT ''
+      imported_at TEXT NOT NULL DEFAULT '',
+      content_hash TEXT DEFAULT NULL
     )
   `);
 

--- a/src/resources/extensions/gsd/db-base-schema.ts
+++ b/src/resources/extensions/gsd/db-base-schema.ts
@@ -77,7 +77,8 @@ export function createBaseSchemaObjects(db: DbAdapter, hooks: BaseSchemaHooks): 
       hit_count INTEGER NOT NULL DEFAULT 0,
       scope TEXT NOT NULL DEFAULT 'project',
       tags TEXT NOT NULL DEFAULT '[]',
-      structured_fields TEXT DEFAULT NULL
+      structured_fields TEXT DEFAULT NULL,
+      last_hit_at TEXT DEFAULT NULL
     )
   `);
 

--- a/src/resources/extensions/gsd/db-migration-steps.ts
+++ b/src/resources/extensions/gsd/db-migration-steps.ts
@@ -416,6 +416,10 @@ export function applyMigrationV26MilestoneCommitAttributions(db: DbAdapter): voi
   db.exec("CREATE INDEX IF NOT EXISTS idx_milestone_commit_attr_milestone ON milestone_commit_attributions(milestone_id)");
 }
 
+export function applyMigrationV27ArtifactHash(db: DbAdapter): void {
+  ensureColumn(db, "artifacts", "content_hash", "ALTER TABLE artifacts ADD COLUMN content_hash TEXT DEFAULT NULL");
+}
+
 export interface MigrationV22Hooks {
   copyQualityGateRowsToRepairedTable(db: DbAdapter): void;
 }

--- a/src/resources/extensions/gsd/db-migration-steps.ts
+++ b/src/resources/extensions/gsd/db-migration-steps.ts
@@ -420,6 +420,10 @@ export function applyMigrationV27ArtifactHash(db: DbAdapter): void {
   ensureColumn(db, "artifacts", "content_hash", "ALTER TABLE artifacts ADD COLUMN content_hash TEXT DEFAULT NULL");
 }
 
+export function applyMigrationV28MemoryLastHitAt(db: DbAdapter): void {
+  ensureColumn(db, "memories", "last_hit_at", "ALTER TABLE memories ADD COLUMN last_hit_at TEXT DEFAULT NULL");
+}
+
 export interface MigrationV22Hooks {
   copyQualityGateRowsToRepairedTable(db: DbAdapter): void;
 }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -23,6 +23,7 @@
 // excluded from this invariant.
 
 import { createRequire } from "node:module";
+import { createHash } from "node:crypto";
 import { existsSync, copyFileSync, mkdirSync, realpathSync } from "node:fs";
 import { dirname } from "node:path";
 import type { Decision, Requirement, GateRow, GateId, GateScope, GateStatus, GateVerdict } from "./types.js";
@@ -78,6 +79,7 @@ import {
   applyMigrationV22QualityGateRepair,
   applyMigrationV23MilestoneQueue,
   applyMigrationV26MilestoneCommitAttributions,
+  applyMigrationV27ArtifactHash,
 } from "./db-migration-steps.js";
 import { isMemoriesFtsAvailableSchema, tryCreateMemoriesFtsSchema } from "./db-memory-fts-schema.js";
 import { createDbOpenState, type DbOpenPhase } from "./db-open-state.js";
@@ -106,7 +108,7 @@ const providerLoader = createSqliteProviderLoader({
   writeStderr: (message: string) => process.stderr.write(message),
 });
 
-export const SCHEMA_VERSION = 26;
+export const SCHEMA_VERSION = 27;
 
 function initSchema(db: DbAdapter, fileBacked: boolean): void {
   if (fileBacked) db.exec("PRAGMA journal_mode=WAL");
@@ -333,6 +335,11 @@ function migrateSchema(db: DbAdapter): void {
     if (currentVersion < 26) {
       applyMigrationV26MilestoneCommitAttributions(db);
       recordSchemaVersion(db, 26);
+    }
+
+    if (currentVersion < 27) {
+      applyMigrationV27ArtifactHash(db);
+      recordSchemaVersion(db, 27);
     }
 
     db.exec("COMMIT");
@@ -913,9 +920,10 @@ export function insertArtifact(a: {
   full_content: string;
 }): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  const contentHash = createHash("sha256").update(a.full_content).digest("hex");
   currentDb.prepare(
-    `INSERT OR REPLACE INTO artifacts (path, artifact_type, milestone_id, slice_id, task_id, full_content, imported_at)
-     VALUES (:path, :artifact_type, :milestone_id, :slice_id, :task_id, :full_content, :imported_at)`,
+    `INSERT OR REPLACE INTO artifacts (path, artifact_type, milestone_id, slice_id, task_id, full_content, imported_at, content_hash)
+     VALUES (:path, :artifact_type, :milestone_id, :slice_id, :task_id, :full_content, :imported_at, :content_hash)`,
   ).run({
     ":path": a.path,
     ":artifact_type": a.artifact_type,
@@ -924,6 +932,7 @@ export function insertArtifact(a: {
     ":task_id": a.task_id,
     ":full_content": a.full_content,
     ":imported_at": new Date().toISOString(),
+    ":content_hash": contentHash,
   });
 }
 

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -80,6 +80,7 @@ import {
   applyMigrationV23MilestoneQueue,
   applyMigrationV26MilestoneCommitAttributions,
   applyMigrationV27ArtifactHash,
+  applyMigrationV28MemoryLastHitAt,
 } from "./db-migration-steps.js";
 import { isMemoriesFtsAvailableSchema, tryCreateMemoriesFtsSchema } from "./db-memory-fts-schema.js";
 import { createDbOpenState, type DbOpenPhase } from "./db-open-state.js";
@@ -108,7 +109,7 @@ const providerLoader = createSqliteProviderLoader({
   writeStderr: (message: string) => process.stderr.write(message),
 });
 
-export const SCHEMA_VERSION = 27;
+export const SCHEMA_VERSION = 28;
 
 function initSchema(db: DbAdapter, fileBacked: boolean): void {
   if (fileBacked) db.exec("PRAGMA journal_mode=WAL");
@@ -340,6 +341,11 @@ function migrateSchema(db: DbAdapter): void {
     if (currentVersion < 27) {
       applyMigrationV27ArtifactHash(db);
       recordSchemaVersion(db, 27);
+    }
+
+    if (currentVersion < 28) {
+      applyMigrationV28MemoryLastHitAt(db);
+      recordSchemaVersion(db, 28);
     }
 
     db.exec("COMMIT");
@@ -3071,8 +3077,8 @@ export function updateMemoryContentRow(
 export function incrementMemoryHitCount(id: string, updatedAt: string): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   currentDb.prepare(
-    "UPDATE memories SET hit_count = hit_count + 1, updated_at = :updated_at WHERE id = :id",
-  ).run({ ":updated_at": updatedAt, ":id": id });
+    "UPDATE memories SET hit_count = hit_count + 1, updated_at = :updated_at, last_hit_at = :last_hit_at WHERE id = :id",
+  ).run({ ":updated_at": updatedAt, ":last_hit_at": updatedAt, ":id": id });
 }
 
 export function supersedeMemoryRow(oldId: string, newId: string, updatedAt: string): void {

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1810,6 +1810,13 @@ export function reconcileWorktreeDb(
       const hasEscalationAwaiting = wtTaskInfo.some((col) => col["name"] === "escalation_awaiting_review");
       const hasEscalationArtifact = wtTaskInfo.some((col) => col["name"] === "escalation_artifact_path");
       const hasEscalationOverride = wtTaskInfo.some((col) => col["name"] === "escalation_override_applied_at");
+      const wtArtifactInfo = adapter.prepare("PRAGMA wt.table_info('artifacts')").all();
+      const hasArtifactContentHash = wtArtifactInfo.some((col) => col["name"] === "content_hash");
+      const wtMemoryInfo = adapter.prepare("PRAGMA wt.table_info('memories')").all();
+      const hasMemoryScope = wtMemoryInfo.some((col) => col["name"] === "scope");
+      const hasMemoryTags = wtMemoryInfo.some((col) => col["name"] === "tags");
+      const hasMemoryStructuredFields = wtMemoryInfo.some((col) => col["name"] === "structured_fields");
+      const hasMemoryLastHitAt = wtMemoryInfo.some((col) => col["name"] === "last_hit_at");
 
       const decConf = adapter.prepare(
         `SELECT m.id FROM decisions m INNER JOIN wt.decisions w ON m.id = w.id WHERE m.decision != w.decision OR m.choice != w.choice OR m.rationale != w.rationale OR ${
@@ -1857,12 +1864,17 @@ export function reconcileWorktreeDb(
           FROM wt.requirements
         `).run());
 
+        // V27: preserve content_hash. If the worktree predates V27 (no column),
+        // fall back to the main DB's existing hash so reconcile doesn't null
+        // out integrity fingerprints on artifacts that were unchanged in wt.
         merged.artifacts = countChanges(adapter.prepare(`
           INSERT OR REPLACE INTO artifacts (
-            path, artifact_type, milestone_id, slice_id, task_id, full_content, imported_at
+            path, artifact_type, milestone_id, slice_id, task_id, full_content, imported_at, content_hash
           )
-          SELECT path, artifact_type, milestone_id, slice_id, task_id, full_content, imported_at
-          FROM wt.artifacts
+          SELECT w.path, w.artifact_type, w.milestone_id, w.slice_id, w.task_id, w.full_content, w.imported_at,
+                 ${hasArtifactContentHash ? "w.content_hash" : "m.content_hash"}
+          FROM wt.artifacts w
+          LEFT JOIN artifacts m ON m.path = w.path
         `).run());
 
         // Merge milestones — worktree may have updated status/planning fields.
@@ -1964,15 +1976,25 @@ export function reconcileWorktreeDb(
           LEFT JOIN tasks m ON m.milestone_id = w.milestone_id AND m.slice_id = w.slice_id AND m.id = w.id
         `).run());
 
-        // Merge memories — keep worktree-learned insights
+        // Merge memories — keep worktree-learned insights.
+        // V18 (scope, tags), V21 (structured_fields), V28 (last_hit_at): for each
+        // column the wt may not yet have (older worktree DB), fall back to the
+        // main DB's existing value via LEFT JOIN so reconcile never silently
+        // resets these fields to defaults on rows that already had them.
         merged.memories = countChanges(adapter.prepare(`
           INSERT OR REPLACE INTO memories (
             seq, id, category, content, confidence, source_unit_type, source_unit_id,
-            created_at, updated_at, superseded_by, hit_count
+            created_at, updated_at, superseded_by, hit_count,
+            scope, tags, structured_fields, last_hit_at
           )
-          SELECT seq, id, category, content, confidence, source_unit_type, source_unit_id,
-                 created_at, updated_at, superseded_by, hit_count
-          FROM wt.memories
+          SELECT w.seq, w.id, w.category, w.content, w.confidence, w.source_unit_type, w.source_unit_id,
+                 w.created_at, w.updated_at, w.superseded_by, w.hit_count,
+                 ${hasMemoryScope ? "w.scope" : "COALESCE(m.scope, 'project')"},
+                 ${hasMemoryTags ? "w.tags" : "COALESCE(m.tags, '[]')"},
+                 ${hasMemoryStructuredFields ? "w.structured_fields" : "m.structured_fields"},
+                 ${hasMemoryLastHitAt ? "w.last_hit_at" : "m.last_hit_at"}
+          FROM wt.memories w
+          LEFT JOIN memories m ON m.id = w.id
         `).run());
 
         // Merge verification evidence — append-only, use INSERT OR IGNORE to avoid duplicates

--- a/src/resources/extensions/gsd/memory-store.ts
+++ b/src/resources/extensions/gsd/memory-store.ts
@@ -258,13 +258,24 @@ export function queryMemoriesRanked(opts: QueryMemoriesOptions): RankedMemory[] 
 
   if (keywordHits.length === 0 && semanticHits.length === 0 && !trimmedQuery) {
     // No query at all — return top-k by decay-aware ranked score.
-    // Fetch a larger candidate pool (5k or at least 50) so the decay factor
-    // can promote a fresh-but-lower-raw-score memory into the top k. Slicing
-    // before applying decay (the previous behavior) defeated the time-decay
-    // ranking — out-of-pool memories could never recover.
+    //
+    // Build the candidate pool from a direct SQL query that honors the
+    // request's activeClause (i.e. include_superseded). Using
+    // getActiveMemoriesRanked here would silently drop superseded rows even
+    // when the caller explicitly opted in, and would slice by raw score
+    // before decay/filters had a chance to reorder.
     const candidatePool = Math.min(Math.max(k * 5, 50), 500);
+    const rows = adapter
+      .prepare(
+        `SELECT * FROM memories ${activeClause}
+         ORDER BY (confidence * (1.0 + hit_count * 0.1)) DESC
+         LIMIT :limit`,
+      )
+      .all({ ':limit': candidatePool });
+
     const ranked: RankedMemory[] = [];
-    for (const memory of getActiveMemoriesRanked(candidatePool)) {
+    for (const row of rows) {
+      const memory = rowToMemory(row);
       if (!passesFilters(memory, opts)) continue;
       const decay = memoryDecayFactor(memory.last_hit_at);
       const score = memory.confidence * (1 + memory.hit_count * 0.1) * decay;

--- a/src/resources/extensions/gsd/memory-store.ts
+++ b/src/resources/extensions/gsd/memory-store.ts
@@ -115,7 +115,7 @@ const CATEGORY_PRIORITY: Record<string, number> = {
  * Future timestamps (clock skew, manual DB edits) clamp to daysAgo=0 so the
  * factor stays in the documented [0.7, 1.0] contract.
  */
-function memoryDecayFactor(lastHitAt: string | null): number {
+export function memoryDecayFactor(lastHitAt: string | null): number {
   if (!lastHitAt) return 1.0;
   const ts = Date.parse(lastHitAt);
   if (!Number.isFinite(ts)) return 1.0;

--- a/src/resources/extensions/gsd/memory-store.ts
+++ b/src/resources/extensions/gsd/memory-store.ts
@@ -109,10 +109,17 @@ const CATEGORY_PRIORITY: Record<string, number> = {
  * Returns 1.0 for never-hit or recently-hit memories, decaying linearly to
  * 0.7 for memories not accessed in 90+ days. Floor at 0.7 keeps old-but-valid
  * knowledge from being fully suppressed.
+ *
+ * Defensive parsing: invalid timestamp strings (NaN from Date.parse) are
+ * treated as "no decay" rather than propagating NaN into score arithmetic.
+ * Future timestamps (clock skew, manual DB edits) clamp to daysAgo=0 so the
+ * factor stays in the documented [0.7, 1.0] contract.
  */
 function memoryDecayFactor(lastHitAt: string | null): number {
   if (!lastHitAt) return 1.0;
-  const daysAgo = (Date.now() - new Date(lastHitAt).getTime()) / 86_400_000;
+  const ts = Date.parse(lastHitAt);
+  if (!Number.isFinite(ts)) return 1.0;
+  const daysAgo = Math.max(0, (Date.now() - ts) / 86_400_000);
   return Math.max(0.7, 1.0 - 0.3 * Math.min(1.0, daysAgo / 90));
 }
 
@@ -250,19 +257,28 @@ export function queryMemoriesRanked(opts: QueryMemoriesOptions): RankedMemory[] 
     : [];
 
   if (keywordHits.length === 0 && semanticHits.length === 0 && !trimmedQuery) {
-    // No query at all — fall back to the existing ranked-by-score listing.
-    return getActiveMemoriesRanked(k).map((memory) => {
+    // No query at all — return top-k by decay-aware ranked score.
+    // Fetch a larger candidate pool (5k or at least 50) so the decay factor
+    // can promote a fresh-but-lower-raw-score memory into the top k. Slicing
+    // before applying decay (the previous behavior) defeated the time-decay
+    // ranking — out-of-pool memories could never recover.
+    const candidatePool = Math.min(Math.max(k * 5, 50), 500);
+    const ranked: RankedMemory[] = [];
+    for (const memory of getActiveMemoriesRanked(candidatePool)) {
+      if (!passesFilters(memory, opts)) continue;
       const decay = memoryDecayFactor(memory.last_hit_at);
       const score = memory.confidence * (1 + memory.hit_count * 0.1) * decay;
-      return {
+      ranked.push({
         memory,
         score,
         keywordRank: null,
         semanticRank: null,
         confidenceBoost: score,
         reason: 'ranked' as const,
-      };
-    }).filter((hit) => passesFilters(hit.memory, opts));
+      });
+    }
+    ranked.sort((a, b) => b.score - a.score);
+    return ranked.slice(0, k);
   }
 
   // 3) Reciprocal rank fusion — each hit contributes 1/(rrfK + rank).

--- a/src/resources/extensions/gsd/memory-store.ts
+++ b/src/resources/extensions/gsd/memory-store.ts
@@ -313,6 +313,8 @@ function passesFilters(memory: Memory, filters: QueryMemoriesFilters): boolean {
   return true;
 }
 
+let ftsWarningEmitted = false;
+
 function keywordSearch(
   adapter: NonNullable<ReturnType<typeof _getAdapter>>,
   rawQuery: string,
@@ -340,14 +342,22 @@ function keywordSearch(
     }
   }
 
-  // LIKE fallback — scans the candidate pool.
+  // LIKE fallback — scans a capped candidate pool.
+  if (!ftsWarningEmitted) {
+    ftsWarningEmitted = true;
+    logWarning('memory-store', 'FTS5 unavailable — using LIKE fallback scan (consider enabling FTS5)');
+  }
+
   const terms = rawQuery
     .toLowerCase()
     .split(/[^a-z0-9_]+/)
     .filter((t) => t.length >= 2);
   if (terms.length === 0) return [];
 
-  const rows = adapter.prepare(`SELECT * FROM memories ${activeClause}`).all();
+  const preScanCap = Math.min(limit * 20, 2000);
+  const rows = adapter
+    .prepare(`SELECT * FROM memories ${activeClause} LIMIT :preScanCap`)
+    .all({ ':preScanCap': preScanCap });
   const scored: Array<{ memory: Memory; score: number }> = [];
   for (const row of rows) {
     const memory = rowToMemory(row);

--- a/src/resources/extensions/gsd/memory-store.ts
+++ b/src/resources/extensions/gsd/memory-store.ts
@@ -376,8 +376,15 @@ function keywordSearch(
   if (terms.length === 0) return [];
 
   const preScanCap = Math.min(limit * 20, 2000);
+  // ORDER BY confidence-weighted hit_count DESC so the cap keeps the most
+  // valuable candidates instead of the oldest-by-rowid (which would silently
+  // exclude recently-stored memories on tables larger than preScanCap).
   const rows = adapter
-    .prepare(`SELECT * FROM memories ${activeClause} LIMIT :preScanCap`)
+    .prepare(
+      `SELECT * FROM memories ${activeClause}
+       ORDER BY (confidence * (1.0 + hit_count * 0.1)) DESC
+       LIMIT :preScanCap`,
+    )
     .all({ ':preScanCap': preScanCap });
   const scored: Array<{ memory: Memory; score: number }> = [];
   for (const row of rows) {

--- a/src/resources/extensions/gsd/memory-store.ts
+++ b/src/resources/extensions/gsd/memory-store.ts
@@ -44,6 +44,8 @@ export interface Memory {
    * decisions table (Step 5) with the original scope/decision/choice/etc.
    */
   structured_fields: Record<string, unknown> | null;
+  /** ISO timestamp of the most recent memory_query hit. NULL until first hit. */
+  last_hit_at: string | null;
 }
 
 export type MemoryActionCreate = {
@@ -100,6 +102,20 @@ const CATEGORY_PRIORITY: Record<string, number> = {
   preference: 5,
 };
 
+// ─── Scoring Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Time-decay factor for memory relevance scoring.
+ * Returns 1.0 for never-hit or recently-hit memories, decaying linearly to
+ * 0.7 for memories not accessed in 90+ days. Floor at 0.7 keeps old-but-valid
+ * knowledge from being fully suppressed.
+ */
+function memoryDecayFactor(lastHitAt: string | null): number {
+  if (!lastHitAt) return 1.0;
+  const daysAgo = (Date.now() - new Date(lastHitAt).getTime()) / 86_400_000;
+  return Math.max(0.7, 1.0 - 0.3 * Math.min(1.0, daysAgo / 90));
+}
+
 // ─── Row Mapping ────────────────────────────────────────────────────────────
 
 function rowToMemory(row: Record<string, unknown>): Memory {
@@ -118,6 +134,7 @@ function rowToMemory(row: Record<string, unknown>): Memory {
     scope: (row['scope'] as string) ?? 'project',
     tags: parseTags(row['tags']),
     structured_fields: parseStructuredFields(row['structured_fields']),
+    last_hit_at: (row['last_hit_at'] as string | null) ?? null,
   };
 }
 
@@ -234,14 +251,18 @@ export function queryMemoriesRanked(opts: QueryMemoriesOptions): RankedMemory[] 
 
   if (keywordHits.length === 0 && semanticHits.length === 0 && !trimmedQuery) {
     // No query at all — fall back to the existing ranked-by-score listing.
-    return getActiveMemoriesRanked(k).map((memory) => ({
-      memory,
-      score: memory.confidence * (1 + memory.hit_count * 0.1),
-      keywordRank: null,
-      semanticRank: null,
-      confidenceBoost: memory.confidence * (1 + memory.hit_count * 0.1),
-      reason: 'ranked' as const,
-    })).filter((hit) => passesFilters(hit.memory, opts));
+    return getActiveMemoriesRanked(k).map((memory) => {
+      const decay = memoryDecayFactor(memory.last_hit_at);
+      const score = memory.confidence * (1 + memory.hit_count * 0.1) * decay;
+      return {
+        memory,
+        score,
+        keywordRank: null,
+        semanticRank: null,
+        confidenceBoost: score,
+        reason: 'ranked' as const,
+      };
+    }).filter((hit) => passesFilters(hit.memory, opts));
   }
 
   // 3) Reciprocal rank fusion — each hit contributes 1/(rrfK + rank).
@@ -275,7 +296,7 @@ export function queryMemoriesRanked(opts: QueryMemoriesOptions): RankedMemory[] 
   const ranked: RankedMemory[] = [];
   for (const entry of fused.values()) {
     if (!passesFilters(entry.memory, opts)) continue;
-    const boost = entry.memory.confidence * (1 + entry.memory.hit_count * 0.1);
+    const boost = entry.memory.confidence * (1 + entry.memory.hit_count * 0.1) * memoryDecayFactor(entry.memory.last_hit_at);
     const reason: RankedMemory['reason'] =
       entry.kwRank != null && entry.semRank != null
         ? 'both'

--- a/src/resources/extensions/gsd/prompt-loader.ts
+++ b/src/resources/extensions/gsd/prompt-loader.ts
@@ -123,17 +123,42 @@ function warmCache(): void {
 }
 
 let warmCacheScheduled = false;
+let warmCacheRan = false;
+let warmCacheTimer: ReturnType<typeof setTimeout> | undefined;
+
+/**
+ * Synchronously snapshot the prompt/template tree into the cache.
+ *
+ * Safe to call immediately after `initResources()` because that function uses
+ * synchronous fs APIs — there is no race window that requires deferring the
+ * cache warm via setTimeout. Idempotent: subsequent calls are no-ops.
+ *
+ * Cancels the fallback `scheduleWarmCache` timer if it is still pending.
+ */
+export function primeCache(): void {
+  if (warmCacheRan) return;
+  if (warmCacheTimer) {
+    clearTimeout(warmCacheTimer);
+    warmCacheTimer = undefined;
+  }
+  warmCacheScheduled = true;
+  warmCacheRan = true;
+  warmCache();
+}
 
 function scheduleWarmCache(): void {
   if (warmCacheScheduled) return;
   warmCacheScheduled = true;
 
   const run = () => {
+    warmCacheTimer = undefined;
+    if (warmCacheRan) return;
+    warmCacheRan = true;
     warmCache();
   };
 
-  const timer = setTimeout(run, 1000);
-  timer.unref?.();
+  warmCacheTimer = setTimeout(run, 1000);
+  warmCacheTimer.unref?.();
 }
 
 // Snapshot the full prompt/template tree after import so extension startup only

--- a/src/resources/extensions/gsd/tests/compaction-snapshot.test.ts
+++ b/src/resources/extensions/gsd/tests/compaction-snapshot.test.ts
@@ -29,7 +29,8 @@ test('buildSnapshot: renders memories, exec history, and active context', () => 
     memories: [
       { id: 'MEM001', category: 'gotcha', content: 'FTS5 needs Porter tokenizer', confidence: 0.9,
         source_unit_type: null, source_unit_id: null, created_at: '', updated_at: '',
-        superseded_by: null, hit_count: 0, scope: 'project', seq: 1, tags: [], structured_fields: null },
+        superseded_by: null, hit_count: 0, scope: 'project', seq: 1, tags: [], structured_fields: null,
+        last_hit_at: null },
     ],
     execHistory: [
       {
@@ -65,6 +66,7 @@ test('buildSnapshot: enforces the byte cap with a truncation marker', () => {
     seq: i,
     tags: [] as string[],
     structured_fields: null,
+    last_hit_at: null,
   }));
   const snap = buildSnapshot(
     { generatedAt: new Date(), memories: longMemories, execHistory: [] },

--- a/src/resources/extensions/gsd/tests/context-budget.test.ts
+++ b/src/resources/extensions/gsd/tests/context-budget.test.ts
@@ -4,7 +4,7 @@
  * No I/O, no extension context, no global state.
  */
 
-import { describe, it } from "node:test";
+import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 
 import {
@@ -16,7 +16,16 @@ import {
   computeBudgets,
   truncateAtSectionBoundary,
   resolveExecutorContextWindow,
+  _resetEmpiricalCacheForTest,
 } from "../context-budget.js";
+
+// Reset the per-provider empirical chars-per-token cache before each test.
+// The hardcoded char-ratio assertions below assume the static fallback path
+// (3.5 / 4.0 chars/token) is used. Without this guard, a prior test that
+// warms tiktoken would populate the cache and silently break these tests.
+beforeEach(() => {
+  _resetEmpiricalCacheForTest();
+});
 
 import type { TokenProvider } from "../token-counter.js";
 

--- a/src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts
@@ -1,0 +1,312 @@
+// gsd-2 / dispatch rule coverage canary test
+//
+// Iterates DISPATCH_RULES in order against representative GSDState stubs and
+// asserts that exactly one rule matches each state, returning the expected
+// unitType (or stop). The goal is a canary: if a future PR adds a new rule
+// in the wrong position and shadows an existing one, this test fails.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { DISPATCH_RULES } from "../auto-dispatch.ts";
+import type { DispatchContext, DispatchAction } from "../auto-dispatch.ts";
+import type { GSDState } from "../types.ts";
+
+// ─── State helpers ────────────────────────────────────────────────────────
+
+function makeState(overrides: Partial<GSDState> = {}): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Test Milestone" },
+    activeSlice: null,
+    activeTask: null,
+    phase: "pre-planning",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+    ...overrides,
+  };
+}
+
+function makeCtx(basePath: string, state: GSDState, mid = "M001"): DispatchContext {
+  return {
+    basePath,
+    mid,
+    midTitle: "Test Milestone",
+    state,
+    prefs: undefined,
+  };
+}
+
+// ─── Disk scaffold helpers ────────────────────────────────────────────────
+
+function writeMilestoneFile(basePath: string, mid: string, suffix: string, content = "stub\n"): void {
+  const dir = join(basePath, ".gsd", "milestones", mid);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${mid}-${suffix}.md`), content);
+}
+
+function writeSliceFile(
+  basePath: string,
+  mid: string,
+  sid: string,
+  suffix: string,
+  content = "stub\n",
+): void {
+  const dir = join(basePath, ".gsd", "milestones", mid, "slices", sid);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${sid}-${suffix}.md`), content);
+}
+
+function writeTaskPlan(basePath: string, mid: string, sid: string, tid: string): void {
+  const dir = join(basePath, ".gsd", "milestones", mid, "slices", sid, "tasks");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${tid}-PLAN.md`), `# ${tid}\n\n## Steps\n- [ ] Step\n`);
+}
+
+// ─── Rule evaluation ──────────────────────────────────────────────────────
+
+interface MatchEntry {
+  ruleName: string;
+  result: DispatchAction;
+}
+
+// First-match-wins semantics: walks DISPATCH_RULES in order and stops at the
+// first non-null result. This mirrors the production resolver and is the
+// canary against rule reordering or shadowing.
+async function findFirstMatch(ctx: DispatchContext): Promise<MatchEntry | null> {
+  for (const rule of DISPATCH_RULES) {
+    const result = await rule.match(ctx);
+    if (result) return { ruleName: rule.name, result };
+  }
+  return null;
+}
+
+function assertMatch(
+  match: MatchEntry | null,
+  expected: { ruleName: string; action: DispatchAction["action"]; unitType?: string },
+  scenario: string,
+): void {
+  assert.ok(match, `${scenario}: no rule matched`);
+  assert.equal(match.ruleName, expected.ruleName, `${scenario}: matched rule mismatch`);
+  assert.equal(match.result.action, expected.action, `${scenario}: action mismatch`);
+  if (expected.action === "dispatch" && expected.unitType) {
+    assert.ok(
+      match.result.action === "dispatch" && match.result.unitType === expected.unitType,
+      `${scenario}: unitType mismatch (got ${
+        match.result.action === "dispatch" ? match.result.unitType : match.result.action
+      })`,
+    );
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+test("dispatch-rule-coverage: escalating-task → stop (info)", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-esc-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const ctx = makeCtx(
+    tmp,
+    makeState({
+      phase: "escalating-task",
+      activeSlice: { id: "S01", title: "Slice" },
+      nextAction: "Resolve escalation X",
+    }),
+  );
+  const match = await findFirstMatch(ctx);
+  assertMatch(
+    match,
+    { ruleName: "escalating-task → pause-for-escalation", action: "stop" },
+    "escalating-task",
+  );
+});
+
+test("dispatch-rule-coverage: pre-planning, no CONTEXT → discuss-milestone", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-disc-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  // Bare milestone dir, no CONTEXT/RESEARCH/ROADMAP files.
+  mkdirSync(join(tmp, ".gsd", "milestones", "M001"), { recursive: true });
+
+  const ctx = makeCtx(tmp, makeState({ phase: "pre-planning" }));
+  const match = await findFirstMatch(ctx);
+  assertMatch(
+    match,
+    {
+      ruleName: "pre-planning (no context) → discuss-milestone",
+      action: "dispatch",
+      unitType: "discuss-milestone",
+    },
+    "pre-planning no context",
+  );
+});
+
+test("dispatch-rule-coverage: pre-planning, has CONTEXT, no RESEARCH → research-milestone", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-res-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  writeMilestoneFile(tmp, "M001", "CONTEXT", "# Context\n");
+
+  const ctx = makeCtx(tmp, makeState({ phase: "pre-planning" }));
+  const match = await findFirstMatch(ctx);
+  assertMatch(
+    match,
+    {
+      ruleName: "pre-planning (no research) → research-milestone",
+      action: "dispatch",
+      unitType: "research-milestone",
+    },
+    "pre-planning no research",
+  );
+});
+
+test("dispatch-rule-coverage: pre-planning, has CONTEXT + RESEARCH → plan-milestone", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-plan-m-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  writeMilestoneFile(tmp, "M001", "CONTEXT", "# Context\n");
+  writeMilestoneFile(tmp, "M001", "RESEARCH", "# Research\n");
+
+  const ctx = makeCtx(tmp, makeState({ phase: "pre-planning" }));
+  const match = await findFirstMatch(ctx);
+  assertMatch(
+    match,
+    {
+      ruleName: "pre-planning (has research) → plan-milestone",
+      action: "dispatch",
+      unitType: "plan-milestone",
+    },
+    "pre-planning has research",
+  );
+});
+
+test("dispatch-rule-coverage: planning with active slice and skip_research → plan-slice", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-plan-s-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  writeMilestoneFile(tmp, "M001", "CONTEXT", "# Context\n");
+  writeMilestoneFile(tmp, "M001", "ROADMAP", "# Roadmap\n");
+
+  const state = makeState({
+    phase: "planning",
+    activeSlice: { id: "S01", title: "First Slice" },
+  });
+  const ctx: DispatchContext = {
+    basePath: tmp,
+    mid: "M001",
+    midTitle: "Test Milestone",
+    state,
+    // Skip slice research so the parallel/single research rules fall through.
+    prefs: { phases: { skip_slice_research: true } } as DispatchContext["prefs"],
+  };
+  const match = await findFirstMatch(ctx);
+  assertMatch(
+    match,
+    {
+      ruleName: "planning → plan-slice",
+      action: "dispatch",
+      unitType: "plan-slice",
+    },
+    "planning → plan-slice",
+  );
+});
+
+test("dispatch-rule-coverage: executing with task plan present → execute-task", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-exec-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  writeMilestoneFile(tmp, "M001", "CONTEXT", "# Context\n");
+  writeSliceFile(tmp, "M001", "S01", "PLAN", "# Plan\n");
+  writeTaskPlan(tmp, "M001", "S01", "T01");
+
+  const state = makeState({
+    phase: "executing",
+    activeSlice: { id: "S01", title: "First Slice" },
+    activeTask: { id: "T01", title: "First Task" },
+  });
+  // Disable reactive dispatch so the parallel batching rule falls through.
+  const ctx: DispatchContext = {
+    basePath: tmp,
+    mid: "M001",
+    midTitle: "Test Milestone",
+    state,
+    prefs: { reactive_execution: { enabled: false } } as DispatchContext["prefs"],
+  };
+  const match = await findFirstMatch(ctx);
+  assertMatch(
+    match,
+    {
+      ruleName: "executing → execute-task",
+      action: "dispatch",
+      unitType: "execute-task",
+    },
+    "executing → execute-task",
+  );
+});
+
+test("dispatch-rule-coverage: summarizing → complete-slice", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-sum-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  // Rule "execution-entry phase (no context)" fires for summarizing if CONTEXT
+  // is missing — write it so the summarizing rule wins.
+  writeMilestoneFile(tmp, "M001", "CONTEXT", "# Context\n");
+
+  const ctx = makeCtx(
+    tmp,
+    makeState({
+      phase: "summarizing",
+      activeSlice: { id: "S01", title: "First Slice" },
+    }),
+  );
+  const match = await findFirstMatch(ctx);
+  assertMatch(
+    match,
+    {
+      ruleName: "summarizing → complete-slice",
+      action: "dispatch",
+      unitType: "complete-slice",
+    },
+    "summarizing → complete-slice",
+  );
+});
+
+test("dispatch-rule-coverage: complete phase → stop", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-disp-cov-done-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const ctx = makeCtx(
+    tmp,
+    makeState({
+      phase: "complete",
+      activeMilestone: null,
+      lastCompletedMilestone: { id: "M001", title: "Test Milestone" },
+    }),
+  );
+  const match = await findFirstMatch(ctx);
+  assertMatch(
+    match,
+    { ruleName: "complete → stop", action: "stop" },
+    "complete → stop",
+  );
+});
+
+// ─── Ordering canary: every scenario above resolves to exactly one rule ────
+
+test("dispatch-rule-coverage: rule registry has the expected size", () => {
+  // Sanity check that complements the per-state assertions: if someone adds a
+  // new rule, this number changes — prompting them to add a state stub above.
+  // Exact count is a brittle but useful canary; update when adding rules
+  // intentionally.
+  assert.equal(
+    DISPATCH_RULES.length,
+    29,
+    `DISPATCH_RULES length changed (got ${DISPATCH_RULES.length}). ` +
+      "If you added a rule, add a state stub to dispatch-rule-coverage.test.ts " +
+      "and update this expected count.",
+  );
+});

--- a/src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-rule-coverage.test.ts
@@ -1,9 +1,10 @@
 // gsd-2 / dispatch rule coverage canary test
 //
 // Iterates DISPATCH_RULES in order against representative GSDState stubs and
-// asserts that exactly one rule matches each state, returning the expected
-// unitType (or stop). The goal is a canary: if a future PR adds a new rule
-// in the wrong position and shadows an existing one, this test fails.
+// asserts that the first matching rule has the expected name and unitType
+// (mirroring auto-dispatch's first-match-wins semantics). The goal is a
+// canary: if a future PR adds a new rule in the wrong position and steals
+// a match from an existing one, this test fails.
 
 import test from "node:test";
 import assert from "node:assert/strict";

--- a/src/resources/extensions/gsd/tests/memory-decay-factor.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-decay-factor.test.ts
@@ -1,0 +1,90 @@
+// gsd-2 / memoryDecayFactor unit tests
+//
+// Pure-function boundary tests for the V28 time-decay scoring helper.
+// The function maps last_hit_at → multiplier in [0.7, 1.0] used by
+// queryMemoriesRanked to down-weight stale memories without fully suppressing
+// them. These tests pin the contract:
+//
+//   - null / invalid / future timestamps → 1.0 (no decay penalty)
+//   - 0 days ago → 1.0
+//   - linear decay between 0 and 90 days
+//   - 90+ days ago → 0.7 floor
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { memoryDecayFactor } from "../memory-store.ts";
+
+const DAY_MS = 86_400_000;
+
+function isoDaysAgo(days: number): string {
+  return new Date(Date.now() - days * DAY_MS).toISOString();
+}
+
+test("memoryDecayFactor: null lastHitAt returns 1.0 (never-hit = no decay)", () => {
+  assert.equal(memoryDecayFactor(null), 1.0);
+});
+
+test("memoryDecayFactor: invalid timestamp string returns 1.0 (defensive)", () => {
+  assert.equal(memoryDecayFactor("not-a-date"), 1.0);
+  assert.equal(memoryDecayFactor(""), 1.0);
+});
+
+test("memoryDecayFactor: future timestamp clamps to daysAgo=0 → 1.0", () => {
+  // Clock skew or manual DB edits can yield future last_hit_at values.
+  // The factor must stay within [0.7, 1.0] regardless.
+  const future = new Date(Date.now() + 30 * DAY_MS).toISOString();
+  const factor = memoryDecayFactor(future);
+  assert.ok(factor <= 1.0, `factor must not exceed 1.0, got ${factor}`);
+  assert.ok(factor >= 0.7, `factor must not fall below 0.7, got ${factor}`);
+  assert.equal(factor, 1.0);
+});
+
+test("memoryDecayFactor: 0 days ago returns 1.0", () => {
+  const factor = memoryDecayFactor(new Date().toISOString());
+  // Tiny clock drift between now-string and Date.now() inside the function;
+  // assert it's effectively 1.0 within float tolerance.
+  assert.ok(Math.abs(factor - 1.0) < 1e-6, `expected ≈1.0, got ${factor}`);
+});
+
+test("memoryDecayFactor: 30 days ago returns ~0.90 (linear midpoint)", () => {
+  // Formula: 1.0 - 0.3 * (30/90) = 1.0 - 0.1 = 0.90
+  const factor = memoryDecayFactor(isoDaysAgo(30));
+  assert.ok(Math.abs(factor - 0.90) < 1e-3, `expected ≈0.90, got ${factor}`);
+});
+
+test("memoryDecayFactor: 60 days ago returns ~0.80", () => {
+  // Formula: 1.0 - 0.3 * (60/90) = 1.0 - 0.2 = 0.80
+  const factor = memoryDecayFactor(isoDaysAgo(60));
+  assert.ok(Math.abs(factor - 0.80) < 1e-3, `expected ≈0.80, got ${factor}`);
+});
+
+test("memoryDecayFactor: 90 days ago returns 0.70 (floor)", () => {
+  const factor = memoryDecayFactor(isoDaysAgo(90));
+  assert.ok(Math.abs(factor - 0.70) < 1e-3, `expected ≈0.70, got ${factor}`);
+});
+
+test("memoryDecayFactor: 180 days ago stays at 0.70 floor", () => {
+  const factor = memoryDecayFactor(isoDaysAgo(180));
+  assert.equal(factor, 0.70);
+});
+
+test("memoryDecayFactor: result always in [0.7, 1.0] for any input", () => {
+  const samples: (string | null)[] = [
+    null,
+    "",
+    "garbage",
+    new Date(0).toISOString(),
+    isoDaysAgo(0),
+    isoDaysAgo(15),
+    isoDaysAgo(45),
+    isoDaysAgo(89),
+    isoDaysAgo(91),
+    isoDaysAgo(365),
+    new Date(Date.now() + 365 * DAY_MS).toISOString(),
+  ];
+  for (const s of samples) {
+    const f = memoryDecayFactor(s);
+    assert.ok(f >= 0.7 && f <= 1.0, `factor out of [0.7, 1.0] for ${s}: ${f}`);
+  }
+});

--- a/src/resources/extensions/gsd/tests/schema-v27-v28-sequence.test.ts
+++ b/src/resources/extensions/gsd/tests/schema-v27-v28-sequence.test.ts
@@ -1,0 +1,156 @@
+// gsd-2 / V27 + V28 schema migration regression tests
+//
+// Same bug class as #4591 (schema-v21-sequence): a migration block can be
+// added but the SCHEMA_VERSION constant left unchanged, causing fresh-install
+// + upgrade paths to silently skip the column add. This file pins both V27
+// (artifacts.content_hash) and V28 (memories.last_hit_at) at the schema and
+// write-path level on fresh-install DBs.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  _getAdapter,
+  insertArtifact,
+  insertMemoryRow,
+  incrementMemoryHitCount,
+  SCHEMA_VERSION,
+} from "../gsd-db.ts";
+
+function makeTmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "gsd-v27v28-"));
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { fs.rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+test("SCHEMA_VERSION constant is at least 28 (V28 migration committed)", () => {
+  assert.ok(
+    SCHEMA_VERSION >= 28,
+    `SCHEMA_VERSION must be ≥ 28 after V28 migration; got ${SCHEMA_VERSION}`,
+  );
+});
+
+test("fresh-install DB has artifacts.content_hash column (V27)", () => {
+  const base = makeTmp();
+  const dbPath = path.join(base, "gsd.db");
+  try {
+    openDatabase(dbPath);
+    const db = _getAdapter()!;
+    const cols = db.prepare("PRAGMA table_info(artifacts)").all() as Array<Record<string, unknown>>;
+    const colNames = new Set(cols.map((c) => c["name"] as string));
+    assert.ok(
+      colNames.has("content_hash"),
+      "V27 must add content_hash column to artifacts on fresh install",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("fresh-install DB has memories.last_hit_at column (V28)", () => {
+  const base = makeTmp();
+  const dbPath = path.join(base, "gsd.db");
+  try {
+    openDatabase(dbPath);
+    const db = _getAdapter()!;
+    const cols = db.prepare("PRAGMA table_info(memories)").all() as Array<Record<string, unknown>>;
+    const colNames = new Set(cols.map((c) => c["name"] as string));
+    assert.ok(
+      colNames.has("last_hit_at"),
+      "V28 must add last_hit_at column to memories on fresh install",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("fresh-install DB stamps SCHEMA_VERSION (≥28) in schema_version table", () => {
+  const base = makeTmp();
+  const dbPath = path.join(base, "gsd.db");
+  try {
+    openDatabase(dbPath);
+    const db = _getAdapter()!;
+    const row = db.prepare("SELECT MAX(version) as v FROM schema_version").get() as Record<string, unknown> | undefined;
+    const max = (row?.["v"] as number) ?? 0;
+    assert.ok(max >= 28, `fresh install must record schema_version ≥ 28; got ${max}`);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("insertArtifact populates content_hash with SHA-256 of full_content (V27 write-path)", () => {
+  const base = makeTmp();
+  const dbPath = path.join(base, "gsd.db");
+  try {
+    openDatabase(dbPath);
+    insertArtifact({
+      path: "M001/PROJECT.md",
+      artifact_type: "PROJECT",
+      milestone_id: "M001",
+      slice_id: null,
+      task_id: null,
+      full_content: "hello world",
+    });
+
+    const db = _getAdapter()!;
+    const row = db
+      .prepare("SELECT content_hash FROM artifacts WHERE path = :p")
+      .get({ ":p": "M001/PROJECT.md" }) as Record<string, unknown> | undefined;
+    const hash = row?.["content_hash"] as string | null | undefined;
+
+    // SHA-256 of "hello world" hex-encoded:
+    const expected = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+    assert.equal(hash, expected, "content_hash must be SHA-256 hex of full_content");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("incrementMemoryHitCount sets last_hit_at alongside hit_count (V28 write-path)", () => {
+  const base = makeTmp();
+  const dbPath = path.join(base, "gsd.db");
+  try {
+    openDatabase(dbPath);
+
+    const created = "2026-01-01T00:00:00.000Z";
+    insertMemoryRow({
+      id: "MEM001",
+      category: "gotcha",
+      content: "test memory",
+      confidence: 0.9,
+      sourceUnitType: null,
+      sourceUnitId: null,
+      createdAt: created,
+      updatedAt: created,
+      scope: "project",
+      tags: [],
+      structuredFields: null,
+    });
+
+    // Before increment: last_hit_at should be NULL
+    const db = _getAdapter()!;
+    const before = db
+      .prepare("SELECT last_hit_at FROM memories WHERE id = :id")
+      .get({ ":id": "MEM001" }) as Record<string, unknown>;
+    assert.equal(before["last_hit_at"], null, "last_hit_at starts NULL on fresh insert");
+
+    const hitTime = "2026-02-01T00:00:00.000Z";
+    incrementMemoryHitCount("MEM001", hitTime);
+
+    const after = db
+      .prepare("SELECT hit_count, last_hit_at FROM memories WHERE id = :id")
+      .get({ ":id": "MEM001" }) as Record<string, unknown>;
+    assert.equal(after["hit_count"], 1, "hit_count increments");
+    assert.equal(after["last_hit_at"], hitTime, "last_hit_at set to provided timestamp");
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tools/memory-tools.ts
+++ b/src/resources/extensions/gsd/tools/memory-tools.ts
@@ -308,6 +308,7 @@ function includeSupersededMemories(rankedActive: Memory[]): Memory[] {
         scope: (row["scope"] as string) ?? "project",
         tags,
         structured_fields: structuredFields,
+        last_hit_at: (row["last_hit_at"] as string | null) ?? null,
       };
     });
   } catch {


### PR DESCRIPTION
## Linked issue

Closes #5498

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Eight commits hardening six identified design problems across the GSD extension, memory store, prompt loader, token counter, auto-dispatch, and DB schema.
**Why:** A code-review pass found silent performance hazards, a timing-race in cache warm-up, an uninitialised encoder causing incorrect token budgets, zero dispatch-rule test coverage, and two missing integrity/decay signals in the DB schema.
**How:** Each problem is fixed surgically in its own commit; a Codex peer review of the stack produced one follow-up commit (#8) tightening the scan ordering, memoising the tiktoken probe, and correcting a test comment.

## What

Eight commits across these modules and files:

- `src/resources/extensions/gsd/memory-store.ts` — LIKE fallback scan cap + warn-once on FTS5 absence; follow-up adds `ORDER BY (confidence * (1.0 + hit_count * 0.1)) DESC` before `LIMIT` so the pre-scan is relevance-ordered rather than rowid-ordered
- `src/resources/extensions/gsd/auto-prompts.ts` — synchronous `primeCache()` call replaces the `setTimeout` warm-up
- `src/resources/extensions/gsd/auto.ts` — calls `primeCache()` after `initResources()` and `void initTokenCounter()` at startup; memoises the tiktoken probe in context-budget path
- `src/resources/extensions/gsd/auto-dispatch.ts` + new test file — 9-test dispatch-rule canary covering 8 representative state transitions, pins rule count at 29
- `src/resources/extensions/gsd/gsd-db.ts` — V27 migration adds `content_hash TEXT` to `artifacts`; V28 migration adds `last_hit_at TEXT` to `memories`; `insertArtifact` computes SHA-256; `incrementMemoryHitCount` sets `last_hit_at`; `queryMemoriesRanked` applies time-decay factor (1.0 → 0.7 floor over 90 days)
- `docs/` — three reference docs: `prompt-map.md`, `db-map.md`, `prompt-db-combined-map.md`

## Why

Six design problems identified in a single code-review pass, tracked in #5498:

1. **Uncapped LIKE scan** — `keywordSearch` fallback did `SELECT * FROM memories` with no `LIMIT`; silent full-table scan on every call when FTS5 is unavailable.
2. **Template cache timing race** — `setTimeout(warmCache, 1000)` is a guess, not a guarantee; if `initResources()` takes longer, the cache warms against stale templates.
3. **Token counter never initialised** — `initTokenCounter()` was exported but never called; every session used the char-ratio approximation despite tiktoken being bundled.
4. **No dispatch-rule tests** — 29 first-match-wins rules with no test coverage; a misplaced rule silently shadows the correct one.
5. **No artifact integrity fingerprint** — `artifacts` table lacked `content_hash`; truncated or corrupted writes go undetected.
6. **No memory time-decay** — stale memories ranked equally with fresh ones; no `last_hit_at` to apply decay retroactively.

## How

Each fix is scoped to its root cause:

- The scan cap uses `min(limit * 20, 2000)` as a practical ceiling and logs a `warn` once per process via a module-level flag.
- The cache race is eliminated by exporting `primeCache()` and calling it synchronously from `auto.ts` immediately after `initResources()` returns; the fallback timer is cancelled.
- The token counter is initialised with `void initTokenCounter()` at extension startup (fire-and-forget; the encoder loads in the background and `computeBudgets` picks it up on the next call).
- The dispatch canary uses `node:test` + `node:assert/strict`, imports the real `DISPATCH_RULES` array, and exercises `matchRule()` directly — no source-grep.
- V27 and V28 follow the established migration pattern (matching V18 `memory_sources.content_hash`); both are `ALTER TABLE … ADD COLUMN` and are fully backward-compatible.
- The tiktoken memoisation (Codex follow-up) encodes the probe string once and caches the chars-per-token ratio for the lifetime of the process.

## Change type

- [x] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes

Both DB migrations are `ALTER TABLE … ADD COLUMN` with a `NULL` default. Existing rows are unaffected. No public API, CLI command, config format, or file structure changes.

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

**Regression / new tests (commit `f1d221f8a`):**

The dispatch-rule canary in `src/resources/extensions/gsd/auto-dispatch.test.ts` covers 8 representative state transitions and pins the rule count. Run with:

```
npm test -- --grep "dispatch rule coverage"
```

**DB migration tests:**

V27 and V28 follow the existing migration test pattern already in the suite. They do not have dedicated new test files but are exercised by the migration harness on startup. Reviewers should confirm `npm test` covers the migration runner.

**Codex peer review:**

The stack was peer-reviewed by Codex before commit `8a7e1db7a` landed. That follow-up commit addresses three medium findings from the review: scan relevance ordering, tiktoken probe memoisation, and a test header comment fix. No findings remain open.

**Reviewer checklist:**

1. Check out `jeremymcs:ai-coding/eager-mccarthy-0ca982`
2. `npm ci && npm run build`
3. `npm test`
4. Verify `auto-dispatch.test.ts` does not use `readFileSync` (no source-grep)
5. Confirm V27/V28 migrations apply cleanly against a fresh DB

## AI disclosure

- [x] This PR includes AI-assisted code — generated and peer-reviewed with Codex; the full stack was reviewed for correctness before submission. The author can explain all changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded system, prompt, and database maps with full flow, schema updated to V28, and detailed artifact/memory lineage.

* **New Features**
  * Memories record recent access and use time-decay for relevance.
  * Artifacts persist deterministic content integrity hashes.

* **Improvements**
  * More accurate empirical token-counting for context budgets and prompt cache priming at startup to reduce latency.
  * Memory search fallback now caps candidates and prioritizes higher-value items.

* **Tests**
  * New/expanded tests for dispatch rules, migrations, memory decay, and schema upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->