### PR TITLE
fix(gsd): heal dangling write-gate state symlink

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -1,4 +1,5 @@
-import { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+// GSD2 - Write gate runtime persistence and policy guards.
+import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readlinkSync, realpathSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import { minimatch } from "minimatch";
@@ -147,6 +148,22 @@ function writeGateSnapshotPath(basePath: string): string {
   return join(basePath, ".gsd", "runtime", "write-gate-state.json");
 }
 
+function ensureWriteGateSnapshotDirectory(basePath: string): void {
+  const gsdPath = join(basePath, ".gsd");
+  if (!existsSync(gsdPath)) {
+    try {
+      const stat = lstatSync(gsdPath);
+      if (stat.isSymbolicLink()) {
+        const target = readlinkSync(gsdPath);
+        mkdirSync(isAbsolute(target) ? target : resolve(basePath, target), { recursive: true });
+      }
+    } catch {
+      // If .gsd truly does not exist, the runtime mkdir below will create it.
+    }
+  }
+  mkdirSync(join(gsdPath, "runtime"), { recursive: true });
+}
+
 function currentWriteGateSnapshot(basePath: string = process.cwd()): WriteGateSnapshot {
   const state = getWriteGateState(basePath);
   return {
@@ -160,7 +177,7 @@ function currentWriteGateSnapshot(basePath: string = process.cwd()): WriteGateSn
 function persistWriteGateSnapshot(basePath: string): void {
   if (!shouldPersistWriteGateSnapshot()) return;
   const path = writeGateSnapshotPath(basePath);
-  mkdirSync(join(basePath, ".gsd", "runtime"), { recursive: true });
+  ensureWriteGateSnapshotDirectory(basePath);
   const tempPath = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
   writeFileSync(tempPath, JSON.stringify(currentWriteGateSnapshot(basePath), null, 2), "utf-8");
   try {

--- a/src/resources/extensions/gsd/tests/write-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate.test.ts
@@ -1,3 +1,4 @@
+// GSD2 - Write gate regression tests.
 /**
  * Unit tests for the CONTEXT.md write-gate (D031 guard chain).
  *
@@ -11,7 +12,7 @@
 
 import test, { afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, writeFileSync, unlinkSync, existsSync, rmSync } from 'node:fs';
+import { mkdirSync, writeFileSync, unlinkSync, existsSync, rmSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -682,6 +683,44 @@ test('write-gate: loadWriteGateSnapshot returns empty default when persist file 
     clearDiscussionFlowState(base);
     try {
       rmSync(base, { recursive: true, force: true });
+    } catch { /* swallow */ }
+  }
+});
+
+// ─── Scenario 30: write-gate persistence recreates dangling external .gsd target ──
+
+test('write-gate: resetWriteGateState persists through dangling .gsd symlink', () => {
+  const base = join(tmpdir(), `gsd-write-gate-dangling-${randomUUID()}`);
+  const externalState = join(tmpdir(), `gsd-write-gate-external-${randomUUID()}`);
+  const stateFilePath = join(base, '.gsd', 'runtime', 'write-gate-state.json');
+  const originalEnv = process.env.GSD_PERSIST_WRITE_GATE_STATE;
+
+  try {
+    process.env.GSD_PERSIST_WRITE_GATE_STATE = '1';
+    mkdirSync(base, { recursive: true });
+    symlinkSync(externalState, join(base, '.gsd'), 'junction');
+    assert.strictEqual(existsSync(join(base, '.gsd')), false, 'precondition: .gsd symlink target is missing');
+
+    resetWriteGateState(base);
+
+    assert.ok(existsSync(externalState), 'missing external state target was recreated');
+    assert.ok(existsSync(stateFilePath), 'write-gate snapshot persisted under .gsd/runtime');
+    assert.deepEqual(loadWriteGateSnapshot(base), {
+      verifiedDepthMilestones: [],
+      verifiedApprovalGates: [],
+      activeQueuePhase: false,
+      pendingGateId: null,
+    });
+  } finally {
+    if (originalEnv === undefined) {
+      delete process.env.GSD_PERSIST_WRITE_GATE_STATE;
+    } else {
+      process.env.GSD_PERSIST_WRITE_GATE_STATE = originalEnv;
+    }
+    clearDiscussionFlowState(base);
+    try {
+      rmSync(base, { recursive: true, force: true });
+      rmSync(externalState, { recursive: true, force: true });
     } catch { /* swallow */ }
   }
 });


### PR DESCRIPTION
## TL;DR

**What:** Recreate a missing external `.gsd` symlink target before write-gate persistence writes its startup snapshot.
**Why:** GSD can crash during extension `session_start` when `.gsd` is a dangling symlink into `~/.gsd/projects/<hash>`.
**How:** Resolve dangling `.gsd` symlinks before creating `.gsd/runtime`, then cover the case with a `node:test` regression.

Closes #5594

## What

This updates `src/resources/extensions/gsd/bootstrap/write-gate.ts` so `persistWriteGateSnapshot()` creates the missing target of a dangling project `.gsd` symlink before attempting to create `.gsd/runtime/write-gate-state.json`.

It also adds a regression test in `src/resources/extensions/gsd/tests/write-gate.test.ts` that reproduces the startup failure pattern with `.gsd -> missing external state` and verifies `resetWriteGateState(base)` persists the snapshot successfully.

## Why

The existing symlink recovery path lives in project setup (`ensureGsdSymlink()`), but this crash happens earlier: `register-hooks` calls `resetWriteGateState()` during `session_start`. If the external state directory was deleted, Node cannot recursively create `.gsd/runtime` through the dangling symlink, so the extension fails before project setup can repair it.

## How

`persistWriteGateSnapshot()` now calls a small helper that:

- checks whether `<base>/.gsd` does not resolve,
- detects whether that unresolved path is actually a symlink via `lstatSync`,
- recreates the symlink target directory, handling absolute and relative symlink targets,
- creates `.gsd/runtime` as before.

## Tests

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/write-gate.test.ts`
- `npm run typecheck:extensions`

## Notes

AI-assisted PR. The related stale worktree/provider error where Claude is pointed at a removed `~/.gsd/projects/<hash>/worktrees/M###` path is a separate lifecycle issue and is not fixed by this narrow startup hotfix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced write-gate snapshot persistence to properly handle edge cases where symlinks may be broken or dangling

* **Tests**
  * Added regression test coverage for write-gate state persistence when encountering dangling symlink scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->