### PR TITLE
fix(pre-execution-checks): multi-root resolution for worktree and submodule layouts

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -37,6 +37,18 @@ export interface PreExecutionResult {
   durationMs: number;
 }
 
+/**
+ * Resolution context for multi-root file lookups.
+ * Addresses false positives in worktree isolation (#5464, #5492, #5462) and
+ * directory-materialization tasks (#5066) by providing additional search paths.
+ */
+export interface ResolutionContext {
+  /** Additional paths to search when a file isn't found at basePath (e.g., project root) */
+  additionalRoots?: string[];
+  /** Path where .gsd/ metadata lives (project root, not worktree). Falls back to basePath. */
+  metadataRoot?: string;
+}
+
 // ─── Package Existence Check ─────────────────────────────────────────────────
 
 /**
@@ -436,6 +448,59 @@ function getExpectedOutputsUpTo(tasks: TaskRow[], taskIndex: number): Set<string
 }
 
 /**
+ * Collect raw (unnormalized) expected_output entries from tasks up to taskIndex.
+ * Preserves trailing slashes for directory-intent detection (#5066).
+ */
+function getRawExpectedOutputsUpTo(tasks: TaskRow[], taskIndex: number): string[] {
+  const outputs: string[] = [];
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i];
+    if (i < taskIndex || task.status === "completed") {
+      outputs.push(...task.expected_output);
+    }
+  }
+  return outputs;
+}
+
+/**
+ * Check if a file exists at any of the resolution roots.
+ */
+function fileExistsInContext(
+  normalizedFile: string,
+  basePath: string,
+  context?: ResolutionContext,
+): boolean {
+  if (existsSync(resolve(basePath, normalizedFile))) return true;
+  if (normalizedFile.startsWith(".gsd/") && context?.metadataRoot) {
+    if (existsSync(resolve(context.metadataRoot, normalizedFile))) return true;
+  }
+  if (context?.additionalRoots) {
+    for (const root of context.additionalRoots) {
+      if (existsSync(resolve(root, normalizedFile))) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if a prior task's expected_output includes a directory that would
+ * contain normalizedFile when materialized (#5066).
+ */
+function isUnderExpectedDirectory(
+  normalizedFile: string,
+  expectedOutputs: Set<string>,
+  rawExpectedOutputs: string[],
+): boolean {
+  for (const rawOutput of rawExpectedOutputs) {
+    if (!rawOutput.endsWith("/")) continue;
+    const normalizedDir = normalizeFilePath(rawOutput);
+    const prefix = normalizedDir + "/";
+    if (normalizedFile.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
  * Check that all files referenced in task.inputs either:
  *   1. Exist on disk, OR
  *   2. Are in a prior task's expected_output, OR
@@ -450,7 +515,8 @@ function getExpectedOutputsUpTo(tasks: TaskRow[], taskIndex: number): Set<string
  */
 export function checkFilePathConsistency(
   tasks: TaskRow[],
-  basePath: string
+  basePath: string,
+  context?: ResolutionContext,
 ): PreExecutionCheckJSON[] {
   const results: PreExecutionCheckJSON[] = [];
 
@@ -470,6 +536,10 @@ export function checkFilePathConsistency(
     const ownOutputs = new Set<string>(task.expected_output.map(normalizeFilePath));
     const filesToCheck = [...task.inputs];
 
+    // Collect raw expected_output entries for directory-intent detection
+    const rawPriorOutputs = getRawExpectedOutputsUpTo(tasks, i);
+    const rawOwnOutputs = task.expected_output;
+
     for (const file of filesToCheck) {
       // Skip empty strings
       if (!file.trim()) continue;
@@ -479,24 +549,29 @@ export function checkFilePathConsistency(
       const normalizedFile = normalizeFilePath(file);
       if (containsGlobPattern(normalizedFile)) continue;
 
-      // Check if file exists on disk
-      const absolutePath = resolve(basePath, normalizedFile);
-      const existsOnDisk = existsSync(absolutePath);
+      // Check if file exists on disk (multi-root aware)
+      const existsOnDisk = fileExistsInContext(normalizedFile, basePath, context);
 
       // Check if file is in prior expected outputs (priorOutputs already normalized)
       const inPriorOutputs = priorOutputs.has(normalizedFile);
       const inOwnOutputs = ownOutputs.has(normalizedFile);
 
+      // File is under a directory that a prior task will materialize (#5066)
+      const underExpectedDir = !existsOnDisk && !inPriorOutputs && !inOwnOutputs
+        ? isUnderExpectedDirectory(normalizedFile, priorOutputs, rawPriorOutputs) ||
+          isUnderExpectedDirectory(normalizedFile, ownOutputs, rawOwnOutputs)
+        : false;
+
       // Directory inputs are satisfied when something produces a file beneath
       // them — either a prior task or the current task itself.
       let directorySatisfied = false;
-      if (!existsOnDisk && !inPriorOutputs && !inOwnOutputs && isDirectoryReference(file)) {
+      if (!existsOnDisk && !inPriorOutputs && !inOwnOutputs && !underExpectedDir && isDirectoryReference(file)) {
         directorySatisfied =
           anyOutputUnderDirectory(normalizedFile, priorOutputs) ||
           anyOutputUnderDirectory(normalizedFile, ownOutputs);
       }
 
-      if (!existsOnDisk && !inPriorOutputs && !inOwnOutputs && !directorySatisfied) {
+      if (!existsOnDisk && !inPriorOutputs && !inOwnOutputs && !underExpectedDir && !directorySatisfied) {
         // If a later task claims to create this file, the ordering check will
         // fire a more precise "sequence violation" error for the same file.
         // Suppress the consistency error here to avoid duplicate noise.
@@ -527,7 +602,8 @@ export function checkFilePathConsistency(
  */
 export function checkTaskOrdering(
   tasks: TaskRow[],
-  basePath: string
+  basePath: string,
+  context?: ResolutionContext,
 ): PreExecutionCheckJSON[] {
   const results: PreExecutionCheckJSON[] = [];
 
@@ -567,8 +643,7 @@ export function checkTaskOrdering(
       // files, and a same-task output under the directory satisfies it.
       if (isDirectoryReference(file)) continue;
       const creator = fileCreators.get(normalizedFile);
-      const absolutePath = resolve(basePath, normalizedFile);
-      const existsOnDisk = existsSync(absolutePath);
+      const existsOnDisk = fileExistsInContext(normalizedFile, basePath, context);
       // Skip if the creating task has already completed — its output is available
       // regardless of disk state (e.g. file was a temp artifact cleaned up after
       // the task ran, or a replan introduced a new earlier-sequence task that
@@ -748,14 +823,15 @@ export function checkInterfaceContracts(
  */
 export async function runPreExecutionChecks(
   tasks: TaskRow[],
-  basePath: string
+  basePath: string,
+  context?: ResolutionContext,
 ): Promise<PreExecutionResult> {
   const startTime = Date.now();
   const allChecks: PreExecutionCheckJSON[] = [];
 
   // Run sync checks first
-  const fileChecks = checkFilePathConsistency(tasks, basePath);
-  const orderingChecks = checkTaskOrdering(tasks, basePath);
+  const fileChecks = checkFilePathConsistency(tasks, basePath, context);
+  const orderingChecks = checkTaskOrdering(tasks, basePath, context);
   const contractChecks = checkInterfaceContracts(tasks, basePath);
 
   allChecks.push(...fileChecks, ...orderingChecks, ...contractChecks);

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -25,6 +25,7 @@ import {
   runPreExecutionChecks,
   normalizeFilePath,
   type PreExecutionResult,
+  type ResolutionContext,
 } from "../pre-execution-checks.ts";
 import type { TaskRow } from "../gsd-db.ts";
 
@@ -2039,5 +2040,208 @@ describe("checkFilePathConsistency quote-wrapped annotation (#3747)", () => {
       0,
       "Annotated file paths and prose inputs should produce zero blocking errors",
     );
+  });
+});
+
+describe("checkFilePathConsistency with ResolutionContext (#5464, #5492)", () => {
+  test("file found at additionalRoots passes even when missing from basePath", (t) => {
+    const worktree = join(tmpdir(), `pre-exec-ctx-wt-${Date.now()}`);
+    const projectRoot = join(tmpdir(), `pre-exec-ctx-root-${Date.now()}`);
+    mkdirSync(worktree, { recursive: true });
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    writeFileSync(join(projectRoot, "src/lib.ts"), "// exists at project root");
+    t.after(() => {
+      rmSync(worktree, { recursive: true, force: true });
+      rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["src/lib.ts"],
+        expected_output: [],
+      }),
+    ];
+
+    const context: ResolutionContext = { additionalRoots: [projectRoot] };
+    const results = checkFilePathConsistency(tasks, worktree, context);
+    assert.equal(results.length, 0, "File at additionalRoots should satisfy the input check");
+  });
+
+  test(".gsd/ metadata path resolved via metadataRoot (#5492)", (t) => {
+    const worktree = join(tmpdir(), `pre-exec-ctx-meta-wt-${Date.now()}`);
+    const projectRoot = join(tmpdir(), `pre-exec-ctx-meta-root-${Date.now()}`);
+    mkdirSync(worktree, { recursive: true });
+    mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
+    writeFileSync(join(projectRoot, ".gsd/DECISIONS.md"), "# Decisions");
+    t.after(() => {
+      rmSync(worktree, { recursive: true, force: true });
+      rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: [".gsd/DECISIONS.md"],
+        expected_output: [],
+      }),
+    ];
+
+    const context: ResolutionContext = { metadataRoot: projectRoot };
+    const results = checkFilePathConsistency(tasks, worktree, context);
+    assert.equal(results.length, 0, ".gsd/ path should resolve via metadataRoot");
+  });
+
+  test(".gsd/ path still fails when not at metadataRoot either", (t) => {
+    const worktree = join(tmpdir(), `pre-exec-ctx-meta-fail-${Date.now()}`);
+    const projectRoot = join(tmpdir(), `pre-exec-ctx-meta-fail-root-${Date.now()}`);
+    mkdirSync(worktree, { recursive: true });
+    mkdirSync(projectRoot, { recursive: true });
+    t.after(() => {
+      rmSync(worktree, { recursive: true, force: true });
+      rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: [".gsd/NONEXISTENT.md"],
+        expected_output: [],
+      }),
+    ];
+
+    const context: ResolutionContext = { metadataRoot: projectRoot };
+    const results = checkFilePathConsistency(tasks, worktree, context);
+    assert.equal(results.length, 1, "Missing .gsd/ file should still fail");
+    assert.equal(results[0].blocking, true);
+  });
+
+  test("without context, behavior is unchanged (single basePath)", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-ctx-none-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["missing-file.ts"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(results.length, 1, "Without context, missing file should still fail");
+    assert.equal(results[0].blocking, true);
+  });
+});
+
+describe("isUnderExpectedDirectory — directory materialization (#5066)", () => {
+  test("file under a prior task's directory output is satisfied", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-dir-mat-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        sequence: 0,
+        inputs: [],
+        expected_output: ["dita-back/"],
+      }),
+      createTask({
+        id: "T02",
+        sequence: 1,
+        inputs: ["dita-back/src/config.ts"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(results.length, 0,
+      "File under a prior task's directory expected_output should not be blocking");
+  });
+
+  test("file NOT under any directory output still fails", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-dir-mat-fail-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        sequence: 0,
+        inputs: [],
+        expected_output: ["other-dir/"],
+      }),
+      createTask({
+        id: "T02",
+        sequence: 1,
+        inputs: ["dita-back/src/config.ts"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(results.length, 1, "File not under any directory output should still fail");
+    assert.equal(results[0].blocking, true);
+  });
+
+  test("file output without trailing slash does not satisfy descendant", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-dir-mat-noslash-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        sequence: 0,
+        inputs: [],
+        expected_output: ["dita-back"],
+      }),
+      createTask({
+        id: "T02",
+        sequence: 1,
+        inputs: ["dita-back/src/config.ts"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(results.length, 1,
+      "Output without trailing slash should NOT satisfy descendant inputs (must be explicit directory)");
+  });
+});
+
+describe("runPreExecutionChecks with ResolutionContext integration", () => {
+  test("passes with context resolving files that would otherwise fail", async (t) => {
+    const worktree = join(tmpdir(), `pre-exec-int-wt-${Date.now()}`);
+    const projectRoot = join(tmpdir(), `pre-exec-int-root-${Date.now()}`);
+    mkdirSync(worktree, { recursive: true });
+    mkdirSync(join(projectRoot, "src"), { recursive: true });
+    mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
+    writeFileSync(join(projectRoot, "src/existing.ts"), "// content");
+    writeFileSync(join(projectRoot, ".gsd/REQUIREMENTS.md"), "# Reqs");
+    t.after(() => {
+      rmSync(worktree, { recursive: true, force: true });
+      rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["src/existing.ts", ".gsd/REQUIREMENTS.md"],
+        expected_output: [],
+      }),
+    ];
+
+    const context: ResolutionContext = {
+      additionalRoots: [projectRoot],
+      metadataRoot: projectRoot,
+    };
+
+    const result = await runPreExecutionChecks(tasks, worktree, context);
+    assert.equal(result.status, "pass",
+      "Files resolvable via context should produce pass status");
+    assert.equal(result.checks.filter((c) => c.blocking).length, 0);
   });
 });


### PR DESCRIPTION
**Issues:** #5066, #5464, #5492, #5462
**Branch:** `fix/pre-exec-resolution-context`
**Type:** fix
**Sibling PR:** #5647 (isLocalPackage — same file, independent concern)

---

## TL;DR

**What:** Pre-execution file checks now support multi-root resolution and directory-output-satisfies-descendant-input logic.
**Why:** Four open issues (#5066, #5464, #5492, #5462) stem from the same design gap — file checks assume a single flat basePath, breaking in worktrees, submodules, and directory-materialization tasks.
**How:** New `ResolutionContext` interface with `additionalRoots` + `metadataRoot`; new `fileExistsInContext()` and `isUnderExpectedDirectory()` helpers; all backward-compatible (context is optional).

## What

`src/resources/extensions/gsd/pre-execution-checks.ts` gains:

1. **`ResolutionContext` interface** (exported) — lets callers provide alternative search paths:
   ```typescript
   export interface ResolutionContext {
     additionalRoots?: string[];  // e.g., project root when in a worktree
     metadataRoot?: string;       // where .gsd/ lives (project root, not worktree)
   }
   ```

2. **`fileExistsInContext()` helper** — replaces bare `existsSync(resolve(basePath, file))` calls:
   - Tries basePath first
   - For `.gsd/` paths, tries `metadataRoot` (#5492)
   - Falls through `additionalRoots` in order (#5464, #5462)

3. **`isUnderExpectedDirectory()` helper** — if a prior task's `expected_output` includes a directory (trailing `/`), any file under that directory is considered satisfied (#5066).

4. **Signature additions** — `checkFilePathConsistency`, `checkTaskOrdering`, and `runPreExecutionChecks` all accept an optional `context?: ResolutionContext` parameter. Fully backward-compatible — omitting it preserves existing single-basePath behavior.

## Why

### Problem class

Pre-execution checks resolve all file paths against a single `basePath`. This produces false-positive blocking failures when:

| Scenario | Issue | Why single-basePath fails |
|---|---|---|
| Worktree isolation | #5464, #5462 | Source files exist at project root, not in the worktree checkout |
| `.gsd/` metadata in worktree | #5492 | `.gsd/DECISIONS.md` etc. live at project root; worktree has only runtime state |
| Setup/materialization tasks | #5066 | T01 creates `dita-back/`, but T02+ inputs under `dita-back/` fail because T01 hasn't run yet |

All four issues share the same root: the checker lacks awareness that files can legitimately exist at locations other than `basePath`.

### Why it's blocking

All four issues produce `blocking: true` failures that halt auto-mode. The only current workaround is manually editing `S0X-PRE-EXEC-VERIFY.json` to `status: "pass"` — undiscoverable and fragile.

### Design philosophy gap

The pre-execution checker was designed for single-directory projects. The shift to worktree isolation and monorepo support introduced multi-root semantics without updating the checker. This PR closes that gap.

**Relationship to #5580 (merged 2026-05-09):** #5580 fixed the inverse problem — the checker was resolving against `s.canonicalProjectRoot` when it should use `s.basePath` (worktree), causing false positives for files a prior slice wrote into the worktree. This PR addresses the reverse direction: files that legitimately exist at `canonicalProjectRoot` (`.gsd/` metadata, `gsd.db`, submodule source) but are invisible from `s.basePath`. Complementary, not overlapping.

## How

### `fileExistsInContext` — the multi-root resolver

```typescript
function fileExistsInContext(
  normalizedFile: string,
  basePath: string,
  context?: ResolutionContext,
): boolean {
  if (existsSync(resolve(basePath, normalizedFile))) return true;

  // .gsd/ metadata paths resolve against the metadata root (#5492)
  if (normalizedFile.startsWith(".gsd/") && context?.metadataRoot) {
    if (existsSync(resolve(context.metadataRoot, normalizedFile))) return true;
  }

  // Additional roots (project root when in worktree, submodule roots)
  if (context?.additionalRoots) {
    for (const root of context.additionalRoots) {
      if (existsSync(resolve(root, normalizedFile))) return true;
    }
  }

  return false;
}
```

### `isUnderExpectedDirectory` — directory materialization (#5066)

```typescript
function isUnderExpectedDirectory(
  normalizedFile: string,
  expectedOutputs: Set<string>,
  rawExpectedOutputs: string[],
): boolean {
  for (const rawOutput of rawExpectedOutputs) {
    if (!rawOutput.endsWith("/")) continue;
    const normalizedDir = normalizeFilePath(rawOutput);
    const prefix = normalizedDir + "/";
    if (normalizedFile.startsWith(prefix)) return true;
  }
  return false;
}
```

This handles the case where T01's `expected_output` includes `"dita-back/"` and T02's `inputs` includes `"dita-back/src/config.ts"`. Previously this was a blocking failure; now it's recognized as satisfied.

### Caller wiring (separate PR or same PR)

In `auto-post-unit.ts`, the call changes from:

```typescript
const result = await runPreExecutionChecks(tasks, s.basePath);
```

to:

```typescript
const result = await runPreExecutionChecks(tasks, s.basePath, {
  additionalRoots: !isSamePathLocal(s.canonicalProjectRoot, s.basePath)
    ? [s.canonicalProjectRoot]
    : undefined,
  metadataRoot: s.canonicalProjectRoot,
});
```

**Existing infrastructure note:** `isSamePathLocal` is a local utility already defined in `auto-post-unit.ts` — no new code required. `s.canonicalProjectRoot` is a getter on `AutoSession` (defined in `auto/session.ts`, used throughout `auto-post-unit.ts`). `s.basePath` is the worktree path confirmed present after the #5580 fix.

**Decision for reviewers:** ship the caller wiring in this PR or as a follow-up? The infrastructure is safe either way — tests pass with and without context.

## Alternatives considered

1. **Always resolve against canonicalProjectRoot** — loses the purpose of worktree isolation (source file edits should be validated against the worktree, not the project root).
2. **Hardcode `.gsd/` path rewriting** — brittle; doesn't generalize to submodules or other multi-root scenarios.
3. **Remove file checks entirely in worktree mode** — throws the baby out with the bathwater; file checks still catch real plan errors.
4. **Pass both paths as positional args** — doesn't scale to N roots (submodules can have many); interface is less self-documenting than a named context.

## Testing

- 92/92 existing tests pass (zero regressions)
- `ResolutionContext` is optional — all existing callers continue working unchanged
- `fileExistsInContext` falls through roots in order — first match wins, no redundant IO
- `isUnderExpectedDirectory` only triggers when the output path has a trailing `/` — won't false-positive on file paths that happen to be prefixes of other files
- Type-check clean (`npx tsc --noEmit --project tsconfig.extensions.json` = 0 errors)

### Regression tests for new helpers

**`fileExistsInContext` — metadataRoot path (fails without fix, passes after):**
- File path starts with `.gsd/`; file does not exist at `basePath` but exists at `metadataRoot`.
  Without `metadataRoot` fallback: blocking failure. After fix: resolves correctly.

**`fileExistsInContext` — additionalRoots (fails without fix, passes after):**
- File exists at `additionalRoots[0]` but not at `basePath`. Single-root check returns false
  and blocks. Multi-root check finds it at root[1] and returns true.

**`isUnderExpectedDirectory` — positive case:**
- `expected_output = ["dita-back/"]`, input file = `"dita-back/src/config.ts"`.
  `isUnderExpectedDirectory` returns `true` → input treated as satisfied. Fails on main (no
  trailing-slash logic), passes after fix.

**`isUnderExpectedDirectory` — negative case (no false positives):**
- `expected_output = ["dita-back"]` (no trailing slash), input = `"dita-back/src/config.ts"`.
  Helper returns `false` — bare file path prefix doesn't match. No behavior change from current.

**Integration: `runPreExecutionChecks` with context (regression):**
- Task plan where input file exists only at `metadataRoot`, not `basePath`. Without context:
  `blocking: true`. With context carrying `metadataRoot`: passes. Confirms end-to-end wiring.

## Issues addressed

| Issue | Status after this PR |
|---|---|
| #5066 (directory materialization) | **Fixed** — `isUnderExpectedDirectory` covers it without caller changes |
| #5492 (.gsd/ metadata in worktree) | **Fixed once caller wired** — `metadataRoot` resolves .gsd/ paths at project root |
| #5464 (submodule source files) | **Fixed once caller wired** — `additionalRoots` includes project root |
| #5462 (canonical project root inputs) | **Fixed once caller wired** — same mechanism as #5464 |

Note: #5462 and #5464 are still open after #5580 (merged 2026-05-09). #5580 fixed the inverse
direction (worktree outputs invisible to project-root checker); this PR fixes project-root metadata
invisible from worktree checker. They address opposite halves of the same split.

## Verification: pre-execution-checks contract intact

### Root cause
`checkFilePathConsistency` and `checkTaskOrdering` resolve all paths against a single `basePath`.
In worktree mode, source files live at the project root, and `.gsd/` metadata always lives at the
project root — not in the worktree. No mechanism existed to declare alternative resolution roots,
producing `blocking: true` false positives.

### Call sites and scope
- `fileExistsInContext()` replaces bare `existsSync(resolve(basePath, file))` calls inside the
  pre-execution checker only. No other files affected.
- `isUnderExpectedDirectory()` is called inside `checkFilePathConsistency`, before the existing
  "input not satisfied" return path.
- Signatures on `checkFilePathConsistency`, `checkTaskOrdering`, and `runPreExecutionChecks`
  gain an optional `context?: ResolutionContext` — all existing callers unchanged (no context =
  exact current behavior).
- `isSamePathLocal` in the caller wiring snippet is an existing utility in `auto-post-unit.ts`.
  `s.canonicalProjectRoot` is a getter on `AutoSession` already used throughout `auto-post-unit.ts`.

### Affected tests
92/92 existing tests pass unchanged. Regression tests written for all five new code paths
(see Testing section). Type-check: `npx tsc --noEmit --project tsconfig.extensions.json` = 0 errors.

### Downstream consumers
All existing callers of `runPreExecutionChecks` are unaffected — `context` is optional, behavior
without it is identical to current.

### Provider API contract
No external API calls added or modified. `fileExistsInContext` uses `existsSync` only.

---

## Checklist

- [x] `fix` — Bug fix
- [x] Linked issues: #5066, #5464, #5492, #5462
- [x] `npm run verify:pr` — tests pass
- [x] One concern per PR (multi-root resolution; package check is sibling PR #5647)
- [x] No drive-by formatting
- [x] Regression tests for new helpers (see Testing section)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced file resolution capabilities to support multiple root directories in pre-execution checks.
  * Added metadata root configuration for expanded file discovery across configured locations.
  * Improved directory handling in task dependency validation and output materialization logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5648)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->