### PR TITLE
ADR-015 runtime invariant modules

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -79,6 +79,22 @@ Each auto-mode unit has a `UnitContextManifest` with a `ToolsPolicy`, and GSD en
 
 Writes outside those allowed paths, unsafe bash commands, and subagent dispatch from non-dispatch planning units are blocked with a hard policy error instead of relying on prompt compliance. In `planning-dispatch` units, prompts steer the parent agent toward read-only specialists such as `scout`, `planner`, `researcher`, `reviewer`, `security`, or `tester`; implementation-tier agents still belong in `execute-task`.
 
+### Pre-Dispatch Runtime Blocks
+
+Before auto mode launches a unit, the orchestration pipeline now enforces runtime invariants in this order: reconcile state, choose the next unit, compile the unit tool contract, validate the worktree or unit root, then persist the runtime transition. A failure in any pre-dispatch step returns a `blocked` result and records the block before a worker session starts.
+
+Common block reasons and operator actions:
+
+| Block reason | What it means | Remediation |
+|--------------|---------------|-------------|
+| State reconciliation blocker | The authoritative database snapshot is already blocked, or state derivation found existing blockers. | Inspect `/gsd status`, `STATE.md`, and the database-backed blocker message; resolve the blocker or run the appropriate GSD recovery command before retrying `/gsd auto`. |
+| `unknown-unit-type` | The dispatch decision selected a unit with no registered `UnitContextManifest`. | Fix the unit registration or manifest mapping. Retrying without a code/config fix will select the same invalid unit. |
+| `missing-closeout-tool` | A closeout unit such as task, slice, milestone, UAT, or gate completion has no required workflow tool available. | Restore the missing `gsd_*` workflow tool registration or update the unit manifest/tool contract so the unit can durably save its result. |
+| `root-missing` / `root-not-directory` | A source-writing unit would run from a missing or invalid unit root. | Recreate or repair the milestone worktree/root, or clear an incorrect `GSD_UNIT_ROOT`, before launching another source-writing unit. |
+| `git-metadata-missing` | A source-writing unit root exists but is not a git worktree or repository root. | Run the unit from the project root or milestone worktree with valid `.git` metadata; recreate the worktree if it was deleted or partially copied. |
+
+Recovery classification now treats deterministic policy, tool-schema, stale-worker, and invalid-worktree failures as non-transient stops. Provider failures still use provider-specific transient classification and may retry automatically, while verification drift and unknown runtime failures escalate for inspection because repeating the same dispatch can preserve the drift.
+
 ### Context Pre-Loading
 
 The dispatch prompt is carefully constructed with:

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -117,6 +117,20 @@ Every auto-mode unit declares a `ToolsPolicy` in its `UnitContextManifest`, and 
 
 Policy violations return a hard block, so unsafe writes, unsafe bash, and subagent dispatch from non-dispatch planning units are stopped at runtime rather than handled as model instructions. In `planning-dispatch` units, prompts steer the parent agent toward read-only specialists such as `scout`, `planner`, `researcher`, `reviewer`, `security`, or `tester`; implementation-tier agents still belong in `execute-task`.
 
+## Pre-Dispatch Runtime Blocks
+
+Before auto mode launches a unit, the orchestration pipeline enforces runtime invariants in this order: reconcile state, choose the next unit, compile the unit tool contract, validate the worktree or unit root, then persist the runtime transition. A failure in any pre-dispatch step returns a `blocked` result before a worker session starts.
+
+| Block Reason | What It Means | Remediation |
+|--------------|---------------|-------------|
+| State reconciliation blocker | The authoritative database snapshot is already blocked, or state derivation found existing blockers. | Inspect `/gsd status`, `STATE.md`, and the database-backed blocker message; resolve the blocker or run the appropriate GSD recovery command before retrying `/gsd auto`. |
+| `unknown-unit-type` | Dispatch selected a unit with no registered `UnitContextManifest`. | Fix the unit registration or manifest mapping. Retrying without a code/config fix will select the same invalid unit. |
+| `missing-closeout-tool` | A closeout unit such as task, slice, milestone, UAT, or gate completion has no required workflow tool available. | Restore the missing `gsd_*` workflow tool registration or update the unit manifest/tool contract so the unit can durably save its result. |
+| `root-missing` / `root-not-directory` | A source-writing unit would run from a missing or invalid unit root. | Recreate or repair the milestone worktree/root, or clear an incorrect `GSD_UNIT_ROOT`, before launching another source-writing unit. |
+| `git-metadata-missing` | A source-writing unit root exists but is not a git worktree or repository root. | Run the unit from the project root or milestone worktree with valid `.git` metadata; recreate the worktree if it was deleted or partially copied. |
+
+Recovery classification treats deterministic policy, tool-schema, stale-worker, and invalid-worktree failures as non-transient stops. Provider failures still use provider-specific transient classification and may retry automatically, while verification drift and unknown runtime failures escalate for inspection because repeating the same dispatch can preserve the drift.
+
 ## Reactive Task Execution
 
 Reactive task execution is enabled by default. During task execution, GSD derives a dependency graph from task-plan IO annotations. With default settings, it only attempts a reactive batch when at least three ready tasks are available and the graph is non-ambiguous. Non-conflicting tasks are dispatched in parallel via subagents; dependent tasks wait for their predecessors.

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -240,6 +240,10 @@ import { resolveUokFlags } from "./uok/flags.js";
 import { validateDirectory } from "./validate-directory.js";
 import { createAutoOrchestrator } from "./auto/orchestrator.js";
 import type { AutoOrchestrationModule, AutoOrchestratorDeps } from "./auto/contracts.js";
+import { reconcileBeforeDispatch } from "./state-reconciliation.js";
+import { compileUnitToolContract } from "./tool-contract.js";
+import { prepareUnitRoot } from "./worktree-safety.js";
+import { classifyFailure } from "./recovery-classification.js";
 // Slice-level parallelism (#2340)
 import { getEligibleSlices } from "./slice-parallel-eligibility.js";
 import { startSliceParallel } from "./slice-parallel-orchestrator.js";
@@ -1599,9 +1603,26 @@ export function createWiredAutoOrchestrationModule(
   let seq = 0;
 
   const deps: AutoOrchestratorDeps = {
+    stateReconciliation: {
+      async reconcileBeforeDispatch() {
+        const result = await reconcileBeforeDispatch(dispatchBasePath);
+        if (!result.ok) {
+          return {
+            ok: false,
+            reason: result.reason,
+            stateSnapshot: result.stateSnapshot,
+          };
+        }
+        return {
+          ok: true,
+          reason: result.repaired.join(", "),
+          stateSnapshot: result.stateSnapshot,
+        };
+      },
+    },
     dispatch: {
-      async decideNextUnit() {
-        const state = await deriveState(dispatchBasePath);
+      async decideNextUnit(input) {
+        const state = input.stateSnapshot;
         const active = state.activeMilestone;
         if (!active) return null;
 
@@ -1625,12 +1646,23 @@ export function createWiredAutoOrchestrationModule(
     },
     recovery: {
       async classifyAndRecover(input) {
-        const reason = input.error instanceof Error ? input.error.message : String(input.error ?? "unknown auto error");
-        return { action: "escalate" as const, reason };
+        const recovery = classifyFailure(input);
+        return { action: recovery.action, reason: recovery.reason };
+      },
+    },
+    toolContract: {
+      async compileUnitToolContract(unitType) {
+        const result = compileUnitToolContract(unitType);
+        if (!result.ok) return { ok: false, reason: result.detail };
+        return { ok: true, reason: result.contract.validationRules.join(", ") };
       },
     },
     worktree: {
-      async prepareForUnit() {},
+      async prepareForUnit(unitType, unitId) {
+        const result = prepareUnitRoot(unitType, unitId, { basePath: dispatchBasePath });
+        if (!result.ok) return { ok: false, reason: result.detail };
+        return { ok: true, reason: result.reason };
+      },
       async syncAfterUnit() {},
       async cleanupOnStop() {},
     },

--- a/src/resources/extensions/gsd/auto/contracts.ts
+++ b/src/resources/extensions/gsd/auto/contracts.ts
@@ -1,3 +1,6 @@
+// Project/App: GSD-2
+// File Purpose: Auto Orchestration module interfaces and ADR-015 invariant adapter contracts.
+
 import type { GSDState } from "../types.js";
 
 export interface AutoSessionContext {
@@ -30,7 +33,7 @@ export interface AutoOrchestrationModule {
 }
 
 export interface DispatchAdapter {
-  decideNextUnit(): Promise<{
+  decideNextUnit(input: { stateSnapshot: GSDState }): Promise<{
     unitType: string;
     unitId: string;
     reason: string;
@@ -49,8 +52,20 @@ export interface RecoveryAdapter {
   }>;
 }
 
+export type InvariantAdapterResult =
+  | { ok: true; reason?: string; stateSnapshot?: GSDState }
+  | { ok: false; reason: string; stateSnapshot?: GSDState };
+
+export interface StateReconciliationAdapter {
+  reconcileBeforeDispatch(): Promise<InvariantAdapterResult & { stateSnapshot?: GSDState }>;
+}
+
+export interface ToolContractAdapter {
+  compileUnitToolContract(unitType: string, unitId: string): Promise<InvariantAdapterResult>;
+}
+
 export interface WorktreeAdapter {
-  prepareForUnit(unitType: string, unitId: string): Promise<void>;
+  prepareForUnit(unitType: string, unitId: string): Promise<InvariantAdapterResult>;
   syncAfterUnit(unitType: string, unitId: string): Promise<void>;
   cleanupOnStop(reason: string): Promise<void>;
 }
@@ -78,7 +93,9 @@ export interface NotificationAdapter {
 }
 
 export interface AutoOrchestratorDeps {
+  stateReconciliation: StateReconciliationAdapter;
   dispatch: DispatchAdapter;
+  toolContract: ToolContractAdapter;
   recovery: RecoveryAdapter;
   worktree: WorktreeAdapter;
   health: HealthAdapter;

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -1,3 +1,6 @@
+// Project/App: GSD-2
+// File Purpose: Auto Orchestration module implementation and ADR-015 invariant pipeline owner.
+
 import type { AutoAdvanceResult, AutoOrchestrationModule, AutoOrchestratorDeps, AutoSessionContext, AutoStatus } from "./contracts.js";
 
 function now(): number {
@@ -36,9 +39,21 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         return blocked;
       }
 
-      const decision = await this.deps.dispatch.decideNextUnit();
+      const reconciliation = await this.deps.stateReconciliation.reconcileBeforeDispatch();
+      if (!reconciliation.ok || !reconciliation.stateSnapshot) {
+        const blocked: AutoAdvanceResult = {
+          kind: "blocked",
+          reason: reconciliation.reason,
+          stateSnapshot: reconciliation.stateSnapshot,
+        };
+        await this.deps.runtime.journalTransition({ name: "advance-blocked", reason: blocked.reason });
+        await this.deps.health.postAdvanceRecord(blocked);
+        return blocked;
+      }
+
+      const decision = await this.deps.dispatch.decideNextUnit({ stateSnapshot: reconciliation.stateSnapshot });
       if (!decision) {
-        const stopped: AutoAdvanceResult = { kind: "stopped", reason: "no remaining units" };
+        const stopped: AutoAdvanceResult = { kind: "stopped", reason: "no remaining units", stateSnapshot: reconciliation.stateSnapshot };
         this.status.phase = "stopped";
         this.status.activeUnit = undefined;
         this.lastAdvanceKey = null;
@@ -61,6 +76,40 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         return blocked;
       }
 
+      const contract = await this.deps.toolContract.compileUnitToolContract(decision.unitType, decision.unitId);
+      if (!contract.ok) {
+        const blocked: AutoAdvanceResult = {
+          kind: "blocked",
+          reason: contract.reason,
+          stateSnapshot: reconciliation.stateSnapshot,
+        };
+        await this.deps.runtime.journalTransition({
+          name: "advance-blocked",
+          reason: blocked.reason,
+          unitType: decision.unitType,
+          unitId: decision.unitId,
+        });
+        await this.deps.health.postAdvanceRecord(blocked);
+        return blocked;
+      }
+
+      const worktree = await this.deps.worktree.prepareForUnit(decision.unitType, decision.unitId);
+      if (!worktree.ok) {
+        const blocked: AutoAdvanceResult = {
+          kind: "blocked",
+          reason: worktree.reason,
+          stateSnapshot: reconciliation.stateSnapshot,
+        };
+        await this.deps.runtime.journalTransition({
+          name: "advance-blocked",
+          reason: blocked.reason,
+          unitType: decision.unitType,
+          unitId: decision.unitId,
+        });
+        await this.deps.health.postAdvanceRecord(blocked);
+        return blocked;
+      }
+
       this.status.activeUnit = { unitType: decision.unitType, unitId: decision.unitId };
       this.status.phase = "running";
       this.lastAdvanceKey = nextKey;
@@ -72,10 +121,9 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         unitType: decision.unitType,
         unitId: decision.unitId,
       });
-      await this.deps.worktree.prepareForUnit(decision.unitType, decision.unitId);
       await this.deps.worktree.syncAfterUnit(decision.unitType, decision.unitId);
 
-      const advanced: AutoAdvanceResult = { kind: "advanced" };
+      const advanced: AutoAdvanceResult = { kind: "advanced", stateSnapshot: reconciliation.stateSnapshot };
       await this.deps.health.postAdvanceRecord(advanced);
       return advanced;
     } catch (error) {

--- a/src/resources/extensions/gsd/recovery-classification.ts
+++ b/src/resources/extensions/gsd/recovery-classification.ts
@@ -1,0 +1,122 @@
+// Project/App: GSD-2
+// File Purpose: ADR-015 Recovery Classification module for runtime failure taxonomy.
+
+import { classifyError, isTransient, type ErrorClass } from "./error-classifier.js";
+
+export type RecoveryFailureKind =
+  | "tool-schema"
+  | "deterministic-policy"
+  | "stale-worker"
+  | "worktree-invalid"
+  | "verification-drift"
+  | "provider"
+  | "runtime-unknown";
+
+export type RecoveryAction = "retry" | "escalate" | "stop";
+
+export interface RecoveryClassificationInput {
+  error: unknown;
+  unitType?: string;
+  unitId?: string;
+  failureKind?: RecoveryFailureKind;
+  retryAfterMs?: number;
+}
+
+export interface RecoveryClassification {
+  failureKind: RecoveryFailureKind;
+  action: RecoveryAction;
+  reason: string;
+  exitReason: string;
+  remediation: string;
+  providerClass?: ErrorClass["kind"];
+}
+
+export function classifyFailure(input: RecoveryClassificationInput): RecoveryClassification {
+  const message = errorMessage(input.error);
+  const failureKind = input.failureKind ?? inferFailureKind(message);
+
+  switch (failureKind) {
+    case "tool-schema":
+      return {
+        failureKind,
+        action: "stop",
+        reason: `Tool schema failure${unitSuffix(input)}: ${message}`,
+        exitReason: "tool-schema",
+        remediation: "Fix the Unit Tool Contract or tool schema before retrying.",
+      };
+    case "deterministic-policy":
+      return {
+        failureKind,
+        action: "stop",
+        reason: `Deterministic policy failure${unitSuffix(input)}: ${message}`,
+        exitReason: "deterministic-policy",
+        remediation: "Resolve the policy blocker; retrying the same Unit will repeat the failure.",
+      };
+    case "stale-worker":
+      return {
+        failureKind,
+        action: "stop",
+        reason: `Stale worker failure${unitSuffix(input)}: ${message}`,
+        exitReason: "stale-worker",
+        remediation: "Clear or reconcile the stale worker before dispatching another Unit.",
+      };
+    case "worktree-invalid":
+      return {
+        failureKind,
+        action: "stop",
+        reason: `Worktree invalid${unitSuffix(input)}: ${message}`,
+        exitReason: "worktree-invalid",
+        remediation: "Repair or recreate the milestone worktree before launching source-writing Units.",
+      };
+    case "verification-drift":
+      return {
+        failureKind,
+        action: "escalate",
+        reason: `Verification drift${unitSuffix(input)}: ${message}`,
+        exitReason: "verification-drift",
+        remediation: "Inspect the verification artifact and reconcile the state snapshot before resuming.",
+      };
+    case "provider": {
+      const providerClass = classifyError(message, input.retryAfterMs);
+      return {
+        failureKind,
+        action: isTransient(providerClass) ? "retry" : "escalate",
+        reason: message,
+        exitReason: `provider-${providerClass.kind}`,
+        remediation: isTransient(providerClass)
+          ? "Retry after the provider/network condition clears."
+          : "Inspect provider credentials, model entitlement, or request shape.",
+        providerClass: providerClass.kind,
+      };
+    }
+    case "runtime-unknown":
+      return {
+        failureKind,
+        action: "escalate",
+        reason: message,
+        exitReason: "runtime-unknown",
+        remediation: "Inspect the runtime error and add a dedicated classification if it is repeatable.",
+      };
+  }
+}
+
+function inferFailureKind(message: string): RecoveryFailureKind {
+  if (/schema|invalid.*tool|tool.*invalid|enum/i.test(message)) return "tool-schema";
+  if (/deterministic policy|policy rejection|write gate|blocked by policy/i.test(message)) return "deterministic-policy";
+  if (/stale worker|stale lock|worker.*stale/i.test(message)) return "stale-worker";
+  if (/worktree|\.git|unit root|git metadata/i.test(message)) return "worktree-invalid";
+  if (/verification drift|assessment drift|state drift/i.test(message)) return "verification-drift";
+
+  const providerClass = classifyError(message);
+  return providerClass.kind === "unknown" ? "runtime-unknown" : "provider";
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error ?? "unknown runtime failure");
+}
+
+function unitSuffix(input: RecoveryClassificationInput): string {
+  if (!input.unitType && !input.unitId) return "";
+  return ` for ${input.unitType ?? "unit"} ${input.unitId ?? ""}`.trimEnd();
+}

--- a/src/resources/extensions/gsd/state-reconciliation.ts
+++ b/src/resources/extensions/gsd/state-reconciliation.ts
@@ -1,0 +1,57 @@
+// Project/App: GSD-2
+// File Purpose: ADR-015 State Reconciliation module for pre-dispatch runtime invariants.
+
+import { deriveState, invalidateStateCache, type DeriveStateOptions } from "./state.js";
+import type { GSDState } from "./types.js";
+
+export type StateReconciliationResult =
+  | {
+      ok: true;
+      stateSnapshot: GSDState;
+      repaired: readonly string[];
+      blockers: readonly string[];
+    }
+  | {
+      ok: false;
+      reason: string;
+      stateSnapshot?: GSDState;
+      repaired: readonly string[];
+      blockers: readonly string[];
+    };
+
+export interface StateReconciliationDeps {
+  invalidateStateCache: () => void;
+  deriveState: (basePath: string, opts?: DeriveStateOptions) => Promise<GSDState>;
+}
+
+const defaultDeps: StateReconciliationDeps = {
+  invalidateStateCache,
+  deriveState,
+};
+
+export async function reconcileBeforeDispatch(
+  basePath: string,
+  deps: StateReconciliationDeps = defaultDeps,
+  opts?: DeriveStateOptions,
+): Promise<StateReconciliationResult> {
+  deps.invalidateStateCache();
+  const stateSnapshot = await deps.deriveState(basePath, opts);
+  const blockers = stateSnapshot.blockers ?? [];
+
+  if (blockers.length > 0 || stateSnapshot.phase === "blocked") {
+    return {
+      ok: false,
+      reason: blockers[0] ?? `State reconciliation blocked in phase ${stateSnapshot.phase}`,
+      stateSnapshot,
+      repaired: ["derive-state-cache-invalidated"],
+      blockers,
+    };
+  }
+
+  return {
+    ok: true,
+    stateSnapshot,
+    repaired: ["derive-state-cache-invalidated"],
+    blockers,
+  };
+}

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1,17 +1,50 @@
+// Project/App: GSD-2
+// File Purpose: Auto Orchestration module contract and ADR-015 invariant sequence tests.
+
 import test from "node:test";
 import assert from "node:assert/strict";
 
 import { createAutoOrchestrator } from "../auto/orchestrator.js";
 import type { AutoOrchestratorDeps } from "../auto/contracts.js";
+import type { GSDState } from "../types.js";
+
+function makeState(): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Milestone" },
+    activeSlice: null,
+    activeTask: null,
+    phase: "executing",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "Execute task",
+    registry: [],
+    requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+    progress: { milestones: { done: 0, total: 1 } },
+  };
+}
 
 function makeDeps(overrides: Partial<AutoOrchestratorDeps> = {}): { deps: AutoOrchestratorDeps; calls: string[] } {
   const calls: string[] = [];
+  const stateSnapshot = makeState();
 
   const deps: AutoOrchestratorDeps = {
+    stateReconciliation: {
+      async reconcileBeforeDispatch() {
+        calls.push("state.reconcile");
+        return { ok: true, stateSnapshot };
+      },
+    },
     dispatch: {
-      async decideNextUnit() {
+      async decideNextUnit(input) {
         calls.push("dispatch.decide");
+        assert.equal(input.stateSnapshot, stateSnapshot);
         return { unitType: "execute-task", unitId: "T01", reason: "ready", preconditions: [] };
+      },
+    },
+    toolContract: {
+      async compileUnitToolContract() {
+        calls.push("tool.compile");
+        return { ok: true };
       },
     },
     recovery: {
@@ -21,7 +54,10 @@ function makeDeps(overrides: Partial<AutoOrchestratorDeps> = {}): { deps: AutoOr
       },
     },
     worktree: {
-      async prepareForUnit() { calls.push("worktree.prepare"); },
+      async prepareForUnit() {
+        calls.push("worktree.prepare");
+        return { ok: true };
+      },
       async syncAfterUnit() { calls.push("worktree.sync"); },
       async cleanupOnStop() { calls.push("worktree.cleanup"); },
     },
@@ -71,6 +107,87 @@ test("advance() returns blocked when health gate denies", async () => {
 
   assert.equal(result.kind, "blocked");
   assert.equal(result.reason, "doctor-block");
+});
+
+test("advance() follows the ADR-015 invariant sequence before journaling advance", async () => {
+  const { deps, calls } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.advance();
+
+  assert.equal(result.kind, "advanced");
+  assert.deepEqual(calls, [
+    "runtime.lock",
+    "health.pre",
+    "state.reconcile",
+    "dispatch.decide",
+    "tool.compile",
+    "worktree.prepare",
+    "journal:advance",
+    "worktree.sync",
+    "health.post",
+  ]);
+});
+
+test("advance() blocks before dispatch when State Reconciliation blocks", async () => {
+  const { deps, calls } = makeDeps({
+    stateReconciliation: {
+      async reconcileBeforeDispatch() {
+        calls.push("state.reconcile");
+        return { ok: false, reason: "state drift blocked", stateSnapshot: makeState() };
+      },
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.advance();
+
+  assert.equal(result.kind, "blocked");
+  assert.equal(result.reason, "state drift blocked");
+  assert.ok(!calls.includes("dispatch.decide"));
+  assert.ok(calls.includes("journal:advance-blocked"));
+});
+
+test("advance() blocks before Runtime persistence when Tool Contract fails", async () => {
+  const { deps, calls } = makeDeps({
+    toolContract: {
+      async compileUnitToolContract() {
+        calls.push("tool.compile");
+        return { ok: false, reason: "unknown Unit" };
+      },
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.advance();
+
+  assert.equal(result.kind, "blocked");
+  assert.equal(result.reason, "unknown Unit");
+  assert.ok(!calls.includes("worktree.prepare"));
+  assert.ok(!calls.includes("journal:advance"));
+  assert.ok(calls.includes("journal:advance-blocked"));
+});
+
+test("advance() blocks before Runtime persistence when Worktree Safety fails", async () => {
+  const { deps, calls } = makeDeps({
+    worktree: {
+      async prepareForUnit() {
+        calls.push("worktree.prepare");
+        return { ok: false, reason: "worktree invalid" };
+      },
+      async syncAfterUnit() { calls.push("worktree.sync"); },
+      async cleanupOnStop() { calls.push("worktree.cleanup"); },
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.advance();
+
+  assert.equal(result.kind, "blocked");
+  assert.equal(result.reason, "worktree invalid");
+  assert.ok(!calls.includes("journal:advance"));
+  assert.ok(!calls.includes("worktree.sync"));
+  assert.ok(calls.includes("journal:advance-blocked"));
 });
 
 test("advance() stops when dispatch has no next unit", async () => {

--- a/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
@@ -1,0 +1,135 @@
+// Project/App: GSD-2
+// File Purpose: ADR-015 runtime invariant module contract tests.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { classifyFailure } from "../recovery-classification.js";
+import { reconcileBeforeDispatch } from "../state-reconciliation.js";
+import { compileUnitToolContract } from "../tool-contract.js";
+import { prepareUnitRoot } from "../worktree-safety.js";
+import type { GSDState } from "../types.js";
+
+function makeState(overrides: Partial<GSDState> = {}): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Milestone" },
+    activeSlice: null,
+    activeTask: null,
+    phase: "planning",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "Plan milestone",
+    registry: [],
+    requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+    progress: { milestones: { done: 0, total: 1 } },
+    ...overrides,
+  };
+}
+
+test("State Reconciliation invalidates cache and returns reconciled state", async () => {
+  const calls: string[] = [];
+  const state = makeState();
+
+  const result = await reconcileBeforeDispatch("/project", {
+    invalidateStateCache() { calls.push("invalidate"); },
+    async deriveState(basePath) {
+      calls.push(`derive:${basePath}`);
+      return state;
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(calls, ["invalidate", "derive:/project"]);
+  assert.equal(result.ok && result.stateSnapshot, state);
+});
+
+test("State Reconciliation blocks when derived state carries blockers", async () => {
+  const result = await reconcileBeforeDispatch("/project", {
+    invalidateStateCache() {},
+    async deriveState() {
+      return makeState({ phase: "blocked", blockers: ["slice lock missing"] });
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(!result.ok && result.reason, "slice lock missing");
+});
+
+test("Tool Contract compiles known Unit prompt and tool policy", () => {
+  const result = compileUnitToolContract("execute-task");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.contract.unitType, "execute-task");
+  assert.deepEqual(result.ok && result.contract.requiredWorkflowTools, ["gsd_task_complete"]);
+  assert.equal(result.ok && result.contract.toolsPolicy.mode, "all");
+  assert.ok(result.ok && result.contract.validationRules.includes("closeout-tool-present"));
+});
+
+test("Tool Contract fails closed for unknown Units", () => {
+  const result = compileUnitToolContract("custom-step");
+
+  assert.equal(result.ok, false);
+  assert.equal(!result.ok && result.reason, "unknown-unit-type");
+});
+
+test("Worktree Safety validates source-writing Unit root git metadata", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-worktree-safety-"));
+  writeFileSync(join(root, ".git"), "gitdir: /tmp/worktrees/M001\n");
+  try {
+    const result = prepareUnitRoot("execute-task", "M001/S01/T01", { basePath: root });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ok && result.sourceWriting, true);
+    assert.equal(result.ok && result.reason, "source-writing-root-valid");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Worktree Safety fails closed when source-writing root lacks git metadata", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-worktree-safety-"));
+  try {
+    const result = prepareUnitRoot("execute-task", "M001/S01/T01", { basePath: root });
+
+    assert.equal(result.ok, false);
+    assert.equal(!result.ok && result.reason, "git-metadata-missing");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Worktree Safety does not require git metadata for planning Units", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-worktree-safety-"));
+  try {
+    mkdirSync(join(root, "nested"));
+    const result = prepareUnitRoot("plan-slice", "M001/S01", { basePath: join(root, "nested") });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.ok && result.sourceWriting, false);
+    assert.equal(result.ok && result.reason, "non-source-writing-root");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Recovery Classification covers ADR-015 failure families", () => {
+  const cases = [
+    ["invalid tool schema enum", "tool-schema", "stop"],
+    ["deterministic policy rejection", "deterministic-policy", "stop"],
+    ["stale worker lease", "stale-worker", "stop"],
+    ["worktree root missing .git", "worktree-invalid", "stop"],
+    ["verification drift in state snapshot", "verification-drift", "escalate"],
+    ["rate limit 429", "provider", "retry"],
+    ["unexpected invariant", "runtime-unknown", "escalate"],
+  ] as const;
+
+  for (const [message, failureKind, action] of cases) {
+    const result = classifyFailure({ error: new Error(message), unitType: "execute-task", unitId: "T01" });
+
+    assert.equal(result.failureKind, failureKind);
+    assert.equal(result.action, action);
+  }
+});

--- a/src/resources/extensions/gsd/tool-contract.ts
+++ b/src/resources/extensions/gsd/tool-contract.ts
@@ -1,0 +1,82 @@
+// Project/App: GSD-2
+// File Purpose: ADR-015 Tool Contract module for Unit prompt, policy, and tool parity.
+
+import {
+  resolveManifest,
+  type ArtifactKey,
+  type ContextModePolicy,
+  type ToolsPolicy,
+} from "./unit-context-manifest.js";
+import { getRequiredWorkflowToolsForAutoUnit } from "./workflow-mcp.js";
+
+export interface UnitToolContract {
+  unitType: string;
+  contextMode: ContextModePolicy;
+  toolsPolicy: ToolsPolicy;
+  requiredWorkflowTools: readonly string[];
+  promptObligations: readonly string[];
+  validationRules: readonly string[];
+  closeoutTools: readonly string[];
+  artifacts: {
+    inline: readonly ArtifactKey[];
+    excerpt: readonly ArtifactKey[];
+    onDemand: readonly ArtifactKey[];
+  };
+}
+
+export type ToolContractResult =
+  | { ok: true; contract: UnitToolContract }
+  | { ok: false; reason: "unknown-unit-type" | "missing-closeout-tool"; detail: string };
+
+export function compileUnitToolContract(unitType: string): ToolContractResult {
+  const manifest = resolveManifest(unitType);
+  if (!manifest) {
+    return {
+      ok: false,
+      reason: "unknown-unit-type",
+      detail: `No Unit manifest is registered for ${unitType}`,
+    };
+  }
+
+  const requiredWorkflowTools = getRequiredWorkflowToolsForAutoUnit(unitType);
+  const closeoutTools = requiredWorkflowTools.filter((tool) =>
+    /^gsd_(?:task|slice|milestone|complete|validate|save|summary)/.test(tool),
+  );
+
+  if (requiresCloseoutTool(unitType) && closeoutTools.length === 0) {
+    return {
+      ok: false,
+      reason: "missing-closeout-tool",
+      detail: `${unitType} has no closeout workflow tool`,
+    };
+  }
+
+  return {
+    ok: true,
+    contract: {
+      unitType,
+      contextMode: manifest.contextMode,
+      toolsPolicy: manifest.tools,
+      requiredWorkflowTools,
+      promptObligations: [
+        `context-mode:${manifest.contextMode}`,
+        `tools-policy:${manifest.tools.mode}`,
+      ],
+      validationRules: [
+        "unit-manifest-present",
+        "workflow-tool-surface-present",
+        ...(requiresCloseoutTool(unitType) ? ["closeout-tool-present"] : []),
+      ],
+      closeoutTools,
+      artifacts: {
+        inline: manifest.artifacts.inline,
+        excerpt: manifest.artifacts.excerpt,
+        onDemand: manifest.artifacts.onDemand,
+      },
+    },
+  };
+}
+
+function requiresCloseoutTool(unitType: string): boolean {
+  return /^(execute-task|reactive-execute|complete-slice|validate-milestone|complete-milestone|run-uat|gate-evaluate)$/.test(unitType);
+}

--- a/src/resources/extensions/gsd/worktree-safety.ts
+++ b/src/resources/extensions/gsd/worktree-safety.ts
@@ -1,0 +1,97 @@
+// Project/App: GSD-2
+// File Purpose: ADR-015 Worktree Safety module for pre-dispatch Unit root validation.
+
+import { existsSync as nodeExistsSync, statSync as nodeStatSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { resolveManifest } from "./unit-context-manifest.js";
+
+export type WorktreeSafetyResult =
+  | {
+      ok: true;
+      root: string;
+      sourceWriting: boolean;
+      reason: "source-writing-root-valid" | "non-source-writing-root";
+    }
+  | {
+      ok: false;
+      reason: "unknown-unit-type" | "root-missing" | "git-metadata-missing" | "root-not-directory";
+      detail: string;
+      root: string;
+      sourceWriting: boolean;
+    };
+
+export interface WorktreeSafetyContext {
+  basePath: string;
+  env?: NodeJS.ProcessEnv;
+  existsSync?: (path: string) => boolean;
+  statSync?: typeof nodeStatSync;
+}
+
+export function prepareUnitRoot(
+  unitType: string,
+  _unitId: string,
+  context: WorktreeSafetyContext,
+): WorktreeSafetyResult {
+  const manifest = resolveManifest(unitType);
+  if (!manifest) {
+    return {
+      ok: false,
+      reason: "unknown-unit-type",
+      detail: `No Unit manifest is registered for ${unitType}`,
+      root: resolve(context.basePath),
+      sourceWriting: true,
+    };
+  }
+
+  const sourceWriting = manifest.tools.mode === "all" || manifest.tools.mode === "docs";
+  const root = resolve(context.env?.GSD_UNIT_ROOT ?? context.basePath);
+  if (!sourceWriting) {
+    return { ok: true, root, sourceWriting, reason: "non-source-writing-root" };
+  }
+
+  const existsSync = context.existsSync ?? nodeExistsSync;
+  const statSync = context.statSync ?? nodeStatSync;
+  if (!existsSync(root)) {
+    return {
+      ok: false,
+      reason: "root-missing",
+      detail: `Source-writing Unit root does not exist: ${root}`,
+      root,
+      sourceWriting,
+    };
+  }
+
+  try {
+    if (!statSync(root).isDirectory()) {
+      return {
+        ok: false,
+        reason: "root-not-directory",
+        detail: `Source-writing Unit root is not a directory: ${root}`,
+        root,
+        sourceWriting,
+      };
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "root-not-directory",
+      detail: `Source-writing Unit root could not be inspected: ${error instanceof Error ? error.message : String(error)}`,
+      root,
+      sourceWriting,
+    };
+  }
+
+  const gitPath = join(root, ".git");
+  if (!existsSync(gitPath)) {
+    return {
+      ok: false,
+      reason: "git-metadata-missing",
+      detail: `Source-writing Unit root is missing git metadata: ${gitPath}`,
+      root,
+      sourceWriting,
+    };
+  }
+
+  return { ok: true, root, sourceWriting, reason: "source-writing-root-valid" };
+}


### PR DESCRIPTION
## TL;DR

**What:** Implements ADR-015 runtime invariant Modules for Auto Orchestration.
**Why:** `advance()` needs to own the pre-dispatch invariant sequence instead of hiding state repair, tool policy, worktree validation, and recovery classification behind Dispatch.
**How:** Adds State Reconciliation, Tool Contract, Worktree Safety, and Recovery Classification Modules, wires them into the Auto Orchestration adapter sequence, and adds direct contract tests.

## What

This PR adds four first-class runtime invariant Modules:

- State Reconciliation: `reconcileBeforeDispatch(basePath)` invalidates derived-state cache and returns a reconciled state snapshot or blockers.
- Tool Contract: `compileUnitToolContract(unitType)` compiles manifest/tool-policy/workflow-tool obligations before persistence.
- Worktree Safety: `prepareUnitRoot(unitType, unitId)` validates source-writing Unit roots fail closed when missing git metadata.
- Recovery Classification: `classifyFailure(input)` normalizes provider, tool-schema, deterministic-policy, stale-worker, worktree-invalid, verification-drift, and unknown runtime failures.

It also updates Auto Orchestration so `advance()` runs the ADR-015 sequence explicitly:

1. State Reconciliation
2. Dispatch decision
3. Tool Contract
4. Worktree Safety
5. Runtime persistence/journal

Closes #5606
Closes #5607
Closes #5608
Closes #5609
Closes #5610

## Why

ADR-015 accepted these Modules because the same runtime invariants were being checked late or hidden in shallow adapters. Keeping the sequence visible in `advance()` improves locality: Dispatch selects a Unit from reconciled state; invariant Modules own their own policies; Runtime persistence happens only after the selected Unit passes contract and root checks.

## How

The implementation keeps the change conservative and extension-local. Each Module wraps existing source-of-truth surfaces instead of replacing the legacy auto loop:

- State Reconciliation delegates to `deriveState` after invalidating the derive cache.
- Tool Contract delegates to `unit-context-manifest` and `workflow-mcp` required tool metadata.
- Worktree Safety delegates source-writing detection to the manifest tool policy and validates the resolved root.
- Recovery Classification reuses the existing provider `error-classifier` and adds ADR-015 failure family mapping.

Tests cover direct Module behavior plus Auto Orchestration order and short-circuit behavior.

AI-assisted: yes.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-orchestrator.test.ts src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts`
- [x] `npm run build:core`
- [x] `npm run typecheck:extensions`
- [x] `npm run test:unit` — 8949 passed, 0 failed, 9 skipped
- [x] `npm run verify:pr` — 8949 passed, 0 failed, 9 skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Strengthened auto-orchestration with enhanced state reconciliation and validation checks before operations
  * Improved error classification and recovery workflows for better system resilience

* **Tests**
  * Expanded test coverage for orchestration workflows, invariant validation, and failure recovery scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5615)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->