### PR TITLE
refactor(gsd-extension): WorktreeStateProjection skeleton + projectRootToWorktree

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1613,7 +1613,11 @@ function buildLifecycleDeps(): WorktreeLifecycleDeps {
 }
 
 function buildLifecycle(): WorktreeLifecycle {
-  return new WorktreeLifecycle(s, buildLifecycleDeps());
+  return new WorktreeLifecycle(
+    s,
+    buildLifecycleDeps(),
+    () => buildResolver(),
+  );
 }
 
 /**

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -293,11 +293,15 @@ export async function _runMilestoneMergeWithStashRestore(
   );
 
   let mergeError: unknown = null;
-  try {
-    deps.resolver.mergeAndExit(milestoneId, ctx.ui);
+  const exitResult = deps.lifecycle.exitMilestone(
+    milestoneId,
+    { merge: true },
+    ctx.ui,
+  );
+  if (exitResult.ok) {
     s.milestoneMergedInPhases = true;
-  } catch (mergeErr) {
-    mergeError = mergeErr;
+  } else {
+    mergeError = exitResult.cause ?? new Error(`exit ${exitResult.reason}`);
   }
 
   // Always attempt to restore the stashed working tree, even on merge error.

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -822,18 +822,15 @@ export async function runPreDispatch(
         deps.captureIntegrationBranch(s.basePath, mid);
       }
       const enterResult = deps.lifecycle.enterMilestone(mid, ctx.ui);
-<<<<<<< HEAD
-      if (!enterResult.ok && enterResult.reason === "lease-conflict") {
-        await deps.pauseAuto(ctx, pi);
-        return { action: "break", reason: "lease-conflict" };
-=======
       if (!enterResult.ok) {
         ctx.ui.notify(
           `Could not enter milestone ${mid}: ${enterResult.reason}. Auto-mode paused before dispatching work.`,
           enterResult.reason === "lease-conflict" ? "error" : "warning",
         );
+        if (enterResult.reason === "lease-conflict") {
+          await deps.pauseAuto(ctx, pi);
+        }
         return { action: "break", reason: `enter-milestone-${enterResult.reason}` };
->>>>>>> c737d75da (Apply babysitter fixes for PR #5600)
       }
     } else {
       // mid is undefined — no milestone to capture integration branch for

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -299,7 +299,7 @@ export async function _runMilestoneMergeWithStashRestore(
     ctx.ui,
   );
   if (exitResult.ok) {
-    s.milestoneMergedInPhases = true;
+    s.milestoneMergedInPhases = exitResult.merged;
   } else {
     mergeError = exitResult.cause ?? new Error(`exit ${exitResult.reason}`);
   }
@@ -822,9 +822,18 @@ export async function runPreDispatch(
         deps.captureIntegrationBranch(s.basePath, mid);
       }
       const enterResult = deps.lifecycle.enterMilestone(mid, ctx.ui);
+<<<<<<< HEAD
       if (!enterResult.ok && enterResult.reason === "lease-conflict") {
         await deps.pauseAuto(ctx, pi);
         return { action: "break", reason: "lease-conflict" };
+=======
+      if (!enterResult.ok) {
+        ctx.ui.notify(
+          `Could not enter milestone ${mid}: ${enterResult.reason}. Auto-mode paused before dispatching work.`,
+          enterResult.reason === "lease-conflict" ? "error" : "warning",
+        );
+        return { action: "break", reason: `enter-milestone-${enterResult.reason}` };
+>>>>>>> c737d75da (Apply babysitter fixes for PR #5600)
       }
     } else {
       // mid is undefined — no milestone to capture integration branch for

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -751,6 +751,11 @@ function makeMockDeps(
     } as any,
     lifecycle: {
       enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
+      exitMilestone: (_mid: string, opts: { merge: boolean }) => ({
+        ok: true,
+        merged: opts.merge,
+        codeFilesChanged: false,
+      }),
     } as any,
     postUnitPreVerification: async () => {
       callLog.push("postUnitPreVerification");
@@ -991,6 +996,15 @@ test("autoLoop marks transition merge complete before postflight recovery stop",
         mergeCalls += 1;
       },
       mergeAndEnterNext: () => {},
+    } as any,
+    lifecycle: {
+      enterMilestone: () => {
+        assert.fail("must not enter the next milestone after postflight recovery fails");
+      },
+      exitMilestone: (_mid: string, opts: { merge: boolean }) => {
+        if (opts.merge) mergeCalls += 1;
+        return { ok: true, merged: opts.merge, codeFilesChanged: false };
+      },
     } as any,
     stopAuto: async (_ctx, _pi, reason) => {
       deps.callLog.push("stopAuto");

--- a/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
@@ -184,6 +184,12 @@ test("runFinalize merges a verified complete-milestone immediately and only once
         mergeCalls++;
       },
     },
+    lifecycle: {
+      exitMilestone(_mid: string, opts: { merge: boolean }) {
+        if (opts.merge) mergeCalls++;
+        return { ok: true, merged: opts.merge, codeFilesChanged: false };
+      },
+    },
   });
 
   assert.equal(result.action, "next");
@@ -201,6 +207,12 @@ test("runFinalize merges a verified complete-milestone immediately and only once
     resolver: {
       mergeAndExit() {
         mergeCalls++;
+      },
+    },
+    lifecycle: {
+      exitMilestone(_mid: string, opts: { merge: boolean }) {
+        if (opts.merge) mergeCalls++;
+        return { ok: true, merged: opts.merge, codeFilesChanged: false };
       },
     },
   });

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -81,6 +81,7 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
   const previousCwd = process.cwd();
   const s = new AutoSession();
   const mergeCalls: string[] = [];
+  let enterMilestoneCalls = 0;
   const notifications: Array<{ message: string; level?: string }> = [];
 
   try {
@@ -105,13 +106,13 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
             throw new Error("synthetic merge failure");
           },
         }) as any,
-<<<<<<< HEAD
-        buildLifecycle: () => ({
-          enterMilestone: () => ({ ok: true }),
-        }) as any,
-=======
-        buildLifecycle: () => ({}) as any,
->>>>>>> 0fe53a695 (Apply CI healing fixes for PR #5600)
+        buildLifecycle: () =>
+          ({
+            enterMilestone: () => {
+              enterMilestoneCalls += 1;
+              return { ok: true };
+            },
+          }) as any,
       },
       {
         classification: "none",
@@ -129,6 +130,7 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
 
     assert.equal(ready, false);
     assert.deepEqual(mergeCalls, ["M002"]);
+    assert.equal(enterMilestoneCalls, 0);
     assert.equal(s.active, false);
     assert.match(
       notifications.map((entry) => entry.message).join("\n"),

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -105,9 +105,13 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
             throw new Error("synthetic merge failure");
           },
         }) as any,
+<<<<<<< HEAD
         buildLifecycle: () => ({
           enterMilestone: () => ({ ok: true }),
         }) as any,
+=======
+        buildLifecycle: () => ({}) as any,
+>>>>>>> 0fe53a695 (Apply CI healing fixes for PR #5600)
       },
       {
         classification: "none",
@@ -138,4 +142,3 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
     rmSync(base, { recursive: true, force: true });
   }
 });
-

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -248,6 +248,14 @@ function makeMockDeps(overrides?: Partial<LoopDeps>): LoopDeps & { callLog: stri
     lifecycle: {
       enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
     } as any,
+    lifecycle: {
+      enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
+      exitMilestone: (_mid: string, opts: { merge: boolean }) => ({
+        ok: true,
+        merged: opts.merge,
+        codeFilesChanged: false,
+      }),
+    } as any,
     postUnitPreVerification: async () => "continue" as const,
     runPostUnitVerification: async () => "continue" as const,
     postUnitPostVerification: async () => "continue" as const,

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -247,9 +247,6 @@ function makeMockDeps(overrides?: Partial<LoopDeps>): LoopDeps & { callLog: stri
     } as any,
     lifecycle: {
       enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
-    } as any,
-    lifecycle: {
-      enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
       exitMilestone: (_mid: string, opts: { merge: boolean }) => ({
         ok: true,
         merged: opts.merge,

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -134,6 +134,11 @@ function makeMockDeps(
     } as any,
     lifecycle: {
       enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
+      exitMilestone: (_mid: string, opts: { merge: boolean }) => ({
+        ok: true,
+        merged: opts.merge,
+        codeFilesChanged: false,
+      }),
     } as any,
     postUnitPreVerification: async () => "continue" as const,
     runPostUnitVerification: async () => "continue" as const,

--- a/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
@@ -71,6 +71,31 @@ function buildIc(opts: {
         }
       },
     },
+    lifecycle: {
+      exitMilestone: (_mid: string, exitOpts: { merge: boolean }) => {
+        log.mergeCalls += 1;
+        if (opts.mergeBehavior === "succeed") {
+          return { ok: true, merged: exitOpts.merge, codeFilesChanged: false };
+        }
+        try {
+          opts.mergeBehavior();
+          return { ok: true, merged: exitOpts.merge, codeFilesChanged: false };
+        } catch (err) {
+          // Mirror Lifecycle's typed-result wrapping of MergeConflictError
+          // and other thrown values per worktree-lifecycle.exitMilestone.
+          const isMergeConflict =
+            err !== null &&
+            typeof err === "object" &&
+            err !== undefined &&
+            (err as { name?: string }).name === "MergeConflictError";
+          return {
+            ok: false,
+            reason: isMergeConflict ? "merge-conflict" : "teardown-failed",
+            cause: err,
+          } as const;
+        }
+      },
+    },
     stopAuto: async (_c?: unknown, _p?: unknown, reason?: string) => {
       log.stopAutoCalls.push(reason);
     },

--- a/src/resources/extensions/gsd/tests/milestone-transition-state-rebuild.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-transition-state-rebuild.test.ts
@@ -79,6 +79,10 @@ test("milestone transition archives completed units and rebuilds state", async (
             calls.push(`enter:${mid}`);
             return { ok: true, mode: "worktree", path: `/wt/${mid}` };
           },
+          exitMilestone: (mid: string, opts: { merge: boolean }) => {
+            calls.push(opts.merge ? `merge:${mid}` : `exit:${mid}`);
+            return { ok: true, merged: opts.merge, codeFilesChanged: false };
+          },
         },
         sendDesktopNotification: () => {},
         logCmuxEvent: () => {},

--- a/src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts
@@ -85,6 +85,16 @@ const ic = {
         throw new Error("remote rejected push");
       },
     },
+    lifecycle: {
+      exitMilestone() {
+        calls.push("merge");
+        return {
+          ok: false,
+          reason: "teardown-failed",
+          cause: new Error("remote rejected push"),
+        };
+      },
+    },
     async stopAuto(_ctx: unknown, _pi: unknown, reason?: string) {
       calls.push(`stop:${reason}`);
     },

--- a/src/resources/extensions/gsd/tests/worktree-journal-events.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-journal-events.test.ts
@@ -180,6 +180,24 @@ describe("worktree journal events", () => {
     assert.equal(start!.data?.mode, "worktree");
   });
 
+  test("mergeAndExit does not emit worktree-merge-start on mode-none no-op", () => {
+    const s = makeSession({
+      basePath: tmp,
+      originalBasePath: tmp,
+    });
+    const deps = makeDeps({
+      isInAutoWorktree: () => false,
+      getIsolationMode: () => "none",
+    });
+    const resolver = new WorktreeResolver(s, deps);
+
+    resolver.mergeAndExit("M001", makeNotifyCtx());
+
+    const entries = readJournalEntries(tmp);
+    const start = entries.find(e => e.eventType === "worktree-merge-start");
+    assert.equal(start, undefined);
+  });
+
   test("mergeAndExit emits worktree-merge-failed on error", () => {
     const s = makeSession({
       basePath: join(tmp, "worktree"),

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -295,3 +295,116 @@ test("enterMilestone returns ok:false reason:invalid-milestone-id on path traver
     assert.ok(separator.cause instanceof Error);
   }
 });
+
+// ─── exitMilestone — typed-result contract ────────────────────────────────────
+
+test("exitMilestone throws when no resolverFactory is provided", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  assert.throws(
+    () => lifecycle.exitMilestone("M001", { merge: true }, ctx),
+    /requires a resolverFactory/,
+  );
+});
+
+test("exitMilestone delegates merge:true to Resolver.mergeAndExit and returns ok:true", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  let calledMid: string | null = null;
+  const fakeResolver = {
+    mergeAndExit: (mid: string) => {
+      calledMid = mid;
+    },
+  };
+  const lifecycle = new WorktreeLifecycle(s, deps, () => fakeResolver as any);
+
+  const result = lifecycle.exitMilestone("M001", { merge: true }, ctx);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.merged, true);
+    assert.equal(result.codeFilesChanged, false);
+  }
+  assert.equal(calledMid, "M001");
+});
+
+test("exitMilestone surfaces MergeConflictError as ok:false reason:merge-conflict", async () => {
+  const { MergeConflictError } = await import("../git-service.js");
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const conflict = new MergeConflictError(
+    ["src/foo.ts"],
+    "merge",
+    "milestone/M001",
+    "main",
+  );
+  const fakeResolver = {
+    mergeAndExit: () => {
+      throw conflict;
+    },
+  };
+  const lifecycle = new WorktreeLifecycle(s, deps, () => fakeResolver as any);
+
+  const result = lifecycle.exitMilestone("M001", { merge: true }, ctx);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, "merge-conflict");
+    assert.equal(result.cause, conflict);
+  }
+});
+
+test("exitMilestone wraps non-conflict throws as ok:false reason:teardown-failed", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const fsErr = new Error("EACCES: permission denied");
+  const fakeResolver = {
+    mergeAndExit: () => {
+      throw fsErr;
+    },
+  };
+  const lifecycle = new WorktreeLifecycle(s, deps, () => fakeResolver as any);
+
+  const result = lifecycle.exitMilestone("M001", { merge: true }, ctx);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, "teardown-failed");
+    assert.equal(result.cause, fsErr);
+  }
+});
+
+test("exitMilestone with merge:false delegates to Resolver.exitMilestone with preserveBranch", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  let receivedOpts: { preserveBranch?: boolean } | undefined;
+  const fakeResolver = {
+    exitMilestone: (
+      _mid: string,
+      _ctx: NotifyCtx,
+      opts?: { preserveBranch?: boolean },
+    ) => {
+      receivedOpts = opts;
+    },
+  };
+  const lifecycle = new WorktreeLifecycle(s, deps, () => fakeResolver as any);
+
+  const result = lifecycle.exitMilestone(
+    "M001",
+    { merge: false, preserveBranch: true },
+    ctx,
+  );
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.merged, false);
+  }
+  assert.deepEqual(receivedOpts, { preserveBranch: true });
+});

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -408,3 +408,115 @@ test("exitMilestone with merge:false delegates to Resolver.exitMilestone with pr
   }
   assert.deepEqual(receivedOpts, { preserveBranch: true });
 });
+
+// ─── Queries (issue #5587) ────────────────────────────────────────────────────
+
+test("isInMilestone returns true when session matches milestone id", () => {
+  const s = makeSession();
+  s.currentMilestoneId = "M001";
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  assert.equal(lifecycle.isInMilestone("M001"), true);
+  assert.equal(lifecycle.isInMilestone("M002"), false);
+});
+
+test("isInMilestone returns false when session has no active milestone", () => {
+  const s = makeSession();
+  s.currentMilestoneId = null;
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  assert.equal(lifecycle.isInMilestone("M001"), false);
+});
+
+test("getCurrentMilestoneIfAny returns the active milestone id or null", () => {
+  const s = makeSession();
+  s.currentMilestoneId = "M042";
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  assert.equal(lifecycle.getCurrentMilestoneIfAny(), "M042");
+
+  s.currentMilestoneId = null;
+  assert.equal(lifecycle.getCurrentMilestoneIfAny(), null);
+});
+
+// ─── degradeToBranchMode (issue #5587) ────────────────────────────────────────
+
+test("degradeToBranchMode sets isolationDegraded and invokes branch-mode helper", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.degradeToBranchMode("M001", ctx);
+
+  assert.equal(s.isolationDegraded, true);
+  assert.equal(
+    deps.calls.filter((c) => c.fn === "enterBranchModeForMilestone").length,
+    1,
+  );
+  assert.equal(deps.calls.filter((c) => c.fn === "invalidateAllCaches").length, 1);
+});
+
+test("degradeToBranchMode is no-op when isolationDegraded is already true", () => {
+  const s = makeSession();
+  s.isolationDegraded = true;
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.degradeToBranchMode("M001", ctx);
+
+  assert.equal(
+    deps.calls.filter((c) => c.fn === "enterBranchModeForMilestone").length,
+    0,
+  );
+});
+
+test("degradeToBranchMode marks degraded and notifies on branch-mode failure", () => {
+  const s = makeSession();
+  const deps = makeDeps({
+    enterBranchModeForMilestone: () => {
+      throw new Error("checkout failed");
+    },
+  });
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.degradeToBranchMode("M001", ctx);
+
+  assert.equal(s.isolationDegraded, true);
+  assert.ok(
+    ctx.messages.some(
+      (m) => m.level === "warning" && m.msg.includes("Branch isolation setup"),
+    ),
+  );
+});
+
+// ─── restoreToProjectRoot (issue #5587) ───────────────────────────────────────
+
+test("restoreToProjectRoot restores basePath to originalBasePath and rebuilds git service", () => {
+  const s = makeSession();
+  s.originalBasePath = "/project";
+  s.basePath = "/project/.gsd/worktrees/M001";
+  const deps = makeDeps();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.restoreToProjectRoot();
+
+  assert.equal(s.basePath, "/project");
+  assert.equal(deps.calls.filter((c) => c.fn === "GitServiceImpl").length, 1);
+  assert.equal(deps.calls.filter((c) => c.fn === "invalidateAllCaches").length, 1);
+});
+
+test("restoreToProjectRoot is no-op when originalBasePath is empty", () => {
+  const s = makeSession();
+  s.originalBasePath = "";
+  s.basePath = "/some/path";
+  const deps = makeDeps();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.restoreToProjectRoot();
+
+  assert.equal(s.basePath, "/some/path"); // unchanged
+  assert.equal(deps.calls.filter((c) => c.fn === "GitServiceImpl").length, 0);
+});

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -11,9 +11,12 @@ import {
   type NotifyCtx,
 } from "../worktree-lifecycle.js";
 import { AutoSession } from "../auto/session.js";
-import { openDatabase, closeDatabase, insertMilestone } from "../gsd-db.js";
+import { closeDatabase, insertMilestone, openDatabase } from "../gsd-db.js";
 import { registerAutoWorker } from "../db/auto-workers.js";
-import { claimMilestoneLease } from "../db/milestone-leases.js";
+import {
+  claimMilestoneLease,
+  getMilestoneLease,
+} from "../db/milestone-leases.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -92,7 +95,7 @@ function makeCtx(): NotifyCtx & {
 }
 
 function makeDbBase(): string {
-  const base = mkdtempSync(join(tmpdir(), "gsd-lifecycle-"));
+  const base = mkdtempSync(join(tmpdir(), "gsd-worktree-lifecycle-"));
   mkdirSync(join(base, ".gsd"), { recursive: true });
   return base;
 }
@@ -192,6 +195,33 @@ test("enterMilestone returns ok:false reason:creation-failed and degrades sessio
   assert.equal(s.basePath, "/project");
 });
 
+test("enterMilestone releases claimed lease when worktree setup fails", (t) => {
+  const base = makeDbBase();
+  t.after(() => cleanupDbBase(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test milestone", status: "active" });
+  const workerId = registerAutoWorker({ projectRootRealpath: base });
+
+  const s = makeSession({
+    basePath: base,
+    originalBasePath: base,
+    workerId,
+  });
+  const deps = makeDeps({
+    createAutoWorktree: () => {
+      throw new Error("boom");
+    },
+  });
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, false);
+  assert.equal(s.milestoneLeaseToken, null);
+  assert.equal(getMilestoneLease("M001")?.status, "released");
+});
+
 test("enterMilestone returns ok:false reason:creation-failed when branch mode throws", () => {
   const s = makeSession();
   const deps = makeDeps({
@@ -210,6 +240,34 @@ test("enterMilestone returns ok:false reason:creation-failed when branch mode th
     assert.equal(result.reason, "creation-failed");
   }
   assert.equal(s.isolationDegraded, true);
+});
+
+test("enterMilestone releases claimed lease when branch setup fails", (t) => {
+  const base = makeDbBase();
+  t.after(() => cleanupDbBase(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test milestone", status: "active" });
+  const workerId = registerAutoWorker({ projectRootRealpath: base });
+
+  const s = makeSession({
+    basePath: base,
+    originalBasePath: base,
+    workerId,
+  });
+  const deps = makeDeps({
+    getIsolationMode: () => "branch",
+    enterBranchModeForMilestone: () => {
+      throw new Error("branch checkout failed");
+    },
+  });
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  const result = lifecycle.enterMilestone("M001", ctx);
+
+  assert.equal(result.ok, false);
+  assert.equal(s.milestoneLeaseToken, null);
+  assert.equal(getMilestoneLease("M001")?.status, "released");
 });
 
 test("enterMilestone enters existing worktree when path resolves", () => {
@@ -318,6 +376,7 @@ test("exitMilestone delegates merge:true to Resolver.mergeAndExit and returns ok
   const fakeResolver = {
     mergeAndExit: (mid: string) => {
       calledMid = mid;
+      return { merged: true, codeFilesChanged: true };
     },
   };
   const lifecycle = new WorktreeLifecycle(s, deps, () => fakeResolver as any);
@@ -327,9 +386,27 @@ test("exitMilestone delegates merge:true to Resolver.mergeAndExit and returns ok
   assert.equal(result.ok, true);
   if (result.ok) {
     assert.equal(result.merged, true);
-    assert.equal(result.codeFilesChanged, false);
+    assert.equal(result.codeFilesChanged, true);
   }
   assert.equal(calledMid, "M001");
+});
+
+test("exitMilestone preserves Resolver.mergeAndExit no-op outcome", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const fakeResolver = {
+    mergeAndExit: () => ({ merged: false, codeFilesChanged: false }),
+  };
+  const lifecycle = new WorktreeLifecycle(s, deps, () => fakeResolver as any);
+
+  const result = lifecycle.exitMilestone("M001", { merge: true }, ctx);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.merged, false);
+    assert.equal(result.codeFilesChanged, false);
+  }
 });
 
 test("exitMilestone surfaces MergeConflictError as ok:false reason:merge-conflict", async () => {

--- a/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
@@ -966,9 +966,10 @@ test("mergeAndExit in branch mode skips when no roadmap", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.mergeAndExit("M001", ctx);
+  const result = resolver.mergeAndExit("M001", ctx);
 
   assert.equal(findCalls(deps.calls, "mergeMilestoneToMain").length, 0);
+  assert.deepEqual(result, { merged: false, codeFilesChanged: false });
 });
 
 test("mergeAndExit in branch mode rebuilds GitService after merge", () => {
@@ -997,11 +998,12 @@ test("mergeAndExit in none mode is a no-op", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.mergeAndExit("M001", ctx);
+  const result = resolver.mergeAndExit("M001", ctx);
 
   assert.equal(findCalls(deps.calls, "mergeMilestoneToMain").length, 0);
   assert.equal(findCalls(deps.calls, "teardownAutoWorktree").length, 0);
   assert.equal(ctx.messages.length, 0);
+  assert.deepEqual(result, { merged: false, codeFilesChanged: false });
 });
 
 // ─── #1906 — metadata-only merge warning ────────────────────────────────────
@@ -1019,7 +1021,7 @@ test("mergeAndExit warns when merge contains no code changes (#1906)", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.mergeAndExit("M001", ctx);
+  const result = resolver.mergeAndExit("M001", ctx);
 
   assert.ok(
     ctx.messages.some((m) => m.msg.includes("NO code changes") && m.level === "warning"),
@@ -1029,6 +1031,7 @@ test("mergeAndExit warns when merge contains no code changes (#1906)", () => {
     !ctx.messages.some((m) => m.msg.includes("merged to main") && m.level === "info"),
     "must NOT emit success-style info notification for metadata-only merge",
   );
+  assert.deepEqual(result, { merged: true, codeFilesChanged: false });
 });
 
 test("mergeAndExit emits info when merge contains code changes (#1906)", () => {
@@ -1044,7 +1047,7 @@ test("mergeAndExit emits info when merge contains code changes (#1906)", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.mergeAndExit("M001", ctx);
+  const result = resolver.mergeAndExit("M001", ctx);
 
   assert.ok(
     ctx.messages.some((m) => m.msg.includes("merged to main") && m.level === "info"),
@@ -1054,6 +1057,7 @@ test("mergeAndExit emits info when merge contains code changes (#1906)", () => {
     !ctx.messages.some((m) => m.msg.includes("NO code changes")),
     "must NOT emit metadata-only warning when code files were merged",
   );
+  assert.deepEqual(result, { merged: true, codeFilesChanged: true });
 });
 
 test("mergeAndExit branch mode warns when merge contains no code changes (#1906)", () => {

--- a/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
@@ -1264,6 +1264,7 @@ test("mergeAndExit is no-op when isolationDegraded is true (#2483)", () => {
     originalBasePath: "/project",
   });
   s.isolationDegraded = true;
+  s.milestoneStartShas.set("M001", "abc123");
   const deps = makeDeps({
     getIsolationMode: () => "worktree",
   });
@@ -1275,6 +1276,7 @@ test("mergeAndExit is no-op when isolationDegraded is true (#2483)", () => {
   assert.equal(findCalls(deps.calls, "mergeMilestoneToMain").length, 0);
   assert.equal(findCalls(deps.calls, "teardownAutoWorktree").length, 0);
   assert.equal(findCalls(deps.calls, "getIsolationMode").length, 0);
+  assert.equal(s.milestoneStartShas.has("M001"), false);
   assert.ok(
     ctx.messages.some(
       (m) => m.level === "info" && m.msg.includes("isolation was degraded"),
@@ -1324,6 +1326,7 @@ test("mergeAndExit in none mode remains a no-op when NOT in a worktree (#2625)",
     basePath: "/project",
     originalBasePath: "/project",
   });
+  s.milestoneStartShas.set("M001", "abc123");
   const deps = makeDeps({
     isInAutoWorktree: () => false,
     getIsolationMode: () => "none",
@@ -1335,6 +1338,7 @@ test("mergeAndExit in none mode remains a no-op when NOT in a worktree (#2625)",
 
   assert.equal(findCalls(deps.calls, "mergeMilestoneToMain").length, 0,
     "must NOT merge when not in a worktree and mode is none");
+  assert.equal(s.milestoneStartShas.has("M001"), false);
 });
 
 // ─── #4380 — Non-MergeConflictError must not be swallowed ────────────────────

--- a/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
@@ -1,0 +1,61 @@
+// Project/App: GSD-2
+// File Purpose: Worktree State Projection Module — typed-Interface contract tests for projectRootToWorktree (ADR-016).
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { WorktreeStateProjection } from "../worktree-state-projection.js";
+import { createWorkspace, scopeMilestone } from "../workspace.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeProjectRoot(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-projection-"));
+  // .gsd directory is required for the workspace contract resolution
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+// ─── projectRootToWorktree — Module contract ────────────────────────────────
+
+test("WorktreeStateProjection can be constructed without arguments", () => {
+  const projection = new WorktreeStateProjection();
+  assert.ok(projection);
+  assert.equal(typeof projection.projectRootToWorktree, "function");
+});
+
+test("projectRootToWorktree accepts a MilestoneScope without throwing on same-path scope", () => {
+  const { dir, cleanup } = makeProjectRoot();
+  try {
+    const workspace = createWorkspace(dir);
+    const scope = scopeMilestone(workspace, "M001");
+    const projection = new WorktreeStateProjection();
+
+    // When the scope's workspace has no worktreeRoot (project-only mode),
+    // the underlying syncProjectRootToWorktree fast-paths to a no-op when
+    // both endpoints resolve to the same path. The Module must accept
+    // this scope and complete silently.
+    assert.doesNotThrow(() => projection.projectRootToWorktree(scope));
+  } finally {
+    cleanup();
+  }
+});
+
+test("projectRootToWorktree is idempotent — repeated calls do not throw", () => {
+  const { dir, cleanup } = makeProjectRoot();
+  try {
+    const workspace = createWorkspace(dir);
+    const scope = scopeMilestone(workspace, "M001");
+    const projection = new WorktreeStateProjection();
+
+    projection.projectRootToWorktree(scope);
+    projection.projectRootToWorktree(scope);
+    assert.ok(true, "two calls did not throw");
+  } finally {
+    cleanup();
+  }
+});

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -29,6 +29,8 @@ import {
   refreshMilestoneLease,
   releaseMilestoneLease,
 } from "./db/milestone-leases.js";
+import { MergeConflictError } from "./git-service.js";
+import type { WorktreeResolver } from "./worktree-resolver.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────
 
@@ -73,6 +75,10 @@ export type EnterResult =
         | "invalid-milestone-id";
       cause?: unknown;
     };
+
+export type ExitResult =
+  | { ok: true; merged: boolean; codeFilesChanged: boolean }
+  | { ok: false; reason: "merge-conflict" | "teardown-failed"; cause?: unknown };
 
 // ─── Validation ──────────────────────────────────────────────────────────
 
@@ -408,13 +414,16 @@ function rebuildGitService(
 export class WorktreeLifecycle {
   private readonly s: AutoSession;
   private readonly deps: WorktreeLifecycleDeps;
+  private readonly resolverFactory?: () => WorktreeResolver;
 
   constructor(
     s: AutoSession,
     deps: WorktreeLifecycleDeps,
+    resolverFactory?: () => WorktreeResolver,
   ) {
     this.s = s;
     this.deps = deps;
+    this.resolverFactory = resolverFactory;
   }
 
   /**
@@ -427,5 +436,61 @@ export class WorktreeLifecycle {
    */
   enterMilestone(milestoneId: string, ctx: NotifyCtx): EnterResult {
     return _enterMilestoneCore(this.s, this.deps, milestoneId, ctx);
+  }
+
+  /**
+   * Exit the current worktree. With `opts.merge === true`, runs the full
+   * merge-and-teardown path (worktree-mode or branch-mode auto-detected).
+   * With `opts.merge === false`, runs auto-commit and teardown without
+   * merging to main.
+   *
+   * Returns a typed `ExitResult`. `MergeConflictError` is surfaced as
+   * `{ ok: false, reason: "merge-conflict", cause }` instead of thrown,
+   * giving callers a typed branch for the expected failure path.
+   * Unexpected failures (filesystem, git permissions, etc.) are wrapped
+   * as `{ ok: false, reason: "teardown-failed", cause }` so callers always
+   * receive a discriminated union — no exceptions for any expected outcome.
+   *
+   * Issue #5586 ships this as a delegating wrapper around
+   * `WorktreeResolver.mergeAndExit`/`exitMilestone`. The full extraction
+   * (~500 lines of merge logic across `_mergeWorktreeMode` and
+   * `_mergeBranchMode`) happens in #5587 when `WorktreeResolver` retires.
+   * The delegating shape preserves caller migration without rewriting
+   * merge-conflict handling mid-flight.
+   *
+   * `codeFilesChanged` is best-effort `false` while delegation is in
+   * place; #5587 will thread the actual value through once the merge
+   * logic moves into the Module.
+   */
+  exitMilestone(
+    milestoneId: string,
+    opts: { merge: boolean; preserveBranch?: boolean },
+    ctx: NotifyCtx,
+  ): ExitResult {
+    if (!this.resolverFactory) {
+      throw new Error(
+        "WorktreeLifecycle.exitMilestone requires a resolverFactory until #5587 retires WorktreeResolver",
+      );
+    }
+    const resolver = this.resolverFactory();
+    if (opts.merge) {
+      try {
+        resolver.mergeAndExit(milestoneId, ctx);
+        return { ok: true, merged: true, codeFilesChanged: false };
+      } catch (err) {
+        if (err instanceof MergeConflictError) {
+          return { ok: false, reason: "merge-conflict", cause: err };
+        }
+        return { ok: false, reason: "teardown-failed", cause: err };
+      }
+    }
+    try {
+      resolver.exitMilestone(milestoneId, ctx, {
+        preserveBranch: opts.preserveBranch,
+      });
+      return { ok: true, merged: false, codeFilesChanged: false };
+    } catch (err) {
+      return { ok: false, reason: "teardown-failed", cause: err };
+    }
   }
 }

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -493,4 +493,71 @@ export class WorktreeLifecycle {
       return { ok: false, reason: "teardown-failed", cause: err };
     }
   }
+
+  /**
+   * Fall back to branch-mode for `milestoneId` after a failed worktree
+   * creation, marking the session's isolation as degraded.
+   *
+   * Currently delegates to `enterBranchModeForMilestone` from auto-worktree.
+   * Idempotent: subsequent calls in a degraded session are no-ops.
+   *
+   * Issue #5587 ships this as a thin adapter; the body extraction joins the
+   * other merge-logic move-out in a follow-up cleanup slice.
+   */
+  degradeToBranchMode(milestoneId: string, ctx: NotifyCtx): void {
+    if (this.s.isolationDegraded) {
+      debugLog("WorktreeLifecycle", {
+        action: "degradeToBranchMode",
+        milestoneId,
+        skipped: true,
+        reason: "already-degraded",
+      });
+      return;
+    }
+    const basePath = resolveWorktreeProjectRoot(
+      this.s.basePath,
+      this.s.originalBasePath,
+    );
+    try {
+      this.deps.enterBranchModeForMilestone(basePath, milestoneId);
+      this.deps.invalidateAllCaches();
+      this.s.isolationDegraded = true;
+      ctx.notify(
+        `Switched to branch milestone/${milestoneId} (isolation degraded).`,
+        "info",
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      ctx.notify(
+        `Branch isolation setup for ${milestoneId} failed: ${msg}. Continuing on current branch.`,
+        "warning",
+      );
+      this.s.isolationDegraded = true;
+    }
+  }
+
+  /**
+   * Restore `s.basePath` to `s.originalBasePath` and rebuild `s.gitService`.
+   * No-op when `originalBasePath` is empty (fresh sessions).
+   *
+   * Used by error/cleanup paths that need the session to behave as if the
+   * worktree was never entered. Does NOT teardown the worktree directory —
+   * callers that need teardown go through `exitMilestone({ merge: false })`.
+   */
+  restoreToProjectRoot(): void {
+    if (!this.s.originalBasePath) return;
+    this.s.basePath = this.s.originalBasePath;
+    rebuildGitService(this.s, this.deps);
+    this.deps.invalidateAllCaches();
+  }
+
+  /** True if `milestoneId` is the session's currently-active milestone. */
+  isInMilestone(milestoneId: string): boolean {
+    return this.s.currentMilestoneId === milestoneId;
+  }
+
+  /** The active milestone id, or `null` if no milestone is active. */
+  getCurrentMilestoneIfAny(): string | null {
+    return this.s.currentMilestoneId;
+  }
 }

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -102,8 +102,9 @@ function releaseHeldMilestoneLease(
       phase,
       releaseLeaseError: err instanceof Error ? err.message : String(err),
     });
+  } finally {
+    s.milestoneLeaseToken = null;
   }
-  s.milestoneLeaseToken = null;
 }
 
 // ─── Implementation core ─────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -86,6 +86,26 @@ function isValidMilestoneId(milestoneId: string): boolean {
   return !/[\/\\]|\.\./.test(milestoneId);
 }
 
+function releaseHeldMilestoneLease(
+  s: AutoSession,
+  milestoneId: string,
+  phase: string,
+): void {
+  if (!s.workerId || s.milestoneLeaseToken === null) return;
+  const token = s.milestoneLeaseToken;
+  try {
+    releaseMilestoneLease(s.workerId, milestoneId, token);
+  } catch (err) {
+    debugLog("WorktreeLifecycle", {
+      action: "enterMilestone",
+      milestoneId,
+      phase,
+      releaseLeaseError: err instanceof Error ? err.message : String(err),
+    });
+  }
+  s.milestoneLeaseToken = null;
+}
+
 // ─── Implementation core ─────────────────────────────────────────────────
 
 /**
@@ -313,6 +333,7 @@ export function _enterMilestoneCore(
         `Branch isolation setup for ${milestoneId} failed: ${msg}. Continuing on current branch.`,
         "warning",
       );
+      releaseHeldMilestoneLease(s, milestoneId, "branch-setup-failed");
       s.isolationDegraded = true;
       return { ok: false, reason: "creation-failed", cause: err };
     }
@@ -384,6 +405,7 @@ export function _enterMilestoneCore(
     );
     // Degrade isolation for the rest of this session so mergeAndExit
     // doesn't try to merge a nonexistent worktree branch (#2483)
+    releaseHeldMilestoneLease(s, milestoneId, "worktree-setup-failed");
     s.isolationDegraded = true;
     // Do NOT update s.basePath — stay in project root
     return { ok: false, reason: "creation-failed", cause: err };
@@ -458,9 +480,9 @@ export class WorktreeLifecycle {
    * The delegating shape preserves caller migration without rewriting
    * merge-conflict handling mid-flight.
    *
-   * `codeFilesChanged` is best-effort `false` while delegation is in
-   * place; #5587 will thread the actual value through once the merge
-   * logic moves into the Module.
+   * `merged` and `codeFilesChanged` are delegated from
+   * `WorktreeResolver.mergeAndExit` so no-op exits do not masquerade as
+   * completed merges.
    */
   exitMilestone(
     milestoneId: string,
@@ -475,8 +497,12 @@ export class WorktreeLifecycle {
     const resolver = this.resolverFactory();
     if (opts.merge) {
       try {
-        resolver.mergeAndExit(milestoneId, ctx);
-        return { ok: true, merged: true, codeFilesChanged: false };
+        const result = resolver.mergeAndExit(milestoneId, ctx);
+        return {
+          ok: true,
+          merged: result.merged,
+          codeFilesChanged: result.codeFilesChanged,
+        };
       } catch (err) {
         if (err instanceof MergeConflictError) {
           return { ok: false, reason: "merge-conflict", cause: err };

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -345,6 +345,7 @@ export class WorktreeResolver {
 
     // If worktree creation failed earlier, skip merge — work is on current branch (#2483)
     if (this.s.isolationDegraded) {
+      this.s.milestoneStartShas.delete(milestoneId);
       debugLog("WorktreeResolver", {
         action: "mergeAndExit",
         milestoneId,
@@ -365,13 +366,6 @@ export class WorktreeResolver {
       mode,
       basePath: this.s.basePath,
     });
-    emitJournalEvent(this.s.originalBasePath || this.s.basePath, {
-      ts: new Date().toISOString(),
-      flowId: randomUUID(),
-      seq: 0,
-      eventType: "worktree-merge-start",
-      data: { milestoneId, mode },
-    });
 
     // #2625: If we are physically inside an auto-worktree, we MUST merge
     // regardless of the current isolation config. This prevents data loss when
@@ -380,6 +374,7 @@ export class WorktreeResolver {
     const inWorktree = this.deps.isInAutoWorktree(this.s.basePath) && this.s.originalBasePath;
 
     if (mode === "none" && !inWorktree) {
+      this.s.milestoneStartShas.delete(milestoneId);
       debugLog("WorktreeResolver", {
         action: "mergeAndExit",
         milestoneId,
@@ -388,6 +383,14 @@ export class WorktreeResolver {
       });
       return { merged: false, codeFilesChanged: false };
     }
+
+    emitJournalEvent(this.s.originalBasePath || this.s.basePath, {
+      ts: new Date().toISOString(),
+      flowId: randomUUID(),
+      seq: 0,
+      eventType: "worktree-merge-start",
+      data: { milestoneId, mode },
+    });
 
     let mergeOutcome: MergeAndExitResult = {
       merged: false,

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -115,6 +115,11 @@ export interface NotifyCtx {
   ) => void;
 }
 
+export interface MergeAndExitResult {
+  merged: boolean;
+  codeFilesChanged: boolean;
+}
+
 // ─── Path Helpers ──────────────────────────────────────────────────────────
 
 /**
@@ -307,7 +312,7 @@ export class WorktreeResolver {
    * Error recovery: on merge failure, always restore `s.basePath` to
    * `s.originalBasePath` and `process.chdir(s.originalBasePath)`.
    */
-  mergeAndExit(milestoneId: string, ctx: NotifyCtx): void {
+  mergeAndExit(milestoneId: string, ctx: NotifyCtx): MergeAndExitResult {
     this.validateMilestoneId(milestoneId);
 
     // Anchor cwd at the project root before any merge work. Some merge code
@@ -350,7 +355,7 @@ export class WorktreeResolver {
         `Skipping worktree merge for ${milestoneId} — isolation was degraded (worktree creation failed earlier). Work is on the current branch.`,
         "info",
       );
-      return;
+      return { merged: false, codeFilesChanged: false };
     }
 
     const mode = this.deps.getIsolationMode(this.s.originalBasePath || this.s.basePath);
@@ -381,16 +386,19 @@ export class WorktreeResolver {
         skipped: true,
         reason: "mode-none",
       });
-      return;
+      return { merged: false, codeFilesChanged: false };
     }
 
-    let actuallyMerged = false;
+    let mergeOutcome: MergeAndExitResult = {
+      merged: false,
+      codeFilesChanged: false,
+    };
     if (
       mode === "worktree" || inWorktree
     ) {
-      actuallyMerged = this._mergeWorktreeMode(milestoneId, ctx);
+      mergeOutcome = this._mergeWorktreeMode(milestoneId, ctx);
     } else if (mode === "branch") {
-      actuallyMerged = this._mergeBranchMode(milestoneId, ctx);
+      mergeOutcome = this._mergeBranchMode(milestoneId, ctx);
     }
 
     // The remainder of this function emits telemetry and runs re-squash.
@@ -398,10 +406,10 @@ export class WorktreeResolver {
     // no-merge path (missing originalBase, no roadmap, wrong branch) the
     // milestone branch was intentionally left unmerged and we must not
     // emit a worktree-merged event or collapse commits on main.
-    if (!actuallyMerged) {
+    if (!mergeOutcome.merged) {
       // Always clear the start-SHA tracker to avoid leaking across sessions.
       this.s.milestoneStartShas.delete(milestoneId);
-      return;
+      return mergeOutcome;
     }
 
     // #4765 — when collapse_cadence=slice AND milestone_resquash=true, the
@@ -452,11 +460,14 @@ export class WorktreeResolver {
         error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
       });
     }
+    return mergeOutcome;
   }
 
-  /** Worktree-mode merge: read roadmap, merge, teardown, reset paths.
-   *  Returns true when a squash-merge actually ran (false on skip paths). */
-  private _mergeWorktreeMode(milestoneId: string, ctx: NotifyCtx): boolean {
+  /** Worktree-mode merge: read roadmap, merge, teardown, reset paths. */
+  private _mergeWorktreeMode(
+    milestoneId: string,
+    ctx: NotifyCtx,
+  ): MergeAndExitResult {
     const originalBase = this.s.originalBasePath;
     if (!originalBase) {
       debugLog("WorktreeResolver", {
@@ -466,10 +477,13 @@ export class WorktreeResolver {
         skipped: true,
         reason: "missing-original-base",
       });
-      return false;
+      return { merged: false, codeFilesChanged: false };
     }
 
-    let merged = false;
+    let mergeOutcome: MergeAndExitResult = {
+      merged: false,
+      codeFilesChanged: false,
+    };
     try {
       const { synced } = this.deps.syncWorktreeStateBack(
         originalBase,
@@ -518,7 +532,10 @@ export class WorktreeResolver {
           milestoneId,
           roadmapContent,
         );
-        merged = true;
+        mergeOutcome = {
+          merged: true,
+          codeFilesChanged: mergeResult.codeFilesChanged,
+        };
 
         // #2945 Bug 3: mergeMilestoneToMain performs best-effort worktree
         // cleanup internally (step 12), but it can silently fail on Windows
@@ -622,12 +639,14 @@ export class WorktreeResolver {
       result: "done",
       basePath: this.s.basePath,
     });
-    return merged;
+    return mergeOutcome;
   }
 
-  /** Branch-mode merge: check current branch, merge if on milestone branch.
-   *  Returns true when a merge actually ran (false on skip paths). */
-  private _mergeBranchMode(milestoneId: string, ctx: NotifyCtx): boolean {
+  /** Branch-mode merge: check current branch, merge if on milestone branch. */
+  private _mergeBranchMode(
+    milestoneId: string,
+    ctx: NotifyCtx,
+  ): MergeAndExitResult {
     try {
       const currentBranch = this.deps.getCurrentBranch(this.s.basePath);
       const milestoneBranch = this.deps.autoWorktreeBranch(milestoneId);
@@ -683,7 +702,7 @@ export class WorktreeResolver {
           skipped: true,
           reason: "no-roadmap",
         });
-        return false;
+        return { merged: false, codeFilesChanged: false };
       }
 
       const roadmapContent = this.deps.readFileSync(roadmapPath, "utf-8");
@@ -714,7 +733,10 @@ export class WorktreeResolver {
         mode: "branch",
         result: "success",
       });
-      return true;
+      return {
+        merged: true,
+        codeFilesChanged: mergeResult.codeFilesChanged,
+      };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       debugLog("WorktreeResolver", {

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -1,0 +1,58 @@
+// GSD-2 — Worktree State Projection module: directional state-flow rules between project root and auto-worktree.
+/**
+ * Worktree State Projection module — first-class Module for directional
+ * state-file flow between the project root and the auto-worktree.
+ *
+ * Per ADR-016, this Module owns:
+ *   - The direction-and-rules of state file flow (project-root authoritative
+ *     for some classes, worktree authoritative for others)
+ *   - The bug-hardened invariants encoded in `syncProjectRootToWorktree` /
+ *     `syncStateToProjectRoot` (additive milestone copy #1886, ASSESSMENT
+ *     verdict overwrite #2821, completed-units forward-sync, WAL/SHM
+ *     cleanup #2478, .gsd symlink edge case #2184)
+ *
+ * Phase 1 of the migration ships only `projectRootToWorktree`. The remaining
+ * verbs (`projectWorktreeToRoot`, `finalizeProjectionForMerge`) are added in
+ * subsequent slices (#5589, #5590).
+ *
+ * Issue #5588 ships this as a delegating wrapper around the existing
+ * `syncProjectRootToWorktree*` helpers in `auto-worktree.ts`. The full body
+ * extraction (with its identity-key check, additive milestone copy, ASSESSMENT
+ * verdict force-overwrite, completed-units forward-sync, WAL/SHM cleanup,
+ * .gsd symlink edge case) joins the legacy helper retirement in #5590.
+ *
+ * Lifecycle does not yet hook this Module into `enterMilestone`; that wiring
+ * lands when the broader caller migration completes alongside the Projection
+ * Module's full Interface.
+ */
+
+import { syncProjectRootToWorktreeByScope } from "./auto-worktree.js";
+import type { MilestoneScope } from "./workspace.js";
+
+/**
+ * Worktree State Projection Module instance.
+ *
+ * Stateless — methods are pure functions of their `MilestoneScope` input.
+ * The class form is retained for testability and to keep the Interface
+ * shape consistent with `WorktreeLifecycle`.
+ */
+export class WorktreeStateProjection {
+  /**
+   * Project state from the project root onto the auto-worktree for `scope`.
+   * Called by Lifecycle's enter path after a successful create/enter, before
+   * any Unit dispatches.
+   *
+   * Owns the rules: identity-key safety check, additive milestone copy
+   * preserving worktree-local files (#1886), ASSESSMENT verdict force-
+   * overwrite (#2821), forward-sync of `completed-units.json`, WAL/SHM
+   * cleanup on legacy worktree-local DB (#2478), and the `.gsd` symlink
+   * realpath edge case (#2184).
+   *
+   * Issue #5588 delegates to `syncProjectRootToWorktreeByScope` to ship the
+   * typed `MilestoneScope`-only Interface without re-implementing the bug-
+   * hardened rules mid-flight. The body extraction joins #5590.
+   */
+  projectRootToWorktree(scope: MilestoneScope): void {
+    syncProjectRootToWorktreeByScope(scope, scope);
+  }
+}


### PR DESCRIPTION
## Summary

- Stand up the second sibling Module from ADR-016: `WorktreeStateProjection`.
- `projectRootToWorktree(scope: MilestoneScope)` exposed as the typed Interface; internally delegates to the existing `syncProjectRootToWorktreeByScope` helper.
- 3 contract tests on the Module Interface; 7572 GSD tests pass.

Stacked on #5599 (#5587). Refs #5588.

## Scope correction

The issue body called for **caller migration end-to-end** and **Lifecycle hooking**. Both deferred:

- The current caller in `phases.ts:594` passes path strings, not `MilestoneScope`. Constructing one requires `s.scope` to be populated — a separate in-progress refactor per the `TODO(C8)` marker in `auto/session.ts`. Caller migration belongs with that effort.
- Lifecycle hook (calling Projection from `enterMilestone`) needs Lifecycle to receive a Projection instance — its own constructor cascade. Deferred to a follow-up.

What this PR delivers: the `MilestoneScope`-typed Module Interface, ready for callers to adopt as scope construction matures. The bug-hardened sync rules continue to live in `auto-worktree.ts`; the body extraction joins #5590.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test:unit` — 7572 passed, 0 failed
- [x] 3 new contract tests (constructor, accepts scope, idempotent)
- [ ] Reviewer agrees the delegation pattern is acceptable as transitional shape
- [ ] Reviewer agrees deferring caller migration to the s.scope rollout is reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Worktree handling reorganized into separate lifecycle and state-projection components to clarify milestone entry/exit and merge flows.

* **New Features**
  * Milestone enter/exit now report structured results; added project→worktree sync operation.

* **Tests**
  * Expanded tests and mocks covering lifecycle transitions, merges, failure modes, and projection idempotency.

* **Documentation**
  * Glossary and architecture ADR updated with new terminology and responsibilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5600)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->