### PR TITLE
fix(gsd): keep complete-slice closeout read-only

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -143,7 +143,7 @@ const AUTO_UNIT_SCOPED_TOOLS: Record<string, readonly string[]> = {
   "plan-slice": ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
   "refine-slice": ["gsd_plan_slice", "gsd_plan_task", "gsd_decision_save"],
   "replan-slice": ["gsd_replan_slice", "gsd_plan_task", "gsd_decision_save"],
-  "complete-slice": ["gsd_slice_complete", "gsd_decision_save", "gsd_requirement_update", "subagent"],
+  "complete-slice": ["gsd_slice_complete", "gsd_task_reopen", "gsd_replan_slice", "gsd_decision_save", "gsd_requirement_update", "subagent"],
   "reassess-roadmap": ["gsd_reassess_roadmap"],
   "execute-task": ["gsd_task_complete", "gsd_decision_save"],
   "execute-task-simple": ["gsd_task_complete", "gsd_decision_save"],

--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -22,22 +22,24 @@ Use `subagent` only for fresh-context review when useful: reviewer for cross-cut
 
 1. Use the inlined Slice Summary and UAT templates.
 2. {{skillActivation}}
-3. Run all slice-level verification checks from the slice plan. Fix failures before marking done; refresh current state if needed.
-4. Task summaries use a flat file layout under `tasks/` such as `T01-SUMMARY.md`, not inside per-task subdirectories like `tasks/T01/SUMMARY.md`. Never use `tasks/*/SUMMARY.md`.
-5. If observability/diagnostics were planned, verify them unless the slice is simple.
-6. Address every gate in Gates to Close. Q8 maps to **Operational Readiness**: health signal, failure signal, recovery procedure, monitoring gaps. Empty sections are recorded as omitted.
-7. If requirement status changed, call `gsd_requirement_update`; do not write `.gsd/REQUIREMENTS.md` directly.
-8. Prepare `gsd_slice_complete` content with camelCase fields `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, and `uatContent`.
-9. Draft concrete UAT with preconditions, numbered steps, expected outcomes, edge cases, UAT Type, and Not Proven By This UAT.
-10. Review the inlined task-summary excerpts for DECISIONS.md and KNOWLEDGE.md-worthy decisions, patterns, and gotchas. Read full `*-SUMMARY.md` files only when an excerpt is absent, truncated, or lacks the specific evidence needed for the slice narrative. Capture significant items with `capture_thought`; do not append knowledge files directly.
-11. Call `gsd_slice_complete`. The DB-backed tool is the canonical write path. Do **not** manually write `{{sliceSummaryPath}}`. Do **not** manually write `{{sliceUatPath}}`. Do not edit roadmap checkboxes; the tool renders files and updates projections.
-12. Do not run git commands.
-13. Update `.gsd/PROJECT.md` with a full `write` only if the current project state needs refresh.
+3. Run all slice-level verification checks from the slice plan through the closeout-safe verification surface (`gsd_exec` / Context Mode verification evidence); refresh current state if needed. Do not use direct `bash` for verification commands.
+4. Complete the slice only when every required verification check passes. If verification fails or the fix requires source changes, do **not** edit source files in this unit and do **not** call `gsd_slice_complete`.
+5. For task-specific failures, call `gsd_task_reopen` with the failing completed task and a concrete reason so execution can redo the work. For plan-invalidating failures, call `gsd_replan_slice` with the blocker and updated execution tasks. Then stop with: "Slice {{sliceId}} needs execution follow-up."
+6. Task summaries use a flat file layout under `tasks/` such as `T01-SUMMARY.md`, not inside per-task subdirectories like `tasks/T01/SUMMARY.md`. Never use `tasks/*/SUMMARY.md`.
+7. If observability/diagnostics were planned, verify them unless the slice is simple.
+8. Address every gate in Gates to Close. Q8 maps to **Operational Readiness**: health signal, failure signal, recovery procedure, monitoring gaps. Empty sections are recorded as omitted.
+9. If requirement status changed, call `gsd_requirement_update`; do not write `.gsd/REQUIREMENTS.md` directly.
+10. Prepare `gsd_slice_complete` content with camelCase fields `milestoneId`, `sliceId`, `sliceTitle`, `oneLiner`, `narrative`, `verification`, and `uatContent`.
+11. Draft concrete UAT with preconditions, numbered steps, expected outcomes, edge cases, UAT Type, and Not Proven By This UAT.
+12. Review the inlined task-summary excerpts for DECISIONS.md and KNOWLEDGE.md-worthy decisions, patterns, and gotchas. Read full `*-SUMMARY.md` files only when an excerpt is absent, truncated, or lacks the specific evidence needed for the slice narrative. Capture significant items with `capture_thought`; do not append knowledge files directly.
+13. When verification passes, call `gsd_slice_complete`. The DB-backed tool is the canonical write path. Do **not** manually write `{{sliceSummaryPath}}`. Do **not** manually write `{{sliceUatPath}}`. Do not edit roadmap checkboxes; the tool renders files and updates projections.
+14. Do not run git commands.
+15. Update `.gsd/PROJECT.md` with a full `write` only if the current project state needs refresh.
 
 **Autonomous execution:** no human is available. Do not call `ask_user_questions` or `secure_env_collect`; make reasonable assumptions and document them.
 
 **File system safety:** if re-reading task summaries, use `find .gsd/milestones/{{milestoneId}}/slices/{{sliceId}}/tasks -name "*-SUMMARY.md"` or `ls .gsd/milestones/{{milestoneId}}/slices/{{sliceId}}/tasks/*-SUMMARY.md`. Never pass `{{slicePath}}` or any directory path directly to the `read` tool.
 
-**You MUST call `gsd_slice_complete` with summary and UAT content before finishing.**
+**You MUST call `gsd_slice_complete` with summary and UAT content before finishing only after verification passes.**
 
 When done, say: "Slice {{sliceId}} complete."

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -227,6 +227,17 @@ test("complete-slice prompt does not instruct LLM to toggle checkboxes manually"
   assert.doesNotMatch(prompt, /change \[ \] to \[x\]/);
 });
 
+test("complete-slice prompt keeps source fixes in execution units", () => {
+  const prompt = readPrompt("complete-slice");
+  assert.match(prompt, /Do not use direct `bash` for verification commands/i);
+  assert.match(prompt, /do \*\*not\*\* edit source files in this unit/i);
+  assert.match(prompt, /do \*\*not\*\* call `gsd_slice_complete`/i);
+  assert.match(prompt, /gsd_task_reopen/);
+  assert.match(prompt, /gsd_replan_slice/);
+  assert.match(prompt, /needs execution follow-up/i);
+  assert.doesNotMatch(prompt, /Fix failures before marking done/i);
+});
+
 test("complete-slice prompt instructs writing summary and UAT files before tool call", () => {
   const prompt = readPrompt("complete-slice");
   assert.match(prompt, /\{\{sliceSummaryPath\}\}/);
@@ -373,7 +384,9 @@ test("execute-task prompt uses camelCase parameter names matching TypeBox schema
 test("complete-slice prompt uses camelCase parameter names matching TypeBox schema", () => {
   const prompt = readPrompt("complete-slice");
   // The gsd_complete_slice tool schema uses camelCase: milestoneId, sliceId
-  const toolCallLine = prompt.split("\n").find((l) => /gsd_complete_slice/.test(l) || /gsd_slice_complete/.test(l));
+  const toolCallLine = prompt.split("\n").find((l) =>
+    (/gsd_complete_slice/.test(l) || /gsd_slice_complete/.test(l)) && /milestoneId/.test(l) && /sliceId/.test(l)
+  );
   assert.ok(toolCallLine, "prompt must contain a gsd_complete_slice or gsd_slice_complete tool call line");
   assert.doesNotMatch(toolCallLine!, /milestone_id/, "must use milestoneId, not milestone_id");
   assert.doesNotMatch(toolCallLine!, /slice_id/, "must use sliceId, not slice_id");

--- a/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
+++ b/src/resources/extensions/gsd/tests/token-tool-gating.test.ts
@@ -124,6 +124,8 @@ test("buildMinimalAutoGsdToolSet includes closeout tool for complete-slice", () 
     "gsd_milestone_status",
     "gsd_checkpoint_db",
     "gsd_task_complete",
+    "gsd_task_reopen",
+    "gsd_replan_slice",
     "gsd_slice_complete",
     "gsd_complete_slice",
     "memory_query",
@@ -131,6 +133,8 @@ test("buildMinimalAutoGsdToolSet includes closeout tool for complete-slice", () 
   ], "complete-slice");
 
   assert.ok(result.includes("gsd_slice_complete"));
+  assert.ok(result.includes("gsd_task_reopen"));
+  assert.ok(result.includes("gsd_replan_slice"));
   assert.ok(result.includes("subagent"));
   assert.ok(result.includes("capture_thought"));
   assert.ok(!result.includes("gsd_task_complete"));

--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -35,6 +35,12 @@ test("auto execute-task requires canonical task completion tool", () => {
   assert.deepEqual(getRequiredWorkflowToolsForAutoUnit("execute-task"), ["gsd_task_complete"]);
 });
 
+test("complete-slice requires closeout and execution handoff tools", () => {
+  const expected = ["gsd_slice_complete", "gsd_task_reopen", "gsd_replan_slice"];
+  assert.deepEqual(getRequiredWorkflowToolsForGuidedUnit("complete-slice"), expected);
+  assert.deepEqual(getRequiredWorkflowToolsForAutoUnit("complete-slice"), expected);
+});
+
 test("deep project setup units declare required workflow MCP tools", () => {
   assert.deepEqual(getRequiredWorkflowToolsForGuidedUnit("discuss-project"), [
     "ask_user_questions",

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -242,6 +242,24 @@ test('planning-dispatch: blocks recon agent under closeout policy', () => {
   assert.doesNotMatch(r.reason!, /read-only specialists/);
 });
 
+test('complete-slice closeout policy blocks edits to user source', () => {
+  const r = shouldBlockPlanningUnit('edit', join(BASE, 'src', 'main.ts'), BASE, 'complete-slice', PLANNING_DISPATCH_REVIEW);
+  assert.strictEqual(r.block, true);
+  assert.match(r.reason!, /complete-slice/);
+  assert.match(r.reason!, /writes are restricted to \.gsd/);
+});
+
+test('complete-slice closeout policy blocks non-allowlisted verification bash', () => {
+  const r = shouldBlockPlanningUnit('bash', 'go test ./...', BASE, 'complete-slice', PLANNING_DISPATCH_REVIEW);
+  assert.strictEqual(r.block, true);
+  assert.match(r.reason!, /bash is restricted/);
+});
+
+test('complete-slice closeout policy allows gsd_exec verification surface', () => {
+  const r = shouldBlockPlanningUnit('gsd_exec', '', BASE, 'complete-slice', PLANNING_DISPATCH_REVIEW);
+  assert.strictEqual(r.block, false);
+});
+
 test('planning-dispatch: still blocks writes to user source (write isolation preserved)', () => {
   const r = shouldBlockPlanningUnit('write', join(BASE, 'src', 'main.ts'), BASE, 'plan-slice', PLANNING_DISPATCH);
   assert.strictEqual(r.block, true);

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -322,7 +322,7 @@ export function getRequiredWorkflowToolsForGuidedUnit(unitType: string): string[
     case "execute-task":
       return ["gsd_task_complete"];
     case "complete-slice":
-      return ["gsd_slice_complete"];
+      return ["gsd_slice_complete", "gsd_task_reopen", "gsd_replan_slice"];
     default:
       return [];
   }
@@ -351,7 +351,7 @@ export function getRequiredWorkflowToolsForAutoUnit(unitType: string): string[] 
     case "reactive-execute":
       return ["gsd_task_complete"];
     case "complete-slice":
-      return ["gsd_slice_complete"];
+      return ["gsd_slice_complete", "gsd_task_reopen", "gsd_replan_slice"];
     case "replan-slice":
       return ["gsd_replan_slice"];
     case "reassess-roadmap":


### PR DESCRIPTION
Closes #5291

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Keeps `complete-slice` as a closeout/read-only-source unit and routes failed verification back to execution.
**Why:** The previous prompt/policy mismatch told closeout to fix source failures while the write gate correctly blocked source edits.
**How:** Updates the complete-slice prompt contract, exposes execution handoff tools, and adds regressions for prompt, write-gate, workflow MCP, and token tool scoping.

## What

- Updates `prompts/complete-slice.md` so closeout verifies through `gsd_exec` / Context Mode evidence and does not use direct `bash`.
- Instructs `complete-slice` to call `gsd_task_reopen` for task-specific failures or `gsd_replan_slice` for plan-invalidating failures instead of editing source.
- Adds `gsd_task_reopen` and `gsd_replan_slice` to the complete-slice workflow/tool gating surfaces.
- Adds regression tests for the prompt contract and runtime policy behavior.

## Why

Issue #5291 identifies two possible coherent contracts. This PR implements the lower-risk contract: `complete-slice` remains a closeout unit that can verify and summarize, but execution-capable units own source changes.

That avoids promoting `complete-slice` to full source-write access while it is still treated as lifecycle-only by post-unit git handling.

## How

- Preserve `TOOLS_PLANNING_DISPATCH_REVIEW` for `complete-slice`.
- Keep review-tier subagent dispatch available.
- Use `gsd_exec` as the closeout-safe verification surface.
- Route failed verification to existing DB-backed handoff tools:
  - `gsd_task_reopen` for redoing completed task work.
  - `gsd_replan_slice` when the plan itself needs to change.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/prompt-contracts.test.ts src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts src/resources/extensions/gsd/tests/workflow-mcp.test.ts src/resources/extensions/gsd/tests/token-tool-gating.test.ts` — 143 passed, 0 failed
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/activity-log.test.ts src/resources/extensions/gsd/tests/prompt-contracts.test.ts` — 66 passed, 0 failed
- `npm run verify:pr` — 8981 passed, 0 failed, 9 skipped

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## AI disclosure

- [x] This PR includes AI-assisted code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task reopening and slice replanning capabilities to the completion workflow for better error recovery.

* **Improvements**
  * Strengthened verification requirements during slice completion to use safer execution methods.
  * Enhanced error handling with explicit blocking when verification fails or source modifications are needed.
  * Refined completion rules for clearer execution constraints and failure scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5713)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->