### PR TITLE
refactor(gsd): ADR-016 phase 2 / B3 — resumeFromPausedSession verb (#5621)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -458,15 +458,10 @@ export function _synthesizePausedSessionRecoveryForTest(
   return synthesizePausedSessionRecovery(basePath, unitType, unitId, sessionFile);
 }
 
-export function _resolvePausedResumeBasePathForTest(
-  basePath: string,
-  pausedWorktreePath: string | null | undefined,
-  pathExists: (path: string) => boolean = existsSync,
-): string {
-  return pausedWorktreePath && pathExists(pausedWorktreePath)
-    ? pausedWorktreePath
-    : basePath;
-}
+// `_resolvePausedResumeBasePathForTest` was retired in ADR-016 phase 2 / B3
+// (#5621). Production callers go through
+// `WorktreeLifecycle.resumeFromPausedSession`; the pure helper for tests is
+// `resolvePausedResumeBasePath` exported from `worktree-lifecycle.ts`.
 
 const DETACHED_AUTO_KEEPALIVE_INTERVAL_MS = 30_000;
 
@@ -2302,7 +2297,8 @@ export async function startAuto(
         { file: "auto.ts", milestoneId: s.currentMilestoneId ?? "" },
       );
     }
-    s.basePath = _resolvePausedResumeBasePathForTest(base, resumeWorktreePath);
+    // ADR-016 phase 2 / B3 (#5621): paused-resume worktree-path adoption.
+    buildLifecycle().resumeFromPausedSession(base, resumeWorktreePath);
     // Rebuild scope now that s.basePath reflects the actual worktree (or project root).
     rebuildScope(s.basePath, s.currentMilestoneId);
     // Ensure the workflow-logger audit log is pinned to the project root

--- a/src/resources/extensions/gsd/tests/resume-dispatch-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/resume-dispatch-worktree.test.ts
@@ -10,7 +10,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
-import { _resolvePausedResumeBasePathForTest } from "../auto.ts";
+// ADR-016 phase 2 / B3 (#5621): the legacy `resolvePausedResumeBasePath`
+// helper was retired and folded into `WorktreeLifecycle.resumeFromPausedSession`.
+// The pure path-resolution function lives in `worktree-lifecycle.ts` for tests
+// that exercise the path-resolution invariant without constructing a session.
+import { resolvePausedResumeBasePath } from "../worktree-lifecycle.ts";
 
 function makeTmpBase(): string {
   const base = join(tmpdir(), `gsd-resume-wt-${randomUUID()}`);
@@ -59,7 +63,7 @@ test("resume base path uses paused-session worktreePath when the worktree exists
   try {
     setupWorktreeOnDisk(wt);
     assert.equal(
-      _resolvePausedResumeBasePathForTest(base, wt),
+      resolvePausedResumeBasePath(base, wt),
       wt,
     );
   } finally {
@@ -72,7 +76,7 @@ test("resume base path falls back to project root when paused worktree is missin
   const wt = makeWorktreePath(base, "M001-test");
   try {
     assert.equal(
-      _resolvePausedResumeBasePathForTest(base, wt),
+      resolvePausedResumeBasePath(base, wt),
       base,
     );
   } finally {

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   WorktreeLifecycle,
+  resolvePausedResumeBasePath,
   type WorktreeLifecycleDeps,
   type NotifyCtx,
 } from "../worktree-lifecycle.js";
@@ -485,6 +486,62 @@ test("adoptSessionRoot does not chdir, rebuild git service, or invalidate caches
   const lifecycle = new WorktreeLifecycle(s, deps);
 
   lifecycle.adoptSessionRoot("/project");
+
+  assert.equal(deps.calls.filter((c) => c.fn === "GitServiceImpl").length, 0);
+  assert.equal(deps.calls.filter((c) => c.fn === "invalidateAllCaches").length, 0);
+});
+
+// ─── resumeFromPausedSession (ADR-016 phase 2 / B3, issue #5621) ──────────────
+
+test("resumeFromPausedSession adopts the persisted worktree path when it exists", () => {
+  const s = makeSession();
+  s.basePath = "/some/old/path";
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  // Inject a pathExists stub via the pure helper export so the verb's
+  // existence check returns true without touching the filesystem.
+  // The verb doesn't accept a stub directly, so we exercise it through
+  // the pure helper to keep the test free of disk side effects.
+  const wt = "/persisted/worktree/M001";
+  // Verify the pure helper's contract first (folded in from the legacy
+  // _resolvePausedResumeBasePathForTest)
+  assert.equal(
+    resolvePausedResumeBasePath("/project", wt, () => true),
+    wt,
+  );
+
+  // Now exercise the verb with a real path that exists (the test cwd).
+  lifecycle.resumeFromPausedSession("/project", process.cwd());
+  assert.equal(s.basePath, process.cwd());
+});
+
+test("resumeFromPausedSession falls back to base when persisted worktree is null", () => {
+  const s = makeSession();
+  s.basePath = "/old";
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  lifecycle.resumeFromPausedSession("/project", null);
+  assert.equal(s.basePath, "/project");
+});
+
+test("resumeFromPausedSession falls back to base when persisted worktree does not exist", () => {
+  const s = makeSession();
+  s.basePath = "/old";
+  const lifecycle = new WorktreeLifecycle(s, makeDeps());
+
+  lifecycle.resumeFromPausedSession(
+    "/project",
+    "/this/path/does/not/exist/abc/xyz",
+  );
+  assert.equal(s.basePath, "/project");
+});
+
+test("resumeFromPausedSession does not chdir, rebuild git service, or invalidate caches", () => {
+  const s = makeSession();
+  const deps = makeDeps();
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.resumeFromPausedSession("/project", null);
 
   assert.equal(deps.calls.filter((c) => c.fn === "GitServiceImpl").length, 0);
   assert.equal(deps.calls.filter((c) => c.fn === "invalidateAllCaches").length, 0);

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -568,6 +568,28 @@ export function _enterMilestoneCore(
   }
 }
 
+/**
+ * Resolve the basePath to adopt on resume from a paused session.
+ *
+ * Returns `persistedWorktreePath` when the path is non-null and exists on
+ * disk; otherwise falls back to `base`. Used by
+ * `WorktreeLifecycle.resumeFromPausedSession` (#5621). Exported as a pure
+ * function so unit tests can exercise the path-resolution logic without
+ * constructing a `WorktreeLifecycle` instance.
+ *
+ * The optional `pathExists` parameter exists only for tests that need to
+ * substitute a stub for `existsSync`.
+ */
+export function resolvePausedResumeBasePath(
+  base: string,
+  persistedWorktreePath: string | null | undefined,
+  pathExists: (p: string) => boolean = existsSync,
+): string {
+  return persistedWorktreePath && pathExists(persistedWorktreePath)
+    ? persistedWorktreePath
+    : base;
+}
+
 function rebuildGitService(
   s: AutoSession,
   deps: WorktreeLifecycleDeps,
@@ -1485,6 +1507,29 @@ export class WorktreeLifecycle {
     } else if (!this.s.originalBasePath) {
       this.s.originalBasePath = base;
     }
+  }
+
+  /**
+   * Resume from a paused session (ADR-016 phase 2 / B3, issue #5621).
+   *
+   * Adopts `persistedWorktreePath` as `s.basePath` when the path is
+   * non-null and exists on disk; otherwise falls back to `base`. Mirrors
+   * the resume guard at `auto.ts:2164` — a stale or removed worktree
+   * directory must not strand the resumed session in an invalid root.
+   *
+   * Folds in the body of the legacy `_resolvePausedResumeBasePathForTest`
+   * helper (see `resolvePausedResumeBasePath` below). After this verb
+   * lands the helper is deleted from `auto.ts` per the slice-7 closure
+   * decision to retire `_*ForTest` suffixes from production paths.
+   *
+   * Like `adoptSessionRoot`, this is a pure session-state mutation — no
+   * chdir, no git service rebuild, no cache invalidation.
+   */
+  resumeFromPausedSession(
+    base: string,
+    persistedWorktreePath: string | null,
+  ): void {
+    this.s.basePath = resolvePausedResumeBasePath(base, persistedWorktreePath);
   }
 
   /** True if `milestoneId` is the session's currently-active milestone. */


### PR DESCRIPTION
## Summary

Second of three B-track session-mutation verbs from #5653 / \`docs/dev/ADR-016-phase-2-design.md\`. After this slice \`s.basePath\` mutation for the paused-session worktree-path adoption goes through the Module instead of a direct assignment in \`auto.ts\`.

Folds in the body of the legacy \`_resolvePausedResumeBasePathForTest\` helper, completing the slice-7 cleanup that retired \`_*ForTest\` suffixes from production paths (this one survived because it sat in the verb path B3 was meant to resolve).

## \`WorktreeLifecycle.resumeFromPausedSession(base, persistedWorktreePath)\`

- Adopts \`persistedWorktreePath\` as \`s.basePath\` when the path is non-null and exists on disk; otherwise falls back to \`base\`.
- Mirrors the existing resume guard at \`auto.ts:2164\` — a stale or removed worktree directory must not strand the resumed session in an invalid root.
- Pure session-state mutation (no chdir, no git service rebuild, no cache invalidation), like \`adoptSessionRoot\`.

Pure path-resolution helper exported as \`resolvePausedResumeBasePath(base, persistedWorktreePath, pathExists?)\` from \`worktree-lifecycle.ts\` for unit tests that exercise the resolution contract without constructing a session.

## Migrated

- \`auto.ts:2164\` — direct assignment → \`buildLifecycle().resumeFromPausedSession(base, resumeWorktreePath);\`
- \`auto.ts:_resolvePausedResumeBasePathForTest\` deleted.
- \`tests/resume-dispatch-worktree.test.ts\` updated to import the new pure helper from \`worktree-lifecycle.ts\`.

## Tests

- 4 new unit tests for \`resumeFromPausedSession\` covering exists / null / missing-path branches and side-effect absence.
- worktree-lifecycle / resume-dispatch-worktree / auto-loop / auto-paused-ui-cleanup regression sweep: **98/98 passing**.
- \`tsc --noEmit\` clean.

## Closes

#5621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Paused session resumption now consistently prefers persisted worktree paths if they exist, falling back to the project root otherwise; resuming avoids unnecessary workspace switching, service reconstruction, and cache invalidation when no persisted worktree is present.
* **Tests**
  * Updated and expanded tests to validate resumed-path selection and ensure no observable side effects in fallback scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5673)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->