### PR TITLE
fix(gsd): skip runtime pre-exec inputs

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -380,6 +380,8 @@ function shouldValidateInputAsPath(raw: string): boolean {
   const trimmed = raw.trim();
   if (!trimmed) return false;
 
+  if (isRuntimeOnlyInput(trimmed)) return false;
+
   const candidate = extractPathFromAnnotation(trimmed);
   if (!candidate) return false;
 
@@ -403,6 +405,10 @@ function shouldValidateInputAsPath(raw: string): boolean {
     /[\\/]/.test(candidate) ||
     /[*?[\]{}]/.test(candidate)
   );
+}
+
+function isRuntimeOnlyInput(raw: string): boolean {
+  return /\(\s*runtime\s*\)/i.test(raw);
 }
 
 function containsGlobPattern(candidate: string): boolean {
@@ -535,6 +541,7 @@ export function checkTaskOrdering(
     const filesToCheck = [...task.inputs];
 
     for (const file of filesToCheck) {
+      if (isRuntimeOnlyInput(file)) continue;
       if (!shouldValidateInputAsPath(file)) continue;
 
       const normalizedFile = normalizeFilePath(file);

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -1,3 +1,6 @@
+// Project/App: GSD-2
+// File Purpose: Unit tests for pre-execution validation checks.
+
 /**
  * pre-execution-checks.test.ts — Unit tests for pre-execution validation checks.
  *
@@ -1542,6 +1545,27 @@ describe("checkFilePathConsistency directory inputs (#4446)", () => {
     assert.equal(results[0].blocking, true);
   });
 
+  test("runtime directory annotation is skipped as a pre-execution file dependency", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-dir-runtime-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T02",
+        inputs: ["entries/ directory (runtime)"],
+        expected_output: ["src/commands/delete.ts", "src/index.ts"],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.deepEqual(
+      results,
+      [],
+      "Runtime-only directory inputs are created during command execution, not required before the task starts",
+    );
+  });
+
   test("tilde-prefixed input is matched against $HOME, not the project basePath", (t) => {
     const fakeHome = join(tmpdir(), `pre-exec-tilde-home-${Date.now()}`);
     const projectDir = join(tmpdir(), `pre-exec-tilde-proj-${Date.now()}`);
@@ -1596,6 +1620,20 @@ describe("checkTaskOrdering directory inputs (#4446)", () => {
       [],
       "Directory reference should not be treated as reading a file created later",
     );
+  });
+
+  test("runtime directory annotation does not produce an ordering violation", () => {
+    const tasks = [
+      createTask({
+        id: "T02",
+        sequence: 0,
+        inputs: ["entries/ directory (runtime)"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkTaskOrdering(tasks, "/tmp");
+    assert.deepEqual(results, []);
   });
 });
 


### PR DESCRIPTION
## TL;DR

**What:** Skips pre-execution file and ordering validation for task inputs explicitly annotated as runtime-only.
**Why:** Valid auto-mode slices can pause when a verification task references a directory created during command execution, such as `entries/ directory (runtime)`.
**How:** Adds a narrow `(runtime)` annotation guard in pre-execution checks and regression coverage for file-path and ordering validation.

## What

This updates GSD pre-execution validation so task inputs marked with `(runtime)` are not treated as required pre-existing filesystem dependencies. The change is scoped to:

- `src/resources/extensions/gsd/pre-execution-checks.ts`
- `src/resources/extensions/gsd/tests/pre-execution-checks.test.ts`

## Why

Auto-mode paused on this blocking failure even though the referenced directory is created by the command under test:

```text
[file] entries/ directory (runtime): Task T02 references 'entries/ directory (runtime)' which doesn't exist and isn't created by prior or same-task outputs
```

That annotation is describing runtime state, not a source input that must exist before task execution starts.

Closes #5508

## How

The patch adds a small runtime-only annotation check for `(runtime)` and applies it before file path consistency and task ordering checks validate an input. Ordinary missing directory inputs still fail; only explicitly runtime-annotated inputs are skipped.

Regression tests cover:

- `entries/ directory (runtime)` does not fail file path consistency checks.
- `entries/ directory (runtime)` does not produce a task ordering violation.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/pre-execution-checks.test.ts` — 94 passed, 0 failed
- [x] Direct replay against `/Users/jeremymcspadden/.gsd/projects/a619a18f9b34/worktrees/M002` — `status: "pass", checks: []`
- [ ] `npm run verify:pr` — fails on unrelated existing ADR-012 provider-equality check in `src/providers/provider-migrations.ts`; build and typecheck completed before the unit-test failure

Failure detail:

```text
ADR-012: provider-equality checks are allowlisted or use isXxxApi helpers
New model.provider === "<transport>" check(s) detected in:
- src/providers/provider-migrations.ts
```

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Notes

AI-assisted implementation. No co-author trailer is included in the commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for runtime-only task input annotations that are automatically excluded from file-path validation and task-ordering consistency checks.

* **Tests**
  * Extended test suite with coverage for runtime-only input annotations and their validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->