### PR TITLE
feat(tui): refresh operations console design

### DIFF
--- a/docs/dev/tui-recommended-design.html
+++ b/docs/dev/tui-recommended-design.html
@@ -1,0 +1,806 @@
+<!--
+Project/App: GSD-2
+File Purpose: Focused recommended TUI redesign mockup for chat, assistant, tool output, footer, and auto-mode surfaces.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GSD Recommended TUI Design</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #10141d;
+      --panel: #171c26;
+      --panel-2: #1d2430;
+      --border: #a7ba78;
+      --border-muted: #4e596d;
+      --text: #dce4f2;
+      --muted: #7d889f;
+      --dim: #4d5870;
+      --accent: #8db7ff;
+      --success: #a8c978;
+      --warning: #e6c06a;
+      --error: #d98484;
+      --add-bg: rgba(89, 138, 74, .28);
+      --del-bg: rgba(136, 62, 68, .34);
+      --warn-bg: rgba(158, 123, 49, .2);
+      --shadow: rgba(0, 0, 0, .36);
+      --font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-width: 320px;
+      background:
+        radial-gradient(circle at 18% -10%, rgba(141, 183, 255, .12), transparent 380px),
+        linear-gradient(180deg, rgba(168, 189, 120, .045), transparent 420px),
+        var(--bg);
+      color: var(--text);
+      font-family: var(--sans);
+    }
+
+    main {
+      width: min(1320px, calc(100vw - 40px));
+      margin: 0 auto;
+      padding: 32px 0 56px;
+    }
+
+    header {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 24px;
+      align-items: end;
+      margin-bottom: 22px;
+    }
+
+    h1 {
+      margin: 0 0 8px;
+      font-size: 28px;
+      letter-spacing: 0;
+    }
+
+    .lede {
+      margin: 0;
+      max-width: 820px;
+      color: var(--muted);
+      line-height: 1.5;
+    }
+
+    .decision {
+      padding: 12px 14px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: rgba(23, 28, 38, .82);
+      color: var(--muted);
+      font-family: var(--font);
+      font-size: 12px;
+      box-shadow: 0 14px 40px var(--shadow);
+    }
+
+    .decision b { color: var(--success); font-weight: 700; }
+
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(0, 1.35fr) minmax(360px, .65fr);
+      gap: 22px;
+      align-items: start;
+    }
+
+    .section {
+      min-width: 0;
+      border: 1px solid var(--border-muted);
+      border-radius: 8px;
+      background: linear-gradient(180deg, rgba(255, 255, 255, .025), transparent), var(--panel);
+      box-shadow: 0 16px 46px var(--shadow);
+      overflow: hidden;
+    }
+
+    .section-title {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 14px 16px;
+      border-bottom: 1px solid rgba(78, 89, 109, .72);
+      background: rgba(16, 20, 29, .56);
+    }
+
+    .section-title h2 {
+      margin: 0;
+      font-size: 15px;
+      letter-spacing: 0;
+    }
+
+    .section-title span {
+      color: var(--muted);
+      font-family: var(--font);
+      font-size: 12px;
+      white-space: nowrap;
+    }
+
+    .terminal {
+      margin: 16px;
+      padding: 16px;
+      border: 1px solid rgba(167, 186, 120, .74);
+      border-radius: 6px;
+      background: #141923;
+      font-family: var(--font);
+      font-size: 14px;
+      line-height: 1.46;
+      overflow: hidden;
+    }
+
+    .muted { color: var(--muted); }
+    .dim { color: var(--dim); }
+    .accent { color: var(--accent); }
+    .success { color: var(--success); }
+    .warning { color: var(--warning); }
+    .error { color: var(--error); }
+
+    .rail {
+      border-left: 3px solid var(--border);
+      padding-left: 14px;
+      margin-bottom: 14px;
+      display: grid;
+      gap: 5px;
+    }
+
+    .speaker {
+      color: var(--accent);
+      font-weight: 700;
+    }
+
+    .tool-card {
+      margin: 14px 0;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      overflow: hidden;
+      background: rgba(16, 20, 29, .38);
+    }
+
+    .tool-header,
+    .tool-footer,
+    .footer-strip,
+    .auto-row {
+      display: flex;
+      justify-content: space-between;
+      gap: 14px;
+      min-width: 0;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    .tool-header {
+      padding: 9px 11px;
+      border-bottom: 1px solid rgba(78, 89, 109, .72);
+      color: var(--accent);
+    }
+
+    .tool-body {
+      padding: 8px 0;
+    }
+
+    .tool-footer {
+      padding: 8px 11px;
+      border-top: 1px solid rgba(78, 89, 109, .6);
+      color: var(--muted);
+    }
+
+    .left,
+    .right {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .right {
+      flex: 0 0 auto;
+      color: var(--muted);
+    }
+
+    .line {
+      display: flex;
+      gap: 12px;
+      min-width: 0;
+      white-space: pre;
+    }
+
+    .ln {
+      width: 5ch;
+      flex: 0 0 5ch;
+      color: var(--dim);
+      text-align: right;
+      user-select: none;
+    }
+
+    .code {
+      min-width: 0;
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .ctx { color: #8d98ae; }
+    .add { color: var(--success); background: var(--add-bg); }
+    .del { color: var(--error); background: var(--del-bg); }
+    .warn-bg { background: var(--warn-bg); }
+
+    .command-card {
+      margin: 10px 0;
+      padding: 9px 11px;
+      border: 1px solid rgba(167, 186, 120, .74);
+      border-radius: 5px;
+      background: rgba(16, 20, 29, .48);
+    }
+
+    .progress {
+      display: inline-grid;
+      grid-template-columns: repeat(14, 8px);
+      gap: 2px;
+      vertical-align: -1px;
+    }
+
+    .seg {
+      height: 12px;
+      border-radius: 1px;
+      background: var(--dim);
+    }
+
+    .seg.fill { background: var(--success); }
+    .seg.run { background: var(--accent); }
+    .seg.warn { background: var(--warning); }
+
+    .footer-strip {
+      align-items: center;
+      padding: 8px 10px;
+      border: 1px solid rgba(78, 89, 109, .72);
+      border-radius: 5px;
+      background: rgba(16, 20, 29, .7);
+      font-family: var(--font);
+      font-size: 13px;
+    }
+
+    .segments {
+      display: flex;
+      gap: 10px;
+      min-width: 0;
+      overflow: hidden;
+    }
+
+    .segment {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: var(--muted);
+    }
+
+    .auto-panel {
+      display: grid;
+      gap: 11px;
+      padding: 13px;
+      border: 1px solid rgba(167, 186, 120, .76);
+      border-radius: 6px;
+      background: rgba(16, 20, 29, .45);
+      font-family: var(--font);
+      font-size: 13px;
+    }
+
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 9px;
+    }
+
+    .metric {
+      min-width: 0;
+      padding: 8px;
+      border: 1px solid rgba(78, 89, 109, .64);
+      border-radius: 4px;
+      background: rgba(29, 36, 48, .58);
+    }
+
+    .metric-label {
+      margin-bottom: 4px;
+      color: var(--muted);
+      font-size: 12px;
+    }
+
+    .metric-value {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .notes {
+      display: grid;
+      gap: 10px;
+      margin-top: 14px;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.45;
+    }
+
+    .note {
+      padding: 10px 12px;
+      border: 1px solid rgba(78, 89, 109, .72);
+      border-radius: 5px;
+      background: rgba(16, 20, 29, .48);
+    }
+
+    .header-lab {
+      margin-top: 22px;
+    }
+
+    .header-grid {
+      display: grid;
+      gap: 16px;
+      padding: 16px;
+    }
+
+    .splash-option {
+      border: 1px solid rgba(78, 89, 109, .72);
+      border-radius: 6px;
+      background: rgba(16, 20, 29, .5);
+      overflow: hidden;
+    }
+
+    .option-label {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 10px 12px;
+      border-bottom: 1px solid rgba(78, 89, 109, .58);
+      color: var(--muted);
+      font-family: var(--font);
+      font-size: 12px;
+    }
+
+    .option-label b {
+      color: var(--accent);
+      font-weight: 700;
+    }
+
+    .splash-terminal {
+      padding: 14px;
+      background: #0f141c;
+      font-family: var(--font);
+      font-size: 13px;
+      line-height: 1.28;
+      color: var(--text);
+      overflow-x: auto;
+    }
+
+    .splash-frame {
+      min-width: 900px;
+      border-top: 1px solid rgba(167, 186, 120, .7);
+      border-bottom: 1px solid rgba(167, 186, 120, .7);
+      padding: 10px 0;
+    }
+
+    .splash-row {
+      display: grid;
+      grid-template-columns: 300px minmax(0, 1fr);
+      gap: 20px;
+      align-items: center;
+    }
+
+    .logo {
+      white-space: pre;
+      color: #9bb0a6;
+      text-shadow: 2px 2px 0 rgba(78, 89, 109, .68);
+      line-height: .86;
+      font-size: 21px;
+    }
+
+    .logo.small {
+      font-size: 14px;
+      line-height: .88;
+    }
+
+    .logo-word {
+      color: var(--border);
+      font-weight: 700;
+      letter-spacing: 0;
+    }
+
+    .panel-line {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      min-width: 0;
+      border-bottom: 1px solid rgba(78, 89, 109, .72);
+      padding: 7px 0;
+    }
+
+    .panel-line:first-child {
+      border-top: 1px solid rgba(78, 89, 109, .72);
+    }
+
+    .kv {
+      display: grid;
+      grid-template-columns: 92px minmax(0, 1fr);
+      gap: 16px;
+      padding: 4px 0;
+    }
+
+    .key {
+      color: var(--muted);
+    }
+
+    .value {
+      color: var(--text);
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .hint-row {
+      display: flex;
+      justify-content: flex-end;
+      gap: 20px;
+      padding-top: 9px;
+      color: var(--muted);
+    }
+
+    .splash-compact {
+      display: grid;
+      grid-template-columns: 118px minmax(0, 1fr) auto;
+      gap: 18px;
+      align-items: center;
+      min-width: 900px;
+      padding: 12px 14px;
+      border: 1px solid rgba(167, 186, 120, .72);
+      border-radius: 5px;
+      background: rgba(16, 20, 29, .48);
+    }
+
+    .rail-panel {
+      border-left: 3px solid var(--border);
+      padding-left: 14px;
+      display: grid;
+      gap: 5px;
+    }
+
+    .dashboard-splash {
+      min-width: 900px;
+      display: grid;
+      grid-template-columns: 210px minmax(0, 1fr);
+      gap: 16px;
+      padding: 13px;
+      border: 1px solid rgba(167, 186, 120, .74);
+      border-radius: 6px;
+      background: rgba(20, 25, 35, .78);
+    }
+
+    .status-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 8px;
+      margin-top: 10px;
+    }
+
+    .status-cell {
+      border: 1px solid rgba(78, 89, 109, .64);
+      border-radius: 4px;
+      padding: 8px;
+      background: rgba(29, 36, 48, .55);
+    }
+
+    .mini-label {
+      color: var(--muted);
+      font-size: 11px;
+      margin-bottom: 4px;
+    }
+
+    .minimal-splash {
+      min-width: 900px;
+      display: grid;
+      gap: 8px;
+      padding: 10px 0;
+      border-top: 1px solid rgba(78, 89, 109, .76);
+      border-bottom: 1px solid rgba(78, 89, 109, .76);
+    }
+
+    .minimal-main {
+      display: flex;
+      justify-content: space-between;
+      gap: 18px;
+      align-items: baseline;
+      padding: 0 2px;
+    }
+
+    .wide-panel {
+      min-width: 900px;
+      border: 1px solid rgba(167, 186, 120, .72);
+      border-radius: 6px;
+      background: rgba(16, 20, 29, .48);
+      overflow: hidden;
+    }
+
+    .wide-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 10px 12px;
+      border-bottom: 1px solid rgba(78, 89, 109, .72);
+    }
+
+    .wide-body {
+      display: grid;
+      grid-template-columns: 1.3fr .7fr .7fr;
+      gap: 0;
+    }
+
+    .wide-body > div {
+      padding: 12px;
+      border-right: 1px solid rgba(78, 89, 109, .58);
+    }
+
+    .wide-body > div:last-child {
+      border-right: 0;
+    }
+
+    @media (max-width: 1040px) {
+      main { width: min(100vw - 24px, 780px); padding-top: 20px; }
+      header, .layout { grid-template-columns: 1fr; }
+      .metrics { grid-template-columns: 1fr; }
+      .tool-header, .tool-footer, .footer-strip, .auto-row { white-space: normal; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>Recommended GSD TUI Direction</h1>
+        <p class="lede">A single cohesive direction for the terminal experience: left-rail assistant messages, diff-first tool cards, compact command cards, a powerline-style footer, and a compact auto-mode widget with health escalation.</p>
+      </div>
+      <div class="decision"><b>Pick:</b> Left rail + diff-first tools + compact auto footer</div>
+    </header>
+
+    <div class="layout">
+      <section class="section">
+        <div class="section-title">
+          <h2>Transcript Recommendation</h2>
+          <span>assistant + tools</span>
+        </div>
+        <div class="terminal">
+          <div class="rail">
+            <div><span class="speaker">GSD</span> <span class="muted">· gpt-5.5 · 12:04 PM</span></div>
+            <div>I’ll update the renderer registration test and run verification.</div>
+            <div class="muted">Plan:</div>
+            <div>1. Adjust the themed renderer stub</div>
+            <div>2. Format and run targeted tests</div>
+            <div>3. Report full-suite failures separately if they are unrelated</div>
+          </div>
+
+          <div class="tool-card">
+            <div class="tool-header">
+              <div class="left">edit tests/renderer-registration.test.ts</div>
+              <div class="right"><span class="success">+4</span> <span class="error">-1</span> · 1 hunk · <span class="success">done</span></div>
+            </div>
+            <div class="tool-body">
+              <div class="line ctx"><span class="ln">189</span><span class="code">const state = {};</span></div>
+              <div class="line ctx"><span class="ln">190</span><span class="code">const coloredTheme = {</span></div>
+              <div class="line ctx"><span class="ln">191</span><span class="code">  ...testTheme(),</span></div>
+              <div class="line del"><span class="ln">-193</span><span class="code">fg: (key: string, text: string) =&gt; `&lt;${key}&gt;${text}&lt;/${key}&gt;`,</span></div>
+              <div class="line add"><span class="ln">+193</span><span class="code">fg: (key: string, text: string) =&gt;</span></div>
+              <div class="line add"><span class="ln">+194</span><span class="code">  ["warning", "success", "error", "borderMuted"].includes(key)</span></div>
+              <div class="line add"><span class="ln">+195</span><span class="code">    ? `&lt;${key}&gt;${text}&lt;/${key}&gt;`</span></div>
+              <div class="line add"><span class="ln">+196</span><span class="code">    : text,</span></div>
+            </div>
+            <div class="tool-footer">
+              <div class="left">output expanded</div>
+              <div class="right">ctrl+o collapse</div>
+            </div>
+          </div>
+
+          <div class="command-card">
+            <div class="auto-row"><span class="left"><span class="accent">$</span> npm run format</span><span class="right"><span class="success">✓</span> 2.1s · output hidden · ctrl+o expand</span></div>
+          </div>
+          <div class="command-card">
+            <div class="auto-row"><span class="left"><span class="accent">$</span> npm test</span><span class="right"><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> 48% running</span></div>
+          </div>
+
+          <div class="rail">
+            <div><span class="speaker">GSD</span> <span class="muted">· verification</span></div>
+            <div>Targeted tests passed. The full unit suite reports two unrelated failures outside this change set.</div>
+          </div>
+        </div>
+      </section>
+
+      <aside class="section">
+        <div class="section-title">
+          <h2>Persistent Surfaces</h2>
+          <span>footer + auto-mode</span>
+        </div>
+        <div class="terminal">
+          <div class="footer-strip">
+            <div class="segments">
+              <span class="segment accent">● GSD AUTO</span>
+              <span class="segment"> feat/tui-refresh</span>
+              <span class="segment">gpt-5.5</span>
+              <span class="segment success">64%hit</span>
+              <span class="segment warning">$1.42</span>
+            </div>
+            <div class="right">ctx 38% · ctrl+d</div>
+          </div>
+
+          <div style="height: 14px"></div>
+
+          <div class="auto-panel">
+            <div class="auto-row">
+              <span class="left"><span class="accent">●</span> GSD <span class="success">AUTO</span> · Executing T03 renderer polish</span>
+              <span class="right">14m · 6m left</span>
+            </div>
+            <div><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> <span class="accent">8/14 tasks</span> · S02 · execute-task</div>
+            <div class="metrics">
+              <div class="metric"><div class="metric-label">Current</div><div class="metric-value">M001/S02/T03</div></div>
+              <div class="metric"><div class="metric-label">Cost</div><div class="metric-value warning">$1.42</div></div>
+              <div class="metric"><div class="metric-label">Context</div><div class="metric-value">38% / 200k</div></div>
+            </div>
+            <div class="muted">~/gsd-2/.worktrees/tui-operations-console-refresh</div>
+          </div>
+
+          <div style="height: 14px"></div>
+
+          <div class="auto-panel warn-bg">
+            <div class="auto-row">
+              <span class="left"><span class="warning">!</span> Recovery signal</span>
+              <span class="right">idle 4m · retry 1</span>
+            </div>
+            <div><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg warn"></span><span class="seg warn"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> <span class="warning">recovery budget 36%</span></div>
+            <div class="muted">ctrl+d diagnose · esc pause</div>
+          </div>
+        </div>
+
+        <div class="notes">
+          <div class="note"><span class="success">Why this works:</span> assistant text stays readable without boxing every message, while tool output gets strong structure where it matters.</div>
+          <div class="note"><span class="accent">Default behavior:</span> command output stays collapsed, diffs expand inline, progress appears only for active work.</div>
+          <div class="note"><span class="warning">Escalation:</span> warnings use the same layout but switch tone, so recovery states are visible without a separate UI mode.</div>
+        </div>
+      </aside>
+    </div>
+
+    <section class="section header-lab">
+      <div class="section-title">
+        <h2>Header / Splash Options</h2>
+        <span>five directions for the first-run/status surface</span>
+      </div>
+      <div class="header-grid">
+        <div class="splash-option">
+          <div class="option-label">
+            <b>01 Refined Current</b>
+            <span>keeps the big mark, fixes hierarchy and spacing</span>
+          </div>
+          <div class="splash-terminal">
+            <div class="splash-frame">
+              <div class="splash-row">
+                <div class="logo"> ██████╗ ███████╗██████╗
+██╔════╝ ██╔════╝██╔══██╗
+██║  ███╗███████╗██║  ██║
+██║   ██║╚════██║██║  ██║
+╚██████╔╝███████║██████╔╝
+ ╚═════╝ ╚══════╝╚═════╝</div>
+                <div>
+                  <div class="panel-line"><span class="logo-word">Get Shit Done</span><span class="muted">v2.81.0</span></div>
+                  <div class="kv"><span class="key">Status</span><span class="value">No active GSD project</span></div>
+                  <div class="kv"><span class="key">Next</span><span class="value accent">/gsd to begin</span></div>
+                  <div class="kv"><span class="key">Workspace</span><span class="value">~/Github/gsd-2</span></div>
+                  <div class="panel-line"><span class="muted">No setup detected</span><span class="muted">/gsd help</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="splash-option">
+          <div class="option-label">
+            <b>02 Compact Rail</b>
+            <span>best when startup should stay quiet inside a chat transcript</span>
+          </div>
+          <div class="splash-terminal">
+            <div class="splash-compact">
+              <div class="logo small"> ███╗ ███╗ ███╗
+██╔╝ ██╔╝ ██╔██╗
+██║  ███╗ ██║██║
+╚██╗ ╚██║ █████╔╝</div>
+              <div class="rail-panel">
+                <div><span class="logo-word">GSD</span> <span class="muted">· Get Shit Done · v2.81.0</span></div>
+                <div>No active GSD project in <span class="muted">~/Github/gsd-2</span></div>
+                <div><span class="accent">/gsd to begin</span> <span class="muted">·</span> /gsd help <span class="muted">·</span> /gsd setup</div>
+              </div>
+              <div class="right">ready</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="splash-option">
+          <div class="option-label">
+            <b>03 Command Center</b>
+            <span>more operational, useful after a project exists</span>
+          </div>
+          <div class="splash-terminal">
+            <div class="dashboard-splash">
+              <div>
+                <div class="logo small"> ██████╗
+██╔════╝
+██║ ███╗
+╚██████╔╝
+ ╚═════╝</div>
+                <div class="hint-row" style="justify-content:flex-start"><span class="accent">GSD</span><span class="muted">v2.81.0</span></div>
+              </div>
+              <div>
+                <div class="panel-line"><span class="logo-word">Project Console</span><span class="muted">idle</span></div>
+                <div class="status-grid">
+                  <div class="status-cell"><div class="mini-label">Project</div><div>No active project</div></div>
+                  <div class="status-cell"><div class="mini-label">Command</div><div class="accent">/gsd start</div></div>
+                  <div class="status-cell"><div class="mini-label">Branch</div><div>main</div></div>
+                  <div class="status-cell"><div class="mini-label">Mode</div><div>manual</div></div>
+                </div>
+                <div class="hint-row"><span>/gsd to begin</span><span>/gsd templates</span><span>/gsd help</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="splash-option">
+          <div class="option-label">
+            <b>04 Minimal Status Bar</b>
+            <span>least visual noise, fastest to scan</span>
+          </div>
+          <div class="splash-terminal">
+            <div class="minimal-splash">
+              <div class="minimal-main">
+                <div><span class="logo-word">● GSD</span> <span class="muted">Get Shit Done</span></div>
+                <div class="muted">v2.81.0</div>
+              </div>
+              <div class="minimal-main">
+                <div>No active project <span class="muted">· ~/Github/gsd-2</span></div>
+                <div><span class="accent">/gsd to begin</span> <span class="muted">· /gsd help</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="splash-option">
+          <div class="option-label">
+            <b>05 Wide Dashboard</b>
+            <span>largest surface, strongest first-run guidance</span>
+          </div>
+          <div class="splash-terminal">
+            <div class="wide-panel">
+              <div class="wide-head">
+                <span><span class="logo-word">GSD</span> <span class="muted">Get Shit Done</span></span>
+                <span class="muted">v2.81.0</span>
+              </div>
+              <div class="wide-body">
+                <div>
+                  <div class="mini-label">Current State</div>
+                  <div>No active GSD project</div>
+                  <div class="muted">Initialize this workspace to enable milestones, slices, auto-mode, and progress tracking.</div>
+                </div>
+                <div>
+                  <div class="mini-label">Primary Action</div>
+                  <div class="accent">/gsd to begin</div>
+                  <div class="muted">guided setup</div>
+                </div>
+                <div>
+                  <div class="mini-label">Secondary</div>
+                  <div>/gsd help</div>
+                  <div class="muted">templates · prefs · status</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/dev/tui-render-options.html
+++ b/docs/dev/tui-render-options.html
@@ -1,0 +1,1248 @@
+<!--
+Project/App: GSD-2
+File Purpose: Static HTML comparison mockups for proposed chat, assistant, and tool-output TUI redesigns.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GSD TUI Render Options</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #11141c;
+      --panel: #171b25;
+      --panel-soft: #1d2330;
+      --line: #a8bd78;
+      --line-muted: #566072;
+      --text: #d8dfef;
+      --muted: #75809a;
+      --dim: #4e5870;
+      --accent: #8db7ff;
+      --success: #a8c978;
+      --warning: #e6c06a;
+      --error: #d78282;
+      --purple: #b7a3ff;
+      --cyan: #75c9cc;
+      --add-bg: rgba(89, 138, 74, .28);
+      --del-bg: rgba(136, 62, 68, .36);
+      --warn-bg: rgba(158, 123, 49, .2);
+      --shadow: rgba(0, 0, 0, .34);
+      --font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-width: 320px;
+      background:
+        linear-gradient(180deg, rgba(141, 183, 255, .06), transparent 360px),
+        var(--bg);
+      color: var(--text);
+      font-family: var(--sans);
+    }
+
+    main {
+      width: min(1480px, calc(100vw - 40px));
+      margin: 0 auto;
+      padding: 32px 0 56px;
+    }
+
+    header {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 24px;
+      align-items: end;
+      margin-bottom: 24px;
+    }
+
+    h1 {
+      margin: 0 0 8px;
+      color: var(--text);
+      font-size: 28px;
+      letter-spacing: 0;
+    }
+
+    .lede {
+      margin: 0;
+      color: var(--muted);
+      max-width: 780px;
+      line-height: 1.5;
+    }
+
+    .legend {
+      display: grid;
+      grid-template-columns: repeat(6, max-content);
+      gap: 10px;
+      align-items: center;
+      padding: 12px;
+      border: 1px solid var(--line-muted);
+      background: rgba(23, 27, 37, .7);
+      border-radius: 8px;
+      font-family: var(--font);
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .swatch {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      white-space: nowrap;
+    }
+
+    .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      display: inline-block;
+      background: currentColor;
+    }
+
+    .accent { color: var(--accent); }
+    .success { color: var(--success); }
+    .warning { color: var(--warning); }
+    .error { color: var(--error); }
+    .purple { color: var(--purple); }
+    .cyan { color: var(--cyan); }
+    .muted { color: var(--muted); }
+    .dim { color: var(--dim); }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 22px;
+    }
+
+    .option {
+      min-width: 0;
+      border: 1px solid var(--line-muted);
+      background: linear-gradient(180deg, rgba(255, 255, 255, .025), transparent), var(--panel);
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0 16px 42px var(--shadow);
+    }
+
+    .option.recommended {
+      border-color: var(--line);
+    }
+
+    .option-header {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 16px 18px;
+      border-bottom: 1px solid rgba(86, 96, 114, .72);
+      background: rgba(17, 20, 28, .52);
+    }
+
+    .option-title {
+      margin: 0;
+      font-size: 15px;
+      letter-spacing: 0;
+    }
+
+    .option-title code {
+      color: var(--accent);
+      font-family: var(--font);
+      font-size: 13px;
+    }
+
+    .option-meta {
+      color: var(--muted);
+      font-family: var(--font);
+      font-size: 12px;
+      white-space: nowrap;
+    }
+
+    .option-body {
+      padding: 18px;
+    }
+
+    .terminal {
+      padding: 18px 18px 16px;
+      border: 1px solid rgba(168, 189, 120, .78);
+      background: #151922;
+      border-radius: 6px;
+      font-family: var(--font);
+      font-size: 14px;
+      line-height: 1.45;
+      overflow: hidden;
+    }
+
+    .terminal + .terminal {
+      margin-top: 16px;
+    }
+
+    .caption {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 10px;
+      color: var(--muted);
+      font-family: var(--font);
+      font-size: 12px;
+    }
+
+    .row {
+      display: flex;
+      gap: 12px;
+      min-width: 0;
+      white-space: pre;
+    }
+
+    .line-no {
+      width: 4ch;
+      flex: 0 0 4ch;
+      color: var(--dim);
+      text-align: right;
+      user-select: none;
+    }
+
+    .code {
+      min-width: 0;
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .add { color: var(--success); background: var(--add-bg); }
+    .del { color: var(--error); background: var(--del-bg); }
+    .warn { color: var(--warning); background: var(--warn-bg); }
+    .ctx { color: #8c96ad; }
+    .keyword { color: #9ebdff; font-weight: 700; }
+    .string { color: var(--success); }
+    .num { color: var(--purple); }
+
+    .rule {
+      color: var(--line-muted);
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
+    .card-line {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      min-width: 0;
+      padding: 7px 0;
+      border-bottom: 1px solid rgba(86, 96, 114, .26);
+    }
+
+    .card-line:last-child {
+      border-bottom: 0;
+    }
+
+    .left, .right {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .right {
+      flex: 0 0 auto;
+      color: var(--muted);
+    }
+
+    .pill {
+      display: inline-block;
+      padding: 1px 7px 2px;
+      border: 1px solid currentColor;
+      border-radius: 999px;
+      font-size: 11px;
+      line-height: 1.4;
+    }
+
+    .progress {
+      display: inline-grid;
+      grid-template-columns: repeat(14, 8px);
+      gap: 2px;
+      vertical-align: -1px;
+    }
+
+    .seg {
+      height: 12px;
+      border-radius: 1px;
+      background: var(--dim);
+    }
+
+    .seg.fill { background: var(--success); }
+    .seg.mid { background: var(--warning); }
+    .seg.run { background: var(--accent); }
+
+    .pipeline {
+      display: grid;
+      gap: 8px;
+      margin-top: 10px;
+    }
+
+    .timeline {
+      display: grid;
+      grid-template-columns: 8ch 11ch 1fr auto;
+      gap: 12px;
+      align-items: baseline;
+    }
+
+    .inspector {
+      display: grid;
+      grid-template-columns: 10ch 1fr;
+      gap: 8px 16px;
+    }
+
+    .rail {
+      border-left: 3px solid var(--line);
+      padding-left: 14px;
+      margin-bottom: 14px;
+    }
+
+    .ide-table {
+      display: grid;
+      grid-template-columns: 4ch 1fr;
+      gap: 0 12px;
+    }
+
+    .minimal {
+      display: grid;
+      gap: 8px;
+    }
+
+    .minimal-row {
+      display: grid;
+      grid-template-columns: 6ch minmax(0, 1fr) 11ch 4ch;
+      gap: 12px;
+      align-items: baseline;
+    }
+
+    .full {
+      grid-column: 1 / -1;
+    }
+
+    .section-title {
+      grid-column: 1 / -1;
+      margin: 18px 0 -4px;
+      padding-top: 22px;
+      border-top: 1px solid rgba(86, 96, 114, .72);
+    }
+
+    .section-title h2 {
+      margin: 0 0 6px;
+      font-size: 20px;
+      letter-spacing: 0;
+    }
+
+    .section-title p {
+      margin: 0;
+      max-width: 820px;
+      color: var(--muted);
+      line-height: 1.45;
+    }
+
+    .assistant-frame {
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 10px 12px;
+      background: rgba(17, 20, 28, .36);
+    }
+
+    .assistant-header {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      color: var(--accent);
+      margin-bottom: 8px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .assistant-body {
+      color: var(--text);
+      display: grid;
+      gap: 6px;
+    }
+
+    .assistant-minimal {
+      display: grid;
+      gap: 8px;
+      padding-left: 2px;
+    }
+
+    .speaker {
+      color: var(--accent);
+      font-weight: 700;
+    }
+
+    .indented {
+      padding-left: 2ch;
+      color: var(--text);
+    }
+
+    .chat-bubble {
+      margin-left: 2ch;
+      padding: 10px 12px;
+      border-left: 2px solid var(--line);
+      background: rgba(29, 35, 48, .64);
+      border-radius: 0 6px 6px 0;
+    }
+
+    .footer-strip {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      min-width: 0;
+      padding: 7px 10px;
+      border: 1px solid rgba(86, 96, 114, .72);
+      background: rgba(17, 20, 28, .66);
+      border-radius: 4px;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    .footer-segments {
+      display: flex;
+      gap: 10px;
+      min-width: 0;
+      overflow: hidden;
+    }
+
+    .segment {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: var(--muted);
+    }
+
+    .auto-panel {
+      display: grid;
+      gap: 10px;
+      padding: 12px;
+      border: 1px solid rgba(168, 189, 120, .7);
+      border-radius: 6px;
+      background: rgba(17, 20, 28, .44);
+    }
+
+    .auto-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .metric {
+      min-width: 0;
+      padding: 8px;
+      border: 1px solid rgba(86, 96, 114, .58);
+      border-radius: 4px;
+      background: rgba(29, 35, 48, .58);
+    }
+
+    .metric-label {
+      color: var(--muted);
+      font-size: 12px;
+      margin-bottom: 4px;
+    }
+
+    .metric-value {
+      color: var(--text);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .stepper {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .step {
+      color: var(--muted);
+    }
+
+    .step.done { color: var(--success); }
+    .step.active { color: var(--accent); }
+    .step.warn { color: var(--warning); }
+
+    .auto-screen {
+      display: grid;
+      gap: 12px;
+    }
+
+    .auto-screen-header,
+    .auto-screen-footer {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      min-width: 0;
+      white-space: nowrap;
+      overflow: hidden;
+      color: var(--muted);
+    }
+
+    .auto-screen-title {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .auto-screen-main {
+      display: grid;
+      grid-template-columns: minmax(0, 1.1fr) minmax(320px, .9fr);
+      gap: 22px;
+      align-items: start;
+      padding: 10px 0;
+      border-top: 1px solid rgba(141, 183, 255, .48);
+      border-bottom: 1px solid rgba(141, 183, 255, .48);
+    }
+
+    .auto-screen-stack {
+      display: grid;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    .auto-task-list {
+      display: grid;
+      gap: 4px;
+      min-width: 0;
+    }
+
+    .auto-task-row {
+      display: grid;
+      grid-template-columns: 4ch minmax(0, 1fr) auto;
+      gap: 10px;
+      align-items: baseline;
+      min-width: 0;
+    }
+
+    .auto-tile-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .auto-alert {
+      padding: 8px 10px;
+      border: 1px solid rgba(230, 192, 106, .72);
+      border-radius: 5px;
+      background: rgba(158, 123, 49, .16);
+      color: var(--warning);
+    }
+
+    .ownership-table {
+      display: grid;
+      gap: 1px;
+      border: 1px solid rgba(86, 96, 114, .72);
+      border-radius: 6px;
+      overflow: hidden;
+      background: rgba(86, 96, 114, .44);
+      font-family: var(--font);
+      font-size: 13px;
+    }
+
+    .ownership-row {
+      display: grid;
+      grid-template-columns: 13ch minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.25fr);
+      gap: 1px;
+      background: rgba(86, 96, 114, .44);
+    }
+
+    .ownership-cell {
+      min-width: 0;
+      padding: 9px 10px;
+      background: #151922;
+      color: var(--muted);
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .ownership-head .ownership-cell {
+      color: var(--text);
+      background: rgba(29, 35, 48, .9);
+      font-weight: 700;
+    }
+
+    .ownership-cell strong {
+      color: var(--text);
+    }
+
+    .auto-rail-layout {
+      display: grid;
+      grid-template-columns: 18ch minmax(0, 1fr);
+      gap: 18px;
+      align-items: start;
+    }
+
+    .auto-rail-menu {
+      display: grid;
+      gap: 6px;
+      color: var(--muted);
+    }
+
+    @media (max-width: 980px) {
+      main { width: min(100vw - 24px, 760px); padding-top: 20px; }
+      header { grid-template-columns: 1fr; }
+      .legend { grid-template-columns: repeat(3, max-content); }
+      .grid { grid-template-columns: 1fr; }
+      .timeline { grid-template-columns: 1fr; gap: 4px; }
+      .minimal-row { grid-template-columns: 5ch 1fr; }
+      .minimal-row .right { grid-column: 2; }
+      .auto-screen-main,
+      .auto-rail-layout { grid-template-columns: 1fr; }
+      .auto-tile-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .ownership-row { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>GSD Chat / Assistant / Tool Output Render Options</h1>
+        <p class="lede">Five terminal-native design directions rendered as HTML previews. The palette mirrors theme-token intent: quiet borders, blue accent, green success, amber warning, red error, and dim metadata.</p>
+      </div>
+      <div class="legend" aria-label="Palette legend">
+        <span class="swatch accent"><span class="dot"></span>accent</span>
+        <span class="swatch success"><span class="dot"></span>success</span>
+        <span class="swatch warning"><span class="dot"></span>warning</span>
+        <span class="swatch error"><span class="dot"></span>error</span>
+        <span class="swatch purple"><span class="dot"></span>meta</span>
+        <span class="swatch muted"><span class="dot"></span>muted</span>
+      </div>
+    </header>
+
+    <section class="grid">
+      <article class="option recommended">
+        <div class="option-header">
+          <h2 class="option-title">1. Diff-First Cards <code>recommended for code work</code></h2>
+          <div class="option-meta">expanded tool-first</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="caption"><span class="accent">╭ edit tests/renderer-registration.test.ts</span><span><span class="success">+4</span> <span class="error">-1</span> · 1 hunk · <span class="success">done</span></span></div>
+            <div class="rule">├──────────────────────────────────────────────────────────────────────────────</div>
+            <div class="row ctx"><span class="line-no">189</span><span class="code">const state = {};</span></div>
+            <div class="row ctx"><span class="line-no">190</span><span class="code">const coloredTheme = {</span></div>
+            <div class="row ctx"><span class="line-no">191</span><span class="code">  ...testTheme(),</span></div>
+            <div class="row del"><span class="line-no">-193</span><span class="code">fg: (key: string, text: string) =&gt; `&lt;${key}&gt;${text}&lt;/${key}&gt;`,</span></div>
+            <div class="row add"><span class="line-no">+193</span><span class="code">fg: (key: string, text: string) =&gt;</span></div>
+            <div class="row add"><span class="line-no">+194</span><span class="code">  ["warning", "success", "error", "borderMuted"].includes(key)</span></div>
+            <div class="row add"><span class="line-no">+195</span><span class="code">    ? `&lt;${key}&gt;${text}&lt;/${key}&gt;`</span></div>
+            <div class="row add"><span class="line-no">+196</span><span class="code">    : text,</span></div>
+            <div class="rule">╰──────────────────────────────────────────────────────────────────── success ─╯</div>
+          </div>
+          <div class="terminal">
+            <div class="card-line"><span class="left"><span class="accent">$</span> npm run format</span><span class="right"><span class="success">✓</span> 2.1s · output hidden · ctrl+o expand</span></div>
+            <div class="card-line"><span class="left"><span class="accent">$</span> npm test</span><span class="right"><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> 48% running</span></div>
+            <div class="card-line"><span class="left"><span class="accent">$</span> npm run check</span><span class="right"><span class="dim">○</span> queued</span></div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option">
+        <div class="option-header">
+          <h2 class="option-title">2. Operations Log <code>dense timeline</code></h2>
+          <div class="option-meta">scan-first</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="timeline"><span class="muted">12:04:18</span><span class="accent">assistant</span><span>Planning renderer update</span><span class="muted">gpt-5.5</span></div>
+            <div class="timeline"><span class="muted">12:04:21</span><span class="success">edit</span><span>tests/renderer-registration.test.ts</span><span><span class="success">+4</span> <span class="error">-1</span> ok</span></div>
+            <div class="timeline"><span class="muted">12:04:24</span><span class="accent">command</span><span>npm run format</span><span class="success">ok 2s</span></div>
+            <div class="timeline"><span class="muted">12:04:37</span><span class="accent">command</span><span>npm test</span><span><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg mid"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> 42%</span></div>
+            <div class="timeline"><span class="muted">12:05:02</span><span class="warning">check</span><span>typecheck:extensions</span><span class="warning">2 warnings</span></div>
+            <div class="timeline"><span class="muted">12:05:11</span><span class="error">command</span><span>npm run check</span><span class="error">failed</span></div>
+          </div>
+          <div class="terminal">
+            <div class="pipeline">
+              <div><span class="success">●</span> format <span class="success">2.1s</span>   <span class="success">●</span> unit <span class="success">8952 passed</span>   <span class="warning">●</span> typecheck <span class="warning">existing errors</span>   <span class="dim">○</span> push</div>
+              <div><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg mid"></span><span class="seg mid"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> <span class="warning">64%</span> · waiting on check</div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option">
+        <div class="option-header">
+          <h2 class="option-title">3. Inspector Panels <code>structured details</code></h2>
+          <div class="option-meta">clean default</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="rail">
+              <div><span class="accent">assistant</span></div>
+              <div class="muted">I’ll update the renderer test, format it, then run the checks.</div>
+            </div>
+            <div class="caption"><span class="accent">╭─ edit</span><span class="success">✓ complete</span></div>
+            <div class="inspector">
+              <span class="muted">file</span><span>tests/renderer-registration.test.ts</span>
+              <span class="muted">summary</span><span>1 replacement, 3 insertions, 1 hunk</span>
+              <span class="muted">result</span><span><span class="success">+4</span> <span class="error">-1</span></span>
+              <span class="muted">view</span><span class="dim">ctrl+o expand diff</span>
+            </div>
+            <div class="rule">╰──────────────────────────────────────────────────────────────────────────────╯</div>
+          </div>
+          <div class="terminal">
+            <div class="caption"><span class="accent">╭─ command</span><span class="accent">● running</span></div>
+            <div class="inspector">
+              <span class="muted">command</span><span>npm test</span>
+              <span class="muted">progress</span><span><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> 39%</span>
+              <span class="muted">output</span><span class="dim">hidden · ctrl+o expand</span>
+            </div>
+            <div class="rule">╰──────────────────────────────────────────────────────────────────────────────╯</div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option">
+        <div class="option-header">
+          <h2 class="option-title">4. Terminal IDE <code>gutter + status badges</code></h2>
+          <div class="option-meta">tooling-heavy</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="caption"><span><span class="pill accent">TOOL: EDIT</span> tests/renderer-registration.test.ts</span><span class="pill success">PASS</span></div>
+            <div class="rule">┌────┬─────────────────────────────────────────────────────────────────────────</div>
+            <div class="ide-table">
+              <span class="line-no muted">ln</span><span class="muted">change</span>
+              <span class="line-no">189</span><span class="ctx">const state = {};</span>
+              <span class="line-no">190</span><span class="ctx">const coloredTheme = {</span>
+              <span class="line-no del">193</span><span class="del">- fg: (...) =&gt; `&lt;${key}&gt;${text}&lt;/${key}&gt;`,</span>
+              <span class="line-no add">193</span><span class="add">+ fg: (...) =&gt;</span>
+              <span class="line-no add">194</span><span class="add">+   ["warning", "success", "error"].includes(key)</span>
+              <span class="line-no add">195</span><span class="add">+     ? `&lt;${key}&gt;${text}&lt;/${key}&gt;`</span>
+            </div>
+            <div class="rule">└────┴──────────────────────────────────────────────────────────── +4 -1 · 1 hunk</div>
+          </div>
+          <div class="terminal">
+            <div class="card-line"><span class="left"><span class="pill accent">RUN</span> npm test</span><span class="right"><span class="accent">●</span> 1m12s</span></div>
+            <div><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> <span class="accent">61%</span> · output hidden · ctrl+o expand</div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option full">
+        <div class="option-header">
+          <h2 class="option-title">5. Minimal Transcript <code>quiet default, rich expand</code></h2>
+          <div class="option-meta">lowest clutter</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="minimal">
+              <div><span class="accent">GSD</span> <span class="muted">Updated the renderer registration test and started verification.</span></div>
+              <div class="minimal-row"><span class="success">edit</span><span>tests/renderer-registration.test.ts</span><span class="right"><span class="success">+4</span> <span class="error">-1</span></span><span class="success">✓</span></div>
+              <div class="minimal-row"><span class="accent">run</span><span>npm run format</span><span class="right">2.1s</span><span class="success">✓</span></div>
+              <div class="minimal-row"><span class="accent">run</span><span>npm test</span><span class="right"><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> 39%</span><span class="accent">●</span></div>
+              <div class="minimal-row"><span class="dim">run</span><span>npm run check</span><span class="right">queued</span><span class="dim">○</span></div>
+            </div>
+          </div>
+          <div class="terminal">
+            <div class="caption"><span class="muted">expanded edit preview</span><span class="dim">ctrl+o collapse</span></div>
+            <div class="row del"><span class="line-no">-193</span><span class="code">fg: (key, text) =&gt; `&lt;${key}&gt;${text}&lt;/${key}&gt;`,</span></div>
+            <div class="row add"><span class="line-no">+193</span><span class="code">fg: (key, text) =&gt; ["warning", "success", "error"].includes(key) ? wrapped : text,</span></div>
+          </div>
+        </div>
+      </article>
+
+      <div class="section-title">
+        <h2>Assistant / Chat Dialog Treatments</h2>
+        <p>These focus on the assistant message itself. They can be paired with any tool-output option above; the strongest pairing is usually left-rail assistant text plus diff-first tool cards.</p>
+      </div>
+
+      <article class="option">
+        <div class="option-header">
+          <h2 class="option-title">A. Framed Assistant Cards <code>structured</code></h2>
+          <div class="option-meta">premium transcript</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="assistant-frame">
+              <div class="assistant-header"><span>GSD · gpt-5.5</span><span class="muted">12:04 PM</span></div>
+              <div class="assistant-body">
+                <div>I’ll update the renderer and run verification.</div>
+                <div class="muted">Plan:</div>
+                <div>1. Add a shared render helper</div>
+                <div>2. Refactor tool output</div>
+                <div>3. Run targeted tests and the PR gate</div>
+              </div>
+            </div>
+          </div>
+          <div class="terminal">
+            <div class="assistant-frame">
+              <div class="assistant-header"><span>GSD · status</span><span class="success">ready</span></div>
+              <div class="assistant-body">
+                <div>Targeted TUI tests passed. The full suite has two unrelated failures.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option">
+        <div class="option-header">
+          <h2 class="option-title">B. Minimal Speaker Labels <code>low visual weight</code></h2>
+          <div class="option-meta">content-first</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="assistant-minimal">
+              <div><span class="speaker">GSD</span> <span class="muted">· gpt-5.5 · 12:04 PM</span></div>
+              <div class="indented">I’ll update the renderer and run verification.</div>
+              <div class="indented muted">Plan:</div>
+              <div class="indented">1. Add a shared render helper</div>
+              <div class="indented">2. Refactor tool output</div>
+              <div class="indented">3. Run targeted tests and the PR gate</div>
+            </div>
+          </div>
+          <div class="terminal">
+            <div><span class="speaker">GSD</span> <span class="muted">· follow-up</span></div>
+            <div class="indented">I found the renderer layer: assistant message, chat frame, tool execution, bash execution, and diff rendering.</div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option recommended">
+        <div class="option-header">
+          <h2 class="option-title">C. Left Rail Conversation <code>recommended</code></h2>
+          <div class="option-meta">best long-session balance</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="rail">
+              <div><span class="speaker">GSD</span> <span class="muted">· gpt-5.5 · 12:04 PM</span></div>
+              <div>I’ll update the renderer and run verification.</div>
+              <div class="muted">Plan:</div>
+              <div>1. Add a shared render helper</div>
+              <div>2. Refactor tool output</div>
+              <div>3. Run targeted tests and the PR gate</div>
+            </div>
+            <div class="card-line"><span class="left"><span class="success">edit</span> tests/renderer-registration.test.ts</span><span class="right"><span class="success">+4</span> <span class="error">-1</span> ✓</span></div>
+          </div>
+          <div class="terminal">
+            <div class="rail">
+              <div><span class="speaker">GSD</span> <span class="muted">· verification</span></div>
+              <div>Targeted tests passed. Typecheck is blocked by unrelated existing errors.</div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option">
+        <div class="option-header">
+          <h2 class="option-title">D. Compact Transcript Mode <code>dense</code></h2>
+          <div class="option-meta">auto-mode friendly</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="timeline"><span class="muted">12:04</span><span class="accent">GSD</span><span>I’ll update the renderer and run verification.</span><span class="muted">gpt-5.5</span></div>
+            <div class="timeline"><span class="muted">12:05</span><span class="accent">GSD</span><span>Plan: helper, tool output refactor, tests.</span><span class="success">ready</span></div>
+            <div class="timeline"><span class="muted">12:06</span><span class="success">edit</span><span>tests/renderer-registration.test.ts</span><span><span class="success">+4</span> <span class="error">-1</span></span></div>
+          </div>
+          <div class="terminal">
+            <div class="caption"><span class="muted">expanded assistant message</span><span class="dim">ctrl+o collapse</span></div>
+            <div class="assistant-frame">
+              <div class="assistant-header"><span>GSD · expanded</span><span class="muted">12:04 PM</span></div>
+              <div class="assistant-body">
+                <div>I’ll update the renderer and run verification.</div>
+                <div>This expanded card shows full markdown when the compact transcript is too terse.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option full">
+        <div class="option-header">
+          <h2 class="option-title">E. Chat Bubble / Message Block <code>conversational</code></h2>
+          <div class="option-meta">softest visual tone</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div><span class="speaker">GSD</span> <span class="muted">· gpt-5.5</span></div>
+            <div class="chat-bubble">
+              <div>I’ll update the renderer and run checks.</div>
+              <div class="muted">The first pass keeps behavior unchanged and focuses on visual consistency.</div>
+            </div>
+          </div>
+          <div class="terminal">
+            <div><span class="speaker">GSD</span> <span class="muted">· after tests</span></div>
+            <div class="chat-bubble">
+              <div>Targeted tests passed. The full unit suite reports two unrelated failures.</div>
+              <div class="pipeline"><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg mid"></span><span class="seg mid"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> <span class="warning">verification partial</span></div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <div class="section-title">
+        <h2>Footer & Auto-Mode Dashboard Treatments</h2>
+        <p>These show options for persistent footer/status areas and the auto-mode progress widget. They can pair with any assistant/tool style above.</p>
+      </div>
+
+      <div class="section-title">
+        <h2>Auto Mode Output Designs</h2>
+        <p>Five full-screen treatments for the live auto-mode surface in the screenshot: current execution, roadmap position, progress, cost, ETA, health, and controls.</p>
+      </div>
+
+      <article class="option full">
+        <div class="option-header">
+          <h2 class="option-title">Footer vs Auto-Mode Content Ownership <code>duplication check</code></h2>
+          <div class="option-meta">design rule</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="ownership-table">
+              <div class="ownership-row ownership-head">
+                <div class="ownership-cell">Signal</div>
+                <div class="ownership-cell">Footer owns</div>
+                <div class="ownership-cell">Auto-mode owns</div>
+                <div class="ownership-cell">Duplication rule</div>
+              </div>
+              <div class="ownership-row">
+                <div class="ownership-cell"><strong>Identity</strong></div>
+                <div class="ownership-cell">GSD, cwd/worktree, branch</div>
+                <div class="ownership-cell">Milestone/slice/task identity</div>
+                <div class="ownership-cell">Footer says where you are; auto says what is running.</div>
+              </div>
+              <div class="ownership-row">
+                <div class="ownership-cell"><strong>Status</strong></div>
+                <div class="ownership-cell">Tiny mode chip: AUTO / manual</div>
+                <div class="ownership-cell">Health detail: progressing, waiting, recovering, paused</div>
+                <div class="ownership-cell">Do not show full health phrase in both places.</div>
+              </div>
+              <div class="ownership-row">
+                <div class="ownership-cell"><strong>Progress</strong></div>
+                <div class="ownership-cell">No task progress when auto panel is visible</div>
+                <div class="ownership-cell">Slices, tasks, current unit, roadmap list</div>
+                <div class="ownership-cell">Auto surface owns all roadmap progress.</div>
+              </div>
+              <div class="ownership-row">
+                <div class="ownership-cell"><strong>Cost</strong></div>
+                <div class="ownership-cell">Session total only when auto panel is hidden</div>
+                <div class="ownership-cell">Auto spend, budget ceiling, projection</div>
+                <div class="ownership-cell">When auto is visible, keep cost in auto only.</div>
+              </div>
+              <div class="ownership-row">
+                <div class="ownership-cell"><strong>Context</strong></div>
+                <div class="ownership-cell">Raw context meter and compaction mode</div>
+                <div class="ownership-cell">Only warnings that affect the active auto unit</div>
+                <div class="ownership-cell">Footer owns 0.2%/1.0M; auto owns “context risk” only.</div>
+              </div>
+              <div class="ownership-row">
+                <div class="ownership-cell"><strong>Model</strong></div>
+                <div class="ownership-cell">Provider/model/thinking state</div>
+                <div class="ownership-cell">Provider wait/retry details when relevant</div>
+                <div class="ownership-cell">Auto does not repeat model unless diagnosing latency.</div>
+              </div>
+              <div class="ownership-row">
+                <div class="ownership-cell"><strong>ETA</strong></div>
+                <div class="ownership-cell">None</div>
+                <div class="ownership-cell">Elapsed, remaining estimate, stall timers</div>
+                <div class="ownership-cell">ETA belongs with active work, not global footer.</div>
+              </div>
+              <div class="ownership-row">
+                <div class="ownership-cell"><strong>Controls</strong></div>
+                <div class="ownership-cell">Global shortcuts only</div>
+                <div class="ownership-cell">Auto-specific pause/dashboard/parallel controls</div>
+                <div class="ownership-cell">If both show controls, footer uses icons/short labels only.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option recommended full">
+        <div class="option-header">
+          <h2 class="option-title">AM1. Command Deck <code>recommended</code></h2>
+          <div class="option-meta">balanced operator view</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="auto-screen">
+              <div class="auto-screen-header">
+                <span class="auto-screen-title"><span class="accent">● GSD</span> <span class="success">AUTO</span> <span class="success">● Progressing well</span></span>
+                <span>18s · ~3h 22m left</span>
+              </div>
+              <div class="auto-screen-main">
+                <div class="auto-screen-stack">
+                  <div><span class="muted">Recurring Expenses</span> <span class="dim">claude-code/claude-sonnet-4-6</span></div>
+                  <div><span class="accent">S01:</span> <b>Schema migration + expense add --repeat</b></div>
+                  <div><span class="accent">▸ executing</span> <span>T01: Add repeat column via idempotent ALTER TABLE in init_schema</span></div>
+                  <div><span class="progress"><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> <span class="muted">0/3 slices · task 1/4</span></div>
+                  <div class="muted">worktrees/M004 (milestone/M004) · 15 hours ago: feat: Budget Tracking</div>
+                </div>
+                <div class="auto-task-list">
+                  <div class="auto-task-row"><span class="accent">› T01</span><span>Add repeat column via idempotent ALTER TABLE...</span><span class="accent">EXECUTE</span></div>
+                  <div class="auto-task-row"><span class="dim">· T02</span><span>Add --repeat option to `expense add` CLI com...</span><span class="dim">queued</span></div>
+                  <div class="auto-task-row"><span class="dim">· T03</span><span>Write tests/test_recurring_add.py covering --...</span><span class="dim">queued</span></div>
+                  <div class="auto-task-row"><span class="dim">· T04</span><span>Run full regression suite and confirm zero f...</span><span class="dim">queued</span></div>
+                </div>
+              </div>
+              <div class="auto-screen-footer">
+                <span><span class="warning">$21.29</span> ───── <span>0.2%/1.0M</span></span>
+                <span>esc pause │ ^G dashboard │ ^P parallel</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option full">
+        <div class="option-header">
+          <h2 class="option-title">AM2. Three-Zone Ops Console <code>health / work / controls</code></h2>
+          <div class="option-meta">fast scanning</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="auto-screen">
+              <div class="auto-tile-grid">
+                <div class="metric"><div class="metric-label">State</div><div class="metric-value success">AUTO · progressing</div></div>
+                <div class="metric"><div class="metric-label">Unit</div><div class="metric-value">M004/S01/T01</div></div>
+                <div class="metric"><div class="metric-label">Budget</div><div class="metric-value warning">$21.29</div></div>
+                <div class="metric"><div class="metric-label">Context</div><div class="metric-value">0.2% / 1.0M</div></div>
+              </div>
+              <div class="auto-screen-main">
+                <div class="auto-screen-stack">
+                  <div class="card-line"><span class="left"><span class="accent">Current task</span> Add repeat column via idempotent ALTER TABLE</span><span class="right">18s</span></div>
+                  <div class="card-line"><span class="left"><span class="accent">Provider</span> claude-code/claude-sonnet-4-6</span><span class="right">thinking off</span></div>
+                  <div class="card-line"><span class="left"><span class="accent">Worktree</span> ~/.gsd/projects/82fa6750e134/worktrees/M004</span><span class="right">main</span></div>
+                </div>
+                <div class="auto-screen-stack">
+                  <div><span class="progress"><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> <span class="accent">task 1/4</span></div>
+                  <div class="stepper"><span class="step active">● execute</span><span class="step">○ test</span><span class="step">○ validate</span><span class="step">○ closeout</span></div>
+                  <div class="muted">esc pause · ^G dashboard · ^P parallel · ^N next event</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option full">
+        <div class="option-header">
+          <h2 class="option-title">AM3. Roadmap-Centered <code>tasks first</code></h2>
+          <div class="option-meta">best for long milestones</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="auto-screen">
+              <div class="auto-screen-header">
+                <span><span class="accent">GSD AUTO</span> · M004 Budget Tracking</span>
+                <span><span class="success">healthy</span> · 0/3 slices · task 1/4</span>
+              </div>
+              <div class="auto-rail-layout">
+                <div class="auto-rail-menu">
+                  <span class="success">● S01 schema</span>
+                  <span class="dim">○ S02 workflow</span>
+                  <span class="dim">○ S03 validation</span>
+                  <span class="dim">○ milestone close</span>
+                </div>
+                <div class="auto-task-list">
+                  <div class="auto-task-row"><span class="accent">▸ T01</span><span>Add repeat column via idempotent ALTER TABLE in init_schema</span><span class="accent">now</span></div>
+                  <div class="auto-task-row"><span class="dim">  T02</span><span>Add --repeat option to `expense add` CLI command</span><span class="dim">next</span></div>
+                  <div class="auto-task-row"><span class="dim">  T03</span><span>Write tests/test_recurring_add.py covering repeat expense creation</span><span class="dim">queued</span></div>
+                  <div class="auto-task-row"><span class="dim">  T04</span><span>Run full regression suite and confirm zero failures</span><span class="dim">queued</span></div>
+                </div>
+              </div>
+              <div class="auto-screen-footer">
+                <span>provider response pending · 18s</span>
+                <span class="warning">$21.29</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option full">
+        <div class="option-header">
+          <h2 class="option-title">AM4. Event Feed + Current Focus <code>debuggable</code></h2>
+          <div class="option-meta">shows motion</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="auto-screen">
+              <div class="auto-screen-main">
+                <div class="auto-screen-stack">
+                  <div><span class="accent">Current focus</span></div>
+                  <div><b>M004/S01/T01</b> · Add repeat column via idempotent ALTER TABLE in init_schema</div>
+                  <div><span class="progress"><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> task 1/4 · 18s</div>
+                  <div class="muted">ETA ~3h 22m · 0.2% context · $21.29 spent</div>
+                </div>
+                <div class="auto-screen-stack">
+                  <div class="timeline"><span class="muted">07:34:12</span><span class="success">start</span><span>execute-task M004/S01/T01</span><span>ok</span></div>
+                  <div class="timeline"><span class="muted">07:34:18</span><span class="accent">model</span><span>waiting for provider response</span><span>18s</span></div>
+                  <div class="timeline"><span class="muted">07:34:19</span><span class="dim">tools</span><span>no active tool calls</span><span>idle</span></div>
+                  <div class="timeline"><span class="muted">07:34:20</span><span class="success">health</span><span>progressing well</span><span>green</span></div>
+                </div>
+              </div>
+              <div class="auto-screen-footer"><span>esc pause</span><span>^G dashboard │ ^P parallel │ ^L logs</span></div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option full">
+        <div class="option-header">
+          <h2 class="option-title">AM5. Recovery-Aware Auto Surface <code>health first</code></h2>
+          <div class="option-meta">clear when things stall</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="auto-screen">
+              <div class="auto-screen-header">
+                <span><span class="warning">● GSD AUTO</span> · provider response slow</span>
+                <span>idle threshold 4m · retry budget 0/2</span>
+              </div>
+              <div class="auto-alert">If this unit stalls, GSD will retry with focused context, then pause with a recovery note instead of hiding the failure.</div>
+              <div class="auto-screen-main">
+                <div class="auto-screen-stack">
+                  <div><span class="accent">Active unit</span> M004/S01/T01</div>
+                  <div>Add repeat column via idempotent ALTER TABLE in init_schema</div>
+                  <div class="muted">last progress: provider request sent · current: waiting for response</div>
+                </div>
+                <div class="auto-tile-grid">
+                  <div class="metric"><div class="metric-label">Health</div><div class="metric-value warning">watching</div></div>
+                  <div class="metric"><div class="metric-label">Elapsed</div><div class="metric-value">18s</div></div>
+                  <div class="metric"><div class="metric-label">ETA</div><div class="metric-value">~3h 22m</div></div>
+                  <div class="metric"><div class="metric-label">Cost</div><div class="metric-value warning">$21.29</div></div>
+                </div>
+              </div>
+              <div class="auto-screen-footer"><span>esc pause · ^D diagnose</span><span class="dim">auto recovery enabled</span></div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option recommended">
+        <div class="option-header">
+          <h2 class="option-title">F1. Powerline Footer + Compact Auto Widget <code>recommended</code></h2>
+          <div class="option-meta">persistent status</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="footer-strip">
+              <div class="footer-segments">
+                <span class="segment accent">● GSD AUTO</span>
+                <span class="segment"> feat/tui-refresh</span>
+                <span class="segment">gpt-5.5</span>
+                <span class="segment success">64%hit</span>
+                <span class="segment warning">$1.42</span>
+              </div>
+              <div class="right">ctx 38% · ctrl+d dashboard</div>
+            </div>
+          </div>
+          <div class="terminal">
+            <div class="auto-panel">
+              <div class="card-line"><span class="left"><span class="accent">●</span> GSD <span class="success">AUTO</span> · Executing T03 renderer polish</span><span class="right">14m · 6m left</span></div>
+              <div><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> <span class="accent">8/14 tasks</span> · S02 · execute-task</div>
+              <div class="muted">~/gsd-2/.worktrees/tui-operations-console-refresh · ctrl+n next · ctrl+p parallel</div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option">
+        <div class="option-header">
+          <h2 class="option-title">F2. Minimal Footer + Full Auto Panel <code>quiet footer</code></h2>
+          <div class="option-meta">dashboard owns detail</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="footer-strip">
+              <div class="footer-segments"><span class="segment accent">GSD</span><span class="segment">feat/tui-refresh</span></div>
+              <div class="right">38% ctx</div>
+            </div>
+          </div>
+          <div class="terminal">
+            <div class="auto-panel">
+              <div class="card-line"><span class="left"><span class="accent">Auto-mode dashboard</span></span><span class="right"><span class="success">healthy</span> · 14m</span></div>
+              <div class="auto-grid">
+                <div class="metric"><div class="metric-label">Current unit</div><div class="metric-value">execute-task · M001/S02/T03</div></div>
+                <div class="metric"><div class="metric-label">Cost</div><div class="metric-value warning">$1.42 · projected $2.10</div></div>
+                <div class="metric"><div class="metric-label">Context</div><div class="metric-value">38% / 200k</div></div>
+              </div>
+              <div class="stepper"><span class="step done">● discuss</span><span class="step done">● plan</span><span class="step active">● execute</span><span class="step">○ verify</span><span class="step">○ complete</span></div>
+              <div><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> <span class="accent">slice 2/4</span></div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option">
+        <div class="option-header">
+          <h2 class="option-title">F3. Mission Control Auto View <code>operator mode</code></h2>
+          <div class="option-meta">parallel friendly</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="footer-strip">
+              <div class="footer-segments"><span class="segment accent">● auto</span><span class="segment success">3 workers alive</span><span class="segment warning">1 warning</span></div>
+              <div class="right">ctrl+p monitor · ctrl+s stop</div>
+            </div>
+          </div>
+          <div class="terminal">
+            <div class="auto-panel">
+              <div class="card-line"><span class="left"><span class="accent">Mission Control</span> · M001 parallel execution</span><span class="right">$4.28 total</span></div>
+              <div class="timeline"><span class="success">M001</span><span>execute</span><span>T03 renderer polish</span><span><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> 31%</span></div>
+              <div class="timeline"><span class="success">M002</span><span>verify</span><span>targeted tests</span><span class="success">✓ passed</span></div>
+              <div class="timeline"><span class="warning">M003</span><span>recover</span><span>typecheck drift</span><span class="warning">retry 1</span></div>
+              <div class="timeline"><span class="dim">M004</span><span>queued</span><span>final PR notes</span><span class="dim">waiting</span></div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option">
+        <div class="option-header">
+          <h2 class="option-title">F4. Stepper Footer + Slim Auto Strip <code>workflow first</code></h2>
+          <div class="option-meta">guided mode</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="footer-strip">
+              <div class="stepper"><span class="step done">● discuss</span><span class="step done">● plan</span><span class="step active">● execute</span><span class="step">○ uat</span><span class="step">○ merge</span></div>
+              <div class="right">next: ctrl+n</div>
+            </div>
+          </div>
+          <div class="terminal">
+            <div class="card-line"><span class="left"><span class="accent">AUTO</span> executing T03 · renderer polish</span><span class="right">8/14 tasks · 14m</span></div>
+            <div><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg run"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> <span class="accent">57%</span> · <span class="muted">npm test running</span></div>
+          </div>
+        </div>
+      </article>
+
+      <article class="option full">
+        <div class="option-header">
+          <h2 class="option-title">F5. Health-First Footer + Alerting Auto Panel <code>recovery focused</code></h2>
+          <div class="option-meta">failures visible</div>
+        </div>
+        <div class="option-body">
+          <div class="terminal">
+            <div class="footer-strip">
+              <div class="footer-segments"><span class="segment warning">! recovering</span><span class="segment">M001/S02/T03</span><span class="segment">idle 4m</span><span class="segment">retry 1</span></div>
+              <div class="right">ctrl+d diagnose · esc pause</div>
+            </div>
+          </div>
+          <div class="terminal">
+            <div class="auto-panel">
+              <div class="card-line"><span class="left"><span class="warning">!</span> Recovery signal</span><span class="right">last progress 4m ago</span></div>
+              <div class="auto-grid">
+                <div class="metric"><div class="metric-label">Blocker</div><div class="metric-value warning">typecheck drift</div></div>
+                <div class="metric"><div class="metric-label">Action</div><div class="metric-value">retry with focused prompt</div></div>
+                <div class="metric"><div class="metric-label">Risk</div><div class="metric-value error">may pause after retry 2</div></div>
+              </div>
+              <div><span class="progress"><span class="seg fill"></span><span class="seg fill"></span><span class="seg fill"></span><span class="seg mid"></span><span class="seg mid"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span><span class="seg"></span></span> <span class="warning">recovery budget 36%</span></div>
+            </div>
+          </div>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
@@ -1,0 +1,39 @@
+// Project/App: GSD-2
+// File Purpose: Visual contract tests for the recommended indented assistant message rail design.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import stripAnsi from "strip-ansi";
+import type { AssistantMessage } from "@gsd/pi-ai";
+
+import { initTheme } from "../../theme/theme.js";
+import { AssistantMessageComponent } from "../assistant-message.js";
+
+initTheme("dark", false);
+
+describe("AssistantMessageComponent recommended rail design", () => {
+	test("renders assistant content with a lightly indented left rail", () => {
+		const message = {
+			id: "m1",
+			role: "assistant",
+			provider: "test",
+			model: "gpt-test",
+			timestamp: 1,
+			content: [{ type: "text", text: "I will update the renderer and run verification." }],
+		} as unknown as AssistantMessage;
+
+		const component = new AssistantMessageComponent(message, true);
+		const raw = component.render(80);
+		const plain = raw.map((line) => stripAnsi(line));
+		const joined = plain.join("\n");
+
+		assert.ok(plain.some((line) => line.startsWith("  ┃ ")), `expected indented rail-prefixed lines:\n${joined}`);
+		assert.ok(raw.some((line) => line.includes("\x1b[48;")), `expected faint assistant block background:\n${raw.join("\n")}`);
+		assert.match(joined, /^\s*┃\s*$/m, "assistant block should include vertical padding rows");
+		assert.match(joined, /GSD/);
+		assert.match(joined, /gpt-test/);
+		assert.match(joined, /update the renderer/);
+		assert.doesNotMatch(joined, /^┃/m, "assistant rail should be slightly indented from the left edge");
+		assert.doesNotMatch(joined, /^╭/m, "assistant messages should not use rounded card borders");
+	});
+});

--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
@@ -8,6 +8,7 @@ import type { AssistantMessage } from "@gsd/pi-ai";
 
 import { initTheme } from "../../theme/theme.js";
 import { AssistantMessageComponent } from "../assistant-message.js";
+import { formatTimestamp } from "../timestamp.js";
 
 initTheme("dark", false);
 
@@ -35,5 +36,21 @@ describe("AssistantMessageComponent recommended rail design", () => {
 		assert.match(joined, /update the renderer/);
 		assert.doesNotMatch(joined, /^┃/m, "assistant rail should be slightly indented from the left edge");
 		assert.doesNotMatch(joined, /^╭/m, "assistant messages should not use rounded card borders");
+	});
+
+	test("renders metadata for a zero timestamp", () => {
+		const message = {
+			id: "m1",
+			role: "assistant",
+			provider: "test",
+			model: "gpt-test",
+			timestamp: 0,
+			content: [{ type: "text", text: "Finished." }],
+		} as unknown as AssistantMessage;
+
+		const component = new AssistantMessageComponent(message, true);
+		const joined = component.render(80).map((line) => stripAnsi(line)).join("\n");
+
+		assert.match(joined, new RegExp(formatTimestamp(0)));
 	});
 });

--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
@@ -1,4 +1,5 @@
-// GSD-2 Interactive Tool Execution Rendering Tests
+// Project/App: GSD-2
+// File Purpose: Tests for interactive terminal tool execution rendering.
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import stripAnsi from "strip-ansi";
@@ -60,6 +61,23 @@ describe("ToolExecutionComponent", () => {
 		assert.match(rendered, /running · \d+(ms|s)/);
 	});
 
+	test("does not duplicate running generic tool labels before args", () => {
+		const rendered = renderToolCollapsed(
+			"Agent",
+			{
+				description: "Scout habit tracker codebase",
+				subagent_type: "Explore",
+				prompt: "Read these files and give me a concise summary of each.",
+			},
+		);
+
+		const labelMatches = rendered.match(/Agent/g) ?? [];
+		assert.equal(labelMatches.length, 1, `expected only the card title to contain Agent:\n${rendered}`);
+		assert.doesNotMatch(rendered, /description="Scout habit tracker codebase"/);
+		assert.doesNotMatch(rendered, /subagent_type="Explore"/);
+		assert.match(rendered, /running · \d+(ms|s)/);
+	});
+
 	test("renders framed header with failed status for failed tool result", () => {
 		const rendered = renderTool(
 			"mcp__demo__do_thing",
@@ -85,6 +103,19 @@ describe("ToolExecutionComponent", () => {
 		assert.match(rendered, /demo\u00b7noop/);
 		assert.doesNotMatch(rendered, /Completed/);
 		assert.doesNotMatch(rendered, /ok=true/);
+	});
+
+	test("does not duplicate generic tool labels in collapsed cards", () => {
+		const rendered = renderToolCollapsed(
+			"TodoWrite",
+			{ todos: [{ content: "Ship it", status: "pending" }] },
+			{ content: [{ type: "text", text: "TodoWrite" }], isError: false },
+		);
+
+		const labelMatches = rendered.match(/TodoWrite/g) ?? [];
+		assert.equal(labelMatches.length, 1, `expected only the card title to contain TodoWrite:\n${rendered}`);
+		assert.match(rendered, /output hidden/);
+		assert.match(rendered, /ctrl\+o expand/);
 	});
 
 	test("exposes phase metadata for successful low-signal tool rows", () => {
@@ -132,8 +163,41 @@ describe("ToolExecutionComponent", () => {
 			},
 		);
 
-		assert.match(rendered, /read .*src\/Inspector\.tsx:4-12/);
+		assert.match(rendered, /Read/);
+		assert.match(rendered, /src\/Inspector\.tsx:4-12/);
 		assert.doesNotMatch(rendered, /source/);
+		assert.doesNotMatch(rendered, /output hidden\n\s*│\s*ctrl\+o expand/);
+	});
+
+	test("renders compact capitalized read rows from file_path args", () => {
+		const rendered = renderToolCollapsed(
+			"Read",
+			{ file_path: "~/Github/gsd-2/src/resources/extensions/gsd/health-widget-core.ts" },
+			{ content: [{ type: "text", text: "hidden body output" }], isError: false },
+		);
+
+		assert.match(rendered, /Read/);
+		assert.match(rendered, /health-widget-core\.ts/);
+		assert.doesNotMatch(rendered, /hidden body output/);
+	});
+
+	test("renders compact read rows from direct result details path", () => {
+		const rendered = renderToolCollapsed(
+			"read",
+			{},
+			{
+				content: [{ type: "text", text: "hidden body output" }],
+				isError: false,
+				details: {
+					path: "/tmp/project/src/resources/extensions/gsd/health-widget-core.ts",
+					range: { start: 1, end: 12 },
+				},
+			},
+		);
+
+		assert.match(rendered, /Read/);
+		assert.match(rendered, /health-widget-core\.ts:1-12/);
+		assert.doesNotMatch(rendered, /hidden body output/);
 	});
 
 	test("renders compact edit rows with target metadata", () => {
@@ -155,8 +219,19 @@ describe("ToolExecutionComponent", () => {
 			},
 		);
 
-		assert.match(rendered, /edit .*src\/Inspector\.tsx:42/);
+		assert.match(rendered, /Edit/);
+		assert.match(rendered, /src\/Inspector\.tsx:42/);
 		assert.doesNotMatch(rendered, /Updated src\/Inspector\.tsx/);
+	});
+
+	test("renders running edit rows with title and target on the top line", () => {
+		const rendered = renderToolCollapsed("edit", { path: "src/Inspector.tsx" });
+
+		const labelMatches = rendered.match(/Edit/g) ?? [];
+		assert.equal(labelMatches.length, 1, `expected tool name only in the card title:\n${rendered}`);
+		assert.match(rendered, /src\/Inspector\.tsx/);
+		assert.match(rendered, /Edit src\/Inspector\.tsx/);
+		assert.match(rendered, /running · \d+(ms|s)/);
 	});
 
 	test("renders compact write rows with target metadata", () => {
@@ -177,8 +252,34 @@ describe("ToolExecutionComponent", () => {
 			},
 		);
 
-		assert.match(rendered, /write .*src\/output\.ts/);
+		assert.match(rendered, /Write/);
+		assert.match(rendered, /src\/output\.ts/);
 		assert.doesNotMatch(rendered, /Successfully wrote/);
+	});
+
+	test("omits default cwd placeholders for collapsed search tools", () => {
+		const rendered = renderToolCollapsed(
+			"Grep",
+			{},
+			{ content: [{ type: "text", text: "hidden body output" }], isError: false },
+		);
+
+		assert.match(rendered, /Grep/);
+		assert.doesNotMatch(rendered, /^│\.\s+│/m, `expected no placeholder cwd body:\n${rendered}`);
+		assert.match(rendered, /output hidden/);
+		assert.doesNotMatch(rendered, /hidden body output/);
+		assert.doesNotMatch(rendered, /^│\s+output hidden/m, `expected compact footer text on the top row:\n${rendered}`);
+	});
+
+	test("keeps meaningful collapsed search targets", () => {
+		const rendered = renderToolCollapsed(
+			"Grep",
+			{ pattern: "Project Initialized", path: "src/resources/extensions/gsd", glob: "*.ts" },
+			{ content: [{ type: "text", text: "hidden body output" }], isError: false },
+		);
+
+		assert.match(rendered, /Project Initialized in src\/resources\/extensions\/gsd \(\*\.ts\)/);
+		assert.doesNotMatch(rendered, /hidden body output/);
 	});
 
 	test("renders compact bash rows with command preview", () => {
@@ -188,7 +289,8 @@ describe("ToolExecutionComponent", () => {
 			{ content: [{ type: "text", text: "ok" }], isError: false, details: { cwd: "/tmp/project" } },
 		);
 
-		assert.match(rendered, /bash npm run typecheck -- --watch false/);
+		assert.match(rendered, /\$ npm run typecheck -- --watch false/);
+		assert.doesNotMatch(rendered, /├/, "collapsed command cards should not include internal divider lines");
 		assert.doesNotMatch(rendered, /\bok\b/);
 	});
 
@@ -339,7 +441,7 @@ describe("ToolExecutionComponent", () => {
 		assert.doesNotMatch(rendered, /gsd_requirement_update/);
 	});
 
-	test("formatCompactArgs truncates long string values inline instead of dumping JSON", () => {
+	test("collapsed generic running tools hide primitive args", () => {
 		const longPath = "/Users/alice/.gsd/projects/4dce7b775013/worktrees/slice-S03-some-long-path-that-exceeds-limit";
 		const rendered = renderToolCollapsed("gsd_slice_complete", {
 			sliceId: "S03",
@@ -347,9 +449,11 @@ describe("ToolExecutionComponent", () => {
 			worktree: longPath,
 		});
 
-		assert.match(rendered, /sliceId="S03"/);
-		assert.match(rendered, /milestoneId="M001"/);
-		assert.match(rendered, /worktree=".*…"/);
+		assert.match(rendered, /Slice Complete/);
+		assert.match(rendered, /running · \d+(ms|s)/);
+		assert.doesNotMatch(rendered, /sliceId="S03"/);
+		assert.doesNotMatch(rendered, /milestoneId="M001"/);
+		assert.doesNotMatch(rendered, /worktree=/);
 		assert.doesNotMatch(rendered, /"sliceId":\s*"S03"/);
 	});
 

--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/user-message-design.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/user-message-design.test.ts
@@ -1,0 +1,48 @@
+// Project/App: GSD-2
+// File Purpose: Visual contract tests for left-edge user chat rails.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import type { AssistantMessage } from "@gsd/pi-ai";
+
+import { initTheme } from "../../theme/theme.js";
+import { AssistantMessageComponent } from "../assistant-message.js";
+import { UserMessageComponent } from "../user-message.js";
+
+initTheme("dark", false);
+
+describe("UserMessageComponent chat rail design", () => {
+	test("renders user messages against the left edge", () => {
+		const component = new UserMessageComponent("Can we make the transcript feel like chat?", undefined, 1, "date-time-iso");
+		const raw = component.render(100);
+		const plain = raw.map((line) => stripVTControlCharacters(line));
+		const joined = plain.join("\n");
+
+		assert.ok(plain.some((line) => /^┃ You/.test(line)), `expected left-edge user rail header:\n${joined}`);
+		assert.ok(plain.some((line) => /^┃ Can we make the transcript feel like chat\?/.test(line)), `expected left-edge user rail body:\n${joined}`);
+		assert.ok(raw.some((line) => line.includes("\x1b[48;")), `expected faint user block background:\n${raw.join("\n")}`);
+		assert.match(joined, /^┃\s*$/m, "user block should include vertical padding rows");
+		assert.match(joined, /feel like chat/);
+		assert.doesNotMatch(joined, /[╭╮╰╯]/, "user rail should not use boxed bubble corners");
+		assert.doesNotMatch(joined, /^  ┃ You/m, "user rail should not be indented like GSD messages");
+	});
+
+	test("uses a different faint background than GSD messages", () => {
+		const user = new UserMessageComponent("Use a distinct user color.");
+		const assistant = new AssistantMessageComponent({
+			id: "m1",
+			role: "assistant",
+			provider: "test",
+			model: "gpt-test",
+			content: [{ type: "text", text: "GSD message." }],
+		} as unknown as AssistantMessage);
+
+		const userBg = user.render(100).join("\n").match(/\x1b\[48;[^m]+m/)?.[0];
+		const assistantBg = assistant.render(100).join("\n").match(/\x1b\[48;[^m]+m/)?.[0];
+
+		assert.ok(userBg, "expected user message background color");
+		assert.ok(assistantBg, "expected assistant message background color");
+		assert.notEqual(userBg, assistantBg, "user and GSD message backgrounds should be distinct");
+	});
+});

--- a/packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.test.ts
@@ -32,7 +32,7 @@ describe("AdaptiveLayoutComponent", () => {
 		assert.match(output, /watch tool output/);
 		assert.doesNotMatch(output, /signals/);
 		assert.doesNotMatch(output, /inspector/);
-		assert.doesNotMatch(output, /\bAUTO\b/);
+		assert.doesNotMatch(output, /\bauto\b/i);
 		assert.match(output, /^╭─+╮/m);
 	});
 
@@ -47,7 +47,7 @@ describe("AdaptiveLayoutComponent", () => {
 		const output = render(component, 68);
 		assert.match(output, /GSD compact/);
 		assert.doesNotMatch(output, /signals/);
-		assert.doesNotMatch(output, /\bAUTO\b/);
+		assert.doesNotMatch(output, /\bauto\b/i);
 	});
 
 	it("renders blocking failure context in debug mode", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.test.ts
@@ -1,4 +1,5 @@
-// GSD2 - Runtime tests for adaptive terminal layout rendering
+// Project/App: GSD-2
+// File Purpose: Runtime tests for adaptive command-center terminal layout rendering.
 
 import assert from "node:assert/strict";
 import { describe, it, before } from "node:test";
@@ -15,7 +16,7 @@ function render(component: AdaptiveLayoutComponent, width: number): string {
 }
 
 describe("AdaptiveLayoutComponent", () => {
-	it("renders workflow command center and inspector on wide terminals", () => {
+	it("renders a rounded workflow command center on wide terminals", () => {
 		const component = new AdaptiveLayoutComponent(() => ({
 			override: "workflow",
 			activeToolCount: 2,
@@ -26,8 +27,13 @@ describe("AdaptiveLayoutComponent", () => {
 
 		const output = render(component, 132);
 		assert.match(output, /GSD Command Center/);
-		assert.match(output, /signals/);
+		assert.match(output, /workflow · ready/);
 		assert.match(output, /2 running/);
+		assert.match(output, /watch tool output/);
+		assert.doesNotMatch(output, /signals/);
+		assert.doesNotMatch(output, /inspector/);
+		assert.doesNotMatch(output, /\bAUTO\b/);
+		assert.match(output, /^╭─+╮/m);
 	});
 
 	it("falls back to a single compact row for narrow workflow terminals", () => {
@@ -41,6 +47,7 @@ describe("AdaptiveLayoutComponent", () => {
 		const output = render(component, 68);
 		assert.match(output, /GSD compact/);
 		assert.doesNotMatch(output, /signals/);
+		assert.doesNotMatch(output, /\bAUTO\b/);
 	});
 
 	it("renders blocking failure context in debug mode", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.ts
@@ -153,8 +153,9 @@ export class AdaptiveLayoutComponent implements Component {
 	}
 
 	private basename(cwd: string): string {
-		const trimmed = cwd.replace(/\/+$/, "");
-		const slash = trimmed.lastIndexOf("/");
+		const trimmed = cwd.replace(/[\\/]+$/, "");
+		if (!trimmed) return cwd.includes("\\") ? "\\" : "/";
+		const slash = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
 		return slash === -1 ? trimmed : trimmed.slice(slash + 1);
 	}
 }

--- a/packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/adaptive-layout.ts
@@ -1,9 +1,11 @@
-// GSD2 - Adaptive terminal mode dashboard for the interactive TUI
+// Project/App: GSD-2
+// File Purpose: Adaptive command-center dashboard for the interactive TUI.
 
-import { style, truncateToWidth, visibleWidth, type Component } from "@gsd/pi-tui";
+import { style, truncateToWidth, type Component } from "@gsd/pi-tui";
 import type { TuiAdaptiveMode, TuiMode } from "../tui-mode.js";
 import { resolveTuiMode } from "../tui-mode.js";
 import { theme, type ThemeColor } from "../theme/theme.js";
+import { alignRight, breakpoint, keyValue, roundedPanel } from "./tui-style-kit.js";
 
 export interface AdaptiveLayoutState {
 	override: TuiAdaptiveMode;
@@ -41,34 +43,44 @@ export class AdaptiveLayoutComponent implements Component {
 	}
 
 	private renderWorkflow(width: number, state: AdaptiveLayoutState): string[] {
-		if (width < 112) return this.renderCompact(width, "workflow", state);
+		if (width < 72) return this.renderCompact(width, "workflow", state);
 
-		const leftWidth = Math.max(44, Math.floor(width * 0.56));
-		const rightWidth = Math.max(32, width - leftWidth - 2);
 		const phase = state.gsdPhase ?? "Ready";
-		const left = this.frame(
-			[
-				this.metric("Active", phase, "modeWorkflow"),
-				this.metric("Tools", state.activeToolCount > 0 ? `${state.activeToolCount} running` : "idle", "toolRunning"),
-				this.metric("Mode", state.override === "auto" ? "auto workflow" : state.override, "modeWorkflow"),
-			],
-			leftWidth,
-			"GSD Command Center",
-			"workflow",
-			"modeWorkflow",
-		);
-		const right = this.frame(
-			[
-				`Session ${state.sessionName ?? "current"}`,
-				`Path ${this.basename(state.cwd)}`,
-				`Next ${state.activeToolCount > 0 ? "watch tool output" : "continue from prompt"}`,
-			],
-			rightWidth,
-			"signals",
-			"inspector",
-			"surfaceAccent",
-		);
-		return this.columns(left, right, leftWidth);
+		const tools = state.activeToolCount > 0 ? `${state.activeToolCount} running` : "idle";
+		const next = state.activeToolCount > 0 ? "watch tool output" : "continue from prompt";
+		const modeLabel = state.override === "auto" ? "workflow" : state.override;
+		const bp = breakpoint(width);
+
+		const rows = bp === "regular"
+			? [
+					keyValue("Status", phase, "modeWorkflow"),
+					keyValue("Tools", tools, state.activeToolCount > 0 ? "toolRunning" : "toolMuted"),
+					keyValue("Session", state.sessionName ?? "current", "text"),
+					keyValue("Next", next, "surfaceAccent"),
+				]
+			: [
+					alignRight(
+						keyValue("Status", phase, "modeWorkflow"),
+						keyValue("Tools", tools, state.activeToolCount > 0 ? "toolRunning" : "toolMuted"),
+						Math.max(1, width - 2),
+					),
+					alignRight(
+						keyValue("Session", state.sessionName ?? "current", "text"),
+						keyValue("Path", this.basename(state.cwd), "text"),
+						Math.max(1, width - 2),
+					),
+					alignRight(
+						keyValue("Next", next, "surfaceAccent"),
+						keyValue("Mode", modeLabel, "modeWorkflow"),
+						Math.max(1, width - 2),
+					),
+				];
+
+		return roundedPanel(rows, width, {
+			title: "GSD Command Center",
+			rightTitle: `${modeLabel} · ${state.lastError ? "blocked" : "ready"}`,
+			tone: state.lastError ? "error" : "default",
+		});
 	}
 
 	private renderValidation(width: number, state: AdaptiveLayoutState): string[] {
@@ -138,18 +150,6 @@ export class AdaptiveLayoutComponent implements Component {
 
 	private metric(label: string, value: string, color: ThemeColor): string {
 		return `${theme.fg("surfaceMuted", `${label.padEnd(8)} `)}${theme.fg(color, value)}`;
-	}
-
-	private columns(left: string[], right: string[], leftWidth: number): string[] {
-		const rows = Math.max(left.length, right.length);
-		const output: string[] = [];
-		for (let i = 0; i < rows; i++) {
-			const leftLine = left[i] ?? "";
-			const rightLine = right[i] ?? "";
-			const gap = " ".repeat(Math.max(2, leftWidth - visibleWidth(leftLine) + 2));
-			output.push(`${leftLine}${gap}${rightLine}`);
-		}
-		return output;
 	}
 
 	private basename(cwd: string): string {

--- a/packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -169,7 +169,7 @@ export class AssistantMessageComponent extends Container {
 		const lines = super.render(contentWidth);
 		const metaParts = [];
 		if (this.lastMessage?.model) metaParts.push(this.lastMessage.model);
-		if (this.showMetadata && this.lastMessage?.timestamp) {
+		if (this.showMetadata && this.lastMessage?.timestamp !== undefined) {
 			metaParts.push(formatTimestamp(this.lastMessage.timestamp, this.timestampFormat));
 		}
 		const rendered = renderAssistantRail(lines, frameWidth, {

--- a/packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -169,7 +169,7 @@ export class AssistantMessageComponent extends Container {
 		const lines = super.render(contentWidth);
 		const metaParts = [];
 		if (this.lastMessage?.model) metaParts.push(this.lastMessage.model);
-		if (this.showMetadata && this.lastMessage?.timestamp !== undefined) {
+		if (this.showMetadata && this.lastMessage?.timestamp != null) {
 			metaParts.push(formatTimestamp(this.lastMessage.timestamp, this.timestampFormat));
 		}
 		const rendered = renderAssistantRail(lines, frameWidth, {

--- a/packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -1,9 +1,11 @@
-// GSD2 TUI - Assistant message card renderer for interactive terminal sessions.
+// Project/App: GSD-2
+// File Purpose: Assistant message rail renderer for interactive terminal sessions.
 import type { AssistantMessage } from "@gsd/pi-ai";
 import { Container, Markdown, type MarkdownTheme, Spacer, Text } from "@gsd/pi-tui";
 import { getMarkdownTheme, theme } from "../theme/theme.js";
 import { type TimestampFormat } from "./timestamp.js";
-import { renderChatFrame } from "./chat-frame.js";
+import { formatTimestamp } from "./timestamp.js";
+import { renderAssistantRail } from "./transcript-design.js";
 
 export interface ContentRange {
 	startIndex: number;
@@ -163,19 +165,17 @@ export class AssistantMessageComponent extends Container {
 
 	override render(width: number): string[] {
 		const frameWidth = Math.max(20, width);
-		const contentWidth = Math.max(1, frameWidth - 4);
+		const contentWidth = Math.max(1, frameWidth - 2);
 		const lines = super.render(contentWidth);
-		const headerLabel = this.lastMessage?.model ? `GSD - ${this.lastMessage.model}` : "GSD";
-		const framed = renderChatFrame(lines, frameWidth, {
-			label: headerLabel,
-			tone: "assistant",
-			timestamp: this.lastMessage?.timestamp,
-			timestampFormat: this.timestampFormat,
-			showTimestamp: this.showMetadata,
-		});
-		if (framed.length === 0) {
-			return framed;
+		const metaParts = [];
+		if (this.lastMessage?.model) metaParts.push(this.lastMessage.model);
+		if (this.showMetadata && this.lastMessage?.timestamp) {
+			metaParts.push(formatTimestamp(this.lastMessage.timestamp, this.timestampFormat));
 		}
-		return ["", ...framed];
+		const rendered = renderAssistantRail(lines, frameWidth, {
+			label: "GSD",
+			meta: metaParts.length > 0 ? `· ${metaParts.join(" · ")}` : undefined,
+		});
+		return rendered.length > 0 ? ["", ...rendered] : rendered;
 	}
 }

--- a/packages/pi-coding-agent/src/modes/interactive/components/bash-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/bash-execution.ts
@@ -150,13 +150,24 @@ export class BashExecutionComponent extends Container {
 		}
 
 		const output = this.outputLines.join("\n");
-		const availableLines = output ? output.split("\n") : [];
+		const contextTruncation = truncateTail(output, {
+			maxLines: DEFAULT_MAX_LINES,
+			maxBytes: DEFAULT_MAX_BYTES,
+		});
+		const truncationResult = this.truncationResult ?? contextTruncation;
+		const fullOutputPath = this.fullOutputPath;
+		const availableLines = contextTruncation.content ? contextTruncation.content.split("\n") : [];
 		const preview = this.expanded ? availableLines : availableLines.slice(-PREVIEW_LINES);
 		const hidden = Math.max(0, availableLines.length - preview.length);
+		const truncationWarning =
+			(truncationResult.truncated || contextTruncation.truncated) && fullOutputPath
+				? [theme.fg("warning", `Output truncated. Full output: ${fullOutputPath}`)]
+				: [];
 		const body = [
 			theme.fg("toolTitle", `$ ${this.command}`),
 			...preview.map((line) => theme.fg("toolOutput", line)),
 			...(hidden > 0 ? [theme.fg("muted", `... ${hidden} earlier lines`)] : []),
+			...truncationWarning,
 		];
 		return [
 			"",

--- a/packages/pi-coding-agent/src/modes/interactive/components/bash-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/bash-execution.ts
@@ -1,6 +1,5 @@
-/**
- * Component for displaying bash command execution with streaming output.
- */
+// Project/App: GSD-2
+// File Purpose: Interactive terminal bash execution renderer with streaming output and recommended command cards.
 
 import { Container, Loader, Spacer, Text, type TUI } from "@gsd/pi-tui";
 import stripAnsi from "strip-ansi";
@@ -13,6 +12,7 @@ import {
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { editorKey, keyHint } from "./keybinding-hints.js";
+import { renderCommandCard, renderTranscriptCard, type StatusTone } from "./transcript-design.js";
 import { truncateToVisualLines } from "./visual-truncate.js";
 
 // Preview line limit when not expanded (matches tool execution behavior)
@@ -118,6 +118,56 @@ export class BashExecutionComponent extends Container {
 		this.loader.stop();
 
 		this.updateDisplay();
+	}
+
+	override render(width: number): string[] {
+		const frameWidth = Math.max(20, width);
+		const elapsedStatus =
+			this.status === "running"
+				? "running"
+				: this.status === "complete"
+					? "success"
+					: this.status === "cancelled"
+						? "cancelled"
+						: `failed${this.exitCode !== undefined ? ` · exit ${this.exitCode}` : ""}`;
+		const tone: StatusTone =
+			this.status === "running"
+				? "running"
+				: this.status === "complete"
+					? "success"
+					: this.status === "cancelled"
+						? "warning"
+						: "error";
+
+		if (!this.expanded && this.status !== "error") {
+			return [
+				"",
+				...renderCommandCard(this.command.replace(/\s+/g, " ").trim(), frameWidth, {
+					status: elapsedStatus,
+					tone,
+				}),
+			];
+		}
+
+		const output = this.outputLines.join("\n");
+		const availableLines = output ? output.split("\n") : [];
+		const preview = this.expanded ? availableLines : availableLines.slice(-PREVIEW_LINES);
+		const hidden = Math.max(0, availableLines.length - preview.length);
+		const body = [
+			theme.fg("toolTitle", `$ ${this.command}`),
+			...preview.map((line) => theme.fg("toolOutput", line)),
+			...(hidden > 0 ? [theme.fg("muted", `... ${hidden} earlier lines`)] : []),
+		];
+		return [
+			"",
+			...renderTranscriptCard(body, frameWidth, {
+				title: "command",
+				right: elapsedStatus,
+				tone,
+				footerLeft: this.expanded ? "output expanded" : "output preview",
+				footerRight: this.expanded ? "ctrl+o collapse" : "ctrl+o expand",
+			}),
+		];
 	}
 
 	private updateDisplay(): void {

--- a/packages/pi-coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/diff.ts
@@ -1,5 +1,5 @@
 import * as Diff from "diff";
-import { theme } from "../theme/theme.js";
+import { getLanguageFromPath, highlightCode, theme } from "../theme/theme.js";
 
 /**
  * Parse diff line to extract prefix, line number, and content.
@@ -66,8 +66,13 @@ function renderIntraLineDiff(oldContent: string, newContent: string): { removedL
 }
 
 export interface RenderDiffOptions {
-	/** File path (unused, kept for API compatibility) */
+	/** File path used to choose syntax highlighting for changed content. */
 	filePath?: string;
+}
+
+function syntaxLine(content: string, lang: string | undefined): string {
+	if (!lang) return content;
+	return highlightCode(content, lang)[0] ?? content;
 }
 
 /**
@@ -76,9 +81,10 @@ export interface RenderDiffOptions {
  * - Removed lines: red, with inverse on changed tokens
  * - Added lines: green, with inverse on changed tokens
  */
-export function renderDiff(diffText: string, _options: RenderDiffOptions = {}): string {
+export function renderDiff(diffText: string, options: RenderDiffOptions = {}): string {
 	const lines = diffText.split("\n");
 	const result: string[] = [];
+	const lang = options.filePath ? getLanguageFromPath(options.filePath) : undefined;
 
 	let i = 0;
 	while (i < lines.length) {
@@ -126,19 +132,19 @@ export function renderDiff(diffText: string, _options: RenderDiffOptions = {}): 
 			} else {
 				// Show all removed lines first, then all added lines
 				for (const removed of removedLines) {
-					result.push(theme.fg("toolDiffRemoved", `-${removed.lineNum} ${replaceTabs(removed.content)}`));
+					result.push(`${theme.fg("toolDiffRemoved", `-${removed.lineNum} `)}${syntaxLine(replaceTabs(removed.content), lang)}`);
 				}
 				for (const added of addedLines) {
-					result.push(theme.fg("toolDiffAdded", `+${added.lineNum} ${replaceTabs(added.content)}`));
+					result.push(`${theme.fg("toolDiffAdded", `+${added.lineNum} `)}${syntaxLine(replaceTabs(added.content), lang)}`);
 				}
 			}
 		} else if (parsed.prefix === "+") {
 			// Standalone added line
-			result.push(theme.fg("toolDiffAdded", `+${parsed.lineNum} ${replaceTabs(parsed.content)}`));
+			result.push(`${theme.fg("toolDiffAdded", `+${parsed.lineNum} `)}${syntaxLine(replaceTabs(parsed.content), lang)}`);
 			i++;
 		} else {
 			// Context line
-			result.push(theme.fg("toolDiffContext", ` ${parsed.lineNum} ${replaceTabs(parsed.content)}`));
+			result.push(`${theme.fg("toolDiffContext", ` ${parsed.lineNum} `)}${syntaxLine(replaceTabs(parsed.content), lang)}`);
 			i++;
 		}
 	}

--- a/packages/pi-coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/footer.ts
@@ -1,8 +1,12 @@
+// Project/App: GSD-2
+// File Purpose: Interactive terminal footer renderer for workspace, model, usage, context, and extension status.
+
 import { type Component, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 import type { AgentSession } from "../../../core/agent-session.js";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.js";
 import { theme } from "../theme/theme.js";
 import { providerAuthBadge, providerDisplayName } from "./model-selector.js";
+import { renderFooterStrip } from "./transcript-design.js";
 
 /**
  * Sanitize text for display in a single-line status.
@@ -155,8 +159,8 @@ export class FooterComponent implements Component {
 			? Math.max(0, Math.min(BAR_WIDTH, Math.round((contextPercentValue / 100) * BAR_WIDTH)))
 			: 0;
 		const bar =
-			theme.fg(barColor, "━".repeat(filled)) +
-			theme.fg("dim", "─".repeat(Math.max(0, BAR_WIDTH - filled)));
+			theme.fg(barColor, "█".repeat(filled)) +
+			theme.fg("dim", "░".repeat(Math.max(0, BAR_WIDTH - filled)));
 		const pctText = contextPercent === "?" ? "?" : `${contextPercent}%`;
 		const suffix = `/${formatTokens(contextWindow)}${autoIndicator}`;
 		const colorizedPct =
@@ -218,34 +222,9 @@ export class FooterComponent implements Component {
 			}
 		}
 
-		const rightSideWidth = visibleWidth(rightSide);
-		const totalNeeded = statsLeftWidth + minPadding + rightSideWidth;
-
-		let statsLine: string;
-		if (totalNeeded <= width) {
-			// Both fit - add padding to right-align model
-			const padding = " ".repeat(width - statsLeftWidth - rightSideWidth);
-			statsLine = statsLeft + padding + rightSide;
-		} else {
-			// Need to truncate right side
-			const availableForRight = width - statsLeftWidth - minPadding;
-			if (availableForRight > 0) {
-				const truncatedRight = truncateToWidth(rightSide, availableForRight, "");
-				const truncatedRightWidth = visibleWidth(truncatedRight);
-				const padding = " ".repeat(Math.max(0, width - statsLeftWidth - truncatedRightWidth));
-				statsLine = statsLeft + padding + truncatedRight;
-			} else {
-				// Not enough space for right side at all
-				statsLine = statsLeft;
-			}
-		}
-
-		// Apply dim to each part separately. statsLeft may contain color codes (for context %)
-		// that end with a reset, which would clear an outer dim wrapper. So we dim the parts
-		// before and after the colored section independently.
+		// Apply dim to the stats group before handing it to the shared footer strip.
+		// statsLeft may contain color codes for context %, so keep coloring local to the group.
 		const dimStatsLeft = theme.fg("dim", statsLeft);
-		const remainder = statsLine.slice(statsLeft.length); // padding + rightSide
-		const dimRemainder = theme.fg("dim", remainder);
 
 		// Extension statuses right-aligned on the pwd line (sorted by key).
 		// Keeps the footer compact by avoiding a dedicated row when the content
@@ -260,18 +239,12 @@ export class FooterComponent implements Component {
 						.join(" ")
 				: "";
 
-		const pwdWidth = visibleWidth(pwd);
-		const extWidth = visibleWidth(extStatusText);
-		let pwdLine: string;
-		if (extStatusText && pwdWidth + 2 + extWidth <= width) {
-			const padding = " ".repeat(width - pwdWidth - extWidth);
-			pwdLine = theme.fg("dim", pwd + padding + extStatusText);
-		} else {
-			pwdLine = truncateToWidth(theme.fg("dim", pwd), width, theme.fg("dim", "..."));
-		}
-
-		const lines = [pwdLine, dimStatsLeft + dimRemainder];
-
-		return lines;
+		const leftSegments = [
+			theme.fg("accent", "● GSD"),
+			theme.fg("dim", pwd),
+			dimStatsLeft,
+		];
+		const footerRight = [rightSide, extStatusText].filter(Boolean).join(" ");
+		return renderFooterStrip(leftSegments, footerRight, width);
 	}
 }

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -1,4 +1,5 @@
-// GSD-2 Interactive Tool Execution Rendering
+// Project/App: GSD-2
+// File Purpose: Interactive terminal tool execution renderer for commands, tool calls, diffs, images, and summaries.
 import {
 	Box,
 	Container,
@@ -24,6 +25,7 @@ import { getLanguageFromPath, highlightCode, theme } from "../theme/theme.js";
 import { shortenPath } from "../utils/shorten-path.js";
 import { renderDiff } from "./diff.js";
 import { keyHint } from "./keybinding-hints.js";
+import { renderCommandCard, renderToolLineCard, renderTranscriptCard, type StatusTone } from "./transcript-design.js";
 import { truncateToVisualLines } from "./visual-truncate.js";
 
 // Preview line limit for bash when not expanded
@@ -81,73 +83,6 @@ function prettifyToolName(name: string, label?: string): string {
 		.split("_")
 		.map((word) => (word.length === 0 ? word : word[0].toUpperCase() + word.slice(1)))
 		.join(" ");
-}
-
-type ToolFrameTone = "pending" | "success" | "error";
-
-function trimOuterBlankLines(lines: string[]): string[] {
-	let start = 0;
-	let end = lines.length;
-	while (start < end && lines[start].trim().length === 0) start++;
-	while (end > start && lines[end - 1].trim().length === 0) end--;
-	return lines.slice(start, end);
-}
-
-function renderToolFrame(
-	contentLines: string[],
-	width: number,
-	opts: {
-		label: string;
-		status: string;
-		tone: ToolFrameTone;
-	},
-): string[] {
-	const outerWidth = Math.max(20, width);
-	const contentWidth = Math.max(1, outerWidth - 2); // "│ " + content
-
-	const borderColor = opts.tone === "error" ? "toolError" : opts.tone === "pending" ? "toolRunning" : "toolSuccess";
-	const topColor = borderColor;
-	const labelColor = opts.tone === "error" ? "toolError" : opts.tone === "pending" ? "toolRunning" : "toolSuccess";
-	const statusColor = opts.tone === "error" ? "toolError" : opts.tone === "pending" ? "toolRunning" : "toolSuccess";
-	const leftStyled = theme.fg(labelColor, theme.bold(opts.label));
-	const rightStyled = theme.fg(statusColor, opts.status);
-	const titleWidth = Math.max(1, outerWidth - 4);
-	const gap = Math.max(1, titleWidth - visibleWidth(leftStyled) - visibleWidth(rightStyled));
-	const headerRow = `${leftStyled}${" ".repeat(gap)}${rightStyled}`;
-	const headerPad = Math.max(0, titleWidth - visibleWidth(headerRow));
-
-	const sourceLines = trimOuterBlankLines(contentLines);
-	const bodyLines = (sourceLines.length > 0 ? sourceLines : [""]).map((line) => {
-		const clipped = truncateToWidth(line, contentWidth, "");
-		return clipped;
-	});
-
-	return style()
-		.border("rounded")
-		.borderColor((line) => theme.fg(line.startsWith("─") ? topColor : borderColor, line))
-		.title(headerRow + " ".repeat(headerPad))
-		.render(bodyLines, outerWidth);
-}
-
-function renderCollapsedToolRow(
-	label: string,
-	status: string,
-	width: number,
-	tone: Extract<ToolFrameTone, "success">,
-): string[] {
-	const outerWidth = Math.max(20, width);
-	const contentWidth = Math.max(1, outerWidth - 2);
-	const statusColor = tone === "success" ? "toolSuccess" : "toolMuted";
-	const labelStyled = theme.fg(statusColor, label);
-	const statusStyled = theme.fg(statusColor, status);
-	const labelWidth = Math.max(1, contentWidth - visibleWidth(statusStyled) - 1);
-	const clippedLabel = truncateToWidth(labelStyled, labelWidth, "");
-	const gap = Math.max(1, contentWidth - visibleWidth(clippedLabel) - visibleWidth(statusStyled));
-	const line = `${clippedLabel}${" ".repeat(gap)}${statusStyled}`;
-	return style()
-		.border("minimal")
-		.borderColor((text) => theme.fg(statusColor, text))
-		.render([line], outerWidth);
 }
 
 const COMPACT_ARG_VALUE_LIMIT = 60;
@@ -211,6 +146,40 @@ function formatToolTarget(target: ToolTargetMetadata): string | undefined {
 		return target.glob ? `${label} (${target.glob})` : label;
 	}
 	return appendLineOrRange(displayPath, target);
+}
+
+function directDetailsTarget(details: unknown, action: string): ToolTargetMetadata | undefined {
+	if (!details || typeof details !== "object") return undefined;
+	const record = details as Record<string, unknown>;
+	const rawPath = record.resolvedPath ?? record.inputPath ?? record.file_path ?? record.path;
+	if (typeof rawPath !== "string" || rawPath.trim().length === 0) return undefined;
+	const target: ToolTargetMetadata = {
+		kind: "file",
+		action,
+		resolvedPath: typeof record.resolvedPath === "string" ? record.resolvedPath : rawPath,
+		inputPath: typeof record.inputPath === "string" ? record.inputPath : rawPath,
+	};
+	if (typeof record.line === "number") {
+		target.line = record.line;
+	}
+	const range = record.range;
+	if (range && typeof range === "object") {
+		const rangeRecord = range as Record<string, unknown>;
+		target.range = {
+			start: typeof rangeRecord.start === "number" ? rangeRecord.start : undefined,
+			end: typeof rangeRecord.end === "number" ? rangeRecord.end : undefined,
+		};
+	}
+	return target;
+}
+
+function firstStringArg(args: Record<string, unknown>, keys: string[]): string | null {
+	for (const key of keys) {
+		const value = str(args[key]);
+		if (value === null) continue;
+		if (value) return value;
+	}
+	return "";
 }
 
 function formatArgsPathTarget(path: string | null, args: Record<string, unknown>): string | undefined {
@@ -692,22 +661,47 @@ export class ToolExecutionComponent extends Container {
 		}
 		const frameWidth = Math.max(20, width);
 		const contentWidth = Math.max(1, frameWidth - 4);
-		const frameTone: ToolFrameTone =
+		const frameTone: "pending" | "success" | "error" =
 			this.result?.isError ? "error" : this.isPartial || !this.result ? "pending" : "success";
 		const elapsed = formatElapsed((this.endedAt ?? Date.now()) - this.startedAt);
-		const frameStatus = `${this.isPartial || !this.result ? "running" : this.result.isError ? "failed" : "success"} · ${elapsed}`;
+		const statusWord = this.isPartial || !this.result ? "running" : this.result.isError ? "failed" : "success";
+		const frameStatus = `${statusWord} · ${elapsed}`;
 		const parsed = parseMcpToolName(this.toolName);
 		const frameLabel = parsed
 			? `${parsed.server}·${parsed.tool}`
 			: prettifyToolName(this.toolName, this.toolDefinition?.label) || "unknown";
-		if (this.shouldRenderCompactSuccess()) {
-			return ["", ...renderCollapsedToolRow(this.getCompactSummary(frameLabel), frameStatus, frameWidth, "success")];
+		const recommendedTone: StatusTone =
+			frameTone === "pending" ? "running" : frameTone === "error" ? "error" : "success";
+
+		if (this.normalizedToolName === "bash" && !this.expanded && !this.result?.isError) {
+			const command = str(this.args?.command);
+			return [
+				"",
+				...renderCommandCard(command && command.length > 0 ? formatCommandPreview(command) : frameLabel, frameWidth, {
+					status: frameStatus,
+					tone: recommendedTone,
+				}),
+			];
+		}
+		const hasImages = this.result?.content?.some((block) => block.type === "image") ?? false;
+		if (!this.expanded && !this.result?.isError && !hasImages) {
+			const compactTarget = this.getCompactTarget();
+			return [
+				"",
+				...renderToolLineCard(frameLabel, compactTarget, frameWidth, {
+					status: frameStatus,
+					tone: recommendedTone,
+					hidden: !this.isPartial && !!this.result,
+				}),
+			];
 		}
 		const lines = super.render(contentWidth);
-		const framed = renderToolFrame(lines, frameWidth, {
-			label: frameLabel,
-			status: frameStatus,
-			tone: frameTone,
+		const framed = renderTranscriptCard(lines, frameWidth, {
+			title: frameLabel,
+			right: frameStatus,
+			tone: recommendedTone,
+			footerLeft: this.expanded ? "output expanded" : undefined,
+			footerRight: this.expanded ? "ctrl+o collapse" : undefined,
 		});
 		return framed.length > 0 ? ["", ...framed] : framed;
 	}
@@ -748,15 +742,6 @@ export class ToolExecutionComponent extends Container {
 		return "Other tool actions";
 	}
 
-	private getCompactSummary(frameLabel: string): string {
-		if (this.normalizedToolName === "bash") {
-			const command = str(this.args?.command);
-			return command ? `bash ${formatCommandPreview(command)}` : frameLabel;
-		}
-		const target = this.getCompactTarget();
-		return target ? `${this.getCompactAction()} ${target}` : frameLabel;
-	}
-
 	private getCompactAction(): string {
 		const target = this.getTargetMetadata();
 		if (target?.action) return target.action === "list" ? "ls" : target.action;
@@ -765,7 +750,8 @@ export class ToolExecutionComponent extends Container {
 
 	private getTargetMetadata(): ToolTargetMetadata | undefined {
 		const target = this.result?.details?.target;
-		return target && typeof target === "object" ? target : undefined;
+		if (target && typeof target === "object") return target;
+		return directDetailsTarget(this.result?.details, this.normalizedToolName);
 	}
 
 	private getCompactTarget(): string | undefined {
@@ -773,7 +759,7 @@ export class ToolExecutionComponent extends Container {
 		const metadataTarget = metadata ? formatToolTarget(metadata) : undefined;
 		if (metadataTarget) return metadataTarget;
 
-		const path = str(this.args?.file_path ?? this.args?.path);
+		const path = firstStringArg(this.args ?? {}, ["file_path", "path", "notebook_path"]);
 		if (path === null) return undefined;
 		if (this.normalizedToolName === "read" || this.normalizedToolName === "hashline_read") {
 			return formatArgsPathTarget(path, this.args);
@@ -782,16 +768,18 @@ export class ToolExecutionComponent extends Container {
 			return path ? shortenPath(path) : undefined;
 		}
 		if (this.normalizedToolName === "ls") {
-			return shortenPath(path || ".");
+			return path ? shortenPath(path) : undefined;
 		}
 		if (this.normalizedToolName === "find") {
 			const pattern = str(this.args?.pattern);
-			return pattern ? `${pattern} in ${shortenPath(path || ".")}` : shortenPath(path || ".");
+			if (pattern) return path ? `${pattern} in ${shortenPath(path)}` : pattern;
+			return path ? shortenPath(path) : undefined;
 		}
 		if (this.normalizedToolName === "grep") {
 			const pattern = str(this.args?.pattern);
 			const glob = str(this.args?.glob);
-			const label = pattern ? `${pattern} in ${shortenPath(path || ".")}` : shortenPath(path || ".");
+			const label = pattern ? (path ? `${pattern} in ${shortenPath(path)}` : pattern) : path ? shortenPath(path) : undefined;
+			if (!label) return glob || undefined;
 			return glob ? `${label} (${glob})` : label;
 		}
 		return undefined;
@@ -1410,23 +1398,14 @@ export class ToolExecutionComponent extends Container {
 			}
 		} else {
 			// Generic tool / MCP tool without a registered renderer.
-			// MCP tool names from Claude Code arrive as `mcp__<server>__<tool>`;
-			// render the server prefix in muted style so the tool name reads
-			// cleanly. GSD-registered MCP tools have already had their prefix
-			// stripped upstream in partial-builder.ts and won't reach this branch.
-			const parsed = parseMcpToolName(this.toolName);
-			const displayName = parsed
-				? parsed.tool
-				: prettifyToolName(this.toolName, this.toolDefinition?.label);
-			const serverPrefix = parsed ? theme.fg("muted", `${parsed.server}\u00b7`) : "";
-			text = serverPrefix + theme.fg("toolTitle", theme.bold(displayName));
-
+			// The frame header already contains the tool identity, so the body
+			// should show only arguments and output.
 			const argsText = formatCompactArgs(this.args, this.expanded);
 			if (argsText) {
 				if (argsText.includes("\n")) {
-					text += `\n\n${theme.fg("toolOutput", argsText)}`;
+					text = theme.fg("toolOutput", argsText);
 				} else {
-					text += " " + theme.fg("toolOutput", argsText);
+					text = theme.fg("toolOutput", argsText);
 				}
 			}
 
@@ -1437,7 +1416,8 @@ export class ToolExecutionComponent extends Container {
 					const maxLines = this.expanded ? lines.length : GENERIC_OUTPUT_PREVIEW_LINES;
 					const displayLines = lines.slice(0, maxLines);
 					const remaining = lines.length - maxLines;
-					text += `\n\n${displayLines.map((line: string) => theme.fg("toolOutput", line)).join("\n")}`;
+					const outputText = displayLines.map((line: string) => theme.fg("toolOutput", line)).join("\n");
+					text += `${text ? "\n\n" : ""}${outputText}`;
 					if (remaining > 0) {
 						text += `${theme.fg("muted", `\n... (${remaining} more lines,`)} ${keyHint("expandTools", "to expand")})`;
 					}

--- a/packages/pi-coding-agent/src/modes/interactive/components/transcript-design.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/transcript-design.ts
@@ -1,0 +1,196 @@
+// Project/App: GSD-2
+// File Purpose: Shared recommended transcript rendering primitives for assistant, tool, command, footer, and auto-mode TUI surfaces.
+
+import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+import { theme, type ThemeBg, type ThemeColor } from "../theme/theme.js";
+import { alignRight, padRight, roundedPanel } from "./tui-style-kit.js";
+
+export type StatusTone = "running" | "success" | "error" | "warning" | "muted";
+
+export function chatMessageWidth(width: number): number {
+	return Math.max(24, Math.min(width, Math.floor(width * 0.72)));
+}
+
+function trimOuterBlankLines(lines: string[]): string[] {
+	let start = 0;
+	let end = lines.length;
+	while (start < end && lines[start].trim().length === 0) start++;
+	while (end > start && lines[end - 1].trim().length === 0) end--;
+	return lines.slice(start, end);
+}
+
+function toneColor(tone: StatusTone): ThemeColor {
+	switch (tone) {
+		case "running": return "toolRunning";
+		case "success": return "border";
+		case "error": return "toolError";
+		case "warning": return "warning";
+		case "muted":
+		default: return "toolMuted";
+	}
+}
+
+export function rightAlign(left: string, right: string, width: number): string {
+	return alignRight(left, right, width);
+}
+
+export function renderAssistantRail(
+	lines: string[],
+	width: number,
+	opts: { label: string; meta?: string; railColor?: ThemeColor } = { label: "GSD" },
+): string[] {
+	const outerWidth = Math.max(20, width);
+	const indent = "  ";
+	const rail = theme.fg(opts.railColor ?? "borderAccent", "┃");
+	const blockWidth = Math.max(1, outerWidth - visibleWidth(indent));
+	const contentWidth = Math.max(1, blockWidth - 2);
+	const header = opts.meta
+		? `${theme.fg("borderAccent", theme.bold(opts.label))} ${theme.fg("dim", opts.meta)}`
+		: theme.fg("borderAccent", theme.bold(opts.label));
+	const source = lines.length > 0 ? lines : [""];
+	const row = (line: string) => `${indent}${theme.bg("customMessageBg", padRight(`${rail} ${line}`, blockWidth))}`;
+	return [
+		row(""),
+		row(truncateToWidth(header, contentWidth, "")),
+		...source.map((line) => row(truncateToWidth(line, contentWidth, ""))),
+		row(""),
+	];
+}
+
+export function renderUserRail(
+	lines: string[],
+	width: number,
+	opts: { label: string; meta?: string },
+): string[] {
+	const outerWidth = Math.max(20, width);
+	const maxMessageWidth = chatMessageWidth(outerWidth);
+	const rawBodyLines = trimOuterBlankLines(lines).length > 0 ? trimOuterBlankLines(lines) : [""];
+	const rail = theme.fg("border", "┃");
+	const contentWidth = Math.max(1, Math.min(maxMessageWidth, outerWidth - 2));
+	const header = opts.meta
+		? `${theme.fg("border", theme.bold(opts.label))} ${theme.fg("dim", opts.meta)}`
+		: theme.fg("border", theme.bold(opts.label));
+	const bodyLines = rawBodyLines.map((line) =>
+		theme.fg("userMessageText", truncateToWidth(line.trimEnd(), contentWidth, ""))
+	);
+	const row = (line: string) => theme.bg("userMessageBg", padRight(`${rail} ${line}`, outerWidth));
+	return [
+		row(""),
+		row(truncateToWidth(header, contentWidth, "")),
+		...bodyLines.map((line) => row(truncateToWidth(line, contentWidth, ""))),
+		row(""),
+	];
+}
+
+function cardRow(line: string, contentWidth: number, paddingX: number, border: (text: string) => string): string {
+	const padded = " ".repeat(paddingX) + padRight(line, contentWidth) + " ".repeat(paddingX);
+	return `${border("│")}${padded}${border("│")}`;
+}
+
+export function renderTranscriptCard(
+	lines: string[],
+	width: number,
+	opts: {
+		title: string;
+		right?: string;
+		tone: StatusTone;
+		footerLeft?: string;
+		footerRight?: string;
+	},
+): string[] {
+	const outerWidth = Math.max(20, width);
+	const innerWidth = Math.max(1, outerWidth - 2);
+	const paddingX = 2;
+	const contentWidth = Math.max(1, innerWidth - paddingX * 2);
+	const borderColor = toneColor(opts.tone);
+	const border = (text: string) => theme.fg(borderColor, text);
+	const title = theme.fg("borderAccent", opts.title);
+	const right = opts.right ? theme.fg(toneColor(opts.tone), opts.right) : "";
+	const header = rightAlign(title, right, contentWidth);
+	const body = lines.map((line) => padRight(line, contentWidth));
+	const footer =
+		opts.footerLeft || opts.footerRight
+			? [rightAlign(theme.fg("dim", opts.footerLeft ?? ""), theme.fg("dim", opts.footerRight ?? ""), contentWidth)]
+			: [];
+	return [
+		border("╭" + "─".repeat(outerWidth - 2) + "╮"),
+		cardRow(header, contentWidth, paddingX, border),
+		...body.map((line) => cardRow(line, contentWidth, paddingX, border)),
+		...footer.map((line) => cardRow(line, contentWidth, paddingX, border)),
+		border("╰" + "─".repeat(outerWidth - 2) + "╯"),
+	];
+}
+
+export function renderToolLineCard(
+	title: string,
+	target: string | undefined,
+	width: number,
+	opts: { status: string; tone: StatusTone; hidden?: boolean; titlePrefix?: string; bg?: ThemeBg },
+): string[] {
+	const outerWidth = Math.max(20, width);
+	const innerWidth = Math.max(1, outerWidth - 2);
+	const paddingX = 2;
+	const contentWidth = Math.max(1, innerWidth - paddingX * 2);
+	const borderColor = toneColor(opts.tone);
+	const border = (text: string) => theme.fg(borderColor, text);
+	const titleText = `${opts.titlePrefix ?? ""}${theme.fg("borderAccent", title)}`;
+	const targetText = target ? ` ${theme.fg("text", target)}` : "";
+	const left = `${titleText}${targetText}`;
+	const statusText = opts.hidden
+		? `${opts.status} · output hidden · ctrl+o expand`
+		: opts.status;
+	const right = theme.fg(opts.tone === "success" ? "success" : borderColor, statusText);
+	const line = rightAlign(left, right, contentWidth);
+	const row = cardRow(line, contentWidth, paddingX, border);
+	return [
+		border("╭" + "─".repeat(outerWidth - 2) + "╮"),
+		opts.bg ? theme.bg(opts.bg, row) : row,
+		border("╰" + "─".repeat(outerWidth - 2) + "╯"),
+	];
+}
+
+export function renderCommandCard(
+	command: string,
+	width: number,
+	opts: { status: string; tone: StatusTone; progress?: string },
+): string[] {
+	const outerWidth = Math.max(20, width);
+	const innerWidth = Math.max(1, outerWidth - 2);
+	const paddingX = 2;
+	const contentWidth = Math.max(1, innerWidth - paddingX * 2);
+	const borderColor = toneColor(opts.tone);
+	const left = `${theme.fg("accent", "$")} ${theme.fg("text", command)}`;
+	const statusText = opts.progress
+		? `${opts.progress} ${opts.status}`
+		: `${opts.status} · output hidden · ctrl+o expand`;
+	const right = theme.fg(opts.tone === "success" ? "success" : borderColor, statusText);
+	const line = rightAlign(left, right, contentWidth);
+	const border = (text: string) => theme.fg(borderColor, text);
+	return [
+		border("╭" + "─".repeat(outerWidth - 2) + "╮"),
+		cardRow(line, contentWidth, paddingX, border),
+		border("╰" + "─".repeat(outerWidth - 2) + "╯"),
+	];
+}
+
+export function renderProgressBar(done: number, total: number, width: number, tone: StatusTone = "success"): string {
+	const clampedWidth = Math.max(0, width);
+	const pct = total > 0 ? Math.max(0, Math.min(1, done / total)) : 0;
+	const filled = Math.round(pct * clampedWidth);
+	return (
+		theme.fg(toneColor(tone), "█".repeat(filled)) +
+		theme.fg("dim", "░".repeat(clampedWidth - filled))
+	);
+}
+
+export function renderFooterStrip(leftSegments: string[], right: string, width: number): string[] {
+	const outerWidth = Math.max(20, width);
+	const innerWidth = Math.max(1, outerWidth - 2);
+	const sep = theme.fg("dim", "  │  ");
+	const rightStyled = theme.fg("dim", right);
+	const rightWidth = visibleWidth(rightStyled);
+	const leftBudget = right ? Math.max(1, innerWidth - rightWidth - 3) : innerWidth;
+	const left = truncateToWidth(leftSegments.filter(Boolean).join(sep), leftBudget, "");
+	const content = rightAlign(left, rightStyled, innerWidth);
+	return roundedPanel([content], outerWidth);
+}

--- a/packages/pi-coding-agent/src/modes/interactive/components/tui-style-kit.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tui-style-kit.ts
@@ -56,15 +56,20 @@ export function roundedPanel(
 		paddingX?: number;
 	} = {},
 ): string[] {
-	const outerWidth = Math.max(20, width);
-	const innerWidth = Math.max(1, outerWidth - 2);
+	const outerWidth = Math.max(1, width);
 	const paddingX = Math.max(0, opts.paddingX ?? 0);
-	const contentWidth = Math.max(1, innerWidth - paddingX * 2);
 	const borderColor = toneColor(opts.tone ?? "default");
 	const border = (text: string) => theme.fg(borderColor, text);
 	const title = opts.title ? theme.fg("borderAccent", opts.title) : "";
 	const rightTitle = opts.rightTitle ? theme.fg("dim", opts.rightTitle) : "";
 	const body = lines.length > 0 ? lines : [""];
+
+	if (outerWidth < 3) {
+		return body.map((line) => truncateToWidth(line, outerWidth, ""));
+	}
+
+	const innerWidth = Math.max(1, outerWidth - 2);
+	const contentWidth = Math.max(1, innerWidth - paddingX * 2);
 
 	const renderedBody = body.map((line) => {
 		const padded = " ".repeat(paddingX) + padRight(line, contentWidth) + " ".repeat(paddingX);

--- a/packages/pi-coding-agent/src/modes/interactive/components/tui-style-kit.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tui-style-kit.ts
@@ -1,0 +1,89 @@
+// Project/App: GSD-2
+// File Purpose: Lip Gloss-inspired terminal layout primitives for GSD interactive TUI surfaces.
+
+import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+import { theme, type ThemeColor } from "../theme/theme.js";
+
+export type TuiTone = "default" | "accent" | "success" | "warning" | "error" | "muted";
+
+export type TuiBreakpoint = "compact" | "regular" | "wide";
+
+export function breakpoint(width: number): TuiBreakpoint {
+	if (width < 72) return "compact";
+	if (width < 112) return "regular";
+	return "wide";
+}
+
+export function padRight(text: string, width: number): string {
+	const clipped = truncateToWidth(text, Math.max(0, width), "");
+	return clipped + " ".repeat(Math.max(0, width - visibleWidth(clipped)));
+}
+
+export function alignRight(left: string, right: string, width: number): string {
+	if (width <= 0) return "";
+	if (!right) return truncateToWidth(left, width, "");
+	const gap = Math.max(1, width - visibleWidth(left) - visibleWidth(right));
+	return truncateToWidth(left + " ".repeat(gap) + right, width, "");
+}
+
+export function toneColor(tone: TuiTone): ThemeColor {
+	switch (tone) {
+		case "accent": return "borderAccent";
+		case "success": return "success";
+		case "warning": return "warning";
+		case "error": return "error";
+		case "muted": return "borderMuted";
+		case "default":
+		default: return "border";
+	}
+}
+
+export function badge(text: string, tone: TuiTone = "default"): string {
+	return theme.fg(toneColor(tone), text);
+}
+
+export function keyValue(label: string, value: string, valueColor: ThemeColor = "text", labelWidth = 10): string {
+	return `${theme.fg("dim", label.padEnd(labelWidth))}${theme.fg(valueColor, value)}`;
+}
+
+export function roundedPanel(
+	lines: string[],
+	width: number,
+	opts: {
+		tone?: TuiTone;
+		title?: string;
+		rightTitle?: string;
+		paddingX?: number;
+	} = {},
+): string[] {
+	const outerWidth = Math.max(20, width);
+	const innerWidth = Math.max(1, outerWidth - 2);
+	const paddingX = Math.max(0, opts.paddingX ?? 0);
+	const contentWidth = Math.max(1, innerWidth - paddingX * 2);
+	const borderColor = toneColor(opts.tone ?? "default");
+	const border = (text: string) => theme.fg(borderColor, text);
+	const title = opts.title ? theme.fg("borderAccent", opts.title) : "";
+	const rightTitle = opts.rightTitle ? theme.fg("dim", opts.rightTitle) : "";
+	const body = lines.length > 0 ? lines : [""];
+
+	const renderedBody = body.map((line) => {
+		const padded = " ".repeat(paddingX) + padRight(line, contentWidth) + " ".repeat(paddingX);
+		return `${border("│")}${padRight(padded, innerWidth)}${border("│")}`;
+	});
+
+	if (!title && !rightTitle) {
+		return [
+			border("╭" + "─".repeat(outerWidth - 2) + "╮"),
+			...renderedBody,
+			border("╰" + "─".repeat(outerWidth - 2) + "╯"),
+		];
+	}
+
+	const header = alignRight(title, rightTitle, innerWidth);
+	return [
+		border("╭" + "─".repeat(outerWidth - 2) + "╮"),
+		`${border("│")}${padRight(header, innerWidth)}${border("│")}`,
+		...renderedBody,
+		border("╰" + "─".repeat(outerWidth - 2) + "╯"),
+	];
+}

--- a/packages/pi-coding-agent/src/modes/interactive/components/user-message.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/user-message.ts
@@ -28,7 +28,10 @@ export class UserMessageComponent extends Container {
 		const messageWidth = chatMessageWidth(frameWidth);
 		const contentWidth = Math.max(1, messageWidth - 2);
 		const lines = super.render(contentWidth);
-		const meta = this.timestamp != null ? formatTimestamp(this.timestamp, this.timestampFormat) : undefined;
+		const meta =
+			this.timestamp !== undefined
+				? formatTimestamp(this.timestamp, this.timestampFormat)
+				: undefined;
 		const framed = renderUserRail(lines, frameWidth, {
 			label: "You",
 			meta,

--- a/packages/pi-coding-agent/src/modes/interactive/components/user-message.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/user-message.ts
@@ -28,7 +28,7 @@ export class UserMessageComponent extends Container {
 		const messageWidth = chatMessageWidth(frameWidth);
 		const contentWidth = Math.max(1, messageWidth - 2);
 		const lines = super.render(contentWidth);
-		const meta = this.timestamp ? formatTimestamp(this.timestamp, this.timestampFormat) : undefined;
+		const meta = this.timestamp != null ? formatTimestamp(this.timestamp, this.timestampFormat) : undefined;
 		const framed = renderUserRail(lines, frameWidth, {
 			label: "You",
 			meta,

--- a/packages/pi-coding-agent/src/modes/interactive/components/user-message.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/user-message.ts
@@ -1,13 +1,16 @@
+// Project/App: GSD-2
+// File Purpose: Left-edge user message rail renderer for interactive chat transcripts.
+
 import { Container, Markdown, type MarkdownTheme } from "@gsd/pi-tui";
 import { getMarkdownTheme } from "../theme/theme.js";
-import { type TimestampFormat } from "./timestamp.js";
-import { renderChatFrame } from "./chat-frame.js";
+import { formatTimestamp, type TimestampFormat } from "./timestamp.js";
+import { chatMessageWidth, renderUserRail } from "./transcript-design.js";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 
 /**
- * Component that renders a user message with a right-aligned timestamp.
+ * Component that renders a user message against the left edge of the chat transcript.
  */
 export class UserMessageComponent extends Container {
 	private timestamp: number | undefined;
@@ -22,14 +25,13 @@ export class UserMessageComponent extends Container {
 
 	override render(width: number): string[] {
 		const frameWidth = Math.max(20, width);
-		const contentWidth = Math.max(1, frameWidth - 4);
+		const messageWidth = chatMessageWidth(frameWidth);
+		const contentWidth = Math.max(1, messageWidth - 2);
 		const lines = super.render(contentWidth);
-		const framed = renderChatFrame(lines, frameWidth, {
+		const meta = this.timestamp ? formatTimestamp(this.timestamp, this.timestampFormat) : undefined;
+		const framed = renderUserRail(lines, frameWidth, {
 			label: "You",
-			tone: "user",
-			timestamp: this.timestamp,
-			timestampFormat: this.timestampFormat,
-			showTimestamp: true,
+			meta,
 		});
 		if (framed.length === 0) {
 			return framed;

--- a/packages/pi-coding-agent/src/modes/interactive/theme/theme-highlight.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/theme/theme-highlight.test.ts
@@ -1,0 +1,23 @@
+// Project/App: GSD-2
+// File Purpose: Tests for safe terminal syntax highlighting fallback.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import stripAnsi from "strip-ansi";
+
+import { highlightCode, initTheme } from "./theme.js";
+
+initTheme("dark", false);
+
+test("highlightCode applies lightweight syntax colors when native highlighting is disabled", () => {
+	const [line] = highlightCode("const answer = 42 // meaning", "typescript");
+
+	assert.ok(line.includes("\x1b["), "expected ANSI color output");
+	assert.equal(stripAnsi(line), "const answer = 42 // meaning");
+});
+
+test("highlightCode keeps plain text unstyled when no language is known", () => {
+	const [line] = highlightCode("const answer = 42");
+
+	assert.equal(line, "const answer = 42");
+});

--- a/packages/pi-coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/theme/theme.ts
@@ -939,6 +939,10 @@ function lightweightHighlightLine(line: string): string {
 			let j = i + 1;
 			while (j < line.length) {
 				if (line[j] === "\\") {
+					if (j + 1 >= line.length) {
+						j = line.length;
+						break;
+					}
 					j += 2;
 					continue;
 				}

--- a/packages/pi-coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/theme/theme.ts
@@ -878,13 +878,114 @@ function getHighlightColors(t: Theme): HighlightColors {
 	return cachedHighlightColors;
 }
 
+const LIGHTWEIGHT_KEYWORDS = new Set([
+	"as",
+	"async",
+	"await",
+	"break",
+	"case",
+	"catch",
+	"class",
+	"const",
+	"continue",
+	"default",
+	"def",
+	"else",
+	"enum",
+	"export",
+	"extends",
+	"false",
+	"fn",
+	"for",
+	"from",
+	"function",
+	"if",
+	"import",
+	"in",
+	"interface",
+	"let",
+	"match",
+	"new",
+	"null",
+	"return",
+	"struct",
+	"switch",
+	"throw",
+	"true",
+	"try",
+	"type",
+	"undefined",
+	"use",
+	"var",
+	"while",
+]);
+
+function lightweightHighlightLine(line: string): string {
+	let out = "";
+	let i = 0;
+	while (i < line.length) {
+		const ch = line[i];
+		const next = line[i + 1];
+		if (ch === "/" && next === "/") {
+			out += theme.fg("syntaxComment", line.slice(i));
+			break;
+		}
+		if (ch === "#") {
+			out += theme.fg("syntaxComment", line.slice(i));
+			break;
+		}
+		if (ch === '"' || ch === "'" || ch === "`") {
+			const quote = ch;
+			let j = i + 1;
+			while (j < line.length) {
+				if (line[j] === "\\") {
+					j += 2;
+					continue;
+				}
+				if (line[j] === quote) {
+					j++;
+					break;
+				}
+				j++;
+			}
+			out += theme.fg("syntaxString", line.slice(i, j));
+			i = j;
+			continue;
+		}
+		if (/[A-Za-z_$]/.test(ch ?? "")) {
+			let j = i + 1;
+			while (j < line.length && /[A-Za-z0-9_$]/.test(line[j] ?? "")) j++;
+			const word = line.slice(i, j);
+			out += LIGHTWEIGHT_KEYWORDS.has(word)
+				? theme.fg("syntaxKeyword", word)
+				: word;
+			i = j;
+			continue;
+		}
+		if (/\d/.test(ch ?? "")) {
+			let j = i + 1;
+			while (j < line.length && /[\d._]/.test(line[j] ?? "")) j++;
+			out += theme.fg("syntaxNumber", line.slice(i, j));
+			i = j;
+			continue;
+		}
+		out += ch;
+		i++;
+	}
+	return out;
+}
+
+function lightweightHighlightCode(code: string): string[] {
+	return code.split("\n").map(lightweightHighlightLine);
+}
+
 /**
  * Highlight code with syntax coloring based on file extension or language.
  * Returns array of highlighted lines.
  */
 export function highlightCode(code: string, lang?: string): string[] {
 	if (!NATIVE_TUI_HIGHLIGHT_ENABLED) {
-		return code.split("\n");
+		return lang ? lightweightHighlightCode(code) : code.split("\n");
 	}
 
 	const validLang = lang && supportsLanguage(lang) ? lang : null;

--- a/packages/pi-coding-agent/src/modes/interactive/theme/themes.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/theme/themes.ts
@@ -20,7 +20,7 @@ import type { ThemeJson } from "./theme-schema.js";
 const dark: ThemeJson = {
 	name: "dark",
 	vars: {
-		cyan: "#8db7ff",
+		cyan: "#7fd4e8",
 		blue: "#8db7ff",
 		green: "#a8c978",
 		red: "#d98484",

--- a/packages/pi-coding-agent/src/modes/interactive/theme/themes.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/theme/themes.ts
@@ -1,4 +1,5 @@
-// GSD2 TUI - Built-in terminal theme definitions.
+// Project/App: GSD-2
+// File Purpose: Built-in terminal theme definitions for interactive TUI rendering.
 /**
  * Built-in theme definitions.
  *
@@ -19,24 +20,24 @@ import type { ThemeJson } from "./theme-schema.js";
 const dark: ThemeJson = {
 	name: "dark",
 	vars: {
-		cyan: "#5cc8c8",
-		blue: "#79b8ff",
-		green: "#7ad38b",
-		red: "#f27b7b",
-		yellow: "#d6b85f",
-		gray: "#87949b",
-		dimGray: "#657178",
-		darkGray: "#303a40",
-		line: "#52616a",
-		lineSoft: "#303a40",
-		textSoft: "#cbd6dc",
-		accent: "#5cc8c8",
-		selectedBg: "#1d282a",
-		userMsgBg: "#202a2f",
-		toolPendingBg: "#252721",
-		toolSuccessBg: "#1c251f",
-		toolErrorBg: "#251e20",
-		customMsgBg: "#202a2f",
+		cyan: "#8db7ff",
+		blue: "#8db7ff",
+		green: "#a8c978",
+		red: "#d98484",
+		yellow: "#e6c06a",
+		gray: "#7d889f",
+		dimGray: "#4d5870",
+		darkGray: "#4e596d",
+		line: "#a7ba78",
+		lineSoft: "#4e596d",
+		textSoft: "#dce4f2",
+		accent: "#8db7ff",
+		selectedBg: "#1d2430",
+		userMsgBg: "#232c3a",
+		toolPendingBg: "#171c26",
+		toolSuccessBg: "#171c26",
+		toolErrorBg: "#241b22",
+		customMsgBg: "#171c26",
 	},
 	colors: {
 		accent: "accent",
@@ -61,11 +62,11 @@ const dark: ThemeJson = {
 		toolPendingBg: "toolPendingBg",
 		toolSuccessBg: "toolSuccessBg",
 		toolErrorBg: "toolErrorBg",
-		toolTitle: "gray",
+		toolTitle: "accent",
 		toolOutput: "textSoft",
 		surfaceTitle: "accent",
 		surfaceAccent: "accent",
-		toolRunning: "yellow",
+		toolRunning: "accent",
 		toolSuccess: "green",
 		toolError: "red",
 
@@ -74,7 +75,7 @@ const dark: ThemeJson = {
 		mdLinkUrl: "dimGray",
 		mdCode: "accent",
 		mdCodeBlock: "green",
-		mdCodeBlockBorder: "gray",
+		mdCodeBlockBorder: "lineSoft",
 		mdQuote: "gray",
 		mdQuoteBorder: "gray",
 		mdHr: "gray",
@@ -101,12 +102,12 @@ const dark: ThemeJson = {
 		thinkingHigh: "#c084fc",
 		thinkingXhigh: "#f472b6",
 
-		bashMode: "green",
+		bashMode: "line",
 	},
 	export: {
-		pageBg: "#111416",
-		cardBg: "#1e2529",
-		infoBg: "#252721",
+		pageBg: "#10141d",
+		cardBg: "#171c26",
+		infoBg: "#1d2430",
 	},
 };
 

--- a/packages/pi-coding-agent/src/modes/interactive/tui-mode.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/tui-mode.test.ts
@@ -1,4 +1,5 @@
-// GSD2 - Tests for adaptive TUI mode selection
+// Project/App: GSD-2
+// File Purpose: Tests for adaptive TUI mode selection and command-center layout rendering.
 
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
@@ -45,7 +46,7 @@ describe("resolveTuiMode", () => {
 });
 
 describe("AdaptiveLayoutComponent", () => {
-	test("renders workflow layout with prototype rule frames", () => {
+	test("renders workflow layout as rounded command center without stale labels", () => {
 		const layout = new AdaptiveLayoutComponent(() => ({
 			override: "workflow",
 			activeToolCount: 2,
@@ -56,10 +57,12 @@ describe("AdaptiveLayoutComponent", () => {
 
 		const plain = layout.render(120).map(stripAnsi);
 
-		assert.match(plain[0], /^─+/, "workflow layout should start with a rule frame");
+		assert.match(plain[0], /^╭─+╮$/, "workflow layout should start with a rounded frame");
 		assert.ok(plain.some((line) => line.includes("GSD Command Center")), "workflow title should render");
-		assert.ok(plain.some((line) => line.includes("signals")), "inspector title should render");
-		assert.ok(plain.some((line) => line.includes("│ Active")), "body rows should keep prototype gutter");
-		assert.ok(!plain.some((line) => /[╭╮╰╯]/.test(line)), "workflow layout should not use rounded box corners");
+		assert.ok(plain.some((line) => line.includes("Status")), "status row should render");
+		assert.ok(plain.some((line) => line.includes("Tools")), "tools row should render");
+		assert.ok(!plain.some((line) => line.includes("signals")), "old signals title should not render");
+		assert.ok(!plain.some((line) => line.includes("inspector")), "old inspector title should not render");
+		assert.ok(!plain.some((line) => /\bAUTO\b/.test(line)), "command center should not imply GSD auto-mode");
 	});
 });

--- a/packages/pi-tui/src/__tests__/overlay-layout.test.ts
+++ b/packages/pi-tui/src/__tests__/overlay-layout.test.ts
@@ -126,7 +126,7 @@ function stripAnsi(line: string): string {
 	// Remove CSI sequences. Good enough for these tests.
 	return line
 		.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
-		.replace(/\x1b\][^\x07]*\x07/g, "");
+		.replace(/\x1b\][\s\S]*?(?:\x07|\x1b\\)/g, "");
 }
 
 describe("compositeOverlays — backdrop", () => {

--- a/packages/pi-tui/src/__tests__/overlay-layout.test.ts
+++ b/packages/pi-tui/src/__tests__/overlay-layout.test.ts
@@ -124,10 +124,29 @@ function applySgr(state: SgrState, paramString: string): void {
 
 function stripAnsi(line: string): string {
 	// Remove CSI sequences. Good enough for these tests.
-	return line.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+	return line
+		.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
+		.replace(/\x1b\][^\x07]*\x07/g, "");
 }
 
 describe("compositeOverlays — backdrop", () => {
+	it("positions overlays against the visible terminal when base content is short", () => {
+		const base = ["footer-like content"];
+		const overlay = makeEntry(["TOP"], {
+			width: 3,
+			anchor: "top-left",
+		});
+
+		const result = compositeOverlays(base, [overlay], 20, 10, 1);
+
+		assert.equal(result.length, 10);
+		assert.ok(stripAnsi(result[0]).startsWith("TOP"), "top overlay should render on terminal row 0");
+		assert.ok(
+			stripAnsi(result.at(-1) ?? "").includes("footer-like content"),
+			"short base content remains bottom-anchored",
+		);
+	});
+
 	it("dims base lines outside the overlay when backdrop is true", () => {
 		const base = ["hello world", "second line"];
 		const overlay = makeEntry(["OVERLAY"], {

--- a/packages/pi-tui/src/overlay-layout.ts
+++ b/packages/pi-tui/src/overlay-layout.ts
@@ -313,13 +313,16 @@ export function compositeOverlays(
 		minLinesNeeded = Math.max(minLinesNeeded, row + overlayLines.length);
 	}
 
-	// Ensure result covers the terminal working area to keep overlay positioning stable across resizes.
-	// maxLinesRendered can exceed current content length after a shrink; pad to keep viewportStart consistent.
-	const workingHeight = Math.max(maxLinesRendered, minLinesNeeded);
+	// Ensure overlays are positioned against the visible terminal grid, not a
+	// short bottom-anchored render buffer. Without the terminal-height floor, a
+	// sparse app screen pushes "top" overlays down with the rest of the content.
+	const workingHeight = Math.max(termHeight, maxLinesRendered, minLinesNeeded);
 
-	// Extend result with empty lines if content is too short for overlay placement or working area
-	while (result.length < workingHeight) {
-		result.push("");
+	// Extend upward when content is shorter than the working area. This keeps
+	// the app's normal content bottom-anchored while giving overlays a full
+	// viewport-sized coordinate system.
+	if (result.length < workingHeight) {
+		result.unshift(...Array.from({ length: workingHeight - result.length }, () => ""));
 	}
 
 	const viewportStart = Math.max(0, workingHeight - termHeight);

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -1097,17 +1097,23 @@ export function setAutoOutcomeWidget(
       const icon = snapshot.status === "complete" ? "✓"
         : snapshot.status === "failed" ? "x"
           : snapshot.status === "blocked" ? "!"
-            : snapshot.status === "paused" ? "Ⅱ"
+            : snapshot.status === "paused" ? "||"
               : "●";
       const innerWidth = Math.max(8, width - 4);
+      const maxLines = 7;
       const lines: string[] = [];
       const elapsed = snapshot.startedAt ? formatAutoElapsed(snapshot.startedAt) : "";
       const heading = `${theme.fg(color, icon)} ${theme.fg("accent", theme.bold("GSD"))} ${theme.fg("text", snapshot.title)}`;
       lines.push(rightAlign(heading, elapsed ? theme.fg("dim", elapsed) : "", innerWidth));
+      const commands = snapshot.commands?.filter(Boolean) ?? [];
+      const commandLine = commands.length > 0 ? theme.fg("dim", commands.join("  ·  ")) : null;
 
       const addWrapped = (text: string, prefix = ""): void => {
+        const reserve = commandLine ? 1 : 0;
+        const remaining = Math.max(0, maxLines - reserve - lines.length);
+        if (remaining === 0) return;
         const available = Math.max(8, innerWidth - visibleWidth(prefix));
-        for (const [idx, line] of wrapVisibleText(text, available).entries()) {
+        for (const [idx, line] of wrapVisibleText(text, available).slice(0, remaining).entries()) {
           lines.push(`${idx === 0 ? prefix : " ".repeat(visibleWidth(prefix))}${line}`);
         }
       };
@@ -1120,12 +1126,11 @@ export function setAutoOutcomeWidget(
       }
       addWrapped(snapshot.nextAction, `${theme.fg("success", "Next")}   `);
 
-      const commands = snapshot.commands?.filter(Boolean) ?? [];
-      if (commands.length > 0) {
-        lines.push(theme.fg("dim", commands.join("  ·  ")));
+      if (commandLine && lines.length < maxLines) {
+        lines.push(commandLine);
       }
 
-      return renderFrame(theme, lines.slice(0, 7), width, { borderColor: color, paddingX: 1 });
+      return renderFrame(theme, lines, width, { borderColor: color, paddingX: 1 });
     },
     invalidate(): void {},
     dispose(): void {},

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -11,14 +11,12 @@
 import type {
   ExtensionContext,
   ExtensionCommandContext,
-  SessionMessageEntry,
   ReadonlyFooterDataProvider,
   Theme,
 } from "@gsd/pi-coding-agent";
 import type { GSDState } from "./types.js";
-import { getCurrentBranch } from "./worktree.js";
 import { getActiveHook } from "./post-unit-hooks.js";
-import { getLedger, getProjectTotals } from "./metrics.js";
+import { getLedger } from "./metrics.js";
 import { getErrorMessage } from "./error-utils.js";
 import { nativeIsRepo } from "./native-git-bridge.js";
 import {
@@ -31,23 +29,19 @@ import { execFileSync } from "node:child_process";
 import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 import { makeUI } from "../shared/tui.js";
 import { GLYPH, INDENT } from "../shared/mod.js";
+import { padRightVisible, renderFrame, renderProgressBar, rightAlign, wrapVisibleText } from "./tui/render-kit.js";
 import { computeProgressScore } from "./progress-score.js";
-import { getActiveWorktreeName } from "./worktree-command.js";
 import {
   getGlobalGSDPreferencesPath,
   getProjectGSDPreferencesPath,
   parsePreferencesMarkdown,
 } from "./preferences.js";
-import { resolveServiceTierIcon, getEffectiveServiceTier } from "./service-tier.js";
 import { parseUnitId } from "./unit-id.js";
 import {
-  formatRtkSavingsLabel,
-  getRtkSessionSavings,
   type RtkSessionSavings,
 } from "../shared/rtk-session-stats.js";
 import { logWarning } from "./workflow-logger.js";
 import { formattedShortcutPair } from "./shortcut-defs.js";
-import { homedir } from "node:os";
 import { readUnitRuntimeRecord, type AutoUnitRuntimeRecord } from "./unit-runtime.js";
 
 // ─── UAT Slice Extraction ─────────────────────────────────────────────────────
@@ -114,6 +108,16 @@ export interface CompletionDashboardSnapshot {
   totalSlices?: number | null;
   allMilestonesComplete?: boolean;
   basePath?: string | null;
+}
+
+export interface AutoOutcomeSurfaceSnapshot {
+  status: "paused" | "stopped" | "blocked" | "failed" | "complete" | "waiting" | "step";
+  title: string;
+  detail?: string | null;
+  unitLabel?: string | null;
+  nextAction: string;
+  commands?: string[];
+  startedAt?: number;
 }
 
 // ─── Unit Description Helpers ─────────────────────────────────────────────────
@@ -627,6 +631,7 @@ export function updateProgressWidget(
   tierBadge?: string,
 ): void {
   if (!ctx.hasUI) return;
+  ctx.ui.setWidget("gsd-outcome", undefined);
 
   // Welcome header is a startup-only banner — permanently suppress it once
   // auto-mode activates. The dashboard widget owns all status from here.
@@ -661,53 +666,11 @@ export function updateProgressWidget(
     updateSliceProgressCache(accessors.getBasePath(), mid.id, slice?.id);
   }
 
-  // Cache git branch at widget creation time (not per render)
-  let cachedBranch: string | null = null;
-  try { cachedBranch = getCurrentBranch(accessors.getBasePath()); } catch (err) { /* not in git repo */
-    logWarning("dashboard", `git branch detection failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
-
-  // Cache short pwd (last 2 path segments only) + worktree/branch info
-  let widgetPwd: string;
-  {
-    let fullPwd = process.cwd();
-    const widgetHome = homedir();
-    if (widgetHome && (fullPwd === widgetHome || fullPwd.startsWith(widgetHome + "/") || fullPwd.startsWith(widgetHome + "\\"))) {
-      fullPwd = `~${fullPwd.slice(widgetHome.length)}`;
-    }
-    const parts = fullPwd.split("/");
-    widgetPwd = parts.length > 2 ? parts.slice(-2).join("/") : fullPwd;
-  }
-  const worktreeName = getActiveWorktreeName();
-  if (worktreeName && cachedBranch) {
-    widgetPwd = `${widgetPwd} (\u2387 ${cachedBranch})`;
-  } else if (cachedBranch) {
-    widgetPwd = `${widgetPwd} (${cachedBranch})`;
-  }
-
-  // Pre-fetch last commit for display
-  refreshLastCommit(accessors.getBasePath());
-
-  // Cache the effective service tier at widget creation time (reads preferences)
-  const effectiveServiceTier = getEffectiveServiceTier();
-
   ctx.ui.setWidget("gsd-progress", (tui, theme) => {
     let pulseBright = true;
     let cachedLines: string[] | undefined;
     let cachedWidth: number | undefined;
-    let cachedRtkLabel: string | null | undefined;
     let cachedRuntimeRecord: AutoUnitRuntimeRecord | null = null;
-
-    const refreshRtkLabel = (): void => {
-      try {
-        const sessionId = ctx.sessionManager.getSessionId();
-        const savings = sessionId ? getRtkSessionSavings(accessors.getBasePath(), sessionId) : null;
-        cachedRtkLabel = formatRtkSavingsLabel(savings);
-      } catch (err) {
-        logWarning("dashboard", `RTK savings lookup failed: ${err instanceof Error ? (err as Error).message : String(err)}`);
-        cachedRtkLabel = null;
-      }
-    };
 
     const refreshRuntimeRecord = (): void => {
       try {
@@ -717,7 +680,6 @@ export function updateProgressWidget(
       }
     };
 
-    refreshRtkLabel();
     refreshRuntimeRecord();
 
     const pulseTimer = setInterval(() => {
@@ -735,7 +697,6 @@ export function updateProgressWidget(
         if (mid) {
           updateSliceProgressCache(accessors.getBasePath(), mid.id, slice?.id);
         }
-        refreshRtkLabel();
         refreshRuntimeRecord();
         cachedLines = undefined;
       } catch (err) { /* non-fatal */
@@ -809,46 +770,6 @@ export function updateProgressWidget(
           }
         }
 
-        // ── Gather stats (needed by multiple modes) ─────────────────────
-        const cmdCtx = accessors.getCmdCtx();
-        let totalInput = 0;
-        let totalCacheRead = 0;
-        if (cmdCtx) {
-          for (const entry of cmdCtx.sessionManager.getEntries()) {
-            if (entry.type === "message") {
-              const msgEntry = entry as SessionMessageEntry;
-              if (msgEntry.message?.role === "assistant") {
-                const u = (msgEntry.message as any).usage;
-                if (u) {
-                  totalInput += u.input || 0;
-                  totalCacheRead += u.cacheRead || 0;
-                }
-              }
-            }
-          }
-        }
-        const mLedger = getLedger();
-        const autoTotals = mLedger ? getProjectTotals(mLedger.units) : null;
-        const cumulativeCost = autoTotals?.cost ?? 0;
-        const cxUsage = cmdCtx?.getContextUsage?.();
-        const cxWindow = cxUsage?.contextWindow ?? cmdCtx?.model?.contextWindow ?? 0;
-        const cxPctVal = cxUsage?.percent ?? 0;
-        const cxPct = cxUsage?.percent !== null ? cxPctVal.toFixed(1) : "?";
-
-        // Model display — prefer dispatched model ID (set after selectAndApplyModel
-        // + hook overrides) over cmdCtx?.model which can be stale (#2899).
-        const dispatchedModelId = accessors.getCurrentDispatchedModelId();
-        const modelId = dispatchedModelId
-          ? dispatchedModelId.split("/").slice(1).join("/") || dispatchedModelId
-          : (cmdCtx?.model?.id ?? "");
-        const modelProvider = dispatchedModelId
-          ? dispatchedModelId.split("/")[0] || ""
-          : (cmdCtx?.model?.provider ?? "");
-        const tierIcon = resolveServiceTierIcon(effectiveServiceTier, modelId);
-        const modelDisplay = (modelProvider && modelId
-          ? `${modelProvider}/${modelId}`
-          : modelId) + (tierIcon ? ` ${tierIcon}` : "");
-
         // ── Mode: off — return empty ──────────────────────────────────
         if (widgetMode === "off") {
           cachedLines = [];
@@ -864,7 +785,7 @@ export function updateProgressWidget(
           return lines;
         }
 
-        // ── Mode: small — header + progress bar + compact stats ───────
+        // ── Mode: small — header + active work progress ───────────────
         if (widgetMode === "small") {
           lines.push("");
 
@@ -878,27 +799,13 @@ export function updateProgressWidget(
           if (shouldRenderRoadmapProgress(roadmapSlices)) {
             const { done, total, activeSliceTasks } = roadmapSlices;
             const barWidth = Math.max(6, Math.min(18, Math.floor(width * 0.25)));
-            const pct = total > 0 ? done / total : 0;
-            const filled = Math.round(pct * barWidth);
-            const bar = theme.fg("success", "━".repeat(filled))
-              + theme.fg("dim", "─".repeat(barWidth - filled));
+            const bar = renderProgressBar(theme, done, total, barWidth);
             let meta = `${theme.fg("text", `${done}`)}${theme.fg("dim", `/${total} slices`)}`;
             if (activeSliceTasks && activeSliceTasks.total > 0) {
               const tn = Math.min(activeSliceTasks.done + 1, activeSliceTasks.total);
               meta += `${theme.fg("dim", " · task ")}${theme.fg("accent", `${tn}`)}${theme.fg("dim", `/${activeSliceTasks.total}`)}`;
             }
             lines.push(`${pad}${bar} ${meta}`);
-          }
-
-          // Compact stats: cost + context only
-          const smallStats: string[] = [];
-          if (cumulativeCost) smallStats.push(theme.fg("warning", `$${cumulativeCost.toFixed(2)}`));
-          const cxDisplay = `${cxPct}%ctx`;
-          if (cxPctVal > 90) smallStats.push(theme.fg("error", cxDisplay));
-          else if (cxPctVal > 70) smallStats.push(theme.fg("warning", cxDisplay));
-          else smallStats.push(theme.fg("dim", cxDisplay));
-          if (smallStats.length > 0) {
-            lines.push(rightAlign("", smallStats.join(theme.fg("dim", "  ")), width));
           }
 
           lines.push(...ui.bar());
@@ -910,11 +817,10 @@ export function updateProgressWidget(
         // ── Mode: full — complete two-column layout ───────────────────
         lines.push("");
 
-        // Context section: milestone + slice + model
+        // Context section: milestone + slice. Footer owns model/cost/context.
         const hasContext = !!(mid || (slice && unitType !== "research-milestone" && unitType !== "plan-milestone"));
         if (mid) {
-          const modelTag = modelDisplay ? theme.fg("muted", `  ${modelDisplay}`) : "";
-          lines.push(truncateToWidth(`${pad}${theme.fg("dim", mid.title)}${modelTag}`, width, "…"));
+          lines.push(truncateToWidth(`${pad}${theme.fg("dim", mid.title)}`, width, "…"));
         }
         if (slice && unitType !== "research-milestone" && unitType !== "plan-milestone") {
           lines.push(truncateToWidth(
@@ -946,10 +852,7 @@ export function updateProgressWidget(
         if (shouldRenderRoadmapProgress(roadmapSlices)) {
           const { done, total, activeSliceTasks } = roadmapSlices;
           const barWidth = Math.max(6, Math.min(18, Math.floor(leftColWidth * 0.4)));
-          const pct = total > 0 ? done / total : 0;
-          const filled = Math.round(pct * barWidth);
-          const bar = theme.fg("success", "━".repeat(filled))
-            + theme.fg("dim", "─".repeat(barWidth - filled));
+          const bar = renderProgressBar(theme, done, total, barWidth);
 
           let meta = `${theme.fg("text", `${done}`)}${theme.fg("dim", `/${total} slices`)}`;
           if (activeSliceTasks && activeSliceTasks.total > 0) {
@@ -1010,7 +913,7 @@ export function updateProgressWidget(
           if (maxRows > 0) {
             lines.push("");
             for (let i = 0; i < maxRows; i++) {
-              const left = padToWidth(truncateToWidth(leftLines[i] ?? "", leftColWidth, "…"), leftColWidth);
+              const left = padRightVisible(truncateToWidth(leftLines[i] ?? "", leftColWidth, "…"), leftColWidth);
               const right = rightLines[i] ?? "";
               lines.push(`${left}${right}`);
             }
@@ -1022,53 +925,8 @@ export function updateProgressWidget(
           }
         }
 
-        // ── Footer: simplified stats + pwd + last commit + hints ────────
+        // ── Auto controls. Footer owns cwd/branch/model/cost/context. ───
         lines.push("");
-        {
-          const sp: string[] = [];
-          if (totalCacheRead + totalInput > 0) {
-            const hitRate = Math.round((totalCacheRead / (totalCacheRead + totalInput)) * 100);
-            const hitColor = hitRate >= 70 ? "success" : hitRate >= 40 ? "warning" : "error";
-            sp.push(theme.fg(hitColor, `${hitRate}%hit`));
-          }
-          if (cumulativeCost) sp.push(theme.fg("warning", `$${cumulativeCost.toFixed(2)}`));
-
-          const CX_BAR_WIDTH = 8;
-          const cxBarFilled = Math.min(
-            CX_BAR_WIDTH,
-            Math.max(0, Math.round((cxPctVal / 100) * CX_BAR_WIDTH)),
-          );
-          const cxBarColor: "error" | "warning" | "success" =
-            cxPctVal > 90 ? "error" : cxPctVal > 70 ? "warning" : "success";
-          const cxBar =
-            theme.fg(cxBarColor, "━".repeat(cxBarFilled)) +
-            theme.fg("dim", "─".repeat(CX_BAR_WIDTH - cxBarFilled));
-          const cxPctText = `${cxPct}%/${formatWidgetTokens(cxWindow)}`;
-          const cxColorized =
-            cxPctVal > 90
-              ? theme.fg("error", cxPctText)
-              : cxPctVal > 70
-                ? theme.fg("warning", cxPctText)
-                : cxPctText;
-          sp.push(`${cxBar} ${cxColorized}`);
-
-          const statsLine = sp.map(p => p.includes("\x1b[") ? p : theme.fg("dim", p))
-            .join(theme.fg("dim", "  "));
-          if (statsLine) {
-            lines.push(rightAlign("", statsLine, width));
-          }
-          if (cachedRtkLabel) {
-            lines.push(rightAlign("", theme.fg("dim", cachedRtkLabel), width));
-          }
-        }
-        // Last commit info
-        const lastCommit = getLastCommit(accessors.getBasePath());
-        const maxCommitLen = 65;
-        const commitMsg = lastCommit
-          ? lastCommit.message.length > maxCommitLen
-            ? lastCommit.message.slice(0, maxCommitLen - 1) + "…"
-            : lastCommit.message
-          : "";
         // Step-mode guidance — shown above keyboard hints when auto is paused
         if (accessors.isStepMode()) {
           lines.push(`${pad}${theme.fg("accent", "→")} ${theme.fg("dim", "Ctrl+N to advance to next step  ·  /gsd status for overview")}`);
@@ -1080,15 +938,7 @@ export function updateProgressWidget(
         hintParts.push(`${formattedShortcutPair("dashboard")} dashboard`);
         hintParts.push(`${formattedShortcutPair("parallel")} parallel`);
         const hintStr = theme.fg("dim", hintParts.join(" | "));
-        const commitStr = lastCommit
-          ? theme.fg("dim", `${lastCommit.timeAgo} ago: ${commitMsg}`)
-          : "";
-        const locationStr = theme.fg("dim", widgetPwd);
-        if (commitStr) {
-          lines.push(rightAlign(`${pad}${locationStr} · ${commitStr}`, hintStr, width));
-        } else {
-          lines.push(rightAlign(`${pad}${locationStr}`, hintStr, width));
-        }
+        lines.push(rightAlign("", hintStr, width));
 
         lines.push(...ui.bar());
 
@@ -1113,6 +963,7 @@ export function setCompletionProgressWidget(
   snapshot: CompletionDashboardSnapshot,
 ): void {
   if (!ctx.hasUI) return;
+  ctx.ui.setWidget("gsd-outcome", undefined);
 
   if (typeof ctx.ui?.setHeader === "function") {
     ctx.ui.setHeader(() => ({
@@ -1208,12 +1059,73 @@ export function setCompletionProgressWidget(
         add(`${theme.fg("accent", "Run totals")} ${stats.join(theme.fg("dim", " · "))}`);
       }
 
+      lines.push("");
+      const nextAction = snapshot.allMilestonesComplete
+        ? "Review the roll-up, then start a new milestone when ready."
+        : "Review the roll-up, inspect status, or continue to the next milestone.";
+      const commands = snapshot.allMilestonesComplete
+        ? ["/gsd status for overview", "/gsd visualize to inspect", "/gsd notifications for history", "/gsd start for new work"]
+        : ["/gsd status for overview", "/gsd visualize to inspect", "/gsd notifications for history", "/gsd auto for next milestone"];
+      add(`${theme.fg("success", "Next")} ${theme.fg("text", nextAction)}`);
+      add(theme.fg("dim", commands.join("  ·  ")));
+
       const location = snapshot.basePath ? theme.fg("dim", snapshot.basePath) : "";
       const reason = theme.fg("dim", snapshot.reason);
       lines.push(rightAlign(`${pad}${truncateToWidth(location, Math.max(0, width - 32), "…")}`, reason, width));
       lines.push(...ui.bar());
 
       return lines;
+    },
+    invalidate(): void {},
+    dispose(): void {},
+  }));
+}
+
+export function setAutoOutcomeWidget(
+  ctx: ExtensionContext,
+  snapshot: AutoOutcomeSurfaceSnapshot,
+): void {
+  if (!ctx.hasUI) return;
+
+  ctx.ui.setWidget("gsd-outcome", (_tui, theme) => ({
+    render(width: number): string[] {
+      const color = snapshot.status === "failed" || snapshot.status === "blocked"
+        ? "warning"
+        : snapshot.status === "complete"
+          ? "success"
+          : "borderAccent";
+      const icon = snapshot.status === "complete" ? "✓"
+        : snapshot.status === "failed" ? "x"
+          : snapshot.status === "blocked" ? "!"
+            : snapshot.status === "paused" ? "Ⅱ"
+              : "●";
+      const innerWidth = Math.max(8, width - 4);
+      const lines: string[] = [];
+      const elapsed = snapshot.startedAt ? formatAutoElapsed(snapshot.startedAt) : "";
+      const heading = `${theme.fg(color, icon)} ${theme.fg("accent", theme.bold("GSD"))} ${theme.fg("text", snapshot.title)}`;
+      lines.push(rightAlign(heading, elapsed ? theme.fg("dim", elapsed) : "", innerWidth));
+
+      const addWrapped = (text: string, prefix = ""): void => {
+        const available = Math.max(8, innerWidth - visibleWidth(prefix));
+        for (const [idx, line] of wrapVisibleText(text, available).entries()) {
+          lines.push(`${idx === 0 ? prefix : " ".repeat(visibleWidth(prefix))}${line}`);
+        }
+      };
+
+      if (snapshot.detail) {
+        addWrapped(snapshot.detail, `${theme.fg("dim", "Reason")} `);
+      }
+      if (snapshot.unitLabel) {
+        addWrapped(snapshot.unitLabel, `${theme.fg("dim", "Last")}   `);
+      }
+      addWrapped(snapshot.nextAction, `${theme.fg("success", "Next")}   `);
+
+      const commands = snapshot.commands?.filter(Boolean) ?? [];
+      if (commands.length > 0) {
+        lines.push(theme.fg("dim", commands.join("  ·  ")));
+      }
+
+      return renderFrame(theme, lines.slice(0, 7), width, { borderColor: color, paddingX: 1 });
     },
     invalidate(): void {},
     dispose(): void {},
@@ -1227,21 +1139,4 @@ function normalizeRollupText(value: string | null | undefined): string | null {
     .trim();
   if (!clean || clean === "(none)" || clean === "None." || clean === "Not provided.") return null;
   return clean;
-}
-
-// ─── Right-align Helper ───────────────────────────────────────────────────────
-
-/** Right-align helper: build a line with left content and right content. */
-function rightAlign(left: string, right: string, width: number): string {
-  const leftVis = visibleWidth(left);
-  const rightVis = visibleWidth(right);
-  const gap = Math.max(1, width - leftVis - rightVis);
-  return truncateToWidth(left + " ".repeat(gap) + right, width, "…");
-}
-
-/** Pad a string with trailing spaces to fill exactly `colWidth` (ANSI-aware). */
-function padToWidth(s: string, colWidth: number): string {
-  const vis = visibleWidth(s);
-  if (vis >= colWidth) return truncateToWidth(s, colWidth, "…");
-  return s + " ".repeat(colWidth - vis);
 }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -943,12 +943,13 @@ function setLifecycleOutcome(
     detail?: string | null;
     nextAction: string;
     commands?: string[];
+    unitLabel?: string | null;
   },
 ): void {
   if (!ctx?.hasUI) return;
   setAutoOutcomeWidget(ctx, {
     ...input,
-    unitLabel: currentUnitLabel(),
+    unitLabel: input.unitLabel ?? currentUnitLabel(),
     startedAt: s.autoStartTime,
   });
 }
@@ -1682,6 +1683,8 @@ export async function pauseAuto(
     logWarning("engine", `paused-session DB write failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
   }
 
+  const pausedUnitLabel = currentUnitLabel();
+
   // Close out the current unit so its runtime record doesn't stay at "dispatched"
   if (s.currentUnit && ctx) {
     try {
@@ -1739,6 +1742,7 @@ export async function pauseAuto(
     detail: _errorContext?.message ?? "Paused by user request.",
     nextAction: `Type to steer, or run ${resumeCmd} to resume.`,
     commands: [resumeCmd, "/gsd status for overview", "/gsd notifications for history"],
+    unitLabel: pausedUnitLabel,
   });
   if (ctx) initHealthWidget(ctx);
   ctx?.ui.notify(

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -947,9 +947,10 @@ function setLifecycleOutcome(
   },
 ): void {
   if (!ctx?.hasUI) return;
+  const { unitLabel: unitLabelOverride, ...rest } = input;
   setAutoOutcomeWidget(ctx, {
-    ...input,
-    unitLabel: input.unitLabel ?? currentUnitLabel(),
+    ...rest,
+    unitLabel: unitLabelOverride !== undefined ? unitLabelOverride : currentUnitLabel(),
     startedAt: s.autoStartTime,
   });
 }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -190,6 +190,7 @@ import {
   type AutoDashboardData,
   updateProgressWidget as _updateProgressWidget,
   setCompletionProgressWidget,
+  setAutoOutcomeWidget,
   updateSliceProgressCache,
   clearSliceProgressCache,
   describeNextUnit as _describeNextUnit,
@@ -665,6 +666,10 @@ export function isAutoActive(): boolean {
   return s.active;
 }
 
+export function isAutoCompletionStopInProgress(): boolean {
+  return s.completionStopInProgress;
+}
+
 /** Test-only seam for validating auto-mode guards (#4704). Do not use in production code. */
 export function _setAutoActiveForTest(active: boolean): void {
   s.active = active;
@@ -925,6 +930,29 @@ function buildSnapshotOpts(
   };
 }
 
+function currentUnitLabel(): string | null {
+  if (!s.currentUnit) return null;
+  return `${unitVerb(s.currentUnit.type)} ${s.currentUnit.id}`;
+}
+
+function setLifecycleOutcome(
+  ctx: ExtensionContext | undefined,
+  input: {
+    status: "paused" | "stopped" | "blocked" | "failed" | "complete" | "waiting" | "step";
+    title: string;
+    detail?: string | null;
+    nextAction: string;
+    commands?: string[];
+  },
+): void {
+  if (!ctx?.hasUI) return;
+  setAutoOutcomeWidget(ctx, {
+    ...input,
+    unitLabel: currentUnitLabel(),
+    startedAt: s.autoStartTime,
+  });
+}
+
 function handleLostSessionLock(
   ctx?: ExtensionContext,
   lockStatus?: SessionLockStatus,
@@ -1012,7 +1040,9 @@ export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void>
   // visible so the user still has a resumable auto-mode signal on screen.
   if (!s.paused) {
     ctx.ui.setStatus("gsd-auto", undefined);
-    ctx.ui.setWidget("gsd-progress", undefined);
+    if (s.completionStopInProgress) {
+      s.completionStopInProgress = false;
+    }
     initHealthWidget(ctx);
   }
 
@@ -1131,6 +1161,7 @@ export async function stopAuto(
   const loadedPreferences = loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences;
   const reasonSuffix = reason ? ` — ${reason}` : "";
   const preserveCompletionSurface = Boolean(options.completionWidget);
+  s.completionStopInProgress = preserveCompletionSurface;
 
   // #4764 — telemetry: record the exit reason, isolation mode, whether an auto
   // worktree was active, and whether the current milestone was merged before
@@ -1383,14 +1414,21 @@ export async function stopAuto(
     // ── Step 8: Ledger notification ──
     try {
       const ledger = getLedger();
+      const isAllComplete = reason === "All milestones complete";
+      const isMilestoneComplete = /^Milestone\s+\S+\s+complete$/i.test(reason ?? "");
+      const notificationPrefix = isAllComplete
+        ? "All milestones complete"
+        : isMilestoneComplete
+          ? `${reason}. Auto-mode finished this milestone`
+          : `Auto-mode stopped${reasonSuffix}`;
       if (ledger && ledger.units.length > 0) {
         const totals = getProjectTotals(ledger.units);
         ctx?.ui.notify(
-          `Auto-mode stopped${reasonSuffix}. Session: ${formatCost(totals.cost)} · ${formatTokenCount(totals.tokens.total)} tokens · ${ledger.units.length} units`,
+          `${notificationPrefix}. Session: ${formatCost(totals.cost)} · ${formatTokenCount(totals.tokens.total)} tokens · ${ledger.units.length} units`,
           "info",
         );
       } else {
-        ctx?.ui.notify(`Auto-mode stopped${reasonSuffix}.`, "info");
+        ctx?.ui.notify(`${notificationPrefix}.`, "info");
       }
     } catch (e) {
       debugLog("stop-cleanup-ledger", { error: e instanceof Error ? e.message : String(e) });
@@ -1542,6 +1580,16 @@ export async function stopAuto(
     ctx?.ui.setStatus("gsd-auto", undefined);
     if (!preserveCompletionSurface) {
       ctx?.ui.setWidget("gsd-progress", undefined);
+      const status = reason?.startsWith("Blocked:") ? "blocked" : reason?.toLowerCase().includes("fail") ? "failed" : "stopped";
+      setLifecycleOutcome(ctx, {
+        status,
+        title: status === "blocked" ? "Auto-mode blocked" : status === "failed" ? "Auto-mode stopped with an issue" : "Auto-mode stopped",
+        detail: reason ?? "Auto-mode stopped.",
+        nextAction: status === "blocked"
+          ? "Fix the blocker, then run /gsd auto to resume."
+          : "Run /gsd status for the current project state, or /gsd auto to continue.",
+        commands: ["/gsd status for overview", "/gsd auto to run", "/gsd visualize to inspect", "/gsd notifications for history"],
+      });
       if (ctx) initHealthWidget(ctx);
     }
     restoreProjectRootEnv();
@@ -1560,7 +1608,7 @@ export async function stopAuto(
     }
 
     // Reset all session state in one call
-    s.reset();
+    s.resetAfterStop({ preserveCompletionSurface });
   }
 }
 
@@ -1684,8 +1732,15 @@ export async function pauseAuto(
   s.verificationRetryCount.clear();
   ctx?.ui.setStatus("gsd-auto", "paused");
   ctx?.ui.setWidget("gsd-progress", undefined);
-  if (ctx) initHealthWidget(ctx);
   const resumeCmd = s.stepMode ? "/gsd next" : "/gsd auto";
+  setLifecycleOutcome(ctx, {
+    status: "paused",
+    title: `${s.stepMode ? "Step" : "Auto"}-mode paused`,
+    detail: _errorContext?.message ?? "Paused by user request.",
+    nextAction: `Type to steer, or run ${resumeCmd} to resume.`,
+    commands: [resumeCmd, "/gsd status for overview", "/gsd notifications for history"],
+  });
+  if (ctx) initHealthWidget(ctx);
   ctx?.ui.notify(
     `${s.stepMode ? "Step" : "Auto"}-mode paused (Escape). Type to interact, or ${resumeCmd} to resume.`,
     "info",

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -377,9 +377,7 @@ export class AutoSession {
   }
 
   resetAfterStop(options: { preserveCompletionSurface?: boolean } = {}): void {
-    const completionStopInProgress = options.preserveCompletionSurface
-      ? this.completionStopInProgress
-      : false;
+    const completionStopInProgress = options.preserveCompletionSurface ? this.completionStopInProgress : false;
     this.reset();
     this.completionStopInProgress = completionStopInProgress;
   }

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -88,6 +88,7 @@ export class AutoSession {
   // ── Lifecycle ────────────────────────────────────────────────────────────
   active = false;
   paused = false;
+  completionStopInProgress = false;
   stepMode = false;
   verbose = false;
   activeEngineId: string | null = null;
@@ -287,6 +288,7 @@ export class AutoSession {
     // Lifecycle
     this.active = false;
     this.paused = false;
+    this.completionStopInProgress = false;
     this.stepMode = false;
     this.verbose = false;
     this.activeEngineId = null;
@@ -372,6 +374,14 @@ export class AutoSession {
     this.orchestration = null;
 
     // Loop promise state lives in auto-loop.ts module scope
+  }
+
+  resetAfterStop(options: { preserveCompletionSurface?: boolean } = {}): void {
+    const completionStopInProgress = options.preserveCompletionSurface
+      ? this.completionStopInProgress
+      : false;
+    this.reset();
+    this.completionStopInProgress = completionStopInProgress;
   }
 
   toJSON(): Record<string, unknown> {

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -339,6 +339,11 @@ export async function handleAgentEnd(
     // errorMessage looks uninformative.
     const rawErrorMsg = ("errorMessage" in lastMsg && lastMsg.errorMessage) ? String(lastMsg.errorMessage) : "";
     if (isUserInitiatedAbortMessage(rawErrorMsg)) {
+      if (isAutoCompletionStopInProgress()) {
+        resetRetryState(retryState);
+        resolveAgentEnd(event);
+        return;
+      }
       resolveAgentEndCancelled({
         message: rawErrorMsg,
         category: "aborted",

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -12,7 +12,14 @@ import {
   resetEmptyTurnCounter,
 } from "../guided-flow.js";
 import { clearPathCache } from "../paths.js";
-import { getAutoDashboardData, getAutoModeStartModel, isAutoActive, pauseAuto, setCurrentDispatchedModelId } from "../auto.js";
+import {
+  getAutoDashboardData,
+  getAutoModeStartModel,
+  isAutoActive,
+  isAutoCompletionStopInProgress,
+  pauseAuto,
+  setCurrentDispatchedModelId,
+} from "../auto.js";
 import { getNextFallbackModel, resolveModelWithFallbacksForUnit } from "../preferences.js";
 import { pauseAutoForProviderError } from "../provider-error-pause.js";
 import {
@@ -295,6 +302,12 @@ export async function handleAgentEnd(
   }
 
   if (isObjectRecord(lastMsg) && "stopReason" in lastMsg && lastMsg.stopReason === "aborted") {
+    if (isAutoCompletionStopInProgress()) {
+      resetRetryState(retryState);
+      resolveAgentEnd(event);
+      return;
+    }
+
     // Empty content with aborted stopReason is a non-fatal agent stop (the LLM
     // chose to end without producing output). Only pause on genuine fatal aborts
     // that carry error context — e.g. errorMessage field or non-empty content

--- a/src/resources/extensions/gsd/bootstrap/register-shortcuts.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-shortcuts.ts
@@ -1,3 +1,6 @@
+// Project/App: GSD-2
+// File Purpose: Registers GSD keyboard shortcuts for dashboard, notifications, and parallel overlays.
+
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
@@ -39,18 +42,12 @@ export function registerShortcuts(pi: ExtensionAPI): void {
   };
 
   const openNotificationsOverlay = async (ctx: ExtensionContext) => {
-    const { GSDNotificationOverlay } = await import("../notification-overlay.js");
+    const { GSDNotificationOverlay, notificationOverlayOptions } = await import("../notification-overlay.js");
     await ctx.ui.custom<boolean>(
       (tui, theme, _kb, done) => new GSDNotificationOverlay(tui, theme, () => done(true)),
       {
         overlay: true,
-        overlayOptions: {
-          width: "80%",
-          minWidth: 60,
-          maxHeight: "88%",
-          anchor: "center",
-          backdrop: true,
-        },
+        overlayOptions: notificationOverlayOptions(),
       },
     );
   };

--- a/src/resources/extensions/gsd/commands/handlers/notifications-handler.ts
+++ b/src/resources/extensions/gsd/commands/handlers/notifications-handler.ts
@@ -1,5 +1,5 @@
-// GSD Extension — /gsd notifications Command Handler
-// View, filter, and clear the persistent notification history.
+// Project/App: GSD-2
+// File Purpose: Handles /gsd notifications commands and opens the notification history overlay.
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
@@ -11,7 +11,7 @@ import {
   unsuppressPersistence,
   type NotifySeverity,
 } from "../../notification-store.js";
-import { GSDNotificationOverlay } from "../../notification-overlay.js";
+import { GSDNotificationOverlay, notificationOverlayOptions } from "../../notification-overlay.js";
 
 const MAX_INLINE_ENTRIES = 40;
 
@@ -108,13 +108,7 @@ export async function handleNotificationsCommand(
           (tui, theme, _kb, done) => new GSDNotificationOverlay(tui, theme, () => done(true)),
           {
             overlay: true,
-            overlayOptions: {
-              width: "80%",
-              minWidth: 60,
-              maxHeight: "88%",
-              anchor: "center",
-              backdrop: true,
-            },
+            overlayOptions: notificationOverlayOptions(),
           },
         );
         if (result !== undefined) {

--- a/src/resources/extensions/gsd/health-widget-core.ts
+++ b/src/resources/extensions/gsd/health-widget-core.ts
@@ -70,7 +70,7 @@ export function buildHealthLines(data: HealthWidgetData, width?: number): string
   }
 
   if (data.projectState === "initialized") {
-    return ["  GSD  Project initialized — run /gsd to continue setup"];
+    return ["  GSD  Project Initialized"];
   }
 
   const leftParts: string[] = [];

--- a/src/resources/extensions/gsd/health-widget.ts
+++ b/src/resources/extensions/gsd/health-widget.ts
@@ -1,12 +1,5 @@
-/**
- * GSD Health Widget — always-on ambient health signal rendered belowEditor.
- *
- * Shows a compact 1-2 line summary: progress score, budget, provider key
- * status, and doctor/environment issue count. Refreshes every 60 seconds.
- * Quiet when everything is healthy; turns amber/red when issues arise.
- *
- * Widget key: "gsd-health", placement: "belowEditor"
- */
+// Project/App: GSD-2
+// File Purpose: Always-on ambient health signal rendered below the editor.
 
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 import type { GSDState } from "./types.js";
@@ -23,6 +16,9 @@ import {
   detectHealthWidgetProjectState,
   type HealthWidgetData,
 } from "./health-widget-core.js";
+
+export const HEALTH_WIDGET_ACTIVE_HINTS =
+  "  /gsd auto to run  ·  /gsd status for overview  ·  /gsd visualize to inspect  ·  /gsd notifications for history  ·  /gsd help";
 
 // ── Data loader ────────────────────────────────────────────────────────────────
 
@@ -136,7 +132,7 @@ export function initHealthWidget(ctx: ExtensionContext): void {
         if (!cachedLines || cachedWidth !== width) {
           cachedLines = buildHealthLines(data, width);
           if (data.projectState === "active") {
-            cachedLines = [...cachedLines, _theme.fg("dim", "  /gsd auto to run  ·  /gsd status for overview  ·  /gsd help")];
+            cachedLines = [...cachedLines, _theme.fg("dim", HEALTH_WIDGET_ACTIVE_HINTS)];
           }
           cachedWidth = width;
         }

--- a/src/resources/extensions/gsd/notification-overlay.ts
+++ b/src/resources/extensions/gsd/notification-overlay.ts
@@ -1,9 +1,8 @@
-// GSD Extension — Notification History Overlay
-// Scrollable panel showing all persisted notifications with severity filtering.
-// Toggled with Ctrl+Alt+N (⌃⌥N on macOS), Ctrl+Shift+N fallback, or /gsd notifications.
+// Project/App: GSD-2
+// File Purpose: Notification history overlay with severity filtering and width-safe TUI rendering.
 
 import type { Theme } from "@gsd/pi-coding-agent";
-import { truncateToWidth, visibleWidth, wrapTextWithAnsi, matchesKey, Key } from "@gsd/pi-tui";
+import { truncateToWidth, visibleWidth, matchesKey, Key } from "@gsd/pi-tui";
 
 import {
   readNotifications,
@@ -14,10 +13,32 @@ import {
   type NotifySeverity,
 } from "./notification-store.js";
 import { formattedShortcutPair } from "./shortcut-defs.js";
-import { padRight, joinColumns } from "../shared/mod.js";
+import {
+  padRightVisible,
+  renderFrame,
+  renderKeyHints,
+  rightAlign,
+  wrapVisibleText,
+} from "./tui/render-kit.js";
 
-type FilterMode = "all" | "error" | "warning" | "info";
-const FILTER_CYCLE: FilterMode[] = ["all", "error", "warning", "info"];
+type FilterMode = "all" | "error" | "warning" | "success" | "info";
+const FILTER_CYCLE: FilterMode[] = ["all", "error", "warning", "success", "info"];
+const OVERLAY_WIDTH = "58%";
+const OVERLAY_MIN_WIDTH = 68;
+const OVERLAY_MAX_HEIGHT_PERCENT = 52;
+const OVERLAY_MARGIN = { top: 2, right: 2, bottom: 6, left: 2 } as const;
+
+export function notificationOverlayOptions() {
+  return {
+    width: OVERLAY_WIDTH,
+    minWidth: OVERLAY_MIN_WIDTH,
+    maxHeight: `${OVERLAY_MAX_HEIGHT_PERCENT}%`,
+    anchor: "top-center",
+    row: "24%",
+    margin: OVERLAY_MARGIN,
+    backdrop: true,
+  } as const;
+}
 
 function severityIcon(severity: NotifySeverity): string {
   switch (severity) {
@@ -27,17 +48,6 @@ function severityIcon(severity: NotifySeverity): string {
     case "info":
     default: return "●";
   }
-}
-
-/** Column-aware word wrap using pi-tui's native wrapper (handles unicode/ANSI). */
-function wrapText(text: string, maxWidth: number): string[] {
-  if (maxWidth <= 0) return [text];
-  const lines = wrapTextWithAnsi(text, maxWidth);
-  // Safety clamp: if any line still exceeds maxWidth (e.g. unbreakable long token),
-  // truncate it with an ellipsis so it cannot bleed past the box border.
-  return lines.map((l) =>
-    visibleWidth(l) > maxWidth ? truncateToWidth(l, maxWidth, "…") : l,
-  );
 }
 
 function formatTimestamp(ts: string): string {
@@ -184,13 +194,19 @@ export class GSDNotificationOverlay {
     }
 
     const content = this.buildContentLines(width);
-    const maxVisibleRows = Math.max(5, process.stdout.rows ? process.stdout.rows - 8 : 24) - 2;
+    const terminalRows = process.stdout.rows || 32;
+    const availableRows = Math.max(1, terminalRows - OVERLAY_MARGIN.top - OVERLAY_MARGIN.bottom);
+    const overlayRows = Math.min(
+      availableRows,
+      Math.max(1, Math.floor((terminalRows * OVERLAY_MAX_HEIGHT_PERCENT) / 100)),
+    );
+    const maxVisibleRows = Math.max(5, overlayRows - 2);
     const visibleContentRows = Math.min(content.length, maxVisibleRows);
     const maxScroll = Math.max(0, content.length - visibleContentRows);
     this.scrollOffset = Math.min(this.scrollOffset, maxScroll);
     const visibleContent = content.slice(this.scrollOffset, this.scrollOffset + visibleContentRows);
 
-    const lines = this.wrapInBox(visibleContent, width);
+    const lines = renderFrame(this.theme, visibleContent, width);
 
     this.cachedWidth = width;
     this.cachedLines = lines;
@@ -227,33 +243,15 @@ export class GSDNotificationOverlay {
     }
   }
 
-  private wrapInBox(inner: string[], width: number): string[] {
-    const th = this.theme;
-    const border = (s: string) => th.fg("borderAccent", s);
-    const innerWidth = width - 4;
-    const lines: string[] = [];
-
-    lines.push(border("╭" + "─".repeat(width - 2) + "╮"));
-    for (const line of inner) {
-      const truncated = truncateToWidth(line, innerWidth);
-      const padWidth = Math.max(0, innerWidth - visibleWidth(truncated));
-      lines.push(border("│") + " " + truncated + " ".repeat(padWidth) + " " + border("│"));
-    }
-    lines.push(border("╰" + "─".repeat(width - 2) + "╯"));
-    return lines;
-  }
-
   private buildContentLines(width: number): string[] {
     const th = this.theme;
-    const shellWidth = width - 4;
-    const contentWidth = Math.min(shellWidth, 128);
-    const sidePad = Math.max(0, Math.floor((shellWidth - contentWidth) / 2));
-    const leftMargin = " ".repeat(sidePad);
+    const shellWidth = Math.max(1, width - 4);
+    const contentWidth = shellWidth;
     const lines: string[] = [];
 
     const row = (content = ""): string => {
       const truncated = truncateToWidth(content, contentWidth);
-      return leftMargin + padRight(truncated, contentWidth);
+      return padRightVisible(truncated, contentWidth);
     };
     const blank = () => row("");
     const hr = () => row(th.fg("dim", "─".repeat(contentWidth)));
@@ -262,9 +260,15 @@ export class GSDNotificationOverlay {
     const title = th.fg("accent", th.bold("Notifications"));
     const filterLabel = this.filter === "all"
       ? th.fg("dim", "all")
-      : th.fg(this.filter === "error" ? "error" : this.filter === "warning" ? "warning" : "dim", this.filter);
+      : th.fg(
+        this.filter === "error" ? "error"
+          : this.filter === "warning" ? "warning"
+            : this.filter === "success" ? "success"
+              : "dim",
+        this.filter,
+      );
     const count = `${this.filteredEntries.length} entries`;
-    lines.push(row(joinColumns(
+    lines.push(row(rightAlign(
       `${title}  ${th.fg("dim", "filter:")} ${filterLabel}`,
       th.fg("dim", count),
       contentWidth,
@@ -273,7 +277,7 @@ export class GSDNotificationOverlay {
 
     // Controls
     const closeShortcut = formattedShortcutPair("notifications");
-    lines.push(row(th.fg("dim", `↑/↓ scroll  f filter  c clear  Esc close  (${closeShortcut})`)));
+    lines.push(row(renderKeyHints(th, ["↑/↓ scroll", "f filter", "c clear", `Esc/${closeShortcut} close`], contentWidth)));
     lines.push(blank());
 
     // Entries
@@ -302,7 +306,7 @@ export class GSDNotificationOverlay {
       const msgMaxWidth = Math.max(10, contentWidth - prefixWidth);
 
       // Wrap long messages onto continuation lines indented to align with message start
-      const msgLines = wrapText(entry.message, msgMaxWidth);
+      const msgLines = wrapVisibleText(entry.message, msgMaxWidth);
       const indent = " ".repeat(prefixWidth);
       for (let i = 0; i < msgLines.length; i++) {
         if (i === 0) {

--- a/src/resources/extensions/gsd/parallel-monitor-overlay.ts
+++ b/src/resources/extensions/gsd/parallel-monitor-overlay.ts
@@ -1,23 +1,23 @@
-/**
- * GSD Parallel Monitor Overlay
- *
- * Full-screen TUI overlay showing real-time parallel worker progress.
- * Opened via `/gsd parallel watch`, Ctrl+Alt+P (⌃⌥P on macOS),
- * or Ctrl+Shift+P fallback.
- * Reads the same data sources as `scripts/parallel-monitor.mjs` but
- * renders as a native pi-tui overlay with theme integration.
- */
+// Project/App: GSD-2
+// File Purpose: Parallel worker monitor overlay with width-safe operations-console rendering.
 
 import { existsSync, statSync, readFileSync, openSync, readSync, closeSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
 import type { Theme } from "@gsd/pi-coding-agent";
-import { truncateToWidth, visibleWidth, matchesKey, Key } from "@gsd/pi-tui";
+import { matchesKey, Key } from "@gsd/pi-tui";
 
-import { formatDuration, STATUS_GLYPH, STATUS_COLOR } from "../shared/mod.js";
+import { formatDuration } from "../shared/mod.js";
 import { formattedShortcutPair } from "./shortcut-defs.js";
 import { resolveGsdPathContract } from "./paths.js";
+import {
+  renderBar,
+  renderKeyHints,
+  renderProgressBar,
+  safeLine,
+  statusGlyph,
+} from "./tui/render-kit.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -277,17 +277,6 @@ function unitTypeLabel(unitType: string | null): string {
   return labels[unitType || ""] || (unitType || "---").toUpperCase().slice(0, 5);
 }
 
-function progressBar(done: number, total: number, width: number): string {
-  if (total === 0) return "░".repeat(width);
-  const filled = Math.round((done / total) * width);
-  return "█".repeat(filled) + "░".repeat(width - filled);
-}
-
-function healthGlyph(alive: boolean, heartbeatAge: number): string {
-  if (!alive) return "○";
-  return "●";
-}
-
 // ─── Overlay Class ────────────────────────────────────────────────────────
 
 export class ParallelMonitorOverlay {
@@ -299,6 +288,7 @@ export class ParallelMonitorOverlay {
   private workers: WorkerView[] = [];
   private events: string[] = [];
   private cachedLines?: string[];
+  private cachedWidth?: number;
   private scrollOffset = 0;
   private disposed = false;
   private resizeHandler: (() => void) | null = null;
@@ -339,6 +329,7 @@ export class ParallelMonitorOverlay {
     this.events = this.events.slice(-10);
 
     this.cachedLines = undefined;
+    this.cachedWidth = undefined;
     this.tui.requestRender();
   }
 
@@ -378,14 +369,15 @@ export class ParallelMonitorOverlay {
 
   invalidate(): void {
     this.cachedLines = undefined;
+    this.cachedWidth = undefined;
   }
 
   render(width: number): string[] {
-    if (this.cachedLines) return this.cachedLines;
+    if (this.cachedLines && this.cachedWidth === width) return this.cachedLines;
 
     const t = this.theme;
     const lines: string[] = [];
-    const w = Math.max(width, 60);
+    const w = Math.max(1, width);
 
     // Header
     const totalCost = this.workers.reduce((s, wk) => s + wk.cost, 0);
@@ -398,7 +390,7 @@ export class ParallelMonitorOverlay {
       t.bold(`$${totalCost.toFixed(2)}`) +
       t.fg("muted", "  │  5s refresh"),
     );
-    lines.push(t.fg("muted", "─".repeat(w)));
+    lines.push(renderBar(t, w));
 
     if (this.workers.length === 0) {
       lines.push("");
@@ -410,7 +402,7 @@ export class ParallelMonitorOverlay {
 
         // Health + ID + state
         const healthColor = wk.alive ? "success" : "error";
-        const glyph = healthGlyph(wk.alive, wk.heartbeatAge);
+        const glyph = statusGlyph(t, wk.alive ? "active" : "idle");
         const stateText = wk.alive
           ? t.fg("success", "RUNNING")
           : t.fg("error", t.bold("DEAD"));
@@ -452,25 +444,29 @@ export class ParallelMonitorOverlay {
           lines.push(`     ${t.fg("muted", "slices")}  ${chips.join("  ")}`);
 
           // Task progress bar
-          const bar = progressBar(wk.doneTasks, wk.totalTasks, 25);
+          const barWidth = Math.max(6, Math.min(25, w - 32));
+          const bar = renderProgressBar(t, wk.doneTasks, wk.totalTasks, barWidth, {
+            filledChar: "█",
+            emptyChar: "░",
+            emptyColor: "dim",
+          });
           const pct = wk.totalTasks > 0 ? Math.round((wk.doneTasks / wk.totalTasks) * 100) : 0;
           lines.push(
-            `     ${t.fg("muted", "tasks")}   ${t.fg("success", bar)}  ${wk.doneTasks}/${wk.totalTasks} ` +
+            `     ${t.fg("muted", "tasks")}   ${bar}  ${wk.doneTasks}/${wk.totalTasks} ` +
             t.fg("muted", `(${pct}%)  │  slices done ${wk.doneSlices}/${wk.totalSlices}`),
           );
         }
 
         // Errors
         for (const err of wk.errors.slice(-2)) {
-          const truncated = err.length > w - 10 ? err.slice(0, w - 11) + "…" : err;
-          lines.push(`     ${t.fg("error", "⚠ " + truncated)}`);
+          lines.push(`     ${t.fg("error", "! " + err)}`);
         }
       }
     }
 
     // Event feed
     lines.push("");
-    lines.push(t.fg("muted", "─".repeat(w)));
+    lines.push(renderBar(t, w));
     lines.push(`  ${t.bold("Recent Events")}`);
 
     if (this.events.length === 0) {
@@ -478,8 +474,7 @@ export class ParallelMonitorOverlay {
     } else {
       for (const evt of this.events.slice(-8)) {
         const mid = evt.match(/^✓ (M\d+)\//)?.[1] || "";
-        const truncated = evt.length > w - 10 ? evt.slice(0, w - 11) + "…" : evt;
-        lines.push(`  ${t.fg("muted", "│")} ${t.fg("accent", mid)} ${truncated.replace(/^✓ M\d+\//, "")}`);
+        lines.push(`  ${t.fg("muted", "│")} ${t.fg("accent", mid)} ${evt.replace(/^✓ M\d+\//, "")}`);
       }
     }
 
@@ -496,14 +491,17 @@ export class ParallelMonitorOverlay {
       }
       lines.push(`  ${t.bold("Total: $" + this.workers.reduce((s, wk) => s + wk.cost, 0).toFixed(2))}`);
     }
-    lines.push(t.fg("muted", `  ESC/q/${formattedShortcutPair("parallel")} close  │  ↑↓ scroll`));
+    lines.push(renderKeyHints(t, [`ESC/q/${formattedShortcutPair("parallel")} close`, "↑↓ scroll"], w));
 
     // Apply scroll — use terminal rows as height estimate
     const termHeight = process.stdout.rows || 40;
     const maxScroll = Math.max(0, lines.length - termHeight);
     this.scrollOffset = Math.min(Math.max(this.scrollOffset, 0), maxScroll);
-    const visible = lines.slice(this.scrollOffset, this.scrollOffset + termHeight);
+    const visible = lines
+      .slice(this.scrollOffset, this.scrollOffset + termHeight)
+      .map((line) => safeLine(line, w));
     this.cachedLines = visible;
+    this.cachedWidth = width;
     return visible;
   }
 }

--- a/src/resources/extensions/gsd/prompts/discuss-headless.md
+++ b/src/resources/extensions/gsd/prompts/discuss-headless.md
@@ -129,7 +129,16 @@ If ANY box is unchecked, **STOP**. Do NOT emit the ready phrase. Emit the missin
 
 Do not announce the ready phrase as something you are "about to" do. The ready phrase is a post-write signal, not an intent signal.
 
-After completing steps 1–7 above, say exactly: "Milestone {{milestoneId}} ready." — nothing else. Auto-mode will start automatically.
+After completing steps 1–7 above, end with this concise user-facing handoff:
+
+```
+Milestone {{milestoneId}} ready.
+
+Next steps:
+- Run `/gsd auto` to start execution if it does not begin automatically.
+- Use `/gsd status` or `/gsd visualize` to inspect the roadmap.
+- Use `/gsd notifications` to review or configure delivery alerts.
+```
 
 ### Multi-Milestone
 
@@ -215,7 +224,16 @@ If ANY box is unchecked, **STOP**. Do NOT emit the ready phrase. Emit the missin
 
 Do not announce the ready phrase as something you are "about to" do. The ready phrase is a post-write signal, not an intent signal.
 
-After completing every step above, say exactly: "Milestone {{milestoneId}} ready." — nothing else. Auto-mode will start automatically.
+After completing every step above, end with this concise user-facing handoff:
+
+```
+Milestone {{milestoneId}} ready.
+
+Next steps:
+- Run `/gsd auto` to start execution if it does not begin automatically.
+- Use `/gsd status` or `/gsd visualize` to inspect the roadmap.
+- Use `/gsd notifications` to review or configure delivery alerts.
+```
 
 ## Critical Rules
 

--- a/src/resources/extensions/gsd/prompts/discuss.md
+++ b/src/resources/extensions/gsd/prompts/discuss.md
@@ -252,7 +252,16 @@ If ANY box is unchecked, **STOP**. Do NOT emit the ready phrase. Emit the missin
 
 Do not announce the ready phrase as something you are "about to" do. It is a post-write signal, not intent.
 
-After completing steps 1–7 above, say exactly: "Milestone {{milestoneId}} ready." — nothing else. Auto-mode will start automatically.
+After completing steps 1–7 above, end with this concise user-facing handoff:
+
+```
+Milestone {{milestoneId}} ready.
+
+Next steps:
+- Run `/gsd auto` to start execution if it does not begin automatically.
+- Use `/gsd status` or `/gsd visualize` to inspect the roadmap.
+- Use `/gsd notifications` to review or configure delivery alerts.
+```
 
 ### Multi-Milestone
 
@@ -345,6 +354,15 @@ If ANY box is unchecked, **STOP**. Do NOT emit the ready phrase. Emit the missin
 
 Do not announce the ready phrase as something you are "about to" do. It is a post-write signal, not intent.
 
-After completing all phases above, say exactly: "Milestone M001 ready." — nothing else. Auto-mode will start automatically.
+After completing all phases above, end with this concise user-facing handoff:
+
+```
+Milestone M001 ready.
+
+Next steps:
+- Run `/gsd auto` to start execution if it does not begin automatically.
+- Use `/gsd status` or `/gsd visualize` to inspect the roadmap.
+- Use `/gsd notifications` to review or configure delivery alerts.
+```
 
 {{inlinedTemplates}}

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -14,6 +14,7 @@ import {
   estimateTimeRemaining,
   extractUatSliceId,
   updateProgressWidget,
+  setAutoOutcomeWidget,
   getRoadmapSlicesSync,
   clearSliceProgressCache,
   getWidgetMode,
@@ -220,6 +221,40 @@ test("formatRuntimeHealthSignal surfaces idle recovery instead of generic progre
   });
 });
 
+test("setAutoOutcomeWidget renders a durable next-action handoff", () => {
+  let widgetFactory: any;
+  setAutoOutcomeWidget(
+    {
+      hasUI: true,
+      ui: {
+        setWidget(key: string, factory: any) {
+          if (key === "gsd-outcome") widgetFactory = factory;
+        },
+      },
+    } as any,
+    {
+      status: "paused",
+      title: "Auto-mode paused",
+      detail: "Paused by user request.",
+      unitLabel: "researching M005/S01",
+      nextAction: "Type to steer, or run /gsd auto to resume.",
+      commands: ["/gsd auto", "/gsd status for overview"],
+      startedAt: Date.now() - 2_000,
+    },
+  );
+
+  assert.equal(typeof widgetFactory, "function");
+  const component = widgetFactory(
+    { requestRender() {} },
+    { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+  );
+  const output = component.render(100).join("\n");
+  assert.match(output, /Auto-mode paused/);
+  assert.match(output, /Paused by user request/);
+  assert.match(output, /researching M005\/S01/);
+  assert.match(output, /\/gsd auto/);
+});
+
 test("shouldRenderRoadmapProgress hides pre-roadmap zero-slice progress", () => {
   assert.equal(shouldRenderRoadmapProgress(null), false);
   assert.equal(shouldRenderRoadmapProgress({ done: 0, total: 0, activeSliceTasks: null } as any), false);
@@ -342,6 +377,70 @@ test("updateProgressWidget refreshes slice progress cache immediately", (t) => {
     total: 3,
     activeSliceTasks: { done: 1, total: 1 },
   });
+});
+
+test("updateProgressWidget full mode keeps footer-owned signals out of auto deck", (t) => {
+  const dir = makeTempDir("command-deck");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  let widget: { render(width: number): string[]; dispose?: () => void } | null = null;
+
+  t.after(() => {
+    widget?.dispose?.();
+    clearSliceProgressCache();
+    cleanup(dir);
+  });
+
+  updateProgressWidget(
+    {
+      hasUI: true,
+      ui: {
+        setHeader() {},
+        setStatus() {},
+        setWidget(_key: string, factory: any) {
+          if (_key === "gsd-progress") {
+            widget = factory(
+              { requestRender() {} },
+              { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+            );
+          }
+        },
+      },
+      sessionManager: { getSessionId: () => "session-1" },
+    } as any,
+    "execute-task",
+    "M004/S01/T01",
+    {
+      phase: "executing",
+      activeMilestone: { id: "M004", title: "Budget Tracking" },
+      activeSlice: { id: "S01", title: "Schema migration + expense add --repeat" },
+      activeTask: { id: "T01", title: "Add repeat column via idempotent ALTER TABLE" },
+    } as any,
+    {
+      getAutoStartTime: () => Date.now() - 18_000,
+      isStepMode: () => false,
+      getCmdCtx: () => ({
+        model: { id: "claude-sonnet-4-6", provider: "claude-code", contextWindow: 1_000_000 },
+        getContextUsage: () => ({ percent: 0.2, contextWindow: 1_000_000 }),
+        sessionManager: { getEntries: () => [] },
+      } as any),
+      getBasePath: () => dir,
+      isVerbose: () => false,
+      isSessionSwitching: () => false,
+      getCurrentDispatchedModelId: () => "claude-code/claude-sonnet-4-6",
+    },
+  );
+
+  const installedWidget = widget as { render(width: number): string[]; dispose?: () => void } | null;
+  assert.ok(installedWidget, "progress widget should be installed");
+  const rendered = installedWidget.render(120).join("\n");
+
+  assert.match(rendered, /GSD\s+AUTO/);
+  assert.match(rendered, /Budget Tracking/);
+  assert.match(rendered, /T01: Add repeat column via idempotent ALTER TABLE/);
+  assert.match(rendered, /dashboard/);
+  assert.doesNotMatch(rendered, /claude-sonnet-4-6/, "footer owns provider/model display");
+  assert.doesNotMatch(rendered, /0\.2%|ctx|1\.0M/, "footer owns raw context meter display");
+  assert.doesNotMatch(rendered, /\$/, "footer owns session cost display");
 });
 
 test("last commit refresh backs off cleanly when base path is not a git repo", (t) => {

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -43,7 +43,7 @@ test("cleanupAfterLoopExit preserves paused auto badge after provider pause", as
   }
 });
 
-test("cleanupAfterLoopExit clears status and widget when auto is not paused", async () => {
+test("cleanupAfterLoopExit clears status without replacing the last auto surface", async () => {
   const statusCalls: unknown[] = [];
   const widgetCalls: unknown[] = [];
 
@@ -62,9 +62,56 @@ test("cleanupAfterLoopExit clears status and widget when auto is not paused", as
     } as any);
 
     assert.deepEqual(statusCalls, [["gsd-auto", undefined]]);
-    assert.deepEqual(widgetCalls, [["gsd-progress", undefined]]);
+    assert.equal(
+      widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-progress" && args[1] === undefined),
+      false,
+      "cleanup must not clear the last meaningful auto progress surface",
+    );
+    assert.equal(
+      widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-outcome"),
+      false,
+      "cleanup must not replace the auto deck with a generic loop-ended card",
+    );
     assert.equal(autoSession.active, false);
     assert.equal(autoSession.paused, false);
+  } finally {
+    autoSession.reset();
+  }
+});
+
+test("cleanupAfterLoopExit preserves completion roll-up after stopAuto reset", async () => {
+  const statusCalls: unknown[] = [];
+  const widgetCalls: unknown[] = [];
+
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.paused = false;
+  autoSession.completionStopInProgress = true;
+  autoSession.resetAfterStop({ preserveCompletionSurface: true });
+
+  try {
+    await cleanupAfterLoopExit({
+      hasUI: true,
+      ui: {
+        setStatus: (...args: unknown[]) => statusCalls.push(args),
+        setWidget: (...args: unknown[]) => widgetCalls.push(args),
+        setHeader: () => {},
+        notify: () => {},
+      },
+    } as any);
+
+    assert.deepEqual(statusCalls, [["gsd-auto", undefined]]);
+    assert.equal(
+      widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-progress" && args[1] === undefined),
+      false,
+      "completion cleanup must not clear the roll-up progress widget",
+    );
+    assert.equal(
+      widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-outcome"),
+      false,
+      "completion cleanup must not replace the roll-up with a generic outcome card",
+    );
+    assert.equal(autoSession.completionStopInProgress, false);
   } finally {
     autoSession.reset();
   }
@@ -168,6 +215,7 @@ test("stopAuto completion closeout reroots session, restores cwd, and preserves 
   const base = mkdtempSync(join(tmpdir(), "gsd-completion-stop-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
+  const notifications: string[] = [];
   const newSessionWorkspaces: string[] = [];
   let restoreCalls = 0;
   const originalRestore = WorktreeLifecycle.prototype.restoreToProjectRoot;
@@ -260,7 +308,9 @@ test("stopAuto completion closeout reroots session, restores cwd, and preserves 
             widgetCalls.push([key, value]);
           },
           setHeader: () => {},
-          notify: () => {},
+          notify: (message: string) => {
+            notifications.push(message);
+          },
         },
         modelRegistry: { find: () => null },
       } as any,
@@ -296,7 +346,23 @@ test("stopAuto completion closeout reroots session, restores cwd, and preserves 
     assert.match(output, /Files: src\/resources\/extensions\/gsd\/auto-dashboard\.ts/);
     assert.match(output, /Lessons: Milestone endings need report output/);
     assert.match(output, /2\/3 slices/);
+    assert.match(output, /Next/);
+    assert.match(output, /Review the roll-up/);
+    assert.match(output, /\/gsd auto for next milestone/);
     assert.doesNotMatch(output, /COMPLETE-MILESTONE/);
+    assert.doesNotMatch(output, /\/gsd auto to resume/);
+    assert.ok(
+      notifications.some(message => message.includes("Milestone M003 complete. Auto-mode finished this milestone.")),
+      "completion stop notification should describe completion, not an aborted pause",
+    );
+    assert.ok(
+      notifications.every(message => !message.includes("/gsd auto to resume")),
+      "completion stop notification must not tell users to resume a finished auto run",
+    );
+    assert.ok(
+      widgetCalls.every(([key, value]) => key !== "gsd-outcome" || value === undefined),
+      "completion stop should use the roll-up as the single final surface",
+    );
   } finally {
     try { closeDatabase(); } catch { /* noop */ }
     autoSession.reset();

--- a/src/resources/extensions/gsd/tests/header-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/header-renderer.test.ts
@@ -5,6 +5,15 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { stripVTControlCharacters } from "node:util";
 import { renderHeaderLines } from "../watch/header-renderer.ts";
+import { splashPalette } from "../watch/splash-palette.ts";
+
+function rgbPattern(hex: string): RegExp {
+  const cleaned = hex.replace("#", "");
+  const r = Number.parseInt(cleaned.slice(0, 2), 16);
+  const g = Number.parseInt(cleaned.slice(2, 4), 16);
+  const b = Number.parseInt(cleaned.slice(4, 6), 16);
+  return new RegExp(`\\x1b\\[38;2;${r};${g};${b}m`);
+}
 
 test("renderHeaderLines uses the command-center splash layout", () => {
   const lines = renderHeaderLines(
@@ -21,8 +30,8 @@ test("renderHeaderLines uses the command-center splash layout", () => {
   const raw = lines.join("\n");
   const plain = stripVTControlCharacters(raw);
 
-  assert.match(raw, /\x1b\[38;2;167;186;120m/, "logo and divider should use the recommended olive border");
-  assert.match(raw, /\x1b\[38;2;141;183;255m/, "header accents should use the recommended blue");
+  assert.match(raw, rgbPattern(splashPalette.border), "logo and divider should use the recommended olive border");
+  assert.match(raw, rgbPattern(splashPalette.accent), "header accents should use the recommended blue");
   assert.match(plain, /Project Console/);
   assert.match(plain, /\/gsd start/);
   assert.match(plain, /\/gsd templates/);

--- a/src/resources/extensions/gsd/tests/header-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/header-renderer.test.ts
@@ -1,0 +1,31 @@
+// Project/App: GSD-2
+// File Purpose: Visual contract tests for the GSD watch header renderer.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import { renderHeaderLines } from "../watch/header-renderer.ts";
+
+test("renderHeaderLines uses the command-center splash layout", () => {
+  const lines = renderHeaderLines(
+    {
+      model: "claude-sonnet-4-6",
+      provider: "anthropic",
+      directory: "~/Github/gsd-2",
+      branch: "feat/tui-refresh",
+      mcpServers: ["context7"],
+    },
+    120,
+  );
+
+  const raw = lines.join("\n");
+  const plain = stripVTControlCharacters(raw);
+
+  assert.match(raw, /\x1b\[38;2;167;186;120m/, "logo and divider should use the recommended olive border");
+  assert.match(raw, /\x1b\[38;2;141;183;255m/, "header accents should use the recommended blue");
+  assert.match(plain, /Project Console/);
+  assert.match(plain, /\/gsd start/);
+  assert.match(plain, /\/gsd templates/);
+  assert.match(plain, /claude-sonnet-4-6/);
+  assert.match(plain, /Context7 ✓/);
+});

--- a/src/resources/extensions/gsd/tests/headless-milestone-parity.test.ts
+++ b/src/resources/extensions/gsd/tests/headless-milestone-parity.test.ts
@@ -87,6 +87,7 @@ describe("headless milestone bootstrap — parity with interactive flow", () => 
     );
     assert.ok(/Next steps:/.test(section), "single-milestone handoff must include next steps");
     assert.ok(/\/gsd auto/.test(section), "single-milestone handoff must mention /gsd auto");
+    assert.ok(/\/gsd status/.test(section), "single-milestone handoff must mention /gsd status");
     assert.ok(/\/gsd visualize/.test(section), "single-milestone handoff must mention /gsd visualize");
     assert.ok(/\/gsd notifications/.test(section), "single-milestone handoff must mention /gsd notifications");
   });
@@ -119,6 +120,7 @@ describe("headless milestone bootstrap — parity with interactive flow", () => 
     );
     assert.ok(/Next steps:/.test(multiSection), "multi-milestone handoff must include next steps");
     assert.ok(/\/gsd auto/.test(multiSection), "multi-milestone handoff must mention /gsd auto");
+    assert.ok(/\/gsd status/.test(multiSection), "multi-milestone handoff must mention /gsd status");
     assert.ok(/\/gsd visualize/.test(multiSection), "multi-milestone handoff must mention /gsd visualize");
     assert.ok(/\/gsd notifications/.test(multiSection), "multi-milestone handoff must mention /gsd notifications");
   });

--- a/src/resources/extensions/gsd/tests/headless-milestone-parity.test.ts
+++ b/src/resources/extensions/gsd/tests/headless-milestone-parity.test.ts
@@ -85,6 +85,10 @@ describe("headless milestone bootstrap — parity with interactive flow", () => 
       /Do not announce the ready phrase as something you are "about to" do/.test(section),
       "single-milestone pre-condition must include the 'do not announce intent' guard",
     );
+    assert.ok(/Next steps:/.test(section), "single-milestone handoff must include next steps");
+    assert.ok(/\/gsd auto/.test(section), "single-milestone handoff must mention /gsd auto");
+    assert.ok(/\/gsd visualize/.test(section), "single-milestone handoff must mention /gsd visualize");
+    assert.ok(/\/gsd notifications/.test(section), "single-milestone handoff must mention /gsd notifications");
   });
 
   test("discuss-headless multi-milestone pre-condition uses the non-bypassable checkbox format", () => {
@@ -113,5 +117,9 @@ describe("headless milestone bootstrap — parity with interactive flow", () => 
       /gates_completed === total/.test(multiSection),
       "multi-milestone pre-condition must still enforce gates_completed === total",
     );
+    assert.ok(/Next steps:/.test(multiSection), "multi-milestone handoff must include next steps");
+    assert.ok(/\/gsd auto/.test(multiSection), "multi-milestone handoff must mention /gsd auto");
+    assert.ok(/\/gsd visualize/.test(multiSection), "multi-milestone handoff must mention /gsd visualize");
+    assert.ok(/\/gsd notifications/.test(multiSection), "multi-milestone handoff must mention /gsd notifications");
   });
 });

--- a/src/resources/extensions/gsd/tests/health-widget.test.ts
+++ b/src/resources/extensions/gsd/tests/health-widget.test.ts
@@ -1,3 +1,6 @@
+// Project/App: GSD-2
+// File Purpose: Tests for the GSD health widget state and footer hint rendering.
+
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -9,6 +12,7 @@ import {
   formatRelativeTime,
   type HealthWidgetData,
 } from "../health-widget-core.ts";
+import { HEALTH_WIDGET_ACTIVE_HINTS } from "../health-widget.ts";
 import { registerHooks } from "../bootstrap/register-hooks.ts";
 
 function makeTempDir(prefix: string): string {
@@ -75,13 +79,11 @@ test("buildHealthLines: none state shows single onboarding line pointing at /gsd
   assert.match(lines[0]!, /\/gsd/);
 });
 
-test("buildHealthLines: initialized state shows single setup line pointing at /gsd", (t) => {
+test("buildHealthLines: initialized state shows concise initialized line", (t) => {
   const lines = buildHealthLines(activeData({ projectState: "initialized" }));
   assert.equal(lines.length, 1, "renders exactly one line");
   assert.ok(!/System OK|Budget|Last commit/.test(lines[0]!), "no active-project chrome");
-  // Distinct from "none" — must mention initialized/setup language and /gsd.
-  assert.match(lines[0]!, /\/gsd/);
-  assert.match(lines[0]!, /initiali[sz]ed|setup/i);
+  assert.equal(lines[0], "  GSD  Project Initialized");
 });
 
 test("buildHealthLines: active state with ledger-driven spend shows spent summary", (t) => {
@@ -89,6 +91,14 @@ test("buildHealthLines: active state with ledger-driven spend shows spent summar
   assert.equal(lines.length, 1);
   assert.match(lines[0]!, /● System OK/);
   assert.match(lines[0]!, /Spent: 42\.0¢/);
+});
+
+test("health widget active hints include visualization and notifications", () => {
+  assert.match(HEALTH_WIDGET_ACTIVE_HINTS, /\/gsd auto to run/);
+  assert.match(HEALTH_WIDGET_ACTIVE_HINTS, /\/gsd status for overview/);
+  assert.match(HEALTH_WIDGET_ACTIVE_HINTS, /\/gsd visualize to inspect/);
+  assert.match(HEALTH_WIDGET_ACTIVE_HINTS, /\/gsd notifications for history/);
+  assert.match(HEALTH_WIDGET_ACTIVE_HINTS, /\/gsd help/);
 });
 
 test("buildHealthLines: active state with budget ceiling shows percent summary", (t) => {

--- a/src/resources/extensions/gsd/tests/notification-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/notification-overlay.test.ts
@@ -99,11 +99,15 @@ describe("notification overlay — wrapText", () => {
 
   test("rendered height stays within the configured overlay max height", (t) => {
     const dir = mkdtempSync(join(tmpdir(), "gsd-notification-overlay-height-"));
-    const previousRows = process.stdout.rows;
+    const originalRowsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "rows");
     Object.defineProperty(process.stdout, "rows", { value: 40, configurable: true });
 
     t.after(() => {
-      Object.defineProperty(process.stdout, "rows", { value: previousRows, configurable: true });
+      if (originalRowsDescriptor) {
+        Object.defineProperty(process.stdout, "rows", originalRowsDescriptor);
+      } else {
+        delete (process.stdout as { rows?: number }).rows;
+      }
       _resetNotificationStore();
       rmSync(dir, { recursive: true, force: true });
     });

--- a/src/resources/extensions/gsd/tests/notification-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/notification-overlay.test.ts
@@ -1,55 +1,53 @@
-// GSD Extension — Notification Overlay Tests
-// Tests for message wrapping in the notification panel.
-// Mirrors the private wrapText from notification-overlay.ts so its contract
-// can be exercised without exporting internals.
+// Project/App: GSD-2
+// File Purpose: Regression tests for notification overlay wrapping and width-safe rendering.
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@gsd/pi-tui";
+import { visibleWidth } from "@gsd/pi-tui";
+import { appendNotification, initNotificationStore, _resetNotificationStore } from "../notification-store.ts";
+import { GSDNotificationOverlay, notificationOverlayOptions } from "../notification-overlay.ts";
+import { wrapVisibleText } from "../tui/render-kit.ts";
 
-// ── wrapText logic (mirrors the private function in notification-overlay.ts) ──
+const fakeTheme = {
+  fg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+};
 
-function wrapText(text: string, maxWidth: number): string[] {
-  if (maxWidth <= 0) return [text];
-  const lines = wrapTextWithAnsi(text, maxWidth);
-  return lines.map((l) =>
-    visibleWidth(l) > maxWidth ? truncateToWidth(l, maxWidth, "…") : l,
-  );
+function assertLinesFit(lines: string[], width: number): void {
+  for (const line of lines) {
+    assert.ok(
+      visibleWidth(line) <= width,
+      `line exceeds maxWidth: visibleWidth=${visibleWidth(line)} max=${width}: "${line}"`,
+    );
+  }
 }
 
 describe("notification overlay — wrapText", () => {
   test("short text returns single line", () => {
-    const result = wrapText("hello world", 80);
+    const result = wrapVisibleText("hello world", 80);
     assert.deepStrictEqual(result, ["hello world"]);
   });
 
   test("long text wraps at word boundaries without exceeding maxWidth", () => {
     const text = "This is a long notification message that should wrap across multiple lines";
-    const result = wrapText(text, 40);
+    const result = wrapVisibleText(text, 40);
     assert.ok(result.length > 1, `expected multiple lines, got ${result.length}`);
-    for (const line of result) {
-      assert.ok(
-        visibleWidth(line) <= 40,
-        `line exceeds maxWidth: "${line}" (${visibleWidth(line)})`,
-      );
-    }
+    assertLinesFit(result, 40);
   });
 
   test("single word exceeding maxWidth is broken to fit column budget", () => {
-    const result = wrapText("superlongwordthatexceedsmaxwidth", 10);
-    for (const line of result) {
-      assert.ok(
-        visibleWidth(line) <= 10,
-        `line exceeds maxWidth: "${line}" (${visibleWidth(line)})`,
-      );
-    }
+    const result = wrapVisibleText("superlongwordthatexceedsmaxwidth", 10);
+    assertLinesFit(result, 10);
   });
 
   test("preserves all words across wrapped lines", () => {
     const words = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"];
     const text = words.join(" ");
-    const result = wrapText(text, 15);
+    const result = wrapVisibleText(text, 15);
     const rejoined = result.join(" ");
     for (const w of words) {
       assert.ok(rejoined.includes(w), `missing word: ${w}`);
@@ -70,23 +68,58 @@ describe("notification overlay — wrapText", () => {
       "(expired — will auto-refresh) ✗ google — not configured " +
       "(aistudio.google.com/apikey) ✗ groq — not configured";
     const maxWidth = 118;
-    const result = wrapText(msg, maxWidth);
-    for (const line of result) {
-      assert.ok(
-        visibleWidth(line) <= maxWidth,
-        `line exceeds column budget: visibleWidth=${visibleWidth(line)} max=${maxWidth}: "${line}"`,
-      );
-    }
+    const result = wrapVisibleText(msg, maxWidth);
+    assertLinesFit(result, maxWidth);
   });
 
   test("unbreakable long token (URL) is clamped to maxWidth", () => {
     const url = "https://example.com/" + "a".repeat(200);
-    const result = wrapText(url, 40);
-    for (const line of result) {
-      assert.ok(
-        visibleWidth(line) <= 40,
-        `line exceeds maxWidth: visibleWidth=${visibleWidth(line)} line="${line}"`,
-      );
+    const result = wrapVisibleText(url, 40);
+    assertLinesFit(result, 40);
+  });
+
+  test("real overlay render fits common terminal widths", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "gsd-notification-overlay-"));
+    t.after(() => {
+      _resetNotificationStore();
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    initNotificationStore(dir);
+    appendNotification("A long notification with " + "x".repeat(180), "warning");
+
+    const overlay = new GSDNotificationOverlay({ requestRender() {} }, fakeTheme as any, () => {});
+    t.after(() => overlay.dispose());
+
+    for (const width of [40, 80, 120]) {
+      assertLinesFit(overlay.render(width), width);
+      overlay.invalidate();
     }
+  });
+
+  test("rendered height stays within the configured overlay max height", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "gsd-notification-overlay-height-"));
+    const previousRows = process.stdout.rows;
+    Object.defineProperty(process.stdout, "rows", { value: 40, configurable: true });
+
+    t.after(() => {
+      Object.defineProperty(process.stdout, "rows", { value: previousRows, configurable: true });
+      _resetNotificationStore();
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    initNotificationStore(dir);
+    for (let i = 0; i < 80; i++) {
+      appendNotification(`notification-${i + 1} with enough text to exercise clipping`, "warning");
+    }
+
+    const overlay = new GSDNotificationOverlay({ requestRender() {} }, fakeTheme as any, () => {});
+    t.after(() => overlay.dispose());
+
+    const rendered = overlay.render(100);
+    const maxHeight = Math.floor((40 * 52) / 100);
+    assert.ok(rendered.length <= maxHeight, `expected ${rendered.length} lines to fit maxHeight ${maxHeight}`);
+    assert.ok(rendered.at(-1)?.includes("╯"), "bottom border should remain visible");
+    assert.equal(notificationOverlayOptions().maxHeight, "52%");
   });
 });

--- a/src/resources/extensions/gsd/tests/notifications-handler.test.ts
+++ b/src/resources/extensions/gsd/tests/notifications-handler.test.ts
@@ -1,3 +1,6 @@
+// Project/App: GSD-2
+// File Purpose: Tests for /gsd notifications command handling and overlay launch behavior.
+
 import test from "node:test";
 import assert from "node:assert/strict";
 import { join } from "node:path";
@@ -56,6 +59,47 @@ test("notifications command falls back to text output when overlay returns undef
 
   assert.equal(notices.length, 1, "text fallback should be emitted when overlay cannot render");
   assert.match(notices[0].message, /Recent notifications:/);
+});
+
+test("notifications command opens a compact bounded overlay", async (t) => {
+  const base = makeTempDir("overlay-options");
+  initNotificationStore(base);
+  appendNotification("Build complete", "success");
+
+  t.after(() => {
+    _resetNotificationStore();
+    cleanup(base);
+  });
+
+  const notices: Array<{ message: string; level?: string }> = [];
+  let capturedOptions: any;
+  await handleNotificationsCommand(
+    "",
+    {
+      hasUI: true,
+      ui: {
+        custom: async (_factory: any, options: any) => {
+          capturedOptions = options;
+          return true;
+        },
+        notify: (message: string, level?: string) => {
+          notices.push({ message, level });
+        },
+      },
+    } as any,
+    {} as any,
+  );
+
+  assert.deepEqual(capturedOptions?.overlayOptions, {
+    width: "58%",
+    minWidth: 68,
+    maxHeight: "52%",
+    anchor: "top-center",
+    row: "24%",
+    margin: { top: 2, right: 2, bottom: 6, left: 2 },
+    backdrop: true,
+  });
+  assert.equal(notices.length, 0, "successful overlay should not emit text fallback");
 });
 
 test("notifications tail caps inline output and hints to open overlay", async (t) => {

--- a/src/resources/extensions/gsd/tests/parallel-monitor-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-monitor-overlay.test.ts
@@ -1,11 +1,19 @@
-import { describe, it } from "node:test";
-import assert from "node:assert";
+// Project/App: GSD-2
+// File Purpose: Regression tests for parallel monitor overlay rendering and input handling.
 
-/**
- * Basic tests for the parallel monitor overlay data helpers.
- * The overlay is primarily a rendering component that reads existing
- * status files — these tests verify the helper logic in isolation.
- */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { visibleWidth } from "@gsd/pi-tui";
+
+function assertLinesFit(lines: string[], width: number): void {
+  for (const line of lines) {
+    assert.ok(
+      visibleWidth(line) <= width,
+      `line exceeds width ${width}: ${visibleWidth(line)} "${line}"`,
+    );
+  }
+}
 
 describe("parallel-monitor-overlay", () => {
   it("progressBar generates correct width", async () => {
@@ -37,6 +45,7 @@ describe("parallel-monitor-overlay", () => {
     const lines = overlay.render(80);
     assert.ok(Array.isArray(lines), "render should return an array");
     assert.ok(lines.length > 0, "render should return at least one line");
+    assertLinesFit(lines, 80);
 
     // Should contain header text
     const joined = lines.join("\n");
@@ -77,6 +86,29 @@ describe("parallel-monitor-overlay", () => {
     (overlay as any).scrollOffset = 999;
     overlay.render(80);
     assert.equal((overlay as any).scrollOffset, 0, "empty overlays clamp scroll to zero");
+    overlay.dispose();
+  });
+
+  it("ParallelMonitorOverlay empty state fits narrow and wide widths", async () => {
+    const mod = await import("../parallel-monitor-overlay.js");
+
+    const mockTui = { requestRender: () => {} };
+    const mockTheme = {
+      fg: (_color: string, text: string) => text,
+      bold: (text: string) => text,
+    };
+    const overlay = new mod.ParallelMonitorOverlay(
+      mockTui,
+      mockTheme as any,
+      () => {},
+      "/nonexistent/path",
+    );
+
+    for (const width of [40, 80, 120]) {
+      assertLinesFit(overlay.render(width), width);
+      overlay.invalidate();
+    }
+
     overlay.dispose();
   });
 });

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -64,6 +64,16 @@ test("discuss prompt allows implementation questions when they materially matter
   assert.doesNotMatch(prompt, /Questions must be about the experience, not the implementation/i);
 });
 
+test("discuss prompt ends milestone planning with next-step handoff", () => {
+  const prompt = readPrompt("discuss");
+  assert.match(prompt, /Next steps:/);
+  assert.match(prompt, /\/gsd auto/);
+  assert.match(prompt, /\/gsd status/);
+  assert.match(prompt, /\/gsd visualize/);
+  assert.match(prompt, /\/gsd notifications/);
+  assert.doesNotMatch(prompt, /nothing else\. Auto-mode will start automatically/);
+});
+
 test("guided discussion prompts avoid wrap-up prompts after every round", () => {
   const milestonePrompt = readPrompt("guided-discuss-milestone");
   const slicePrompt = readPrompt("guided-discuss-slice");

--- a/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
@@ -250,6 +250,7 @@ test("auto-dashboard widget render output fits common terminal widths", (t) => {
       bold: (text: string) => text,
     },
   );
+  t.after(() => component.dispose?.());
 
   for (const width of [40, 80, 120]) {
     assertLinesFit(component.render(width), width);

--- a/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
@@ -10,6 +10,7 @@ import assert from "node:assert/strict";
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { visibleWidth } from "@gsd/pi-tui";
 
 import { setCompletionProgressWidget, updateProgressWidget } from "../auto-dashboard.ts";
 import type { GSDState } from "../types.ts";
@@ -45,6 +46,15 @@ const baseAccessors = {
   isSessionSwitching: () => false,
   getCurrentDispatchedModelId: () => null,
 };
+
+function assertLinesFit(lines: string[], width: number): void {
+  for (const line of lines) {
+    assert.ok(
+      visibleWidth(line) <= width,
+      `line exceeds width ${width}: ${visibleWidth(line)} "${line}"`,
+    );
+  }
+}
 
 // ── Header lifecycle ────────────────────────────────────────────────────
 
@@ -205,6 +215,46 @@ test("auto-dashboard widget render output omits Ctrl+N guidance when isStepMode 
 
   const hasStepHint = lines.some((line: string) => line.includes("Ctrl+N to advance"));
   assert.equal(hasStepHint, false, "step-mode hint must NOT appear when isStepMode is false");
+
+  if (component.dispose) component.dispose();
+});
+
+test("auto-dashboard widget render output fits common terminal widths", (t) => {
+  const dir = makeTempDir("width-safe");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  t.after(() => cleanup(dir));
+
+  let widgetFactory: ((tui: unknown, theme: unknown) => any) | undefined;
+
+  updateProgressWidget(
+    {
+      hasUI: true,
+      ui: {
+        setWidget(_key: string, factory: any) { widgetFactory = factory; },
+        setHeader() {},
+        setStatus() {},
+      },
+    } as any,
+    "execute-task",
+    "M001/S01/T01",
+    baseState,
+    { ...baseAccessors, getBasePath: () => dir },
+  );
+
+  assert.ok(widgetFactory);
+
+  const component = widgetFactory!(
+    { requestRender() {} },
+    {
+      fg: (_color: string, text: string) => text,
+      bold: (text: string) => text,
+    },
+  );
+
+  for (const width of [40, 80, 120]) {
+    assertLinesFit(component.render(width), width);
+    component.invalidate();
+  }
 
   if (component.dispose) component.dispose();
 });

--- a/src/resources/extensions/gsd/tests/tui-render-kit.test.ts
+++ b/src/resources/extensions/gsd/tests/tui-render-kit.test.ts
@@ -1,0 +1,66 @@
+// Project/App: GSD-2
+// File Purpose: Unit tests for shared GSD TUI render helpers.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { visibleWidth } from "@gsd/pi-tui";
+import {
+  padRightVisible,
+  renderFrame,
+  renderKeyHints,
+  renderProgressBar,
+  rightAlign,
+  safeLine,
+  wrapVisibleText,
+  type ThemeLike,
+} from "../tui/render-kit.ts";
+
+const theme: ThemeLike = {
+  fg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+};
+
+function assertWidth(lines: string[], width: number): void {
+  for (const line of lines) {
+    assert.ok(
+      visibleWidth(line) <= width,
+      `line exceeds width ${width}: ${visibleWidth(line)} "${line}"`,
+    );
+  }
+}
+
+describe("tui render kit", () => {
+  test("safeLine clamps visible width", () => {
+    assert.equal(visibleWidth(safeLine("abcdef", 4)), 4);
+    assert.equal(safeLine("abcdef", 0), "");
+  });
+
+  test("padRightVisible fills exact visible width", () => {
+    const line = padRightVisible("abc", 8);
+    assert.equal(visibleWidth(line), 8);
+  });
+
+  test("rightAlign keeps output within width", () => {
+    for (const width of [10, 40, 80]) {
+      assertWidth([rightAlign("left side with overflow", "right side", width)], width);
+    }
+  });
+
+  test("wrapVisibleText clamps long words and ansi-aware content", () => {
+    const lines = wrapVisibleText("https://example.com/" + "a".repeat(120), 24);
+    assert.ok(lines.length > 0);
+    assertWidth(lines, 24);
+  });
+
+  test("renderFrame keeps borders and rows within width", () => {
+    for (const width of [3, 40, 80]) {
+      assertWidth(renderFrame(theme, ["row", "long ".repeat(40)], width), width);
+    }
+  });
+
+  test("renderKeyHints and renderProgressBar fit caller budgets", () => {
+    assert.ok(visibleWidth(renderKeyHints(theme, ["↑↓ scroll", "esc close"], 12)) <= 12);
+    assert.equal(visibleWidth(renderProgressBar(theme, 2, 4, 16)), 16);
+  });
+});

--- a/src/resources/extensions/gsd/tui/render-kit.ts
+++ b/src/resources/extensions/gsd/tui/render-kit.ts
@@ -1,0 +1,109 @@
+// Project/App: GSD-2
+// File Purpose: Shared terminal rendering helpers for GSD extension TUI surfaces.
+
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@gsd/pi-tui";
+
+export interface ThemeLike {
+  fg(color: string, text: string): string;
+  bold(text: string): string;
+}
+
+export function safeLine(text: string, width: number, ellipsis = "…"): string {
+  if (width <= 0) return "";
+  return truncateToWidth(text, width, ellipsis);
+}
+
+export function padRightVisible(text: string, width: number): string {
+  if (width <= 0) return "";
+  const truncated = safeLine(text, width);
+  const pad = Math.max(0, width - visibleWidth(truncated));
+  return truncated + " ".repeat(pad);
+}
+
+export function rightAlign(left: string, right: string, width: number): string {
+  if (width <= 0) return "";
+  if (!right) return safeLine(left, width);
+  if (!left) return safeLine(" ".repeat(Math.max(0, width - visibleWidth(right))) + right, width);
+  const gap = Math.max(1, width - visibleWidth(left) - visibleWidth(right));
+  return safeLine(left + " ".repeat(gap) + right, width);
+}
+
+export function wrapVisibleText(text: string, width: number): string[] {
+  if (width <= 0) return [text];
+  return wrapTextWithAnsi(text, width).map((line) =>
+    visibleWidth(line) > width ? truncateToWidth(line, width, "…") : line,
+  );
+}
+
+export function renderBar(theme: ThemeLike, width: number, color = "muted"): string {
+  return safeLine(theme.fg(color, "─".repeat(Math.max(0, width))), width, "");
+}
+
+export function renderKeyHints(theme: ThemeLike, hints: string[], width: number): string {
+  return safeLine(theme.fg("dim", hints.filter(Boolean).join("  │  ")), width);
+}
+
+export function renderProgressBar(
+  theme: ThemeLike,
+  done: number,
+  total: number,
+  width: number,
+  options: {
+    filledColor?: string;
+    emptyColor?: string;
+    filledChar?: string;
+    emptyChar?: string;
+  } = {},
+): string {
+  const barWidth = Math.max(0, width);
+  const pct = total > 0 ? Math.max(0, Math.min(1, done / total)) : 0;
+  const filled = Math.round(pct * barWidth);
+  const filledChar = options.filledChar ?? "█";
+  const emptyChar = options.emptyChar ?? "░";
+  return (
+    theme.fg(options.filledColor ?? "success", filledChar.repeat(filled)) +
+    theme.fg(options.emptyColor ?? "dim", emptyChar.repeat(barWidth - filled))
+  );
+}
+
+export function statusGlyph(
+  theme: ThemeLike,
+  level: "active" | "idle" | "warning" | "error" | "success",
+): string {
+  switch (level) {
+    case "active": return theme.fg("success", "●");
+    case "success": return theme.fg("success", "✓");
+    case "warning": return theme.fg("warning", "!");
+    case "error": return theme.fg("error", "x");
+    case "idle":
+    default: return theme.fg("dim", "○");
+  }
+}
+
+export function renderFrame(
+  theme: ThemeLike,
+  inner: string[],
+  width: number,
+  options: { borderColor?: string; paddingX?: number } = {},
+): string[] {
+  if (width < 4) return inner.map((line) => safeLine(line, width));
+
+  const borderColor = options.borderColor ?? "borderAccent";
+  const paddingX = Math.max(0, options.paddingX ?? 1);
+  const contentWidth = Math.max(0, width - 2 - paddingX * 2);
+  const border = (text: string) => theme.fg(borderColor, text);
+  const pad = " ".repeat(paddingX);
+
+  const lines = [border("╭" + "─".repeat(width - 2) + "╮")];
+  for (const line of inner) {
+    lines.push(
+      border("│") +
+      pad +
+      padRightVisible(line, contentWidth) +
+      pad +
+      border("│"),
+    );
+  }
+  lines.push(border("╰" + "─".repeat(width - 2) + "╯"));
+  return lines.map((line) => safeLine(line, width, ""));
+}

--- a/src/resources/extensions/gsd/watch/header-renderer.ts
+++ b/src/resources/extensions/gsd/watch/header-renderer.ts
@@ -234,8 +234,8 @@ export function formatMcpRow(servers: string[], width: number): string {
  * and workspace state easier to scan.
  */
 export function renderHeaderLines(data: HeaderData, width: number): string[] {
-  const outerWidth = Math.max(1, width);
-  if (outerWidth < 40) return renderStackedHeader(data, outerWidth);
+  if (width < 40) return renderStackedHeader(data, width);
+  const outerWidth = width;
   const innerWidth = Math.max(0, outerWidth - 2);
   const logoLines = GSD_LOGO;
   const logoWidth = Math.max(...logoLines.map((line) => visibleWidth(line)));
@@ -295,7 +295,7 @@ export function renderHeaderLines(data: HeaderData, width: number): string[] {
  * Fallback stacked layout for narrow terminals (< 20 cols for info panel).
  */
 function renderStackedHeader(data: HeaderData, width: number): string[] {
-  const outerWidth = Math.max(1, width);
+  const outerWidth = Math.max(0, width);
   if (outerWidth < 3) {
     return [color(truncateToWidth("GSD", outerWidth, ""), colors.accent)];
   }

--- a/src/resources/extensions/gsd/watch/header-renderer.ts
+++ b/src/resources/extensions/gsd/watch/header-renderer.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { visibleWidth, truncateToWidth } from "@gsd/pi-tui";
 import { loadEffectiveGSDPreferences } from "../preferences.js";
 import { gsdHome } from "../gsd-home.js";
+import { splashPalette } from "./splash-palette.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -35,12 +36,12 @@ function rgb(hex: string): string {
 }
 
 const colors = {
-  accent: rgb("#8db7ff"),
-  border: rgb("#a7ba78"),
-  muted: rgb("#7d889f"),
-  dim: rgb("#4d5870"),
-  text: rgb("#dce4f2"),
-  success: rgb("#a8c978"),
+  accent: rgb(splashPalette.accent),
+  border: rgb(splashPalette.border),
+  muted: rgb(splashPalette.muted),
+  dim: rgb(splashPalette.dim),
+  text: rgb(splashPalette.text),
+  success: rgb(splashPalette.success),
 };
 
 function color(text: string, colorCode: string): string {
@@ -63,7 +64,8 @@ function rightAlign(left: string, right: string, width: number): string {
 }
 
 function frameLine(content: string, width: number): string {
-  const innerWidth = Math.max(1, width - 2);
+  if (width < 3) return truncateToWidth(content, Math.max(0, width), "");
+  const innerWidth = Math.max(0, width - 2);
   return `${color("│", colors.border)}${padVisible(content, innerWidth)}${color("│", colors.border)}`;
 }
 
@@ -232,8 +234,9 @@ export function formatMcpRow(servers: string[], width: number): string {
  * and workspace state easier to scan.
  */
 export function renderHeaderLines(data: HeaderData, width: number): string[] {
-  const outerWidth = Math.max(40, width);
-  const innerWidth = Math.max(1, outerWidth - 2);
+  const outerWidth = Math.max(1, width);
+  if (outerWidth < 40) return renderStackedHeader(data, outerWidth);
+  const innerWidth = Math.max(0, outerWidth - 2);
   const logoLines = GSD_LOGO;
   const logoWidth = Math.max(...logoLines.map((line) => visibleWidth(line)));
   const gap = ` ${color("│", colors.dim)} `;
@@ -278,13 +281,13 @@ export function renderHeaderLines(data: HeaderData, width: number): string[] {
   ];
 
   const lines = [
-    color("╭" + "─".repeat(outerWidth - 2) + "╮", colors.border),
+    color("╭" + "─".repeat(Math.max(0, outerWidth - 2)) + "╮", colors.border),
   ];
   for (let i = 0; i < logoLines.length; i++) {
     const logo = padVisible(color(logoLines[i], colors.border), logoWidth);
     lines.push(frameLine(`${logo}${gap}${panelLines[i] ?? ""}`, outerWidth));
   }
-  lines.push(color("╰" + "─".repeat(outerWidth - 2) + "╯", colors.border));
+  lines.push(color("╰" + "─".repeat(Math.max(0, outerWidth - 2)) + "╯", colors.border));
   return lines;
 }
 
@@ -292,8 +295,11 @@ export function renderHeaderLines(data: HeaderData, width: number): string[] {
  * Fallback stacked layout for narrow terminals (< 20 cols for info panel).
  */
 function renderStackedHeader(data: HeaderData, width: number): string[] {
-  const outerWidth = Math.max(40, width);
-  const lines: string[] = [color("╭" + "─".repeat(outerWidth - 2) + "╮", colors.border)];
+  const outerWidth = Math.max(1, width);
+  if (outerWidth < 3) {
+    return [color(truncateToWidth("GSD", outerWidth, ""), colors.accent)];
+  }
+  const lines: string[] = [color("╭" + "─".repeat(Math.max(0, outerWidth - 2)) + "╮", colors.border)];
 
   // Title
   lines.push(frameLine(`${color("GSD", colors.accent)} ${bold(color("Project Console", colors.text))}`, outerWidth));
@@ -305,10 +311,10 @@ function renderStackedHeader(data: HeaderData, width: number): string[] {
   lines.push(frameLine(formatInfoLine("Model", data.model, outerWidth - 2), outerWidth));
 
   // MCP
-  const mcpRow = formatMcpRow(data.mcpServers, outerWidth - 7);
+  const mcpRow = formatMcpRow(data.mcpServers, Math.max(1, outerWidth - 7));
   if (mcpRow) lines.push(frameLine(`${color("MCP", colors.muted)} ${mcpRow}`, outerWidth));
   lines.push(frameLine(`${color("/gsd to begin", colors.accent)}  ${color("/gsd help", colors.muted)}`, outerWidth));
-  lines.push(color("╰" + "─".repeat(outerWidth - 2) + "╯", colors.border));
+  lines.push(color("╰" + "─".repeat(Math.max(0, outerWidth - 2)) + "╯", colors.border));
 
   return lines;
 }

--- a/src/resources/extensions/gsd/watch/header-renderer.ts
+++ b/src/resources/extensions/gsd/watch/header-renderer.ts
@@ -1,5 +1,5 @@
-// GSD Watch — Header renderer: ASCII logo, session info, MCP status, remote questions
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+// Project/App: GSD-2
+// File Purpose: Watch-mode terminal header and splash renderer for GSD project status.
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
@@ -11,27 +11,61 @@ import { gsdHome } from "../gsd-home.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-/**
- * GSD ASCII logo — inlined here because the canonical src/logo.ts is outside
- * the resources rootDir and cannot be imported directly.
- */
 const GSD_LOGO: readonly string[] = [
-  '   ██████╗ ███████╗██████╗ ',
-  '  ██╔════╝ ██╔════╝██╔══██╗',
-  '  ██║  ███╗███████╗██║  ██║',
-  '  ██║   ██║╚════██║██║  ██║',
-  '  ╚██████╔╝███████║██████╔╝',
-  '   ╚═════╝ ╚══════╝╚═════╝ ',
+  "   ██████╗ ███████╗██████╗ ",
+  "  ██╔════╝ ██╔════╝██╔══██╗",
+  "  ██║  ███╗███████╗██║  ██║",
+  "  ██║   ██║╚════██║██║  ██║",
+  "  ╚██████╔╝███████║██████╔╝",
+  "   ╚═════╝ ╚══════╝╚═════╝ ",
 ];
-
-/** Separator character for the horizontal divider line. */
-const SEPARATOR_CHAR = "─";
-
-/** Vertical bar between logo and info panel. */
-const PANEL_DIVIDER = "│";
 
 /** Label column width for Model/Provider/Directory/Branch rows. */
 const LABEL_COL_WIDTH = 10;
+
+const ANSI_RESET = "\x1b[0m";
+const ANSI_BOLD = "\x1b[1m";
+
+function rgb(hex: string): string {
+  const cleaned = hex.replace("#", "");
+  const r = Number.parseInt(cleaned.slice(0, 2), 16);
+  const g = Number.parseInt(cleaned.slice(2, 4), 16);
+  const b = Number.parseInt(cleaned.slice(4, 6), 16);
+  return `\x1b[38;2;${r};${g};${b}m`;
+}
+
+const colors = {
+  accent: rgb("#8db7ff"),
+  border: rgb("#a7ba78"),
+  muted: rgb("#7d889f"),
+  dim: rgb("#4d5870"),
+  text: rgb("#dce4f2"),
+  success: rgb("#a8c978"),
+};
+
+function color(text: string, colorCode: string): string {
+  return `${colorCode}${text}${ANSI_RESET}`;
+}
+
+function bold(text: string): string {
+  return `${ANSI_BOLD}${text}${ANSI_RESET}`;
+}
+
+function padVisible(text: string, width: number): string {
+  const clipped = truncateToWidth(text, Math.max(0, width), "");
+  return clipped + " ".repeat(Math.max(0, width - visibleWidth(clipped)));
+}
+
+function rightAlign(left: string, right: string, width: number): string {
+  if (!right) return truncateToWidth(left, width, "");
+  const gap = Math.max(1, width - visibleWidth(left) - visibleWidth(right));
+  return truncateToWidth(left + " ".repeat(gap) + right, width, "");
+}
+
+function frameLine(content: string, width: number): string {
+  const innerWidth = Math.max(1, width - 2);
+  return `${color("│", colors.border)}${padVisible(content, innerWidth)}${color("│", colors.border)}`;
+}
 
 // ─── Data Readers ─────────────────────────────────────────────────────────────
 
@@ -163,12 +197,11 @@ export function gatherHeaderData(projectRoot: string): HeaderData {
  * Returns empty string if value is empty.
  */
 function formatInfoLine(label: string, value: string, availableWidth: number): string {
-  const bold = `\x1b[1m${label}\x1b[0m`;
-  const labelVis = visibleWidth(bold);
-  const padding = " ".repeat(Math.max(1, LABEL_COL_WIDTH - labelVis));
+  const labelText = bold(color(label, colors.text));
+  const padding = " ".repeat(Math.max(1, LABEL_COL_WIDTH - label.length));
   const maxValueWidth = Math.max(1, availableWidth - LABEL_COL_WIDTH);
   const truncValue = truncateToWidth(value, maxValueWidth, "…");
-  return bold + padding + truncValue;
+  return labelText + padding + color(truncValue, colors.muted);
 }
 
 /**
@@ -181,7 +214,7 @@ export function formatMcpRow(servers: string[], width: number): string {
   // Capitalize first letter of each server name
   const items = servers.map(s => {
     const cap = s.charAt(0).toUpperCase() + s.slice(1);
-    return `${cap} ✓`;
+    return `${color(cap, colors.accent)} ${color("✓", colors.success)}`;
   });
 
   const full = items.join("  ·  ");
@@ -194,59 +227,64 @@ export function formatMcpRow(servers: string[], width: number): string {
 /**
  * Render the full header as an array of terminal-safe strings.
  *
- * Layout: GSD ASCII logo on the left, info panel on the right separated by │.
- * Below: MCP server row, remote questions row, separator line.
+ * Layout: compact GSD mark on the left with a command-center status panel on
+ * the right. This keeps the splash visual while making the actionable command
+ * and workspace state easier to scan.
  */
 export function renderHeaderLines(data: HeaderData, width: number): string[] {
-  const lines: string[] = [];
-
-  // Logo is 6 lines tall. Info panel has: title + blank + model + provider + directory + branch = 6 lines
+  const outerWidth = Math.max(40, width);
+  const innerWidth = Math.max(1, outerWidth - 2);
   const logoLines = GSD_LOGO;
-  const logoWidth = Math.max(...logoLines.map(l => visibleWidth(l)));
+  const logoWidth = Math.max(...logoLines.map((line) => visibleWidth(line)));
+  const gap = ` ${color("│", colors.dim)} `;
+  const panelWidth = innerWidth - logoWidth - visibleWidth(gap);
 
-  // Calculate available width for the info panel
-  // Layout: logo + " " + "│" + " " = logoWidth + 3
-  const dividerOverhead = 3; // " │ "
-  const infoPanelWidth = width - logoWidth - dividerOverhead;
-
-  // If terminal is too narrow for side-by-side, fall back to stacked layout
-  if (infoPanelWidth < 20) {
+  if (panelWidth < 44) {
     return renderStackedHeader(data, width);
   }
 
-  // Build info panel lines (6 lines to match logo height)
-  const infoLines: string[] = [
-    `\x1b[1mGet Shit Done\x1b[0m`,
-    "",
-    formatInfoLine("Model", data.model, infoPanelWidth),
-    formatInfoLine("Provider", data.provider, infoPanelWidth),
-    formatInfoLine("Directory", data.directory, infoPanelWidth),
-    formatInfoLine("Branch", data.branch, infoPanelWidth),
+  const mcpRow = formatMcpRow(data.mcpServers, Math.max(1, panelWidth - 9)) || color("none configured", colors.dim);
+  const panelLines = [
+    rightAlign(
+      `${color("GSD", colors.accent)} ${bold(color("Project Console", colors.text))}`,
+      color("idle", colors.muted),
+      panelWidth,
+    ),
+    rightAlign(
+      `${color("Project", colors.muted)} ${color(data.directory, colors.text)}`,
+      `${color("Command", colors.muted)} ${color("/gsd start", colors.accent)}`,
+      panelWidth,
+    ),
+    rightAlign(
+      `${color("Branch", colors.muted)} ${color(data.branch, colors.text)}`,
+      `${color("Mode", colors.muted)} ${color("manual", colors.text)}`,
+      panelWidth,
+    ),
+    rightAlign(
+      `${color("MCP", colors.muted)} ${mcpRow}`,
+      `${color("Model", colors.muted)} ${color(data.model, colors.text)}`,
+      panelWidth,
+    ),
+    rightAlign(
+      `${color("Provider", colors.muted)} ${color(data.provider, colors.text)}`,
+      `${color("Workspace", colors.muted)} ${color(data.directory, colors.text)}`,
+      panelWidth,
+    ),
+    rightAlign(
+      color("/gsd to begin", colors.accent),
+      `${color("/gsd templates", colors.muted)}  ${color("/gsd help", colors.muted)}`,
+      panelWidth,
+    ),
   ];
 
-  // Merge logo and info panel side by side
-  const maxLines = Math.max(logoLines.length, infoLines.length);
-  for (let i = 0; i < maxLines; i++) {
-    const logoLine = i < logoLines.length ? logoLines[i] : "";
-    const infoLine = i < infoLines.length ? infoLines[i] : "";
-
-    // Pad logo line to consistent width
-    const logoPad = " ".repeat(Math.max(0, logoWidth - visibleWidth(logoLine)));
-    lines.push(`${logoLine}${logoPad} ${PANEL_DIVIDER} ${infoLine}`);
+  const lines = [
+    color("╭" + "─".repeat(outerWidth - 2) + "╮", colors.border),
+  ];
+  for (let i = 0; i < logoLines.length; i++) {
+    const logo = padVisible(color(logoLines[i], colors.border), logoWidth);
+    lines.push(frameLine(`${logo}${gap}${panelLines[i] ?? ""}`, outerWidth));
   }
-
-  // Blank line after logo+info block
-  lines.push("");
-
-  // MCP server row
-  const mcpRow = formatMcpRow(data.mcpServers, width);
-  if (mcpRow) {
-    lines.push(` ${mcpRow}`);
-  }
-
-  // Separator line
-  lines.push(SEPARATOR_CHAR.repeat(width));
-
+  lines.push(color("╰" + "─".repeat(outerWidth - 2) + "╯", colors.border));
   return lines;
 }
 
@@ -254,25 +292,23 @@ export function renderHeaderLines(data: HeaderData, width: number): string[] {
  * Fallback stacked layout for narrow terminals (< 20 cols for info panel).
  */
 function renderStackedHeader(data: HeaderData, width: number): string[] {
-  const lines: string[] = [];
+  const outerWidth = Math.max(40, width);
+  const lines: string[] = [color("╭" + "─".repeat(outerWidth - 2) + "╮", colors.border)];
 
   // Title
-  lines.push(`\x1b[1mGet Shit Done\x1b[0m`);
-  lines.push("");
+  lines.push(frameLine(`${color("GSD", colors.accent)} ${bold(color("Project Console", colors.text))}`, outerWidth));
 
   // Info
-  lines.push(formatInfoLine("Model", data.model, width));
-  lines.push(formatInfoLine("Provider", data.provider, width));
-  lines.push(formatInfoLine("Directory", data.directory, width));
-  lines.push(formatInfoLine("Branch", data.branch, width));
-  lines.push("");
+  lines.push(frameLine(formatInfoLine("Project", data.directory, outerWidth - 2), outerWidth));
+  lines.push(frameLine(formatInfoLine("Command", "/gsd start", outerWidth - 2), outerWidth));
+  lines.push(frameLine(formatInfoLine("Branch", data.branch, outerWidth - 2), outerWidth));
+  lines.push(frameLine(formatInfoLine("Model", data.model, outerWidth - 2), outerWidth));
 
   // MCP
-  const mcpRow = formatMcpRow(data.mcpServers, width);
-  if (mcpRow) lines.push(` ${mcpRow}`);
-
-  // Separator
-  lines.push(SEPARATOR_CHAR.repeat(width));
+  const mcpRow = formatMcpRow(data.mcpServers, outerWidth - 7);
+  if (mcpRow) lines.push(frameLine(`${color("MCP", colors.muted)} ${mcpRow}`, outerWidth));
+  lines.push(frameLine(`${color("/gsd to begin", colors.accent)}  ${color("/gsd help", colors.muted)}`, outerWidth));
+  lines.push(color("╰" + "─".repeat(outerWidth - 2) + "╯", colors.border));
 
   return lines;
 }

--- a/src/resources/extensions/gsd/watch/splash-palette.ts
+++ b/src/resources/extensions/gsd/watch/splash-palette.ts
@@ -1,0 +1,11 @@
+// Project/App: GSD-2
+// File Purpose: Shared RGB palette for the pre-theme GSD watch splash.
+
+export const splashPalette = {
+  accent: "#8db7ff",
+  border: "#a7ba78",
+  muted: "#7d889f",
+  dim: "#4d5870",
+  text: "#dce4f2",
+  success: "#a8c978",
+} as const;

--- a/src/tests/footer-component.test.ts
+++ b/src/tests/footer-component.test.ts
@@ -1,3 +1,6 @@
+// Project/App: GSD-2
+// File Purpose: Regression tests for the interactive terminal footer renderer.
+
 import test from "node:test";
 import assert from "node:assert/strict";
 import { stripVTControlCharacters } from "node:util";
@@ -6,7 +9,7 @@ import { initTheme } from "../../packages/pi-coding-agent/src/modes/interactive/
 
 initTheme("dark", false);
 
-test("FooterComponent dims the pwd row including right-aligned extension statuses", () => {
+test("FooterComponent renders a rounded operations-console footer with extension statuses", () => {
   const footer = new FooterComponent(
     {
       state: {
@@ -30,10 +33,15 @@ test("FooterComponent dims the pwd row including right-aligned extension statuse
     } as any,
   );
 
-  const lines = footer.render(100).map((line) => stripVTControlCharacters(line));
+  const lines = footer.render(160).map((line) => stripVTControlCharacters(line));
 
-  assert.equal(lines.length, 2);
-  assert.match(lines[0], /\(main\)/);
-  assert.match(lines[0], /ready synced$/);
-  assert.doesNotMatch(lines[1], /ready synced/);
+  assert.equal(lines.length, 3);
+  assert.match(lines[0], /^╭─+╮$/);
+  assert.match(lines[1], /^\│/);
+  assert.match(lines[1], /\(main\)/);
+  assert.match(lines[1], /ready synced\s*│$/);
+  assert.match(lines[1], /● GSD/);
+  assert.match(lines[1], /● GSD  │  .* \(main\)  │  /);
+  assert.match(lines[1], /12\.5%\/1\.0k/);
+  assert.match(lines[2], /^╰─+╯$/);
 });

--- a/src/tests/tui-classic-theme.test.ts
+++ b/src/tests/tui-classic-theme.test.ts
@@ -18,14 +18,15 @@ test("dark built-in theme uses the terminal card prototype palette", () => {
 	assert.ok("dark" in builtinThemes, "dark should be available as a built-in theme");
 	const theme = builtinThemes.dark;
 
-	assert.equal(theme.vars?.accent, "#5cc8c8");
-	assert.equal(theme.vars?.line, "#52616a");
-	assert.equal(theme.vars?.toolPendingBg, "#252721");
-	assert.equal(theme.vars?.toolSuccessBg, "#1c251f");
-	assert.equal(theme.vars?.toolErrorBg, "#251e20");
+	assert.equal(theme.vars?.accent, "#8db7ff");
+	assert.equal(theme.vars?.line, "#a7ba78");
+	assert.equal(theme.vars?.userMsgBg, "#232c3a");
+	assert.equal(theme.vars?.toolPendingBg, "#171c26");
+	assert.equal(theme.vars?.toolSuccessBg, "#171c26");
+	assert.equal(theme.vars?.toolErrorBg, "#241b22");
 	assert.equal(theme.colors.border, "line");
 	assert.equal(theme.colors.borderAccent, "accent");
-	assert.equal(theme.colors.toolRunning, "yellow");
+	assert.equal(theme.colors.toolRunning, "accent");
 	assert.equal(theme.colors.toolSuccess, "green");
 	assert.equal(theme.colors.toolError, "red");
 });

--- a/src/tests/welcome-screen.test.ts
+++ b/src/tests/welcome-screen.test.ts
@@ -40,7 +40,7 @@ test('renders GSD logo', () => {
 test('renders version', () => {
   const out = strip(capture({ version: '2.38.0' }))
   assert.ok(out.includes('v2.38.0'), 'version missing')
-  assert.ok(out.includes('Get Shit Done'), 'brand name missing')
+  assert.ok(out.includes('Project Console'), 'command-center title missing')
 })
 
 test('renders GSD project state or fallback hint', (t) => {
@@ -67,6 +67,7 @@ test('renders GSD project state or fallback hint', (t) => {
 test('renders cwd hint', () => {
   const out = strip(capture({ version: '1.0.0' }))
   assert.ok(out.includes('/gsd to begin'), 'hint line missing')
+  assert.ok(out.includes('/gsd start'), 'primary command missing')
 })
 
 test('skips when not a TTY', (t) => {
@@ -102,7 +103,7 @@ test('omits remote channel when not provided', () => {
   assert.ok(!out.includes('Telegram'), 'should not show Telegram when no remote')
 })
 
-test('Active row truncates with ellipsis when milestone text overflows panel width', (t) => {
+test('Project row truncates with ellipsis when milestone text overflows panel width', (t) => {
   const tmp = mkdtempSync(join(tmpdir(), 'gsd-welcome-test-'))
   mkdirSync(join(tmp, '.gsd'))
   writeFileSync(
@@ -126,13 +127,13 @@ test('Active row truncates with ellipsis when milestone text overflows panel wid
 
   const columns = (process.stderr as any).columns as number
   const out = strip(capture({ version: '1.0.0' }))
-  const activeLine = out.split('\n').find(l => /Active\s/.test(l))
-  assert.ok(activeLine, 'Active row should be present')
-  assert.ok(activeLine!.includes('…'), 'Active row should truncate long text with ellipsis')
-  assert.ok(activeLine!.length <= columns, `Active row length ${activeLine!.length} should not exceed terminal width ${columns}`)
+  const projectLine = out.split('\n').find(l => /Project\s+M001/.test(l))
+  assert.ok(projectLine, 'Project row should be present')
+  assert.ok(projectLine!.includes('…'), 'Project row should truncate long text with ellipsis')
+  assert.ok(projectLine!.length <= columns, `Project row length ${projectLine!.length} should not exceed terminal width ${columns}`)
 })
 
-test('Active row does not truncate short milestone text', (t) => {
+test('Project row does not truncate short milestone text', (t) => {
   const tmp = mkdtempSync(join(tmpdir(), 'gsd-welcome-test-'))
   mkdirSync(join(tmp, '.gsd'))
   writeFileSync(join(tmp, '.gsd', 'STATE.md'), '**Active Milestone:** M001: Short title\n')
@@ -148,23 +149,23 @@ test('Active row does not truncate short milestone text', (t) => {
   })
 
   const out = strip(capture({ version: '1.0.0' }))
-  const activeLine = out.split('\n').find(l => /Active\s/.test(l))
-  assert.ok(activeLine, 'Active row should be present')
-  assert.ok(activeLine!.includes('M001: Short title'), 'short title should appear in full')
-  assert.ok(!activeLine!.includes('…'), 'short title should not be truncated')
+  const projectLine = out.split('\n').find(l => /Project\s+M001/.test(l))
+  assert.ok(projectLine, 'Project row should be present')
+  assert.ok(projectLine!.includes('M001: Short title'), 'short title should appear in full')
+  assert.ok(!projectLine!.includes('…'), 'short title should not be truncated')
 })
 
-test('separator lines extend to full terminal width on wide terminals', (t) => {
+test('rounded command-center borders extend to full terminal width on wide terminals', (t) => {
   const origColumns = process.stderr.columns
   ;(process.stderr as any).columns = 250
   t.after(() => { ;(process.stderr as any).columns = origColumns })
 
   const out = strip(capture({ version: '1.0.0' }))
   const lines = out.split('\n')
-  // Top and bottom separator bars should be 249 chars (columns - 1)
-  const separatorLines = lines.filter(l => /^─+$/.test(l.trim()))
-  assert.ok(separatorLines.length >= 2, 'expected at least 2 full-width separator lines')
-  for (const sep of separatorLines) {
-    assert.equal(sep.trim().length, 249, `separator should be 249 chars wide, got ${sep.trim().length}`)
+  // Top and bottom rounded borders should be 249 chars (columns - 1)
+  const borderLines = lines.filter(l => /^[╭╰]─+[╮╯]$/.test(l.trim()))
+  assert.equal(borderLines.length, 2, 'expected top and bottom rounded border lines')
+  for (const border of borderLines) {
+    assert.equal(border.trim().length, 249, `border should be 249 chars wide, got ${border.trim().length}`)
   }
 })

--- a/src/welcome-screen.ts
+++ b/src/welcome-screen.ts
@@ -108,7 +108,7 @@ function clampVisible(s: string, w: number): string {
   if (w <= 0) return ''
   if (visLen(s) <= w) return s
   const plain = stripAnsi(s)
-  return plain.length > w ? plain.slice(0, Math.max(0, w - 1)) + '…' : plain
+  return plain.slice(0, Math.max(0, w - 1)) + '…'
 }
 
 export function buildWelcomeScreenLines(opts: WelcomeScreenOptions): string[] {
@@ -129,6 +129,14 @@ export function buildWelcomeScreenLines(opts: WelcomeScreenOptions): string[] {
   if (process.env.CONTEXT7_API_KEY)   toolParts.push('Context7 ✓')
   if (remoteChannel)                  toolParts.push(`${remoteChannel.charAt(0).toUpperCase() + remoteChannel.slice(1)} ✓`)
 
+  const innerWidth = Math.max(1, termWidth - 2)
+  const logoWidth = Math.max(...GSD_LOGO.map((line) => visLen(line)))
+  const divider = ` ${chalk.dim('│')} `
+  const panelWidth = innerWidth - logoWidth - visLen(divider)
+  if (panelWidth < 44) {
+    return ['', `  Get Shit Done v${version}`, `  ${shortCwd}`, '']
+  }
+
   // "Welcome back" context lines — GSD state if available, else hint.
   // Intentionally avoids data already shown in the footer (model, provider,
   // pwd, branch).
@@ -139,7 +147,8 @@ export function buildWelcomeScreenLines(opts: WelcomeScreenOptions): string[] {
   if (state?.milestone) {
     const statusParts = [state.milestone, state.phase, state.slice].filter(Boolean)
     projectText = statusParts.join(' · ')
-    commandText = state.nextAction ? clampVisible(state.nextAction, 46) : '/gsd next'
+    const maxActionWidth = Math.max(10, panelWidth - 30)
+    commandText = state.nextAction ? clampVisible(state.nextAction, maxActionWidth) : '/gsd next'
     modeText = state.phase ?? 'active'
   }
 
@@ -149,14 +158,6 @@ export function buildWelcomeScreenLines(opts: WelcomeScreenOptions): string[] {
     : mcpCount > 0
       ? `${mcpCount} server${mcpCount === 1 ? '' : 's'} configured`
       : 'none configured'
-
-  const innerWidth = Math.max(1, termWidth - 2)
-  const logoWidth = Math.max(...GSD_LOGO.map((line) => visLen(line)))
-  const divider = ` ${chalk.dim('│')} `
-  const panelWidth = innerWidth - logoWidth - visLen(divider)
-  if (panelWidth < 44) {
-    return ['', `  Get Shit Done v${version}`, `  ${shortCwd}`, '']
-  }
 
   const label = (s: string) => chalk.dim(s)
   const value = (s: string) => chalk.hex('#dce4f2')(s)

--- a/src/welcome-screen.ts
+++ b/src/welcome-screen.ts
@@ -1,8 +1,11 @@
+// Project/App: GSD-2
+// File Purpose: Startup welcome screen rendering for the GSD terminal experience.
+
 /**
  * GSD Welcome Screen
  *
- * Two-panel bar layout: full-width accent bars at top/bottom (matching the
- * auto-mode progress widget style), logo left (fixed width), info right.
+ * Command-center layout: rounded terminal card with compact logo, project
+ * state, primary action, branch/workspace, and secondary hints.
  * Falls back to simple text on narrow terminals (<70 cols) or non-TTY.
  */
 
@@ -85,7 +88,27 @@ function visLen(s: string): number {
 
 /** Right-pad a string to the given visible width. */
 function rpad(s: string, w: number): string {
-  return s + ' '.repeat(Math.max(0, w - visLen(s)))
+  const clamped = clampVisible(s, w)
+  return clamped + ' '.repeat(Math.max(0, w - visLen(clamped)))
+}
+
+function rightAlign(left: string, right: string, width: number): string {
+  if (!right) return clampVisible(left, width)
+  const gap = Math.max(1, width - visLen(left) - visLen(right))
+  return clampVisible(left + ' '.repeat(gap) + right, width)
+}
+
+function frameLine(content: string, width: number): string {
+  const inner = Math.max(1, width - 2)
+  return chalk.hex('#a7ba78')('│') + rpad(content, inner) + chalk.hex('#a7ba78')('│')
+}
+
+/** Clamp rendered terminal output by visible columns. Falls back to plain text only when truncating. */
+function clampVisible(s: string, w: number): string {
+  if (w <= 0) return ''
+  if (visLen(s) <= w) return s
+  const plain = stripAnsi(s)
+  return plain.length > w ? plain.slice(0, Math.max(0, w - 1)) + '…' : plain
 }
 
 export function buildWelcomeScreenLines(opts: WelcomeScreenOptions): string[] {
@@ -98,24 +121,6 @@ export function buildWelcomeScreenLines(opts: WelcomeScreenOptions): string[] {
     return ['', `  Get Shit Done v${version}`, `  ${shortCwd}`, '']
   }
 
-  // ── Panel widths ────────────────────────────────────────────────────────────
-  // Layout: 1 leading space + LEFT_INNER logo content + 1 inner divider + RIGHT_INNER info
-  // Total: 1 + LEFT_INNER + 1 + RIGHT_INNER = termWidth
-  const LEFT_INNER = 34
-  const RIGHT_INNER = termWidth - LEFT_INNER - 2  // 2 = leading space + inner divider
-
-  // ── Bar/divider chars (matching GLYPH.separator + widget ui.bar() style) ────
-  const H = '─', DV = '│', DS = '├'
-
-  // ── Left rows: blank + 6 logo lines + blank (8 total) ───────────────────────
-  const leftRows = ['', ...GSD_LOGO, '']
-
-  // ── Right rows (8 total, null = divider) ────────────────────────────────────
-  const titleLeft  = `  ${chalk.bold('Get Shit Done')}`
-  const titleRight = chalk.dim(`v${version}`)
-  const titleFill  = RIGHT_INNER - visLen(titleLeft) - visLen(titleRight)
-  const titleRow   = titleLeft + ' '.repeat(Math.max(1, titleFill)) + titleRight
-
   const toolParts: string[] = []
   if (process.env.BRAVE_API_KEY)      toolParts.push('Brave ✓')
   if (process.env.BRAVE_ANSWERS_KEY)  toolParts.push('Answers ✓')
@@ -124,77 +129,58 @@ export function buildWelcomeScreenLines(opts: WelcomeScreenOptions): string[] {
   if (process.env.CONTEXT7_API_KEY)   toolParts.push('Context7 ✓')
   if (remoteChannel)                  toolParts.push(`${remoteChannel.charAt(0).toUpperCase() + remoteChannel.slice(1)} ✓`)
 
-  // Tools left, hint right-aligned on the same row
-  const toolsLeft  = toolParts.length > 0 ? chalk.dim('  ' + toolParts.join('  ·  ')) : ''
-  const hintRight  = chalk.dim('/gsd to begin  ·  /gsd help')
-  const footerFill = RIGHT_INNER - visLen(toolsLeft) - visLen(hintRight)
-  const footerRow  = toolsLeft + ' '.repeat(Math.max(1, footerFill)) + hintRight
-
   // "Welcome back" context lines — GSD state if available, else hint.
   // Intentionally avoids data already shown in the footer (model, provider,
   // pwd, branch).
   const state = readGsdState()
-  let line1 = ''
-  let line2 = ''
+  let projectText = 'No active GSD project'
+  let commandText = '/gsd start'
+  let modeText = 'manual'
   if (state?.milestone) {
     const statusParts = [state.milestone, state.phase, state.slice].filter(Boolean)
-    const activePrefix = '  Active     '
-    const maxActiveLen = RIGHT_INNER - activePrefix.length - 1
-    let activeText = statusParts.join(' · ')
-    if (activeText.length > maxActiveLen) activeText = activeText.slice(0, maxActiveLen - 1) + '…'
-    line1 = `${activePrefix}${chalk.dim(activeText)}`
-    line2 = state.nextAction
-      ? `  Next       ${chalk.dim(state.nextAction)}`
-      : ''
-  } else {
-    line1 = `  Status     ${chalk.dim('No active GSD project')}`
-    line2 = `             ${chalk.dim('/gsd to begin')}`
+    projectText = statusParts.join(' · ')
+    commandText = state.nextAction ? clampVisible(state.nextAction, 46) : '/gsd next'
+    modeText = state.phase ?? 'active'
   }
-  const sessionLine = line1
-  const projectLine = line2
 
   const mcpCount = countMcpServers()
-  const mcpLine = mcpCount > 0
-    ? `  MCP        ${chalk.dim(`${mcpCount} server${mcpCount === 1 ? '' : 's'} configured`)}`
-    : ''
+  const mcpText = toolParts.length > 0
+    ? toolParts.join('  ·  ')
+    : mcpCount > 0
+      ? `${mcpCount} server${mcpCount === 1 ? '' : 's'} configured`
+      : 'none configured'
 
-  const DIVIDER = null
-  const rightRows: (string | null)[] = [
-    titleRow,
-    DIVIDER,
-    sessionLine,
-    projectLine,
-    mcpLine,
-    '',
-    DIVIDER,
-    footerRow,
+  const innerWidth = Math.max(1, termWidth - 2)
+  const logoWidth = Math.max(...GSD_LOGO.map((line) => visLen(line)))
+  const divider = ` ${chalk.dim('│')} `
+  const panelWidth = innerWidth - logoWidth - visLen(divider)
+  if (panelWidth < 44) {
+    return ['', `  Get Shit Done v${version}`, `  ${shortCwd}`, '']
+  }
+
+  const label = (s: string) => chalk.dim(s)
+  const value = (s: string) => chalk.hex('#dce4f2')(s)
+  const accent = (s: string) => chalk.hex('#8db7ff')(s)
+  const panelRows = [
+    rightAlign(`${accent('GSD')} ${chalk.bold(value('Project Console'))}`, chalk.dim(`v${version}`), panelWidth),
+    rightAlign(`${label('Project')} ${value(projectText)}`, `${label('Command')} ${accent(commandText)}`, panelWidth),
+    rightAlign(`${label('Workspace')} ${value(shortCwd)}`, `${label('Mode')} ${value(modeText)}`, panelWidth),
+    rightAlign(`${label('MCP')} ${chalk.dim(mcpText)}`, `${label('Status')} ${value(state?.milestone ? 'active' : 'idle')}`, panelWidth),
+    rightAlign(`${label('Next')} ${accent('/gsd to begin')}`, `${label('Setup')} ${accent('/gsd start')}`, panelWidth),
+    rightAlign(chalk.dim('/gsd templates'), chalk.dim('/gsd help'), panelWidth),
   ]
 
   // ── Render ──────────────────────────────────────────────────────────────────
   const out: string[] = ['']
-
-  // Top bar — full-width accent separator, matches auto-mode widget ui.bar()
-  out.push(chalk.cyan(H.repeat(termWidth)))
-
-  for (let i = 0; i < 8; i++) {
-    const row      = leftRows[i] ?? ''
-    const lContent = rpad(row ? chalk.cyan(row) : '', LEFT_INNER)
-    const rRow     = rightRows[i]
-
-    if (rRow === null) {
-      // Section divider: left logo area + dim ├────... extending right
-      out.push(' ' + lContent + chalk.dim(DS + H.repeat(RIGHT_INNER)))
-    } else {
-      // Content row: 1 space + logo │ info (no outer vertical borders)
-      out.push(' ' + lContent + chalk.dim(DV) + rpad(rRow, RIGHT_INNER))
-    }
+  out.push(chalk.hex('#a7ba78')('╭' + '─'.repeat(termWidth - 2) + '╮'))
+  for (let i = 0; i < GSD_LOGO.length; i++) {
+    const logo = rpad(chalk.hex('#a7ba78')(GSD_LOGO[i]), logoWidth)
+    out.push(frameLine(`${logo}${divider}${panelRows[i] ?? ''}`, termWidth))
   }
-
-  // Bottom bar — full-width accent separator
-  out.push(chalk.cyan(H.repeat(termWidth)))
+  out.push(chalk.hex('#a7ba78')('╰' + '─'.repeat(termWidth - 2) + '╯'))
   out.push('')
 
-  return out
+  return out.map((line) => clampVisible(line, termWidth))
 }
 
 export function printWelcomeScreen(opts: WelcomeScreenOptions): void {


### PR DESCRIPTION
## TL;DR

**What:** Refreshes the operations console TUI across chat, tools, footer/header, overlays, auto-mode, and completion roll-up surfaces.
**Why:** The prior surfaces were visually inconsistent and some lifecycle states left users on empty or misleading stop screens.
**How:** Adds shared transcript/rendering primitives, updates theme tokens and TUI components, anchors overlays to the visible viewport, and preserves meaningful auto-mode/roll-up surfaces during cleanup.

## What

This PR updates the terminal UI design system and GSD auto-mode surfaces:

- Adds TUI design mockups in `docs/dev/tui-render-options.html` and `docs/dev/tui-recommended-design.html`.
- Adds shared transcript styling primitives for chat rails, tool cards, and common terminal layout helpers.
- Refreshes assistant/user message rendering, tool execution cards, bash/diff output, footer, welcome/header, notifications, parallel monitor, and auto dashboard surfaces.
- Adds syntax highlighting support for tool output/diffs where supported by the theme layer.
- Updates progress bars and theme tokens to match the command-center design direction.
- Keeps milestone completion roll-ups visible as the final surface and prevents generic cleanup cards from replacing the last meaningful auto-mode deck.

## Why

Closes #5699.

The TUI had grown a mix of styles across chat, assistant output, tool output, footer/header, notifications, and auto-mode. More importantly, end-of-turn and end-of-milestone cleanup could clear the useful screen and leave users with an empty viewport or generic instructions like “auto loop ended” / “resume” after completed work.

## How

The implementation consolidates the visual language around theme-aware rails, framed tool cards, consistent command/footer spacing, viewport-aware overlay placement, and durable auto-mode closeout surfaces. Completion roll-ups now include next instructions directly and cleanup preserves the last meaningful auto surface instead of replacing it with a generic card.

This PR is AI-assisted. I reviewed the generated changes and verified them locally.

## Change type checklist

- [x] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Verification

- [x] `npm run verify:pr`
  - `build:core` passed
  - `typecheck:extensions` passed
  - compiled unit suite passed: `8976 passed, 0 failed, 9 skipped`

Additional focused checks run during development:

- `auto-paused-ui-cleanup.test.ts`
- `auto-dashboard.test.ts`
- `tui-render-kit.test.ts`
- `overlay-layout.test.ts`
- `user-message-design.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified TUI design system with rounded "command‑center", transcript-style cards, rails, command/result cards, progress bars, and an outcome/next‑action widget for auto-mode handoffs.

* **Improvements**
  * Width- and ANSI-safe rendering helpers, safer syntax-highlighting fallback, refined footer/header layouts, compact progress/status visuals, and preserved completion lifecycle behavior.

* **Visual Updates**
  * Dark theme palette refreshed; welcome screen and headers adopt the new rounded command‑center style.

* **Documentation**
  * Added dark-themed TUI design mockups and render option previews.

* **Tests**
  * Expanded visual contract and overlay/widget rendering coverage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5708)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->