### PR TITLE
refactor(gsd-extension): ADR-017 phase 1 / sketch-flag pattern proof

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,6 +11,8 @@
 - **DB snapshot persistence**: crash-safe persistence of a full SQLite image exported from `sql.js`, written as a same-directory temporary file and atomically renamed over the live database path.
 - **Worktree Lifecycle**: creation, entry, teardown, and merge of an auto-mode worktree, including `s.basePath` mutation, `process.chdir` discipline, and milestone lease coordination.
 - **Worktree State Projection**: directional flow of state files between the project root and the auto-worktree, where one side is authoritative per file class (e.g., project root is authoritative for `completed-units.json` after crash recovery; worktree is authoritative for in-flight artifacts).
+- **Drift**: a state-shape mismatch between DB rows, disk artifacts, and in-memory state that has a known repair. Distinct from a `blocker`, which describes a terminal condition needing human attention or recovery escalation.
+- **Drift catalog**: the discriminated union of drift kinds the State Reconciliation Module recognizes and can repair.
 
 ## Architecture terms adopted for this area
 
@@ -22,12 +24,15 @@
 - **Runtime persistence adapter**: adapter behind the Runtime persistence seam.
 - **Notification adapter**: adapter behind the Notification seam.
 - **DB snapshot persistence module**: the deep module that owns `sql.js` snapshot write semantics, including temp-file naming, fsync, cleanup, and rename ordering.
-- **State Reconciliation module**: module that reconciles DB-authoritative runtime state with durable disk projections before a Dispatch decision.
+- **State Reconciliation module**: module that runs `reconcileBeforeDispatch` before any Dispatch decision or worker spawn. Surfaces terminal `blockers: string[]` and machine-actionable `DriftRecord[]`. Owns the drift catalog (detectors and idempotent repairs). Throws `ReconciliationFailedError` to Recovery Classification on persistent or repair-failed drift. See `docs/dev/ADR-017-state-reconciliation-drift-driven.md`.
 - **Worktree Safety module**: module that validates project root, worktree registration, lease ownership, and git health before a source-writing Unit runs.
 - **Worktree Lifecycle module**: module that owns worktree create/enter/teardown/merge verbs, `s.basePath` mutation, and `process.chdir` discipline. Sole owner of these mutations across single-loop and parallel callers.
 - **Worktree State Projection module**: module that owns the direction-and-rules of state file flow between project root and auto-worktree. Encodes the bug-hardened invariants (additive milestone copy, ASSESSMENT verdict overwrite, completed-units forward-sync, WAL/SHM cleanup) that `syncProjectRootToWorktree` and `syncStateToProjectRoot` carry today.
-- **Recovery Classification module**: module that maps provider, tool, policy, git, worktree, and runtime failures to a Recovery decision.
+- **Recovery Classification module**: module that maps provider, tool, policy, git, worktree, runtime, and reconciliation-drift failures to a Recovery decision.
 - **Tool Contract module**: module that keeps Unit prompts, tool schemas, tool policy, and pre-dispatch validation aligned.
+- **DriftRecord**: typed, machine-actionable signal of a single drift instance. Discriminated union over drift kinds; carries the identifiers (e.g., milestone id, slice id) the matching repair needs.
+- **Drift repair**: idempotent function that resolves one `DriftRecord`. Repairs are owned by the State Reconciliation Module's `drift/` folder; owning modules retain raw primitives (DB writes, file IO) but not the detection-and-repair composition.
+- **Reconciliation pass**: one cycle of derive → detect drift → apply repairs → re-derive, performed by `reconcileBeforeDispatch`. Capped at 2 passes per call; loops only when the prior pass fully succeeded but new drift surfaces in the re-derive.
 
 ## Current decision in force
 
@@ -54,6 +59,10 @@ See `docs/dev/ADR-015-runtime-invariant-modules.md`.
 Dispatch remains responsible for selecting the next Unit from reconciled state. It should not own DB/disk repair, tool-policy compilation, or worktree root preparation.
 
 - Worktree Safety should fail closed for source-writing Units under worktree isolation. A Unit whose Tool Contract permits writes outside `.gsd/**` must run in a proven milestone worktree root; it must not silently degrade to project-root source writes when the worktree is missing, empty, unregistered, on the wrong branch, or no longer lease-owned. Planning-only Units may continue to write `.gsd/**` artifacts at the project root.
+
+- State Reconciliation should be drift-driven. The Module surfaces terminal `blockers: string[]` and machine-actionable `DriftRecord[]`. Each pre-dispatch and pre-spawn site calls `reconcileBeforeDispatch` (strict closure). Drift catalog includes sketch-flag, merge-state, stale-worker, unregistered-milestone, roadmap-divergence, missing-completion-timestamp. Repairs are idempotent. Re-derive is capped at 2 passes (loops only on cascading-drift success path). Persistent or repair-failed drift throws `ReconciliationFailedError` to Recovery Classification (kind `reconciliation-drift`).
+
+  See `docs/dev/ADR-017-state-reconciliation-drift-driven.md`.
 
 ## Current implementation snapshot (phase 1)
 

--- a/docs/dev/ADR-017-state-reconciliation-drift-driven.md
+++ b/docs/dev/ADR-017-state-reconciliation-drift-driven.md
@@ -94,7 +94,7 @@ async function reconcileBeforeDispatch(
 
 `state-reconciliation/` folder owns detectors **and** repairs:
 
-```
+```text
 state-reconciliation/
   index.ts          → reconcileBeforeDispatch
   errors.ts         → ReconciliationFailedError

--- a/docs/dev/ADR-017-state-reconciliation-drift-driven.md
+++ b/docs/dev/ADR-017-state-reconciliation-drift-driven.md
@@ -1,0 +1,142 @@
+<!-- Project/App: GSD-2 -->
+<!-- File Purpose: ADR for drift-driven design of the State Reconciliation Module. -->
+
+# ADR-017: Drift-Driven State Reconciliation
+
+**Status:** Accepted
+**Date:** 2026-05-10
+**Author:** GSD architecture review
+**Related:** ADR-014 (deep Auto Orchestration module), ADR-015 (runtime invariant modules), ADR-016 trio (worktree split + fail-closed)
+
+## Context
+
+ADR-015 named the **State Reconciliation Module** as one of four runtime invariant modules and specified `reconcileBeforeDispatch(basePath)` as its Interface. The module landed at `src/resources/extensions/gsd/state-reconciliation.ts` (57 lines) but its current implementation only invalidates the state cache and calls `deriveState`. The Interface returns `repaired: readonly string[]` but the only value ever returned is `["derive-state-cache-invalidated"]` — the cache invalidation itself, dressed up as a repair.
+
+The repair helpers CONTEXT.md names — sketch-flag healing, merge-state reconciliation, PROJECT.md/ROADMAP.md drift, completion-timestamp drift — exist in scattered places, or do not exist at all:
+
+- `autoHealSketchFlags` (`gsd-db.ts:1156`): exists, **zero callers**.
+- `reconcileMergeState` (`auto-recovery.ts:1118`): exists, called only by post-failure recovery paths.
+- `repairStaleRenders` (`markdown-renderer.ts:937`): exists.
+- Stale-worker, PROJECT.md/ROADMAP.md, completion-timestamp repair: **no implementation**.
+
+The module has one production caller (the Auto Orchestration adapter in `auto.ts:1753`). Without specifying what reconciliation actually does, the module is a hypothetical seam — the discipline ADR-016 chased out for worktree handling.
+
+## Decision
+
+State Reconciliation runs **drift-driven blocker repair** before every Dispatch decision and before every worker spawn. The Module exposes two surfaces:
+
+1. **`blockers: string[]`** (existing) — terminal, human-readable. Indicates conditions reconciliation cannot resolve (DB unavailable, slice lock invalid, dependency cycle).
+2. **`DriftRecord[]`** (new) — typed, discriminated union of repairable drift kinds. Each `DriftRecord` carries the identifiers its matching repair needs.
+
+### Drift catalog (initial)
+
+```ts
+type DriftRecord =
+  | { kind: "stale-sketch-flag"; mid: string; sid: string }
+  | { kind: "unmerged-merge-state"; basePath: string }
+  | { kind: "stale-worker"; lockPath: string; pid: number }
+  | { kind: "unregistered-milestone"; milestoneId: string }
+  | { kind: "roadmap-divergence"; milestoneId: string; sliceId?: string }
+  | {
+      kind: "missing-completion-timestamp";
+      entity: "task" | "slice" | "milestone";
+      ids: string[];
+    };
+```
+
+### Lifecycle
+
+```ts
+async function reconcileBeforeDispatch(
+  basePath: string,
+  deps: ReconciliationDeps,
+): Promise<ReconciliationResult> {
+  for (let pass = 0; pass < 2; pass++) {
+    const s = await deps.deriveState(basePath);
+    const drift = detectAllDrift(s, deps);
+    if (drift.length === 0) {
+      return { ok: true, stateSnapshot: s, repaired: [], blockers: s.blockers ?? [] };
+    }
+
+    const failures: Array<{ drift: DriftRecord; cause: unknown }> = [];
+    for (const d of drift) {
+      try {
+        await applyRepair(d, deps);
+      } catch (cause) {
+        failures.push({ drift: d, cause });
+      }
+    }
+    if (failures.length > 0) {
+      throw new ReconciliationFailedError({ failures, pass });
+    }
+    // pass succeeded; loop runs again to detect cascading drift
+  }
+
+  const finalState = await deps.deriveState(basePath);
+  const persistent = detectAllDrift(finalState, deps);
+  if (persistent.length > 0) {
+    throw new ReconciliationFailedError({ persistentDrift: persistent });
+  }
+  return {
+    ok: true,
+    stateSnapshot: finalState,
+    repaired: [],
+    blockers: finalState.blockers ?? [],
+  };
+}
+```
+
+- **Re-derive cycle is capped at 2.** The loop runs only when the prior pass fully succeeded and re-derive surfaces NEW drift (cascading repairs — e.g., fixing a milestone registration uncovers a downstream completion-timestamp drift). Persistent or failed drift after pass 2 throws.
+- **All repairs must be idempotent.** Re-derive can re-trigger detection on transient state; repairs must be safe under retry.
+- **Failure throws.** `ReconciliationFailedError` is caught by the caller and routed to `classifyFailure({ error, failureKind: "reconciliation-drift" })`.
+
+### Module home
+
+`state-reconciliation/` folder owns detectors **and** repairs:
+
+```
+state-reconciliation/
+  index.ts          → reconcileBeforeDispatch
+  errors.ts         → ReconciliationFailedError
+  drift/
+    sketch-flag.ts  → detect + repair (relocated from gsd-db.ts)
+    merge-state.ts  → detect + repair (relocated from auto-recovery.ts)
+    stale-worker.ts → detect + repair (new)
+    project-md.ts   → detect + repair (new)
+    roadmap.ts      → detect + repair (new)
+    completion.ts   → detect + repair (new)
+  registry.ts       → DriftKind → { detect, repair }
+```
+
+Owning modules retain their raw primitives (e.g., `setSliceSketchFlag`, the SELECT query) but the **detection-and-repair composition** lives in the drift folder.
+
+### Caller closure
+
+Strict closure — every pre-dispatch / pre-spawn site calls `reconcileBeforeDispatch`:
+
+- Single-loop auto: already wired via `auto/orchestrator.ts:42` (existing).
+- Workers spawned by parallel orchestration: already covered (each spawned worker runs its own auto-loop with reconcile).
+- **Parent processes that spawn workers**: need new wiring at the `startParallel` / `startSliceParallel` call sites (`auto.ts`, `auto/phases.ts`, `commands/handlers/parallel.ts`) so workers do not independently race on the same drift.
+
+### Recovery Classification contract change
+
+Add new `RecoveryFailureKind: "reconciliation-drift"` with action `escalate` and remediation pointing at the persistent drift kinds. Update `classifyFailure` in `recovery-classification.ts` to recognise `ReconciliationFailedError`.
+
+## Consequences
+
+- `gsd-db.ts:1156` `autoHealSketchFlags` relocates to `state-reconciliation/drift/sketch-flag.ts`. `gsd-db.ts` keeps `setSliceSketchFlag` and the SELECT primitive.
+- `auto-recovery.ts:1118` `reconcileMergeState` and supporting helpers relocate to `state-reconciliation/drift/merge-state.ts`. `auto-recovery.ts` shrinks; remaining post-failure helpers (`verifyExpectedArtifact`, `writeBlockerPlaceholder`) stay.
+- Four new repair functions land: stale-worker, PROJECT.md sync, ROADMAP.md sync, completion-timestamp backfill.
+- `state.ts` `blockers: string[]` is unchanged; existing call sites that read `s.blockers` are unaffected.
+- Detector cost is paid on every `advance()` tick. Cheap detectors (DB queries, `existsSync`) run unconditionally; markdown-parsing detectors must be designed to short-circuit when artifacts are unchanged.
+- Every drift kind has a contract test: seeded drift → reconcile → assert repaired. Persistent-drift cases are tested with non-idempotent fixture setups.
+- The Module's Interface becomes the test surface for runtime drift handling. Single-drift unit tests can target `drift/<kind>.ts` directly.
+
+## Alternatives considered
+
+- **Idempotent self-healing** (every tick attempts every known repair, no detection layer). Rejected: pays the repair cost on every advance even when state is clean, and provides no signal for telemetry/observability about which drift was actually present.
+- **Passive — derive only**. Rejected: dormant repairs (`autoHealSketchFlags` has zero callers today) stay dormant. The seam exists but solves nothing.
+- **Predicate-matched repairs over free-text blockers**. Rejected as fragile: this is the same pattern as the dispatch rule registry, which has already shown drift between two parallel rule sources (see `auto-dispatch.ts:1474`). Typed drift records make new repair additions a type-system change instead of a regex audit.
+- **Loop until stable (uncapped)**. Rejected for runaway risk. Cap=2 is enough for cascading repairs without unbounded retry.
+- **First-failure aborts the pass**. Rejected: loses repair work for unrelated drift. Collecting failures within a pass and throwing at end-of-pass keeps the failure surface complete.
+- **Detectors and repairs delegated to owning modules** (each owner exposes its own `detect` + `repair`). Rejected: the canonical zero-caller bug (`autoHealSketchFlags` shipped in `gsd-db.ts` for over a year without wiring) shows that owners do not naturally compose detection-and-repair into a pre-dispatch lifecycle. Locality wins here — one folder reviews the whole catalog.

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -240,7 +240,10 @@ import { resolveUokFlags } from "./uok/flags.js";
 import { validateDirectory } from "./validate-directory.js";
 import { createAutoOrchestrator } from "./auto/orchestrator.js";
 import type { AutoOrchestrationModule, AutoOrchestratorDeps } from "./auto/contracts.js";
-import { reconcileBeforeDispatch } from "./state-reconciliation.js";
+import {
+  reconcileBeforeDispatch,
+  ReconciliationFailedError,
+} from "./state-reconciliation.js";
 import { compileUnitToolContract } from "./tool-contract.js";
 import { createWorktreeSafetyModule } from "./worktree-safety.js";
 import { resolveManifest } from "./unit-context-manifest.js";
@@ -1751,19 +1754,30 @@ export function createWiredAutoOrchestrationModule(
   const deps: AutoOrchestratorDeps = {
     stateReconciliation: {
       async reconcileBeforeDispatch() {
-        const result = await reconcileBeforeDispatch(dispatchBasePath);
-        if (!result.ok) {
+        try {
+          const result = await reconcileBeforeDispatch(dispatchBasePath);
+          if (result.blockers.length > 0) {
+            return {
+              ok: false,
+              reason: result.blockers[0],
+              stateSnapshot: result.stateSnapshot,
+            };
+          }
+          const repairedKinds = result.repaired.map((d) => d.kind);
           return {
-            ok: false,
-            reason: result.reason,
+            ok: true,
+            reason:
+              repairedKinds.length > 0
+                ? `repaired: ${repairedKinds.join(", ")}`
+                : "clean",
             stateSnapshot: result.stateSnapshot,
           };
+        } catch (err) {
+          if (err instanceof ReconciliationFailedError) {
+            return { ok: false, reason: err.message };
+          }
+          throw err;
         }
-        return {
-          ok: true,
-          reason: result.repaired.join(", "),
-          stateSnapshot: result.stateSnapshot,
-        };
       },
     },
     dispatch: {

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1136,33 +1136,17 @@ export function setSliceSketchFlag(milestoneId: string, sliceId: string, isSketc
 }
 
 /**
- * ADR-011 auto-heal: reconcile stale is_sketch=1 rows whose PLAN already exists.
- *
- * Callers pass a predicate that resolves whether a plan file exists for a slice.
- * The predicate MUST use the canonical path resolver (`resolveSliceFile`, etc.)
- * to keep path logic in one place — do not hand-roll the path inside the callback.
- *
- * Recovers from two scenarios:
- *   1. Crash between `gsd_plan_slice` write and the sketch flag flip.
- *   2. Flag-OFF downgrade path: when `progressive_planning` is off, the dispatch
- *      rule routes sketch slices to plan-slice, which writes PLAN.md but leaves
- *      `is_sketch=1` — the next state derivation auto-heals it to 0 here.
- *
- * Not aggressive in practice: PLAN.md is only written via the DB-backed
- * `gsd_plan_slice` tool (which also inserts tasks), so a "stale PLAN.md with
- * is_sketch=1" is extremely unlikely to indicate anything other than the two
- * recovery scenarios above.
+ * ADR-017 raw primitive: returns slice IDs in a milestone whose is_sketch flag
+ * is still 1. The stale-sketch-flag drift handler at
+ * `state-reconciliation/drift/sketch-flag.ts` composes this with PLAN.md
+ * existence checks to detect drift, then writes via `setSliceSketchFlag`.
  */
-export function autoHealSketchFlags(milestoneId: string, hasPlanFile: (sliceId: string) => boolean): void {
-  if (!currentDb) return;
+export function getSketchedSliceIds(milestoneId: string): string[] {
+  if (!currentDb) return [];
   const rows = currentDb.prepare(
     `SELECT id FROM slices WHERE milestone_id = :mid AND is_sketch = 1`,
   ).all({ ":mid": milestoneId }) as Array<{ id: string }>;
-  for (const row of rows) {
-    if (hasPlanFile(row.id)) {
-      setSliceSketchFlag(milestoneId, row.id, false);
-    }
-  }
+  return rows.map((r) => r.id);
 }
 
 export function upsertSlicePlanning(milestoneId: string, sliceId: string, planning: Partial<SlicePlanningRecord>): void {

--- a/src/resources/extensions/gsd/recovery-classification.ts
+++ b/src/resources/extensions/gsd/recovery-classification.ts
@@ -2,6 +2,7 @@
 // File Purpose: ADR-015 Recovery Classification module for runtime failure taxonomy.
 
 import { classifyError, isTransient, type ErrorClass } from "./error-classifier.js";
+import { ReconciliationFailedError } from "./state-reconciliation.js";
 
 export type RecoveryFailureKind =
   | "tool-schema"
@@ -9,6 +10,7 @@ export type RecoveryFailureKind =
   | "stale-worker"
   | "worktree-invalid"
   | "verification-drift"
+  | "reconciliation-drift"
   | "provider"
   | "runtime-unknown";
 
@@ -33,7 +35,13 @@ export interface RecoveryClassification {
 
 export function classifyFailure(input: RecoveryClassificationInput): RecoveryClassification {
   const message = errorMessage(input.error);
-  const failureKind = input.failureKind ?? inferFailureKind(message);
+  // ADR-017: ReconciliationFailedError is a typed throw from the State
+  // Reconciliation Module. Recognize it by class regardless of caller-supplied
+  // failureKind so the taxonomy stays consistent.
+  const failureKind =
+    input.error instanceof ReconciliationFailedError
+      ? "reconciliation-drift"
+      : input.failureKind ?? inferFailureKind(message);
 
   switch (failureKind) {
     case "tool-schema":
@@ -75,6 +83,15 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
         reason: `Verification drift${unitSuffix(input)}: ${message}`,
         exitReason: "verification-drift",
         remediation: "Inspect the verification artifact and reconcile the state snapshot before resuming.",
+      };
+    case "reconciliation-drift":
+      return {
+        failureKind,
+        action: "escalate",
+        reason: `Reconciliation drift${unitSuffix(input)}: ${message}`,
+        exitReason: "reconciliation-drift",
+        remediation:
+          "Inspect the persistent or repair-failed drift kinds reported by the State Reconciliation Module before resuming.",
       };
     case "provider": {
       const providerClass = classifyError(message, input.retryAfterMs);

--- a/src/resources/extensions/gsd/state-reconciliation.ts
+++ b/src/resources/extensions/gsd/state-reconciliation.ts
@@ -1,57 +1,19 @@
 // Project/App: GSD-2
-// File Purpose: ADR-015 State Reconciliation module for pre-dispatch runtime invariants.
+// File Purpose: ADR-017 State Reconciliation Module — public entry point.
+// Re-exports the drift-driven implementation from the state-reconciliation/
+// folder so existing import paths (./state-reconciliation.js) keep working.
 
-import { deriveState, invalidateStateCache, type DeriveStateOptions } from "./state.js";
-import type { GSDState } from "./types.js";
+export {
+  reconcileBeforeDispatch,
+  ReconciliationFailedError,
+  DRIFT_REGISTRY,
+} from "./state-reconciliation/index.js";
 
-export type StateReconciliationResult =
-  | {
-      ok: true;
-      stateSnapshot: GSDState;
-      repaired: readonly string[];
-      blockers: readonly string[];
-    }
-  | {
-      ok: false;
-      reason: string;
-      stateSnapshot?: GSDState;
-      repaired: readonly string[];
-      blockers: readonly string[];
-    };
-
-export interface StateReconciliationDeps {
-  invalidateStateCache: () => void;
-  deriveState: (basePath: string, opts?: DeriveStateOptions) => Promise<GSDState>;
-}
-
-const defaultDeps: StateReconciliationDeps = {
-  invalidateStateCache,
-  deriveState,
-};
-
-export async function reconcileBeforeDispatch(
-  basePath: string,
-  deps: StateReconciliationDeps = defaultDeps,
-  opts?: DeriveStateOptions,
-): Promise<StateReconciliationResult> {
-  deps.invalidateStateCache();
-  const stateSnapshot = await deps.deriveState(basePath, opts);
-  const blockers = stateSnapshot.blockers ?? [];
-
-  if (blockers.length > 0 || stateSnapshot.phase === "blocked") {
-    return {
-      ok: false,
-      reason: blockers[0] ?? `State reconciliation blocked in phase ${stateSnapshot.phase}`,
-      stateSnapshot,
-      repaired: ["derive-state-cache-invalidated"],
-      blockers,
-    };
-  }
-
-  return {
-    ok: true,
-    stateSnapshot,
-    repaired: ["derive-state-cache-invalidated"],
-    blockers,
-  };
-}
+export type {
+  DriftContext,
+  DriftHandler,
+  DriftRecord,
+  ReconciliationDeps,
+  ReconciliationFailureDetail,
+  ReconciliationResult,
+} from "./state-reconciliation/index.js";

--- a/src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts
@@ -1,0 +1,68 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 stale-sketch-flag drift handler. Relocated from
+// gsd-db.ts where autoHealSketchFlags previously lived with zero callers.
+//
+// Recovers from two scenarios (per ADR-011):
+//   1. Crash between gsd_plan_slice's PLAN.md write and the sketch flag flip.
+//   2. Flag-OFF downgrade: when progressive_planning is off, dispatch routes
+//      sketch slices to plan-slice, which writes PLAN.md but leaves
+//      is_sketch=1 — the next reconciliation pass clears it.
+
+import { existsSync } from "node:fs";
+
+import {
+  getSketchedSliceIds,
+  isDbAvailable,
+  setSliceSketchFlag,
+} from "../../gsd-db.js";
+import { resolveSliceFile } from "../../paths.js";
+import type { GSDState } from "../../types.js";
+import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
+
+type SketchFlagDrift = Extract<DriftRecord, { kind: "stale-sketch-flag" }>;
+
+export function detectStaleSketchFlags(
+  state: GSDState,
+  ctx: DriftContext,
+): SketchFlagDrift[] {
+  if (!isDbAvailable()) return [];
+  const mid = state.activeMilestone?.id;
+  if (!mid) return [];
+
+  const sliceIds = getSketchedSliceIds(mid);
+  return sliceIds
+    .filter((sid) => {
+      const planPath = resolveSliceFile(ctx.basePath, mid, sid, "PLAN");
+      return planPath !== null && existsSync(planPath);
+    })
+    .map((sid) => ({ kind: "stale-sketch-flag" as const, mid, sid }));
+}
+
+export function repairStaleSketchFlag(record: SketchFlagDrift): void {
+  setSliceSketchFlag(record.mid, record.sid, false);
+}
+
+export const sketchFlagHandler: DriftHandler<SketchFlagDrift> = {
+  kind: "stale-sketch-flag",
+  detect: detectStaleSketchFlags,
+  repair: (record) => {
+    repairStaleSketchFlag(record);
+  },
+};
+
+/**
+ * Legacy entry point preserved for callers that supply a custom hasPlanFile
+ * predicate. Prefer the drift handler (sketchFlagHandler) for new code.
+ */
+export function autoHealSketchFlags(
+  milestoneId: string,
+  hasPlanFile: (sliceId: string) => boolean,
+): void {
+  if (!isDbAvailable()) return;
+  const sliceIds = getSketchedSliceIds(milestoneId);
+  for (const sid of sliceIds) {
+    if (hasPlanFile(sid)) {
+      setSliceSketchFlag(milestoneId, sid, false);
+    }
+  }
+}

--- a/src/resources/extensions/gsd/state-reconciliation/errors.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/errors.ts
@@ -1,0 +1,50 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 typed reconciliation failure for Recovery Classification.
+
+import type { DriftRecord } from "./types.js";
+
+export interface ReconciliationFailureDetail {
+  drift: DriftRecord;
+  cause: unknown;
+}
+
+export interface ReconciliationFailedErrorOptions {
+  failures?: ReadonlyArray<ReconciliationFailureDetail>;
+  persistentDrift?: ReadonlyArray<DriftRecord>;
+  pass?: number;
+}
+
+/**
+ * Thrown by reconcileBeforeDispatch when:
+ *   - one or more repair functions throw within a pass (`failures` populated), or
+ *   - drift persists after the cap=2 lifecycle (`persistentDrift` populated).
+ *
+ * Recovery Classification recognizes this error via instanceof and maps it to
+ * failureKind "reconciliation-drift" with action "escalate".
+ */
+export class ReconciliationFailedError extends Error {
+  readonly failures: ReadonlyArray<ReconciliationFailureDetail>;
+  readonly persistentDrift: ReadonlyArray<DriftRecord>;
+  readonly pass?: number;
+
+  constructor(opts: ReconciliationFailedErrorOptions) {
+    super(formatMessage(opts));
+    this.name = "ReconciliationFailedError";
+    this.failures = opts.failures ?? [];
+    this.persistentDrift = opts.persistentDrift ?? [];
+    this.pass = opts.pass;
+  }
+}
+
+function formatMessage(opts: ReconciliationFailedErrorOptions): string {
+  if (opts.failures && opts.failures.length > 0) {
+    const kinds = opts.failures.map((f) => f.drift.kind).join(", ");
+    const passSuffix = opts.pass !== undefined ? ` in pass ${opts.pass}` : "";
+    return `Reconciliation repair failed${passSuffix} for drift kinds: ${kinds}`;
+  }
+  if (opts.persistentDrift && opts.persistentDrift.length > 0) {
+    const kinds = opts.persistentDrift.map((d) => d.kind).join(", ");
+    return `Reconciliation drift persisted after cap=2 passes: ${kinds}`;
+  }
+  return "Reconciliation failed";
+}

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -1,0 +1,133 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 drift-driven State Reconciliation Module entry point.
+// reconcileBeforeDispatch runs before every Dispatch decision and worker spawn.
+
+import {
+  deriveState as defaultDeriveState,
+  invalidateStateCache as defaultInvalidate,
+} from "../state.js";
+import type { GSDState } from "../types.js";
+
+import {
+  ReconciliationFailedError,
+  type ReconciliationFailureDetail,
+} from "./errors.js";
+import { DRIFT_REGISTRY } from "./registry.js";
+import type {
+  DriftContext,
+  DriftHandler,
+  DriftRecord,
+  ReconciliationDeps,
+  ReconciliationResult,
+} from "./types.js";
+
+export type {
+  DriftContext,
+  DriftHandler,
+  DriftRecord,
+  ReconciliationDeps,
+  ReconciliationResult,
+} from "./types.js";
+export { ReconciliationFailedError } from "./errors.js";
+export type { ReconciliationFailureDetail } from "./errors.js";
+export { DRIFT_REGISTRY } from "./registry.js";
+
+const MAX_PASSES = 2;
+
+const defaultDeps: ReconciliationDeps = {
+  invalidateStateCache: defaultInvalidate,
+  deriveState: defaultDeriveState,
+};
+
+/**
+ * Drift-driven pre-dispatch reconciliation per ADR-017.
+ *
+ * Lifecycle: derive → detect drift → apply repairs → re-derive. Capped at
+ * MAX_PASSES (=2) cycles. The loop runs only when the prior pass fully
+ * succeeded but re-derive surfaces NEW drift (cascading repairs — e.g.
+ * fixing milestone registration uncovers a downstream completion-timestamp
+ * drift).
+ *
+ * Returns ok=true with `repaired` and terminal `blockers` populated.
+ * Throws ReconciliationFailedError when:
+ *   - any repair function throws within a pass, or
+ *   - drift persists after the cap.
+ */
+export async function reconcileBeforeDispatch(
+  basePath: string,
+  deps: ReconciliationDeps = defaultDeps,
+): Promise<ReconciliationResult> {
+  const registry = deps.registry ?? DRIFT_REGISTRY;
+  const repaired: DriftRecord[] = [];
+
+  for (let pass = 0; pass < MAX_PASSES; pass++) {
+    deps.invalidateStateCache();
+    const stateSnapshot = await deps.deriveState(basePath, deps.deriveStateOptions);
+    const ctx: DriftContext = { basePath, state: stateSnapshot };
+
+    const drift = await detectAllDrift(stateSnapshot, ctx, registry);
+    if (drift.length === 0) {
+      return {
+        ok: true,
+        stateSnapshot,
+        repaired,
+        blockers: stateSnapshot.blockers ?? [],
+      };
+    }
+
+    const failures: ReconciliationFailureDetail[] = [];
+    for (const record of drift) {
+      const handler = registry.find((h) => h.kind === record.kind);
+      if (!handler) {
+        failures.push({
+          drift: record,
+          cause: new Error(
+            `No drift handler registered for kind "${record.kind}"`,
+          ),
+        });
+        continue;
+      }
+      try {
+        await handler.repair(record, ctx);
+        repaired.push(record);
+      } catch (cause) {
+        failures.push({ drift: record, cause });
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new ReconciliationFailedError({ failures, pass });
+    }
+    // Pass fully succeeded; loop runs again to detect cascading drift.
+  }
+
+  // After MAX_PASSES, one more derive+detect to verify nothing persists.
+  deps.invalidateStateCache();
+  const finalState = await deps.deriveState(basePath, deps.deriveStateOptions);
+  const finalCtx: DriftContext = { basePath, state: finalState };
+  const persistent = await detectAllDrift(finalState, finalCtx, registry);
+
+  if (persistent.length > 0) {
+    throw new ReconciliationFailedError({ persistentDrift: persistent });
+  }
+
+  return {
+    ok: true,
+    stateSnapshot: finalState,
+    repaired,
+    blockers: finalState.blockers ?? [],
+  };
+}
+
+async function detectAllDrift(
+  state: GSDState,
+  ctx: DriftContext,
+  registry: ReadonlyArray<DriftHandler>,
+): Promise<DriftRecord[]> {
+  const collected: DriftRecord[] = [];
+  for (const handler of registry) {
+    const detected = await handler.detect(state, ctx);
+    collected.push(...detected);
+  }
+  return collected;
+}

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -1,0 +1,10 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 drift handler registry. Single source of truth for
+// the catalog. Tests can override per-call via ReconciliationDeps.registry.
+
+import { sketchFlagHandler } from "./drift/sketch-flag.js";
+import type { DriftHandler } from "./types.js";
+
+export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler> = [
+  sketchFlagHandler,
+];

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -1,0 +1,71 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 types for drift-driven state reconciliation.
+
+import type { DeriveStateOptions } from "../state.js";
+import type { GSDState } from "../types.js";
+
+/**
+ * Discriminated union over drift kinds the State Reconciliation Module
+ * recognizes. Each variant carries the identifiers its matching repair needs.
+ *
+ * Subsequent ADR-017 issues add variants: unmerged-merge-state, stale-render,
+ * stale-worker, unregistered-milestone, roadmap-divergence,
+ * missing-completion-timestamp.
+ */
+export type DriftRecord =
+  | { kind: "stale-sketch-flag"; mid: string; sid: string };
+
+/**
+ * Context threaded to detector and repair functions. Keeps handlers from
+ * re-deriving state for themselves.
+ */
+export interface DriftContext {
+  basePath: string;
+  state: GSDState;
+}
+
+/**
+ * One drift kind's detect+repair composition.
+ *
+ * Repairs MUST be idempotent: re-running yields the same outcome. This is
+ * load-bearing for the cap=2 lifecycle — the second pass may detect drift
+ * that the first pass already partially repaired.
+ */
+export interface DriftHandler<T extends DriftRecord = DriftRecord> {
+  kind: T["kind"];
+  detect: (state: GSDState, ctx: DriftContext) => T[] | Promise<T[]>;
+  repair: (record: T, ctx: DriftContext) => Promise<void> | void;
+}
+
+/**
+ * Result of a successful reconcileBeforeDispatch call.
+ *
+ * `blockers` are TERMINAL conditions (DB unavailable, slice lock invalid,
+ * dependency cycle) that reconciliation cannot resolve. The caller decides
+ * how to handle them; the orchestrator adapter at auto.ts maps non-empty
+ * blockers to ok=false for the orchestrator's InvariantAdapterResult.
+ *
+ * On repair failure or drift persisting past the cap, reconcileBeforeDispatch
+ * throws ReconciliationFailedError instead of returning.
+ */
+export interface ReconciliationResult {
+  ok: true;
+  stateSnapshot: GSDState;
+  repaired: readonly DriftRecord[];
+  blockers: readonly string[];
+}
+
+/**
+ * Dependencies for reconcileBeforeDispatch. Tests inject fakes for the
+ * registry and state derivation; production callers use defaults.
+ */
+export interface ReconciliationDeps {
+  invalidateStateCache: () => void;
+  deriveState: (
+    basePath: string,
+    opts?: DeriveStateOptions,
+  ) => Promise<GSDState>;
+  /** Override of the drift handler catalog. Defaults to DRIFT_REGISTRY. */
+  registry?: ReadonlyArray<DriftHandler>;
+  deriveStateOptions?: DeriveStateOptions;
+}

--- a/src/resources/extensions/gsd/tests/progressive-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/progressive-planning.test.ts
@@ -14,9 +14,9 @@ import {
   insertMilestone,
   insertSlice,
   setSliceSketchFlag,
-  autoHealSketchFlags,
   getSlice,
 } from "../gsd-db.ts";
+import { autoHealSketchFlags } from "../state-reconciliation/drift/sketch-flag.ts";
 import { deriveStateFromDb } from "../state.ts";
 import { resolveDispatch } from "../auto-dispatch.ts";
 import type { DispatchContext } from "../auto-dispatch.ts";

--- a/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
@@ -42,16 +42,19 @@ test("State Reconciliation invalidates cache and returns reconciled state", asyn
   assert.equal(result.ok && result.stateSnapshot, state);
 });
 
-test("State Reconciliation blocks when derived state carries blockers", async () => {
+test("State Reconciliation surfaces terminal blockers in result (ADR-017)", async () => {
+  // Under ADR-017, blockers are terminal but do not throw — they ride along
+  // in the result so the orchestrator adapter can map them to ok=false.
   const result = await reconcileBeforeDispatch("/project", {
     invalidateStateCache() {},
     async deriveState() {
       return makeState({ phase: "blocked", blockers: ["slice lock missing"] });
     },
+    registry: [],
   });
 
-  assert.equal(result.ok, false);
-  assert.equal(!result.ok && result.reason, "slice lock missing");
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.blockers, ["slice lock missing"]);
 });
 
 test("Tool Contract compiles known Unit prompt and tool policy", () => {

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1,0 +1,212 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 contract tests for drift-driven State Reconciliation
+// (issue #5700). Covers: end-to-end sketch-flag drift, repair-throw path, and
+// Recovery Classification mapping for ReconciliationFailedError.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  getSlice,
+} from "../gsd-db.ts";
+import {
+  reconcileBeforeDispatch,
+  ReconciliationFailedError,
+  type DriftHandler,
+  type DriftRecord,
+} from "../state-reconciliation.ts";
+import { classifyFailure } from "../recovery-classification.ts";
+import type { GSDState } from "../types.ts";
+
+function makeState(overrides: Partial<GSDState> = {}): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Milestone" },
+    activeSlice: null,
+    activeTask: null,
+    phase: "planning",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "Plan milestone",
+    registry: [],
+    requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+    progress: { milestones: { done: 0, total: 1 } },
+    ...overrides,
+  };
+}
+
+function makeFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-drift-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S02"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try {
+    closeDatabase();
+  } catch {
+    /* noop */
+  }
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* noop */
+  }
+}
+
+test("ADR-017 (#5700): sketch-flag drift detected and repaired end-to-end", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({
+    id: "S02",
+    milestoneId: "M001",
+    title: "Feature",
+    status: "pending",
+    risk: "medium",
+    depends: [],
+    demo: "S02 demo.",
+    sequence: 1,
+    isSketch: true,
+    sketchScope: "limited",
+  });
+
+  // Simulate the post-crash scenario: PLAN.md exists on disk but the
+  // is_sketch flag is still 1.
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
+    "# S02 Plan\n",
+  );
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 1, "pre: flagged as sketch");
+
+  const state = makeState({ activeMilestone: { id: "M001", title: "Test" } });
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => state,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "post: flag cleared");
+  assert.equal(result.repaired.length, 1);
+  assert.equal(result.repaired[0]?.kind, "stale-sketch-flag");
+  if (result.repaired[0]?.kind === "stale-sketch-flag") {
+    assert.equal(result.repaired[0].mid, "M001");
+    assert.equal(result.repaired[0].sid, "S02");
+  }
+});
+
+test("ADR-017 (#5700): repair failure throws ReconciliationFailedError with shape", async () => {
+  const seenDrift: DriftRecord = { kind: "stale-sketch-flag", mid: "M001", sid: "S02" };
+  const handler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => [seenDrift],
+    repair: () => {
+      throw new Error("simulated repair failure");
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      reconcileBeforeDispatch("/project", {
+        invalidateStateCache: () => {},
+        deriveState: async () => makeState(),
+        registry: [handler],
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof ReconciliationFailedError, "must be ReconciliationFailedError");
+      assert.equal(err.failures.length, 1);
+      assert.equal(err.failures[0]?.drift.kind, "stale-sketch-flag");
+      assert.ok(err.failures[0]?.cause instanceof Error);
+      assert.equal((err.failures[0]?.cause as Error).message, "simulated repair failure");
+      assert.equal(err.pass, 0);
+      assert.equal(err.persistentDrift.length, 0);
+      return true;
+    },
+  );
+});
+
+test("ADR-017 (#5700): persistent drift after cap=2 throws ReconciliationFailedError", async () => {
+  // Detect always returns one drift; repair is a no-op (drift never goes away).
+  const persistent: DriftRecord = { kind: "stale-sketch-flag", mid: "M001", sid: "S02" };
+  const handler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => [persistent],
+    repair: () => {
+      /* no-op: drift cannot be cleared */
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      reconcileBeforeDispatch("/project", {
+        invalidateStateCache: () => {},
+        deriveState: async () => makeState(),
+        registry: [handler],
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof ReconciliationFailedError);
+      assert.equal(err.failures.length, 0);
+      assert.equal(err.persistentDrift.length, 1);
+      assert.equal(err.persistentDrift[0]?.kind, "stale-sketch-flag");
+      return true;
+    },
+  );
+});
+
+test("ADR-017 (#5700): classifyFailure recognizes ReconciliationFailedError", () => {
+  const err = new ReconciliationFailedError({
+    failures: [
+      {
+        drift: { kind: "stale-sketch-flag", mid: "M001", sid: "S02" },
+        cause: new Error("boom"),
+      },
+    ],
+    pass: 0,
+  });
+
+  const result = classifyFailure({ error: err });
+
+  assert.equal(result.failureKind, "reconciliation-drift");
+  assert.equal(result.action, "escalate");
+  assert.equal(result.exitReason, "reconciliation-drift");
+  assert.match(result.remediation, /persistent or repair-failed drift kinds/);
+});
+
+test("ADR-017 (#5700): cascading drift triggers second pass within cap", async () => {
+  // First pass detects drift A; repair "fixes" it. Second pass detects drift B
+  // (cascading); repair fixes it. Third call would see no drift. Cap=2 means
+  // we have exactly two repair passes available.
+  const detectedSequence: DriftRecord[][] = [
+    [{ kind: "stale-sketch-flag", mid: "M001", sid: "S02" }],
+    [{ kind: "stale-sketch-flag", mid: "M001", sid: "S03" }],
+    [],
+  ];
+  let detectCallIdx = 0;
+  const repaired: DriftRecord[] = [];
+
+  const handler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => detectedSequence[detectCallIdx++] ?? [],
+    repair: (record) => {
+      repaired.push(record);
+    },
+  };
+
+  const result = await reconcileBeforeDispatch("/project", {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+    registry: [handler],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.repaired.length, 2, "both passes' repairs collected");
+  assert.equal(repaired.length, 2);
+});


### PR DESCRIPTION
## Summary

- Implements ADR-017's drift-driven State Reconciliation Module end-to-end using `stale-sketch-flag` as the pattern proof
- New `state-reconciliation/` folder owns the drift catalog (detectors + idempotent repairs); `reconcileBeforeDispatch` runs a cap=2 derive→detect→repair→re-derive lifecycle that loops only on the cascading-drift success path
- `ReconciliationFailedError` thrown on persistent or repair-failed drift; Recovery Classification recognises it as the new `reconciliation-drift` failure kind
- `autoHealSketchFlags` relocates from `gsd-db.ts` (where it had zero callers) into `state-reconciliation/drift/sketch-flag.ts`; raw `setSliceSketchFlag` primitive stays in `gsd-db.ts`
- Lands the infrastructure that follow-on issues #5701–#5707 extend (one drift kind per issue, plus caller-closure audit)

Design: `docs/dev/ADR-017-state-reconciliation-drift-driven.md`.

## Test plan

- [x] `npm run typecheck:extensions` — clean for new code (pre-existing errors in unrelated files, not introduced here)
- [x] `npm run test:unit` over `src/resources/extensions/gsd/tests/` — 7569 passed, 0 failed, 8 skipped
- [x] New contract tests in `tests/state-reconciliation-drift.test.ts` cover all #5700 acceptance criteria: end-to-end sketch-flag drift, repair-throw, persistent-drift throw, classifyFailure mapping, cascading second pass
- [x] Existing tests adapted to new return shape: `runtime-invariant-modules.test.ts` (blockers now ride along in result rather than forcing ok=false), `progressive-planning.test.ts` (import path for `autoHealSketchFlags` updated)

Closes #5700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drift-driven state reconciliation runs pre-dispatch/pre-spawn and automatically detects/repairs state inconsistencies, including stale sketch flags.

* **Bug Fixes**
  * Improved error handling and recovery classification with a new "reconciliation-drift" failure kind.

* **Documentation**
  * Added ADR-017 detailing the drift-driven reconciliation design and responsibilities.

* **Tests**
  * Added and updated tests covering drift detection, repair flows, failure cases, and classification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5709)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->