### PR TITLE
fix(gsd): harden auto-mode closeout recovery

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session-tool-refresh.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-tool-refresh.test.ts
@@ -130,4 +130,22 @@ describe("#3616 — newSession() restores narrowed tool set when cwd unchanged",
 			"cwd-changed branch must rebuild with includeAllExtensionTools: true",
 		);
 	});
+
+	it("uses explicit cwd option instead of process.cwd() when rebuilding runtime", async () => {
+		const session = await createSession();
+		const explicitCwd = mkdtempSync(join(testDir, "explicit-cwd-"));
+		(session as any)._cwd = process.cwd();
+
+		let buildRuntimeCalled = false;
+		const originalBuild = (session as any)._buildRuntime.bind(session);
+		(session as any)._buildRuntime = (options?: { includeAllExtensionTools?: boolean }) => {
+			buildRuntimeCalled = true;
+			return originalBuild(options);
+		};
+
+		const ok = await session.newSession({ cwd: explicitCwd });
+		assert.equal(ok, true);
+		assert.equal((session as any)._cwd, explicitCwd);
+		assert.ok(buildRuntimeCalled, "explicit cwd differing from prior cwd must rebuild runtime");
+	});
 });

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1645,6 +1645,8 @@ export class AgentSession {
 	async newSession(options?: {
 		parentSession?: string;
 		setup?: (sessionManager: SessionManager) => Promise<void>;
+		/** Explicit working directory for the new session/tool runtime. */
+		cwd?: string;
 		/** See ExtensionCommandContext.newSession for docs (#3731). */
 		abortSignal?: AbortSignal;
 	}): Promise<boolean> {
@@ -1679,10 +1681,11 @@ export class AgentSession {
 		} finally {
 			this._sessionSwitchPending = false;
 		}
-		// Update cwd to current process directory — auto-mode may have chdir'd
-		// into a worktree since the original session was created.
+		// Update cwd for the new tool runtime. Auto-mode passes an explicit cwd
+		// so session routing does not depend on global process.cwd() after
+		// worktree merge/teardown. Other callers keep the historical behavior.
 		const previousCwd = this._cwd;
-		this._cwd = process.cwd();
+		this._cwd = options?.cwd ?? process.cwd();
 		this.sessionManager.newSession({ parentSession: options?.parentSession });
 		this.agent.sessionId = this.sessionManager.getSessionId();
 		this._steeringMessages = [];

--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -173,6 +173,8 @@ export type ExtensionErrorListener = (error: ExtensionError) => void;
 export type NewSessionHandler = (options?: {
 	parentSession?: string;
 	setup?: (sessionManager: SessionManager) => Promise<void>;
+	/** Explicit working directory for the new session/tool runtime. */
+	cwd?: string;
 	/** See ExtensionCommandContext.newSession for docs (#3731). */
 	abortSignal?: AbortSignal;
 }) => Promise<{ cancelled: boolean }>;

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -309,6 +309,9 @@ export interface ExtensionCommandContext extends ExtensionContext {
 	newSession(options?: {
 		parentSession?: string;
 		setup?: (sessionManager: SessionManager) => Promise<void>;
+		/** Explicit working directory for the new session/tool runtime.
+		 *  When omitted, newSession() captures process.cwd() for backwards compatibility. */
+		cwd?: string;
 		/** When aborted before the session is fully configured, newSession() returns
 		 *  early without rebuilding the tool runtime. Used by runUnit() to discard
 		 *  a late-resolving newSession() after the session-creation timeout fires,
@@ -1759,6 +1762,8 @@ export interface ExtensionCommandContextActions {
 	newSession: (options?: {
 		parentSession?: string;
 		setup?: (sessionManager: SessionManager) => Promise<void>;
+		/** See ExtensionCommandContext.newSession for docs. */
+		cwd?: string;
 		/** See ExtensionCommandContext.newSession for docs (#3731). */
 		abortSignal?: AbortSignal;
 	}) => Promise<{ cancelled: boolean }>;

--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -306,7 +306,7 @@ export async function dispatchDirectPhase(
       return;
     }
 
-    const result = await ctx.newSession();
+    const result = await ctx.newSession({ cwd: dispatchBase });
     if (result.cancelled) {
       ctx.ui.notify("Session creation cancelled.", "warning");
       return;

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2313,7 +2313,7 @@ export async function dispatchHookUnit(
     return false;
   }
 
-  const result = await s.cmdCtx!.newSession();
+  const result = await s.cmdCtx!.newSession({ cwd: s.basePath });
   if (result.cancelled) {
     await stopAuto(ctx, pi);
     return false;

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1157,6 +1157,21 @@ export async function stopAuto(
       debugLog("stop-cleanup-basepath", { error: e instanceof Error ? e.message : String(e) });
     }
 
+    // Re-root the active command session/tool runtime after worktree teardown.
+    // mergeAndExit restores process.cwd(), but AgentSession has already captured
+    // its own cwd for tools and system prompt; refresh it before returning to the
+    // user so follow-up commands do not target a removed milestone worktree.
+    if (s.originalBasePath && ctx && s.cmdCtx) {
+      try {
+        const result = await s.cmdCtx.newSession({ cwd: s.basePath });
+        if (result.cancelled) {
+          logWarning("engine", "post-stop session re-root was cancelled", { file: "auto.ts", basePath: s.basePath });
+        }
+      } catch (err) {
+        logWarning("engine", `post-stop session re-root failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts", basePath: s.basePath });
+      }
+    }
+
     // ── Step 8: Ledger notification ──
     try {
       const ledger = getLedger();

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -23,7 +23,7 @@ import type { CmuxLogLevel } from "../../shared/cmux-events.js";
 import type { JournalEntry } from "../journal.js";
 import type { MergeReconcileResult } from "../auto-recovery.js";
 import type { UokTurnObserver } from "../uok/contracts.js";
-import type { PreflightResult } from "../clean-root-preflight.js";
+import type { PostflightResult, PreflightResult } from "../clean-root-preflight.js";
 
 type PauseAutoFn = (
   ctx?: ExtensionContext,
@@ -141,7 +141,7 @@ export interface LoopDeps {
     milestoneId: string,
     stashMarker: string | undefined,
     notify: (message: string, level: "info" | "warning" | "error") => void,
-  ) => void;
+  ) => PostflightResult;
 
   // Budget/context/secrets
   getLedger: () => unknown;

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -687,6 +687,8 @@ export async function runPreDispatch(
     );
     try {
       deps.resolver.mergeAndExit(s.currentMilestoneId!, ctx.ui);
+      // Prevent stopAuto() from attempting the same merge again if postflight recovery stops here.
+      s.milestoneMergedInPhases = true;
     } catch (mergeErr) {
       if (mergeErr instanceof MergeConflictError) {
         // Real code conflicts — stop the loop instead of retrying forever (#2330)

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -57,6 +57,7 @@ import { getEligibleSlices } from "../slice-parallel-eligibility.js";
 import { startSliceParallel } from "../slice-parallel-orchestrator.js";
 import { isDbAvailable, getMilestoneSlices } from "../gsd-db.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
+import type { PostflightResult, PreflightResult } from "../clean-root-preflight.js";
 import { ensurePlanV2Graph, isEmptyPlanV2GraphResult, isMissingFinalizedContextResult } from "../uok/plan-v2.js";
 import { resolveUokFlags } from "../uok/flags.js";
 import { UokGateRunner } from "../uok/gate-runner.js";
@@ -207,6 +208,38 @@ async function closeoutAndStop(
     s.currentUnit = null;
   }
   await deps.stopAuto(ctx, pi, reason);
+}
+
+async function stopOnPostflightRecoveryNeeded(
+  ic: IterationContext,
+  result: PostflightResult,
+  milestoneId: string,
+): Promise<{ action: "break"; reason: string } | null> {
+  if (!result.needsManualRecovery) return null;
+  const { ctx, pi, deps } = ic;
+  const reason = `Post-merge stash restore failed for milestone ${milestoneId}`;
+  ctx.ui.notify(
+    `${reason}. Resolve the working tree before resuming auto-mode. ${result.message}`,
+    "error",
+  );
+  await deps.stopAuto(ctx, pi, reason);
+  return { action: "break", reason: "postflight-stash-restore-failed" };
+}
+
+async function restorePreflightStashOrStop(
+  ic: IterationContext,
+  preflight: PreflightResult,
+  milestoneId: string,
+): Promise<{ action: "break"; reason: string } | null> {
+  if (!preflight.stashPushed) return null;
+  const { ctx, s, deps } = ic;
+  const result = deps.postflightPopStash(
+    s.originalBasePath || s.basePath,
+    milestoneId,
+    preflight.stashMarker,
+    ctx.ui.notify.bind(ctx.ui),
+  );
+  return stopOnPostflightRecoveryNeeded(ic, result, milestoneId);
 }
 
 async function emitCancelledUnitEnd(
@@ -674,13 +707,13 @@ export async function runPreDispatch(
       return { action: "break", reason: "merge-failed" };
     }
     // #2909: postflight — restore stashed changes after successful merge
-    if (preflightTransition.stashPushed) {
-      deps.postflightPopStash(
-        s.originalBasePath || s.basePath,
+    {
+      const postflightStop = await restorePreflightStashOrStop(
+        ic,
+        preflightTransition,
         s.currentMilestoneId!,
-        preflightTransition.stashMarker,
-        ctx.ui.notify.bind(ctx.ui),
       );
+      if (postflightStop) return postflightStop;
     }
 
     // PR creation (auto_pr) is handled inside mergeMilestoneToMain (#2302)
@@ -788,13 +821,13 @@ export async function runPreDispatch(
           return { action: "break", reason: "merge-failed" };
         }
         // #2909: postflight — restore stashed changes after successful merge
-        if (preflightAllComplete.stashPushed) {
-          deps.postflightPopStash(
-            s.originalBasePath || s.basePath,
+        {
+          const postflightStop = await restorePreflightStashOrStop(
+            ic,
+            preflightAllComplete,
             s.currentMilestoneId,
-            preflightAllComplete.stashMarker,
-            ctx.ui.notify.bind(ctx.ui),
           );
+          if (postflightStop) return postflightStop;
         }
 
         // PR creation (auto_pr) is handled inside mergeMilestoneToMain (#2302)
@@ -917,13 +950,13 @@ export async function runPreDispatch(
         return { action: "break", reason: "merge-failed" };
       }
       // #2909: postflight — restore stashed changes after successful merge
-      if (preflightComplete.stashPushed) {
-        deps.postflightPopStash(
-          s.originalBasePath || s.basePath,
+      {
+        const postflightStop = await restorePreflightStashOrStop(
+          ic,
+          preflightComplete,
           s.currentMilestoneId,
-          preflightComplete.stashMarker,
-          ctx.ui.notify.bind(ctx.ui),
         );
+        if (postflightStop) return postflightStop;
       }
 
       // PR creation (auto_pr) is handled inside mergeMilestoneToMain (#2302)

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -85,7 +85,10 @@ export async function runUnit(
   const sessionAbortController = new AbortController();
   _setSessionSwitchInFlight(true);
   try {
-    const sessionPromise = s.cmdCtx!.newSession({ abortSignal: sessionAbortController.signal }).finally(() => {
+    const sessionPromise = s.cmdCtx!.newSession({
+      abortSignal: sessionAbortController.signal,
+      cwd: s.basePath,
+    }).finally(() => {
       if (sessionSwitchGeneration === mySessionSwitchGeneration) {
         _setSessionSwitchInFlight(false);
       }

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -3,13 +3,13 @@
  *
  * #2909: Adds a fast-path git status check before milestone completion merges.
  * When the working tree is dirty the user is warned and changes are auto-stashed
- * so the merge can proceed cleanly.  After the merge completes, postflightPopStash
- * restores the stashed changes.
+ * so the merge can proceed cleanly. After the merge completes, postflightPopStash
+ * restores the stashed changes and reports whether manual recovery is needed.
  *
  * Design constraints (from Trek-e approval):
  *  - Warn the user before stashing (no silent surprises)
  *  - git stash push / git stash pop only — no custom stash management layer
- *  - Stash/pop errors are logged but MUST NOT block the merge
+ *  - Stash/pop errors are logged but MUST NOT block the merge itself
  *  - Fast-path status check — clean trees pay no extra cost
  */
 
@@ -25,6 +25,13 @@ export interface PreflightResult {
   stashMarker?: string;
   /** human-readable summary of what happened (empty string for clean trees) */
   summary: string;
+}
+
+export interface PostflightResult {
+  restored: boolean;
+  needsManualRecovery: boolean;
+  message: string;
+  stashRef?: string;
 }
 
 function findPreflightStashRef(basePath: string, milestoneId: string, stashMarker?: string): string | null {
@@ -112,14 +119,15 @@ export function preflightCleanRoot(
  *
  * Only called when preflightCleanRoot returned stashPushed=true.
  * Any pop error (e.g. conflict) is logged and notified but does NOT throw —
- * the merge already completed successfully.
+ * the merge already completed successfully. Callers must treat
+ * needsManualRecovery=true as a dirty workspace stop, not a clean completion.
  */
 export function postflightPopStash(
   basePath: string,
   milestoneId: string,
   stashMarker: string | undefined,
   notify: (message: string, level: "info" | "warning" | "error") => void,
-): void {
+): PostflightResult {
   let stashRef: string | null = null;
   try {
     stashRef = findPreflightStashRef(basePath, milestoneId, stashMarker);
@@ -127,7 +135,11 @@ export function postflightPopStash(
       const msg = `No matching GSD preflight stash found for milestone ${milestoneId}; leaving stash list untouched.`;
       logWarning("preflight", msg);
       notify(msg, "warning");
-      return;
+      return {
+        restored: false,
+        needsManualRecovery: true,
+        message: msg,
+      };
     }
     execFileSync("git", ["stash", "pop", stashRef], {
       cwd: basePath,
@@ -135,7 +147,14 @@ export function postflightPopStash(
       encoding: "utf-8",
       env: GIT_NO_PROMPT_ENV,
     });
-    notify(`Restored stashed changes after milestone ${milestoneId} merge.`, "info");
+    const msg = `Restored stashed changes after milestone ${milestoneId} merge.`;
+    notify(msg, "info");
+    return {
+      restored: true,
+      needsManualRecovery: false,
+      message: msg,
+      stashRef,
+    };
   } catch (err) {
     // Pop conflicts mean the merged code collides with the stashed changes.
     // Log a warning — the user needs to resolve manually, but the merge succeeded.
@@ -145,5 +164,11 @@ export function postflightPopStash(
     const msg = `git stash pop ${stashRef ?? ""}`.trim() + ` failed after merge of milestone ${milestoneId}: ${err instanceof Error ? err.message : String(err)}. ${restoreHint}`;
     logWarning("preflight", msg);
     notify(msg, "warning");
+    return {
+      restored: false,
+      needsManualRecovery: true,
+      message: msg,
+      ...(stashRef ? { stashRef } : {}),
+    };
   }
 }

--- a/src/resources/extensions/gsd/prompts/complete-milestone.md
+++ b/src/resources/extensions/gsd/prompts/complete-milestone.md
@@ -6,6 +6,8 @@ You are executing GSD auto-mode.
 
 Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
 
+If any inlined plan, summary, verification command, or prior artifact names an absolute path outside `{{workingDirectory}}`, treat that path as stale context. Convert it to the equivalent relative path under `{{workingDirectory}}` before reading, writing, or executing. If no equivalent path exists under `{{workingDirectory}}`, record a verification failure and stop; do not edit or run commands in another checkout.
+
 ## Mission
 
 All slices are complete. Verify the integrated work, persist milestone completion, refresh project state, and write the final record future milestones will rely on.

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -689,7 +689,11 @@ function makeMockDeps(
     resolveMilestoneFile: () => null,
     reconcileMergeState: () => "clean",
     preflightCleanRoot: () => ({ stashPushed: false, summary: "" }),
-    postflightPopStash: () => {},
+    postflightPopStash: () => ({
+      restored: true,
+      needsManualRecovery: false,
+      message: "restored",
+    }),
     getLedger: () => null,
     getProjectTotals: () => ({ cost: 0 }),
     formatCost: (c: number) => `$${c.toFixed(2)}`,
@@ -854,6 +858,73 @@ test("autoLoop exits on terminal complete state", async (t) => {
   assert.ok(
     !deps.callLog.includes("resolveDispatch"),
     "should not dispatch when complete",
+  );
+});
+
+test("autoLoop stops before success notification when postflight stash restore needs recovery", async () => {
+  _resetPendingResolve();
+
+  const notifications: Array<{ msg: string; level: string }> = [];
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.ui.notify = (msg: string, level: string) => {
+    notifications.push({ msg, level });
+  };
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+  let stopReason = "";
+
+  const deps = makeMockDeps({
+    deriveState: async () => {
+      deps.callLog.push("deriveState");
+      return {
+        phase: "complete",
+        activeMilestone: { id: "M001", title: "Test", status: "complete" },
+        activeSlice: null,
+        activeTask: null,
+        registry: [{ id: "M001", status: "complete" }],
+        blockers: [],
+      } as any;
+    },
+    preflightCleanRoot: () => ({
+      stashPushed: true,
+      stashMarker: "gsd-preflight-stash:M001:test",
+      summary: "stashed",
+    }),
+    postflightPopStash: () => ({
+      restored: false,
+      needsManualRecovery: true,
+      message: "git stash pop stash@{0} failed after merge of milestone M001",
+      stashRef: "stash@{0}",
+    }),
+    sendDesktopNotification: () => {
+      deps.callLog.push("sendDesktopNotification");
+    },
+    logCmuxEvent: () => {
+      deps.callLog.push("logCmuxEvent");
+    },
+    stopAuto: async (_ctx, _pi, reason) => {
+      deps.callLog.push("stopAuto");
+      stopReason = reason ?? "";
+    },
+  });
+
+  await autoLoop(ctx, pi, s, deps);
+
+  assert.equal(stopReason, "Post-merge stash restore failed for milestone M001");
+  assert.ok(
+    notifications.some(
+      (n) => n.level === "error" && n.msg.includes("Post-merge stash restore failed for milestone M001"),
+    ),
+    "failed postflight restore must be surfaced as an error",
+  );
+  assert.ok(
+    !deps.callLog.includes("sendDesktopNotification"),
+    "must not emit milestone success desktop notification after stash restore failure",
+  );
+  assert.ok(
+    !deps.callLog.includes("logCmuxEvent"),
+    "must not emit milestone success cmux event after stash restore failure",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -928,6 +928,78 @@ test("autoLoop stops before success notification when postflight stash restore n
   );
 });
 
+test("autoLoop marks transition merge complete before postflight recovery stop", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.ui.notify = () => {};
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+  let mergeCalls = 0;
+  let stopReason = "";
+
+  const deps = makeMockDeps({
+    deriveState: async () => {
+      deps.callLog.push("deriveState");
+      return {
+        phase: "executing",
+        activeMilestone: { id: "M002", title: "Next", status: "active" },
+        activeSlice: null,
+        activeTask: null,
+        registry: [
+          { id: "M001", title: "Done", status: "complete" },
+          { id: "M002", title: "Next", status: "active" },
+        ],
+        blockers: [],
+      } as any;
+    },
+    preflightCleanRoot: () => ({
+      stashPushed: true,
+      stashMarker: "gsd-preflight-stash:M001:test",
+      summary: "stashed",
+    }),
+    postflightPopStash: () => ({
+      restored: false,
+      needsManualRecovery: true,
+      message: "git stash pop stash@{0} failed after merge of milestone M001",
+      stashRef: "stash@{0}",
+    }),
+    resolver: {
+      get workPath() {
+        return "/tmp/project";
+      },
+      get projectRoot() {
+        return "/tmp/project";
+      },
+      get lockPath() {
+        return "/tmp/project";
+      },
+      enterMilestone: () => {
+        assert.fail("must not enter the next milestone after postflight recovery fails");
+      },
+      exitMilestone: () => {},
+      mergeAndExit: () => {
+        mergeCalls += 1;
+      },
+      mergeAndEnterNext: () => {},
+    } as any,
+    stopAuto: async (_ctx, _pi, reason) => {
+      deps.callLog.push("stopAuto");
+      stopReason = reason ?? "";
+      if (!s.milestoneMergedInPhases) {
+        deps.resolver.mergeAndExit("M001", ctx.ui);
+      }
+    },
+  });
+
+  await autoLoop(ctx, pi, s, deps);
+
+  assert.equal(stopReason, "Post-merge stash restore failed for milestone M001");
+  assert.equal(s.milestoneMergedInPhases, true);
+  assert.equal(mergeCalls, 1, "postflight recovery stop must not re-run an already completed transition merge");
+});
+
 test("autoLoop pauses when provider readiness cancels before dispatch", async () => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { autoSession } from "../auto-runtime-state.ts";
+import { dispatchHookUnit } from "../auto.ts";
 import { registerHooks } from "../bootstrap/register-hooks.ts";
 import { clearDiscussionFlowState, getPendingGate } from "../bootstrap/write-gate.ts";
 
@@ -106,6 +107,61 @@ describe("#3512: gsd-auto-wrapup must not interrupt in-flight tool calls", () =>
       !contextSection.includes("triggerTurn: true"),
       "Context budget wrapup must not use hardcoded triggerTurn: true",
     );
+  });
+});
+
+describe("hook dispatch session cwd", () => {
+  test("dispatchHookUnit passes basePath explicitly to newSession", async (t) => {
+    const originalCwd = process.cwd();
+    const basePath = mkdtempSync(join(tmpdir(), "gsd-hook-cwd-"));
+    mkdirSync(join(basePath, ".gsd"), { recursive: true });
+    autoSession.reset();
+    t.after(() => {
+      try {
+        process.chdir(originalCwd);
+      } catch {
+        // best effort cleanup after cwd-sensitive dispatch tests
+      }
+      autoSession.reset();
+      rmSync(basePath, { recursive: true, force: true });
+    });
+
+    let newSessionOptions: unknown;
+    const ctx = {
+      ui: {
+        notify: () => {},
+        setStatus: () => {},
+        setWidget: () => {},
+      },
+      modelRegistry: {
+        getAvailable: () => [],
+      },
+      sessionManager: {
+        getSessionFile: () => join(basePath, "session.jsonl"),
+      },
+      newSession: async (options?: unknown) => {
+        newSessionOptions = options;
+        return { cancelled: false };
+      },
+    };
+    const pi = {
+      sendMessage: () => {},
+      setModel: async () => true,
+    };
+
+    const dispatched = await dispatchHookUnit(
+      ctx as any,
+      pi as any,
+      "review",
+      "execute-task",
+      "M001/S01/T01",
+      "review the completed unit",
+      undefined,
+      basePath,
+    );
+
+    assert.equal(dispatched, true);
+    assert.deepEqual(newSessionOptions, { cwd: basePath });
   });
 });
 

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -131,9 +131,11 @@ test("postflightPopStash — restores stashed changes and emits info notificatio
     run('git commit -m "simulate merge"', repo);
 
     const postNotifications: Array<{ msg: string; level: string }> = [];
-    postflightPopStash(repo, "M004", preflight.stashMarker, (msg, level) => {
+    const postflight = postflightPopStash(repo, "M004", preflight.stashMarker, (msg, level) => {
       postNotifications.push({ msg, level });
     });
+    assert.equal(postflight.restored, true, "postflight must report successful restore");
+    assert.equal(postflight.needsManualRecovery, false, "successful restore must not need manual recovery");
 
     // The stashed README.md change must be restored
     const content = readFileSync(join(repo, "README.md"), "utf-8");
@@ -171,7 +173,8 @@ test("preflight + merge + postflight round-trip preserves uncommitted changes", 
     run('git commit -m "feat: add feature"', repo);
 
     // Postflight: pop stash
-    postflightPopStash(repo, "M005", preflight.stashMarker, () => {});
+    const postflight = postflightPopStash(repo, "M005", preflight.stashMarker, () => {});
+    assert.equal(postflight.needsManualRecovery, false, "clean restore must not stop auto-mode");
 
     // README.md must still have our local content
     const restored = readFileSync(join(repo, "README.md"), "utf-8");
@@ -197,9 +200,12 @@ test("postflightPopStash conflict warning names the exact stash ref", () => {
     run('git commit -m "simulate conflicting merge"', repo);
 
     const notifications: Array<{ msg: string; level: string }> = [];
-    postflightPopStash(repo, "M005C", preflight.stashMarker, (msg, level) => {
+    const postflight = postflightPopStash(repo, "M005C", preflight.stashMarker, (msg, level) => {
       notifications.push({ msg, level });
     });
+    assert.equal(postflight.restored, false, "conflicted restore must report restored=false");
+    assert.equal(postflight.needsManualRecovery, true, "conflicted restore must require manual recovery");
+    assert.match(postflight.message, /failed after merge of milestone M005C/);
 
     const warning = notifications.find((n) => n.level === "warning")?.msg ?? "";
     assert.match(warning, /git stash pop stash@\{\d+\}/);
@@ -219,7 +225,8 @@ test("postflightPopStash restores the matching GSD stash, not stash@{0}", () => 
     writeFileSync(join(repo, "other.txt"), "other stash\n");
     run('git stash push --include-untracked -m "unrelated newer stash"', repo);
 
-    postflightPopStash(repo, "M006", preflight.stashMarker, () => {});
+    const postflight = postflightPopStash(repo, "M006", preflight.stashMarker, () => {});
+    assert.equal(postflight.needsManualRecovery, false, "targeted restore must not need manual recovery");
 
     const content = readFileSync(join(repo, "README.md"), "utf-8");
     assert.equal(content.replace(/\r\n/g, "\n"), "# target stash\n");
@@ -242,7 +249,8 @@ test("postflightPopStash restores the exact preflight marker when another same-m
     writeFileSync(join(repo, "same-milestone.txt"), "newer same milestone stash\n");
     run('git stash push --include-untracked -m "gsd-preflight-stash [gsd-preflight-stash:M007:other]"', repo);
 
-    postflightPopStash(repo, "M007", preflight.stashMarker, () => {});
+    const postflight = postflightPopStash(repo, "M007", preflight.stashMarker, () => {});
+    assert.equal(postflight.needsManualRecovery, false, "exact marker restore must not need manual recovery");
 
     const content = readFileSync(join(repo, "README.md"), "utf-8");
     assert.equal(content.replace(/\r\n/g, "\n"), "# target stash\n");
@@ -260,7 +268,8 @@ test("postflightPopStash falls back to milestone marker prefix when exact marker
     writeFileSync(join(repo, "README.md"), "# fallback stash\n");
     run('git stash push --include-untracked -m "gsd-preflight-stash [gsd-preflight-stash:M008:fallback]"', repo);
 
-    postflightPopStash(repo, "M008", undefined, () => {});
+    const postflight = postflightPopStash(repo, "M008", undefined, () => {});
+    assert.equal(postflight.needsManualRecovery, false, "fallback marker restore must not need manual recovery");
 
     const content = readFileSync(join(repo, "README.md"), "utf-8");
     assert.equal(content.replace(/\r\n/g, "\n"), "# fallback stash\n");

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -192,7 +192,11 @@ function makeMockDeps(overrides?: Partial<LoopDeps>): LoopDeps & { callLog: stri
     resolveMilestoneFile: () => null,
     reconcileMergeState: () => "clean",
     preflightCleanRoot: () => ({ stashPushed: false, summary: "" }),
-    postflightPopStash: () => {},
+    postflightPopStash: () => ({
+      restored: true,
+      needsManualRecovery: false,
+      message: "restored",
+    }),
     getLedger: () => null,
     getProjectTotals: () => ({ cost: 0 }),
     formatCost: (c: number) => `$${c.toFixed(2)}`,

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -85,7 +85,11 @@ function makeMockDeps(
     resolveMilestoneFile: () => null,
     reconcileMergeState: () => "clean",
     preflightCleanRoot: () => ({ stashPushed: false, summary: "" }),
-    postflightPopStash: () => {},
+    postflightPopStash: () => ({
+      restored: true,
+      needsManualRecovery: false,
+      message: "restored",
+    }),
     getLedger: () => ({ units: [] }),
     getProjectTotals: () => ({ cost: 0 }),
     formatCost: (c: number) => `$${c.toFixed(2)}`,


### PR DESCRIPTION
## TL;DR

**What:** Harden GSD auto-mode milestone closeout when post-merge stash restore or worktree teardown leaves stale runtime state.
**Why:** Auto-mode could report success after a merge even though local recovery failed, then follow-up commands could target a deleted milestone worktree.
**How:** Return structured postflight stash results, stop before success on recovery failures, and explicitly re-root new agent sessions to the restored project cwd.

## What

This updates auto-mode closeout behavior across the GSD extension and coding-agent session refresh path:

- `postflightPopStash()` now returns a structured result describing whether restore succeeded or manual recovery is required.
- Auto-loop checks that result before success notification and stops with a clear recovery error when stash restore fails.
- `newSession()` accepts an explicit `cwd`, and auto-mode passes the restored base path after worktree teardown/session rebuild.
- Complete-milestone prompt guidance rejects stale absolute paths outside `{{workingDirectory}}`.
- Regression tests cover stash-pop recovery failure, success-notification suppression, explicit cwd refresh, and updated postflight result semantics.

## Why

Closes #5516

The observed closeout failure completed and merged `M003`, removed the worktree, then emitted a deleted-worktree cwd error and left the root project with a stash-pop conflict. The workflow needed to distinguish "merge succeeded" from "closeout is fully clean" and refresh the active tool runtime after worktree teardown.

## How

The fix keeps the merge itself non-throwing but makes postflight recovery explicit:

- `postflightPopStash()` returns `needsManualRecovery: true` for missing matching stash refs or stash-pop conflicts.
- `auto/phases.ts` centralizes postflight handling and returns a break action before desktop/cmux success events if recovery is needed.
- `AgentSession.newSession({ cwd })` preserves historical `process.cwd()` behavior for existing callers while letting auto-mode pass a known-good base path.
- Auto-mode stop cleanup calls `newSession({ cwd: s.basePath })` after restoring the original base path.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/agent-session-tool-refresh.test.ts src/resources/extensions/gsd/tests/auto-loop.test.ts src/resources/extensions/gsd/tests/clean-root-preflight.test.ts src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts`
- [x] `npm run typecheck:extensions`
- [x] `git diff --check`
- [ ] `npm run verify:pr` currently fails on an unrelated ADR-012 provider equality guard in `src/providers/provider-migrations.ts`, which this branch does not modify.

## AI assistance

AI-assisted implementation and verification. No AI co-author is included in the commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `cwd` parameter to session creation, allowing explicit working directory specification instead of relying on global process directory.
  * Postflight stash restoration now returns structured result with recovery status.

* **Bug Fixes**
  * Sessions now properly anchor to intended directories after worktree changes.

* **Tests**
  * Added coverage for explicit working directory handling in session creation.
  * Added tests for postflight stash restoration failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->