### PR TITLE
fix(gsd): defer discussion approval gate

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -31,6 +31,13 @@ import { approvalGateIdForUnit, isExplicitApprovalResponse, shouldPauseForUserAp
 let isFirstSession = true;
 let approvalQuestionAbortInFlight = false;
 
+interface DeferredApprovalGate {
+  gateId: string;
+  basePath: string;
+}
+
+let deferredApprovalGate: DeferredApprovalGate | null = null;
+
 async function deriveGsdState(basePath: string) {
   const { deriveState } = await import("../state.js");
   return deriveState(basePath);
@@ -83,6 +90,46 @@ async function applyCompactionThresholdOverride(ctx: ExtensionContext): Promise<
   } catch {
     // Non-fatal: leave any existing override in place.
   }
+}
+
+function clearDeferredApprovalGate(basePath?: string): void {
+  if (!basePath || deferredApprovalGate?.basePath === basePath) {
+    deferredApprovalGate = null;
+  }
+}
+
+function deferApprovalGate(gateId: string, basePath: string): void {
+  deferredApprovalGate = { gateId, basePath };
+}
+
+function activateDeferredApprovalGate(basePath: string): void {
+  if (deferredApprovalGate?.basePath !== basePath) return;
+  setPendingGate(deferredApprovalGate.gateId, basePath);
+  deferredApprovalGate = null;
+}
+
+function isContextDraftSummarySave(toolName: string, input: unknown): boolean {
+  if (toolName !== "gsd_summary_save" && toolName !== "summary_save") return false;
+  if (!input || typeof input !== "object") return false;
+  return (input as { artifact_type?: unknown }).artifact_type === "CONTEXT-DRAFT";
+}
+
+function shouldBlockDeferredApprovalTool(
+  toolName: string,
+  input: unknown,
+  basePath: string,
+): { block: boolean; reason?: string } {
+  if (deferredApprovalGate?.basePath !== basePath) return { block: false };
+  if (toolName === "ask_user_questions") return { block: false };
+  if (isContextDraftSummarySave(toolName, input)) return { block: false };
+  return {
+    block: true,
+    reason: [
+      `HARD BLOCK: Approval question "${deferredApprovalGate.gateId}" has been shown to the user.`,
+      `Only CONTEXT-DRAFT persistence may finish in this same assistant turn.`,
+      `Wait for the user's answer before calling additional tools.`,
+    ].join(" "),
+  };
 }
 
 export function resolveNotificationStoreBasePath(cwd: string = process.cwd()): string {
@@ -140,6 +187,7 @@ export function registerHooks(
     resetWriteGateState(process.cwd());
     resetToolCallLoopGuard();
     approvalQuestionAbortInFlight = false;
+    clearDeferredApprovalGate();
     await resetAskUserQuestionsTurnCache();
     await syncServiceTierStatus(ctx);
     await applyDisabledModelProviderPolicy(ctx);
@@ -189,6 +237,7 @@ export function registerHooks(
     initSessionNotifications(ctx);
     resetWriteGateState(process.cwd());
     resetToolCallLoopGuard();
+    clearDeferredApprovalGate();
     await resetAskUserQuestionsTurnCache();
     clearDiscussionFlowState(process.cwd());
     await syncServiceTierStatus(ctx);
@@ -225,6 +274,7 @@ export function registerHooks(
       if (milestoneId) markDepthVerified(milestoneId, beforeAgentBasePath);
       clearPendingGate(beforeAgentBasePath);
     }
+    clearDeferredApprovalGate(beforeAgentBasePath);
 
     // GSD's own context injection (existing behavior — unchanged).
     const { buildBeforeAgentStartResult } = await import("./system-context.js");
@@ -275,7 +325,11 @@ export function registerHooks(
     resetToolCallLoopGuard();
     await resetAskUserQuestionsTurnCache();
     const { handleAgentEnd } = await import("./agent-end-recovery.js");
-    await handleAgentEnd(pi, event, ctx);
+    try {
+      await handleAgentEnd(pi, event, ctx);
+    } finally {
+      activateDeferredApprovalGate(process.cwd());
+    }
   });
 
   // Squash-merge quick-task branch back to the original branch after the
@@ -377,15 +431,16 @@ export function registerHooks(
     if (!shouldPauseForUserApprovalQuestion(unitType, [event.message])) return;
 
     const gateId = approvalGateIdForUnit(unitType, unitId);
-    if (gateId) setPendingGate(gateId, process.cwd());
+    if (gateId) deferApprovalGate(gateId, process.cwd());
 
     approvalQuestionAbortInFlight = true;
     ctx.ui.notify(
       `${unitType}${unitId ? ` ${unitId}` : ""} is waiting for your approval - pausing before more tool calls run.`,
       "info",
     );
-    // The pending gate set above blocks subsequent non-read-only tool calls
-    // via the tool_call hook below, so we do not abort the in-flight stream.
+    // The durable pending gate is activated at agent_end so same-turn
+    // CONTEXT-DRAFT persistence can finish after the text boundary streams.
+    // The tool_call hook below still blocks non-draft tools in this turn.
     // Aborting mid-stream eats the model's question text on external CLI
     // providers (Claude Code SDK) because lastTextContent isn't populated
     // from in-flight builder state — the user only ever sees "Claude Code
@@ -416,6 +471,13 @@ export function registerHooks(
     if (loopCheck.block) {
       return { block: true, reason: loopCheck.reason };
     }
+
+    const deferredGateGuard = shouldBlockDeferredApprovalTool(
+      toolName,
+      event.input,
+      discussionBasePath,
+    );
+    if (deferredGateGuard.block) return deferredGateGuard;
 
     // ── Discussion gate enforcement: track pending gate questions ─────────
     // Only gate-shaped ask_user_questions calls should block execution.

--- a/src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts
@@ -3,8 +3,13 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { autoSession } from "../auto-runtime-state.ts";
+import { registerHooks } from "../bootstrap/register-hooks.ts";
+import { clearDiscussionFlowState, getPendingGate } from "../bootstrap/write-gate.ts";
 
 const autoTimersPath = join(import.meta.dirname, "..", "auto-timers.ts");
 const autoTimersSrc = readFileSync(autoTimersPath, "utf-8");
@@ -17,6 +22,37 @@ const runUnitSrc = readFileSync(runUnitPath, "utf-8");
 
 const registerHooksPath = join(import.meta.dirname, "..", "bootstrap", "register-hooks.ts");
 const registerHooksSrc = readFileSync(registerHooksPath, "utf-8");
+
+function makeHookHarness() {
+  const handlers = new Map<string, Array<(event: any, ctx: any) => Promise<any>>>();
+  const pi = {
+    on(name: string, handler: (event: any, ctx: any) => Promise<any>) {
+      const current = handlers.get(name) ?? [];
+      current.push(handler);
+      handlers.set(name, current);
+    },
+  };
+  const ctx = {
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setWidget: () => {},
+    },
+    modelRegistry: {
+      setDisabledModelProviders: () => {},
+    },
+    setCompactionThresholdOverride: () => {},
+  };
+  async function emit(name: string, event: any): Promise<any> {
+    for (const handler of handlers.get(name) ?? []) {
+      const result = await handler(event, ctx);
+      if (result?.block) return result;
+    }
+    return undefined;
+  }
+  registerHooks(pi as any, []);
+  return { emit };
+}
 
 describe("#3512: gsd-auto-wrapup must not interrupt in-flight tool calls", () => {
   test("soft timeout wrapup gates triggerTurn on getInFlightToolCount() === 0", () => {
@@ -193,7 +229,7 @@ describe("#4365: tool_execution_start hook must pass toolName to markToolStart",
 });
 
 describe("deep setup approval questions pause immediately", () => {
-  test("register-hooks sets pending gate during message_update without aborting the stream", () => {
+  test("register-hooks defers the pending gate during message_update without aborting the stream", () => {
     const startMarker = 'pi.on("message_update"';
     const endMarker = 'pi.on("session_shutdown"';
     const messageUpdateSection = registerHooksSrc.slice(
@@ -210,8 +246,8 @@ describe("deep setup approval questions pause immediately", () => {
       "message_update must detect approval/question boundaries",
     );
     assert.ok(
-      messageUpdateSection.includes("approvalGateIdForUnit") && messageUpdateSection.includes("setPendingGate"),
-      "plain-text approval questions must set the durable write gate",
+      messageUpdateSection.includes("approvalGateIdForUnit") && messageUpdateSection.includes("deferApprovalGate"),
+      "plain-text approval questions must defer the durable write gate until same-turn draft persistence can finish",
     );
     assert.ok(
       messageUpdateSection.includes("getDiscussionMilestoneIdFor") && messageUpdateSection.includes('"discuss-milestone"'),
@@ -221,5 +257,75 @@ describe("deep setup approval questions pause immediately", () => {
       !messageUpdateSection.includes("ctx.abort()"),
       "message_update must NOT abort the stream — aborting eats the model's question text on external CLI providers; the pending gate set above blocks subsequent tool calls instead",
     );
+  });
+
+  test("plain-text approval boundary defers durable gate until same-turn CONTEXT-DRAFT can save", async () => {
+    const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-deferred-approval-")));
+    const previousCwd = process.cwd();
+    try {
+      mkdirSync(join(base, ".gsd", "milestones", "M003"), { recursive: true });
+      process.chdir(base);
+      clearDiscussionFlowState(base);
+      autoSession.reset();
+      autoSession.basePath = base;
+      autoSession.currentUnit = {
+        type: "discuss-milestone",
+        id: "M003",
+        startedAt: Date.now(),
+      };
+
+      const { emit } = makeHookHarness();
+      await emit("message_update", {
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Did I capture that correctly? If not, tell me what I missed." }],
+        },
+      });
+
+      assert.equal(
+        getPendingGate(base),
+        null,
+        "approval text should not install the durable pending gate until the assistant turn ends",
+      );
+
+      const draftResult = await emit("tool_call", {
+        toolCallId: "draft-save",
+        toolName: "gsd_summary_save",
+        input: {
+          milestone_id: "M003",
+          artifact_type: "CONTEXT-DRAFT",
+          content: "# M003 Draft\n",
+        },
+      });
+      assert.equal(
+        draftResult?.block,
+        undefined,
+        "same-turn CONTEXT-DRAFT persistence should remain allowed after the approval text streams",
+      );
+
+      const finalContextResult = await emit("tool_call", {
+        toolCallId: "final-context",
+        toolName: "gsd_summary_save",
+        input: {
+          milestone_id: "M003",
+          artifact_type: "CONTEXT",
+          content: "# M003 Context\n",
+        },
+      });
+      assert.equal(finalContextResult?.block, true, "final CONTEXT must still wait for approval");
+      assert.match(finalContextResult.reason, /Approval question "depth_verification_M003_confirm"/);
+
+      await emit("agent_end", { messages: [] });
+      assert.equal(
+        getPendingGate(base),
+        "depth_verification_M003_confirm",
+        "agent_end should activate the durable pending gate for the next turn",
+      );
+    } finally {
+      process.chdir(previousCwd);
+      autoSession.reset();
+      clearDiscussionFlowState(base);
+      rmSync(base, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## TL;DR

**What:** Defers durable discussion approval-gate activation until the assistant turn ends while allowing same-turn `CONTEXT-DRAFT` summary saves.
**Why:** The gate could block `summary_save CONTEXT-DRAFT` immediately after the approval question streamed, producing `Error: unknown` before the user had a chance to answer.
**How:** Tracks a deferred approval gate during `message_update`, permits only same-turn draft persistence and the approval question tool, then installs the durable pending gate at `agent_end`.

## What

- Adds a deferred approval-gate state in `src/resources/extensions/gsd/bootstrap/register-hooks.ts`.
- Allows `gsd_summary_save` / `summary_save` with `artifact_type: "CONTEXT-DRAFT"` after the approval text boundary streams in the same assistant turn.
- Blocks final context saves and other tools once the approval question has appeared.
- Adds a regression test covering the exact plain-text approval boundary and same-turn draft-save path.

## Why

During deep milestone discussion, the prompt asks for incremental `CONTEXT-DRAFT` persistence and then asks the user to confirm the captured context. The old `message_update` gate placement installed the durable pending gate as soon as the plain-text approval question streamed, so the still-in-flight draft save could be blocked before approval was even possible.

Closes #5512

## How

The hook now stores the pending approval gate as deferred when the approval text is detected. While deferred, the `tool_call` hook allows only `ask_user_questions` and `CONTEXT-DRAFT` summary saves; all other tools are hard-blocked. At `agent_end`, after normal end-of-turn recovery runs, the deferred gate is promoted to the durable pending gate for the next user turn.

## Change type checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/write-gate.test.ts`
- [x] `git diff --check`
- [x] `npm run typecheck:extensions`
- [ ] `npm run verify:pr` — fails on unrelated existing ADR-012 provider allowlist test in `src/providers/provider-migrations.ts`; this branch does not touch that file.

## AI Assistance

This PR was AI-assisted. No AI co-author is included in the commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified approval gate behavior to defer blocking until agent completion while maintaining tool call restrictions during approval workflows.
  * Refined tool call handling to properly distinguish between different tool contexts.

* **Tests**
  * Expanded test coverage for approval gate and tool lifecycle behavior in auto-wrapup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->