### PR TITLE
Reduce GSD token consumption at provider boundary

### DIFF
--- a/docs/extension-sdk/api-reference.md
+++ b/docs/extension-sdk/api-reference.md
@@ -79,6 +79,10 @@ Handlers receive the event payload and an `ExtensionContext`. Return values vary
 | `pi.getActiveTools()` | `getActiveTools(): string[]` | Get currently active tool names |
 | `pi.getAllTools()` | `getAllTools(): ToolInfo[]` | Get all registered tools (name, description, parameters) |
 | `pi.setActiveTools(names)` | `setActiveTools(toolNames: string[])` | Enable/disable tools at runtime |
+| `pi.getVisibleSkills()` | `getVisibleSkills(): string[] \| undefined` | Get the prompt-only skill visibility filter |
+| `pi.setVisibleSkills(names)` | `setVisibleSkills(skillNames: string[] \| undefined)` | Limit which loaded skills are advertised in `<available_skills>` |
+
+`setVisibleSkills()` only changes the skill catalog rendered into the next system prompt. It does not unload skills or disable the Skill tool; pass `undefined` to restore the full loaded skill catalog.
 
 ### Model Management
 
@@ -375,7 +379,10 @@ pi.on("tool_call", (event, ctx) => {
 
 | Event | Type | Return Type | Description |
 |-------|------|-------------|-------------|
+| `adjust_tool_set` | `AdjustToolSetEvent` | `AdjustToolSetResult` | After built-in provider compatibility filtering and before the provider request. Can return `{ toolNames }` to narrow or reorder the final request tool set. |
 | `model_select` | `ModelSelectEvent` | — | Model changed. Includes `model`, `previousModel`, and `source` (`"set"`, `"cycle"`, `"restore"`). |
+
+`AdjustToolSetEvent` includes `selectedModelApi`, `selectedModelProvider`, `selectedModelId`, `activeToolNames`, `filteredTools`, and metadata-only `requestCustomMessages`. The final tool list is also the list seen by `PI_TOKEN_AUDIT` and the provider request.
 
 ---
 

--- a/docs/extension-sdk/building-extensions.md
+++ b/docs/extension-sdk/building-extensions.md
@@ -754,7 +754,13 @@ const all = pi.getAllTools();
 
 // Enable/disable tools at runtime
 pi.setActiveTools(["bash", "read", "my_tool"]);
+
+// Limit the skills advertised in <available_skills> without unloading them
+pi.setVisibleSkills(["my-skill", "debug-extension"]);
+pi.setVisibleSkills(undefined); // restore all loaded skills
 ```
+
+When a model/provider has request-time tool limits, Pi applies built-in provider compatibility filtering immediately before the provider call. Extensions can subscribe to `adjust_tool_set` to inspect the selected model and metadata-only request tail, then return `{ toolNames }` to narrow or reorder the final tool set for that single request.
 
 ---
 

--- a/docs/token-consumption-savings-evidence.md
+++ b/docs/token-consumption-savings-evidence.md
@@ -1,0 +1,49 @@
+<!-- Project/App: GSD-2 -->
+<!-- File Purpose: Token consumption savings PR evidence summary. -->
+
+# Token Consumption Savings Evidence
+
+This PR uses `PI_TOKEN_AUDIT=1` audit output to target repeat prompt cost at the final provider boundary without logging raw prompt, system, tool, tool-result, or user content.
+
+## Measured Baselines
+
+| Log | Rows | Estimated input tokens avg | Tool count avg | Tool schema chars avg | Custom chars avg | Notes |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `/tmp/gsd-token-audit-min-tools.log` | n/a | 45,504 | 44 | 43,971 | 55,657 | Initial minimal-tools sample still had high custom/context cost. |
+| `/tmp/gsd-token-audit-min-tools-context-cap.log` | 14 | n/a | 138 | 137,296 | 20,210 | Context cap helped custom payloads, but full tool schema still dominated. |
+| `/tmp/gsd-token-audit-auto-tools-before-start2.log` | 12 | n/a | 105 | 80,272 | 25,025 | Auto still carried broad workflow/tool surfaces. |
+| `/tmp/gsd-token-audit-auto-tools-before-start3.log` | 7 | n/a | 15 | 17,224 | 22,026 | Strict auto scoping brought normal auto turns near the target surface. |
+| `/tmp/gsd-token-audit-auto-tools-before-start4.log` | 4 | n/a | 15 | 16,313 | 38,707 | Auto tool schema stayed low; custom closeout context still spiked. |
+
+Run 5 exposed the remaining workflow bucket:
+
+| Surface | Rows | Estimated input tokens avg | Tool count avg | Tool schema chars avg | Custom chars avg |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gsd-auto` | 5 | 20,775 | 15 | 16,818 | 16,499 |
+| `gsd-run` | 7 | 73,367 | 102 | 76,520 | 104,122 |
+| `gsd-doctor-heal` | 1 | 46,309 | 103 | 76,953 | 29,468 |
+
+`toolResultChars` stayed at zero in the sampled logs, so tool-result replay compression remains deferred.
+
+## Savings Implemented
+
+- Final provider-boundary audit: `PI_TOKEN_AUDIT=1` reports metadata-only section sizes after context transforms and final tool filtering.
+- UI semantics: session token/cost totals stay visible, but they are not presented as live context percentage.
+- Provider request-time filtering: provider compatibility is applied immediately before send, then GSD workflow/auto scoping narrows the remaining compatible tools.
+- GSD auto/workflow tool scoping: auto units, guided workflow dispatch, `gsd-run`, and `gsd-doctor-heal` use scoped tool surfaces with a full-tools escape hatch.
+- Prompt/context cuts: hidden GSD context defaults to a cap, `KNOWLEDGE.md` defaults to a 12k cap, auto preambles stay bounded, and malformed summaries no longer inline unbounded legacy bodies.
+- Workflow/doctor cuts: workflow dispatch uses a capped section-aware protocol excerpt, and doctor heal sends summary plus top actionable issues instead of duplicating the full report.
+- Skill prompt visibility: GSD narrows `<available_skills>` per unit using the existing `skillFilter` prompt seam while keeping skills loaded and invocable.
+
+## Local Verification
+
+Targeted commands run in `.worktrees/token-consumption-savings-pr`:
+
+```bash
+node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/token-tool-gating.test.ts src/resources/extensions/gsd/tests/system-context-memory.test.ts src/resources/extensions/gsd/tests/prompt-duplication-cuts.test.ts src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts src/resources/extensions/gsd/tests/knowledge.test.ts src/resources/extensions/gsd/tests/workflow-protocol-excerpt.test.ts
+node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test vscode-extension/test/rpc-display-contract.test.ts
+node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-agent-core/src/token-audit.test.ts packages/pi-coding-agent/src/core/skill-tool.test.ts packages/pi-coding-agent/src/core/sdk-tool-filter.test.ts
+npm run test:compile
+node --test dist-test/packages/pi-agent-core/src/token-audit.test.js dist-test/packages/pi-agent-core/src/agent-loop.test.js
+npm run typecheck:extensions
+```

--- a/gitbook/reference/environment-variables.md
+++ b/gitbook/reference/environment-variables.md
@@ -12,6 +12,7 @@
 | `GSD_FETCH_ALLOWED_URLS` | (none) | Comma-separated hostnames exempt from internal URL blocking. |
 | `GSD_ALLOWED_COMMAND_PREFIXES` | (built-in) | Comma-separated command prefixes allowed for value resolution. |
 | `GSD_WEB_PROJECT_CWD` | — | Default project path for `gsd --web` when `?project=` is not specified. |
+| `PI_TOKEN_AUDIT` | (unset) | Set to literal `1` to emit metadata-only provider-boundary prompt/tool audit JSONL on stderr. Other values are ignored. |
 | `PI_TOKEN_TELEMETRY` | (unset) | Set to literal `1` to emit opt-in per-call token telemetry as JSONL on stderr. Other values are ignored. |
 
 ## LLM Provider Keys
@@ -53,6 +54,18 @@
 | `CONTEXT7_API_KEY` | Context7 documentation lookup |
 | `DISCORD_BOT_TOKEN` | Discord remote questions |
 | `TELEGRAM_BOT_TOKEN` | Telegram remote questions |
+
+## Token Audit
+
+Set `PI_TOKEN_AUDIT=1` to emit metadata-only audit records for each provider attempt. Audit output is for prompt-size investigation: it reports section sizes, message/tool counts, cache-neutral character totals, and largest message/tool summaries after context transforms and final tool filtering. It does not log raw prompt text, tool result text, user text, system prompt text, or tool schemas.
+
+```bash
+PI_TOKEN_AUDIT=1 gsd headless --json auto \
+  > gsd-events.jsonl \
+  2> token-audit.jsonl
+```
+
+Audit records use `type: "token_audit"` for Pi's normalized context and `type: "token_audit_provider_payload"` for the final provider payload around `before_provider_request` hooks. Use the provider-payload records to verify the exact message and tool surface sent to the model.
 
 ## Token Telemetry
 

--- a/packages/pi-agent-core/src/agent-loop.test.ts
+++ b/packages/pi-agent-core/src/agent-loop.test.ts
@@ -25,6 +25,7 @@ describe("agent-loop — pauseTurn handling (#2869)", () => {
 		}) as typeof process.stderr.write;
 
 		try {
+			let filteredMessages: AgentMessage[] | undefined;
 			const streamFn = (_model: Model<any>, llmContext: any): AssistantMessageEventStream => {
 				assert.equal(llmContext.messages.length, 1, "audit boundary must use transformed context");
 				assert.equal(llmContext.messages[0].content[0].text, "transformed");
@@ -47,6 +48,10 @@ describe("agent-loop — pauseTurn handling (#2869)", () => {
 					{ role: "user", content: [{ type: "text", text: "transformed" }], timestamp: Date.now() },
 				],
 				convertToLlm: (msgs) => msgs.filter((m): m is any => m.role !== "custom"),
+				filterTools: (tools, _signal, messages) => {
+					filteredMessages = messages;
+					return tools;
+				},
 				toolExecution: "sequential",
 			};
 
@@ -61,6 +66,7 @@ describe("agent-loop — pauseTurn handling (#2869)", () => {
 
 			assert.match(written, /"type":"token_audit"/);
 			assert.match(written, /"messageCount":1/);
+			assert.equal((filteredMessages?.[0] as any)?.content?.[0]?.text, "transformed");
 			assert.doesNotMatch(written, /transformed|original|new prompt|sensitive system/);
 		} finally {
 			process.stderr.write = originalWrite;

--- a/packages/pi-agent-core/src/agent-loop.test.ts
+++ b/packages/pi-agent-core/src/agent-loop.test.ts
@@ -10,6 +10,128 @@ import { AssistantMessageEventStream, EventStream } from "@gsd/pi-ai";
 import type { AssistantMessage, AssistantMessageEvent, Model } from "@gsd/pi-ai";
 
 describe("agent-loop — pauseTurn handling (#2869)", () => {
+	it("emits token audit after context transforms when opted in", async () => {
+		const finalStop = makeAssistantMessage({
+			content: [{ type: "text", text: "Done." }],
+			stopReason: "stop",
+		});
+		const original = process.env.PI_TOKEN_AUDIT;
+		const originalWrite = process.stderr.write;
+		let written = "";
+		process.env.PI_TOKEN_AUDIT = "1";
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			written += chunk.toString();
+			return true;
+		}) as typeof process.stderr.write;
+
+		try {
+			const streamFn = (_model: Model<any>, llmContext: any): AssistantMessageEventStream => {
+				assert.equal(llmContext.messages.length, 1, "audit boundary must use transformed context");
+				assert.equal(llmContext.messages[0].content[0].text, "transformed");
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: finalStop });
+					stream.push({ type: "done", message: finalStop });
+					stream.end(finalStop);
+				});
+				return stream;
+			};
+			const context: AgentContext = {
+				systemPrompt: "sensitive system",
+				messages: [{ role: "user", content: [{ type: "text", text: "original" }], timestamp: Date.now() }],
+				tools: [],
+			};
+			const config: AgentLoopConfig = {
+				model: TEST_MODEL,
+				transformContext: async () => [
+					{ role: "user", content: [{ type: "text", text: "transformed" }], timestamp: Date.now() },
+				],
+				convertToLlm: (msgs) => msgs.filter((m): m is any => m.role !== "custom"),
+				toolExecution: "sequential",
+			};
+
+			const stream = agentLoop(
+				[{ role: "user", content: [{ type: "text", text: "new prompt" }], timestamp: Date.now() }],
+				context,
+				config,
+				undefined,
+				streamFn as any,
+			);
+			await collectEvents(stream);
+
+			assert.match(written, /"type":"token_audit"/);
+			assert.match(written, /"messageCount":1/);
+			assert.doesNotMatch(written, /transformed|original|new prompt|sensitive system/);
+		} finally {
+			process.stderr.write = originalWrite;
+			if (original === undefined) delete process.env.PI_TOKEN_AUDIT;
+			else process.env.PI_TOKEN_AUDIT = original;
+		}
+	});
+
+	it("applies final tool filtering before token audit and provider streaming", async () => {
+		const finalStop = makeAssistantMessage({
+			content: [{ type: "text", text: "Done." }],
+			stopReason: "stop",
+		});
+		const original = process.env.PI_TOKEN_AUDIT;
+		const originalWrite = process.stderr.write;
+		let written = "";
+		process.env.PI_TOKEN_AUDIT = "1";
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			written += chunk.toString();
+			return true;
+		}) as typeof process.stderr.write;
+
+		try {
+			const streamFn = (_model: Model<any>, llmContext: any): AssistantMessageEventStream => {
+				assert.deepEqual(llmContext.tools?.map((tool: AgentTool) => tool.name), ["write_file"]);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: finalStop });
+					stream.push({ type: "done", message: finalStop });
+					stream.end(finalStop);
+				});
+				return stream;
+			};
+			const context: AgentContext = {
+				systemPrompt: "You are a test agent.",
+				messages: [{ role: "user", content: [{ type: "text", text: "Use a tool" }], timestamp: Date.now() }],
+				tools: [
+					makeToolWithSchema(),
+					{
+						...makeToolWithSchema(),
+						name: "drop_tool",
+						label: "Drop Tool",
+					},
+				],
+			};
+			const config: AgentLoopConfig = {
+				model: TEST_MODEL,
+				convertToLlm: (msgs) => msgs.filter((m): m is any => m.role !== "custom"),
+				filterTools: async (tools) => tools.filter((tool) => tool.name === "write_file"),
+				toolExecution: "sequential",
+			};
+
+			const stream = agentLoop(
+				[{ role: "user", content: [{ type: "text", text: "Use a tool" }], timestamp: Date.now() }],
+				context,
+				config,
+				undefined,
+				streamFn as any,
+			);
+			await collectEvents(stream);
+
+			assert.match(written, /"toolCount":1/);
+			assert.match(written, /"name":"write_file"/);
+			assert.doesNotMatch(written, /drop_tool/);
+		} finally {
+			process.stderr.write = originalWrite;
+			if (original === undefined) delete process.env.PI_TOKEN_AUDIT;
+			else process.env.PI_TOKEN_AUDIT = original;
+		}
+	});
+
 	it("continues to a second assistant turn when stopReason is pauseTurn", async () => {
 		const pauseTurn = makeAssistantMessage({
 			content: [{ type: "text", text: "Still working..." }],

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -417,7 +417,7 @@ async function streamAssistantResponse(
 
 	// Convert to LLM-compatible messages (AgentMessage[] → Message[])
 	const llmMessages = await config.convertToLlm(messages);
-	const tools = config.filterTools ? await config.filterTools(context.tools ?? [], signal) : context.tools;
+	const tools = config.filterTools ? await config.filterTools(context.tools ?? [], signal, messages) : context.tools;
 
 	// Build LLM context
 	const llmContext: Context = {

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -21,6 +21,7 @@ import type {
 	AgentToolResult,
 	StreamFn,
 } from "./types.js";
+import { maybeLogTokenAudit } from "./token-audit.js";
 
 /**
  * Maximum number of consecutive turns where ALL tool calls in the turn fail
@@ -416,13 +417,15 @@ async function streamAssistantResponse(
 
 	// Convert to LLM-compatible messages (AgentMessage[] → Message[])
 	const llmMessages = await config.convertToLlm(messages);
+	const tools = config.filterTools ? await config.filterTools(context.tools ?? [], signal) : context.tools;
 
 	// Build LLM context
 	const llmContext: Context = {
 		systemPrompt: context.systemPrompt,
 		messages: llmMessages,
-		tools: context.tools,
+		tools,
 	};
+	maybeLogTokenAudit(llmContext, messages);
 
 	const streamFunction = streamFn || streamSimple;
 

--- a/packages/pi-agent-core/src/agent.ts
+++ b/packages/pi-agent-core/src/agent.ts
@@ -53,6 +53,11 @@ export interface AgentOptions {
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
 
 	/**
+	 * Optional final tool filter applied immediately before each provider call.
+	 */
+	filterTools?: AgentLoopConfig["filterTools"];
+
+	/**
 	 * Steering mode: "all" = send all steering messages at once, "one-at-a-time" = one per turn
 	 */
 	steeringMode?: "all" | "one-at-a-time";
@@ -144,6 +149,7 @@ export class Agent {
 	private abortController?: AbortController;
 	private convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	private transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
+	private filterTools?: AgentLoopConfig["filterTools"];
 	private steeringQueue: QueueEntry[] = [];
 	private followUpQueue: QueueEntry[] = [];
 	private steeringMode: "all" | "one-at-a-time";
@@ -166,6 +172,7 @@ export class Agent {
 		this._state = { ...this._state, ...opts.initialState };
 		this.convertToLlm = opts.convertToLlm || defaultConvertToLlm;
 		this.transformContext = opts.transformContext;
+		this.filterTools = opts.filterTools;
 		this.steeringMode = opts.steeringMode || "one-at-a-time";
 		this.followUpMode = opts.followUpMode || "one-at-a-time";
 		this.streamFn = opts.streamFn || streamSimple;
@@ -509,6 +516,7 @@ export class Agent {
 			maxRetryDelayMs: this._maxRetryDelayMs,
 			convertToLlm: this.convertToLlm,
 			transformContext: this.transformContext,
+			filterTools: this.filterTools,
 			getApiKey: this.getApiKey,
 			getSteeringMessages: async () => {
 				if (skipInitialSteeringPoll) {

--- a/packages/pi-agent-core/src/index.ts
+++ b/packages/pi-agent-core/src/index.ts
@@ -4,5 +4,7 @@ export * from "./agent.js";
 export * from "./agent-loop.js";
 // Proxy utilities
 export * from "./proxy.js";
+// Token audit utilities
+export * from "./token-audit.js";
 // Types
 export * from "./types.js";

--- a/packages/pi-agent-core/src/token-audit.test.ts
+++ b/packages/pi-agent-core/src/token-audit.test.ts
@@ -1,0 +1,189 @@
+// Project/App: GSD-2
+// File Purpose: Tests for provider-boundary token payload audit helpers.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Type } from "@sinclair/typebox";
+import type { Context } from "@gsd/pi-ai";
+import type { AgentMessage } from "./types.js";
+import {
+	buildProviderPayloadAuditSummary,
+	buildTokenAuditSummary,
+	maybeLogProviderPayloadAudit,
+	maybeLogTokenAudit,
+} from "./token-audit.js";
+
+test("buildTokenAuditSummary reports payload section sizes without content fields", () => {
+	const context: Context = {
+		systemPrompt: "system prompt",
+		tools: [
+			{
+				name: "read",
+				description: "Read a file",
+				parameters: Type.Object({ path: Type.String() }),
+			},
+			{
+				name: "large_tool",
+				description: "Large schema".repeat(20),
+				parameters: Type.Object({ value: Type.String() }),
+			},
+		],
+		messages: [
+			{ role: "user", content: [{ type: "text", text: "hello" }], timestamp: 1 },
+			{
+				role: "toolResult",
+				toolCallId: "call-1",
+				toolName: "read",
+				content: [{ type: "text", text: "tool output" }],
+				isError: false,
+				timestamp: 2,
+			},
+			{ role: "user", content: [{ type: "image", data: "abc123", mimeType: "image/png" }], timestamp: 3 },
+		],
+	};
+	const sourceMessages = [
+		...context.messages,
+		{
+			role: "custom",
+			customType: "gsd-memory",
+			content: "memory block",
+			display: false,
+			timestamp: 4,
+		} as AgentMessage,
+	];
+
+	const summary = buildTokenAuditSummary(context, sourceMessages);
+
+	assert.equal(summary.systemChars, "system prompt".length);
+	assert.equal(summary.toolCount, 2);
+	assert.equal(summary.messageCount, 3);
+	assert.equal(summary.toolResultChars, "tool output".length);
+	assert.equal(summary.imageCount, 1);
+	assert.ok(summary.toolSchemaChars > 0);
+	assert.ok(summary.customMessageChars > 0);
+	assert.ok(summary.estimatedInputTokens > 0);
+	assert.deepEqual(
+		summary.largestMessages.map((message) => Object.keys(message).sort()),
+		summary.largestMessages.map(() => ["chars", "index", "role", "type"]),
+	);
+	assert.equal(summary.largestTools[0].name, "large_tool");
+	assert.deepEqual(
+		summary.largestTools.map((tool) => Object.keys(tool).sort()),
+		summary.largestTools.map(() => ["chars", "name"]),
+	);
+	assert.deepEqual(summary.largestCustomMessages, [
+		{ index: 3, role: "custom", customType: "gsd-memory", chars: summary.largestCustomMessages[0].chars },
+	]);
+	assert.ok(!JSON.stringify(summary).includes("tool output"));
+	assert.ok(!JSON.stringify(summary).includes("memory block"));
+});
+
+test("maybeLogTokenAudit is opt-in and emits metadata only", () => {
+	const original = process.env.PI_TOKEN_AUDIT;
+	const originalWrite = process.stderr.write;
+	let written = "";
+	process.stderr.write = ((chunk: string | Uint8Array) => {
+		written += chunk.toString();
+		return true;
+	}) as typeof process.stderr.write;
+
+	try {
+		delete process.env.PI_TOKEN_AUDIT;
+		maybeLogTokenAudit({ messages: [{ role: "user", content: "secret prompt", timestamp: 1 }] }, []);
+		assert.equal(written, "");
+
+		process.env.PI_TOKEN_AUDIT = "1";
+		maybeLogTokenAudit({ systemPrompt: "hidden system", messages: [{ role: "user", content: "secret prompt", timestamp: 1 }] }, []);
+		assert.match(written, /"type":"token_audit"/);
+		assert.doesNotMatch(written, /secret prompt/);
+		assert.doesNotMatch(written, /hidden system/);
+	} finally {
+		process.stderr.write = originalWrite;
+		if (original === undefined) delete process.env.PI_TOKEN_AUDIT;
+		else process.env.PI_TOKEN_AUDIT = original;
+	}
+});
+
+test("provider payload audit summarizes post-hook payload without raw content", () => {
+	const payload = {
+		system: "secret system content",
+		tools: [{
+			type: "function",
+			function: {
+				name: "read",
+				description: "secret tool description",
+				parameters: { type: "object" },
+			},
+		}],
+		messages: [
+			{ role: "user", content: "secret user content" },
+			{ role: "assistant", content: [{ type: "text", text: "secret assistant content" }] },
+		],
+	};
+
+	const summary = buildProviderPayloadAuditSummary(payload);
+
+	assert.equal(summary.messageCount, 2);
+	assert.equal(summary.toolCount, 1);
+	assert.ok(summary.payloadChars > 0);
+	assert.ok(summary.toolSchemaChars > 0);
+	assert.deepEqual(summary.largestTools.map((tool) => tool.name), ["read"]);
+	assert.equal(JSON.stringify(summary).includes("secret"), false);
+});
+
+test("provider payload audit recognizes Gemini and Bedrock payload shapes", () => {
+	const gemini = buildProviderPayloadAuditSummary({
+		contents: [{ role: "user", parts: [{ text: "hidden gemini prompt" }] }],
+		config: {
+			tools: [{
+				functionDeclarations: [
+					{ name: "gsd_exec", description: "hidden declaration", parameters: { type: "object" } },
+				],
+			}],
+		},
+	});
+	const bedrock = buildProviderPayloadAuditSummary({
+		messages: [{ role: "user", content: [{ text: "hidden bedrock prompt" }] }],
+		toolConfig: {
+			tools: [
+				{ toolSpec: { name: "gsd_resume", description: "hidden tool", inputSchema: { json: {} } } },
+			],
+		},
+	});
+
+	assert.equal(gemini.messageCount, 1);
+	assert.equal(gemini.toolCount, 1);
+	assert.deepEqual(gemini.largestTools.map((tool) => tool.name), ["gsd_exec"]);
+	assert.equal(JSON.stringify(gemini).includes("hidden"), false);
+
+	assert.equal(bedrock.messageCount, 1);
+	assert.equal(bedrock.toolCount, 1);
+	assert.deepEqual(bedrock.largestTools.map((tool) => tool.name), ["gsd_resume"]);
+	assert.equal(JSON.stringify(bedrock).includes("hidden"), false);
+});
+
+test("provider payload audit logging is metadata-only", () => {
+	const original = process.env.PI_TOKEN_AUDIT;
+	const originalWrite = process.stderr.write;
+	let written = "";
+	process.env.PI_TOKEN_AUDIT = "1";
+	process.stderr.write = ((chunk: string | Uint8Array) => {
+		written += chunk.toString();
+		return true;
+	}) as typeof process.stderr.write;
+
+	try {
+		maybeLogProviderPayloadAudit({
+			messages: [{ role: "user", content: "raw prompt text must not log" }],
+			tools: [{ name: "bash", description: "raw tool description must not log" }],
+		}, "after");
+		assert.match(written, /"type":"token_audit_provider_payload"/);
+		assert.match(written, /"phase":"after"/);
+		assert.doesNotMatch(written, /raw prompt text/);
+		assert.doesNotMatch(written, /raw tool description/);
+	} finally {
+		process.stderr.write = originalWrite;
+		if (original === undefined) delete process.env.PI_TOKEN_AUDIT;
+		else process.env.PI_TOKEN_AUDIT = original;
+	}
+});

--- a/packages/pi-agent-core/src/token-audit.ts
+++ b/packages/pi-agent-core/src/token-audit.ts
@@ -1,0 +1,287 @@
+// Project/App: GSD-2
+// File Purpose: Provider-boundary token payload audit helpers.
+
+import type { Context, ImageContent, Message, TextContent, Tool } from "@gsd/pi-ai";
+import type { AgentMessage } from "./types.js";
+
+const CHARS_PER_TOKEN = 4;
+const LARGEST_MESSAGE_LIMIT = 5;
+const LARGEST_TOOL_LIMIT = 10;
+const LARGEST_CUSTOM_MESSAGE_LIMIT = 5;
+
+export interface TokenAuditMessageSummary {
+	index: number;
+	role: string;
+	type: string;
+	chars: number;
+}
+
+export interface TokenAuditToolSummary {
+	name: string;
+	chars: number;
+}
+
+export interface TokenAuditCustomMessageSummary {
+	index: number;
+	role: string;
+	customType?: string;
+	chars: number;
+}
+
+export interface TokenAuditSummary {
+	systemChars: number;
+	toolSchemaChars: number;
+	messageCharsByRole: Record<string, number>;
+	toolResultChars: number;
+	customMessageChars: number;
+	imageCount: number;
+	estimatedInputTokens: number;
+	messageCount: number;
+	toolCount: number;
+	largestMessages: TokenAuditMessageSummary[];
+	largestTools: TokenAuditToolSummary[];
+	largestCustomMessages: TokenAuditCustomMessageSummary[];
+}
+
+export interface ProviderPayloadAuditSummary {
+	payloadChars: number;
+	messageCharsByRole: Record<string, number>;
+	toolSchemaChars: number;
+	imageCount: number;
+	messageCount: number;
+	toolCount: number;
+	largestMessages: TokenAuditMessageSummary[];
+	largestTools: TokenAuditToolSummary[];
+}
+
+export function buildTokenAuditSummary(context: Context, sourceMessages: AgentMessage[]): TokenAuditSummary {
+	const systemChars = context.systemPrompt?.length ?? 0;
+	const toolSummaries = summarizeTools(context.tools ?? []);
+	const toolSchemaChars = toolSummaries.reduce((sum, tool) => sum + tool.chars, 0);
+	const messageSummaries = context.messages.map((message, index) => summarizeMessage(message, index));
+	const messageCharsByRole: Record<string, number> = {};
+	let toolResultChars = 0;
+	let imageCount = 0;
+
+	for (const summary of messageSummaries) {
+		messageCharsByRole[summary.role] = (messageCharsByRole[summary.role] ?? 0) + summary.chars;
+	}
+
+	for (const message of context.messages) {
+		imageCount += countImagesInMessage(message);
+		if (message.role === "toolResult") {
+			toolResultChars += countContentChars(message.content);
+		}
+	}
+
+	const customMessageSummaries = summarizeCustomMessages(sourceMessages);
+	const customMessageChars = customMessageSummaries.reduce((sum, message) => sum + message.chars, 0);
+
+	const totalChars =
+		systemChars +
+		toolSchemaChars +
+		messageSummaries.reduce((sum, message) => sum + message.chars, 0);
+
+	return {
+		systemChars,
+		toolSchemaChars,
+		messageCharsByRole,
+		toolResultChars,
+		customMessageChars,
+		imageCount,
+		estimatedInputTokens: Math.ceil(totalChars / CHARS_PER_TOKEN),
+		messageCount: context.messages.length,
+		toolCount: context.tools?.length ?? 0,
+		largestMessages: [...messageSummaries].sort((a, b) => b.chars - a.chars).slice(0, LARGEST_MESSAGE_LIMIT),
+		largestTools: [...toolSummaries].sort((a, b) => b.chars - a.chars).slice(0, LARGEST_TOOL_LIMIT),
+		largestCustomMessages: [...customMessageSummaries]
+			.sort((a, b) => b.chars - a.chars)
+			.slice(0, LARGEST_CUSTOM_MESSAGE_LIMIT),
+	};
+}
+
+export function maybeLogTokenAudit(context: Context, sourceMessages: AgentMessage[]): void {
+	if (process.env.PI_TOKEN_AUDIT !== "1") return;
+	const summary = buildTokenAuditSummary(context, sourceMessages);
+	process.stderr.write(`${JSON.stringify({ type: "token_audit", summary })}\n`);
+}
+
+export function buildProviderPayloadAuditSummary(payload: unknown): ProviderPayloadAuditSummary {
+	const record = asRecord(payload);
+	const messages = extractProviderMessages(record);
+	const tools = extractProviderTools(record);
+	const messageSummaries = messages.map((message, index) => summarizeProviderMessage(message, index));
+	const toolSummaries = tools.map((tool) => summarizeProviderTool(tool));
+	const messageCharsByRole: Record<string, number> = {};
+	let imageCount = 0;
+
+	for (const summary of messageSummaries) {
+		messageCharsByRole[summary.role] = (messageCharsByRole[summary.role] ?? 0) + summary.chars;
+	}
+	for (const message of messages) {
+		imageCount += countImagesInValue(message);
+	}
+
+	return {
+		payloadChars: safeJsonLength(payload),
+		messageCharsByRole,
+		toolSchemaChars: toolSummaries.reduce((sum, tool) => sum + tool.chars, 0),
+		imageCount,
+		messageCount: messages.length,
+		toolCount: tools.length,
+		largestMessages: [...messageSummaries].sort((a, b) => b.chars - a.chars).slice(0, LARGEST_MESSAGE_LIMIT),
+		largestTools: [...toolSummaries].sort((a, b) => b.chars - a.chars).slice(0, LARGEST_TOOL_LIMIT),
+	};
+}
+
+export function maybeLogProviderPayloadAudit(payload: unknown, phase: string): void {
+	if (process.env.PI_TOKEN_AUDIT !== "1") return;
+	const summary = buildProviderPayloadAuditSummary(payload);
+	process.stderr.write(`${JSON.stringify({ type: "token_audit_provider_payload", phase, summary })}\n`);
+}
+
+function summarizeMessage(message: Message, index: number): TokenAuditMessageSummary {
+	return {
+		index,
+		role: message.role,
+		type: messageType(message),
+		chars: safeJsonLength(message),
+	};
+}
+
+function messageType(message: Message): string {
+	if (message.role === "assistant") {
+		const types = new Set(message.content.map((content) => content.type));
+		return types.size > 0 ? Array.from(types).join("+") : "assistant";
+	}
+	if (message.role === "toolResult") return message.toolName || "toolResult";
+	if (typeof message.content === "string") return "text";
+	const types = new Set(message.content.map((content) => content.type));
+	return types.size > 0 ? Array.from(types).join("+") : "user";
+}
+
+function summarizeTools(tools: Tool[]): TokenAuditToolSummary[] {
+	return tools.map((tool) => ({
+		name: tool.name,
+		chars: safeJsonLength(tool),
+	}));
+}
+
+function summarizeCustomMessages(messages: AgentMessage[]): TokenAuditCustomMessageSummary[] {
+	return messages.flatMap((message, index) => {
+		if (!isCustomOrInjectedMessage(message)) return [];
+		const customType = (message as { customType?: unknown }).customType;
+		return [{
+			index,
+			role: String((message as { role?: unknown }).role ?? "unknown"),
+			customType: typeof customType === "string" ? customType : undefined,
+			chars: safeJsonLength(message),
+		}];
+	});
+}
+
+function summarizeProviderMessage(message: unknown, index: number): TokenAuditMessageSummary {
+	const record = asRecord(message);
+	const role = typeof record?.role === "string" ? record.role : "unknown";
+	const type = typeof record?.type === "string" ? record.type : role;
+	return { index, role, type, chars: safeJsonLength(message) };
+}
+
+function summarizeProviderTool(tool: unknown): TokenAuditToolSummary {
+	const record = asRecord(tool);
+	const name =
+		typeof record?.name === "string"
+			? record.name
+			: typeof asRecord(record?.function)?.name === "string"
+				? String(asRecord(record?.function)?.name)
+				: typeof asRecord(record?.toolSpec)?.name === "string"
+					? String(asRecord(record?.toolSpec)?.name)
+					: "unknown";
+	return { name, chars: safeJsonLength(tool) };
+}
+
+function extractProviderMessages(record: Record<string, unknown> | null): unknown[] {
+	const candidates = [
+		getArrayField(record, "messages"),
+		getArrayField(record, "input"),
+		getArrayField(record, "contents"),
+	].filter((value): value is unknown[] => value !== null);
+	if (candidates.length > 0) return candidates[0];
+	const input = record?.input;
+	return typeof input === "string" ? [{ role: "input", content: input }] : [];
+}
+
+function extractProviderTools(record: Record<string, unknown> | null): unknown[] {
+	const direct = getArrayField(record, "tools")
+		?? getNestedArrayField(record, ["config", "tools"])
+		?? getNestedArrayField(record, ["toolConfig", "tools"])
+		?? getNestedArrayField(record, ["tool_config", "tools"])
+		?? [];
+	return direct.flatMap(expandProviderToolEntry);
+}
+
+function expandProviderToolEntry(tool: unknown): unknown[] {
+	const record = asRecord(tool);
+	const functionDeclarations =
+		getArrayField(record, "functionDeclarations")
+		?? getArrayField(record, "function_declarations");
+	if (functionDeclarations) return functionDeclarations;
+	return [tool];
+}
+
+function countImagesInMessage(message: Message): number {
+	if (!("content" in message) || !Array.isArray(message.content)) return 0;
+	return message.content.filter((content): content is ImageContent => content.type === "image").length;
+}
+
+function countImagesInValue(value: unknown): number {
+	if (!value || typeof value !== "object") return 0;
+	if (Array.isArray(value)) {
+		return value.reduce((sum, item) => sum + countImagesInValue(item), 0);
+	}
+	const record = value as Record<string, unknown>;
+	let count = record.type === "image" || record.type === "input_image" ? 1 : 0;
+	for (const nested of Object.values(record)) {
+		count += countImagesInValue(nested);
+	}
+	return count;
+}
+
+function countContentChars(content: string | (TextContent | ImageContent)[]): number {
+	if (typeof content === "string") return content.length;
+	return content.reduce((sum, block) => {
+		if (block.type === "text") return sum + block.text.length;
+		if (block.type === "image") return sum + block.data.length;
+		return sum;
+	}, 0);
+}
+
+function isCustomOrInjectedMessage(message: AgentMessage): boolean {
+	const role = (message as { role?: unknown }).role;
+	return role === "custom" || role === "bashExecution" || role === "branchSummary" || role === "compactionSummary";
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function getArrayField(record: Record<string, unknown> | null, key: string): unknown[] | null {
+	const value = record?.[key];
+	return Array.isArray(value) ? value : null;
+}
+
+function getNestedArrayField(record: Record<string, unknown> | null, path: string[]): unknown[] | null {
+	let current: unknown = record;
+	for (const key of path) {
+		current = asRecord(current)?.[key];
+	}
+	return Array.isArray(current) ? current : null;
+}
+
+function safeJsonLength(value: unknown): number {
+	try {
+		return JSON.stringify(value)?.length ?? 0;
+	} catch {
+		return 0;
+	}
+}

--- a/packages/pi-agent-core/src/types.ts
+++ b/packages/pi-agent-core/src/types.ts
@@ -139,8 +139,14 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 *
 	 * Use this for runtime policy that depends on the fully active tool set.
 	 * The returned list is what token audit and the provider request both see.
+	 * Receives the post-transform AgentMessage context so policy can scope
+	 * request-local custom messages without inspecting provider payload text.
 	 */
-	filterTools?: (tools: AgentTool<any>[], signal?: AbortSignal) => AgentTool<any>[] | Promise<AgentTool<any>[]>;
+	filterTools?: (
+		tools: AgentTool<any>[],
+		signal?: AbortSignal,
+		messages?: AgentMessage[],
+	) => AgentTool<any>[] | Promise<AgentTool<any>[]>;
 
 	/**
 	 * Resolves an API key dynamically for each LLM call.

--- a/packages/pi-agent-core/src/types.ts
+++ b/packages/pi-agent-core/src/types.ts
@@ -135,6 +135,14 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
 
 	/**
+	 * Optional final tool filter applied immediately before each provider call.
+	 *
+	 * Use this for runtime policy that depends on the fully active tool set.
+	 * The returned list is what token audit and the provider request both see.
+	 */
+	filterTools?: (tools: AgentTool<any>[], signal?: AbortSignal) => AgentTool<any>[] | Promise<AgentTool<any>[]>;
+
+	/**
 	 * Resolves an API key dynamically for each LLM call.
 	 *
 	 * Useful for short-lived OAuth tokens (e.g., GitHub Copilot) that may expire

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1716,6 +1716,7 @@ export class AgentSession {
 		this._steeringMessages = [];
 		this._followUpMessages = [];
 		this._pendingNextTurnMessages = [];
+		this._visibleSkillNames = undefined;
 
 		this.sessionManager.appendThinkingLevelChange(this.thinkingLevel);
 
@@ -2383,6 +2384,7 @@ export class AgentSession {
 		this.settingsManager.reload();
 		resetApiProviders();
 		await this._resourceLoader.reload();
+		this._visibleSkillNames = undefined;
 		this._buildRuntime({
 			activeToolNames: this.getActiveToolNames(),
 			flagValues: previousFlagValues,
@@ -2572,6 +2574,7 @@ export class AgentSession {
 		this._steeringMessages = [];
 		this._followUpMessages = [];
 		this._pendingNextTurnMessages = [];
+		this._visibleSkillNames = undefined;
 
 		// Set new session
 		this.sessionManager.setSessionFile(sessionPath);

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -305,6 +305,8 @@ export class AgentSession {
 
 	// Base system prompt (without extension appends) - used to apply fresh appends each turn
 	private _baseSystemPrompt = "";
+	// Optional prompt-only skill catalog filter. Skills remain loaded and invocable by name.
+	private _visibleSkillNames: Set<string> | undefined = undefined;
 
 	constructor(config: AgentSessionConfig) {
 		this.agent = config.agent;
@@ -867,6 +869,25 @@ export class AgentSession {
 		this.agent.setSystemPrompt(this._baseSystemPrompt);
 	}
 
+	/**
+	 * Set or clear a prompt-only filter for the <available_skills> catalog.
+	 *
+	 * This does not unload skills or disable the Skill tool. It only controls
+	 * which loaded skills are advertised in the system prompt on rebuild.
+	 */
+	setVisibleSkillsByName(skillNames: string[] | undefined): void {
+		this._visibleSkillNames = skillNames === undefined
+			? undefined
+			: new Set(skillNames.map((name) => name.trim().toLowerCase()).filter(Boolean));
+		this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
+		this.agent.setSystemPrompt(this._baseSystemPrompt);
+	}
+
+	/** Get the current prompt-only skill catalog filter, if one is active. */
+	getVisibleSkillNames(): string[] | undefined {
+		return this._visibleSkillNames ? [...this._visibleSkillNames] : undefined;
+	}
+
 	/** Whether compaction or branch summarization is currently running */
 	get isCompacting(): boolean {
 		return this._compactionOrchestrator.isCompacting;
@@ -1045,6 +1066,9 @@ export class AgentSession {
 		return buildSystemPrompt({
 			cwd: this._cwd,
 			skills: loadedSkills,
+			skillFilter: this._visibleSkillNames
+				? (skill) => this._visibleSkillNames!.has(skill.name.trim().toLowerCase())
+				: undefined,
 			contextFiles: loadedContextFiles,
 			customPrompt: loaderSystemPrompt,
 			appendSystemPrompt,
@@ -2189,6 +2213,8 @@ export class AgentSession {
 				getActiveTools: () => this.getActiveToolNames(),
 				getAllTools: () => this.getAllTools(),
 				setActiveTools: (toolNames) => this.setActiveToolsByName(toolNames),
+				getVisibleSkills: () => this.getVisibleSkillNames(),
+				setVisibleSkills: (skillNames) => this.setVisibleSkillsByName(skillNames),
 				refreshTools: () => this._refreshToolRegistry(),
 				getCommands,
 				setModel: async (model, options) => {

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -415,6 +415,8 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		getActiveTools: notInitialized,
 		getAllTools: notInitialized,
 		setActiveTools: notInitialized,
+		getVisibleSkills: notInitialized,
+		setVisibleSkills: notInitialized,
 		// registerTool() is valid during extension load; refresh is only needed post-bind.
 		refreshTools: () => {},
 		getCommands: notInitialized,
@@ -564,6 +566,14 @@ function createExtensionAPI(
 
 		setActiveTools(toolNames: string[]): void {
 			runtime.setActiveTools(toolNames);
+		},
+
+		getVisibleSkills(): string[] | undefined {
+			return runtime.getVisibleSkills();
+		},
+
+		setVisibleSkills(skillNames: string[] | undefined): void {
+			runtime.setVisibleSkills(skillNames);
 		},
 
 		getCommands() {

--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -412,6 +412,8 @@ export class ExtensionRunner {
 		this.runtime.getActiveTools = actions.getActiveTools;
 		this.runtime.getAllTools = actions.getAllTools;
 		this.runtime.setActiveTools = actions.setActiveTools;
+		this.runtime.getVisibleSkills = actions.getVisibleSkills;
+		this.runtime.setVisibleSkills = actions.setVisibleSkills;
 		this.runtime.refreshTools = actions.refreshTools;
 		this.runtime.getCommands = actions.getCommands;
 		this.runtime.setModel = actions.setModel;

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -851,6 +851,13 @@ export interface BeforeModelSelectResult {
 	modelId: string;
 }
 
+export interface AdjustToolSetRequestCustomMessage {
+	/** Index in the post-transform AgentMessage context. */
+	index: number;
+	/** Custom message type only; prompt/content text is intentionally omitted. */
+	customType: string;
+}
+
 /**
  * Fired after model selection to allow extensions to adjust the active tool set (ADR-005 Phase 4).
  * Extensions can add, remove, or reorder tools based on the selected model's provider capabilities.
@@ -867,6 +874,12 @@ export interface AdjustToolSetEvent {
 	activeToolNames: string[];
 	/** Tools already filtered by provider compatibility */
 	filteredTools: string[];
+	/**
+	 * Custom message metadata in the current request tail, measured from the
+	 * latest assistant message. This is metadata-only so extensions can scope
+	 * queued custom-message turns without seeing raw prompt content.
+	 */
+	requestCustomMessages?: AdjustToolSetRequestCustomMessage[];
 }
 
 /** Result from adjust_tool_set event handler. Return { toolNames } to override tool set. */

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -1489,6 +1489,20 @@ export interface ExtensionAPI {
 	/** Set the active tools by name. */
 	setActiveTools(toolNames: string[]): void;
 
+	/**
+	 * Get the prompt-only skill catalog filter, if one is active.
+	 * Undefined means all loaded skills remain visible in <available_skills>.
+	 */
+	getVisibleSkills(): string[] | undefined;
+
+	/**
+	 * Set or clear the prompt-only skill catalog filter.
+	 *
+	 * This changes which loaded skills are advertised in <available_skills>;
+	 * it does not unload skills or disable the Skill tool.
+	 */
+	setVisibleSkills(skillNames: string[] | undefined): void;
+
 	/** Get available slash commands in the current session. */
 	getCommands(): SlashCommandInfo[];
 
@@ -1730,6 +1744,8 @@ export interface ExtensionActions {
 	getActiveTools: () => string[];
 	getAllTools: () => ToolInfo[];
 	setActiveTools: (toolNames: string[]) => void;
+	getVisibleSkills: () => string[] | undefined;
+	setVisibleSkills: (skillNames: string[] | undefined) => void;
 	refreshTools: () => void;
 	getCommands: () => SlashCommandInfo[];
 	setModel: (model: Model<any>, options?: { persist?: boolean }) => Promise<boolean>;

--- a/packages/pi-coding-agent/src/core/hooks-runner.test.ts
+++ b/packages/pi-coding-agent/src/core/hooks-runner.test.ts
@@ -38,6 +38,8 @@ function stubRuntime(): ExtensionRuntime {
     getActiveTools: () => [],
     getAllTools: () => [],
     setActiveTools: () => {},
+    getVisibleSkills: () => undefined,
+    setVisibleSkills: () => {},
     refreshTools: () => {},
     getCommands: () => [],
     setModel: async () => false,

--- a/packages/pi-coding-agent/src/core/sdk-tool-filter.test.ts
+++ b/packages/pi-coding-agent/src/core/sdk-tool-filter.test.ts
@@ -5,7 +5,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { Type } from "@sinclair/typebox";
 import type { AgentTool } from "@gsd/pi-agent-core";
-import { filterToolsForProviderRequest } from "./sdk.js";
+import { filterToolsForProviderRequest, getAdjustToolSetRequestCustomMessages } from "./sdk.js";
 import { registerToolCompatibility, resetToolCompatibilityRegistry } from "./tools/tool-compatibility-registry.js";
 
 function tool(name: string): AgentTool {
@@ -26,7 +26,7 @@ test("filterToolsForProviderRequest removes provider-incompatible tools", () => 
 
 		const result = filterToolsForProviderRequest(
 			[tool("bash"), tool("image_result_tool"), tool("complex_schema_tool")],
-			{ api: "google-generative-ai" },
+			{ api: "google-generative-ai", provider: "google" },
 		);
 
 		assert.deepEqual(result.compatible.map((entry) => entry.name), ["bash", "image_result_tool"]);
@@ -34,4 +34,27 @@ test("filterToolsForProviderRequest removes provider-incompatible tools", () => 
 	} finally {
 		resetToolCompatibilityRegistry();
 	}
+});
+
+test("filterToolsForProviderRequest enforces provider-specific hard caps at send time", () => {
+	const result = filterToolsForProviderRequest(
+		Array.from({ length: 130 }, (_, index) => tool(`tool_${index}`)),
+		{ api: "openai-completions", provider: "groq" },
+	);
+
+	assert.equal(result.compatible.length, 128);
+	assert.deepEqual(result.filtered.map((entry) => entry.name), ["tool_128", "tool_129"]);
+});
+
+test("getAdjustToolSetRequestCustomMessages only reports custom messages in the current request tail", () => {
+	const messages = [
+		{ role: "custom", customType: "gsd-run", content: "old workflow", display: false, timestamp: 1 },
+		{ role: "assistant", content: [{ type: "text", text: "done" }], timestamp: 2 },
+		{ role: "user", content: [{ type: "text", text: "normal prompt" }], timestamp: 3 },
+		{ role: "custom", customType: "gsd-doctor-heal", content: "current workflow", display: false, timestamp: 4 },
+	] as any[];
+
+	assert.deepEqual(getAdjustToolSetRequestCustomMessages(messages), [
+		{ index: 3, customType: "gsd-doctor-heal" },
+	]);
 });

--- a/packages/pi-coding-agent/src/core/sdk-tool-filter.test.ts
+++ b/packages/pi-coding-agent/src/core/sdk-tool-filter.test.ts
@@ -20,15 +20,18 @@ function tool(name: string): AgentTool {
 
 test("filterToolsForProviderRequest removes provider-incompatible tools", () => {
 	resetToolCompatibilityRegistry();
-	registerToolCompatibility("image_result_tool", { producesImages: true });
-	registerToolCompatibility("complex_schema_tool", { schemaFeatures: ["patternProperties"] });
+	try {
+		registerToolCompatibility("image_result_tool", { producesImages: true });
+		registerToolCompatibility("complex_schema_tool", { schemaFeatures: ["patternProperties"] });
 
-	const result = filterToolsForProviderRequest(
-		[tool("bash"), tool("image_result_tool"), tool("complex_schema_tool")],
-		{ api: "google-generative-ai" },
-	);
+		const result = filterToolsForProviderRequest(
+			[tool("bash"), tool("image_result_tool"), tool("complex_schema_tool")],
+			{ api: "google-generative-ai" },
+		);
 
-	assert.deepEqual(result.compatible.map((entry) => entry.name), ["bash", "image_result_tool"]);
-	assert.deepEqual(result.filtered.map((entry) => entry.name), ["complex_schema_tool"]);
-	resetToolCompatibilityRegistry();
+		assert.deepEqual(result.compatible.map((entry) => entry.name), ["bash", "image_result_tool"]);
+		assert.deepEqual(result.filtered.map((entry) => entry.name), ["complex_schema_tool"]);
+	} finally {
+		resetToolCompatibilityRegistry();
+	}
 });

--- a/packages/pi-coding-agent/src/core/sdk-tool-filter.test.ts
+++ b/packages/pi-coding-agent/src/core/sdk-tool-filter.test.ts
@@ -1,0 +1,34 @@
+// Project/App: GSD-2
+// File Purpose: Tests final provider request-time tool compatibility filtering.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Type } from "@sinclair/typebox";
+import type { AgentTool } from "@gsd/pi-agent-core";
+import { filterToolsForProviderRequest } from "./sdk.js";
+import { registerToolCompatibility, resetToolCompatibilityRegistry } from "./tools/tool-compatibility-registry.js";
+
+function tool(name: string): AgentTool {
+	return {
+		name,
+		label: name,
+		description: name,
+		parameters: Type.Object({}),
+		execute: async () => ({ content: [], details: undefined }),
+	};
+}
+
+test("filterToolsForProviderRequest removes provider-incompatible tools", () => {
+	resetToolCompatibilityRegistry();
+	registerToolCompatibility("image_result_tool", { producesImages: true });
+	registerToolCompatibility("complex_schema_tool", { schemaFeatures: ["patternProperties"] });
+
+	const result = filterToolsForProviderRequest(
+		[tool("bash"), tool("image_result_tool"), tool("complex_schema_tool")],
+		{ api: "google-generative-ai" },
+	);
+
+	assert.deepEqual(result.compatible.map((entry) => entry.name), ["bash", "image_result_tool"]);
+	assert.deepEqual(result.filtered.map((entry) => entry.name), ["complex_schema_tool"]);
+	resetToolCompatibilityRegistry();
+});

--- a/packages/pi-coding-agent/src/core/sdk.ts
+++ b/packages/pi-coding-agent/src/core/sdk.ts
@@ -39,9 +39,23 @@ export function canRestoreSessionModel(
 	return modelRegistry.isProviderRequestReady(model.provider);
 }
 
+const PROVIDER_TOOL_LIMITS: Record<string, number> = {
+	groq: 128,
+};
+
+function resolveProviderToolLimit(
+	providerCaps: ReturnType<typeof getProviderCapabilities>,
+	provider: string | undefined,
+): number {
+	if (provider && PROVIDER_TOOL_LIMITS[provider]) {
+		return PROVIDER_TOOL_LIMITS[provider];
+	}
+	return providerCaps.maxTools > 0 ? providerCaps.maxTools : 0;
+}
+
 export function filterToolsForProviderRequest(
 	tools: AgentTool[],
-	model: Pick<Model<any>, "api">,
+	model: Pick<Model<any>, "api" | "provider">,
 ): { compatible: AgentTool[]; filtered: AgentTool[] } {
 	const providerCaps = getProviderCapabilities(model.api);
 	if (!providerCaps.toolCalling) {
@@ -61,6 +75,12 @@ export function filterToolsForProviderRequest(
 			compatible.push(tool);
 		}
 	}
+
+	const toolLimit = resolveProviderToolLimit(providerCaps, model.provider);
+	if (toolLimit > 0 && compatible.length > toolLimit) {
+		filtered.push(...compatible.splice(toolLimit));
+	}
+
 	return { compatible, filtered };
 }
 import { Agent, maybeLogProviderPayloadAudit, type AgentMessage, type AgentTool, type ThinkingLevel } from "@gsd/pi-agent-core";
@@ -108,6 +128,21 @@ import {
 	writeTool,
 } from "./tools/index.js";
 import { getToolCompatibility } from "./tools/tool-compatibility-registry.js";
+
+export function getAdjustToolSetRequestCustomMessages(
+	messages: readonly AgentMessage[] | undefined,
+): Array<{ index: number; customType: string }> {
+	if (!messages) return [];
+	const requestMessages: Array<{ index: number; customType: string }> = [];
+	for (let index = messages.length - 1; index >= 0; index--) {
+		const message = messages[index] as { role?: unknown; customType?: unknown };
+		if (message?.role === "assistant") break;
+		if (message?.role === "custom" && typeof message.customType === "string") {
+			requestMessages.push({ index, customType: message.customType });
+		}
+	}
+	return requestMessages.reverse();
+}
 
 export interface CreateAgentSessionOptions {
 	/** Working directory for project-local discovery. Default: process.cwd() */
@@ -429,7 +464,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			if (!runner) return messages;
 			return runner.emitContext(messages);
 		},
-		filterTools: async (tools) => {
+		filterTools: async (tools, _signal, messages) => {
 			const currentModel = agent.state.activeInferenceModel ?? agent.state.model ?? model;
 			if (!currentModel) return tools;
 			const providerFiltered = filterToolsForProviderRequest(tools, currentModel);
@@ -441,6 +476,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				selectedModelId: currentModel.id,
 				activeToolNames: providerFiltered.compatible.map((tool) => tool.name),
 				filteredTools: providerFiltered.filtered.map((tool) => tool.name),
+				requestCustomMessages: getAdjustToolSetRequestCustomMessages(messages),
 			});
 			if (!result?.toolNames) return providerFiltered.compatible;
 			const allowedNames = new Set(result.toolNames);

--- a/packages/pi-coding-agent/src/core/sdk.ts
+++ b/packages/pi-coding-agent/src/core/sdk.ts
@@ -38,8 +38,33 @@ export function canRestoreSessionModel(
 ): boolean {
 	return modelRegistry.isProviderRequestReady(model.provider);
 }
-import { Agent, type AgentMessage, type ThinkingLevel } from "@gsd/pi-agent-core";
-import type { Message, Model } from "@gsd/pi-ai";
+
+export function filterToolsForProviderRequest(
+	tools: AgentTool[],
+	model: Pick<Model<any>, "api">,
+): { compatible: AgentTool[]; filtered: AgentTool[] } {
+	const providerCaps = getProviderCapabilities(model.api);
+	if (!providerCaps.toolCalling) {
+		return { compatible: [], filtered: tools };
+	}
+
+	const compatible: AgentTool[] = [];
+	const filtered: AgentTool[] = [];
+	for (const tool of tools) {
+		const compat = getToolCompatibility(tool.name);
+		if (
+			(compat?.producesImages && !providerCaps.imageToolResults) ||
+			compat?.schemaFeatures?.some((feature) => providerCaps.unsupportedSchemaFeatures.includes(feature))
+		) {
+			filtered.push(tool);
+		} else {
+			compatible.push(tool);
+		}
+	}
+	return { compatible, filtered };
+}
+import { Agent, maybeLogProviderPayloadAudit, type AgentMessage, type AgentTool, type ThinkingLevel } from "@gsd/pi-agent-core";
+import { getProviderCapabilities, type Message, type Model } from "@gsd/pi-ai";
 import { getAgentDir, getDocsPath } from "../config.js";
 import { AgentSession } from "./agent-session.js";
 import { AuthStorage } from "./auth-storage.js";
@@ -82,6 +107,7 @@ import {
 	type ToolName,
 	writeTool,
 } from "./tools/index.js";
+import { getToolCompatibility } from "./tools/tool-compatibility-registry.js";
 
 export interface CreateAgentSessionOptions {
 	/** Working directory for project-local discovery. Default: process.cwd() */
@@ -390,15 +416,34 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		onPayload: async (payload, currentModel) => {
 			const runner = extensionRunnerRef.current;
 			if (!runner?.hasHandlers("before_provider_request")) {
+				maybeLogProviderPayloadAudit(payload, "before_provider_request:unchanged");
 				return payload;
 			}
-			return runner.emitBeforeProviderRequest(payload, currentModel);
+			const nextPayload = await runner.emitBeforeProviderRequest(payload, currentModel);
+			maybeLogProviderPayloadAudit(nextPayload, "before_provider_request:after");
+			return nextPayload;
 		},
 		sessionId: sessionManager.getSessionId(),
 		transformContext: async (messages) => {
 			const runner = extensionRunnerRef.current;
 			if (!runner) return messages;
 			return runner.emitContext(messages);
+		},
+		filterTools: async (tools) => {
+			const currentModel = agent.state.activeInferenceModel ?? agent.state.model ?? model;
+			const providerFiltered = filterToolsForProviderRequest(tools, currentModel);
+			const runner = extensionRunnerRef.current;
+			if (!runner?.hasHandlers("adjust_tool_set")) return providerFiltered.compatible;
+			const result = await runner.emitAdjustToolSet({
+				selectedModelApi: currentModel.api,
+				selectedModelProvider: currentModel.provider,
+				selectedModelId: currentModel.id,
+				activeToolNames: providerFiltered.compatible.map((tool) => tool.name),
+				filteredTools: providerFiltered.filtered.map((tool) => tool.name),
+			});
+			if (!result?.toolNames) return providerFiltered.compatible;
+			const allowedNames = new Set(result.toolNames);
+			return providerFiltered.compatible.filter((tool) => allowedNames.has(tool.name));
 		},
 		steeringMode: settingsManager.getSteeringMode(),
 		followUpMode: settingsManager.getFollowUpMode(),

--- a/packages/pi-coding-agent/src/core/sdk.ts
+++ b/packages/pi-coding-agent/src/core/sdk.ts
@@ -431,6 +431,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		},
 		filterTools: async (tools) => {
 			const currentModel = agent.state.activeInferenceModel ?? agent.state.model ?? model;
+			if (!currentModel) return tools;
 			const providerFiltered = filterToolsForProviderRequest(tools, currentModel);
 			const runner = extensionRunnerRef.current;
 			if (!runner?.hasHandlers("adjust_tool_set")) return providerFiltered.compatible;

--- a/packages/pi-coding-agent/src/core/skill-tool.test.ts
+++ b/packages/pi-coding-agent/src/core/skill-tool.test.ts
@@ -1,3 +1,6 @@
+// Project/App: GSD-2
+// File Purpose: Tests skill invocation and prompt-only skill visibility behavior.
+
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -85,5 +88,30 @@ describe("Skill tool", () => {
 		const message = result.content[0]?.type === "text" ? result.content[0].text : "";
 		assert.match(message, /^Skill "nonexistent" not found\. Available skills: /);
 		assert.match(message, /swift-testing/);
+	});
+
+	it("filters skill catalog without unloading skills or disabling Skill tool", async () => {
+		writeSkill(testDir, "alpha", "Use alpha.");
+		writeSkill(testDir, "beta", "Use beta.");
+		const session = await createSession();
+
+		assert.match(session.systemPrompt, /<name>alpha<\/name>/);
+		assert.match(session.systemPrompt, /<name>beta<\/name>/);
+
+		session.setVisibleSkillsByName(["alpha"]);
+		assert.deepEqual(session.getVisibleSkillNames(), ["alpha"]);
+		assert.match(session.systemPrompt, /<name>alpha<\/name>/);
+		assert.doesNotMatch(session.systemPrompt, /<name>beta<\/name>/);
+
+		const tool = session.state.tools.find((entry) => entry.name === "Skill");
+		assert.ok(tool, "Skill tool should remain active");
+		const result = await tool.execute("call-3", { skill: "beta" });
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+		assert.match(text, /<skill name="beta"/);
+
+		session.setVisibleSkillsByName(undefined);
+		assert.equal(session.getVisibleSkillNames(), undefined);
+		assert.match(session.systemPrompt, /<name>alpha<\/name>/);
+		assert.match(session.systemPrompt, /<name>beta<\/name>/);
 	});
 });

--- a/packages/pi-coding-agent/src/core/system-prompt.ts
+++ b/packages/pi-coding-agent/src/core/system-prompt.ts
@@ -59,13 +59,12 @@ export interface BuildSystemPromptOptions {
 	 * Append a `Current date and time: <toLocaleString>` line to the system
 	 * prompt. Default: `false`.
 	 *
-	 * Anthropic prompt caching matches on byte-for-byte prefix equality.
-	 * Embedding a per-call timestamp in the system prompt invalidates the
-	 * cache on every request, forcing a full re-write that costs *more*
-	 * than an uncached call (cache-write premium). Most agentic flows do
-	 * not need wall-clock awareness in the system prompt — opt in only
-	 * when the consumer genuinely needs it (e.g. a clock-sensitive agent),
-	 * and inject it via a non-cached channel (user message) when possible.
+	 * Provider prompt caches generally depend on stable prompt prefixes.
+	 * Embedding a per-call timestamp in the system prompt invalidates that
+	 * stability on every request, often forcing full prompt reprocessing.
+	 * Most agentic flows do not need wall-clock awareness in the system
+	 * prompt — opt in only when the consumer genuinely needs it, and inject
+	 * it via a non-cached channel (user message) when possible.
 	 */
 	includeDateTime?: boolean;
 }
@@ -86,9 +85,8 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	} = options;
 	const resolvedCwd = toPosixPath(cwd ?? process.cwd());
 
-	// Per-call timestamps invalidate Anthropic prompt caching (the cache
-	// matches on byte-for-byte prefix equality). Compute lazily and only
-	// when explicitly opted in via `includeDateTime`.
+	// Per-call timestamps invalidate provider prompt cache stability. Compute
+	// lazily and only when explicitly opted in via `includeDateTime`.
 	const dateTimeLine = includeDateTime
 		? `\nCurrent date and time: ${new Date().toLocaleString("en-US", {
 			weekday: "long",

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -45,12 +45,12 @@ import { classifyProject, type ProjectClassification } from "./detection.js";
 // ─── Preamble Cap ─────────────────────────────────────────────────────────────
 
 /**
- * Historical static ceiling for the preamble cap. Kept as an upper bound even
+ * Static ceiling for the preamble cap. Kept as an upper bound even
  * after context-window-aware sizing so large-window users don't suddenly see
- * 10× looser caps than before. Small-window users get a tighter cap derived
+ * 10× looser caps than needed. Small-window users get a tighter cap derived
  * from their configured executor window.
  */
-const MAX_PREAMBLE_CHARS = 30_000;
+const MAX_PREAMBLE_CHARS = 20_000;
 
 /**
  * Resolve prompt budgets from the configured executor context window.
@@ -185,8 +185,8 @@ function formatCloseoutReviewInstructions(validationContent: string | null, vali
 }
 
 function capPreamble(preamble: string): string {
-  // Cap inlined context at min(historical 30K ceiling, scaled inline budget).
-  // The ceiling preserves pre-fix behavior for large-window users; the scaled
+  // Cap inlined context at min(static ceiling, scaled inline budget).
+  // The ceiling bounds repeated auto prompt payloads; the scaled
   // budget tightens the cap for small-window users whose true safe limit is
   // below 30K. `computeBudgets` allocates 40% of total chars to inline context.
   const budget = Math.min(MAX_PREAMBLE_CHARS, resolvePromptBudgets().inlineContextBudgetChars);
@@ -636,8 +636,81 @@ export async function buildSliceSummaryExcerpt(
     return lines.join("\n");
   } catch {
     // Defensive — any parse failure falls back to full inline.
-    return `### ${sid} Summary\nSource: \`${relPath}\`\n\n${content.trim()}`;
+    return `### ${sid} Summary\nSource: \`${relPath}\`\n\n${capMalformedSummary(content, relPath)}`;
   }
+}
+
+export async function buildTaskSummaryExcerpt(
+  absPath: string | null, relPath: string, tid: string, options?: { blocker?: boolean },
+): Promise<string> {
+  const label = options?.blocker ? "Blocker Task Summary" : "Task Summary";
+  const header = `### ${label}: ${tid} (excerpt)\nSource: \`${relPath}\``;
+  const content = absPath ? await loadFile(absPath) : null;
+  if (!content) {
+    return `${header}\n\n_(not found — file does not exist yet)_`;
+  }
+
+  try {
+    const s = parseSummary(content);
+    if (!s.frontmatter.id) {
+      return `### ${label}: ${tid}\nSource: \`${relPath}\`\n\n${capMalformedSummary(content, relPath)}`;
+    }
+
+    const lines: string[] = [header, ""];
+    if (s.title) lines.push(`**Title:** ${s.title}`);
+    if (s.oneLiner) lines.push(`**One-liner:** ${s.oneLiner}`);
+    if (s.frontmatter.verification_result) {
+      lines.push(`**Verification:** \`${s.frontmatter.verification_result}\``);
+    }
+    lines.push(`**Blocker discovered:** ${s.frontmatter.blocker_discovered ? "yes — read full summary if blocker details are insufficient" : "no"}`);
+    if (s.frontmatter.provides.length > 0) lines.push(`**Provides:** ${s.frontmatter.provides.slice(0, 4).join("; ")}`);
+    if (s.frontmatter.key_decisions.length > 0) lines.push(`**Key decisions:** ${s.frontmatter.key_decisions.slice(0, 4).join("; ")}`);
+    if (s.frontmatter.patterns_established.length > 0) lines.push(`**Patterns established:** ${s.frontmatter.patterns_established.slice(0, 4).join("; ")}`);
+    if (s.frontmatter.key_files.length > 0) {
+      const files = s.frontmatter.key_files.slice(0, 6);
+      const more = s.frontmatter.key_files.length > files.length ? ` (+${s.frontmatter.key_files.length - files.length} more)` : "";
+      lines.push(`**Key files:** ${files.join(", ")}${more}`);
+    }
+
+    const SECTION_CAP_CHARS = 500;
+    const capSection = (body: string): string => {
+      const trimmed = body.trim();
+      if (trimmed.length <= SECTION_CAP_CHARS) return trimmed;
+      return `${trimmed.slice(0, SECTION_CAP_CHARS)}\n… (truncated — see full \`${relPath}\`)`;
+    };
+
+    const verification = extractMarkdownSection(content, "Verification");
+    const diagnostics = extractMarkdownSection(content, "Diagnostics");
+    const knownIssues = extractMarkdownSection(content, "Known Issues");
+
+    if (verification && verification.trim()) {
+      lines.push("", "#### Verification", capSection(verification));
+    }
+    if (diagnostics && diagnostics.trim()) {
+      lines.push("", "#### Diagnostics", capSection(diagnostics));
+    }
+    if (s.deviations && s.deviations.trim()) {
+      lines.push("", "#### Deviations", capSection(s.deviations));
+    }
+    if (knownIssues && knownIssues.trim()) {
+      lines.push("", "#### Known issues", capSection(knownIssues));
+    }
+
+    lines.push(
+      "",
+      `> **On-demand:** read \`${relPath}\` only when this excerpt is absent/truncated or you need fuller blocker, implementation, or file-change evidence.`,
+    );
+    return lines.join("\n");
+  } catch {
+    return `### ${label}: ${tid}\nSource: \`${relPath}\`\n\n${capMalformedSummary(content, relPath)}`;
+  }
+}
+
+function capMalformedSummary(content: string, relPath: string): string {
+  const trimmed = content.trim();
+  const limit = 1_500;
+  if (trimmed.length <= limit) return trimmed;
+  return `${trimmed.slice(0, limit).trimEnd()}\n\n[Truncated malformed summary — read \`${relPath}\` for full details.]`;
 }
 
 /**
@@ -914,7 +987,7 @@ export async function inlineKnowledgeScoped(
  * plan-milestone, complete-slice, complete-milestone, validate-milestone,
  * reassess-roadmap) previously injected the full KNOWLEDGE.md (~226KB for a
  * real project) on every invocation. This helper scopes by caller-supplied
- * keywords and caps the payload at `maxChars` (default 30,000 chars).
+ * keywords and caps the payload at `maxChars` (default 12,000 chars).
  *
  * Returns null when no KNOWLEDGE.md exists or no entries match any keyword.
  */
@@ -923,7 +996,7 @@ export async function inlineKnowledgeBudgeted(
   keywords: string[],
   options?: { maxChars?: number },
 ): Promise<string | null> {
-  const DEFAULT_MAX_CHARS = 30_000;
+  const DEFAULT_MAX_CHARS = 12_000;
   const HARD_MAX_CHARS = 100_000;
   const raw = Number(options?.maxChars ?? DEFAULT_MAX_CHARS);
   const maxChars = Number.isFinite(raw)
@@ -2378,10 +2451,9 @@ export async function buildCompleteSlicePrompt(
         const blocks: string[] = [];
         for (const file of summaryFiles) {
           const absPath = join(tDir, file);
-          const content = await loadFile(absPath);
-          if (!content) continue;
           const relPath = `${sRel}/tasks/${file}`;
-          blocks.push(`### Task Summary: ${file.replace(/-SUMMARY\.md$/i, "")}\nSource: \`${relPath}\`\n\n${content.trim()}`);
+          const taskId = file.replace(/-SUMMARY\.md$/i, "");
+          blocks.push(await buildTaskSummaryExcerpt(absPath, relPath, taskId));
         }
         return blocks.length > 0 ? blocks.join("\n\n---\n\n") : null;
       }
@@ -2758,7 +2830,7 @@ export async function buildReplanSlicePrompt(
       const relPath = `${sRel}/tasks/${file}`;
       if (summary.frontmatter.blocker_discovered) {
         blockerTaskId = summary.frontmatter.id || file.replace(/-SUMMARY\.md$/i, "");
-        inlined.push(`### Blocker Task Summary: ${blockerTaskId}\nSource: \`${relPath}\`\n\n${content.trim()}`);
+        inlined.push(await buildTaskSummaryExcerpt(absPath, relPath, blockerTaskId, { blocker: true }));
       }
     }
   }

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -125,6 +125,24 @@ export function buildMinimalGsdWorkflowToolSet(activeToolNames: readonly string[
   return [...new Set([...preserved, ...scoped])];
 }
 
+export function buildRequestScopedGsdToolSet(
+  activeToolNames: readonly string[],
+  requestCustomMessages: readonly { customType?: string }[] | undefined,
+): string[] | undefined {
+  for (let index = (requestCustomMessages?.length ?? 0) - 1; index >= 0; index--) {
+    const currentCustomType = requestCustomMessages?.[index]?.customType;
+    if (
+      currentCustomType === "gsd-run" ||
+      currentCustomType === "gsd-discuss" ||
+      currentCustomType === "gsd-doctor-heal" ||
+      currentCustomType === "gsd-triage"
+    ) {
+      return buildMinimalGsdWorkflowToolSet(activeToolNames);
+    }
+  }
+  return undefined;
+}
+
 export function isFullGsdToolSurfaceRequested(): boolean {
   return process.env.PI_GSD_FULL_TOOLS === "1";
 }
@@ -1037,15 +1055,17 @@ export function registerHooks(
   // Return undefined to let the built-in provider compatibility filtering proceed.
   pi.on("adjust_tool_set", async (event) => {
     if (isFullGsdToolSurfaceRequested()) return undefined;
+    const removed = new Set(event.filteredTools);
+    const providerCompatible = event.activeToolNames.filter((name) => !removed.has(name));
+    const requestScoped = buildRequestScopedGsdToolSet(providerCompatible, event.requestCustomMessages);
+    if (requestScoped) {
+      return { toolNames: requestScoped };
+    }
     const dash = getAutoRuntimeSnapshot();
     if (dash.active && dash.currentUnit) {
-      const removed = new Set(event.filteredTools);
-      const providerCompatible = event.activeToolNames.filter((name) => !removed.has(name));
       return { toolNames: buildMinimalAutoGsdToolSet(providerCompatible, dash.currentUnit.type) };
     }
     if (isGeneralGsdToolScopingRequested()) {
-      const removed = new Set(event.filteredTools);
-      const providerCompatible = event.activeToolNames.filter((name) => !removed.has(name));
       return { toolNames: buildMinimalGsdToolSet(providerCompatible) };
     }
     return undefined;

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -1,3 +1,6 @@
+// Project/App: GSD-2
+// File Purpose: Registers GSD extension runtime hooks and token-saving tool policies.
+
 import { join } from "node:path";
 
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
@@ -25,6 +28,7 @@ import { initNotificationWidget } from "../notification-widget.js";
 import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { extractSubagentAgentClasses } from "./subagent-input.js";
 import { approvalGateIdForUnit, isExplicitApprovalResponse, shouldPauseForUserApprovalQuestion } from "../user-input-boundary.js";
+import { resolveSkillManifest } from "../skill-manifest.js";
 
 // Skip the welcome screen on the very first session_start — cli.ts already
 // printed it before the TUI launched. Only re-print on /clear (subsequent sessions).
@@ -37,6 +41,156 @@ interface DeferredApprovalGate {
 }
 
 let deferredApprovalGate: DeferredApprovalGate | null = null;
+
+export const MINIMAL_GSD_TOOL_NAMES = [
+  "gsd_exec",
+  "gsd_exec_search",
+  "gsd_resume",
+  "gsd_milestone_status",
+  "gsd_checkpoint_db",
+  "memory_query",
+  "capture_thought",
+] as const;
+
+export const MINIMAL_AUTO_BASE_TOOL_NAMES = [
+  "ask_user_questions",
+  "bash",
+  "bg_shell",
+  "edit",
+  "glob",
+  "grep",
+  "ls",
+  "read",
+  "write",
+] as const;
+
+const AUTO_UNIT_SCOPED_TOOLS: Record<string, readonly string[]> = {
+  "research-milestone": ["gsd_summary_save", "gsd_decision_save"],
+  "plan-milestone": ["gsd_plan_milestone", "gsd_decision_save", "gsd_requirement_update"],
+  "discuss-milestone": ["gsd_summary_save", "gsd_decision_save", "gsd_requirement_save"],
+  "validate-milestone": ["gsd_validate_milestone", "gsd_reassess_roadmap", "subagent"],
+  "complete-milestone": ["gsd_complete_milestone", "subagent"],
+  "research-slice": ["gsd_summary_save", "gsd_decision_save"],
+  "plan-slice": ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
+  "refine-slice": ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
+  "replan-slice": ["gsd_replan_slice", "gsd_plan_task", "gsd_decision_save"],
+  "complete-slice": ["gsd_slice_complete", "gsd_decision_save", "gsd_requirement_update", "subagent"],
+  "reassess-roadmap": ["gsd_reassess_roadmap"],
+  "execute-task": ["gsd_task_complete", "gsd_decision_save"],
+  "execute-task-simple": ["gsd_task_complete", "gsd_decision_save"],
+  "reactive-execute": ["gsd_task_complete", "gsd_decision_save"],
+  "run-uat": ["gsd_summary_save"],
+  "gate-evaluate": ["gsd_save_gate_result"],
+  "rewrite-docs": ["gsd_summary_save", "gsd_decision_save"],
+  "workflow-preferences": ["gsd_summary_save"],
+  "discuss-project": ["gsd_summary_save", "gsd_decision_save", "gsd_requirement_save"],
+  "discuss-requirements": ["gsd_requirement_save", "gsd_summary_save"],
+  "research-decision": ["gsd_summary_save"],
+  "research-project": ["gsd_summary_save", "gsd_decision_save"],
+};
+
+const WORKFLOW_GSD_TOOL_NAMES = [
+  ...MINIMAL_GSD_TOOL_NAMES,
+  ...Object.values(AUTO_UNIT_SCOPED_TOOLS).flat(),
+].filter(isGsdManagedTool);
+
+function isGsdManagedTool(name: string): boolean {
+  return name.startsWith("gsd_") || name === "memory_query" || name === "capture_thought" || name === "gsd_graph";
+}
+
+export function buildMinimalGsdToolSet(activeToolNames: readonly string[]): string[] {
+  const active = new Set(activeToolNames);
+  const preserved = activeToolNames.filter((name) => !isGsdManagedTool(name));
+  const minimal = MINIMAL_GSD_TOOL_NAMES.filter((name) => active.has(name));
+  return [...new Set([...preserved, ...minimal])];
+}
+
+export function buildMinimalAutoGsdToolSet(
+  activeToolNames: readonly string[],
+  unitType: string | undefined,
+): string[] {
+  const active = new Set(activeToolNames);
+  const unitTools = unitType ? AUTO_UNIT_SCOPED_TOOLS[unitType] ?? [] : [];
+  const autoBaseTools = new Set<string>(MINIMAL_AUTO_BASE_TOOL_NAMES);
+  const preserved = activeToolNames.filter((name) => autoBaseTools.has(name));
+  const scoped = [...MINIMAL_GSD_TOOL_NAMES, ...unitTools].filter((name) => active.has(name));
+  return [...new Set([...preserved, ...scoped])];
+}
+
+export function buildMinimalGsdWorkflowToolSet(activeToolNames: readonly string[]): string[] {
+  const active = new Set(activeToolNames);
+  const autoBaseTools = new Set<string>(MINIMAL_AUTO_BASE_TOOL_NAMES);
+  const preserved = activeToolNames.filter((name) => autoBaseTools.has(name));
+  const scoped = WORKFLOW_GSD_TOOL_NAMES.filter((name) => active.has(name));
+  return [...new Set([...preserved, ...scoped])];
+}
+
+export function isFullGsdToolSurfaceRequested(): boolean {
+  return process.env.PI_GSD_FULL_TOOLS === "1";
+}
+
+function isGeneralGsdToolScopingRequested(): boolean {
+  return process.env.PI_GSD_MINIMAL_TOOLS === "1";
+}
+
+export interface ScopedGsdWorkflowState {
+  tools: string[] | null;
+  visibleSkills: string[] | undefined;
+  restoreVisibleSkills: boolean;
+}
+
+type GsdWorkflowScopeApi = Pick<ExtensionAPI, "getActiveTools" | "setActiveTools"> & Partial<Pick<ExtensionAPI, "getVisibleSkills" | "setVisibleSkills">>;
+
+function applyMinimalGsdToolSurface(pi: ExtensionAPI): void {
+  if (isFullGsdToolSurfaceRequested()) return;
+  const dash = getAutoRuntimeSnapshot();
+  if (dash.active && dash.currentUnit) {
+    pi.setActiveTools(buildMinimalAutoGsdToolSet(pi.getActiveTools(), dash.currentUnit.type));
+    return;
+  }
+  if (!isGeneralGsdToolScopingRequested()) return;
+  pi.setActiveTools(buildMinimalGsdToolSet(pi.getActiveTools()));
+}
+
+export function scopeGsdWorkflowToolsForDispatch(
+  pi: GsdWorkflowScopeApi,
+  unitType?: string,
+): ScopedGsdWorkflowState | null {
+  if (isFullGsdToolSurfaceRequested()) return null;
+  const current = pi.getActiveTools();
+  const scoped = unitType
+    ? buildMinimalAutoGsdToolSet(current, unitType)
+    : buildMinimalGsdWorkflowToolSet(current);
+  const toolsChanged = !(scoped.length === current.length && scoped.every((name, index) => name === current[index]));
+  const skillManifest = resolveSkillManifest(unitType);
+  const canScopeSkills = skillManifest !== null && pi.getVisibleSkills && pi.setVisibleSkills;
+  if (!toolsChanged && !canScopeSkills) {
+    return null;
+  }
+  if (toolsChanged) {
+    pi.setActiveTools(scoped);
+  }
+  const visibleSkills = canScopeSkills ? pi.getVisibleSkills!() : undefined;
+  if (canScopeSkills) {
+    pi.setVisibleSkills!(skillManifest);
+  }
+  return {
+    tools: toolsChanged ? current : null,
+    visibleSkills,
+    restoreVisibleSkills: Boolean(canScopeSkills),
+  };
+}
+
+export function restoreGsdWorkflowTools(
+  pi: Pick<ExtensionAPI, "setActiveTools"> & Partial<Pick<ExtensionAPI, "setVisibleSkills">>,
+  savedState: ScopedGsdWorkflowState | null,
+): void {
+  if (!savedState) return;
+  if (savedState.tools) pi.setActiveTools(savedState.tools);
+  if (savedState.restoreVisibleSkills && pi.setVisibleSkills) {
+    pi.setVisibleSkills(savedState.visibleSkills);
+  }
+}
 
 async function deriveGsdState(basePath: string) {
   const { deriveState } = await import("../state.js");
@@ -268,6 +422,8 @@ export function registerHooks(
   });
 
   pi.on("before_agent_start", async (event, ctx: ExtensionContext) => {
+    applyMinimalGsdToolSurface(pi);
+
     // Wait for ecosystem loader to finish (no-op after first turn).
     const { getEcosystemReadyPromise } = await import("../ecosystem/loader.js");
     await getEcosystemReadyPromise();
@@ -879,8 +1035,19 @@ export function registerHooks(
   // Tool set adaptation hook (ADR-005 Phase 4)
   // Extensions can override tool set after model selection by returning { toolNames: [...] }
   // Return undefined to let the built-in provider compatibility filtering proceed.
-  pi.on("adjust_tool_set", async (_event) => {
-    // Default: no override — let provider capability filtering handle tool set
+  pi.on("adjust_tool_set", async (event) => {
+    if (isFullGsdToolSurfaceRequested()) return undefined;
+    const dash = getAutoRuntimeSnapshot();
+    if (dash.active && dash.currentUnit) {
+      const removed = new Set(event.filteredTools);
+      const providerCompatible = event.activeToolNames.filter((name) => !removed.has(name));
+      return { toolNames: buildMinimalAutoGsdToolSet(providerCompatible, dash.currentUnit.type) };
+    }
+    if (isGeneralGsdToolScopingRequested()) {
+      const removed = new Set(event.filteredTools);
+      const providerCompatible = event.activeToolNames.filter((name) => !removed.has(name));
+      return { toolNames: buildMinimalGsdToolSet(providerCompatible) };
+    }
     return undefined;
   });
 }

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: System prompt and hidden context bootstrap for GSD sessions.
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 
@@ -21,6 +23,11 @@ import { toPosixPath } from "../../shared/mod.js";
 import { autoEnableCmuxPreferences } from "../commands-cmux.js";
 import { gsdHome } from "../gsd-home.js";
 
+const DEFAULT_CONTEXT_MESSAGE_MAX_CHARS = 4_000;
+const DEFAULT_KNOWLEDGE_MAX_CHARS = 12_000;
+const DEFAULT_CODEBASE_MAX_CHARS = 8_000;
+const MIN_CONTEXT_MESSAGE_MAX_CHARS = 1_000;
+const MIN_KNOWLEDGE_MAX_CHARS = 1_000;
 
 /**
  * Bundled skill triggers — resolved dynamically at runtime instead of
@@ -158,8 +165,6 @@ export async function buildBeforeAgentStartResult(
     logWarning("bootstrap", `decisions backfill failed: ${(e as Error).message}`);
   }
 
-  const memoryBlock = await loadMemoryBlock(event.prompt ?? "");
-
   let newSkillsBlock = "";
   if (hasSkillSnapshot()) {
     const newSkills = detectNewSkills();
@@ -190,11 +195,10 @@ export async function buildBeforeAgentStartResult(
       if (rawContent) {
         // Cap injection size to ~2 000 tokens to avoid bloating every request.
         // Full map is always available at .gsd/CODEBASE.md.
-        const MAX_CODEBASE_CHARS = 8_000;
         const generatedMatch = rawContent.match(/Generated: (\S+)/);
         const generatedAt = generatedMatch?.[1] ?? "unknown";
-        const content = rawContent.length > MAX_CODEBASE_CHARS
-          ? rawContent.slice(0, MAX_CODEBASE_CHARS) + "\n\n*(truncated — see .gsd/CODEBASE.md for full map)*"
+        const content = rawContent.length > DEFAULT_CODEBASE_MAX_CHARS
+          ? rawContent.slice(0, DEFAULT_CODEBASE_MAX_CHARS) + "\n\n*(truncated — see .gsd/CODEBASE.md for full map)*"
           : rawContent;
         codebaseBlock = `\n\n[PROJECT CODEBASE — File structure and descriptions (generated ${generatedAt}, auto-refreshed when GSD detects tracked file changes; use /gsd codebase stats for status)]\n\n${content}`;
       }
@@ -206,6 +210,9 @@ export async function buildBeforeAgentStartResult(
   warnDeprecatedAgentInstructions();
 
   const injection = await buildGuidedExecuteContextInjection(event.prompt, process.cwd());
+  const memoryBlock = await loadMemoryBlock(event.prompt ?? "", {
+    includePromptRelevant: !(injection && isLowEntropyResumePrompt(event.prompt ?? "")),
+  });
 
   // Re-inject forensics context on follow-up turns (#2941)
   const forensicsInjection = !injection ? buildForensicsContextInjection(process.cwd(), event.prompt) : null;
@@ -218,12 +225,9 @@ export async function buildBeforeAgentStartResult(
     : "";
 
   // memoryBlock is FTS-queried against the user prompt and changes per call.
-  // Removing it from `fullSystem` keeps the system-prompt cache breakpoint
-  // stable across calls — the only scoped goal of this fix. The pi-ai
-  // Anthropic adapter additionally cache-marks the last user turn, so the
-  // memoryBlock injected via the context message may itself be cached up to
-  // that boundary; that's orthogonal and unchanged from prior behavior. The
-  // load-bearing win here is preserving the system+tools cache hit. (#5019)
+  // Keeping it out of `fullSystem` preserves provider prompt-cache stability
+  // for the static system/tool prefix. The dynamic memory block rides the
+  // volatile context message instead. (#5019)
   const fullSystem = `${event.systemPrompt}\n\n[SYSTEM CONTEXT — GSD]\n\n${systemContent}${preferenceBlock}${knowledgeBlock}${codebaseBlock}${newSkillsBlock}${worktreeBlock}${subagentModelBlock}`;
 
   stopContextTimer({
@@ -255,19 +259,53 @@ export function buildContextMessage(opts: {
   injection: string | null;
   forensicsInjection: string | null;
 }): { customType: string; content: string; display: false } | null {
-  const memoryContent = opts.memoryBlock.trim();
+  const contextCharLimit = getContextMessageCharLimit();
+  const memoryContent = markMemoryContextSupplied(opts.memoryBlock.trim());
   if (opts.injection) {
-    const content = memoryContent ? `${memoryContent}\n\n${opts.injection}` : opts.injection;
+    const content = limitContextMessageContent(
+      memoryContent ? `${memoryContent}\n\n${opts.injection}` : opts.injection,
+      contextCharLimit,
+    );
     return { customType: "gsd-guided-context", content, display: false as const };
   }
   if (opts.forensicsInjection) {
-    const content = memoryContent ? `${memoryContent}\n\n${opts.forensicsInjection}` : opts.forensicsInjection;
+    const content = limitContextMessageContent(
+      memoryContent ? `${memoryContent}\n\n${opts.forensicsInjection}` : opts.forensicsInjection,
+      contextCharLimit,
+    );
     return { customType: "gsd-forensics", content, display: false as const };
   }
   if (memoryContent) {
-    return { customType: "gsd-memory", content: memoryContent, display: false as const };
+    return {
+      customType: "gsd-memory",
+      content: limitContextMessageContent(memoryContent, contextCharLimit),
+      display: false as const,
+    };
   }
   return null;
+}
+
+function getContextMessageCharLimit(): number | null {
+  const raw = process.env.PI_GSD_CONTEXT_MAX_CHARS;
+  if (!raw) return DEFAULT_CONTEXT_MESSAGE_MAX_CHARS;
+  if (raw === "0") return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < MIN_CONTEXT_MESSAGE_MAX_CHARS) {
+    return DEFAULT_CONTEXT_MESSAGE_MAX_CHARS;
+  }
+  return Math.floor(parsed);
+}
+
+function limitContextMessageContent(content: string, limit: number | null): string {
+  if (!limit || content.length <= limit) return content;
+  const suffix = "\n\n[GSD Context Truncated]\nFull context is available from the referenced .gsd files and tools; read on demand only if this excerpt lacks required evidence.";
+  const headBudget = Math.max(0, limit - suffix.length);
+  return `${content.slice(0, headBudget).trimEnd()}${suffix}`;
+}
+
+function markMemoryContextSupplied(memoryContent: string): string {
+  if (!memoryContent) return "";
+  return `[GSD Context Metadata]\n- Memory supplied: yes\n\n${memoryContent}`;
 }
 
 /**
@@ -288,7 +326,10 @@ export function buildContextMessage(opts: {
  * with a token-budget cap. Failures degrade gracefully — the function never
  * throws and returns "" so the system prompt construction continues.
  */
-export async function loadMemoryBlock(userPrompt: string): Promise<string> {
+export async function loadMemoryBlock(
+  userPrompt: string,
+  opts: { includePromptRelevant?: boolean } = {},
+): Promise<string> {
   try {
     const { formatMemoriesForPrompt, getActiveMemoriesRanked, queryMemoriesRanked } = await import("../memory-store.js");
 
@@ -310,7 +351,7 @@ export async function loadMemoryBlock(userPrompt: string): Promise<string> {
 
     let relevant: typeof allRanked = [];
     const trimmed = userPrompt.trim();
-    if (trimmed) {
+    if (trimmed && opts.includePromptRelevant !== false) {
       const hits = queryMemoriesRanked({ query: trimmed, k: QUERY_K });
       relevant = hits.map((h) => h.memory).filter((m) => !criticalIds.has(m.id));
     }
@@ -362,12 +403,35 @@ export function loadKnowledgeBlock(gsdHomeDir: string, cwd: string): { block: st
   }
 
   const parts: string[] = [];
-  if (globalKnowledge) parts.push(`## Global Knowledge\n\n${globalKnowledge}`);
-  if (projectKnowledge) parts.push(`## Project Knowledge\n\n${projectKnowledge}`);
+  if (globalKnowledge) {
+    parts.push(`## Global Knowledge\nSource: \`${globalKnowledgePath}\`\n\n${globalKnowledge}`);
+  }
+  if (projectKnowledge) {
+    parts.push(`## Project Knowledge\nSource: \`${knowledgePath}\`\n\n${projectKnowledge}`);
+  }
+  const body = limitKnowledgeBlock(parts.join("\n\n"), getKnowledgeCharLimit());
   return {
-    block: `\n\n[KNOWLEDGE — Rules, patterns, and lessons learned]\n\n${parts.join("\n\n")}`,
+    block: `\n\n[KNOWLEDGE — Rules, patterns, and lessons learned]\n\n${body}`,
     globalSizeKb,
   };
+}
+
+function getKnowledgeCharLimit(): number | null {
+  const raw = process.env.PI_GSD_KNOWLEDGE_MAX_CHARS;
+  if (!raw) return DEFAULT_KNOWLEDGE_MAX_CHARS;
+  if (raw === "0") return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < MIN_KNOWLEDGE_MAX_CHARS) {
+    return DEFAULT_KNOWLEDGE_MAX_CHARS;
+  }
+  return Math.floor(parsed);
+}
+
+function limitKnowledgeBlock(content: string, limit: number | null): string {
+  if (!limit || content.length <= limit) return content;
+  const suffix = "\n\n[Knowledge Truncated]\nFull KNOWLEDGE.md content remains available at the source path(s) above; read on demand only if this excerpt lacks a required rule.";
+  const headBudget = Math.max(0, limit - suffix.length);
+  return `${content.slice(0, headBudget).trimEnd()}${suffix}`;
 }
 
 function buildWorktreeContextBlock(): string {
@@ -423,6 +487,11 @@ function buildWorktreeContextBlock(): string {
  */
 const RESUME_INTENT_PATTERNS = /^(continue|resume|ok|go|go ahead|proceed|keep going|carry on|next|yes|yeah|yep|sure|do it|let's go|pick up where you left off)$/;
 
+export function isLowEntropyResumePrompt(prompt: string): boolean {
+  const trimmed = prompt.trim().toLowerCase().replace(/[.!?,]+$/g, "");
+  return RESUME_INTENT_PATTERNS.test(trimmed);
+}
+
 async function buildGuidedExecuteContextInjection(prompt: string, basePath: string): Promise<string | null> {
   const ensureStateDbOpen = async () => {
     const { ensureDbOpen } = await import("./dynamic-tools.js");
@@ -452,8 +521,7 @@ async function buildGuidedExecuteContextInjection(prompt: string, basePath: stri
   // control/help/diagnostic prompts with unrelated execution context.
   // Phase-gated: only fire during "executing" to avoid misrouting during
   // replanning, gate evaluation, or other non-execution phases.
-  const trimmed = prompt.trim().toLowerCase().replace(/[.!?,]+$/g, "");
-  if (RESUME_INTENT_PATTERNS.test(trimmed)) {
+  if (isLowEntropyResumePrompt(prompt)) {
     await ensureStateDbOpen();
     const state = await deriveState(basePath);
     if (state.phase === "executing" && state.activeTask && state.activeMilestone && state.activeSlice) {

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -26,6 +26,15 @@ import { isAutoActive, checkRemoteAutoSession } from "./auto.js";
 import { getAutoWorktreePath } from "./auto-worktree.js";
 import { currentDirectoryRoot, projectRoot } from "./commands/context.js";
 import { loadPrompt } from "./prompt-loader.js";
+import {
+  buildDoctorHealIssuePayload,
+  buildDoctorHealSummary,
+  buildWorkflowDispatchContent,
+} from "./workflow-protocol.js";
+import {
+  restoreGsdWorkflowTools,
+  scopeGsdWorkflowToolsForDispatch,
+} from "./bootstrap/register-hooks.js";
 
 const UPDATE_REGISTRY_URL = "https://registry.npmjs.org/gsd-pi/latest";
 const UPDATE_FETCH_TIMEOUT_MS = 5000;
@@ -72,18 +81,23 @@ export function dispatchDoctorHeal(pi: ExtensionAPI, scope: string | undefined, 
   const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(gsdHome(), "agent", "GSD-WORKFLOW.md");
   const workflow = readFileSync(workflowPath, "utf-8");
   const prompt = loadPrompt("doctor-heal", {
-    doctorSummary: reportText,
-    structuredIssues,
+    doctorSummary: buildDoctorHealSummary(reportText),
+    structuredIssues: buildDoctorHealIssuePayload(structuredIssues),
     scopeLabel: scope ?? "active milestone / blocking scope",
     doctorCommandSuffix: scope ? ` ${scope}` : "",
   });
 
-  const content = `Read the following GSD workflow protocol and execute exactly.\n\n${workflow}\n\n## Your Task\n\n${prompt}`;
+  const content = buildWorkflowDispatchContent({ workflow, workflowPath, task: prompt });
+  const savedTools = scopeGsdWorkflowToolsForDispatch(pi);
 
-  pi.sendMessage(
-    { customType: "gsd-doctor-heal", content, display: false },
-    { triggerTurn: true },
-  );
+  try {
+    pi.sendMessage(
+      { customType: "gsd-doctor-heal", content, display: false },
+      { triggerTurn: true },
+    );
+  } finally {
+    restoreGsdWorkflowTools(pi, savedTools);
+  }
 }
 
 /** Parse doctor command args into structured flags and positionals (pure, no I/O). */
@@ -258,15 +272,20 @@ export async function handleTriage(ctx: ExtensionCommandContext, pi: ExtensionAP
 
   const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(gsdHome(), "agent", "GSD-WORKFLOW.md");
   const workflow = readFileSync(workflowPath, "utf-8");
+  const savedTools = scopeGsdWorkflowToolsForDispatch(pi);
 
-  pi.sendMessage(
-    {
-      customType: "gsd-triage",
-      content: `Read the following GSD workflow protocol and execute exactly.\n\n${workflow}\n\n## Your Task\n\n${prompt}`,
-      display: false,
-    },
-    { triggerTurn: true },
-  );
+  try {
+    pi.sendMessage(
+      {
+        customType: "gsd-triage",
+        content: buildWorkflowDispatchContent({ workflow, workflowPath, task: prompt }),
+        display: false,
+      },
+      { triggerTurn: true },
+    );
+  } finally {
+    restoreGsdWorkflowTools(pi, savedTools);
+  }
 }
 
 export async function handleSteer(change: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {

--- a/src/resources/extensions/gsd/ecosystem/gsd-extension-api.ts
+++ b/src/resources/extensions/gsd/ecosystem/gsd-extension-api.ts
@@ -204,6 +204,9 @@ export function createGSDExtensionAPI(
     getAllTools: () => pi.getAllTools(),
     setActiveTools: (...args: Parameters<ExtensionAPI["setActiveTools"]>) =>
       pi.setActiveTools(...args),
+    getVisibleSkills: () => pi.getVisibleSkills(),
+    setVisibleSkills: (...args: Parameters<ExtensionAPI["setVisibleSkills"]>) =>
+      pi.setVisibleSkills(...args),
     getCommands: () => pi.getCommands(),
 
     // ── Model & thinking ───────────────────────────────────────────────

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -86,6 +86,8 @@ export {
 import { logWarning } from "./workflow-logger.js";
 import { deleteRuntimeKv } from "./db/runtime-kv.js";
 import { PAUSED_SESSION_KV_KEY } from "./interrupted-session.js";
+import { buildWorkflowDispatchContent } from "./workflow-protocol.js";
+import { isFullGsdToolSurfaceRequested, restoreGsdWorkflowTools, scopeGsdWorkflowToolsForDispatch } from "./bootstrap/register-hooks.js";
 
 type AutoStartOptions = Parameters<typeof startAutoDetached>[4];
 type AutoStartLauncher = typeof startAutoDetached;
@@ -1062,27 +1064,35 @@ async function dispatchWorkflow(
     }
   }
 
-  // Scope tools for discuss flows (#2949).
+  // Scope tools for guided workflow turns (#2949, token-consumption savings).
   // Providers with grammar-based constrained decoding (xAI/Grok) return
   // "Grammar is too complex" when the combined tool schema is too large.
-  // Discuss flows only need a small subset of GSD tools — strip the heavy
-  // planning/execution/completion tools to keep the grammar within limits.
-  let savedTools: string[] | null = null;
-  if (unitType?.startsWith("discuss-")) {
+  // Guided workflow turns only need the active unit's tool surface; strip
+  // unrelated GSD tools and broad non-GSD tools for this queued turn, then
+  // restore so the narrowed surface does not leak into future dispatches.
+  let savedTools: ReturnType<typeof scopeGsdWorkflowToolsForDispatch> = null;
+  if (unitType?.startsWith("discuss-") && !isFullGsdToolSurfaceRequested()) {
     const currentTools = pi.getActiveTools();
-    savedTools = currentTools;
     // Keep all non-GSD tools (builtins, other extensions) and only the
     // GSD tools on the discuss allowlist.
     const scopedTools = currentTools.filter(
       (t) => !t.startsWith("gsd_") || DISCUSS_TOOLS_ALLOWLIST.includes(t),
     );
     pi.setActiveTools(scopedTools);
+    const scopedState = scopeGsdWorkflowToolsForDispatch(pi, unitType);
+    savedTools = {
+      tools: currentTools,
+      visibleSkills: scopedState?.visibleSkills,
+      restoreVisibleSkills: scopedState?.restoreVisibleSkills ?? false,
+    };
     debugLog("discuss-tool-scoping", {
       unitType,
       before: currentTools.length,
-      after: scopedTools.length,
-      removed: currentTools.length - scopedTools.length,
+      after: pi.getActiveTools().length,
+      removed: currentTools.length - pi.getActiveTools().length,
     });
+  } else {
+    savedTools = scopeGsdWorkflowToolsForDispatch(pi, unitType);
   }
 
   const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(gsdHome(), "agent", "GSD-WORKFLOW.md");
@@ -1091,7 +1101,7 @@ async function dispatchWorkflow(
   pi.sendMessage(
     {
       customType,
-      content: `Read the following GSD workflow protocol and execute exactly.\n\n${workflow}\n\n## Your Task\n\n${note}`,
+      content: buildWorkflowDispatchContent({ workflow, workflowPath, task: note }),
       display: false,
     },
     { triggerTurn: true },
@@ -1100,9 +1110,7 @@ async function dispatchWorkflow(
   // Restore full tool set after the message is queued. The LLM turn has
   // already captured the scoped set — restoring prevents the narrowed
   // tools from leaking into subsequent dispatches (#3628).
-  if (savedTools) {
-    pi.setActiveTools(savedTools);
-  }
+  restoreGsdWorkflowTools(pi, savedTools);
 }
 
 function getStructuredQuestionsAvailability(

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -1098,19 +1098,22 @@ async function dispatchWorkflow(
   const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(gsdHome(), "agent", "GSD-WORKFLOW.md");
   const workflow = readFileSync(workflowPath, "utf-8");
 
-  pi.sendMessage(
-    {
-      customType,
-      content: buildWorkflowDispatchContent({ workflow, workflowPath, task: note }),
-      display: false,
-    },
-    { triggerTurn: true },
-  );
-
-  // Restore full tool set after the message is queued. The LLM turn has
-  // already captured the scoped set — restoring prevents the narrowed
-  // tools from leaking into subsequent dispatches (#3628).
-  restoreGsdWorkflowTools(pi, savedTools);
+  try {
+    pi.sendMessage(
+      {
+        customType,
+        content: buildWorkflowDispatchContent({ workflow, workflowPath, task: note }),
+        display: false,
+      },
+      { triggerTurn: true },
+    );
+  } finally {
+    // Restore full tool set after the message is queued. The LLM turn has
+    // already captured the scoped set — restoring prevents the narrowed
+    // tools from leaking into subsequent dispatches (#3628). The finally
+    // block ensures restoration even if sendMessage throws.
+    restoreGsdWorkflowTools(pi, savedTools);
+  }
 }
 
 function getStructuredQuestionsAvailability(

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -1071,34 +1071,40 @@ async function dispatchWorkflow(
   // unrelated GSD tools and broad non-GSD tools for this queued turn, then
   // restore so the narrowed surface does not leak into future dispatches.
   let savedTools: ReturnType<typeof scopeGsdWorkflowToolsForDispatch> = null;
-  if (unitType?.startsWith("discuss-") && !isFullGsdToolSurfaceRequested()) {
-    const currentTools = pi.getActiveTools();
-    // Keep all non-GSD tools (builtins, other extensions) and only the
-    // GSD tools on the discuss allowlist.
-    const scopedTools = currentTools.filter(
-      (t) => !t.startsWith("gsd_") || DISCUSS_TOOLS_ALLOWLIST.includes(t),
-    );
-    pi.setActiveTools(scopedTools);
-    const scopedState = scopeGsdWorkflowToolsForDispatch(pi, unitType);
-    savedTools = {
-      tools: currentTools,
-      visibleSkills: scopedState?.visibleSkills,
-      restoreVisibleSkills: scopedState?.restoreVisibleSkills ?? false,
-    };
-    debugLog("discuss-tool-scoping", {
-      unitType,
-      before: currentTools.length,
-      after: pi.getActiveTools().length,
-      removed: currentTools.length - pi.getActiveTools().length,
-    });
-  } else {
-    savedTools = scopeGsdWorkflowToolsForDispatch(pi, unitType);
-  }
-
-  const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(gsdHome(), "agent", "GSD-WORKFLOW.md");
-  const workflow = readFileSync(workflowPath, "utf-8");
 
   try {
+    const currentTools = pi.getActiveTools();
+    savedTools = {
+      tools: currentTools,
+      visibleSkills: typeof pi.getVisibleSkills === "function" ? pi.getVisibleSkills() : undefined,
+      restoreVisibleSkills: typeof pi.setVisibleSkills === "function",
+    };
+    if (unitType?.startsWith("discuss-") && !isFullGsdToolSurfaceRequested()) {
+      // Keep all non-GSD tools (builtins, other extensions) and only the
+      // GSD tools on the discuss allowlist.
+      const scopedTools = currentTools.filter(
+        (t) => !t.startsWith("gsd_") || DISCUSS_TOOLS_ALLOWLIST.includes(t),
+      );
+      pi.setActiveTools(scopedTools);
+      const scopedState = scopeGsdWorkflowToolsForDispatch(pi, unitType);
+      savedTools = {
+        tools: currentTools,
+        visibleSkills: scopedState?.visibleSkills ?? savedTools.visibleSkills,
+        restoreVisibleSkills: scopedState?.restoreVisibleSkills ?? savedTools.restoreVisibleSkills,
+      };
+      debugLog("discuss-tool-scoping", {
+        unitType,
+        before: currentTools.length,
+        after: pi.getActiveTools().length,
+        removed: currentTools.length - pi.getActiveTools().length,
+      });
+    } else {
+      savedTools = scopeGsdWorkflowToolsForDispatch(pi, unitType) ?? savedTools;
+    }
+
+    const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(gsdHome(), "agent", "GSD-WORKFLOW.md");
+    const workflow = readFileSync(workflowPath, "utf-8");
+
     pi.sendMessage(
       {
         customType,

--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -29,7 +29,7 @@ Use `subagent` only for fresh-context review when useful: reviewer for cross-cut
 7. If requirement status changed, call `gsd_requirement_update`; do not write `.gsd/REQUIREMENTS.md` directly.
 8. Prepare `gsd_slice_complete` content with camelCase fields `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, and `uatContent`.
 9. Draft concrete UAT with preconditions, numbered steps, expected outcomes, edge cases, UAT Type, and Not Proven By This UAT.
-10. Review task summaries for DECISIONS.md and KNOWLEDGE.md-worthy decisions, patterns, and gotchas. Capture significant items with `capture_thought`; do not append knowledge files directly.
+10. Review the inlined task-summary excerpts for DECISIONS.md and KNOWLEDGE.md-worthy decisions, patterns, and gotchas. Read full `*-SUMMARY.md` files only when an excerpt is absent, truncated, or lacks the specific evidence needed for the slice narrative. Capture significant items with `capture_thought`; do not append knowledge files directly.
 11. Call `gsd_slice_complete`. The DB-backed tool is the canonical write path. Do **not** manually write `{{sliceSummaryPath}}`. Do **not** manually write `{{sliceUatPath}}`. Do not edit roadmap checkboxes; the tool renders files and updates projections.
 12. Do not run git commands.
 13. Update `.gsd/PROJECT.md` with a full `write` only if the current project state needs refresh.

--- a/src/resources/extensions/gsd/prompts/execute-task.md
+++ b/src/resources/extensions/gsd/prompts/execute-task.md
@@ -33,7 +33,7 @@ You execute. The inlined task plan is authoritative. Verify referenced files and
 ## Execution Rules
 
 1. Tersely narrate transitions, decisions, and verification outcomes between tool-call clusters.
-2. Call `memory_query` with 2-4 keywords from the task title and touched files unless this is purely mechanical.
+2. Use the injected memory/context blocks first. Call `memory_query` with 2-4 keywords from the task title and touched files only when no injected memory block exists or the inlined memory/context is insufficient for this task.
 3. {{skillActivation}} Follow activated skills before code edits.
 4. Execute the task plan. Before any `Write` that creates an artifact or output file, check whether that path already exists. If it does, read it first and decide whether the work is already done, should be extended, or truly needs replacement.
 5. Build real behavior through the intended surface; stubs/mocks belong in tests only.
@@ -59,10 +59,12 @@ Keep about **{{verificationBudget}}** for verification and summary. If context i
 - If the plan is fundamentally invalid, set `blocker_discovered: true` in the summary and explain.
 - For downstream-impacting ambiguity that cannot be resolved from code, plans, or decisions, include an `escalation` object with question, options, recommendation, rationale, and `continueWithDefault`.
 - Capture meaningful architecture/pattern/observability decisions with `capture_thought`; capture non-obvious gotchas or conventions only when they save future investigation.
-- Read the template at `{{taskSummaryTemplatePath}}`.
+- Use the inlined Task Summary template below. Read `{{taskSummaryTemplatePath}}` only if the inlined template is absent or visibly truncated.
 - Call `gsd_task_complete` with camelCase fields `milestoneId`, `sliceId`, `taskId`, `oneLiner`, `narrative`, `verification`, and `verificationEvidence`.
 - The DB-backed tool is the canonical write path. Do **not** manually write `{{taskSummaryPath}}` or edit PLAN.md checkboxes; the tool renders the summary and updates state.
 - Do not run git commands; the system commits from your summary.
+
+{{inlinedTemplates}}
 
 **Autonomous execution:** no human is available. Do not call `ask_user_questions` or `secure_env_collect`; make reasonable assumptions and document them.
 

--- a/src/resources/extensions/gsd/prompts/replan-slice.md
+++ b/src/resources/extensions/gsd/prompts/replan-slice.md
@@ -8,7 +8,7 @@ Your working directory is `{{workingDirectory}}`. All file reads, writes, and sh
 
 A completed task reported `blocker_discovered: true`, meaning the current slice plan cannot be executed as-is. Your job is to rewrite the remaining tasks in the slice plan to address the blocker while preserving all completed work.
 
-All relevant context has been preloaded below — the roadmap, current slice plan, the blocker task summary, and decisions are inlined. Start working immediately without re-reading these files.
+All relevant context has been preloaded below — the roadmap, current slice plan, blocker task summary excerpt, and decisions are inlined. Start working immediately without re-reading these files.
 
 {{inlinedContext}}
 
@@ -30,7 +30,7 @@ Consider these captures when rewriting the remaining tasks — they represent th
 
 ## Instructions
 
-1. Read the blocker task summary carefully. Understand exactly what was discovered and why it blocks the current plan.
+1. Use the inlined blocker summary excerpt first. Read the full blocker task summary only if the excerpt is absent, marked truncated, or lacks the specific blocker evidence needed to replan.
 2. Analyze the remaining `[ ]` tasks in the slice plan. Determine which are still valid, which need modification, and which should be replaced.
 3. **Persist replan state through `gsd_replan_slice`.** Call it with: `milestoneId`, `sliceId`, `blockerTaskId`, `blockerDescription`, `whatChanged`, `updatedTasks` (array of task objects with taskId, title, description, estimate, files, verify, inputs, expectedOutput), `removedTaskIds` (array of task ID strings). The tool structurally enforces preservation of completed tasks, writes replan history to the DB, re-renders `{{planPath}}`, and renders `{{replanPath}}`. Preserve or update the Threat Surface and Requirement Impact sections if the replan changes the slice's security posture or requirement coverage.
 4. If any incomplete task had a `T0x-PLAN.md`, remove or rewrite it to match the new task description.

--- a/src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts
@@ -261,3 +261,34 @@ test("#4780 closer prompt: uses excerpts + lists on-demand slice SUMMARY paths",
     `closer prompt length ${prompt.length} should be < raw summary size ${rawSize} + 20KB headroom`,
   );
 });
+
+test("complete-milestone prompt caps repeated inlined context around 20k chars", async (t) => {
+  const base = createBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  writeRoadmap(base, makeRoadmap());
+  writeSummary(base, "S01", makeFatSummary("S01"));
+  writeSummary(base, "S02", makeFatSummary("S02"));
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"),
+    "# M001 Context\n\n" + "Large milestone context body. ".repeat(1200),
+  );
+  writeFileSync(
+    join(base, ".gsd", "KNOWLEDGE.md"),
+    "# Project Knowledge\n\n## Patterns\n\n### Test Milestone shared\n" + "Large scoped knowledge body. ".repeat(1200),
+  );
+
+  const prompt = await buildCompleteMilestonePrompt("M001", "Test Milestone", base);
+  const contextStart = prompt.indexOf("## Inlined Context (preloaded");
+  const contextEnd = prompt.indexOf("## Steps", contextStart);
+  assert.ok(contextStart >= 0, "prompt should include inlined context");
+  assert.ok(contextEnd > contextStart, "prompt should include steps after inlined context");
+
+  const inlinedContext = prompt.slice(contextStart, contextEnd);
+  assert.ok(
+    inlinedContext.length <= 21_000,
+    `inlined context ${inlinedContext.length} chars should stay near the 20k cap`,
+  );
+  assert.match(inlinedContext, /\[\.\.\.truncated \d+ sections\]/);
+});

--- a/src/resources/extensions/gsd/tests/complete-slice-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-composer.test.ts
@@ -113,8 +113,9 @@ test("#4782 phase 3: buildCompleteSlicePrompt composes roadmap → plan → task
     "task summaries precede slice-summary template",
   );
 
-  // Task body inlined
-  assert.match(prompt, /Task one did the thing/);
+  // Task summary excerpt is inlined; full narrative remains on-demand.
+  assert.match(prompt, /### Task Summary: T01 \(excerpt\)/);
+  assert.doesNotMatch(prompt, /Task one did the thing/);
 });
 
 test("#4782 phase 3: buildCompleteSlicePrompt handles missing task summaries gracefully", async (t) => {

--- a/src/resources/extensions/gsd/tests/execute-task-rendering.test.ts
+++ b/src/resources/extensions/gsd/tests/execute-task-rendering.test.ts
@@ -39,6 +39,7 @@ test("execute-task prompt renders compact execution and completion gates", async
     taskPlanPath: ".gsd/milestones/M001/slices/S01/tasks/T01-PLAN.md",
     priorTaskLines: "- None",
     skillActivation: "Load relevant skills.",
+    inlinedTemplates: "### Output Template: Task Summary\nSource: `templates/task-summary.md`",
     templatesDir: join(fixtureRoot, "templates"),
     taskSummaryTemplatePath: "C:\\Users\\Test\\.gsd\\agent\\extensions\\gsd\\templates\\task-summary.md",
     verificationBudget: "~10K chars",
@@ -46,12 +47,14 @@ test("execute-task prompt renders compact execution and completion gates", async
   });
 
   assert.match(prompt, /You execute\./);
-  assert.match(prompt, /Call `memory_query`/);
+  assert.match(prompt, /Call `memory_query`.*only when no injected memory block exists/s);
   assert.match(prompt, /Before any `Write` that creates an artifact or output file/);
   assert.match(prompt, /Build real behavior/);
   assert.match(prompt, /Background process rule/);
   assert.match(prompt, /blocker_discovered: true/);
-  assert.match(prompt, /C:\\Users\\Test\\.gsd\\agent\\extensions\\gsd\\templates\\task-summary\.md/);
+  assert.match(prompt, /Use the inlined Task Summary template below/);
+  assert.match(prompt, /Read `C:\\Users\\Test\\.gsd\\agent\\extensions\\gsd\\templates\\task-summary\.md` only if the inlined template is absent or visibly truncated/);
+  assert.match(prompt, /### Output Template: Task Summary/);
   assert.doesNotMatch(prompt, /\{\{templatesDir\}\}\/task-summary\.md/);
   assert.match(prompt, /Call `gsd_task_complete`/);
   assert.match(prompt, /Do not run git commands/);

--- a/src/resources/extensions/gsd/tests/knowledge.test.ts
+++ b/src/resources/extensions/gsd/tests/knowledge.test.ts
@@ -249,6 +249,28 @@ test('loadKnowledgeBlock: reports globalSizeKb above 4KB threshold', () => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
+test('loadKnowledgeBlock: caps repeated system prompt knowledge by default with source path', () => {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'gsd-kb-')));
+  const gsdHome = join(tmp, 'home');
+  const cwd = join(tmp, 'project');
+  mkdirSync(join(cwd, '.gsd'), { recursive: true });
+  mkdirSync(join(gsdHome, 'agent'), { recursive: true });
+  writeFileSync(join(cwd, '.gsd', 'KNOWLEDGE.md'), `K001: ${'large project knowledge '.repeat(1200)}`);
+
+  const original = process.env.PI_GSD_KNOWLEDGE_MAX_CHARS;
+  delete process.env.PI_GSD_KNOWLEDGE_MAX_CHARS;
+  try {
+    const result = loadKnowledgeBlock(gsdHome, cwd);
+    assert.ok(result.block.includes('Source: `'));
+    assert.ok(result.block.length <= 12_500, `knowledge block ${result.block.length} should stay near default cap`);
+    assert.ok(result.block.includes('[Knowledge Truncated]'));
+  } finally {
+    if (original === undefined) delete process.env.PI_GSD_KNOWLEDGE_MAX_CHARS;
+    else process.env.PI_GSD_KNOWLEDGE_MAX_CHARS = original;
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 // ─── inlineKnowledgeBudgeted — issue #4719 ─────────────────────────────────
 // Milestone-phase prompts must not inject the full KNOWLEDGE.md. The budgeted
 // helper scopes by milestone-level keywords and caps the injected size.
@@ -310,6 +332,31 @@ test('inlineKnowledgeBudgeted: caps payload below budget for large files', async
     result!,
     /\[\.\.\.truncated \d+ chars; rerun with narrower scope if needed\]/,
     'should include truncation note when budget is exceeded',
+  );
+
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('inlineKnowledgeBudgeted: default budget keeps auto prompt knowledge compact', async () => {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'gsd-knowledge-')));
+  const gsdDir = join(tmp, '.gsd');
+  mkdirSync(gsdDir, { recursive: true });
+
+  const entries = Array.from({ length: 300 }, (_, i) =>
+    `### Entry ${i}: shared topic\n${'default budget filler '.repeat(25)}\n`,
+  ).join('\n');
+  writeFileSync(join(gsdDir, 'KNOWLEDGE.md'), `# Project Knowledge\n\n## Patterns\n\n${entries}`);
+
+  const result = await inlineKnowledgeBudgeted(tmp, ['shared']);
+  assert.ok(result !== null, 'should return content');
+  assert.ok(
+    result!.length <= 12_500,
+    `default payload ${result!.length} chars should stay near the 12k budget`,
+  );
+  assert.match(
+    result!,
+    /\[\.\.\.truncated \d+ chars; rerun with narrower scope if needed\]/,
+    'should include truncation note when default budget is exceeded',
   );
 
   rmSync(tmp, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/prompt-duplication-cuts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-duplication-cuts.test.ts
@@ -1,0 +1,230 @@
+// Project/App: GSD-2
+// File Purpose: Verifies low-risk auto-prompt duplication cuts render through prompt builders.
+
+import test from "node:test";
+import type { TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { invalidateAllCaches } from "../cache.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+  upsertMilestonePlanning,
+} from "../gsd-db.ts";
+
+type AutoPromptBuilders = typeof import("../auto-prompts.ts");
+
+function makeBase(prefix: string): string {
+  const base = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  invalidateAllCaches();
+  rmSync(base, { recursive: true, force: true });
+}
+
+async function loadAutoPromptBuilders(t: TestContext): Promise<AutoPromptBuilders> {
+  const previousGsdHome = process.env.GSD_HOME;
+  const isolatedHome = mkdtempSync(join(tmpdir(), "gsd-prompt-loader-home-"));
+  process.env.GSD_HOME = isolatedHome;
+  t.after(() => {
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(isolatedHome, { recursive: true, force: true });
+  });
+  return import(`../auto-prompts.ts?promptDupCuts=${Date.now()}-${Math.random()}`) as Promise<AutoPromptBuilders>;
+}
+
+function seedDb(base: string, taskStatus = "complete"): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Prompt Cuts", status: "active", depends_on: [] });
+  upsertMilestonePlanning("M001", {
+    title: "Prompt Cuts",
+    status: "active",
+    vision: "Reduce duplicate prompt reads.",
+    successCriteria: ["Prompt builders render compact context."],
+    keyRisks: [],
+    proofStrategy: [],
+    verificationContract: "",
+    verificationIntegration: "",
+    verificationOperational: "",
+    verificationUat: "",
+    definitionOfDone: [],
+    requirementCoverage: "",
+    boundaryMapMarkdown: "",
+  });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Prompt Slice",
+    status: "active",
+    risk: "low",
+    depends: [],
+    demo: "",
+    sequence: 1,
+  });
+  insertTask({
+    id: "T01",
+    sliceId: "S01",
+    milestoneId: "M001",
+    title: "Task one",
+    status: taskStatus,
+  });
+}
+
+function writeRoadmapAndPlan(base: string): void {
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    [
+      "# M001 Roadmap",
+      "## Slices",
+      "- [ ] **S01: Prompt Slice** `risk:low` `depends:[]`",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+    [
+      "# S01 Plan",
+      "",
+      "**Goal:** Reduce duplicate prompt reads.",
+      "",
+      "## Tasks",
+      "- [x] **T01: Task one** `est:15m`",
+    ].join("\n"),
+  );
+}
+
+function writeTaskSummary(base: string, options?: { blocker?: boolean; repeatedNarrative?: string }): void {
+  const narrative = options?.repeatedNarrative ?? "This full implementation narrative should stay out of closer prompts.";
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md"),
+    [
+      "---",
+      "id: T01",
+      "parent: S01",
+      "milestone: M001",
+      "provides:",
+      "  - prompt context reduction",
+      "key_files:",
+      "  - src/resources/extensions/gsd/auto-prompts.ts",
+      "key_decisions:",
+      "  - use compact excerpts before full reads",
+      "patterns_established:",
+      "  - excerpt-first complete-slice context",
+      "observability_surfaces: []",
+      "duration: 15m",
+      "verification_result: passed",
+      "completed_at: 2026-05-06T12:00:00Z",
+      `blocker_discovered: ${options?.blocker ? "true" : "false"}`,
+      "---",
+      "",
+      "# T01: Task one",
+      "**One-line result.**",
+      "",
+      "## What Happened",
+      narrative,
+      "",
+      "## Verification",
+      "node:test passed.",
+      "",
+      "## Diagnostics",
+      "Prompt size stayed bounded.",
+    ].join("\n"),
+  );
+}
+
+test("execute-task rendering makes memory_query and template disk reads fallback-only", async (t) => {
+  const base = makeBase("gsd-execute-dup-cuts-");
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seedDb(base, "pending");
+  writeRoadmapAndPlan(base);
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-PLAN.md"),
+    "# T01 Plan\n\nDo the prompt edit.\n",
+  );
+
+  const { buildExecuteTaskPrompt } = await loadAutoPromptBuilders(t);
+  const prompt = await buildExecuteTaskPrompt("M001", "S01", "Prompt Slice", "T01", "Task one", base);
+
+  assert.match(prompt, /Call `memory_query`.*only when no injected memory block exists or the inlined memory\/context is insufficient/s);
+  assert.doesNotMatch(prompt, /Call `memory_query` with 2-4 keywords from the task title and touched files unless this is purely mechanical/);
+  assert.match(prompt, /Use the inlined Task Summary template below/);
+  assert.match(prompt, /Read `.*task-summary\.md` only if the inlined template is absent or visibly truncated/);
+  assert.doesNotMatch(prompt, /Read the template at `.*task-summary\.md`/);
+  assert.match(prompt, /### Output Template: Task Summary/);
+});
+
+test("complete-slice renders task summary excerpts without full summary bodies", async (t) => {
+  const base = makeBase("gsd-complete-slice-excerpts-");
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seedDb(base);
+  writeRoadmapAndPlan(base);
+  const repeatedNarrative = "FULL_TASK_BODY_SHOULD_NOT_RENDER ".repeat(40);
+  writeTaskSummary(base, { repeatedNarrative });
+
+  const { buildCompleteSlicePrompt } = await loadAutoPromptBuilders(t);
+  const prompt = await buildCompleteSlicePrompt("M001", "Prompt Cuts", "S01", "Prompt Slice", base);
+
+  assert.match(prompt, /### Task Summary: T01 \(excerpt\)/);
+  assert.match(prompt, /On-demand.*read `\.gsd\/milestones\/M001\/slices\/S01\/tasks\/T01-SUMMARY\.md` only when this excerpt is absent\/truncated/s);
+  assert.doesNotMatch(prompt, /FULL_TASK_BODY_SHOULD_NOT_RENDER/);
+  assert.match(prompt, /Review the inlined task-summary excerpts/);
+});
+
+test("complete-slice caps malformed task summaries instead of inlining full bodies", async (t) => {
+  const base = makeBase("gsd-complete-slice-malformed-excerpts-");
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seedDb(base);
+  writeRoadmapAndPlan(base);
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md"),
+    [
+      "# Legacy summary without frontmatter id",
+      "LEGACY_FULL_BODY_SHOULD_BE_CAPPED ".repeat(200),
+    ].join("\n"),
+  );
+
+  const { buildCompleteSlicePrompt } = await loadAutoPromptBuilders(t);
+  const prompt = await buildCompleteSlicePrompt("M001", "Prompt Cuts", "S01", "Prompt Slice", base);
+
+  assert.match(prompt, /Truncated malformed summary/);
+  assert.ok(prompt.length < 20_000);
+  assert.ok((prompt.match(/LEGACY_FULL_BODY_SHOULD_BE_CAPPED/g) ?? []).length < 60);
+});
+
+test("replan-slice renders blocker summary excerpt and tells the agent to read full only on demand", async (t) => {
+  const base = makeBase("gsd-replan-excerpts-");
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seedDb(base);
+  writeRoadmapAndPlan(base);
+  writeTaskSummary(base, {
+    blocker: true,
+    repeatedNarrative: "FULL_BLOCKER_BODY_SHOULD_NOT_RENDER ".repeat(40),
+  });
+
+  const { buildReplanSlicePrompt } = await loadAutoPromptBuilders(t);
+  const prompt = await buildReplanSlicePrompt("M001", "Prompt Cuts", "S01", "Prompt Slice", base);
+
+  assert.match(prompt, /### Blocker Task Summary: T01 \(excerpt\)/);
+  assert.match(prompt, /Use the inlined blocker summary excerpt first/);
+  assert.match(prompt, /Read the full blocker task summary only if the excerpt is absent, marked truncated, or lacks the specific blocker evidence needed to replan/);
+  assert.doesNotMatch(prompt, /FULL_BLOCKER_BODY_SHOULD_NOT_RENDER/);
+  assert.doesNotMatch(prompt, /Read the blocker task summary carefully/);
+});

--- a/src/resources/extensions/gsd/tests/restore-tools-after-discuss.test.ts
+++ b/src/resources/extensions/gsd/tests/restore-tools-after-discuss.test.ts
@@ -24,7 +24,7 @@ describe('restore tools after discuss flow scoping (#3628)', () => {
   it('savedTools is declared before the discuss scoping block', () => {
     // savedTools must be declared before the discuss-* check
     const savedToolsDecl = src.indexOf('let savedTools')
-    const discussCheck = src.indexOf('if (unitType?.startsWith("discuss-"))')
+    const discussCheck = src.indexOf('if (unitType?.startsWith("discuss-")')
     assert.ok(savedToolsDecl !== -1, 'savedTools variable must be declared')
     assert.ok(discussCheck !== -1, 'discuss-* type check must exist')
     assert.ok(
@@ -34,39 +34,35 @@ describe('restore tools after discuss flow scoping (#3628)', () => {
   })
 
   it('savedTools captures current tools inside the discuss block', () => {
-    const discussCheck = src.indexOf('if (unitType?.startsWith("discuss-"))')
+    const discussCheck = src.indexOf('if (unitType?.startsWith("discuss-")')
     assert.ok(discussCheck !== -1)
 
     // Look for savedTools assignment within the discuss block
-    const blockAfter = extractSourceRegion(src, 'if (unitType?.startsWith("discuss-"))')
+    const blockAfter = extractSourceRegion(src, 'if (unitType?.startsWith("discuss-")')
     assert.ok(
-      blockAfter.includes('savedTools = currentTools'),
-      'savedTools must be assigned from currentTools inside the discuss block',
+      blockAfter.includes('tools: currentTools'),
+      'savedTools must capture currentTools inside the discuss block',
     )
   })
 
   it('savedTools is restored after sendMessage', () => {
     // #4573: guided-flow.ts now contains multiple `triggerTurn: true` calls
     // (ready-phrase and empty-turn recovery paths). The discuss-flow scoping
-    // sendMessage is the one that follows `savedTools = currentTools`, so
+    // sendMessage is the one that follows `tools: currentTools`, so
     // anchor the search there rather than at the first `triggerTurn: true`.
-    const savedToolsAssign = src.indexOf('savedTools = currentTools')
-    assert.ok(savedToolsAssign !== -1, 'savedTools = currentTools must exist')
+    const savedToolsAssign = src.indexOf('tools: currentTools')
+    assert.ok(savedToolsAssign !== -1, 'savedTools must capture currentTools')
 
     const sendMsg = src.indexOf('triggerTurn: true', savedToolsAssign)
     assert.ok(sendMsg !== -1, 'discuss-flow sendMessage with triggerTurn must exist after savedTools capture')
 
-    // After sendMessage, savedTools should be restored via setActiveTools.
+    // After sendMessage, savedTools should be restored via the shared helper.
     // Use fromIdx to anchor at the discuss-flow sendMessage, not the first
     // triggerTurn: true occurrence in the file.
     const afterSend = extractSourceRegion(src, 'triggerTurn: true', { fromIdx: savedToolsAssign })
     assert.ok(
-      afterSend.includes('if (savedTools)'),
-      'savedTools restoration guard must exist after sendMessage',
-    )
-    assert.ok(
-      afterSend.includes('setActiveTools(savedTools)'),
-      'setActiveTools(savedTools) must be called to restore the full tool set',
+      afterSend.includes('restoreGsdWorkflowTools(pi, savedTools)'),
+      'restoreGsdWorkflowTools(pi, savedTools) must restore the full scoped state',
     )
   })
 })

--- a/src/resources/extensions/gsd/tests/restore-tools-after-discuss.test.ts
+++ b/src/resources/extensions/gsd/tests/restore-tools-after-discuss.test.ts
@@ -33,16 +33,41 @@ describe('restore tools after discuss flow scoping (#3628)', () => {
     )
   })
 
-  it('savedTools captures current tools inside the discuss block', () => {
+  it('savedTools captures current tools before scoping can mutate active state', () => {
     const discussCheck = src.indexOf('if (unitType?.startsWith("discuss-")')
     assert.ok(discussCheck !== -1)
 
-    // Look for savedTools assignment within the discuss block
-    const blockAfter = extractSourceRegion(src, 'if (unitType?.startsWith("discuss-")')
+    const currentToolsDecl = src.indexOf('const currentTools = pi.getActiveTools()')
+    const savedToolsAssign = src.indexOf('savedTools = {', currentToolsDecl)
+    const firstMutation = src.indexOf('pi.setActiveTools(scopedTools)')
     assert.ok(
-      blockAfter.includes('tools: currentTools'),
-      'savedTools must capture currentTools inside the discuss block',
+      currentToolsDecl !== -1 && savedToolsAssign !== -1 && firstMutation !== -1,
+      'guided-flow.ts must capture current tools, save them, and then scope active tools',
     )
+    assert.ok(
+      currentToolsDecl < savedToolsAssign && savedToolsAssign < firstMutation,
+      'savedTools must capture currentTools before any discuss scoping mutation',
+    )
+    assert.ok(
+      src.slice(savedToolsAssign, firstMutation).includes('tools: currentTools'),
+      'savedTools must include currentTools before the first scoping mutation',
+    )
+  })
+
+  it('scoping and workflow read happen inside the restore try block', () => {
+    const savedToolsDecl = src.indexOf('let savedTools')
+    const tryIdx = src.indexOf('try {', savedToolsDecl)
+    const firstMutation = src.indexOf('pi.setActiveTools(scopedTools)')
+    const workflowRead = src.indexOf('readFileSync(workflowPath')
+    const finallyIdx = src.indexOf('} finally {', tryIdx)
+
+    assert.ok(savedToolsDecl !== -1, 'savedTools variable must be declared')
+    assert.ok(tryIdx !== -1, 'restore try block must exist')
+    assert.ok(firstMutation !== -1, 'discuss scoping mutation must exist')
+    assert.ok(workflowRead !== -1, 'workflow file read must exist')
+    assert.ok(finallyIdx !== -1, 'restore finally block must exist')
+    assert.ok(tryIdx < firstMutation && firstMutation < finallyIdx, 'scoping mutation must be inside try/finally')
+    assert.ok(tryIdx < workflowRead && workflowRead < finallyIdx, 'workflow file read must be inside try/finally')
   })
 
   it('savedTools is restored after sendMessage', () => {

--- a/src/resources/extensions/gsd/tests/system-context-memory.test.ts
+++ b/src/resources/extensions/gsd/tests/system-context-memory.test.ts
@@ -1,0 +1,112 @@
+// Project/App: GSD-2
+// File Purpose: System context memory gating regression tests.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildContextMessage, isLowEntropyResumePrompt, loadMemoryBlock } from "../bootstrap/system-context.ts";
+import { closeDatabase, openDatabase } from "../gsd-db.ts";
+import { createMemory } from "../memory-store.ts";
+
+test("buildContextMessage marks hidden guided context when memory is supplied", () => {
+  const message = buildContextMessage({
+    memoryBlock: "\n\n[MEMORY]\n\n- keep this",
+    injection: "[GSD Guided Execute Context]\nUse the task plan.",
+    forensicsInjection: null,
+  });
+
+  assert.ok(message, "expected hidden context message");
+  assert.equal(message.customType, "gsd-guided-context");
+  assert.equal(message.display, false);
+  assert.match(message.content, /\[GSD Context Metadata\]\n- Memory supplied: yes/);
+  assert.ok(
+    message.content.indexOf("Memory supplied: yes") < message.content.indexOf("[GSD Guided Execute Context]"),
+    "memory marker should appear before guided context",
+  );
+});
+
+test("buildContextMessage caps hidden context by default", () => {
+  const original = process.env.PI_GSD_CONTEXT_MAX_CHARS;
+  delete process.env.PI_GSD_CONTEXT_MAX_CHARS;
+  try {
+    const message = buildContextMessage({
+      memoryBlock: "",
+      injection: `[GSD Guided Execute Context]\n${"large context\n".repeat(500)}`,
+      forensicsInjection: null,
+    });
+
+    assert.ok(message, "expected hidden context message");
+    assert.equal(message.customType, "gsd-guided-context");
+    assert.ok(message.content.length <= 4000);
+    assert.match(message.content, /\[GSD Context Truncated\]/);
+  } finally {
+    if (original === undefined) delete process.env.PI_GSD_CONTEXT_MAX_CHARS;
+    else process.env.PI_GSD_CONTEXT_MAX_CHARS = original;
+  }
+});
+
+test("buildContextMessage supports explicit context cap override", () => {
+  const original = process.env.PI_GSD_CONTEXT_MAX_CHARS;
+  process.env.PI_GSD_CONTEXT_MAX_CHARS = "1200";
+  try {
+    const message = buildContextMessage({
+      memoryBlock: "",
+      injection: `[GSD Guided Execute Context]\n${"large context\n".repeat(200)}`,
+      forensicsInjection: null,
+    });
+
+    assert.ok(message, "expected hidden context message");
+    assert.equal(message.customType, "gsd-guided-context");
+    assert.ok(message.content.length <= 1200);
+    assert.match(message.content, /\[GSD Context Truncated\]/);
+  } finally {
+    if (original === undefined) delete process.env.PI_GSD_CONTEXT_MAX_CHARS;
+    else process.env.PI_GSD_CONTEXT_MAX_CHARS = original;
+  }
+});
+
+test("buildContextMessage does not add memory marker when only guided context is supplied", () => {
+  const message = buildContextMessage({
+    memoryBlock: "",
+    injection: "[GSD Guided Execute Context]\nUse the task plan.",
+    forensicsInjection: null,
+  });
+
+  assert.ok(message, "expected guided context message");
+  assert.equal(message.customType, "gsd-guided-context");
+  assert.doesNotMatch(message.content, /Memory supplied: yes/);
+});
+
+test("loadMemoryBlock keeps critical memories while gating prompt-relevant query hits", async () => {
+  closeDatabase();
+  assert.equal(openDatabase(":memory:"), true);
+  try {
+    createMemory({
+      category: "gotcha",
+      content: "Always preserve critical resume safety context.",
+      confidence: 0.95,
+    });
+    createMemory({
+      category: "preference",
+      content: "React dashboard preference should only appear for a React prompt query.",
+      confidence: 0.95,
+    });
+
+    const withPromptRelevant = await loadMemoryBlock("React dashboard", { includePromptRelevant: true });
+    assert.match(withPromptRelevant, /critical resume safety context/);
+    assert.match(withPromptRelevant, /React dashboard preference/);
+
+    const withoutPromptRelevant = await loadMemoryBlock("React dashboard", { includePromptRelevant: false });
+    assert.match(withoutPromptRelevant, /critical resume safety context/);
+    assert.doesNotMatch(withoutPromptRelevant, /React dashboard preference/);
+  } finally {
+    closeDatabase();
+  }
+});
+
+test("isLowEntropyResumePrompt identifies bare resume prompts only", () => {
+  assert.equal(isLowEntropyResumePrompt("continue"), true);
+  assert.equal(isLowEntropyResumePrompt("Go ahead."), true);
+  assert.equal(isLowEntropyResumePrompt("run the tests"), false);
+  assert.equal(isLowEntropyResumePrompt("/gsd auto"), false);
+});

--- a/src/resources/extensions/gsd/tests/system-context-message-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/system-context-message-routing.test.ts
@@ -1,9 +1,5 @@
-// GSD bootstrap + system-context-message-routing.test — regression coverage
-// for #5019. `memoryBlock` is FTS-queried against the user prompt and changes
-// per call; embedding it in the cached system prefix invalidates Anthropic
-// prompt-cache hits on every request. The fix routes memory through the
-// existing context-message channel (volatile user-message suffix) and combines
-// it with any active guided-execute or forensics injection.
+// Project/App: GSD-2
+// File Purpose: Regression coverage for volatile system-context message routing.
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
@@ -11,6 +7,8 @@ import assert from "node:assert/strict";
 import { buildContextMessage } from "../bootstrap/system-context.ts";
 
 describe("buildContextMessage (#5019 — memory routing)", () => {
+  const markedMemory = "[GSD Context Metadata]\n- Memory supplied: yes\n\n[MEMORY]\nrule one";
+
   test("returns null when nothing to inject", () => {
     const result = buildContextMessage({
       memoryBlock: "",
@@ -37,7 +35,7 @@ describe("buildContextMessage (#5019 — memory routing)", () => {
     });
     assert.ok(result, "expected a context message");
     assert.equal(result.customType, "gsd-memory");
-    assert.equal(result.content, "[MEMORY]\nrule one\nrule two");
+    assert.equal(result.content, "[GSD Context Metadata]\n- Memory supplied: yes\n\n[MEMORY]\nrule one\nrule two");
     assert.equal(result.display, false);
   });
 
@@ -71,7 +69,7 @@ describe("buildContextMessage (#5019 — memory routing)", () => {
     });
     assert.ok(result);
     assert.equal(result.customType, "gsd-guided-context");
-    assert.equal(result.content, "[MEMORY]\nrule one\n\n[GUIDED]\nexecute T01");
+    assert.equal(result.content, `${markedMemory}\n\n[GUIDED]\nexecute T01`);
   });
 
   test("memory + forensics: memory prepended, customType is gsd-forensics", () => {
@@ -82,7 +80,7 @@ describe("buildContextMessage (#5019 — memory routing)", () => {
     });
     assert.ok(result);
     assert.equal(result.customType, "gsd-forensics");
-    assert.equal(result.content, "[MEMORY]\nrule one\n\n[FORENSICS]\ninvestigation context");
+    assert.equal(result.content, `${markedMemory}\n\n[FORENSICS]\ninvestigation context`);
   });
 
   test("guided takes precedence over forensics when both are somehow present", () => {

--- a/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
+++ b/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
@@ -4,7 +4,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildMinimalAutoGsdToolSet, buildMinimalGsdToolSet, buildMinimalGsdWorkflowToolSet, MINIMAL_AUTO_BASE_TOOL_NAMES, MINIMAL_GSD_TOOL_NAMES, restoreGsdWorkflowTools, scopeGsdWorkflowToolsForDispatch } from "../bootstrap/register-hooks.ts";
+import { buildMinimalAutoGsdToolSet, buildMinimalGsdToolSet, buildMinimalGsdWorkflowToolSet, buildRequestScopedGsdToolSet, MINIMAL_AUTO_BASE_TOOL_NAMES, MINIMAL_GSD_TOOL_NAMES, restoreGsdWorkflowTools, scopeGsdWorkflowToolsForDispatch } from "../bootstrap/register-hooks.ts";
 
 test("buildMinimalGsdToolSet preserves non-GSD tools and replaces broad GSD surface", () => {
   const result = buildMinimalGsdToolSet([
@@ -193,6 +193,38 @@ test("buildMinimalGsdWorkflowToolSet keeps workflow GSD tools but drops broad no
   assert.ok(!result.includes("mac_find"));
   assert.ok(!result.includes("subagent"));
   assert.ok(!result.includes("gsd_graph"));
+});
+
+test("buildRequestScopedGsdToolSet scopes queued workflow custom-message requests", () => {
+  const result = buildRequestScopedGsdToolSet([
+    "ask_user_questions",
+    "bash",
+    "browser_wait_for",
+    "lsp",
+    "read",
+    "write",
+    "gsd_plan_milestone",
+    "gsd_complete_milestone",
+    "gsd_task_complete",
+    "gsd_graph",
+    "memory_query",
+    "capture_thought",
+  ], [{ customType: "gsd-run" }, { customType: "gsd-memory" }]);
+
+  assert.ok(result);
+  assert.ok(result.includes("ask_user_questions"));
+  assert.ok(result.includes("bash"));
+  assert.ok(result.includes("read"));
+  assert.ok(result.includes("write"));
+  assert.ok(result.includes("gsd_plan_milestone"));
+  assert.ok(result.includes("gsd_complete_milestone"));
+  assert.ok(!result.includes("browser_wait_for"));
+  assert.ok(!result.includes("lsp"));
+  assert.ok(!result.includes("gsd_graph"));
+});
+
+test("buildRequestScopedGsdToolSet ignores stale workflow messages outside the current request tail", () => {
+  assert.equal(buildRequestScopedGsdToolSet(["bash", "gsd_plan_milestone"], []), undefined);
 });
 
 test("scopeGsdWorkflowToolsForDispatch applies and restores per-unit skill visibility", () => {

--- a/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
+++ b/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
@@ -1,0 +1,259 @@
+// Project/App: GSD-2
+// File Purpose: Tests for opt-in GSD tool surface reduction.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildMinimalAutoGsdToolSet, buildMinimalGsdToolSet, buildMinimalGsdWorkflowToolSet, MINIMAL_AUTO_BASE_TOOL_NAMES, MINIMAL_GSD_TOOL_NAMES, restoreGsdWorkflowTools, scopeGsdWorkflowToolsForDispatch } from "../bootstrap/register-hooks.ts";
+
+test("buildMinimalGsdToolSet preserves non-GSD tools and replaces broad GSD surface", () => {
+  const result = buildMinimalGsdToolSet([
+    "bash",
+    "read",
+    "browser_open",
+    "gsd_plan_milestone",
+    "gsd_task_complete",
+    "gsd_exec",
+    "gsd_exec_search",
+    "gsd_resume",
+    "gsd_milestone_status",
+    "gsd_checkpoint_db",
+    "memory_query",
+    "capture_thought",
+    "gsd_graph",
+  ]);
+
+  assert.ok(result.includes("bash"));
+  assert.ok(result.includes("read"));
+  assert.ok(result.includes("browser_open"));
+  for (const toolName of MINIMAL_GSD_TOOL_NAMES) {
+    assert.ok(result.includes(toolName), `expected ${toolName}`);
+  }
+  assert.ok(!result.includes("gsd_plan_milestone"));
+  assert.ok(!result.includes("gsd_task_complete"));
+  assert.ok(!result.includes("gsd_graph"));
+});
+
+test("buildMinimalGsdToolSet deduplicates preserved and minimal tools", () => {
+  const result = buildMinimalGsdToolSet(["bash", "bash", "memory_query"]);
+
+  assert.deepEqual(result.filter((toolName) => toolName === "bash"), ["bash"]);
+  assert.deepEqual(result.filter((toolName) => toolName === "memory_query"), ["memory_query"]);
+});
+
+test("buildMinimalGsdToolSet does not reintroduce provider-filtered GSD tools", () => {
+  const result = buildMinimalGsdToolSet(["bash", "read", "memory_query"]);
+
+  assert.deepEqual(result, ["bash", "read", "memory_query"]);
+  assert.ok(!result.includes("gsd_exec"));
+});
+
+test("buildMinimalAutoGsdToolSet keeps unit-specific completion tools without aliases", () => {
+  const result = buildMinimalAutoGsdToolSet([
+    "ask_user_questions",
+    "bash",
+    "read",
+    "lsp",
+    "browser_click",
+    "gsd_task_complete",
+    "gsd_complete_task",
+    "gsd_exec",
+    "gsd_exec_search",
+    "gsd_resume",
+    "gsd_milestone_status",
+    "gsd_checkpoint_db",
+    "gsd_slice_complete",
+    "gsd_complete_slice",
+    "memory_query",
+    "capture_thought",
+  ], "execute-task");
+
+  assert.ok(result.includes("ask_user_questions"));
+  assert.ok(result.includes("bash"));
+  assert.ok(result.includes("read"));
+  assert.ok(result.includes("gsd_task_complete"));
+  assert.ok(result.includes("memory_query"));
+  assert.ok(!result.includes("lsp"));
+  assert.ok(!result.includes("browser_click"));
+  assert.ok(!result.includes("gsd_complete_task"));
+  assert.ok(!result.includes("gsd_slice_complete"));
+  assert.ok(!result.includes("gsd_complete_slice"));
+});
+
+test("buildMinimalAutoGsdToolSet keeps only the auto base non-GSD tools", () => {
+  const result = buildMinimalAutoGsdToolSet([
+    "ask_user_questions",
+    "bash",
+    "bg_shell",
+    "browser_wait_for",
+    "edit",
+    "glob",
+    "grep",
+    "lsp",
+    "ls",
+    "mac_find",
+    "read",
+    "subagent",
+    "write",
+    "gsd_exec",
+    "gsd_exec_search",
+    "gsd_resume",
+    "gsd_milestone_status",
+    "gsd_checkpoint_db",
+    "memory_query",
+    "capture_thought",
+  ], "execute-task");
+
+  for (const toolName of MINIMAL_AUTO_BASE_TOOL_NAMES) {
+    assert.ok(result.includes(toolName), `expected ${toolName}`);
+  }
+  assert.ok(!result.includes("browser_wait_for"));
+  assert.ok(!result.includes("lsp"));
+  assert.ok(!result.includes("mac_find"));
+  assert.ok(!result.includes("subagent"));
+});
+
+test("buildMinimalAutoGsdToolSet includes closeout tool for complete-slice", () => {
+  const result = buildMinimalAutoGsdToolSet([
+    "bash",
+    "read",
+    "subagent",
+    "gsd_exec",
+    "gsd_exec_search",
+    "gsd_resume",
+    "gsd_milestone_status",
+    "gsd_checkpoint_db",
+    "gsd_task_complete",
+    "gsd_slice_complete",
+    "gsd_complete_slice",
+    "memory_query",
+    "capture_thought",
+  ], "complete-slice");
+
+  assert.ok(result.includes("gsd_slice_complete"));
+  assert.ok(result.includes("subagent"));
+  assert.ok(result.includes("capture_thought"));
+  assert.ok(!result.includes("gsd_task_complete"));
+  assert.ok(!result.includes("gsd_complete_slice"));
+});
+
+test("buildMinimalAutoGsdToolSet covers execute-task-simple", () => {
+  const result = buildMinimalAutoGsdToolSet([
+    "bash",
+    "read",
+    "gsd_task_complete",
+    "gsd_decision_save",
+    "gsd_plan_task",
+    "memory_query",
+    "capture_thought",
+  ], "execute-task-simple");
+
+  assert.ok(result.includes("gsd_task_complete"));
+  assert.ok(result.includes("gsd_decision_save"));
+  assert.ok(!result.includes("gsd_plan_task"));
+});
+
+test("buildMinimalGsdWorkflowToolSet keeps workflow GSD tools but drops broad non-GSD tools", () => {
+  const result = buildMinimalGsdWorkflowToolSet([
+    "ask_user_questions",
+    "bash",
+    "bg_shell",
+    "browser_wait_for",
+    "edit",
+    "lsp",
+    "mac_find",
+    "read",
+    "subagent",
+    "write",
+    "gsd_plan_milestone",
+    "gsd_complete_milestone",
+    "gsd_task_complete",
+    "gsd_summary_save",
+    "memory_query",
+    "capture_thought",
+    "gsd_exec",
+    "gsd_exec_search",
+    "gsd_resume",
+    "gsd_milestone_status",
+    "gsd_checkpoint_db",
+    "gsd_graph",
+  ]);
+
+  assert.ok(result.includes("ask_user_questions"));
+  assert.ok(result.includes("bash"));
+  assert.ok(result.includes("bg_shell"));
+  assert.ok(result.includes("read"));
+  assert.ok(result.includes("write"));
+  assert.ok(result.includes("gsd_plan_milestone"));
+  assert.ok(result.includes("gsd_complete_milestone"));
+  assert.ok(result.includes("gsd_task_complete"));
+  assert.ok(result.includes("gsd_summary_save"));
+  assert.ok(!result.includes("browser_wait_for"));
+  assert.ok(!result.includes("lsp"));
+  assert.ok(!result.includes("mac_find"));
+  assert.ok(!result.includes("subagent"));
+  assert.ok(!result.includes("gsd_graph"));
+});
+
+test("scopeGsdWorkflowToolsForDispatch applies and restores per-unit skill visibility", () => {
+  const calls: Array<{ kind: "tools" | "skills"; value: string[] | undefined }> = [];
+  let activeTools = [
+    "bash",
+    "read",
+    "lsp",
+    "gsd_plan_milestone",
+    "gsd_decision_save",
+    "memory_query",
+    "capture_thought",
+  ];
+  let visibleSkills: string[] | undefined = ["previous-skill"];
+
+  const state = scopeGsdWorkflowToolsForDispatch({
+    getActiveTools: () => activeTools,
+    setActiveTools: (names) => {
+      activeTools = names;
+      calls.push({ kind: "tools", value: names });
+    },
+    getVisibleSkills: () => visibleSkills,
+    setVisibleSkills: (names) => {
+      visibleSkills = names;
+      calls.push({ kind: "skills", value: names });
+    },
+  }, "plan-milestone");
+
+  assert.ok(state);
+  assert.deepEqual(visibleSkills, [
+    "write-milestone-brief",
+    "decompose-into-slices",
+    "design-an-interface",
+    "grill-me",
+    "write-docs",
+    "api-design",
+    "tdd",
+    "verify-before-complete",
+  ]);
+  assert.ok(!activeTools.includes("lsp"));
+
+  restoreGsdWorkflowTools({
+    setActiveTools: (names) => {
+      activeTools = names;
+      calls.push({ kind: "tools", value: names });
+    },
+    setVisibleSkills: (names) => {
+      visibleSkills = names;
+      calls.push({ kind: "skills", value: names });
+    },
+  }, state);
+
+  assert.deepEqual(activeTools, [
+    "bash",
+    "read",
+    "lsp",
+    "gsd_plan_milestone",
+    "gsd_decision_save",
+    "memory_query",
+    "capture_thought",
+  ]);
+  assert.deepEqual(visibleSkills, ["previous-skill"]);
+  assert.equal(calls.filter((call) => call.kind === "skills").length, 2);
+});

--- a/src/resources/extensions/gsd/tests/unstructured-continue-context-injection.test.ts
+++ b/src/resources/extensions/gsd/tests/unstructured-continue-context-injection.test.ts
@@ -1,4 +1,5 @@
-// GSD-2 — Regression test for #3615: unstructured "continue" must inject task context
+// Project/App: GSD-2
+// File Purpose: Regression test for unstructured continue task-context injection.
 // Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 
 /**
@@ -55,12 +56,12 @@ describe("#3615 — structural: fallback exists with correct guards", () => {
     );
   });
 
-  test("fallback is intent-gated via RESUME_INTENT_PATTERNS", () => {
+  test("fallback is intent-gated via isLowEntropyResumePrompt", () => {
     const afterFallback = fnBody.indexOf("// Fallback:");
     const fallbackSection = fnBody.slice(afterFallback);
     assert.ok(
-      fallbackSection.includes("RESUME_INTENT_PATTERNS"),
-      "fallback must check RESUME_INTENT_PATTERNS before deriveState",
+      fallbackSection.includes("isLowEntropyResumePrompt(prompt)"),
+      "fallback must check isLowEntropyResumePrompt before deriveState",
     );
   });
 

--- a/src/resources/extensions/gsd/tests/workflow-protocol-excerpt.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-protocol-excerpt.test.ts
@@ -1,0 +1,99 @@
+// Project/App: GSD-2
+// File Purpose: Tests for capped GSD workflow protocol and doctor-heal payload helpers.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildDoctorHealIssuePayload,
+  buildDoctorHealSummary,
+  buildWorkflowDispatchContent,
+  buildWorkflowProtocolExcerpt,
+} from "../workflow-protocol.ts";
+
+test("workflow protocol helper emits capped excerpt plus source path", () => {
+  const workflow = `# Protocol\n${"FULL_WORKFLOW_BODY ".repeat(500)}`;
+  const excerpt = buildWorkflowProtocolExcerpt(workflow, "/tmp/GSD-WORKFLOW.md", { maxChars: 1200 });
+
+  assert.match(excerpt, /Source: `\/tmp\/GSD-WORKFLOW\.md`/);
+  assert.match(excerpt, /\[Workflow Protocol Truncated\]/);
+  assert.ok(excerpt.length < workflow.length);
+  assert.ok(excerpt.length < 1600);
+});
+
+test("workflow dispatch uses excerpt instead of full workflow body", () => {
+  const workflow = `# Protocol\n${"FULL_WORKFLOW_BODY ".repeat(500)}`;
+  const content = buildWorkflowDispatchContent({
+    workflow,
+    workflowPath: "/tmp/GSD-WORKFLOW.md",
+    task: "Run the selected unit.",
+    maxProtocolChars: 1200,
+  });
+
+  assert.match(content, /## GSD Workflow Protocol Excerpt/);
+  assert.match(content, /## Your Task/);
+  assert.match(content, /Run the selected unit/);
+  assert.ok(content.length < workflow.length);
+});
+
+test("workflow protocol excerpt includes late verification and advance rules", () => {
+  const workflow = [
+    "# GSD Workflow",
+    "intro",
+    "## Quick Start",
+    "quick",
+    "## File Format Reference",
+    "format ".repeat(400),
+    "## The Phases",
+    "phase overview",
+    "### Phase 4: Execute",
+    "execute rules",
+    "### Phase 5: Verify",
+    "verification rules",
+    "### Phase 7: Advance",
+    "advance rules",
+  ].join("\n");
+
+  const excerpt = buildWorkflowProtocolExcerpt(workflow, "/tmp/GSD-WORKFLOW.md", { maxChars: 1300 });
+
+  assert.match(excerpt, /Quick Start/);
+  assert.match(excerpt, /Phase 5: Verify/);
+  assert.match(excerpt, /Phase 7: Advance/);
+  assert.doesNotMatch(excerpt, /format format format format format/);
+});
+
+test("doctor heal summary omits duplicated full report body", () => {
+  const report = [
+    "# GSD doctor heal prep.",
+    "Scope: M001",
+    "Status: warning",
+    "Warnings: 9",
+    "",
+    "VERY_LONG_FULL_REPORT_BODY ".repeat(300),
+  ].join("\n");
+
+  const summary = buildDoctorHealSummary(report, { maxChars: 900 });
+
+  assert.match(summary, /GSD doctor heal prep/);
+  assert.match(summary, /Warnings: 9/);
+  assert.ok(summary.length <= 900);
+  assert.doesNotMatch(summary, /VERY_LONG_FULL_REPORT_BODY VERY_LONG_FULL_REPORT_BODY VERY_LONG_FULL_REPORT_BODY/);
+});
+
+test("doctor heal issue payload keeps top actionable issues and caps detail", () => {
+  const issues = Array.from({ length: 20 }, (_, index) =>
+    `### Issue ${index + 1}\n${`detail ${index + 1} `.repeat(80)}`,
+  ).join("\n");
+
+  const payload = buildDoctorHealIssuePayload(issues, {
+    maxIssues: 3,
+    maxIssueChars: 180,
+    maxChars: 900,
+  });
+
+  assert.match(payload, /Issue 1/);
+  assert.match(payload, /Issue 3/);
+  assert.doesNotMatch(payload, /Issue 4/);
+  assert.match(payload, /17 additional actionable issue/);
+  assert.ok(payload.length <= 900);
+});

--- a/src/resources/extensions/gsd/workflow-protocol.ts
+++ b/src/resources/extensions/gsd/workflow-protocol.ts
@@ -1,0 +1,160 @@
+// Project/App: GSD-2
+// File Purpose: Shared capped workflow protocol and doctor-heal prompt payload helpers.
+
+const DEFAULT_WORKFLOW_PROTOCOL_EXCERPT_CHARS = 4_000;
+const MIN_WORKFLOW_PROTOCOL_EXCERPT_CHARS = 1_000;
+const DEFAULT_DOCTOR_SUMMARY_CHARS = 2_400;
+const DEFAULT_DOCTOR_ISSUE_CHARS = 300;
+const DEFAULT_DOCTOR_MAX_ISSUES = 12;
+const DEFAULT_DOCTOR_ISSUES_CHARS = 4_000;
+
+export function buildWorkflowProtocolExcerpt(
+  workflow: string,
+  workflowPath: string,
+  opts: { maxChars?: number } = {},
+): string {
+  const limit = opts.maxChars ?? getWorkflowProtocolExcerptLimit();
+  const trimmed = workflow.trim();
+  const excerpt = buildPrioritizedWorkflowExcerpt(trimmed, limit);
+  const truncated = trimmed.length > excerpt.length;
+  const lines = [
+    "## GSD Workflow Protocol Excerpt",
+    `Source: \`${workflowPath}\``,
+    "",
+    excerpt,
+  ];
+  if (truncated) {
+    lines.push(
+      "",
+      "[Workflow Protocol Truncated]",
+      "The full workflow protocol remains available at the source path above. Read it only if this excerpt lacks a rule required for the dispatched task.",
+    );
+  }
+  return lines.join("\n");
+}
+
+export function buildWorkflowDispatchContent(opts: {
+  workflow: string;
+  workflowPath: string;
+  task: string;
+  maxProtocolChars?: number;
+}): string {
+  return [
+    "Read the following GSD workflow protocol excerpt and execute exactly. Use the source path for a full protocol read only if the excerpt lacks a required rule.",
+    "",
+    buildWorkflowProtocolExcerpt(opts.workflow, opts.workflowPath, { maxChars: opts.maxProtocolChars }),
+    "",
+    "## Your Task",
+    "",
+    opts.task.trim(),
+  ].join("\n");
+}
+
+export function buildDoctorHealSummary(reportText: string, opts: { maxChars?: number } = {}): string {
+  const limit = opts.maxChars ?? DEFAULT_DOCTOR_SUMMARY_CHARS;
+  const lines = reportText.split(/\r?\n/).map((line) => line.trimEnd());
+  const summaryLines = lines.filter((line) =>
+    line.length > 0 && (
+      /^#/.test(line) ||
+      /^(scope|status|summary|checks?|errors?|warnings?|fixes?|issues?)\b/i.test(line) ||
+      /doctor/i.test(line)
+    ),
+  );
+  const selected = summaryLines.length > 0 ? summaryLines : lines.filter((line) => line.trim()).slice(0, 24);
+  return capText(selected.join("\n"), limit, "Full doctor report is available in the command output; use the structured issue list below for repairs.");
+}
+
+export function buildDoctorHealIssuePayload(
+  structuredIssues: string,
+  opts: { maxIssues?: number; maxIssueChars?: number; maxChars?: number } = {},
+): string {
+  const maxIssues = opts.maxIssues ?? DEFAULT_DOCTOR_MAX_ISSUES;
+  const maxIssueChars = opts.maxIssueChars ?? DEFAULT_DOCTOR_ISSUE_CHARS;
+  const maxChars = opts.maxChars ?? DEFAULT_DOCTOR_ISSUES_CHARS;
+  const blocks = splitIssueBlocks(structuredIssues);
+  const topBlocks = blocks.slice(0, maxIssues).map((block) =>
+    capText(block, maxIssueChars, "Issue details truncated; inspect the relevant artifact before editing."),
+  );
+  if (blocks.length > maxIssues) {
+    topBlocks.push(`[${blocks.length - maxIssues} additional actionable issue(s) omitted from prompt. Re-run /gsd doctor heal after this repair pass.]`);
+  }
+  return capText(topBlocks.join("\n\n"), maxChars, "Structured issue list truncated; repair top actionable issues first and re-run doctor heal.");
+}
+
+function getWorkflowProtocolExcerptLimit(): number {
+  const raw = process.env.PI_GSD_WORKFLOW_PROTOCOL_MAX_CHARS;
+  if (!raw) return DEFAULT_WORKFLOW_PROTOCOL_EXCERPT_CHARS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < MIN_WORKFLOW_PROTOCOL_EXCERPT_CHARS) {
+    return DEFAULT_WORKFLOW_PROTOCOL_EXCERPT_CHARS;
+  }
+  return Math.floor(parsed);
+}
+
+function buildPrioritizedWorkflowExcerpt(workflow: string, limit: number): string {
+  if (workflow.length <= limit) return workflow;
+  const sections = splitMarkdownSections(workflow);
+  const wanted = [
+    /^# /,
+    /^## Quick Start\b/i,
+    /^## The Hierarchy\b/i,
+    /^## The Phases\b/i,
+    /^### Phase 4: Execute\b/i,
+    /^### Phase 5: Verify\b/i,
+    /^### Observable Truths\b/i,
+    /^### Artifacts\b/i,
+    /^### Key Links\b/i,
+    /^### Phase 6: Summarize\b/i,
+    /^### Phase 7: Advance\b/i,
+  ];
+  const selected: string[] = [];
+  const used = new Set<number>();
+  for (const pattern of wanted) {
+    const index = sections.findIndex((section, sectionIndex) =>
+      !used.has(sectionIndex) && pattern.test(section.heading),
+    );
+    if (index >= 0) {
+      used.add(index);
+      selected.push(sections[index].text);
+    }
+  }
+  const body = selected.length > 0 ? selected.join("\n\n") : workflow;
+  return capText(body, limit, "Workflow protocol excerpt capped; read the source path for omitted details.");
+}
+
+function splitMarkdownSections(markdown: string): Array<{ heading: string; text: string }> {
+  const lines = markdown.split(/\r?\n/);
+  const sections: Array<{ heading: string; text: string }> = [];
+  let currentHeading = lines[0]?.startsWith("#") ? lines[0] : "# Preamble";
+  let current: string[] = [];
+  for (const line of lines) {
+    if (/^#{1,3}\s+/.test(line) && current.length > 0) {
+      sections.push({ heading: currentHeading, text: current.join("\n").trim() });
+      currentHeading = line;
+      current = [line];
+      continue;
+    }
+    if (/^#{1,3}\s+/.test(line)) currentHeading = line;
+    current.push(line);
+  }
+  if (current.length > 0) {
+    sections.push({ heading: currentHeading, text: current.join("\n").trim() });
+  }
+  return sections.filter((section) => section.text.length > 0);
+}
+
+function splitIssueBlocks(structuredIssues: string): string[] {
+  const trimmed = structuredIssues.trim();
+  if (!trimmed) return ["No structured issue details were provided."];
+  const split = trimmed.split(/\n(?=(?:#{2,6}\s+|\d+\.\s+|- \*\*|- \[[ x]\]))/i)
+    .map((block) => block.trim())
+    .filter(Boolean);
+  return split.length > 0 ? split : [trimmed];
+}
+
+function capText(text: string, limit: number, notice: string): string {
+  if (text.length <= limit) return text;
+  const suffix = `\n\n[Truncated]\n${notice}`;
+  const headBudget = Math.max(0, limit - suffix.length);
+  return `${text.slice(0, headBudget).trimEnd()}${suffix}`;
+}

--- a/src/resources/extensions/gsd/workflow-protocol.ts
+++ b/src/resources/extensions/gsd/workflow-protocol.ts
@@ -16,7 +16,7 @@ export function buildWorkflowProtocolExcerpt(
   const limit = opts.maxChars ?? getWorkflowProtocolExcerptLimit();
   const trimmed = workflow.trim();
   const excerpt = buildPrioritizedWorkflowExcerpt(trimmed, limit);
-  const truncated = trimmed.length > excerpt.length;
+  const truncated = trimmed.length > limit;
   const lines = [
     "## GSD Workflow Protocol Excerpt",
     `Source: \`${workflowPath}\``,

--- a/vscode-extension/src/rpc-display.ts
+++ b/vscode-extension/src/rpc-display.ts
@@ -3,6 +3,11 @@
 
 import type { BashResult, SessionStats } from "@gsd-build/contracts" with { "resolution-mode": "import" };
 
+export interface ContextUsageDisplay {
+	percent: number | null;
+	text: string;
+}
+
 export function getSessionInputTokens(stats: SessionStats | null | undefined): number {
 	return stats?.tokens.input ?? 0;
 }
@@ -29,6 +34,13 @@ export function getSessionCost(stats: SessionStats | null | undefined): number {
 
 export function hasSessionTokenStats(stats: SessionStats | null | undefined): boolean {
 	return getSessionInputTokens(stats) > 0 || getSessionOutputTokens(stats) > 0;
+}
+
+export function getContextUsageDisplay(_stats: SessionStats | null | undefined): ContextUsageDisplay {
+	return {
+		percent: null,
+		text: "Context unknown",
+	};
 }
 
 export function formatSessionStatsLines(stats: SessionStats): string[] {

--- a/vscode-extension/src/sidebar.ts
+++ b/vscode-extension/src/sidebar.ts
@@ -4,6 +4,7 @@
 import * as vscode from "vscode";
 import type { GsdClient, SessionStats, ThinkingLevel } from "./gsd-client.js";
 import {
+	getContextUsageDisplay,
 	getSessionCacheReadTokens,
 	getSessionCacheWriteTokens,
 	getSessionCost,
@@ -206,7 +207,6 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 		let autoCompaction = false;
 		let autoRetry = false;
 		let stats: SessionStats | null = null;
-		let contextWindow = 0;
 		let steeringMode: "all" | "one-at-a-time" = "all";
 		let followUpMode: "all" | "one-at-a-time" = "all";
 
@@ -226,7 +226,6 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 				isStreaming = state.isStreaming;
 				isCompacting = state.isCompacting;
 				autoCompaction = state.autoCompactionEnabled;
-				contextWindow = state.model?.contextWindow ?? 0;
 				steeringMode = state.steeringMode;
 				followUpMode = state.followUpMode;
 			} catch {
@@ -256,7 +255,6 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			autoCompaction,
 			autoRetry,
 			stats,
-			contextWindow,
 			steeringMode,
 			followUpMode,
 		});
@@ -285,7 +283,6 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 		autoCompaction: boolean;
 		autoRetry: boolean;
 		stats: SessionStats | null;
-		contextWindow: number;
 		steeringMode: "all" | "one-at-a-time";
 		followUpMode: "all" | "one-at-a-time";
 	}): string {
@@ -304,10 +301,9 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			? `$${cost.toFixed(4)}`
 			: "";
 
-		// Context window
+		// Live context usage is unknown until provider-bound audit data is available.
 		const totalTokens = getSessionTotalTokens(info.stats);
-		const contextPct = info.contextWindow > 0 ? Math.min(100, Math.round((totalTokens / info.contextWindow) * 100)) : 0;
-		const contextColor = contextPct > 80 ? "#f44747" : contextPct > 50 ? "#cca700" : "#4ec9b0";
+		const contextUsage = getContextUsageDisplay(info.stats);
 
 		// Only show stats that have real data
 		const hasStats = hasSessionTokenStats(info.stats);
@@ -318,6 +314,7 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 		let statRows = "";
 		if (hasStats && info.stats) {
 			const pairs: [string, string][] = [];
+			if (totalTokens) pairs.push(["Session tokens", formatNum(totalTokens)]);
 			if (getSessionInputTokens(info.stats)) pairs.push(["In", formatNum(getSessionInputTokens(info.stats))]);
 			if (getSessionOutputTokens(info.stats)) pairs.push(["Out", formatNum(getSessionOutputTokens(info.stats))]);
 			if (getSessionCacheReadTokens(info.stats)) pairs.push(["Cache R", formatNum(getSessionCacheReadTokens(info.stats))]);
@@ -618,8 +615,8 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			modelDisplay,
 			sessionDisplay,
 			costDisplay,
-			contextPct,
-			contextColor,
+			contextUsage,
+			totalTokens,
 			hasStats: !!hasStats,
 			statRows,
 			nonce,
@@ -686,7 +683,6 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			autoCompaction: boolean;
 			autoRetry: boolean;
 			stats: SessionStats | null;
-			contextWindow: number;
 			steeringMode: "all" | "one-at-a-time";
 			followUpMode: "all" | "one-at-a-time";
 		},
@@ -695,8 +691,8 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			modelDisplay: string;
 			sessionDisplay: string;
 			costDisplay: string;
-			contextPct: number;
-			contextColor: string;
+			contextUsage: ReturnType<typeof getContextUsageDisplay>;
+			totalTokens: number;
 			hasStats: boolean;
 			statRows: string;
 			nonce: string;
@@ -722,14 +718,14 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 			<span class="sep">/</span>
 			<span data-command="cycleThinking" style="cursor:pointer" title="Click to cycle thinking level">${info.thinkingLevel === "off" ? "no think" : info.thinkingLevel}</span>
 		</div>
-		${info.contextWindow > 0 ? `
 		<div class="context-bar">
+			${ui.contextUsage.percent !== null ? `
 			<div class="context-track">
-				<div class="context-fill" style="width:${ui.contextPct}%;background:${ui.contextColor}"></div>
+				<div class="context-fill" style="width:${ui.contextUsage.percent}%;background:#4ec9b0"></div>
 			</div>
-			<div class="context-text">${ui.contextPct}% context (${formatNum(getSessionTotalTokens(info.stats))} / ${formatNum(info.contextWindow)})</div>
+			` : ""}
+			<div class="context-text">${escapeHtml(ui.contextUsage.text)}${ui.totalTokens ? ` / Session tokens: ${formatNum(ui.totalTokens)}` : ""}</div>
 		</div>
-		` : ""}
 	</div>
 
 	${info.isStreaming ? `

--- a/vscode-extension/test/rpc-display-contract.test.ts
+++ b/vscode-extension/test/rpc-display-contract.test.ts
@@ -8,6 +8,7 @@ import {
 	formatSessionStatsLines,
 	getBashExitCode,
 	getBashOutput,
+	getContextUsageDisplay,
 	getSessionCost,
 	getSessionTotalTokens,
 } from "../src/rpc-display.ts";
@@ -33,6 +34,10 @@ test("session stats display helpers consume canonical token and cost fields", ()
 
 	assert.equal(getSessionTotalTokens(stats), 185);
 	assert.equal(getSessionCost(stats), 0.1234);
+	assert.deepEqual(getContextUsageDisplay(stats), {
+		percent: null,
+		text: "Context unknown",
+	});
 	assert.deepEqual(formatSessionStatsLines(stats), [
 		"Input tokens: 100",
 		"Output tokens: 50",


### PR DESCRIPTION
## TL;DR

**What:** Adds provider-boundary token auditing and token-saving request/prompt scoping for GSD workflows.
**Why:** Long auto/workflow sessions were repeatedly sending oversized tool schemas and duplicated workflow context, causing live prompt payloads to spike early in a session.
**How:** Measure the final provider payload, stop misleading cumulative-token context UI, scope tools per provider/request/workflow turn, cap repeated GSD prompt/context injections, and record before/after audit evidence.

Closes #5547

## What

This PR adds metadata-only `PI_TOKEN_AUDIT=1` summaries at the final agent provider boundary and after provider request hooks. It reports section sizes, counts, largest metadata-only message/tool entries, estimated input tokens, and never logs raw prompt content.

It also updates the VS Code/sidebar token display so cumulative session tokens stay labeled as spend and are no longer presented as live context percentage.

For savings, this PR scopes tools at final request time, preserving provider compatibility before extension-level tool reduction. GSD auto/guided/doctor workflow turns get narrower per-turn tool surfaces with a full-tools escape hatch, and skill visibility is filtered in prompts without unloading skill availability.

GSD prompt/context injections now use capped excerpts for repeated workflow protocol, knowledge, hidden context, task summaries, replan blockers, and doctor-heal issue payloads.

## Why

Audit logs showed the dominant live prompt bucket was repeated full tool schemas, with some turns sending roughly 100+ tools and 70k+ tool-schema characters. After auto tool scoping, measured auto turns were near 15 tools, but `gsd-run` and `gsd-doctor-heal` still exposed broad workflow/tool payloads. Tool-result replay stayed at zero in the measured logs, so replay compression is intentionally deferred.

## How

- Adds `packages/pi-agent-core/src/token-audit.ts` and final-send audit logging behind `PI_TOKEN_AUDIT=1`.
- Adds provider-payload audit after `before_provider_request` while keeping output metadata-only.
- Adds final request-time tool filtering, then lets GSD hooks further scope only provider-compatible tools.
- Adds GSD workflow/auto/doctor tool surfaces and `PI_GSD_FULL_TOOLS=1` escape hatch.
- Adds prompt-visible skill filtering so skills remain callable without all skill text appearing in every prompt.
- Adds capped workflow protocol and doctor-heal payload builders.
- Caps GSD memory/context/knowledge and repeated auto prompt payloads by default with env overrides where appropriate.
- Adds `docs/token-consumption-savings-evidence.md` with the measured audit buckets used to drive the cuts.

## Verification

- `npm run build:core`
- `npm run test:packages`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/restore-tools-after-discuss.test.ts`
- `npm run verify:pr` (`9149 passed, 0 failed, 9 skipped`)

## Change type checklist

- [x] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None expected. Token audit and full-tools behavior are controlled by opt-in environment variables, while default GSD workflow scoping keeps the explicit full surface available through `PI_GSD_FULL_TOOLS=1`.

## AI-assisted contribution

This PR is AI-assisted. The changes were implemented and verified locally with the commands listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in token consumption audit logging (metadata-only)
  * Provider-aware tool filtering with an adjust_tool_set hook and minimal/tool-surface scoping
  * Prompt-only visible-skill filtering (controls which skills appear in prompts)

* **Improvements**
  * Capped/excerpted workflow and task prompt generation to reduce payload size
  * Configurable context/knowledge truncation and improved memory selection
  * VS Code sidebar uses provider audit data for context usage display

* **Documentation**
  * Added token consumption savings evidence and env var docs

* **Tests**
  * Expanded tests for audits, tool gating, prompt excerpts, and context routing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->