### PR TITLE
chore(agents): add docs/agents/ config + docs/adr/ scaffold

### DIFF
--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -13,7 +13,7 @@ If any of these files don't exist, **proceed silently**. Don't flag their absenc
 
 Single-context layout (this repo):
 
-```
+```text
 /
 ├── CONTEXT.md
 ├── docs/adr/

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context layout (this repo):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-...md
+│   └── 0002-...md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -2,12 +2,12 @@
 
 Issues and PRDs for this repo live as GitHub issues on **`gsd-build/gsd-2`** (the `upstream` remote). Use the `gh` CLI for all operations.
 
-This clone has multiple remotes (`origin` is a personal fork at `jeremymcs/gsd-2`, `upstream` is the canonical repo). Always pass `-R gsd-build/gsd-2` so commands hit the canonical tracker rather than auto-resolving to the fork.
+This clone may have multiple remotes (`origin` is a personal fork, `upstream` is the canonical repo). Always pass `-R gsd-build/gsd-2` so commands hit the canonical tracker rather than auto-resolving to the fork.
 
 ## Conventions
 
 - **Create an issue**: `gh issue create -R gsd-build/gsd-2 --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> -R gsd-build/gsd-2 --comments`, filtering comments by `jq` and also fetching labels.
+- **Read an issue**: `gh issue view <number> -R gsd-build/gsd-2 --json number,title,body,labels,comments --jq '{number, title, body, labels: [.labels[].name], comments: [.comments[].body]}'`.
 - **List issues**: `gh issue list -R gsd-build/gsd-2 --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> -R gsd-build/gsd-2 --body "..."`
 - **Apply / remove labels**: `gh issue edit <number> -R gsd-build/gsd-2 --add-label "..."` / `--remove-label "..."`

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on **`gsd-build/gsd-2`** (the `upstream` remote). Use the `gh` CLI for all operations.
+
+This clone has multiple remotes (`origin` is a personal fork at `jeremymcs/gsd-2`, `upstream` is the canonical repo). Always pass `-R gsd-build/gsd-2` so commands hit the canonical tracker rather than auto-resolving to the fork.
+
+## Conventions
+
+- **Create an issue**: `gh issue create -R gsd-build/gsd-2 --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> -R gsd-build/gsd-2 --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list -R gsd-build/gsd-2 --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> -R gsd-build/gsd-2 --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> -R gsd-build/gsd-2 --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> -R gsd-build/gsd-2 --comment "..."`
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue on `gsd-build/gsd-2`.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> -R gsd-build/gsd-2 --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -14,7 +14,7 @@ When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the 
 
 `needs-triage` and `needs-info` already exist on `gsd-build/gsd-2`. The other three (`ready-for-agent`, `ready-for-human`, `wontfix`) will be created on first use:
 
-```
+```bash
 gh label create ready-for-agent -R gsd-build/gsd-2 --description "Fully specified, ready for an AFK agent" --color 0E8A16
 gh label create ready-for-human -R gsd-build/gsd-2 --description "Requires human implementation" --color 1D76DB
 gh label create wontfix         -R gsd-build/gsd-2 --description "Will not be actioned"          --color CCCCCC

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,23 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+`needs-triage` and `needs-info` already exist on `gsd-build/gsd-2`. The other three (`ready-for-agent`, `ready-for-human`, `wontfix`) will be created on first use:
+
+```
+gh label create ready-for-agent -R gsd-build/gsd-2 --description "Fully specified, ready for an AFK agent" --color 0E8A16
+gh label create ready-for-human -R gsd-build/gsd-2 --description "Requires human implementation" --color 1D76DB
+gh label create wontfix         -R gsd-build/gsd-2 --description "Will not be actioned"          --color CCCCCC
+```
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

Repo-level config files, read by the engineering skills (\`to-issues\`, \`triage\`, \`to-prd\`, \`qa\`, \`improve-codebase-architecture\`, \`diagnose\`, \`tdd\`, \`grill-with-docs\`).

- \`docs/agents/issue-tracker.md\` — issues live on \`gsd-build/gsd-2\` via \`gh -R gsd-build/gsd-2\` (this clone has multiple remotes; the explicit \`-R\` prevents commands auto-resolving to a personal fork).
- \`docs/agents/triage-labels.md\` — five canonical triage roles map 1:1 to label strings; includes \`gh label create\` commands for the three missing ones.
- \`docs/agents/domain.md\` — single-context layout (CONTEXT.md + docs/adr/ at root). Consumer rules for skills.
- \`docs/adr/.gitkeep\` — placeholder so skills that read \`docs/adr/\` don't fail on missing directory.

\`AGENTS.md\` (gitignored, per-clone) was updated locally with an \`## Agent skills\` section pointing at these docs; not committed.

## Test plan

- [ ] No code changes; doc additions only
- [ ] Reviewer confirms label vocabulary in \`triage-labels.md\` matches your team's intent
- [ ] Reviewer confirms the issue-tracker convention (\`-R gsd-build/gsd-2\`) is correct for AFK agent workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added domain-consumption guidance for engineering agents, including reading foundational context first, using canonical vocabulary verbatim, and flagging outputs that contradict existing decisions.
  * Added an issue-tracker CLI guide with command patterns for creating, reading, listing, commenting, labeling, and closing tickets.
  * Added triage-label mapping and setup guidance to standardize label usage and creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->