### PR TITLE
fix: restore symlink when empty .gsd directory clobbers live external state

### DIFF
--- a/src/resources/extensions/gsd/notification-store.ts
+++ b/src/resources/extensions/gsd/notification-store.ts
@@ -3,7 +3,7 @@
 // .gsd/notifications.jsonl so they survive context resets and session restarts.
 // Rotates at MAX_ENTRIES to prevent unbounded growth.
 
-import { appendFileSync, existsSync, mkdirSync, openSync, closeSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, lstatSync, mkdirSync, openSync, closeSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
@@ -298,7 +298,17 @@ function _withLock<T>(basePath: string, fn: () => T): T {
 
   for (let i = 0; i < maxAttempts; i++) {
     try {
-      mkdirSync(join(basePath, ".gsd"), { recursive: true });
+      // Guard: don't create a real directory if a symlink (even dangling) exists.
+      // ensureGsdSymlink will heal dangling symlinks on next startup. (#5696)
+      const gsdDir = join(basePath, ".gsd");
+      try {
+        const gsdStat = lstatSync(gsdDir);
+        if (!gsdStat.isSymbolicLink()) {
+          mkdirSync(gsdDir, { recursive: true });
+        }
+      } catch {
+        mkdirSync(gsdDir, { recursive: true });
+      }
       fd = openSync(lockPath, "wx");
       break;
     } catch (err: any) {

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -628,7 +628,25 @@ function ensureGsdSymlinkCore(projectPath: string): string {
     }
 
     if (stat.isDirectory()) {
-      // Real directory in the main repo — migration will handle this later.
+      // Real directory — check if it's an empty shell that should be a symlink.
+      // This happens when a crash destroys the symlink and other code (e.g.
+      // notification-store mkdirSync) creates a bare directory before this
+      // function can heal it. If external state exists but the local dir is
+      // empty, restore the symlink. (#5696)
+      if (!inWorktree && hasProjectState(externalPath) && !hasProjectState(localGsd)) {
+        try {
+          const strayEntries = readdirSync(localGsd);
+          for (const entry of strayEntries) {
+            const src = join(localGsd, entry);
+            const dst = join(externalPath, entry);
+            if (!existsSync(dst)) {
+              try { renameSync(src, dst); } catch { /* skip conflicting */ }
+            }
+          }
+        } catch { /* non-fatal — dir may already be empty */ }
+        return replaceWithSymlink();
+      }
+      // Real directory with state — legacy migration will handle this later.
       // In worktrees, keep the directory in place and let syncGsdStateToWorktree
       // refresh its contents. Replacing a git-tracked .gsd directory with a
       // symlink makes git think tracked planning files were deleted.


### PR DESCRIPTION
## Summary

Fixes #5696 — after a session crash destroys the `.gsd` symlink, the next boot creates an empty real directory that blocks symlink restoration, causing the agent to report total state loss while data sits untouched at `~/.gsd/projects/<hash>/`.

**Two changes:**

1. **`repo-identity.ts`** — In `ensureGsdSymlinkCore`'s `isDirectory()` branch, detect when external state exists but the local directory is an empty crash artifact. Move any stray files to external, then restore the correct symlink.

2. **`notification-store.ts`** — Guard the `mkdirSync(.gsd)` call with an `lstatSync` check. If a symlink (even dangling) exists at that path, don't create a real directory over it — let `ensureGsdSymlink` handle healing on next startup.

## Test plan

- [ ] Simulate: remove `.gsd` symlink, trigger notification-store init, verify it doesn't create a real directory over a dangling symlink
- [ ] Simulate: create empty `.gsd/` real directory with live state at external path, run `ensureGsdSymlinkCore`, verify symlink is restored
- [ ] Verify worktree paths are unaffected (the fix explicitly checks `!inWorktree`)
- [ ] Verify existing `hasProjectState` logic correctly distinguishes empty dirs from dirs with state

## Root cause

See #5696 for full analysis. The cascade: crash kills symlink → notification-store `mkdirSync` creates empty real dir → `ensureGsdSymlinkCore` sees real dir, returns it without checking external state → agent sees empty state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of internal directory and symlink handling to prevent unintended directory creation and support safer state migration scenarios.

* **Chores**
  * Enhanced safety checks for cross-process operations and directory management logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5697)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->