### PR TITLE
feat(tui): show tool targets in compact output

### DIFF
--- a/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
+++ b/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
@@ -1049,7 +1049,9 @@ test("chat-controller rolls up only contiguous low-signal tool runs on message_e
 	assert.equal(host.chatContainer.children[1]?.constructor?.name, "AssistantMessageComponent");
 	assert.equal(host.chatContainer.children[2]?.constructor?.name, "ToolPhaseSummaryComponent");
 	assert.match(host.chatContainer.children[0].render(120).join("\n"), /Setup \/ shell 2 actions/);
-	assert.match(host.chatContainer.children[2].render(120).join("\n"), /Context reads 2 actions/);
+	const readSummary = host.chatContainer.children[2].render(120).join("\n");
+	assert.match(readSummary, /Context reads · 2 files/);
+	assert.match(readSummary, /\/tmp\/a · \/tmp\/b/);
 	assert.equal(host.chatContainer._prevRender, null, "summary reposition must invalidate the chat container render cache");
 });
 

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -69,6 +69,7 @@ import type {
 	LsToolInput,
 	ReadToolDetails,
 	ReadToolInput,
+	WriteToolDetails,
 	WriteToolInput,
 } from "../tools/index.js";
 
@@ -1031,7 +1032,7 @@ export interface EditToolResultEvent extends ToolResultEventBase {
 
 export interface WriteToolResultEvent extends ToolResultEventBase {
 	toolName: "write";
-	details: undefined;
+	details: WriteToolDetails | undefined;
 }
 
 export interface GrepToolResultEvent extends ToolResultEventBase {

--- a/packages/pi-coding-agent/src/core/tools/bash.ts
+++ b/packages/pi-coding-agent/src/core/tools/bash.ts
@@ -116,6 +116,7 @@ const bashSchema = Type.Object({
 export type BashToolInput = Static<typeof bashSchema>;
 
 export interface BashToolDetails {
+	cwd?: string;
 	truncation?: TruncationResult;
 	fullOutputPath?: string;
 	artifactId?: string;
@@ -384,6 +385,7 @@ export function createBashTool(cwd: string, options?: BashToolOptions): AgentToo
 						onUpdate({
 							content: [{ type: "text", text: truncation.content || "" }],
 							details: {
+								cwd: spawnContext.cwd,
 								truncation: truncation.truncated ? truncation : undefined,
 								fullOutputPath: spillFilePath,
 							},
@@ -412,10 +414,11 @@ export function createBashTool(cwd: string, options?: BashToolOptions): AgentToo
 						let outputText = truncation.content || "(no output)";
 
 						// Build details with truncation info
-						let details: BashToolDetails | undefined;
+						let details: BashToolDetails | undefined = { cwd: spawnContext.cwd };
 
 						if (truncation.truncated) {
 							details = {
+								...details,
 								truncation,
 								fullOutputPath: spillFilePath,
 								...(spillArtifactId ? { artifactId: spillArtifactId } : {}),

--- a/packages/pi-coding-agent/src/core/tools/edit.ts
+++ b/packages/pi-coding-agent/src/core/tools/edit.ts
@@ -13,6 +13,7 @@ import {
 } from "./edit-diff.js";
 import { notifyFileChanged } from "../lsp/client.js";
 import { resolveToCwd } from "./path-utils.js";
+import { createToolTarget, type ToolTargetMetadata } from "./tool-target.js";
 
 const editSchema = Type.Object({
 	path: Type.String({ description: "Path to the file to edit (relative or absolute)" }),
@@ -27,6 +28,7 @@ export interface EditToolDetails {
 	diff: string;
 	/** Line number of the first change in the new file (for editor navigation) */
 	firstChangedLine?: number;
+	target?: ToolTargetMetadata;
 }
 
 /**
@@ -208,7 +210,17 @@ export function createEditTool(cwd: string, options?: EditToolOptions): AgentToo
 									text: `Successfully replaced text in ${path}.`,
 								},
 							],
-							details: { diff: diffResult.diff, firstChangedLine: diffResult.firstChangedLine },
+							details: {
+								diff: diffResult.diff,
+								firstChangedLine: diffResult.firstChangedLine,
+								target: createToolTarget({
+									kind: "file",
+									action: "edit",
+									inputPath: path,
+									resolvedPath: absolutePath,
+									line: diffResult.firstChangedLine,
+								}),
+							},
 						});
 					} catch (error: any) {
 						// Clean up abort handler

--- a/packages/pi-coding-agent/src/core/tools/find.ts
+++ b/packages/pi-coding-agent/src/core/tools/find.ts
@@ -5,6 +5,7 @@ import { existsSync } from "fs";
 import path from "path";
 import { FIND_DEFAULT_LIMIT } from "../constants.js";
 import { resolveToCwd } from "./path-utils.js";
+import { createToolTarget, type ToolTargetMetadata } from "./tool-target.js";
 import { DEFAULT_MAX_BYTES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
 
 const findSchema = Type.Object({
@@ -20,6 +21,7 @@ export type FindToolInput = Static<typeof findSchema>;
 const DEFAULT_LIMIT = FIND_DEFAULT_LIMIT;
 
 export interface FindToolDetails {
+	target?: ToolTargetMetadata;
 	truncation?: TruncationResult;
 	resultLimitReached?: number;
 }
@@ -73,6 +75,13 @@ export function createFindTool(cwd: string, options?: FindToolOptions): AgentToo
 				(async () => {
 					try {
 						const searchPath = resolveToCwd(searchDir || ".", cwd);
+						const target = createToolTarget({
+							kind: "search",
+							action: "find",
+							inputPath: searchDir || ".",
+							resolvedPath: searchPath,
+							pattern,
+						});
 						const effectiveLimit = limit ?? DEFAULT_LIMIT;
 						const ops = customOps ?? defaultFindOperations;
 
@@ -93,7 +102,7 @@ export function createFindTool(cwd: string, options?: FindToolOptions): AgentToo
 							if (results.length === 0) {
 								resolve({
 									content: [{ type: "text", text: "No files found matching pattern" }],
-									details: undefined,
+									details: { target },
 								});
 								return;
 							}
@@ -111,7 +120,7 @@ export function createFindTool(cwd: string, options?: FindToolOptions): AgentToo
 							const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
 
 							let resultOutput = truncation.content;
-							const details: FindToolDetails = {};
+							const details: FindToolDetails = { target };
 							const notices: string[] = [];
 
 							if (resultLimitReached) {
@@ -130,7 +139,7 @@ export function createFindTool(cwd: string, options?: FindToolOptions): AgentToo
 
 							resolve({
 								content: [{ type: "text", text: resultOutput }],
-								details: Object.keys(details).length > 0 ? details : undefined,
+								details,
 							});
 							return;
 						}
@@ -150,7 +159,7 @@ export function createFindTool(cwd: string, options?: FindToolOptions): AgentToo
 						if (globResult.matches.length === 0) {
 							resolve({
 								content: [{ type: "text", text: "No files found matching pattern" }],
-								details: undefined,
+								details: { target },
 							});
 							return;
 						}
@@ -163,7 +172,7 @@ export function createFindTool(cwd: string, options?: FindToolOptions): AgentToo
 						const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
 
 						let resultOutput = truncation.content;
-						const details: FindToolDetails = {};
+						const details: FindToolDetails = { target };
 						const notices: string[] = [];
 
 						if (resultLimitReached) {
@@ -184,7 +193,7 @@ export function createFindTool(cwd: string, options?: FindToolOptions): AgentToo
 
 						resolve({
 							content: [{ type: "text", text: resultOutput }],
-							details: Object.keys(details).length > 0 ? details : undefined,
+							details,
 						});
 					} catch (e: any) {
 						signal?.removeEventListener("abort", onAbort);

--- a/packages/pi-coding-agent/src/core/tools/grep.ts
+++ b/packages/pi-coding-agent/src/core/tools/grep.ts
@@ -6,6 +6,7 @@ import { readFileSync, statSync } from "fs";
 import path from "path";
 import { ensureTool } from "../../utils/tools-manager.js";
 import { resolveToCwd } from "./path-utils.js";
+import { createToolTarget, type ToolTargetMetadata } from "./tool-target.js";
 import {
 	DEFAULT_MAX_BYTES,
 	formatSize,
@@ -34,6 +35,7 @@ export type GrepToolInput = Static<typeof grepSchema>;
 const DEFAULT_LIMIT = 100;
 
 export interface GrepToolDetails {
+	target?: ToolTargetMetadata;
 	truncation?: TruncationResult;
 	matchLimitReached?: number;
 	linesTruncated?: boolean;
@@ -112,6 +114,14 @@ export function createGrepTool(cwd: string, options?: GrepToolOptions): AgentToo
 						}
 
 						const searchPath = resolveToCwd(searchDir || ".", cwd);
+						const target = createToolTarget({
+							kind: "search",
+							action: "grep",
+							inputPath: searchDir || ".",
+							resolvedPath: searchPath,
+							pattern,
+							glob,
+						});
 						const ops = customOps ?? defaultGrepOperations;
 
 						let isDirectory: boolean;
@@ -282,7 +292,7 @@ export function createGrepTool(cwd: string, options?: GrepToolOptions): AgentToo
 
 							if (matchCount === 0) {
 								settle(() =>
-									resolve({ content: [{ type: "text", text: "No matches found" }], details: undefined }),
+									resolve({ content: [{ type: "text", text: "No matches found" }], details: { target } }),
 								);
 								return;
 							}
@@ -298,7 +308,7 @@ export function createGrepTool(cwd: string, options?: GrepToolOptions): AgentToo
 							const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
 
 							let output = truncation.content;
-							const details: GrepToolDetails = {};
+							const details: GrepToolDetails = { target };
 
 							// Build notices
 							const notices: string[] = [];
@@ -329,7 +339,7 @@ export function createGrepTool(cwd: string, options?: GrepToolOptions): AgentToo
 							settle(() =>
 								resolve({
 									content: [{ type: "text", text: output }],
-									details: Object.keys(details).length > 0 ? details : undefined,
+									details,
 								}),
 							);
 						});

--- a/packages/pi-coding-agent/src/core/tools/hashline-read.ts
+++ b/packages/pi-coding-agent/src/core/tools/hashline-read.ts
@@ -17,6 +17,7 @@ import { formatDimensionNote, resizeImage } from "../../utils/image-resize.js";
 import { detectSupportedImageMimeTypeFromFile } from "../../utils/mime.js";
 import { formatHashLines } from "./hashline.js";
 import { resolveReadPath } from "./path-utils.js";
+import { createToolTarget, type ToolTargetMetadata } from "./tool-target.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
 
 const readSchema = Type.Object({
@@ -28,6 +29,7 @@ const readSchema = Type.Object({
 export type HashlineReadToolInput = Static<typeof readSchema>;
 
 export interface HashlineReadToolDetails {
+	target?: ToolTargetMetadata;
 	truncation?: TruncationResult;
 }
 
@@ -66,6 +68,19 @@ export function createHashlineReadTool(cwd: string, options?: HashlineReadToolOp
 			signal?: AbortSignal,
 		) => {
 			const absolutePath = resolveReadPath(path, cwd);
+			const target = createToolTarget({
+				kind: "file",
+				action: "read",
+				inputPath: path,
+				resolvedPath: absolutePath,
+				range:
+					offset !== undefined || limit !== undefined
+						? {
+								start: offset ?? 1,
+								end: limit !== undefined ? (offset ?? 1) + Math.max(0, limit - 1) : undefined,
+							}
+						: undefined,
+			});
 
 			return new Promise<{ content: (TextContent | ImageContent)[]; details: HashlineReadToolDetails | undefined }>(
 				(resolve, reject) => {
@@ -186,7 +201,7 @@ export function createHashlineReadTool(cwd: string, options?: HashlineReadToolOp
 							if (aborted) return;
 
 							if (signal) signal.removeEventListener("abort", onAbort);
-							resolve({ content, details });
+							resolve({ content, details: { ...details, target } });
 						} catch (error: any) {
 							if (signal) signal.removeEventListener("abort", onAbort);
 							if (!aborted) {

--- a/packages/pi-coding-agent/src/core/tools/hashline-read.ts
+++ b/packages/pi-coding-agent/src/core/tools/hashline-read.ts
@@ -17,7 +17,7 @@ import { formatDimensionNote, resizeImage } from "../../utils/image-resize.js";
 import { detectSupportedImageMimeTypeFromFile } from "../../utils/mime.js";
 import { formatHashLines } from "./hashline.js";
 import { resolveReadPath } from "./path-utils.js";
-import { createToolTarget, type ToolTargetMetadata } from "./tool-target.js";
+import { createReadFileTarget, type ToolTargetMetadata } from "./tool-target.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
 
 const readSchema = Type.Object({
@@ -68,19 +68,7 @@ export function createHashlineReadTool(cwd: string, options?: HashlineReadToolOp
 			signal?: AbortSignal,
 		) => {
 			const absolutePath = resolveReadPath(path, cwd);
-			const target = createToolTarget({
-				kind: "file",
-				action: "read",
-				inputPath: path,
-				resolvedPath: absolutePath,
-				range:
-					offset !== undefined || limit !== undefined
-						? {
-								start: offset ?? 1,
-								end: limit !== undefined ? (offset ?? 1) + Math.max(0, limit - 1) : undefined,
-							}
-						: undefined,
-			});
+			const target = createReadFileTarget(path, absolutePath, offset, limit);
 
 			return new Promise<{ content: (TextContent | ImageContent)[]; details: HashlineReadToolDetails | undefined }>(
 				(resolve, reject) => {

--- a/packages/pi-coding-agent/src/core/tools/index.ts
+++ b/packages/pi-coding-agent/src/core/tools/index.ts
@@ -70,10 +70,18 @@ export {
 export {
 	createWriteTool,
 	type WriteOperations,
+	type WriteToolDetails,
 	type WriteToolInput,
 	type WriteToolOptions,
 	writeTool,
 } from "./write.js";
+export {
+	createToolTarget,
+	type ToolTargetAction,
+	type ToolTargetKind,
+	type ToolTargetMetadata,
+	type ToolTargetRange,
+} from "./tool-target.js";
 export {
 	createHashlineEditTool,
 	type HashlineEditInput,

--- a/packages/pi-coding-agent/src/core/tools/ls.ts
+++ b/packages/pi-coding-agent/src/core/tools/ls.ts
@@ -3,6 +3,7 @@ import { type Static, Type } from "@sinclair/typebox";
 import { existsSync, readdirSync, statSync } from "fs";
 import nodePath from "path";
 import { resolveToCwd } from "./path-utils.js";
+import { createToolTarget, type ToolTargetMetadata } from "./tool-target.js";
 import { DEFAULT_MAX_BYTES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
 
 const lsSchema = Type.Object({
@@ -15,6 +16,7 @@ export type LsToolInput = Static<typeof lsSchema>;
 const DEFAULT_LIMIT = 500;
 
 export interface LsToolDetails {
+	target?: ToolTargetMetadata;
 	truncation?: TruncationResult;
 	entryLimitReached?: number;
 }
@@ -68,6 +70,12 @@ export function createLsTool(cwd: string, options?: LsToolOptions): AgentTool<ty
 				(async () => {
 					try {
 						const dirPath = resolveToCwd(path || ".", cwd);
+						const target = createToolTarget({
+							kind: "directory",
+							action: "list",
+							inputPath: path || ".",
+							resolvedPath: dirPath,
+						});
 						const effectiveLimit = limit ?? DEFAULT_LIMIT;
 
 						// Check if path exists
@@ -124,7 +132,7 @@ export function createLsTool(cwd: string, options?: LsToolOptions): AgentTool<ty
 						signal?.removeEventListener("abort", onAbort);
 
 						if (results.length === 0) {
-							resolve({ content: [{ type: "text", text: "(empty directory)" }], details: undefined });
+							resolve({ content: [{ type: "text", text: "(empty directory)" }], details: { target } });
 							return;
 						}
 
@@ -133,7 +141,7 @@ export function createLsTool(cwd: string, options?: LsToolOptions): AgentTool<ty
 						const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
 
 						let output = truncation.content;
-						const details: LsToolDetails = {};
+						const details: LsToolDetails = { target };
 
 						// Build notices
 						const notices: string[] = [];
@@ -154,7 +162,7 @@ export function createLsTool(cwd: string, options?: LsToolOptions): AgentTool<ty
 
 						resolve({
 							content: [{ type: "text", text: output }],
-							details: Object.keys(details).length > 0 ? details : undefined,
+							details,
 						});
 					} catch (e: any) {
 						signal?.removeEventListener("abort", onAbort);

--- a/packages/pi-coding-agent/src/core/tools/read.ts
+++ b/packages/pi-coding-agent/src/core/tools/read.ts
@@ -6,6 +6,7 @@ import { access as fsAccess, readFile as fsReadFile } from "fs/promises";
 import { formatDimensionNote, resizeImage } from "../../utils/image-resize.js";
 import { detectSupportedImageMimeTypeFromFile } from "../../utils/mime.js";
 import { resolveReadPath } from "./path-utils.js";
+import { createToolTarget, type ToolTargetMetadata } from "./tool-target.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
 
 const readSchema = Type.Object({
@@ -17,6 +18,7 @@ const readSchema = Type.Object({
 export type ReadToolInput = Static<typeof readSchema>;
 
 export interface ReadToolDetails {
+	target?: ToolTargetMetadata;
 	truncation?: TruncationResult;
 }
 
@@ -61,6 +63,19 @@ export function createReadTool(cwd: string, options?: ReadToolOptions): AgentToo
 			signal?: AbortSignal,
 		) => {
 			const absolutePath = resolveReadPath(path, cwd);
+			const target = createToolTarget({
+				kind: "file",
+				action: "read",
+				inputPath: path,
+				resolvedPath: absolutePath,
+				range:
+					offset !== undefined || limit !== undefined
+						? {
+								start: offset ?? 1,
+								end: limit !== undefined ? (offset ?? 1) + Math.max(0, limit - 1) : undefined,
+							}
+						: undefined,
+			});
 
 			return new Promise<{ content: (TextContent | ImageContent)[]; details: ReadToolDetails | undefined }>(
 				(resolve, reject) => {
@@ -210,7 +225,7 @@ export function createReadTool(cwd: string, options?: ReadToolOptions): AgentToo
 								signal.removeEventListener("abort", onAbort);
 							}
 
-							resolve({ content, details });
+							resolve({ content, details: { ...details, target } });
 						} catch (error: any) {
 							// Clean up abort handler
 							if (signal) {

--- a/packages/pi-coding-agent/src/core/tools/read.ts
+++ b/packages/pi-coding-agent/src/core/tools/read.ts
@@ -6,7 +6,7 @@ import { access as fsAccess, readFile as fsReadFile } from "fs/promises";
 import { formatDimensionNote, resizeImage } from "../../utils/image-resize.js";
 import { detectSupportedImageMimeTypeFromFile } from "../../utils/mime.js";
 import { resolveReadPath } from "./path-utils.js";
-import { createToolTarget, type ToolTargetMetadata } from "./tool-target.js";
+import { createReadFileTarget, type ToolTargetMetadata } from "./tool-target.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
 
 const readSchema = Type.Object({
@@ -63,19 +63,7 @@ export function createReadTool(cwd: string, options?: ReadToolOptions): AgentToo
 			signal?: AbortSignal,
 		) => {
 			const absolutePath = resolveReadPath(path, cwd);
-			const target = createToolTarget({
-				kind: "file",
-				action: "read",
-				inputPath: path,
-				resolvedPath: absolutePath,
-				range:
-					offset !== undefined || limit !== undefined
-						? {
-								start: offset ?? 1,
-								end: limit !== undefined ? (offset ?? 1) + Math.max(0, limit - 1) : undefined,
-							}
-						: undefined,
-			});
+			const target = createReadFileTarget(path, absolutePath, offset, limit);
 
 			return new Promise<{ content: (TextContent | ImageContent)[]; details: ReadToolDetails | undefined }>(
 				(resolve, reject) => {

--- a/packages/pi-coding-agent/src/core/tools/tool-target-metadata.test.ts
+++ b/packages/pi-coding-agent/src/core/tools/tool-target-metadata.test.ts
@@ -30,6 +30,14 @@ test("read metadata records resolved path without changing output text", async (
 		assert.equal(result.content[0]?.type, "text");
 		assert.match(result.content[0]?.text ?? "", /^two/);
 		assert.equal((result.content[0]?.text ?? "").includes(filePath), false);
+
+		const zeroOffsetResult = await createReadTool(cwd).execute("read-zero-offset", {
+			path: "fixture.txt",
+			offset: 0,
+			limit: 1,
+		});
+
+		assert.deepEqual(zeroOffsetResult.details?.target?.range, { start: 1, end: 1 });
 	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 	}

--- a/packages/pi-coding-agent/src/core/tools/tool-target-metadata.test.ts
+++ b/packages/pi-coding-agent/src/core/tools/tool-target-metadata.test.ts
@@ -1,0 +1,119 @@
+// GSD-2 - Behavior coverage for tool target metadata.
+
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { createEditTool } from "./edit.js";
+import { createFindTool } from "./find.js";
+import { createGrepTool } from "./grep.js";
+import { createLsTool } from "./ls.js";
+import { createReadTool } from "./read.js";
+import { createWriteTool } from "./write.js";
+
+test("read metadata records resolved path without changing output text", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "gsd-read-target-"));
+	try {
+		const filePath = join(cwd, "fixture.txt");
+		writeFileSync(filePath, "one\ntwo\nthree\n", "utf8");
+
+		const result = await createReadTool(cwd).execute("read-1", {
+			path: "fixture.txt",
+			offset: 2,
+			limit: 1,
+		});
+
+		assert.equal(result.details?.target?.resolvedPath, filePath);
+		assert.deepEqual(result.details?.target?.range, { start: 2, end: 2 });
+		assert.equal(result.content[0]?.type, "text");
+		assert.match(result.content[0]?.text ?? "", /^two/);
+		assert.doesNotMatch(result.content[0]?.text ?? "", new RegExp(filePath));
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("write metadata records resolved path without changing output text", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "gsd-write-target-"));
+	try {
+		const filePath = join(cwd, "out.txt");
+		const result = await createWriteTool(cwd).execute("write-1", {
+			path: "out.txt",
+			content: "hello",
+		});
+
+		assert.equal(result.details?.target?.resolvedPath, filePath);
+		assert.equal(result.content[0]?.type, "text");
+		assert.equal(result.content[0]?.text, "Successfully wrote 5 bytes to out.txt");
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("edit metadata records first changed line and resolved path", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "gsd-edit-target-"));
+	try {
+		const filePath = join(cwd, "edit.txt");
+		writeFileSync(filePath, "alpha\nbeta\ngamma\n", "utf8");
+
+		const result = await createEditTool(cwd).execute("edit-1", {
+			path: "edit.txt",
+			oldText: "beta",
+			newText: "delta",
+		});
+
+		assert.equal(result.details?.target?.resolvedPath, filePath);
+		assert.equal(result.details?.target?.line, 2);
+		assert.equal(result.details?.firstChangedLine, 2);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("list and find metadata record resolved targets", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "gsd-search-target-"));
+	try {
+		const srcPath = join(cwd, "src");
+		const filePath = join(srcPath, "needle.txt");
+		mkdirSync(srcPath);
+		writeFileSync(filePath, "needle\n", "utf8");
+
+		const lsResult = await createLsTool(cwd).execute("ls-1", { path: "src" });
+		assert.equal(lsResult.details?.target?.resolvedPath, srcPath);
+
+		const findResult = await createFindTool(cwd, {
+			operations: {
+				exists: () => true,
+				glob: async () => [filePath],
+			},
+		}).execute("find-1", { path: "src", pattern: "needle" });
+		assert.equal(findResult.details?.target?.resolvedPath, srcPath);
+		assert.equal(findResult.details?.target?.pattern, "needle");
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("grep metadata records resolved search target", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "gsd-grep-target-"));
+	try {
+		const srcPath = join(cwd, "src");
+		mkdirSync(srcPath);
+		writeFileSync(join(srcPath, "needle.txt"), "needle\n", "utf8");
+
+		const result = await createGrepTool(cwd).execute("grep-1", {
+			path: "src",
+			pattern: "needle",
+			literal: true,
+		});
+
+		assert.equal(result.details?.target?.resolvedPath, srcPath);
+		assert.equal(result.details?.target?.pattern, "needle");
+		assert.equal(result.content[0]?.type, "text");
+		assert.match(result.content[0]?.text ?? "", /needle\.txt:1: needle/);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-coding-agent/src/core/tools/tool-target-metadata.test.ts
+++ b/packages/pi-coding-agent/src/core/tools/tool-target-metadata.test.ts
@@ -29,7 +29,7 @@ test("read metadata records resolved path without changing output text", async (
 		assert.deepEqual(result.details?.target?.range, { start: 2, end: 2 });
 		assert.equal(result.content[0]?.type, "text");
 		assert.match(result.content[0]?.text ?? "", /^two/);
-		assert.doesNotMatch(result.content[0]?.text ?? "", new RegExp(filePath));
+		assert.equal((result.content[0]?.text ?? "").includes(filePath), false);
 	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 	}

--- a/packages/pi-coding-agent/src/core/tools/tool-target.ts
+++ b/packages/pi-coding-agent/src/core/tools/tool-target.ts
@@ -1,0 +1,25 @@
+// GSD-2 - Shared target metadata for tool output rendering.
+
+export type ToolTargetKind = "file" | "directory" | "search" | "command";
+
+export type ToolTargetAction = "read" | "write" | "edit" | "list" | "find" | "grep" | "bash";
+
+export interface ToolTargetRange {
+	start: number;
+	end?: number;
+}
+
+export interface ToolTargetMetadata {
+	kind: ToolTargetKind;
+	action: ToolTargetAction;
+	inputPath?: string;
+	resolvedPath?: string;
+	pattern?: string;
+	glob?: string;
+	line?: number;
+	range?: ToolTargetRange;
+}
+
+export function createToolTarget(target: ToolTargetMetadata): ToolTargetMetadata {
+	return target;
+}

--- a/packages/pi-coding-agent/src/core/tools/tool-target.ts
+++ b/packages/pi-coding-agent/src/core/tools/tool-target.ts
@@ -30,6 +30,8 @@ export function createReadFileTarget(
 	offset?: number,
 	limit?: number,
 ): ToolTargetMetadata {
+	const effectiveOffset = Math.max(1, offset ?? 1);
+
 	return createToolTarget({
 		kind: "file",
 		action: "read",
@@ -38,8 +40,8 @@ export function createReadFileTarget(
 		range:
 			offset !== undefined || limit !== undefined
 				? {
-						start: offset ?? 1,
-						end: limit !== undefined ? (offset ?? 1) + Math.max(0, limit - 1) : undefined,
+						start: effectiveOffset,
+						end: limit !== undefined ? effectiveOffset + Math.max(0, limit - 1) : undefined,
 					}
 				: undefined,
 	});

--- a/packages/pi-coding-agent/src/core/tools/tool-target.ts
+++ b/packages/pi-coding-agent/src/core/tools/tool-target.ts
@@ -23,3 +23,24 @@ export interface ToolTargetMetadata {
 export function createToolTarget(target: ToolTargetMetadata): ToolTargetMetadata {
 	return target;
 }
+
+export function createReadFileTarget(
+	inputPath: string,
+	resolvedPath: string,
+	offset?: number,
+	limit?: number,
+): ToolTargetMetadata {
+	return createToolTarget({
+		kind: "file",
+		action: "read",
+		inputPath,
+		resolvedPath,
+		range:
+			offset !== undefined || limit !== undefined
+				? {
+						start: offset ?? 1,
+						end: limit !== undefined ? (offset ?? 1) + Math.max(0, limit - 1) : undefined,
+					}
+				: undefined,
+	});
+}

--- a/packages/pi-coding-agent/src/core/tools/write.ts
+++ b/packages/pi-coding-agent/src/core/tools/write.ts
@@ -4,6 +4,7 @@ import { mkdir as fsMkdir, writeFile as fsWriteFile } from "fs/promises";
 import { dirname } from "path";
 import { notifyFileChanged } from "../lsp/client.js";
 import { resolveToCwd } from "./path-utils.js";
+import { createToolTarget, type ToolTargetMetadata } from "./tool-target.js";
 
 const writeSchema = Type.Object({
 	path: Type.String({ description: "Path to the file to write (relative or absolute)" }),
@@ -11,6 +12,10 @@ const writeSchema = Type.Object({
 });
 
 export type WriteToolInput = Static<typeof writeSchema>;
+
+export interface WriteToolDetails {
+	target?: ToolTargetMetadata;
+}
 
 /**
  * Pluggable operations for the write tool.
@@ -50,7 +55,7 @@ export function createWriteTool(cwd: string, options?: WriteToolOptions): AgentT
 			const absolutePath = resolveToCwd(path, cwd);
 			const dir = dirname(absolutePath);
 
-			return new Promise<{ content: Array<{ type: "text"; text: string }>; details: undefined }>(
+			return new Promise<{ content: Array<{ type: "text"; text: string }>; details: WriteToolDetails | undefined }>(
 				(resolve, reject) => {
 					// Check if already aborted
 					if (signal?.aborted) {
@@ -98,7 +103,14 @@ export function createWriteTool(cwd: string, options?: WriteToolOptions): AgentT
 
 							resolve({
 								content: [{ type: "text", text: `Successfully wrote ${content.length} bytes to ${path}` }],
-								details: undefined,
+								details: {
+									target: createToolTarget({
+										kind: "file",
+										action: "write",
+										inputPath: path,
+										resolvedPath: absolutePath,
+									}),
+								},
 							});
 						} catch (error: any) {
 							// Clean up abort handler

--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
@@ -113,10 +113,124 @@ describe("ToolExecutionComponent", () => {
 		assert.deepEqual(component.getRollupPhase()?.label, "Other tool actions");
 	});
 
+	test("renders compact read rows with target metadata", () => {
+		const rendered = renderToolCollapsed(
+			"read",
+			{ path: "src/Inspector.tsx" },
+			{
+				content: [{ type: "text", text: "source" }],
+				isError: false,
+				details: {
+					target: {
+						kind: "file",
+						action: "read",
+						inputPath: "src/Inspector.tsx",
+						resolvedPath: "/tmp/project/src/Inspector.tsx",
+						range: { start: 4, end: 12 },
+					},
+				},
+			},
+		);
+
+		assert.match(rendered, /read .*src\/Inspector\.tsx:4-12/);
+		assert.doesNotMatch(rendered, /source/);
+	});
+
+	test("renders compact edit rows with target metadata", () => {
+		const rendered = renderToolCollapsed(
+			"edit",
+			{ path: "src/Inspector.tsx" },
+			{
+				content: [{ type: "text", text: "Updated src/Inspector.tsx" }],
+				isError: false,
+				details: {
+					target: {
+						kind: "file",
+						action: "edit",
+						inputPath: "src/Inspector.tsx",
+						resolvedPath: "/tmp/project/src/Inspector.tsx",
+						line: 42,
+					},
+				},
+			},
+		);
+
+		assert.match(rendered, /edit .*src\/Inspector\.tsx:42/);
+		assert.doesNotMatch(rendered, /Updated src\/Inspector\.tsx/);
+	});
+
+	test("renders compact write rows with target metadata", () => {
+		const rendered = renderToolCollapsed(
+			"write",
+			{ path: "src/output.ts", content: "ok" },
+			{
+				content: [{ type: "text", text: "Successfully wrote 2 bytes to src/output.ts" }],
+				isError: false,
+				details: {
+					target: {
+						kind: "file",
+						action: "write",
+						inputPath: "src/output.ts",
+						resolvedPath: "/tmp/project/src/output.ts",
+					},
+				},
+			},
+		);
+
+		assert.match(rendered, /write .*src\/output\.ts/);
+		assert.doesNotMatch(rendered, /Successfully wrote/);
+	});
+
+	test("renders compact bash rows with command preview", () => {
+		const rendered = renderToolCollapsed(
+			"bash",
+			{ command: "npm run typecheck -- --watch false" },
+			{ content: [{ type: "text", text: "ok" }], isError: false, details: { cwd: "/tmp/project" } },
+		);
+
+		assert.match(rendered, /bash npm run typecheck -- --watch false/);
+		assert.doesNotMatch(rendered, /\bok\b/);
+	});
+
+	test("keeps failed tools expanded and error visible", () => {
+		const rendered = renderToolCollapsed(
+			"edit",
+			{ path: "src/Inspector.tsx" },
+			{
+				content: [{ type: "text", text: "Could not find target text" }],
+				isError: true,
+				details: {
+					target: {
+						kind: "file",
+						action: "edit",
+						inputPath: "src/Inspector.tsx",
+						resolvedPath: "/tmp/project/src/Inspector.tsx",
+					},
+				},
+			},
+		);
+
+		assert.match(rendered, /Could not find target text/);
+		assert.match(rendered, /edit/);
+	});
+
 	test("renders phase-based summaries for rolled-up tool executions", () => {
 		const phases: ToolExecutionPhase[] = [
 			{ label: "Setup / shell", count: 6, durationMs: 12 },
-			{ label: "Context reads", count: 4, durationMs: 6 },
+			{
+				label: "Context reads",
+				count: 4,
+				durationMs: 6,
+				actionLabel: "read",
+				targets: ["/tmp/project/src/a.ts", "/tmp/project/src/b.ts"],
+			},
+			{
+				label: "File changes",
+				count: 3,
+				durationMs: 5,
+				actionLabel: "edit",
+				targets: ["/tmp/project/src/Inspector.tsx:42", "/tmp/project/src/CompareView.tsx:8"],
+			},
 			{ label: "Requirement writes", count: 4, durationMs: 4 },
 			{ label: "Memory lookups", count: 4, durationMs: 4 },
 			{ label: "Finalization", count: 1, durationMs: 1 },
@@ -124,7 +238,10 @@ describe("ToolExecutionComponent", () => {
 		const rendered = stripAnsi(new ToolPhaseSummaryComponent(phases).render(120).join("\n"));
 
 		assert.match(rendered, /Setup \/ shell 6 actions\s+success · 12ms/);
-		assert.match(rendered, /Context reads 4 actions\s+success · 6ms/);
+		assert.match(rendered, /Context reads · 2 files\s+success · 6ms/);
+		assert.match(rendered, /src\/a\.ts/);
+		assert.match(rendered, /File changes · 2 files, 3 edits\s+success · 5ms/);
+		assert.match(rendered, /src\/Inspector\.tsx:42/);
 		assert.match(rendered, /Requirement writes 4 actions\s+success · 4ms/);
 		assert.match(rendered, /Memory lookups 4 actions\s+success · 4ms/);
 		assert.match(rendered, /Finalization 1 action\s+success · 1ms/);

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -111,9 +111,10 @@ function renderToolFrame(
 	const statusColor = opts.tone === "error" ? "toolError" : opts.tone === "pending" ? "toolRunning" : "toolSuccess";
 	const leftStyled = theme.fg(labelColor, theme.bold(opts.label));
 	const rightStyled = theme.fg(statusColor, opts.status);
-	const gap = Math.max(1, outerWidth - visibleWidth(leftStyled) - visibleWidth(rightStyled));
+	const titleWidth = Math.max(1, outerWidth - 4);
+	const gap = Math.max(1, titleWidth - visibleWidth(leftStyled) - visibleWidth(rightStyled));
 	const headerRow = `${leftStyled}${" ".repeat(gap)}${rightStyled}`;
-	const headerPad = Math.max(0, outerWidth - visibleWidth(headerRow));
+	const headerPad = Math.max(0, titleWidth - visibleWidth(headerRow));
 
 	const sourceLines = trimOuterBlankLines(contentLines);
 	const bodyLines = (sourceLines.length > 0 ? sourceLines : [""]).map((line) => {
@@ -122,7 +123,7 @@ function renderToolFrame(
 	});
 
 	return style()
-		.border("rule")
+		.border("rounded")
 		.borderColor((line) => theme.fg(line.startsWith("─") ? topColor : borderColor, line))
 		.title(headerRow + " ".repeat(headerPad))
 		.render(bodyLines, outerWidth);
@@ -157,11 +158,125 @@ export type ToolExecutionPhase = {
 	label: string;
 	count: number;
 	durationMs: number;
+	targets?: string[];
+	actionLabel?: string;
+};
+
+type ToolTargetMetadata = {
+	kind?: string;
+	action?: string;
+	inputPath?: string;
+	resolvedPath?: string;
+	pattern?: string;
+	glob?: string;
+	line?: number;
+	range?: {
+		start?: number;
+		end?: number;
+	};
 };
 
 function formatElapsed(ms: number): string {
 	if (ms < 1000) return `${ms}ms`;
 	return `${Math.max(1, Math.round(ms / 1000))}s`;
+}
+
+function formatCommandPreview(command: string): string {
+	return truncateToWidth(command.replace(/\s+/g, " ").trim(), 64, "");
+}
+
+function appendLineOrRange(displayPath: string | undefined, target: ToolTargetMetadata): string | undefined {
+	if (!displayPath) return undefined;
+	if (typeof target.line === "number" && Number.isFinite(target.line)) {
+		return `${displayPath}:${target.line}`;
+	}
+	const start = target.range?.start;
+	if (typeof start === "number" && Number.isFinite(start)) {
+		const end = target.range?.end;
+		const suffix =
+			typeof end === "number" && Number.isFinite(end) && end !== start
+				? `${start}-${end}`
+				: `${start}`;
+		return `${displayPath}:${suffix}`;
+	}
+	return displayPath;
+}
+
+function formatToolTarget(target: ToolTargetMetadata): string | undefined {
+	const path = target.resolvedPath || target.inputPath;
+	const displayPath = path ? shortenPath(path) : undefined;
+	if (target.kind === "search") {
+		const searchTarget = displayPath ?? target.inputPath ?? ".";
+		const label = target.pattern ? `${target.pattern} in ${searchTarget}` : searchTarget;
+		return target.glob ? `${label} (${target.glob})` : label;
+	}
+	return appendLineOrRange(displayPath, target);
+}
+
+function formatArgsPathTarget(path: string | null, args: Record<string, unknown>): string | undefined {
+	if (!path) return undefined;
+	const start = typeof args.offset === "number" ? args.offset : undefined;
+	const limit = typeof args.limit === "number" ? args.limit : undefined;
+	const range =
+		start !== undefined || limit !== undefined
+			? {
+					start: start ?? 1,
+					end: limit !== undefined ? (start ?? 1) + Math.max(0, limit - 1) : undefined,
+				}
+			: undefined;
+	return appendLineOrRange(shortenPath(path), { range });
+}
+
+function stripLineSuffix(target: string): string {
+	return target.replace(/:\d+(?:-\d+)?$/, "");
+}
+
+function uniqueTargets(targets: string[] | undefined): string[] {
+	const seen = new Set<string>();
+	const unique: string[] = [];
+	for (const target of targets ?? []) {
+		if (!target || seen.has(target)) continue;
+		seen.add(target);
+		unique.push(target);
+	}
+	return unique;
+}
+
+function summarizePhaseLabel(phase: ToolExecutionPhase): string {
+	const phaseTargets = uniqueTargets(phase.targets);
+	const baseTargets = uniqueTargets(phaseTargets.map(stripLineSuffix));
+	if (phase.label === "File changes" && baseTargets.length > 0) {
+		const fileWord = baseTargets.length === 1 ? "file" : "files";
+		const actionWord =
+			phase.actionLabel === "write"
+				? phase.count === 1
+					? "write"
+					: "writes"
+				: phase.actionLabel === undefined
+					? phase.count === 1
+						? "action"
+						: "actions"
+					: phase.count === 1
+						? "edit"
+						: "edits";
+		return `${phase.label} · ${baseTargets.length} ${fileWord}, ${phase.count} ${actionWord}`;
+	}
+	if (phase.label === "Context reads" && baseTargets.length > 0) {
+		const fileWord = baseTargets.length === 1 ? "file" : "files";
+		return `${phase.label} · ${baseTargets.length} ${fileWord}`;
+	}
+	if (phase.label === "Setup / shell" && phaseTargets.length > 0) {
+		return `${phase.label} · ${phase.count} ${phase.count === 1 ? "command" : "commands"}`;
+	}
+	return `${phase.label} ${phase.count} ${phase.count === 1 ? "action" : "actions"}`;
+}
+
+function summarizePhaseTargets(phase: ToolExecutionPhase, width: number): string | undefined {
+	const phaseTargets = uniqueTargets(phase.targets);
+	if (phaseTargets.length === 0) return undefined;
+	const shown = phaseTargets.slice(0, 3);
+	const suffix = phaseTargets.length > shown.length ? ` +${phaseTargets.length - shown.length} more` : "";
+	return truncateToWidth(shown.join(" · ") + suffix, width, "");
 }
 
 /**
@@ -607,10 +722,13 @@ export class ToolExecutionComponent extends Container {
 		if (!this.shouldRenderCompactSuccess()) return null;
 		const label = this.getPhaseLabel();
 		const endedAt = this.endedAt ?? Date.now();
+		const target = this.getCompactTarget();
 		return {
 			label,
 			count: 1,
 			durationMs: Math.max(0, endedAt - this.startedAt),
+			targets: target ? [target] : undefined,
+			actionLabel: this.getCompactAction(),
 		};
 	}
 
@@ -631,7 +749,52 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	private getCompactSummary(frameLabel: string): string {
-		return frameLabel;
+		if (this.normalizedToolName === "bash") {
+			const command = str(this.args?.command);
+			return command ? `bash ${formatCommandPreview(command)}` : frameLabel;
+		}
+		const target = this.getCompactTarget();
+		return target ? `${this.getCompactAction()} ${target}` : frameLabel;
+	}
+
+	private getCompactAction(): string {
+		const target = this.getTargetMetadata();
+		if (target?.action) return target.action === "list" ? "ls" : target.action;
+		return this.normalizedToolName;
+	}
+
+	private getTargetMetadata(): ToolTargetMetadata | undefined {
+		const target = this.result?.details?.target;
+		return target && typeof target === "object" ? target : undefined;
+	}
+
+	private getCompactTarget(): string | undefined {
+		const metadata = this.getTargetMetadata();
+		const metadataTarget = metadata ? formatToolTarget(metadata) : undefined;
+		if (metadataTarget) return metadataTarget;
+
+		const path = str(this.args?.file_path ?? this.args?.path);
+		if (path === null) return undefined;
+		if (this.normalizedToolName === "read" || this.normalizedToolName === "hashline_read") {
+			return formatArgsPathTarget(path, this.args);
+		}
+		if (this.normalizedToolName === "write" || this.normalizedToolName === "edit") {
+			return path ? shortenPath(path) : undefined;
+		}
+		if (this.normalizedToolName === "ls") {
+			return shortenPath(path || ".");
+		}
+		if (this.normalizedToolName === "find") {
+			const pattern = str(this.args?.pattern);
+			return pattern ? `${pattern} in ${shortenPath(path || ".")}` : shortenPath(path || ".");
+		}
+		if (this.normalizedToolName === "grep") {
+			const pattern = str(this.args?.pattern);
+			const glob = str(this.args?.glob);
+			const label = pattern ? `${pattern} in ${shortenPath(path || ".")}` : shortenPath(path || ".");
+			return glob ? `${label} (${glob})` : label;
+		}
+		return undefined;
 	}
 
 	private updateDisplay(): void {
@@ -861,6 +1024,10 @@ export class ToolExecutionComponent extends Container {
 			// Truncation warnings
 			const truncation = this.result.details?.truncation;
 			const fullOutputPath = this.result.details?.fullOutputPath;
+			const cwd = this.result.details?.cwd;
+			if (this.expanded && typeof cwd === "string" && cwd.length > 0) {
+				this.contentBox.addChild(new Text(`\n${theme.fg("muted", `cwd ${shortenPath(cwd)}`)}`, 0, 0));
+			}
 			if (truncation?.truncated || fullOutputPath) {
 				const warnings: string[] = [];
 				if (fullOutputPath) {
@@ -1288,19 +1455,21 @@ export class ToolPhaseSummaryComponent extends Container {
 	}
 
 	getPhases(): ToolExecutionPhase[] {
-		return this.phases.map((phase) => ({ ...phase }));
+		return this.phases.map((phase) => ({ ...phase, targets: phase.targets ? [...phase.targets] : undefined }));
 	}
 
 	override render(width: number): string[] {
 		const frameWidth = Math.max(20, width);
-		const rows = this.phases.map((phase) => {
-			const left = `${phase.label} ${phase.count} ${phase.count === 1 ? "action" : "actions"}`;
+		const rows = this.phases.flatMap((phase) => {
+			const left = summarizePhaseLabel(phase);
 			const right = `success · ${formatElapsed(phase.durationMs)}`;
 			const contentWidth = Math.max(1, frameWidth - 2);
 			const leftWidth = Math.max(1, contentWidth - visibleWidth(right) - 1);
 			const leftText = truncateToWidth(left, leftWidth, "");
 			const gap = Math.max(1, contentWidth - visibleWidth(leftText) - visibleWidth(right));
-			return `${theme.fg("toolSuccess", leftText)}${" ".repeat(gap)}${theme.fg("toolSuccess", right)}`;
+			const summaryRow = `${theme.fg("toolSuccess", leftText)}${" ".repeat(gap)}${theme.fg("toolSuccess", right)}`;
+			const targetRow = summarizePhaseTargets(phase, contentWidth);
+			return targetRow ? [summaryRow, theme.fg("muted", targetRow)] : [summaryRow];
 		});
 
 		return ["", ...style().border("minimal").borderColor((text) => theme.fg("toolSuccess", text)).render(rows, frameWidth)];

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.test.ts
@@ -146,24 +146,43 @@ test("handleAgentEvent: standalone completed tool events roll up incrementally",
 		["read-2", "read"],
 		["edit-1", "edit"],
 	] as const) {
+		const target =
+			toolName === "edit"
+				? {
+						kind: "file",
+						action: "edit",
+						inputPath: `src/${toolCallId}.txt`,
+						resolvedPath: `/tmp/project/src/${toolCallId}.txt`,
+						line: 10,
+					}
+				: {
+						kind: "file",
+						action: "read",
+						inputPath: `src/${toolCallId}.txt`,
+						resolvedPath: `/tmp/project/src/${toolCallId}.txt`,
+					};
 		await handleAgentEvent(host, {
 			type: "tool_execution_start",
 			toolCallId,
 			toolName,
-			args: { path: `/tmp/${toolCallId}.txt` },
+			args: { path: `src/${toolCallId}.txt` },
 		} as any);
 		await handleAgentEvent(host, {
 			type: "tool_execution_end",
 			toolCallId,
 			toolName,
-			result: { content: [], isError: false },
+			result: { content: [], details: { target }, isError: false },
 			isError: false,
 		} as any);
 	}
 
 	const rendered = stripAnsi(chatContainer.render(100).join("\n"));
-	assert.match(rendered, /Context reads 2 actions\s+success · \d+(ms|s)/);
-	assert.match(rendered, /File changes 1 action\s+success · \d+(ms|s)/);
-	assert.doesNotMatch(rendered, /\bread\s+success ·/);
+	assert.match(rendered, /Context reads · 2 files\s+success · \d+(ms|s)/);
+	assert.match(rendered, /src\/read-1\.txt/);
+	assert.match(rendered, /src\/read-2\.txt/);
+	assert.match(rendered, /File changes · 1 file, 1 edit\s+success · \d+(ms|s)/);
+	assert.match(rendered, /src\/edit-1\.txt:10/);
+	assert.doesNotMatch(rendered, /^\s*│?\s*read\s+success ·/m);
+	assert.doesNotMatch(rendered, /^\s*│?\s*edit\s+success ·/m);
 	assert.ok(renderCount > 0);
 });

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -113,9 +113,25 @@ function mergeToolPhases(phases: ToolExecutionPhase[]): ToolExecutionPhase[] {
 		if (previous?.label === phase.label) {
 			previous.count += phase.count;
 			previous.durationMs += phase.durationMs;
+			previous.targets = mergeTargets(previous.targets, phase.targets);
+			if (previous.actionLabel !== phase.actionLabel) {
+				previous.actionLabel = undefined;
+			}
 		} else {
-			merged.push({ ...phase });
+			merged.push({ ...phase, targets: phase.targets ? [...phase.targets] : undefined });
 		}
+	}
+	return merged;
+}
+
+function mergeTargets(existing: string[] | undefined, incoming: string[] | undefined): string[] | undefined {
+	if (!existing && !incoming) return undefined;
+	const seen = new Set<string>();
+	const merged: string[] = [];
+	for (const target of [...(existing ?? []), ...(incoming ?? [])]) {
+		if (!target || seen.has(target)) continue;
+		seen.add(target);
+		merged.push(target);
 	}
 	return merged;
 }


### PR DESCRIPTION
## TL;DR

**What:** Adds target-aware compact output for interactive TUI tool runs.
**Why:** Tool rows that only say `read` or `edit` hide the file or target being acted on.
**How:** Adds target metadata to file/search tool results and renders compact labels from metadata before falling back to args.

## What

This updates interactive TUI tool output so compact completed rows show useful targets such as paths, commands, or search labels. It also adds tests for target metadata and compact rendering behavior.

## Why

The current completed tool output is too low-signal during long sessions. Showing the actual target makes the chat log easier to audit without expanding every tool card.

## How

- Adds target metadata helpers for built-in tools.
- Populates metadata in read/write/edit/find/grep/ls/hashline-read/bash-related paths where available.
- Updates interactive tool execution rendering and rollup behavior.
- Adds focused node:test coverage for metadata and compact UI labels.

## Change type checklist

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Verification

Draft PR. Full `npm run verify:pr` was not rerun during this PR packaging pass.

AI-assisted contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools now always include rich target metadata (kind/action, resolved paths, ranges/lines, patterns); new helpers create and export target primitives.
  * Write tool returns target details; bash tool includes cwd in outputs; read/edit/ls/find/grep produce consistent target info.
  * Tool execution UI shows deduplicated, labeled phase summaries and compact rollups; expanded bash shows muted cwd.

* **Tests**
  * Added tests validating target metadata and UI formatting for read/write/edit/ls/find/grep/bash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->