### PR TITLE
fix(gsd): harden milestone merge closeout

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Auto-mode post-unit git, verification, projection, and hook processing.
 /**
  * Post-unit processing for auto-loop — auto-commit, doctor run,
  * state rebuild, projection checks, DB tool closeout, hooks, triage, and
@@ -102,6 +104,67 @@ function formatPreExecutionCheckDetail(check: PreExecutionCheckJSON): string {
 
 const COMPLETE_MILESTONE_DB_SETTLE_MS = 1500;
 const COMPLETE_MILESTONE_DB_SETTLE_POLL_MS = 100;
+
+function stripKnownIdPrefix(value: string | undefined | null, id: string): string | undefined {
+  const raw = String(value ?? "").trim();
+  if (!raw) return undefined;
+  const lower = raw.toLowerCase();
+  const idLower = id.toLowerCase();
+  if (lower.startsWith(`${idLower}:`)) return raw.slice(id.length + 1).trim() || undefined;
+  return raw;
+}
+
+async function buildTaskCommitContextForUnit(
+  basePath: string,
+  unitId: string,
+): Promise<TaskCommitContext | undefined> {
+  const { milestone: mid, slice: sid, task: tid } = parseUnitId(unitId);
+  if (!mid || !sid || !tid) return undefined;
+
+  const milestone = isDbAvailable() ? getMilestone(mid) : null;
+  const slice = isDbAvailable() ? getSlice(mid, sid) : null;
+  const task = isDbAvailable() ? getTask(mid, sid, tid) : null;
+  let summary: ReturnType<typeof parseSummary> | null = null;
+
+  const summaryPath = resolveTaskFile(basePath, mid, sid, tid, "SUMMARY");
+  if (summaryPath) {
+    try {
+      const summaryContent = await loadFile(summaryPath);
+      if (summaryContent) summary = parseSummary(summaryContent);
+    } catch (e) {
+      debugLog("postUnit", { phase: "task-summary-parse", error: String(e) });
+    }
+  }
+
+  if (!summary && !task) return undefined;
+
+  let ghIssueNumber: number | undefined;
+  try {
+    const { getTaskIssueNumberForCommit } = await import("../github-sync/sync.js");
+    ghIssueNumber = getTaskIssueNumberForCommit(basePath, mid, sid, tid) ?? undefined;
+  } catch (err) {
+    logWarning("engine", `GitHub issue lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return {
+    taskId: `${sid}/${tid}`,
+    taskDisplayId: tid,
+    taskTitle:
+      stripKnownIdPrefix(summary?.title, tid) ??
+      stripKnownIdPrefix(task?.title, tid) ??
+      tid,
+    milestoneId: mid,
+    milestoneTitle: stripKnownIdPrefix(milestone?.title, mid),
+    sliceId: sid,
+    sliceTitle: stripKnownIdPrefix(slice?.title, sid),
+    oneLiner: summary?.oneLiner || task?.one_liner || undefined,
+    keyFiles:
+      summary?.frontmatter.key_files?.filter(f => !f.includes("{{")) ??
+      task?.key_files ??
+      undefined,
+    issueNumber: ghIssueNumber,
+  };
+}
 
 async function waitForMilestoneDbClose(mid: string): Promise<boolean> {
   const deadline = Date.now() + COMPLETE_MILESTONE_DB_SETTLE_MS;
@@ -377,35 +440,7 @@ export async function autoCommitUnit(
     let taskContext: TaskCommitContext | undefined;
 
     if (unitType === "execute-task") {
-      const { milestone: mid, slice: sid, task: tid } = parseUnitId(unitId);
-      if (mid && sid && tid) {
-        const summaryPath = resolveTaskFile(basePath, mid, sid, tid, "SUMMARY");
-        if (summaryPath) {
-          try {
-            const summaryContent = await loadFile(summaryPath);
-            if (summaryContent) {
-              const summary = parseSummary(summaryContent);
-              let ghIssueNumber: number | undefined;
-              try {
-                const { getTaskIssueNumberForCommit } = await import("../github-sync/sync.js");
-                ghIssueNumber = getTaskIssueNumberForCommit(basePath, mid, sid, tid) ?? undefined;
-              } catch (err) {
-                logWarning("engine", `GitHub issue lookup failed: ${err instanceof Error ? err.message : String(err)}`);
-              }
-
-              taskContext = {
-                taskId: `${sid}/${tid}`,
-                taskTitle: summary.title?.replace(/^T\d+:\s*/, "") || tid,
-                oneLiner: summary.oneLiner || undefined,
-                keyFiles: summary.frontmatter.key_files?.filter(f => !f.includes("{{")) || undefined,
-                issueNumber: ghIssueNumber,
-              };
-            }
-          } catch (e) {
-            debugLog("postUnit", { phase: "task-summary-parse", error: String(e) });
-          }
-        }
-      }
+      taskContext = await buildTaskCommitContextForUnit(basePath, unitId);
     }
 
     _resetHasChangesCache();
@@ -477,37 +512,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       let taskContext: TaskCommitContext | undefined;
 
       if (turnAction === "commit" && s.currentUnit.type === "execute-task") {
-        const { milestone: mid, slice: sid, task: tid } = parseUnitId(s.currentUnit.id);
-        if (mid && sid && tid) {
-          const summaryPath = resolveTaskFile(s.basePath, mid, sid, tid, "SUMMARY");
-          if (summaryPath) {
-            try {
-              const summaryContent = await loadFile(summaryPath);
-              if (summaryContent) {
-                const summary = parseSummary(summaryContent);
-                // Look up GitHub issue number for commit linking
-                let ghIssueNumber: number | undefined;
-                try {
-                  const { getTaskIssueNumberForCommit } = await import("../github-sync/sync.js");
-                  ghIssueNumber = getTaskIssueNumberForCommit(s.basePath, mid, sid, tid) ?? undefined;
-                } catch (err) {
-                  // GitHub sync not available — skip
-                  logWarning("engine", `GitHub issue lookup failed: ${err instanceof Error ? err.message : String(err)}`);
-                }
-
-                taskContext = {
-                  taskId: `${sid}/${tid}`,
-                  taskTitle: summary.title?.replace(/^T\d+:\s*/, "") || tid,
-                  oneLiner: summary.oneLiner || undefined,
-                  keyFiles: summary.frontmatter.key_files?.filter(f => !f.includes("{{")) || undefined,
-                  issueNumber: ghIssueNumber,
-                };
-              }
-            } catch (e) {
-              debugLog("postUnit", { phase: "task-summary-parse", error: String(e) });
-            }
-          }
-        }
+        taskContext = await buildTaskCommitContextForUnit(s.basePath, s.currentUnit.id);
       }
 
       // Invalidate the nativeHasChanges cache before auto-commit (#1853).

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Auto-mode bootstrap, worktree recovery, and fresh-start initialization.
 /**
  * Auto-mode bootstrap — fresh-start initialization path.
  *
@@ -898,7 +900,25 @@ export async function bootstrapAutoSession(
     {
       const orphan = findUnmergedCompletedMilestone(base, getIsolationMode(base));
       if (orphan && orphan !== state.activeMilestone?.id) {
+        const priorBasePath = s.basePath;
+        const priorOriginalBasePath = s.originalBasePath;
+        s.originalBasePath = base;
+        s.basePath = getAutoWorktreePath(base, orphan) ?? base;
         const result = _mergeOrphanCompletedMilestone(buildResolver(), orphan, ctx.ui);
+        if (!result.merged) {
+          s.basePath = base;
+          s.originalBasePath = base;
+          try {
+            process.chdir(base);
+          } catch (err) {
+            logWarning("bootstrap", `could not restore cwd after orphan merge failure: ${err instanceof Error ? err.message : String(err)}`);
+          }
+          return releaseLockAndReturn();
+        }
+        if (!s.active) {
+          s.basePath = priorBasePath || base;
+          s.originalBasePath = priorOriginalBasePath || base;
+        }
         if (result.merged) {
           invalidateAllCaches();
           state = await deriveState(base);

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -28,6 +28,7 @@ import {
   isDbAvailable,
   getMilestone,
   getMilestoneSlices,
+  getSliceTasks,
   closeDatabase,
   openDatabase,
   getDbPath,
@@ -225,6 +226,15 @@ export function _isExpectedWorktreeUnlinkErrorForTest(
   code: string | undefined,
 ): boolean {
   return code === "ENOENT" || code === "EISDIR";
+}
+
+function stripGsdDisplayPrefix(value: string | undefined | null, id: string): string | undefined {
+  const raw = String(value ?? "").trim();
+  if (!raw) return undefined;
+  const lower = raw.toLowerCase();
+  const idLower = id.toLowerCase();
+  if (lower.startsWith(`${idLower}:`)) return raw.slice(id.length + 1).trim() || undefined;
+  return raw;
 }
 
 // ─── ASSESSMENT Force-Sync Helper (#2821) ─────────────────────────────────
@@ -1780,18 +1790,25 @@ export function mergeMilestoneToMain(
   }
 
   // 2. Get completed slices for commit message
-  let completedSlices: { id: string; title: string }[] = [];
+  let completedSlices: { id: string; title: string; tasks: Array<{ id: string; title: string }> }[] = [];
   if (isDbAvailable()) {
     completedSlices = getMilestoneSlices(milestoneId)
       .filter(s => s.status === "complete")
-      .map(s => ({ id: s.id, title: s.title }));
+      .map(s => ({
+        id: s.id,
+        title: stripGsdDisplayPrefix(s.title, s.id) ?? s.id,
+        tasks: getSliceTasks(milestoneId, s.id).map((task) => ({
+          id: task.id,
+          title: stripGsdDisplayPrefix(task.title, task.id) ?? task.id,
+        })),
+      }));
   }
   // Fallback: parse roadmap content when DB is unavailable
   if (completedSlices.length === 0 && roadmapContent) {
     const sliceRe = /- \[x\] \*\*(\w+):\s*(.+?)\*\*/gi;
     let m: RegExpExecArray | null;
     while ((m = sliceRe.exec(roadmapContent)) !== null) {
-      completedSlices.push({ id: m[1], title: m[2] });
+      completedSlices.push({ id: m[1], title: m[2], tasks: [] });
     }
   }
 
@@ -1864,8 +1881,7 @@ export function mergeMilestoneToMain(
 
   // 6. Build rich commit message
   const dbMilestone = getMilestone(milestoneId);
-  let milestoneTitle =
-    (dbMilestone?.title ?? "").replace(/^M\d+:\s*/, "").trim();
+  let milestoneTitle = stripGsdDisplayPrefix(dbMilestone?.title, milestoneId) ?? "";
   // Fallback: parse title from roadmap content header (e.g. "# M020: Backend foundation")
   if (!milestoneTitle && roadmapContent) {
     const titleMatch = roadmapContent.match(new RegExp(`^#\\s+${milestoneId}:\\s*(.+)`, "m"));
@@ -1873,14 +1889,21 @@ export function mergeMilestoneToMain(
   }
   milestoneTitle = milestoneTitle || milestoneId;
   const subject = `feat: ${milestoneTitle}`;
+  const milestoneContext = milestoneTitle === milestoneId
+    ? `Milestone: ${milestoneId}`
+    : `Milestone: ${milestoneId} - ${milestoneTitle}`;
   let body = "";
   if (completedSlices.length > 0) {
     const sliceLines = completedSlices
       .map((s) => `- ${s.id}: ${s.title}`)
       .join("\n");
-    body = `\n\nCompleted slices:\n${sliceLines}\n\nGSD-Milestone: ${milestoneId}\nBranch: ${milestoneBranch}`;
+    const taskLines = completedSlices
+      .flatMap((s) => s.tasks.map((task) => `- ${s.id}/${task.id}: ${task.title}`))
+      .join("\n");
+    const taskBlock = taskLines ? `\n\nCompleted tasks:\n${taskLines}` : "";
+    body = `\n\nCompleted slices:\n${sliceLines}${taskBlock}\n\n${milestoneContext}\nGSD-Milestone: ${milestoneId}\nBranch: ${milestoneBranch}`;
   } else {
-    body = `\n\nGSD-Milestone: ${milestoneId}\nBranch: ${milestoneBranch}`;
+    body = `\n\n${milestoneContext}\nGSD-Milestone: ${milestoneId}\nBranch: ${milestoneBranch}`;
   }
   const commitMessage = subject + body;
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Auto-mode orchestration, session lifecycle, and stop handling.
 /**
  * GSD Auto Mode — Fresh Session Per Unit
  *
@@ -969,7 +971,23 @@ function handleLostSessionLock(
  * the stale unit state, progress widget, status badge, and restores CWD so
  * the dashboard does not show an orphaned timer and the shell is usable.
  */
-function cleanupAfterLoopExit(ctx: ExtensionContext): void {
+export async function rerootCommandSession(
+  cmdCtx: Pick<ExtensionCommandContext, "newSession"> | null | undefined,
+  workspaceRoot: string,
+): Promise<{ status: "skipped" | "ok" | "cancelled" | "failed"; error?: string }> {
+  if (!cmdCtx || !workspaceRoot) return { status: "skipped" };
+  try {
+    const result = await cmdCtx.newSession({ workspaceRoot });
+    return result.cancelled ? { status: "cancelled" } : { status: "ok" };
+  } catch (err) {
+    return {
+      status: "failed",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void> {
   s.currentUnit = null;
   s.active = false;
   deactivateGSD();
@@ -1007,10 +1025,19 @@ function cleanupAfterLoopExit(ctx: ExtensionContext): void {
       logWarning("engine", `chdir failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
     }
   }
+
+  if (s.originalBasePath && s.cmdCtx) {
+    const result = await rerootCommandSession(s.cmdCtx, s.basePath);
+    if (result.status === "cancelled") {
+      logWarning("engine", "post-loop session re-root was cancelled", { file: "auto.ts", basePath: s.basePath });
+    } else if (result.status === "failed") {
+      logWarning("engine", `post-loop session re-root failed: ${result.error ?? "unknown"}`, { file: "auto.ts", basePath: s.basePath });
+    }
+  }
 }
 
-export function _cleanupAfterLoopExitForTest(ctx: ExtensionContext): void {
-  cleanupAfterLoopExit(ctx);
+export function _cleanupAfterLoopExitForTest(ctx: ExtensionContext): Promise<void> {
+  return cleanupAfterLoopExit(ctx);
 }
 
 export type AutoWorktreeExitAction = "skip" | "merge" | "preserve";
@@ -1175,11 +1202,11 @@ export async function stopAuto(
           logWarning("engine", `milestone summary check failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
         }
 
-        const exitAction = _resolveAutoWorktreeExitActionForTest(
-          s.currentMilestoneId,
-          s.milestoneMergedInPhases,
+        const exitAction = _selectStopAutoWorktreeExit({
+          currentMilestoneId: s.currentMilestoneId,
           milestoneComplete,
-        );
+          milestoneMergedInPhases: s.milestoneMergedInPhases,
+        });
 
         if (exitAction === "merge") {
           // Milestone is complete — merge worktree branch back to main
@@ -1192,6 +1219,10 @@ export async function stopAuto(
         }
       }
     } catch (e) {
+      ctx?.ui.notify(
+        `Worktree cleanup failed for ${s.currentMilestoneId ?? "current milestone"}: ${e instanceof Error ? e.message : String(e)}. Resolve the preserved branch/worktree and run /gsd auto to resume.`,
+        "warning",
+      );
       debugLog("stop-cleanup-worktree", { error: e instanceof Error ? e.message : String(e) });
     }
 
@@ -1242,13 +1273,11 @@ export async function stopAuto(
     // its own cwd for tools and system prompt; refresh it before returning to the
     // user so follow-up commands do not target a removed milestone worktree.
     if (s.originalBasePath && ctx && s.cmdCtx) {
-      try {
-        const result = await s.cmdCtx.newSession({ workspaceRoot: s.basePath });
-        if (result.cancelled) {
-          logWarning("engine", "post-stop session re-root was cancelled", { file: "auto.ts", basePath: s.basePath });
-        }
-      } catch (err) {
-        logWarning("engine", `post-stop session re-root failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts", basePath: s.basePath });
+      const result = await rerootCommandSession(s.cmdCtx, s.basePath);
+      if (result.status === "cancelled") {
+        logWarning("engine", "post-stop session re-root was cancelled", { file: "auto.ts", basePath: s.basePath });
+      } else if (result.status === "failed") {
+        logWarning("engine", `post-stop session re-root failed: ${result.error ?? "unknown"}`, { file: "auto.ts", basePath: s.basePath });
       }
     }
 
@@ -1378,6 +1407,17 @@ export async function stopAuto(
     // Reset all session state in one call
     s.reset();
   }
+}
+
+export type StopAutoWorktreeExitAction = "none" | "merge" | "preserve";
+
+export function _selectStopAutoWorktreeExit(args: {
+  currentMilestoneId: string | null;
+  milestoneComplete: boolean;
+  milestoneMergedInPhases: boolean;
+}): StopAutoWorktreeExitAction {
+  if (!args.currentMilestoneId || args.milestoneMergedInPhases) return "none";
+  return args.milestoneComplete ? "merge" : "preserve";
 }
 
 /**
@@ -2182,7 +2222,7 @@ export async function startAuto(
       runKernelLoop: runUokKernelLoop,
       runLegacyLoop: runLegacyAutoLoop,
     });
-    cleanupAfterLoopExit(ctx);
+    await cleanupAfterLoopExit(ctx);
     return;
   }
 
@@ -2242,7 +2282,7 @@ export async function startAuto(
     runKernelLoop: runUokKernelLoop,
     runLegacyLoop: runLegacyAutoLoop,
   });
-  cleanupAfterLoopExit(ctx);
+  await cleanupAfterLoopExit(ctx);
 }
 
 // describeNextUnit is imported from auto-dashboard.ts and re-exported

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Auto-loop pipeline phases, merge closeout, and finalize handling.
 /**
  * auto/phases.ts — Pipeline phases for the auto-loop.
  *
@@ -343,6 +345,21 @@ export async function _runMilestoneMergeWithStashRestore(
     return stopOnPostflightRecoveryNeeded(ic, stashResult, milestoneId);
   }
   return null;
+}
+
+export async function _runMilestoneMergeOnceWithStashRestore(
+  ic: IterationContext,
+  milestoneId: string,
+): Promise<{ action: "break"; reason: string } | null> {
+  if (ic.s.milestoneMergedInPhases) {
+    debugLog("autoLoop", {
+      phase: "milestone-merge-skip",
+      reason: "already-merged-in-phases",
+      milestoneId,
+    });
+    return null;
+  }
+  return _runMilestoneMergeWithStashRestore(ic, milestoneId);
 }
 
 async function emitCancelledUnitEnd(
@@ -784,7 +801,7 @@ export async function runPreDispatch(
     // Worktree lifecycle on milestone transition — merge current, enter next.
     // #2909 / #5538-followup: preflight stash + always-on postflight pop.
     {
-      const stop = await _runMilestoneMergeWithStashRestore(ic, s.currentMilestoneId!);
+      const stop = await _runMilestoneMergeOnceWithStashRestore(ic, s.currentMilestoneId!);
       if (stop) return stop;
     }
 
@@ -866,7 +883,7 @@ export async function runPreDispatch(
       // All milestones complete — merge milestone branch before stopping.
       if (s.currentMilestoneId) {
         // #2909 / #5538-followup: preflight stash + always-on postflight pop.
-        const stop = await _runMilestoneMergeWithStashRestore(ic, s.currentMilestoneId);
+        const stop = await _runMilestoneMergeOnceWithStashRestore(ic, s.currentMilestoneId);
         if (stop) return stop;
         // PR creation (auto_pr) is handled inside mergeMilestoneToMain (#2302)
       }
@@ -961,7 +978,7 @@ export async function runPreDispatch(
     // Milestone merge on complete (before closeout so branch state is clean).
     if (s.currentMilestoneId) {
       // #2909 / #5538-followup: preflight stash + always-on postflight pop.
-      const stop = await _runMilestoneMergeWithStashRestore(ic, s.currentMilestoneId);
+      const stop = await _runMilestoneMergeOnceWithStashRestore(ic, s.currentMilestoneId);
       if (stop) return stop;
       // PR creation (auto_pr) is handled inside mergeMilestoneToMain (#2302)
     }
@@ -2346,6 +2363,11 @@ export async function runFinalize(
     // Step mode — exit the loop (caller handles wizard)
     debugLog("autoLoop", { phase: "exit", reason: "step-wizard" });
     return { action: "break", reason: "step-wizard" };
+  }
+
+  if (preUnitSnapshot?.type === "complete-milestone" && s.currentMilestoneId) {
+    const stop = await _runMilestoneMergeOnceWithStashRestore(ic, s.currentMilestoneId);
+    if (stop) return stop;
   }
 
   // Both pre and post verification completed without timeout — reset counter

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -5,7 +5,7 @@ import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { Text } from "@gsd/pi-tui";
 
 import { loadEffectiveGSDPreferences } from "../preferences.js";
-import { ensureDbOpen } from "./dynamic-tools.js";
+import { ensureDbOpen, safeWorkspaceCwd } from "./dynamic-tools.js";
 import { loadWriteGateSnapshot, shouldBlockRootArtifactSaveInSnapshot } from "./write-gate.js";
 import { StringEnum } from "@gsd/pi-ai";
 import { logError } from "../workflow-logger.js";
@@ -20,7 +20,7 @@ function toolWorkspaceRoot(ctx: unknown): string {
   if (ctx && typeof ctx === "object" && typeof (ctx as { cwd?: unknown }).cwd === "string") {
     return (ctx as { cwd: string }).cwd;
   }
-  return process.cwd();
+  return safeWorkspaceCwd();
 }
 
 /**

--- a/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
@@ -1,4 +1,7 @@
+// Project/App: GSD-2
+// File Purpose: Registers workspace-aware dynamic filesystem and shell tools.
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname } from "node:path";
 
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
@@ -8,11 +11,21 @@ import { DEFAULT_BASH_TIMEOUT_SECS } from "../constants.js";
 import { setLogBasePath, logWarning } from "../workflow-logger.js";
 import { resolveGsdPathContract } from "../paths.js";
 
+export function safeWorkspaceCwd(): string {
+  try {
+    return process.cwd();
+  } catch {
+    const projectRoot = process.env.GSD_PROJECT_ROOT;
+    if (projectRoot && existsSync(projectRoot)) return projectRoot;
+    return homedir();
+  }
+}
+
 function resolveToolWorkspaceRoot(ctx?: unknown): string {
   if (ctx && typeof ctx === "object" && typeof (ctx as { cwd?: unknown }).cwd === "string") {
     return (ctx as { cwd: string }).cwd;
   }
-  return process.cwd();
+  return safeWorkspaceCwd();
 }
 
 /**
@@ -25,7 +38,7 @@ export function resolveProjectRootDbPath(basePath: string): string {
   return resolveGsdPathContract(basePath).projectDb;
 }
 
-export async function ensureDbOpen(basePath: string = process.cwd()): Promise<boolean> {
+export async function ensureDbOpen(basePath: string = safeWorkspaceCwd()): Promise<boolean> {
   try {
     const db = await import("../gsd-db.js");
     const contract = resolveGsdPathContract(basePath);
@@ -57,7 +70,8 @@ export async function ensureDbOpen(basePath: string = process.cwd()): Promise<bo
 }
 
 export function registerDynamicTools(pi: ExtensionAPI): void {
-  const baseBash = createBashTool(process.cwd(), {
+  const fallbackRoot = safeWorkspaceCwd();
+  const baseBash = createBashTool(fallbackRoot, {
     spawnHook: (ctx) => ctx,
   });
   const dynamicBash = {
@@ -82,7 +96,7 @@ export function registerDynamicTools(pi: ExtensionAPI): void {
   };
   pi.registerTool(dynamicBash as any);
 
-  const baseWrite = createWriteTool(process.cwd());
+  const baseWrite = createWriteTool(fallbackRoot);
   pi.registerTool({
     ...baseWrite,
     execute: async (
@@ -97,7 +111,7 @@ export function registerDynamicTools(pi: ExtensionAPI): void {
     },
   } as any);
 
-  const baseRead = createReadTool(process.cwd());
+  const baseRead = createReadTool(fallbackRoot);
   pi.registerTool({
     ...baseRead,
     execute: async (
@@ -112,7 +126,7 @@ export function registerDynamicTools(pi: ExtensionAPI): void {
     },
   } as any);
 
-  const baseEdit = createEditTool(process.cwd());
+  const baseEdit = createEditTool(fallbackRoot);
   pi.registerTool({
     ...baseEdit,
     execute: async (

--- a/src/resources/extensions/gsd/bootstrap/exec-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/exec-tools.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Registers Context Mode execution tools.
 // GSD2 — Exec (context-mode) tool registration.
 //
 // Exposes the Context Mode runtime tools in-process. Default-on; opt out with
@@ -6,11 +8,13 @@
 import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 
+import { safeWorkspaceCwd } from "./dynamic-tools.js";
+
 function toolWorkspaceRoot(ctx: unknown): string {
   if (ctx && typeof ctx === "object" && typeof (ctx as { cwd?: unknown }).cwd === "string") {
     return (ctx as { cwd: string }).cwd;
   }
-  return process.cwd();
+  return safeWorkspaceCwd();
 }
 
 async function loadContextModePreferences(baseDir: string) {

--- a/src/resources/extensions/gsd/bootstrap/journal-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/journal-tools.ts
@@ -1,14 +1,17 @@
+// Project/App: GSD-2
+// File Purpose: Registers journal query tools.
 import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 
 import { queryJournal } from "../journal.js";
 import { logWarning } from "../workflow-logger.js";
+import { safeWorkspaceCwd } from "./dynamic-tools.js";
 
 function toolWorkspaceRoot(ctx: unknown): string {
   if (ctx && typeof ctx === "object" && typeof (ctx as { cwd?: unknown }).cwd === "string") {
     return (ctx as { cwd: string }).cwd;
   }
-  return process.cwd();
+  return safeWorkspaceCwd();
 }
 
 export function registerJournalTools(pi: ExtensionAPI): void {

--- a/src/resources/extensions/gsd/bootstrap/memory-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/memory-tools.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Registers memory-layer tools.
 // GSD2 — Memory tool registration
 //
 // Exposes the memory-layer tools (capture_thought, memory_query, gsd_graph)
@@ -7,7 +9,7 @@
 import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 
-import { ensureDbOpen } from "./dynamic-tools.js";
+import { ensureDbOpen, safeWorkspaceCwd } from "./dynamic-tools.js";
 import {
   executeGsdGraph,
   executeMemoryCapture,
@@ -18,7 +20,7 @@ function toolWorkspaceRoot(ctx: unknown): string {
   if (ctx && typeof ctx === "object" && typeof (ctx as { cwd?: unknown }).cwd === "string") {
     return (ctx as { cwd: string }).cwd;
   }
-  return process.cwd();
+  return safeWorkspaceCwd();
 }
 
 export function registerMemoryTools(pi: ExtensionAPI): void {

--- a/src/resources/extensions/gsd/bootstrap/query-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/query-tools.ts
@@ -1,14 +1,16 @@
+// Project/App: GSD-2
+// File Purpose: Registers read-only DB query tools.
 // GSD2 — Read-only query tools exposing DB state to the LLM via the WAL connection
 
 import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
-import { ensureDbOpen } from "./dynamic-tools.js";
+import { ensureDbOpen, safeWorkspaceCwd } from "./dynamic-tools.js";
 
 function toolWorkspaceRoot(ctx: unknown): string {
   if (ctx && typeof ctx === "object" && typeof (ctx as { cwd?: unknown }).cwd === "string") {
     return (ctx as { cwd: string }).cwd;
   }
-  return process.cwd();
+  return safeWorkspaceCwd();
 }
 
 export function registerQueryTools(pi: ExtensionAPI): void {

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Handles operational /gsd subcommands.
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
 import { enableDebug } from "../../debug-logger.js";
@@ -15,7 +17,7 @@ import { handleRemote } from "../../../remote-questions/mod.js";
 import { handleShip } from "../../commands-ship.js";
 import { handleSessionReport } from "../../commands-session-report.js";
 import { handlePrBranch } from "../../commands-pr-branch.js";
-import { projectRoot } from "../context.js";
+import { currentDirectoryRoot, projectRoot } from "../context.js";
 
 export async function handleOpsCommand(trimmed: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<boolean> {
   if (trimmed === "init") {
@@ -117,7 +119,7 @@ export async function handleOpsCommand(trimmed: string, ctx: ExtensionCommandCon
     return true;
   }
   if (trimmed === "triage") {
-    await handleTriage(ctx, pi, process.cwd());
+    await handleTriage(ctx, pi, currentDirectoryRoot());
     return true;
   }
   if (trimmed === "config") {

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Git operations, commit-message formatting, and turn git actions.
 /**
  * GSD Git Service
  *
@@ -129,6 +131,11 @@ export interface TurnGitActionResult {
 export interface TaskCommitContext {
   taskId: string;
   taskTitle: string;
+  milestoneId?: string;
+  milestoneTitle?: string;
+  sliceId?: string;
+  sliceTitle?: string;
+  taskDisplayId?: string;
   /** The one-liner from the task summary (e.g. "Added retry-aware worker status logging") */
   oneLiner?: string;
   /** Files modified by this task (from task summary frontmatter) */
@@ -170,6 +177,11 @@ export function buildTaskCommitMessage(ctx: TaskCommitContext): string {
     bodyParts.push(fileLines);
   }
 
+  const contextLines = buildTaskCommitContextLines(ctx);
+  if (contextLines.length > 0) {
+    bodyParts.push(`GSD context:\n${contextLines.join("\n")}`);
+  }
+
   // Trailers: GSD-Task first, then Resolves
   bodyParts.push(`GSD-Task: ${ctx.taskId}`);
 
@@ -178,6 +190,28 @@ export function buildTaskCommitMessage(ctx: TaskCommitContext): string {
   }
 
   return `${subject}\n\n${bodyParts.join("\n\n")}`;
+}
+
+function buildTaskCommitContextLines(ctx: TaskCommitContext): string[] {
+  const lines: string[] = [];
+  const milestone = formatNamedContext(ctx.milestoneId, ctx.milestoneTitle);
+  const slice = formatNamedContext(ctx.sliceId, ctx.sliceTitle);
+  const taskId = ctx.taskDisplayId ?? ctx.taskId.split("/").pop();
+  const task = formatNamedContext(taskId, ctx.taskTitle);
+
+  if (milestone) lines.push(`- Milestone: ${milestone}`);
+  if (slice) lines.push(`- Slice: ${slice}`);
+  if (task) lines.push(`- Task: ${task}`);
+  return lines;
+}
+
+function formatNamedContext(id: string | undefined, title: string | undefined): string | null {
+  const cleanId = id?.trim();
+  const cleanTitle = title?.trim();
+  if (!cleanId && !cleanTitle) return null;
+  if (!cleanId) return cleanTitle ?? null;
+  if (!cleanTitle || cleanTitle === cleanId) return cleanId;
+  return `${cleanId} - ${cleanTitle}`;
 }
 
 function sanitizeCommitSubjectDescription(value: string): string {

--- a/src/resources/extensions/gsd/slice-cadence.ts
+++ b/src/resources/extensions/gsd/slice-cadence.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Slice-cadence merge and milestone resquash git operations.
 /**
  * Slice-cadence collapse — #4765.
  *
@@ -40,6 +42,7 @@ import { logWarning } from "./workflow-logger.js";
 import { emitSliceMerged, emitMilestoneResquash } from "./worktree-telemetry.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
+import { getMilestone, getSlice, isDbAvailable } from "./gsd-db.js";
 
 /**
  * Auto-worktree milestone branch name. Must match autoWorktreeBranch() in
@@ -70,6 +73,50 @@ function cleanupMergeArtifacts(projectRoot: string): void {
   } catch (err) {
     logWarning("worktree", `merge artifact cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
   }
+}
+
+function stripKnownIdPrefix(value: string | undefined | null, id: string): string | undefined {
+  const raw = String(value ?? "").trim();
+  if (!raw) return undefined;
+  const lower = raw.toLowerCase();
+  const idLower = id.toLowerCase();
+  if (lower.startsWith(`${idLower}:`)) return raw.slice(id.length + 1).trim() || undefined;
+  return raw;
+}
+
+function getSliceMergeNames(milestoneId: string, sliceId: string): {
+  milestoneTitle?: string;
+  sliceTitle?: string;
+} {
+  if (!isDbAvailable()) return {};
+  return {
+    milestoneTitle: stripKnownIdPrefix(getMilestone(milestoneId)?.title, milestoneId),
+    sliceTitle: stripKnownIdPrefix(getSlice(milestoneId, sliceId)?.title, sliceId),
+  };
+}
+
+function buildSliceMergeCommitMessage(milestoneId: string, sliceId: string, milestoneBranch: string): string {
+  const names = getSliceMergeNames(milestoneId, sliceId);
+  const sliceLabel = names.sliceTitle ?? sliceId;
+  const subject = `feat: ${sliceLabel} - ${sliceId} of ${milestoneId} (slice-cadence)`;
+  const body = [
+    `Slice: ${sliceId}${names.sliceTitle ? ` - ${names.sliceTitle}` : ""}`,
+    `Milestone: ${milestoneId}${names.milestoneTitle ? ` - ${names.milestoneTitle}` : ""}`,
+    `GSD-Slice: ${sliceId}`,
+    `GSD-Milestone: ${milestoneId}`,
+    `Branch: ${milestoneBranch}`,
+  ];
+  return `${subject}\n\n${body.join("\n")}`;
+}
+
+function buildMilestoneResquashCommitMessage(milestoneId: string, sliceCount: number): string {
+  const milestoneTitle = isDbAvailable()
+    ? stripKnownIdPrefix(getMilestone(milestoneId)?.title, milestoneId)
+    : undefined;
+  const subject = milestoneTitle
+    ? `feat: ${milestoneTitle} (${milestoneId}, ${sliceCount} slices re-squashed)`
+    : `feat: ${milestoneId} (${sliceCount} slices re-squashed)`;
+  return `${subject}\n\nMilestone: ${milestoneId}${milestoneTitle ? ` - ${milestoneTitle}` : ""}\nGSD-Milestone: ${milestoneId}`;
 }
 
 function advanceMilestoneBranch(
@@ -227,7 +274,7 @@ export function mergeSliceToMain(
     // Commit the squash with a slice-scoped message
     const commitSha = nativeCommit(
       projectRoot,
-      `gsd: merge ${sliceId} of ${milestoneId} (slice-cadence)`,
+      buildSliceMergeCommitMessage(milestoneId, sliceId, milestoneBranch),
     );
 
     // Advance the milestone branch to main so the next slice's commits start
@@ -327,7 +374,7 @@ export function resquashMilestoneOnMain(
 
     const newSha = nativeCommit(
       projectRoot,
-      `gsd: complete milestone ${milestoneId} (${sliceCount} slices re-squashed)`,
+      buildMilestoneResquashCommitMessage(milestoneId, sliceCount),
       { allowEmpty: true },
     );
 

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -1,44 +1,85 @@
+// Project/App: GSD-2
+// File Purpose: Behavior tests for auto-loop cleanup after paused provider exits.
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { cleanupAfterLoopExit, rerootCommandSession } from "../auto.ts";
 import { autoSession } from "../auto-runtime-state.ts";
-import { _cleanupAfterLoopExitForTest } from "../auto.ts";
 
-test.afterEach(() => {
+test("cleanupAfterLoopExit preserves paused auto badge after provider pause", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-paused-cleanup-"));
+  const previousCwd = process.cwd();
+  const statuses: Array<[string, string | undefined]> = [];
+
   autoSession.reset();
-});
-
-test("#3370: cleanupAfterLoopExit preserves paused auto badge after provider pause", () => {
-  const statusCalls: unknown[] = [];
-  const widgetCalls: unknown[] = [];
   autoSession.active = true;
   autoSession.paused = true;
+  autoSession.basePath = join(base, ".gsd", "worktrees", "M001");
+  autoSession.originalBasePath = base;
 
-  _cleanupAfterLoopExitForTest({
-    ui: {
-      setStatus: (...args: unknown[]) => statusCalls.push(args),
-      setWidget: (...args: unknown[]) => widgetCalls.push(args),
-    },
-  } as any);
+  try {
+    await cleanupAfterLoopExit({
+      ui: {
+        setStatus: (key: string, value: string | undefined) => {
+          statuses.push([key, value]);
+        },
+        setWidget: () => {},
+        notify: () => {},
+      },
+    } as any);
 
-  assert.deepEqual(statusCalls, []);
-  assert.deepEqual(widgetCalls, []);
-  assert.equal(autoSession.active, false);
-  assert.equal(autoSession.paused, true);
+    assert.equal(statuses.some(([key]) => key === "gsd-auto"), false);
+    assert.equal(autoSession.active, false);
+    assert.equal(autoSession.paused, true);
+  } finally {
+    autoSession.reset();
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
-test("#3370: cleanupAfterLoopExit clears status and widget when auto is not paused", () => {
+test("cleanupAfterLoopExit clears status and widget when auto is not paused", async () => {
   const statusCalls: unknown[] = [];
   const widgetCalls: unknown[] = [];
+
+  autoSession.reset();
   autoSession.active = true;
   autoSession.paused = false;
 
-  _cleanupAfterLoopExitForTest({
-    ui: {
-      setStatus: (...args: unknown[]) => statusCalls.push(args),
-      setWidget: (...args: unknown[]) => widgetCalls.push(args),
-    },
-  } as any);
+  try {
+    await cleanupAfterLoopExit({
+      hasUI: false,
+      ui: {
+        setStatus: (...args: unknown[]) => statusCalls.push(args),
+        setWidget: (...args: unknown[]) => widgetCalls.push(args),
+        notify: () => {},
+      },
+    } as any);
 
-  assert.deepEqual(statusCalls, [["gsd-auto", undefined]]);
-  assert.deepEqual(widgetCalls, [["gsd-progress", undefined]]);
+    assert.deepEqual(statusCalls, [["gsd-auto", undefined]]);
+    assert.deepEqual(widgetCalls, [["gsd-progress", undefined]]);
+    assert.equal(autoSession.active, false);
+    assert.equal(autoSession.paused, false);
+  } finally {
+    autoSession.reset();
+  }
+});
+
+test("rerootCommandSession refreshes command workspace to project root", async () => {
+  const calls: string[] = [];
+  const result = await rerootCommandSession(
+    {
+      newSession: async ({ workspaceRoot }: { workspaceRoot: string }) => {
+        calls.push(workspaceRoot);
+        return { cancelled: false };
+      },
+    } as any,
+    "/project/root",
+  );
+
+  assert.deepEqual(result, { status: "ok" });
+  assert.deepEqual(calls, ["/project/root"]);
 });

--- a/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Auto-loop phase lifecycle regression tests.
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -27,6 +29,59 @@ async function runSuccessfulFinalize(s: AutoSession) {
     postUnitPreVerification: async () => "continue",
     runPostUnitVerification: async () => "continue",
     postUnitPostVerification: async () => "continue",
+  };
+
+  return runFinalize(
+    {
+      ctx: { ui: { notify() {} } },
+      pi: {},
+      s,
+      deps,
+      prefs: undefined,
+      iteration: 1,
+      flowId: "flow-1",
+      nextSeq: () => 1,
+    } as any,
+    {
+      unitType: unit.type,
+      unitId: unit.id,
+      prompt: "",
+      finalPrompt: "",
+      pauseAfterUatDispatch: false,
+      state: {} as any,
+      mid: "M001",
+      midTitle: "Milestone",
+      isRetry: false,
+      previousTier: undefined,
+    },
+    {
+      recentUnits: [],
+      stuckRecoveryAttempts: 0,
+      consecutiveFinalizeTimeouts: 0,
+    },
+  );
+}
+
+async function runFinalizeWithDeps(s: AutoSession, depsOverrides: Record<string, unknown>) {
+  const unit = s.currentUnit;
+  assert.ok(unit, "test setup must provide currentUnit");
+
+  writeUnitRuntimeRecord(s.basePath, unit.type, unit.id, unit.startedAt, {
+    phase: "dispatched",
+  });
+
+  const deps = {
+    clearUnitTimeout() {},
+    buildSnapshotOpts() {
+      return {};
+    },
+    stopAuto: async () => {},
+    pauseAuto: async () => {},
+    updateProgressWidget() {},
+    postUnitPreVerification: async () => "continue",
+    runPostUnitVerification: async () => "continue",
+    postUnitPostVerification: async () => "continue",
+    ...depsOverrides,
   };
 
   return runFinalize(
@@ -101,4 +156,55 @@ test("runFinalize marks unit runtime finalized after successful finalize", async
   } finally {
     rmSync(base, { recursive: true, force: true });
   }
+});
+
+test("runFinalize merges a verified complete-milestone immediately and only once", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-finalize-merge-"));
+  t.after(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const s = new AutoSession();
+  const startedAt = Date.now();
+  let mergeCalls = 0;
+  s.basePath = base;
+  s.originalBasePath = base;
+  s.currentMilestoneId = "M001";
+  s.currentUnit = {
+    type: "complete-milestone",
+    id: "M001",
+    startedAt,
+  };
+
+  const result = await runFinalizeWithDeps(s, {
+    preflightCleanRoot: () => ({ stashPushed: false }),
+    postflightPopStash: () => ({ needsManualRecovery: false }),
+    resolver: {
+      mergeAndExit() {
+        mergeCalls++;
+      },
+    },
+  });
+
+  assert.equal(result.action, "next");
+  assert.equal(mergeCalls, 1);
+  assert.equal(s.milestoneMergedInPhases, true);
+
+  s.currentUnit = {
+    type: "complete-milestone",
+    id: "M001",
+    startedAt: startedAt + 1,
+  };
+  const second = await runFinalizeWithDeps(s, {
+    preflightCleanRoot: () => ({ stashPushed: false }),
+    postflightPopStash: () => ({ needsManualRecovery: false }),
+    resolver: {
+      mergeAndExit() {
+        mergeCalls++;
+      },
+    },
+  });
+
+  assert.equal(second.action, "next");
+  assert.equal(mergeCalls, 1);
 });

--- a/src/resources/extensions/gsd/tests/auto-project-root-env.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-project-root-env.test.ts
@@ -1,9 +1,17 @@
+// Project/App: GSD-2
+// File Purpose: Behavior tests for auto-mode project-root environment cleanup.
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import {
+  cleanupAfterLoopExit,
   _captureProjectRootEnvForTest,
   _restoreProjectRootEnvForTest,
 } from "../auto.ts";
+import { autoSession } from "../auto-runtime-state.ts";
 
 test.afterEach(() => {
   _restoreProjectRootEnvForTest();
@@ -28,4 +36,39 @@ test("auto-mode project-root env restore deletes GSD_PROJECT_ROOT when it was in
 
   _restoreProjectRootEnvForTest();
   assert.equal(process.env.GSD_PROJECT_ROOT, undefined);
+});
+
+test("cleanupAfterLoopExit restores captured GSD_PROJECT_ROOT", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-project-root-env-"));
+  const previousCwd = process.cwd();
+  const previousProjectRoot = process.env.GSD_PROJECT_ROOT;
+
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.basePath = join(base, ".gsd", "worktrees", "M001");
+  autoSession.originalBasePath = base;
+  autoSession.projectRootEnvCaptured = true;
+  autoSession.hadProjectRootEnv = true;
+  autoSession.previousProjectRootEnv = "/previous/project";
+  process.env.GSD_PROJECT_ROOT = base;
+
+  try {
+    await cleanupAfterLoopExit({
+      ui: {
+        setStatus: () => {},
+        setWidget: () => {},
+        notify: () => {},
+      },
+    } as any);
+
+    assert.equal(process.env.GSD_PROJECT_ROOT, "/previous/project");
+    assert.equal(autoSession.projectRootEnvCaptured, false);
+    assert.equal(autoSession.previousProjectRootEnv, null);
+  } finally {
+    autoSession.reset();
+    process.chdir(previousCwd);
+    if (previousProjectRoot === undefined) delete process.env.GSD_PROJECT_ROOT;
+    else process.env.GSD_PROJECT_ROOT = previousProjectRoot;
+    rmSync(base, { recursive: true, force: true });
+  }
 });

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -1,0 +1,138 @@
+// Project/App: GSD-2
+// File Purpose: Bootstrap behavior tests for completed milestone orphan merges.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { bootstrapAutoSession } from "../auto-start.ts";
+import { AutoSession } from "../auto/session.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  openDatabase,
+} from "../gsd-db.ts";
+
+function runGit(base: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: base,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function makeRepoWithUnmergedCompletedMilestone(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-orphan-bootstrap-"));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "PREFERENCES.md"),
+    "---\ngit:\n  isolation: \"branch\"\n---\n",
+  );
+  runGit(base, ["init"]);
+  runGit(base, ["config", "user.email", "test@test.com"]);
+  runGit(base, ["config", "user.name", "Test"]);
+  writeFileSync(join(base, "README.md"), "# test\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "init"]);
+  runGit(base, ["branch", "-M", "main"]);
+
+  runGit(base, ["checkout", "-b", "milestone/M002"]);
+  writeFileSync(join(base, "m002.txt"), "complete but unmerged\n");
+  runGit(base, ["add", "-A"]);
+  runGit(base, ["commit", "-m", "feat: M002 work"]);
+  runGit(base, ["checkout", "main"]);
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M002", title: "Completed milestone", status: "complete" });
+  insertMilestone({ id: "M003", title: "Next milestone", status: "active" });
+  closeDatabase();
+
+  return base;
+}
+
+function makeCtx(notifications: Array<{ message: string; level?: string }>) {
+  const model = { provider: "claude-code", id: "claude-sonnet-4-6", contextWindow: 128000 };
+  return {
+    ui: {
+      notify: (message: string, level?: string) => {
+        notifications.push({ message, level });
+      },
+      setStatus: () => {},
+      setWidget: () => {},
+    },
+    model,
+    modelRegistry: {
+      getAvailable: () => [model],
+      isProviderRequestReady: () => true,
+      getProviderAuthMode: () => "oauth",
+    },
+    sessionManager: {
+      getSessionId: () => "orphan-bootstrap-test",
+      getSessionFile: () => null,
+      getEntries: () => [],
+    },
+  };
+}
+
+test("bootstrap aborts before starting next milestone when completed orphan merge fails", async () => {
+  const base = makeRepoWithUnmergedCompletedMilestone();
+  const previousCwd = process.cwd();
+  const s = new AutoSession();
+  const mergeCalls: string[] = [];
+  const notifications: Array<{ message: string; level?: string }> = [];
+
+  try {
+    const ready = await bootstrapAutoSession(
+      s,
+      makeCtx(notifications) as any,
+      {
+        getThinkingLevel: () => "medium",
+        getActiveTools: () => [],
+        events: { emit: () => {} },
+      } as any,
+      base,
+      false,
+      false,
+      {
+        shouldUseWorktreeIsolation: () => true,
+        registerSigtermHandler: () => {},
+        lockBase: () => base,
+        buildResolver: () => ({
+          mergeAndExit: (milestoneId: string) => {
+            mergeCalls.push(milestoneId);
+            throw new Error("synthetic merge failure");
+          },
+        }) as any,
+      },
+      {
+        classification: "none",
+        lock: null,
+        pausedSession: null,
+        state: null,
+        recovery: null,
+        recoveryPrompt: null,
+        recoveryToolCallCount: 0,
+        artifactSatisfied: false,
+        hasResumableDiskState: false,
+        isBootstrapCrash: false,
+      },
+    );
+
+    assert.equal(ready, false);
+    assert.deepEqual(mergeCalls, ["M002"]);
+    assert.equal(s.active, false);
+    assert.match(
+      notifications.map((entry) => entry.message).join("\n"),
+      /Could not merge orphan milestone M002: synthetic merge failure/,
+    );
+  } finally {
+    try {
+      closeDatabase();
+    } catch {}
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+

--- a/src/resources/extensions/gsd/tests/cwd-fallback-hardening.test.ts
+++ b/src/resources/extensions/gsd/tests/cwd-fallback-hardening.test.ts
@@ -1,0 +1,138 @@
+// Project/App: GSD-2
+// File Purpose: Behavior tests for deleted-cwd fallback handling.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerDbTools } from "../bootstrap/db-tools.ts";
+import { registerDynamicTools, ensureDbOpen, safeWorkspaceCwd } from "../bootstrap/dynamic-tools.ts";
+import { registerExecTools } from "../bootstrap/exec-tools.ts";
+import { registerJournalTools } from "../bootstrap/journal-tools.ts";
+import { registerMemoryTools } from "../bootstrap/memory-tools.ts";
+import { registerQueryTools } from "../bootstrap/query-tools.ts";
+
+async function withDeletedCwd(fn: (projectRoot: string) => Promise<void> | void): Promise<void> {
+  const previousCwd = process.cwd();
+  const previousProjectRoot = process.env.GSD_PROJECT_ROOT;
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-safe-cwd-project-"));
+  const removedCwd = mkdtempSync(join(tmpdir(), "gsd-removed-cwd-"));
+
+  process.env.GSD_PROJECT_ROOT = projectRoot;
+  process.chdir(removedCwd);
+  rmSync(removedCwd, { recursive: true, force: true });
+
+  try {
+    assert.throws(() => process.cwd(), /ENOENT/);
+    await fn(projectRoot);
+  } finally {
+    process.chdir(previousCwd);
+    if (previousProjectRoot === undefined) delete process.env.GSD_PROJECT_ROOT;
+    else process.env.GSD_PROJECT_ROOT = previousProjectRoot;
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+}
+
+function collectTools(register: (pi: any) => void): any[] {
+  const tools: any[] = [];
+  register({
+    registerTool(tool: any) {
+      tools.push(tool);
+    },
+  });
+  return tools;
+}
+
+test("safeWorkspaceCwd falls back to captured project root when cwd was removed", async () => {
+  await withDeletedCwd((projectRoot) => {
+    assert.equal(safeWorkspaceCwd(), projectRoot);
+  });
+});
+
+test("ensureDbOpen default path does not throw when cwd was removed", async () => {
+  await withDeletedCwd(async () => {
+    assert.equal(await ensureDbOpen(), false);
+  });
+});
+
+test("dynamic tools register when cwd was removed", async () => {
+  await withDeletedCwd(() => {
+    const tools = collectTools(registerDynamicTools);
+    assert.equal(tools.length, 4);
+  });
+});
+
+test("db-backed tool fallbacks return normal unavailable-db errors when cwd was removed", async () => {
+  await withDeletedCwd(async () => {
+    const tools = collectTools(registerDbTools);
+    const decisionSave = tools.find((tool) => tool.name === "gsd_decision_save");
+
+    const result = await decisionSave.execute(
+      "call-1",
+      {
+        scope: "test",
+        decision: "Handle deleted cwd",
+        choice: "Use captured project root",
+        rationale: "The worktree cwd may disappear during cleanup.",
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    assert.equal(result.details.error, "db_unavailable");
+  });
+});
+
+test("memory and query tools do not throw when cwd was removed", async () => {
+  await withDeletedCwd(async () => {
+    const memoryTools = collectTools(registerMemoryTools);
+    const queryTools = collectTools(registerQueryTools);
+
+    await assert.doesNotReject(() =>
+      memoryTools.find((tool) => tool.name === "memory_query").execute(
+        "call-1",
+        { query: "cwd fallback" },
+        undefined,
+        undefined,
+        undefined,
+      ),
+    );
+    await assert.doesNotReject(() =>
+      queryTools.find((tool) => tool.name === "gsd_milestone_status").execute(
+        "call-2",
+        { milestoneId: "M001" },
+        undefined,
+        undefined,
+        undefined,
+      ),
+    );
+  });
+});
+
+test("journal and exec tools do not throw when cwd was removed", async () => {
+  await withDeletedCwd(async () => {
+    const journalTools = collectTools(registerJournalTools);
+    const execTools = collectTools(registerExecTools);
+
+    await assert.doesNotReject(() =>
+      journalTools.find((tool) => tool.name === "gsd_journal_query").execute(
+        "call-1",
+        { limit: 1 },
+        undefined,
+        undefined,
+        undefined,
+      ),
+    );
+    await assert.doesNotReject(() =>
+      execTools.find((tool) => tool.name === "gsd_resume").execute(
+        "call-2",
+        {},
+        undefined,
+        undefined,
+        undefined,
+      ),
+    );
+  });
+});

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Auto-worktree milestone squash-merge integration tests.
 /**
  * auto-worktree-milestone-merge.test.ts — Integration tests for mergeMilestoneToMain.
  *
@@ -25,6 +27,13 @@ import {
 import { getSliceBranchName } from "../../worktree.ts";
 import { nativeMergeSquash } from "../../native-git-bridge.ts";
 import { drainLogs, setStderrLoggingEnabled } from "../../workflow-logger.ts";
+import {
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+} from "../../gsd-db.ts";
 
 function run(cmd: string, cwd: string): string {
   // Safe: all inputs are hardcoded test strings, not user input
@@ -117,6 +126,7 @@ describe("auto-worktree-milestone-merge", { timeout: 300_000 }, () => {
 
   afterEach(() => {
     process.chdir(savedCwd);
+    closeDatabase();
     for (const d of tempDirs) {
       if (existsSync(d)) rmSync(d, { recursive: true, force: true });
     }
@@ -179,6 +189,24 @@ describe("auto-worktree-milestone-merge", { timeout: 300_000 }, () => {
     addSliceToMilestone(repo, wtPath, "M020", "S03", "Logging infra", [
       { file: "logger.ts", content: "export const log = () => {};\n", message: "add logger" },
     ]);
+    openDatabase(":memory:");
+    insertMilestone({ id: "M020", title: "M020: Backend foundation", status: "complete" });
+    for (const slice of [
+      { id: "S01", title: "Core API", tasks: [{ id: "T01", title: "Create API router" }] },
+      { id: "S02", title: "Error handling", tasks: [{ id: "T02", title: "Handle API errors" }] },
+      { id: "S03", title: "Logging infra", tasks: [{ id: "T03", title: "Wire request logging" }] },
+    ]) {
+      insertSlice({ id: slice.id, milestoneId: "M020", title: slice.title, status: "complete" });
+      for (const task of slice.tasks) {
+        insertTask({
+          id: task.id,
+          sliceId: slice.id,
+          milestoneId: "M020",
+          title: task.title,
+          status: "complete",
+        });
+      }
+    }
 
     const roadmap = makeRoadmap("M020", "Backend foundation", [
       { id: "S01", title: "Core API" },
@@ -193,13 +221,20 @@ describe("auto-worktree-milestone-merge", { timeout: 300_000 }, () => {
     assert.ok(result.commitMessage.includes("- S01: Core API"), "body lists S01");
     assert.ok(result.commitMessage.includes("- S02: Error handling"), "body lists S02");
     assert.ok(result.commitMessage.includes("- S03: Logging infra"), "body lists S03");
+    assert.ok(result.commitMessage.includes("Completed tasks:"), "body lists completed tasks");
+    assert.ok(result.commitMessage.includes("- S01/T01: Create API router"), "body lists S01 task");
+    assert.ok(result.commitMessage.includes("- S02/T02: Handle API errors"), "body lists S02 task");
+    assert.ok(result.commitMessage.includes("Milestone: M020 - Backend foundation"), "body has human milestone context");
     assert.ok(result.commitMessage.includes("GSD-Milestone: M020"), "body has GSD-Milestone trailer");
     assert.ok(result.commitMessage.includes("Branch: milestone/M020"), "body has branch metadata");
+    assert.ok(!result.commitMessage.includes("auto-commit after complete-milestone"), "body avoids generic complete-milestone fallback");
+    assert.ok(!result.commitMessage.includes("GSD-Unit:"), "body avoids generic unit trailer");
 
     const gitMsg = run("git log -1 --format=%B main", repo).trim();
     assert.match(gitMsg, /^feat:/, "git commit message starts with feat:");
     assert.ok(gitMsg.includes("GSD-Milestone: M020"), "git commit has GSD-Milestone trailer");
     assert.ok(gitMsg.includes("- S01: Core API"), "git commit body has S01");
+    assert.ok(gitMsg.includes("- S03/T03: Wire request logging"), "git commit body has task names");
   });
 
   test("nothing to commit — safe when no code changes (#1738, #1792)", () => {

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Git service integration and commit-message tests.
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync, readFileSync } from "node:fs";
@@ -211,7 +213,12 @@ describe('git-service', async () => {
   test('buildTaskCommitMessage', () => {
     const msg = buildTaskCommitMessage({
       taskId: "S01/T02",
+      taskDisplayId: "T02",
       taskTitle: "implement user authentication",
+      milestoneId: "M001",
+      milestoneTitle: "User management",
+      sliceId: "S01",
+      sliceTitle: "Authentication",
       oneLiner: "Added JWT-based auth with refresh token rotation",
       keyFiles: ["src/auth.ts", "src/middleware/jwt.ts"],
     });
@@ -220,7 +227,12 @@ describe('git-service', async () => {
     assert.ok(msg.includes("JWT-based auth"), "message includes one-liner content");
     assert.ok(msg.includes("- src/auth.ts"), "message body includes key files");
     assert.ok(msg.includes("- src/middleware/jwt.ts"), "message body includes second key file");
+    assert.ok(msg.includes("GSD context:"), "message includes human GSD context block");
+    assert.ok(msg.includes("- Milestone: M001 - User management"), "message includes milestone name");
+    assert.ok(msg.includes("- Slice: S01 - Authentication"), "message includes slice name");
+    assert.ok(msg.includes("- Task: T02 - implement user authentication"), "message includes task name");
     assert.ok(msg.includes("GSD-Task: S01/T02"), "GSD-Task trailer in body");
+    assert.ok(!msg.includes("chore: auto-commit after execute-task"), "message does not use generic fallback");
   });
 
   test('buildTaskCommitMessage sanitizes subject text', () => {

--- a/src/resources/extensions/gsd/tests/slice-cadence.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-cadence.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Slice-cadence merge and resquash tests.
 /**
  * Tests for slice-cadence collapse — #4765.
  *
@@ -20,6 +22,7 @@ import {
 } from "../slice-cadence.ts";
 import { MergeConflictError } from "../git-service.ts";
 import { summarizeWorktreeTelemetry } from "../worktree-telemetry.ts";
+import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
 
 function git(args: string[], cwd: string): string {
   return execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
@@ -81,6 +84,7 @@ describe("mergeSliceToMain", () => {
 
   afterEach(() => {
     try { process.chdir(originalCwd); } catch { /* */ }
+    closeDatabase();
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -107,6 +111,25 @@ describe("mergeSliceToMain", () => {
     const summary = summarizeWorktreeTelemetry(dir);
     assert.equal(summary.slicesMerged, 1);
     assert.equal(summary.sliceMergeConflicts, 0);
+  });
+
+  test("slice-cadence commit messages include milestone and slice names", () => {
+    openDatabase(":memory:");
+    insertMilestone({ id: "M001", title: "M001: Backend foundation", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "S01: Core API", status: "complete" });
+    enterMilestoneBranch(dir, "M001");
+    commitFile(dir, "feature.txt", "slice 1 work\n", "feat: S01 work");
+
+    process.chdir(dir);
+    mergeSliceToMain(dir, "M001", "S01");
+
+    const subject = git(["log", "-1", "--format=%s", "main"], dir);
+    const body = git(["log", "-1", "--format=%B", "main"], dir);
+    assert.equal(subject, "feat: Core API - S01 of M001 (slice-cadence)");
+    assert.ok(body.includes("Slice: S01 - Core API"));
+    assert.ok(body.includes("Milestone: M001 - Backend foundation"));
+    assert.ok(body.includes("GSD-Slice: S01"));
+    assert.ok(body.includes("GSD-Milestone: M001"));
   });
 
   test("merges slices to the recorded integration branch", () => {

--- a/src/resources/extensions/gsd/tests/stop-auto-merge-back.test.ts
+++ b/src/resources/extensions/gsd/tests/stop-auto-merge-back.test.ts
@@ -1,31 +1,58 @@
-// GSD-2 — stopAuto worktree exit strategy regression tests.
+// Project/App: GSD-2
+// File Purpose: Stop-auto worktree exit strategy regression tests.
+/**
+ * stop-auto-merge-back.test.ts — Regression test for #2317.
+ *
+ * When auto-mode stops after a milestone is complete, stopAuto should trigger
+ * merge-back (mergeAndExit) instead of just exiting the worktree with
+ * preserveBranch: true. Otherwise milestone code stays stranded on the
+ * worktree branch and never reaches main.
+ */
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { _selectStopAutoWorktreeExit } from "../auto.ts";
 
-import { _resolveAutoWorktreeExitActionForTest } from "../auto.ts";
-
-test("completed milestones merge the auto worktree back", () => {
+test("#2317: stopAuto should check milestone completion status before choosing exit strategy", () => {
   assert.equal(
-    _resolveAutoWorktreeExitActionForTest("M001", false, true),
+    _selectStopAutoWorktreeExit({
+      currentMilestoneId: "M001",
+      milestoneComplete: true,
+      milestoneMergedInPhases: false,
+    }),
     "merge",
   );
 });
 
-test("incomplete milestones preserve the branch for resumption", () => {
+test("#2317: stopAuto still preserves branch for incomplete milestones", () => {
   assert.equal(
-    _resolveAutoWorktreeExitActionForTest("M001", false, false),
+    _selectStopAutoWorktreeExit({
+      currentMilestoneId: "M001",
+      milestoneComplete: false,
+      milestoneMergedInPhases: false,
+    }),
     "preserve",
   );
 });
 
-test("already-merged or missing milestone exits skip worktree teardown", () => {
+test("#2317: stopAuto does not merge a milestone already merged in phases", () => {
   assert.equal(
-    _resolveAutoWorktreeExitActionForTest("M001", true, true),
-    "skip",
+    _selectStopAutoWorktreeExit({
+      currentMilestoneId: "M001",
+      milestoneComplete: true,
+      milestoneMergedInPhases: true,
+    }),
+    "none",
   );
+});
+
+test("#2317: stopAuto skips worktree teardown when no milestone is active", () => {
   assert.equal(
-    _resolveAutoWorktreeExitActionForTest(null, false, true),
-    "skip",
+    _selectStopAutoWorktreeExit({
+      currentMilestoneId: null,
+      milestoneComplete: true,
+      milestoneMergedInPhases: false,
+    }),
+    "none",
   );
 });

--- a/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
@@ -529,6 +529,42 @@ test("exitMilestone commits, tears down, and resets basePath", () => {
   assert.equal(findCalls(deps.calls, "invalidateAllCaches").length, 1);
 });
 
+test("exitMilestone moves cwd to project root before teardown", (t) => {
+  const originalCwd = process.cwd();
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-exit-cwd-")));
+  const wtPath = join(base, ".gsd", "worktrees", "M001");
+  mkdirSync(wtPath, { recursive: true });
+  t.after(() => {
+    process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  process.chdir(wtPath);
+  const s = makeSession({
+    basePath: wtPath,
+    originalBasePath: base,
+  });
+  const deps = makeDeps({
+    isInAutoWorktree: () => true,
+  });
+  deps.teardownAutoWorktree = (
+    teardownBasePath: string,
+    milestoneId: string,
+    opts?: { preserveBranch?: boolean },
+  ) => {
+    deps.calls.push({ fn: "teardownAutoWorktree", args: [teardownBasePath, milestoneId, opts] });
+    assert.equal(process.cwd(), base);
+    rmSync(wtPath, { recursive: true, force: true });
+  };
+  const ctx = makeNotifyCtx();
+  const resolver = new WorktreeResolver(s, deps);
+
+  resolver.exitMilestone("M001", ctx);
+
+  assert.equal(process.cwd(), base);
+  assert.equal(s.basePath, base);
+});
+
 test("exitMilestone is no-op when not in worktree", () => {
   const s = makeSession();
   const deps = makeDeps({

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -476,19 +476,47 @@ export class WorktreeResolver {
         phase: "auto-commit-failed",
         error: err instanceof Error ? err.message : String(err),
       });
+      ctx.notify(
+        `Auto-commit before exiting ${milestoneId} failed: ${err instanceof Error ? err.message : String(err)}. Branch ${this.deps.autoWorktreeBranch(milestoneId)} is preserved for recovery.`,
+        "warning",
+      );
     }
 
+    if (this.s.originalBasePath) {
+      try {
+        process.chdir(this.s.originalBasePath);
+      } catch (err) {
+        debugLog("WorktreeResolver", {
+          action: "exitMilestone",
+          milestoneId,
+          phase: "pre-teardown-chdir-failed",
+          originalBasePath: this.s.originalBasePath,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        ctx.notify(
+          `Could not leave milestone worktree before cleanup: ${err instanceof Error ? err.message : String(err)}. Branch ${this.deps.autoWorktreeBranch(milestoneId)} is preserved for recovery.`,
+          "warning",
+        );
+      }
+    }
+
+    let teardownFailed = false;
     try {
       this.deps.teardownAutoWorktree(this.s.originalBasePath, milestoneId, {
         preserveBranch: opts?.preserveBranch ?? false,
       });
     } catch (err) {
+      teardownFailed = true;
       debugLog("WorktreeResolver", {
         action: "exitMilestone",
         milestoneId,
         phase: "teardown-failed",
         error: err instanceof Error ? err.message : String(err),
       });
+      ctx.notify(
+        `Worktree cleanup failed for ${milestoneId}: ${err instanceof Error ? err.message : String(err)}. Branch ${this.deps.autoWorktreeBranch(milestoneId)} is preserved for recovery.`,
+        "warning",
+      );
     }
 
     this.restoreToProjectRoot();
@@ -498,7 +526,12 @@ export class WorktreeResolver {
       result: "done",
       basePath: this.s.basePath,
     });
-    ctx.notify(`Exited worktree for ${milestoneId}`, "info");
+    ctx.notify(
+      teardownFailed
+        ? `Worktree exit for ${milestoneId} needs manual cleanup.`
+        : `Exited worktree for ${milestoneId}`,
+      teardownFailed ? "warning" : "info",
+    );
   }
 
   // ── Merge and Exit ─────────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Hardens auto-mode milestone merge closeout, commit naming, preserved-stop recovery, and deleted-cwd fallback handling.
**Why:** Completed milestones could remain unmerged while later milestones started, and cleanup could leave GSD rooted in a removed worktree.
**How:** Adds idempotent milestone merge paths, blocks bootstrap on failed orphan merges, enriches commit context, anchors teardown cwd, and routes tool fallbacks through a safe workspace cwd helper.

## What

- Merge verified `complete-milestone` work immediately and idempotently after finalize.
- Stop bootstrap from starting a later milestone when a completed orphan milestone cannot merge back first.
- Preserve incomplete milestone branches/worktrees with clearer recovery notifications and cwd anchoring before teardown.
- Include milestone, slice, and task names in task commits, slice-cadence commits, and milestone squash commit bodies while preserving `GSD-Task: Sxx/Tyy` trailers.
- Harden DB, memory, query, journal, exec, and dynamic tool fallbacks when `process.cwd()` throws because a worktree was removed.
- Replace source-grep coverage with behavior tests for merge boundaries, commit messages, and cwd recovery.

## Why

This fixes a release blocker in auto-mode closeout. A completed milestone branch could remain outside the integration branch while the next milestone started, and cleanup paths could leave the terminal/session effectively rooted in a deleted worktree. That made recovery confusing and could close or destabilize the TUI.

Closes #5576

## How

- Reuses the existing milestone merge path behind an idempotent helper so transition/finalize/terminal closeout agree on merge state.
- Treats completed-but-unmerged orphan milestones as a bootstrap blocker when merge fails, preserving the branch for recovery instead of continuing.
- Builds task commit context once from DB rows plus task summaries, then passes that metadata through both task commit paths.
- Adds completed slice/task names to milestone squash messages so identity survives the final merge to main.
- Adds `safeWorkspaceCwd()` and uses it across GSD bootstrap tool registries that previously fell back directly to `process.cwd()`.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/cwd-fallback-hardening.test.ts src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts src/resources/extensions/gsd/tests/auto-project-root-env.test.ts src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts src/resources/extensions/gsd/tests/orphan-merge-bootstrap.test.ts src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts src/resources/extensions/gsd/tests/stop-auto-merge-back.test.ts src/resources/extensions/gsd/tests/worktree-resolver.test.ts src/resources/extensions/gsd/tests/integration/auto-worktree-milestone-merge.test.ts src/resources/extensions/gsd/tests/integration/git-service.test.ts src/resources/extensions/gsd/tests/slice-cadence.test.ts` — 174 passed
- [x] `bash scripts/check-source-grep-tests.sh`
- [x] `git diff --check`
- [x] `npm run verify:pr` — 9233 passed, 0 failed, 9 skipped

## Breaking changes

None expected. This preserves existing recovery parsing that depends on `GSD-Task: Sxx/Tyy`.

## AI assistance

AI-assisted implementation and verification. No AI co-author is included in the commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer commit messages and commit-body context showing milestone/slice/task identifiers and titles.
  * Session rerooting helper and clearer worktree-exit actions to improve auto-run control.

* **Bug Fixes**
  * Better cwd/workspace fallback and resilience when current directories are missing.
  * Prevent duplicate milestone merges and improve restore/teardown notifications for failed auto-commits.

* **Tests**
  * Expanded integration and behavior tests covering cwd fallbacks, merge lifecycle, rerooting, and commit formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->