### PR TITLE
refactor(gsd-extension): ADR-017 / stale-worker drift detection and repair

### DIFF
--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -598,6 +598,47 @@ export function isSessionLockProcessAlive(data: SessionLockData): boolean {
 }
 
 /**
+ * ADR-017 raw primitive: remove orphaned lock artifacts (lock dir + lock file)
+ * when the recorded PID is dead or no metadata is present. Mirrors the
+ * pre-flight cleanup logic in acquireSessionLock so the stale-worker drift
+ * handler can clear the orphan proactively without going through the full
+ * acquire path. No-op when the lock is held by an alive process.
+ *
+ * Returns true when artifacts were removed (drift was present).
+ */
+export function removeStaleSessionLock(basePath: string): boolean {
+  const lp = lockPath(basePath);
+  const gsdDir = gsdRoot(basePath);
+  const lockTarget = effectiveLockTarget(gsdDir);
+  const lockDir = lockTarget + ".lock";
+
+  const existingData = readExistingLockData(lp);
+  const isOrphan =
+    !existingData ||
+    (typeof existingData.pid === "number" && !isPidAlive(existingData.pid));
+  if (!isOrphan) return false;
+
+  let removed = false;
+  if (existsSync(lockDir)) {
+    try {
+      rmSync(lockDir, { recursive: true, force: true });
+      removed = true;
+    } catch {
+      /* best-effort */
+    }
+  }
+  if (existsSync(lp)) {
+    try {
+      unlinkSync(lp);
+      removed = true;
+    } catch {
+      /* best-effort */
+    }
+  }
+  return removed;
+}
+
+/**
  * Returns true if we currently hold a session lock for the given path.
  */
 export function isSessionLockHeld(basePath: string): boolean {

--- a/src/resources/extensions/gsd/state-reconciliation/drift/merge-state.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/merge-state.ts
@@ -23,7 +23,6 @@ import {
 } from "../../native-git-bridge.js";
 import type { GSDState } from "../../types.js";
 import { logError, logWarning } from "../../workflow-logger.js";
-import { resolveGitDir } from "../../worktree-manager.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
 
 export type MergeReconcileResult = "clean" | "reconciled" | "blocked";

--- a/src/resources/extensions/gsd/state-reconciliation/drift/merge-state.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/merge-state.ts
@@ -122,7 +122,6 @@ function reconcileOtherInProgressGitOps(
       label: "cherry-pick",
       indicators: [join(gitDir, "CHERRY_PICK_HEAD")],
       abort: () => {
-        // No native helper; fall back to git CLI.
         try {
           execFileSync("git", ["cherry-pick", "--abort"], {
             cwd: basePath,
@@ -130,11 +129,7 @@ function reconcileOtherInProgressGitOps(
             encoding: "utf-8",
           });
         } catch (err) {
-          logWarning(
-            "recovery",
-            `cherry-pick --abort failed: ${getErrorMessage(err)}`,
-          );
-          throw err;
+          throw new Error(`cherry-pick --abort failed: ${getErrorMessage(err)}`);
         }
       },
     },
@@ -149,11 +144,7 @@ function reconcileOtherInProgressGitOps(
             encoding: "utf-8",
           });
         } catch (err) {
-          logWarning(
-            "recovery",
-            `revert --abort failed: ${getErrorMessage(err)}`,
-          );
-          throw err;
+          throw new Error(`revert --abort failed: ${getErrorMessage(err)}`);
         }
       },
     },

--- a/src/resources/extensions/gsd/state-reconciliation/drift/merge-state.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/merge-state.ts
@@ -23,6 +23,7 @@ import {
 } from "../../native-git-bridge.js";
 import type { GSDState } from "../../types.js";
 import { logError, logWarning } from "../../workflow-logger.js";
+import { resolveGitDir } from "../../worktree-manager.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
 
 export type MergeReconcileResult = "clean" | "reconciled" | "blocked";

--- a/src/resources/extensions/gsd/state-reconciliation/drift/stale-worker.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/stale-worker.ts
@@ -1,0 +1,46 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 stale-worker drift handler. Detects session-lock
+// artifacts whose owning PID is no longer alive (typical after SIGKILL or
+// laptop sleep where the heartbeat wasn't released cleanly), and clears them
+// before the next dispatch attempts to acquire the lock.
+
+import {
+  effectiveLockFile,
+  isSessionLockProcessAlive,
+  readSessionLockData,
+  removeStaleSessionLock,
+} from "../../session-lock.js";
+import type { GSDState } from "../../types.js";
+import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
+
+type StaleWorkerDrift = Extract<DriftRecord, { kind: "stale-worker" }>;
+
+export function detectStaleWorkerDrift(
+  _state: GSDState,
+  ctx: DriftContext,
+): StaleWorkerDrift[] {
+  const data = readSessionLockData(ctx.basePath);
+  if (!data) return [];
+  if (typeof data.pid !== "number") return [];
+  if (isSessionLockProcessAlive(data)) return [];
+
+  return [
+    {
+      kind: "stale-worker",
+      lockPath: effectiveLockFile(),
+      pid: data.pid,
+    },
+  ];
+}
+
+export function repairStaleWorker(_record: StaleWorkerDrift, ctx: DriftContext): void {
+  // removeStaleSessionLock is idempotent: it re-reads lock state and is a
+  // no-op when the lock is held by an alive process. Safe under cap=2 retry.
+  removeStaleSessionLock(ctx.basePath);
+}
+
+export const staleWorkerHandler: DriftHandler<StaleWorkerDrift> = {
+  kind: "stale-worker",
+  detect: detectStaleWorkerDrift,
+  repair: repairStaleWorker,
+};

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -5,6 +5,7 @@
 import { mergeStateHandler } from "./drift/merge-state.js";
 import { sketchFlagHandler } from "./drift/sketch-flag.js";
 import { staleRenderHandler } from "./drift/stale-render.js";
+import { staleWorkerHandler } from "./drift/stale-worker.js";
 import type { DriftHandler } from "./types.js";
 
 // Each handler is parameterized over its specific DriftRecord variant for
@@ -16,4 +17,5 @@ export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler<any>> = [
   sketchFlagHandler,
   mergeStateHandler,
   staleRenderHandler,
+  staleWorkerHandler,
 ];

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -8,13 +8,14 @@ import type { GSDState } from "../types.js";
  * Discriminated union over drift kinds the State Reconciliation Module
  * recognizes. Each variant carries the identifiers its matching repair needs.
  *
- * Subsequent ADR-017 issues add variants: stale-worker, unregistered-milestone,
+ * Subsequent ADR-017 issues add variants: unregistered-milestone,
  * roadmap-divergence, missing-completion-timestamp.
  */
 export type DriftRecord =
   | { kind: "stale-sketch-flag"; mid: string; sid: string }
   | { kind: "unmerged-merge-state"; basePath: string }
-  | { kind: "stale-render"; renderPath: string; reason: string };
+  | { kind: "stale-render"; renderPath: string; reason: string }
+  | { kind: "stale-worker"; lockPath: string; pid: number };
 
 /**
  * Context threaded to detector and repair functions. Keeps handlers from

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1,8 +1,9 @@
 // Project/App: GSD-2
 // File Purpose: ADR-017 contract tests for drift-driven State Reconciliation.
-// Covers sketch-flag (#5700), merge-state (#5701), and stale-render (#5702)
-// drift end-to-end, plus the repair-throw and persistent-drift error paths,
-// and Recovery Classification mapping for ReconciliationFailedError.
+// Covers sketch-flag (#5700), merge-state (#5701), stale-render (#5702), and
+// stale-worker (#5703) drift end-to-end, plus the repair-throw and
+// persistent-drift error paths and Recovery Classification mapping for
+// ReconciliationFailedError.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -460,6 +461,79 @@ test("ADR-017 (#5702): stale-render detector reason strings match repair contrac
     "T01 is complete with summary in DB but SUMMARY.md missing on disk",
     "T01 is done in DB but unchecked in plan",
   ].sort());
+});
+
+// ─── #5703: stale-worker drift ───────────────────────────────────────────────
+
+const DEAD_PID = 999_999_999; // far above any realistic system PID; process.kill(pid, 0) → ESRCH
+
+function writeFakeSessionLock(base: string, pid: number): string {
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+  const lockFile = join(gsdDir, "auto.lock");
+  // Mirror SessionLockData minimum shape
+  writeFileSync(
+    lockFile,
+    JSON.stringify({
+      pid,
+      startedAt: new Date().toISOString(),
+      unitType: "starting",
+      unitId: "bootstrap",
+    }),
+  );
+  // Also create the proper-lockfile directory artifact at <gsdDir>.lock
+  mkdirSync(`${gsdDir}.lock`, { recursive: true });
+  return lockFile;
+}
+
+test("ADR-017 (#5703): stale-worker drift detected and orphaned lock cleared", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-worker-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const lockFile = writeFakeSessionLock(base, DEAD_PID);
+  assert.ok(existsSync(lockFile), "pre: lock file written");
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(existsSync(lockFile), false, "post: orphaned lock file removed");
+  const workerRepaired = result.repaired.find((d) => d.kind === "stale-worker");
+  assert.ok(workerRepaired, "repaired list should include the stale-worker drift");
+  if (workerRepaired?.kind === "stale-worker") {
+    assert.equal(workerRepaired.pid, DEAD_PID);
+  }
+});
+
+test("ADR-017 (#5703): live worker lock is not cleared", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-worker-live-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  // PID 1 (init/launchd): process.kill(1, 0) returns EPERM as non-root, which
+  // isPidAlive correctly treats as alive. process.pid would be rejected by the
+  // self-PID guard in isPidAlive (treated as not alive).
+  const ALIVE_PID = 1;
+  const lockFile = writeFakeSessionLock(base, ALIVE_PID);
+  assert.ok(existsSync(lockFile), "pre: lock file written");
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    existsSync(lockFile),
+    true,
+    "live lock must NOT be cleared (would steal the lock from a running session)",
+  );
+  assert.equal(
+    result.repaired.some((d) => d.kind === "stale-worker"),
+    false,
+    "no stale-worker drift should be reported when the lock owner is alive",
+  );
 });
 
 // ─── Lifecycle and classification ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- New drift kind `stale-worker`: detects session locks whose recorded PID is no longer alive (typical after SIGKILL or laptop sleep) and clears them so the next dispatch can acquire cleanly.
- Adds `removeStaleSessionLock(basePath)` to `session-lock.ts` — mirrors the pre-flight cleanup logic already inlined in `acquireSessionLock`. Idempotent: no-op when the lock owner is alive.
- `DriftRecord` extended with `{ kind: "stale-worker"; lockPath: string; pid: number }`; `staleWorkerHandler` registered.
- Contract tests cover both branches: orphaned lock (PID 999_999_999, never alive) is cleared and recorded; live lock (PID 1, EPERM treated as alive) is left untouched.

> **Stacked on #5709 → #5711 → #5718.**

## Test plan

- [x] `npm run typecheck:extensions` clean for new code
- [x] Full gsd unit suite — 7574 passed, 0 failed, 8 skipped (2 new contract tests added)
- [x] Caught a fixture bug: `process.pid` would be rejected by `isPidAlive`'s self-PID guard (returns false). Test uses PID 1 instead, where `process.kill(1, 0)` returns EPERM and `isPidAlive` correctly treats it as alive.

Closes #5703.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and cleanup of orphaned session locks left by disconnected worker processes
  * Enhanced git merge state reconciliation with automatic conflict resolution for managed system files
  * Centralized registry for coordinated state drift detection and repair operations

* **Tests**
  * Added comprehensive end-to-end test coverage for stale session lock detection and cleanup workflows

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5720)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->