### PR TITLE
fix: route Claude Code through session cwd

### DIFF
--- a/packages/pi-ai/src/types.ts
+++ b/packages/pi-ai/src/types.ts
@@ -1,3 +1,4 @@
+// GSD2 - Shared AI provider type definitions
 import type { AssistantMessageEventStream } from "./utils/event-stream.js";
 
 export type { AssistantMessageEventStream } from "./utils/event-stream.js";
@@ -116,6 +117,8 @@ export type ProviderStreamOptions = StreamOptions & Record<string, unknown>;
 
 // Unified options with reasoning passed to streamSimple() and completeSimple()
 export interface SimpleStreamOptions extends StreamOptions {
+	/** Workspace root for providers that spawn local processes. */
+	cwd?: string;
 	reasoning?: ThinkingLevel;
 	/** Custom token budgets for thinking levels (token-based providers only) */
 	thinkingBudgets?: ThinkingBudgets;

--- a/packages/pi-coding-agent/src/core/agent-session-tool-refresh.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-tool-refresh.test.ts
@@ -1,3 +1,4 @@
+// GSD2 - Agent session workspace-root refresh regression tests
 // Regression test for #3616: newSession() must restore the full tool set
 // when cwd is unchanged.
 //
@@ -26,7 +27,7 @@ import { SettingsManager } from "./settings-manager.js";
 
 let testDir: string;
 
-async function createSession(): Promise<AgentSession> {
+async function createSession(options: { workspaceRootRef?: { current: string } } = {}): Promise<AgentSession> {
 	const agentDir = join(testDir, "agent-home");
 	const authStorage = AuthStorage.inMemory({});
 	const modelRegistry = new ModelRegistry(authStorage, join(agentDir, "models.json"));
@@ -48,6 +49,7 @@ async function createSession(): Promise<AgentSession> {
 		cwd: testDir,
 		resourceLoader,
 		modelRegistry,
+		workspaceRootRef: options.workspaceRootRef,
 	});
 }
 
@@ -154,5 +156,17 @@ describe("#3616 — newSession() restores narrowed tool set when cwd unchanged",
 			true,
 			"explicit workspaceRoot rebuild must pass includeAllExtensionTools: true",
 		);
+	});
+
+	it("updates provider workspace root ref when newSession uses explicit workspaceRoot", async () => {
+		const workspaceRootRef = { current: "" };
+		const session = await createSession({ workspaceRootRef });
+		const explicitWorkspaceRoot = mkdtempSync(join(testDir, "provider-workspace-"));
+
+		assert.equal(workspaceRootRef.current, testDir);
+
+		const ok = await session.newSession({ workspaceRoot: explicitWorkspaceRoot });
+		assert.equal(ok, true);
+		assert.equal(workspaceRootRef.current, explicitWorkspaceRoot);
 	});
 });

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1,3 +1,4 @@
+// GSD2 - Agent session lifecycle and workspace runtime coordination
 /**
  * AgentSession - Core abstraction for agent lifecycle and session management.
  *
@@ -167,6 +168,8 @@ export interface AgentSessionConfig {
 	baseToolsOverride?: Record<string, AgentTool>;
 	/** Mutable ref used by Agent to access the current ExtensionRunner */
 	extensionRunnerRef?: { current?: ExtensionRunner };
+	/** Mutable ref used by providers to access the current workspace root. */
+	workspaceRootRef?: { current: string };
 	/** Optional: check if the claude-code CLI provider is ready (installed + authed).
 	 * Passed through to RetryHandler for third-party block recovery (#3772). */
 	isClaudeCodeReady?: () => boolean;
@@ -284,6 +287,7 @@ export class AgentSession {
 	private _baseToolRegistry: Map<string, AgentTool> = new Map();
 	private _cwd: string;
 	private _extensionRunnerRef?: { current?: ExtensionRunner };
+	private _workspaceRootRef?: { current: string };
 	private _initialActiveToolNames?: string[];
 	private _baseToolsOverride?: Record<string, AgentTool>;
 	private _extensionUIContext?: ExtensionUIContext;
@@ -323,6 +327,10 @@ export class AgentSession {
 			this._modelRegistry,
 		);
 		this._extensionRunnerRef = config.extensionRunnerRef;
+		this._workspaceRootRef = config.workspaceRootRef;
+		if (this._workspaceRootRef) {
+			this._workspaceRootRef.current = this._cwd;
+		}
 		this._initialActiveToolNames = config.initialActiveToolNames;
 		this._baseToolsOverride = config.baseToolsOverride;
 
@@ -1711,6 +1719,9 @@ export class AgentSession {
 		// historical default.
 		const previousCwd = this._cwd;
 		this._cwd = options?.workspaceRoot ?? process.cwd();
+		if (this._workspaceRootRef) {
+			this._workspaceRootRef.current = this._cwd;
+		}
 		this.sessionManager.newSession({ parentSession: options?.parentSession });
 		this.agent.sessionId = this.sessionManager.getSessionId();
 		this._steeringMessages = [];

--- a/packages/pi-coding-agent/src/core/sdk.ts
+++ b/packages/pi-coding-agent/src/core/sdk.ts
@@ -1,3 +1,4 @@
+// GSD2 - Coding agent session factory and runtime wiring
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
@@ -439,6 +440,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	};
 
 	const extensionRunnerRef: { current?: ExtensionRunner } = {};
+	const workspaceRootRef: { current: string } = { current: cwd };
 
 	agent = new Agent({
 		initialState: {
@@ -491,8 +493,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		getProviderOptions: async (currentModel) => {
 			if (currentModel.provider !== "claude-code") return undefined;
 			const runner = extensionRunnerRef.current;
-			if (!runner?.hasUI()) return undefined;
+			if (!runner?.hasUI()) {
+				return { cwd: workspaceRootRef.current };
+			}
 			return {
+				cwd: workspaceRootRef.current,
 				extensionUIContext: runner.getUIContext(),
 			};
 		},
@@ -636,6 +641,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		modelRegistry,
 		initialActiveToolNames,
 		extensionRunnerRef,
+		workspaceRootRef,
 		isClaudeCodeReady: options.isClaudeCodeReady,
 	});
 	const extensionsResult = resourceLoader.getExtensions();

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1,3 +1,4 @@
+// GSD2 - Claude Code CLI provider stream adapter
 /**
  * Stream adapter: bridges the Claude Agent SDK into GSD's streamSimple contract.
  *
@@ -59,6 +60,11 @@ type ToolCallWithExternalResult = ToolCall & {
 /** `SimpleStreamOptions` extended with an optional extension UI context for elicitation dialogs. */
 interface ClaudeCodeStreamOptions extends SimpleStreamOptions {
 	extensionUIContext?: ExtensionUIContext;
+}
+
+/** Resolve the workspace root for local Claude Code process execution. */
+export function resolveClaudeCodeCwd(options?: SimpleStreamOptions): string {
+	return options?.cwd && options.cwd.trim().length > 0 ? options.cwd : process.cwd();
 }
 
 /** A single selectable option within an SDK elicitation schema field. */
@@ -1307,8 +1313,9 @@ export function buildSdkOptions(
 	overrides?: { permissionMode?: "bypassPermissions" | "acceptEdits" | "default" | "plan" },
 	extraOptions: Record<string, unknown> & { reasoning?: ThinkingLevel } = {},
 ): Record<string, unknown> {
-	const { reasoning, ...sdkExtraOptions } = extraOptions;
-	const mcpServers = buildWorkflowMcpServers();
+	const { reasoning, cwd, ...sdkExtraOptions } = extraOptions;
+	const sdkCwd = typeof cwd === "string" && cwd.trim().length > 0 ? cwd : process.cwd();
+	const mcpServers = buildWorkflowMcpServers(sdkCwd);
 	const permissionMode = overrides?.permissionMode ?? "bypassPermissions";
 	// Globally unblock the tools GSD expects Claude Code to run. When the
 	// workflow MCP server is available, prefer its `ask_user_questions` tool over
@@ -1349,7 +1356,7 @@ export function buildSdkOptions(
 		model: modelId,
 		includePartialMessages: true,
 		persistSession: true,
-		cwd: process.cwd(),
+		cwd: sdkCwd,
 		permissionMode,
 		allowDangerouslySkipPermissions: permissionMode === "bypassPermissions",
 		settingSources: ["project"],
@@ -1661,6 +1668,7 @@ async function pumpSdkMessages(
 		const queryPrompt = buildSdkQueryPrompt(context, prompt);
 		const permissionMode = await resolveClaudePermissionMode();
 		const uiContext = (options as ClaudeCodeStreamOptions | undefined)?.extensionUIContext;
+		const cwd = resolveClaudeCodeCwd(options);
 		const canUseToolHandler = createClaudeCodeCanUseToolHandler(uiContext);
 		// When no UI is available (headless / auto-mode), auto-approve all
 		// tool requests. This replaces the old bypassPermissions workaround.
@@ -1672,6 +1680,7 @@ async function pumpSdkMessages(
 			prompt,
 			{ permissionMode },
 			{
+				cwd,
 				reasoning: options?.reasoning,
 				canUseTool: canUseToolFallback,
 				...(uiContext

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1,3 +1,4 @@
+// GSD2 - Claude Code stream adapter regression tests
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
@@ -15,6 +16,7 @@ import {
 	buildPromptFromContext,
 	buildSdkQueryPrompt,
 	buildSdkOptions,
+	resolveClaudeCodeCwd,
 	createClaudeCodeCanUseToolHandler,
 	buildBashPermissionPattern,
 	buildBashPermissionPatternOptions,
@@ -669,6 +671,45 @@ describe("stream-adapter — session persistence (#2859)", () => {
 	test("buildSdkOptions sets model and prompt correctly", () => {
 		const options = buildSdkOptions("claude-sonnet-4-20250514", "hello world");
 		assert.equal(options.model, "claude-sonnet-4-20250514");
+	});
+
+	test("buildSdkOptions prefers explicit cwd over process cwd for local SDK execution", () => {
+		const explicitCwd = "/tmp/gsd-session-root";
+		const options = buildSdkOptions("claude-sonnet-4-20250514", "hello world", undefined, { cwd: explicitCwd });
+		assert.equal(options.cwd, explicitCwd);
+	});
+
+	test("buildSdkOptions uses explicit cwd when auto-detecting workflow MCP launch config", () => {
+		const explicitCwd = realpathSync(mkdtempSync(join(tmpdir(), "claude-sdk-cwd-")));
+		const restore = setWorkflowMcpEnv({});
+		try {
+			delete process.env.GSD_WORKFLOW_MCP_COMMAND;
+			delete process.env.GSD_WORKFLOW_MCP_NAME;
+			delete process.env.GSD_WORKFLOW_MCP_ARGS;
+			delete process.env.GSD_WORKFLOW_MCP_ENV;
+			delete process.env.GSD_WORKFLOW_MCP_CWD;
+
+			const distDir = join(explicitCwd, "packages", "mcp-server", "dist");
+			mkdirSync(distDir, { recursive: true });
+			writeFileSync(join(distDir, "cli.js"), "#!/usr/bin/env node\n");
+
+			const options = buildSdkOptions("claude-sonnet-4-20250514", "hello world", undefined, { cwd: explicitCwd });
+			const mcpServers = options.mcpServers as Record<string, any>;
+			assert.equal(mcpServers["gsd-workflow"].cwd, explicitCwd);
+			assert.equal(mcpServers["gsd-workflow"].env.GSD_WORKFLOW_PROJECT_ROOT, explicitCwd);
+		} finally {
+			restore();
+			rmSync(explicitCwd, { recursive: true, force: true });
+		}
+	});
+
+	test("resolveClaudeCodeCwd falls back to process cwd when no stream cwd is provided", () => {
+		assert.equal(resolveClaudeCodeCwd(), process.cwd());
+		assert.equal(resolveClaudeCodeCwd({ cwd: "   " }), process.cwd());
+	});
+
+	test("resolveClaudeCodeCwd returns stream cwd when provided", () => {
+		assert.equal(resolveClaudeCodeCwd({ cwd: "/tmp/current-session" }), "/tmp/current-session");
 	});
 
 	test("buildSdkOptions enables betas for sonnet models", () => {


### PR DESCRIPTION
## TL;DR

**What:** Threads the current `AgentSession` workspace root into Claude Code provider requests.
**Why:** Claude Code could launch from a deleted milestone worktree after auto-mode merged/teared down that worktree.
**How:** Stores the current session cwd in a mutable provider ref, forwards it through `SimpleStreamOptions`, and makes the Claude Code SDK/workflow MCP config prefer that explicit cwd over ambient `process.cwd()`.

## What

This updates the provider handoff path for external Claude Code requests:

- Adds optional `cwd` to `SimpleStreamOptions` for providers that spawn local processes.
- Keeps a session workspace-root ref synchronized when `AgentSession.newSession({ workspaceRoot })` changes roots.
- Passes that cwd from the coding-agent session factory into Claude Code provider options.
- Uses the explicit cwd for Claude Code SDK options and workflow MCP auto-detection.

Closes #5596

## Why

The auto-mode tool runtime already re-roots during milestone transitions, but the Claude Code provider was still using `process.cwd()`. If the process cwd still pointed at a just-removed milestone worktree, the provider failed with a deleted-path error like:

```text
Path "/Users/jeremymcspadden/.gsd/projects/.../worktrees/M002" does not exist
```

That can stall the next dispatch after a successful milestone merge.

## How

The fix keeps the change narrow: session state remains the source of truth, and providers receive only the cwd they need. The Claude adapter resolves a cwd from stream options first, then falls back to `process.cwd()` for existing callers.

## Tests

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts packages/pi-coding-agent/src/core/agent-session-tool-refresh.test.ts`
- `npm run build:native-pkg && npm run build:pi-ai && npm run build:pi-agent-core && npm run build:pi-tui && npm run build:pi-coding-agent`
- `npm run build:rpc-client && npm run build:mcp-server && npm run typecheck:extensions`

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## AI-assisted

This PR was AI-assisted. The change was inspected, tested, and committed without AI co-author attribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for explicitly specifying a workspace root when using Claude Code, allowing tools and MCP servers to operate relative to the designated workspace.
  * Workspace root is now properly tracked and synchronized across session transitions.

* **Bug Fixes**
  * Claude Code provider now returns workspace configuration even when running outside the extension environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->