### PR TITLE
[codex] update README release notes for 2.80

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,75 +27,49 @@ One command. Walk away. Come back to a built project with clean git history.
 
 ---
 
-## What's New in v2.79
+## What's New in v2.80
 
-### DB-Authoritative Runtime State
+### DB-Authoritative Context
 
-- **Auto-mode coordination tables (#5247)** — workers, leases, dispatches, and a command queue are now first-class DB rows, replacing ad-hoc files for cross-process auto coordination.
-- **`auto.lock` + `paused-session.json` → DB (#5250)** — phase C pt 2 of the runtime-state migration. The on-disk lockfile and paused-session JSON are gone; lock acquisition, stale-lock detection, and pause state all live in `gsd.db`.
-- **Stuck-state migration (#5249)** — `copyPlanningArtifacts` / `reconcile` deleted; auto-mode writers canonicalize through the DB instead of mirroring artifacts to disk.
-- **`gsd headless recover`** — non-TTY DB recovery command for unattended environments where the interactive recover flow can't run.
-- **Doctor surfaces DB locks** — `gsd doctor` reports DB-backed stale locks and flags exhausted `run-uat` retry counters so wedged runs are visible without log archaeology.
+- **UOK contracts are DB-authoritative** — runtime contract state now flows through the database instead of file-first projections.
+- **Auto-run context mode fully wired** — context-mode execution is connected end-to-end for auto runs.
+- **Planned slice recovery** — planned slices recover correctly after artifact writes.
 
-### Workspace & Worktree Isolation
+### Auto, Deep Mode & Gates
 
-- **`GsdWorkspace` + `MilestoneScope` handle types** — workspace identity is now an explicit handle threaded through writers, metrics, and the DB connection instead of a module singleton.
-- **Symlink-safe canonicalization** — `deriveState` read root and cache key are canonicalized; path normalization unified on `realpathSync.native`; `gsdRootCache` keys normalized and decoupled from per-turn cache clears; `git-root` anchor guarded against `~/.gsd` resolution.
-- **Worktree-scoped DB + metrics** — `gsd-db` connections and metrics ledgers are scoped by workspace identity, so concurrent milestones in separate worktrees can't cross-contaminate state.
-- **Worktree cwd anchoring** — subagent dispatch anchors to the canonical worktree path, `mergeAndExit` anchors cwd at project root (closes [#5079](https://github.com/gsd-build/GSD-2/issues/5079)), MCP cwd is hardened against drift, and dispatch stops on cwd anchor failures.
-- **Slice isolation through resolver (#5246)** — slice merge isolation routed through the worktree resolver; `originalBase` checks use `isSamePath` instead of string equality; `auto-worktree` validates `milestoneId` match in `ByScope` wrappers.
-- **Worktree CLI commands** — `gsd worktree {list, merge, clean, remove}` exposed in the TUI dispatcher.
+- **Deep queued milestones continue** — deep project milestones can resume through queued work instead of stalling.
+- **Deep project registration** — deep project milestones are registered as part of the workflow.
+- **Depth-verification gate fixes** — gate workflow regressions were closed, including case-insensitive plan-slice artifact resolution.
+- **Task commits bound to milestone completion** — automated task commits now respect the milestone completion guard.
 
-### Deep Planning Mode (Phase 11)
+### MCP, Post-Exec & Cross-Platform
 
-- **`/gsd new-project --deep`** — opt-in deep mode for new projects, with `research-decision` and `research-project` dispatch units, deep-mode artifact validators, and gated approval flows that pause the milestone instead of aborting on grounding/discovery questions.
-- **EVAL-REVIEW system** — `/gsd eval-review` command, frontmatter schema, pre-ship soft warning when EVAL-REVIEW status is incomplete, and registration in the catalog + ops dispatcher.
-- **Project-shape-aware discuss depth** — discuss-phase questioning depth scales via the project-shape classifier; tiny apps cap research and auto-skip stale research blockers; deep research is opt-in and blocked while a marker is in flight.
-- **Approval-gate hardening** — deep approval gates verified, opening interview question protected from approval abort, plain-text setup approvals gated, deep setup state guarded against phantom transitions.
+- **Post-exec import hardening** — explicit extension fallbacks, dotted module stems, React Router `+types`, and `+types` guards are handled more carefully.
+- **MCP write gating** — `gsd_exec` writes are gated, with Windows path-separator test coverage tightened.
+- **Project saves stay successful** — saving a project no longer fails just because registration fails.
+- **Home-directory fallback** — `currentDirectoryRoot` uses `homedir()` fallback behavior for better cross-platform consistency.
 
-### Auto Pipeline & Dispatch
+### Reliability & Review Hardening
 
-- **Delegation-policy verdicts** — dispatch actions are annotated with a per-tool background-safety policy verdict; the policy itself is codified instead of inferred per call.
-- **Reactive-execute default** — auto-dispatch defaults to reactive-execute when ≥3 ready tasks are queued, replacing the always-sequential fallback.
-- **Proactive rate limiting (#2996)** — `min_request_interval_ms` preference paces auto-mode requests; the interval is stamped at dispatch.
-- **Manifest-driven skill surfacing** — `auto-prompts` surfaces manifest skills via recommendations + auto-match; planning-dispatch mode added to the unit manifest for slice plan/complete; runtime tools-policy enforced for planning units (#4934).
-- **Subagent telemetry** — dispatch telemetry, stronger prompt guidelines, and model-override threading (`??` consistently used for `modelOverride`).
+- **Auto orchestration seams and contracts** — orchestration boundaries were made more explicit and review feedback was folded in.
+- **Cancellation context preserved** — auto-mode pauses keep cancellation context instead of dropping it.
+- **Recovery stop lifecycle** — recovery stop now emits the expected lifecycle event.
+- **Trace and cleanup fixes** — trace correlation, cleanup-on-throw, audit context reset, and `onTurnResult` phase-result guards were tightened.
 
-### MCP, Models & Cross-Platform
+See the full [Changelog](./CHANGELOG.md) for the complete v2.80 entry and prior releases.
 
-- **Global MCP config** — `mcp-client` reads `~/.gsd/mcp.json` for user-level MCP server config.
-- **`ask_user_questions` over MCP** — host elicitation tried before remote channel; multi-select array shape preserved; explicit cancellation handled; remote answers normalized into `structuredContent`.
-- **Model routing overhaul** — cross-provider tier resolution, provider-agnostic profile-tier defaults, disabled-provider routing denylist, resolved tier model IDs normalized, and `findModelForTier` with behavioral tests.
-- **Ollama** — configurable probe/request timeouts via env vars (clamped); cloud / long-variant context windows reported correctly.
-- **Windows fixes** — home directory resolved correctly (#5015), `Path` env lookup repaired, Windows-safe env CLI shims, DEP0190 avoided in Claude CLI binary probes, tool-bootstrap skipped when tools are on PATH.
-- **Anthropic prompt-cache preserved (#5019)** — `pi-coding-agent` and `gsd` no longer thrash the cache on dispatch.
+<details>
+<summary>v2.79 highlights</summary>
 
-### Git, GitHub Sync & Reliability
+- **DB-backed runtime coordination** — workers, leases, dispatches, command queue, locks, paused-session state, and stuck-state recovery moved into `gsd.db`
+- **Workspace/worktree isolation** — `GsdWorkspace` and `MilestoneScope` handles, symlink-safe canonicalization, worktree-scoped DB/metrics, cwd anchoring, and `gsd worktree {list, merge, clean, remove}`
+- **Deep planning mode** — `/gsd new-project --deep`, research dispatch units, EVAL-REVIEW, project-shape-aware questioning, and approval-gate hardening
+- **Auto pipeline upgrades** — delegation-policy verdicts, reactive-execute default, proactive rate limiting, manifest-driven skill surfacing, and subagent telemetry
+- **MCP/model/cross-platform fixes** — global MCP config, `ask_user_questions` over MCP, provider-agnostic model routing, Ollama timeouts, Windows fixes, and Anthropic prompt-cache preservation
+- **Git and recovery reliability** — self-merge guards, safer slice cadence, milestone-ID reservation, auto-commit hygiene, retryable GitHub sync, atomic metrics writes, and stronger teardown handling
+- **VS Code and TUI polish** — checkpoint tree view, image paste preservation, and bundled `/gsd` slash command protection
 
-- **Integration-branch self-merge guard (#5024)** — milestone refuses to self-merge when the integration branch equals the milestone branch; self-merge ref guard normalized.
-- **Slice-cadence safety** — integration branch used for slice cadence, dirty worktree state preserved on merge, checked-out slice worktrees advance safely, slice PRs deferred until completion, slice-PR sync stays retryable on failure.
-- **Milestone-ID reservation** — DB rows included in reservation; ghost IDs reused in `nextMilestoneId` to close gaps; `ensurePreconditions` guarded against phantom IDs (#4996); orphan milestone-dir doctor check (#4996); milestone-dir creation deferred until first artifact write.
-- **Auto-commit hygiene** — task commits scoped to reported files, generated commit subjects sanitized, user hooks run on automated commits, milestone-tagged commits bound when `.gsd/` is gitignored (#5033), startup blocked on `git index.lock`.
-- **GitHub sync** — issues no longer closed before delivery, failed task closure / slice PR sync stay retryable, config cache scoped by project, safe git environment used.
-
-### Safety, Recovery & Hardening
-
-- **Policy-block pause through dispatch errors** — pause state is preserved when dispatch errors out mid-policy-block.
-- **Skip-validation persistence** — skip-validation state persists and gate rows are cleared on recover.
-- **Cancelled-gate hard block** — redirected to `ask_user_questions`; false plain-text claim dropped from the message.
-- **Write-gate basePath required** — `process.cwd()` defaults removed; basePath threaded through pre-existing tests.
-- **Atomic metrics writes** — parallel-mode `metrics.json` writes merge atomically; ledger cache invalidated after prune; `saveLedger` aborts when lock not acquired; stale-lock detection adds PID stamp + async yield.
-- **Auto-worktree teardown** — `activeWorkspace` guaranteed cleared on teardown failure; teardown try/finally broadened to cover `chdir`; cleanup steps mirrored on the abort path; warning emitted on resume when persisted worktree is missing.
-- **Empty-turn nudge** — no longer auto-replies to user questions; deferred on mid-line approval prompts.
-- **Refuses project writes from `$HOME`** — and surfaces real SQL errors from `capture_thought` instead of swallowing them.
-
-### VS Code & TUI
-
-- **Checkpoint tree view** — registered in the VS Code extension; checkpoint file existence restored; RPC file-mutation events tracked; agent diff scoped to tracked files.
-- **TUI image paste** — pasted images preserved on regular submit.
-- **Bundled `/gsd` slash command protected** — core handler refuses to overwrite the bundled command.
-
-See the full [Changelog](./CHANGELOG.md) for the complete v2.79 entry and prior releases.
+</details>
 
 <details>
 <summary>v2.78 highlights</summary>


### PR DESCRIPTION
## TL;DR

**What:** Updates the README release highlights from v2.79 to v2.80.
**Why:** The package and changelog are already on 2.80, but the README still advertised v2.79.
**How:** Replaces the top release summary with v2.80 highlights from CHANGELOG.md and moves v2.79 into a compact archive section.

## What

This PR updates only README.md. It refreshes the "What's New" section for v2.80 and keeps the v2.79 highlights available in a collapsed details block.

## Why

The README should match the current 2.80 release documentation without manually bumping package versions.

## How

The summary was derived from the existing CHANGELOG.md v2.80 entry and condensed for the README. No runtime behavior changes.

## Validation

- git diff --check

AI-assisted PR; no AI co-author added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release highlights for v2.80, featuring DB-authoritative context, auto/deep mode gates, MCP/post-exec/cross-platform updates, and reliability/review hardening improvements
  * Previous v2.79 highlights reorganized into collapsible section for streamlined navigation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5645)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->