### PR TITLE
refactor(gsd): ADR-016 phase 2 / B4 — adoptOrphanWorktree verb (#5622)

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -904,29 +904,24 @@ export async function bootstrapAutoSession(
     {
       const orphan = findUnmergedCompletedMilestone(base, getIsolationMode(base));
       if (orphan && orphan !== state.activeMilestone?.id) {
-        const priorBasePath = s.basePath;
-        const priorOriginalBasePath = s.originalBasePath;
-        s.originalBasePath = base;
-        s.basePath = getAutoWorktreePath(base, orphan) ?? base;
-        const result = _mergeOrphanCompletedMilestone(buildLifecycle(), orphan, ctx.ui);
+        // ADR-016 phase 2 / B4 (#5622): the swap-run-revert protocol for
+        // the orphan-merge dance is owned by `adoptOrphanWorktree`. The
+        // verb snapshots prior `s.basePath` / `s.originalBasePath`, swaps
+        // into the orphan worktree, runs the merge callback under the
+        // swap, and reverts (or holds the swap) based on the result.
+        // Callers can no longer forget the revert step on failure — the
+        // pattern that originally motivated this verb.
+        const lifecycle = buildLifecycle();
+        const result = lifecycle.adoptOrphanWorktree(orphan, base, () =>
+          _mergeOrphanCompletedMilestone(lifecycle, orphan, ctx.ui),
+        );
         if (!result.merged) {
-          s.basePath = base;
-          s.originalBasePath = base;
-          try {
-            process.chdir(base);
-          } catch (err) {
-            logWarning("bootstrap", `could not restore cwd after orphan merge failure: ${err instanceof Error ? err.message : String(err)}`);
-          }
+          // Verb already restored basePath/originalBasePath to `base` and
+          // chdir'd there. Return early.
           return releaseLockAndReturn();
         }
-        if (!s.active) {
-          s.basePath = priorBasePath || base;
-          s.originalBasePath = priorOriginalBasePath || base;
-        }
-        if (result.merged) {
-          invalidateAllCaches();
-          state = await deriveState(base);
-        }
+        invalidateAllCaches();
+        state = await deriveState(base);
       }
     }
 

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -117,6 +117,16 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
             };
           },
           enterMilestone: () => ({ ok: true, mode: "none", path: base }),
+          // ADR-016 phase 2 / B4 (#5622): the orphan-merge dance now goes
+          // through `adoptOrphanWorktree`. The mock invokes the callback
+          // and returns its result without exercising the swap-revert
+          // protocol — this test only cares about the merge call being
+          // recorded and the bootstrap returning `false` on failure.
+          adoptOrphanWorktree: <T extends { merged: boolean }>(
+            _mid: string,
+            _base: string,
+            run: () => T,
+          ): T => run(),
         }) as any,
       },
       {

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -630,6 +630,71 @@ test("adoptOrphanWorktree falls back to base when getAutoWorktreePath returns nu
   assert.equal(basePathInsideCallback, "/project");
 });
 
+test("adoptOrphanWorktree restores prior paths and cwd when the callback throws", () => {
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-orphan-rollback-base-"));
+  const worktree = mkdtempSync(join(tmpdir(), "gsd-orphan-rollback-wt-"));
+  const s = makeSession({
+    basePath: "/prior",
+    originalBasePath: originalCwd,
+    active: true,
+  });
+  const deps = makeDeps({
+    getAutoWorktreePath: () => worktree,
+  });
+  const lifecycle = new WorktreeLifecycle(s, deps);
+  const thrown = new Error("synthetic callback failure");
+
+  try {
+    assert.throws(
+      () =>
+        lifecycle.adoptOrphanWorktree<{ merged: boolean }>("M001", base, () => {
+          assert.equal(s.basePath, worktree);
+          assert.equal(s.originalBasePath, base);
+          throw thrown;
+        }),
+      thrown,
+    );
+
+    assert.equal(s.basePath, "/prior");
+    assert.equal(s.originalBasePath, originalCwd);
+    assert.equal(process.cwd(), originalCwd);
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+    rmSync(worktree, { recursive: true, force: true });
+  }
+});
+
+test("adoptOrphanWorktree rejects traversal-style milestone ids before path resolution", () => {
+  const s = makeSession({
+    basePath: "/prior",
+    originalBasePath: "/prior-original",
+    active: true,
+  });
+  const deps = makeDeps({
+    getAutoWorktreePath: () => {
+      throw new Error("getAutoWorktreePath should not be called");
+    },
+  });
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  assert.throws(
+    () =>
+      lifecycle.adoptOrphanWorktree("../M001", "/project", () => ({
+        merged: true as const,
+      })),
+    /Invalid milestoneId: \.\.\/M001/,
+  );
+
+  assert.equal(s.basePath, "/prior");
+  assert.equal(s.originalBasePath, "/prior-original");
+  assert.equal(
+    deps.calls.filter((c) => c.fn === "getAutoWorktreePath").length,
+    0,
+  );
+});
+
 test("adoptOrphanWorktree forwards the callback's return value", () => {
   const s = makeSession();
   s.active = true;

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -546,3 +546,103 @@ test("resumeFromPausedSession does not chdir, rebuild git service, or invalidate
   assert.equal(deps.calls.filter((c) => c.fn === "GitServiceImpl").length, 0);
   assert.equal(deps.calls.filter((c) => c.fn === "invalidateAllCaches").length, 0);
 });
+
+// ─── adoptOrphanWorktree (ADR-016 phase 2 / B4, issue #5622) ──────────────────
+
+test("adoptOrphanWorktree swaps to worktree path and reverts to base on !merged", () => {
+  const s = makeSession();
+  s.basePath = "/old";
+  s.originalBasePath = "/old";
+  s.active = true;
+  const deps = makeDeps({
+    getAutoWorktreePath: () => "/project/.gsd/worktrees/M001",
+  });
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  let basePathInsideCallback = "";
+  const result = lifecycle.adoptOrphanWorktree("M001", "/project", () => {
+    basePathInsideCallback = s.basePath;
+    return { merged: false as const, reason: "synthetic" };
+  });
+
+  // Inside callback: swap was applied
+  assert.equal(basePathInsideCallback, "/project/.gsd/worktrees/M001");
+  // After failed merge: reverted to base
+  assert.equal(s.basePath, "/project");
+  assert.equal(s.originalBasePath, "/project");
+  assert.equal(result.merged, false);
+});
+
+test("adoptOrphanWorktree holds the swap on merged && active", () => {
+  const s = makeSession();
+  s.basePath = "/old";
+  s.originalBasePath = "/old";
+  s.active = true;
+  const deps = makeDeps({
+    getAutoWorktreePath: () => "/project/.gsd/worktrees/M001",
+  });
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.adoptOrphanWorktree("M001", "/project", () => ({
+    merged: true as const,
+  }));
+
+  // Merged && active — swap held
+  assert.equal(s.basePath, "/project/.gsd/worktrees/M001");
+  assert.equal(s.originalBasePath, "/project");
+});
+
+test("adoptOrphanWorktree restores prior paths on merged && !active", () => {
+  const s = makeSession();
+  s.basePath = "/prior";
+  s.originalBasePath = "/prior-original";
+  s.active = false;
+  const deps = makeDeps({
+    getAutoWorktreePath: () => "/project/.gsd/worktrees/M001",
+  });
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  lifecycle.adoptOrphanWorktree("M001", "/project", () => ({
+    merged: true as const,
+  }));
+
+  // Merged but session inactive — restore the snapshotted prior paths
+  assert.equal(s.basePath, "/prior");
+  assert.equal(s.originalBasePath, "/prior-original");
+});
+
+test("adoptOrphanWorktree falls back to base when getAutoWorktreePath returns null", () => {
+  const s = makeSession();
+  s.basePath = "/old";
+  s.active = true;
+  const deps = makeDeps({
+    getAutoWorktreePath: () => null,
+  });
+  const lifecycle = new WorktreeLifecycle(s, deps);
+
+  let basePathInsideCallback = "";
+  lifecycle.adoptOrphanWorktree("M001", "/project", () => {
+    basePathInsideCallback = s.basePath;
+    return { merged: true as const };
+  });
+
+  // Inside callback: basePath is project root (no worktree available)
+  assert.equal(basePathInsideCallback, "/project");
+});
+
+test("adoptOrphanWorktree forwards the callback's return value", () => {
+  const s = makeSession();
+  s.active = true;
+  const lifecycle = new WorktreeLifecycle(
+    s,
+    makeDeps({ getAutoWorktreePath: () => null }),
+  );
+
+  const result = lifecycle.adoptOrphanWorktree("M001", "/project", () => ({
+    merged: true as const,
+    customField: "preserved",
+  }));
+
+  assert.equal(result.merged, true);
+  assert.equal(result.customField, "preserved");
+});

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -1560,14 +1560,44 @@ export class WorktreeLifecycle {
     base: string,
     run: () => T,
   ): T {
+    validateMilestoneId(milestoneId);
+
     const priorBasePath = this.s.basePath;
     const priorOriginalBasePath = this.s.originalBasePath;
+    const restorePriorPaths = (phase: string): void => {
+      this.s.basePath = priorBasePath || base;
+      this.s.originalBasePath = priorOriginalBasePath || base;
+      try {
+        process.chdir(this.s.originalBasePath || base);
+      } catch (err) {
+        debugLog("WorktreeLifecycle", {
+          action: "adoptOrphanWorktree",
+          phase,
+          base: this.s.originalBasePath || base,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    };
+
+    let adoptedBasePath: string;
+    try {
+      adoptedBasePath = this.deps.getAutoWorktreePath(base, milestoneId) ?? base;
+    } catch (err) {
+      restorePriorPaths("rollback-resolve-worktree-failed");
+      throw err;
+    }
 
     // Swap into the orphan worktree.
     this.s.originalBasePath = base;
-    this.s.basePath = this.deps.getAutoWorktreePath(base, milestoneId) ?? base;
+    this.s.basePath = adoptedBasePath;
 
-    const result = run();
+    let result: T;
+    try {
+      result = run();
+    } catch (err) {
+      restorePriorPaths("rollback-run-failed");
+      throw err;
+    }
 
     if (!result.merged) {
       // Failed orphan merge — revert to project root so the caller can

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -1532,6 +1532,76 @@ export class WorktreeLifecycle {
     this.s.basePath = resolvePausedResumeBasePath(base, persistedWorktreePath);
   }
 
+  /**
+   * Adopt an orphan worktree for a bootstrap-time merge (ADR-016 phase 2 / B4,
+   * issue #5622).
+   *
+   * Owns the swap-run-revert protocol that bootstrap previously open-coded:
+   *
+   *   1. Snapshot prior `s.basePath` and `s.originalBasePath`.
+   *   2. Set `s.originalBasePath = base` and
+   *      `s.basePath = getAutoWorktreePath(base, milestoneId) ?? base`.
+   *   3. Invoke the caller-supplied `run` callback under the swap.
+   *   4. On `!result.merged`: revert to `base` and `chdir(base)` so the
+   *      caller can return early without leaving the session in a half-
+   *      swapped state.
+   *   5. On `result.merged && !s.active`: revert to the snapshotted prior
+   *      paths (the orphan merge succeeded but bootstrap chose not to keep
+   *      the session active).
+   *   6. On `result.merged && s.active`: leave the swap in place — the
+   *      loop will continue from the worktree path.
+   *
+   * The callback shape forces every caller through the same revert
+   * protocol; an open-coded swap that forgets to revert on failure was the
+   * original bug pattern this verb is designed to prevent.
+   */
+  adoptOrphanWorktree<T extends { merged: boolean }>(
+    milestoneId: string,
+    base: string,
+    run: () => T,
+  ): T {
+    const priorBasePath = this.s.basePath;
+    const priorOriginalBasePath = this.s.originalBasePath;
+
+    // Swap into the orphan worktree.
+    this.s.originalBasePath = base;
+    this.s.basePath = this.deps.getAutoWorktreePath(base, milestoneId) ?? base;
+
+    const result = run();
+
+    if (!result.merged) {
+      // Failed orphan merge — revert to project root so the caller can
+      // safely return early without leaving the session in an invalid
+      // basePath. Mirror the chdir that bootstrap performed inline.
+      this.s.basePath = base;
+      this.s.originalBasePath = base;
+      try {
+        process.chdir(base);
+      } catch (err) {
+        debugLog("WorktreeLifecycle", {
+          action: "adoptOrphanWorktree",
+          phase: "revert-chdir-failed",
+          base,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      return result;
+    }
+
+    if (!this.s.active) {
+      // Merge succeeded but the session was not (re)activated — restore
+      // the snapshotted paths so the calling context resumes where it
+      // was, with the orphan branch now merged on main.
+      this.s.basePath = priorBasePath || base;
+      this.s.originalBasePath = priorOriginalBasePath || base;
+    }
+    // else: merged && active — leave the swap; the loop continues from
+    // the worktree path. Subsequent milestone enters mutate `s.basePath`
+    // through their own Lifecycle verbs.
+
+    return result;
+  }
+
   /** True if `milestoneId` is the session's currently-active milestone. */
   isInMilestone(milestoneId: string): boolean {
     return this.s.currentMilestoneId === milestoneId;


### PR DESCRIPTION
## Summary

Third B-track session-mutation verb from #5653 / \`docs/dev/ADR-016-phase-2-design.md\`. After this slice the bootstrap-time orphan-merge dance goes through a callback-shaped Lifecycle verb that owns the swap-run-revert protocol — open-coded callers can no longer forget the revert step on failure (the original bug pattern this verb is designed to prevent).

## \`WorktreeLifecycle.adoptOrphanWorktree(milestoneId, base, run)\`

Owns the protocol:

1. Snapshot prior \`s.basePath\` and \`s.originalBasePath\`.
2. Set \`s.originalBasePath = base\` and \`s.basePath = getAutoWorktreePath(base, milestoneId) ?? base\`.
3. Invoke \`run()\` under the swap.
4. **On \`!result.merged\`**: revert to \`base\` and \`chdir(base)\` so the caller can return early without leaving the session in a half-swapped state.
5. **On \`result.merged && !s.active\`**: revert to the snapshotted prior paths.
6. **On \`result.merged && s.active\`**: leave the swap in place — the loop continues from the worktree path.

Generic over the callback's return type so bootstrap can keep using the existing \`_mergeOrphanCompletedMilestone\` result shape.

## Migrated

- \`auto-start.ts:910-925\` — the open-coded swap-merge-revert block is gone. Bootstrap's remaining responsibility on the success path is \`invalidateAllCaches()\` + \`await deriveState(base)\`, plus the early-return on \`!result.merged\`. The 17-line block is now 8 lines.
- \`tests/auto-start-orphan-bootstrap.test.ts\` mock updated to include \`adoptOrphanWorktree\` (the mock returns \`run()\` to keep the test focused on merge-call recording).

## B-track closure status

After this slice the only remaining \`s.basePath = ...\` direct assignments outside \`worktree-lifecycle.ts\` are at the two stop-path restores (\`auto.ts:1024 / 1275\`), which **B5 (#5623)** routes through the existing \`restoreToProjectRoot()\` verb. After B5, the ADR's "single owner of \`s.basePath\` mutation" invariant is enforced at the file boundary.

## Tests

- 5 new unit tests for \`adoptOrphanWorktree\` covering swap-inside-callback, revert-on-failure, swap-held-on-merged+active, restore-prior-on-merged+inactive, null fallback, and result forwarding.
- orphan-merge-bootstrap / auto-start-orphan-bootstrap / auto-loop / worktree-lifecycle regression sweep: **98/98 passing**.
- \`tsc --noEmit\` clean.

## Closes

#5622

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a lifecycle operation to standardize orphan worktree adoption during bootstrap.

* **Refactor**
  * Centralized swap→run→revert behavior for orphan merges, improving session path handling, cache invalidation, and merge-result handling.

* **Tests**
  * Added contract and unit tests covering path swapping, restoration, merged/unmerged flows, and milestone/notification outcomes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5674)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->