### PR TITLE
refactor(gsd-extension): ADR-017 / missing-completion-timestamp drift

### DIFF
--- a/src/resources/extensions/gsd/state-reconciliation/drift/completion.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/completion.ts
@@ -1,0 +1,157 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 missing-completion-timestamp drift handler. Detects
+// tasks/slices/milestones marked complete (status = 'complete' | 'done') in
+// the DB but whose `completed_at` column is null, and where the on-disk
+// SUMMARY.md attests to completion. Backfills `completed_at` from the
+// SUMMARY.md mtime — deterministic and idempotent (re-running yields the
+// same value).
+
+import { existsSync, statSync } from "node:fs";
+
+import {
+  getMilestone,
+  getMilestoneSlices,
+  getSliceTasks,
+  isDbAvailable,
+  updateMilestoneStatus,
+  updateSliceStatus,
+  updateTaskStatus,
+} from "../../gsd-db.js";
+import {
+  resolveMilestoneFile,
+  resolveSliceFile,
+  resolveTaskFile,
+} from "../../paths.js";
+import type { GSDState } from "../../types.js";
+import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
+
+type CompletionTimestampDrift = Extract<
+  DriftRecord,
+  { kind: "missing-completion-timestamp" }
+>;
+
+const COMPLETE_STATUSES = new Set(["complete", "done"]);
+
+function summaryMtimeIso(path: string): string | null {
+  try {
+    return statSync(path).mtime.toISOString();
+  } catch {
+    return null;
+  }
+}
+
+export function detectMissingCompletionTimestampDrift(
+  state: GSDState,
+  ctx: DriftContext,
+): CompletionTimestampDrift[] {
+  if (!isDbAvailable()) return [];
+  const mid = state.activeMilestone?.id;
+  if (!mid) return [];
+
+  const milestone = getMilestone(mid);
+  if (!milestone) return [];
+
+  const drifts: CompletionTimestampDrift[] = [];
+
+  // Milestone-level
+  if (
+    COMPLETE_STATUSES.has(milestone.status) &&
+    milestone.completed_at === null
+  ) {
+    const summary = resolveMilestoneFile(ctx.basePath, mid, "SUMMARY");
+    if (summary && existsSync(summary)) {
+      drifts.push({
+        kind: "missing-completion-timestamp",
+        entity: "milestone",
+        ids: [mid],
+      });
+    }
+  }
+
+  // Slice and task levels iterate independently — tasks can complete before
+  // the parent slice closes, so task drift must be checked even when the
+  // slice is still pending.
+  for (const slice of getMilestoneSlices(mid)) {
+    if (
+      COMPLETE_STATUSES.has(slice.status) &&
+      slice.completed_at === null
+    ) {
+      const summary = resolveSliceFile(ctx.basePath, mid, slice.id, "SUMMARY");
+      if (summary && existsSync(summary)) {
+        drifts.push({
+          kind: "missing-completion-timestamp",
+          entity: "slice",
+          ids: [`${mid}/${slice.id}`],
+        });
+      }
+    }
+
+    for (const task of getSliceTasks(mid, slice.id)) {
+      if (!COMPLETE_STATUSES.has(task.status)) continue;
+      if (task.completed_at !== null) continue;
+      const taskSummary = resolveTaskFile(
+        ctx.basePath,
+        mid,
+        slice.id,
+        task.id,
+        "SUMMARY",
+      );
+      if (taskSummary && existsSync(taskSummary)) {
+        drifts.push({
+          kind: "missing-completion-timestamp",
+          entity: "task",
+          ids: [`${mid}/${slice.id}/${task.id}`],
+        });
+      }
+    }
+  }
+
+  return drifts;
+}
+
+export function repairMissingCompletionTimestamp(
+  record: CompletionTimestampDrift,
+  ctx: DriftContext,
+): void {
+  const composite = record.ids[0];
+  if (!composite) return;
+  const parts = composite.split("/");
+
+  if (record.entity === "milestone") {
+    const [mid] = parts;
+    if (!mid) return;
+    const milestone = getMilestone(mid);
+    if (!milestone || milestone.completed_at !== null) return;
+    const summary = resolveMilestoneFile(ctx.basePath, mid, "SUMMARY");
+    const ts = summary ? summaryMtimeIso(summary) : null;
+    updateMilestoneStatus(mid, milestone.status, ts ?? new Date().toISOString());
+    return;
+  }
+
+  if (record.entity === "slice") {
+    const [mid, sid] = parts;
+    if (!mid || !sid) return;
+    const slice = getMilestoneSlices(mid).find((s) => s.id === sid);
+    if (!slice || slice.completed_at !== null) return;
+    const summary = resolveSliceFile(ctx.basePath, mid, sid, "SUMMARY");
+    const ts = summary ? summaryMtimeIso(summary) : null;
+    updateSliceStatus(mid, sid, slice.status, ts ?? new Date().toISOString());
+    return;
+  }
+
+  if (record.entity === "task") {
+    const [mid, sid, tid] = parts;
+    if (!mid || !sid || !tid) return;
+    const task = getSliceTasks(mid, sid).find((t) => t.id === tid);
+    if (!task || task.completed_at !== null) return;
+    const summary = resolveTaskFile(ctx.basePath, mid, sid, tid, "SUMMARY");
+    const ts = summary ? summaryMtimeIso(summary) : null;
+    updateTaskStatus(mid, sid, tid, task.status, ts ?? new Date().toISOString());
+  }
+}
+
+export const completionTimestampHandler: DriftHandler<CompletionTimestampDrift> = {
+  kind: "missing-completion-timestamp",
+  detect: detectMissingCompletionTimestampDrift,
+  repair: repairMissingCompletionTimestamp,
+};

--- a/src/resources/extensions/gsd/state-reconciliation/drift/completion.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/completion.ts
@@ -121,10 +121,15 @@ export function repairMissingCompletionTimestamp(
     const [mid] = parts;
     if (!mid) return;
     const milestone = getMilestone(mid);
-    if (!milestone || milestone.completed_at !== null) return;
+    if (
+      !milestone ||
+      milestone.completed_at !== null ||
+      !COMPLETE_STATUSES.has(milestone.status)
+    ) return;
     const summary = resolveMilestoneFile(ctx.basePath, mid, "SUMMARY");
     const ts = summary ? summaryMtimeIso(summary) : null;
-    updateMilestoneStatus(mid, milestone.status, ts ?? new Date().toISOString());
+    if (!ts) return;
+    updateMilestoneStatus(mid, milestone.status, ts);
     return;
   }
 
@@ -132,10 +137,15 @@ export function repairMissingCompletionTimestamp(
     const [mid, sid] = parts;
     if (!mid || !sid) return;
     const slice = getMilestoneSlices(mid).find((s) => s.id === sid);
-    if (!slice || slice.completed_at !== null) return;
+    if (
+      !slice ||
+      slice.completed_at !== null ||
+      !COMPLETE_STATUSES.has(slice.status)
+    ) return;
     const summary = resolveSliceFile(ctx.basePath, mid, sid, "SUMMARY");
     const ts = summary ? summaryMtimeIso(summary) : null;
-    updateSliceStatus(mid, sid, slice.status, ts ?? new Date().toISOString());
+    if (!ts) return;
+    updateSliceStatus(mid, sid, slice.status, ts);
     return;
   }
 
@@ -143,10 +153,15 @@ export function repairMissingCompletionTimestamp(
     const [mid, sid, tid] = parts;
     if (!mid || !sid || !tid) return;
     const task = getSliceTasks(mid, sid).find((t) => t.id === tid);
-    if (!task || task.completed_at !== null) return;
+    if (
+      !task ||
+      task.completed_at !== null ||
+      !COMPLETE_STATUSES.has(task.status)
+    ) return;
     const summary = resolveTaskFile(ctx.basePath, mid, sid, tid, "SUMMARY");
     const ts = summary ? summaryMtimeIso(summary) : null;
-    updateTaskStatus(mid, sid, tid, task.status, ts ?? new Date().toISOString());
+    if (!ts) return;
+    updateTaskStatus(mid, sid, tid, task.status, ts);
   }
 }
 

--- a/src/resources/extensions/gsd/state-reconciliation/registry.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/registry.ts
@@ -2,6 +2,7 @@
 // File Purpose: ADR-017 drift handler registry. Single source of truth for
 // the catalog. Tests can override per-call via ReconciliationDeps.registry.
 
+import { completionTimestampHandler } from "./drift/completion.js";
 import { mergeStateHandler } from "./drift/merge-state.js";
 import { unregisteredMilestoneHandler } from "./drift/project-md.js";
 import { roadmapDivergenceHandler } from "./drift/roadmap.js";
@@ -22,4 +23,5 @@ export const DRIFT_REGISTRY: ReadonlyArray<DriftHandler<any>> = [
   staleWorkerHandler,
   unregisteredMilestoneHandler,
   roadmapDivergenceHandler,
+  completionTimestampHandler,
 ];

--- a/src/resources/extensions/gsd/state-reconciliation/types.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/types.ts
@@ -7,8 +7,6 @@ import type { GSDState } from "../types.js";
 /**
  * Discriminated union over drift kinds the State Reconciliation Module
  * recognizes. Each variant carries the identifiers its matching repair needs.
- *
- * Subsequent ADR-017 issues add variants: missing-completion-timestamp.
  */
 export type DriftRecord =
   | { kind: "stale-sketch-flag"; mid: string; sid: string }
@@ -16,7 +14,12 @@ export type DriftRecord =
   | { kind: "stale-render"; renderPath: string; reason: string }
   | { kind: "stale-worker"; lockPath: string; pid: number }
   | { kind: "unregistered-milestone"; milestoneId: string }
-  | { kind: "roadmap-divergence"; milestoneId: string; sliceId?: string };
+  | { kind: "roadmap-divergence"; milestoneId: string; sliceId?: string }
+  | {
+      kind: "missing-completion-timestamp";
+      entity: "task" | "slice" | "milestone";
+      ids: string[];
+    };
 
 /**
  * Context threaded to detector and repair functions. Keeps handlers from

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -9,7 +9,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -779,7 +779,9 @@ test("ADR-017 (#5706): task with SUMMARY but null completed_at → backfilled", 
   // an external recovery path or a partial state migration).
   updateTaskStatus("M001", "S01", "T01", "complete", undefined);
   // SUMMARY.md attests to completion on disk.
-  writeFileSync(join(tasksDir, "T01-SUMMARY.md"), "# T01 Summary\n");
+  const summaryPath = join(tasksDir, "T01-SUMMARY.md");
+  writeFileSync(summaryPath, "# T01 Summary\n");
+  const summaryMtimeMs = statSync(summaryPath).mtime.getTime();
 
   const taskBefore = getSliceTasks("M001", "S01").find((t) => t.id === "T01");
   assert.equal(taskBefore?.status, "complete");
@@ -793,7 +795,9 @@ test("ADR-017 (#5706): task with SUMMARY but null completed_at → backfilled", 
   assert.equal(result.ok, true);
   const taskAfter = getSliceTasks("M001", "S01").find((t) => t.id === "T01");
   assert.ok(taskAfter?.completed_at, "post: completed_at populated");
-  assert.equal(typeof taskAfter?.completed_at, "string");
+  const completedAtMs = Date.parse(taskAfter?.completed_at ?? "");
+  assert.ok(Number.isFinite(completedAtMs), "post: completed_at is parseable ISO string");
+  assert.equal(completedAtMs, summaryMtimeMs, "post: completed_at derived from SUMMARY mtime");
   const drift = result.repaired.find((d) => d.kind === "missing-completion-timestamp");
   assert.ok(drift, "drift recorded");
   if (drift?.kind === "missing-completion-timestamp") {
@@ -815,7 +819,9 @@ test("ADR-017 (#5706): repair is idempotent — re-running preserves the timesta
   insertMilestone({ id: "M001", title: "Test", status: "active" });
   insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending", risk: "low", depends: [], demo: "", sequence: 1 });
   updateSliceStatus("M001", "S01", "complete", undefined);
-  writeFileSync(join(sliceDir, "S01-SUMMARY.md"), "# S01 Summary\n");
+  const summaryPath = join(sliceDir, "S01-SUMMARY.md");
+  writeFileSync(summaryPath, "# S01 Summary\n");
+  const summaryMtimeMs = statSync(summaryPath).mtime.getTime();
 
   const firstResult = await reconcileBeforeDispatch(base, {
     invalidateStateCache: () => {},
@@ -824,6 +830,9 @@ test("ADR-017 (#5706): repair is idempotent — re-running preserves the timesta
   assert.equal(firstResult.ok, true);
   const tsAfterFirst = getSlice("M001", "S01")?.completed_at;
   assert.ok(tsAfterFirst, "first pass: completed_at populated");
+  const completedAtMs = Date.parse(tsAfterFirst ?? "");
+  assert.ok(Number.isFinite(completedAtMs), "first pass: completed_at is parseable ISO string");
+  assert.equal(completedAtMs, summaryMtimeMs, "first pass: completed_at derived from SUMMARY mtime");
 
   // Second pass — drift is already cleared, no record should appear, and
   // the existing timestamp is untouched.

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -1,10 +1,10 @@
 // Project/App: GSD-2
 // File Purpose: ADR-017 contract tests for drift-driven State Reconciliation.
 // Covers sketch-flag (#5700), merge-state (#5701), stale-render (#5702),
-// stale-worker (#5703), unregistered-milestone (#5704), and roadmap-
-// divergence (#5705) drift end-to-end, plus the repair-throw and
-// persistent-drift error paths and Recovery Classification mapping for
-// ReconciliationFailedError.
+// stale-worker (#5703), unregistered-milestone (#5704), roadmap-divergence
+// (#5705), and missing-completion-timestamp (#5706) drift end-to-end, plus
+// the repair-throw and persistent-drift error paths and Recovery
+// Classification mapping for ReconciliationFailedError.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -22,7 +22,10 @@ import {
   insertTask,
   getMilestone,
   getSlice,
+  getSliceTasks,
   setSliceSummaryMd,
+  updateSliceStatus,
+  updateTaskStatus,
 } from "../gsd-db.ts";
 import { clearParseCache } from "../files.ts";
 import { clearPathCache } from "../paths.ts";
@@ -754,6 +757,87 @@ test("ADR-017 (#5705): in-sync ROADMAP and DB → no roadmap-divergence drift", 
     false,
     "no roadmap-divergence drift should be reported when DB matches markdown",
   );
+});
+
+// ─── #5706: missing-completion-timestamp drift ──────────────────────────────
+
+test("ADR-017 (#5706): task with SUMMARY but null completed_at → backfilled", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-completion-task-"));
+  const tasksDir = join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending", risk: "low", depends: [], demo: "", sequence: 1 });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Task", status: "pending" });
+
+  // Move T01 to complete WITHOUT setting completed_at (simulating drift after
+  // an external recovery path or a partial state migration).
+  updateTaskStatus("M001", "S01", "T01", "complete", undefined);
+  // SUMMARY.md attests to completion on disk.
+  writeFileSync(join(tasksDir, "T01-SUMMARY.md"), "# T01 Summary\n");
+
+  const taskBefore = getSliceTasks("M001", "S01").find((t) => t.id === "T01");
+  assert.equal(taskBefore?.status, "complete");
+  assert.equal(taskBefore?.completed_at, null, "pre: completed_at is null");
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Test" } }),
+  });
+
+  assert.equal(result.ok, true);
+  const taskAfter = getSliceTasks("M001", "S01").find((t) => t.id === "T01");
+  assert.ok(taskAfter?.completed_at, "post: completed_at populated");
+  assert.equal(typeof taskAfter?.completed_at, "string");
+  const drift = result.repaired.find((d) => d.kind === "missing-completion-timestamp");
+  assert.ok(drift, "drift recorded");
+  if (drift?.kind === "missing-completion-timestamp") {
+    assert.equal(drift.entity, "task");
+    assert.deepEqual(drift.ids, ["M001/S01/T01"]);
+  }
+});
+
+test("ADR-017 (#5706): repair is idempotent — re-running preserves the timestamp", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-completion-idempotent-"));
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  mkdirSync(sliceDir, { recursive: true });
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending", risk: "low", depends: [], demo: "", sequence: 1 });
+  updateSliceStatus("M001", "S01", "complete", undefined);
+  writeFileSync(join(sliceDir, "S01-SUMMARY.md"), "# S01 Summary\n");
+
+  const firstResult = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Test" } }),
+  });
+  assert.equal(firstResult.ok, true);
+  const tsAfterFirst = getSlice("M001", "S01")?.completed_at;
+  assert.ok(tsAfterFirst, "first pass: completed_at populated");
+
+  // Second pass — drift is already cleared, no record should appear, and
+  // the existing timestamp is untouched.
+  const secondResult = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState({ activeMilestone: { id: "M001", title: "Test" } }),
+  });
+  assert.equal(secondResult.ok, true);
+  assert.equal(
+    secondResult.repaired.some((d) => d.kind === "missing-completion-timestamp"),
+    false,
+    "second pass: no drift detected after first repair",
+  );
+  assert.equal(getSlice("M001", "S01")?.completed_at, tsAfterFirst, "timestamp unchanged");
 });
 
 // ─── Lifecycle and classification ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- New drift kind `missing-completion-timestamp`: detects entities (tasks/slices/milestones) marked complete in the DB whose `completed_at` is null, when SUMMARY.md on disk attests to completion. Backfills the timestamp from the SUMMARY's mtime — deterministic and idempotent.
- Detector scopes to the active milestone (state.activeMilestone). Iterates slices and tasks independently — tasks can complete before the parent slice closes, so task drift must be checked even when the slice is still pending.
- `DriftRecord` extended with `{ kind: "missing-completion-timestamp"; entity: "task" | "slice" | "milestone"; ids: string[] }`. One composite id per record (e.g. `"M001/S01/T01"` for tasks).
- Two contract tests: task drift backfill; idempotent re-run preserves the timestamp and emits no further drift.

> **Stacked on #5709 → #5711 → #5718 → #5720 → #5721 → #5722.**

## Test plan

- [x] `npm run typecheck:extensions` clean for new code
- [x] Full gsd unit suite — 7580 passed, 0 failed, 8 skipped (2 new contract tests added)
- [x] Caught a bug in the first cut: task iteration was nested inside the slice's `continue` early-exit, so tasks were only checked when the parent slice was complete. Fixed by separating slice and task iteration paths.

Closes #5706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic state reconciliation for missing completion timestamps on completed entities.
  * Detection and repair of roadmap divergence, syncing milestone slice order and dependencies into the database.
  * State drift repairs run before auto-mode selects the next unit.

* **Documentation**
  * Added “Repairable State Drift” guidance for pre-dispatch reconciliation behavior.

* **Tests**
  * Added E2E tests covering roadmap divergence and completion-timestamp backfill.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5723)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->