### PR TITLE
refactor(gsd-extension): ADR-017 / unregistered-milestone drift

### DIFF
--- a/src/resources/extensions/gsd/state-reconciliation/drift/project-md.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/project-md.ts
@@ -1,0 +1,69 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 unregistered-milestone drift handler. Detects
+// milestones whose on-disk directory has meaningful content (ROADMAP/
+// CONTEXT/SUMMARY) but no DB row, then runs the markdown importer to
+// reconcile. PROJECT.md is the human-facing index — the importer's source
+// of truth is the .gsd/milestones/ directory tree.
+
+import { existsSync } from "node:fs";
+
+import { getMilestone, isDbAvailable } from "../../gsd-db.js";
+import { migrateHierarchyToDb } from "../../md-importer.js";
+import { findMilestoneIds } from "../../milestone-ids.js";
+import { resolveMilestoneFile } from "../../paths.js";
+import type { GSDState } from "../../types.js";
+import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
+
+type UnregisteredMilestoneDrift = Extract<
+  DriftRecord,
+  { kind: "unregistered-milestone" }
+>;
+
+function milestoneHasContent(basePath: string, milestoneId: string): boolean {
+  const roadmap = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
+  const context = resolveMilestoneFile(basePath, milestoneId, "CONTEXT");
+  const summary = resolveMilestoneFile(basePath, milestoneId, "SUMMARY");
+  return (
+    (roadmap !== null && existsSync(roadmap)) ||
+    (context !== null && existsSync(context)) ||
+    (summary !== null && existsSync(summary))
+  );
+}
+
+export function detectUnregisteredMilestoneDrift(
+  _state: GSDState,
+  ctx: DriftContext,
+): UnregisteredMilestoneDrift[] {
+  if (!isDbAvailable()) return [];
+
+  const drifts: UnregisteredMilestoneDrift[] = [];
+  for (const milestoneId of findMilestoneIds(ctx.basePath)) {
+    if (getMilestone(milestoneId)) continue;
+    if (!milestoneHasContent(ctx.basePath, milestoneId)) continue;
+    drifts.push({ kind: "unregistered-milestone", milestoneId });
+  }
+  return drifts;
+}
+
+/**
+ * Repair: invoke the markdown importer. migrateHierarchyToDb walks the same
+ * findMilestoneIds list the detector uses and INSERTs OR IGNOREs every
+ * missing milestone (and its slices/tasks) — idempotent under cap=2 retry.
+ *
+ * Note: even though we receive one record at a time, the importer is a
+ * project-wide operation. Repeated invocation across multiple drift records
+ * in the same pass is wasteful but safe; a future optimization could
+ * coalesce by checking whether the importer has already run this pass.
+ */
+export function repairUnregisteredMilestone(
+  _record: UnregisteredMilestoneDrift,
+  ctx: DriftContext,
+): void {
+  migrateHierarchyToDb(ctx.basePath);
+}
+
+export const unregisteredMilestoneHandler: DriftHandler<UnregisteredMilestoneDrift> = {
+  kind: "unregistered-milestone",
+  detect: detectUnregisteredMilestoneDrift,
+  repair: repairUnregisteredMilestone,
+};

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -3,6 +3,7 @@
 // the catalog. Tests can override per-call via ReconciliationDeps.registry.
 
 import { mergeStateHandler } from "./drift/merge-state.js";
+import { unregisteredMilestoneHandler } from "./drift/project-md.js";
 import { sketchFlagHandler } from "./drift/sketch-flag.js";
 import { staleRenderHandler } from "./drift/stale-render.js";
 import { staleWorkerHandler } from "./drift/stale-worker.js";
@@ -18,4 +19,5 @@ export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler<any>> = [
   mergeStateHandler,
   staleRenderHandler,
   staleWorkerHandler,
+  unregisteredMilestoneHandler,
 ];

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -8,14 +8,15 @@ import type { GSDState } from "../types.js";
  * Discriminated union over drift kinds the State Reconciliation Module
  * recognizes. Each variant carries the identifiers its matching repair needs.
  *
- * Subsequent ADR-017 issues add variants: unregistered-milestone,
- * roadmap-divergence, missing-completion-timestamp.
+ * Subsequent ADR-017 issues add variants: roadmap-divergence,
+ * missing-completion-timestamp.
  */
 export type DriftRecord =
   | { kind: "stale-sketch-flag"; mid: string; sid: string }
   | { kind: "unmerged-merge-state"; basePath: string }
   | { kind: "stale-render"; renderPath: string; reason: string }
-  | { kind: "stale-worker"; lockPath: string; pid: number };
+  | { kind: "stale-worker"; lockPath: string; pid: number }
+  | { kind: "unregistered-milestone"; milestoneId: string };
 
 /**
  * Context threaded to detector and repair functions. Keeps handlers from

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1,9 +1,9 @@
 // Project/App: GSD-2
 // File Purpose: ADR-017 contract tests for drift-driven State Reconciliation.
-// Covers sketch-flag (#5700), merge-state (#5701), stale-render (#5702), and
-// stale-worker (#5703) drift end-to-end, plus the repair-throw and
-// persistent-drift error paths and Recovery Classification mapping for
-// ReconciliationFailedError.
+// Covers sketch-flag (#5700), merge-state (#5701), stale-render (#5702),
+// stale-worker (#5703), and unregistered-milestone (#5704) drift end-to-end,
+// plus the repair-throw and persistent-drift error paths and Recovery
+// Classification mapping for ReconciliationFailedError.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -19,6 +19,7 @@ import {
   insertMilestone,
   insertSlice,
   insertTask,
+  getMilestone,
   getSlice,
   setSliceSummaryMd,
 } from "../gsd-db.ts";
@@ -533,6 +534,89 @@ test("ADR-017 (#5703): live worker lock is not cleared", async (t) => {
     result.repaired.some((d) => d.kind === "stale-worker"),
     false,
     "no stale-worker drift should be reported when the lock owner is alive",
+  );
+});
+
+// ─── #5704: unregistered-milestone drift ────────────────────────────────────
+
+test("ADR-017 (#5704): unregistered-milestone drift detected and DB row inserted", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-projmd-"));
+  const milestoneDir = join(base, ".gsd", "milestones", "M042");
+  mkdirSync(milestoneDir, { recursive: true });
+  // Roadmap with one slice — meaningful content, will be picked up by importer
+  writeFileSync(
+    join(milestoneDir, "M042-ROADMAP.md"),
+    [
+      "# M042: Test Milestone",
+      "",
+      "**Vision:** Verify unregistered-milestone drift",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: Foundation** `risk:medium` `depends:[]`",
+      "",
+    ].join("\n"),
+  );
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  // Pre-condition: filesystem has the milestone, DB does NOT.
+  assert.equal(getMilestone("M042"), null, "pre: DB has no row for M042");
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.ok(getMilestone("M042"), "post: DB row inserted for M042");
+  const milestoneRepaired = result.repaired.find(
+    (d) => d.kind === "unregistered-milestone",
+  );
+  assert.ok(milestoneRepaired, "repaired list should include the unregistered-milestone drift");
+  if (milestoneRepaired?.kind === "unregistered-milestone") {
+    assert.equal(milestoneRepaired.milestoneId, "M042");
+  }
+});
+
+test("ADR-017 (#5704): registered milestone (DB row present) → no drift", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-projmd-clean-"));
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(
+    join(milestoneDir, "M001-ROADMAP.md"),
+    [
+      "# M001: Test",
+      "",
+      "**Vision:** Already-registered milestone",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: Slice** `risk:low` `depends:[]`",
+      "",
+    ].join("\n"),
+  );
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.repaired.some((d) => d.kind === "unregistered-milestone"),
+    false,
+    "no drift should be reported when the milestone is already in the DB",
   );
 });
 


### PR DESCRIPTION
## Summary

- New drift kind `unregistered-milestone`: detects milestone directories with meaningful content (ROADMAP/CONTEXT/SUMMARY) that don't have a DB row, then reconciles by invoking `migrateHierarchyToDb` (idempotent via INSERT OR IGNORE).
- Detector compares `findMilestoneIds(basePath)` (filesystem source of truth for the importer) against `getMilestone(id)` lookups. Content gate prevents flagging ghost directories.
- `DriftRecord` extended with `{ kind: "unregistered-milestone"; milestoneId: string }`; handler registered.
- Two contract tests: unregistered + content-present → reconcile → DB row inserted; pre-registered → no drift recorded.

> **Stacked on #5709 → #5711 → #5718 → #5720.**

## Test plan

- [x] `npm run typecheck:extensions` clean for new code
- [x] Full gsd unit suite — 7576 passed, 0 failed, 8 skipped (2 new contract tests added)

Closes #5704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and reconciliation of unregistered milestones to ensure consistency between on-disk and registered milestone data.

* **Tests**
  * Added comprehensive test coverage for the new drift detection and repair capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5721)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->