### PR TITLE
refactor(gsd-extension): ADR-017 / roadmap-divergence drift

### DIFF
--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -324,6 +324,10 @@ FOREIGN KEY (milestone_id, slice_id) → slices
 FOREIGN KEY (milestone_id, depends_on_slice_id) → slices
 ```
 - Index: `idx_slice_deps_target`
+- Maintained from the milestone `ROADMAP.md` slice `depends` declarations. The
+  ADR-017 `roadmap-divergence` reconciliation repair re-imports the roadmap as
+  the source of truth, then refreshes this junction table so dependency checks
+  see the same edges as the markdown projection.
 
 ---
 

--- a/docs/dev/ADR-017-state-reconciliation-drift-driven.md
+++ b/docs/dev/ADR-017-state-reconciliation-drift-driven.md
@@ -44,6 +44,14 @@ type DriftRecord =
     };
 ```
 
+`roadmap-divergence` means the milestone `ROADMAP.md` projection and DB slice
+rows no longer agree on slice presence, sequence, or declared `depends` values.
+Its repair treats `ROADMAP.md` as the source of truth: the markdown hierarchy is
+re-imported into the DB, then each parsed slice's `depends` list is synced into
+the `slice_dependencies` junction table. This keeps both the JSON `slices.depends`
+column and the relational dependency view aligned before Dispatch decides which
+slice or task can run.
+
 ### Lifecycle
 
 ```ts

--- a/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
@@ -1,0 +1,109 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 roadmap-divergence drift handler. Detects mismatches
+// between ROADMAP.md (parsed slice sequence + depends declarations) and the
+// DB slice rows for that milestone, then reconciles via the markdown
+// importer plus an explicit junction-table sync.
+
+import { existsSync, readFileSync } from "node:fs";
+
+import {
+  getMilestone,
+  getMilestoneSlices,
+  isDbAvailable,
+  syncSliceDependencies,
+} from "../../gsd-db.js";
+import { migrateHierarchyToDb } from "../../md-importer.js";
+import { findMilestoneIds } from "../../milestone-ids.js";
+import { parseRoadmap } from "../../parsers-legacy.js";
+import { resolveMilestoneFile } from "../../paths.js";
+import type { GSDState } from "../../types.js";
+import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
+
+type RoadmapDivergenceDrift = Extract<
+  DriftRecord,
+  { kind: "roadmap-divergence" }
+>;
+
+function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function milestoneHasDivergence(
+  basePath: string,
+  milestoneId: string,
+): boolean {
+  const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
+  if (!roadmapPath || !existsSync(roadmapPath)) return false;
+
+  let roadmap: ReturnType<typeof parseRoadmap>;
+  try {
+    roadmap = parseRoadmap(readFileSync(roadmapPath, "utf-8"));
+  } catch {
+    return false;
+  }
+
+  const dbSlices = getMilestoneSlices(milestoneId);
+  const dbSliceMap = new Map(dbSlices.map((s) => [s.id, s]));
+
+  for (let i = 0; i < roadmap.slices.length; i++) {
+    const roadmapSlice = roadmap.slices[i]!;
+    const expectedSequence = i + 1;
+    const dbSlice = dbSliceMap.get(roadmapSlice.id);
+    if (!dbSlice) return true; // Roadmap has a slice the DB doesn't.
+    if (dbSlice.sequence !== expectedSequence) return true;
+    if (!arraysEqual(dbSlice.depends, roadmapSlice.depends)) return true;
+  }
+  return false;
+}
+
+export function detectRoadmapDivergenceDrift(
+  _state: GSDState,
+  ctx: DriftContext,
+): RoadmapDivergenceDrift[] {
+  if (!isDbAvailable()) return [];
+
+  const drifts: RoadmapDivergenceDrift[] = [];
+  for (const milestoneId of findMilestoneIds(ctx.basePath)) {
+    // Skip milestones that don't yet have a DB row — that's the
+    // unregistered-milestone drift handler's responsibility.
+    if (!getMilestone(milestoneId)) continue;
+    if (milestoneHasDivergence(ctx.basePath, milestoneId)) {
+      drifts.push({ kind: "roadmap-divergence", milestoneId });
+    }
+  }
+  return drifts;
+}
+
+/**
+ * Repair a milestone's roadmap divergence:
+ *   1. migrateHierarchyToDb upserts slice rows (sequence + depends JSON
+ *      update via ON CONFLICT DO UPDATE).
+ *   2. syncSliceDependencies updates the junction table per slice — the
+ *      importer only writes the JSON column, not the relational view.
+ */
+export function repairRoadmapDivergence(
+  record: RoadmapDivergenceDrift,
+  ctx: DriftContext,
+): void {
+  migrateHierarchyToDb(ctx.basePath);
+
+  const roadmapPath = resolveMilestoneFile(ctx.basePath, record.milestoneId, "ROADMAP");
+  if (!roadmapPath || !existsSync(roadmapPath)) return;
+
+  try {
+    const roadmap = parseRoadmap(readFileSync(roadmapPath, "utf-8"));
+    for (const slice of roadmap.slices) {
+      syncSliceDependencies(record.milestoneId, slice.id, slice.depends);
+    }
+  } catch {
+    /* parse failure: detector will fire again next pass */
+  }
+}
+
+export const roadmapDivergenceHandler: DriftHandler<RoadmapDivergenceDrift> = {
+  kind: "roadmap-divergence",
+  detect: detectRoadmapDivergenceDrift,
+  repair: repairRoadmapDivergence,
+};

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -4,6 +4,7 @@
 
 import { mergeStateHandler } from "./drift/merge-state.js";
 import { unregisteredMilestoneHandler } from "./drift/project-md.js";
+import { roadmapDivergenceHandler } from "./drift/roadmap.js";
 import { sketchFlagHandler } from "./drift/sketch-flag.js";
 import { staleRenderHandler } from "./drift/stale-render.js";
 import { staleWorkerHandler } from "./drift/stale-worker.js";
@@ -20,4 +21,5 @@ export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler<any>> = [
   staleRenderHandler,
   staleWorkerHandler,
   unregisteredMilestoneHandler,
+  roadmapDivergenceHandler,
 ];

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -8,15 +8,15 @@ import type { GSDState } from "../types.js";
  * Discriminated union over drift kinds the State Reconciliation Module
  * recognizes. Each variant carries the identifiers its matching repair needs.
  *
- * Subsequent ADR-017 issues add variants: roadmap-divergence,
- * missing-completion-timestamp.
+ * Subsequent ADR-017 issues add variants: missing-completion-timestamp.
  */
 export type DriftRecord =
   | { kind: "stale-sketch-flag"; mid: string; sid: string }
   | { kind: "unmerged-merge-state"; basePath: string }
   | { kind: "stale-render"; renderPath: string; reason: string }
   | { kind: "stale-worker"; lockPath: string; pid: number }
-  | { kind: "unregistered-milestone"; milestoneId: string };
+  | { kind: "unregistered-milestone"; milestoneId: string }
+  | { kind: "roadmap-divergence"; milestoneId: string; sliceId?: string };
 
 /**
  * Context threaded to detector and repair functions. Keeps handlers from

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -706,7 +706,10 @@ test("ADR-017 (#5705): ROADMAP declares slice missing from DB → slice inserted
   });
 
   assert.equal(result.ok, true);
-  assert.ok(getSlice("M001", "S02"), "post: S02 inserted into DB after repair");
+  const s02 = getSlice("M001", "S02");
+  assert.ok(s02, "post: S02 inserted into DB after repair");
+  assert.equal(s02?.sequence, 2, "post: S02 sequence matches ROADMAP order");
+  assert.deepEqual(s02?.depends, ["S01"], "post: S02 depends matches ROADMAP");
   const roadmapRepaired = result.repaired.find((d) => d.kind === "roadmap-divergence");
   assert.ok(roadmapRepaired, "repaired list should include the roadmap-divergence drift");
   if (roadmapRepaired?.kind === "roadmap-divergence") {

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1,9 +1,10 @@
 // Project/App: GSD-2
 // File Purpose: ADR-017 contract tests for drift-driven State Reconciliation.
 // Covers sketch-flag (#5700), merge-state (#5701), stale-render (#5702),
-// stale-worker (#5703), and unregistered-milestone (#5704) drift end-to-end,
-// plus the repair-throw and persistent-drift error paths and Recovery
-// Classification mapping for ReconciliationFailedError.
+// stale-worker (#5703), unregistered-milestone (#5704), and roadmap-
+// divergence (#5705) drift end-to-end, plus the repair-throw and
+// persistent-drift error paths and Recovery Classification mapping for
+// ReconciliationFailedError.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -617,6 +618,93 @@ test("ADR-017 (#5704): registered milestone (DB row present) → no drift", asyn
     result.repaired.some((d) => d.kind === "unregistered-milestone"),
     false,
     "no drift should be reported when the milestone is already in the DB",
+  );
+});
+
+// ─── #5705: roadmap-divergence drift ─────────────────────────────────────────
+
+test("ADR-017 (#5705): roadmap-divergence drift detected and DB depends synced", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-"));
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneDir, { recursive: true });
+  // ROADMAP.md declares S02 depends on [S01]
+  writeFileSync(
+    join(milestoneDir, "M001-ROADMAP.md"),
+    [
+      "# M001: Test",
+      "",
+      "**Vision:** Verify roadmap-divergence drift",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: Foundation** `risk:medium` `depends:[]`",
+      "- [ ] **S02: Feature** `risk:medium` `depends:[S01]`",
+      "",
+    ].join("\n"),
+  );
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  // Seed DB with S02 depending on []  — diverges from ROADMAP.md
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Foundation", status: "pending", risk: "medium", depends: [], demo: "", sequence: 1 });
+  insertSlice({ id: "S02", milestoneId: "M001", title: "Feature", status: "pending", risk: "medium", depends: [], demo: "", sequence: 2 });
+
+  assert.deepEqual(getSlice("M001", "S02")?.depends, [], "pre: DB has S02.depends = []");
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(getSlice("M001", "S02")?.depends, ["S01"], "post: DB depends matches ROADMAP.md");
+  const roadmapRepaired = result.repaired.find((d) => d.kind === "roadmap-divergence");
+  assert.ok(roadmapRepaired, "repaired list should include the roadmap-divergence drift");
+  if (roadmapRepaired?.kind === "roadmap-divergence") {
+    assert.equal(roadmapRepaired.milestoneId, "M001");
+  }
+});
+
+test("ADR-017 (#5705): in-sync ROADMAP and DB → no roadmap-divergence drift", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-clean-"));
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(
+    join(milestoneDir, "M001-ROADMAP.md"),
+    [
+      "# M001: Test",
+      "",
+      "**Vision:** Already in sync",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: Foundation** `risk:low` `depends:[]`",
+      "",
+    ].join("\n"),
+  );
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Foundation", status: "pending", risk: "low", depends: [], demo: "", sequence: 1 });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(
+    result.repaired.some((d) => d.kind === "roadmap-divergence"),
+    false,
+    "no roadmap-divergence drift should be reported when DB matches markdown",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -669,6 +669,51 @@ test("ADR-017 (#5705): roadmap-divergence drift detected and DB depends synced",
   }
 });
 
+test("ADR-017 (#5705): ROADMAP declares slice missing from DB → slice inserted and drift reported", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-newslice-"));
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneDir, { recursive: true });
+  // ROADMAP.md declares S01 and S02; DB will only have S01.
+  writeFileSync(
+    join(milestoneDir, "M001-ROADMAP.md"),
+    [
+      "# M001: Test",
+      "",
+      "**Vision:** Verify new-slice insertion via roadmap-divergence repair",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: Foundation** `risk:medium` `depends:[]`",
+      "- [ ] **S02: Feature** `risk:medium` `depends:[S01]`",
+      "",
+    ].join("\n"),
+  );
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  // Only insert S01 — S02 is intentionally absent from the DB.
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Foundation", status: "pending", risk: "medium", depends: [], demo: "", sequence: 1 });
+
+  assert.equal(getSlice("M001", "S02"), null, "pre: S02 has no DB row");
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.ok(getSlice("M001", "S02"), "post: S02 inserted into DB after repair");
+  const roadmapRepaired = result.repaired.find((d) => d.kind === "roadmap-divergence");
+  assert.ok(roadmapRepaired, "repaired list should include the roadmap-divergence drift");
+  if (roadmapRepaired?.kind === "roadmap-divergence") {
+    assert.equal(roadmapRepaired.milestoneId, "M001");
+  }
+});
+
 test("ADR-017 (#5705): in-sync ROADMAP and DB → no roadmap-divergence drift", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-clean-"));
   const milestoneDir = join(base, ".gsd", "milestones", "M001");


### PR DESCRIPTION
## Summary

- New drift kind `roadmap-divergence`: detects per-milestone mismatches between ROADMAP.md (sequence + depends declarations) and the DB slice rows. Reconciles via `migrateHierarchyToDb` (upserts sequence + depends JSON) plus an explicit `syncSliceDependencies` pass to update the junction table the importer skips.
- Detector compares each parsed roadmap slice's expected sequence (parse order) and depends array against the corresponding `getMilestoneSlices` row. Skips milestones missing DB rows entirely — that path is `unregistered-milestone` drift's territory.
- `DriftRecord` extended with `{ kind: "roadmap-divergence"; milestoneId: string; sliceId?: string }` (`sliceId` optional; current emitter is per-milestone).
- Two contract tests: ROADMAP.md declares `S02.depends=[S01]` while DB has `[]` → reconcile updates DB; in-sync state → no drift.

> **Stacked on #5709 → #5711 → #5718 → #5720 → #5721.**

## Test plan

- [x] `npm run typecheck:extensions` clean for new code
- [x] Full gsd unit suite — 7578 passed, 0 failed, 8 skipped (2 new contract tests added)

Closes #5705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and reconciliation for milestones that exist on disk but are not yet in the database.
  * Added automatic detection and repair for roadmap inconsistencies between disk and database representations.

* **Tests**
  * Added comprehensive test coverage for milestone synchronization and roadmap reconciliation scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5722)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->