### PR TITLE
refactor(gsd): ADR-016 phase 2 / B2 — adoptSessionRoot verb (#5620)

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1040,7 +1040,10 @@ export async function bootstrapAutoSession(
     s.stepMode = requestedStepMode;
     s.verbose = verboseMode;
     s.cmdCtx = ctx;
-    s.basePath = base;
+    // ADR-016 phase 2 / B2 (#5620): single owner of bootstrap basePath
+    // mutation. Sets s.basePath = base and s.originalBasePath = base
+    // (originalBasePath is empty on a fresh bootstrap).
+    buildLifecycle().adoptSessionRoot(base);
     s.unitDispatchCount.clear();
     s.unitRecoveryCount.clear();
     s.lastBudgetAlertLevel = 0;
@@ -1098,7 +1101,9 @@ export async function bootstrapAutoSession(
     }
 
     // ── Auto-worktree setup ──
-    s.originalBasePath = base;
+    // s.originalBasePath was set to `base` by `adoptSessionRoot(base)` above
+    // (ADR-016 phase 2 / B2, #5620). The redundant assignment that used to
+    // live here is gone.
 
     const isUnderGsdWorktrees = (p: string): boolean => {
       // Direct layout: /.gsd/worktrees/

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2145,7 +2145,12 @@ export async function startAuto(
     s.verbose = verboseMode;
     s.stepMode = requestedStepMode;
     s.cmdCtx = ctx;
-    s.basePath = base;
+    // ADR-016 phase 2 / B2 (#5620): bootstrap basePath transition before
+    // the resume path consults persisted worktree state. Defensive about
+    // s.originalBasePath — the meta-restore above (line 2003 / 2055) may
+    // have already populated it from paused metadata; the verb preserves
+    // that value.
+    buildLifecycle().adoptSessionRoot(base);
     // ── Resume worktree: if the paused session was inside a milestone worktree,
     // apply that path as the dispatch basePath immediately (#3723).
     // This ensures the dispatch loop runs from the worktree directory even when
@@ -2463,7 +2468,12 @@ export async function dispatchHookUnit(
     s.pendingQuickTasks = [];
   }
 
-  s.basePath = targetBasePath;
+  // ADR-016 phase 2 / B2 (#5620): hook-trigger basePath transition. Treats
+  // the trigger as a bootstrap variant — if the session is fresh,
+  // `originalBasePath` gets set to `targetBasePath`; if the session was
+  // already active with an established `originalBasePath`, the verb
+  // preserves it.
+  buildLifecycle().adoptSessionRoot(targetBasePath);
   if (!s.orchestration) {
     ensureOrchestrationModule(ctx, pi, s.basePath);
   }

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -100,6 +100,14 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
         registerSigtermHandler: () => {},
         lockBase: () => base,
         buildLifecycle: () => ({
+          adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
+            s.basePath = sessionBase;
+            if (originalBase !== undefined) {
+              s.originalBasePath = originalBase;
+            } else if (!s.originalBasePath) {
+              s.originalBasePath = sessionBase;
+            }
+          },
           exitMilestone: (milestoneId: string) => {
             mergeCalls.push(milestoneId);
             return {

--- a/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
@@ -273,7 +273,16 @@ test("deep project setup: bootstrap can start auto-mode without an active milest
         shouldUseWorktreeIsolation: () => false,
         registerSigtermHandler: () => {},
         lockBase: () => base,
-        buildLifecycle: () => ({}) as any,
+        buildLifecycle: () => ({
+          adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
+            s.basePath = sessionBase;
+            if (originalBase !== undefined) {
+              s.originalBasePath = originalBase;
+            } else if (!s.originalBasePath) {
+              s.originalBasePath = sessionBase;
+            }
+          },
+        }) as any,
       },
       {
         classification: "none",
@@ -378,7 +387,16 @@ test("deep project setup: bootstrap continues queued M002 without milestone cont
         shouldUseWorktreeIsolation: () => false,
         registerSigtermHandler: () => {},
         lockBase: () => base,
-        buildLifecycle: () => ({}) as any,
+        buildLifecycle: () => ({
+          adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
+            s.basePath = sessionBase;
+            if (originalBase !== undefined) {
+              s.originalBasePath = originalBase;
+            } else if (!s.originalBasePath) {
+              s.originalBasePath = sessionBase;
+            }
+          },
+        }) as any,
       },
       {
         classification: "none",

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -432,3 +432,60 @@ test("restoreToProjectRoot is no-op when originalBasePath is empty", () => {
   assert.equal(s.basePath, "/some/path"); // unchanged
   assert.equal(deps.calls.filter((c) => c.fn === "GitServiceImpl").length, 0);
 });
+
+// ─── adoptSessionRoot (ADR-016 phase 2 / B2, issue #5620) ─────────────────────
+
+test("adoptSessionRoot sets basePath and seeds originalBasePath on a fresh session", () => {
+  const s = makeSession();
+  s.basePath = "";
+  s.originalBasePath = "";
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  lifecycle.adoptSessionRoot("/project");
+
+  assert.equal(s.basePath, "/project");
+  assert.equal(s.originalBasePath, "/project");
+});
+
+test("adoptSessionRoot preserves a pre-existing originalBasePath when no override is passed", () => {
+  // Resume-from-paused path (auto.ts:2148 after meta-restore at 2003/2055):
+  // s.originalBasePath was already restored from paused metadata; the verb
+  // must NOT overwrite that value.
+  const s = makeSession();
+  s.basePath = "";
+  s.originalBasePath = "/persisted/project-root";
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  lifecycle.adoptSessionRoot("/project");
+
+  assert.equal(s.basePath, "/project");
+  assert.equal(s.originalBasePath, "/persisted/project-root");
+});
+
+test("adoptSessionRoot honors an explicit originalBase override", () => {
+  const s = makeSession();
+  s.basePath = "";
+  s.originalBasePath = "/old-root";
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  lifecycle.adoptSessionRoot("/project", "/explicit-original");
+
+  assert.equal(s.basePath, "/project");
+  assert.equal(s.originalBasePath, "/explicit-original");
+});
+
+test("adoptSessionRoot does not chdir, rebuild git service, or invalidate caches", () => {
+  // The verb is a pure session-state mutation. Side effects (chdir, git
+  // service rebuild, cache invalidation) belong to other Lifecycle verbs
+  // (`enterMilestone`, `restoreToProjectRoot`).
+  const s = makeSession();
+  s.basePath = "";
+  s.originalBasePath = "";
+  const deps = makeDeps();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.adoptSessionRoot("/project");
+
+  assert.equal(deps.calls.filter((c) => c.fn === "GitServiceImpl").length, 0);
+  assert.equal(deps.calls.filter((c) => c.fn === "invalidateAllCaches").length, 0);
+});

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -1243,6 +1243,34 @@ export class WorktreeLifecycle {
     this.deps.invalidateAllCaches();
   }
 
+  /**
+   * Adopt a session root (ADR-016 phase 2 / B2, issue #5620).
+   *
+   * Sole owner of `s.basePath` mutation for bootstrap-class transitions:
+   * initial session start, paused-resume entry (before persisted-state
+   * consultation), and hook-trigger session activation. Defensive about
+   * `s.originalBasePath`:
+   *
+   * - When `originalBase` is explicit: overwrite.
+   * - Otherwise, set `s.originalBasePath` only if it is currently empty —
+   *   resume paths that already restored `s.originalBasePath` from paused
+   *   metadata keep their value.
+   *
+   * Does NOT chdir; callers that need cwd alignment with the new basePath
+   * are responsible for it. Does NOT rebuild `s.gitService` — callers that
+   * mutate `s.basePath` to a non-project-root path (e.g. a worktree on a
+   * subsequent milestone enter) go through `enterMilestone`, which handles
+   * the rebuild.
+   */
+  adoptSessionRoot(base: string, originalBase?: string): void {
+    this.s.basePath = base;
+    if (originalBase !== undefined) {
+      this.s.originalBasePath = originalBase;
+    } else if (!this.s.originalBasePath) {
+      this.s.originalBasePath = base;
+    }
+  }
+
   /** True if `milestoneId` is the session's currently-active milestone. */
   isInMilestone(milestoneId: string): boolean {
     return this.s.currentMilestoneId === milestoneId;


### PR DESCRIPTION
## Summary

First of three B-track session-mutation verbs from the design note in #5653 / `docs/dev/ADR-016-phase-2-design.md`. After this slice the Worktree Lifecycle Module is the sole owner of \`s.basePath\` mutation for bootstrap-class transitions: initial session start, paused-resume entry, and hook-trigger session activation.

## \`WorktreeLifecycle.adoptSessionRoot(base, originalBase?)\`

- Always sets \`s.basePath = base\`.
- **Defensive on \`s.originalBasePath\`**: an explicit \`originalBase\` overwrites, but the no-arg form preserves a pre-existing value. This matters for the resume path where the meta-restore block (auto.ts:2003/2055) already restored \`originalBasePath\` from paused metadata before the verb is reached at auto.ts:2148.
- **Pure session-state mutation.** Does NOT chdir, rebuild git service, or invalidate caches — those belong to other verbs (\`enterMilestone\`, \`restoreToProjectRoot\`).

## Migrated call sites

| Site | Old code | New code |
|---|---|---|
| \`auto-start.ts:1043\` | \`s.basePath = base;\` (with \`s.originalBasePath = base;\` 60 lines later) | \`buildLifecycle().adoptSessionRoot(base);\` (the redundant later assignment is gone) |
| \`auto.ts:2148\` | \`s.basePath = base;\` | \`buildLifecycle().adoptSessionRoot(base);\` (preserves originalBasePath from meta-restore) |
| \`auto.ts:2466\` | \`s.basePath = targetBasePath;\` | \`buildLifecycle().adoptSessionRoot(targetBasePath);\` (hook-trigger as bootstrap variant) |

The hook-trigger open question from the design note is resolved: \`dispatchHookUnit\` is treated as a bootstrap variant, and the verb's defensive originalBasePath logic preserves any pre-existing value if the session was already active.

## Closure progress

After this slice the only \`s.basePath = ...\` assignments outside \`worktree-lifecycle.ts\` are:

- auto-start.ts:910/913/923 — orphan-adopt → **B4 (#5622)**
- auto.ts:2164 — paused-resume worktree-path override → **B3 (#5621)**
- auto.ts:1024/1275 — stop-path restores → **B5 (#5623)** (parity with existing \`restoreToProjectRoot\`)

## Tests

- 4 new unit tests for \`adoptSessionRoot\`: fresh-session seeding, resume-path preservation, explicit override, side-effect absence.
- worktree-lifecycle / auto-start / auto-loop / orphan-merge-bootstrap / auto-paused-ui-cleanup regression sweep: **99/99 passing**.
- \`tsc --noEmit\` clean.

## Closes

#5620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized session-root adoption to standardize base path/worktree initialization across startup and runtime.

* **Refactor**
  * Startup, resume, and hook execution flows updated to use the centralized root adoption for consistent behavior.

* **Tests**
  * Added tests covering session-root adoption: initial seeding, preservation, explicit overrides, and absence of side effects.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5672)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->