### PR TITLE
fix(gsd): back off verification retries

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -83,6 +83,7 @@ import {
   finalizeProjectResearchTimeout,
 } from "./project-research-policy.js";
 import { validateArtifact } from "./schemas/validate.js";
+import { verificationRetryKey } from "./auto/verification-retry-policy.js";
 
 // ─── Path Comparison Helper ───────────────────────────────────────────────
 /** Compare two paths for physical identity, tolerating trailing slashes and symlinks. */
@@ -1016,6 +1017,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         );
         s.pendingVerificationRetry = null;
         s.verificationRetryCount.delete(retryKey);
+        s.verificationRetryFailureHashes.delete(retryKey);
         triggerArtifactVerified = verifyExpectedArtifact(s.currentUnit.type, s.currentUnit.id, s.basePath);
         if (triggerArtifactVerified) {
           invalidateAllCaches();
@@ -1074,6 +1076,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         s.lastToolInvocationError = null;
         s.pendingVerificationRetry = null;
         s.verificationRetryCount.delete(retryKey);
+        s.verificationRetryFailureHashes.delete(retryKey);
         writeBlockerPlaceholder(s.currentUnit.type, s.currentUnit.id, s.basePath, reason);
         ctx.ui.notify(
           `${s.currentUnit.type} ${s.currentUnit.id} — deterministic policy rejection, wrote blocker placeholder (no retries) (#4973)`,
@@ -1111,6 +1114,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           );
           if (attempt > MAX_ARTIFACT_VERIFICATION_RETRIES) {
             s.verificationRetryCount.delete(retryKey);
+            s.verificationRetryFailureHashes.delete(retryKey);
             debugLog("postUnit", { phase: "artifact-verify-exhausted", unitType: s.currentUnit.type, unitId: s.currentUnit.id, attempt });
             ctx.ui.notify(
               `${failureDetails} Pausing auto-mode after ${MAX_ARTIFACT_VERIFICATION_RETRIES} retries.`,
@@ -1137,7 +1141,9 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       // Verification succeeded — clear the retry counter so a future failure
       // of the same unit gets a full retry budget instead of the stale count.
       if (triggerArtifactVerified) {
-        s.verificationRetryCount.delete(`${s.currentUnit.type}:${s.currentUnit.id}`);
+        const retryKey = verificationRetryKey(s.currentUnit.type, s.currentUnit.id);
+        s.verificationRetryCount.delete(retryKey);
+        s.verificationRetryFailureHashes.delete(retryKey);
       }
     } else {
       // Hook unit completed — no additional processing needed

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -39,6 +39,7 @@ import type { VerificationResult as VerificationGateResult } from "./types.js";
 import { join } from "node:path";
 import { resolveUokFlags } from "./uok/flags.js";
 import { UokGateRunner } from "./uok/gate-runner.js";
+import { verificationRetryKey } from "./auto/verification-retry-policy.js";
 
 export interface VerificationContext {
   s: AutoSession;
@@ -331,7 +332,8 @@ export async function runPostUnitVerification(
     }
 
     // Write verification evidence JSON
-    const attempt = s.verificationRetryCount.get(s.currentUnit.id) ?? 0;
+    const retryKey = verificationRetryKey(s.currentUnit.type, s.currentUnit.id);
+    const attempt = s.verificationRetryCount.get(retryKey) ?? 0;
     if (mid && sid && tid) {
       try {
         const sDir = resolveSlicePath(s.basePath, mid, sid);
@@ -364,7 +366,8 @@ export async function runPostUnitVerification(
         ));
 
     if (advisoryFailure) {
-      s.verificationRetryCount.delete(s.currentUnit.id);
+      s.verificationRetryCount.delete(retryKey);
+      s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
       ctx.ui.notify(
         result.discoverySource === "package-json"
@@ -565,13 +568,15 @@ export async function runPostUnitVerification(
 
     // ── Auto-fix retry logic ──
     if (result.passed) {
-      s.verificationRetryCount.delete(s.currentUnit.id);
+      s.verificationRetryCount.delete(retryKey);
+      s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
       return "continue";
     } else if (postExecBlockingFailure) {
       // Post-execution failures are cross-task consistency issues — retrying the same task won't fix them.
       // Skip retry and pause immediately for human review.
-      s.verificationRetryCount.delete(s.currentUnit.id);
+      s.verificationRetryCount.delete(retryKey);
+      s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
       ctx.ui.notify(
         `Post-execution checks failed — cross-task consistency issue detected, pausing for human review`,
@@ -581,7 +586,7 @@ export async function runPostUnitVerification(
       return "pause";
     } else if (autoFixEnabled && attempt + 1 <= maxRetries) {
       const nextAttempt = attempt + 1;
-      s.verificationRetryCount.set(s.currentUnit.id, nextAttempt);
+      s.verificationRetryCount.set(retryKey, nextAttempt);
       s.pendingVerificationRetry = {
         unitId: s.currentUnit.id,
         failureContext: formatFailureContext(result),
@@ -601,7 +606,8 @@ export async function runPostUnitVerification(
       return "retry";
     } else {
       // Gate failed, retries exhausted
-      s.verificationRetryCount.delete(s.currentUnit.id);
+      s.verificationRetryCount.delete(retryKey);
+      s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
       const exhaustedFails = result.checks
         .filter((c) => c.exitCode !== 0)

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -74,11 +74,62 @@ import {
 } from "../workflow-mcp.js";
 import { resolveManifest } from "../unit-context-manifest.js";
 import { createWorktreeSafetyModule, type WorktreeSafetyResult } from "../worktree-safety.js";
+import { decideVerificationRetry, verificationRetryKey } from "./verification-retry-policy.js";
 
 // ─── Path Comparison Helper ───────────────────────────────────────────────
 /** Compare two paths for physical identity, tolerating trailing slashes and symlinks. */
 function isSamePathLocal(a: string, b: string): boolean {
   return normalizeWorktreePathForCompare(a) === normalizeWorktreePathForCompare(b);
+}
+
+async function applyVerificationRetryPolicy(
+  ic: IterationContext,
+  unitType: string | undefined,
+  phase: "artifact-verification-retry" | "verification-retry",
+): Promise<PhaseResult | null> {
+  const { ctx, pi, s, deps } = ic;
+  const retryInfo = s.pendingVerificationRetry;
+  const key = unitType && retryInfo
+    ? verificationRetryKey(unitType, retryInfo.unitId)
+    : undefined;
+  const decision = decideVerificationRetry({
+    unitType,
+    retryInfo,
+    previousFailureHash: key ? s.verificationRetryFailureHashes.get(key) : undefined,
+  });
+
+  if (decision.action === "pause") {
+    s.pendingVerificationRetry = null;
+    debugLog("autoLoop", {
+      phase: `${phase}-paused`,
+      reason: decision.reason,
+      unitType,
+      unitId: retryInfo?.unitId,
+      failureHash: decision.failureHash,
+    });
+    ctx.ui.notify(
+      decision.reason === "duplicate-failure-context"
+        ? `Verification retry for ${unitType ?? "unit"} ${retryInfo?.unitId ?? "unknown"} produced the same failure context. Pausing auto-mode instead of re-dispatching.`
+        : "Verification retry requested without retry context. Pausing auto-mode instead of re-dispatching.",
+      "warning",
+    );
+    await deps.pauseAuto(ctx, pi);
+    return { action: "break", reason: decision.reason };
+  }
+
+  s.verificationRetryFailureHashes.set(decision.key, decision.failureHash);
+  debugLog("autoLoop", {
+    phase: `${phase}-backoff`,
+    iteration: ic.iteration,
+    unitType,
+    unitId: retryInfo?.unitId,
+    attempt: retryInfo?.attempt,
+    delayMs: decision.delayMs,
+    baseDelayMs: decision.baseDelayMs,
+    failureHash: decision.failureHash,
+  });
+  await new Promise<void>((resolve) => setTimeout(resolve, decision.delayMs));
+  return null;
 }
 
 export function shouldDegradeEmptyWorktreeToProjectRoot(
@@ -2386,6 +2437,14 @@ export async function runFinalize(
           attempt: retryInfo?.attempt,
         },
       });
+      const retryPolicyResult = await applyVerificationRetryPolicy(
+        ic,
+        preUnitSnapshot?.type,
+        "artifact-verification-retry",
+      );
+      if (retryPolicyResult) {
+        return retryPolicyResult;
+      }
       // Continue the loop — next iteration will inject the retry context into the prompt.
       debugLog("autoLoop", { phase: "artifact-verification-retry", iteration: ic.iteration });
       return { action: "continue" };
@@ -2423,6 +2482,14 @@ export async function runFinalize(
         debugLog("autoLoop", { phase: "sidecar-verification-retry-skipped", iteration: ic.iteration });
       } else {
         // s.pendingVerificationRetry was set by runPostUnitVerification.
+        const retryPolicyResult = await applyVerificationRetryPolicy(
+          ic,
+          iterData.unitType,
+          "verification-retry",
+        );
+        if (retryPolicyResult) {
+          return retryPolicyResult;
+        }
         // Continue the loop — next iteration will inject the retry context into the prompt.
         debugLog("autoLoop", { phase: "verification-retry", iteration: ic.iteration });
         return { action: "continue" };

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -158,6 +158,7 @@ export class AutoSession {
   pendingCrashRecovery: string | null = null;
   pendingVerificationRetry: PendingVerificationRetry | null = null;
   readonly verificationRetryCount = new Map<string, number>();
+  readonly verificationRetryFailureHashes = new Map<string, string>();
   pausedSessionFile: string | null = null;
   pausedUnitType: string | null = null;
   pausedUnitId: string | null = null;
@@ -334,6 +335,7 @@ export class AutoSession {
     this.pendingCrashRecovery = null;
     this.pendingVerificationRetry = null;
     this.verificationRetryCount.clear();
+    this.verificationRetryFailureHashes.clear();
     this.pausedSessionFile = null;
     this.pausedUnitType = null;
     this.pausedUnitId = null;

--- a/src/resources/extensions/gsd/auto/verification-retry-policy.ts
+++ b/src/resources/extensions/gsd/auto/verification-retry-policy.ts
@@ -1,0 +1,82 @@
+// Project/App: GSD-2
+// File Purpose: Central retry policy for auto-mode verification redispatches.
+
+import { createHash } from "node:crypto";
+
+import type { PendingVerificationRetry } from "./session.js";
+
+export const VERIFICATION_RETRY_BASE_DELAY_MS = 2_000;
+export const VERIFICATION_RETRY_MAX_DELAY_MS = 30_000;
+export const VERIFICATION_RETRY_JITTER_RATIO = 0.1;
+
+export type VerificationRetryDecision =
+  | {
+      action: "delay";
+      key: string;
+      failureHash: string;
+      delayMs: number;
+      baseDelayMs: number;
+    }
+  | {
+      action: "pause";
+      reason: "missing-retry-context" | "duplicate-failure-context";
+      key?: string;
+      failureHash?: string;
+    };
+
+export function verificationRetryKey(unitType: string, unitId: string): string {
+  return `${unitType}:${unitId}`;
+}
+
+export function hashVerificationFailureContext(failureContext: string): string {
+  const normalized = failureContext.replace(/\r\n/g, "\n").trim();
+  return createHash("sha256").update(normalized).digest("hex");
+}
+
+export function verificationRetryDelayMs(
+  attempt: number,
+  random: () => number = Math.random,
+): { delayMs: number; baseDelayMs: number } {
+  const safeAttempt = Math.max(1, Math.floor(attempt));
+  const baseDelayMs = Math.min(
+    VERIFICATION_RETRY_MAX_DELAY_MS,
+    VERIFICATION_RETRY_BASE_DELAY_MS * 2 ** (safeAttempt - 1),
+  );
+  const jitterSpanMs = Math.round(baseDelayMs * VERIFICATION_RETRY_JITTER_RATIO);
+  const jitterMs = Math.round((random() - 0.5) * 2 * jitterSpanMs);
+  const delayMs = Math.min(
+    VERIFICATION_RETRY_MAX_DELAY_MS,
+    Math.max(0, baseDelayMs + jitterMs),
+  );
+  return { delayMs, baseDelayMs };
+}
+
+export function decideVerificationRetry(input: {
+  unitType: string | undefined;
+  retryInfo: PendingVerificationRetry | null | undefined;
+  previousFailureHash: string | undefined;
+  random?: () => number;
+}): VerificationRetryDecision {
+  const { retryInfo, unitType } = input;
+  if (!retryInfo || !unitType) {
+    return { action: "pause", reason: "missing-retry-context" };
+  }
+
+  const key = verificationRetryKey(unitType, retryInfo.unitId);
+  const failureHash = hashVerificationFailureContext(retryInfo.failureContext);
+  if (input.previousFailureHash === failureHash) {
+    return {
+      action: "pause",
+      reason: "duplicate-failure-context",
+      key,
+      failureHash,
+    };
+  }
+
+  return {
+    action: "delay",
+    key,
+    failureHash,
+    ...verificationRetryDelayMs(retryInfo.attempt, input.random),
+  };
+}

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -784,6 +784,7 @@ function makeLoopSession(overrides?: Partial<Record<string, unknown>>) {
     lastBudgetAlertLevel: 0,
     pendingVerificationRetry: null,
     pendingCrashRecovery: null,
+    verificationRetryFailureHashes: new Map<string, string>(),
     pendingQuickTasks: [],
     sidecarQueue: [],
     autoModeStartModel: null,
@@ -1403,86 +1404,152 @@ test("crash lock records session file from AFTER newSession, not before (#1710)"
 
 test("autoLoop handles verification retry by continuing loop", async (t) => {
   _resetPendingResolve();
+  mock.timers.enable({ apis: ["Date", "setTimeout"], now: 10_000 });
 
-  const ctx = makeMockCtx();
-  ctx.ui.setStatus = () => {};
-  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
-  const pi = makeMockPi();
+  try {
+    const ctx = makeMockCtx();
+    ctx.ui.setStatus = () => {};
+    ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+    const pi = makeMockPi();
 
-  let verifyCallCount = 0;
-  let deriveCallCount = 0;
-  const s = makeLoopSession();
+    let verifyCallCount = 0;
+    let deriveCallCount = 0;
+    const s = makeLoopSession();
 
-  // Pre-queued verification actions: each entry provides a side-effect + return value
-  type VerifyAction = { sideEffect?: () => void; response: "retry" | "continue" };
-  const verificationActions: VerifyAction[] = [
-    {
-      sideEffect: () => {
-        // Simulate retry — set pendingVerificationRetry on session
+    // Pre-queued verification actions: each entry provides a side-effect + return value
+    type VerifyAction = { sideEffect?: () => void; response: "retry" | "continue" };
+    const verificationActions: VerifyAction[] = [
+      {
+        sideEffect: () => {
+          // Simulate retry — set pendingVerificationRetry on session
+          s.pendingVerificationRetry = {
+            unitId: "M001/S01/T01",
+            failureContext: "test failed: expected X got Y",
+            attempt: 1,
+          };
+        },
+        response: "retry",
+      },
+      { response: "continue" },
+    ];
+
+    const deps = makeMockDeps({
+      deriveState: async () => {
+        deriveCallCount++;
+        deps.callLog.push("deriveState");
+        return {
+          phase: "executing",
+          activeMilestone: { id: "M001", title: "Test", status: "active" },
+          activeSlice: { id: "S01", title: "Slice 1" },
+          activeTask: { id: "T01" },
+          registry: [{ id: "M001", status: "active" }],
+          blockers: [],
+        } as any;
+      },
+      runPostUnitVerification: async () => {
+        const action = verificationActions[verifyCallCount] ?? { response: "continue" as const };
+        verifyCallCount++;
+        deps.callLog.push("runPostUnitVerification");
+        action.sideEffect?.();
+        return action.response;
+      },
+      postUnitPostVerification: async () => {
+        deps.callLog.push("postUnitPostVerification");
+        // After the retry cycle completes, deactivate
+        s.active = false;
+        return "continue" as const;
+      },
+    });
+
+    const loopPromise = autoLoop(ctx, pi, s, deps);
+
+    // First iteration: runUnit → verification returns "retry" → loop continues
+    await waitForMicrotasks(() => pi.calls.length === 1, "first dispatch");
+    resolveAgentEnd(makeEvent()); // resolve first unit
+
+    await drainMicrotasks(100);
+    mock.timers.tick(30_000);
+    await waitForMicrotasks(() => pi.calls.length === 2, "retry dispatch");
+    resolveAgentEnd(makeEvent()); // resolve retry unit
+
+    await loopPromise;
+
+    // Verify deriveState was called twice (two iterations)
+    const deriveCount = deps.callLog.filter((c) => c === "deriveState").length;
+    assert.ok(
+      deriveCount >= 2,
+      `deriveState should be called at least 2 times (got ${deriveCount})`,
+    );
+
+    // Verify verification was called twice
+    assert.equal(
+      verifyCallCount,
+      2,
+      "verification should have been called twice (once retry, once pass)",
+    );
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("autoLoop pauses instead of redispatching identical verification failure context", async () => {
+  _resetPendingResolve();
+  mock.timers.enable({ apis: ["Date", "setTimeout"], now: 15_000 });
+
+  try {
+    const ctx = makeMockCtx();
+    ctx.ui.setStatus = () => {};
+    ctx.ui.notify = () => {};
+    ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+    const pi = makeMockPi();
+    const s = makeLoopSession();
+    let verifyCallCount = 0;
+    let pauseCallCount = 0;
+
+    const deps = makeMockDeps({
+      deriveState: async () =>
+        ({
+          phase: "executing",
+          activeMilestone: { id: "M001", title: "Test", status: "active" },
+          activeSlice: { id: "S01", title: "Slice 1" },
+          activeTask: { id: "T01" },
+          registry: [{ id: "M001", status: "active" }],
+          blockers: [],
+        }) as any,
+      runPostUnitVerification: async () => {
+        verifyCallCount++;
+        deps.callLog.push("runPostUnitVerification");
         s.pendingVerificationRetry = {
           unitId: "M001/S01/T01",
           failureContext: "test failed: expected X got Y",
-          attempt: 1,
+          attempt: verifyCallCount,
         };
+        return "retry" as const;
       },
-      response: "retry",
-    },
-    { response: "continue" },
-  ];
+      pauseAuto: async () => {
+        pauseCallCount++;
+        s.active = false;
+      },
+    });
 
-  const deps = makeMockDeps({
-    deriveState: async () => {
-      deriveCallCount++;
-      deps.callLog.push("deriveState");
-      return {
-        phase: "executing",
-        activeMilestone: { id: "M001", title: "Test", status: "active" },
-        activeSlice: { id: "S01", title: "Slice 1" },
-        activeTask: { id: "T01" },
-        registry: [{ id: "M001", status: "active" }],
-        blockers: [],
-      } as any;
-    },
-    runPostUnitVerification: async () => {
-      const action = verificationActions[verifyCallCount] ?? { response: "continue" as const };
-      verifyCallCount++;
-      deps.callLog.push("runPostUnitVerification");
-      action.sideEffect?.();
-      return action.response;
-    },
-    postUnitPostVerification: async () => {
-      deps.callLog.push("postUnitPostVerification");
-      // After the retry cycle completes, deactivate
-      s.active = false;
-      return "continue" as const;
-    },
-  });
+    const loopPromise = autoLoop(ctx, pi, s, deps);
 
-  const loopPromise = autoLoop(ctx, pi, s, deps);
+    await waitForMicrotasks(() => pi.calls.length === 1, "first dispatch");
+    resolveAgentEnd(makeEvent());
+    await drainMicrotasks(100);
+    mock.timers.tick(30_000);
 
-  // First iteration: runUnit → verification returns "retry" → loop continues
-  await new Promise((r) => setTimeout(r, 50));
-  resolveAgentEnd(makeEvent()); // resolve first unit
+    await waitForMicrotasks(() => pi.calls.length === 2, "retry dispatch");
+    resolveAgentEnd(makeEvent());
 
-  // Second iteration: runUnit → verification returns "continue"
-  await new Promise((r) => setTimeout(r, 50));
-  resolveAgentEnd(makeEvent()); // resolve retry unit
+    await loopPromise;
 
-  await loopPromise;
-
-  // Verify deriveState was called twice (two iterations)
-  const deriveCount = deps.callLog.filter((c) => c === "deriveState").length;
-  assert.ok(
-    deriveCount >= 2,
-    `deriveState should be called at least 2 times (got ${deriveCount})`,
-  );
-
-  // Verify verification was called twice
-  assert.equal(
-    verifyCallCount,
-    2,
-    "verification should have been called twice (once retry, once pass)",
-  );
+    assert.equal(verifyCallCount, 2);
+    assert.equal(pi.calls.length, 2, "duplicate failure should not be redispatched a third time");
+    assert.equal(pauseCallCount, 1, "duplicate failure should pause auto-mode");
+  } finally {
+    mock.timers.reset();
+  }
 });
 
 test("autoLoop handles dispatch stop action", async (t) => {
@@ -1871,74 +1938,83 @@ test("stuck detection: window resets recovery when deriveState returns a differe
 
 test("stuck detection: does not push to window during verification retry", async () => {
   _resetPendingResolve();
+  mock.timers.enable({ apis: ["Date", "setTimeout"], now: 20_000 });
 
-  const ctx = makeMockCtx();
-  ctx.ui.setStatus = () => {};
-  ctx.ui.notify = () => {};
-  const pi = makeMockPi();
-  const s = makeLoopSession();
+  try {
+    const ctx = makeMockCtx();
+    ctx.ui.setStatus = () => {};
+    ctx.ui.notify = () => {};
+    const pi = makeMockPi();
+    const s = makeLoopSession();
 
-  let verifyCallCount = 0;
-  let stopReason = "";
+    let verifyCallCount = 0;
+    let stopReason = "";
 
-  // Pre-queued responses: 3 retries then a continue (exit)
-  const verifyActions: Array<() => "retry" | "continue"> = [
-    () => { s.pendingVerificationRetry = { unitId: "M001/S01/T01", failureContext: "test failed", attempt: 1 }; return "retry"; },
-    () => { s.pendingVerificationRetry = { unitId: "M001/S01/T01", failureContext: "test failed", attempt: 2 }; return "retry"; },
-    () => { s.pendingVerificationRetry = { unitId: "M001/S01/T01", failureContext: "test failed", attempt: 3 }; return "retry"; },
-    () => { s.active = false; return "continue"; },
-  ];
+    // Pre-queued responses: 3 retries then a continue (exit). Failure
+    // contexts differ so this test exercises stuck-window behavior without
+    // tripping duplicate-failure suppression.
+    const verifyActions: Array<() => "retry" | "continue"> = [
+      () => { s.pendingVerificationRetry = { unitId: "M001/S01/T01", failureContext: "test failed: 1", attempt: 1 }; return "retry"; },
+      () => { s.pendingVerificationRetry = { unitId: "M001/S01/T01", failureContext: "test failed: 2", attempt: 2 }; return "retry"; },
+      () => { s.pendingVerificationRetry = { unitId: "M001/S01/T01", failureContext: "test failed: 3", attempt: 3 }; return "retry"; },
+      () => { s.active = false; return "continue"; },
+    ];
 
-  const deps = makeMockDeps({
-    deriveState: async () =>
-      ({
-        phase: "executing",
-        activeMilestone: { id: "M001", title: "Test", status: "active" },
-        activeSlice: { id: "S01", title: "Slice 1" },
-        activeTask: { id: "T01" },
-        registry: [{ id: "M001", status: "active" }],
-        blockers: [],
-      }) as any,
-    resolveDispatch: async () => ({
-      action: "dispatch" as const,
-      unitType: "execute-task",
-      unitId: "M001/S01/T01",
-      prompt: "do the thing",
-    }),
-    runPostUnitVerification: async () => {
-      const action = verifyActions[verifyCallCount] ?? (() => { s.active = false; return "continue" as const; });
-      verifyCallCount++;
-      deps.callLog.push("runPostUnitVerification");
-      return action();
-    },
-    stopAuto: async (_ctx?: any, _pi?: any, reason?: string) => {
-      deps.callLog.push("stopAuto");
-      stopReason = reason ?? "";
-      s.active = false;
-    },
-  });
+    const deps = makeMockDeps({
+      deriveState: async () =>
+        ({
+          phase: "executing",
+          activeMilestone: { id: "M001", title: "Test", status: "active" },
+          activeSlice: { id: "S01", title: "Slice 1" },
+          activeTask: { id: "T01" },
+          registry: [{ id: "M001", status: "active" }],
+          blockers: [],
+        }) as any,
+      resolveDispatch: async () => ({
+        action: "dispatch" as const,
+        unitType: "execute-task",
+        unitId: "M001/S01/T01",
+        prompt: "do the thing",
+      }),
+      runPostUnitVerification: async () => {
+        const action = verifyActions[verifyCallCount] ?? (() => { s.active = false; return "continue" as const; });
+        verifyCallCount++;
+        deps.callLog.push("runPostUnitVerification");
+        return action();
+      },
+      stopAuto: async (_ctx?: any, _pi?: any, reason?: string) => {
+        deps.callLog.push("stopAuto");
+        stopReason = reason ?? "";
+        s.active = false;
+      },
+    });
 
-  const loopPromise = autoLoop(ctx, pi, s, deps);
+    const loopPromise = autoLoop(ctx, pi, s, deps);
 
-  // Resolve agent_end for 4 iterations (1 initial + 3 retries)
-  for (let i = 0; i < 4; i++) {
-    await new Promise((r) => setTimeout(r, 30));
-    resolveAgentEnd(makeEvent());
+    // Resolve agent_end for 4 iterations (1 initial + 3 retries)
+    for (let i = 1; i <= 4; i++) {
+      await waitForMicrotasks(() => pi.calls.length === i, `dispatch ${i}`);
+      resolveAgentEnd(makeEvent());
+      await drainMicrotasks(100);
+      mock.timers.tick(30_000);
+    }
+
+    await loopPromise;
+
+    // Even though same unit was derived 4 times, verification retries should
+    // not push to the sliding window, so stuck detection should not have fired
+    assert.ok(
+      !stopReason.includes("Stuck"),
+      `stuck detection should not fire during verification retries, got: ${stopReason}`,
+    );
+    assert.equal(
+      verifyCallCount,
+      4,
+      "verification should have been called 4 times (1 initial + 3 retries)",
+    );
+  } finally {
+    mock.timers.reset();
   }
-
-  await loopPromise;
-
-  // Even though same unit was derived 4 times, verification retries should
-  // not push to the sliding window, so stuck detection should not have fired
-  assert.ok(
-    !stopReason.includes("Stuck"),
-    `stuck detection should not fire during verification retries, got: ${stopReason}`,
-  );
-  assert.equal(
-    verifyCallCount,
-    4,
-    "verification should have been called 4 times (1 initial + 3 retries)",
-  );
 });
 
 // ── detectStuck unit tests ────────────────────────────────────────────────────
@@ -2315,60 +2391,75 @@ test("session-switch abort grace window is short-lived and resettable", () => {
 
 test("autoLoop re-iterates when postUnitPreVerification returns retry (#1571)", async () => {
   _resetPendingResolve();
+  mock.timers.enable({ apis: ["Date", "setTimeout"], now: 30_000 });
 
-  const ctx = makeMockCtx();
-  ctx.ui.setStatus = () => {};
-  const pi = makeMockPi();
-  const s = makeLoopSession();
+  try {
+    const ctx = makeMockCtx();
+    ctx.ui.setStatus = () => {};
+    const pi = makeMockPi();
+    const s = makeLoopSession();
 
-  let preVerifyCallCount = 0;
-  // Pre-queued responses: first call returns "retry", second returns "continue"
-  const preVerifyResponses = ["retry", "continue"] as const;
+    let preVerifyCallCount = 0;
+    // Pre-queued responses: first call returns "retry", second returns "continue"
+    const preVerifyResponses = ["retry", "continue"] as const;
 
-  const deps = makeMockDeps({
-    deriveState: async () => {
-      deps.callLog.push("deriveState");
-      return {
-        phase: "executing",
-        activeMilestone: { id: "M001", title: "Test", status: "active" },
-        activeSlice: { id: "S01", title: "Slice 1" },
-        activeTask: { id: "T01" },
-        registry: [{ id: "M001", status: "active" }],
-        blockers: [],
-      } as any;
-    },
-    postUnitPreVerification: async () => {
-      deps.callLog.push("postUnitPreVerification");
-      return preVerifyResponses[preVerifyCallCount++] ?? "continue";
-    },
-    postUnitPostVerification: async () => {
-      deps.callLog.push("postUnitPostVerification");
-      s.active = false;
-      return "continue" as const;
-    },
-  });
+    const deps = makeMockDeps({
+      deriveState: async () => {
+        deps.callLog.push("deriveState");
+        return {
+          phase: "executing",
+          activeMilestone: { id: "M001", title: "Test", status: "active" },
+          activeSlice: { id: "S01", title: "Slice 1" },
+          activeTask: { id: "T01" },
+          registry: [{ id: "M001", status: "active" }],
+          blockers: [],
+        } as any;
+      },
+      postUnitPreVerification: async () => {
+        deps.callLog.push("postUnitPreVerification");
+        const response = preVerifyResponses[preVerifyCallCount++] ?? "continue";
+        if (response === "retry") {
+          s.pendingVerificationRetry = {
+            unitId: "M001/S01/T01",
+            failureContext: "missing artifact",
+            attempt: 1,
+          };
+        }
+        return response;
+      },
+      postUnitPostVerification: async () => {
+        deps.callLog.push("postUnitPostVerification");
+        s.active = false;
+        return "continue" as const;
+      },
+    });
 
-  const loopPromise = autoLoop(ctx, pi, s, deps);
+    const loopPromise = autoLoop(ctx, pi, s, deps);
 
-  await new Promise((r) => setTimeout(r, 50));
-  resolveAgentEnd(makeEvent());
+    await waitForMicrotasks(() => pi.calls.length === 1, "first dispatch");
+    resolveAgentEnd(makeEvent());
 
-  await new Promise((r) => setTimeout(r, 50));
-  resolveAgentEnd(makeEvent());
+    await drainMicrotasks(100);
+    mock.timers.tick(30_000);
+    await waitForMicrotasks(() => pi.calls.length === 2, "retry dispatch");
+    resolveAgentEnd(makeEvent());
 
-  await loopPromise;
+    await loopPromise;
 
-  assert.equal(preVerifyCallCount, 2, "preVerification should be called twice");
+    assert.equal(preVerifyCallCount, 2, "preVerification should be called twice");
 
-  const postVerifyCalls = deps.callLog.filter(
-    (c: string) => c === "runPostUnitVerification",
-  );
-  const postPostVerifyCalls = deps.callLog.filter(
-    (c: string) => c === "postUnitPostVerification",
-  );
+    const postVerifyCalls = deps.callLog.filter(
+      (c: string) => c === "runPostUnitVerification",
+    );
+    const postPostVerifyCalls = deps.callLog.filter(
+      (c: string) => c === "postUnitPostVerification",
+    );
 
-  assert.equal(postVerifyCalls.length, 1, "runPostUnitVerification should only be called once");
-  assert.equal(postPostVerifyCalls.length, 1, "postUnitPostVerification should only be called once");
+    assert.equal(postVerifyCalls.length, 1, "runPostUnitVerification should only be called once");
+    assert.equal(postPostVerifyCalls.length, 1, "postUnitPostVerification should only be called once");
+  } finally {
+    mock.timers.reset();
+  }
 });
 
 // ─── stopAuto unitPromise leak regression (#1799) ────────────────────────────

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -250,14 +250,14 @@ describe("Post-execution blocking failure retry bypass", () => {
     const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
     
     // Pre-set some retry state
-    s.verificationRetryCount.set("M001/S01/T01", 2);
+    s.verificationRetryCount.set("execute-task:M001/S01/T01", 2);
 
     const vctx: VerificationContext = { s, ctx, pi };
     const result = await runPostUnitVerification(vctx, pauseAutoMock);
 
     // On success, retry count should be cleared
     assert.equal(result, "continue");
-    assert.equal(s.verificationRetryCount.has("M001/S01/T01"), false);
+    assert.equal(s.verificationRetryCount.has("execute-task:M001/S01/T01"), false);
   });
 
   test("post-exec failure notification mentions cross-task consistency", async () => {

--- a/src/resources/extensions/gsd/tests/verification-retry-policy.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-retry-policy.test.ts
@@ -1,0 +1,83 @@
+// Project/App: GSD-2
+// File Purpose: Unit tests for auto-mode verification retry backoff decisions.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  decideVerificationRetry,
+  hashVerificationFailureContext,
+  verificationRetryDelayMs,
+  verificationRetryKey,
+  VERIFICATION_RETRY_MAX_DELAY_MS,
+} from "../auto/verification-retry-policy.ts";
+
+test("verificationRetryDelayMs uses exponential backoff with cap", () => {
+  assert.deepEqual(verificationRetryDelayMs(1, () => 0.5), {
+    delayMs: 2_000,
+    baseDelayMs: 2_000,
+  });
+  assert.deepEqual(verificationRetryDelayMs(2, () => 0.5), {
+    delayMs: 4_000,
+    baseDelayMs: 4_000,
+  });
+  assert.deepEqual(verificationRetryDelayMs(3, () => 0.5), {
+    delayMs: 8_000,
+    baseDelayMs: 8_000,
+  });
+  assert.deepEqual(verificationRetryDelayMs(99, () => 0.5), {
+    delayMs: VERIFICATION_RETRY_MAX_DELAY_MS,
+    baseDelayMs: VERIFICATION_RETRY_MAX_DELAY_MS,
+  });
+});
+
+test("decideVerificationRetry pauses on duplicate failure context", () => {
+  const failureContext = "lint failed\n";
+  const failureHash = hashVerificationFailureContext(failureContext);
+  const decision = decideVerificationRetry({
+    unitType: "execute-task",
+    retryInfo: {
+      unitId: "M001/S01/T01",
+      failureContext,
+      attempt: 2,
+    },
+    previousFailureHash: failureHash,
+    random: () => 0.5,
+  });
+
+  assert.deepEqual(decision, {
+    action: "pause",
+    reason: "duplicate-failure-context",
+    key: verificationRetryKey("execute-task", "M001/S01/T01"),
+    failureHash,
+  });
+});
+
+test("decideVerificationRetry delays changed failure context", () => {
+  const decision = decideVerificationRetry({
+    unitType: "execute-task",
+    retryInfo: {
+      unitId: "M001/S01/T01",
+      failureContext: "test failed differently",
+      attempt: 2,
+    },
+    previousFailureHash: hashVerificationFailureContext("test failed"),
+    random: () => 0.5,
+  });
+
+  assert.equal(decision.action, "delay");
+  assert.equal(decision.key, verificationRetryKey("execute-task", "M001/S01/T01"));
+  assert.equal(decision.delayMs, 4_000);
+  assert.equal(decision.baseDelayMs, 4_000);
+});
+
+test("decideVerificationRetry pauses when retry context is missing", () => {
+  assert.deepEqual(
+    decideVerificationRetry({
+      unitType: "execute-task",
+      retryInfo: null,
+      previousFailureHash: undefined,
+    }),
+    { action: "pause", reason: "missing-retry-context" },
+  );
+});


### PR DESCRIPTION
## TL;DR

**What:** Adds centralized backoff and duplicate-failure suppression for auto-mode verification retry redispatches.
**Why:** Verification retries currently re-enter the loop immediately, burning retry budget and LLM sessions during flapping or unchanged failures.
**How:** Routes artifact and verification-gate retries through a shared retry policy that normalizes keys, hashes failure context, applies exponential backoff with jitter, and pauses on identical failure context.

## What

- Added `verification-retry-policy` for retry key normalization, failure-context hashing, and capped exponential backoff.
- Added per-session retry failure hashes and cleared them on verification success, advisory/exhausted paths, deterministic short-circuits, and artifact success.
- Routed both artifact verification and post-unit verification retry exits through the policy before returning `continue`.
- Added regression coverage for backoff, duplicate failure suppression, and existing retry-loop behavior.

## Why

Fixes #5670. The retry producers set `pendingVerificationRetry`, but `runFinalize` converted retries directly into loop `continue`, causing immediate redispatch with no delay or duplicate-failure guard. Identical failures could consume the whole retry budget without new information.

## How

The policy uses a stable `${unitType}:${unitId}` retry key, hashes normalized failure context, delays retry redispatch with 2s/4s/8s/etc. backoff capped at 30s plus jitter, and pauses auto-mode when the current failure hash matches the prior retry for the same unit.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/verification-retry-policy.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-loop.test.ts`
- `npm run verify:pr` — 8992 passed, 0 failed, 9 skipped

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted implementation. No co-author metadata included.