### PR TITLE
fix(gsd-tui): header lifecycle, scroll stability, and wizard step guidance

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -602,6 +602,21 @@ export function updateProgressWidget(
 ): void {
   if (!ctx.hasUI) return;
 
+  // Welcome header is a startup-only banner — permanently suppress it once
+  // auto-mode activates. The dashboard widget owns all status from here.
+  // Note: setHeader(undefined) restores the built-in header (logo +
+  // instructions). To actually render zero lines, install an empty header.
+  if (typeof ctx.ui?.setHeader === "function") {
+    ctx.ui.setHeader(() => ({
+      render(): string[] { return []; },
+      invalidate(): void {},
+    }));
+  }
+  // Clear wizard step badge — auto-mode owns the UI from this point
+  if (typeof ctx.ui?.setStatus === "function") {
+    ctx.ui.setStatus("gsd-step", undefined);
+  }
+
   const verb = unitVerb(unitType);
   const phaseLabel = unitPhaseLabel(unitType);
   const mid = state.activeMilestone;
@@ -1028,6 +1043,11 @@ export function updateProgressWidget(
             ? lastCommit.message.slice(0, maxCommitLen - 1) + "…"
             : lastCommit.message
           : "";
+        // Step-mode guidance — shown above keyboard hints when auto is paused
+        if (accessors.isStepMode()) {
+          lines.push(`${pad}${theme.fg("accent", "→")} ${theme.fg("dim", "Ctrl+N to advance to next step  ·  /gsd status for overview")}`);
+        }
+
         // Hints line
         const hintParts: string[] = [];
         hintParts.push("esc pause");

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -84,16 +84,26 @@ async function installWelcomeHeader(ctx: ExtensionContext): Promise<void> {
       if (rc) remoteChannel = rc.channel;
     } catch { /* non-fatal */ }
 
-    ctx.ui.setHeader(() => ({
-      render(width: number): string[] {
-        return welcome.buildWelcomeScreenLines({
-          version: process.env.GSD_VERSION || "0.0.0",
-          remoteChannel,
-          width,
-        });
-      },
-      invalidate(): void {},
-    }));
+    ctx.ui.setHeader(() => {
+      let cachedLines: string[] | undefined;
+      let cachedWidth: number | undefined;
+      return {
+        render(width: number): string[] {
+          if (cachedLines !== undefined && cachedWidth === width) return cachedLines;
+          cachedLines = welcome.buildWelcomeScreenLines({
+            version: process.env.GSD_VERSION || "0.0.0",
+            remoteChannel,
+            width,
+          });
+          cachedWidth = width;
+          return cachedLines;
+        },
+        invalidate(): void {
+          cachedLines = undefined;
+          cachedWidth = undefined;
+        },
+      };
+    });
   } catch {
     /* non-fatal */
   }

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -2218,6 +2218,7 @@ export async function showSmartEntry(
 
     if (isFirst) {
       // First ever — skip wizard, just ask directly
+      ctx.ui.setStatus("gsd-step", "New Milestone · answer the questions above to plan");
       setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId: nextId, step: stepMode });
       await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
         `New project, milestone ${nextId}. Do NOT read or explore .gsd/ — it's empty scaffolding.`,
@@ -2246,6 +2247,7 @@ export async function showSmartEntry(
       if (choice === "quick_task") {
         await runQuickTaskChoice(ctx, pi);
       } else if (choice === "new_milestone") {
+        ctx.ui.setStatus("gsd-step", "New Milestone · answer the questions above to plan");
         setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId: nextId, step: stepMode });
         await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
           `New milestone ${nextId}.`,
@@ -2447,6 +2449,7 @@ export async function showSmartEntry(
       if (choice === "quick_task") {
         await runQuickTaskChoice(ctx, pi);
       } else if (choice === "plan") {
+        ctx.ui.setStatus("gsd-step", "Planning Milestone · decomposing into slices");
         setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId, step: stepMode });
         await dispatchWorkflow(
           pi,
@@ -2579,6 +2582,7 @@ export async function showSmartEntry(
     });
 
     if (choice === "plan") {
+      ctx.ui.setStatus("gsd-step", "Slice Planning · answer the questions above");
       await dispatchWorkflow(
         pi,
         await buildPlanSlicePrompt(milestoneId, milestoneTitle, sliceId, sliceTitle, basePath),
@@ -2641,6 +2645,7 @@ export async function showSmartEntry(
     });
 
     if (choice === "complete") {
+      ctx.ui.setStatus("gsd-step", "Completing Slice · review changes above");
       await dispatchWorkflow(
         pi,
         await buildCompleteSlicePrompt(milestoneId, milestoneTitle, sliceId, sliceTitle, basePath),
@@ -2709,6 +2714,7 @@ export async function showSmartEntry(
     }
 
     if (choice === "execute") {
+      ctx.ui.setStatus("gsd-step", "Executing Task · follow progress above");
       if (hasInterrupted) {
         await dispatchWorkflow(pi, loadPrompt("guided-resume-task", {
           milestoneId,

--- a/src/resources/extensions/gsd/health-widget.ts
+++ b/src/resources/extensions/gsd/health-widget.ts
@@ -135,6 +135,9 @@ export function initHealthWidget(ctx: ExtensionContext): void {
       render(width: number): string[] {
         if (!cachedLines || cachedWidth !== width) {
           cachedLines = buildHealthLines(data, width);
+          if (data.projectState === "active") {
+            cachedLines = [...cachedLines, _theme.fg("dim", "  /gsd auto to run  ·  /gsd status for overview  ·  /gsd help")];
+          }
           cachedWidth = width;
         }
         return cachedLines;

--- a/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
@@ -1,0 +1,210 @@
+// Project/App: GSD-2
+// File Purpose: Regression tests for the TUI header lifecycle fixes —
+// header is suppressed (zero lines) when auto-mode activates, the wizard
+// step status badge is cleared, the NEXT-mode footer hint renders when
+// step mode is active, and the health widget appends guidance for active
+// projects.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { updateProgressWidget } from "../auto-dashboard.ts";
+import type { GSDState } from "../types.ts";
+
+interface CapturedSetHeader {
+  factory: ((tui: unknown, theme: unknown) => { render(width: number): string[]; invalidate(): void }) | undefined;
+}
+
+function makeTempDir(prefix: string): string {
+  return join(
+    tmpdir(),
+    `gsd-tui-lifecycle-test-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+}
+
+function cleanup(dir: string): void {
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+
+const baseState: GSDState = {
+  phase: "executing",
+  activeMilestone: { id: "M001", title: "Milestone" },
+  activeSlice: { id: "S01", title: "Slice" },
+  activeTask: { id: "T01", title: "Task" },
+} as unknown as GSDState;
+
+const baseAccessors = {
+  getAutoStartTime: () => 0,
+  isStepMode: () => false,
+  getCmdCtx: () => null,
+  getBasePath: () => "/tmp",
+  isVerbose: () => false,
+  isSessionSwitching: () => false,
+  getCurrentDispatchedModelId: () => null,
+};
+
+// ── Header lifecycle ────────────────────────────────────────────────────
+
+test("updateProgressWidget installs an EMPTY-rendering header (not undefined) — addresses codex P1 finding that setHeader(undefined) restores the built-in logo+instructions header", (t) => {
+  const dir = makeTempDir("empty-header");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  t.after(() => cleanup(dir));
+
+  const captured: CapturedSetHeader = { factory: undefined };
+  let setHeaderCallCount = 0;
+
+  updateProgressWidget(
+    {
+      hasUI: true,
+      ui: {
+        setWidget() {},
+        setHeader(factory: any) {
+          setHeaderCallCount++;
+          captured.factory = factory;
+        },
+        setStatus() {},
+      },
+    } as any,
+    "execute-task",
+    "M001/S01/T01",
+    baseState,
+    { ...baseAccessors, getBasePath: () => dir },
+  );
+
+  assert.equal(setHeaderCallCount, 1, "setHeader must be called exactly once when widget installs");
+  assert.notEqual(captured.factory, undefined, "factory must NOT be undefined — undefined restores the built-in logo+instructions header (codex P1)");
+  assert.equal(typeof captured.factory, "function", "factory must be a component-creating function");
+
+  const component = captured.factory!(null, null);
+  const rendered = component.render(80);
+  assert.deepEqual(rendered, [], "empty header component must render zero lines so auto-mode actually suppresses the welcome banner");
+});
+
+test("updateProgressWidget clears the gsd-step wizard badge when auto-mode activates", (t) => {
+  const dir = makeTempDir("step-badge");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  t.after(() => cleanup(dir));
+
+  const statusCalls: Array<[string, string | undefined]> = [];
+
+  updateProgressWidget(
+    {
+      hasUI: true,
+      ui: {
+        setWidget() {},
+        setHeader() {},
+        setStatus(key: string, value: string | undefined) { statusCalls.push([key, value]); },
+      },
+    } as any,
+    "execute-task",
+    "M001/S01/T01",
+    baseState,
+    { ...baseAccessors, getBasePath: () => dir },
+  );
+
+  assert.ok(
+    statusCalls.some(([key, value]) => key === "gsd-step" && value === undefined),
+    `expected setStatus("gsd-step", undefined) to be called; got ${JSON.stringify(statusCalls)}`,
+  );
+});
+
+test("updateProgressWidget gracefully no-ops when ctx.ui lacks setHeader/setStatus (RPC mode)", (t) => {
+  const dir = makeTempDir("rpc-mode");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  t.after(() => cleanup(dir));
+
+  // ctx.ui without setHeader / setStatus — must not throw.
+  assert.doesNotThrow(() => {
+    updateProgressWidget(
+      {
+        hasUI: true,
+        ui: { setWidget() {} },
+      } as any,
+      "execute-task",
+      "M001/S01/T01",
+      baseState,
+      { ...baseAccessors, getBasePath: () => dir },
+    );
+  });
+});
+
+// ── NEXT-mode footer guidance ───────────────────────────────────────────
+
+test("auto-dashboard widget render output includes Ctrl+N guidance when isStepMode is true", (t) => {
+  const dir = makeTempDir("step-hint");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  t.after(() => cleanup(dir));
+
+  let widgetFactory: ((tui: unknown, theme: unknown) => any) | undefined;
+
+  updateProgressWidget(
+    {
+      hasUI: true,
+      ui: {
+        setWidget(_key: string, factory: any) { widgetFactory = factory; },
+        setHeader() {},
+        setStatus() {},
+      },
+    } as any,
+    "execute-task",
+    "M001/S01/T01",
+    baseState,
+    { ...baseAccessors, getBasePath: () => dir, isStepMode: () => true },
+  );
+
+  assert.ok(widgetFactory, "widget factory must be installed");
+
+  const fakeTui = { requestRender() {} };
+  const fakeTheme = {
+    fg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  };
+  const component = widgetFactory!(fakeTui, fakeTheme);
+  const lines = component.render(120);
+
+  const hasStepHint = lines.some((line: string) => line.includes("Ctrl+N to advance"));
+  assert.ok(hasStepHint, `expected step-mode hint in render output; got:\n${lines.join("\n")}`);
+
+  if (component.dispose) component.dispose();
+});
+
+test("auto-dashboard widget render output omits Ctrl+N guidance when isStepMode is false", (t) => {
+  const dir = makeTempDir("no-step-hint");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  t.after(() => cleanup(dir));
+
+  let widgetFactory: ((tui: unknown, theme: unknown) => any) | undefined;
+
+  updateProgressWidget(
+    {
+      hasUI: true,
+      ui: {
+        setWidget(_key: string, factory: any) { widgetFactory = factory; },
+        setHeader() {},
+        setStatus() {},
+      },
+    } as any,
+    "execute-task",
+    "M001/S01/T01",
+    baseState,
+    { ...baseAccessors, getBasePath: () => dir, isStepMode: () => false },
+  );
+
+  assert.ok(widgetFactory);
+
+  const fakeTui = { requestRender() {} };
+  const fakeTheme = {
+    fg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  };
+  const component = widgetFactory!(fakeTui, fakeTheme);
+  const lines = component.render(120);
+
+  const hasStepHint = lines.some((line: string) => line.includes("Ctrl+N to advance"));
+  assert.equal(hasStepHint, false, "step-mode hint must NOT appear when isStepMode is false");
+
+  if (component.dispose) component.dispose();
+});


### PR DESCRIPTION
## Summary

- **Header caching**: `register-hooks.ts` — the welcome header's `render()` now caches output by terminal width (was reading `STATE.md` from disk 1.25×/sec). `invalidate()` actually clears the cache (was an empty no-op).
- **Header lifecycle**: `auto-dashboard.ts` — `updateProgressWidget()` permanently removes the welcome header (`setHeader(undefined)`) when auto-mode starts. The header is a startup-only banner; the progress widget owns all status from that point. This also clears the `gsd-step` wizard badge.
- **Scroll regression fix**: By removing the header's 12 extra lines from the total render height during auto-mode, line-count changes in the progress widget are less likely to cross the terminal height threshold and trigger `fullRender(true)` (the "scrolls up" behavior).
- **NEXT-mode guidance**: `auto-dashboard.ts` — widget footer shows `→ Ctrl+N to advance to next step` when auto is paused in step mode.
- **Idle guidance**: `health-widget.ts` — health widget appends `/gsd auto to run · /gsd status for overview · /gsd help` for active GSD projects.
- **Wizard step badges**: `guided-flow.ts` — `setStatus("gsd-step", ...)` badges are set before key LLM dispatches (new milestone, plan milestone, plan slice, complete slice, execute task) so users can see which wizard phase they're in between turns.

## Test plan

- [ ] Start GSD — welcome header (logo + `/gsd to begin`) visible at startup
- [ ] Run `/gsd auto` — header disappears immediately, progress widget appears, no scroll
- [ ] Let pulse timer fire (800ms) — no viewport scroll or flicker
- [ ] Trigger a task/slice state change mid-run — no full-redraw scroll
- [ ] Pause auto-mode in step mode — widget footer shows `→ Ctrl+N to advance` hint
- [ ] Let auto-mode finish — health widget shows `/gsd auto to run` guidance line
- [ ] Run `/gsd` on a new project — footer badge says "New Milestone · answer the questions above to plan" while LLM is active
- [ ] Run `/gsd` on a project with context but no roadmap — badge says "Planning Milestone · decomposing into slices"
- [ ] Confirm welcome header does NOT reappear after `/clear` or auto-mode end
- [ ] Resize terminal while header is visible — `invalidate()` fires and header re-renders at new width

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added step-mode guidance line in progress widget footer when step mode is active

* **Improvements**
  * Optimized welcome header rendering with caching to avoid redundant recomputation
  * Added command hint suggestions to health widget display for active projects
  * Enhanced step status indicators throughout wizard flow for clearer progress tracking

* **Bug Fixes**
  * Suppresses startup-only UI header and clears step status badge when the progress widget mounts

* **Tests**
  * Added regression tests covering header lifecycle, status clearing, and step-mode footer guidance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5611)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->