### PR TITLE
[codex] Fix auto-mode session-transition abort handling

### DIFF
--- a/docs/dev/extending-pi/07-events-the-nervous-system.md
+++ b/docs/dev/extending-pi/07-events-the-nervous-system.md
@@ -32,6 +32,13 @@ Events are the core of the extension system. They fall into five categories:
 | `context` | Before each LLM call | `{ messages: [...] }` (modified copy) |
 | `message_start/update/end` | Message lifecycle | — |
 
+Agent lifecycle, turn, and message events may include optional `sessionId` and
+`turnId` fields for correlating events from the same session turn. `agent_end`
+and `stop` may also include `abortOrigin`, one of `"session-transition"`,
+`"user"`, `"timeout"`, or `"unknown"`. Treat `"session-transition"` as internal
+session-control flow rather than a user/provider failure when settling work from
+`agent_end`.
+
 ### 7.3 Tool Events
 
 | Event | When | Can Return |

--- a/docs/extension-sdk/api-reference.md
+++ b/docs/extension-sdk/api-reference.md
@@ -296,6 +296,25 @@ Configuration for `pi.registerProvider()`.
 
 All events are subscribed via `pi.on(eventName, handler)`. Handlers receive `(event, ctx: ExtensionContext)` unless noted otherwise.
 
+### Agent Event Metadata
+
+Agent lifecycle events carry optional correlation metadata when the current provider/session can supply it:
+
+| Field | Type | Events | Description |
+|-------|------|--------|-------------|
+| `sessionId` | `string` | `agent_start`, `agent_end`, `stop`, `turn_start`, `turn_end`, `message_start`, `message_update`, `message_end` | Current session identifier. Treat as optional for compatibility with older emitters and synthetic events. |
+| `turnId` | `string` | `agent_start`, `agent_end`, `stop`, `turn_start`, `turn_end`, `message_start`, `message_update`, `message_end` | Correlates events emitted for the same agent turn. Treat as optional. |
+| `abortOrigin` | `"session-transition" \| "user" \| "timeout" \| "unknown"` | `agent_end`, `stop` | Present when the agent loop ended because an abort was observed. |
+
+`abortOrigin` lets consumers distinguish user-visible cancellation from internal control flow:
+
+| Value | Meaning |
+|-------|---------|
+| `"session-transition"` | Internal abort used while switching, forking, or creating sessions. Extensions that settle work from `agent_end` should usually ignore this origin for the active unit/session. |
+| `"user"` | User-initiated cancellation, such as Escape, RPC `abort`, or `ctx.abort()`. |
+| `"timeout"` | Timeout-driven cancellation. |
+| `"unknown"` | Abort was observed but the caller did not provide a more specific origin. |
+
 ### Session Events
 
 | Event | Type | Return Type | Description |
@@ -325,10 +344,11 @@ All events are subscribed via `pi.on(eventName, handler)`. Handlers receive `(ev
 | Event | Type | Return Type | Description |
 |-------|------|-------------|-------------|
 | `before_agent_start` | `BeforeAgentStartEvent` | `BeforeAgentStartEventResult` | After user submits prompt, before agent loop. Can inject system prompt or message. |
-| `agent_start` | `AgentStartEvent` | — | Agent loop started |
-| `agent_end` | `AgentEndEvent` | — | Agent loop ended. Includes `messages` array. |
-| `turn_start` | `TurnStartEvent` | — | Start of each turn. Includes `turnIndex` and `timestamp`. |
-| `turn_end` | `TurnEndEvent` | — | End of each turn. Includes `turnIndex`, `message`, and `toolResults`. |
+| `agent_start` | `AgentStartEvent` | — | Agent loop started. May include `sessionId` and `turnId`. |
+| `agent_end` | `AgentEndEvent` | — | Agent loop ended. Includes `messages`; may include `sessionId`, `turnId`, and `abortOrigin`. |
+| `stop` | `StopEvent` | — | Agent is truly idle with no follow-up or steering pending. May include `sessionId`, `turnId`, and `abortOrigin`. |
+| `turn_start` | `TurnStartEvent` | — | Start of each turn. Includes `turnIndex` and `timestamp`; may include `sessionId` and `turnId`. |
+| `turn_end` | `TurnEndEvent` | — | End of each turn. Includes `turnIndex`, `message`, and `toolResults`; may include `sessionId` and `turnId`. |
 | `context` | `ContextEvent` | `ContextEventResult` | Before each LLM call. Can modify `messages` array. |
 | `before_provider_request` | `BeforeProviderRequestEvent` | `unknown` | Before provider request is sent. Can replace the payload. |
 
@@ -336,9 +356,9 @@ All events are subscribed via `pi.on(eventName, handler)`. Handlers receive `(ev
 
 | Event | Type | Return Type | Description |
 |-------|------|-------------|-------------|
-| `message_start` | `MessageStartEvent` | — | A message started (user, assistant, or toolResult) |
-| `message_update` | `MessageUpdateEvent` | — | Token-by-token streaming updates during assistant message |
-| `message_end` | `MessageEndEvent` | — | A message ended |
+| `message_start` | `MessageStartEvent` | — | A message started (user, assistant, or toolResult). May include `sessionId` and `turnId`. |
+| `message_update` | `MessageUpdateEvent` | — | Token-by-token streaming updates during assistant message. May include `sessionId` and `turnId`. |
+| `message_end` | `MessageEndEvent` | — | A message ended. May include `sessionId` and `turnId`. |
 
 ### Tool Events
 
@@ -419,5 +439,6 @@ if (isToolResultEventType<"my_tool", MyDetails>("my_tool", event)) {
 | `ProviderConfig` | `@gsd/pi-coding-agent` | Provider registration config |
 | `ExtensionFactory` | `@gsd/pi-coding-agent` | `(pi: ExtensionAPI) => void \| Promise<void>` |
 | `ContextUsage` | `@gsd/pi-coding-agent` | `{ tokens, contextWindow, percent }` |
+| `AgentAbortOrigin` | `@gsd/pi-agent-core` | `"session-transition" \| "user" \| "timeout" \| "unknown"` |
 | `ThinkingLevel` | `@gsd/pi-agent-core` | `"off" \| "low" \| "medium" \| "high" \| "xhigh"` |
 | `TSchema` | `@sinclair/typebox` | TypeBox schema type for tool parameters |

--- a/docs/extension-sdk/api-reference.md
+++ b/docs/extension-sdk/api-reference.md
@@ -302,8 +302,8 @@ Agent lifecycle events carry optional correlation metadata when the current prov
 
 | Field | Type | Events | Description |
 |-------|------|--------|-------------|
-| `sessionId` | `string` | `agent_start`, `agent_end`, `stop`, `turn_start`, `turn_end`, `message_start`, `message_update`, `message_end` | Current session identifier. Treat as optional for compatibility with older emitters and synthetic events. |
-| `turnId` | `string` | `agent_start`, `agent_end`, `stop`, `turn_start`, `turn_end`, `message_start`, `message_update`, `message_end` | Correlates events emitted for the same agent turn. Treat as optional. |
+| `sessionId` | `string` | `agent_start`, `agent_end`, `stop`, `turn_start`, `turn_end`, `message_start`, `message_update`, `message_end`, `tool_execution_start`, `tool_execution_update`, `tool_execution_end` | Current session identifier. Treat as optional for compatibility with older emitters and synthetic events. |
+| `turnId` | `string` | `agent_start`, `agent_end`, `stop`, `turn_start`, `turn_end`, `message_start`, `message_update`, `message_end`, `tool_execution_start`, `tool_execution_update`, `tool_execution_end` | Correlates events emitted for the same agent turn. Treat as optional. |
 | `abortOrigin` | `"session-transition" \| "user" \| "timeout" \| "unknown"` | `agent_end`, `stop` | Present when the agent loop ended because an abort was observed. |
 
 `abortOrigin` lets consumers distinguish user-visible cancellation from internal control flow:
@@ -366,9 +366,9 @@ Agent lifecycle events carry optional correlation metadata when the current prov
 |-------|------|-------------|-------------|
 | `tool_call` | `ToolCallEvent` | `ToolCallEventResult` | Before a tool executes. Return `{ block: true, reason? }` to block. |
 | `tool_result` | `ToolResultEvent` | `ToolResultEventResult` | After a tool executes. Can modify `content`, `details`, or `isError`. |
-| `tool_execution_start` | `ToolExecutionStartEvent` | — | Tool started executing |
-| `tool_execution_update` | `ToolExecutionUpdateEvent` | — | Tool streaming/partial output |
-| `tool_execution_end` | `ToolExecutionEndEvent` | — | Tool finished executing |
+| `tool_execution_start` | `ToolExecutionStartEvent` | — | Tool started executing. May include `sessionId` and `turnId`. |
+| `tool_execution_update` | `ToolExecutionUpdateEvent` | — | Tool streaming/partial output. May include `sessionId` and `turnId`. |
+| `tool_execution_end` | `ToolExecutionEndEvent` | — | Tool finished executing. May include `sessionId` and `turnId`. |
 
 `ToolCallEvent` is a discriminated union by `toolName`. Use `isToolCallEventType()` and `isToolResultEventType()` type guards for narrowing:
 

--- a/packages/pi-agent-core/src/agent.ts
+++ b/packages/pi-agent-core/src/agent.ts
@@ -14,9 +14,11 @@ import {
 	type ThinkingBudgets,
 	type Transport,
 } from "@gsd/pi-ai";
+import { randomUUID } from "crypto";
 import { agentLoop, agentLoopContinue, ZERO_USAGE } from "./agent-loop.js";
 import type {
 	AgentContext,
+	AgentAbortOrigin,
 	AgentEvent,
 	AgentLoopConfig,
 	AgentMessage,
@@ -147,6 +149,7 @@ export class Agent {
 
 	private listeners = new Set<(e: AgentEvent) => void>();
 	private abortController?: AbortController;
+	private abortOrigin?: AgentAbortOrigin;
 	private convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	private transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
 	private filterTools?: AgentLoopConfig["filterTools"];
@@ -389,7 +392,8 @@ export class Agent {
 		this._state.messages = [];
 	}
 
-	abort() {
+	abort(origin: AgentAbortOrigin = "unknown") {
+		this.abortOrigin = origin;
 		this.abortController?.abort();
 	}
 
@@ -483,6 +487,8 @@ export class Agent {
 		const model = this._state.model;
 		if (!model) throw new Error("No model configured");
 
+		const turnId = randomUUID();
+		const sessionId = this._sessionId;
 		this._state.activeInferenceModel = model;
 
 		this.runningPrompt = new Promise<void>((resolve) => {
@@ -539,31 +545,32 @@ export class Agent {
 				: agentLoopContinue(context, config, this.abortController.signal, this.streamFn);
 
 			for await (const event of stream) {
+				const stampedEvent = this.stampEvent(event, sessionId, turnId);
 				// Update internal state based on events
-				switch (event.type) {
+				switch (stampedEvent.type) {
 					case "message_start":
 					case "message_update":
-						partial = event.message;
-						this._state.streamMessage = event.message;
+						partial = stampedEvent.message;
+						this._state.streamMessage = stampedEvent.message;
 						break;
 
 					case "message_end":
 						partial = null;
 						this._state.streamMessage = null;
-						this.appendMessage(event.message);
+						this.appendMessage(stampedEvent.message);
 						break;
 
 					case "tool_execution_start":
-						this._updatePendingToolCalls("add", event.toolCallId);
+						this._updatePendingToolCalls("add", stampedEvent.toolCallId);
 						break;
 
 					case "tool_execution_end":
-						this._updatePendingToolCalls("delete", event.toolCallId);
+						this._updatePendingToolCalls("delete", stampedEvent.toolCallId);
 						break;
 
 					case "turn_end":
-						if (event.message.role === "assistant" && (event.message as any).errorMessage) {
-							this._state.error = (event.message as any).errorMessage;
+						if (stampedEvent.message.role === "assistant" && (stampedEvent.message as any).errorMessage) {
+							this._state.error = (stampedEvent.message as any).errorMessage;
 						}
 						break;
 
@@ -574,7 +581,7 @@ export class Agent {
 				}
 
 				// Emit to listeners
-				this.emit(event);
+				this.emit(stampedEvent);
 			}
 
 			// Handle any remaining partial message
@@ -608,16 +615,42 @@ export class Agent {
 
 			this.appendMessage(errorMsg);
 			this._state.error = err?.message || String(err);
-			this.emit({ type: "agent_end", messages: [errorMsg] });
+			const agentEndEvent: AgentEvent = {
+				type: "agent_end",
+				messages: [errorMsg],
+				sessionId,
+				turnId,
+			};
+			if (this.abortController?.signal.aborted) {
+				agentEndEvent.abortOrigin = this.abortOrigin ?? "unknown";
+			}
+			this.emit(agentEndEvent);
 		} finally {
 			this._state.isStreaming = false;
 			this._state.streamMessage = null;
 			this._state.pendingToolCalls = new Set<string>();
 			this._state.activeInferenceModel = undefined;
+			this.abortOrigin = undefined;
 			this.abortController = undefined;
 			this.resolveRunningPrompt?.();
 			this.runningPrompt = undefined;
 			this.resolveRunningPrompt = undefined;
+		}
+	}
+
+	private stampEvent(event: AgentEvent, sessionId: string | undefined, turnId: string): AgentEvent {
+		switch (event.type) {
+			case "agent_start":
+			case "agent_end":
+			case "turn_start":
+			case "turn_end":
+			case "message_start":
+			case "message_update":
+			case "message_end":
+			case "tool_execution_start":
+			case "tool_execution_update":
+			case "tool_execution_end":
+				return { ...event, sessionId, turnId };
 		}
 	}
 

--- a/packages/pi-agent-core/src/types.ts
+++ b/packages/pi-agent-core/src/types.ts
@@ -334,23 +334,25 @@ export interface AgentContext {
 	tools?: AgentTool<any>[];
 }
 
+export type AgentAbortOrigin = "session-transition" | "user" | "timeout" | "unknown";
+
 /**
  * Events emitted by the Agent for UI updates.
  * These events provide fine-grained lifecycle information for messages, turns, and tool executions.
  */
 export type AgentEvent =
 	// Agent lifecycle
-	| { type: "agent_start" }
-	| { type: "agent_end"; messages: AgentMessage[] }
+	| { type: "agent_start"; sessionId?: string; turnId?: string }
+	| { type: "agent_end"; messages: AgentMessage[]; sessionId?: string; turnId?: string; abortOrigin?: AgentAbortOrigin }
 	// Turn lifecycle - a turn is one assistant response + any tool calls/results
-	| { type: "turn_start" }
-	| { type: "turn_end"; message: AgentMessage; toolResults: ToolResultMessage[] }
+	| { type: "turn_start"; sessionId?: string; turnId?: string }
+	| { type: "turn_end"; message: AgentMessage; toolResults: ToolResultMessage[]; sessionId?: string; turnId?: string }
 	// Message lifecycle - emitted for user, assistant, and toolResult messages
-	| { type: "message_start"; message: AgentMessage }
+	| { type: "message_start"; message: AgentMessage; sessionId?: string; turnId?: string }
 	// Only emitted for assistant messages during streaming
-	| { type: "message_update"; message: AgentMessage; assistantMessageEvent: AssistantMessageEvent }
-	| { type: "message_end"; message: AgentMessage }
+	| { type: "message_update"; message: AgentMessage; assistantMessageEvent: AssistantMessageEvent; sessionId?: string; turnId?: string }
+	| { type: "message_end"; message: AgentMessage; sessionId?: string; turnId?: string }
 	// Tool execution lifecycle
-	| { type: "tool_execution_start"; toolCallId: string; toolName: string; args: any }
-	| { type: "tool_execution_update"; toolCallId: string; toolName: string; args: any; partialResult: any }
-	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError: boolean };
+	| { type: "tool_execution_start"; toolCallId: string; toolName: string; args: any; sessionId?: string; turnId?: string }
+	| { type: "tool_execution_update"; toolCallId: string; toolName: string; args: any; partialResult: any; sessionId?: string; turnId?: string }
+	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError: boolean; sessionId?: string; turnId?: string };

--- a/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
@@ -235,6 +235,7 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 	it("abort() marks synthetic agent_end processing while extension handlers run", async () => {
 		const session = await createSession();
 		const observedProcessingStates: boolean[] = [];
+		const observedOrigins: unknown[] = [];
 
 		(session as any).agent.abort = () => {};
 		(session as any).agent.waitForIdle = async () => {};
@@ -242,6 +243,7 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 			emit: async (event: any) => {
 				if (event.type === "agent_end") {
 					observedProcessingStates.push((session as any)._processingAgentEnd);
+					observedOrigins.push(event.abortOrigin);
 				}
 			},
 			emitStop: async () => {
@@ -249,9 +251,10 @@ describe("#4243 — abort() must run before _disconnectFromAgent()", () => {
 			},
 		};
 
-		await session.abort();
+		await session.abort({ origin: "session-transition" });
 
 		assert.deepEqual(observedProcessingStates, [true, true]);
+		assert.deepEqual(observedOrigins, ["session-transition"]);
 		assert.equal((session as any)._processingAgentEnd, false);
 	});
 

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -17,6 +17,7 @@ import { readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import type {
 	Agent,
+	AgentAbortOrigin,
 	AgentEvent,
 	AgentMessage,
 	AgentState,
@@ -350,7 +351,7 @@ export class AgentSession {
 			emit: (event) => this._emit(event),
 			disconnectFromAgent: () => this._disconnectFromAgent(),
 			reconnectToAgent: () => this._reconnectToAgent(),
-			abort: () => this.abort(),
+			abort: () => this.abort({ origin: "user" }),
 		});
 
 		// Always subscribe to agent events for internal handling
@@ -657,11 +658,21 @@ export class AgentSession {
 
 		if (event.type === "agent_start") {
 			this._turnIndex = 0;
-			await extensionRunner.emit({ type: "agent_start" });
+			await extensionRunner.emit({
+				type: "agent_start",
+				sessionId: event.sessionId,
+				turnId: event.turnId,
+			});
 		} else if (event.type === "agent_end") {
 			this._processingAgentEnd = true;
 			try {
-				await extensionRunner.emit({ type: "agent_end", messages: event.messages });
+				await extensionRunner.emit({
+					type: "agent_end",
+					messages: event.messages,
+					sessionId: event.sessionId,
+					turnId: event.turnId,
+					abortOrigin: event.abortOrigin,
+				});
 				// `stop` fires on true quiescence: the agent cleanly completed and is now
 				// waiting for the user. Use the last assistant message's stopReason to
 				// distinguish clean completion from error/cancellation.
@@ -674,7 +685,13 @@ export class AgentSession {
 								? "error"
 								: "completed"
 						: "completed";
-				await extensionRunner.emitStop({ reason: stopReason, lastMessage: last });
+				await extensionRunner.emitStop({
+					reason: stopReason,
+					lastMessage: last,
+					sessionId: event.sessionId,
+					turnId: event.turnId,
+					abortOrigin: event.abortOrigin,
+				});
 			} finally {
 				this._processingAgentEnd = false;
 			}
@@ -683,6 +700,8 @@ export class AgentSession {
 				type: "turn_start",
 				turnIndex: this._turnIndex,
 				timestamp: Date.now(),
+				sessionId: event.sessionId,
+				turnId: event.turnId,
 			};
 			await extensionRunner.emit(extensionEvent);
 		} else if (event.type === "turn_end") {
@@ -691,6 +710,8 @@ export class AgentSession {
 				turnIndex: this._turnIndex,
 				message: event.message,
 				toolResults: event.toolResults,
+				sessionId: event.sessionId,
+				turnId: event.turnId,
 			};
 			await extensionRunner.emit(extensionEvent);
 			this._turnIndex++;
@@ -698,6 +719,8 @@ export class AgentSession {
 			const extensionEvent: MessageStartEvent = {
 				type: "message_start",
 				message: event.message,
+				sessionId: event.sessionId,
+				turnId: event.turnId,
 			};
 			await extensionRunner.emit(extensionEvent);
 		} else if (event.type === "message_update") {
@@ -705,12 +728,16 @@ export class AgentSession {
 				type: "message_update",
 				message: event.message,
 				assistantMessageEvent: event.assistantMessageEvent,
+				sessionId: event.sessionId,
+				turnId: event.turnId,
 			};
 			await extensionRunner.emit(extensionEvent);
 		} else if (event.type === "message_end") {
 			const extensionEvent: MessageEndEvent = {
 				type: "message_end",
 				message: event.message,
+				sessionId: event.sessionId,
+				turnId: event.turnId,
 			};
 			await extensionRunner.emit(extensionEvent);
 		} else if (event.type === "tool_execution_start") {
@@ -1596,9 +1623,9 @@ export class AgentSession {
 	/**
 	 * Abort current operation and wait for agent to become idle.
 	 */
-	async abort(): Promise<void> {
+	async abort(options?: { origin?: AgentAbortOrigin }): Promise<void> {
 		this._retryHandler.abortRetry();
-		this.agent.abort();
+		this.agent.abort(options?.origin);
 		await this.agent.waitForIdle();
 		// Ensure agent_end is emitted even when abort interrupts a tool call (#1414).
 		// The agent may go idle without emitting agent_end if the abort happens
@@ -1612,6 +1639,8 @@ export class AgentSession {
 				await this._extensionRunner.emit({
 					type: "agent_end",
 					messages,
+					sessionId: this.sessionId,
+					abortOrigin: options?.origin,
 				});
 				const last = messages[messages.length - 1];
 				const stopReason: "completed" | "cancelled" | "error" | "blocked" =
@@ -1622,7 +1651,12 @@ export class AgentSession {
 								? "error"
 								: "completed"
 						: "cancelled";
-				await this._extensionRunner.emitStop({ reason: stopReason, lastMessage: last });
+				await this._extensionRunner.emitStop({
+					reason: stopReason,
+					lastMessage: last,
+					sessionId: this.sessionId,
+					abortOrigin: options?.origin,
+				});
 			} finally {
 				this._processingAgentEnd = wasProcessingAgentEnd;
 			}
@@ -1655,7 +1689,7 @@ export class AgentSession {
 			await this.agent.waitForIdle();
 			return;
 		}
-		await this.abort();
+		await this.abort({ origin: "session-transition" });
 	}
 
 	/**
@@ -2229,7 +2263,7 @@ export class AgentSession {
 			{
 				getModel: () => this.model,
 				isIdle: () => !this.isStreaming,
-				abort: () => this.abort(),
+				abort: () => this.abort({ origin: "user" }),
 				hasPendingMessages: () => this.pendingMessageCount > 0,
 				shutdown: () => {
 					this._extensionShutdownHandler?.();

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -9,6 +9,7 @@
  */
 
 import type {
+	AgentAbortOrigin,
 	AgentMessage,
 	AgentToolResult,
 	AgentToolUpdateCallback,
@@ -561,12 +562,17 @@ export interface BeforeAgentStartEvent {
 /** Fired when an agent loop starts */
 export interface AgentStartEvent {
 	type: "agent_start";
+	sessionId?: string;
+	turnId?: string;
 }
 
 /** Fired when an agent loop ends */
 export interface AgentEndEvent {
 	type: "agent_end";
 	messages: AgentMessage[];
+	sessionId?: string;
+	turnId?: string;
+	abortOrigin?: AgentAbortOrigin;
 }
 
 /**
@@ -578,6 +584,9 @@ export interface StopEvent {
 	type: "stop";
 	reason: "completed" | "cancelled" | "error" | "blocked";
 	lastMessage?: AgentMessage;
+	sessionId?: string;
+	turnId?: string;
+	abortOrigin?: AgentAbortOrigin;
 }
 
 /**
@@ -767,6 +776,8 @@ export interface TurnStartEvent {
 	type: "turn_start";
 	turnIndex: number;
 	timestamp: number;
+	sessionId?: string;
+	turnId?: string;
 }
 
 /** Fired at the end of each turn */
@@ -775,12 +786,16 @@ export interface TurnEndEvent {
 	turnIndex: number;
 	message: AgentMessage;
 	toolResults: ToolResultMessage[];
+	sessionId?: string;
+	turnId?: string;
 }
 
 /** Fired when a message starts (user, assistant, or toolResult) */
 export interface MessageStartEvent {
 	type: "message_start";
 	message: AgentMessage;
+	sessionId?: string;
+	turnId?: string;
 }
 
 /** Fired during assistant message streaming with token-by-token updates */
@@ -788,12 +803,16 @@ export interface MessageUpdateEvent {
 	type: "message_update";
 	message: AgentMessage;
 	assistantMessageEvent: AssistantMessageEvent;
+	sessionId?: string;
+	turnId?: string;
 }
 
 /** Fired when a message ends */
 export interface MessageEndEvent {
 	type: "message_end";
 	message: AgentMessage;
+	sessionId?: string;
+	turnId?: string;
 }
 
 /** Fired when a tool starts executing */

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1372,7 +1372,7 @@ export class InteractiveMode {
 			modelRegistry: this.session.modelRegistry,
 			model: this.session.model,
 			isIdle: () => !this.session.isStreaming,
-			abort: () => this.session.abort(),
+				abort: () => this.session.abort({ origin: "user" }),
 			hasPendingMessages: () => this.session.pendingMessageCount > 0,
 			shutdown: () => {
 				this.shutdownRequested = true;
@@ -3037,7 +3037,7 @@ export class InteractiveMode {
 		if (allQueued.length === 0) {
 			this.updatePendingMessagesDisplay();
 			if (options?.abort) {
-				this.agent.abort();
+					this.agent.abort("user");
 			}
 			return 0;
 		}
@@ -3047,7 +3047,7 @@ export class InteractiveMode {
 		this.editor.setText(combinedText);
 		this.updatePendingMessagesDisplay();
 		if (options?.abort) {
-			this.agent.abort();
+				this.agent.abort("user");
 		}
 		return allQueued.length;
 	}

--- a/packages/pi-coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/pi-coding-agent/src/modes/rpc/rpc-mode.ts
@@ -533,7 +533,7 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			}
 
 			case "abort": {
-				await session.abort();
+					await session.abort({ origin: "user" });
 				return success(id, "abort");
 			}
 

--- a/packages/rpc-client/README.md
+++ b/packages/rpc-client/README.md
@@ -78,6 +78,13 @@ const unsubscribe = client.onEvent((event) => {
 });
 ```
 
+Agent events are delivered as `SdkAgentEvent` records. Lifecycle, turn, message,
+and tool-execution events may include optional `sessionId` and `turnId` fields
+for correlation. `agent_end` may also include `abortOrigin` with one of
+`"session-transition"`, `"user"`, `"timeout"`, or `"unknown"`; treat
+`"session-transition"` as internal session-control flow rather than a user
+cancel or provider failure.
+
 ### Helpers
 
 | Method                                | Description                              |

--- a/src/resources/extensions/gsd/auto/types.ts
+++ b/src/resources/extensions/gsd/auto/types.ts
@@ -45,6 +45,9 @@ export const BUDGET_THRESHOLDS: Array<{
  */
 export interface AgentEndEvent {
   messages: unknown[];
+  sessionId?: string;
+  turnId?: string;
+  abortOrigin?: "session-transition" | "user" | "timeout" | "unknown";
 }
 
 /**

--- a/src/resources/extensions/gsd/auto/unit-runner-events.ts
+++ b/src/resources/extensions/gsd/auto/unit-runner-events.ts
@@ -1,0 +1,15 @@
+// GSD-2 + src/resources/extensions/gsd/auto/unit-runner-events.ts - Classifies agent lifecycle events before Unit settlement.
+
+import type { AgentEndEvent } from "./types.js";
+
+export function isInternalSessionTransitionAbortEvent(
+  event: Pick<AgentEndEvent, "abortOrigin">,
+): boolean {
+  return event.abortOrigin === "session-transition";
+}
+
+export function shouldIgnoreAgentEndForActiveUnit(
+  event: Pick<AgentEndEvent, "abortOrigin">,
+): boolean {
+  return isInternalSessionTransitionAbortEvent(event);
+}

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -2,7 +2,7 @@
 
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 
-import type { ErrorContext } from "../auto/types.js";
+import type { AgentEndEvent, ErrorContext } from "../auto/types.js";
 import { logWarning } from "../workflow-logger.js";
 import {
   checkDeepProjectSetupAfterTurn,
@@ -21,6 +21,7 @@ import {
   resolveAgentEnd,
   resolveAgentEndCancelled,
 } from "../auto/resolve.js";
+import { shouldIgnoreAgentEndForActiveUnit } from "../auto/unit-runner-events.js";
 import { resolveModelId } from "../auto-model-selection.js";
 import { resolveProjectRoot } from "../worktree.js";
 import { clearDiscussionFlowState } from "./write-gate.js";
@@ -36,6 +37,10 @@ import { blockModel, isModelBlocked } from "../blocked-models.js";
 
 const retryState = createRetryState();
 const MAX_NETWORK_RETRIES = 2;
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
+}
 /**
  * Cap on auto-resume attempts for sustained transient-provider errors.
  *
@@ -116,6 +121,14 @@ export function isClaudeCodeSessionSwitchAbortMessage(lastMsg: unknown): boolean
   }
 
   return false;
+}
+
+export function isBareClaudeCodeStreamAbortPlaceholder(lastMsg: unknown): boolean {
+  if (!lastMsg || typeof lastMsg !== "object") return false;
+  const m = lastMsg as { stopReason?: unknown; errorMessage?: unknown; content?: unknown };
+  if (m.stopReason !== "aborted" || m.errorMessage) return false;
+  const text = readAssistantTextContent(m.content).trim().replace(/\s+/g, " ").toLowerCase();
+  return text === "claude code stream aborted by caller";
 }
 
 /**
@@ -215,7 +228,7 @@ async function pauseTransientWithBackoff(
 
 export async function handleAgentEnd(
   pi: ExtensionAPI,
-  event: { messages: any[] },
+  event: AgentEndEvent,
   ctx: ExtensionContext,
 ): Promise<void> {
   // #4648 — Invalidate the directory-listing cache before any artifact-existence
@@ -257,6 +270,10 @@ export async function handleAgentEnd(
 
   if (!isAutoActive()) return;
 
+  if (shouldIgnoreAgentEndForActiveUnit(event)) {
+    return;
+  }
+
   const lastMsg = event.messages[event.messages.length - 1];
   if (isSessionSwitchInFlight()) {
     _handleSessionSwitchAgentEnd(lastMsg, resolveAgentEndCancelled);
@@ -270,7 +287,14 @@ export async function handleAgentEnd(
     return;
   }
 
-  if (lastMsg && "stopReason" in lastMsg && lastMsg.stopReason === "aborted") {
+  if (isBareClaudeCodeStreamAbortPlaceholder(lastMsg)) {
+    // The Claude Code adapter can emit this placeholder after a prior turn has
+    // already completed and the next unit is active. It has no user/provider
+    // diagnostic value and must not cancel the newly-dispatched unit.
+    return;
+  }
+
+  if (isObjectRecord(lastMsg) && "stopReason" in lastMsg && lastMsg.stopReason === "aborted") {
     // Empty content with aborted stopReason is a non-fatal agent stop (the LLM
     // chose to end without producing output). Only pause on genuine fatal aborts
     // that carry error context — e.g. errorMessage field or non-empty content
@@ -296,7 +320,7 @@ export async function handleAgentEnd(
     await pauseAuto(ctx, pi, _buildAbortedPauseContext(lastMsg as { errorMessage?: unknown }));
     return;
   }
-  if (lastMsg && "stopReason" in lastMsg && lastMsg.stopReason === "error") {
+  if (isObjectRecord(lastMsg) && "stopReason" in lastMsg && lastMsg.stopReason === "error") {
     // #3588: errorMessage can be useless (e.g. "success") while the real error
     // is in the assistant message text content. Fall back to content when
     // errorMessage looks uninformative.

--- a/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
+++ b/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
@@ -6,8 +6,10 @@ import assert from "node:assert/strict";
 
 import {
   _handleSessionSwitchAgentEnd,
+  isBareClaudeCodeStreamAbortPlaceholder,
   isClaudeCodeSessionSwitchAbortMessage,
 } from "../bootstrap/agent-end-recovery.js";
+import { shouldIgnoreAgentEndForActiveUnit } from "../auto/unit-runner-events.js";
 import type { ErrorContext } from "../auto/types.js";
 
 test("user-abort message during session-switch is dropped (not propagated as cancellation)", () => {
@@ -75,6 +77,60 @@ test("Claude Code stream-aborted placeholder during session-switch is dropped", 
   );
 
   assert.equal(cancelledWith, null);
+});
+
+test("late bare Claude Code stream-aborted placeholder is classified as internal", () => {
+  // Reproduces the M003/S04 failure shape from testingapp1: the previous unit
+  // completed, the next unit was dispatched, then Claude Code emitted a
+  // zero-token stream-aborted placeholder. That marker belongs to session
+  // transition cleanup, not the active unit.
+  assert.equal(
+    isBareClaudeCodeStreamAbortPlaceholder({
+      stopReason: "aborted",
+      content: [{ type: "text", text: "Claude Code stream aborted by caller" }],
+    }),
+    true,
+  );
+
+  assert.equal(
+    isBareClaudeCodeStreamAbortPlaceholder({
+      stopReason: "aborted",
+      errorMessage: "stream torn down mid-flight",
+      content: [{ type: "text", text: "Claude Code stream aborted by caller" }],
+    }),
+    false,
+    "diagnostic aborts must stay on the normal cancelled path",
+  );
+
+  assert.equal(
+    isBareClaudeCodeStreamAbortPlaceholder({
+      stopReason: "aborted",
+      content: [{ type: "text", text: "Request aborted by user" }],
+    }),
+    false,
+    "user abort markers outside the session-switch path must not be swallowed",
+  );
+});
+
+test("typed session-transition abort events are classified as internal", () => {
+  assert.equal(
+    shouldIgnoreAgentEndForActiveUnit({
+      abortOrigin: "session-transition",
+    }),
+    true,
+  );
+
+  assert.equal(
+    shouldIgnoreAgentEndForActiveUnit({
+      abortOrigin: "user",
+    }),
+    false,
+  );
+
+  assert.equal(
+    shouldIgnoreAgentEndForActiveUnit({}),
+    false,
+  );
 });
 
 test("Claude Code session-switch abort detection is narrow", () => {


### PR DESCRIPTION
## TL;DR

**What:** Tags agent aborts with causal metadata and teaches GSD auto-mode to ignore internal session-transition aborts.
**Why:** Auto-mode could stop after a successful Unit when Claude Code emitted a late transition-cleanup abort marker.
**How:** Propagate `sessionId`, `turnId`, and `abortOrigin` through core agent events, tag session-switch/user abort paths, and classify transition aborts before Unit settlement.

## What

- Adds `AgentAbortOrigin` plus optional `sessionId`, `turnId`, and `abortOrigin` fields to agent and extension lifecycle events.
- Tags `newSession()`/session-transition aborts as `session-transition` and public TUI/RPC aborts as `user`.
- Adds a GSD auto Unit event classifier that ignores `session-transition` `agent_end` events for the active Unit.
- Keeps the narrow Claude Code `stream aborted by caller` placeholder guard as compatibility fallback for untyped/older events.
- Adds regression coverage for the observed session-switch abort misclassification path.

## Why

Closes #5632.

In the `testingapp1` M003/S04 auto-mode run, the Unit completed successfully and auto-mode dispatched `complete-slice`, but a late Claude Code abort placeholder from session transition cleanup arrived afterward. Because abort events had no ownership metadata, GSD treated that internal cleanup event as the active Unit aborting and dropped the user back to the TUI.

## How

The agent core now stamps lifecycle events with a per-turn id and current session id. `Agent.abort()` accepts a causal origin, `AgentSession` forwards that origin through `agent_end` and `stop`, and GSD auto-mode classifies `abortOrigin: "session-transition"` as internal cleanup instead of Unit failure. User abort entry points continue to flow through the normal cancellation path as `abortOrigin: "user"`.

## Validation

- `npm run verify:pr`
- Focused regression: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts`
- Focused lifecycle test: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts`

## Change Type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Notes

AI-assisted PR. No co-author metadata added to the commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent lifecycle, turn, message and tool events may include optional sessionId and turnId; agent_end includes abortOrigin for clearer termination context.
  * Abort flows now propagate an abort origin through the runtime and extension hooks.

* **Bug Fixes**
  * Prevents treating internal session-transition aborts as user cancellations; hardened handling of stream-abort/message edge cases during unit recovery.

* **Tests**
  * Added regression tests for session-switch abort classification.

* **Documentation**
  * Updated docs and API reference to describe event metadata and abortOrigin semantics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5633)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->