### PR TITLE
refactor(gsd): ADR-016 phase 2 / A2 — extract mergeMilestoneStandalone (#5618)

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -90,6 +90,32 @@ export interface AutoDashboardData {
   remoteSession?: { pid: number; startedAt: string; unitType: string; unitId: string };
 }
 
+export interface CompletionDashboardSnapshot {
+  milestoneId?: string | null;
+  milestoneTitle?: string | null;
+  oneLiner?: string | null;
+  successCriteriaResults?: string | null;
+  definitionOfDoneResults?: string | null;
+  requirementOutcomes?: string | null;
+  deviations?: string | null;
+  followUps?: string | null;
+  keyDecisions?: string[];
+  keyFiles?: string[];
+  lessonsLearned?: string[];
+  reason: string;
+  startedAt: number;
+  totalCost: number;
+  totalTokens: number;
+  unitCount: number;
+  cacheHitRate?: number | null;
+  contextPercent?: number | null;
+  contextWindow?: number | null;
+  completedSlices?: number | null;
+  totalSlices?: number | null;
+  allMilestonesComplete?: boolean;
+  basePath?: string | null;
+}
+
 // ─── Unit Description Helpers ─────────────────────────────────────────────────
 
 export function unitVerb(unitType: string): string {
@@ -1080,6 +1106,127 @@ export function updateProgressWidget(
       },
     };
   });
+}
+
+export function setCompletionProgressWidget(
+  ctx: ExtensionContext,
+  snapshot: CompletionDashboardSnapshot,
+): void {
+  if (!ctx.hasUI) return;
+
+  if (typeof ctx.ui?.setHeader === "function") {
+    ctx.ui.setHeader(() => ({
+      render(): string[] { return []; },
+      invalidate(): void {},
+    }));
+  }
+  if (typeof ctx.ui?.setStatus === "function") {
+    ctx.ui.setStatus("gsd-step", undefined);
+  }
+
+  ctx.ui.setWidget("gsd-progress", (_tui, theme) => ({
+    render(width: number): string[] {
+      const ui = makeUI(theme, width);
+      const pad = INDENT.base;
+      const lines: string[] = [];
+      const contentWidth = Math.max(20, width - visibleWidth(pad));
+      const add = (line = ""): void => {
+        lines.push(line ? truncateToWidth(`${pad}${line}`, width, "…") : "");
+      };
+      const addSection = (label: string, value: string | null | undefined, indent = ""): void => {
+        const clean = normalizeRollupText(value);
+        if (!clean) return;
+        add(`${indent}${theme.fg("accent", label)} ${theme.fg("text", truncateToWidth(clean, contentWidth - indent.length - label.length - 1, "…"))}`);
+      };
+      const addList = (label: string, values: string[] | undefined, limit: number, indent = ""): void => {
+        const clean = (values ?? []).map(normalizeRollupText).filter((v): v is string => !!v);
+        if (clean.length === 0) return;
+        const shown = clean.slice(0, limit);
+        const more = clean.length > shown.length ? ` (+${clean.length - shown.length} more)` : "";
+        add(`${indent}${theme.fg("accent", label)} ${theme.fg("text", truncateToWidth(shown.join("; ") + more, contentWidth - indent.length - label.length - 1, "…"))}`);
+      };
+
+      lines.push(...ui.bar());
+
+      const elapsed = formatAutoElapsed(snapshot.startedAt);
+      const heading = snapshot.allMilestonesComplete
+        ? "All milestones complete"
+        : snapshot.milestoneId
+          ? `Milestone ${snapshot.milestoneId} roll-up`
+          : "Milestone roll-up";
+      lines.push(rightAlign(`${pad}${theme.fg("accent", theme.bold(heading))}`, elapsed ? theme.fg("dim", elapsed) : "", width));
+
+      if (snapshot.milestoneTitle) {
+        add(theme.fg("text", snapshot.milestoneTitle));
+      }
+
+      lines.push("");
+      add(theme.fg("accent", "Outcome"));
+      addSection("", snapshot.oneLiner, "  ");
+
+      const changed = [
+        ...(snapshot.successCriteriaResults ? [snapshot.successCriteriaResults] : []),
+        ...(snapshot.requirementOutcomes ? [snapshot.requirementOutcomes] : []),
+        ...(snapshot.keyDecisions ?? []),
+      ].map(normalizeRollupText).filter((v): v is string => !!v).slice(0, 4);
+      if (changed.length > 0) {
+        lines.push("");
+        add(theme.fg("accent", "What changed"));
+        for (const item of changed) add(`  - ${theme.fg("text", item)}`);
+      }
+
+      const verification = [
+        snapshot.definitionOfDoneResults,
+        snapshot.deviations ? `Deviations: ${snapshot.deviations}` : null,
+        snapshot.followUps ? `Follow-ups: ${snapshot.followUps}` : null,
+      ].map(normalizeRollupText).filter((v): v is string => !!v);
+      if (verification.length > 0 || (snapshot.keyFiles?.length ?? 0) > 0) {
+        lines.push("");
+        add(theme.fg("accent", "Verification"));
+        for (const item of verification.slice(0, 3)) add(`  - ${theme.fg("text", item)}`);
+        addList("Files:", snapshot.keyFiles, 4, "  ");
+      }
+
+      if ((snapshot.lessonsLearned?.length ?? 0) > 0) {
+        lines.push("");
+        addList("Lessons:", snapshot.lessonsLearned, 2);
+      }
+
+      const hasSliceTotals = typeof snapshot.completedSlices === "number" && typeof snapshot.totalSlices === "number" && snapshot.totalSlices > 0;
+
+      lines.push("");
+      const stats: string[] = [];
+      if (hasSliceTotals) stats.push(theme.fg("success", `${snapshot.completedSlices}/${snapshot.totalSlices} slices`));
+      if (snapshot.unitCount > 0) stats.push(theme.fg("dim", `${snapshot.unitCount} units`));
+      if (snapshot.totalTokens > 0) stats.push(theme.fg("dim", `${formatWidgetTokens(snapshot.totalTokens)} tokens`));
+      if (snapshot.totalCost > 0) stats.push(theme.fg("warning", `$${snapshot.totalCost.toFixed(2)}`));
+      if (typeof snapshot.cacheHitRate === "number") {
+        const hitColor = snapshot.cacheHitRate >= 70 ? "success" : snapshot.cacheHitRate >= 40 ? "warning" : "error";
+        stats.push(theme.fg(hitColor, `${Math.round(snapshot.cacheHitRate)}% cache hit`));
+      }
+      if (stats.length > 0) {
+        add(`${theme.fg("accent", "Run totals")} ${stats.join(theme.fg("dim", " · "))}`);
+      }
+
+      const location = snapshot.basePath ? theme.fg("dim", snapshot.basePath) : "";
+      const reason = theme.fg("dim", snapshot.reason);
+      lines.push(rightAlign(`${pad}${truncateToWidth(location, Math.max(0, width - 32), "…")}`, reason, width));
+      lines.push(...ui.bar());
+
+      return lines;
+    },
+    invalidate(): void {},
+    dispose(): void {},
+  }));
+}
+
+function normalizeRollupText(value: string | null | undefined): string | null {
+  const clean = value
+    ?.replace(/\s+/g, " ")
+    .replace(/^[-*]\s+/, "")
+    .trim();
+  if (!clean || clean === "(none)" || clean === "None." || clean === "Not provided.") return null;
+  return clean;
 }
 
 // ─── Right-align Helper ───────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -16,6 +16,7 @@ import type {
   ExtensionAPI,
   ExtensionContext,
   ExtensionCommandContext,
+  SessionMessageEntry,
 } from "@gsd/pi-coding-agent";
 
 import { deriveState } from "./state.js";
@@ -32,7 +33,7 @@ import {
   setRuntimeKv,
   deleteRuntimeKv,
 } from "./db/runtime-kv.js";
-import { getManifestStatus } from "./files.js";
+import { extractSection, getManifestStatus, splitFrontmatter, parseFrontmatterMap } from "./files.js";
 export { inlinePriorMilestoneSummary } from "./files.js";
 import { collectSecretsFromManifest } from "../get-secrets-from-user.js";
 import {
@@ -188,6 +189,7 @@ import { isClosedStatus } from "./status-guards.js";
 import {
   type AutoDashboardData,
   updateProgressWidget as _updateProgressWidget,
+  setCompletionProgressWidget,
   updateSliceProgressCache,
   clearSliceProgressCache,
   describeNextUnit as _describeNextUnit,
@@ -201,7 +203,7 @@ import {
   deregisterSigtermHandler as _deregisterSigtermHandler,
   detectWorkingTreeActivity,
 } from "./auto-supervisor.js";
-import { isDbAvailable, getMilestone } from "./gsd-db.js";
+import { isDbAvailable, getMilestone, getMilestoneSlices } from "./gsd-db.js";
 import { markLatestActiveForWorkerCanceled } from "./db/unit-dispatches.js";
 import { writeUnitRuntimeRecord } from "./unit-runtime.js";
 import { countPendingCaptures } from "./captures.js";
@@ -231,7 +233,7 @@ import { bootstrapAutoSession, openProjectDbIfPresent, type BootstrapDeps } from
 import { initHealthWidget } from "./health-widget.js";
 import { runLegacyAutoLoop, runUokKernelLoop } from "./auto/loop.js";
 import { resolveAgentEnd, resolveAgentEndCancelled, _resetPendingResolve, isSessionSwitchInFlight } from "./auto/resolve.js";
-import type { LoopDeps } from "./auto/loop-deps.js";
+import type { LoopDeps, StopAutoOptions } from "./auto/loop-deps.js";
 import type { ErrorContext } from "./auto/types.js";
 import { runAutoLoopWithUok } from "./uok/kernel.js";
 import { resolveUokFlags } from "./uok/flags.js";
@@ -1046,6 +1048,58 @@ export function _cleanupAfterLoopExitForTest(ctx: ExtensionContext): Promise<voi
 
 export type AutoWorktreeExitAction = "skip" | "merge" | "preserve";
 
+interface MilestoneCompletionRollup {
+  milestoneTitle?: string;
+  oneLiner?: string;
+  successCriteriaResults?: string;
+  definitionOfDoneResults?: string;
+  requirementOutcomes?: string;
+  deviations?: string;
+  followUps?: string;
+  keyDecisions?: string[];
+  keyFiles?: string[];
+  lessonsLearned?: string[];
+}
+
+function normalizeFrontmatterList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map(item => typeof item === "string" ? item.trim() : "")
+    .filter(item => item.length > 0 && item !== "(none)");
+}
+
+function firstBoldParagraph(body: string): string | undefined {
+  const match = body.match(/\*\*([^*\n][\s\S]*?)\*\*/);
+  return match?.[1]?.replace(/\s+/g, " ").trim() || undefined;
+}
+
+function loadMilestoneCompletionRollup(basePath: string, milestoneId: string | null | undefined): MilestoneCompletionRollup {
+  if (!milestoneId) return {};
+  const summaryPath = resolveMilestoneFile(basePath, milestoneId, "SUMMARY");
+  if (!summaryPath || !existsSync(summaryPath)) return {};
+
+  try {
+    const raw = readFileSync(summaryPath, "utf-8");
+    const [frontmatterLines, body] = splitFrontmatter(raw);
+    const frontmatter = frontmatterLines ? parseFrontmatterMap(frontmatterLines) : {};
+    return {
+      milestoneTitle: typeof frontmatter.title === "string" ? frontmatter.title : undefined,
+      oneLiner: firstBoldParagraph(body),
+      successCriteriaResults: extractSection(body, "Success Criteria Results") ?? undefined,
+      definitionOfDoneResults: extractSection(body, "Definition of Done Results") ?? undefined,
+      requirementOutcomes: extractSection(body, "Requirement Outcomes") ?? undefined,
+      deviations: extractSection(body, "Deviations") ?? undefined,
+      followUps: extractSection(body, "Follow-ups") ?? undefined,
+      keyDecisions: normalizeFrontmatterList(frontmatter.key_decisions),
+      keyFiles: normalizeFrontmatterList(frontmatter.key_files),
+      lessonsLearned: normalizeFrontmatterList(frontmatter.lessons_learned),
+    };
+  } catch (err) {
+    logWarning("dashboard", `completion roll-up summary read failed: ${err instanceof Error ? err.message : String(err)}`);
+    return {};
+  }
+}
+
 export function _resolveAutoWorktreeExitActionForTest(
   currentMilestoneId: string | null | undefined,
   milestoneMergedInPhases: boolean,
@@ -1063,10 +1117,12 @@ export async function stopAuto(
   ctx?: ExtensionContext,
   pi?: ExtensionAPI,
   reason?: string,
+  options: StopAutoOptions = {},
 ): Promise<void> {
   if (!s.active && !s.paused) return;
   const loadedPreferences = loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences;
   const reasonSuffix = reason ? ` — ${reason}` : "";
+  const preserveCompletionSurface = Boolean(options.completionWidget);
 
   // #4764 — telemetry: record the exit reason and whether the current milestone
   // was merged before we entered stopAuto. This is the producer-side signal for
@@ -1288,7 +1344,7 @@ export async function stopAuto(
     // mergeAndExit restores process.cwd(), but AgentSession has already captured
     // its own cwd for tools and system prompt; refresh it before returning to the
     // user so follow-up commands do not target a removed milestone worktree.
-    if (s.originalBasePath && ctx && s.cmdCtx) {
+    if (!preserveCompletionSurface && s.originalBasePath && ctx && s.cmdCtx) {
       const result = await rerootCommandSession(s.cmdCtx, s.basePath);
       if (result.status === "cancelled") {
         logWarning("engine", "post-stop session re-root was cancelled", { file: "auto.ts", basePath: s.basePath });
@@ -1311,6 +1367,71 @@ export async function stopAuto(
       }
     } catch (e) {
       debugLog("stop-cleanup-ledger", { error: e instanceof Error ? e.message : String(e) });
+    }
+
+    if (preserveCompletionSurface && ctx && options.completionWidget) {
+      const ledger = getLedger();
+      const units = ledger?.units ?? [];
+      const totals = units.length > 0 ? getProjectTotals(units) : null;
+      let totalInput = 0;
+      let totalCacheRead = 0;
+      try {
+        for (const entry of s.cmdCtx?.sessionManager?.getEntries?.() ?? []) {
+          if (entry.type === "message") {
+            const msgEntry = entry as SessionMessageEntry;
+            if (msgEntry.message?.role === "assistant") {
+              const usage = (msgEntry.message as any).usage;
+              if (usage) {
+                totalInput += usage.input || 0;
+                totalCacheRead += usage.cacheRead || 0;
+              }
+            }
+          }
+        }
+      } catch (err) {
+        logWarning("dashboard", `completion stats lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      const contextUsage = s.cmdCtx?.getContextUsage?.();
+      const milestoneId = options.completionWidget.milestoneId ?? s.currentMilestoneId;
+      const rollup = loadMilestoneCompletionRollup(s.originalBasePath || s.basePath, milestoneId);
+      let completedSlices: number | null = null;
+      let totalSlices: number | null = null;
+      if (milestoneId && isDbAvailable()) {
+        try {
+          const slices = getMilestoneSlices(milestoneId);
+          completedSlices = slices.filter(slice => isClosedStatus(slice.status)).length;
+          totalSlices = slices.length;
+        } catch (err) {
+          logWarning("dashboard", `completion slice stats lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+      setCompletionProgressWidget(ctx, {
+        milestoneId,
+        milestoneTitle: options.completionWidget.milestoneTitle ?? rollup.milestoneTitle,
+        oneLiner: rollup.oneLiner,
+        successCriteriaResults: rollup.successCriteriaResults,
+        definitionOfDoneResults: rollup.definitionOfDoneResults,
+        requirementOutcomes: rollup.requirementOutcomes,
+        deviations: rollup.deviations,
+        followUps: rollup.followUps,
+        keyDecisions: rollup.keyDecisions,
+        keyFiles: rollup.keyFiles,
+        lessonsLearned: rollup.lessonsLearned,
+        reason: reason ?? "Milestone complete",
+        startedAt: s.autoStartTime,
+        totalCost: totals?.cost ?? 0,
+        totalTokens: totals?.tokens.total ?? 0,
+        unitCount: units.length,
+        cacheHitRate: totalCacheRead + totalInput > 0
+          ? (totalCacheRead / (totalCacheRead + totalInput)) * 100
+          : null,
+        contextPercent: contextUsage?.percent ?? null,
+        contextWindow: contextUsage?.contextWindow ?? s.cmdCtx?.model?.contextWindow ?? null,
+        completedSlices,
+        totalSlices,
+        allMilestonesComplete: options.completionWidget.allMilestonesComplete,
+        basePath: s.originalBasePath || s.basePath || null,
+      });
     }
 
     // ── Step 9: Cmux sidebar / event log ──
@@ -1403,8 +1524,10 @@ export async function stopAuto(
 
     // UI cleanup
     ctx?.ui.setStatus("gsd-auto", undefined);
-    ctx?.ui.setWidget("gsd-progress", undefined);
-    if (ctx) initHealthWidget(ctx);
+    if (!preserveCompletionSurface) {
+      ctx?.ui.setWidget("gsd-progress", undefined);
+      if (ctx) initHealthWidget(ctx);
+    }
     restoreProjectRootEnv();
     restoreMilestoneLockEnv();
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1561,8 +1561,15 @@ export async function pauseAuto(
  * deps bag is intentionally focused — Lifecycle does not see the wider auto-
  * mode dependency graph.
  */
-function buildLifecycle(): WorktreeLifecycle {
-  const lifecycleDeps = {
+/**
+ * Construct a `WorktreeLifecycleDeps` bag without binding to any session.
+ *
+ * Exported so session-less callers (currently `parallel-merge.ts`) can build
+ * the same deps and call `mergeMilestoneStandalone` through the Worktree
+ * Lifecycle Module instead of bypassing it (ADR-016 phase 2 / A2).
+ */
+export function buildWorktreeLifecycleDeps(): WorktreeLifecycleDeps {
+  return {
     enterAutoWorktree,
     createAutoWorktree,
     enterBranchModeForMilestone,
@@ -1583,7 +1590,10 @@ function buildLifecycle(): WorktreeLifecycle {
     readFileSync: (path: string, encoding: string) =>
       readFileSync(path, encoding as BufferEncoding),
   } as unknown as WorktreeLifecycleDeps;
-  return new WorktreeLifecycle(s, lifecycleDeps);
+}
+
+function buildLifecycle(): WorktreeLifecycle {
+  return new WorktreeLifecycle(s, buildWorktreeLifecycleDeps());
 }
 
 /**

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1313,6 +1313,19 @@ export async function stopAuto(
       }
     }
 
+    const completionMilestoneId = options.completionWidget?.milestoneId ?? s.currentMilestoneId;
+    let completedSlices: number | null = null;
+    let totalSlices: number | null = null;
+    if (completionMilestoneId && isDbAvailable()) {
+      try {
+        const slices = getMilestoneSlices(completionMilestoneId);
+        completedSlices = slices.filter(slice => isClosedStatus(slice.status)).length;
+        totalSlices = slices.length;
+      } catch (err) {
+        logWarning("dashboard", `completion slice stats lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
     // ── Step 6: DB cleanup ──
     if (isDbAvailable()) {
       try {
@@ -1344,12 +1357,12 @@ export async function stopAuto(
     // mergeAndExit restores process.cwd(), but AgentSession has already captured
     // its own cwd for tools and system prompt; refresh it before returning to the
     // user so follow-up commands do not target a removed milestone worktree.
-    if (!preserveCompletionSurface && s.originalBasePath && ctx && s.cmdCtx) {
-      const result = await rerootCommandSession(s.cmdCtx, s.basePath);
+    if (s.originalBasePath && ctx && s.cmdCtx) {
+      const result = await rerootCommandSession(s.cmdCtx, s.originalBasePath);
       if (result.status === "cancelled") {
-        logWarning("engine", "post-stop session re-root was cancelled", { file: "auto.ts", basePath: s.basePath });
+        logWarning("engine", "post-stop session re-root was cancelled", { file: "auto.ts", basePath: s.originalBasePath });
       } else if (result.status === "failed") {
-        logWarning("engine", `post-stop session re-root failed: ${result.error ?? "unknown"}`, { file: "auto.ts", basePath: s.basePath });
+        logWarning("engine", `post-stop session re-root failed: ${result.error ?? "unknown"}`, { file: "auto.ts", basePath: s.originalBasePath });
       }
     }
 
@@ -1392,19 +1405,8 @@ export async function stopAuto(
         logWarning("dashboard", `completion stats lookup failed: ${err instanceof Error ? err.message : String(err)}`);
       }
       const contextUsage = s.cmdCtx?.getContextUsage?.();
-      const milestoneId = options.completionWidget.milestoneId ?? s.currentMilestoneId;
+      const milestoneId = completionMilestoneId;
       const rollup = loadMilestoneCompletionRollup(s.originalBasePath || s.basePath, milestoneId);
-      let completedSlices: number | null = null;
-      let totalSlices: number | null = null;
-      if (milestoneId && isDbAvailable()) {
-        try {
-          const slices = getMilestoneSlices(milestoneId);
-          completedSlices = slices.filter(slice => isClosedStatus(slice.status)).length;
-          totalSlices = slices.length;
-        } catch (err) {
-          logWarning("dashboard", `completion slice stats lookup failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-      }
       setCompletionProgressWidget(ctx, {
         milestoneId,
         milestoneTitle: options.completionWidget.milestoneTitle ?? rollup.milestoneTitle,

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1313,10 +1313,12 @@ export async function stopAuto(
       }
     }
 
+    // Pre-compute completion widget slice counts while the DB is still open.
+    // Step 8 runs after closeDatabase(), so DB-backed slice lookups must happen here.
     const completionMilestoneId = options.completionWidget?.milestoneId ?? s.currentMilestoneId;
     let completedSlices: number | null = null;
     let totalSlices: number | null = null;
-    if (completionMilestoneId && isDbAvailable()) {
+    if (preserveCompletionSurface && options.completionWidget && completionMilestoneId && isDbAvailable()) {
       try {
         const slices = getMilestoneSlices(completionMilestoneId);
         completedSlices = slices.filter(slice => isClosedStatus(slice.status)).length;

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -26,6 +26,14 @@ import type { MergeReconcileResult } from "../auto-recovery.js";
 import type { UokTurnObserver } from "../uok/contracts.js";
 import type { PostflightResult, PreflightResult } from "../clean-root-preflight.js";
 
+export interface StopAutoOptions {
+  completionWidget?: {
+    milestoneId?: string | null;
+    milestoneTitle?: string | null;
+    allMilestonesComplete?: boolean;
+  };
+}
+
 type PauseAutoFn = (
   ctx?: ExtensionContext,
   pi?: ExtensionAPI,
@@ -46,6 +54,7 @@ export interface LoopDeps {
     ctx?: ExtensionContext,
     pi?: ExtensionAPI,
     reason?: string,
+    options?: StopAutoOptions,
   ) => Promise<void>;
   pauseAuto: PauseAutoFn;
   clearUnitTimeout: () => void;

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1008,7 +1008,13 @@ export async function runPreDispatch(
         "All milestones complete.",
         "success",
       );
-      await deps.stopAuto(ctx, pi, "All milestones complete");
+      await deps.stopAuto(ctx, pi, "All milestones complete", {
+        completionWidget: {
+          milestoneId: s.currentMilestoneId,
+          milestoneTitle: midTitle,
+          allMilestonesComplete: true,
+        },
+      });
     } else if (incomplete.length === 0 && state.registry.length === 0) {
       // Empty registry — no milestones visible, likely a path resolution bug
       const diag = `basePath=${s.basePath}, phase=${state.phase}`;
@@ -1103,7 +1109,23 @@ export async function runPreDispatch(
       `Milestone ${mid} complete.`,
       "success",
     );
-    await closeoutAndStop(ctx, pi, s, deps, `Milestone ${mid} complete`);
+    if (s.currentUnit) {
+      await deps.closeoutUnit(
+        ctx,
+        s.basePath,
+        s.currentUnit.type,
+        s.currentUnit.id,
+        s.currentUnit.startedAt,
+        deps.buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id),
+      );
+      s.currentUnit = null;
+    }
+    await deps.stopAuto(ctx, pi, `Milestone ${mid} complete`, {
+      completionWidget: {
+        milestoneId: mid,
+        milestoneTitle: midTitle,
+      },
+    });
     debugLog("autoLoop", { phase: "exit", reason: "milestone-complete" });
     deps.emitJournalEvent({ ts: new Date().toISOString(), flowId: ic.flowId, seq: ic.nextSeq(), eventType: "terminal", data: { reason: "milestone-complete", milestoneId: mid } });
     return { action: "break", reason: "milestone-complete" };

--- a/src/resources/extensions/gsd/parallel-merge.ts
+++ b/src/resources/extensions/gsd/parallel-merge.ts
@@ -8,9 +8,13 @@
 import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
-import { loadFile } from "./files.js";
-import { resolveGsdPathContract, resolveMilestoneFile } from "./paths.js";
-import { mergeMilestoneToMain } from "./auto-worktree.js";
+import { resolveGsdPathContract } from "./paths.js";
+import { getAutoWorktreePath } from "./auto-worktree.js";
+import { buildWorktreeLifecycleDeps } from "./auto.js";
+import {
+  mergeMilestoneStandalone,
+  type MergeStandaloneResult,
+} from "./worktree-lifecycle.js";
 import { MergeConflictError } from "./git-service.js";
 import { removeSessionStatus } from "./session-status-io.js";
 import type { WorkerInfo } from "./parallel-orchestrator.js";
@@ -136,44 +140,46 @@ export function determineMergeOrder(
 
 /**
  * Attempt to merge a single milestone's worktree back to main.
- * Wraps mergeMilestoneToMain with error handling for parallel context.
+ *
+ * Routes through `WorktreeLifecycle.mergeMilestoneStandalone` so parallel
+ * callers get the same projection-finalize / roadmap-fallback / secondary-
+ * teardown invariants as the single-loop path. Closes the parallel-merge
+ * bypass that ADR-016 names (issue #5618).
  */
 export async function mergeCompletedMilestone(
   basePath: string,
   milestoneId: string,
 ): Promise<MergeResult> {
+  // Resolve the worktree path explicitly; parallel-merge has no AutoSession
+  // to read it from. Only use the worktree path when git actually knows
+  // about it (`getAutoWorktreePath` returns non-null). When the directory
+  // exists on disk but isn't a registered git worktree (e.g. a stale
+  // session-status marker dir), fall back to the project root and let the
+  // standalone's mode detection pick branch-mode or skipped — using the
+  // un-registered dir as `worktreeBasePath` would cause `getCurrentBranch`
+  // to fail with a "Worktree HEAD diverged" error.
+  const registeredWtPath = getAutoWorktreePath(basePath, milestoneId);
+  const worktreeBasePath = registeredWtPath ?? basePath;
+
+  let result: MergeStandaloneResult;
   try {
-    // Load the roadmap content (needed by mergeMilestoneToMain)
-    const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
-    if (!roadmapPath) {
-      return {
-        milestoneId,
-        success: false,
-        error: `No roadmap found for ${milestoneId}`,
-      };
-    }
-
-    const roadmapContent = await loadFile(roadmapPath);
-    if (!roadmapContent) {
-      return {
-        milestoneId,
-        success: false,
-        error: `Could not read roadmap for ${milestoneId}`,
-      };
-    }
-
-    // Attempt the merge
-    const result = mergeMilestoneToMain(basePath, milestoneId, roadmapContent);
-
-    // Clean up parallel session status
-    removeSessionStatus(basePath, milestoneId);
-
-    return {
+    result = mergeMilestoneStandalone(buildWorktreeLifecycleDeps(), {
+      originalBasePath: basePath,
+      worktreeBasePath,
       milestoneId,
-      success: true,
-      commitMessage: result.commitMessage,
-      pushed: result.pushed,
-    };
+      // Parallel context never runs with degraded isolation — workers only
+      // exist when isolation succeeded. Pass `false` explicitly so the
+      // standalone's degraded-skip branch is not reached.
+      isolationDegraded: false,
+      notify: (msg, level) => {
+        // Surface user-visible messages from the standalone through the
+        // workflow logger so the parallel merge's progress is visible in
+        // the same channel as the rest of the parallel orchestration.
+        if (level === "error" || level === "warning") {
+          logWarning("parallel", `${milestoneId}: ${msg}`);
+        }
+      },
+    });
   } catch (err) {
     if (err instanceof MergeConflictError) {
       return {
@@ -189,6 +195,27 @@ export async function mergeCompletedMilestone(
       error: getErrorMessage(err),
     };
   }
+
+  if (!result.merged) {
+    return {
+      milestoneId,
+      success: false,
+      error:
+        result.mode === "skipped"
+          ? `Merge skipped for ${milestoneId} (mode=none or isolation degraded).`
+          : `No roadmap for ${milestoneId} — milestone branch preserved for manual merge.`,
+    };
+  }
+
+  // Clean up parallel session status — only on a real merge.
+  removeSessionStatus(basePath, milestoneId);
+
+  return {
+    milestoneId,
+    success: true,
+    commitMessage: result.commitMessage,
+    pushed: result.pushed,
+  };
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -2,11 +2,11 @@
 // File Purpose: Behavior tests for auto-loop cleanup after paused provider exits.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { cleanupAfterLoopExit, rerootCommandSession } from "../auto.ts";
+import { cleanupAfterLoopExit, rerootCommandSession, stopAuto } from "../auto.ts";
 import { autoSession } from "../auto-runtime-state.ts";
 
 test("cleanupAfterLoopExit preserves paused auto badge after provider pause", async () => {
@@ -82,4 +82,131 @@ test("rerootCommandSession refreshes command workspace to project root", async (
 
   assert.deepEqual(result, { status: "ok" });
   assert.deepEqual(calls, ["/project/root"]);
+});
+
+test("stopAuto completion closeout preserves final widget and skips fresh session", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-completion-stop-"));
+  const previousCwd = process.cwd();
+  const widgetCalls: Array<[string, unknown]> = [];
+  let newSessionCalls = 0;
+  const milestoneDir = join(base, ".gsd", "milestones", "M003");
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(join(milestoneDir, "M003-SUMMARY.md"), [
+    "---",
+    "id: M003",
+    'title: "Budget tracking"',
+    "status: complete",
+    "key_decisions:",
+    "  - Keep completion closeout in the same TUI surface.",
+    "key_files:",
+    "  - src/resources/extensions/gsd/auto-dashboard.ts",
+    "lessons_learned:",
+    "  - Milestone endings need report output, not auto-loop status.",
+    "---",
+    "",
+    "# M003: Budget tracking",
+    "",
+    "**Added budget warning output and provider roll-up details.**",
+    "",
+    "## Success Criteria Results",
+    "",
+    "Budget warnings appear at milestone completion.",
+    "",
+    "## Definition of Done Results",
+    "",
+    "Completion leaves the report surface visible.",
+    "",
+    "## Requirement Outcomes",
+    "",
+    "Users can see what shipped without opening a fresh session.",
+    "",
+    "## Deviations",
+    "",
+    "None.",
+    "",
+    "## Follow-ups",
+    "",
+    "None.",
+    "",
+  ].join("\n"), "utf-8");
+
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.paused = false;
+  autoSession.basePath = base;
+  autoSession.originalBasePath = base;
+  autoSession.currentMilestoneId = "M003";
+  autoSession.autoStartTime = Date.now() - 60_000;
+  autoSession.cmdCtx = {
+    newSession: async () => {
+      newSessionCalls++;
+      return { cancelled: false };
+    },
+    sessionManager: {
+      getEntries: () => [
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            usage: { input: 100, cacheRead: 900 },
+          },
+        },
+      ],
+    },
+    getContextUsage: () => ({ percent: 0.9, contextWindow: 1_000_000 }),
+    model: { contextWindow: 1_000_000 },
+  } as any;
+
+  try {
+    await stopAuto(
+      {
+        hasUI: true,
+        ui: {
+          setStatus: () => {},
+          setWidget: (key: string, value: unknown) => {
+            widgetCalls.push([key, value]);
+          },
+          setHeader: () => {},
+          notify: () => {},
+        },
+        modelRegistry: { find: () => null },
+      } as any,
+      { events: { emit: () => {} } } as any,
+      "Milestone M003 complete",
+      {
+        completionWidget: {
+          milestoneId: "M003",
+          milestoneTitle: "Budget tracking",
+        },
+      },
+    );
+
+    assert.equal(newSessionCalls, 0, "completion stop must not open a fresh command session");
+    assert.equal(
+      widgetCalls.some(([key, value]) => key === "gsd-progress" && value === undefined),
+      false,
+      "completion stop must not clear the final progress widget",
+    );
+    assert.ok(
+      widgetCalls.some(([key, value]) => key === "gsd-progress" && typeof value === "function"),
+      "completion stop must install a final progress widget",
+    );
+    const factory = widgetCalls.find(([key, value]) => key === "gsd-progress" && typeof value === "function")?.[1] as any;
+    const component = factory(
+      { requestRender() {} },
+      { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+    );
+    const output = component.render(140).join("\n");
+    assert.match(output, /Milestone M003 roll-up/);
+    assert.match(output, /Outcome/);
+    assert.match(output, /Added budget warning output/);
+    assert.match(output, /Verification/);
+    assert.match(output, /Files: src\/resources\/extensions\/gsd\/auto-dashboard\.ts/);
+    assert.match(output, /Lessons: Milestone endings need report output/);
+    assert.doesNotMatch(output, /COMPLETE-MILESTONE/);
+  } finally {
+    autoSession.reset();
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
 });

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 
 import { cleanupAfterLoopExit, rerootCommandSession, stopAuto } from "../auto.ts";
 import { autoSession } from "../auto-runtime-state.ts";
+import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
 
 test("cleanupAfterLoopExit preserves paused auto badge after provider pause", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-paused-cleanup-"));
@@ -84,11 +85,11 @@ test("rerootCommandSession refreshes command workspace to project root", async (
   assert.deepEqual(calls, ["/project/root"]);
 });
 
-test("stopAuto completion closeout preserves final widget and skips fresh session", async () => {
+test("stopAuto completion closeout reroots session and preserves final widget", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-completion-stop-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
-  let newSessionCalls = 0;
+  const newSessionWorkspaces: string[] = [];
   const milestoneDir = join(base, ".gsd", "milestones", "M003");
   mkdirSync(milestoneDir, { recursive: true });
   writeFileSync(join(milestoneDir, "M003-SUMMARY.md"), [
@@ -131,15 +132,22 @@ test("stopAuto completion closeout preserves final widget and skips fresh sessio
   ].join("\n"), "utf-8");
 
   autoSession.reset();
+  openDatabase(join(base, "gsd-test.db"));
+  insertMilestone({ id: "M003", title: "Budget tracking", status: "complete" });
+  insertSlice({ id: "S01", milestoneId: "M003", title: "Complete slice", status: "complete", sequence: 1 });
+  insertSlice({ id: "S02", milestoneId: "M003", title: "Done slice", status: "done", sequence: 2 });
+  insertSlice({ id: "S03", milestoneId: "M003", title: "Pending slice", status: "active", sequence: 3 });
+
   autoSession.active = true;
   autoSession.paused = false;
-  autoSession.basePath = base;
+  autoSession.basePath = join(base, ".gsd", "worktrees", "M003");
   autoSession.originalBasePath = base;
   autoSession.currentMilestoneId = "M003";
   autoSession.autoStartTime = Date.now() - 60_000;
   autoSession.cmdCtx = {
-    newSession: async () => {
-      newSessionCalls++;
+    newSession: async ({ workspaceRoot }: { workspaceRoot: string }) => {
+      newSessionWorkspaces.push(workspaceRoot);
+      widgetCalls.push(["gsd-progress", undefined]);
       return { cancelled: false };
     },
     sessionManager: {
@@ -181,17 +189,14 @@ test("stopAuto completion closeout preserves final widget and skips fresh sessio
       },
     );
 
-    assert.equal(newSessionCalls, 0, "completion stop must not open a fresh command session");
-    assert.equal(
-      widgetCalls.some(([key, value]) => key === "gsd-progress" && value === undefined),
-      false,
-      "completion stop must not clear the final progress widget",
-    );
+    assert.deepEqual(newSessionWorkspaces, [base], "completion stop must reroot command session to original project root");
     assert.ok(
       widgetCalls.some(([key, value]) => key === "gsd-progress" && typeof value === "function"),
       "completion stop must install a final progress widget",
     );
-    const factory = widgetCalls.find(([key, value]) => key === "gsd-progress" && typeof value === "function")?.[1] as any;
+    const lastProgressWidget = widgetCalls.filter(([key]) => key === "gsd-progress").at(-1);
+    assert.equal(typeof lastProgressWidget?.[1], "function", "completion stop must leave the final progress widget installed after reroot");
+    const factory = lastProgressWidget?.[1] as any;
     const component = factory(
       { requestRender() {} },
       { fg: (_color: string, text: string) => text, bold: (text: string) => text },
@@ -203,8 +208,10 @@ test("stopAuto completion closeout preserves final widget and skips fresh sessio
     assert.match(output, /Verification/);
     assert.match(output, /Files: src\/resources\/extensions\/gsd\/auto-dashboard\.ts/);
     assert.match(output, /Lessons: Milestone endings need report output/);
+    assert.match(output, /2\/3 slices/);
     assert.doesNotMatch(output, /COMPLETE-MILESTONE/);
   } finally {
+    try { closeDatabase(); } catch { /* noop */ }
     autoSession.reset();
     process.chdir(previousCwd);
     rmSync(base, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/parallel-merge.test.ts
@@ -85,7 +85,49 @@ function cleanup(dir: string): void {
   try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
 }
 
-/** Set up a milestone roadmap file in .gsd/milestones/<MID>/ */
+/**
+ * Write `.gsd/preferences.md` with `git.isolation: branch` so the merge
+ * routes through the standalone Lifecycle merge body in branch mode rather
+ * than falling through `getIsolationMode === "none"` to a skipped result.
+ *
+ * Parallel-merge in production runs with `git.isolation: worktree` and a
+ * real auto-worktree on disk; these integration tests use branch mode as a
+ * simpler equivalent that exercises the same merge path without requiring
+ * `git worktree add` setup. ADR-016 phase 2 / A2 routes parallel-merge
+ * through the Module, which performs mode detection — branch mode keeps
+ * the test simple while still going through the Module.
+ */
+function setupBranchIsolation(repo: string): void {
+  mkdirSync(join(repo, ".gsd"), { recursive: true });
+  writeFileSync(
+    join(repo, ".gsd", "preferences.md"),
+    "## Git\n- isolation: branch\n",
+  );
+  // Commit on main so subsequent `git checkout main` restores the file.
+  // Without this commit, `createMilestoneBranch`'s checkout dance carries
+  // the uncommitted file onto the milestone branch and back-checking-out
+  // main loses the preference file before `mergeMilestoneStandalone`
+  // reads it (ADR-016 phase 2 / A2).
+  try {
+    run("git add .gsd/preferences.md", repo);
+    run('git commit -m "test: add branch-isolation preferences"', repo);
+  } catch { /* file may already be committed */ }
+}
+
+/**
+ * Set up a milestone roadmap file in .gsd/milestones/<MID>/ AND commit it on
+ * the current branch.
+ *
+ * The commit is required after ADR-016 phase 2 / A2 because the standalone
+ * Module-level merge (now used by parallel-merge) reads the roadmap _after_
+ * its branch checkout. Uncommitted roadmaps on `main` survive a checkout
+ * for the first milestone but get committed onto the milestone branch by
+ * `autoCommitDirtyState`, which then doesn't reproduce them on the next
+ * milestone branch's checkout.
+ *
+ * Real production runs commit roadmap files on each milestone branch as
+ * part of the unit's normal output; tests should mirror that.
+ */
 function setupRoadmap(repo: string, mid: string, title: string, slices: string[]): void {
   const dir = join(repo, ".gsd", "milestones", mid);
   mkdirSync(dir, { recursive: true });
@@ -94,6 +136,10 @@ function setupRoadmap(repo: string, mid: string, title: string, slices: string[]
     join(dir, `${mid}-ROADMAP.md`),
     `# ${mid}: ${title}\n\n## Slices\n${sliceLines}\n`,
   );
+  try {
+    run(`git add .gsd/milestones/${mid}/${mid}-ROADMAP.md`, repo);
+    run(`git commit -m "test: add roadmap for ${mid}"`, repo);
+  } catch { /* file may already be committed; not a git repo; etc. */ }
 }
 
 /** Create a milestone branch with file changes, then return to main. */
@@ -234,15 +280,36 @@ test("formatMergeResults — mixed results", () => {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 test("mergeCompletedMilestone — missing roadmap returns error result", async () => {
-  const base = join(tmpdir(), `parallel-merge-noroadmap-${Date.now()}`);
-  mkdirSync(join(base, ".gsd"), { recursive: true });
+  const savedCwd = process.cwd();
+  // Use a real git repo so the standalone's branch-mode merge body can
+  // call `getCurrentBranch` without throwing. The roadmap is intentionally
+  // omitted so the merge ends in the "no-roadmap" branch.
+  const repo = createTempRepo();
   try {
-    const result = await mergeCompletedMilestone(base, "M999");
+    setupBranchIsolation(repo);
+    // Create a milestone branch but no roadmap file — this is the
+    // condition under test.
+    run("git checkout -b milestone/M999", repo);
+    writeFileSync(join(repo, "feature.ts"), "export {};\n");
+    run("git add .", repo);
+    run('git commit -m "M999 feature"', repo);
+    run("git checkout main", repo);
+
+    process.chdir(repo);
+    const result = await mergeCompletedMilestone(repo, "M999");
+
     assert.equal(result.success, false);
-    assert.ok(result.error?.includes("No roadmap found") || result.error?.includes("Could not read"));
+    // A2 widens the error surface vs. the legacy bypass: the standalone
+    // routes through the Module, so the no-roadmap path teardowns the
+    // (non-existent) worktree branch and surfaces a typed failure.
+    // What matters is `success: false`; the exact wording can shift as
+    // the standalone evolves.
+    assert.ok(result.error, "should report a non-empty error");
     assert.equal(result.milestoneId, "M999");
   } finally {
-    cleanup(base);
+    process.chdir(savedCwd);
+    try { run("git reset --hard HEAD", repo); } catch { /* */ }
+    cleanup(repo);
   }
 });
 
@@ -251,13 +318,23 @@ test("mergeCompletedMilestone — clean merge, session status cleaned up", async
   const repo = createTempRepo();
 
   try {
+    // Route the merge through the Module's branch-mode path. With default
+    // `isolation: none`, the standalone returns `{ mode: "skipped" }`
+    // (ADR-016 phase 2 / A2). Branch mode exercises the same Module-level
+    // merge body without requiring an on-disk auto-worktree.
+    setupBranchIsolation(repo);
+
+    // Set up roadmap on main BEFORE the milestone branch is created so the
+    // roadmap is in the milestone branch's history. After A2, the standalone
+    // reads the roadmap _inside_ the merge body (after the branch checkout)
+    // — the file must therefore exist in the milestone branch's tree, not
+    // just as an uncommitted file on main.
+    setupRoadmap(repo, "M010", "Auth System", ["S01: JWT module"]);
+
     // Create milestone branch with a new file
     createMilestoneBranch(repo, "M010", [
       { name: "auth.ts", content: "export const auth = true;\n" },
     ]);
-
-    // Set up roadmap
-    setupRoadmap(repo, "M010", "Auth System", ["S01: JWT module"]);
 
     // Write session status to verify cleanup
     writeSessionStatus(repo, {
@@ -309,6 +386,11 @@ test("mergeCompletedMilestone — conflict returns structured error with file li
   const repo = createTempRepo();
 
   try {
+    setupBranchIsolation(repo);
+
+    // Roadmap committed on main BEFORE branching — see "clean merge" test.
+    setupRoadmap(repo, "M020", "Conflict Test", ["S01: Conflict scenario"]);
+
     // Create milestone branch that modifies README.md
     run("git checkout -b milestone/M020", repo);
     writeFileSync(join(repo, "README.md"), "# M020 version\n");
@@ -320,9 +402,6 @@ test("mergeCompletedMilestone — conflict returns structured error with file li
     writeFileSync(join(repo, "README.md"), "# main version (diverged)\n");
     run("git add .", repo);
     run('git commit -m "main changes README"', repo);
-
-    // Set up roadmap
-    setupRoadmap(repo, "M020", "Conflict Test", ["S01: Conflict scenario"]);
 
     process.chdir(repo);
     const result = await mergeCompletedMilestone(repo, "M020");
@@ -350,6 +429,12 @@ test("mergeAllCompleted — merges in sequential order", async () => {
   const repo = createTempRepo();
 
   try {
+    setupBranchIsolation(repo);
+
+    // Roadmaps committed on main BEFORE branching — see "clean merge" test.
+    setupRoadmap(repo, "M001", "Auth", ["S01: Auth module"]);
+    setupRoadmap(repo, "M002", "Dashboard", ["S01: Dashboard module"]);
+
     // M001: adds auth.ts
     createMilestoneBranch(repo, "M001", [
       { name: "auth.ts", content: "export const auth = true;\n" },
@@ -358,9 +443,6 @@ test("mergeAllCompleted — merges in sequential order", async () => {
     createMilestoneBranch(repo, "M002", [
       { name: "dashboard.ts", content: "export const dash = true;\n" },
     ]);
-
-    setupRoadmap(repo, "M001", "Auth", ["S01: Auth module"]);
-    setupRoadmap(repo, "M002", "Dashboard", ["S01: Dashboard module"]);
 
     const workers = [
       makeWorker({ milestoneId: "M002", startedAt: 100 }),
@@ -373,9 +455,9 @@ test("mergeAllCompleted — merges in sequential order", async () => {
     // Both should succeed
     assert.equal(results.length, 2, "should have two results");
     assert.equal(results[0]!.milestoneId, "M001", "M001 merged first (sequential)");
-    assert.equal(results[0]!.success, true, "M001 should succeed");
+    assert.equal(results[0]!.success, true, `M001 should succeed: ${results[0]!.error}`);
     assert.equal(results[1]!.milestoneId, "M002", "M002 merged second");
-    assert.equal(results[1]!.success, true, "M002 should succeed");
+    assert.equal(results[1]!.success, true, `M002 should succeed: ${results[1]!.error}`);
 
     // Both files on main
     assert.ok(existsSync(join(repo, "auth.ts")), "auth.ts on main");
@@ -391,6 +473,12 @@ test("mergeAllCompleted — stops on first conflict, skips later milestones", as
   const repo = createTempRepo();
 
   try {
+    setupBranchIsolation(repo);
+
+    // Roadmaps committed on main BEFORE branching — see "clean merge" test.
+    setupRoadmap(repo, "M001", "Conflict milestone", ["S01: Conflict test"]);
+    setupRoadmap(repo, "M002", "Clean milestone", ["S01: Clean test"]);
+
     // M001: modifies README.md (will conflict with main)
     run("git checkout -b milestone/M001", repo);
     writeFileSync(join(repo, "README.md"), "# M001 version\n");
@@ -407,9 +495,6 @@ test("mergeAllCompleted — stops on first conflict, skips later milestones", as
     writeFileSync(join(repo, "README.md"), "# main diverged version\n");
     run("git add .", repo);
     run('git commit -m "main diverges README"', repo);
-
-    setupRoadmap(repo, "M001", "Conflict milestone", ["S01: Conflict test"]);
-    setupRoadmap(repo, "M002", "Clean milestone", ["S01: Clean test"]);
 
     const workers = [
       makeWorker({ milestoneId: "M001" }),
@@ -442,6 +527,12 @@ test("mergeAllCompleted — by-completion order respects startedAt", async () =>
   const repo = createTempRepo();
 
   try {
+    setupBranchIsolation(repo);
+
+    // Roadmaps committed on main BEFORE branching — see "clean merge" test.
+    setupRoadmap(repo, "M001", "Auth", ["S01: Auth module"]);
+    setupRoadmap(repo, "M002", "Feature", ["S01: Feature module"]);
+
     // M001: adds auth.ts (started later)
     createMilestoneBranch(repo, "M001", [
       { name: "auth.ts", content: "export const auth = true;\n" },
@@ -450,9 +541,6 @@ test("mergeAllCompleted — by-completion order respects startedAt", async () =>
     createMilestoneBranch(repo, "M002", [
       { name: "feature.ts", content: "export const feature = true;\n" },
     ]);
-
-    setupRoadmap(repo, "M001", "Auth", ["S01: Auth module"]);
-    setupRoadmap(repo, "M002", "Feature", ["S01: Feature module"]);
 
     const workers = [
       makeWorker({ milestoneId: "M001", startedAt: 2000 }),
@@ -549,11 +637,15 @@ test("mergeAllCompleted — discovers DB-complete milestones when workers show e
   const repo = createTempRepo();
 
   try {
+    setupBranchIsolation(repo);
+
+    // Roadmap committed on main BEFORE branching — see "clean merge" test.
+    setupRoadmap(repo, "M011", "Feature System", ["S01: Feature module"]);
+
     // Create milestone branch with a file
     createMilestoneBranch(repo, "M011", [
       { name: "feature.ts", content: "export const feature = true;\n" },
     ]);
-    setupRoadmap(repo, "M011", "Feature System", ["S01: Feature module"]);
 
     // Set up canonical DB showing M011 is complete
     setupCanonicalDbWithWorktree(repo, "M011");

--- a/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
@@ -11,7 +11,7 @@ import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { updateProgressWidget } from "../auto-dashboard.ts";
+import { setCompletionProgressWidget, updateProgressWidget } from "../auto-dashboard.ts";
 import type { GSDState } from "../types.ts";
 
 interface CapturedSetHeader {
@@ -205,6 +205,75 @@ test("auto-dashboard widget render output omits Ctrl+N guidance when isStepMode 
 
   const hasStepHint = lines.some((line: string) => line.includes("Ctrl+N to advance"));
   assert.equal(hasStepHint, false, "step-mode hint must NOT appear when isStepMode is false");
+
+  if (component.dispose) component.dispose();
+});
+
+test("completion dashboard keeps final milestone roll-up in the progress widget", (t) => {
+  const dir = makeTempDir("completion-widget");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  t.after(() => cleanup(dir));
+
+  let widgetFactory: ((tui: unknown, theme: unknown) => any) | undefined;
+
+  setCompletionProgressWidget(
+    {
+      hasUI: true,
+      ui: {
+        setWidget(_key: string, factory: any) { widgetFactory = factory; },
+        setHeader() {},
+        setStatus() {},
+      },
+    } as any,
+    {
+      milestoneId: "M003",
+      milestoneTitle: "Budget tracking",
+      oneLiner: "Added milestone budget warning output and provider roll-up details.",
+      successCriteriaResults: "Budget warnings appear at the end of milestone completion.",
+      requirementOutcomes: "Users can see what shipped without opening a fresh session.",
+      keyFiles: ["src/resources/extensions/gsd/auto-dashboard.ts", "src/resources/extensions/gsd/auto.ts"],
+      keyDecisions: ["Keep completion closeout in the same TUI surface."],
+      followUps: "None.",
+      reason: "Milestone M003 complete",
+      startedAt: Date.now() - 90_000,
+      totalCost: 21.29,
+      totalTokens: 1_000_000,
+      unitCount: 8,
+      cacheHitRate: 100,
+      contextPercent: 0.9,
+      contextWindow: 1_000_000,
+      completedSlices: 3,
+      totalSlices: 3,
+      basePath: dir,
+    },
+  );
+
+  assert.ok(widgetFactory, "completion widget factory must be installed");
+
+  const fakeTui = { requestRender() {} };
+  const fakeTheme = {
+    fg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  };
+  const component = widgetFactory!(fakeTui, fakeTheme);
+  const output = component.render(140).join("\n");
+
+  assert.match(output, /Milestone M003 roll-up/);
+  assert.match(output, /Budget tracking/);
+  assert.match(output, /Outcome/);
+  assert.match(output, /Added milestone budget warning output/);
+  assert.match(output, /What changed/);
+  assert.match(output, /Budget warnings appear/);
+  assert.match(output, /Users can see what shipped/);
+  assert.match(output, /Keep completion closeout/);
+  assert.match(output, /Verification/);
+  assert.match(output, /Files: src\/resources\/extensions\/gsd\/auto-dashboard\.ts/);
+  assert.match(output, /Run totals 3\/3 slices/);
+  assert.match(output, /100% cache hit/);
+  assert.match(output, /\$21\.29/);
+  assert.match(output, /1\.0M tokens/);
+  assert.match(output, /8 units/);
+  assert.doesNotMatch(output, /COMPLETE-MILESTONE/);
 
   if (component.dispose) component.dispose();
 });

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -102,7 +102,11 @@ export interface WorktreeLifecycleDeps {
     basePath: string,
     milestoneId: string,
     roadmapContent: string,
-  ) => { pushed: boolean; codeFilesChanged: boolean };
+  ) => {
+    pushed: boolean;
+    codeFilesChanged: boolean;
+    commitMessage?: string;
+  };
   getCurrentBranch: (basePath: string) => string;
   /**
    * Force-checkout the named branch in `basePath`. Required by the branch-mode
@@ -165,6 +169,49 @@ export type EnterResult =
 export type ExitResult =
   | { ok: true; merged: boolean; codeFilesChanged: boolean }
   | { ok: false; reason: "merge-conflict" | "teardown-failed"; cause?: unknown };
+
+/**
+ * Session-less merge entry context. Per ADR-016 phase 2 / A1 (#5616), the
+ * merge body is structurally session-less — it reads project root, worktree
+ * path, and milestoneId. Single-loop callers (`_mergeAndExit`) build a
+ * MergeContext from `this.s`. Parallel callers (`parallel-merge.ts`) build
+ * one directly without an `AutoSession`.
+ */
+export interface MergeContext {
+  /** Project root — merge target (where `git merge --squash` lands). */
+  originalBasePath: string;
+  /**
+   * Current worktree path or project root when in branch mode. Used as the
+   * cwd anchor for `mergeMilestoneToMain` and the source for
+   * `Projection.finalizeProjectionForMerge`.
+   */
+  worktreeBasePath: string;
+  milestoneId: string;
+  /**
+   * When true, `mergeMilestoneStandalone` returns `{ merged: false,
+   * mode: "skipped" }` immediately (mirrors the single-loop guard). Default
+   * `false` for parallel callers, which never run with degraded isolation.
+   */
+  isolationDegraded?: boolean;
+  notify: NotifyCtx["notify"];
+}
+
+/**
+ * Result of `mergeMilestoneStandalone`. `mode` lets callers decide which
+ * session-bound side effects to run (worktree-mode → `restoreToProjectRoot`,
+ * branch-mode → `rebuildGitService`, skipped → none).
+ */
+export interface MergeStandaloneResult {
+  merged: boolean;
+  mode: "worktree" | "branch" | "skipped";
+  codeFilesChanged: boolean;
+  pushed: boolean;
+  /**
+   * Commit message produced by the squash merge, if available. Forwarded
+   * from `mergeMilestoneToMain`. Only populated when `merged === true`.
+   */
+  commitMessage?: string;
+}
 
 // ─── Validation ──────────────────────────────────────────────────────────
 
@@ -523,6 +570,443 @@ function rebuildGitService(
   ) as AutoSession["gitService"];
 }
 
+// ─── Session-less merge entry (ADR-016 phase 2 / A1) ─────────────────────
+
+/**
+ * Worktree-mode merge body. Session-less — operates on a `MergeContext`.
+ *
+ * On error: emits the "worktree-merge-failed" journal event, notifies the
+ * user, cleans up stale `SQUASH_MSG` / `MERGE_HEAD` / `MERGE_MSG` files
+ * (#1389), and chdirs back to project root before rethrowing. Session-side
+ * cleanup (`restoreToProjectRoot`, `gitService` rebuild) is the caller's
+ * responsibility.
+ */
+function _mergeWorktreeModeImpl(
+  deps: WorktreeLifecycleDeps,
+  mctx: MergeContext,
+): MergeStandaloneResult {
+  const { originalBasePath, worktreeBasePath, milestoneId, notify } = mctx;
+  if (!originalBasePath) {
+    debugLog("WorktreeLifecycle", {
+      action: "mergeAndExit",
+      milestoneId,
+      mode: "worktree",
+      skipped: true,
+      reason: "missing-original-base",
+    });
+    return {
+      merged: false,
+      mode: "worktree",
+      codeFilesChanged: false,
+      pushed: false,
+    };
+  }
+
+  try {
+    // ADR-016: final projection before teardown. Replaces the legacy
+    // syncWorktreeStateBack(originalBase, basePath, milestoneId) call.
+    const finalScope = scopeMilestone(
+      createWorkspace(worktreeBasePath),
+      milestoneId,
+    );
+    const { synced } = deps.worktreeProjection.finalizeProjectionForMerge(
+      finalScope,
+    );
+    if (synced.length > 0) {
+      debugLog("WorktreeLifecycle", {
+        action: "mergeAndExit",
+        milestoneId,
+        phase: "reverse-sync",
+        synced: synced.length,
+      });
+    }
+
+    // Resolve roadmap — try project root first, then worktree path as
+    // fallback. The worktree may hold the only copy when state-back
+    // projection silently dropped it or .gsd/ is not symlinked. Without
+    // the fallback, a missing roadmap triggers bare teardown which
+    // deletes the branch and orphans all milestone commits (#1573).
+    let roadmapPath = deps.resolveMilestoneFile(
+      originalBasePath,
+      milestoneId,
+      "ROADMAP",
+    );
+    if (
+      !roadmapPath &&
+      !isSamePathPhysical(worktreeBasePath, originalBasePath)
+    ) {
+      roadmapPath = deps.resolveMilestoneFile(
+        worktreeBasePath,
+        milestoneId,
+        "ROADMAP",
+      );
+      if (roadmapPath) {
+        debugLog("WorktreeLifecycle", {
+          action: "mergeAndExit",
+          milestoneId,
+          phase: "roadmap-fallback",
+          note: "resolved from worktree path",
+        });
+      }
+    }
+
+    if (!roadmapPath) {
+      // No roadmap at either location — teardown but PRESERVE the branch
+      // so commits are not orphaned (#1573).
+      deps.teardownAutoWorktree(originalBasePath, milestoneId, {
+        preserveBranch: true,
+      });
+      notify(
+        `Exited worktree for ${milestoneId} (no roadmap found — branch preserved for manual merge).`,
+        "warning",
+      );
+      return {
+        merged: false,
+        mode: "worktree",
+        codeFilesChanged: false,
+        pushed: false,
+      };
+    }
+
+    const roadmapContent = deps.readFileSync(roadmapPath, "utf-8");
+    const mergeResult = deps.mergeMilestoneToMain(
+      originalBasePath,
+      milestoneId,
+      roadmapContent,
+    );
+
+    // #2945 Bug 3: mergeMilestoneToMain performs best-effort worktree
+    // cleanup internally (step 12), but it can silently fail on Windows
+    // or when the worktree directory is locked. Perform a secondary
+    // teardown here to ensure the worktree is properly cleaned up.
+    // Idempotent — if already removed, teardownAutoWorktree no-ops.
+    try {
+      deps.teardownAutoWorktree(originalBasePath, milestoneId);
+    } catch {
+      // Best-effort — primary cleanup in mergeMilestoneToMain may have
+      // already removed the worktree.
+    }
+
+    if (mergeResult.codeFilesChanged) {
+      notify(
+        `Milestone ${milestoneId} merged to main.${mergeResult.pushed ? " Pushed to remote." : ""}`,
+        "info",
+      );
+    } else {
+      // #1906 — milestone produced only .gsd/ metadata. Surface
+      // clearly so the user knows the milestone is not truly complete.
+      notify(
+        `WARNING: Milestone ${milestoneId} merged to main but contained NO code changes — only .gsd/ metadata files. ` +
+          `The milestone summary may describe planned work that was never implemented. ` +
+          `Review the milestone output and re-run if code is missing.`,
+        "warning",
+      );
+    }
+
+    return {
+      merged: true,
+      mode: "worktree",
+      codeFilesChanged: mergeResult.codeFilesChanged,
+      pushed: mergeResult.pushed,
+      commitMessage: mergeResult.commitMessage,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    debugLog("WorktreeLifecycle", {
+      action: "mergeAndExit",
+      milestoneId,
+      result: "error",
+      error: msg,
+      fallback: "chdir-to-project-root",
+    });
+    emitJournalEvent(originalBasePath || worktreeBasePath, {
+      ts: new Date().toISOString(),
+      flowId: randomUUID(),
+      seq: 0,
+      eventType: "worktree-merge-failed",
+      data: { milestoneId, error: msg },
+    });
+    // Surface a clear, actionable error. Worktree and milestone branch
+    // are intentionally preserved — nothing has been deleted. User can
+    // retry /gsd dispatch complete-milestone or merge manually once the
+    // underlying issue is fixed (#1668, #1891).
+    notify(
+      `Milestone merge failed: ${msg}. Your worktree and milestone branch are preserved — retry with \`/gsd dispatch complete-milestone\` or merge manually.`,
+      "warning",
+    );
+
+    // Clean up stale merge state left by failed squash-merge (#1389)
+    try {
+      const gitDir = join(originalBasePath || worktreeBasePath, ".git");
+      for (const f of ["SQUASH_MSG", "MERGE_HEAD", "MERGE_MSG"]) {
+        const p = join(gitDir, f);
+        if (existsSync(p)) unlinkSync(p);
+      }
+    } catch {
+      /* best-effort */
+    }
+
+    // Error recovery: always chdir back to project root so subsequent
+    // process.cwd() calls don't ENOENT. Session-side cleanup
+    // (restoreToProjectRoot, gitService rebuild) is the caller's
+    // responsibility.
+    if (originalBasePath) {
+      try {
+        process.chdir(originalBasePath);
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    // Re-throw: MergeConflictError stops the auto loop (#2330);
+    // non-conflict errors must also propagate so broken states are
+    // diagnosable (#4380).
+    throw err;
+  }
+}
+
+/**
+ * Branch-mode merge body. Session-less.
+ *
+ * Session-side `gitService` rebuild after HEAD changes is the caller's
+ * responsibility. The branch-mode `UserNotifiedError` sentinel still flows
+ * through unchanged so the outer caller can suppress duplicate toasts.
+ */
+function _mergeBranchModeImpl(
+  deps: WorktreeLifecycleDeps,
+  mctx: MergeContext,
+): MergeStandaloneResult {
+  const { worktreeBasePath, milestoneId, notify } = mctx;
+  try {
+    const currentBranch = deps.getCurrentBranch(worktreeBasePath);
+    const milestoneBranch = deps.autoWorktreeBranch(milestoneId);
+
+    if (currentBranch !== milestoneBranch) {
+      // #5538-followup: previous behaviour was to silently `return false`
+      // when HEAD wasn't on the milestone branch — that let the loop
+      // advance with the milestone's commits stranded on the branch.
+      // Attempt recovery by force-checking-out the milestone branch; if
+      // that fails, throw so the caller pauses auto-mode and the user
+      // sees the failure instead of a silent merge skip.
+      debugLog("WorktreeLifecycle", {
+        action: "mergeAndExit",
+        milestoneId,
+        mode: "branch",
+        recovery: "checkout-milestone-branch",
+        currentBranch,
+        milestoneBranch,
+      });
+      try {
+        deps.checkoutBranch(worktreeBasePath, milestoneBranch);
+      } catch (checkoutErr) {
+        const checkoutMsg =
+          checkoutErr instanceof Error
+            ? checkoutErr.message
+            : String(checkoutErr);
+        notify(
+          `Cannot merge milestone ${milestoneId}: working tree is on ${currentBranch} and checkout to ${milestoneBranch} failed (${checkoutMsg}). Resolve manually and run /gsd auto to resume.`,
+          "error",
+        );
+        throw new UserNotifiedError(checkoutMsg, checkoutErr);
+      }
+
+      const reverify = deps.getCurrentBranch(worktreeBasePath);
+      if (reverify !== milestoneBranch) {
+        const reverifyMsg = `branch checkout to ${milestoneBranch} reported success but current branch is ${reverify}`;
+        notify(
+          `Cannot merge milestone ${milestoneId}: ${reverifyMsg}. Resolve manually and run /gsd auto to resume.`,
+          "error",
+        );
+        throw new UserNotifiedError(reverifyMsg);
+      }
+    }
+
+    const roadmapPath = deps.resolveMilestoneFile(
+      worktreeBasePath,
+      milestoneId,
+      "ROADMAP",
+    );
+    if (!roadmapPath) {
+      debugLog("WorktreeLifecycle", {
+        action: "mergeAndExit",
+        milestoneId,
+        mode: "branch",
+        skipped: true,
+        reason: "no-roadmap",
+      });
+      return {
+        merged: false,
+        mode: "branch",
+        codeFilesChanged: false,
+        pushed: false,
+      };
+    }
+
+    const roadmapContent = deps.readFileSync(roadmapPath, "utf-8");
+    const mergeResult = deps.mergeMilestoneToMain(
+      worktreeBasePath,
+      milestoneId,
+      roadmapContent,
+    );
+
+    if (mergeResult.codeFilesChanged) {
+      notify(
+        `Milestone ${milestoneId} merged (branch mode).${mergeResult.pushed ? " Pushed to remote." : ""}`,
+        "info",
+      );
+    } else {
+      notify(
+        `WARNING: Milestone ${milestoneId} merged (branch mode) but contained NO code changes — only .gsd/ metadata. ` +
+          `Review the milestone output and re-run if code is missing.`,
+        "warning",
+      );
+    }
+    debugLog("WorktreeLifecycle", {
+      action: "mergeAndExit",
+      milestoneId,
+      mode: "branch",
+      result: "success",
+    });
+    return {
+      merged: true,
+      mode: "branch",
+      codeFilesChanged: mergeResult.codeFilesChanged,
+      pushed: mergeResult.pushed,
+      commitMessage: mergeResult.commitMessage,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    debugLog("WorktreeLifecycle", {
+      action: "mergeAndExit",
+      milestoneId,
+      mode: "branch",
+      result: "error",
+      error: msg,
+    });
+    if (!(err instanceof UserNotifiedError)) {
+      notify(`Milestone merge failed (branch mode): ${msg}`, "warning");
+    }
+    // Re-throw all errors so callers can apply their own recovery (#4380).
+    throw err;
+  }
+}
+
+/**
+ * Session-less merge entry (ADR-016 phase 2 / A1, issue #5618).
+ *
+ * Runs the worktree-mode or branch-mode merge body without touching session
+ * state. Used directly by `parallel-merge.ts` and indirectly (via
+ * `_mergeAndExit`) by the single-loop path. Caller is responsible for any
+ * session-side cleanup based on the returned `mode`.
+ *
+ * **CWD anchor**: anchors `process.cwd()` at `originalBasePath` before the
+ * merge to mirror the single-loop guard against ENOENT after teardown
+ * (de73fb43d). Best-effort; silent on failure.
+ *
+ * **Failure handling**: `MergeConflictError` and other unrecoverable errors
+ * propagate to the caller. The caller is responsible for any state restore
+ * (single-loop callers re-`chdir` and `restoreToProjectRoot`; parallel
+ * callers surface to the user as a `MergeResult` with `success: false`).
+ */
+export function mergeMilestoneStandalone(
+  deps: WorktreeLifecycleDeps,
+  mctx: MergeContext,
+): MergeStandaloneResult {
+  const { originalBasePath, worktreeBasePath, milestoneId, notify } = mctx;
+  validateMilestoneId(milestoneId);
+
+  // Anchor cwd at the project root before any merge work. Some merge paths
+  // (mergeMilestoneToMain, slice-cadence) chdir explicitly; others (branch-
+  // mode, isolation-degraded skip) do not. If the worktree dir is later
+  // torn down while cwd still points into it, every subsequent
+  // process.cwd() throws ENOENT — which after de73fb43d surfaces as a
+  // session-failed cancel and (in headless mode) terminates the whole gsd
+  // process. Best-effort: silent on failure so synthetic test paths still
+  // pass.
+  if (originalBasePath) {
+    try {
+      process.chdir(originalBasePath);
+    } catch (err) {
+      debugLog("WorktreeLifecycle", {
+        action: "mergeAndExit",
+        phase: "pre-merge-chdir-failed",
+        milestoneId,
+        originalBasePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (mctx.isolationDegraded) {
+    debugLog("WorktreeLifecycle", {
+      action: "mergeAndExit",
+      milestoneId,
+      skipped: true,
+      reason: "isolation-degraded",
+    });
+    notify(
+      `Skipping worktree merge for ${milestoneId} — isolation was degraded (worktree creation failed earlier). Work is on the current branch.`,
+      "info",
+    );
+    return {
+      merged: false,
+      mode: "skipped",
+      codeFilesChanged: false,
+      pushed: false,
+    };
+  }
+
+  const mode = deps.getIsolationMode(originalBasePath || worktreeBasePath);
+  debugLog("WorktreeLifecycle", {
+    action: "mergeAndExit",
+    milestoneId,
+    mode,
+    basePath: worktreeBasePath,
+  });
+  emitJournalEvent(originalBasePath || worktreeBasePath, {
+    ts: new Date().toISOString(),
+    flowId: randomUUID(),
+    seq: 0,
+    eventType: "worktree-merge-start",
+    data: { milestoneId, mode },
+  });
+
+  // #2625: If we are physically inside an auto-worktree, we MUST merge
+  // regardless of the current isolation config. This prevents data loss
+  // when the default isolation mode changes between versions.
+  const inWorktree =
+    deps.isInAutoWorktree(worktreeBasePath) && Boolean(originalBasePath);
+
+  if (mode === "none" && !inWorktree) {
+    debugLog("WorktreeLifecycle", {
+      action: "mergeAndExit",
+      milestoneId,
+      skipped: true,
+      reason: "mode-none",
+    });
+    return {
+      merged: false,
+      mode: "skipped",
+      codeFilesChanged: false,
+      pushed: false,
+    };
+  }
+
+  if (mode === "worktree" || inWorktree) {
+    return _mergeWorktreeModeImpl(deps, mctx);
+  }
+  if (mode === "branch") {
+    return _mergeBranchModeImpl(deps, mctx);
+  }
+  // Defensive fallback — should not reach here given the mode-none guard above.
+  return {
+    merged: false,
+    mode: "skipped",
+    codeFilesChanged: false,
+    pushed: false,
+  };
+}
+
 // ─── Module class ────────────────────────────────────────────────────────
 
 /**
@@ -742,102 +1226,56 @@ export class WorktreeLifecycle {
   /**
    * Merge the completed milestone branch back to main and exit the worktree.
    *
-   * - **worktree mode**: reads the roadmap, runs squash merge, projects
-   *   final state back via Projection.finalizeProjectionForMerge, tears
-   *   down the worktree, restores `s.basePath`. Falls back to bare
-   *   teardown (preserving the branch) if no roadmap exists.
-   * - **branch mode**: validates HEAD is on the milestone branch (recovers
-   *   via checkout if not), merges, rebuilds GitService.
-   * - **none**: no-op unless physically inside an auto-worktree (#2625).
+   * Session-bound wrapper around `mergeMilestoneStandalone`. Builds a
+   * `MergeContext` from `this.s`, layers session-side bookkeeping on top of
+   * the result:
    *
-   * Returns true when an actual squash-merge ran. Throws MergeConflictError
-   * (and other non-recoverable errors) for callers to handle.
+   * - resquash-on-merge using `s.milestoneStartShas`
+   * - merge-completion telemetry (duration)
+   * - mode-specific session restore: worktree-mode → `restoreToProjectRoot`,
+   *   branch-mode → `gitService` rebuild
+   *
+   * Returns `true` when an actual squash-merge ran. Errors propagate after
+   * `restoreToProjectRoot()` runs so callers always receive a consistent
+   * session.
    */
   private _mergeAndExit(milestoneId: string, ctx: NotifyCtx): boolean {
-    validateMilestoneId(milestoneId);
-
-    // Anchor cwd at the project root before any merge work. Some merge
-    // paths (mergeMilestoneToMain, slice-cadence) chdir explicitly; others
-    // (branch-mode, isolation-degraded skip) do not. If the worktree dir
-    // is later torn down while cwd still points into it, every subsequent
-    // process.cwd() throws ENOENT — which after de73fb43d surfaces as a
-    // session-failed cancel and (in headless mode) terminates the whole
-    // gsd process. Best-effort: silent on failure so synthetic test paths
-    // still pass.
-    if (this.s.originalBasePath) {
-      try {
-        process.chdir(this.s.originalBasePath);
-      } catch (err) {
-        debugLog("WorktreeLifecycle", {
-          action: "mergeAndExit",
-          phase: "pre-merge-chdir-failed",
-          milestoneId,
-          originalBasePath: this.s.originalBasePath,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
-
     // #4764 — telemetry: record start timestamp so we can emit merge duration.
     const mergeStartedAt = new Date().toISOString();
     const mergeStartMs = Date.now();
 
-    if (this.s.isolationDegraded) {
-      debugLog("WorktreeLifecycle", {
-        action: "mergeAndExit",
+    let result: MergeStandaloneResult;
+    try {
+      result = mergeMilestoneStandalone(this.deps, {
+        originalBasePath: this.s.originalBasePath,
+        worktreeBasePath: this.s.basePath,
         milestoneId,
-        skipped: true,
-        reason: "isolation-degraded",
+        isolationDegraded: this.s.isolationDegraded,
+        notify: ctx.notify,
       });
-      ctx.notify(
-        `Skipping worktree merge for ${milestoneId} — isolation was degraded (worktree creation failed earlier). Work is on the current branch.`,
-        "info",
-      );
-      return false;
+    } catch (err) {
+      // Standalone has already done its session-less cleanup
+      // (chdir, SQUASH_MSG cleanup, journal event). Layer session-side
+      // restore on top so callers get a consistent session.
+      this.restoreToProjectRoot();
+      throw err;
     }
 
-    const mode = this.deps.getIsolationMode(
-      this.s.originalBasePath || this.s.basePath,
-    );
-    debugLog("WorktreeLifecycle", {
-      action: "mergeAndExit",
-      milestoneId,
-      mode,
-      basePath: this.s.basePath,
-    });
-    emitJournalEvent(this.s.originalBasePath || this.s.basePath, {
-      ts: new Date().toISOString(),
-      flowId: randomUUID(),
-      seq: 0,
-      eventType: "worktree-merge-start",
-      data: { milestoneId, mode },
-    });
-
-    // #2625: If we are physically inside an auto-worktree, we MUST merge
-    // regardless of the current isolation config. This prevents data loss
-    // when the default isolation mode changes between versions.
-    const inWorktree =
-      this.deps.isInAutoWorktree(this.s.basePath) && this.s.originalBasePath;
-
-    if (mode === "none" && !inWorktree) {
-      debugLog("WorktreeLifecycle", {
-        action: "mergeAndExit",
-        milestoneId,
-        skipped: true,
-        reason: "mode-none",
-      });
-      return false;
-    }
-
-    let actuallyMerged = false;
-    if (mode === "worktree" || inWorktree) {
-      actuallyMerged = this._mergeWorktreeMode(milestoneId, ctx);
-    } else if (mode === "branch") {
-      actuallyMerged = this._mergeBranchMode(milestoneId, ctx);
-    }
-
-    if (!actuallyMerged) {
+    if (!result.merged) {
+      // Skip / no-roadmap / mode-none paths. milestoneStartShas housekeeping
+      // is unconditional; mode-specific session restore happens for
+      // worktree-mode (preserve-branch path tore down the worktree, so
+      // basePath must restore) and not for branch-mode (no basePath change).
       this.s.milestoneStartShas.delete(milestoneId);
+      if (result.mode === "worktree") {
+        this.restoreToProjectRoot();
+        debugLog("WorktreeLifecycle", {
+          action: "mergeAndExit",
+          milestoneId,
+          result: "done",
+          basePath: this.s.basePath,
+        });
+      }
       return false;
     }
 
@@ -855,12 +1293,12 @@ export class WorktreeLifecycle {
           getCollapseCadence(prefs) === "slice" &&
           getMilestoneResquash(prefs)
         ) {
-          const result = resquashMilestoneOnMain(
+          const resquashResult = resquashMilestoneOnMain(
             this.s.originalBasePath || this.s.basePath,
             milestoneId,
             startSha,
           );
-          if (result.resquashed) {
+          if (resquashResult.resquashed) {
             ctx.notify(
               `slice-cadence: re-squashed slice commits for ${milestoneId} into a single milestone commit.`,
               "info",
@@ -900,290 +1338,28 @@ export class WorktreeLifecycle {
             : String(telemetryErr),
       });
     }
+
+    // Mode-specific session restore.
+    if (result.mode === "worktree") {
+      this.restoreToProjectRoot();
+      debugLog("WorktreeLifecycle", {
+        action: "mergeAndExit",
+        milestoneId,
+        result: "done",
+        basePath: this.s.basePath,
+      });
+    } else if (result.mode === "branch") {
+      // Rebuild GitService after merge (branch HEAD changed)
+      rebuildGitService(this.s, this.deps);
+    }
     return true;
   }
 
-  /** Worktree-mode merge body. Returns true when an actual squash-merge ran. */
-  private _mergeWorktreeMode(milestoneId: string, ctx: NotifyCtx): boolean {
-    const originalBase = this.s.originalBasePath;
-    if (!originalBase) {
-      debugLog("WorktreeLifecycle", {
-        action: "mergeAndExit",
-        milestoneId,
-        mode: "worktree",
-        skipped: true,
-        reason: "missing-original-base",
-      });
-      return false;
-    }
-
-    let merged = false;
-    try {
-      // ADR-016: final projection before teardown. Replaces the legacy
-      // syncWorktreeStateBack(originalBase, basePath, milestoneId) call.
-      const finalScope = scopeMilestone(
-        createWorkspace(this.s.basePath),
-        milestoneId,
-      );
-      const { synced } =
-        this.deps.worktreeProjection.finalizeProjectionForMerge(finalScope);
-      if (synced.length > 0) {
-        debugLog("WorktreeLifecycle", {
-          action: "mergeAndExit",
-          milestoneId,
-          phase: "reverse-sync",
-          synced: synced.length,
-        });
-      }
-
-      // Resolve roadmap — try project root first, then worktree path as
-      // fallback. The worktree may hold the only copy when state-back
-      // projection silently dropped it or .gsd/ is not symlinked. Without
-      // the fallback, a missing roadmap triggers bare teardown which
-      // deletes the branch and orphans all milestone commits (#1573).
-      let roadmapPath = this.deps.resolveMilestoneFile(
-        originalBase,
-        milestoneId,
-        "ROADMAP",
-      );
-      if (
-        !roadmapPath &&
-        !isSamePathPhysical(this.s.basePath, originalBase)
-      ) {
-        roadmapPath = this.deps.resolveMilestoneFile(
-          this.s.basePath,
-          milestoneId,
-          "ROADMAP",
-        );
-        if (roadmapPath) {
-          debugLog("WorktreeLifecycle", {
-            action: "mergeAndExit",
-            milestoneId,
-            phase: "roadmap-fallback",
-            note: "resolved from worktree path",
-          });
-        }
-      }
-
-      if (roadmapPath) {
-        const roadmapContent = this.deps.readFileSync(roadmapPath, "utf-8");
-        const mergeResult = this.deps.mergeMilestoneToMain(
-          originalBase,
-          milestoneId,
-          roadmapContent,
-        );
-        merged = true;
-
-        // #2945 Bug 3: mergeMilestoneToMain performs best-effort worktree
-        // cleanup internally (step 12), but it can silently fail on Windows
-        // or when the worktree directory is locked. Perform a secondary
-        // teardown here to ensure the worktree is properly cleaned up.
-        // Idempotent — if already removed, teardownAutoWorktree no-ops.
-        try {
-          this.deps.teardownAutoWorktree(originalBase, milestoneId);
-        } catch {
-          // Best-effort — primary cleanup in mergeMilestoneToMain may have
-          // already removed the worktree.
-        }
-
-        if (mergeResult.codeFilesChanged) {
-          ctx.notify(
-            `Milestone ${milestoneId} merged to main.${mergeResult.pushed ? " Pushed to remote." : ""}`,
-            "info",
-          );
-        } else {
-          // #1906 — milestone produced only .gsd/ metadata. Surface
-          // clearly so the user knows the milestone is not truly complete.
-          ctx.notify(
-            `WARNING: Milestone ${milestoneId} merged to main but contained NO code changes — only .gsd/ metadata files. ` +
-              `The milestone summary may describe planned work that was never implemented. ` +
-              `Review the milestone output and re-run if code is missing.`,
-            "warning",
-          );
-        }
-      } else {
-        // No roadmap at either location — teardown but PRESERVE the branch
-        // so commits are not orphaned (#1573).
-        this.deps.teardownAutoWorktree(originalBase, milestoneId, {
-          preserveBranch: true,
-        });
-        ctx.notify(
-          `Exited worktree for ${milestoneId} (no roadmap found — branch preserved for manual merge).`,
-          "warning",
-        );
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      debugLog("WorktreeLifecycle", {
-        action: "mergeAndExit",
-        milestoneId,
-        result: "error",
-        error: msg,
-        fallback: "chdir-to-project-root",
-      });
-      emitJournalEvent(this.s.originalBasePath || this.s.basePath, {
-        ts: new Date().toISOString(),
-        flowId: randomUUID(),
-        seq: 0,
-        eventType: "worktree-merge-failed",
-        data: { milestoneId, error: msg },
-      });
-      // Surface a clear, actionable error. Worktree and milestone branch
-      // are intentionally preserved — nothing has been deleted. User can
-      // retry /gsd dispatch complete-milestone or merge manually once the
-      // underlying issue is fixed (#1668, #1891).
-      ctx.notify(
-        `Milestone merge failed: ${msg}. Your worktree and milestone branch are preserved — retry with \`/gsd dispatch complete-milestone\` or merge manually.`,
-        "warning",
-      );
-
-      // Clean up stale merge state left by failed squash-merge (#1389)
-      try {
-        const gitDir = join(originalBase || this.s.basePath, ".git");
-        for (const f of ["SQUASH_MSG", "MERGE_HEAD", "MERGE_MSG"]) {
-          const p = join(gitDir, f);
-          if (existsSync(p)) unlinkSync(p);
-        }
-      } catch {
-        /* best-effort */
-      }
-
-      // Error recovery: always restore to project root
-      if (originalBase) {
-        try {
-          process.chdir(originalBase);
-        } catch {
-          /* best-effort */
-        }
-      }
-
-      // Restore state before re-throwing so callers always get a
-      // consistent session (#4380).
-      this.restoreToProjectRoot();
-      // Re-throw: MergeConflictError stops the auto loop (#2330);
-      // non-conflict errors must also propagate so broken states are
-      // diagnosable (#4380).
-      throw err;
-    }
-
-    // Always restore basePath and rebuild — whether merge succeeded or failed
-    this.restoreToProjectRoot();
-    debugLog("WorktreeLifecycle", {
-      action: "mergeAndExit",
-      milestoneId,
-      result: "done",
-      basePath: this.s.basePath,
-    });
-    return merged;
-  }
-
-  /** Branch-mode merge body. Returns true when a merge actually ran. */
-  private _mergeBranchMode(milestoneId: string, ctx: NotifyCtx): boolean {
-    try {
-      const currentBranch = this.deps.getCurrentBranch(this.s.basePath);
-      const milestoneBranch = this.deps.autoWorktreeBranch(milestoneId);
-
-      if (currentBranch !== milestoneBranch) {
-        // #5538-followup: previous behaviour was to silently `return false`
-        // when HEAD wasn't on the milestone branch — that let the loop
-        // advance with the milestone's commits stranded on the branch.
-        // Attempt recovery by force-checking-out the milestone branch; if
-        // that fails, throw so the caller pauses auto-mode and the user
-        // sees the failure instead of a silent merge skip.
-        debugLog("WorktreeLifecycle", {
-          action: "mergeAndExit",
-          milestoneId,
-          mode: "branch",
-          recovery: "checkout-milestone-branch",
-          currentBranch,
-          milestoneBranch,
-        });
-        try {
-          this.deps.checkoutBranch(this.s.basePath, milestoneBranch);
-        } catch (checkoutErr) {
-          const checkoutMsg =
-            checkoutErr instanceof Error
-              ? checkoutErr.message
-              : String(checkoutErr);
-          ctx.notify(
-            `Cannot merge milestone ${milestoneId}: working tree is on ${currentBranch} and checkout to ${milestoneBranch} failed (${checkoutMsg}). Resolve manually and run /gsd auto to resume.`,
-            "error",
-          );
-          throw new UserNotifiedError(checkoutMsg, checkoutErr);
-        }
-
-        const reverify = this.deps.getCurrentBranch(this.s.basePath);
-        if (reverify !== milestoneBranch) {
-          const reverifyMsg = `branch checkout to ${milestoneBranch} reported success but current branch is ${reverify}`;
-          ctx.notify(
-            `Cannot merge milestone ${milestoneId}: ${reverifyMsg}. Resolve manually and run /gsd auto to resume.`,
-            "error",
-          );
-          throw new UserNotifiedError(reverifyMsg);
-        }
-      }
-
-      const roadmapPath = this.deps.resolveMilestoneFile(
-        this.s.basePath,
-        milestoneId,
-        "ROADMAP",
-      );
-      if (!roadmapPath) {
-        debugLog("WorktreeLifecycle", {
-          action: "mergeAndExit",
-          milestoneId,
-          mode: "branch",
-          skipped: true,
-          reason: "no-roadmap",
-        });
-        return false;
-      }
-
-      const roadmapContent = this.deps.readFileSync(roadmapPath, "utf-8");
-      const mergeResult = this.deps.mergeMilestoneToMain(
-        this.s.basePath,
-        milestoneId,
-        roadmapContent,
-      );
-
-      // Rebuild GitService after merge (branch HEAD changed)
-      rebuildGitService(this.s, this.deps);
-
-      if (mergeResult.codeFilesChanged) {
-        ctx.notify(
-          `Milestone ${milestoneId} merged (branch mode).${mergeResult.pushed ? " Pushed to remote." : ""}`,
-          "info",
-        );
-      } else {
-        ctx.notify(
-          `WARNING: Milestone ${milestoneId} merged (branch mode) but contained NO code changes — only .gsd/ metadata. ` +
-            `Review the milestone output and re-run if code is missing.`,
-          "warning",
-        );
-      }
-      debugLog("WorktreeLifecycle", {
-        action: "mergeAndExit",
-        milestoneId,
-        mode: "branch",
-        result: "success",
-      });
-      return true;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      debugLog("WorktreeLifecycle", {
-        action: "mergeAndExit",
-        milestoneId,
-        mode: "branch",
-        result: "error",
-        error: msg,
-      });
-      if (!(err instanceof UserNotifiedError)) {
-        ctx.notify(`Milestone merge failed (branch mode): ${msg}`, "warning");
-      }
-      // Re-throw all errors so callers can apply their own recovery (#4380).
-      throw err;
-    }
-  }
+  // ── Removed: _mergeWorktreeMode / _mergeBranchMode bodies ────────────
+  // The merge bodies moved to file-scope `_mergeWorktreeModeImpl` and
+  // `_mergeBranchModeImpl`, callable from the session-less
+  // `mergeMilestoneStandalone` entry. The previous private methods are
+  // gone; `_mergeAndExit` above is the only session-bound caller.
 
   /**
    * Fall back to branch-mode for `milestoneId` after a failed worktree


### PR DESCRIPTION
## Summary

Closes the parallel-merge bypass that ADR-016 was specifically written to fix. Per the design note in PR #5653 / [\`docs/dev/ADR-016-phase-2-design.md\`](https://github.com/gsd-build/gsd-2/blob/docs/adr-016-phase-2-design/docs/dev/ADR-016-phase-2-design.md), this slice picks **Option A**: a session-less merge entry on Lifecycle rather than a separate \`MergeRunner\` Module.

After this PR:

- \`parallel-merge.ts\` no longer imports \`mergeMilestoneToMain\` directly — it goes through \`Lifecycle.mergeMilestoneStandalone\`. The bypass-closure invariant from ADR-016 (_"no caller — single-loop or parallel — bypasses the Module-level Interface for the verbs the Module owns"_) is now enforced for the worktree-mode merge verb.
- The merge body lives at file scope as \`mergeMilestoneStandalone(deps, mctx)\` plus \`_mergeWorktreeModeImpl\` / \`_mergeBranchModeImpl\` helpers. The class's \`_mergeAndExit\` becomes a thin session-bookkeeping wrapper.
- A3 (#5619) is unblocked — \`mergeMilestoneToMain\` now has no callers outside \`worktree-lifecycle.ts\` and can be made private in the next slice.

## Module-level changes

**\`worktree-lifecycle.ts\`**

- Add \`MergeContext\` and \`MergeStandaloneResult\` types.
- Add \`mergeMilestoneStandalone(deps, mctx)\` — pre-merge cwd anchor, isolation-degraded skip, mode detection, journal events. Returns a typed result with \`mode\` so callers can run the right session-side cleanup.
- Add \`_mergeWorktreeModeImpl\` and \`_mergeBranchModeImpl\` — the bodies that previously lived as private class methods. Worktree-mode error handling (SQUASH_MSG cleanup, chdir-back, journal emit) stays inside the impl; session-side \`restoreToProjectRoot\` moves to the caller.
- Refactor \`WorktreeLifecycle._mergeAndExit\` into a thin wrapper. Layers session bookkeeping on the standalone result: \`milestoneStartShas\` / resquash for slice-cadence, post-merge telemetry, mode-specific session restore.
- Forward \`commitMessage\` from \`mergeMilestoneToMain\` through the deps signature and result type so parallel callers preserve the field.

**\`auto.ts\`**

- Split deps construction out of \`buildLifecycle()\` into an exported \`buildWorktreeLifecycleDeps()\` factory. \`parallel-merge.ts\` consumes the same deps shape without needing an \`AutoSession\`.

**\`parallel-merge.ts\`**

- \`mergeCompletedMilestone\` now constructs deps and calls \`mergeMilestoneStandalone\`.
- \`worktreeBasePath\` comes from \`getAutoWorktreePath\` only when git knows the worktree (registered). Stale dirs that aren't real worktrees fall back to project root and route through branch-mode merge.
- Roadmap loading moves into the standalone. Parallel callers no longer pre-read the roadmap.

## Test changes

- \`tests/integration/parallel-merge.test.ts\`: 21/21 passing
  - Add \`setupBranchIsolation(repo)\` helper. Default \`isolation: none\` makes the standalone return \`{ mode: \"skipped\" }\`; explicit branch isolation routes through the Module's branch-mode merge body. Mirrors production setup (production runs with \`worktree\` isolation; branch is the simpler equivalent for tests that don't create real auto-worktrees).
  - \`setupRoadmap\` now commits the roadmap on main; tests reordered so it runs before \`createMilestoneBranch\` so milestone branches inherit the roadmap. The standalone reads the roadmap inside the merge body (after the branch checkout), so the file must exist in the milestone branch's tree.
  - "missing roadmap" test rewritten to use a real git repo so the standalone's branch-mode \`getCurrentBranch\` does not throw before reaching the no-roadmap branch.
- merge-area regression sweep (worktree-lifecycle, orphan-merge, auto-loop, parallel-orchestration, state-corruption, milestone-merge, phases-merge, stale-worktree, etc.): **189/189 passing**
- Full TypeScript compile: clean

## Bypass-closure verification

\`\`\`
$ grep -rn 'mergeMilestoneToMain' src/resources/extensions/gsd/ | grep -v test | grep -v worktree-lifecycle
src/resources/extensions/gsd/auto-worktree.ts:1506:export function mergeMilestoneToMain(...)
src/resources/extensions/gsd/auto.ts:1579:    mergeMilestoneToMain,  // ← passed through buildWorktreeLifecycleDeps
\`\`\`

Only the definition and the deps-factory wiring reference the symbol. \`parallel-merge.ts\` does not. A3 (#5619) will remove the \`export\` keyword to enforce the closure at the file boundary.

## Test plan

- [x] \`tests/integration/parallel-merge.test.ts\` — 21/21
- [x] merge-area regression sweep — 189/189
- [x] \`tsc --noEmit\` clean
- [ ] CI checks pass on the PR
- [ ] Babysitter review run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completion dashboard now preserves the final progress view and shows milestone roll‑up (outcomes, verification, run totals, cache hit rate, cost/tokens, location/reason).
  * Stop operation accepts options to request the preserved completion widget and surface final rollout details.

* **Refactor**
  * Milestone merge flow and lifecycle deps split into session‑independent operations with clearer mode‑specific restore and merge outcome handling.

* **Tests**
  * Integration tests exercise real git branch‑isolation; added UI regression tests confirming preserved completion dashboard output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5656)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->