### PR TITLE
refactor(gsd-extension): extract Worktree Lifecycle Module — enterMilestone

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,6 +9,8 @@
 - **Recovery decision**: retry/escalate/abort choice after runtime failure.
 - **Runtime persistence**: lock state, transition journal, and any persisted execution state required for safe resume.
 - **DB snapshot persistence**: crash-safe persistence of a full SQLite image exported from `sql.js`, written as a same-directory temporary file and atomically renamed over the live database path.
+- **Worktree Lifecycle**: creation, entry, teardown, and merge of an auto-mode worktree, including `s.basePath` mutation, `process.chdir` discipline, and milestone lease coordination.
+- **Worktree State Projection**: directional flow of state files between the project root and the auto-worktree, where one side is authoritative per file class (e.g., project root is authoritative for `completed-units.json` after crash recovery; worktree is authoritative for in-flight artifacts).
 
 ## Architecture terms adopted for this area
 
@@ -22,6 +24,8 @@
 - **DB snapshot persistence module**: the deep module that owns `sql.js` snapshot write semantics, including temp-file naming, fsync, cleanup, and rename ordering.
 - **State Reconciliation module**: module that reconciles DB-authoritative runtime state with durable disk projections before a Dispatch decision.
 - **Worktree Safety module**: module that validates project root, worktree registration, lease ownership, and git health before a source-writing Unit runs.
+- **Worktree Lifecycle module**: module that owns worktree create/enter/teardown/merge verbs, `s.basePath` mutation, and `process.chdir` discipline. Sole owner of these mutations across single-loop and parallel callers.
+- **Worktree State Projection module**: module that owns the direction-and-rules of state file flow between project root and auto-worktree. Encodes the bug-hardened invariants (additive milestone copy, ASSESSMENT verdict overwrite, completed-units forward-sync, WAL/SHM cleanup) that `syncProjectRootToWorktree` and `syncStateToProjectRoot` carry today.
 - **Recovery Classification module**: module that maps provider, tool, policy, git, worktree, and runtime failures to a Recovery decision.
 - **Tool Contract module**: module that keeps Unit prompts, tool schemas, tool policy, and pre-dispatch validation aligned.
 

--- a/docs/dev/ADR-016-worktree-lifecycle-and-projection.md
+++ b/docs/dev/ADR-016-worktree-lifecycle-and-projection.md
@@ -1,0 +1,111 @@
+# ADR-016: Split Worktree Handling Into Lifecycle and State Projection Modules
+
+**Status:** Accepted
+**Date:** 2026-05-08
+**Author:** GSD architecture review
+**Related:** ADR-014 (deep Auto Orchestration module), ADR-015 (runtime invariant modules), ADR-001 (branchless worktree architecture)
+
+## Context
+
+Worktree handling currently lives in two places:
+
+- `src/resources/extensions/gsd/worktree-resolver.ts` — a class facade that wraps `s.basePath`/`s.originalBasePath` mutation and the merge-or-teardown lifecycle. Constructor takes a 28-field dependency interface (`WorktreeResolverDeps`).
+- `src/resources/extensions/gsd/auto-worktree.ts` — 2,500+ lines of function exports owning worktree create/enter/teardown/merge plus a separate set of state-sync helpers (`syncProjectRootToWorktree`, `syncStateToProjectRoot`, `syncWorktreeStateBack`, etc.).
+
+The boundary between the two is unclear. `WorktreeResolver` is meant to centralise `s.basePath` mutation, but it delegates lifecycle work back to functions in `auto-worktree.ts` via 28 injected callbacks. Parallel orchestration paths (`parallel-orchestrator.ts`, `slice-parallel-orchestrator.ts`, `parallel-merge.ts`, `auto-post-unit.ts`) bypass `WorktreeResolver` entirely and call `auto-worktree.ts` exports directly. The discipline `WorktreeResolver` enforces (lease claim, no-double-chdir, single owner of `s.basePath` writes) is therefore enforced **only on the single-loop auto path**. A seam respected by one of two callers is not a real seam.
+
+ADR-015 names a **Worktree Safety module** for *validation* of worktree state before a source-writing Unit dispatches. Validation is upstream of mutation: it depends on knowing what the current worktree state is, which depends on the mutation/lifecycle module having already produced it. The current code conflates the two concerns.
+
+The state-sync helpers carry load-bearing invariants from past stuck-loop bugs (#1886, #2184, #2478, #2821). Those rules are not pass-through file copies — they encode which side is authoritative for which file class (e.g., project root authoritative for `completed-units.json` after crash recovery; worktree authoritative for in-flight artifacts). Today those rules are scattered across functions whose names ("sync") imply bidirectional convergence rather than the directional projection they actually perform.
+
+## Decision
+
+Deepen worktree handling into two sibling **Modules** behind the Auto Orchestration module:
+
+1. **Worktree Lifecycle module** — owner of create / enter / exit / merge verbs, `s.basePath` mutation, and `process.chdir` discipline. Sole owner of these mutations across single-loop and parallel callers.
+2. **Worktree State Projection module** — owner of the direction-and-rules of state file flow between project root and auto-worktree.
+
+Each module exposes a small Interface that callers and tests can use directly. The implementation can keep internal helpers, but no caller — single-loop or parallel — bypasses the Module-level Interface for the verbs the Module owns.
+
+### Lifecycle Interface (verb-per-transition)
+
+```ts
+interface WorktreeLifecycle {
+  enterMilestone(milestoneId: string, ctx: NotifyCtx): EnterResult;
+  exitMilestone(
+    milestoneId: string,
+    opts: { merge: boolean },
+    ctx: NotifyCtx,
+  ): ExitResult;
+  degradeToBranchMode(milestoneId: string, ctx: NotifyCtx): void;
+  restoreToProjectRoot(): void;
+  isInMilestone(milestoneId: string): boolean;
+  getCurrentMilestoneIfAny(): string | null;
+}
+
+type EnterResult =
+  | { ok: true; mode: "worktree" | "branch"; path: string }
+  | { ok: false; reason: "isolation-degraded" | "lease-conflict" | "creation-failed"; cause?: unknown };
+
+type ExitResult =
+  | { ok: true; merged: boolean; codeFilesChanged: boolean }
+  | { ok: false; reason: "merge-conflict" | "teardown-failed"; cause?: unknown };
+```
+
+Constructor takes a small dep set (notify, leaseStore, gitServiceFactory, journal, telemetry). The 28-field `WorktreeResolverDeps` is retired.
+
+### State Projection Interface (three direction-typed verbs)
+
+```ts
+interface WorktreeStateProjection {
+  projectRootToWorktree(scope: MilestoneScope): void;
+  projectWorktreeToRoot(scope: MilestoneScope): void;
+  finalizeProjectionForMerge(scope: MilestoneScope): void;
+}
+```
+
+All verbs are `MilestoneScope`-typed only. The legacy path-string variants (`syncProjectRootToWorktree(projectRoot, worktreePath, milestoneId)` and equivalents) and their `*ByScope` aliases are retired together with the helpers they wrap.
+
+Each verb's Implementation owns its direction's bug-hardened rules. `projectRootToWorktree` owns: identity-key safety check, additive milestone copy (#1886), ASSESSMENT verdict force-overwrite (#2821), `completed-units.json` forward-sync, WAL/SHM cleanup (#2478), `.gsd` symlink edge case (#2184). `projectWorktreeToRoot` owns the worktree → root rules (project root authoritative for diagnostics; markdown projections do not flow back; non-fatal sync). `finalizeProjectionForMerge` owns the post-merge final-capture rules.
+
+### Dependency direction
+
+Lifecycle calls Projection. Projection has no Lifecycle dependency. Lifecycle invokes:
+
+- `Projection.projectRootToWorktree(scope)` from `enterMilestone` after a successful create or enter, before any Unit dispatches.
+- `Projection.finalizeProjectionForMerge(scope)` from `exitMilestone` after a successful merge, before teardown.
+
+`Projection.projectWorktreeToRoot(scope)` is called by callers outside Lifecycle (post-unit pipeline; pre-merge sync paths). Lifecycle does not own that verb's invocation.
+
+## Why this decision
+
+**Deletion test on each Module.** Inlining either Module's verbs would scatter their concerns across the auto loop, post-unit pipeline, parallel orchestrators, and merge paths. Each Module's invariants concentrate into a different shape than the other's: Lifecycle invariants centre on `s.basePath` and `process.chdir` ordering across milestone boundaries; Projection invariants centre on per-file authoritative-direction rules. Two Modules give locality to two distinct change frequencies — Lifecycle changes when worktree shape changes, Projection changes when a new state-drift bug becomes a rule.
+
+**Bypass closure.** The current `WorktreeResolver` is a Seam respected by only one of two caller groups. Promoting Lifecycle and Projection to first-class Modules with explicit Interfaces forces parallel orchestrators and merge paths through the same Modules. One adapter in single-loop + one adapter in parallel = a real Seam.
+
+**Test surface.** Today, `auto-worktree.ts` exports 14 `_*ForTest` helpers because the file is too large to test holistically. With Lifecycle and Projection as the test surface, those helpers become private internals, and tests assert behaviour through the Module Interfaces.
+
+**Sibling to ADR-015's Worktree Safety.** Validation depends on mutation. ADR-015's `prepareUnitRoot()` becomes implementable as: call `Lifecycle.isInMilestone(...)` and `getCurrentMilestoneIfAny()`, validate the result, return a typed Recovery decision on failure. Without this ADR, Worktree Safety would have to re-derive worktree state from disk inputs.
+
+## Invariants
+
+- Single owner of `s.basePath` mutation across the codebase: the Worktree Lifecycle module. No caller writes `s.basePath` directly.
+- Single owner of `process.chdir()` for worktree transitions: the Lifecycle Module. The class must not double-chdir; this constraint moves from a comment in `worktree-resolver.ts` to an enforced internal invariant.
+- Lifecycle calls Projection; Projection does not call Lifecycle. The dependency direction is one-way.
+- Projection rules per direction are fixed, not parameter-bag-driven. Callers do not pass options that change which files cross the boundary or in what direction.
+- `MilestoneScope` is the only input type for Projection verbs. Path-string overloads are not added.
+- Expected failures (worktree creation failed, lease conflict, merge conflict, teardown failed) flow through typed result unions; only unexpected failures throw.
+
+## Consequences
+
+**Migration is end-to-end per verb.** Each verb is migrated across all its current callers in one PR — including parallel orchestrators. Half-migrated verbs would re-create the bypass problem the ADR is meant to fix. The implementation work is broken into seven slices (one per verb per Module, plus a final cleanup slice that retires the deprecated path-based duality and `_*ForTest` exports).
+
+**`WorktreeResolver` retires.** `worktree-resolver.ts` is deleted after the four Lifecycle verbs are live. Its standalone export `resolveProjectRoot(originalBasePath, basePath)` either moves to `worktree-root.ts` if still needed or is deleted with its callers.
+
+**`auto-worktree.ts` shrinks substantially.** Its lifecycle verbs and state-sync helpers move into the two Modules. Remaining standalone helpers (`escapeStaleWorktree`, `cleanStaleRuntimeUnits`, `runWorktreePostCreateHook`, `autoWorktreeBranch`) either stay as helper exports the Modules call internally, or move inside the Module Implementation files, depending on which is cleaner after migration.
+
+**Worktree Safety (ADR-015) is implementable on top of these Modules**, not in parallel with them. Its `prepareUnitRoot()` Interface depends on Lifecycle's query verbs.
+
+**Existing helpers that become pass-through after migration are deleted under the deletion test.** This includes any `WorktreeResolver` getters whose responsibility is fully absorbed by Lifecycle, and any `auto-worktree.ts` exports whose entire body moves inside a Module.
+
+This ADR extends ADR-014 (Auto Orchestration depth) and is a sibling to ADR-015 (validation) for the mutation/projection concerns. It does not supersede either.

--- a/docs/dev/ADR-016-worktree-lifecycle-and-projection.md
+++ b/docs/dev/ADR-016-worktree-lifecycle-and-projection.md
@@ -44,8 +44,8 @@ interface WorktreeLifecycle {
 }
 
 type EnterResult =
-  | { ok: true; mode: "worktree" | "branch"; path: string }
-  | { ok: false; reason: "isolation-degraded" | "lease-conflict" | "creation-failed"; cause?: unknown };
+  | { ok: true; mode: "worktree" | "branch" | "none"; path: string }
+  | { ok: false; reason: "isolation-degraded" | "lease-conflict" | "creation-failed" | "invalid-milestone-id"; cause?: unknown };
 
 type ExitResult =
   | { ok: true; merged: boolean; codeFilesChanged: boolean }

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -96,6 +96,7 @@ import {
   resolveDynamicRoutingConfig,
 } from "./preferences-models.js";
 import type { WorktreeResolver } from "./worktree-resolver.js";
+import type { WorktreeLifecycle } from "./worktree-lifecycle.js";
 import { getSessionModelOverride } from "./session-model-override.js";
 
 export interface BootstrapDeps {
@@ -103,6 +104,7 @@ export interface BootstrapDeps {
   registerSigtermHandler: (basePath: string) => void;
   lockBase: () => string;
   buildResolver: () => WorktreeResolver;
+  buildLifecycle: () => WorktreeLifecycle;
 }
 
 export function resolveIsolationNoneBranchCheckout(
@@ -531,6 +533,7 @@ export async function bootstrapAutoSession(
     registerSigtermHandler,
     lockBase,
     buildResolver,
+    buildLifecycle,
   } = deps;
 
   const dirCheck = validateDirectory(base);
@@ -1115,7 +1118,7 @@ export async function bootstrapAutoSession(
       !detectWorktreeName(base) &&
       !isUnderGsdWorktrees(base)
     ) {
-      buildResolver().enterMilestone(s.currentMilestoneId, {
+      buildLifecycle().enterMilestone(s.currentMilestoneId, {
         notify: ctx.ui.notify.bind(ctx.ui),
       });
       if (s.basePath !== base) {

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1118,9 +1118,16 @@ export async function bootstrapAutoSession(
       !detectWorktreeName(base) &&
       !isUnderGsdWorktrees(base)
     ) {
-      buildLifecycle().enterMilestone(s.currentMilestoneId, {
+      const enterResult = buildLifecycle().enterMilestone(s.currentMilestoneId, {
         notify: ctx.ui.notify.bind(ctx.ui),
       });
+      if (!enterResult.ok && enterResult.reason === "lease-conflict") {
+        ctx.ui.notify(
+          `Cannot enter milestone ${s.currentMilestoneId}: lease is held by another worker.`,
+          "error",
+        );
+        return releaseLockAndReturn();
+      }
       if (s.basePath !== base) {
         // Successfully entered worktree — re-register SIGTERM handler at original base
         registerSigtermHandler(s.originalBasePath);

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1121,11 +1121,23 @@ export async function bootstrapAutoSession(
       const enterResult = buildLifecycle().enterMilestone(s.currentMilestoneId, {
         notify: ctx.ui.notify.bind(ctx.ui),
       });
-      if (!enterResult.ok && enterResult.reason === "lease-conflict") {
-        ctx.ui.notify(
-          `Cannot enter milestone ${s.currentMilestoneId}: lease is held by another worker.`,
-          "error",
-        );
+      if (!enterResult.ok) {
+        if (enterResult.reason === "lease-conflict") {
+          ctx.ui.notify(
+            `Cannot enter milestone ${s.currentMilestoneId}: lease is held by another worker.`,
+            "error",
+          );
+        } else if (enterResult.reason === "creation-failed") {
+          ctx.ui.notify(
+            `Cannot enter milestone ${s.currentMilestoneId}: worktree/branch creation failed. Isolation is degraded.`,
+            "error",
+          );
+        } else if (enterResult.reason === "invalid-milestone-id") {
+          ctx.ui.notify(
+            `Cannot enter milestone ${s.currentMilestoneId}: milestone id is invalid.`,
+            "error",
+          );
+        }
         return releaseLockAndReturn();
       }
       if (s.basePath !== base) {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -247,6 +247,10 @@ import {
   WorktreeResolver,
   type WorktreeResolverDeps,
 } from "./worktree-resolver.js";
+import {
+  WorktreeLifecycle,
+  type WorktreeLifecycleDeps,
+} from "./worktree-lifecycle.js";
 import { reorderForCaching } from "./prompt-ordering.js";
 import { initTokenCounter } from "./token-counter.js";
 
@@ -1583,6 +1587,23 @@ function buildResolver(): WorktreeResolver {
 }
 
 /**
+ * Build a WorktreeLifecycle Module wrapping the current session.
+ *
+ * Per ADR-016, the Lifecycle Module is the typed-Interface owner of milestone
+ * entry/exit verbs. Phase 1 (issue #5585) ships only `enterMilestone`; the
+ * remaining verbs migrate from `WorktreeResolver` in subsequent slices.
+ *
+ * `WorktreeLifecycleDeps` is structurally a subset of `WorktreeResolverDeps`,
+ * so we can reuse `buildResolverDeps()` directly.
+ */
+function buildLifecycle(): WorktreeLifecycle {
+  return new WorktreeLifecycle(
+    s,
+    buildResolverDeps() as unknown as WorktreeLifecycleDeps,
+  );
+}
+
+/**
  * Thin entry glue for the new Auto Orchestration module.
  *
  * This intentionally wires only dispatch + error notification today, with
@@ -1826,6 +1847,9 @@ function buildLoopDeps(pi: ExtensionAPI): LoopDeps {
 
     // WorktreeResolver
     resolver: buildResolver(),
+
+    // Worktree Lifecycle Module (ADR-016)
+    lifecycle: buildLifecycle(),
 
     // Post-unit processing
     postUnitPreVerification,
@@ -2130,7 +2154,7 @@ export async function startAuto(
       !detectWorktreeName(s.basePath) &&
       !detectWorktreeName(s.originalBasePath)
     ) {
-      buildResolver().enterMilestone(s.currentMilestoneId, {
+      buildLifecycle().enterMilestone(s.currentMilestoneId, {
         notify: ctx.ui.notify.bind(ctx.ui),
       });
       // s.basePath may have been updated to a worktree path by enterMilestone.
@@ -2236,6 +2260,7 @@ export async function startAuto(
     registerSigtermHandler,
     lockBase,
     buildResolver,
+    buildLifecycle,
   };
 
   // Register the worker before bootstrap enters a milestone worktree.

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1593,14 +1593,23 @@ function buildResolver(): WorktreeResolver {
  * entry/exit verbs. Phase 1 (issue #5585) ships only `enterMilestone`; the
  * remaining verbs migrate from `WorktreeResolver` in subsequent slices.
  *
- * `WorktreeLifecycleDeps` is structurally a subset of `WorktreeResolverDeps`,
- * so we can reuse `buildResolverDeps()` directly.
  */
+function buildLifecycleDeps(): WorktreeLifecycleDeps {
+  const deps = buildResolverDeps();
+  return {
+    enterAutoWorktree: deps.enterAutoWorktree,
+    createAutoWorktree: deps.createAutoWorktree,
+    enterBranchModeForMilestone: deps.enterBranchModeForMilestone,
+    getAutoWorktreePath: deps.getAutoWorktreePath,
+    getIsolationMode: deps.getIsolationMode,
+    invalidateAllCaches: deps.invalidateAllCaches,
+    GitServiceImpl: deps.GitServiceImpl,
+    loadEffectiveGSDPreferences: deps.loadEffectiveGSDPreferences,
+  };
+}
+
 function buildLifecycle(): WorktreeLifecycle {
-  return new WorktreeLifecycle(
-    s,
-    buildResolverDeps() as unknown as WorktreeLifecycleDeps,
-  );
+  return new WorktreeLifecycle(s, buildLifecycleDeps());
 }
 
 /**
@@ -2154,9 +2163,17 @@ export async function startAuto(
       !detectWorktreeName(s.basePath) &&
       !detectWorktreeName(s.originalBasePath)
     ) {
-      buildLifecycle().enterMilestone(s.currentMilestoneId, {
+      const enterResult = buildLifecycle().enterMilestone(s.currentMilestoneId, {
         notify: ctx.ui.notify.bind(ctx.ui),
       });
+      if (!enterResult.ok && enterResult.reason === "lease-conflict") {
+        ctx.ui.notify(
+          `Cannot resume milestone ${s.currentMilestoneId}: lease is held by another worker.`,
+          "error",
+        );
+        await stopAuto(ctx, pi, "lease-conflict during resume");
+        return;
+      }
       // s.basePath may have been updated to a worktree path by enterMilestone.
       rebuildScope(s.basePath, s.currentMilestoneId);
     }

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -19,6 +19,7 @@ import type {
 } from "../auto-verification.js";
 import type { DispatchAction, DispatchContext } from "../auto-dispatch.js";
 import type { WorktreeResolver } from "../worktree-resolver.js";
+import type { WorktreeLifecycle } from "../worktree-lifecycle.js";
 import type { CmuxLogLevel } from "../../shared/cmux-events.js";
 import type { JournalEntry } from "../journal.js";
 import type { MergeReconcileResult } from "../auto-recovery.js";
@@ -271,6 +272,9 @@ export interface LoopDeps {
 
   // WorktreeResolver
   resolver: WorktreeResolver;
+
+  // Worktree Lifecycle Module (ADR-016)
+  lifecycle: WorktreeLifecycle;
 
   // Post-unit processing
   postUnitPreVerification: (

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -817,7 +817,7 @@ export async function runPreDispatch(
       if (deps.getIsolationMode(s.basePath) !== "none") {
         deps.captureIntegrationBranch(s.basePath, mid);
       }
-      deps.resolver.enterMilestone(mid, ctx.ui);
+      deps.lifecycle.enterMilestone(mid, ctx.ui);
     } else {
       // mid is undefined — no milestone to capture integration branch for
     }

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -817,7 +817,11 @@ export async function runPreDispatch(
       if (deps.getIsolationMode(s.basePath) !== "none") {
         deps.captureIntegrationBranch(s.basePath, mid);
       }
-      deps.lifecycle.enterMilestone(mid, ctx.ui);
+      const enterResult = deps.lifecycle.enterMilestone(mid, ctx.ui);
+      if (!enterResult.ok && enterResult.reason === "lease-conflict") {
+        await deps.pauseAuto(ctx, pi);
+        return { action: "break", reason: "lease-conflict" };
+      }
     } else {
       // mid is undefined — no milestone to capture integration branch for
     }

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -109,7 +109,7 @@ export class AutoSession {
   workerId: string | null = null;
   /**
    * Active milestone lease fencing token, set by claimMilestoneLease() inside
-   * worktree-resolver.enterMilestone(). Threaded into recordDispatchClaim()
+   * worktree-lifecycle._enterMilestoneCore(). Threaded into recordDispatchClaim()
    * as milestone_lease_token so out-of-band dispatches by a stale worker
    * are detectable.
    */

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -747,6 +747,9 @@ function makeMockDeps(
       mergeAndExit: () => {},
       mergeAndEnterNext: () => {},
     } as any,
+    lifecycle: {
+      enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
+    } as any,
     postUnitPreVerification: async () => {
       callLog.push("postUnitPreVerification");
       return "continue" as const;

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -742,7 +742,9 @@ function makeMockDeps(
       get lockPath() {
         return "/tmp/project";
       },
-      enterMilestone: () => {},
+      enterMilestone: () => {
+        assert.fail("auto-loop should call deps.lifecycle.enterMilestone, not resolver.enterMilestone");
+      },
       exitMilestone: () => {},
       mergeAndExit: () => {},
       mergeAndEnterNext: () => {},

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -105,6 +105,9 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
             throw new Error("synthetic merge failure");
           },
         }) as any,
+        buildLifecycle: () => ({
+          enterMilestone: () => ({ ok: true }),
+        }) as any,
       },
       {
         classification: "none",

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -237,6 +237,9 @@ function makeMockDeps(overrides?: Partial<LoopDeps>): LoopDeps & { callLog: stri
       mergeAndExit: () => {},
       mergeAndEnterNext: () => {},
     } as any,
+    lifecycle: {
+      enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
+    } as any,
     postUnitPreVerification: async () => "continue" as const,
     runPostUnitVerification: async () => "continue" as const,
     postUnitPostVerification: async () => "continue" as const,

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -232,10 +232,18 @@ function makeMockDeps(overrides?: Partial<LoopDeps>): LoopDeps & { callLog: stri
       get workPath() { return "/tmp/project"; },
       get projectRoot() { return "/tmp/project"; },
       get lockPath() { return "/tmp/project"; },
-      enterMilestone: () => {},
-      exitMilestone: () => {},
-      mergeAndExit: () => {},
-      mergeAndEnterNext: () => {},
+      enterMilestone: () => {
+        assert.fail("custom-engine loop should call deps.lifecycle.enterMilestone, not resolver.enterMilestone");
+      },
+      exitMilestone: () => {
+        assert.fail("custom-engine loop should not call resolver.exitMilestone");
+      },
+      mergeAndExit: () => {
+        assert.fail("custom-engine loop should not call resolver.mergeAndExit");
+      },
+      mergeAndEnterNext: () => {
+        assert.fail("custom-engine loop should not call resolver.mergeAndEnterNext");
+      },
     } as any,
     lifecycle: {
       enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),

--- a/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
@@ -274,6 +274,9 @@ test("deep project setup: bootstrap can start auto-mode without an active milest
         registerSigtermHandler: () => {},
         lockBase: () => base,
         buildResolver: () => ({}) as any,
+        buildLifecycle: () => ({
+          enterMilestone: () => ({ ok: true }),
+        }) as any,
       },
       {
         classification: "none",
@@ -379,6 +382,9 @@ test("deep project setup: bootstrap continues queued M002 without milestone cont
         registerSigtermHandler: () => {},
         lockBase: () => base,
         buildResolver: () => ({}) as any,
+        buildLifecycle: () => ({
+          enterMilestone: () => ({ ok: true }),
+        }) as any,
       },
       {
         classification: "none",

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -128,10 +128,12 @@ function makeMockDeps(
       get workPath() { return "/tmp/project"; },
       get projectRoot() { return "/tmp/project"; },
       get lockPath() { return "/tmp/project"; },
-      enterMilestone: () => {},
       exitMilestone: () => {},
       mergeAndExit: () => {},
       mergeAndEnterNext: () => {},
+    } as any,
+    lifecycle: {
+      enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
     } as any,
     postUnitPreVerification: async () => "continue" as const,
     runPostUnitVerification: async () => "continue" as const,

--- a/src/resources/extensions/gsd/tests/milestone-transition-state-rebuild.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-transition-state-rebuild.test.ts
@@ -73,7 +73,12 @@ test("milestone transition archives completed units and rebuilds state", async (
         postflightPopStash: () => ({ ok: true, needsManualRecovery: false }),
         resolver: {
           mergeAndExit: () => calls.push("merge"),
-          enterMilestone: (mid: string) => calls.push(`enter:${mid}`),
+        },
+        lifecycle: {
+          enterMilestone: (mid: string) => {
+            calls.push(`enter:${mid}`);
+            return { ok: true, mode: "worktree", path: `/wt/${mid}` };
+          },
         },
         sendDesktopNotification: () => {},
         logCmuxEvent: () => {},

--- a/src/resources/extensions/gsd/tests/worktree-journal-events.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-journal-events.test.ts
@@ -8,6 +8,7 @@ import {
   type WorktreeResolverDeps,
   type NotifyCtx,
 } from "../worktree-resolver.js";
+import { WorktreeLifecycle } from "../worktree-lifecycle.js";
 import { AutoSession } from "../auto/session.js";
 import type { JournalEntry } from "../journal.js";
 
@@ -102,7 +103,7 @@ describe("worktree journal events", () => {
     const deps = makeDeps({ getAutoWorktreePath: () => null });
     const resolver = new WorktreeResolver(s, deps);
 
-    resolver.enterMilestone("M001", makeNotifyCtx());
+    new WorktreeLifecycle(s, deps).enterMilestone("M001", makeNotifyCtx());
 
     const entries = readJournalEntries(tmp);
     const enter = entries.find(e => e.eventType === "worktree-enter");
@@ -119,7 +120,7 @@ describe("worktree journal events", () => {
     });
     const resolver = new WorktreeResolver(s, deps);
 
-    resolver.enterMilestone("M001", makeNotifyCtx());
+    new WorktreeLifecycle(s, deps).enterMilestone("M001", makeNotifyCtx());
 
     const entries = readJournalEntries(tmp);
     const enter = entries.find(e => e.eventType === "worktree-enter");
@@ -132,7 +133,7 @@ describe("worktree journal events", () => {
     const deps = makeDeps({ shouldUseWorktreeIsolation: () => false, getIsolationMode: () => "none" });
     const resolver = new WorktreeResolver(s, deps);
 
-    resolver.enterMilestone("M001", makeNotifyCtx());
+    new WorktreeLifecycle(s, deps).enterMilestone("M001", makeNotifyCtx());
 
     const entries = readJournalEntries(tmp);
     const skip = entries.find(e => e.eventType === "worktree-skip");
@@ -149,7 +150,7 @@ describe("worktree journal events", () => {
     });
     const resolver = new WorktreeResolver(s, deps);
 
-    resolver.enterMilestone("M001", makeNotifyCtx());
+    new WorktreeLifecycle(s, deps).enterMilestone("M001", makeNotifyCtx());
 
     const entries = readJournalEntries(tmp);
     const failed = entries.find(e => e.eventType === "worktree-create-failed");
@@ -210,7 +211,7 @@ describe("worktree journal events", () => {
     const deps = makeDeps({ shouldUseWorktreeIsolation: () => false });
     const resolver = new WorktreeResolver(s, deps);
 
-    resolver.enterMilestone("M001", makeNotifyCtx());
+    new WorktreeLifecycle(s, deps).enterMilestone("M001", makeNotifyCtx());
 
     const entries = readJournalEntries(tmp);
     assert.ok(entries.length > 0, "at least one entry should exist");

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -1,0 +1,228 @@
+// Project/App: GSD-2
+// File Purpose: Worktree Lifecycle Module — typed-result contract tests for enterMilestone (ADR-016).
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  WorktreeLifecycle,
+  type WorktreeLifecycleDeps,
+  type NotifyCtx,
+} from "../worktree-lifecycle.js";
+import { AutoSession } from "../auto/session.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+interface CallLog {
+  fn: string;
+  args: unknown[];
+}
+
+function makeSession(overrides?: Partial<AutoSession>): AutoSession {
+  const s = new AutoSession();
+  s.basePath = overrides?.basePath ?? "/project";
+  s.originalBasePath = overrides?.originalBasePath ?? "/project";
+  Object.assign(s, overrides);
+  return s;
+}
+
+function makeDeps(
+  overrides?: Partial<WorktreeLifecycleDeps>,
+): WorktreeLifecycleDeps & { calls: CallLog[] } {
+  const calls: CallLog[] = [];
+  const deps: WorktreeLifecycleDeps & { calls: CallLog[] } = {
+    calls,
+    enterAutoWorktree: (basePath, milestoneId) => {
+      calls.push({ fn: "enterAutoWorktree", args: [basePath, milestoneId] });
+      return `/project/.gsd/worktrees/${milestoneId}`;
+    },
+    createAutoWorktree: (basePath, milestoneId) => {
+      calls.push({ fn: "createAutoWorktree", args: [basePath, milestoneId] });
+      return `/project/.gsd/worktrees/${milestoneId}`;
+    },
+    enterBranchModeForMilestone: (basePath, milestoneId) => {
+      calls.push({
+        fn: "enterBranchModeForMilestone",
+        args: [basePath, milestoneId],
+      });
+    },
+    getAutoWorktreePath: (basePath, milestoneId) => {
+      calls.push({ fn: "getAutoWorktreePath", args: [basePath, milestoneId] });
+      return null;
+    },
+    getIsolationMode: () => {
+      calls.push({ fn: "getIsolationMode", args: [] });
+      return "worktree";
+    },
+    invalidateAllCaches: () => {
+      calls.push({ fn: "invalidateAllCaches", args: [] });
+    },
+    GitServiceImpl: class MockGitService {
+      basePath: string;
+      gitConfig: unknown;
+      constructor(basePath: string, gitConfig: unknown) {
+        calls.push({ fn: "GitServiceImpl", args: [basePath, gitConfig] });
+        this.basePath = basePath;
+        this.gitConfig = gitConfig;
+      }
+    } as unknown as WorktreeLifecycleDeps["GitServiceImpl"],
+    loadEffectiveGSDPreferences: () => {
+      calls.push({ fn: "loadEffectiveGSDPreferences", args: [] });
+      return { preferences: { git: {} } };
+    },
+    ...overrides,
+  };
+  if (overrides) {
+    for (const [k, v] of Object.entries(overrides)) {
+      if (k !== "calls") {
+        (deps as unknown as Record<string, unknown>)[k] = v;
+      }
+    }
+  }
+  return deps;
+}
+
+function makeCtx(): NotifyCtx & {
+  messages: Array<{ msg: string; level?: string }>;
+} {
+  const messages: Array<{ msg: string; level?: string }> = [];
+  return {
+    messages,
+    notify: (msg, level) => {
+      messages.push({ msg, level });
+    },
+  };
+}
+
+// ─── enterMilestone — typed-result contract ──────────────────────────────────
+
+test("enterMilestone returns ok:true mode:worktree on successful create", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.mode, "worktree");
+    assert.equal(result.path, "/project/.gsd/worktrees/M001");
+  }
+  assert.equal(s.basePath, "/project/.gsd/worktrees/M001");
+});
+
+test("enterMilestone returns ok:true mode:branch on successful branch fallback", () => {
+  const s = makeSession();
+  const deps = makeDeps({ getIsolationMode: () => "branch" });
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.mode, "branch");
+    assert.equal(result.path, "/project");
+  }
+  // Branch mode does not mutate s.basePath
+  assert.equal(s.basePath, "/project");
+});
+
+test("enterMilestone returns ok:true mode:none when isolation disabled", () => {
+  const s = makeSession();
+  const deps = makeDeps({ getIsolationMode: () => "none" });
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.mode, "none");
+    assert.equal(result.path, "/project");
+  }
+  assert.equal(s.basePath, "/project");
+});
+
+test("enterMilestone returns ok:false reason:isolation-degraded when session degraded", () => {
+  const s = makeSession({ isolationDegraded: true });
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, "isolation-degraded");
+  }
+  // No worktree primitives invoked
+  assert.equal(deps.calls.filter((c) => c.fn === "createAutoWorktree").length, 0);
+  assert.equal(deps.calls.filter((c) => c.fn === "enterAutoWorktree").length, 0);
+});
+
+test("enterMilestone returns ok:false reason:creation-failed and degrades session on worktree throw", () => {
+  const s = makeSession();
+  const deps = makeDeps({
+    createAutoWorktree: () => {
+      throw new Error("boom");
+    },
+  });
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, "creation-failed");
+    assert.ok(result.cause instanceof Error);
+  }
+  assert.equal(s.isolationDegraded, true);
+  // s.basePath unchanged on failure
+  assert.equal(s.basePath, "/project");
+});
+
+test("enterMilestone returns ok:false reason:creation-failed when branch mode throws", () => {
+  const s = makeSession();
+  const deps = makeDeps({
+    getIsolationMode: () => "branch",
+    enterBranchModeForMilestone: () => {
+      throw new Error("branch checkout failed");
+    },
+  });
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, "creation-failed");
+  }
+  assert.equal(s.isolationDegraded, true);
+});
+
+test("enterMilestone enters existing worktree when path resolves", () => {
+  const s = makeSession();
+  const deps = makeDeps({
+    getAutoWorktreePath: () => "/project/.gsd/worktrees/M001",
+  });
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, true);
+  assert.equal(deps.calls.filter((c) => c.fn === "enterAutoWorktree").length, 1);
+  assert.equal(deps.calls.filter((c) => c.fn === "createAutoWorktree").length, 0);
+});
+
+test("enterMilestone throws on milestoneId with path traversal", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  assert.throws(() => lifecycle.enterMilestone("../escape", ctx), /Invalid milestoneId/);
+  assert.throws(() => lifecycle.enterMilestone("a/b", ctx), /Invalid milestoneId/);
+});

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -76,13 +76,6 @@ function makeDeps(
     },
     ...overrides,
   };
-  if (overrides) {
-    for (const [k, v] of Object.entries(overrides)) {
-      if (k !== "calls") {
-        (deps as unknown as Record<string, unknown>)[k] = v;
-      }
-    }
-  }
   return deps;
 }
 

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -2,12 +2,18 @@
 // File Purpose: Worktree Lifecycle Module — typed-result contract tests for enterMilestone (ADR-016).
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   WorktreeLifecycle,
   type WorktreeLifecycleDeps,
   type NotifyCtx,
 } from "../worktree-lifecycle.js";
 import { AutoSession } from "../auto/session.js";
+import { openDatabase, closeDatabase, insertMilestone } from "../gsd-db.js";
+import { registerAutoWorker } from "../db/auto-workers.js";
+import { claimMilestoneLease } from "../db/milestone-leases.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -90,6 +96,17 @@ function makeCtx(): NotifyCtx & {
       messages.push({ msg, level });
     },
   };
+}
+
+function makeDbBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-lifecycle-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanupDbBase(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
 }
 
 // ─── enterMilestone — typed-result contract ──────────────────────────────────
@@ -217,12 +234,71 @@ test("enterMilestone enters existing worktree when path resolves", () => {
   assert.equal(deps.calls.filter((c) => c.fn === "createAutoWorktree").length, 0);
 });
 
-test("enterMilestone throws on milestoneId with path traversal", () => {
+test("enterMilestone returns ok:false reason:lease-conflict when another worker holds the lease", (t) => {
+  const base = makeDbBase();
+  t.after(() => cleanupDbBase(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  const holder = registerAutoWorker({ projectRootRealpath: base });
+  const contender = registerAutoWorker({ projectRootRealpath: base });
+  const claim = claimMilestoneLease(holder, "M001");
+  assert.equal(claim.ok, true);
+
+  const s = makeSession({ basePath: base, originalBasePath: base, workerId: contender });
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, "lease-conflict");
+  }
+  assert.equal(s.isolationDegraded, false);
+  assert.equal(deps.calls.filter((c) => c.fn === "createAutoWorktree").length, 0);
+  assert.equal(deps.calls.filter((c) => c.fn === "enterAutoWorktree").length, 0);
+});
+
+test("enterMilestone is idempotent when already in the milestone worktree", () => {
+  const s = makeSession({
+    basePath: "/project/.gsd/worktrees/M001",
+    originalBasePath: "/project",
+    currentMilestoneId: "M001",
+  });
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.mode, "worktree");
+    assert.equal(result.path, "/project/.gsd/worktrees/M001");
+  }
+  assert.equal(s.basePath, "/project/.gsd/worktrees/M001");
+  assert.equal(deps.calls.filter((c) => c.fn === "createAutoWorktree").length, 0);
+  assert.equal(deps.calls.filter((c) => c.fn === "enterAutoWorktree").length, 0);
+});
+
+test("enterMilestone returns ok:false reason:invalid-milestone-id on path traversal", () => {
   const s = makeSession();
   const deps = makeDeps();
   const ctx = makeCtx();
   const lifecycle = new WorktreeLifecycle(s, deps);
 
-  assert.throws(() => lifecycle.enterMilestone("../escape", ctx), /Invalid milestoneId/);
-  assert.throws(() => lifecycle.enterMilestone("a/b", ctx), /Invalid milestoneId/);
+  const traversal = lifecycle.enterMilestone("../escape", ctx);
+  assert.equal(traversal.ok, false);
+  if (!traversal.ok) {
+    assert.equal(traversal.reason, "invalid-milestone-id");
+    assert.ok(traversal.cause instanceof Error);
+  }
+
+  const separator = lifecycle.enterMilestone("a/b", ctx);
+  assert.equal(separator.ok, false);
+  if (!separator.ok) {
+    assert.equal(separator.reason, "invalid-milestone-id");
+    assert.ok(separator.cause instanceof Error);
+  }
 });

--- a/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
@@ -10,6 +10,7 @@ import {
   type WorktreeResolverDeps,
   type NotifyCtx,
 } from "../worktree-resolver.js";
+import { WorktreeLifecycle } from "../worktree-lifecycle.js";
 import { AutoSession } from "../auto/session.js";
 import {
   closeDatabase,
@@ -258,7 +259,7 @@ test("enterMilestone creates new worktree when none exists", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   assert.equal(s.basePath, "/project/.gsd/worktrees/M001");
   assert.equal(findCalls(deps.calls, "createAutoWorktree").length, 1);
@@ -279,7 +280,7 @@ test("enterMilestone enters existing worktree instead of creating", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   assert.equal(s.basePath, "/project/.gsd/worktrees/M001");
   assert.equal(findCalls(deps.calls, "enterAutoWorktree").length, 1);
@@ -294,7 +295,7 @@ test("enterMilestone is no-op when isolation mode is none", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   assert.equal(s.basePath, "/project"); // unchanged
   assert.equal(findCalls(deps.calls, "createAutoWorktree").length, 0);
@@ -314,7 +315,7 @@ test("enterMilestone passes project root to isolation mode guard", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   assert.equal(checkedBasePath, "/project");
   assert.equal(findCalls(deps.calls, "createAutoWorktree").length, 0);
@@ -331,7 +332,7 @@ test("enterMilestone does NOT update basePath on creation failure", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   assert.equal(s.basePath, "/project"); // unchanged — error recovery
   assert.ok(
@@ -357,7 +358,7 @@ test("enterMilestone uses originalBasePath as base for worktree ops", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M002", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M002", ctx);
 
   assert.equal(createdFrom, "/project"); // uses originalBasePath, not current basePath
 });
@@ -388,7 +389,7 @@ test("enterMilestone does not create double-nested worktree when originalBasePat
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M002", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M002", ctx);
 
   // The path passed to createAutoWorktree must be the project root, NOT the
   // worktree path. If it equals wtPath the worktree would be created at
@@ -424,7 +425,7 @@ test("enterMilestone reacquires a released same-milestone lease before worktree 
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   const row = getMilestoneLease("M001");
   assert.ok(row);
@@ -446,7 +447,7 @@ test("enterMilestone in branch mode calls enterBranchModeForMilestone and rebuil
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   // Branch mode: no worktree created, basePath unchanged
   assert.equal(s.basePath, "/project");
@@ -469,7 +470,7 @@ test("enterMilestone in branch mode uses originalBasePath as base", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   assert.equal(calledWith, "/project");
 });
@@ -485,7 +486,7 @@ test("enterMilestone in branch mode degrades isolation on failure", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   assert.equal(s.basePath, "/project"); // unchanged
   assert.ok(s.isolationDegraded);
@@ -501,7 +502,7 @@ test("enterMilestone branch mode is skipped when isolationDegraded", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   assert.equal(findCalls(deps.calls, "enterBranchModeForMilestone").length, 0);
   assert.equal(findCalls(deps.calls, "createAutoWorktree").length, 0);
@@ -1192,7 +1193,7 @@ test("GitService is rebuilt with the NEW basePath after enterMilestone", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   assert.equal(gitServiceBasePath, "/project/.gsd/worktrees/M001"); // new path, not old
 });
@@ -1232,7 +1233,7 @@ test("enterMilestone sets isolationDegraded when worktree creation throws (#2483
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   assert.equal(s.isolationDegraded, true);
   assert.equal(s.basePath, "/project"); // unchanged — error recovery
@@ -1245,7 +1246,7 @@ test("enterMilestone is no-op when isolationDegraded is true (#2483)", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.enterMilestone("M001", ctx);
+  new WorktreeLifecycle(s, deps).enterMilestone("M001", ctx);
 
   assert.equal(s.basePath, "/project"); // unchanged
   assert.equal(findCalls(deps.calls, "createAutoWorktree").length, 0);

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -1,0 +1,398 @@
+// GSD-2 — Worktree Lifecycle module: owns milestone entry/exit lifecycle behind a small, typed Interface.
+/**
+ * Worktree Lifecycle module — first-class Module for worktree create/enter/exit/merge.
+ *
+ * Per ADR-016, this Module is the sole owner of:
+ *   - `s.basePath` mutation across the session
+ *   - `process.chdir()` discipline for worktree transitions (delegated to
+ *     `enterAutoWorktree`/`createAutoWorktree`, which chdir internally)
+ *   - milestone lease coordination (claim/refresh/release fencing tokens)
+ *
+ * Phase 1 of the migration ships only `enterMilestone`. The remaining verbs
+ * (`exitMilestone`, `degradeToBranchMode`, `restoreToProjectRoot`, queries) are
+ * extracted from `WorktreeResolver` in subsequent slices.
+ *
+ * The implementation lives in `_enterMilestoneCore` so `WorktreeResolver` can
+ * call the same body during its internal `mergeAndEnterNext` recursion without
+ * a circular reference. Both classes share the body until the Resolver retires.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import type { AutoSession } from "./auto/session.js";
+import { debugLog } from "./debug-logger.js";
+import { emitJournalEvent } from "./journal.js";
+import { emitWorktreeCreated } from "./worktree-telemetry.js";
+import { resolveWorktreeProjectRoot } from "./worktree-root.js";
+import {
+  claimMilestoneLease,
+  refreshMilestoneLease,
+  releaseMilestoneLease,
+} from "./db/milestone-leases.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────
+
+export interface NotifyCtx {
+  notify: (
+    msg: string,
+    level?: "info" | "warning" | "error" | "success",
+  ) => void;
+}
+
+/**
+ * Dependencies the Worktree Lifecycle Module needs from auto-mode wiring.
+ *
+ * Structurally a subset of `WorktreeResolverDeps`. `WorktreeResolver` can pass
+ * its own deps where these are expected — TypeScript's structural typing
+ * handles the narrowing.
+ */
+export interface WorktreeLifecycleDeps {
+  enterAutoWorktree: (basePath: string, milestoneId: string) => string;
+  createAutoWorktree: (basePath: string, milestoneId: string) => string;
+  enterBranchModeForMilestone: (basePath: string, milestoneId: string) => void;
+  getAutoWorktreePath: (basePath: string, milestoneId: string) => string | null;
+  getIsolationMode: (basePath?: string) => "worktree" | "branch" | "none";
+  invalidateAllCaches: () => void;
+  GitServiceImpl: new (basePath: string, gitConfig: unknown) => unknown;
+  loadEffectiveGSDPreferences: () =>
+    | { preferences?: { git?: Record<string, unknown> } }
+    | undefined;
+}
+
+export type EnterResult =
+  | { ok: true; mode: "worktree" | "branch" | "none"; path: string }
+  | {
+      ok: false;
+      reason:
+        | "isolation-degraded"
+        | "lease-conflict"
+        | "creation-failed"
+        | "invalid-milestone-id";
+      cause?: unknown;
+    };
+
+// ─── Validation ──────────────────────────────────────────────────────────
+
+function validateMilestoneId(milestoneId: string): void {
+  if (/[\/\\]|\.\./.test(milestoneId)) {
+    throw new Error(
+      `Invalid milestoneId: ${milestoneId} — contains path separators or traversal`,
+    );
+  }
+}
+
+// ─── Implementation core ─────────────────────────────────────────────────
+
+/**
+ * Shared implementation of milestone entry. Called by both
+ * `WorktreeLifecycle.enterMilestone` and the legacy
+ * `WorktreeResolver.mergeAndEnterNext` internal recursion until the Resolver
+ * retires (slice #5587).
+ *
+ * Side effects (preserved from the original `WorktreeResolver.enterMilestone`):
+ *   - mutates `s.milestoneLeaseToken` on lease claim/release/refresh
+ *   - mutates `s.basePath` on successful worktree entry
+ *   - mutates `s.gitService` (rebuilt against the new base path)
+ *   - mutates `s.isolationDegraded` on hard failure of branch/worktree setup
+ *   - emits journal events: worktree-skip, worktree-enter, worktree-create-failed
+ *   - emits worktree-created telemetry on successful entry
+ *   - notifies the caller via `ctx.notify` for every user-visible outcome
+ */
+export function _enterMilestoneCore(
+  s: AutoSession,
+  deps: WorktreeLifecycleDeps,
+  milestoneId: string,
+  ctx: NotifyCtx,
+): EnterResult {
+  validateMilestoneId(milestoneId);
+
+  if (s.isolationDegraded) {
+    debugLog("WorktreeLifecycle", {
+      action: "enterMilestone",
+      milestoneId,
+      skipped: true,
+      reason: "isolation-degraded",
+    });
+    return { ok: false, reason: "isolation-degraded" };
+  }
+
+  // Phase B: claim a milestone lease before any worktree mutation. Two
+  // workers cannot enter the same milestone concurrently. Best-effort:
+  // skip if no worker registered (single-worker fallback) or DB
+  // unavailable; reuse existing lease if we already hold it on this
+  // milestone (re-entry within the same session).
+  if (s.workerId) {
+    if (
+      s.currentMilestoneId === milestoneId &&
+      s.milestoneLeaseToken !== null
+    ) {
+      const refreshed = refreshMilestoneLease(
+        s.workerId,
+        milestoneId,
+        s.milestoneLeaseToken,
+      );
+      if (refreshed) {
+        debugLog("WorktreeLifecycle", {
+          action: "enterMilestone",
+          milestoneId,
+          leaseRefreshed: true,
+          fencingToken: s.milestoneLeaseToken,
+        });
+      } else {
+        debugLog("WorktreeLifecycle", {
+          action: "enterMilestone",
+          milestoneId,
+          staleLeaseToken: s.milestoneLeaseToken,
+        });
+        s.milestoneLeaseToken = null;
+      }
+    }
+
+    // If we held a different milestone, release it first so other
+    // workers don't have to wait for TTL.
+    if (
+      s.currentMilestoneId &&
+      s.currentMilestoneId !== milestoneId &&
+      s.milestoneLeaseToken !== null
+    ) {
+      try {
+        releaseMilestoneLease(
+          s.workerId,
+          s.currentMilestoneId,
+          s.milestoneLeaseToken,
+        );
+      } catch (err) {
+        debugLog("WorktreeLifecycle", {
+          action: "enterMilestone",
+          milestoneId,
+          releasePriorLeaseError:
+            err instanceof Error ? err.message : String(err),
+        });
+      }
+      s.milestoneLeaseToken = null;
+    }
+
+    if (s.milestoneLeaseToken === null) {
+      try {
+        const claim = claimMilestoneLease(s.workerId, milestoneId);
+        if (claim.ok) {
+          s.milestoneLeaseToken = claim.token;
+          debugLog("WorktreeLifecycle", {
+            action: "enterMilestone",
+            milestoneId,
+            leaseAcquired: true,
+            fencingToken: claim.token,
+            expiresAt: claim.expiresAt,
+          });
+        } else {
+          // Lease held by another worker — fail loud so the user can
+          // see the conflict instead of silently double-running.
+          const msg = `Milestone ${milestoneId} is held by worker ${claim.byWorker} until ${claim.expiresAt}.`;
+          debugLog("WorktreeLifecycle", {
+            action: "enterMilestone",
+            milestoneId,
+            leaseHeldByOther: claim.byWorker,
+            expiresAt: claim.expiresAt,
+          });
+          ctx.notify(
+            `${msg} Another auto-mode worker is active. Stop it before entering ${milestoneId}.`,
+            "error",
+          );
+          return { ok: false, reason: "lease-conflict" };
+        }
+      } catch (err) {
+        // DB unavailable or other error — log and fall through to the
+        // pre-Phase-B single-worker behavior so a fresh project before
+        // DB init still works.
+        debugLog("WorktreeLifecycle", {
+          action: "enterMilestone",
+          milestoneId,
+          leaseError: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  // Resolve the project root for worktree operations via shared helper.
+  // Handles the case where originalBasePath is falsy and basePath is itself
+  // a worktree path — prevents double-nested worktree paths (#3729).
+  const basePath = resolveWorktreeProjectRoot(s.basePath, s.originalBasePath);
+  const mode = deps.getIsolationMode(basePath);
+
+  if (mode === "none") {
+    debugLog("WorktreeLifecycle", {
+      action: "enterMilestone",
+      milestoneId,
+      skipped: true,
+      reason: "isolation-disabled",
+    });
+    emitJournalEvent(s.originalBasePath || s.basePath, {
+      ts: new Date().toISOString(),
+      flowId: randomUUID(),
+      seq: 0,
+      eventType: "worktree-skip",
+      data: { milestoneId, reason: "isolation-disabled" },
+    });
+    return { ok: true, mode: "none", path: basePath };
+  }
+
+  debugLog("WorktreeLifecycle", {
+    action: "enterMilestone",
+    milestoneId,
+    mode,
+    basePath,
+  });
+
+  // ── Branch mode: create/checkout milestone branch, stay in project root ──
+  if (mode === "branch") {
+    try {
+      deps.enterBranchModeForMilestone(basePath, milestoneId);
+      // basePath does not change — no worktree, no chdir.
+      // Rebuild GitService so the new HEAD is reflected, then flush any
+      // path-keyed caches that may have been populated before the checkout.
+      rebuildGitService(s, deps);
+      deps.invalidateAllCaches();
+      debugLog("WorktreeLifecycle", {
+        action: "enterMilestone",
+        milestoneId,
+        mode: "branch",
+        result: "success",
+      });
+      emitJournalEvent(basePath, {
+        ts: new Date().toISOString(),
+        flowId: randomUUID(),
+        seq: 0,
+        eventType: "worktree-skip",
+        data: { milestoneId, reason: "branch-mode-no-worktree" },
+      });
+      ctx.notify(`Switched to branch milestone/${milestoneId}.`, "info");
+      return { ok: true, mode: "branch", path: basePath };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      debugLog("WorktreeLifecycle", {
+        action: "enterMilestone",
+        milestoneId,
+        mode: "branch",
+        result: "error",
+        error: msg,
+      });
+      ctx.notify(
+        `Branch isolation setup for ${milestoneId} failed: ${msg}. Continuing on current branch.`,
+        "warning",
+      );
+      s.isolationDegraded = true;
+      return { ok: false, reason: "creation-failed", cause: err };
+    }
+  }
+
+  // ── Worktree mode ────────────────────────────────────────────────────────
+  try {
+    const existingPath = deps.getAutoWorktreePath(basePath, milestoneId);
+    let wtPath: string;
+
+    if (existingPath) {
+      wtPath = deps.enterAutoWorktree(basePath, milestoneId);
+    } else {
+      wtPath = deps.createAutoWorktree(basePath, milestoneId);
+    }
+
+    s.basePath = wtPath;
+    rebuildGitService(s, deps);
+
+    debugLog("WorktreeLifecycle", {
+      action: "enterMilestone",
+      milestoneId,
+      result: "success",
+      wtPath,
+    });
+    emitJournalEvent(s.originalBasePath || s.basePath, {
+      ts: new Date().toISOString(),
+      flowId: randomUUID(),
+      seq: 0,
+      eventType: "worktree-enter",
+      data: { milestoneId, wtPath, created: !existingPath },
+    });
+    // #4764 — record creation/enter as a lifecycle event so the telemetry
+    // aggregator can pair it with the eventual worktree-merged event.
+    try {
+      emitWorktreeCreated(s.originalBasePath || s.basePath, milestoneId, {
+        reason: existingPath ? "enter-milestone" : "create-milestone",
+      });
+    } catch (telemetryErr) {
+      debugLog("WorktreeLifecycle", {
+        action: "enterMilestone",
+        phase: "telemetry-emit",
+        error:
+          telemetryErr instanceof Error
+            ? telemetryErr.message
+            : String(telemetryErr),
+      });
+    }
+    ctx.notify(`Entered worktree for ${milestoneId} at ${wtPath}`, "info");
+    return { ok: true, mode: "worktree", path: wtPath };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    debugLog("WorktreeLifecycle", {
+      action: "enterMilestone",
+      milestoneId,
+      result: "error",
+      error: msg,
+    });
+    emitJournalEvent(s.originalBasePath || s.basePath, {
+      ts: new Date().toISOString(),
+      flowId: randomUUID(),
+      seq: 0,
+      eventType: "worktree-create-failed",
+      data: { milestoneId, error: msg, fallback: "project-root" },
+    });
+    ctx.notify(
+      `Auto-worktree creation for ${milestoneId} failed: ${msg}. Continuing in project root.`,
+      "warning",
+    );
+    // Degrade isolation for the rest of this session so mergeAndExit
+    // doesn't try to merge a nonexistent worktree branch (#2483)
+    s.isolationDegraded = true;
+    // Do NOT update s.basePath — stay in project root
+    return { ok: false, reason: "creation-failed", cause: err };
+  }
+}
+
+function rebuildGitService(
+  s: AutoSession,
+  deps: WorktreeLifecycleDeps,
+): void {
+  const gitConfig =
+    deps.loadEffectiveGSDPreferences()?.preferences?.git ?? {};
+  s.gitService = new deps.GitServiceImpl(
+    s.basePath,
+    gitConfig,
+  ) as AutoSession["gitService"];
+}
+
+// ─── Module class ────────────────────────────────────────────────────────
+
+/**
+ * Worktree Lifecycle module instance.
+ *
+ * Constructed once per auto-mode session. Holds the session reference so
+ * verbs can mutate `s.basePath` and related coordination state directly
+ * without round-tripping through callers.
+ */
+export class WorktreeLifecycle {
+  constructor(
+    private readonly s: AutoSession,
+    private readonly deps: WorktreeLifecycleDeps,
+  ) {}
+
+  /**
+   * Enter or create the auto-worktree for `milestoneId`. Idempotent if
+   * already in this milestone (lease refreshed; basePath unchanged).
+   *
+   * Returns a typed `EnterResult` describing the outcome. Callers may
+   * ignore the result if they read `s.basePath` directly afterwards
+   * (legacy behaviour); new callers should branch on the result.
+   */
+  enterMilestone(milestoneId: string, ctx: NotifyCtx): EnterResult {
+    return _enterMilestoneCore(this.s, this.deps, milestoneId, ctx);
+  }
+}

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -76,13 +76,8 @@ export type EnterResult =
 
 // ─── Validation ──────────────────────────────────────────────────────────
 
-function validateMilestoneId(milestoneId: string): Error | null {
-  if (/[\/\\]|\.\./.test(milestoneId)) {
-    return new Error(
-      `Invalid milestoneId: ${milestoneId} — contains path separators or traversal`,
-    );
-  }
-  return null;
+function isValidMilestoneId(milestoneId: string): boolean {
+  return !/[\/\\]|\.\./.test(milestoneId);
 }
 
 // ─── Implementation core ─────────────────────────────────────────────────
@@ -108,8 +103,7 @@ export function _enterMilestoneCore(
   milestoneId: string,
   ctx: NotifyCtx,
 ): EnterResult {
-  const validationError = validateMilestoneId(milestoneId);
-  if (validationError) {
+  if (!isValidMilestoneId(milestoneId)) {
     debugLog("WorktreeLifecycle", {
       action: "enterMilestone",
       milestoneId,
@@ -118,7 +112,9 @@ export function _enterMilestoneCore(
     return {
       ok: false,
       reason: "invalid-milestone-id",
-      cause: validationError,
+      cause: new Error(
+        `Invalid milestoneId: ${milestoneId} — contains path separators or traversal`,
+      ),
     };
   }
 

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -45,6 +45,9 @@ export interface NotifyCtx {
  * Structurally a subset of `WorktreeResolverDeps`. `WorktreeResolver` can pass
  * its own deps where these are expected — TypeScript's structural typing
  * handles the narrowing.
+ *
+ * TODO(#5586): collapse this to the ADR target dep set after the resolver
+ * recursion retires; shrinking it now would force a parallel migration.
  */
 export interface WorktreeLifecycleDeps {
   enterAutoWorktree: (basePath: string, milestoneId: string) => string;
@@ -73,12 +76,13 @@ export type EnterResult =
 
 // ─── Validation ──────────────────────────────────────────────────────────
 
-function validateMilestoneId(milestoneId: string): void {
+function validateMilestoneId(milestoneId: string): Error | null {
   if (/[\/\\]|\.\./.test(milestoneId)) {
-    throw new Error(
+    return new Error(
       `Invalid milestoneId: ${milestoneId} — contains path separators or traversal`,
     );
   }
+  return null;
 }
 
 // ─── Implementation core ─────────────────────────────────────────────────
@@ -104,7 +108,19 @@ export function _enterMilestoneCore(
   milestoneId: string,
   ctx: NotifyCtx,
 ): EnterResult {
-  validateMilestoneId(milestoneId);
+  const validationError = validateMilestoneId(milestoneId);
+  if (validationError) {
+    debugLog("WorktreeLifecycle", {
+      action: "enterMilestone",
+      milestoneId,
+      rejected: "invalid-milestone-id",
+    });
+    return {
+      ok: false,
+      reason: "invalid-milestone-id",
+      cause: validationError,
+    };
+  }
 
   if (s.isolationDegraded) {
     debugLog("WorktreeLifecycle", {
@@ -243,6 +259,21 @@ export function _enterMilestoneCore(
     basePath,
   });
 
+  if (
+    mode === "worktree" &&
+    s.currentMilestoneId === milestoneId &&
+    s.basePath !== basePath
+  ) {
+    debugLog("WorktreeLifecycle", {
+      action: "enterMilestone",
+      milestoneId,
+      mode: "worktree",
+      result: "already-entered",
+      wtPath: s.basePath,
+    });
+    return { ok: true, mode: "worktree", path: s.basePath };
+  }
+
   // ── Branch mode: create/checkout milestone branch, stay in project root ──
   if (mode === "branch") {
     try {
@@ -379,10 +410,16 @@ function rebuildGitService(
  * without round-tripping through callers.
  */
 export class WorktreeLifecycle {
+  private readonly s: AutoSession;
+  private readonly deps: WorktreeLifecycleDeps;
+
   constructor(
-    private readonly s: AutoSession,
-    private readonly deps: WorktreeLifecycleDeps,
-  ) {}
+    s: AutoSession,
+    deps: WorktreeLifecycleDeps,
+  ) {
+    this.s = s;
+    this.deps = deps;
+  }
 
   /**
    * Enter or create the auto-worktree for `milestoneId`. Idempotent if

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -21,11 +21,11 @@ import type { AutoSession } from "./auto/session.js";
 import { debugLog } from "./debug-logger.js";
 import { MergeConflictError } from "./git-service.js";
 import { emitJournalEvent } from "./journal.js";
-import { emitWorktreeCreated, emitWorktreeMerged } from "./worktree-telemetry.js";
+import { emitWorktreeMerged } from "./worktree-telemetry.js";
 import { getCollapseCadence, getMilestoneResquash, resquashMilestoneOnMain } from "./slice-cadence.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { resolveWorktreeProjectRoot, normalizeWorktreePathForCompare } from "./worktree-root.js";
-import { claimMilestoneLease, refreshMilestoneLease, releaseMilestoneLease } from "./db/milestone-leases.js";
+import { _enterMilestoneCore } from "./worktree-lifecycle.js";
 
 // ─── Path Comparison Helper ────────────────────────────────────────────────
 /**
@@ -192,250 +192,9 @@ export class WorktreeResolver {
   }
 
   // ── Enter Milestone ────────────────────────────────────────────────────
-
-  /**
-   * Enter or create a worktree for the given milestone.
-   *
-   * Only acts if `shouldUseWorktreeIsolation()` returns true.
-   * Delegates to `enterAutoWorktree` (existing) or `createAutoWorktree` (new).
-   * Those functions call `process.chdir()` internally — we do NOT double-chdir.
-   *
-   * Updates `s.basePath` and rebuilds GitService on success.
-   * On failure: notifies a warning and does NOT update `s.basePath`.
-   */
-  enterMilestone(milestoneId: string, ctx: NotifyCtx): void {
-    this.validateMilestoneId(milestoneId);
-
-    // If worktree creation failed earlier this session, skip all future attempts
-    if (this.s.isolationDegraded) {
-      debugLog("WorktreeResolver", {
-        action: "enterMilestone",
-        milestoneId,
-        skipped: true,
-        reason: "isolation-degraded",
-      });
-      return;
-    }
-
-    // Phase B: claim a milestone lease before any worktree mutation. Two
-    // workers cannot enter the same milestone concurrently. Best-effort:
-    // skip if no worker registered (single-worker fallback) or DB
-    // unavailable; reuse existing lease if we already hold it on this
-    // milestone (re-entry within the same session).
-    if (this.s.workerId) {
-      if (this.s.currentMilestoneId === milestoneId && this.s.milestoneLeaseToken !== null) {
-        const refreshed = refreshMilestoneLease(
-          this.s.workerId,
-          milestoneId,
-          this.s.milestoneLeaseToken,
-        );
-        if (refreshed) {
-          debugLog("WorktreeResolver", {
-            action: "enterMilestone",
-            milestoneId,
-            leaseRefreshed: true,
-            fencingToken: this.s.milestoneLeaseToken,
-          });
-        } else {
-          debugLog("WorktreeResolver", {
-            action: "enterMilestone",
-            milestoneId,
-            staleLeaseToken: this.s.milestoneLeaseToken,
-          });
-          this.s.milestoneLeaseToken = null;
-        }
-      }
-
-      // If we held a different milestone, release it first so other
-      // workers don't have to wait for TTL.
-      if (this.s.currentMilestoneId && this.s.currentMilestoneId !== milestoneId && this.s.milestoneLeaseToken !== null) {
-        try {
-          releaseMilestoneLease(this.s.workerId, this.s.currentMilestoneId, this.s.milestoneLeaseToken);
-        } catch (err) {
-          debugLog("WorktreeResolver", {
-            action: "enterMilestone",
-            milestoneId,
-            releasePriorLeaseError: err instanceof Error ? err.message : String(err),
-          });
-        }
-        this.s.milestoneLeaseToken = null;
-      }
-
-      if (this.s.milestoneLeaseToken === null) {
-        try {
-          const claim = claimMilestoneLease(this.s.workerId, milestoneId);
-          if (claim.ok) {
-            this.s.milestoneLeaseToken = claim.token;
-            debugLog("WorktreeResolver", {
-              action: "enterMilestone",
-              milestoneId,
-              leaseAcquired: true,
-              fencingToken: claim.token,
-              expiresAt: claim.expiresAt,
-            });
-          } else {
-            // Lease held by another worker — fail loud so the user can
-            // see the conflict instead of silently double-running.
-            const msg = `Milestone ${milestoneId} is held by worker ${claim.byWorker} until ${claim.expiresAt}.`;
-            debugLog("WorktreeResolver", {
-              action: "enterMilestone",
-              milestoneId,
-              leaseHeldByOther: claim.byWorker,
-              expiresAt: claim.expiresAt,
-            });
-            ctx.notify(`${msg} Another auto-mode worker is active. Stop it before entering ${milestoneId}.`, "error");
-            return;
-          }
-        } catch (err) {
-          // DB unavailable or other error — log and fall through to the
-          // pre-Phase-B single-worker behavior so a fresh project before
-          // DB init still works.
-          debugLog("WorktreeResolver", {
-            action: "enterMilestone",
-            milestoneId,
-            leaseError: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-    }
-
-    // Resolve the project root for worktree operations via shared helper.
-    // Handles the case where originalBasePath is falsy and basePath is itself
-    // a worktree path — prevents double-nested worktree paths (#3729).
-    const basePath = resolveProjectRoot(this.s.originalBasePath, this.s.basePath);
-    const mode = this.deps.getIsolationMode(basePath);
-
-    if (mode === "none") {
-      debugLog("WorktreeResolver", {
-        action: "enterMilestone",
-        milestoneId,
-        skipped: true,
-        reason: "isolation-disabled",
-      });
-      emitJournalEvent(this.s.originalBasePath || this.s.basePath, {
-        ts: new Date().toISOString(),
-        flowId: randomUUID(),
-        seq: 0,
-        eventType: "worktree-skip",
-        data: { milestoneId, reason: "isolation-disabled" },
-      });
-      return;
-    }
-
-    debugLog("WorktreeResolver", {
-      action: "enterMilestone",
-      milestoneId,
-      mode,
-      basePath,
-    });
-
-    // ── Branch mode: create/checkout milestone branch, stay in project root ──
-    if (mode === "branch") {
-      try {
-        this.deps.enterBranchModeForMilestone(basePath, milestoneId);
-        // basePath does not change — no worktree, no chdir.
-        // Rebuild GitService so the new HEAD is reflected, then flush any
-        // path-keyed caches that may have been populated before the checkout.
-        this.rebuildGitService();
-        this.deps.invalidateAllCaches();
-        debugLog("WorktreeResolver", {
-          action: "enterMilestone",
-          milestoneId,
-          mode: "branch",
-          result: "success",
-        });
-        emitJournalEvent(basePath, {
-          ts: new Date().toISOString(),
-          flowId: randomUUID(),
-          seq: 0,
-          eventType: "worktree-skip",
-          data: { milestoneId, reason: "branch-mode-no-worktree" },
-        });
-        ctx.notify(`Switched to branch milestone/${milestoneId}.`, "info");
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        debugLog("WorktreeResolver", {
-          action: "enterMilestone",
-          milestoneId,
-          mode: "branch",
-          result: "error",
-          error: msg,
-        });
-        ctx.notify(
-          `Branch isolation setup for ${milestoneId} failed: ${msg}. Continuing on current branch.`,
-          "warning",
-        );
-        this.s.isolationDegraded = true;
-      }
-      return;
-    }
-
-    // ── Worktree mode ─────────────────────────────────────────────────────────
-    try {
-      const existingPath = this.deps.getAutoWorktreePath(basePath, milestoneId);
-      let wtPath: string;
-
-      if (existingPath) {
-        wtPath = this.deps.enterAutoWorktree(basePath, milestoneId);
-      } else {
-        wtPath = this.deps.createAutoWorktree(basePath, milestoneId);
-      }
-
-      this.s.basePath = wtPath;
-      this.rebuildGitService();
-
-      debugLog("WorktreeResolver", {
-        action: "enterMilestone",
-        milestoneId,
-        result: "success",
-        wtPath,
-      });
-      emitJournalEvent(this.s.originalBasePath || this.s.basePath, {
-        ts: new Date().toISOString(),
-        flowId: randomUUID(),
-        seq: 0,
-        eventType: "worktree-enter",
-        data: { milestoneId, wtPath, created: !existingPath },
-      });
-      // #4764 — record creation/enter as a lifecycle event so the telemetry
-      // aggregator can pair it with the eventual worktree-merged event.
-      try {
-        emitWorktreeCreated(this.s.originalBasePath || this.s.basePath, milestoneId, {
-          reason: existingPath ? "enter-milestone" : "create-milestone",
-        });
-      } catch (telemetryErr) {
-        debugLog("WorktreeResolver", {
-          action: "enterMilestone",
-          phase: "telemetry-emit",
-          error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
-        });
-      }
-      ctx.notify(`Entered worktree for ${milestoneId} at ${wtPath}`, "info");
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      debugLog("WorktreeResolver", {
-        action: "enterMilestone",
-        milestoneId,
-        result: "error",
-        error: msg,
-      });
-      emitJournalEvent(this.s.originalBasePath || this.s.basePath, {
-        ts: new Date().toISOString(),
-        flowId: randomUUID(),
-        seq: 0,
-        eventType: "worktree-create-failed",
-        data: { milestoneId, error: msg, fallback: "project-root" },
-      });
-      ctx.notify(
-        `Auto-worktree creation for ${milestoneId} failed: ${msg}. Continuing in project root.`,
-        "warning",
-      );
-      // Degrade isolation for the rest of this session so mergeAndExit
-      // doesn't try to merge a nonexistent worktree branch (#2483)
-      this.s.isolationDegraded = true;
-      // Do NOT update s.basePath — stay in project root
-    }
-  }
+  // The enterMilestone verb moved to the Worktree Lifecycle Module
+  // (ADR-016 / issue #5585). External callers use WorktreeLifecycle.enterMilestone.
+  // The internal mergeAndEnterNext recursion calls _enterMilestoneCore directly.
 
   // ── Exit Milestone ─────────────────────────────────────────────────────
 
@@ -1003,6 +762,6 @@ export class WorktreeResolver {
       // the current one unmerged.
       if (this.s.basePath !== this.projectRoot) throw err;
     }
-    this.enterMilestone(nextMilestoneId, ctx);
+    _enterMilestoneCore(this.s, this.deps, nextMilestoneId, ctx);
   }
 }

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -25,7 +25,7 @@ import { emitWorktreeMerged } from "./worktree-telemetry.js";
 import { getCollapseCadence, getMilestoneResquash, resquashMilestoneOnMain } from "./slice-cadence.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { resolveWorktreeProjectRoot, normalizeWorktreePathForCompare } from "./worktree-root.js";
-import { _enterMilestoneCore } from "./worktree-lifecycle.js";
+import { _enterMilestoneCore, type EnterResult } from "./worktree-lifecycle.js";
 
 // ─── Path Comparison Helper ────────────────────────────────────────────────
 /**
@@ -745,7 +745,7 @@ export class WorktreeResolver {
     currentMilestoneId: string,
     nextMilestoneId: string,
     ctx: NotifyCtx,
-  ): void {
+  ): EnterResult {
     debugLog("WorktreeResolver", {
       action: "mergeAndEnterNext",
       currentMilestoneId,
@@ -762,6 +762,6 @@ export class WorktreeResolver {
       // the current one unmerged.
       if (this.s.basePath !== this.projectRoot) throw err;
     }
-    _enterMilestoneCore(this.s, this.deps, nextMilestoneId, ctx);
+    return _enterMilestoneCore(this.s, this.deps, nextMilestoneId, ctx);
   }
 }


### PR DESCRIPTION
## Summary

- Stand up `WorktreeLifecycle` Module with the first verb (`enterMilestone`) wired through every direct caller end-to-end.
- Returns a typed `EnterResult` discriminated union; expected failures are typed reasons, not exceptions.
- Implementation in `_enterMilestoneCore` so the Resolver's internal `mergeAndEnterNext` recursion shares the body without a circular reference.
- `WorktreeResolver.enterMilestone` deleted; the rest of the class remains until later slices.
- 8945 unit tests pass; regression coverage for stuck-loop bugs #1886, #2184, #2478, #2821 intact.

Stacked on #5591 (ADR-016). Closes #5585. Unblocks #5586, #5588.

> **Scope correction (in issue body):** Audit showed parallel orchestrators don't call `createAutoWorktree`/`enterAutoWorktree` directly — they use lower-level helpers. The "parallel bypass" framing applies to merge (#5586) and possibly state-sync (#5588/#5589), not entry. Migration scope narrowed accordingly.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test:unit` — 8945 passed, 0 failed
- [x] New `worktree-lifecycle.test.ts` — 8 contract tests on `EnterResult`
- [x] `worktree-resolver.test.ts` enterMilestone tests reshaped to target `WorktreeLifecycle.enterMilestone` (no `_*ForTest` exports added)
- [x] `worktree-journal-events.test.ts` reshaped
- [x] `milestone-transition-state-rebuild.test.ts` + `journal-integration.test.ts` — `LoopDeps` mocks updated with `lifecycle` field
- [ ] Reviewer agrees the deletion-test reasoning for `_enterMilestoneCore` (shared body) is acceptable while `WorktreeResolver` lives — the duplication retires in #5587 with the rest of the class
- [ ] Reviewer agrees `WorktreeLifecycleDeps` (8 fields) is the right starting size; further reduction happens as helpers fold into the Module Implementation in subsequent slices

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR and glossary entries describing worktree lifecycle and state-projection concepts and ownership.

* **Refactor**
  * Centralized milestone entry behind a lifecycle surface; auto-mode now uses it and surfaces clear outcomes (success, lease conflict, creation failure, invalid milestone). Auto-mode will pause/abort on lease conflicts or creation failures and notify the user.

* **Tests**
  * Expanded tests covering lifecycle entry, lease handling, failure modes, idempotency, and milestone validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->