### PR TITLE
[codex] fix TUI welcome header persistence

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -857,24 +857,6 @@ if (!process.stdin.isTTY || !process.stdout.isTTY) {
   printNonTtyErrorAndExit(missing, true)
 }
 
-// Welcome screen — shown on every fresh interactive session before TUI takes over.
-// Skip when the first-run banner was already printed in loader.ts (prevents double banner).
-if (!process.env.GSD_FIRST_RUN_BANNER) {
-  const { printWelcomeScreen } = await import('./welcome-screen.js')
-  let remoteChannel: string | undefined
-  try {
-    const { resolveRemoteConfig } = await import('./resources/extensions/remote-questions/config.js')
-    const rc = resolveRemoteConfig()
-    if (rc) remoteChannel = rc.channel
-  } catch { /* non-fatal */ }
-  printWelcomeScreen({
-    version: process.env.GSD_VERSION || '0.0.0',
-    modelName: settingsManager.getDefaultModel() || undefined,
-    provider: settingsManager.getDefaultProvider() || undefined,
-    remoteChannel,
-  })
-}
-
 const interactiveMode = new InteractiveMode(session)
 markStartup('InteractiveMode')
 printStartupTimings()

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -418,6 +418,11 @@ function makeErrorMessage(model: string, errorMsg: string): AssistantMessage {
 	};
 }
 
+export function isClaudeCodeAbortErrorMessage(message: string | undefined | null): boolean {
+	if (!message) return false;
+	return /\b(?:claude code process aborted by user|request aborted by user|process aborted by user)\b/i.test(message);
+}
+
 /**
  * Generator exhaustion without a terminal result means the SDK stream was
  * interrupted mid-turn. Surface it as an error so downstream recovery logic
@@ -1840,6 +1845,14 @@ async function pumpSdkMessages(
 		stream.push({ type: "error", reason: "error", error: fallback });
 	} catch (err) {
 		const errorMsg = err instanceof Error ? err.message : String(err);
+		if (options?.signal?.aborted || isClaudeCodeAbortErrorMessage(errorMsg)) {
+			stream.push({
+				type: "error",
+				reason: "aborted",
+				error: makeAbortedMessage(modelId, lastTextContent),
+			});
+			return;
+		}
 		stream.push({
 			type: "error",
 			reason: "error",

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
 	makeStreamExhaustedErrorMessage,
+	isClaudeCodeAbortErrorMessage,
 	getResultErrorMessage,
 	makeAbortedMessage,
 	mergePendingToolCalls,
@@ -1212,6 +1213,12 @@ describe("stream-adapter — MCP elicitation bridge", () => {
 // ---------------------------------------------------------------------------
 
 describe("stream-adapter — abort classification (F2)", () => {
+	test("recognizes Claude Code SDK abort exceptions", () => {
+		assert.equal(isClaudeCodeAbortErrorMessage("Claude Code process aborted by user"), true);
+		assert.equal(isClaudeCodeAbortErrorMessage("Request aborted by user"), true);
+		assert.equal(isClaudeCodeAbortErrorMessage("rate limit exceeded"), false);
+	});
+
 	test("makeAbortedMessage sets stopReason to 'aborted', not 'error'", () => {
 		const message = makeAbortedMessage("claude-sonnet-4-6", "");
 		assert.equal(message.stopReason, "aborted");

--- a/src/resources/extensions/gsd/auto/resolve.ts
+++ b/src/resources/extensions/gsd/auto/resolve.ts
@@ -23,6 +23,9 @@ import { bumpTurnGeneration } from "./turn-epoch.js";
 let _currentResolve: ((result: UnitResult) => void) | null = null;
 let _sessionSwitchInFlight = false;
 let _pendingSwitchCancellation: { errorContext?: ErrorContext } | null = null;
+let _sessionSwitchAbortGraceUntil = 0;
+
+const DEFAULT_SESSION_SWITCH_ABORT_GRACE_MS = 2_000;
 
 // ─── Setters (needed for cross-module mutation) ─────────────────────────────
 
@@ -32,6 +35,21 @@ export function _setCurrentResolve(fn: ((result: UnitResult) => void) | null): v
 
 export function _setSessionSwitchInFlight(v: boolean): void {
   _sessionSwitchInFlight = v;
+}
+
+export function _markSessionSwitchAbortGraceWindow(durationMs = DEFAULT_SESSION_SWITCH_ABORT_GRACE_MS): void {
+  _sessionSwitchAbortGraceUntil = Math.max(
+    _sessionSwitchAbortGraceUntil,
+    Date.now() + durationMs,
+  );
+}
+
+export function _clearSessionSwitchAbortGraceWindow(): void {
+  _sessionSwitchAbortGraceUntil = 0;
+}
+
+export function isSessionSwitchAbortGraceActive(now = Date.now()): boolean {
+  return now < _sessionSwitchAbortGraceUntil;
 }
 
 export function _clearCurrentResolve(): void {
@@ -142,6 +160,7 @@ export function _resetPendingResolve(): void {
   _currentResolve = null;
   _sessionSwitchInFlight = false;
   _pendingSwitchCancellation = null;
+  _sessionSwitchAbortGraceUntil = 0;
 }
 
 export function _hasPendingResolveForTest(): boolean {

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -14,6 +14,7 @@ import type { UnitResult } from "./types.js";
 import {
   _clearCurrentResolve,
   _consumePendingSwitchCancellation,
+  _markSessionSwitchAbortGraceWindow,
   _setCurrentResolve,
   _setSessionSwitchInFlight,
 } from "./resolve.js";
@@ -65,6 +66,7 @@ export async function runUnit(
       workspaceRoot: s.basePath,
     }).finally(() => {
       if (sessionSwitchGeneration === mySessionSwitchGeneration) {
+        _markSessionSwitchAbortGraceWindow();
         _setSessionSwitchInFlight(false);
       }
     });
@@ -128,6 +130,7 @@ export async function runUnit(
   // ── Create the agent_end promise (per-unit one-shot) ──
   // This happens after newSession completes so session-switch agent_end events
   // from the previous session cannot resolve the new unit.
+  _markSessionSwitchAbortGraceWindow();
   _setSessionSwitchInFlight(false);
   const unitPromise = new Promise<UnitResult>((resolve) => {
     _setCurrentResolve(resolve);

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -15,7 +15,12 @@ import { clearPathCache } from "../paths.js";
 import { getAutoDashboardData, getAutoModeStartModel, isAutoActive, pauseAuto, setCurrentDispatchedModelId } from "../auto.js";
 import { getNextFallbackModel, resolveModelWithFallbacksForUnit } from "../preferences.js";
 import { pauseAutoForProviderError } from "../provider-error-pause.js";
-import { isSessionSwitchInFlight, resolveAgentEnd, resolveAgentEndCancelled } from "../auto/resolve.js";
+import {
+  isSessionSwitchAbortGraceActive,
+  isSessionSwitchInFlight,
+  resolveAgentEnd,
+  resolveAgentEndCancelled,
+} from "../auto/resolve.js";
 import { resolveModelId } from "../auto-model-selection.js";
 import { resolveProjectRoot } from "../worktree.js";
 import { clearDiscussionFlowState } from "./write-gate.js";
@@ -77,6 +82,39 @@ export function isUserInitiatedAbortMessage(message: string | undefined | null):
   return /\b(?:claude code process aborted by user|request aborted by user|process aborted by user)\b/i.test(message);
 }
 
+function readAssistantTextContent(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((block) => {
+      if (!block || typeof block !== "object") return "";
+      const text = (block as { text?: unknown }).text;
+      return typeof text === "string" ? text : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function isClaudeCodeSessionSwitchAbortMessage(lastMsg: unknown): boolean {
+  if (!lastMsg || typeof lastMsg !== "object") return false;
+  const m = lastMsg as { stopReason?: unknown; errorMessage?: unknown; content?: unknown };
+  const rawErrorMsg = m.errorMessage ? String(m.errorMessage) : "";
+  const textContent = readAssistantTextContent(m.content);
+  const hasUserAbortText =
+    isUserInitiatedAbortMessage(rawErrorMsg) ||
+    isUserInitiatedAbortMessage(textContent);
+
+  if (m.stopReason === "error") {
+    return hasUserAbortText;
+  }
+
+  if (m.stopReason === "aborted") {
+    if (rawErrorMsg && !isUserInitiatedAbortMessage(rawErrorMsg)) return false;
+    return hasUserAbortText || textContent.trim() === "Claude Code stream aborted by caller";
+  }
+
+  return false;
+}
+
 /**
  * Resolve an agent_end event observed while a session switch is in flight.
  *
@@ -89,10 +127,11 @@ export function isUserInitiatedAbortMessage(message: string | undefined | null):
  * "Auto-mode stopped — Unit aborted: Claude Code process aborted by user"
  * even though no user input occurred.
  *
- * The user-abort branch is intentionally ignored when the abort fires while
- * the session-switch is in flight: the abort is the expected side-effect of
- * the transition, not a user signal. Other branches (genuine `stopReason ===
- * "aborted"` with content/errorMessage) preserve the prior behavior.
+ * Claude Code abort markers are intentionally ignored when the abort fires
+ * while the session-switch is in flight: the abort is the expected side-effect
+ * of the transition, not a user signal. Other branches (genuine `stopReason
+ * === "aborted"` with diagnostic content/errorMessage) preserve the prior
+ * behavior.
  */
 export function _handleSessionSwitchAgentEnd(
   lastMsg: unknown,
@@ -100,6 +139,11 @@ export function _handleSessionSwitchAgentEnd(
 ): void {
   if (!lastMsg || typeof lastMsg !== "object") return;
   const m = lastMsg as { stopReason?: unknown; errorMessage?: unknown; content?: unknown };
+
+  if (isClaudeCodeSessionSwitchAbortMessage(m)) {
+    // Internal abort from in-flight session transition — drop on the floor.
+    return;
+  }
 
   if (m.stopReason === "error") {
     const rawErrorMsg = m.errorMessage ? String(m.errorMessage) : "";
@@ -201,6 +245,13 @@ export async function handleAgentEnd(
   const lastMsg = event.messages[event.messages.length - 1];
   if (isSessionSwitchInFlight()) {
     _handleSessionSwitchAgentEnd(lastMsg, resolveAgentEndCancelled);
+    return;
+  }
+
+  if (isSessionSwitchAbortGraceActive() && isClaudeCodeSessionSwitchAbortMessage(lastMsg)) {
+    // Claude Code can report the abort from `newSession()` a few hundred ms
+    // after the guard drops. That event belongs to the old turn; do not let it
+    // cancel the freshly-dispatched unit.
     return;
   }
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -1,7 +1,9 @@
 // Project/App: GSD-2
 // File Purpose: Registers GSD extension runtime hooks and token-saving tool policies.
 
-import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 import { isToolCallEventType } from "@gsd/pi-coding-agent";
@@ -30,14 +32,71 @@ import { extractSubagentAgentClasses } from "./subagent-input.js";
 import { approvalGateIdForUnit, isExplicitApprovalResponse, shouldPauseForUserApprovalQuestion } from "../user-input-boundary.js";
 import { resolveSkillManifest } from "../skill-manifest.js";
 
-// Skip the welcome screen on the very first session_start — cli.ts already
-// printed it before the TUI launched. Only re-print on /clear (subsequent sessions).
-let isFirstSession = true;
 let approvalQuestionAbortInFlight = false;
 
 interface DeferredApprovalGate {
   gateId: string;
   basePath: string;
+}
+
+type WelcomeScreenModule = {
+  buildWelcomeScreenLines(opts: { version: string; remoteChannel?: string; width?: number }): string[];
+};
+
+async function loadWelcomeScreenModule(): Promise<WelcomeScreenModule | undefined> {
+  const candidates: string[] = [];
+  const gsdBinPath = process.env.GSD_BIN_PATH;
+  if (gsdBinPath) {
+    candidates.push(join(dirname(gsdBinPath), "welcome-screen.js"));
+  }
+
+  const packageRoot = process.env.GSD_PKG_ROOT;
+  if (packageRoot) {
+    candidates.push(join(packageRoot, "dist", "welcome-screen.js"));
+    candidates.push(join(packageRoot, "src", "welcome-screen.ts"));
+  }
+
+  for (const candidate of candidates) {
+    try {
+      if (!existsSync(candidate)) continue;
+      const mod = await import(pathToFileURL(candidate).href) as Partial<WelcomeScreenModule>;
+      if (typeof mod.buildWelcomeScreenLines === "function") {
+        return mod as WelcomeScreenModule;
+      }
+    } catch {
+      // Try the next package layout.
+    }
+  }
+  return undefined;
+}
+
+async function installWelcomeHeader(ctx: ExtensionContext): Promise<void> {
+  if (!ctx.hasUI || typeof ctx.ui?.setHeader !== "function") return;
+
+  try {
+    const welcome = await loadWelcomeScreenModule();
+    if (!welcome) return;
+
+    let remoteChannel: string | undefined;
+    try {
+      const { resolveRemoteConfig } = await import("../../remote-questions/config.js");
+      const rc = resolveRemoteConfig();
+      if (rc) remoteChannel = rc.channel;
+    } catch { /* non-fatal */ }
+
+    ctx.ui.setHeader(() => ({
+      render(width: number): string[] {
+        return welcome.buildWelcomeScreenLines({
+          version: process.env.GSD_VERSION || "0.0.0",
+          remoteChannel,
+          width,
+        });
+      },
+      invalidate(): void {},
+    }));
+  } catch {
+    /* non-fatal */
+  }
 }
 
 let deferredApprovalGate: DeferredApprovalGate | null = null;
@@ -382,28 +441,7 @@ export function registerHooks(
       const prefs = loadEffectiveGSDPreferences(basePath);
       process.env.GSD_SHOW_TOKEN_COST = prefs?.preferences.show_token_cost ? "1" : "";
     } catch { /* non-fatal */ }
-    if (isFirstSession) {
-      isFirstSession = false;
-    } else {
-      try {
-        const gsdBinPath = process.env.GSD_BIN_PATH;
-        if (gsdBinPath) {
-          const { dirname } = await import("node:path");
-          const { printWelcomeScreen } = await import(
-            join(dirname(gsdBinPath), "welcome-screen.js")
-          ) as { printWelcomeScreen: (opts: { version: string; modelName?: string; provider?: string; remoteChannel?: string }) => void };
-
-          let remoteChannel: string | undefined;
-          try {
-            const { resolveRemoteConfig } = await import("../../remote-questions/config.js");
-            const rc = resolveRemoteConfig();
-            if (rc) remoteChannel = rc.channel;
-          } catch { /* non-fatal */ }
-
-          printWelcomeScreen({ version: process.env.GSD_VERSION || "0.0.0", remoteChannel });
-        }
-      } catch { /* non-fatal */ }
-    }
+    await installWelcomeHeader(ctx);
     await loadToolApiKeysForSession();
     if (isAutoActive()) {
       ctx.ui.setWidget("gsd-health", undefined);

--- a/src/resources/extensions/gsd/db/unit-dispatches.ts
+++ b/src/resources/extensions/gsd/db/unit-dispatches.ts
@@ -98,6 +98,70 @@ function isAlreadyActiveConstraintError(err: unknown): boolean {
   return /\bUNIQUE\b|\bconstraint failed\b/i.test(msg);
 }
 
+function settleStaleActiveDispatchForUnit(input: RecordClaimInput, now: string): void {
+  const db = _getAdapter()!;
+  const active = db.prepare(
+    `SELECT id, status, worker_id, milestone_lease_token
+     FROM unit_dispatches
+     WHERE unit_id = :unit_id
+       AND status IN ('claimed','running')
+     ORDER BY id DESC
+     LIMIT 1`,
+  ).get({ ":unit_id": input.unitId }) as
+    | { id: number; status: DispatchStatus; worker_id: string; milestone_lease_token: number }
+    | undefined;
+
+  if (!active) return;
+  if (
+    active.worker_id === input.workerId &&
+    active.milestone_lease_token === input.milestoneLeaseToken
+  ) {
+    return;
+  }
+
+  const reason = "stale-dispatch-lease-takeover";
+  const result = db.prepare(
+    `UPDATE unit_dispatches
+     SET status = 'canceled',
+         ended_at = :ended_at,
+         exit_reason = :reason
+     WHERE id = :id
+       AND status IN ('claimed','running')
+       AND (worker_id != :worker_id OR milestone_lease_token != :token)`,
+  ).run({
+    ":id": active.id,
+    ":ended_at": now,
+    ":reason": reason,
+    ":worker_id": input.workerId,
+    ":token": input.milestoneLeaseToken,
+  });
+
+  const changes =
+    typeof (result as { changes?: unknown }).changes === "number"
+      ? (result as { changes: number }).changes
+      : 0;
+  if (changes < 1) return;
+
+  insertAuditEvent({
+    eventId: randomUUID(),
+    traceId: input.traceId,
+    turnId: input.turnId ?? undefined,
+    category: "orchestration",
+    type: "dispatch-stale-canceled",
+    ts: now,
+    payload: {
+      dispatchId: active.id,
+      unitId: input.unitId,
+      priorStatus: active.status,
+      priorWorkerId: active.worker_id,
+      priorMilestoneLeaseToken: active.milestone_lease_token,
+      takeoverWorkerId: input.workerId,
+      takeoverMilestoneLeaseToken: input.milestoneLeaseToken,
+      reason,
+    },
+  });
+}
+
 /**
  * Insert a new dispatch row in `claimed` state. Atomic guard against
  * double-claim (B2): the partial unique index
@@ -134,6 +198,8 @@ export function recordDispatchClaim(input: RecordClaimInput): RecordClaimResult 
         milestoneLeaseToken: input.milestoneLeaseToken,
       };
     }
+
+    settleStaleActiveDispatchForUnit(input, now);
 
     try {
       const result = db.prepare(

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -11,8 +11,11 @@ import {
   _hasPendingResolveForTest,
   _setActiveSession,
   _setSessionSwitchInFlight,
+  _markSessionSwitchAbortGraceWindow,
+  _clearSessionSwitchAbortGraceWindow,
   _consumePendingSwitchCancellation,
   isSessionSwitchInFlight,
+  isSessionSwitchAbortGraceActive,
 } from "../auto/resolve.js";
 import { runUnit } from "../auto/run-unit.js";
 import { autoLoop } from "../auto/loop.js";
@@ -2301,6 +2304,18 @@ test("resolveAgentEndCancelled queues cancellation that arrives during session s
   assert.equal(pending.errorContext.message, "Claude Code process aborted by user");
   assert.equal(_consumePendingSwitchCancellation(), null);
   _resetPendingResolve();
+});
+
+test("session-switch abort grace window is short-lived and resettable", () => {
+  _resetPendingResolve();
+
+  _markSessionSwitchAbortGraceWindow(1_000);
+
+  assert.equal(isSessionSwitchAbortGraceActive(Date.now()), true);
+  assert.equal(isSessionSwitchAbortGraceActive(Date.now() + 10_000), false);
+
+  _clearSessionSwitchAbortGraceWindow();
+  assert.equal(isSessionSwitchAbortGraceActive(), false);
 });
 
 // ─── #1571: artifact verification retry ──────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/session-start-footer.test.ts
+++ b/src/resources/extensions/gsd/tests/session-start-footer.test.ts
@@ -206,6 +206,83 @@ test("session_start does NOT call setFooter or suppress gsd-health when isAutoAc
   assert.equal(healthWidgetHideCount, 0, "gsd-health must NOT be hidden when isAutoActive() is false");
 });
 
+test("session_start installs the welcome screen as the TUI header", async (t) => {
+  const dir = join(
+    tmpdir(),
+    `gsd-welcome-header-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(join(dir, "bin"), { recursive: true });
+  mkdirSync(join(dir, "dist"), { recursive: true });
+  writeFileSync(join(dir, "bin", "welcome-screen.js"), "export const stale = true;\n", "utf-8");
+  writeFileSync(
+    join(dir, "dist", "welcome-screen.js"),
+    [
+      "export function buildWelcomeScreenLines(opts) {",
+      "  return [`welcome ${opts.version} ${opts.remoteChannel ?? 'none'} ${opts.width}`];",
+      "}",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const originalCwd = process.cwd();
+  const originalGsdPkgRoot = process.env.GSD_PKG_ROOT;
+  const originalGsdBinPath = process.env.GSD_BIN_PATH;
+  const originalGsdVersion = process.env.GSD_VERSION;
+  const originalFirstRunBanner = process.env.GSD_FIRST_RUN_BANNER;
+  process.chdir(dir);
+  process.env.GSD_PKG_ROOT = dir;
+  process.env.GSD_BIN_PATH = join(dir, "bin", "loader.js");
+  process.env.GSD_VERSION = "9.9.9-test";
+  delete process.env.GSD_FIRST_RUN_BANNER;
+  t.after(() => {
+    process.chdir(originalCwd);
+    if (originalGsdPkgRoot === undefined) delete process.env.GSD_PKG_ROOT;
+    else process.env.GSD_PKG_ROOT = originalGsdPkgRoot;
+    if (originalGsdBinPath === undefined) delete process.env.GSD_BIN_PATH;
+    else process.env.GSD_BIN_PATH = originalGsdBinPath;
+    if (originalGsdVersion === undefined) delete process.env.GSD_VERSION;
+    else process.env.GSD_VERSION = originalGsdVersion;
+    if (originalFirstRunBanner === undefined) delete process.env.GSD_FIRST_RUN_BANNER;
+    else process.env.GSD_FIRST_RUN_BANNER = originalFirstRunBanner;
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  const handlers = new Map<string, (event: unknown, ctx: any) => Promise<void> | void>();
+  const pi = {
+    on(event: string, handler: (event: unknown, ctx: any) => Promise<void> | void) {
+      handlers.set(event, handler);
+    },
+  } as any;
+
+  registerHooks(pi, []);
+
+  const sessionStart = handlers.get("session_start");
+  assert.ok(sessionStart, "session_start handler must be registered");
+
+  let headerFactory: ((tui: unknown, theme: unknown) => { render(width: number): string[] }) | undefined;
+  await sessionStart!({}, {
+    hasUI: true,
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setFooter: () => {},
+      setHeader: (factory: typeof headerFactory) => {
+        headerFactory = factory;
+      },
+      setWorkingMessage: () => {},
+      onTerminalInput: () => () => {},
+      setWidget: () => {},
+    },
+    sessionManager: { getSessionId: () => null },
+    model: null,
+  } as any);
+
+  assert.equal(typeof headerFactory, "function", "session_start should install a header factory");
+  const header = headerFactory!({}, {});
+  assert.deepEqual(header.render(123), ["welcome 9.9.9-test none 123"]);
+});
+
 test("session_start and session_switch apply disabled model provider policy from current preferences", async (t) => {
   const dir = join(
     tmpdir(),

--- a/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
+++ b/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
@@ -4,7 +4,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { _handleSessionSwitchAgentEnd } from "../bootstrap/agent-end-recovery.js";
+import {
+  _handleSessionSwitchAgentEnd,
+  isClaudeCodeSessionSwitchAbortMessage,
+} from "../bootstrap/agent-end-recovery.js";
 import type { ErrorContext } from "../auto/types.js";
 
 test("user-abort message during session-switch is dropped (not propagated as cancellation)", () => {
@@ -54,6 +57,48 @@ test("genuine stopReason='aborted' with errorMessage during session-switch still
     category: "aborted",
     isTransient: true,
   });
+});
+
+test("Claude Code stream-aborted placeholder during session-switch is dropped", () => {
+  let cancelledWith: unknown = null;
+  const resolveCancelled = (ctx: ErrorContext) => {
+    cancelledWith = ctx;
+    return true;
+  };
+
+  _handleSessionSwitchAgentEnd(
+    {
+      stopReason: "aborted",
+      content: [{ type: "text", text: "Claude Code stream aborted by caller" }],
+    },
+    resolveCancelled,
+  );
+
+  assert.equal(cancelledWith, null);
+});
+
+test("Claude Code session-switch abort detection is narrow", () => {
+  assert.equal(
+    isClaudeCodeSessionSwitchAbortMessage({
+      stopReason: "error",
+      content: [{ type: "text", text: "Claude Code error: Claude Code process aborted by user" }],
+    }),
+    true,
+  );
+  assert.equal(
+    isClaudeCodeSessionSwitchAbortMessage({
+      stopReason: "aborted",
+      content: [{ type: "text", text: "Claude Code stream aborted by caller" }],
+    }),
+    true,
+  );
+  assert.equal(
+    isClaudeCodeSessionSwitchAbortMessage({
+      stopReason: "aborted",
+      content: [{ type: "text", text: "partial output before network failure" }],
+    }),
+    false,
+  );
 });
 
 test("empty-content aborted during session-switch is silently ignored", () => {

--- a/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-dispatches.test.ts
@@ -13,7 +13,7 @@ import {
   insertSlice,
 } from "../gsd-db.ts";
 import { registerAutoWorker } from "../db/auto-workers.ts";
-import { claimMilestoneLease } from "../db/milestone-leases.ts";
+import { claimMilestoneLease, releaseMilestoneLease } from "../db/milestone-leases.ts";
 import {
   recordDispatchClaim,
   markRunning,
@@ -103,6 +103,55 @@ test("partial unique index rejects double-claim of the same active unit", (t) =>
     assert.equal(second.error, "already_active");
     assert.equal(second.existingWorker, workerId);
   }
+});
+
+test("recordDispatchClaim cancels stale active dispatch after lease takeover", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  const { workerId: firstWorkerId, leaseToken: firstLeaseToken } = setup(base);
+
+  const first = recordDispatchClaim({
+    traceId: "t-first",
+    workerId: firstWorkerId,
+    milestoneLeaseToken: firstLeaseToken,
+    milestoneId: "M001",
+    sliceId: "S01",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+  });
+  assert.equal(first.ok, true);
+  if (!first.ok) return;
+  markRunning(first.dispatchId);
+
+  assert.equal(releaseMilestoneLease(firstWorkerId, "M001", firstLeaseToken), true);
+  const takeoverWorkerId = registerAutoWorker({ projectRootRealpath: base });
+  const takeoverLease = claimMilestoneLease(takeoverWorkerId, "M001");
+  assert.equal(takeoverLease.ok, true);
+  if (!takeoverLease.ok) return;
+
+  const second = recordDispatchClaim({
+    traceId: "t-takeover",
+    workerId: takeoverWorkerId,
+    milestoneLeaseToken: takeoverLease.token,
+    milestoneId: "M001",
+    sliceId: "S01",
+    unitType: "plan-slice",
+    unitId: "M001/S01",
+    attemptN: 2,
+  });
+
+  assert.equal(second.ok, true);
+  if (!second.ok) return;
+
+  const recent = getRecentForUnit("M001/S01", 5);
+  assert.equal(recent.length, 2);
+  assert.equal(recent[0].id, second.dispatchId);
+  assert.equal(recent[0].status, "claimed");
+  assert.equal(recent[0].worker_id, takeoverWorkerId);
+  assert.equal(recent[0].attempt_n, 2);
+  assert.equal(recent[1].id, first.dispatchId);
+  assert.equal(recent[1].status, "canceled");
+  assert.equal(recent[1].exit_reason, "stale-dispatch-lease-takeover");
 });
 
 test("after markCompleted, a fresh claim for the same unit succeeds", (t) => {

--- a/src/welcome-screen.ts
+++ b/src/welcome-screen.ts
@@ -69,6 +69,7 @@ export interface WelcomeScreenOptions {
   modelName?: string
   provider?: string
   remoteChannel?: string
+  width?: number
 }
 
 function getShortCwd(): string {
@@ -87,17 +88,14 @@ function rpad(s: string, w: number): string {
   return s + ' '.repeat(Math.max(0, w - visLen(s)))
 }
 
-export function printWelcomeScreen(opts: WelcomeScreenOptions): void {
-  if (!process.stderr.isTTY) return
-
+export function buildWelcomeScreenLines(opts: WelcomeScreenOptions): string[] {
   const { version, remoteChannel } = opts
   const shortCwd = getShortCwd()
-  const termWidth = (process.stderr.columns || 80) - 1
+  const termWidth = Math.max(1, (opts.width ?? process.stderr.columns ?? 80) - 1)
 
   // Narrow terminal fallback
   if (termWidth < 70) {
-    process.stderr.write(`\n  Get Shit Done v${version}\n  ${shortCwd}\n\n`)
-    return
+    return ['', `  Get Shit Done v${version}`, `  ${shortCwd}`, '']
   }
 
   // ── Panel widths ────────────────────────────────────────────────────────────
@@ -196,5 +194,10 @@ export function printWelcomeScreen(opts: WelcomeScreenOptions): void {
   out.push(chalk.cyan(H.repeat(termWidth)))
   out.push('')
 
-  process.stderr.write(out.join('\n') + '\n')
+  return out
+}
+
+export function printWelcomeScreen(opts: WelcomeScreenOptions): void {
+  if (!process.stderr.isTTY) return
+  process.stderr.write(buildWelcomeScreenLines(opts).join('\n') + '\n')
 }


### PR DESCRIPTION
## TL;DR

**What:** Keeps the GSD welcome banner inside the interactive TUI as the session header.
**Why:** The previous pre-TUI stderr banner could disappear as soon as the TUI performed its first redraw.
**How:** Reuses the existing welcome renderer as a line-producing component, installs it through the GSD session_start hook, and removes the one-off CLI print path.

## What

This changes the startup welcome screen flow for interactive GSD sessions:

- `src/welcome-screen.ts` now exposes `buildWelcomeScreenLines(...)` so the existing banner can be rendered by TUI components.
- `src/resources/extensions/gsd/bootstrap/register-hooks.ts` installs the welcome screen as the custom TUI header during `session_start`.
- `src/cli.ts` no longer prints the welcome screen before `InteractiveMode` starts.
- `session-start-footer.test.ts` now covers the header installation path, including fallback past a stale module that lacks the new export.

## Why

The launch banner was written directly to stderr before the TUI owned the terminal. On startup, the TUI could then clear/redraw the viewport and replace the banner with the compact command-center view, making the first-screen welcome state flash and disappear.

Putting the same banner into the TUI header makes it part of the normal render tree, so subsequent redraws preserve it.

## How

The welcome renderer was split into a pure line builder plus the existing `printWelcomeScreen(...)` wrapper. The GSD extension loads that builder from the active package layout, verifies that the expected export exists, and registers a header component with `ctx.ui.setHeader(...)`.

The loader tries `GSD_BIN_PATH` ancestry first, then package `dist`, then source mode. That keeps packaged installs and source-dev runs working even when a stale `dist/welcome-screen.js` exists locally.

## Validation

- [x] `npm run test:compile`
- [x] `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/resources/extensions/gsd/tests/session-start-footer.test.js` — 6/6 passing
- [x] `node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/tests/welcome-screen.test.js` — 11/11 passing
- [x] Source-dev fallback smoke: `welcome header installed via source fallback`
- [ ] `npm run typecheck:extensions` — currently fails on unrelated existing errors around `workspaceRoot`, `getVisibleSkills`/`setVisibleSkills`, `requestCustomMessages`, and implicit `names` parameters in `token-tool-gating.test.ts`.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None expected.

## AI assistance

This PR is AI-assisted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced session-switch abort grace window for improved handling of rapid session transitions.

* **Bug Fixes**
  * Enhanced detection and handling of Claude Code abort messages during streaming operations.
  * Improved abort classification during session switches to prevent unnecessary cancellations.
  * Added TTY validation in interactive mode with clearer error messaging for non-terminal environments.
  * Better dispatch claim resolution when multiple workers access the same session.

* **Refactor**
  * Refactored welcome screen output generation for modular reusability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->