### PR TITLE
refactor(gsd-extension): WorktreeStateProjection.projectWorktreeToRoot

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1613,7 +1613,11 @@ function buildLifecycleDeps(): WorktreeLifecycleDeps {
 }
 
 function buildLifecycle(): WorktreeLifecycle {
-  return new WorktreeLifecycle(s, buildLifecycleDeps());
+  return new WorktreeLifecycle(
+    s,
+    buildLifecycleDeps(),
+    () => buildResolver(),
+  );
 }
 
 /**

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -293,11 +293,15 @@ export async function _runMilestoneMergeWithStashRestore(
   );
 
   let mergeError: unknown = null;
-  try {
-    deps.resolver.mergeAndExit(milestoneId, ctx.ui);
+  const exitResult = deps.lifecycle.exitMilestone(
+    milestoneId,
+    { merge: true },
+    ctx.ui,
+  );
+  if (exitResult.ok) {
     s.milestoneMergedInPhases = true;
-  } catch (mergeErr) {
-    mergeError = mergeErr;
+  } else {
+    mergeError = exitResult.cause ?? new Error(`exit ${exitResult.reason}`);
   }
 
   // Always attempt to restore the stashed working tree, even on merge error.

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -824,7 +824,7 @@ export async function runPreDispatch(
       const enterResult = deps.lifecycle.enterMilestone(mid, ctx.ui);
       if (!enterResult.ok && enterResult.reason === "lease-conflict") {
         await deps.pauseAuto(ctx, pi);
-        return { action: "break", reason: "lease-conflict" };
+        return { action: "break", reason: "milestone-lease-conflict" };
       }
     } else {
       // mid is undefined — no milestone to capture integration branch for

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -109,7 +109,7 @@ export class AutoSession {
   workerId: string | null = null;
   /**
    * Active milestone lease fencing token, set by claimMilestoneLease() inside
-   * worktree-lifecycle._enterMilestoneCore(). Threaded into recordDispatchClaim()
+   * WorktreeLifecycle.enterMilestone(). Threaded into recordDispatchClaim()
    * as milestone_lease_token so out-of-band dispatches by a stale worker
    * are detectable.
    */

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -751,6 +751,11 @@ function makeMockDeps(
     } as any,
     lifecycle: {
       enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
+      exitMilestone: (_mid: string, opts: { merge: boolean }) => ({
+        ok: true,
+        merged: opts.merge,
+        codeFilesChanged: false,
+      }),
     } as any,
     postUnitPreVerification: async () => {
       callLog.push("postUnitPreVerification");
@@ -991,6 +996,15 @@ test("autoLoop marks transition merge complete before postflight recovery stop",
         mergeCalls += 1;
       },
       mergeAndEnterNext: () => {},
+    } as any,
+    lifecycle: {
+      enterMilestone: () => {
+        assert.fail("must not enter the next milestone after postflight recovery fails");
+      },
+      exitMilestone: (_mid: string, opts: { merge: boolean }) => {
+        if (opts.merge) mergeCalls += 1;
+        return { ok: true, merged: opts.merge, codeFilesChanged: false };
+      },
     } as any,
     stopAuto: async (_ctx, _pi, reason) => {
       deps.callLog.push("stopAuto");

--- a/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
@@ -184,6 +184,12 @@ test("runFinalize merges a verified complete-milestone immediately and only once
         mergeCalls++;
       },
     },
+    lifecycle: {
+      exitMilestone(_mid: string, opts: { merge: boolean }) {
+        if (opts.merge) mergeCalls++;
+        return { ok: true, merged: opts.merge, codeFilesChanged: false };
+      },
+    },
   });
 
   assert.equal(result.action, "next");
@@ -201,6 +207,12 @@ test("runFinalize merges a verified complete-milestone immediately and only once
     resolver: {
       mergeAndExit() {
         mergeCalls++;
+      },
+    },
+    lifecycle: {
+      exitMilestone(_mid: string, opts: { merge: boolean }) {
+        if (opts.merge) mergeCalls++;
+        return { ok: true, merged: opts.merge, codeFilesChanged: false };
       },
     },
   });

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -105,9 +105,13 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
             throw new Error("synthetic merge failure");
           },
         }) as any,
+<<<<<<< HEAD
         buildLifecycle: () => ({
           enterMilestone: () => ({ ok: true }),
         }) as any,
+=======
+        buildLifecycle: () => ({}) as any,
+>>>>>>> 0c5221c2c (Apply babysitter fixes for PR #5601)
       },
       {
         classification: "none",
@@ -138,4 +142,3 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
     rmSync(base, { recursive: true, force: true });
   }
 });
-

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -105,13 +105,9 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
             throw new Error("synthetic merge failure");
           },
         }) as any,
-<<<<<<< HEAD
         buildLifecycle: () => ({
           enterMilestone: () => ({ ok: true }),
         }) as any,
-=======
-        buildLifecycle: () => ({}) as any,
->>>>>>> 0c5221c2c (Apply babysitter fixes for PR #5601)
       },
       {
         classification: "none",

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -248,6 +248,7 @@ function makeMockDeps(overrides?: Partial<LoopDeps>): LoopDeps & { callLog: stri
     lifecycle: {
       enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
     } as any,
+    lifecycle: {} as any,
     postUnitPreVerification: async () => "continue" as const,
     runPostUnitVerification: async () => "continue" as const,
     postUnitPostVerification: async () => "continue" as const,

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -248,7 +248,6 @@ function makeMockDeps(overrides?: Partial<LoopDeps>): LoopDeps & { callLog: stri
     lifecycle: {
       enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
     } as any,
-    lifecycle: {} as any,
     postUnitPreVerification: async () => "continue" as const,
     runPostUnitVerification: async () => "continue" as const,
     postUnitPostVerification: async () => "continue" as const,

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -134,6 +134,11 @@ function makeMockDeps(
     } as any,
     lifecycle: {
       enterMilestone: () => ({ ok: true, mode: "worktree", path: "/tmp/project" }),
+      exitMilestone: (_mid: string, opts: { merge: boolean }) => ({
+        ok: true,
+        merged: opts.merge,
+        codeFilesChanged: false,
+      }),
     } as any,
     postUnitPreVerification: async () => "continue" as const,
     runPostUnitVerification: async () => "continue" as const,

--- a/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
@@ -71,6 +71,31 @@ function buildIc(opts: {
         }
       },
     },
+    lifecycle: {
+      exitMilestone: (_mid: string, exitOpts: { merge: boolean }) => {
+        log.mergeCalls += 1;
+        if (opts.mergeBehavior === "succeed") {
+          return { ok: true, merged: exitOpts.merge, codeFilesChanged: false };
+        }
+        try {
+          opts.mergeBehavior();
+          return { ok: true, merged: exitOpts.merge, codeFilesChanged: false };
+        } catch (err) {
+          // Mirror Lifecycle's typed-result wrapping of MergeConflictError
+          // and other thrown values per worktree-lifecycle.exitMilestone.
+          const isMergeConflict =
+            err !== null &&
+            typeof err === "object" &&
+            err !== undefined &&
+            (err as { name?: string }).name === "MergeConflictError";
+          return {
+            ok: false,
+            reason: isMergeConflict ? "merge-conflict" : "teardown-failed",
+            cause: err,
+          } as const;
+        }
+      },
+    },
     stopAuto: async (_c?: unknown, _p?: unknown, reason?: string) => {
       log.stopAutoCalls.push(reason);
     },

--- a/src/resources/extensions/gsd/tests/milestone-transition-state-rebuild.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-transition-state-rebuild.test.ts
@@ -79,6 +79,10 @@ test("milestone transition archives completed units and rebuilds state", async (
             calls.push(`enter:${mid}`);
             return { ok: true, mode: "worktree", path: `/wt/${mid}` };
           },
+          exitMilestone: (mid: string, opts: { merge: boolean }) => {
+            calls.push(opts.merge ? `merge:${mid}` : `exit:${mid}`);
+            return { ok: true, merged: opts.merge, codeFilesChanged: false };
+          },
         },
         sendDesktopNotification: () => {},
         logCmuxEvent: () => {},

--- a/src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts
@@ -85,6 +85,16 @@ const ic = {
         throw new Error("remote rejected push");
       },
     },
+    lifecycle: {
+      exitMilestone() {
+        calls.push("merge");
+        return {
+          ok: false,
+          reason: "teardown-failed",
+          cause: new Error("remote rejected push"),
+        };
+      },
+    },
     async stopAuto(_ctx: unknown, _pi: unknown, reason?: string) {
       calls.push(`stop:${reason}`);
     },

--- a/src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts
@@ -79,12 +79,6 @@ const ic = {
       calls.push("postflight");
       return { ok: true, needsManualRecovery: false };
     },
-    resolver: {
-      mergeAndExit() {
-        calls.push("merge");
-        throw new Error("remote rejected push");
-      },
-    },
     lifecycle: {
       exitMilestone() {
         calls.push("merge");

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -295,3 +295,116 @@ test("enterMilestone returns ok:false reason:invalid-milestone-id on path traver
     assert.ok(separator.cause instanceof Error);
   }
 });
+
+// ─── exitMilestone — typed-result contract ────────────────────────────────────
+
+test("exitMilestone throws when no resolverFactory is provided", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  assert.throws(
+    () => lifecycle.exitMilestone("M001", { merge: true }, ctx),
+    /requires a resolverFactory/,
+  );
+});
+
+test("exitMilestone delegates merge:true to Resolver.mergeAndExit and returns ok:true", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  let calledMid: string | null = null;
+  const fakeResolver = {
+    mergeAndExit: (mid: string) => {
+      calledMid = mid;
+    },
+  };
+  const lifecycle = new WorktreeLifecycle(s, deps, () => fakeResolver as any);
+
+  const result = lifecycle.exitMilestone("M001", { merge: true }, ctx);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.merged, true);
+    assert.equal(result.codeFilesChanged, false);
+  }
+  assert.equal(calledMid, "M001");
+});
+
+test("exitMilestone surfaces MergeConflictError as ok:false reason:merge-conflict", async () => {
+  const { MergeConflictError } = await import("../git-service.js");
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const conflict = new MergeConflictError(
+    ["src/foo.ts"],
+    "merge",
+    "milestone/M001",
+    "main",
+  );
+  const fakeResolver = {
+    mergeAndExit: () => {
+      throw conflict;
+    },
+  };
+  const lifecycle = new WorktreeLifecycle(s, deps, () => fakeResolver as any);
+
+  const result = lifecycle.exitMilestone("M001", { merge: true }, ctx);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, "merge-conflict");
+    assert.equal(result.cause, conflict);
+  }
+});
+
+test("exitMilestone wraps non-conflict throws as ok:false reason:teardown-failed", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const fsErr = new Error("EACCES: permission denied");
+  const fakeResolver = {
+    mergeAndExit: () => {
+      throw fsErr;
+    },
+  };
+  const lifecycle = new WorktreeLifecycle(s, deps, () => fakeResolver as any);
+
+  const result = lifecycle.exitMilestone("M001", { merge: true }, ctx);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, "teardown-failed");
+    assert.equal(result.cause, fsErr);
+  }
+});
+
+test("exitMilestone with merge:false delegates to Resolver.exitMilestone with preserveBranch", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  let receivedOpts: { preserveBranch?: boolean } | undefined;
+  const fakeResolver = {
+    exitMilestone: (
+      _mid: string,
+      _ctx: NotifyCtx,
+      opts?: { preserveBranch?: boolean },
+    ) => {
+      receivedOpts = opts;
+    },
+  };
+  const lifecycle = new WorktreeLifecycle(s, deps, () => fakeResolver as any);
+
+  const result = lifecycle.exitMilestone(
+    "M001",
+    { merge: false, preserveBranch: true },
+    ctx,
+  );
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.merged, false);
+  }
+  assert.deepEqual(receivedOpts, { preserveBranch: true });
+});

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -408,3 +408,115 @@ test("exitMilestone with merge:false delegates to Resolver.exitMilestone with pr
   }
   assert.deepEqual(receivedOpts, { preserveBranch: true });
 });
+
+// ─── Queries (issue #5587) ────────────────────────────────────────────────────
+
+test("isInMilestone returns true when session matches milestone id", () => {
+  const s = makeSession();
+  s.currentMilestoneId = "M001";
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  assert.equal(lifecycle.isInMilestone("M001"), true);
+  assert.equal(lifecycle.isInMilestone("M002"), false);
+});
+
+test("isInMilestone returns false when session has no active milestone", () => {
+  const s = makeSession();
+  s.currentMilestoneId = null;
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  assert.equal(lifecycle.isInMilestone("M001"), false);
+});
+
+test("getCurrentMilestoneIfAny returns the active milestone id or null", () => {
+  const s = makeSession();
+  s.currentMilestoneId = "M042";
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  assert.equal(lifecycle.getCurrentMilestoneIfAny(), "M042");
+
+  s.currentMilestoneId = null;
+  assert.equal(lifecycle.getCurrentMilestoneIfAny(), null);
+});
+
+// ─── degradeToBranchMode (issue #5587) ────────────────────────────────────────
+
+test("degradeToBranchMode sets isolationDegraded and invokes branch-mode helper", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.degradeToBranchMode("M001", ctx);
+
+  assert.equal(s.isolationDegraded, true);
+  assert.equal(
+    deps.calls.filter((c) => c.fn === "enterBranchModeForMilestone").length,
+    1,
+  );
+  assert.equal(deps.calls.filter((c) => c.fn === "invalidateAllCaches").length, 1);
+});
+
+test("degradeToBranchMode is no-op when isolationDegraded is already true", () => {
+  const s = makeSession();
+  s.isolationDegraded = true;
+  const deps = makeDeps();
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.degradeToBranchMode("M001", ctx);
+
+  assert.equal(
+    deps.calls.filter((c) => c.fn === "enterBranchModeForMilestone").length,
+    0,
+  );
+});
+
+test("degradeToBranchMode marks degraded and notifies on branch-mode failure", () => {
+  const s = makeSession();
+  const deps = makeDeps({
+    enterBranchModeForMilestone: () => {
+      throw new Error("checkout failed");
+    },
+  });
+  const ctx = makeCtx();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.degradeToBranchMode("M001", ctx);
+
+  assert.equal(s.isolationDegraded, true);
+  assert.ok(
+    ctx.messages.some(
+      (m) => m.level === "warning" && m.msg.includes("Branch isolation setup"),
+    ),
+  );
+});
+
+// ─── restoreToProjectRoot (issue #5587) ───────────────────────────────────────
+
+test("restoreToProjectRoot restores basePath to originalBasePath and rebuilds git service", () => {
+  const s = makeSession();
+  s.originalBasePath = "/project";
+  s.basePath = "/project/.gsd/worktrees/M001";
+  const deps = makeDeps();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.restoreToProjectRoot();
+
+  assert.equal(s.basePath, "/project");
+  assert.equal(deps.calls.filter((c) => c.fn === "GitServiceImpl").length, 1);
+  assert.equal(deps.calls.filter((c) => c.fn === "invalidateAllCaches").length, 1);
+});
+
+test("restoreToProjectRoot is no-op when originalBasePath is empty", () => {
+  const s = makeSession();
+  s.originalBasePath = "";
+  s.basePath = "/some/path";
+  const deps = makeDeps();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.restoreToProjectRoot();
+
+  assert.equal(s.basePath, "/some/path"); // unchanged
+  assert.equal(deps.calls.filter((c) => c.fn === "GitServiceImpl").length, 0);
+});

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -118,6 +118,10 @@ test("enterMilestone returns ok:true mode:worktree on successful create", () => 
     assert.equal(result.path, "/project/.gsd/worktrees/M001");
   }
   assert.equal(s.basePath, "/project/.gsd/worktrees/M001");
+  assert.equal(
+    deps.calls.filter((c) => c.fn === "invalidateAllCaches").length,
+    1,
+  );
 });
 
 test("enterMilestone returns ok:true mode:branch on successful branch fallback", () => {
@@ -318,6 +322,7 @@ test("exitMilestone delegates merge:true to Resolver.mergeAndExit and returns ok
   const fakeResolver = {
     mergeAndExit: (mid: string) => {
       calledMid = mid;
+      return { merged: false, codeFilesChanged: true };
     },
   };
   const lifecycle = new WorktreeLifecycle(s, deps, () => fakeResolver as any);
@@ -326,8 +331,8 @@ test("exitMilestone delegates merge:true to Resolver.mergeAndExit and returns ok
 
   assert.equal(result.ok, true);
   if (result.ok) {
-    assert.equal(result.merged, true);
-    assert.equal(result.codeFilesChanged, false);
+    assert.equal(result.merged, false);
+    assert.equal(result.codeFilesChanged, true);
   }
   assert.equal(calledMid, "M001");
 });

--- a/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
@@ -59,3 +59,40 @@ test("projectRootToWorktree is idempotent — repeated calls do not throw", () =
     cleanup();
   }
 });
+
+// ─── projectWorktreeToRoot — Module contract ────────────────────────────────
+
+test("projectWorktreeToRoot exists and accepts a MilestoneScope", () => {
+  const projection = new WorktreeStateProjection();
+  assert.equal(typeof projection.projectWorktreeToRoot, "function");
+});
+
+test("projectWorktreeToRoot is non-fatal on same-path scope (project-only mode)", () => {
+  const { dir, cleanup } = makeProjectRoot();
+  try {
+    const workspace = createWorkspace(dir);
+    const scope = scopeMilestone(workspace, "M001");
+    const projection = new WorktreeStateProjection();
+
+    // Same project root on both sides — sync helper fast-paths to no-op.
+    // Module must accept and complete silently.
+    assert.doesNotThrow(() => projection.projectWorktreeToRoot(scope));
+  } finally {
+    cleanup();
+  }
+});
+
+test("projectWorktreeToRoot is idempotent on repeated calls", () => {
+  const { dir, cleanup } = makeProjectRoot();
+  try {
+    const workspace = createWorkspace(dir);
+    const scope = scopeMilestone(workspace, "M001");
+    const projection = new WorktreeStateProjection();
+
+    projection.projectWorktreeToRoot(scope);
+    projection.projectWorktreeToRoot(scope);
+    assert.ok(true, "two calls did not throw");
+  } finally {
+    cleanup();
+  }
+});

--- a/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-state-projection.test.ts
@@ -1,0 +1,61 @@
+// Project/App: GSD-2
+// File Purpose: Worktree State Projection Module — typed-Interface contract tests for projectRootToWorktree (ADR-016).
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { WorktreeStateProjection } from "../worktree-state-projection.js";
+import { createWorkspace, scopeMilestone } from "../workspace.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeProjectRoot(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-projection-"));
+  // .gsd directory is required for the workspace contract resolution
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+// ─── projectRootToWorktree — Module contract ────────────────────────────────
+
+test("WorktreeStateProjection can be constructed without arguments", () => {
+  const projection = new WorktreeStateProjection();
+  assert.ok(projection);
+  assert.equal(typeof projection.projectRootToWorktree, "function");
+});
+
+test("projectRootToWorktree accepts a MilestoneScope without throwing on same-path scope", () => {
+  const { dir, cleanup } = makeProjectRoot();
+  try {
+    const workspace = createWorkspace(dir);
+    const scope = scopeMilestone(workspace, "M001");
+    const projection = new WorktreeStateProjection();
+
+    // When the scope's workspace has no worktreeRoot (project-only mode),
+    // the underlying syncProjectRootToWorktree fast-paths to a no-op when
+    // both endpoints resolve to the same path. The Module must accept
+    // this scope and complete silently.
+    assert.doesNotThrow(() => projection.projectRootToWorktree(scope));
+  } finally {
+    cleanup();
+  }
+});
+
+test("projectRootToWorktree is idempotent — repeated calls do not throw", () => {
+  const { dir, cleanup } = makeProjectRoot();
+  try {
+    const workspace = createWorkspace(dir);
+    const scope = scopeMilestone(workspace, "M001");
+    const projection = new WorktreeStateProjection();
+
+    projection.projectRootToWorktree(scope);
+    projection.projectRootToWorktree(scope);
+    assert.ok(true, "two calls did not throw");
+  } finally {
+    cleanup();
+  }
+});

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -29,6 +29,8 @@ import {
   refreshMilestoneLease,
   releaseMilestoneLease,
 } from "./db/milestone-leases.js";
+import { MergeConflictError } from "./git-service.js";
+import type { WorktreeResolver } from "./worktree-resolver.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────
 
@@ -73,6 +75,10 @@ export type EnterResult =
         | "invalid-milestone-id";
       cause?: unknown;
     };
+
+export type ExitResult =
+  | { ok: true; merged: boolean; codeFilesChanged: boolean }
+  | { ok: false; reason: "merge-conflict" | "teardown-failed"; cause?: unknown };
 
 // ─── Validation ──────────────────────────────────────────────────────────
 
@@ -408,13 +414,16 @@ function rebuildGitService(
 export class WorktreeLifecycle {
   private readonly s: AutoSession;
   private readonly deps: WorktreeLifecycleDeps;
+  private readonly resolverFactory?: () => WorktreeResolver;
 
   constructor(
     s: AutoSession,
     deps: WorktreeLifecycleDeps,
+    resolverFactory?: () => WorktreeResolver,
   ) {
     this.s = s;
     this.deps = deps;
+    this.resolverFactory = resolverFactory;
   }
 
   /**
@@ -427,5 +436,61 @@ export class WorktreeLifecycle {
    */
   enterMilestone(milestoneId: string, ctx: NotifyCtx): EnterResult {
     return _enterMilestoneCore(this.s, this.deps, milestoneId, ctx);
+  }
+
+  /**
+   * Exit the current worktree. With `opts.merge === true`, runs the full
+   * merge-and-teardown path (worktree-mode or branch-mode auto-detected).
+   * With `opts.merge === false`, runs auto-commit and teardown without
+   * merging to main.
+   *
+   * Returns a typed `ExitResult`. `MergeConflictError` is surfaced as
+   * `{ ok: false, reason: "merge-conflict", cause }` instead of thrown,
+   * giving callers a typed branch for the expected failure path.
+   * Unexpected failures (filesystem, git permissions, etc.) are wrapped
+   * as `{ ok: false, reason: "teardown-failed", cause }` so callers always
+   * receive a discriminated union — no exceptions for any expected outcome.
+   *
+   * Issue #5586 ships this as a delegating wrapper around
+   * `WorktreeResolver.mergeAndExit`/`exitMilestone`. The full extraction
+   * (~500 lines of merge logic across `_mergeWorktreeMode` and
+   * `_mergeBranchMode`) happens in #5587 when `WorktreeResolver` retires.
+   * The delegating shape preserves caller migration without rewriting
+   * merge-conflict handling mid-flight.
+   *
+   * `codeFilesChanged` is best-effort `false` while delegation is in
+   * place; #5587 will thread the actual value through once the merge
+   * logic moves into the Module.
+   */
+  exitMilestone(
+    milestoneId: string,
+    opts: { merge: boolean; preserveBranch?: boolean },
+    ctx: NotifyCtx,
+  ): ExitResult {
+    if (!this.resolverFactory) {
+      throw new Error(
+        "WorktreeLifecycle.exitMilestone requires a resolverFactory until #5587 retires WorktreeResolver",
+      );
+    }
+    const resolver = this.resolverFactory();
+    if (opts.merge) {
+      try {
+        resolver.mergeAndExit(milestoneId, ctx);
+        return { ok: true, merged: true, codeFilesChanged: false };
+      } catch (err) {
+        if (err instanceof MergeConflictError) {
+          return { ok: false, reason: "merge-conflict", cause: err };
+        }
+        return { ok: false, reason: "teardown-failed", cause: err };
+      }
+    }
+    try {
+      resolver.exitMilestone(milestoneId, ctx, {
+        preserveBranch: opts.preserveBranch,
+      });
+      return { ok: true, merged: false, codeFilesChanged: false };
+    } catch (err) {
+      return { ok: false, reason: "teardown-failed", cause: err };
+    }
   }
 }

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -493,4 +493,71 @@ export class WorktreeLifecycle {
       return { ok: false, reason: "teardown-failed", cause: err };
     }
   }
+
+  /**
+   * Fall back to branch-mode for `milestoneId` after a failed worktree
+   * creation, marking the session's isolation as degraded.
+   *
+   * Currently delegates to `enterBranchModeForMilestone` from auto-worktree.
+   * Idempotent: subsequent calls in a degraded session are no-ops.
+   *
+   * Issue #5587 ships this as a thin adapter; the body extraction joins the
+   * other merge-logic move-out in a follow-up cleanup slice.
+   */
+  degradeToBranchMode(milestoneId: string, ctx: NotifyCtx): void {
+    if (this.s.isolationDegraded) {
+      debugLog("WorktreeLifecycle", {
+        action: "degradeToBranchMode",
+        milestoneId,
+        skipped: true,
+        reason: "already-degraded",
+      });
+      return;
+    }
+    const basePath = resolveWorktreeProjectRoot(
+      this.s.basePath,
+      this.s.originalBasePath,
+    );
+    try {
+      this.deps.enterBranchModeForMilestone(basePath, milestoneId);
+      this.deps.invalidateAllCaches();
+      this.s.isolationDegraded = true;
+      ctx.notify(
+        `Switched to branch milestone/${milestoneId} (isolation degraded).`,
+        "info",
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      ctx.notify(
+        `Branch isolation setup for ${milestoneId} failed: ${msg}. Continuing on current branch.`,
+        "warning",
+      );
+      this.s.isolationDegraded = true;
+    }
+  }
+
+  /**
+   * Restore `s.basePath` to `s.originalBasePath` and rebuild `s.gitService`.
+   * No-op when `originalBasePath` is empty (fresh sessions).
+   *
+   * Used by error/cleanup paths that need the session to behave as if the
+   * worktree was never entered. Does NOT teardown the worktree directory —
+   * callers that need teardown go through `exitMilestone({ merge: false })`.
+   */
+  restoreToProjectRoot(): void {
+    if (!this.s.originalBasePath) return;
+    this.s.basePath = this.s.originalBasePath;
+    rebuildGitService(this.s, this.deps);
+    this.deps.invalidateAllCaches();
+  }
+
+  /** True if `milestoneId` is the session's currently-active milestone. */
+  isInMilestone(milestoneId: string): boolean {
+    return this.s.currentMilestoneId === milestoneId;
+  }
+
+  /** The active milestone id, or `null` if no milestone is active. */
+  getCurrentMilestoneIfAny(): string | null {
+    return this.s.currentMilestoneId;
+  }
 }

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -331,6 +331,7 @@ export function _enterMilestoneCore(
 
     s.basePath = wtPath;
     rebuildGitService(s, deps);
+    deps.invalidateAllCaches();
 
     debugLog("WorktreeLifecycle", {
       action: "enterMilestone",
@@ -458,9 +459,9 @@ export class WorktreeLifecycle {
    * The delegating shape preserves caller migration without rewriting
    * merge-conflict handling mid-flight.
    *
-   * `codeFilesChanged` is best-effort `false` while delegation is in
-   * place; #5587 will thread the actual value through once the merge
-   * logic moves into the Module.
+   * Merge metadata is returned by `WorktreeResolver` while delegation is in
+   * place; #5587 will keep this contract when the merge logic moves into
+   * the Module.
    */
   exitMilestone(
     milestoneId: string,
@@ -475,8 +476,12 @@ export class WorktreeLifecycle {
     const resolver = this.resolverFactory();
     if (opts.merge) {
       try {
-        resolver.mergeAndExit(milestoneId, ctx);
-        return { ok: true, merged: true, codeFilesChanged: false };
+        const result = resolver.mergeAndExit(milestoneId, ctx);
+        return {
+          ok: true,
+          merged: result.merged,
+          codeFilesChanged: result.codeFilesChanged,
+        };
       } catch (err) {
         if (err instanceof MergeConflictError) {
           return { ok: false, reason: "merge-conflict", cause: err };

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -106,6 +106,11 @@ export interface WorktreeResolverDeps {
   ) => void;
 }
 
+export interface MergeAndExitResult {
+  merged: boolean;
+  codeFilesChanged: boolean;
+}
+
 // ─── Notify Context ────────────────────────────────────────────────────────
 
 export interface NotifyCtx {
@@ -307,7 +312,7 @@ export class WorktreeResolver {
    * Error recovery: on merge failure, always restore `s.basePath` to
    * `s.originalBasePath` and `process.chdir(s.originalBasePath)`.
    */
-  mergeAndExit(milestoneId: string, ctx: NotifyCtx): void {
+  mergeAndExit(milestoneId: string, ctx: NotifyCtx): MergeAndExitResult {
     this.validateMilestoneId(milestoneId);
 
     // Anchor cwd at the project root before any merge work. Some merge code
@@ -350,7 +355,7 @@ export class WorktreeResolver {
         `Skipping worktree merge for ${milestoneId} — isolation was degraded (worktree creation failed earlier). Work is on the current branch.`,
         "info",
       );
-      return;
+      return { merged: false, codeFilesChanged: false };
     }
 
     const mode = this.deps.getIsolationMode(this.s.originalBasePath || this.s.basePath);
@@ -381,27 +386,30 @@ export class WorktreeResolver {
         skipped: true,
         reason: "mode-none",
       });
-      return;
+      return { merged: false, codeFilesChanged: false };
     }
 
-    let actuallyMerged = false;
+    let mergeResult: MergeAndExitResult = {
+      merged: false,
+      codeFilesChanged: false,
+    };
     if (
       mode === "worktree" || inWorktree
     ) {
-      actuallyMerged = this._mergeWorktreeMode(milestoneId, ctx);
+      mergeResult = this._mergeWorktreeMode(milestoneId, ctx);
     } else if (mode === "branch") {
-      actuallyMerged = this._mergeBranchMode(milestoneId, ctx);
+      mergeResult = this._mergeBranchMode(milestoneId, ctx);
     }
 
     // The remainder of this function emits telemetry and runs re-squash.
-    // Both are gated on actuallyMerged — if the _merge* helper took a
+    // Both are gated on mergeResult.merged — if the _merge* helper took a
     // no-merge path (missing originalBase, no roadmap, wrong branch) the
     // milestone branch was intentionally left unmerged and we must not
     // emit a worktree-merged event or collapse commits on main.
-    if (!actuallyMerged) {
+    if (!mergeResult.merged) {
       // Always clear the start-SHA tracker to avoid leaking across sessions.
       this.s.milestoneStartShas.delete(milestoneId);
-      return;
+      return mergeResult;
     }
 
     // #4765 — when collapse_cadence=slice AND milestone_resquash=true, the
@@ -452,11 +460,12 @@ export class WorktreeResolver {
         error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
       });
     }
+    return mergeResult;
   }
 
   /** Worktree-mode merge: read roadmap, merge, teardown, reset paths.
-   *  Returns true when a squash-merge actually ran (false on skip paths). */
-  private _mergeWorktreeMode(milestoneId: string, ctx: NotifyCtx): boolean {
+   *  Returns merge metadata when a squash-merge actually ran. */
+  private _mergeWorktreeMode(milestoneId: string, ctx: NotifyCtx): MergeAndExitResult {
     const originalBase = this.s.originalBasePath;
     if (!originalBase) {
       debugLog("WorktreeResolver", {
@@ -466,10 +475,11 @@ export class WorktreeResolver {
         skipped: true,
         reason: "missing-original-base",
       });
-      return false;
+      return { merged: false, codeFilesChanged: false };
     }
 
     let merged = false;
+    let codeFilesChanged = false;
     try {
       const { synced } = this.deps.syncWorktreeStateBack(
         originalBase,
@@ -519,6 +529,7 @@ export class WorktreeResolver {
           roadmapContent,
         );
         merged = true;
+        codeFilesChanged = mergeResult.codeFilesChanged;
 
         // #2945 Bug 3: mergeMilestoneToMain performs best-effort worktree
         // cleanup internally (step 12), but it can silently fail on Windows
@@ -622,12 +633,12 @@ export class WorktreeResolver {
       result: "done",
       basePath: this.s.basePath,
     });
-    return merged;
+    return { merged, codeFilesChanged };
   }
 
   /** Branch-mode merge: check current branch, merge if on milestone branch.
-   *  Returns true when a merge actually ran (false on skip paths). */
-  private _mergeBranchMode(milestoneId: string, ctx: NotifyCtx): boolean {
+   *  Returns merge metadata when a merge actually ran. */
+  private _mergeBranchMode(milestoneId: string, ctx: NotifyCtx): MergeAndExitResult {
     try {
       const currentBranch = this.deps.getCurrentBranch(this.s.basePath);
       const milestoneBranch = this.deps.autoWorktreeBranch(milestoneId);
@@ -683,7 +694,7 @@ export class WorktreeResolver {
           skipped: true,
           reason: "no-roadmap",
         });
-        return false;
+        return { merged: false, codeFilesChanged: false };
       }
 
       const roadmapContent = this.deps.readFileSync(roadmapPath, "utf-8");
@@ -714,7 +725,7 @@ export class WorktreeResolver {
         mode: "branch",
         result: "success",
       });
-      return true;
+      return { merged: true, codeFilesChanged: mergeResult.codeFilesChanged };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       debugLog("WorktreeResolver", {

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -11,9 +11,9 @@
  *     verdict overwrite #2821, completed-units forward-sync, WAL/SHM
  *     cleanup #2478, .gsd symlink edge case #2184)
  *
- * Phase 1 of the migration ships only `projectRootToWorktree`. The remaining
- * verbs (`projectWorktreeToRoot`, `finalizeProjectionForMerge`) are added in
- * subsequent slices (#5589, #5590).
+ * Phase 1 shipped `projectRootToWorktree`; this slice also introduces
+ * `projectWorktreeToRoot` as a delegating wrapper. `finalizeProjectionForMerge`
+ * remains for a subsequent slice (#5590).
  *
  * Issue #5588 ships this as a delegating wrapper around the existing
  * `syncProjectRootToWorktree*` helpers in `auto-worktree.ts`. The full body

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -1,0 +1,58 @@
+// GSD-2 — Worktree State Projection module: directional state-flow rules between project root and auto-worktree.
+/**
+ * Worktree State Projection module — first-class Module for directional
+ * state-file flow between the project root and the auto-worktree.
+ *
+ * Per ADR-016, this Module owns:
+ *   - The direction-and-rules of state file flow (project-root authoritative
+ *     for some classes, worktree authoritative for others)
+ *   - The bug-hardened invariants encoded in `syncProjectRootToWorktree` /
+ *     `syncStateToProjectRoot` (additive milestone copy #1886, ASSESSMENT
+ *     verdict overwrite #2821, completed-units forward-sync, WAL/SHM
+ *     cleanup #2478, .gsd symlink edge case #2184)
+ *
+ * Phase 1 of the migration ships only `projectRootToWorktree`. The remaining
+ * verbs (`projectWorktreeToRoot`, `finalizeProjectionForMerge`) are added in
+ * subsequent slices (#5589, #5590).
+ *
+ * Issue #5588 ships this as a delegating wrapper around the existing
+ * `syncProjectRootToWorktree*` helpers in `auto-worktree.ts`. The full body
+ * extraction (with its identity-key check, additive milestone copy, ASSESSMENT
+ * verdict force-overwrite, completed-units forward-sync, WAL/SHM cleanup,
+ * .gsd symlink edge case) joins the legacy helper retirement in #5590.
+ *
+ * Lifecycle does not yet hook this Module into `enterMilestone`; that wiring
+ * lands when the broader caller migration completes alongside the Projection
+ * Module's full Interface.
+ */
+
+import { syncProjectRootToWorktreeByScope } from "./auto-worktree.js";
+import type { MilestoneScope } from "./workspace.js";
+
+/**
+ * Worktree State Projection Module instance.
+ *
+ * Stateless — methods are pure functions of their `MilestoneScope` input.
+ * The class form is retained for testability and to keep the Interface
+ * shape consistent with `WorktreeLifecycle`.
+ */
+export class WorktreeStateProjection {
+  /**
+   * Project state from the project root onto the auto-worktree for `scope`.
+   * Called by Lifecycle's enter path after a successful create/enter, before
+   * any Unit dispatches.
+   *
+   * Owns the rules: identity-key safety check, additive milestone copy
+   * preserving worktree-local files (#1886), ASSESSMENT verdict force-
+   * overwrite (#2821), forward-sync of `completed-units.json`, WAL/SHM
+   * cleanup on legacy worktree-local DB (#2478), and the `.gsd` symlink
+   * realpath edge case (#2184).
+   *
+   * Issue #5588 delegates to `syncProjectRootToWorktreeByScope` to ship the
+   * typed `MilestoneScope`-only Interface without re-implementing the bug-
+   * hardened rules mid-flight. The body extraction joins #5590.
+   */
+  projectRootToWorktree(scope: MilestoneScope): void {
+    syncProjectRootToWorktreeByScope(scope, scope);
+  }
+}

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -26,7 +26,10 @@
  * Module's full Interface.
  */
 
-import { syncProjectRootToWorktreeByScope } from "./auto-worktree.js";
+import {
+  syncProjectRootToWorktreeByScope,
+  syncStateToProjectRootByScope,
+} from "./auto-worktree.js";
 import type { MilestoneScope } from "./workspace.js";
 
 /**
@@ -54,5 +57,23 @@ export class WorktreeStateProjection {
    */
   projectRootToWorktree(scope: MilestoneScope): void {
     syncProjectRootToWorktreeByScope(scope, scope);
+  }
+
+  /**
+   * Project state from the auto-worktree back onto the project root for `scope`.
+   * Called by the post-unit pipeline between Units, and by Lifecycle's exit
+   * path before merge.
+   *
+   * Owns the rules: identity-key safety check, project-root authoritative
+   * for diagnostics, markdown projections do NOT flow back to project root,
+   * non-fatal — sync failure must not block the caller.
+   *
+   * Issue #5589 delegates to `syncStateToProjectRootByScope` to ship the
+   * typed `MilestoneScope`-only Interface without re-implementing the
+   * non-fatal-on-failure contract mid-flight. The body extraction joins
+   * the legacy helper retirement in #5590.
+   */
+  projectWorktreeToRoot(scope: MilestoneScope): void {
+    syncStateToProjectRootByScope(scope, scope);
   }
 }

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -41,7 +41,9 @@ import type { MilestoneScope } from "./workspace.js";
  */
 export class WorktreeStateProjection {
   /**
-   * Project state from the project root onto the auto-worktree for `scope`.
+   * Project state from the project root onto the auto-worktree for the scope
+   * pair. `worktreeScope` may be omitted only for project-only/same-path
+   * callers where the helper intentionally fast-paths to a no-op.
    * Called by Lifecycle's enter path after a successful create/enter, before
    * any Unit dispatches.
    *
@@ -55,12 +57,17 @@ export class WorktreeStateProjection {
    * typed `MilestoneScope`-only Interface without re-implementing the bug-
    * hardened rules mid-flight. The body extraction joins #5590.
    */
-  projectRootToWorktree(scope: MilestoneScope): void {
-    syncProjectRootToWorktreeByScope(scope, scope);
+  projectRootToWorktree(
+    rootScope: MilestoneScope,
+    worktreeScope: MilestoneScope = rootScope,
+  ): void {
+    syncProjectRootToWorktreeByScope(rootScope, worktreeScope);
   }
 
   /**
-   * Project state from the auto-worktree back onto the project root for `scope`.
+   * Project state from the auto-worktree back onto the project root for the
+   * scope pair. `rootScope` may be omitted only for project-only/same-path
+   * callers where the helper intentionally fast-paths to a no-op.
    * Called by the post-unit pipeline between Units, and by Lifecycle's exit
    * path before merge.
    *
@@ -73,7 +80,10 @@ export class WorktreeStateProjection {
    * non-fatal-on-failure contract mid-flight. The body extraction joins
    * the legacy helper retirement in #5590.
    */
-  projectWorktreeToRoot(scope: MilestoneScope): void {
-    syncStateToProjectRootByScope(scope, scope);
+  projectWorktreeToRoot(
+    worktreeScope: MilestoneScope,
+    rootScope: MilestoneScope = worktreeScope,
+  ): void {
+    syncStateToProjectRootByScope(worktreeScope, rootScope);
   }
 }


### PR DESCRIPTION
## Summary

- Add `projectWorktreeToRoot(scope: MilestoneScope)` to `WorktreeStateProjection`. Delegates to `syncStateToProjectRootByScope`.
- 3 new contract tests; 7575 GSD tests pass.

Stacked on #5600 (#5588). Refs #5589.

## Scope correction

Caller migration deferred (same reasoning as #5588) — direct callers of `syncStateToProjectRoot*` (`auto-post-unit.ts`, `parallel-merge.ts`) pass path strings rather than `MilestoneScope`. Migrating them belongs with the `s.scope` rollout per the `TODO(C8)` marker in `auto/session.ts`.

The non-fatal-on-failure contract is preserved by delegation; the delegate already swallows errors per its existing contract.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test:unit` — 7575 passed, 0 failed
- [x] 3 new contract tests
- [ ] Reviewer agrees the delegation pattern is acceptable as transitional shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal milestone management system with enhanced error handling and more reliable state tracking during transitions
  * Strengthened merge operation error categorization with structured result types for better reliability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5601)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->