### PR TITLE
fix(gsd): use explicit workspace roots

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -51,6 +51,10 @@ LLM provider SDKs (Anthropic, OpenAI, Google, etc.) are lazy-loaded on first use
 
 Every dispatch creates a new agent session. The LLM starts with a clean context window containing only the pre-inlined artifacts it needs. This prevents quality degradation from context accumulation.
 
+### Workspace Roots, Not Ambient `cwd`
+
+GSD workflow code must treat the active project/worktree as explicit state, not infer it from ambient `process.cwd()`. Prefer `AutoSession.scope`, `s.canonicalProjectRoot`, `s.basePath`, `s.originalBasePath`, hook `ctx.cwd`, or an explicit `basePath` parameter depending on the boundary. `cwd` remains valid as a subprocess/shell option in generic Pi tooling, but GSD identity, DB paths, workflow gates, auto-mode sessions, and dynamic tool execution should be rooted from explicit workflow state.
+
 ## Bundled Extensions
 
 | Extension | What It Provides |

--- a/packages/pi-coding-agent/src/core/agent-session-tool-refresh.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-tool-refresh.test.ts
@@ -130,4 +130,22 @@ describe("#3616 — newSession() restores narrowed tool set when cwd unchanged",
 			"cwd-changed branch must rebuild with includeAllExtensionTools: true",
 		);
 	});
+
+	it("uses explicit workspaceRoot option instead of process.cwd() when rebuilding runtime", async () => {
+		const session = await createSession();
+		const explicitWorkspaceRoot = mkdtempSync(join(testDir, "explicit-workspace-"));
+		(session as any)._cwd = process.cwd();
+
+		let buildRuntimeCalled = false;
+		const originalBuild = (session as any)._buildRuntime.bind(session);
+		(session as any)._buildRuntime = (options?: { includeAllExtensionTools?: boolean }) => {
+			buildRuntimeCalled = true;
+			return originalBuild(options);
+		};
+
+		const ok = await session.newSession({ workspaceRoot: explicitWorkspaceRoot });
+		assert.equal(ok, true);
+		assert.equal((session as any)._cwd, explicitWorkspaceRoot);
+		assert.ok(buildRuntimeCalled, "explicit workspace root differing from prior root must rebuild runtime");
+	});
 });

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1645,6 +1645,8 @@ export class AgentSession {
 	async newSession(options?: {
 		parentSession?: string;
 		setup?: (sessionManager: SessionManager) => Promise<void>;
+		/** Explicit workspace root for the new session/tool runtime. */
+		workspaceRoot?: string;
 		/** See ExtensionCommandContext.newSession for docs (#3731). */
 		abortSignal?: AbortSignal;
 	}): Promise<boolean> {
@@ -1666,10 +1668,10 @@ export class AgentSession {
 		try {
 			await this._settleCurrentTurnForSessionTransition();
 
-			// #3731: If the caller aborted (e.g. runUnit() timed out and restored cwd to
-			// project root), discard this session before capturing process.cwd() and
-			// rebuilding the tool runtime. Without this check, the late newSession()
-			// would rebuild tools with root cwd, breaking worktree isolation.
+			// #3731: If the caller aborted (e.g. runUnit() timed out while the
+			// worktree was being torn down), discard this session before rebuilding
+			// the tool runtime. Without this check, the late newSession() could
+			// rebuild tools with a stale workspace root.
 			if (options?.abortSignal?.aborted) {
 				return false;
 			}
@@ -1679,10 +1681,12 @@ export class AgentSession {
 		} finally {
 			this._sessionSwitchPending = false;
 		}
-		// Update cwd to current process directory — auto-mode may have chdir'd
-		// into a worktree since the original session was created.
+		// Update the workspace root for the new tool runtime. Auto-mode passes
+		// this explicitly so session routing does not depend on global
+		// process.cwd() after worktree merge/teardown. Other callers keep the
+		// historical default.
 		const previousCwd = this._cwd;
-		this._cwd = process.cwd();
+		this._cwd = options?.workspaceRoot ?? process.cwd();
 		this.sessionManager.newSession({ parentSession: options?.parentSession });
 		this.agent.sessionId = this.sessionManager.getSessionId();
 		this._steeringMessages = [];

--- a/packages/pi-coding-agent/src/core/extensions/runner.test.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.test.ts
@@ -160,7 +160,7 @@ describe("ExtensionRunner.emitToolCall", () => {
 });
 
 describe("ExtensionRunner.createContext", () => {
-	it("uses the live process cwd instead of the constructor cwd", (t) => {
+	it("uses the constructor workspace root instead of ambient process cwd", (t) => {
 		const originalCwd = process.cwd();
 		const dir = mkdtempSync(join(tmpdir(), "runner-test-"));
 		const projectDir = join(dir, "project");
@@ -179,8 +179,8 @@ describe("ExtensionRunner.createContext", () => {
 		const realProjectDir = realpathSync(projectDir);
 		process.chdir(realProjectDir);
 
-		assert.equal(runner.createContext().cwd, realProjectDir);
-		assert.equal(runner.createCommandContext().cwd, realProjectDir);
+		assert.equal(runner.createContext().cwd, originalCwd);
+		assert.equal(runner.createCommandContext().cwd, originalCwd);
 	});
 
 	it("does not let lifecycle event handlers close the TUI", async (t) => {

--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -173,6 +173,8 @@ export type ExtensionErrorListener = (error: ExtensionError) => void;
 export type NewSessionHandler = (options?: {
 	parentSession?: string;
 	setup?: (sessionManager: SessionManager) => Promise<void>;
+	/** Explicit workspace root for the new session/tool runtime. */
+	workspaceRoot?: string;
 	/** See ExtensionCommandContext.newSession for docs (#3731). */
 	abortSignal?: AbortSignal;
 }) => Promise<{ cancelled: boolean }>;
@@ -275,11 +277,7 @@ export class ExtensionRunner {
 	}
 
 	private currentCwd(): string {
-		try {
-			return process.cwd();
-		} catch {
-			return this.cwd;
-		}
+		return this.cwd;
 	}
 
 	/**

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -309,10 +309,13 @@ export interface ExtensionCommandContext extends ExtensionContext {
 	newSession(options?: {
 		parentSession?: string;
 		setup?: (sessionManager: SessionManager) => Promise<void>;
+		/** Explicit workspace root for the new session/tool runtime.
+		 *  When omitted, newSession() captures process.cwd() for backwards compatibility. */
+		workspaceRoot?: string;
 		/** When aborted before the session is fully configured, newSession() returns
 		 *  early without rebuilding the tool runtime. Used by runUnit() to discard
 		 *  a late-resolving newSession() after the session-creation timeout fires,
-		 *  preventing the tool runtime from being rebuilt with the wrong cwd (#3731). */
+		 *  preventing the tool runtime from being rebuilt with a stale workspace root (#3731). */
 		abortSignal?: AbortSignal;
 	}): Promise<{ cancelled: boolean }>;
 
@@ -1759,6 +1762,8 @@ export interface ExtensionCommandContextActions {
 	newSession: (options?: {
 		parentSession?: string;
 		setup?: (sessionManager: SessionManager) => Promise<void>;
+		/** See ExtensionCommandContext.newSession for docs. */
+		workspaceRoot?: string;
 		/** See ExtensionCommandContext.newSession for docs (#3731). */
 		abortSignal?: AbortSignal;
 	}) => Promise<{ cancelled: boolean }>;

--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -31,7 +31,6 @@ import { loadEffectiveGSDPreferences } from "./preferences.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { pauseAuto } from "./auto.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
-import { logWarning } from "./workflow-logger.js";
 import {
   getWorkflowTransportSupportError,
   getRequiredWorkflowToolsForAutoUnit,
@@ -290,38 +289,13 @@ export async function dispatchDirectPhase(
 
   ctx.ui.notify(`Dispatching ${unitType} for ${unitId}...`, "info");
 
-  const originalCwd = process.cwd();
-
-  try {
-    // Ensure cwd matches dispatchBase BEFORE newSession() captures it. Synchronous —
-    // no awaits between chdir and newSession.
-    try {
-      if (process.cwd() !== dispatchBase) {
-        process.chdir(dispatchBase);
-      }
-    } catch (err) {
-      const msg = `Failed to chdir before direct-dispatch newSession (basePath: ${dispatchBase}): ${err instanceof Error ? err.message : String(err)}`;
-      logWarning("engine", msg, { file: "auto-direct-dispatch.ts", basePath: dispatchBase, error: err instanceof Error ? err.message : String(err) });
-      ctx.ui.notify(`${msg}. Cancelling dispatch to avoid running in the wrong directory.`, "error");
-      return;
-    }
-
-    const result = await ctx.newSession();
-    if (result.cancelled) {
-      ctx.ui.notify("Session creation cancelled.", "warning");
-      return;
-    }
-    pi.sendMessage(
-      { customType: "gsd-dispatch", content: prompt, display: false },
-      { triggerTurn: true },
-    );
-  } finally {
-    try {
-      if (process.cwd() !== originalCwd) {
-        process.chdir(originalCwd);
-      }
-    } catch (err) {
-      logWarning("engine", `Failed to restore cwd after direct dispatch: ${err instanceof Error ? err.message : String(err)}`, { file: "auto-direct-dispatch.ts", basePath: originalCwd });
-    }
+  const result = await ctx.newSession({ workspaceRoot: dispatchBase });
+  if (result.cancelled) {
+    ctx.ui.notify("Session creation cancelled.", "warning");
+    return;
   }
+  pi.sendMessage(
+    { customType: "gsd-dispatch", content: prompt, display: false },
+    { triggerTurn: true },
+  );
 }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1157,6 +1157,21 @@ export async function stopAuto(
       debugLog("stop-cleanup-basepath", { error: e instanceof Error ? e.message : String(e) });
     }
 
+    // Re-root the active command session/tool runtime after worktree teardown.
+    // mergeAndExit restores process.cwd(), but AgentSession has already captured
+    // its own cwd for tools and system prompt; refresh it before returning to the
+    // user so follow-up commands do not target a removed milestone worktree.
+    if (s.originalBasePath && ctx && s.cmdCtx) {
+      try {
+        const result = await s.cmdCtx.newSession({ workspaceRoot: s.basePath });
+        if (result.cancelled) {
+          logWarning("engine", "post-stop session re-root was cancelled", { file: "auto.ts", basePath: s.basePath });
+        }
+      } catch (err) {
+        logWarning("engine", `post-stop session re-root failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts", basePath: s.basePath });
+      }
+    }
+
     // ── Step 8: Ledger notification ──
     try {
       const ledger = getLedger();
@@ -2281,24 +2296,7 @@ export async function dispatchHookUnit(
     startedAt: hookStartedAt,
   };
 
-  // Ensure cwd matches basePath BEFORE newSession() captures it (#1389).
-  // newSession() snapshots process.cwd() during construction; chdir-ing
-  // afterward leaves the session rooted to whatever cwd was when the call
-  // was made. Must be synchronous — no awaits between chdir and newSession.
-  try { if (process.cwd() !== s.basePath) process.chdir(s.basePath); } catch (err) {
-    const msg = `Failed to chdir before hook newSession (basePath: ${s.basePath}): ${err instanceof Error ? err.message : String(err)}`;
-    logWarning("engine", msg, { file: "auto.ts", basePath: s.basePath, error: err instanceof Error ? err.message : String(err) });
-    ctx.ui.notify(`${msg}. Cancelling hook dispatch to avoid running in the wrong directory.`, "error");
-    if (wasActive) {
-      s.basePath = previousBasePath;
-      s.currentUnit = previousCurrentUnit;
-    } else {
-      s.reset();
-    }
-    return false;
-  }
-
-  const result = await s.cmdCtx!.newSession();
+  const result = await s.cmdCtx!.newSession({ workspaceRoot: s.basePath });
   if (result.cancelled) {
     await stopAuto(ctx, pi);
     return false;

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -48,44 +48,22 @@ export async function runUnit(
 ): Promise<UnitResult> {
   debugLog("runUnit", { phase: "start", unitType, unitId });
 
-  // Ensure cwd matches basePath BEFORE newSession() captures it. The new
-  // session reads process.cwd() during construction to anchor its tool
-  // runtime and system prompt; if cwd has drifted (async_bash, background
-  // jobs, prior unit cleanup), the session would otherwise be rooted to
-  // the wrong directory. Must be synchronous — no awaits between chdir
-  // and newSession (#1389, #4762 follow-up).
-  try {
-    if (process.cwd() !== s.basePath) {
-      process.chdir(s.basePath);
-    }
-  } catch (e) {
-    const msg = `Failed to chdir to basePath before newSession (basePath: ${s.basePath}): ${String(e)}`;
-    logWarning("engine", msg, { basePath: s.basePath, error: String(e) });
-    return {
-      status: "cancelled",
-      errorContext: {
-        message: msg,
-        category: "session-failed",
-        isTransient: true,
-      },
-    };
-  }
-
   // ── Session creation with timeout ──
   debugLog("runUnit", { phase: "session-create", unitType, unitId });
 
   let sessionResult: { cancelled: boolean };
   let sessionTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const mySessionSwitchGeneration = ++sessionSwitchGeneration;
-  // #3731: Cancellation controller for newSession(). When the session-creation
-  // timeout fires, we abort this controller so that the still-in-flight
-  // newSession() discards itself after await this.abort() completes, preventing
-  // it from capturing the (now-root) process.cwd() and rebuilding the tool
-  // runtime with the wrong cwd.
+  // #3731: Cancellation controller for newSession(). When session creation
+  // times out, abort before a late session switch can rebuild the tool runtime
+  // against a stale workspace root.
   const sessionAbortController = new AbortController();
   _setSessionSwitchInFlight(true);
   try {
-    const sessionPromise = s.cmdCtx!.newSession({ abortSignal: sessionAbortController.signal }).finally(() => {
+    const sessionPromise = s.cmdCtx!.newSession({
+      abortSignal: sessionAbortController.signal,
+      workspaceRoot: s.basePath,
+    }).finally(() => {
       if (sessionSwitchGeneration === mySessionSwitchGeneration) {
         _setSessionSwitchInFlight(false);
       }

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -16,6 +16,13 @@ async function loadWorkflowExecutors(): Promise<typeof import("../tools/workflow
   return import("../tools/workflow-tool-executors.js");
 }
 
+function toolWorkspaceRoot(ctx: unknown): string {
+  if (ctx && typeof ctx === "object" && typeof (ctx as { cwd?: unknown }).cwd === "string") {
+    return (ctx as { cwd: string }).cwd;
+  }
+  return process.cwd();
+}
+
 /**
  * Register an alias tool that shares the same execute function as its canonical counterpart.
  * The alias description and promptGuidelines direct the LLM to prefer the canonical name.
@@ -38,8 +45,8 @@ function registerAlias(pi: ExtensionAPI, toolDef: any, aliasName: string, canoni
   });
 }
 
-function requirementRootWriteGuard(operation: string): { content: Array<{ type: "text"; text: string }>; details: Record<string, unknown>; isError: true } | null {
-  const guard = shouldBlockRootArtifactSaveInSnapshot(loadWriteGateSnapshot(process.cwd()), "REQUIREMENTS");
+function requirementRootWriteGuard(operation: string, basePath: string): { content: Array<{ type: "text"; text: string }>; details: Record<string, unknown>; isError: true } | null {
+  const guard = shouldBlockRootArtifactSaveInSnapshot(loadWriteGateSnapshot(basePath), "REQUIREMENTS");
   if (!guard.block) return null;
   return {
     content: [{ type: "text", text: `Error ${operation} requirement: ${guard.reason ?? "requirements write blocked"}` }],
@@ -65,7 +72,8 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_decision_save (formerly gsd_save_decision) ─────────────────────
 
   const decisionSaveExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
-    const dbAvailable = await ensureDbOpen();
+    const basePath = toolWorkspaceRoot(_ctx);
+    const dbAvailable = await ensureDbOpen(basePath);
     if (!dbAvailable) {
       return {
         content: [{ type: "text" as const, text: "Error: GSD database is not available. Cannot save decision." }],
@@ -84,7 +92,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
           when_context: params.when_context,
           made_by: params.made_by,
         },
-        process.cwd(),
+        basePath,
       );
       return {
         content: [{ type: "text" as const, text: `Saved decision ${id}` }],
@@ -152,9 +160,10 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_requirement_update (formerly gsd_update_requirement) ───────────
 
   const requirementUpdateExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
-    const gateBlock = requirementRootWriteGuard("update_requirement");
+    const basePath = toolWorkspaceRoot(_ctx);
+    const gateBlock = requirementRootWriteGuard("update_requirement", basePath);
     if (gateBlock) return gateBlock;
-    const dbAvailable = await ensureDbOpen();
+    const dbAvailable = await ensureDbOpen(basePath);
     if (!dbAvailable) {
       return {
         content: [{ type: "text" as const, text: "Error: GSD database is not available. Cannot update requirement." }],
@@ -170,7 +179,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       if (params.description !== undefined) updates.description = params.description;
       if (params.primary_owner !== undefined) updates.primary_owner = params.primary_owner;
       if (params.supporting_slices !== undefined) updates.supporting_slices = params.supporting_slices;
-      await updateRequirementInDb(params.id, updates, process.cwd());
+      await updateRequirementInDb(params.id, updates, basePath);
       return {
         content: [{ type: "text" as const, text: `Updated requirement ${params.id}` }],
         details: { operation: "update_requirement", id: params.id } as any,
@@ -232,9 +241,10 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_requirement_save ─────────────────────────────────────────────
 
   const requirementSaveExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
-    const gateBlock = requirementRootWriteGuard("save_requirement");
+    const basePath = toolWorkspaceRoot(_ctx);
+    const gateBlock = requirementRootWriteGuard("save_requirement", basePath);
     if (gateBlock) return gateBlock;
-    const dbAvailable = await ensureDbOpen();
+    const dbAvailable = await ensureDbOpen(basePath);
     if (!dbAvailable) {
       return {
         content: [{ type: "text" as const, text: "Error: GSD database is not available. Cannot save requirement." }],
@@ -255,7 +265,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
           validation: params.validation,
           notes: params.notes,
         },
-        process.cwd(),
+        basePath,
       );
       return {
         content: [{ type: "text" as const, text: `Saved requirement ${result.id}` }],
@@ -335,7 +345,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
   const summarySaveExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
     const { executeSummarySave } = await loadWorkflowExecutors();
-    return executeSummarySave(params, process.cwd());
+    return executeSummarySave(params, toolWorkspaceRoot(_ctx));
   };
 
   const summarySaveTool = {
@@ -386,24 +396,24 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
   const milestoneGenerateIdExecute = async (_toolCallId: string, _params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
     try {
+      const basePath = toolWorkspaceRoot(_ctx);
       // Claim a reserved ID if the guided-flow already previewed one to the user.
       // This guarantees the ID shown in the UI matches the one materialised on disk.
       const { claimReservedId, findMilestoneIds, getReservedMilestoneIds, nextMilestoneId } = await import("../guided-flow.js");
       const reserved = claimReservedId();
       if (reserved) {
-        await ensureMilestoneDbRow(reserved);
+        await ensureMilestoneDbRow(reserved, basePath);
         return {
           content: [{ type: "text" as const, text: reserved }],
           details: { operation: "generate_milestone_id", id: reserved, source: "reserved" } as any,
         };
       }
 
-      const basePath = process.cwd();
       const existingIds = findMilestoneIds(basePath);
       const uniqueEnabled = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
       const allIds = [...new Set([...existingIds, ...getReservedMilestoneIds()])];
       const newId = nextMilestoneId(allIds, uniqueEnabled);
-      await ensureMilestoneDbRow(newId);
+      await ensureMilestoneDbRow(newId, basePath);
       return {
         content: [{ type: "text" as const, text: newId }],
         details: { operation: "generate_milestone_id", id: newId, existingCount: existingIds.length, uniqueEnabled } as any,
@@ -423,8 +433,8 @@ export function registerDbTools(pi: ExtensionAPI): void {
    * later writes the full row. Silently skips if the DB isn't available yet
    * (pre-migration).
    */
-  async function ensureMilestoneDbRow(milestoneId: string): Promise<void> {
-    const dbAvailable = await ensureDbOpen();
+  async function ensureMilestoneDbRow(milestoneId: string, basePath: string): Promise<void> {
+    const dbAvailable = await ensureDbOpen(basePath);
     if (!dbAvailable) return;
     try {
       const { insertMilestone } = await import("../gsd-db.js");
@@ -471,7 +481,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
   const planMilestoneExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
     const { executePlanMilestone } = await loadWorkflowExecutors();
-    return executePlanMilestone(params, process.cwd());
+    return executePlanMilestone(params, toolWorkspaceRoot(_ctx));
   };
 
   const planMilestoneTool = {
@@ -541,7 +551,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
   const planSliceExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
     const { executePlanSlice } = await loadWorkflowExecutors();
-    return executePlanSlice(params, process.cwd());
+    return executePlanSlice(params, toolWorkspaceRoot(_ctx));
   };
 
   const planSliceTool = {
@@ -590,7 +600,8 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_plan_task (gsd_task_plan alias) ───────────────────────────────
 
   const planTaskExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
-    const dbAvailable = await ensureDbOpen();
+    const basePath = toolWorkspaceRoot(_ctx);
+    const dbAvailable = await ensureDbOpen(basePath);
     if (!dbAvailable) {
       return {
         content: [{ type: "text" as const, text: "Error: GSD database is not available. Cannot plan task." }],
@@ -599,7 +610,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
     }
     try {
       const { handlePlanTask } = await import("../tools/plan-task.js");
-      const result = await handlePlanTask(params, process.cwd());
+      const result = await handlePlanTask(params, basePath);
       if ("error" in result) {
         return {
           content: [{ type: "text" as const, text: `Error planning task: ${result.error}` }],
@@ -664,7 +675,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
   const taskCompleteExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
     const { executeTaskComplete } = await loadWorkflowExecutors();
-    return executeTaskComplete(params, process.cwd());
+    return executeTaskComplete(params, toolWorkspaceRoot(_ctx));
   };
 
   const taskCompleteTool = {
@@ -735,7 +746,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
   const sliceCompleteExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
     const { executeSliceComplete } = await loadWorkflowExecutors();
-    return executeSliceComplete(params, process.cwd());
+    return executeSliceComplete(params, toolWorkspaceRoot(_ctx));
   };
 
   const sliceCompleteTool = {
@@ -835,7 +846,8 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_skip_slice (#3477 / #3487) ───────────────────────────────────
 
   const skipSliceExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
-    const dbAvailable = await ensureDbOpen();
+    const basePath = toolWorkspaceRoot(_ctx);
+    const dbAvailable = await ensureDbOpen(basePath);
     if (!dbAvailable) {
       return {
         content: [{ type: "text" as const, text: "Error: GSD database is not available. Cannot skip slice." }],
@@ -868,7 +880,6 @@ export function registerDbTools(pi: ExtensionAPI): void {
       // Rebuild STATE.md so it reflects the skip immediately (#3477).
       // Without this, /gsd auto reads stale STATE.md and resumes the skipped slice.
       try {
-        const basePath = process.cwd();
         const { rebuildState } = await import("../doctor.js");
         await rebuildState(basePath);
       } catch (err) {
@@ -928,7 +939,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
   const milestoneCompleteExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
     const { executeCompleteMilestone } = await loadWorkflowExecutors();
-    return executeCompleteMilestone(params, process.cwd());
+    return executeCompleteMilestone(params, toolWorkspaceRoot(_ctx));
   };
 
   const milestoneCompleteTool = {
@@ -974,7 +985,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
   const milestoneValidateExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
     const { executeValidateMilestone } = await loadWorkflowExecutors();
-    return executeValidateMilestone(params, process.cwd());
+    return executeValidateMilestone(params, toolWorkspaceRoot(_ctx));
   };
 
   const milestoneValidateTool = {
@@ -1012,7 +1023,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
   const replanSliceExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
     const { executeReplanSlice } = await loadWorkflowExecutors();
-    return executeReplanSlice(params, process.cwd());
+    return executeReplanSlice(params, toolWorkspaceRoot(_ctx));
   };
 
   const replanSliceTool = {
@@ -1063,7 +1074,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
   const reassessRoadmapExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
     const { executeReassessRoadmap } = await loadWorkflowExecutors();
-    return executeReassessRoadmap(params, process.cwd());
+    return executeReassessRoadmap(params, toolWorkspaceRoot(_ctx));
   };
 
   const reassessRoadmapTool = {
@@ -1122,7 +1133,8 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // Single-writer v3, Stream 3: reversibility tools for closed units.
 
   const reopenTaskExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
-    const dbAvailable = await ensureDbOpen();
+    const basePath = toolWorkspaceRoot(_ctx);
+    const dbAvailable = await ensureDbOpen(basePath);
     if (!dbAvailable) {
       return {
         content: [{ type: "text" as const, text: "Error: GSD database is not available. Cannot reopen task." }],
@@ -1131,7 +1143,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
     }
     try {
       const { handleReopenTask } = await import("../tools/reopen-task.js");
-      const result = await handleReopenTask(params, process.cwd());
+      const result = await handleReopenTask(params, basePath);
       if ("error" in result) {
         return {
           content: [{ type: "text" as const, text: `Error reopening task: ${result.error}` }],
@@ -1188,7 +1200,8 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_slice_reopen (gsd_reopen_slice alias) ─────────────────────────
 
   const reopenSliceExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
-    const dbAvailable = await ensureDbOpen();
+    const basePath = toolWorkspaceRoot(_ctx);
+    const dbAvailable = await ensureDbOpen(basePath);
     if (!dbAvailable) {
       return {
         content: [{ type: "text" as const, text: "Error: GSD database is not available. Cannot reopen slice." }],
@@ -1197,7 +1210,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
     }
     try {
       const { handleReopenSlice } = await import("../tools/reopen-slice.js");
-      const result = await handleReopenSlice(params, process.cwd());
+      const result = await handleReopenSlice(params, basePath);
       if ("error" in result) {
         return {
           content: [{ type: "text" as const, text: `Error reopening slice: ${result.error}` }],
@@ -1254,7 +1267,8 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_milestone_reopen (gsd_reopen_milestone alias) ─────────────────
 
   const reopenMilestoneExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
-    const dbAvailable = await ensureDbOpen();
+    const basePath = toolWorkspaceRoot(_ctx);
+    const dbAvailable = await ensureDbOpen(basePath);
     if (!dbAvailable) {
       return {
         content: [{ type: "text" as const, text: "Error: GSD database is not available. Cannot reopen milestone." }],
@@ -1263,7 +1277,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
     }
     try {
       const { handleReopenMilestone } = await import("../tools/reopen-milestone.js");
-      const result = await handleReopenMilestone(params, process.cwd());
+      const result = await handleReopenMilestone(params, basePath);
       if ("error" in result) {
         return {
           content: [{ type: "text" as const, text: `Error reopening milestone: ${result.error}` }],
@@ -1319,7 +1333,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
   const saveGateResultExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
     const { executeSaveGateResult } = await loadWorkflowExecutors();
-    return executeSaveGateResult(params, process.cwd());
+    return executeSaveGateResult(params, toolWorkspaceRoot(_ctx));
   };
 
   const saveGateResultTool = {

--- a/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
@@ -8,6 +8,13 @@ import { DEFAULT_BASH_TIMEOUT_SECS } from "../constants.js";
 import { setLogBasePath, logWarning } from "../workflow-logger.js";
 import { resolveGsdPathContract } from "../paths.js";
 
+function resolveToolWorkspaceRoot(ctx?: unknown): string {
+  if (ctx && typeof ctx === "object" && typeof (ctx as { cwd?: unknown }).cwd === "string") {
+    return (ctx as { cwd: string }).cwd;
+  }
+  return process.cwd();
+}
+
 /**
  * Resolve the correct DB path for the current working directory.
  * If `basePath` is inside a `.gsd/worktrees/<MID>/` directory, returns
@@ -51,7 +58,7 @@ export async function ensureDbOpen(basePath: string = process.cwd()): Promise<bo
 
 export function registerDynamicTools(pi: ExtensionAPI): void {
   const baseBash = createBashTool(process.cwd(), {
-    spawnHook: (ctx) => ({ ...ctx, cwd: process.cwd() }),
+    spawnHook: (ctx) => ctx,
   });
   const dynamicBash = {
     ...baseBash,
@@ -62,11 +69,15 @@ export function registerDynamicTools(pi: ExtensionAPI): void {
       onUpdate?: unknown,
       ctx?: unknown,
     ) => {
+      const basePath = resolveToolWorkspaceRoot(ctx);
+      const fresh = createBashTool(basePath, {
+        spawnHook: (spawnCtx) => ({ ...spawnCtx, cwd: basePath }),
+      });
       const paramsWithTimeout = {
         ...params,
         timeout: params.timeout ?? DEFAULT_BASH_TIMEOUT_SECS,
       };
-      return (baseBash as any).execute(toolCallId, paramsWithTimeout, signal, onUpdate, ctx);
+      return (fresh as any).execute(toolCallId, paramsWithTimeout, signal, onUpdate, ctx);
     },
   };
   pi.registerTool(dynamicBash as any);
@@ -81,7 +92,7 @@ export function registerDynamicTools(pi: ExtensionAPI): void {
       onUpdate?: unknown,
       ctx?: unknown,
     ) => {
-      const fresh = createWriteTool(process.cwd());
+      const fresh = createWriteTool(resolveToolWorkspaceRoot(ctx));
       return (fresh as any).execute(toolCallId, params, signal, onUpdate, ctx);
     },
   } as any);
@@ -96,7 +107,7 @@ export function registerDynamicTools(pi: ExtensionAPI): void {
       onUpdate?: unknown,
       ctx?: unknown,
     ) => {
-      const fresh = createReadTool(process.cwd());
+      const fresh = createReadTool(resolveToolWorkspaceRoot(ctx));
       return (fresh as any).execute(toolCallId, params, signal, onUpdate, ctx);
     },
   } as any);
@@ -111,7 +122,7 @@ export function registerDynamicTools(pi: ExtensionAPI): void {
       onUpdate?: unknown,
       ctx?: unknown,
     ) => {
-      const fresh = createEditTool(process.cwd());
+      const fresh = createEditTool(resolveToolWorkspaceRoot(ctx));
       return (fresh as any).execute(toolCallId, params, signal, onUpdate, ctx);
     },
   } as any);

--- a/src/resources/extensions/gsd/bootstrap/exec-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/exec-tools.ts
@@ -6,6 +6,13 @@
 import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 
+function toolWorkspaceRoot(ctx: unknown): string {
+  if (ctx && typeof ctx === "object" && typeof (ctx as { cwd?: unknown }).cwd === "string") {
+    return (ctx as { cwd: string }).cwd;
+  }
+  return process.cwd();
+}
+
 async function loadContextModePreferences(baseDir: string) {
   const [{ loadEffectiveGSDPreferences }, { logWarning }] = await Promise.all([
     import("../preferences.js"),
@@ -54,7 +61,7 @@ export function registerExecTools(pi: ExtensionAPI): void {
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
       const { executeGsdExec } = await import("../tools/exec-tool.js");
-      const baseDir = process.cwd();
+      const baseDir = toolWorkspaceRoot(_ctx);
       return executeGsdExec(params as Parameters<typeof executeGsdExec>[0], {
         baseDir,
         preferences: await loadContextModePreferences(baseDir),
@@ -85,7 +92,7 @@ export function registerExecTools(pi: ExtensionAPI): void {
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
       const { executeExecSearch } = await import("../tools/exec-search-tool.js");
-      const baseDir = process.cwd();
+      const baseDir = toolWorkspaceRoot(_ctx);
       return executeExecSearch(params as Parameters<typeof executeExecSearch>[0], {
         baseDir,
         preferences: await loadContextModePreferences(baseDir),
@@ -108,7 +115,7 @@ export function registerExecTools(pi: ExtensionAPI): void {
     parameters: Type.Object({}),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
       const { executeResume } = await import("../tools/resume-tool.js");
-      const baseDir = process.cwd();
+      const baseDir = toolWorkspaceRoot(_ctx);
       return executeResume(params as Parameters<typeof executeResume>[0], {
         baseDir,
         preferences: await loadContextModePreferences(baseDir),

--- a/src/resources/extensions/gsd/bootstrap/journal-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/journal-tools.ts
@@ -4,6 +4,13 @@ import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { queryJournal } from "../journal.js";
 import { logWarning } from "../workflow-logger.js";
 
+function toolWorkspaceRoot(ctx: unknown): string {
+  if (ctx && typeof ctx === "object" && typeof (ctx as { cwd?: unknown }).cwd === "string") {
+    return (ctx as { cwd: string }).cwd;
+  }
+  return process.cwd();
+}
+
 export function registerJournalTools(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "gsd_journal_query",
@@ -36,7 +43,7 @@ export function registerJournalTools(pi: ExtensionAPI): void {
         if (params.after !== undefined) filters.after = params.after;
         if (params.before !== undefined) filters.before = params.before;
 
-        const entries = queryJournal(process.cwd(), filters);
+        const entries = queryJournal(toolWorkspaceRoot(_ctx), filters);
         const limited = entries.slice(0, params.limit ?? 100);
 
         if (limited.length === 0) {

--- a/src/resources/extensions/gsd/bootstrap/memory-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/memory-tools.ts
@@ -14,6 +14,13 @@ import {
   executeMemoryQuery,
 } from "../tools/memory-tools.js";
 
+function toolWorkspaceRoot(ctx: unknown): string {
+  if (ctx && typeof ctx === "object" && typeof (ctx as { cwd?: unknown }).cwd === "string") {
+    return (ctx as { cwd: string }).cwd;
+  }
+  return process.cwd();
+}
+
 export function registerMemoryTools(pi: ExtensionAPI): void {
   // ─── capture_thought ────────────────────────────────────────────────────
 
@@ -57,7 +64,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
       ),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
-      const ok = await ensureDbOpen();
+      const ok = await ensureDbOpen(toolWorkspaceRoot(_ctx));
       if (!ok) {
         return {
           content: [{ type: "text" as const, text: "Error: GSD database is not available. Cannot capture memory." }],
@@ -108,7 +115,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
       ),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
-      const ok = await ensureDbOpen();
+      const ok = await ensureDbOpen(toolWorkspaceRoot(_ctx));
       if (!ok) {
         return {
           content: [{ type: "text" as const, text: "Error: GSD database is not available. Cannot query memory." }],
@@ -149,7 +156,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
       ], { description: "Only include edges with this relation type" })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
-      const ok = await ensureDbOpen();
+      const ok = await ensureDbOpen(toolWorkspaceRoot(_ctx));
       if (!ok) {
         return {
           content: [{ type: "text" as const, text: "Error: GSD database is not available." }],

--- a/src/resources/extensions/gsd/bootstrap/query-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/query-tools.ts
@@ -4,6 +4,13 @@ import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { ensureDbOpen } from "./dynamic-tools.js";
 
+function toolWorkspaceRoot(ctx: unknown): string {
+  if (ctx && typeof ctx === "object" && typeof (ctx as { cwd?: unknown }).cwd === "string") {
+    return (ctx as { cwd: string }).cwd;
+  }
+  return process.cwd();
+}
+
 export function registerQueryTools(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "gsd_milestone_status",
@@ -20,7 +27,7 @@ export function registerQueryTools(pi: ExtensionAPI): void {
       milestoneId: Type.String({ description: "Milestone ID to query (e.g. M001)" }),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
-      const dbAvailable = await ensureDbOpen();
+      const dbAvailable = await ensureDbOpen(toolWorkspaceRoot(_ctx));
       if (!dbAvailable) {
         return {
           content: [{ type: "text", text: "Error: GSD database is not available. Cannot read milestone status." }],
@@ -47,7 +54,7 @@ export function registerQueryTools(pi: ExtensionAPI): void {
     ],
     parameters: Type.Object({}),
     async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
-      const dbAvailable = await ensureDbOpen();
+      const dbAvailable = await ensureDbOpen(toolWorkspaceRoot(_ctx));
       if (!dbAvailable) {
         return {
           content: [{ type: "text", text: "Error: GSD database is not available. Cannot checkpoint." }],

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -31,6 +31,13 @@ import { approvalGateIdForUnit, isExplicitApprovalResponse, shouldPauseForUserAp
 let isFirstSession = true;
 let approvalQuestionAbortInFlight = false;
 
+interface DeferredApprovalGate {
+  gateId: string;
+  basePath: string;
+}
+
+let deferredApprovalGate: DeferredApprovalGate | null = null;
+
 async function deriveGsdState(basePath: string) {
   const { deriveState } = await import("../state.js");
   return deriveState(basePath);
@@ -85,12 +92,56 @@ async function applyCompactionThresholdOverride(ctx: ExtensionContext): Promise<
   }
 }
 
-export function resolveNotificationStoreBasePath(cwd: string = process.cwd()): string {
-  return resolveWorktreeProjectRoot(cwd);
+function clearDeferredApprovalGate(basePath?: string): void {
+  if (!basePath || deferredApprovalGate?.basePath === basePath) {
+    deferredApprovalGate = null;
+  }
+}
+
+function deferApprovalGate(gateId: string, basePath: string): void {
+  deferredApprovalGate = { gateId, basePath };
+}
+
+function contextBasePath(ctx?: { cwd?: string }): string {
+  return typeof ctx?.cwd === "string" ? ctx.cwd : process.cwd();
+}
+
+function activateDeferredApprovalGate(basePath: string): void {
+  if (deferredApprovalGate?.basePath !== basePath) return;
+  setPendingGate(deferredApprovalGate.gateId, basePath);
+  deferredApprovalGate = null;
+}
+
+function isContextDraftSummarySave(toolName: string, input: unknown): boolean {
+  if (toolName !== "gsd_summary_save" && toolName !== "summary_save") return false;
+  if (!input || typeof input !== "object") return false;
+  return (input as { artifact_type?: unknown }).artifact_type === "CONTEXT-DRAFT";
+}
+
+function shouldBlockDeferredApprovalTool(
+  toolName: string,
+  input: unknown,
+  basePath: string,
+): { block: boolean; reason?: string } {
+  if (deferredApprovalGate?.basePath !== basePath) return { block: false };
+  if (toolName === "ask_user_questions") return { block: false };
+  if (isContextDraftSummarySave(toolName, input)) return { block: false };
+  return {
+    block: true,
+    reason: [
+      `HARD BLOCK: Approval question "${deferredApprovalGate.gateId}" has been shown to the user.`,
+      `Only CONTEXT-DRAFT persistence may finish in this same assistant turn.`,
+      `Wait for the user's answer before calling additional tools.`,
+    ].join(" "),
+  };
+}
+
+export function resolveNotificationStoreBasePath(basePath: string): string {
+  return resolveWorktreeProjectRoot(basePath);
 }
 
 function initSessionNotifications(ctx: ExtensionContext): void {
-  initNotificationStore(resolveNotificationStoreBasePath());
+  initNotificationStore(resolveNotificationStoreBasePath(contextBasePath(ctx)));
   installNotifyInterceptor(ctx);
   initNotificationWidget(ctx);
 }
@@ -132,23 +183,25 @@ export function registerHooks(
   ecosystemHandlers: GSDEcosystemBeforeAgentStartHandler[],
 ): void {
   pi.on("session_start", async (_event, ctx) => {
+    const basePath = contextBasePath(ctx);
     initSessionNotifications(ctx);
     if (!isAutoActive()) {
       const { initHealthWidget } = await import("../health-widget.js");
       initHealthWidget(ctx);
     }
-    resetWriteGateState(process.cwd());
+    resetWriteGateState(basePath);
     resetToolCallLoopGuard();
     approvalQuestionAbortInFlight = false;
+    clearDeferredApprovalGate();
     await resetAskUserQuestionsTurnCache();
     await syncServiceTierStatus(ctx);
     await applyDisabledModelProviderPolicy(ctx);
     await applyCompactionThresholdOverride(ctx);
     // Skip MCP auto-prep when running inside an auto-worktree (see session_switch below).
     const { isInAutoWorktree } = await import("../auto-worktree.js");
-    if (!isInAutoWorktree(process.cwd())) {
+    if (!isInAutoWorktree(basePath)) {
       const { prepareWorkflowMcpForProject } = await import("../workflow-mcp-auto-prep.js");
-      prepareWorkflowMcpForProject(ctx, process.cwd());
+      prepareWorkflowMcpForProject(ctx, basePath);
     }
 
     // Apply show_token_cost preference (#1515)
@@ -186,11 +239,13 @@ export function registerHooks(
   });
 
   pi.on("session_switch", async (_event, ctx) => {
+    const basePath = contextBasePath(ctx);
     initSessionNotifications(ctx);
-    resetWriteGateState(process.cwd());
+    resetWriteGateState(basePath);
     resetToolCallLoopGuard();
+    clearDeferredApprovalGate();
     await resetAskUserQuestionsTurnCache();
-    clearDiscussionFlowState(process.cwd());
+    clearDiscussionFlowState(basePath);
     await syncServiceTierStatus(ctx);
     await applyDisabledModelProviderPolicy(ctx);
     await applyCompactionThresholdOverride(ctx);
@@ -199,9 +254,9 @@ export function registerHooks(
     // post-chdir rewrites the file mid-run (non-idempotent due to cwd-relative
     // CLI path resolution), dirtying the tree and breaking the milestone merge.
     const { isInAutoWorktree } = await import("../auto-worktree.js");
-    if (!isInAutoWorktree(process.cwd())) {
+    if (!isInAutoWorktree(basePath)) {
       const { prepareWorkflowMcpForProject } = await import("../workflow-mcp-auto-prep.js");
-      prepareWorkflowMcpForProject(ctx, process.cwd());
+      prepareWorkflowMcpForProject(ctx, basePath);
     }
     await loadToolApiKeysForSession();
     if (!isAutoActive()) {
@@ -217,7 +272,7 @@ export function registerHooks(
     const { getEcosystemReadyPromise } = await import("../ecosystem/loader.js");
     await getEcosystemReadyPromise();
 
-    const beforeAgentBasePath = process.cwd();
+    const beforeAgentBasePath = contextBasePath(ctx);
     const pendingApprovalGate = getPendingGate(beforeAgentBasePath);
     if (pendingApprovalGate && isExplicitApprovalResponse(event.prompt, pendingApprovalGate)) {
       markApprovalGateVerified(pendingApprovalGate, beforeAgentBasePath);
@@ -225,6 +280,7 @@ export function registerHooks(
       if (milestoneId) markDepthVerified(milestoneId, beforeAgentBasePath);
       clearPendingGate(beforeAgentBasePath);
     }
+    clearDeferredApprovalGate(beforeAgentBasePath);
 
     // GSD's own context injection (existing behavior — unchanged).
     const { buildBeforeAgentStartResult } = await import("./system-context.js");
@@ -233,7 +289,7 @@ export function registerHooks(
     // Refresh the snapshot used by ecosystem getPhase()/getActiveUnit().
     // deriveState has its own ~100ms cache so this is cheap on repeat calls.
     try {
-      const state = await deriveGsdState(process.cwd());
+      const state = await deriveGsdState(beforeAgentBasePath);
       updateSnapshot(state);
     } catch {
       updateSnapshot(null);
@@ -275,7 +331,11 @@ export function registerHooks(
     resetToolCallLoopGuard();
     await resetAskUserQuestionsTurnCache();
     const { handleAgentEnd } = await import("./agent-end-recovery.js");
-    await handleAgentEnd(pi, event, ctx);
+    try {
+      await handleAgentEnd(pi, event, ctx);
+    } finally {
+      activateDeferredApprovalGate(contextBasePath(ctx));
+    }
   });
 
   // Squash-merge quick-task branch back to the original branch after the
@@ -290,8 +350,8 @@ export function registerHooks(
     }
   });
 
-  pi.on("session_before_compact", async () => {
-    const basePath = process.cwd();
+  pi.on("session_before_compact", async (_event, ctx) => {
+    const basePath = contextBasePath(ctx);
     // Context Mode is default-on. Write the resumable snapshot before any
     // active-auto cancel return so auto sessions still leave re-entry context.
     await writeContextModeCompactionSnapshot(basePath);
@@ -358,7 +418,7 @@ export function registerHooks(
     if (!unitType) {
       try {
         const { getPendingDeepProjectSetupUnitForContext } = await import("../guided-flow.js");
-        const pending = getPendingDeepProjectSetupUnitForContext(ctx, process.cwd());
+        const pending = getPendingDeepProjectSetupUnitForContext(ctx, contextBasePath(ctx));
         unitType = pending?.unitType;
         unitId = pending?.unitId;
       } catch {
@@ -367,7 +427,7 @@ export function registerHooks(
     }
 
     if (!unitType) {
-      const milestoneId = await getDiscussionMilestoneIdFor(process.cwd());
+      const milestoneId = await getDiscussionMilestoneIdFor(contextBasePath(ctx));
       if (milestoneId) {
         unitType = "discuss-milestone";
         unitId = milestoneId;
@@ -377,15 +437,16 @@ export function registerHooks(
     if (!shouldPauseForUserApprovalQuestion(unitType, [event.message])) return;
 
     const gateId = approvalGateIdForUnit(unitType, unitId);
-    if (gateId) setPendingGate(gateId, process.cwd());
+    if (gateId) deferApprovalGate(gateId, contextBasePath(ctx));
 
     approvalQuestionAbortInFlight = true;
     ctx.ui.notify(
       `${unitType}${unitId ? ` ${unitId}` : ""} is waiting for your approval - pausing before more tool calls run.`,
       "info",
     );
-    // The pending gate set above blocks subsequent non-read-only tool calls
-    // via the tool_call hook below, so we do not abort the in-flight stream.
+    // The durable pending gate is activated at agent_end so same-turn
+    // CONTEXT-DRAFT persistence can finish after the text boundary streams.
+    // The tool_call hook below still blocks non-draft tools in this turn.
     // Aborting mid-stream eats the model's question text on external CLI
     // providers (Claude Code SDK) because lastTextContent isn't populated
     // from in-flight builder state — the user only ever sees "Claude Code
@@ -396,7 +457,7 @@ export function registerHooks(
     const { isParallelActive, shutdownParallel } = await import("../parallel-orchestrator.js");
     if (isParallelActive()) {
       try {
-        await shutdownParallel(process.cwd());
+        await shutdownParallel(contextBasePath(ctx));
       } catch {
         // best-effort
       }
@@ -408,14 +469,21 @@ export function registerHooks(
     }
   });
 
-  pi.on("tool_call", async (event) => {
-    const discussionBasePath = process.cwd();
+  pi.on("tool_call", async (event, ctx) => {
+    const discussionBasePath = contextBasePath(ctx);
     const toolName = canonicalToolName(event.toolName);
     // ── Loop guard: block repeated identical tool calls ──
     const loopCheck = checkToolCallLoop(toolName, event.input as Record<string, unknown>);
     if (loopCheck.block) {
       return { block: true, reason: loopCheck.reason };
     }
+
+    const deferredGateGuard = shouldBlockDeferredApprovalTool(
+      toolName,
+      event.input,
+      discussionBasePath,
+    );
+    if (deferredGateGuard.block) return deferredGateGuard;
 
     // ── Discussion gate enforcement: track pending gate questions ─────────
     // Only gate-shaped ask_user_questions calls should block execution.
@@ -586,7 +654,7 @@ export function registerHooks(
     }
   });
 
-  pi.on("tool_result", async (event) => {
+  pi.on("tool_result", async (event, ctx) => {
     if (isAutoActive() && typeof event.toolCallId === "string") {
       markToolEnd(event.toolCallId);
     }
@@ -605,7 +673,7 @@ export function registerHooks(
     }
     const toolName = canonicalToolName(event.toolName);
     if (toolName !== "ask_user_questions") return;
-    const basePath = process.cwd();
+    const basePath = contextBasePath(ctx);
     const milestoneId = await getDiscussionMilestoneIdFor(basePath);
     const queueActive = isQueuePhaseActive(basePath);
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -66,7 +66,7 @@ function makeMockSession(opts?: {
     verbose: false,
     basePath: process.cwd(),
     cmdCtx: {
-      newSession: (options?: { abortSignal?: AbortSignal }) => {
+      newSession: (options?: { abortSignal?: AbortSignal; workspaceRoot?: string }) => {
         opts?.onNewSessionStart?.(session);
         if (opts?.newSessionThrows) {
           return Promise.reject(new Error(opts.newSessionThrows));
@@ -78,7 +78,7 @@ function makeMockSession(opts?: {
             setTimeout(() => {
               // Simulate AgentSession.newSession() checking abortSignal after
               // its internal async work (abort()) completes — this is where the
-              // real code captures process.cwd() and rebuilds the tool runtime.
+              // real code selects a workspace root and rebuilds the tool runtime.
               // If the signal is aborted, the real code discards the session.
               opts?.onSignalCheck?.(options?.abortSignal?.aborted ?? false);
               opts?.onNewSessionSettle?.(session);
@@ -548,10 +548,9 @@ test("runUnit proceeds when isProviderRequestReady throws (defensive) (#4555)", 
   assert.equal(pi.calls.length, 0);
 });
 
-test("late-resolving newSession() after timeout receives aborted signal so tool runtime is not configured with root cwd (#3731)", async () => {
-  // When newSession() times out in runUnit(), auto-mode restores cwd to project
-  // root. If newSession() later resolves, it must NOT use process.cwd() to
-  // configure the tool runtime (which would give it root cwd, not worktree cwd).
+test("late-resolving newSession() after timeout receives aborted signal so tool runtime is not configured with stale workspace root (#3731)", async () => {
+  // When newSession() times out in runUnit(), a late resolution must not
+  // configure the tool runtime against a stale workspace root.
   //
   // The fix: runUnit creates an AbortController, aborts it on timeout, and passes
   // the signal to newSession(). AgentSession.newSession() checks the signal after
@@ -566,8 +565,8 @@ test("late-resolving newSession() after timeout receives aborted signal so tool 
 
     // newSession mock simulates AgentSession.newSession() behavior:
     // after an internal delay (representing await this.abort()), it checks the
-    // abortSignal — that's where the real code would capture process.cwd() and
-    // call _buildRuntime. If aborted, the real code must discard the session.
+    // abortSignal before selecting the workspace root and calling _buildRuntime.
+    // If aborted, the real code must discard the session.
     const s = makeMockSession({
       newSessionDelayMs: 200_000, // longer than NEW_SESSION_TIMEOUT_MS (120s)
       onSignalCheck: (aborted) => {
@@ -600,7 +599,7 @@ test("late-resolving newSession() after timeout receives aborted signal so tool 
       abortedWhenLateSessionSettled,
       true,
       "runUnit must pass an aborted AbortSignal to newSession() when it resolves after the session-creation timeout (#3731). " +
-      "Without this, AgentSession.newSession() captures root process.cwd() and rebuilds the tool runtime with wrong cwd.",
+      "Without this, AgentSession.newSession() can rebuild the tool runtime with a stale workspace root.",
     );
   } finally {
     mock.timers.reset();

--- a/src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts
@@ -3,8 +3,14 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { autoSession } from "../auto-runtime-state.ts";
+import { dispatchHookUnit } from "../auto.ts";
+import { registerHooks } from "../bootstrap/register-hooks.ts";
+import { clearDiscussionFlowState, getPendingGate } from "../bootstrap/write-gate.ts";
 
 const autoTimersPath = join(import.meta.dirname, "..", "auto-timers.ts");
 const autoTimersSrc = readFileSync(autoTimersPath, "utf-8");
@@ -17,6 +23,37 @@ const runUnitSrc = readFileSync(runUnitPath, "utf-8");
 
 const registerHooksPath = join(import.meta.dirname, "..", "bootstrap", "register-hooks.ts");
 const registerHooksSrc = readFileSync(registerHooksPath, "utf-8");
+
+function makeHookHarness() {
+  const handlers = new Map<string, Array<(event: any, ctx: any) => Promise<any>>>();
+  const pi = {
+    on(name: string, handler: (event: any, ctx: any) => Promise<any>) {
+      const current = handlers.get(name) ?? [];
+      current.push(handler);
+      handlers.set(name, current);
+    },
+  };
+  const ctx = {
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setWidget: () => {},
+    },
+    modelRegistry: {
+      setDisabledModelProviders: () => {},
+    },
+    setCompactionThresholdOverride: () => {},
+  };
+  async function emit(name: string, event: any): Promise<any> {
+    for (const handler of handlers.get(name) ?? []) {
+      const result = await handler(event, ctx);
+      if (result?.block) return result;
+    }
+    return undefined;
+  }
+  registerHooks(pi as any, []);
+  return { emit };
+}
 
 describe("#3512: gsd-auto-wrapup must not interrupt in-flight tool calls", () => {
   test("soft timeout wrapup gates triggerTurn on getInFlightToolCount() === 0", () => {
@@ -73,10 +110,65 @@ describe("#3512: gsd-auto-wrapup must not interrupt in-flight tool calls", () =>
   });
 });
 
+describe("hook dispatch session workspace root", () => {
+  test("dispatchHookUnit passes basePath explicitly to newSession", async (t) => {
+    const originalCwd = process.cwd();
+    const basePath = mkdtempSync(join(tmpdir(), "gsd-hook-cwd-"));
+    mkdirSync(join(basePath, ".gsd"), { recursive: true });
+    autoSession.reset();
+    t.after(() => {
+      try {
+        process.chdir(originalCwd);
+      } catch {
+        // best effort cleanup after cwd-sensitive dispatch tests
+      }
+      autoSession.reset();
+      rmSync(basePath, { recursive: true, force: true });
+    });
+
+    let newSessionOptions: unknown;
+    const ctx = {
+      ui: {
+        notify: () => {},
+        setStatus: () => {},
+        setWidget: () => {},
+      },
+      modelRegistry: {
+        getAvailable: () => [],
+      },
+      sessionManager: {
+        getSessionFile: () => join(basePath, "session.jsonl"),
+      },
+      newSession: async (options?: unknown) => {
+        newSessionOptions = options;
+        return { cancelled: false };
+      },
+    };
+    const pi = {
+      sendMessage: () => {},
+      setModel: async () => true,
+    };
+
+    const dispatched = await dispatchHookUnit(
+      ctx as any,
+      pi as any,
+      "review",
+      "execute-task",
+      "M001/S01/T01",
+      "review the completed unit",
+      undefined,
+      basePath,
+    );
+
+    assert.equal(dispatched, true);
+    assert.deepEqual(newSessionOptions, { workspaceRoot: basePath });
+  });
+});
+
 describe("#4276: pending/skipped tools stay visible to auto-mode hooks", () => {
   test("tool_call handler marks GSD tools in-flight before execution_start", () => {
     const startMarker = 'pi.on("tool_call", async (event, ctx) => {';
-    const endMarker = 'pi.on("tool_result", async (event) => {';
+    const endMarker = 'pi.on("tool_result", async (event, ctx) => {';
     const toolCallSection = registerHooksSrc.slice(
       registerHooksSrc.indexOf(startMarker),
       registerHooksSrc.indexOf(endMarker),
@@ -90,7 +182,7 @@ describe("#4276: pending/skipped tools stay visible to auto-mode hooks", () => {
   });
 
   test("tool_result handler clears pending tools and records queued-skip errors", () => {
-    const startMarker = 'pi.on("tool_result", async (event) => {';
+    const startMarker = 'pi.on("tool_result", async (event, ctx) => {';
     const endMarker = 'pi.on("tool_execution_start", async (event) => {';
     const toolResultSection = registerHooksSrc.slice(
       registerHooksSrc.indexOf(startMarker),
@@ -193,7 +285,7 @@ describe("#4365: tool_execution_start hook must pass toolName to markToolStart",
 });
 
 describe("deep setup approval questions pause immediately", () => {
-  test("register-hooks sets pending gate during message_update without aborting the stream", () => {
+  test("register-hooks defers the pending gate during message_update without aborting the stream", () => {
     const startMarker = 'pi.on("message_update"';
     const endMarker = 'pi.on("session_shutdown"';
     const messageUpdateSection = registerHooksSrc.slice(
@@ -210,8 +302,8 @@ describe("deep setup approval questions pause immediately", () => {
       "message_update must detect approval/question boundaries",
     );
     assert.ok(
-      messageUpdateSection.includes("approvalGateIdForUnit") && messageUpdateSection.includes("setPendingGate"),
-      "plain-text approval questions must set the durable write gate",
+      messageUpdateSection.includes("approvalGateIdForUnit") && messageUpdateSection.includes("deferApprovalGate"),
+      "plain-text approval questions must defer the durable write gate until same-turn draft persistence can finish",
     );
     assert.ok(
       messageUpdateSection.includes("getDiscussionMilestoneIdFor") && messageUpdateSection.includes('"discuss-milestone"'),
@@ -221,5 +313,75 @@ describe("deep setup approval questions pause immediately", () => {
       !messageUpdateSection.includes("ctx.abort()"),
       "message_update must NOT abort the stream — aborting eats the model's question text on external CLI providers; the pending gate set above blocks subsequent tool calls instead",
     );
+  });
+
+  test("plain-text approval boundary defers durable gate until same-turn CONTEXT-DRAFT can save", async () => {
+    const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-deferred-approval-")));
+    const previousCwd = process.cwd();
+    try {
+      mkdirSync(join(base, ".gsd", "milestones", "M003"), { recursive: true });
+      process.chdir(base);
+      clearDiscussionFlowState(base);
+      autoSession.reset();
+      autoSession.basePath = base;
+      autoSession.currentUnit = {
+        type: "discuss-milestone",
+        id: "M003",
+        startedAt: Date.now(),
+      };
+
+      const { emit } = makeHookHarness();
+      await emit("message_update", {
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Did I capture that correctly? If not, tell me what I missed." }],
+        },
+      });
+
+      assert.equal(
+        getPendingGate(base),
+        null,
+        "approval text should not install the durable pending gate until the assistant turn ends",
+      );
+
+      const draftResult = await emit("tool_call", {
+        toolCallId: "draft-save",
+        toolName: "gsd_summary_save",
+        input: {
+          milestone_id: "M003",
+          artifact_type: "CONTEXT-DRAFT",
+          content: "# M003 Draft\n",
+        },
+      });
+      assert.equal(
+        draftResult?.block,
+        undefined,
+        "same-turn CONTEXT-DRAFT persistence should remain allowed after the approval text streams",
+      );
+
+      const finalContextResult = await emit("tool_call", {
+        toolCallId: "final-context",
+        toolName: "gsd_summary_save",
+        input: {
+          milestone_id: "M003",
+          artifact_type: "CONTEXT",
+          content: "# M003 Context\n",
+        },
+      });
+      assert.equal(finalContextResult?.block, true, "final CONTEXT must still wait for approval");
+      assert.match(finalContextResult.reason, /Approval question "depth_verification_M003_confirm"/);
+
+      await emit("agent_end", { messages: [] });
+      assert.equal(
+        getPendingGate(base),
+        "depth_verification_M003_confirm",
+        "agent_end should activate the durable pending gate for the next turn",
+      );
+    } finally {
+      process.chdir(previousCwd);
+      autoSession.reset();
+      clearDiscussionFlowState(base);
+      rmSync(base, { recursive: true, force: true });
+    }
   });
 });

--- a/src/resources/extensions/gsd/tests/journal-query-tool.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-query-tool.test.ts
@@ -52,6 +52,16 @@ async function executeToolInDir(tool: any, params: Record<string, unknown>, dir:
   }
 }
 
+async function executeToolWithContextRoot(tool: any, params: Record<string, unknown>, processDir: string, contextRoot: string) {
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(processDir);
+    return await tool.execute("test-call-id", params, undefined, undefined, { cwd: contextRoot });
+  } finally {
+    process.chdir(originalCwd);
+  }
+}
+
 // ─── Registration ─────────────────────────────────────────────────────────────
 
 test("registerJournalTools registers gsd_journal_query tool", () => {
@@ -123,6 +133,28 @@ test("gsd_journal_query respects limit parameter", async () => {
     assert.equal(entries.length, 2, "Should return only 2 entries");
   } finally {
     cleanup(base);
+  }
+});
+
+test("gsd_journal_query uses context cwd instead of process cwd", async () => {
+  const processBase = makeTmpBase();
+  const contextBase = makeTmpBase();
+  try {
+    emitJournalEvent(processBase, makeEntry({ seq: 0, flowId: "process-flow" }));
+    emitJournalEvent(contextBase, makeEntry({ seq: 0, flowId: "context-flow" }));
+
+    const pi = makeMockPi();
+    registerJournalTools(pi);
+    const tool = pi.tools[0];
+
+    const result = await executeToolWithContextRoot(tool, { limit: 5 }, processBase, contextBase);
+    const entries = JSON.parse(result.content[0].text) as JournalEntry[];
+
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].flowId, "context-flow");
+  } finally {
+    cleanup(processBase);
+    cleanup(contextBase);
   }
 });
 

--- a/src/resources/extensions/gsd/tests/query-tools-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/query-tools-db-open.test.ts
@@ -28,8 +28,8 @@ describe('query-tools ensureDbOpen usage (#3672)', () => {
   });
 
   test('calls ensureDbOpen() before DB queries', () => {
-    assert.match(source, /await ensureDbOpen\(\)/,
-      'query-tools should call await ensureDbOpen()');
+    assert.match(source, /await ensureDbOpen\([^)]*\)/,
+      'query-tools should call await ensureDbOpen(...)');
   });
 
   test('no longer imports isDbAvailable in the execute path', () => {
@@ -41,7 +41,7 @@ describe('query-tools ensureDbOpen usage (#3672)', () => {
   });
 
   test('uses dbAvailable result from ensureDbOpen', () => {
-    assert.match(source, /dbAvailable\s*=\s*await ensureDbOpen\(\)/,
+    assert.match(source, /dbAvailable\s*=\s*await ensureDbOpen\([^)]*\)/,
       'should store ensureDbOpen result in dbAvailable');
   });
 });

--- a/src/resources/extensions/gsd/tests/worktree-path-injection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-path-injection.test.ts
@@ -79,7 +79,7 @@ async function waitFor(condition: () => boolean, label: string): Promise<void> {
   assert.fail(`Timed out waiting for ${label} after ${timeoutMs}ms`);
 }
 
-test("runUnit changes cwd to basePath before creating a new session", async (t) => {
+test("runUnit passes basePath as workspaceRoot without changing process cwd", async (t) => {
   _resetPendingResolve();
 
   const originalCwd = process.cwd();
@@ -93,13 +93,15 @@ test("runUnit changes cwd to basePath before creating a new session", async (t) 
 
   process.chdir(drifted);
 
+  let newSessionWorkspaceRoot: string | undefined;
   let cwdAtNewSession: string | undefined;
   const session = {
     active: true,
     basePath: base,
     verbose: false,
     cmdCtx: {
-      newSession: () => {
+      newSession: (options?: { workspaceRoot?: string }) => {
+        newSessionWorkspaceRoot = options?.workspaceRoot;
         cwdAtNewSession = process.cwd();
         return Promise.resolve({ cancelled: false });
       },
@@ -119,10 +121,12 @@ test("runUnit changes cwd to basePath before creating a new session", async (t) 
 
   const result = await resultPromise;
   assert.equal(result.status, "completed");
-  assert.equal(cwdAtNewSession, base);
+  assert.equal(newSessionWorkspaceRoot, base);
+  assert.equal(cwdAtNewSession, drifted);
+  assert.equal(process.cwd(), drifted);
 });
 
-test("runUnit cancels before creating a session when basePath chdir fails", async (t) => {
+test("runUnit does not chdir or cancel when basePath is not a live directory", async (t) => {
   _resetPendingResolve();
 
   const originalCwd = process.cwd();
@@ -136,14 +140,14 @@ test("runUnit cancels before creating a session when basePath chdir fails", asyn
 
   process.chdir(drifted);
 
-  let newSessionCalled = false;
+  let newSessionWorkspaceRoot: string | undefined;
   const session = {
     active: true,
     basePath: base,
     verbose: false,
     cmdCtx: {
-      newSession: () => {
-        newSessionCalled = true;
+      newSession: (options?: { workspaceRoot?: string }) => {
+        newSessionWorkspaceRoot = options?.workspaceRoot;
         return Promise.resolve({ cancelled: false });
       },
     },
@@ -156,15 +160,14 @@ test("runUnit cancels before creating a session when basePath chdir fails", asyn
   } as any;
   const ctx = { ui: { notify: () => {} }, model: { id: "test-model" } } as any;
 
-  const result = await runUnit(ctx, pi, session, "task", "T01", "prompt");
+  const resultPromise = runUnit(ctx, pi, session, "task", "T01", "prompt");
+  await waitFor(() => pi.calls.length === 1, "runUnit dispatch");
+  resolveAgentEnd({ messages: [{ role: "assistant" }] });
 
-  assert.equal(result.status, "cancelled");
-  assert.equal(result.errorContext?.category, "session-failed");
-  assert.equal(result.errorContext?.isTransient, true);
-  assert.match(result.errorContext?.message ?? "", /Failed to chdir to basePath before newSession/);
-  assert.ok(result.errorContext?.message.includes(base), "error should include the failed basePath");
-  assert.equal(newSessionCalled, false, "newSession must not run after chdir failure");
-  assert.equal(pi.calls.length, 0, "unit must not dispatch after chdir failure");
+  const result = await resultPromise;
+  assert.equal(result.status, "completed");
+  assert.equal(newSessionWorkspaceRoot, base);
+  assert.equal(process.cwd(), drifted);
 });
 
 test("direct dispatch redirects to the canonical milestone worktree before newSession", async (t) => {
@@ -185,12 +188,12 @@ test("direct dispatch redirects to the canonical milestone worktree before newSe
 
   process.chdir(drifted);
 
-  let cwdAtNewSession: string | undefined;
+  let newSessionWorkspaceRoot: string | undefined;
   let sentPrompt: string | undefined;
   const ctx = {
     ui: { notify: () => {} },
-    newSession: async () => {
-      cwdAtNewSession = process.cwd();
+    newSession: async (options?: { workspaceRoot?: string }) => {
+      newSessionWorkspaceRoot = options?.workspaceRoot;
       return { cancelled: false };
     },
   } as any;
@@ -202,7 +205,7 @@ test("direct dispatch redirects to the canonical milestone worktree before newSe
 
   await dispatchDirectPhase(ctx, pi, "research-milestone", base);
 
-  assert.equal(cwdAtNewSession, worktreeRoot);
+  assert.equal(newSessionWorkspaceRoot, worktreeRoot);
   assert.equal(process.cwd(), drifted);
   assert.ok(sentPrompt?.includes(worktreeRoot), "prompt should name the canonical worktree root");
 });


### PR DESCRIPTION
## TL;DR

Use explicit workspace roots for GSD auto-mode and extension tool execution instead of relying on ambient `process.cwd()`.

Closes #5525

## What

- Adds explicit `workspaceRoot` plumbing through `AgentSession.newSession()` and `ExtensionRunner` context creation.
- Passes auto-mode milestone/worktree roots directly when dispatching run units, hook units, and direct phases.
- Updates GSD bootstrap tool handlers to resolve paths from `ctx.cwd` or explicit helper roots instead of ambient cwd.
- Documents the workspace-root contract in the developer architecture notes.
- Adds regression coverage for session refresh, extension runner context, hook dispatch, journal/query tools, and worktree path injection.

## Why

Auto-mode was still depending on process-wide cwd changes in several places. That made workflow identity fragile when hooks, tool sessions, and test isolation used different expected roots. The fix keeps workspace identity local to the dispatch/tool context instead of mutating process-global state.

## How

- Threads `workspaceRoot` into session/runtime creation.
- Uses command context cwd in GSD bootstrap tools.
- Removes pre-session `process.chdir()` dependency from auto-mode dispatch paths.
- Keeps fallbacks for direct test harnesses that do not provide a command context.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation only
- [ ] Refactor only
- [ ] Test only

## Tests

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/worktree-path-injection.test.ts src/resources/extensions/gsd/tests/journal-query-tool.test.ts src/resources/extensions/gsd/tests/query-tools-db-open.test.ts src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/extensions/runner.test.ts packages/pi-coding-agent/src/core/agent-session-tool-refresh.test.ts src/resources/extensions/gsd/tests/auto-loop.test.ts --test-name-pattern "workspace root|workspaceRoot|late-resolving"`
- [x] `npm run verify:pr` (`9084 passed, 0 failed, 9 skipped`)

## Notes

This PR is intentionally separate from #5522. It is based on `main` and does not include the auto-mode trigger-order/worktree-health patch from that PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified architecture guidance to require explicit workspace/project roots for workflows.

* **Bug Fixes**
  * Improved workspace-root handling so sessions and tools reliably target the intended project directory without changing the process working directory.

* **Refactor**
  * Deferred approval-gate handling refined to activate at the correct workflow stage.

* **Tests**
  * Expanded and updated tests to cover workspace-root behavior and approval-gate scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->