### PR TITLE
fix(gsd): use s.basePath for pre-execution file checks in worktree isolation

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1320,10 +1320,11 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
 
         const strictMode = prefs?.enhanced_verification_strict === true;
 
-        // Run pre-execution checks against the canonical project root. In
-        // worktree isolation, s.basePath can point at a metadata-only worktree,
-        // while source files remain under the project root.
-        const preExecutionBasePath = s.canonicalProjectRoot;
+        // Run pre-execution checks against s.basePath — the actual checkout
+        // where prior-slice files were created.  In worktree isolation,
+        // s.canonicalProjectRoot is the project root and lacks files that a
+        // prior slice wrote to the worktree but hasn't merged to main yet.
+        const preExecutionBasePath = s.basePath;
         const result: PreExecutionResult = await runPreExecutionChecks(tasks, preExecutionBasePath);
 
         // Log summary to stderr in existing verification output format

--- a/src/resources/extensions/gsd/tests/pre-execution-pause-wiring.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-pause-wiring.test.ts
@@ -486,6 +486,63 @@ describe("Pre-execution checks → pauseAuto wiring", () => {
     );
   });
 
+  test("files present in s.basePath (worktree) but absent from canonicalProjectRoot do not block", async () => {
+    // Regression: pre-exec checks used canonicalProjectRoot (project root), so
+    // files that a prior slice created in the worktree were falsely flagged as
+    // missing because they hadn't merged to main yet. Fix: use s.basePath.
+
+    // Create a separate "worktree" directory with the referenced files present.
+    const worktreeDir = join(tempDir, "worktree");
+    mkdirSync(join(worktreeDir, "lib"), { recursive: true });
+    mkdirSync(join(worktreeDir, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+    writeFileSync(join(worktreeDir, "lib", "types.ts"), "export type Habit = { id: string; name: string; };");
+    writeFileSync(join(worktreeDir, "lib", "useLocalStorage.ts"), "export function useLocalStorage() {}");
+
+    // The DB lives under tempDir (the "project root"). Insert slice + tasks.
+    insertMilestone({ id: "M001" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Test Slice", risk: "low" });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Task that reads prior-slice files",
+      status: "pending",
+      planning: {
+        description: "Reads lib/types.ts and lib/useLocalStorage.ts from prior slice",
+        estimate: "1h",
+        files: [],
+        verify: "npm test",
+        inputs: ["lib/types.ts", "lib/useLocalStorage.ts"],
+        expectedOutput: ["lib/utils.ts"],
+        observabilityImpact: "",
+      },
+      sequence: 0,
+    });
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+
+    // s.basePath = worktreeDir (files exist here)
+    // Override canonicalProjectRoot → tempDir (files do NOT exist there)
+    const s = makeMockSession(worktreeDir, { type: "plan-slice", id: "M001/S01" });
+    Object.defineProperty(s, "canonicalProjectRoot", { get: () => tempDir });
+
+    const pctx = makePostUnitContext(s, ctx, pi, pauseAutoMock);
+    const result = await postUnitPostVerification(pctx);
+
+    assert.equal(
+      pauseAutoMock.mock.callCount(),
+      0,
+      "pauseAuto should NOT be called when referenced files exist in s.basePath (worktree)",
+    );
+    assert.equal(
+      result,
+      "continue",
+      "postUnitPostVerification should return 'continue' when worktree files satisfy pre-exec inputs",
+    );
+  });
+
   test("uok gate runner persists pre-execution gate outcomes when enabled", async () => {
     writePreferences({
       enhanced_verification: true,


### PR DESCRIPTION
## TL;DR

**What:** Pre-execution checks now resolve task input paths against `s.basePath` instead of `s.canonicalProjectRoot`.
**Why:** In worktree isolation, prior-slice files live in the worktree checkout (`s.basePath`) and haven't merged to the project root yet — causing false-positive blocking errors that halted auto-mode.
**How:** One-line change at the call site; `s.basePath` is where the agent executes and where all prior-slice outputs land.

## What

Changed `preExecutionBasePath` from `s.canonicalProjectRoot` to `s.basePath` in `postUnitPostVerification` (`auto-post-unit.ts`).

Added a regression test in `pre-execution-pause-wiring.test.ts` that creates files in a worktree subdirectory, mocks `canonicalProjectRoot` to a separate directory without those files, and asserts `pauseAuto` is not called.

## Why

When GSD runs in worktree isolation, each milestone gets its own git worktree under `.gsd/projects/<id>/worktrees/<milestone>/`. The agent writes all files into that worktree. `s.basePath` points to the worktree; `s.canonicalProjectRoot` points to the project root.

A slice's pre-execution checks validate that files listed in task `inputs` exist on disk. The old code resolved paths against `s.canonicalProjectRoot`. Files that a prior slice created in the worktree (e.g. `lib/types.ts`, `lib/useLocalStorage.ts`) haven't been merged to the project root yet — so `existsSync(resolve(canonicalProjectRoot, "lib/types.ts"))` returns `false` even though the file exists in the worktree at `s.basePath`.

Result: auto-mode pauses with false blocking errors immediately after planning every slice that reads files from a prior slice.

## How

`s.basePath` is the directory where the agent actually executes tasks. It is always the correct root for resolving task input paths regardless of isolation mode:
- **worktree isolation** — `s.basePath` is the worktree, which contains all prior-slice outputs
- **branch isolation / none** — `s.basePath` equals the project root, same result as before

The regression test verifies the exact scenario from the bug: files present in `s.basePath` but absent from `canonicalProjectRoot` do not trigger a blocking pre-exec failure.

---

- [x] `fix` — Bug fix

> AI-assisted: diagnosed and written with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pre-execution checks that were incorrectly blocking in worktree isolation scenarios when referenced files were available in the actual checkout.

* **Tests**
  * Added regression test for pre-execution check handling in worktree scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->