### PR TITLE
[codex] fix worktree unmerged exit false positives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'npm'

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1124,10 +1124,9 @@ export async function stopAuto(
   const reasonSuffix = reason ? ` — ${reason}` : "";
   const preserveCompletionSurface = Boolean(options.completionWidget);
 
-  // #4764 — telemetry: record the exit reason and whether the current milestone
-  // was merged before we entered stopAuto. This is the producer-side signal for
-  // the #4761 orphan class: milestoneMerged=false + currentMilestoneId present
-  // is exactly the pattern that strands work.
+  // #4764 — telemetry: record the exit reason, isolation mode, whether an auto
+  // worktree was active, and whether the current milestone was merged before
+  // stopAuto. The unmerged-work warning is only meaningful for real worktrees.
   try {
     const { emitAutoExit } = await import("./worktree-telemetry.js");
     type AutoExitReason =
@@ -1152,10 +1151,13 @@ export async function stopAuto(
                 : rawReason === "stop" || rawReason === "pause"
                   ? rawReason
                   : "other";
-    emitAutoExit(s.originalBasePath || s.basePath, {
+    const telemetryBase = s.originalBasePath || s.basePath;
+    emitAutoExit(telemetryBase, {
       reason: normalizedReason,
       milestoneId: s.currentMilestoneId ?? undefined,
       milestoneMerged: s.milestoneMergedInPhases === true,
+      isolationMode: getIsolationMode(telemetryBase),
+      worktreeActive: isInAutoWorktree(s.basePath),
     });
   } catch (err) {
     logWarning("engine", `auto-exit telemetry failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/resources/extensions/gsd/tests/worktree-telemetry.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-telemetry.test.ts
@@ -89,12 +89,57 @@ test("emitAutoExit records reason and unmerged-work signal", () => {
       reason: "pause",
       milestoneId: "M003",
       milestoneMerged: false,
+      isolationMode: "worktree",
+      worktreeActive: true,
     });
     const entries = queryJournal(base, { eventType: "auto-exit" });
     assert.equal(entries.length, 1);
     assert.equal(entries[0].data?.reason, "pause");
     assert.equal(entries[0].data?.milestoneMerged, false);
+    assert.equal(entries[0].data?.isolationMode, "worktree");
+    assert.equal(entries[0].data?.worktreeActive, true);
   } finally { cleanup(base); }
+});
+
+test("summarizeWorktreeTelemetry only counts unmerged exits from active worktrees", (t) => {
+  const base = makeTmpBase();
+  t.after(() => cleanup(base));
+
+  emitAutoExit(base, {
+    reason: "pause",
+    milestoneId: "M003",
+    milestoneMerged: false,
+    isolationMode: "none",
+    worktreeActive: false,
+  });
+  emitAutoExit(base, {
+    reason: "stop",
+    milestoneId: "M004",
+    milestoneMerged: false,
+    isolationMode: "branch",
+    worktreeActive: false,
+  });
+  emitAutoExit(base, {
+    reason: "other",
+    milestoneId: "M005",
+    milestoneMerged: false,
+    isolationMode: "worktree",
+    worktreeActive: false,
+  });
+  emitAutoExit(base, {
+    reason: "blocked",
+    milestoneId: "M006",
+    milestoneMerged: false,
+  });
+
+  const summary = summarizeWorktreeTelemetry(base);
+  assert.equal(summary.exitsWithUnmergedWork, 0);
+  assert.deepStrictEqual(summary.exitsByReason, {
+    "pause": 1,
+    "stop": 1,
+    "other": 1,
+    "blocked": 1,
+  });
 });
 
 test("summarizeWorktreeTelemetry aggregates events correctly", () => {
@@ -110,8 +155,20 @@ test("summarizeWorktreeTelemetry aggregates events correctly", () => {
     emitWorktreeOrphaned(base, "M002", { reason: "in-progress-unmerged", commitsAhead: 2 });
     emitWorktreeOrphaned(base, "M003", { reason: "complete-unmerged" });
 
-    emitAutoExit(base, { reason: "pause", milestoneId: "M002", milestoneMerged: false });
-    emitAutoExit(base, { reason: "stop", milestoneId: "M002", milestoneMerged: false });
+    emitAutoExit(base, {
+      reason: "pause",
+      milestoneId: "M002",
+      milestoneMerged: false,
+      isolationMode: "worktree",
+      worktreeActive: true,
+    });
+    emitAutoExit(base, {
+      reason: "stop",
+      milestoneId: "M002",
+      milestoneMerged: false,
+      isolationMode: "worktree",
+      worktreeActive: true,
+    });
     emitAutoExit(base, { reason: "all-complete", milestoneId: "M001", milestoneMerged: true });
 
     const summary = summarizeWorktreeTelemetry(base);

--- a/src/resources/extensions/gsd/worktree-telemetry.ts
+++ b/src/resources/extensions/gsd/worktree-telemetry.ts
@@ -42,6 +42,7 @@ function baseEntry(eventType: JournalEntry["eventType"], data: Record<string, un
 // silently fragment the telemetry buckets produced by summarizeWorktreeTelemetry.
 
 export type WorktreeCreatedReason = "create-milestone" | "enter-milestone";
+export type WorktreeIsolationMode = "worktree" | "branch" | "none";
 export type AutoExitReason =
   | "pause"
   | "stop"
@@ -126,6 +127,8 @@ export function emitAutoExit(
     reason: AutoExitReason;
     milestoneId?: string;
     milestoneMerged: boolean;
+    isolationMode?: WorktreeIsolationMode;
+    worktreeActive?: boolean;
   },
 ): void {
   emitJournalEvent(projectRoot, baseEntry("auto-exit", {
@@ -133,6 +136,8 @@ export function emitAutoExit(
     flowId: meta.flowId,
     milestoneId: meta.milestoneId,
     milestoneMerged: meta.milestoneMerged,
+    isolationMode: meta.isolationMode,
+    worktreeActive: meta.worktreeActive,
     exitedAt: now(),
   }));
 }
@@ -222,7 +227,7 @@ export interface WorktreeTelemetrySummary {
   mergeConflicts: number;
   /** Auto-exit reasons and their counts */
   exitsByReason: Record<string, number>;
-  /** Auto-exits where the milestone was NOT merged before exit — the #4761 producer metric */
+  /** Auto-exits from an active worktree where the milestone was NOT merged before exit */
   exitsWithUnmergedWork: number;
   /** Count of canonical-root-redirects (how often #4761 validation would have read stale state) */
   canonicalRedirects: number;
@@ -279,7 +284,7 @@ export function summarizeWorktreeTelemetry(
       case "auto-exit": {
         const reason = typeof d.reason === "string" ? d.reason : "unknown";
         summary.exitsByReason[reason] = (summary.exitsByReason[reason] ?? 0) + 1;
-        if (d.milestoneMerged === false) summary.exitsWithUnmergedWork++;
+        if (d.milestoneMerged === false && d.worktreeActive === true) summary.exitsWithUnmergedWork++;
         break;
       }
       case "canonical-root-redirect":


### PR DESCRIPTION
## TL;DR

**What:** Gates `worktree-unmerged-exit` telemetry on an actually active auto worktree.
**Why:** `milestoneMerged` defaults false, so exits in `none`/`branch` mode were counted as unmerged work even when no worktree existed.
**How:** Emit `isolationMode` and `worktreeActive` on `auto-exit`, and only increment `exitsWithUnmergedWork` when `worktreeActive === true`.

## What

- Adds optional `isolationMode` and `worktreeActive` metadata to `auto-exit` journal events.
- Updates `stopAuto` to emit the configured isolation mode from the canonical project root and the current physical auto-worktree state.
- Updates the telemetry summary so unmerged-exit warnings only count active worktree exits.
- Adds regression coverage for `none`, `branch`, degraded `worktree` mode without an active worktree, and legacy events missing `worktreeActive`.

## Why

Issue #5671 reported false `worktree-unmerged-exit` warnings where no worktree had ever been created. The root cause was that `milestoneMergedInPhases` defaults to false and the summarizer treated every false value as stranded work, regardless of whether auto-mode was actually running from a worktree.

Closes #5671

## How

The fix keeps the existing exit-reason buckets intact, but separates “milestone was not merged” from “there was an active worktree that could strand work.” Older events without `worktreeActive` no longer increment the warning counter because they do not prove worktree participation.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/worktree-telemetry.test.ts` — 11 passed, 0 failed
- `git diff --check` — passed
- `npm run verify:pr` — build:core completed, then failed during `typecheck:extensions` on pre-existing `claude-code-cli` `SimpleStreamOptions.cwd` errors outside this PR

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## AI-assisted

This PR was AI-assisted. No AI co-author is included in the commit.
