### PR TITLE
refactor(gsd-extension): ADR-017 / migrate merge-state drift

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,6 +11,8 @@
 - **DB snapshot persistence**: crash-safe persistence of a full SQLite image exported from `sql.js`, written as a same-directory temporary file and atomically renamed over the live database path.
 - **Worktree Lifecycle**: creation, entry, teardown, and merge of an auto-mode worktree, including `s.basePath` mutation, `process.chdir` discipline, and milestone lease coordination.
 - **Worktree State Projection**: directional flow of state files between the project root and the auto-worktree, where one side is authoritative per file class (e.g., project root is authoritative for `completed-units.json` after crash recovery; worktree is authoritative for in-flight artifacts).
+- **Drift**: a state-shape mismatch between DB rows, disk artifacts, and in-memory state that has a known repair. Distinct from a `blocker`, which describes a terminal condition needing human attention or recovery escalation.
+- **Drift catalog**: the discriminated union of drift kinds the State Reconciliation Module recognizes and can repair.
 
 ## Architecture terms adopted for this area
 
@@ -22,12 +24,15 @@
 - **Runtime persistence adapter**: adapter behind the Runtime persistence seam.
 - **Notification adapter**: adapter behind the Notification seam.
 - **DB snapshot persistence module**: the deep module that owns `sql.js` snapshot write semantics, including temp-file naming, fsync, cleanup, and rename ordering.
-- **State Reconciliation module**: module that reconciles DB-authoritative runtime state with durable disk projections before a Dispatch decision.
+- **State Reconciliation module**: module that runs `reconcileBeforeDispatch` before any Dispatch decision or worker spawn. Surfaces terminal `blockers: string[]` and machine-actionable `DriftRecord[]`. Owns the drift catalog (detectors and idempotent repairs). Throws `ReconciliationFailedError` to Recovery Classification on persistent or repair-failed drift. See `docs/dev/ADR-017-state-reconciliation-drift-driven.md`.
 - **Worktree Safety module**: module that validates project root, worktree registration, lease ownership, and git health before a source-writing Unit runs.
 - **Worktree Lifecycle module**: module that owns worktree create/enter/teardown/merge verbs, `s.basePath` mutation, and `process.chdir` discipline. Sole owner of these mutations across single-loop and parallel callers.
 - **Worktree State Projection module**: module that owns the direction-and-rules of state file flow between project root and auto-worktree. Encodes the bug-hardened invariants (additive milestone copy, ASSESSMENT verdict overwrite, completed-units forward-sync, WAL/SHM cleanup) that `syncProjectRootToWorktree` and `syncStateToProjectRoot` carry today.
-- **Recovery Classification module**: module that maps provider, tool, policy, git, worktree, and runtime failures to a Recovery decision.
+- **Recovery Classification module**: module that maps provider, tool, policy, git, worktree, runtime, and reconciliation-drift failures to a Recovery decision.
 - **Tool Contract module**: module that keeps Unit prompts, tool schemas, tool policy, and pre-dispatch validation aligned.
+- **DriftRecord**: typed, machine-actionable signal of a single drift instance. Discriminated union over drift kinds; carries the identifiers (e.g., milestone id, slice id) the matching repair needs.
+- **Drift repair**: idempotent function that resolves one `DriftRecord`. Repairs are owned by the State Reconciliation Module's `drift/` folder; owning modules retain raw primitives (DB writes, file IO) but not the detection-and-repair composition.
+- **Reconciliation pass**: one cycle of derive → detect drift → apply repairs → re-derive, performed by `reconcileBeforeDispatch`. Capped at 2 passes per call; loops only when the prior pass fully succeeded but new drift surfaces in the re-derive.
 
 ## Current decision in force
 
@@ -54,6 +59,10 @@ See `docs/dev/ADR-015-runtime-invariant-modules.md`.
 Dispatch remains responsible for selecting the next Unit from reconciled state. It should not own DB/disk repair, tool-policy compilation, or worktree root preparation.
 
 - Worktree Safety should fail closed for source-writing Units under worktree isolation. A Unit whose Tool Contract permits writes outside `.gsd/**` must run in a proven milestone worktree root; it must not silently degrade to project-root source writes when the worktree is missing, empty, unregistered, on the wrong branch, or no longer lease-owned. Planning-only Units may continue to write `.gsd/**` artifacts at the project root.
+
+- State Reconciliation should be drift-driven. The Module surfaces terminal `blockers: string[]` and machine-actionable `DriftRecord[]`. Each pre-dispatch and pre-spawn site calls `reconcileBeforeDispatch` (strict closure). Drift catalog includes sketch-flag, merge-state, stale-worker, unregistered-milestone, roadmap-divergence, missing-completion-timestamp. Repairs are idempotent. Re-derive is capped at 2 passes (loops only on cascading-drift success path). Persistent or repair-failed drift throws `ReconciliationFailedError` to Recovery Classification (kind `reconciliation-drift`).
+
+  See `docs/dev/ADR-017-state-reconciliation-drift-driven.md`.
 
 ## Current implementation snapshot (phase 1)
 

--- a/docs/dev/ADR-017-state-reconciliation-drift-driven.md
+++ b/docs/dev/ADR-017-state-reconciliation-drift-driven.md
@@ -94,7 +94,7 @@ async function reconcileBeforeDispatch(
 
 `state-reconciliation/` folder owns detectors **and** repairs:
 
-```
+```text
 state-reconciliation/
   index.ts          → reconcileBeforeDispatch
   errors.ts         → ReconciliationFailedError

--- a/docs/dev/ADR-017-state-reconciliation-drift-driven.md
+++ b/docs/dev/ADR-017-state-reconciliation-drift-driven.md
@@ -1,0 +1,142 @@
+<!-- Project/App: GSD-2 -->
+<!-- File Purpose: ADR for drift-driven design of the State Reconciliation Module. -->
+
+# ADR-017: Drift-Driven State Reconciliation
+
+**Status:** Accepted
+**Date:** 2026-05-10
+**Author:** GSD architecture review
+**Related:** ADR-014 (deep Auto Orchestration module), ADR-015 (runtime invariant modules), ADR-016 trio (worktree split + fail-closed)
+
+## Context
+
+ADR-015 named the **State Reconciliation Module** as one of four runtime invariant modules and specified `reconcileBeforeDispatch(basePath)` as its Interface. The module landed at `src/resources/extensions/gsd/state-reconciliation.ts` (57 lines) but its current implementation only invalidates the state cache and calls `deriveState`. The Interface returns `repaired: readonly string[]` but the only value ever returned is `["derive-state-cache-invalidated"]` — the cache invalidation itself, dressed up as a repair.
+
+The repair helpers CONTEXT.md names — sketch-flag healing, merge-state reconciliation, PROJECT.md/ROADMAP.md drift, completion-timestamp drift — exist in scattered places, or do not exist at all:
+
+- `autoHealSketchFlags` (`gsd-db.ts:1156`): exists, **zero callers**.
+- `reconcileMergeState` (`auto-recovery.ts:1118`): exists, called only by post-failure recovery paths.
+- `repairStaleRenders` (`markdown-renderer.ts:937`): exists.
+- Stale-worker, PROJECT.md/ROADMAP.md, completion-timestamp repair: **no implementation**.
+
+The module has one production caller (the Auto Orchestration adapter in `auto.ts:1753`). Without specifying what reconciliation actually does, the module is a hypothetical seam — the discipline ADR-016 chased out for worktree handling.
+
+## Decision
+
+State Reconciliation runs **drift-driven blocker repair** before every Dispatch decision and before every worker spawn. The Module exposes two surfaces:
+
+1. **`blockers: string[]`** (existing) — terminal, human-readable. Indicates conditions reconciliation cannot resolve (DB unavailable, slice lock invalid, dependency cycle).
+2. **`DriftRecord[]`** (new) — typed, discriminated union of repairable drift kinds. Each `DriftRecord` carries the identifiers its matching repair needs.
+
+### Drift catalog (initial)
+
+```ts
+type DriftRecord =
+  | { kind: "stale-sketch-flag"; mid: string; sid: string }
+  | { kind: "unmerged-merge-state"; basePath: string }
+  | { kind: "stale-worker"; lockPath: string; pid: number }
+  | { kind: "unregistered-milestone"; milestoneId: string }
+  | { kind: "roadmap-divergence"; milestoneId: string; sliceId?: string }
+  | {
+      kind: "missing-completion-timestamp";
+      entity: "task" | "slice" | "milestone";
+      ids: string[];
+    };
+```
+
+### Lifecycle
+
+```ts
+async function reconcileBeforeDispatch(
+  basePath: string,
+  deps: ReconciliationDeps,
+): Promise<ReconciliationResult> {
+  for (let pass = 0; pass < 2; pass++) {
+    const s = await deps.deriveState(basePath);
+    const drift = detectAllDrift(s, deps);
+    if (drift.length === 0) {
+      return { ok: true, stateSnapshot: s, repaired: [], blockers: s.blockers ?? [] };
+    }
+
+    const failures: Array<{ drift: DriftRecord; cause: unknown }> = [];
+    for (const d of drift) {
+      try {
+        await applyRepair(d, deps);
+      } catch (cause) {
+        failures.push({ drift: d, cause });
+      }
+    }
+    if (failures.length > 0) {
+      throw new ReconciliationFailedError({ failures, pass });
+    }
+    // pass succeeded; loop runs again to detect cascading drift
+  }
+
+  const finalState = await deps.deriveState(basePath);
+  const persistent = detectAllDrift(finalState, deps);
+  if (persistent.length > 0) {
+    throw new ReconciliationFailedError({ persistentDrift: persistent });
+  }
+  return {
+    ok: true,
+    stateSnapshot: finalState,
+    repaired: [],
+    blockers: finalState.blockers ?? [],
+  };
+}
+```
+
+- **Re-derive cycle is capped at 2.** The loop runs only when the prior pass fully succeeded and re-derive surfaces NEW drift (cascading repairs — e.g., fixing a milestone registration uncovers a downstream completion-timestamp drift). Persistent or failed drift after pass 2 throws.
+- **All repairs must be idempotent.** Re-derive can re-trigger detection on transient state; repairs must be safe under retry.
+- **Failure throws.** `ReconciliationFailedError` is caught by the caller and routed to `classifyFailure({ error, failureKind: "reconciliation-drift" })`.
+
+### Module home
+
+`state-reconciliation/` folder owns detectors **and** repairs:
+
+```
+state-reconciliation/
+  index.ts          → reconcileBeforeDispatch
+  errors.ts         → ReconciliationFailedError
+  drift/
+    sketch-flag.ts  → detect + repair (relocated from gsd-db.ts)
+    merge-state.ts  → detect + repair (relocated from auto-recovery.ts)
+    stale-worker.ts → detect + repair (new)
+    project-md.ts   → detect + repair (new)
+    roadmap.ts      → detect + repair (new)
+    completion.ts   → detect + repair (new)
+  registry.ts       → DriftKind → { detect, repair }
+```
+
+Owning modules retain their raw primitives (e.g., `setSliceSketchFlag`, the SELECT query) but the **detection-and-repair composition** lives in the drift folder.
+
+### Caller closure
+
+Strict closure — every pre-dispatch / pre-spawn site calls `reconcileBeforeDispatch`:
+
+- Single-loop auto: already wired via `auto/orchestrator.ts:42` (existing).
+- Workers spawned by parallel orchestration: already covered (each spawned worker runs its own auto-loop with reconcile).
+- **Parent processes that spawn workers**: need new wiring at the `startParallel` / `startSliceParallel` call sites (`auto.ts`, `auto/phases.ts`, `commands/handlers/parallel.ts`) so workers do not independently race on the same drift.
+
+### Recovery Classification contract change
+
+Add new `RecoveryFailureKind: "reconciliation-drift"` with action `escalate` and remediation pointing at the persistent drift kinds. Update `classifyFailure` in `recovery-classification.ts` to recognise `ReconciliationFailedError`.
+
+## Consequences
+
+- `gsd-db.ts:1156` `autoHealSketchFlags` relocates to `state-reconciliation/drift/sketch-flag.ts`. `gsd-db.ts` keeps `setSliceSketchFlag` and the SELECT primitive.
+- `auto-recovery.ts:1118` `reconcileMergeState` and supporting helpers relocate to `state-reconciliation/drift/merge-state.ts`. `auto-recovery.ts` shrinks; remaining post-failure helpers (`verifyExpectedArtifact`, `writeBlockerPlaceholder`) stay.
+- Four new repair functions land: stale-worker, PROJECT.md sync, ROADMAP.md sync, completion-timestamp backfill.
+- `state.ts` `blockers: string[]` is unchanged; existing call sites that read `s.blockers` are unaffected.
+- Detector cost is paid on every `advance()` tick. Cheap detectors (DB queries, `existsSync`) run unconditionally; markdown-parsing detectors must be designed to short-circuit when artifacts are unchanged.
+- Every drift kind has a contract test: seeded drift → reconcile → assert repaired. Persistent-drift cases are tested with non-idempotent fixture setups.
+- The Module's Interface becomes the test surface for runtime drift handling. Single-drift unit tests can target `drift/<kind>.ts` directly.
+
+## Alternatives considered
+
+- **Idempotent self-healing** (every tick attempts every known repair, no detection layer). Rejected: pays the repair cost on every advance even when state is clean, and provides no signal for telemetry/observability about which drift was actually present.
+- **Passive — derive only**. Rejected: dormant repairs (`autoHealSketchFlags` has zero callers today) stay dormant. The seam exists but solves nothing.
+- **Predicate-matched repairs over free-text blockers**. Rejected as fragile: this is the same pattern as the dispatch rule registry, which has already shown drift between two parallel rule sources (see `auto-dispatch.ts:1474`). Typed drift records make new repair additions a type-system change instead of a regex audit.
+- **Loop until stable (uncapped)**. Rejected for runaway risk. Cap=2 is enough for cascading repairs without unbounded retry.
+- **First-failure aborts the pass**. Rejected: loses repair work for unrelated drift. Collecting failures within a pass and throwing at end-of-pass keeps the failure surface complete.
+- **Detectors and repairs delegated to owning modules** (each owner exposes its own `detect` + `repair`). Rejected: the canonical zero-caller bug (`autoHealSketchFlags` shipped in `gsd-db.ts` for over a year without wiring) shows that owners do not naturally compose detection-and-repair into a pre-dispatch lifecycle. Locality wins here — one folder reviews the whole catalog.

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -7,7 +7,6 @@
  * globals or AutoContext dependency.
  */
 
-import type { ExtensionContext } from "@gsd/pi-coding-agent";
 import { parseUnitId } from "./unit-id.js";
 import { MILESTONE_ID_RE } from "./milestone-ids.js";
 import { appendEvent } from "./workflow-events.js";
@@ -20,15 +19,6 @@ import { getErrorMessage } from "./error-utils.js";
 import { logWarning, logError } from "./workflow-logger.js";
 import { readIntegrationBranch } from "./git-service.js";
 import { isClosedStatus } from "./status-guards.js";
-import {
-  nativeConflictFiles,
-  nativeCommit,
-  nativeCheckoutTheirs,
-  nativeAddPaths,
-  nativeMergeAbort,
-  nativeRebaseAbort,
-  nativeResetHard,
-} from "./native-git-bridge.js";
 import {
   resolveSlicePath,
   resolveSliceFile,
@@ -46,7 +36,6 @@ import {
   mkdirSync,
   readFileSync,
   writeFileSync,
-  unlinkSync,
 } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
@@ -1001,205 +990,14 @@ export function writeBlockerPlaceholder(
 }
 
 // ─── Merge State Reconciliation ───────────────────────────────────────────────
+// Body relocated to state-reconciliation/drift/merge-state.ts (ADR-017 #5701).
+// Re-exported here for backward compatibility with existing call sites:
+// auto.ts, auto/loop-deps.ts, tests/integration/auto-recovery.test.ts.
 
-/**
- * Best-effort abort of a pending merge/squash and hard-reset to HEAD.
- * Handles both real merges (MERGE_HEAD) and squash merges (SQUASH_MSG).
- */
-function abortAndResetMerge(
-  basePath: string,
-  hasMergeHead: boolean,
-  squashMsgPath: string,
-): void {
-  if (hasMergeHead) {
-    try {
-      nativeMergeAbort(basePath);
-    } catch (err) {
-      /* best-effort */
-      logWarning("recovery", `git merge-abort failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  } else if (squashMsgPath) {
-    try {
-      unlinkSync(squashMsgPath);
-    } catch (err) {
-      /* best-effort */
-      logWarning("recovery", `file unlink failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
-  try {
-    nativeResetHard(basePath);
-  } catch (err) {
-    /* best-effort */
-    logError("recovery", `git reset failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
-}
-
-export type MergeReconcileResult = "clean" | "reconciled" | "blocked";
-
-/**
- * Detect and abort other in-progress git operations left behind by a SIGKILL'd
- * worker (rebase, cherry-pick, revert). Without this, a killed worker mid-rebase
- * leaves `.git/rebase-merge/` or `.git/CHERRY_PICK_HEAD` and the worktree is
- * wedged until the user manually runs the matching `--abort`.
- *
- * Called before merge-state reconciliation because these states block any
- * subsequent merge/commit operation. (Issue #4980 HIGH-7)
- */
-function reconcileOtherInProgressGitOps(
-  basePath: string,
-  ctx: ExtensionContext,
-): "clean" | "reconciled" | "blocked" {
-  const gitDir = join(basePath, ".git");
-  const states: Array<{
-    label: string;
-    indicators: string[];
-    abort: () => void;
-  }> = [
-    {
-      label: "rebase",
-      indicators: [join(gitDir, "rebase-merge"), join(gitDir, "rebase-apply")],
-      abort: () => nativeRebaseAbort(basePath),
-    },
-    {
-      label: "cherry-pick",
-      indicators: [join(gitDir, "CHERRY_PICK_HEAD")],
-      abort: () => {
-        // No native helper; fall back to git CLI.
-        try {
-          execFileSync("git", ["cherry-pick", "--abort"], {
-            cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8",
-          });
-        } catch (err) { logWarning("recovery", `cherry-pick --abort failed: ${getErrorMessage(err)}`); }
-      },
-    },
-    {
-      label: "revert",
-      indicators: [join(gitDir, "REVERT_HEAD")],
-      abort: () => {
-        try {
-          execFileSync("git", ["revert", "--abort"], {
-            cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8",
-          });
-        } catch (err) { logWarning("recovery", `revert --abort failed: ${getErrorMessage(err)}`); }
-      },
-    },
-  ];
-
-  let reconciled = false;
-  for (const s of states) {
-    const present = s.indicators.some((p) => existsSync(p));
-    if (!present) continue;
-    try {
-      s.abort();
-      ctx.ui.notify(
-        `Detected leftover ${s.label} state from prior session — aborted.`,
-        "warning",
-      );
-      reconciled = true;
-    } catch (err) {
-      logError("recovery", `${s.label} abort failed: ${getErrorMessage(err)}`);
-      ctx.ui.notify(
-        `Detected leftover ${s.label} state but auto-abort failed. ` +
-        `Run \`git ${s.label} --abort\` manually before retrying.`,
-        "error",
-      );
-      return "blocked";
-    }
-  }
-  return reconciled ? "reconciled" : "clean";
-}
-
-/**
- * Detect leftover merge state from a prior session and reconcile it.
- * If MERGE_HEAD or SQUASH_MSG exists, check whether conflicts are resolved.
- * If resolved: finalize the commit. If only .gsd conflicts remain: auto-resolve.
- * If code conflicts remain: fail safe without modifying the worktree.
- */
-export function reconcileMergeState(
-  basePath: string,
-  ctx: ExtensionContext,
-): MergeReconcileResult {
-  // First, abort any rebase/cherry-pick/revert left over from a SIGKILL'd
-  // worker. Doing this before the merge-state check unblocks any merge that
-  // would otherwise refuse with "you have unfinished operation". (HIGH-7)
-  const otherOpsResult = reconcileOtherInProgressGitOps(basePath, ctx);
-  if (otherOpsResult === "blocked") return "blocked";
-
-  const mergeHeadPath = join(basePath, ".git", "MERGE_HEAD");
-  const squashMsgPath = join(basePath, ".git", "SQUASH_MSG");
-  const hasMergeHead = existsSync(mergeHeadPath);
-  const hasSquashMsg = existsSync(squashMsgPath);
-  if (!hasMergeHead && !hasSquashMsg) {
-    // If we cleaned up another op type, return "reconciled" so the caller
-    // re-derives state from a known-good baseline.
-    return otherOpsResult === "reconciled" ? "reconciled" : "clean";
-  }
-
-  const conflictedFiles = nativeConflictFiles(basePath);
-  if (conflictedFiles.length === 0) {
-    // All conflicts resolved — finalize the merge/squash commit
-    try {
-      const commitSha = nativeCommit(basePath, "chore(gsd): reconcile merge state");
-      if (commitSha) {
-        const mode = hasMergeHead ? "merge" : "squash commit";
-        ctx.ui.notify(`Finalized leftover ${mode} from prior session.`, "info");
-      } else {
-        ctx.ui.notify("No new commit needed for leftover merge/squash state — already committed.", "info");
-      }
-    } catch (err) {
-      const errorMessage = getErrorMessage(err);
-      ctx.ui.notify(`Failed to finalize leftover merge/squash commit: ${errorMessage}`, "error");
-      return "blocked";
-    }
-  } else {
-    // Still conflicted — try auto-resolving .gsd/ state file conflicts (#530)
-    const gsdConflicts = conflictedFiles.filter((f) => f.startsWith(".gsd/"));
-    const codeConflicts = conflictedFiles.filter((f) => !f.startsWith(".gsd/"));
-
-    if (gsdConflicts.length > 0 && codeConflicts.length === 0) {
-      // All conflicts are in .gsd/ state files — auto-resolve by accepting theirs
-      let resolved = true;
-      try {
-        nativeCheckoutTheirs(basePath, gsdConflicts);
-        nativeAddPaths(basePath, gsdConflicts);
-      } catch (e) {
-        logError("recovery", `auto-resolve .gsd/ conflicts failed: ${(e as Error).message}`);
-        resolved = false;
-      }
-      if (resolved) {
-        try {
-          nativeCommit(
-            basePath,
-            "chore: auto-resolve .gsd/ state file conflicts",
-          );
-          ctx.ui.notify(
-            `Auto-resolved ${gsdConflicts.length} .gsd/ state file conflict(s) from prior merge.`,
-            "info",
-          );
-        } catch (e) {
-          logError("recovery", `auto-commit .gsd/ conflict resolution failed: ${(e as Error).message}`);
-          resolved = false;
-        }
-      }
-      if (!resolved) {
-        abortAndResetMerge(basePath, hasMergeHead, squashMsgPath);
-        ctx.ui.notify(
-          "Detected leftover merge state — auto-resolve failed, cleaned up. Re-deriving state.",
-          "warning",
-        );
-      }
-    } else {
-      // Code conflicts present — fail safe and preserve any manual resolution
-      // work instead of discarding it with merge --abort/reset --hard.
-      ctx.ui.notify(
-        "Detected leftover merge state with unresolved code conflicts. Auto-mode will pause without modifying the worktree so manual conflict resolution is preserved.",
-        "error",
-      );
-      return "blocked";
-    }
-  }
-  return "reconciled";
-}
+export {
+  reconcileMergeState,
+  type MergeReconcileResult,
+} from "./state-reconciliation/drift/merge-state.js";
 
 // ─── Loop Remediation ─────────────────────────────────────────────────────────
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -240,10 +240,7 @@ import { resolveUokFlags } from "./uok/flags.js";
 import { validateDirectory } from "./validate-directory.js";
 import { createAutoOrchestrator } from "./auto/orchestrator.js";
 import type { AutoOrchestrationModule, AutoOrchestratorDeps } from "./auto/contracts.js";
-import {
-  reconcileBeforeDispatch,
-  ReconciliationFailedError,
-} from "./state-reconciliation.js";
+import { reconcileBeforeDispatch } from "./state-reconciliation.js";
 import { compileUnitToolContract } from "./tool-contract.js";
 import { createWorktreeSafetyModule } from "./worktree-safety.js";
 import { resolveManifest } from "./unit-context-manifest.js";
@@ -1754,30 +1751,23 @@ export function createWiredAutoOrchestrationModule(
   const deps: AutoOrchestratorDeps = {
     stateReconciliation: {
       async reconcileBeforeDispatch() {
-        try {
-          const result = await reconcileBeforeDispatch(dispatchBasePath);
-          if (result.blockers.length > 0) {
-            return {
-              ok: false,
-              reason: result.blockers[0],
-              stateSnapshot: result.stateSnapshot,
-            };
-          }
-          const repairedKinds = result.repaired.map((d) => d.kind);
+        const result = await reconcileBeforeDispatch(dispatchBasePath);
+        if (result.blockers.length > 0) {
           return {
-            ok: true,
-            reason:
-              repairedKinds.length > 0
-                ? `repaired: ${repairedKinds.join(", ")}`
-                : "clean",
+            ok: false,
+            reason: result.blockers[0],
             stateSnapshot: result.stateSnapshot,
           };
-        } catch (err) {
-          if (err instanceof ReconciliationFailedError) {
-            return { ok: false, reason: err.message };
-          }
-          throw err;
         }
+        const repairedKinds = result.repaired.map((d) => d.kind);
+        return {
+          ok: true,
+          reason:
+            repairedKinds.length > 0
+              ? `repaired: ${repairedKinds.join(", ")}`
+              : "clean",
+          stateSnapshot: result.stateSnapshot,
+        };
       },
     },
     dispatch: {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -240,7 +240,10 @@ import { resolveUokFlags } from "./uok/flags.js";
 import { validateDirectory } from "./validate-directory.js";
 import { createAutoOrchestrator } from "./auto/orchestrator.js";
 import type { AutoOrchestrationModule, AutoOrchestratorDeps } from "./auto/contracts.js";
-import { reconcileBeforeDispatch } from "./state-reconciliation.js";
+import {
+  reconcileBeforeDispatch,
+  ReconciliationFailedError,
+} from "./state-reconciliation.js";
 import { compileUnitToolContract } from "./tool-contract.js";
 import { createWorktreeSafetyModule } from "./worktree-safety.js";
 import { resolveManifest } from "./unit-context-manifest.js";
@@ -1751,19 +1754,30 @@ export function createWiredAutoOrchestrationModule(
   const deps: AutoOrchestratorDeps = {
     stateReconciliation: {
       async reconcileBeforeDispatch() {
-        const result = await reconcileBeforeDispatch(dispatchBasePath);
-        if (!result.ok) {
+        try {
+          const result = await reconcileBeforeDispatch(dispatchBasePath);
+          if (result.blockers.length > 0) {
+            return {
+              ok: false,
+              reason: result.blockers[0],
+              stateSnapshot: result.stateSnapshot,
+            };
+          }
+          const repairedKinds = result.repaired.map((d) => d.kind);
           return {
-            ok: false,
-            reason: result.reason,
+            ok: true,
+            reason:
+              repairedKinds.length > 0
+                ? `repaired: ${repairedKinds.join(", ")}`
+                : "clean",
             stateSnapshot: result.stateSnapshot,
           };
+        } catch (err) {
+          if (err instanceof ReconciliationFailedError) {
+            return { ok: false, reason: err.message };
+          }
+          throw err;
         }
-        return {
-          ok: true,
-          reason: result.repaired.join(", "),
-          stateSnapshot: result.stateSnapshot,
-        };
       },
     },
     dispatch: {

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1136,33 +1136,17 @@ export function setSliceSketchFlag(milestoneId: string, sliceId: string, isSketc
 }
 
 /**
- * ADR-011 auto-heal: reconcile stale is_sketch=1 rows whose PLAN already exists.
- *
- * Callers pass a predicate that resolves whether a plan file exists for a slice.
- * The predicate MUST use the canonical path resolver (`resolveSliceFile`, etc.)
- * to keep path logic in one place — do not hand-roll the path inside the callback.
- *
- * Recovers from two scenarios:
- *   1. Crash between `gsd_plan_slice` write and the sketch flag flip.
- *   2. Flag-OFF downgrade path: when `progressive_planning` is off, the dispatch
- *      rule routes sketch slices to plan-slice, which writes PLAN.md but leaves
- *      `is_sketch=1` — the next state derivation auto-heals it to 0 here.
- *
- * Not aggressive in practice: PLAN.md is only written via the DB-backed
- * `gsd_plan_slice` tool (which also inserts tasks), so a "stale PLAN.md with
- * is_sketch=1" is extremely unlikely to indicate anything other than the two
- * recovery scenarios above.
+ * ADR-017 raw primitive: returns slice IDs in a milestone whose is_sketch flag
+ * is still 1. The stale-sketch-flag drift handler at
+ * `state-reconciliation/drift/sketch-flag.ts` composes this with PLAN.md
+ * existence checks to detect drift, then writes via `setSliceSketchFlag`.
  */
-export function autoHealSketchFlags(milestoneId: string, hasPlanFile: (sliceId: string) => boolean): void {
-  if (!currentDb) return;
+export function getSketchedSliceIds(milestoneId: string): string[] {
+  if (!currentDb) return [];
   const rows = currentDb.prepare(
     `SELECT id FROM slices WHERE milestone_id = :mid AND is_sketch = 1`,
   ).all({ ":mid": milestoneId }) as Array<{ id: string }>;
-  for (const row of rows) {
-    if (hasPlanFile(row.id)) {
-      setSliceSketchFlag(milestoneId, row.id, false);
-    }
-  }
+  return rows.map((r) => r.id);
 }
 
 export function upsertSlicePlanning(milestoneId: string, sliceId: string, planning: Partial<SlicePlanningRecord>): void {

--- a/src/resources/extensions/gsd/recovery-classification.ts
+++ b/src/resources/extensions/gsd/recovery-classification.ts
@@ -2,6 +2,7 @@
 // File Purpose: ADR-015 Recovery Classification module for runtime failure taxonomy.
 
 import { classifyError, isTransient, type ErrorClass } from "./error-classifier.js";
+import { ReconciliationFailedError } from "./state-reconciliation.js";
 
 export type RecoveryFailureKind =
   | "tool-schema"
@@ -9,6 +10,7 @@ export type RecoveryFailureKind =
   | "stale-worker"
   | "worktree-invalid"
   | "verification-drift"
+  | "reconciliation-drift"
   | "provider"
   | "runtime-unknown";
 
@@ -33,7 +35,13 @@ export interface RecoveryClassification {
 
 export function classifyFailure(input: RecoveryClassificationInput): RecoveryClassification {
   const message = errorMessage(input.error);
-  const failureKind = input.failureKind ?? inferFailureKind(message);
+  // ADR-017: ReconciliationFailedError is a typed throw from the State
+  // Reconciliation Module. Recognize it by class regardless of caller-supplied
+  // failureKind so the taxonomy stays consistent.
+  const failureKind =
+    input.error instanceof ReconciliationFailedError
+      ? "reconciliation-drift"
+      : input.failureKind ?? inferFailureKind(message);
 
   switch (failureKind) {
     case "tool-schema":
@@ -75,6 +83,15 @@ export function classifyFailure(input: RecoveryClassificationInput): RecoveryCla
         reason: `Verification drift${unitSuffix(input)}: ${message}`,
         exitReason: "verification-drift",
         remediation: "Inspect the verification artifact and reconcile the state snapshot before resuming.",
+      };
+    case "reconciliation-drift":
+      return {
+        failureKind,
+        action: "escalate",
+        reason: `Reconciliation drift${unitSuffix(input)}: ${message}`,
+        exitReason: "reconciliation-drift",
+        remediation:
+          "Inspect the persistent or repair-failed drift kinds reported by the State Reconciliation Module before resuming.",
       };
     case "provider": {
       const providerClass = classifyError(message, input.retryAfterMs);

--- a/src/resources/extensions/gsd/state-reconciliation.ts
+++ b/src/resources/extensions/gsd/state-reconciliation.ts
@@ -1,57 +1,19 @@
 // Project/App: GSD-2
-// File Purpose: ADR-015 State Reconciliation module for pre-dispatch runtime invariants.
+// File Purpose: ADR-017 State Reconciliation Module — public entry point.
+// Re-exports the drift-driven implementation from the state-reconciliation/
+// folder so existing import paths (./state-reconciliation.js) keep working.
 
-import { deriveState, invalidateStateCache, type DeriveStateOptions } from "./state.js";
-import type { GSDState } from "./types.js";
+export {
+  reconcileBeforeDispatch,
+  ReconciliationFailedError,
+  DRIFT_REGISTRY,
+} from "./state-reconciliation/index.js";
 
-export type StateReconciliationResult =
-  | {
-      ok: true;
-      stateSnapshot: GSDState;
-      repaired: readonly string[];
-      blockers: readonly string[];
-    }
-  | {
-      ok: false;
-      reason: string;
-      stateSnapshot?: GSDState;
-      repaired: readonly string[];
-      blockers: readonly string[];
-    };
-
-export interface StateReconciliationDeps {
-  invalidateStateCache: () => void;
-  deriveState: (basePath: string, opts?: DeriveStateOptions) => Promise<GSDState>;
-}
-
-const defaultDeps: StateReconciliationDeps = {
-  invalidateStateCache,
-  deriveState,
-};
-
-export async function reconcileBeforeDispatch(
-  basePath: string,
-  deps: StateReconciliationDeps = defaultDeps,
-  opts?: DeriveStateOptions,
-): Promise<StateReconciliationResult> {
-  deps.invalidateStateCache();
-  const stateSnapshot = await deps.deriveState(basePath, opts);
-  const blockers = stateSnapshot.blockers ?? [];
-
-  if (blockers.length > 0 || stateSnapshot.phase === "blocked") {
-    return {
-      ok: false,
-      reason: blockers[0] ?? `State reconciliation blocked in phase ${stateSnapshot.phase}`,
-      stateSnapshot,
-      repaired: ["derive-state-cache-invalidated"],
-      blockers,
-    };
-  }
-
-  return {
-    ok: true,
-    stateSnapshot,
-    repaired: ["derive-state-cache-invalidated"],
-    blockers,
-  };
-}
+export type {
+  DriftContext,
+  DriftHandler,
+  DriftRecord,
+  ReconciliationDeps,
+  ReconciliationFailureDetail,
+  ReconciliationResult,
+} from "./state-reconciliation/index.js";

--- a/src/resources/extensions/gsd/state-reconciliation/drift/merge-state.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/merge-state.ts
@@ -7,7 +7,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 
@@ -33,6 +33,24 @@ type NotifyFn = (
 ) => void;
 
 const SILENT_NOTIFY: NotifyFn = () => {};
+
+function resolveGitDir(basePath: string): string {
+  try {
+    const gitDir = execFileSync("git", ["rev-parse", "--git-dir"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    }).trim();
+
+    if (gitDir.length > 0) {
+      return isAbsolute(gitDir) ? gitDir : resolve(basePath, gitDir);
+    }
+  } catch (err) {
+    logWarning("recovery", `gitdir resolution failed: ${getErrorMessage(err)}`);
+  }
+
+  return join(basePath, ".git");
+}
 
 /**
  * Best-effort abort of a pending merge/squash and hard-reset to HEAD.
@@ -88,7 +106,7 @@ function reconcileOtherInProgressGitOps(
   basePath: string,
   notify: NotifyFn,
 ): MergeReconcileResult {
-  const gitDir = join(basePath, ".git");
+  const gitDir = resolveGitDir(basePath);
   const states: Array<{
     label: string;
     indicators: string[];
@@ -115,6 +133,7 @@ function reconcileOtherInProgressGitOps(
             "recovery",
             `cherry-pick --abort failed: ${getErrorMessage(err)}`,
           );
+          throw err;
         }
       },
     },
@@ -133,6 +152,7 @@ function reconcileOtherInProgressGitOps(
             "recovery",
             `revert --abort failed: ${getErrorMessage(err)}`,
           );
+          throw err;
         }
       },
     },
@@ -177,8 +197,9 @@ function reconcileMergeStateCore(
   const otherOpsResult = reconcileOtherInProgressGitOps(basePath, notify);
   if (otherOpsResult === "blocked") return "blocked";
 
-  const mergeHeadPath = join(basePath, ".git", "MERGE_HEAD");
-  const squashMsgPath = join(basePath, ".git", "SQUASH_MSG");
+  const gitDir = resolveGitDir(basePath);
+  const mergeHeadPath = join(gitDir, "MERGE_HEAD");
+  const squashMsgPath = join(gitDir, "SQUASH_MSG");
   const hasMergeHead = existsSync(mergeHeadPath);
   const hasSquashMsg = existsSync(squashMsgPath);
   if (!hasMergeHead && !hasSquashMsg) {
@@ -280,7 +301,7 @@ export function reconcileMergeState(
 type MergeStateDrift = Extract<DriftRecord, { kind: "unmerged-merge-state" }>;
 
 function hasMergeStateLeftovers(basePath: string): boolean {
-  const gitDir = join(basePath, ".git");
+  const gitDir = resolveGitDir(basePath);
   return (
     existsSync(join(gitDir, "MERGE_HEAD")) ||
     existsSync(join(gitDir, "SQUASH_MSG")) ||

--- a/src/resources/extensions/gsd/state-reconciliation/drift/merge-state.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/merge-state.ts
@@ -1,0 +1,325 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 unmerged-merge-state drift handler. Relocated from
+// auto-recovery.ts as part of issue #5701. Owns:
+//   - rebase/cherry-pick/revert leftover cleanup (#4980 HIGH-7)
+//   - MERGE_HEAD / SQUASH_MSG reconciliation with auto-resolve of .gsd/
+//     conflicts (#530, #2542)
+
+import { execFileSync } from "node:child_process";
+import { existsSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+import type { ExtensionContext } from "@gsd/pi-coding-agent";
+
+import { getErrorMessage } from "../../error-utils.js";
+import {
+  nativeAddPaths,
+  nativeCheckoutTheirs,
+  nativeCommit,
+  nativeConflictFiles,
+  nativeMergeAbort,
+  nativeRebaseAbort,
+  nativeResetHard,
+} from "../../native-git-bridge.js";
+import type { GSDState } from "../../types.js";
+import { logError, logWarning } from "../../workflow-logger.js";
+import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
+
+export type MergeReconcileResult = "clean" | "reconciled" | "blocked";
+
+type NotifyFn = (
+  message: string,
+  severity: "info" | "warning" | "error",
+) => void;
+
+const SILENT_NOTIFY: NotifyFn = () => {};
+
+/**
+ * Best-effort abort of a pending merge/squash and hard-reset to HEAD.
+ * Handles both real merges (MERGE_HEAD) and squash merges (SQUASH_MSG).
+ */
+function abortAndResetMerge(
+  basePath: string,
+  hasMergeHead: boolean,
+  squashMsgPath: string,
+): void {
+  if (hasMergeHead) {
+    try {
+      nativeMergeAbort(basePath);
+    } catch (err) {
+      /* best-effort */
+      logWarning(
+        "recovery",
+        `git merge-abort failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  } else if (squashMsgPath) {
+    try {
+      unlinkSync(squashMsgPath);
+    } catch (err) {
+      /* best-effort */
+      logWarning(
+        "recovery",
+        `file unlink failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  try {
+    nativeResetHard(basePath);
+  } catch (err) {
+    /* best-effort */
+    logError(
+      "recovery",
+      `git reset failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Detect and abort other in-progress git operations left behind by a SIGKILL'd
+ * worker (rebase, cherry-pick, revert). Without this, a killed worker
+ * mid-rebase leaves `.git/rebase-merge/` or `.git/CHERRY_PICK_HEAD` and the
+ * worktree is wedged until the user manually runs the matching `--abort`.
+ *
+ * Called before merge-state reconciliation because these states block any
+ * subsequent merge/commit operation. (#4980 HIGH-7)
+ */
+function reconcileOtherInProgressGitOps(
+  basePath: string,
+  notify: NotifyFn,
+): MergeReconcileResult {
+  const gitDir = join(basePath, ".git");
+  const states: Array<{
+    label: string;
+    indicators: string[];
+    abort: () => void;
+  }> = [
+    {
+      label: "rebase",
+      indicators: [join(gitDir, "rebase-merge"), join(gitDir, "rebase-apply")],
+      abort: () => nativeRebaseAbort(basePath),
+    },
+    {
+      label: "cherry-pick",
+      indicators: [join(gitDir, "CHERRY_PICK_HEAD")],
+      abort: () => {
+        // No native helper; fall back to git CLI.
+        try {
+          execFileSync("git", ["cherry-pick", "--abort"], {
+            cwd: basePath,
+            stdio: ["ignore", "pipe", "pipe"],
+            encoding: "utf-8",
+          });
+        } catch (err) {
+          logWarning(
+            "recovery",
+            `cherry-pick --abort failed: ${getErrorMessage(err)}`,
+          );
+        }
+      },
+    },
+    {
+      label: "revert",
+      indicators: [join(gitDir, "REVERT_HEAD")],
+      abort: () => {
+        try {
+          execFileSync("git", ["revert", "--abort"], {
+            cwd: basePath,
+            stdio: ["ignore", "pipe", "pipe"],
+            encoding: "utf-8",
+          });
+        } catch (err) {
+          logWarning(
+            "recovery",
+            `revert --abort failed: ${getErrorMessage(err)}`,
+          );
+        }
+      },
+    },
+  ];
+
+  let reconciled = false;
+  for (const s of states) {
+    const present = s.indicators.some((p) => existsSync(p));
+    if (!present) continue;
+    try {
+      s.abort();
+      notify(
+        `Detected leftover ${s.label} state from prior session — aborted.`,
+        "warning",
+      );
+      reconciled = true;
+    } catch (err) {
+      logError("recovery", `${s.label} abort failed: ${getErrorMessage(err)}`);
+      notify(
+        `Detected leftover ${s.label} state but auto-abort failed. ` +
+          `Run \`git ${s.label} --abort\` manually before retrying.`,
+        "error",
+      );
+      return "blocked";
+    }
+  }
+  return reconciled ? "reconciled" : "clean";
+}
+
+/**
+ * Core: detect leftover merge state and reconcile it. Takes a NotifyFn so the
+ * legacy reconcileMergeState(basePath, ctx) wrapper and the drift handler can
+ * both call it — the drift handler uses SILENT_NOTIFY.
+ */
+function reconcileMergeStateCore(
+  basePath: string,
+  notify: NotifyFn,
+): MergeReconcileResult {
+  // First, abort any rebase/cherry-pick/revert left over from a SIGKILL'd
+  // worker. Doing this before the merge-state check unblocks any merge that
+  // would otherwise refuse with "you have unfinished operation". (HIGH-7)
+  const otherOpsResult = reconcileOtherInProgressGitOps(basePath, notify);
+  if (otherOpsResult === "blocked") return "blocked";
+
+  const mergeHeadPath = join(basePath, ".git", "MERGE_HEAD");
+  const squashMsgPath = join(basePath, ".git", "SQUASH_MSG");
+  const hasMergeHead = existsSync(mergeHeadPath);
+  const hasSquashMsg = existsSync(squashMsgPath);
+  if (!hasMergeHead && !hasSquashMsg) {
+    return otherOpsResult === "reconciled" ? "reconciled" : "clean";
+  }
+
+  const conflictedFiles = nativeConflictFiles(basePath);
+  if (conflictedFiles.length === 0) {
+    // All conflicts resolved — finalize the merge/squash commit
+    try {
+      const commitSha = nativeCommit(basePath, "chore(gsd): reconcile merge state");
+      if (commitSha) {
+        const mode = hasMergeHead ? "merge" : "squash commit";
+        notify(`Finalized leftover ${mode} from prior session.`, "info");
+      } else {
+        notify(
+          "No new commit needed for leftover merge/squash state — already committed.",
+          "info",
+        );
+      }
+    } catch (err) {
+      const errorMessage = getErrorMessage(err);
+      notify(
+        `Failed to finalize leftover merge/squash commit: ${errorMessage}`,
+        "error",
+      );
+      return "blocked";
+    }
+  } else {
+    // Still conflicted — try auto-resolving .gsd/ state file conflicts (#530)
+    const gsdConflicts = conflictedFiles.filter((f) => f.startsWith(".gsd/"));
+    const codeConflicts = conflictedFiles.filter((f) => !f.startsWith(".gsd/"));
+
+    if (gsdConflicts.length > 0 && codeConflicts.length === 0) {
+      let resolved = true;
+      try {
+        nativeCheckoutTheirs(basePath, gsdConflicts);
+        nativeAddPaths(basePath, gsdConflicts);
+      } catch (e) {
+        logError(
+          "recovery",
+          `auto-resolve .gsd/ conflicts failed: ${(e as Error).message}`,
+        );
+        resolved = false;
+      }
+      if (resolved) {
+        try {
+          nativeCommit(
+            basePath,
+            "chore: auto-resolve .gsd/ state file conflicts",
+          );
+          notify(
+            `Auto-resolved ${gsdConflicts.length} .gsd/ state file conflict(s) from prior merge.`,
+            "info",
+          );
+        } catch (e) {
+          logError(
+            "recovery",
+            `auto-commit .gsd/ conflict resolution failed: ${(e as Error).message}`,
+          );
+          resolved = false;
+        }
+      }
+      if (!resolved) {
+        abortAndResetMerge(basePath, hasMergeHead, squashMsgPath);
+        notify(
+          "Detected leftover merge state — auto-resolve failed, cleaned up. Re-deriving state.",
+          "warning",
+        );
+      }
+    } else {
+      // Code conflicts present — fail safe and preserve any manual resolution
+      // work instead of discarding it with merge --abort/reset --hard.
+      notify(
+        "Detected leftover merge state with unresolved code conflicts. Auto-mode will pause without modifying the worktree so manual conflict resolution is preserved.",
+        "error",
+      );
+      return "blocked";
+    }
+  }
+  return "reconciled";
+}
+
+/**
+ * Legacy entry point preserved for existing callers (auto.ts, auto/phases.ts
+ * via loop-deps, integration tests). New code prefers the drift handler.
+ */
+export function reconcileMergeState(
+  basePath: string,
+  ctx: ExtensionContext,
+): MergeReconcileResult {
+  return reconcileMergeStateCore(basePath, (message, severity) =>
+    ctx.ui.notify(message, severity),
+  );
+}
+
+// ─── Drift Handler ────────────────────────────────────────────────────────────
+
+type MergeStateDrift = Extract<DriftRecord, { kind: "unmerged-merge-state" }>;
+
+function hasMergeStateLeftovers(basePath: string): boolean {
+  const gitDir = join(basePath, ".git");
+  return (
+    existsSync(join(gitDir, "MERGE_HEAD")) ||
+    existsSync(join(gitDir, "SQUASH_MSG")) ||
+    existsSync(join(gitDir, "rebase-merge")) ||
+    existsSync(join(gitDir, "rebase-apply")) ||
+    existsSync(join(gitDir, "CHERRY_PICK_HEAD")) ||
+    existsSync(join(gitDir, "REVERT_HEAD"))
+  );
+}
+
+export function detectMergeStateDrift(
+  _state: GSDState,
+  ctx: DriftContext,
+): MergeStateDrift[] {
+  if (hasMergeStateLeftovers(ctx.basePath)) {
+    return [{ kind: "unmerged-merge-state", basePath: ctx.basePath }];
+  }
+  return [];
+}
+
+/**
+ * Repair: invoke the reconciliation core with a silent notify. If the
+ * underlying reconciliation reports "blocked" (e.g., unresolved code
+ * conflicts present), throw so reconcileBeforeDispatch surfaces the drift
+ * via ReconciliationFailedError.
+ */
+export function repairMergeStateDrift(record: MergeStateDrift): void {
+  const result = reconcileMergeStateCore(record.basePath, SILENT_NOTIFY);
+  if (result === "blocked") {
+    throw new Error(
+      `Merge state reconciliation blocked for ${record.basePath} — likely unresolved code conflicts. Manual intervention required.`,
+    );
+  }
+}
+
+export const mergeStateHandler: DriftHandler<MergeStateDrift> = {
+  kind: "unmerged-merge-state",
+  detect: detectMergeStateDrift,
+  repair: (record) => {
+    repairMergeStateDrift(record);
+  },
+};

--- a/src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts
@@ -1,0 +1,68 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 stale-sketch-flag drift handler. Relocated from
+// gsd-db.ts where autoHealSketchFlags previously lived with zero callers.
+//
+// Recovers from two scenarios (per ADR-011):
+//   1. Crash between gsd_plan_slice's PLAN.md write and the sketch flag flip.
+//   2. Flag-OFF downgrade: when progressive_planning is off, dispatch routes
+//      sketch slices to plan-slice, which writes PLAN.md but leaves
+//      is_sketch=1 — the next reconciliation pass clears it.
+
+import { existsSync } from "node:fs";
+
+import {
+  getSketchedSliceIds,
+  isDbAvailable,
+  setSliceSketchFlag,
+} from "../../gsd-db.js";
+import { resolveSliceFile } from "../../paths.js";
+import type { GSDState } from "../../types.js";
+import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
+
+type SketchFlagDrift = Extract<DriftRecord, { kind: "stale-sketch-flag" }>;
+
+export function detectStaleSketchFlags(
+  state: GSDState,
+  ctx: DriftContext,
+): SketchFlagDrift[] {
+  if (!isDbAvailable()) return [];
+  const mid = state.activeMilestone?.id;
+  if (!mid) return [];
+
+  const sliceIds = getSketchedSliceIds(mid);
+  return sliceIds
+    .filter((sid) => {
+      const planPath = resolveSliceFile(ctx.basePath, mid, sid, "PLAN");
+      return planPath !== null && existsSync(planPath);
+    })
+    .map((sid) => ({ kind: "stale-sketch-flag" as const, mid, sid }));
+}
+
+export function repairStaleSketchFlag(record: SketchFlagDrift): void {
+  setSliceSketchFlag(record.mid, record.sid, false);
+}
+
+export const sketchFlagHandler: DriftHandler<SketchFlagDrift> = {
+  kind: "stale-sketch-flag",
+  detect: detectStaleSketchFlags,
+  repair: (record) => {
+    repairStaleSketchFlag(record);
+  },
+};
+
+/**
+ * Legacy entry point preserved for callers that supply a custom hasPlanFile
+ * predicate. Prefer the drift handler (sketchFlagHandler) for new code.
+ */
+export function autoHealSketchFlags(
+  milestoneId: string,
+  hasPlanFile: (sliceId: string) => boolean,
+): void {
+  if (!isDbAvailable()) return;
+  const sliceIds = getSketchedSliceIds(milestoneId);
+  for (const sid of sliceIds) {
+    if (hasPlanFile(sid)) {
+      setSliceSketchFlag(milestoneId, sid, false);
+    }
+  }
+}

--- a/src/resources/extensions/gsd/state-reconciliation/errors.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/errors.ts
@@ -8,8 +8,18 @@ export interface ReconciliationFailureDetail {
   cause: unknown;
 }
 
+export interface ReconciliationDetectionFailureDetail {
+  handlerKind: string;
+  phase: "detect";
+  basePath: string;
+  statePhase?: string;
+  activeMilestoneId?: string;
+  cause: unknown;
+}
+
 export interface ReconciliationFailedErrorOptions {
   failures?: ReadonlyArray<ReconciliationFailureDetail>;
+  detectionFailures?: ReadonlyArray<ReconciliationDetectionFailureDetail>;
   persistentDrift?: ReadonlyArray<DriftRecord>;
   pass?: number;
 }
@@ -24,6 +34,7 @@ export interface ReconciliationFailedErrorOptions {
  */
 export class ReconciliationFailedError extends Error {
   readonly failures: ReadonlyArray<ReconciliationFailureDetail>;
+  readonly detectionFailures: ReadonlyArray<ReconciliationDetectionFailureDetail>;
   readonly persistentDrift: ReadonlyArray<DriftRecord>;
   readonly pass?: number;
 
@@ -31,12 +42,18 @@ export class ReconciliationFailedError extends Error {
     super(formatMessage(opts));
     this.name = "ReconciliationFailedError";
     this.failures = opts.failures ?? [];
+    this.detectionFailures = opts.detectionFailures ?? [];
     this.persistentDrift = opts.persistentDrift ?? [];
     this.pass = opts.pass;
   }
 }
 
 function formatMessage(opts: ReconciliationFailedErrorOptions): string {
+  if (opts.detectionFailures && opts.detectionFailures.length > 0) {
+    const kinds = opts.detectionFailures.map((f) => f.handlerKind).join(", ");
+    const passSuffix = opts.pass !== undefined ? ` in pass ${opts.pass}` : "";
+    return `Reconciliation detect failed${passSuffix} for handlers: ${kinds}`;
+  }
   if (opts.failures && opts.failures.length > 0) {
     const kinds = opts.failures.map((f) => f.drift.kind).join(", ");
     const passSuffix = opts.pass !== undefined ? ` in pass ${opts.pass}` : "";

--- a/src/resources/extensions/gsd/state-reconciliation/errors.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/errors.ts
@@ -1,0 +1,50 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 typed reconciliation failure for Recovery Classification.
+
+import type { DriftRecord } from "./types.js";
+
+export interface ReconciliationFailureDetail {
+  drift: DriftRecord;
+  cause: unknown;
+}
+
+export interface ReconciliationFailedErrorOptions {
+  failures?: ReadonlyArray<ReconciliationFailureDetail>;
+  persistentDrift?: ReadonlyArray<DriftRecord>;
+  pass?: number;
+}
+
+/**
+ * Thrown by reconcileBeforeDispatch when:
+ *   - one or more repair functions throw within a pass (`failures` populated), or
+ *   - drift persists after the cap=2 lifecycle (`persistentDrift` populated).
+ *
+ * Recovery Classification recognizes this error via instanceof and maps it to
+ * failureKind "reconciliation-drift" with action "escalate".
+ */
+export class ReconciliationFailedError extends Error {
+  readonly failures: ReadonlyArray<ReconciliationFailureDetail>;
+  readonly persistentDrift: ReadonlyArray<DriftRecord>;
+  readonly pass?: number;
+
+  constructor(opts: ReconciliationFailedErrorOptions) {
+    super(formatMessage(opts));
+    this.name = "ReconciliationFailedError";
+    this.failures = opts.failures ?? [];
+    this.persistentDrift = opts.persistentDrift ?? [];
+    this.pass = opts.pass;
+  }
+}
+
+function formatMessage(opts: ReconciliationFailedErrorOptions): string {
+  if (opts.failures && opts.failures.length > 0) {
+    const kinds = opts.failures.map((f) => f.drift.kind).join(", ");
+    const passSuffix = opts.pass !== undefined ? ` in pass ${opts.pass}` : "";
+    return `Reconciliation repair failed${passSuffix} for drift kinds: ${kinds}`;
+  }
+  if (opts.persistentDrift && opts.persistentDrift.length > 0) {
+    const kinds = opts.persistentDrift.map((d) => d.kind).join(", ");
+    return `Reconciliation drift persisted after cap=2 passes: ${kinds}`;
+  }
+  return "Reconciliation failed";
+}

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -65,7 +65,7 @@ export async function reconcileBeforeDispatch(
     const stateSnapshot = await deps.deriveState(basePath, deps.deriveStateOptions);
     const ctx: DriftContext = { basePath, state: stateSnapshot };
 
-    const drift = await detectAllDrift(stateSnapshot, ctx, registry);
+    const drift = await detectAllDrift(stateSnapshot, ctx, registry, pass);
     if (drift.length === 0) {
       return {
         ok: true,
@@ -105,7 +105,7 @@ export async function reconcileBeforeDispatch(
   deps.invalidateStateCache();
   const finalState = await deps.deriveState(basePath, deps.deriveStateOptions);
   const finalCtx: DriftContext = { basePath, state: finalState };
-  const persistent = await detectAllDrift(finalState, finalCtx, registry);
+  const persistent = await detectAllDrift(finalState, finalCtx, registry, MAX_PASSES);
 
   if (persistent.length > 0) {
     throw new ReconciliationFailedError({ persistentDrift: persistent });
@@ -124,11 +124,28 @@ async function detectAllDrift(
   ctx: DriftContext,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   registry: ReadonlyArray<DriftHandler<any>>,
+  pass: number,
 ): Promise<DriftRecord[]> {
   const collected: DriftRecord[] = [];
   for (const handler of registry) {
-    const detected = await handler.detect(state, ctx);
-    collected.push(...detected);
+    try {
+      const detected = await handler.detect(state, ctx);
+      collected.push(...detected);
+    } catch (cause) {
+      throw new ReconciliationFailedError({
+        detectionFailures: [
+          {
+            handlerKind: handler.kind,
+            phase: "detect",
+            basePath: ctx.basePath,
+            statePhase: state.phase,
+            activeMilestoneId: state.activeMilestone?.id,
+            cause,
+          },
+        ],
+        pass,
+      });
+    }
   }
   return collected;
 }

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -1,0 +1,133 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 drift-driven State Reconciliation Module entry point.
+// reconcileBeforeDispatch runs before every Dispatch decision and worker spawn.
+
+import {
+  deriveState as defaultDeriveState,
+  invalidateStateCache as defaultInvalidate,
+} from "../state.js";
+import type { GSDState } from "../types.js";
+
+import {
+  ReconciliationFailedError,
+  type ReconciliationFailureDetail,
+} from "./errors.js";
+import { DRIFT_REGISTRY } from "./registry.js";
+import type {
+  DriftContext,
+  DriftHandler,
+  DriftRecord,
+  ReconciliationDeps,
+  ReconciliationResult,
+} from "./types.js";
+
+export type {
+  DriftContext,
+  DriftHandler,
+  DriftRecord,
+  ReconciliationDeps,
+  ReconciliationResult,
+} from "./types.js";
+export { ReconciliationFailedError } from "./errors.js";
+export type { ReconciliationFailureDetail } from "./errors.js";
+export { DRIFT_REGISTRY } from "./registry.js";
+
+const MAX_PASSES = 2;
+
+const defaultDeps: ReconciliationDeps = {
+  invalidateStateCache: defaultInvalidate,
+  deriveState: defaultDeriveState,
+};
+
+/**
+ * Drift-driven pre-dispatch reconciliation per ADR-017.
+ *
+ * Lifecycle: derive → detect drift → apply repairs → re-derive. Capped at
+ * MAX_PASSES (=2) cycles. The loop runs only when the prior pass fully
+ * succeeded but re-derive surfaces NEW drift (cascading repairs — e.g.
+ * fixing milestone registration uncovers a downstream completion-timestamp
+ * drift).
+ *
+ * Returns ok=true with `repaired` and terminal `blockers` populated.
+ * Throws ReconciliationFailedError when:
+ *   - any repair function throws within a pass, or
+ *   - drift persists after the cap.
+ */
+export async function reconcileBeforeDispatch(
+  basePath: string,
+  deps: ReconciliationDeps = defaultDeps,
+): Promise<ReconciliationResult> {
+  const registry = deps.registry ?? DRIFT_REGISTRY;
+  const repaired: DriftRecord[] = [];
+
+  for (let pass = 0; pass < MAX_PASSES; pass++) {
+    deps.invalidateStateCache();
+    const stateSnapshot = await deps.deriveState(basePath, deps.deriveStateOptions);
+    const ctx: DriftContext = { basePath, state: stateSnapshot };
+
+    const drift = await detectAllDrift(stateSnapshot, ctx, registry);
+    if (drift.length === 0) {
+      return {
+        ok: true,
+        stateSnapshot,
+        repaired,
+        blockers: stateSnapshot.blockers ?? [],
+      };
+    }
+
+    const failures: ReconciliationFailureDetail[] = [];
+    for (const record of drift) {
+      const handler = registry.find((h) => h.kind === record.kind);
+      if (!handler) {
+        failures.push({
+          drift: record,
+          cause: new Error(
+            `No drift handler registered for kind "${record.kind}"`,
+          ),
+        });
+        continue;
+      }
+      try {
+        await handler.repair(record, ctx);
+        repaired.push(record);
+      } catch (cause) {
+        failures.push({ drift: record, cause });
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new ReconciliationFailedError({ failures, pass });
+    }
+    // Pass fully succeeded; loop runs again to detect cascading drift.
+  }
+
+  // After MAX_PASSES, one more derive+detect to verify nothing persists.
+  deps.invalidateStateCache();
+  const finalState = await deps.deriveState(basePath, deps.deriveStateOptions);
+  const finalCtx: DriftContext = { basePath, state: finalState };
+  const persistent = await detectAllDrift(finalState, finalCtx, registry);
+
+  if (persistent.length > 0) {
+    throw new ReconciliationFailedError({ persistentDrift: persistent });
+  }
+
+  return {
+    ok: true,
+    stateSnapshot: finalState,
+    repaired,
+    blockers: finalState.blockers ?? [],
+  };
+}
+
+async function detectAllDrift(
+  state: GSDState,
+  ctx: DriftContext,
+  registry: ReadonlyArray<DriftHandler>,
+): Promise<DriftRecord[]> {
+  const collected: DriftRecord[] = [];
+  for (const handler of registry) {
+    const detected = await handler.detect(state, ctx);
+    collected.push(...detected);
+  }
+  return collected;
+}

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -122,7 +122,8 @@ export async function reconcileBeforeDispatch(
 async function detectAllDrift(
   state: GSDState,
   ctx: DriftContext,
-  registry: ReadonlyArray<DriftHandler>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registry: ReadonlyArray<DriftHandler<any>>,
 ): Promise<DriftRecord[]> {
   const collected: DriftRecord[] = [];
   for (const handler of registry) {

--- a/src/resources/extensions/gsd/state-reconciliation/index.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/index.ts
@@ -105,7 +105,7 @@ export async function reconcileBeforeDispatch(
   deps.invalidateStateCache();
   const finalState = await deps.deriveState(basePath, deps.deriveStateOptions);
   const finalCtx: DriftContext = { basePath, state: finalState };
-  const persistent = await detectAllDrift(finalState, finalCtx, registry, MAX_PASSES);
+  const persistent = await detectAllDrift(finalState, finalCtx, registry);
 
   if (persistent.length > 0) {
     throw new ReconciliationFailedError({ persistentDrift: persistent });
@@ -124,7 +124,7 @@ async function detectAllDrift(
   ctx: DriftContext,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   registry: ReadonlyArray<DriftHandler<any>>,
-  pass: number,
+  pass?: number,
 ): Promise<DriftRecord[]> {
   const collected: DriftRecord[] = [];
   for (const handler of registry) {
@@ -133,16 +133,7 @@ async function detectAllDrift(
       collected.push(...detected);
     } catch (cause) {
       throw new ReconciliationFailedError({
-        detectionFailures: [
-          {
-            handlerKind: handler.kind,
-            phase: "detect",
-            basePath: ctx.basePath,
-            statePhase: state.phase,
-            activeMilestoneId: state.activeMilestone?.id,
-            cause,
-          },
-        ],
+        failures: [{ drift: { kind: handler.kind } as DriftRecord, cause }],
         pass,
       });
     }

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -1,0 +1,10 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 drift handler registry. Single source of truth for
+// the catalog. Tests can override per-call via ReconciliationDeps.registry.
+
+import { sketchFlagHandler } from "./drift/sketch-flag.js";
+import type { DriftHandler } from "./types.js";
+
+export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler> = [
+  sketchFlagHandler,
+];

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -2,9 +2,16 @@
 // File Purpose: ADR-017 drift handler registry. Single source of truth for
 // the catalog. Tests can override per-call via ReconciliationDeps.registry.
 
+import { mergeStateHandler } from "./drift/merge-state.js";
 import { sketchFlagHandler } from "./drift/sketch-flag.js";
 import type { DriftHandler } from "./types.js";
 
-export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler> = [
+// Each handler is parameterized over its specific DriftRecord variant for
+// internal type safety. The registry stores them under DriftHandler<any> so
+// handlers with disjoint repair parameter types coexist; the lifecycle matches
+// by kind before invoking repair, so this is sound at runtime.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler<any>> = [
   sketchFlagHandler,
+  mergeStateHandler,
 ];

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -1,0 +1,71 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 types for drift-driven state reconciliation.
+
+import type { DeriveStateOptions } from "../state.js";
+import type { GSDState } from "../types.js";
+
+/**
+ * Discriminated union over drift kinds the State Reconciliation Module
+ * recognizes. Each variant carries the identifiers its matching repair needs.
+ *
+ * Subsequent ADR-017 issues add variants: unmerged-merge-state, stale-render,
+ * stale-worker, unregistered-milestone, roadmap-divergence,
+ * missing-completion-timestamp.
+ */
+export type DriftRecord =
+  | { kind: "stale-sketch-flag"; mid: string; sid: string };
+
+/**
+ * Context threaded to detector and repair functions. Keeps handlers from
+ * re-deriving state for themselves.
+ */
+export interface DriftContext {
+  basePath: string;
+  state: GSDState;
+}
+
+/**
+ * One drift kind's detect+repair composition.
+ *
+ * Repairs MUST be idempotent: re-running yields the same outcome. This is
+ * load-bearing for the cap=2 lifecycle — the second pass may detect drift
+ * that the first pass already partially repaired.
+ */
+export interface DriftHandler<T extends DriftRecord = DriftRecord> {
+  kind: T["kind"];
+  detect: (state: GSDState, ctx: DriftContext) => T[] | Promise<T[]>;
+  repair: (record: T, ctx: DriftContext) => Promise<void> | void;
+}
+
+/**
+ * Result of a successful reconcileBeforeDispatch call.
+ *
+ * `blockers` are TERMINAL conditions (DB unavailable, slice lock invalid,
+ * dependency cycle) that reconciliation cannot resolve. The caller decides
+ * how to handle them; the orchestrator adapter at auto.ts maps non-empty
+ * blockers to ok=false for the orchestrator's InvariantAdapterResult.
+ *
+ * On repair failure or drift persisting past the cap, reconcileBeforeDispatch
+ * throws ReconciliationFailedError instead of returning.
+ */
+export interface ReconciliationResult {
+  ok: true;
+  stateSnapshot: GSDState;
+  repaired: readonly DriftRecord[];
+  blockers: readonly string[];
+}
+
+/**
+ * Dependencies for reconcileBeforeDispatch. Tests inject fakes for the
+ * registry and state derivation; production callers use defaults.
+ */
+export interface ReconciliationDeps {
+  invalidateStateCache: () => void;
+  deriveState: (
+    basePath: string,
+    opts?: DeriveStateOptions,
+  ) => Promise<GSDState>;
+  /** Override of the drift handler catalog. Defaults to DRIFT_REGISTRY. */
+  registry?: ReadonlyArray<DriftHandler>;
+  deriveStateOptions?: DeriveStateOptions;
+}

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -8,12 +8,12 @@ import type { GSDState } from "../types.js";
  * Discriminated union over drift kinds the State Reconciliation Module
  * recognizes. Each variant carries the identifiers its matching repair needs.
  *
- * Subsequent ADR-017 issues add variants: unmerged-merge-state, stale-render,
- * stale-worker, unregistered-milestone, roadmap-divergence,
- * missing-completion-timestamp.
+ * Subsequent ADR-017 issues add variants: stale-render, stale-worker,
+ * unregistered-milestone, roadmap-divergence, missing-completion-timestamp.
  */
 export type DriftRecord =
-  | { kind: "stale-sketch-flag"; mid: string; sid: string };
+  | { kind: "stale-sketch-flag"; mid: string; sid: string }
+  | { kind: "unmerged-merge-state"; basePath: string };
 
 /**
  * Context threaded to detector and repair functions. Keeps handlers from
@@ -65,7 +65,13 @@ export interface ReconciliationDeps {
     basePath: string,
     opts?: DeriveStateOptions,
   ) => Promise<GSDState>;
-  /** Override of the drift handler catalog. Defaults to DRIFT_REGISTRY. */
-  registry?: ReadonlyArray<DriftHandler>;
+  /**
+   * Override of the drift handler catalog. Defaults to DRIFT_REGISTRY. Each
+   * handler is parameterized over its own DriftRecord variant; the union of
+   * disjoint parameter types in repair forces the array element type to
+   * DriftHandler<any> here (see registry.ts comment).
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registry?: ReadonlyArray<DriftHandler<any>>;
   deriveStateOptions?: DeriveStateOptions;
 }

--- a/src/resources/extensions/gsd/tests/progressive-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/progressive-planning.test.ts
@@ -14,9 +14,9 @@ import {
   insertMilestone,
   insertSlice,
   setSliceSketchFlag,
-  autoHealSketchFlags,
   getSlice,
 } from "../gsd-db.ts";
+import { autoHealSketchFlags } from "../state-reconciliation/drift/sketch-flag.ts";
 import { deriveStateFromDb } from "../state.ts";
 import { resolveDispatch } from "../auto-dispatch.ts";
 import type { DispatchContext } from "../auto-dispatch.ts";

--- a/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
+++ b/src/resources/extensions/gsd/tests/runtime-invariant-modules.test.ts
@@ -42,16 +42,19 @@ test("State Reconciliation invalidates cache and returns reconciled state", asyn
   assert.equal(result.ok && result.stateSnapshot, state);
 });
 
-test("State Reconciliation blocks when derived state carries blockers", async () => {
+test("State Reconciliation surfaces terminal blockers in result (ADR-017)", async () => {
+  // Under ADR-017, blockers are terminal but do not throw — they ride along
+  // in the result so the orchestrator adapter can map them to ok=false.
   const result = await reconcileBeforeDispatch("/project", {
     invalidateStateCache() {},
     async deriveState() {
       return makeState({ phase: "blocked", blockers: ["slice lock missing"] });
     },
+    registry: [],
   });
 
-  assert.equal(result.ok, false);
-  assert.equal(!result.ok && result.reason, "slice lock missing");
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.blockers, ["slice lock missing"]);
 });
 
 test("Tool Contract compiles known Unit prompt and tool policy", () => {

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -136,6 +136,42 @@ test("ADR-017 (#5700): repair failure throws ReconciliationFailedError with shap
   );
 });
 
+test("ADR-017 (#5700): detector failure throws ReconciliationFailedError with shape", async () => {
+  const handler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => {
+      throw new Error("simulated detect failure");
+    },
+    repair: () => {
+      /* detect fails before repair */
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      reconcileBeforeDispatch("/project", {
+        invalidateStateCache: () => {},
+        deriveState: async () => makeState(),
+        registry: [handler],
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof ReconciliationFailedError, "must be ReconciliationFailedError");
+      assert.equal(err.detectionFailures.length, 1);
+      assert.equal(err.detectionFailures[0]?.handlerKind, "stale-sketch-flag");
+      assert.equal(err.detectionFailures[0]?.phase, "detect");
+      assert.equal(err.detectionFailures[0]?.basePath, "/project");
+      assert.equal(err.detectionFailures[0]?.statePhase, "planning");
+      assert.equal(err.detectionFailures[0]?.activeMilestoneId, "M001");
+      assert.ok(err.detectionFailures[0]?.cause instanceof Error);
+      assert.equal((err.detectionFailures[0]?.cause as Error).message, "simulated detect failure");
+      assert.equal(err.pass, 0);
+      assert.equal(err.failures.length, 0);
+      assert.equal(err.persistentDrift.length, 0);
+      return true;
+    },
+  );
+});
+
 test("ADR-017 (#5700): persistent drift after cap=2 throws ReconciliationFailedError", async () => {
   // Detect always returns one drift; repair is a no-op (drift never goes away).
   const persistent: DriftRecord = { kind: "stale-sketch-flag", mid: "M001", sid: "S02" };
@@ -236,6 +272,48 @@ test("ADR-017 (#5701): merge-state drift detected and repaired end-to-end", asyn
   if (mergeRepaired?.kind === "unmerged-merge-state") {
     assert.equal(mergeRepaired.basePath, base);
   }
+});
+
+test("ADR-017 (#5701): merge-state drift is detected in linked worktrees", async (t) => {
+  const base = makeGitBase();
+  const worktree = join(tmpdir(), `gsd-adr017-worktree-${randomUUID()}`);
+  t.after(() => {
+    rmTreeQuiet(worktree);
+    rmTreeQuiet(base);
+  });
+
+  execFileSync("git", ["checkout", "-b", "feature"], { cwd: base, stdio: "ignore" });
+  writeFileSync(join(base, "feature.txt"), "feature content");
+  execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "add feature"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["checkout", "main"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["worktree", "add", "-b", "wt-main", worktree, "main"], {
+    cwd: base,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["merge", "--no-ff", "--no-commit", "feature"], {
+    cwd: worktree,
+    stdio: "ignore",
+  });
+
+  const mergeHeadPath = execFileSync("git", ["rev-parse", "--git-path", "MERGE_HEAD"], {
+    cwd: worktree,
+    encoding: "utf-8",
+  }).trim();
+  assert.ok(existsSync(mergeHeadPath), "pre: MERGE_HEAD exists in resolved worktree gitdir");
+  assert.equal(existsSync(join(worktree, ".git", "MERGE_HEAD")), false);
+
+  const result = await reconcileBeforeDispatch(worktree, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(existsSync(mergeHeadPath), false, "post: MERGE_HEAD cleared after reconciliation");
+  assert.ok(
+    result.repaired.some((d) => d.kind === "unmerged-merge-state"),
+    "repaired list should include the worktree merge-state drift record",
+  );
 });
 
 test("ADR-017 (#5701): no merge state → detector returns no drift", async (t) => {

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1,13 +1,16 @@
 // Project/App: GSD-2
-// File Purpose: ADR-017 contract tests for drift-driven State Reconciliation
-// (issue #5700). Covers: end-to-end sketch-flag drift, repair-throw path, and
-// Recovery Classification mapping for ReconciliationFailedError.
+// File Purpose: ADR-017 contract tests for drift-driven State Reconciliation.
+// Covers sketch-flag drift (#5700) and merge-state drift (#5701) end-to-end,
+// plus the repair-throw and persistent-drift error paths, and Recovery
+// Classification mapping for ReconciliationFailedError.
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
 
 import {
   openDatabase,
@@ -179,6 +182,80 @@ test("ADR-017 (#5700): classifyFailure recognizes ReconciliationFailedError", ()
   assert.equal(result.exitReason, "reconciliation-drift");
   assert.match(result.remediation, /persistent or repair-failed drift kinds/);
 });
+
+// ─── #5701: merge-state drift ────────────────────────────────────────────────
+
+function makeGitBase(): string {
+  const base = join(tmpdir(), `gsd-adr017-merge-${randomUUID()}`);
+  mkdirSync(base, { recursive: true });
+  execFileSync("git", ["init", "--initial-branch=main"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: base, stdio: "ignore" });
+  writeFileSync(join(base, ".gitkeep"), "");
+  execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: base, stdio: "ignore" });
+  return base;
+}
+
+function rmTreeQuiet(base: string): void {
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* noop */
+  }
+}
+
+test("ADR-017 (#5701): merge-state drift detected and repaired end-to-end", async (t) => {
+  const base = makeGitBase();
+  t.after(() => rmTreeQuiet(base));
+
+  // Build a clean fast-forward-resolvable merge: feature branch with one file,
+  // then start merge --no-commit on main so MERGE_HEAD exists with no conflicts.
+  execFileSync("git", ["checkout", "-b", "feature"], { cwd: base, stdio: "ignore" });
+  writeFileSync(join(base, "feature.txt"), "feature content");
+  execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "add feature"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["checkout", "main"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["merge", "--no-ff", "--no-commit", "feature"], { cwd: base, stdio: "ignore" });
+
+  assert.ok(existsSync(join(base, ".git", "MERGE_HEAD")), "pre: MERGE_HEAD exists");
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    existsSync(join(base, ".git", "MERGE_HEAD")),
+    false,
+    "post: MERGE_HEAD cleared after reconciliation",
+  );
+  const mergeRepaired = result.repaired.find((d) => d.kind === "unmerged-merge-state");
+  assert.ok(mergeRepaired, "repaired list should include the merge-state drift record");
+  if (mergeRepaired?.kind === "unmerged-merge-state") {
+    assert.equal(mergeRepaired.basePath, base);
+  }
+});
+
+test("ADR-017 (#5701): no merge state → detector returns no drift", async (t) => {
+  const base = makeGitBase();
+  t.after(() => rmTreeQuiet(base));
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.repaired.some((d) => d.kind === "unmerged-merge-state"),
+    false,
+    "no merge drift should be reported when the repo is clean",
+  );
+});
+
+// ─── Lifecycle and classification ────────────────────────────────────────────
 
 test("ADR-017 (#5700): cascading drift triggers second pass within cap", async () => {
   // First pass detects drift A; repair "fixes" it. Second pass detects drift B

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1,0 +1,212 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 contract tests for drift-driven State Reconciliation
+// (issue #5700). Covers: end-to-end sketch-flag drift, repair-throw path, and
+// Recovery Classification mapping for ReconciliationFailedError.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  getSlice,
+} from "../gsd-db.ts";
+import {
+  reconcileBeforeDispatch,
+  ReconciliationFailedError,
+  type DriftHandler,
+  type DriftRecord,
+} from "../state-reconciliation.ts";
+import { classifyFailure } from "../recovery-classification.ts";
+import type { GSDState } from "../types.ts";
+
+function makeState(overrides: Partial<GSDState> = {}): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Milestone" },
+    activeSlice: null,
+    activeTask: null,
+    phase: "planning",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "Plan milestone",
+    registry: [],
+    requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+    progress: { milestones: { done: 0, total: 1 } },
+    ...overrides,
+  };
+}
+
+function makeFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-drift-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S02"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try {
+    closeDatabase();
+  } catch {
+    /* noop */
+  }
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* noop */
+  }
+}
+
+test("ADR-017 (#5700): sketch-flag drift detected and repaired end-to-end", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({
+    id: "S02",
+    milestoneId: "M001",
+    title: "Feature",
+    status: "pending",
+    risk: "medium",
+    depends: [],
+    demo: "S02 demo.",
+    sequence: 1,
+    isSketch: true,
+    sketchScope: "limited",
+  });
+
+  // Simulate the post-crash scenario: PLAN.md exists on disk but the
+  // is_sketch flag is still 1.
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
+    "# S02 Plan\n",
+  );
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 1, "pre: flagged as sketch");
+
+  const state = makeState({ activeMilestone: { id: "M001", title: "Test" } });
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => state,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "post: flag cleared");
+  assert.equal(result.repaired.length, 1);
+  assert.equal(result.repaired[0]?.kind, "stale-sketch-flag");
+  if (result.repaired[0]?.kind === "stale-sketch-flag") {
+    assert.equal(result.repaired[0].mid, "M001");
+    assert.equal(result.repaired[0].sid, "S02");
+  }
+});
+
+test("ADR-017 (#5700): repair failure throws ReconciliationFailedError with shape", async () => {
+  const seenDrift: DriftRecord = { kind: "stale-sketch-flag", mid: "M001", sid: "S02" };
+  const handler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => [seenDrift],
+    repair: () => {
+      throw new Error("simulated repair failure");
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      reconcileBeforeDispatch("/project", {
+        invalidateStateCache: () => {},
+        deriveState: async () => makeState(),
+        registry: [handler],
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof ReconciliationFailedError, "must be ReconciliationFailedError");
+      assert.equal(err.failures.length, 1);
+      assert.equal(err.failures[0]?.drift.kind, "stale-sketch-flag");
+      assert.ok(err.failures[0]?.cause instanceof Error);
+      assert.equal((err.failures[0]?.cause as Error).message, "simulated repair failure");
+      assert.equal(err.pass, 0);
+      assert.equal(err.persistentDrift.length, 0);
+      return true;
+    },
+  );
+});
+
+test("ADR-017 (#5700): persistent drift after cap=2 throws ReconciliationFailedError", async () => {
+  // Detect always returns one drift; repair is a no-op (drift never goes away).
+  const persistent: DriftRecord = { kind: "stale-sketch-flag", mid: "M001", sid: "S02" };
+  const handler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => [persistent],
+    repair: () => {
+      /* no-op: drift cannot be cleared */
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      reconcileBeforeDispatch("/project", {
+        invalidateStateCache: () => {},
+        deriveState: async () => makeState(),
+        registry: [handler],
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof ReconciliationFailedError);
+      assert.equal(err.failures.length, 0);
+      assert.equal(err.persistentDrift.length, 1);
+      assert.equal(err.persistentDrift[0]?.kind, "stale-sketch-flag");
+      return true;
+    },
+  );
+});
+
+test("ADR-017 (#5700): classifyFailure recognizes ReconciliationFailedError", () => {
+  const err = new ReconciliationFailedError({
+    failures: [
+      {
+        drift: { kind: "stale-sketch-flag", mid: "M001", sid: "S02" },
+        cause: new Error("boom"),
+      },
+    ],
+    pass: 0,
+  });
+
+  const result = classifyFailure({ error: err });
+
+  assert.equal(result.failureKind, "reconciliation-drift");
+  assert.equal(result.action, "escalate");
+  assert.equal(result.exitReason, "reconciliation-drift");
+  assert.match(result.remediation, /persistent or repair-failed drift kinds/);
+});
+
+test("ADR-017 (#5700): cascading drift triggers second pass within cap", async () => {
+  // First pass detects drift A; repair "fixes" it. Second pass detects drift B
+  // (cascading); repair fixes it. Third call would see no drift. Cap=2 means
+  // we have exactly two repair passes available.
+  const detectedSequence: DriftRecord[][] = [
+    [{ kind: "stale-sketch-flag", mid: "M001", sid: "S02" }],
+    [{ kind: "stale-sketch-flag", mid: "M001", sid: "S03" }],
+    [],
+  ];
+  let detectCallIdx = 0;
+  const repaired: DriftRecord[] = [];
+
+  const handler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => detectedSequence[detectCallIdx++] ?? [],
+    repair: (record) => {
+      repaired.push(record);
+    },
+  };
+
+  const result = await reconcileBeforeDispatch("/project", {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+    registry: [handler],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.repaired.length, 2, "both passes' repairs collected");
+  assert.equal(repaired.length, 2);
+});

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -156,16 +156,12 @@ test("ADR-017 (#5700): detector failure throws ReconciliationFailedError with sh
       }),
     (err: unknown) => {
       assert.ok(err instanceof ReconciliationFailedError, "must be ReconciliationFailedError");
-      assert.equal(err.detectionFailures.length, 1);
-      assert.equal(err.detectionFailures[0]?.handlerKind, "stale-sketch-flag");
-      assert.equal(err.detectionFailures[0]?.phase, "detect");
-      assert.equal(err.detectionFailures[0]?.basePath, "/project");
-      assert.equal(err.detectionFailures[0]?.statePhase, "planning");
-      assert.equal(err.detectionFailures[0]?.activeMilestoneId, "M001");
-      assert.ok(err.detectionFailures[0]?.cause instanceof Error);
-      assert.equal((err.detectionFailures[0]?.cause as Error).message, "simulated detect failure");
+      assert.equal(err.failures.length, 1);
+      assert.equal(err.failures[0]?.drift.kind, "stale-sketch-flag");
+      assert.ok(err.failures[0]?.cause instanceof Error);
+      assert.equal((err.failures[0]?.cause as Error).message, "simulated detect failure");
       assert.equal(err.pass, 0);
-      assert.equal(err.failures.length, 0);
+      assert.equal(err.detectionFailures.length, 0);
       assert.equal(err.persistentDrift.length, 0);
       return true;
     },


### PR DESCRIPTION
## Summary

- Relocates `reconcileMergeState` + helpers (`abortAndResetMerge`, `reconcileOtherInProgressGitOps`) from `auto-recovery.ts` to `state-reconciliation/drift/merge-state.ts`
- Extracts user-facing `ctx.ui.notify` behind a `NotifyFn` callback so the legacy `reconcileMergeState(basePath, ctx)` signature is preserved as a thin wrapper, and the drift handler can pass a silent variant
- Adds `unmerged-merge-state` to the `DriftRecord` union; registers `mergeStateHandler` in `DRIFT_REGISTRY`. Repair throws when the underlying reconciliation reports `"blocked"` so `reconcileBeforeDispatch` surfaces it via `ReconciliationFailedError` (→ `recovery-classification` `reconciliation-drift`)
- `auto-recovery.ts` shrinks by ~200 lines; existing callers (`auto.ts`, `auto/loop-deps.ts`, `tests/integration/auto-recovery.test.ts`) continue to import `reconcileMergeState` from `auto-recovery.ts` via thin re-export
- New contract test seeds a real git merge with `MERGE_HEAD` and asserts `reconcileBeforeDispatch` clears it and records the drift

> **Stacked on #5709.** Merge #5709 first; this PR's diff will narrow to only `#5701`'s changes once that lands.

## Test plan

- [x] `npm run typecheck:extensions` — clean for new code (remaining errors are pre-existing on `upstream/main` and unrelated to this work)
- [x] Full gsd unit suite — 7571 passed, 0 failed, 8 skipped (2 new merge-state contract tests added)
- [x] Existing `tests/integration/auto-recovery.test.ts` tests for `reconcileMergeState` continue to pass via the re-export

Closes #5701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drift-driven state reconciliation (per-drift detection + repairs), capped at 2 passes; returns repaired items and terminal blockers.
  * New recovery kind "reconciliation-drift" with dedicated escalation messaging.
  * Built-in handlers to clean up merge-state leftovers and clear stale sketch flags.

* **Documentation**
  * Updated architecture docs and ADR describing the drift-driven reconciliation design.

* **Tests**
  * Added end-to-end and unit tests for detection, repair, failure shapes, and cap behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5711)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->