### PR TITLE
Recover stale GSD milestone leases before dispatch

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -38,7 +38,7 @@ import {
   getRecentForUnit as getRecentDispatchesForUnit,
   getRecentUnitKeysForProjectRoot,
 } from "../db/unit-dispatches.js";
-import { refreshMilestoneLease } from "../db/milestone-leases.js";
+import { claimMilestoneLease, refreshMilestoneLease } from "../db/milestone-leases.js";
 import { heartbeatAutoWorker } from "../db/auto-workers.js";
 import { getRuntimeKv, setRuntimeKv } from "../db/runtime-kv.js";
 import { resolveUokFlags } from "../uok/flags.js";
@@ -70,7 +70,7 @@ import {
 } from "./workflow-dispatch-ledger.js";
 import { emitOpenUnitEndForUnit } from "../crash-recovery.js";
 import { writeUnitRuntimeRecord } from "../unit-runtime.js";
-import { openDispatchClaim } from "./workflow-dispatch-claim.js";
+import { ensureDispatchLease, openDispatchClaim } from "./workflow-dispatch-claim.js";
 import { completeWorkflowIteration } from "./workflow-iteration-completion.js";
 import { createWorkflowJournalReporter } from "./workflow-journal-reporter.js";
 import { createWorkflowPhaseReporter } from "./workflow-phase-reporter.js";
@@ -162,6 +162,29 @@ function logDispatchClaimFailed(err: unknown): void {
   debugLog("autoLoop", {
     phase: "dispatch-claim-failed",
     error: err instanceof Error ? err.message : String(err),
+  });
+}
+
+function logDispatchLeaseRecovered(details: {
+  milestoneId: string;
+  workerId: string;
+  token: number;
+  recovered: boolean;
+}): void {
+  debugLog("autoLoop", {
+    phase: details.recovered ? "dispatch-lease-recovered" : "dispatch-lease-acquired",
+    ...details,
+  });
+}
+
+function logDispatchLeaseRecoveryFailed(details: {
+  milestoneId?: string;
+  workerId?: string;
+  reason: string;
+}): void {
+  debugLog("autoLoop", {
+    phase: "dispatch-lease-recovery-failed",
+    ...details,
   });
 }
 
@@ -273,6 +296,10 @@ export async function autoLoop(
       logHeartbeatFailure: err => debugLog("autoLoop", {
         phase: "heartbeat-failed",
         error: err instanceof Error ? err.message : String(err),
+      }),
+      logLeaseRefreshMiss: details => debugLog("autoLoop", {
+        phase: "lease-refresh-missed",
+        ...details,
       }),
     });
 
@@ -703,25 +730,74 @@ export async function autoLoop(
 
       // Phase B: claim a unit_dispatches row before invoking the unit. The
       // partial unique index idx_unit_dispatches_active_per_unit prevents
-      // a second worker from claiming the same unit concurrently. Returns
-      // null when DB unavailable, no worker registered, or no active lease
-      // — those degraded paths fall through to the existing single-worker
-      // semantics with no ledger entry, preserving back-compat.
-      const dispatchClaim = openDispatchClaim(s, flowId, turnId, iterData, {
+      // a second worker from claiming the same unit concurrently. When this
+      // process has a worker identity, make the milestone lease explicit before
+      // claiming so a step-mode handoff cannot leave us running with a stale
+      // in-memory token and no backing lease row.
+      const leaseBeforeClaim = ensureDispatchLease(s, iterData.mid, {
+        claimMilestoneLease,
+        logLeaseRecovered: logDispatchLeaseRecovered,
+        logLeaseRecoveryFailed: logDispatchLeaseRecoveryFailed,
+      });
+      if (leaseBeforeClaim.kind === "blocked" || leaseBeforeClaim.kind === "failed") {
+        const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} before dispatching ${iterData.unitType} ${iterData.unitId}: ${leaseBeforeClaim.reason}`;
+        ctx.ui.notify(msg, "error");
+        finishTurn("stopped", "execution", msg);
+        await deps.stopAuto(ctx, pi, msg);
+        break;
+      }
+
+      let dispatchClaim = openDispatchClaim(s, flowId, turnId, iterData, {
         getRecentDispatchesForUnit,
         recordDispatchClaim,
         markDispatchRunning,
         logClaimRejected: logDispatchClaimRejected,
         logClaimFailed: logDispatchClaimFailed,
       });
-      const dispatchDecision = decideDispatchClaim(
+      let dispatchDecision = decideDispatchClaim(
         dispatchClaim.kind === "opened"
           ? { kind: "opened", dispatchId: dispatchClaim.dispatchId }
           : dispatchClaim.kind === "skip"
             ? { kind: "skip", reason: dispatchClaim.reason }
             : { kind: "degraded" },
       );
+      if (dispatchDecision.action === "skip" && dispatchDecision.reason === "stale-lease") {
+        const leaseRecovery = ensureDispatchLease(s, iterData.mid, {
+          claimMilestoneLease,
+          logLeaseRecovered: logDispatchLeaseRecovered,
+          logLeaseRecoveryFailed: logDispatchLeaseRecoveryFailed,
+        }, { forceReclaim: true });
+        if (leaseRecovery.kind === "ready") {
+          dispatchClaim = openDispatchClaim(s, flowId, turnId, iterData, {
+            getRecentDispatchesForUnit,
+            recordDispatchClaim,
+            markDispatchRunning,
+            logClaimRejected: logDispatchClaimRejected,
+            logClaimFailed: logDispatchClaimFailed,
+          });
+          dispatchDecision = decideDispatchClaim(
+            dispatchClaim.kind === "opened"
+              ? { kind: "opened", dispatchId: dispatchClaim.dispatchId }
+              : dispatchClaim.kind === "skip"
+                ? { kind: "skip", reason: dispatchClaim.reason }
+                : { kind: "degraded" },
+          );
+        } else {
+          const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} while claiming ${iterData.unitType} ${iterData.unitId}: ${leaseRecovery.reason}`;
+          ctx.ui.notify(msg, "error");
+          finishTurn("stopped", "execution", msg);
+          await deps.stopAuto(ctx, pi, msg);
+          break;
+        }
+      }
       if (dispatchDecision.action === "skip") {
+        if (dispatchDecision.reason === "stale-lease") {
+          const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} while claiming ${iterData.unitType} ${iterData.unitId}; dispatch claim still failed after recovery.`;
+          ctx.ui.notify(msg, "error");
+          finishTurn("stopped", "execution", msg);
+          await deps.stopAuto(ctx, pi, msg);
+          break;
+        }
         finishTurn("skipped", "execution", dispatchDecision.reason);
         continue;
       }

--- a/src/resources/extensions/gsd/auto/workflow-dispatch-claim.ts
+++ b/src/resources/extensions/gsd/auto/workflow-dispatch-claim.ts
@@ -9,6 +9,16 @@ export type DispatchClaimOutcome =
   | { kind: "skip"; reason: "already-active" | "stale-lease"; existingId?: number; existingWorker?: string }
   | { kind: "degraded" };
 
+export type DispatchLeaseOutcome =
+  | { kind: "ready"; token: number; recovered: boolean }
+  | { kind: "degraded"; reason: "missing-worker" | "missing-milestone" }
+  | { kind: "blocked"; reason: string }
+  | { kind: "failed"; reason: string };
+
+type ClaimMilestoneLeaseResult =
+  | { ok: true; token: number; expiresAt: string }
+  | { ok: false; error: "held_by"; byWorker: string; expiresAt: string };
+
 interface RecentDispatch {
   attempt_n?: number | null;
 }
@@ -44,6 +54,58 @@ export interface OpenDispatchClaimDeps {
   logClaimFailed: (err: unknown) => void;
 }
 
+export interface EnsureDispatchLeaseDeps {
+  claimMilestoneLease: (workerId: string, milestoneId: string) => ClaimMilestoneLeaseResult;
+  logLeaseRecovered: (details: {
+    milestoneId: string;
+    workerId: string;
+    token: number;
+    recovered: boolean;
+  }) => void;
+  logLeaseRecoveryFailed: (details: {
+    milestoneId?: string;
+    workerId?: string;
+    reason: string;
+  }) => void;
+}
+
+export function ensureDispatchLease(
+  s: AutoSession,
+  milestoneId: string | undefined,
+  deps: EnsureDispatchLeaseDeps,
+  opts: { forceReclaim?: boolean } = {},
+): DispatchLeaseOutcome {
+  if (!s.workerId) return { kind: "degraded", reason: "missing-worker" };
+  if (!milestoneId) return { kind: "degraded", reason: "missing-milestone" };
+  if (!opts.forceReclaim && typeof s.milestoneLeaseToken === "number") {
+    return { kind: "ready", token: s.milestoneLeaseToken, recovered: false };
+  }
+
+  s.milestoneLeaseToken = null;
+  try {
+    const claim = deps.claimMilestoneLease(s.workerId, milestoneId);
+    if (!claim.ok) {
+      const reason = `Milestone ${milestoneId} is held by worker ${claim.byWorker} until ${claim.expiresAt}.`;
+      deps.logLeaseRecoveryFailed({ milestoneId, workerId: s.workerId, reason });
+      return { kind: "blocked", reason };
+    }
+
+    s.currentMilestoneId = milestoneId;
+    s.milestoneLeaseToken = claim.token;
+    deps.logLeaseRecovered({
+      milestoneId,
+      workerId: s.workerId,
+      token: claim.token,
+      recovered: opts.forceReclaim === true,
+    });
+    return { kind: "ready", token: claim.token, recovered: opts.forceReclaim === true };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    deps.logLeaseRecoveryFailed({ milestoneId, workerId: s.workerId, reason });
+    return { kind: "failed", reason };
+  }
+}
+
 export function openDispatchClaim(
   s: AutoSession,
   flowId: string,
@@ -51,7 +113,7 @@ export function openDispatchClaim(
   iterData: IterationData,
   deps: OpenDispatchClaimDeps,
 ): DispatchClaimOutcome {
-  if (!s.workerId || s.milestoneLeaseToken === null) return { kind: "degraded" };
+  if (!s.workerId || typeof s.milestoneLeaseToken !== "number") return { kind: "degraded" };
   const mid = iterData.mid;
   if (!mid) return { kind: "degraded" };
 

--- a/src/resources/extensions/gsd/auto/workflow-worker-heartbeat.ts
+++ b/src/resources/extensions/gsd/auto/workflow-worker-heartbeat.ts
@@ -15,6 +15,11 @@ export interface MaintainWorkerHeartbeatDeps {
     fencingToken: number,
   ) => boolean;
   logHeartbeatFailure: (err: unknown) => void;
+  logLeaseRefreshMiss?: (details: {
+    workerId: string;
+    milestoneId: string;
+    fencingToken: number;
+  }) => void;
 }
 
 export function maintainWorkerHeartbeat(
@@ -26,11 +31,19 @@ export function maintainWorkerHeartbeat(
   try {
     deps.heartbeatAutoWorker(session.workerId);
     if (session.currentMilestoneId && session.milestoneLeaseToken) {
-      deps.refreshMilestoneLease(
+      const refreshed = deps.refreshMilestoneLease(
         session.workerId,
         session.currentMilestoneId,
         session.milestoneLeaseToken,
       );
+      if (!refreshed) {
+        deps.logLeaseRefreshMiss?.({
+          workerId: session.workerId,
+          milestoneId: session.currentMilestoneId,
+          fencingToken: session.milestoneLeaseToken,
+        });
+        session.milestoneLeaseToken = null;
+      }
     }
   } catch (err) {
     deps.logHeartbeatFailure(err);

--- a/src/resources/extensions/gsd/tests/workflow-dispatch-claim.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-dispatch-claim.test.ts
@@ -7,7 +7,9 @@ import test from "node:test";
 import type { AutoSession } from "../auto/session.ts";
 import type { IterationData } from "../auto/types.ts";
 import {
+  ensureDispatchLease,
   openDispatchClaim,
+  type EnsureDispatchLeaseDeps,
   type OpenDispatchClaimDeps,
 } from "../auto/workflow-dispatch-claim.ts";
 
@@ -47,6 +49,25 @@ function makeDeps(overrides?: Partial<OpenDispatchClaimDeps>): OpenDispatchClaim
     logClaimFailed: () => {},
     ...overrides,
   };
+}
+
+function makeLeaseDeps(overrides?: Partial<EnsureDispatchLeaseDeps>): {
+  deps: EnsureDispatchLeaseDeps;
+  calls: unknown[];
+  failures: unknown[];
+} {
+  const calls: unknown[] = [];
+  const failures: unknown[] = [];
+  const deps: EnsureDispatchLeaseDeps = {
+    claimMilestoneLease: (workerId, milestoneId) => {
+      calls.push(["claim", workerId, milestoneId]);
+      return { ok: true, token: 8, expiresAt: "2030-01-01T00:00:00.000Z" };
+    },
+    logLeaseRecovered: details => calls.push(["recovered", details]),
+    logLeaseRecoveryFailed: details => failures.push(details),
+    ...overrides,
+  };
+  return { deps, calls, failures };
 }
 
 test("openDispatchClaim degrades when worker identity or lease token is missing", () => {
@@ -155,4 +176,125 @@ test("openDispatchClaim degrades on claim write failures", () => {
 
   assert.deepEqual(outcome, { kind: "degraded" });
   assert.deepEqual(logged, [writeError]);
+});
+
+test("ensureDispatchLease degrades without worker identity or milestone id", () => {
+  const { deps, calls } = makeLeaseDeps({
+    claimMilestoneLease: () => assert.fail("claimMilestoneLease should not be called"),
+  });
+
+  assert.deepEqual(
+    ensureDispatchLease(makeSession({ workerId: null }), "M001", deps),
+    { kind: "degraded", reason: "missing-worker" },
+  );
+  assert.deepEqual(
+    ensureDispatchLease(makeSession(), undefined, deps),
+    { kind: "degraded", reason: "missing-milestone" },
+  );
+  assert.deepEqual(calls, []);
+});
+
+test("ensureDispatchLease reuses an existing numeric token", () => {
+  const { deps, calls } = makeLeaseDeps({
+    claimMilestoneLease: () => assert.fail("claimMilestoneLease should not be called"),
+  });
+
+  const session = makeSession({ milestoneLeaseToken: 7 });
+  const outcome = ensureDispatchLease(session, "M001", deps);
+
+  assert.deepEqual(outcome, { kind: "ready", token: 7, recovered: false });
+  assert.equal(session.milestoneLeaseToken, 7);
+  assert.deepEqual(calls, []);
+});
+
+test("ensureDispatchLease claims a lease when the session has no token", () => {
+  const { deps, calls, failures } = makeLeaseDeps();
+  const session = makeSession({
+    currentMilestoneId: "M001",
+    milestoneLeaseToken: null,
+  });
+
+  const outcome = ensureDispatchLease(session, "M001", deps);
+
+  assert.deepEqual(outcome, { kind: "ready", token: 8, recovered: false });
+  assert.equal(session.currentMilestoneId, "M001");
+  assert.equal(session.milestoneLeaseToken, 8);
+  assert.deepEqual(calls, [
+    ["claim", "worker-1", "M001"],
+    ["recovered", {
+      milestoneId: "M001",
+      workerId: "worker-1",
+      token: 8,
+      recovered: false,
+    }],
+  ]);
+  assert.deepEqual(failures, []);
+});
+
+test("ensureDispatchLease force-reclaims after a stale dispatch claim", () => {
+  const { deps, calls } = makeLeaseDeps({
+    claimMilestoneLease: (workerId, milestoneId) => {
+      calls.push(["claim", workerId, milestoneId]);
+      return { ok: true, token: 9, expiresAt: "2030-01-01T00:00:00.000Z" };
+    },
+  });
+  const session = makeSession({ milestoneLeaseToken: 7 });
+
+  const outcome = ensureDispatchLease(session, "M001", deps, { forceReclaim: true });
+
+  assert.deepEqual(outcome, { kind: "ready", token: 9, recovered: true });
+  assert.equal(session.milestoneLeaseToken, 9);
+  assert.deepEqual(calls, [
+    ["claim", "worker-1", "M001"],
+    ["recovered", {
+      milestoneId: "M001",
+      workerId: "worker-1",
+      token: 9,
+      recovered: true,
+    }],
+  ]);
+});
+
+test("ensureDispatchLease blocks when another worker holds the lease", () => {
+  const { deps, failures } = makeLeaseDeps({
+    claimMilestoneLease: () => ({
+      ok: false,
+      error: "held_by",
+      byWorker: "worker-2",
+      expiresAt: "2030-01-01T00:00:00.000Z",
+    }),
+  });
+  const session = makeSession({ milestoneLeaseToken: null });
+
+  const outcome = ensureDispatchLease(session, "M001", deps);
+
+  assert.deepEqual(outcome, {
+    kind: "blocked",
+    reason: "Milestone M001 is held by worker worker-2 until 2030-01-01T00:00:00.000Z.",
+  });
+  assert.equal(session.milestoneLeaseToken, null);
+  assert.deepEqual(failures, [{
+    milestoneId: "M001",
+    workerId: "worker-1",
+    reason: "Milestone M001 is held by worker worker-2 until 2030-01-01T00:00:00.000Z.",
+  }]);
+});
+
+test("ensureDispatchLease fails closed on claim errors", () => {
+  const { deps, failures } = makeLeaseDeps({
+    claimMilestoneLease: () => {
+      throw new Error("db unavailable");
+    },
+  });
+  const session = makeSession({ milestoneLeaseToken: null });
+
+  const outcome = ensureDispatchLease(session, "M001", deps);
+
+  assert.deepEqual(outcome, { kind: "failed", reason: "db unavailable" });
+  assert.equal(session.milestoneLeaseToken, null);
+  assert.deepEqual(failures, [{
+    milestoneId: "M001",
+    workerId: "worker-1",
+    reason: "db unavailable",
+  }]);
 });

--- a/src/resources/extensions/gsd/tests/workflow-worker-heartbeat.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-worker-heartbeat.test.ts
@@ -14,9 +14,11 @@ function makeDeps(overrides?: Partial<MaintainWorkerHeartbeatDeps>): {
   deps: MaintainWorkerHeartbeatDeps;
   calls: unknown[];
   errors: unknown[];
+  misses: unknown[];
 } {
   const calls: unknown[] = [];
   const errors: unknown[] = [];
+  const misses: unknown[] = [];
   const deps: MaintainWorkerHeartbeatDeps = {
     heartbeatAutoWorker: workerId => calls.push(["heartbeat", workerId]),
     refreshMilestoneLease: (workerId, milestoneId, token) => {
@@ -24,9 +26,10 @@ function makeDeps(overrides?: Partial<MaintainWorkerHeartbeatDeps>): {
       return true;
     },
     logHeartbeatFailure: err => errors.push(err),
+    logLeaseRefreshMiss: details => misses.push(details),
     ...overrides,
   };
-  return { deps, calls, errors };
+  return { deps, calls, errors, misses };
 }
 
 test("maintainWorkerHeartbeat no-ops without a worker id", () => {
@@ -120,4 +123,32 @@ test("maintainWorkerHeartbeat logs and suppresses lease refresh failures", () =>
     ["refresh", "worker-1", "M001", 7],
   ]);
   assert.deepEqual(errors, [failure]);
+});
+
+test("maintainWorkerHeartbeat clears stale lease tokens when refresh misses", () => {
+  const { deps, calls, errors, misses } = makeDeps({
+    refreshMilestoneLease: (workerId, milestoneId, token) => {
+      calls.push(["refresh", workerId, milestoneId, token]);
+      return false;
+    },
+  });
+  const session: WorkerHeartbeatSession = {
+    workerId: "worker-1",
+    currentMilestoneId: "M001",
+    milestoneLeaseToken: 7,
+  };
+
+  maintainWorkerHeartbeat(session, deps);
+
+  assert.deepEqual(calls, [
+    ["heartbeat", "worker-1"],
+    ["refresh", "worker-1", "M001", 7],
+  ]);
+  assert.deepEqual(errors, []);
+  assert.deepEqual(misses, [{
+    workerId: "worker-1",
+    milestoneId: "M001",
+    fencingToken: 7,
+  }]);
+  assert.equal(session.milestoneLeaseToken, null);
 });


### PR DESCRIPTION
Closes #5560
Related to #5268

## TL;DR

**What:** Re-validate/recover the milestone lease at the dispatch boundary before writing `unit_dispatches`.

**Why:** A fresh project handoff can leave auto-mode with a worker identity but no live `milestone_leases` row, causing `execute-task` to be skipped as `stale-lease` until stuck detection blames a missing task summary.

**How:** Clear stale heartbeat tokens, claim/reclaim leases before dispatch, retry one stale-lease claim, and stop with an explicit lost-lease error if recovery cannot proceed.

## What

- Added `ensureDispatchLease` to turn missing/stale milestone lease state into an explicit ready/blocked/failed decision before dispatch.
- Updated auto-loop dispatch claim handling to recover from `stale-lease` once, then fail closed with a clear control-plane error instead of silently skipping turns.
- Updated worker heartbeat refresh handling so a missed lease refresh clears the in-memory token.
- Added focused unit coverage for missing-token claim, force re-claim, held-by-other-worker, claim exceptions, and heartbeat refresh misses.

## Why

The observed incident was not a provider execution failure. The provider never started `execute-task M001/S01/T01`; `recordDispatchClaim` rejected the unit as `stale-lease` and auto-mode repeatedly skipped it until the stuck detector reported a missing `T01-SUMMARY.md`. That recovery hint was downstream noise because the summary could never have been written.

This patch treats a missing/stale milestone lease as a control-plane invariant to repair before dispatching work.

## How

- `maintainWorkerHeartbeat` now treats a false `refreshMilestoneLease` as a lease miss, logs it, and invalidates the session token.
- `autoLoop` calls `ensureDispatchLease` before `openDispatchClaim` when a worker/milestone is present.
- A `stale-lease` dispatch skip triggers one forced lease re-claim and claim retry.
- Recovery blocked by another worker or DB failure stops auto-mode with an explicit lease message.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-dispatch-claim.test.ts src/resources/extensions/gsd/tests/workflow-worker-heartbeat.test.ts`
- [x] `npm run typecheck:extensions` (completed inside `npm run verify:pr` after `build:core`)
- [x] `npm run test:compile`
- [x] `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test dist-test/src/resources/extensions/gsd/tests/workflow-dispatch-claim.test.js dist-test/src/resources/extensions/gsd/tests/workflow-worker-heartbeat.test.js`
- [x] `git diff --check`
- [ ] `npm run verify:pr` - core build and extension typecheck completed, then full compiled unit run failed in unrelated existing tests: `.ts` import-resolution failures in prompt/extension import tests, one `metrics-lock-retry-sleep` timing assertion, and `auto-supervisor.test.mjs`; summary was `9201 passed, 18 failed, 9 skipped`.

## Checklist

- [x] Linked issue included.
- [x] Branch uses CONTRIBUTING naming convention.
- [x] Commit uses Conventional Commits.
- [x] Tests added/updated for changed behavior.
- [x] AI-assisted development disclosed: implemented with Codex assistance and locally verified as listed above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-dispatch workflow now automatically validates milestone lease availability before opening dispatch claims, with built-in recovery attempts for stale lease scenarios.

* **Bug Fixes**
  * Improved monitoring of lease refresh failures with enhanced error handling. Sessions properly clear stale lease tokens, and users receive timely notifications when lease acquisition fails or is blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->