### PR TITLE
fix(gsd): avoid empty auto worktree dispatch

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -77,6 +77,17 @@ function isSamePathLocal(a: string, b: string): boolean {
   return normalizeWorktreePathForCompare(a) === normalizeWorktreePathForCompare(b);
 }
 
+export function shouldDegradeEmptyWorktreeToProjectRoot(
+  worktreeClassification: ReturnType<typeof classifyProject>,
+  projectRootClassification: ReturnType<typeof classifyProject>,
+): boolean {
+  return (
+    worktreeClassification.kind === "greenfield" &&
+    projectRootClassification.kind !== "greenfield" &&
+    projectRootClassification.kind !== "invalid-repo"
+  );
+}
+
 // ─── Session timeout auto-resume state ────────────────────────────────────────
 
 let consecutiveSessionTimeouts = 0;
@@ -1575,6 +1586,29 @@ export async function runUnitPhase(
         return { action: "break", reason: "worktree-invalid" };
       }
     } else if (projectClassification.kind === "greenfield") {
+      const projectRoot = s.canonicalProjectRoot;
+      if (!isSamePathLocal(s.basePath, projectRoot)) {
+        const projectRootClassification = classifyProject(projectRoot);
+        if (shouldDegradeEmptyWorktreeToProjectRoot(projectClassification, projectRootClassification)) {
+          debugLog("runUnitPhase", {
+            phase: "worktree-health-degrade-to-project-root",
+            worktreePath: s.basePath,
+            projectRoot,
+            worktreeClassification: projectClassification,
+            projectRootClassification,
+          });
+          ctx.ui.notify(
+            `Warning: ${s.basePath} has no project content, but ${projectRoot} does. Continuing in project root because the milestone worktree cannot represent untracked project files.`,
+            "warning",
+          );
+          s.basePath = projectRoot;
+          s.isolationDegraded = true;
+          projectClassification = projectRootClassification;
+        }
+      }
+    }
+
+    if (projectClassification.kind === "greenfield") {
       debugLog("runUnitPhase", { phase: "worktree-health-greenfield", basePath: s.basePath, classification: projectClassification });
       ctx.ui.notify(`Warning: ${s.basePath} has no project content yet — proceeding as greenfield project`, "warning");
     } else if (projectClassification.kind === "untyped-existing") {

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -1183,6 +1183,33 @@ export function nativeRmForce(basePath: string, paths: string[]): void {
   }
 }
 
+function runGitWorktreeAdd(
+  basePath: string,
+  wtPath: string,
+  branch: string,
+  createBranch?: boolean,
+  startPoint?: string,
+): void {
+  if (createBranch) {
+    const branchRef = gitExec(basePath, ["show-ref", "--verify", `refs/heads/${branch}`], true);
+    if (branchRef) {
+      gitExec(basePath, ["worktree", "add", wtPath, branch]);
+      return;
+    }
+    gitExec(basePath, ["worktree", "add", "-b", branch, wtPath, startPoint ?? "HEAD"]);
+  } else {
+    gitExec(basePath, ["worktree", "add", wtPath, branch]);
+  }
+}
+
+export function assertWorktreeMaterialized(wtPath: string): void {
+  if (existsSync(join(wtPath, ".git"))) return;
+  throw new GSDError(
+    GSD_GIT_ERROR,
+    `git worktree add did not materialize a valid worktree at ${wtPath}: missing .git file`,
+  );
+}
+
 /**
  * Add a new git worktree.
  * Native: libgit2 worktree API.
@@ -1198,14 +1225,20 @@ export function nativeWorktreeAdd(
   const native = loadNative();
   if (native) {
     native.gitWorktreeAdd(basePath, wtPath, branch, createBranch, startPoint);
-    return;
+    try {
+      assertWorktreeMaterialized(wtPath);
+      return;
+    } catch {
+      rmSync(wtPath, { recursive: true, force: true });
+      gitExec(basePath, ["worktree", "prune"], true);
+      runGitWorktreeAdd(basePath, wtPath, branch, createBranch, startPoint);
+      assertWorktreeMaterialized(wtPath);
+      return;
+    }
   }
 
-  if (createBranch) {
-    gitExec(basePath, ["worktree", "add", "-b", branch, wtPath, startPoint ?? "HEAD"]);
-  } else {
-    gitExec(basePath, ["worktree", "add", wtPath, branch]);
-  }
+  runGitWorktreeAdd(basePath, wtPath, branch, createBranch, startPoint);
+  assertWorktreeMaterialized(wtPath);
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
@@ -12,11 +12,18 @@
 
 import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
-import { nativeIsRepo, nativeCommit, nativeResetHard, nativeBranchDelete } from "../native-git-bridge.js";
+import {
+  assertWorktreeMaterialized,
+  nativeBranchDelete,
+  nativeCommit,
+  nativeIsRepo,
+  nativeResetHard,
+  nativeWorktreeAdd,
+} from "../native-git-bridge.js";
 
 // Note: prior static-analysis tests that scanned native-git-bridge.ts for
 // the raw shell-spawn pattern were removed under #4827 — the integration
@@ -113,6 +120,31 @@ describe("native-git-bridge #4180: fallback runtime behaviour", () => {
     assert.throws(
       () => nativeBranchDelete(repo, "does-not-exist"),
       /GSD_GIT_ERROR|git branch -D does-not-exist failed/,
+    );
+  });
+
+  test("assertWorktreeMaterialized rejects directories without a .git file", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "ngb-worktree-missing-git-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+    assert.throws(
+      () => assertWorktreeMaterialized(dir),
+      /missing \.git file/,
+    );
+  });
+
+  test("nativeWorktreeAdd materializes a valid .git marker", (t) => {
+    const wtPath = join(repo, ".gsd", "worktrees", "M001");
+    t.after(() => {
+      try { git(["worktree", "remove", "--force", wtPath], repo); } catch { /* noop */ }
+    });
+
+    nativeWorktreeAdd(repo, wtPath, "milestone/M001", true, "HEAD");
+
+    assert.equal(
+      existsSync(join(wtPath, ".git")),
+      true,
+      "created worktree must have the .git file required by later health checks",
     );
   });
 });

--- a/src/resources/extensions/gsd/tests/worktree-project-root-degrade.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-project-root-degrade.test.ts
@@ -1,0 +1,66 @@
+// GSD-2 + Worktree dispatch guard: degrade empty worktrees over real project roots.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldDegradeEmptyWorktreeToProjectRoot } from "../auto/phases.ts";
+import type { ProjectClassification } from "../detection.ts";
+
+function classification(kind: ProjectClassification["kind"]): ProjectClassification {
+  return {
+    kind,
+    signals: {
+      detectedFiles: [],
+      isGitRepo: true,
+      isMonorepo: false,
+      xcodePlatforms: [],
+      hasCI: false,
+      hasTests: false,
+      verificationCommands: [],
+    },
+    trackedFiles: [],
+    untrackedFiles: [],
+    contentFiles: [],
+    markers: [],
+    reason: kind,
+  };
+}
+
+describe("worktree project-root degradation", () => {
+  test("degrades when worktree is greenfield but project root has content", () => {
+    assert.equal(
+      shouldDegradeEmptyWorktreeToProjectRoot(
+        classification("greenfield"),
+        classification("typed-existing"),
+      ),
+      true,
+    );
+    assert.equal(
+      shouldDegradeEmptyWorktreeToProjectRoot(
+        classification("greenfield"),
+        classification("untyped-existing"),
+      ),
+      true,
+    );
+  });
+
+  test("keeps true greenfield worktrees in worktree mode", () => {
+    assert.equal(
+      shouldDegradeEmptyWorktreeToProjectRoot(
+        classification("greenfield"),
+        classification("greenfield"),
+      ),
+      false,
+    );
+  });
+
+  test("does not degrade when project root classification is invalid", () => {
+    assert.equal(
+      shouldDegradeEmptyWorktreeToProjectRoot(
+        classification("greenfield"),
+        classification("invalid-repo"),
+      ),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Adds worktree materialization checks and an execute-task fallback when an isolated milestone worktree is empty but the canonical project root has content.
**Why:** Auto-mode can otherwise repeatedly dispatch into an empty/invalid worktree and get stuck without producing task summaries.
**How:** Assert `.git` exists after worktree creation, fall back to CLI `git worktree add` when native creation does not materialize, and degrade execute-task dispatch to the project root for unrepresented project files.

## What

This changes the GSD auto-mode worktree path in two places:

- `nativeWorktreeAdd()` now verifies that the target worktree has a `.git` marker after creation and retries through CLI git if the native path fails to materialize one.
- `runUnitPhase()` now detects the case where the milestone worktree is greenfield but the canonical project root is an existing project, then continues in the project root with isolation marked degraded.
- Regression tests cover the missing `.git` worktree case and the project-root degradation decision.

## Why

Closes #5533.

After the explicit-root fixes from the prior worktree patch, a local auto-mode run still got stuck on execute-task because the milestone worktree was empty/invalid while the real generated project files existed in the canonical project root. This is broader than one test app: any auto-mode project with real content not represented in the milestone worktree can hit the same dispatch loop.

## How

The fix keeps the behavior conservative:

- Prefer a valid isolated worktree when it can be materialized.
- If native worktree creation reports success but no `.git` marker appears, remove the bad target, prune stale entries, and retry with CLI git.
- If execute-task sees an empty worktree but a real project root, continue in the project root instead of treating the slice as a true greenfield project.

AI-assisted contribution: implemented and verified with Codex; no AI co-author is included in the commit.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts src/resources/extensions/gsd/tests/worktree-project-root-degrade.test.ts`
- [x] `npm run verify:pr` (`9121 passed, 0 failed, 9 skipped`)

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced worktree creation with validation and automatic recovery logic on failures
  * Improved handling of empty worktrees by degrading to project root when appropriate

* **Tests**
  * Added test coverage for worktree validation and fallback scenarios
  * Added test coverage for worktree-to-project-root degradation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->