### PR TITLE
fix(gsd): repair complete-milestone closeout drift

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Runtime tests for TUI tool cards, success notifications, and blocking errors.
 // GSD2 TUI Tests - Runtime coverage for tool-card cleanup and success notification rendering.
 // Runtime regression tests for the post-compaction tool-card cleanup and the
 // green-bordered success-notification rendering. Replaces the source-grep
@@ -18,7 +20,7 @@ import { Container, Text } from "@gsd/pi-tui";
 import stripAnsi from "strip-ansi";
 
 import { initTheme, theme } from "../theme/theme.js";
-import { renderExtensionNotifyInChat, shouldRenderExtensionNotifyInChat } from "../interactive-mode.js";
+import { renderBlockingErrorBanner, renderExtensionNotifyInChat, shouldRenderExtensionNotifyInChat } from "../interactive-mode.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { ToolExecutionComponent } from "./tool-execution.js";
 
@@ -55,6 +57,34 @@ describe("Extension warning notifications", () => {
 				`${type} notification text should appear in chat output`,
 			);
 		}
+	});
+});
+
+describe("Blocking error banner", () => {
+	it("keeps full error notifications renderable outside chat history", () => {
+		const banner = new Container();
+		const message = [
+			"Pre-execution checks failed: 3 blocking issues found",
+			"  - [file] lib/types.ts: Task T01 references 'lib/types.ts'",
+			"See .gsd/milestones/M001/slices/S02/S02-PRE-EXEC-VERIFY.json for full details.",
+		].join("\n");
+
+		renderBlockingErrorBanner(banner, message);
+
+		const rendered = banner.render(140).map(stripAnsi).join("\n");
+		assert.match(rendered, /Error: Pre-execution checks failed: 3 blocking issues found/);
+		assert.match(rendered, /Task T01 references 'lib\/types\.ts'/);
+		assert.match(rendered, /S02-PRE-EXEC-VERIFY\.json/);
+	});
+
+	it("clears the sticky banner when the blocking error is cleared", () => {
+		const banner = new Container();
+
+		renderBlockingErrorBanner(banner, "Provider failed");
+		assert.match(banner.render(80).map(stripAnsi).join("\n"), /Provider failed/);
+
+		renderBlockingErrorBanner(banner, undefined);
+		assert.equal(banner.render(80).map(stripAnsi).join("\n"), "");
 	});
 });
 

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1,3 +1,6 @@
+// Project/App: GSD-2
+// File Purpose: Interactive TUI mode and session UI rendering.
+// GSD2 - Interactive TUI mode for coding-agent sessions.
 /**
  * Interactive mode for the coding agent.
  * Handles TUI rendering and user interaction, delegating business logic to AgentSession.
@@ -212,6 +215,14 @@ export function renderExtensionNotifyInChat(
 	return { rendered: true, statusSpacer: spacer, statusText };
 }
 
+export function renderBlockingErrorBanner(container: Container, message: string | undefined): void {
+	container.clear();
+	if (!message) return;
+
+	container.addChild(new Spacer(1));
+	container.addChild(new Text(theme.fg("error", `Error: ${message}`), 1, 0));
+}
+
 /**
  * Options for InteractiveMode initialization.
  */
@@ -250,6 +261,7 @@ export class InteractiveMode {
 	private adaptiveLayout: AdaptiveLayoutComponent;
 	private statusContainer: Container;
 	private pinnedMessageContainer: Container;
+	private blockingErrorContainer: Container;
 	private defaultEditor: CustomEditor;
 	private editor: EditorComponent;
 	private autocompleteProvider: CombinedAutocompleteProvider | undefined;
@@ -380,6 +392,7 @@ export class InteractiveMode {
 		}));
 		this.statusContainer = new Container();
 		this.pinnedMessageContainer = new Container();
+		this.blockingErrorContainer = new Container();
 		this.widgetContainerAbove = new Container();
 		this.widgetContainerBelow = new Container();
 		this.keybindings = KeybindingsManager.create();
@@ -587,6 +600,7 @@ export class InteractiveMode {
 		this.ui.addChild(this.pendingMessagesContainer);
 		this.ui.addChild(this.statusContainer);
 		this.ui.addChild(this.pinnedMessageContainer);
+		this.ui.addChild(this.blockingErrorContainer);
 		this.renderWidgets(); // Initialize with default spacer
 		this.ui.addChild(this.widgetContainerAbove);
 		this.ui.addChild(this.editorContainer);
@@ -1891,6 +1905,10 @@ export class InteractiveMode {
 	 * Show a notification for extensions.
 	 */
 	private showExtensionNotify(message: string, type?: ExtensionNotifyType): void {
+		if (type === "error") {
+			this.lastBlockingError = message;
+			renderBlockingErrorBanner(this.blockingErrorContainer, this.lastBlockingError);
+		}
 		const result = renderExtensionNotifyInChat(this.chatContainer, message, type);
 		if (!result.rendered) {
 			return;
@@ -2897,6 +2915,7 @@ export class InteractiveMode {
 
 	showError(errorMessage: string): void {
 		this.lastBlockingError = errorMessage;
+		renderBlockingErrorBanner(this.blockingErrorContainer, this.lastBlockingError);
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new Text(theme.fg("error", `Error: ${errorMessage}`), 1, 0));
 		this.ui.requestRender();
@@ -2904,6 +2923,8 @@ export class InteractiveMode {
 
 	clearBlockingError(): void {
 		this.lastBlockingError = undefined;
+		renderBlockingErrorBanner(this.blockingErrorContainer, undefined);
+		this.ui.requestRender();
 	}
 
 	showWarning(warningMessage: string): void {

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -217,7 +217,7 @@ export function renderExtensionNotifyInChat(
 
 export function renderBlockingErrorBanner(container: Container, message: string | undefined): void {
 	container.clear();
-	if (!message) return;
+	if (message === undefined) return;
 
 	container.addChild(new Spacer(1));
 	container.addChild(new Text(theme.fg("error", `Error: ${message}`), 1, 0));

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1047,8 +1047,12 @@ export function _resolveAutoWorktreeExitActionForTest(
   milestoneMergedInPhases: boolean,
   milestoneComplete: boolean,
 ): AutoWorktreeExitAction {
-  if (!currentMilestoneId || milestoneMergedInPhases) return "skip";
-  return milestoneComplete ? "merge" : "preserve";
+  const action = _selectStopAutoWorktreeExit({
+    currentMilestoneId: currentMilestoneId ?? null,
+    milestoneComplete,
+    milestoneMergedInPhases,
+  });
+  return action === "none" ? "skip" : action;
 }
 
 export async function stopAuto(

--- a/src/resources/extensions/gsd/bootstrap/sanitize-complete-milestone.ts
+++ b/src/resources/extensions/gsd/bootstrap/sanitize-complete-milestone.ts
@@ -39,6 +39,8 @@ function toStrArray(v: unknown): string[] {
  * CompleteMilestoneParams, tolerating type mismatches from LLM JSON quirks.
  */
 export function sanitizeCompleteMilestoneParams(raw: Record<string, unknown>): CompleteMilestoneParams {
+  const actorName = toStr(raw.actorName);
+  const triggerReason = toStr(raw.triggerReason);
   return {
     milestoneId: toStr(raw.milestoneId),
     title: toStr(raw.title),
@@ -53,5 +55,7 @@ export function sanitizeCompleteMilestoneParams(raw: Record<string, unknown>): C
     followUps: toStr(raw.followUps),
     deviations: toStr(raw.deviations),
     verificationPassed: raw.verificationPassed === true || raw.verificationPassed === "true",
+    ...(actorName ? { actorName } : {}),
+    ...(triggerReason ? { triggerReason } : {}),
   };
 }

--- a/src/resources/extensions/gsd/commands-eval-review.ts
+++ b/src/resources/extensions/gsd/commands-eval-review.ts
@@ -26,7 +26,7 @@
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { open, readFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 
@@ -304,7 +304,7 @@ export async function buildEvalReviewContext(
   }
 
   const truncated = summaryRead.truncated || specTruncated;
-  const outputPath = evalReviewWritePath(state.sliceDir, state.sliceId);
+  const outputPath = evalReviewWritePath(realpathSync(state.sliceDir), state.sliceId);
   const basePath = projectRoot();
   const relativeOutputPath = relative(basePath, outputPath);
 

--- a/src/resources/extensions/gsd/prompts/complete-milestone.md
+++ b/src/resources/extensions/gsd/prompts/complete-milestone.md
@@ -16,7 +16,7 @@ Preloaded context includes roadmap, requirements, decisions, project context, an
 
 Start with what the excerpts give you. Read full files when the section heads signal richer context you need.
 
-**On-demand Read ordering:** Complete all slice SUMMARY Reads you need for cross-slice synthesis, the Decision Re-evaluation table, and LEARNINGS **before** calling `gsd_complete_milestone` (step 12). Once that tool runs, the milestone is marked complete in the DB, so it must be the final persistent milestone-closeout write.
+**On-demand Read ordering:** Complete all slice SUMMARY Reads you need for cross-slice synthesis, the Decision Re-evaluation table, and LEARNINGS **before** calling `gsd_complete_milestone` (step 13). Once that tool runs, the milestone is marked complete in the DB, so it must be the final persistent milestone-closeout write.
 
 ### Closeout Review Mode
 
@@ -45,7 +45,7 @@ Subagents report only; they do not write user source. Fold any findings into Dec
 
 ### Verification Gate — STOP if verification failed
 
-**If ANY verification failure was recorded in steps 3, 4, or 5, you MUST follow the failure path below. Do NOT proceed with steps 9–13.**
+**If ANY verification failure was recorded in steps 4, 5, or 6, you MUST follow the failure path below. Do NOT proceed with steps 10–14.**
 
 **Failure path** (verification failed):
 - Do NOT call `gsd_complete_milestone`.
@@ -69,13 +69,15 @@ Subagents report only; they do not write user source. Fold any findings into Dec
    - `title` (string) — Milestone title
    - `oneLiner` (string) — One-sentence summary of what the milestone achieved
    - `narrative` (string) — Detailed narrative of what happened during the milestone
+   - `verificationPassed` (boolean) — Must be `true`; confirms code-change verification, success criteria, and definition-of-done checks all passed
+
+   **Recommended parameters** (the schema accepts these as optional, but always fill them in — the rendered SUMMARY shows empty sections when omitted):
    - `successCriteriaResults` (string) — Markdown detailing how each success criterion was met or not met
    - `definitionOfDoneResults` (string) — Markdown detailing how each definition-of-done item was met
    - `requirementOutcomes` (string) — Markdown detailing requirement status transitions with evidence
    - `keyDecisions` (array of strings) — Key architectural/pattern decisions made during the milestone
    - `keyFiles` (array of strings) — Key files created or modified during the milestone
    - `lessonsLearned` (array of strings) — Lessons learned during the milestone
-   - `verificationPassed` (boolean) — Must be `true`; confirms code-change verification, success criteria, and definition-of-done checks all passed
 
    **Optional parameters:**
    - `followUps` (string) — Follow-up items for future milestones
@@ -84,6 +86,6 @@ Subagents report only; they do not write user source. Fold any findings into Dec
 14. Do not commit manually — the system auto-commits your changes after this unit completes.
 - Say: "Milestone {{milestoneId}} complete."
 
-**Important:** Do NOT skip code-change, success-criteria, or definition-of-done verification (steps 3-5). The summary must reflect verified outcomes. Verification failures block completion; there is no override. If a verification tool fails, errors, or returns unexpected output, treat it as failure.
+**Important:** Do NOT skip code-change, success-criteria, or definition-of-done verification (steps 4-6). The summary must reflect verified outcomes. Verification failures block completion; there is no override. If a verification tool fails, errors, or returns unexpected output, treat it as failure.
 
 **File system safety:** When scanning milestone directories for evidence, use `ls` or `find` first. Never pass a directory path (e.g. `tasks/`, `slices/`) to `read`; it only accepts file paths.

--- a/src/resources/extensions/gsd/prompts/complete-milestone.md
+++ b/src/resources/extensions/gsd/prompts/complete-milestone.md
@@ -71,7 +71,7 @@ Subagents report only; they do not write user source. Fold any findings into Dec
    - `narrative` (string) — Detailed narrative of what happened during the milestone
    - `verificationPassed` (boolean) — Must be `true`; confirms code-change verification, success criteria, and definition-of-done checks all passed
 
-   **Recommended parameters** (the schema accepts these as optional, but always fill them in — the rendered SUMMARY shows empty sections when omitted):
+   **Recommended parameters** (the schema accepts these as optional, but always fill them in — omitted values render as placeholders such as "Not provided.", "None.", or "(none)"):
    - `successCriteriaResults` (string) — Markdown detailing how each success criterion was met or not met
    - `definitionOfDoneResults` (string) — Markdown detailing how each definition-of-done item was met
    - `requirementOutcomes` (string) — Markdown detailing requirement status transitions with evidence

--- a/src/resources/extensions/gsd/tests/cmux.test.ts
+++ b/src/resources/extensions/gsd/tests/cmux.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Unit tests for cmux integration, layout, and CLI isolation.
 import test, { describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -293,8 +295,15 @@ describe("CmuxClient stdio isolation", () => {
       await client.listSurfaceIds();
 
       const calls = fs.readFileSync(logPath, "utf-8").trim().split("\n").map((line) => JSON.parse(line));
-      assert.deepEqual(calls[0]?.slice(0, 2), ["set-status", "gsd"]);
-      assert.deepEqual(calls[1]?.slice(0, 2), ["list-surfaces", "--json"]);
+      const commandPrefixes = calls.map((call) => call.slice(0, 2));
+      assert.ok(
+        commandPrefixes.some((prefix) => JSON.stringify(prefix) === JSON.stringify(["set-status", "gsd"])),
+        "set-status command should be invoked",
+      );
+      assert.ok(
+        commandPrefixes.some((prefix) => JSON.stringify(prefix) === JSON.stringify(["list-surfaces", "--json"])),
+        "list-surfaces command should be invoked",
+      );
     } finally {
       process.env.PATH = originalPath;
       fs.rmSync(binDir, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/complete-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone.test.ts
@@ -547,4 +547,144 @@ describe("complete-milestone", () => {
       cleanup(base);
     }
   });
+
+  test("verification-gate step numbers match the actual numbered verification steps", () => {
+    // Regression for step-number drift: step 1 (duplicate guard) was inserted
+    // in ea5a2cc0 and the rest renumbered, but the gate text was not updated.
+    // Re-derive the verification-step indices from the rendered prompt and
+    // assert the gate / "Important" footer reference the correct numbers.
+    const prompt = loadPromptFromWorktree("complete-milestone", {
+      workingDirectory: "/tmp/test-project",
+      milestoneId: "M001",
+      milestoneTitle: "Step Number Drift",
+      roadmapPath: ".gsd/milestones/M001/M001-ROADMAP.md",
+      inlinedContext: "context",
+      milestoneSummaryPath: ".gsd/milestones/M001/M001-SUMMARY.md",
+      skillActivation: "{{skillActivation block}}",
+      extractLearningsSteps: "{{extract learnings block}}",
+    });
+
+    function findStep(needle: RegExp): number {
+      const lines = prompt.split("\n");
+      for (const line of lines) {
+        const m = /^(\d+)\.\s/.exec(line);
+        if (m && needle.test(line)) return Number(m[1]);
+      }
+      throw new Error(`no numbered step matches ${needle}`);
+    }
+
+    const codeChange = findStep(/Verify code changes/);
+    const successCriteria = findStep(/Verify every \*\*success criterion\*\*/);
+    const defOfDone = findStep(/Verify \*\*definition of done\*\*/);
+    const completeMilestone = findStep(/Persist completion through `gsd_complete_milestone`/);
+    const requirementUpdate = findStep(/gsd_requirement_update/);
+
+    // Gate clause references the verification steps.
+    const gateLine = prompt.split("\n").find(l => l.includes("Verification failure was recorded") || l.includes("verification failure was recorded"));
+    assert.ok(gateLine, "verification gate sentence is present");
+    assert.ok(
+      gateLine!.includes(`steps ${codeChange}, ${successCriteria}, or ${defOfDone}`),
+      `gate must cite verification steps ${codeChange}, ${successCriteria}, ${defOfDone}; got: ${gateLine}`,
+    );
+    // "Do NOT proceed with steps X-Y" — Y must be at least the gsd_complete_milestone step.
+    const proceedMatch = /Do NOT proceed with steps (\d+)[–-](\d+)/.exec(gateLine!);
+    assert.ok(proceedMatch, "gate must include a 'Do NOT proceed with steps X–Y' clause");
+    assert.ok(
+      Number(proceedMatch![1]) > requirementUpdate - 1 && Number(proceedMatch![2]) >= completeMilestone,
+      `'Do NOT proceed' range ${proceedMatch![1]}–${proceedMatch![2]} must cover steps from after the gate through gsd_complete_milestone (${completeMilestone})`,
+    );
+
+    // "Important" footer references the same verification steps.
+    const importantLine = prompt.split("\n").find(l => l.includes("Do NOT skip code-change"));
+    assert.ok(importantLine, "Important footer is present");
+    assert.ok(
+      importantLine!.includes(`steps ${codeChange}-${defOfDone}`) ||
+        importantLine!.includes(`steps ${codeChange}–${defOfDone}`),
+      `Important footer must cite verification range ${codeChange}-${defOfDone}; got: ${importantLine}`,
+    );
+
+    // On-demand Read ordering line cites the gsd_complete_milestone step.
+    const readOrderLine = prompt.split("\n").find(l => l.includes("On-demand Read ordering"));
+    assert.ok(readOrderLine, "On-demand Read ordering line is present");
+    assert.ok(
+      readOrderLine!.includes(`(step ${completeMilestone})`),
+      `On-demand Read ordering must cite step ${completeMilestone}; got: ${readOrderLine}`,
+    );
+  });
+
+  test("sanitizeCompleteMilestoneParams preserves actorName and triggerReason", async () => {
+    const { sanitizeCompleteMilestoneParams } = await import("../bootstrap/sanitize-complete-milestone.ts");
+
+    const sanitized = sanitizeCompleteMilestoneParams({
+      milestoneId: "M001",
+      title: "T",
+      oneLiner: "x",
+      narrative: "n",
+      verificationPassed: true,
+      actorName: "  executor-01  ",
+      triggerReason: " milestone validation passed ",
+    } as any);
+
+    assert.strictEqual(sanitized.actorName, "executor-01");
+    assert.strictEqual(sanitized.triggerReason, "milestone validation passed");
+  });
+
+  test("sanitizeCompleteMilestoneParams omits blank actorName/triggerReason rather than emitting empty strings", async () => {
+    const { sanitizeCompleteMilestoneParams } = await import("../bootstrap/sanitize-complete-milestone.ts");
+
+    const sanitized = sanitizeCompleteMilestoneParams({
+      milestoneId: "M001",
+      title: "T",
+      oneLiner: "x",
+      narrative: "n",
+      verificationPassed: true,
+      // actorName/triggerReason omitted
+    } as any);
+
+    assert.strictEqual(sanitized.actorName, undefined);
+    assert.strictEqual(sanitized.triggerReason, undefined);
+  });
+
+  test("rendered SUMMARY.md uses placeholder text for empty enrichment fields", async () => {
+    const { handleCompleteMilestone } = await import("../tools/complete-milestone.ts");
+    const base = createFixtureBase();
+    const mid = "M001";
+    const dbPath = join(base, ".gsd", "gsd.db");
+    try {
+      openDatabase(dbPath);
+      insertMilestone({ id: mid, title: "Empty Enrichment", status: "active" });
+      insertSlice({ id: "S01", milestoneId: mid, title: "Slice", status: "complete" });
+      insertTask({ id: "T01", sliceId: "S01", milestoneId: mid, title: "Task", status: "complete" });
+
+      const result = await handleCompleteMilestone({
+        milestoneId: mid,
+        title: "Empty Enrichment",
+        oneLiner: "no enrichment",
+        narrative: "did the thing",
+        // enrichment fields intentionally empty (post-sanitizer state)
+        successCriteriaResults: "",
+        definitionOfDoneResults: "",
+        requirementOutcomes: "",
+        keyDecisions: [],
+        keyFiles: [],
+        lessonsLearned: [],
+        followUps: "",
+        deviations: "",
+        verificationPassed: true,
+      }, base);
+
+      assert.ok(!("error" in result), `handler should succeed: ${JSON.stringify(result)}`);
+      const summary = readFileSync((result as { summaryPath: string }).summaryPath, "utf-8");
+      assert.match(summary, /## Success Criteria Results\n\nNot provided\./);
+      assert.match(summary, /## Definition of Done Results\n\nNot provided\./);
+      assert.match(summary, /## Requirement Outcomes\n\nNot provided\./);
+      assert.match(summary, /## Deviations\n\nNone\./);
+      assert.match(summary, /## Follow-ups\n\nNone\./);
+    } finally {
+      try { closeDatabase(); } catch { /* */ }
+      clearPathCache();
+      clearParseCache();
+      cleanup(base);
+    }
+  });
 });

--- a/src/resources/extensions/gsd/tests/integration/commands-eval-review.integration.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/commands-eval-review.integration.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Integration tests for the /gsd eval-review helper chain.
 /**
  * Integration test for `/gsd eval-review` .
  *
@@ -10,7 +12,7 @@
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -119,7 +121,7 @@ describe("integration: /gsd eval-review helper chain on a real on-disk slice", (
     );
     assert.equal(ctx.truncated, false);
     assert.equal(ctx.sliceId, "S07");
-    assert.equal(ctx.outputPath, evalReviewWritePath(layout.sliceDir, "S07"));
+    assert.equal(ctx.outputPath, evalReviewWritePath(realpathSync(layout.sliceDir), "S07"));
 
     const prompt = buildEvalReviewPrompt(ctx);
 

--- a/src/resources/extensions/gsd/tests/pre-execution-pause-wiring.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-pause-wiring.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Integration tests for pre-execution check pause wiring.
 /**
  * pre-execution-pause-wiring.test.ts — Integration tests for pre-execution check → pauseAuto wiring.
  *

--- a/src/resources/extensions/gsd/tests/pre-execution-pause-wiring.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-pause-wiring.test.ts
@@ -29,6 +29,11 @@ let tempDir: string;
 let dbPath: string;
 let originalCwd: string;
 
+function resetAllCaches(): void {
+  invalidateAllCaches();
+  _clearGsdRootCache();
+}
+
 /**
  * Create a minimal mock ExtensionContext.
  */
@@ -114,8 +119,8 @@ function setupTestEnvironment(): void {
   // Change cwd so loadEffectiveGSDPreferences finds our PREFERENCES.md
   process.chdir(tempDir);
   
-  // Clear gsdRoot cache so it finds the new .gsd directory
-  _clearGsdRootCache();
+  // Clear caches so it finds the new .gsd directory and preferences.
+  resetAllCaches();
   
   // Initialize DB
   dbPath = join(gsdDir, "gsd.db");
@@ -138,6 +143,7 @@ function cleanupTestEnvironment(): void {
   } catch {
     // Ignore close errors
   }
+  resetAllCaches();
   try {
     rmSync(tempDir, { recursive: true, force: true });
   } catch {
@@ -160,8 +166,7 @@ ${yamlLines.join("\n")}
 `;
   writeFileSync(join(tempDir, ".gsd", "PREFERENCES.md"), prefsContent);
   // Invalidate caches so the new preferences file is found
-  invalidateAllCaches();
-  _clearGsdRootCache();
+  resetAllCaches();
 }
 
 /**
@@ -489,6 +494,12 @@ describe("Pre-execution checks → pauseAuto wiring", () => {
   });
 
   test("files present in s.basePath (worktree) but absent from canonicalProjectRoot do not block", async () => {
+    writePreferences({
+      enhanced_verification: true,
+      enhanced_verification_pre: true,
+      enhanced_verification_strict: false,
+    });
+
     // Regression: pre-exec checks used canonicalProjectRoot (project root), so
     // files that a prior slice created in the worktree were falsely flagged as
     // missing because they hadn't merged to main yet. Fix: use s.basePath.

--- a/src/resources/extensions/gsd/tools/complete-milestone.ts
+++ b/src/resources/extensions/gsd/tools/complete-milestone.ts
@@ -32,21 +32,21 @@ export interface CompleteMilestoneParams {
   oneLiner: string;
   narrative: string;
   verificationPassed: boolean;
-  /** @optional — defaults to "Not provided." when omitted by models with limited tool-calling */
+  /** @optional — empty/omitted renders as "Not provided." */
   successCriteriaResults?: string;
-  /** @optional — defaults to "Not provided." when omitted */
+  /** @optional — empty/omitted renders as "Not provided." */
   definitionOfDoneResults?: string;
-  /** @optional — defaults to "Not provided." when omitted */
+  /** @optional — empty/omitted renders as "Not provided." */
   requirementOutcomes?: string;
-  /** @optional — defaults to [] when omitted */
+  /** @optional — empty/omitted renders as "(none)" */
   keyDecisions?: string[];
-  /** @optional — defaults to [] when omitted */
+  /** @optional — empty/omitted renders as "(none)" */
   keyFiles?: string[];
-  /** @optional — defaults to [] when omitted */
+  /** @optional — empty/omitted renders as "(none)" */
   lessonsLearned?: string[];
-  /** @optional — defaults to "None." when omitted */
+  /** @optional — empty/omitted renders as "None." */
   followUps?: string;
-  /** @optional — defaults to "None." when omitted */
+  /** @optional — empty/omitted renders as "None." */
   deviations?: string;
   /** Optional caller-provided identity for audit trail */
   actorName?: string;
@@ -61,8 +61,7 @@ export interface CompleteMilestoneResult {
   alreadyComplete?: boolean;
 }
 
-function renderMilestoneSummaryMarkdown(params: CompleteMilestoneParams): string {
-  const now = new Date().toISOString();
+function renderMilestoneSummaryMarkdown(params: CompleteMilestoneParams, completedAt: string): string {
   const displayTitle = stripIdPrefix(params.title, params.milestoneId);
 
   // Apply defaults for optional enrichment fields (#2771)
@@ -86,7 +85,7 @@ function renderMilestoneSummaryMarkdown(params: CompleteMilestoneParams): string
 id: ${params.milestoneId}
 title: "${displayTitle}"
 status: complete
-completed_at: ${now}
+completed_at: ${completedAt}
 key_decisions:
 ${keyDecisionsYaml}
 key_files:
@@ -105,15 +104,15 @@ ${params.narrative}
 
 ## Success Criteria Results
 
-${params.successCriteriaResults ?? "Not provided."}
+${params.successCriteriaResults || "Not provided."}
 
 ## Definition of Done Results
 
-${params.definitionOfDoneResults ?? "Not provided."}
+${params.definitionOfDoneResults || "Not provided."}
 
 ## Requirement Outcomes
 
-${params.requirementOutcomes ?? "Not provided."}
+${params.requirementOutcomes || "Not provided."}
 
 ## Deviations
 
@@ -193,7 +192,7 @@ export async function handleCompleteMilestone(
   }
 
   // ── Filesystem operations (outside transaction) ─────────────────────────
-  const summaryMd = renderMilestoneSummaryMarkdown(params);
+  const summaryMd = renderMilestoneSummaryMarkdown(params, completedAt);
 
   let summaryPath: string;
   const milestoneDir = resolveMilestonePath(basePath, params.milestoneId);

--- a/src/tests/provider-equality-allowlist.test.ts
+++ b/src/tests/provider-equality-allowlist.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Provider equality guardrail tests for ADR-012.
 // gsd-2: provider-equality guardrail test (ADR-012)
 //
 // Purpose: prevent regressions of bug class #4478 — gating API-shape-dependent
@@ -129,18 +131,25 @@ function walk(dir: string, out: string[]): void {
   }
 }
 
+function canonicalAllowlistPath(rel: string): string {
+  // dist-test can contain this compatibility copy alongside src/provider-migrations.ts.
+  if (rel === "src/providers/provider-migrations.ts") return "src/provider-migrations.ts";
+  return rel;
+}
+
 function collectHits(): string[] {
   const files: string[] = [];
   walk(join(REPO_ROOT, "src"), files);
   walk(join(REPO_ROOT, "packages"), files);
 
-  const hits: string[] = [];
+  const hits = new Set<string>();
   for (const abs of files) {
     const rel = relative(REPO_ROOT, abs).split(sep).join("/");
+    // allow-source-grep: ADR-012 guardrail intentionally scans source files for provider equality anti-patterns.
     const contents = readFileSync(abs, "utf8");
-    if (PROVIDER_EQ_RE.test(contents)) hits.push(rel);
+    if (PROVIDER_EQ_RE.test(contents)) hits.add(canonicalAllowlistPath(rel));
   }
-  return hits.sort();
+  return Array.from(hits).sort();
 }
 
 test("ADR-012: provider-equality checks are allowlisted or use isXxxApi helpers", () => {

--- a/src/tests/provider-equality-allowlist.test.ts
+++ b/src/tests/provider-equality-allowlist.test.ts
@@ -131,10 +131,13 @@ function walk(dir: string, out: string[]): void {
   }
 }
 
-function canonicalAllowlistPath(rel: string): string {
+const CANONICAL_ALLOWLIST_PATHS: Record<string, string> = {
   // dist-test can contain this compatibility copy alongside src/provider-migrations.ts.
-  if (rel === "src/providers/provider-migrations.ts") return "src/provider-migrations.ts";
-  return rel;
+  "src/providers/provider-migrations.ts": "src/provider-migrations.ts",
+};
+
+function canonicalAllowlistPath(rel: string): string {
+  return CANONICAL_ALLOWLIST_PATHS[rel] ?? rel;
 }
 
 function collectHits(): string[] {


### PR DESCRIPTION
## Linked issue

No issue — internal-audit-driven cleanup (CONTRIBUTING.md grants bug fixes for obvious problems an exception to the issue-first requirement). The audit of the `complete_milestone` closeout phase surfaced three drift bugs that all touch the same path, so they're fixed together.

## TL;DR

**What:** Fix three drift bugs in the `complete_milestone` closeout path — prompt step-number cross-references, sanitizer silently dropping audit identity, and unreachable `??` fallbacks producing empty SUMMARY sections.
**Why:** A recent step insertion left three prompt cross-references citing old numbers; the sanitizer dropped `actorName`/`triggerReason` even though the tool schema accepted them; `?? "Not provided."` never fired because the sanitizer always returns a string.
**How:** Realign prompt cross-references with a regression test that programmatically re-derives expected step numbers; pass audit identity through the sanitizer (omitting blanks); switch enrichment fallbacks from `??` to `||`; thread `completedAt` from handler into renderer so SUMMARY frontmatter and DB row share a timestamp.

## What

- **`prompts/complete-milestone.md`** — three cross-references (verification gate, "Important" footer, on-demand-Read ordering) realigned to current step numbers; parameter list reorganized into Required / Recommended / Optional to match `Type.Optional` in the JSON schema.
- **`bootstrap/sanitize-complete-milestone.ts`** — pass `actorName` and `triggerReason` through, omitting blank values so we don't write empty audit identity strings.
- **`tools/complete-milestone.ts`** — five enrichment-field fallbacks switched from `??` to `||`; `completedAt` threaded from `handleCompleteMilestone` into `renderMilestoneSummaryMarkdown` so SUMMARY frontmatter and the DB row share a timestamp.
- **`tests/complete-milestone.test.ts`** — four new tests:
  - regression for prompt step-number drift (re-derives expected numbers from the rendered prompt)
  - sanitizer round-trip for `actorName` / `triggerReason`
  - sanitizer omits blank audit identity instead of emitting empty strings
  - SUMMARY uses placeholder text when enrichment fields are empty

## Why

Audit of the `complete_milestone` phase surfaced five issues introduced across recent commits. They all touch the same closeout path, so they're fixed together rather than as separate one-line PRs:

- A new step 1 was inserted in `ea5a2cc0` and the rest renumbered, but three cross-references still cited the old numbers. Step 3 became `{{skillActivation}}`, so the verification gate was pointing models at the wrong step.
- The sanitizer enumerated 13 fields and silently dropped `actorName` / `triggerReason`, leaving every `complete_milestone` event log entry with empty audit identity even though the tool schema and handler both accept them.
- Three of five enrichment fields used `?? "Not provided."` defaults that never fired (the sanitizer always returns a string, so `??` short-circuits past the default), so the rendered SUMMARY had empty H2 sections instead of placeholder text.
- `renderMilestoneSummaryMarkdown` minted its own `new Date().toISOString()`, so the SUMMARY frontmatter `completed_at` and the DB row's `completedAt` were skewed by however long the surrounding work took.

## How

- Realign prompt cross-references and add a regression test that programmatically re-derives expected verification-step numbers from the rendered prompt, so the test fails the next time a step is inserted/removed without updating cross-references.
- Pass `actorName` / `triggerReason` through the sanitizer with blank-omission so we don't accidentally emit empty strings into the audit log.
- Replace `??` with `||` across all five enrichment-field fallbacks for consistent empty-string-to-placeholder handling.
- Thread `completedAt` from `handleCompleteMilestone` into `renderMilestoneSummaryMarkdown` so the SUMMARY frontmatter and DB row share the same timestamp.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included — 4 new tests covering all three fixes (prompt drift, sanitizer round-trip, sanitizer blank-omission, SUMMARY placeholders)
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code — drafted with Claude after an audit pass on the closeout phase; tests run via `node:test` locally.

## Note on the diff view

This branch was opened on top of #5579 (now merged). Until GitHub recomputes the merge base, the "Files changed" tab may still show 11 files; the real diff against current `main` is 4 files / 164 additions / 19 deletions. Hitting "Update branch" (rebase mode) or a force-push of the same branch will refresh the view.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blocking error banner display in interactive mode.
  * Error handling now captures actor name and trigger reason during milestone completion.

* **Bug Fixes**
  * Corrected step references in milestone completion documentation for improved clarity.
  * Fixed output path computation for consistent validation.

* **Tests**
  * Enhanced test coverage for error banner rendering and milestone completion validation.
  * Improved test reliability through cache invalidation and path canonicalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->