### PR TITLE
fix: restore terminal state on crash to prevent garbled CSI-u output

### DIFF
--- a/packages/pi-coding-agent/src/main.ts
+++ b/packages/pi-coding-agent/src/main.ts
@@ -352,43 +352,56 @@ async function handleConfigCommand(args: string[]): Promise<boolean> {
 
 export async function main(args: string[]) {
 	// Catch unhandled promise rejections so the process doesn't silently disappear
-	process.on("unhandledRejection", (reason) => {
-		const message = reason instanceof Error ? reason.stack ?? reason.message : String(reason);
-		console.error(`\nFatal: unhandled promise rejection\n${message}`);
-		process.exitCode = 1;
-	});
+// Restore terminal state on ANY exit path (normal, error, signal, Ctrl+Break).
+// This is the single source-of-truth cleanup — all other handlers delegate to it.
+function restoreTerminal(): void {
+	try {
+		process.stdout.write("\x1b[<u");
+		process.stdout.write("\x1b[>4;0m");
+		process.stdout.write("\x1b[?2004l");
+		process.stdout.write("\x1b[?25h");
+		process.stdout.write("\x1b[J");
+	} catch { /* terminal may already be closed */ }
+}
 
-	// Catch uncaught exceptions and restore terminal state before crashing.
-	// When the process dies without calling terminal.stop(), the Kitty keyboard
-	// protocol and raw mode remain active, causing garbled CSI-u escape
-	// sequences to leak into the parent shell for every subsequent keypress.
-	process.on("uncaughtException", (err) => {
-		try {
-			process.stdout.write("\x1b[<u");
-			process.stdout.write("\x1b[>4;0m");
-			process.stdout.write("\x1b[?2004l");
-			process.stdout.write("\x1b[?25h");
-			process.stdout.write("\x1b[J");
-		} catch { /* terminal may already be closed */ }
-		const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-		console.error(`\nFatal: uncaught exception\n${message}`);
-		process.exit(1);
-	});
+// Catch unhandled promise rejections — includes terminal cleanup (was missing!)
+process.on("unhandledRejection", (reason) => {
+	const message = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason);
+	console.error(`\nFatal: unhandled promise rejection\n${message}`);
+	restoreTerminal();
+	process.exitCode = 1;
+});
 
-	// Catch SIGINT (Ctrl+C) so Kitty keyboard protocol is disabled before exit.
-	// Without this, a forced interruption leaves the terminal in raw+Kitty mode
-	// and every subsequent keypress leaks CSI-u garbage into the shell.
-	process.on("SIGINT", () => {
-		try {
-			process.stdout.write("\x1b[<u");
-			process.stdout.write("\x1b[>4;0m");
-			process.stdout.write("\x1b[?2004l");
-			process.stdout.write("\x1b[?25h");
-			process.stdout.write("\x1b[J");
-		} catch { /* terminal may already be closed */ }
-		console.error("\nInterrupted — terminal state restored.");
-		process.exit(130);
-	});
+// Catch uncaught exceptions and restore terminal state before crashing.
+// When the process dies without calling terminal.stop(), the Kitty keyboard
+// protocol and raw mode remain active, causing garbled CSI-u escape
+// sequences to leak into the parent shell for every subsequent keypress.
+process.on("uncaughtException", (err) => {
+	restoreTerminal();
+	const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+	console.error(`\nFatal: uncaught exception\n${message}`);
+	process.exit(1);
+});
+
+// Catch SIGINT (Ctrl+C). On Windows, setRawMode(true) may suppress this,
+// but it doesn't hurt to have it for Unix and terminal emulators that pass it through.
+process.on("SIGINT", () => {
+	restoreTerminal();
+	console.error("\nInterrupted — terminal state restored.");
+	process.exit(130);
+});
+
+// Catch Ctrl+Break on Windows — this always fires regardless of raw mode.
+process.on("SIGBREAK", () => {
+	restoreTerminal();
+	console.error("\nInterrupted (Ctrl+Break) — terminal state restored.");
+	process.exit(130);
+});
+
+// Safety net: failsafe exit handler for normal exits and any exit code path.
+process.on("exit", () => {
+	restoreTerminal();
+});
 
 	const offlineMode = args.includes("--offline") || isTruthyEnvFlag(process.env.PI_OFFLINE);
 	if (offlineMode) {

--- a/packages/pi-coding-agent/src/main.ts
+++ b/packages/pi-coding-agent/src/main.ts
@@ -375,6 +375,21 @@ export async function main(args: string[]) {
 		process.exit(1);
 	});
 
+	// Catch SIGINT (Ctrl+C) so Kitty keyboard protocol is disabled before exit.
+	// Without this, a forced interruption leaves the terminal in raw+Kitty mode
+	// and every subsequent keypress leaks CSI-u garbage into the shell.
+	process.on("SIGINT", () => {
+		try {
+			process.stdout.write("\x1b[<u");
+			process.stdout.write("\x1b[>4;0m");
+			process.stdout.write("\x1b[?2004l");
+			process.stdout.write("\x1b[?25h");
+			process.stdout.write("\x1b[J");
+		} catch { /* terminal may already be closed */ }
+		console.error("\nInterrupted — terminal state restored.");
+		process.exit(130);
+	});
+
 	const offlineMode = args.includes("--offline") || isTruthyEnvFlag(process.env.PI_OFFLINE);
 	if (offlineMode) {
 		process.env.PI_OFFLINE = "1";

--- a/packages/pi-coding-agent/src/main.ts
+++ b/packages/pi-coding-agent/src/main.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Main entry point for the coding agent CLI.
  *
  * This file handles CLI argument parsing and translates them into
@@ -356,6 +356,23 @@ export async function main(args: string[]) {
 		const message = reason instanceof Error ? reason.stack ?? reason.message : String(reason);
 		console.error(`\nFatal: unhandled promise rejection\n${message}`);
 		process.exitCode = 1;
+	});
+
+	// Catch uncaught exceptions and restore terminal state before crashing.
+	// When the process dies without calling terminal.stop(), the Kitty keyboard
+	// protocol and raw mode remain active, causing garbled CSI-u escape
+	// sequences to leak into the parent shell for every subsequent keypress.
+	process.on("uncaughtException", (err) => {
+		try {
+			process.stdout.write("\x1b[<u");
+			process.stdout.write("\x1b[>4;0m");
+			process.stdout.write("\x1b[?2004l");
+			process.stdout.write("\x1b[?25h");
+			process.stdout.write("\x1b[J");
+		} catch { /* terminal may already be closed */ }
+		const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+		console.error(`\nFatal: uncaught exception\n${message}`);
+		process.exit(1);
 	});
 
 	const offlineMode = args.includes("--offline") || isTruthyEnvFlag(process.env.PI_OFFLINE);

--- a/packages/pi-tui/src/terminal.ts
+++ b/packages/pi-tui/src/terminal.ts
@@ -139,7 +139,10 @@ export class ProcessTerminal implements Terminal {
 		this.stdinBuffer = new StdinBuffer({ timeout: 50 });
 
 		// Kitty protocol response pattern: \x1b[?<flags>u
-		const kittyResponsePattern = /^\x1b\[\?(\d+)u$/;
+		// Some terminals (e.g. WezTerm, foot) respond with semicolon-delimited
+		// flags like \x1b[?1;4u which the old regex missed, causing the
+		// response to pass through as raw input.
+		const kittyResponsePattern = /^\x1b\[\?([\d;]+)u$/;
 
 		// Forward individual sequences to the input handler
 		this.stdinBuffer.on("data", (sequence) => {
@@ -281,9 +284,12 @@ export class ProcessTerminal implements Terminal {
 		// Disable bracketed paste mode
 		process.stdout.write("\x1b[?2004l");
 
-		// Disable Kitty keyboard protocol if not already done by drainInput()
+		// Disable Kitty keyboard protocol if not already done by drainInput().
+		// ALWAYS send the disable escape — the in-memory flag may be stale
+		// after a crash recovery, but the terminal's protocol state persists.
+		// Sending \x1b[<u when already disabled is a harmless no-op.
+		process.stdout.write("\x1b[<u");
 		if (this._kittyProtocolActive) {
-			process.stdout.write("\x1b[<u");
 			this._kittyProtocolActive = false;
 			setKittyProtocolActive(false);
 		}


### PR DESCRIPTION
When gsd2 crashes or the TUI freezes, the Kitty keyboard protocol and raw terminal mode are not cleaned up, causing every subsequent keypress to emit CSI-u escape sequences as visible garbage and preventing Ctrl+C from working.

Root cause: ProcessTerminal enables Kitty protocol on start() but stop() only disables it when the in-memory flag says it's active. On uncaught exception the flag is stale but terminal state persists.

Fixes:
1. terminal.ts: widen Kitty response regex for semicolon-delimited flags (WezTerm, foot etc. respond with e.g. \x1b[?1;4u)
2. terminal.ts: always send \x1b[<u in stop(), not gated by state flag (\x1b[<u is harmless no-op when already disabled)
3. main.ts: add uncaughtException handler that force-disables Kitty protocol, modifyOtherKeys, bracketed paste, and restores cursor before exiting

## Linked issue

<!--
PRs without a linked issue will be closed.
Open or find an issue first: https://github.com/gsd-build/gsd-2/issues
-->

Closes #<!-- issue number — required -->

- [ ] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** <!-- One sentence — what does this change? -->
**Why:** <!-- One sentence — why is it needed? -->
**How:** <!-- One sentence — what's the approach? -->

## What

<!-- Detailed description of the change. What files, modules, or systems are affected? -->

## Why

<!-- The motivation. What problem does this solve? -->

## How

<!-- The approach. How does the implementation work? Key decisions and alternatives considered? -->

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [ ] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [ ] This PR includes AI-assisted code <!-- If so, note the tool and what was tested -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal state is now reliably restored on crashes, uncaught exceptions, interrupts, and process exit, preventing garbled output and ensuring clean exits.
  * Terminal protocol detection accepts varied responses and always sends the disable sequence, improving compatibility with Kitty and other terminals.
  * Added additional exit-path safeguards to ensure terminal cleanup on all termination paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5583)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->