### PR TITLE
refactor(gsd-extension): ADR-017 / strict caller closure for parallel spawns

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -58,6 +58,7 @@ import { withTimeout, FINALIZE_PRE_TIMEOUT_MS, FINALIZE_POST_TIMEOUT_MS } from "
 import { getEligibleSlices } from "../slice-parallel-eligibility.js";
 import { startSliceParallel } from "../slice-parallel-orchestrator.js";
 import { isDbAvailable, getMilestoneSlices } from "../gsd-db.js";
+import { reconcileBeforeSpawn } from "../state-reconciliation.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
 import type { PostflightResult, PreflightResult } from "../clean-root-preflight.js";
 import { ensurePlanV2Graph, isEmptyPlanV2GraphResult, isMissingFinalizedContextResult } from "../uok/plan-v2.js";
@@ -878,6 +879,16 @@ export async function runPreDispatch(
             `Slice-parallel: dispatching ${eligible.length} eligible slices for ${mid}.`,
             "info",
           );
+          // ADR-017 #5707: reconcile before spawning so each worker doesn't
+          // independently race on the same drift. Failure aborts the spawn.
+          const spawnGate = await reconcileBeforeSpawn(s.basePath);
+          if (!spawnGate.ok) {
+            ctx.ui.notify(
+              `Slice-parallel: aborting spawn — ${spawnGate.reason}`,
+              "error",
+            );
+            return { action: "break", reason: `slice-parallel-reconciliation-failed: ${spawnGate.reason}` };
+          }
           const result = await startSliceParallel(
             s.basePath,
             mid,

--- a/src/resources/extensions/gsd/commands/handlers/parallel.ts
+++ b/src/resources/extensions/gsd/commands/handlers/parallel.ts
@@ -14,6 +14,7 @@ import {
 import { formatEligibilityReport } from "../../parallel-eligibility.js";
 import { formatMergeResults, mergeAllCompleted, mergeCompletedMilestone } from "../../parallel-merge.js";
 import { loadEffectiveGSDPreferences, resolveParallelConfig } from "../../preferences.js";
+import { reconcileBeforeSpawn } from "../../state-reconciliation.js";
 import { projectRoot } from "../context.js";
 function emitParallelMessage(pi: ExtensionAPI, content: string): void {
   pi.sendMessage({ customType: "gsd-parallel", content, display: true });
@@ -38,6 +39,17 @@ export async function handleParallelCommand(trimmed: string, _ctx: ExtensionComm
     const report = formatEligibilityReport(candidates);
     if (candidates.eligible.length === 0) {
       emitParallelMessage(pi, `${report}\n\nNo milestones are eligible for parallel execution.`);
+      return true;
+    }
+    // ADR-017 #5707: reconcile before spawning so workers don't independently
+    // race on the same drift. Failures abort the spawn with an actionable
+    // user-visible message.
+    const gate = await reconcileBeforeSpawn(root);
+    if (!gate.ok) {
+      emitParallelMessage(
+        pi,
+        `${report}\n\nParallel orchestration aborted before spawn — ${gate.reason}`,
+      );
       return true;
     }
     const result = await startParallel(

--- a/src/resources/extensions/gsd/state-reconciliation.ts
+++ b/src/resources/extensions/gsd/state-reconciliation.ts
@@ -17,3 +17,9 @@ export type {
   ReconciliationFailureDetail,
   ReconciliationResult,
 } from "./state-reconciliation/index.js";
+
+export { reconcileBeforeSpawn } from "./state-reconciliation/spawn-gate.js";
+export type {
+  SpawnGateDeps,
+  SpawnGateResult,
+} from "./state-reconciliation/spawn-gate.js";

--- a/src/resources/extensions/gsd/state-reconciliation/spawn-gate.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/spawn-gate.ts
@@ -1,0 +1,60 @@
+// Project/App: GSD-2
+// File Purpose: ADR-017 #5707 caller-closure helper. Parent processes that
+// spawn auto-loop workers must reconcile before spawn — otherwise each
+// worker independently detects+repairs the same drift, racing on shared
+// state. This helper centralises the reconcile+catch flow so the two
+// production spawn sites (commands/handlers/parallel.ts and auto/phases.ts
+// startSliceParallel) share one contract.
+
+import {
+  reconcileBeforeDispatch,
+  ReconciliationFailedError,
+  type ReconciliationDeps,
+} from "./index.js";
+
+export type SpawnGateResult =
+  | { ok: true; reason?: string }
+  | { ok: false; reason: string };
+
+export interface SpawnGateDeps extends Partial<ReconciliationDeps> {
+  reconcile?: typeof reconcileBeforeDispatch;
+}
+
+/**
+ * Run reconciliation before spawning workers. Returns ok=true when the run
+ * completed without throwing (blockers ride along but don't fail the gate —
+ * spawn callers can choose how to handle them). On
+ * ReconciliationFailedError, returns ok=false with the error message so the
+ * caller can surface it to the user without re-throwing.
+ *
+ * Other unexpected errors propagate; they are not part of the drift
+ * taxonomy.
+ */
+export async function reconcileBeforeSpawn(
+  basePath: string,
+  deps: SpawnGateDeps = {},
+): Promise<SpawnGateResult> {
+  const reconcileFn = deps.reconcile ?? reconcileBeforeDispatch;
+  try {
+    const result = await reconcileFn(basePath, deps as ReconciliationDeps);
+    if (result.blockers.length > 0) {
+      return {
+        ok: false,
+        reason: `Reconciliation blocker: ${result.blockers[0]}`,
+      };
+    }
+    const repairedKinds = result.repaired.map((d) => d.kind);
+    return {
+      ok: true,
+      reason:
+        repairedKinds.length > 0
+          ? `repaired before spawn: ${repairedKinds.join(", ")}`
+          : undefined,
+    };
+  } catch (err) {
+    if (err instanceof ReconciliationFailedError) {
+      return { ok: false, reason: err.message };
+    }
+    throw err;
+  }
+}

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -33,6 +33,7 @@ import { detectStaleRenders } from "../markdown-renderer.ts";
 import { invalidateStateCache } from "../state.ts";
 import {
   reconcileBeforeDispatch,
+  reconcileBeforeSpawn,
   ReconciliationFailedError,
   type DriftHandler,
   type DriftRecord,
@@ -847,6 +848,74 @@ test("ADR-017 (#5706): repair is idempotent — re-running preserves the timesta
     "second pass: no drift detected after first repair",
   );
   assert.equal(getSlice("M001", "S01")?.completed_at, tsAfterFirst, "timestamp unchanged");
+});
+
+// ─── #5707: caller closure (reconcileBeforeSpawn) ────────────────────────────
+
+test("ADR-017 (#5707): reconcileBeforeSpawn returns ok=true on clean reconciliation", async () => {
+  const result = await reconcileBeforeSpawn("/project", {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+    registry: [],
+  });
+  assert.equal(result.ok, true);
+});
+
+test("ADR-017 (#5707): reconcileBeforeSpawn surfaces blockers as ok=false", async () => {
+  const result = await reconcileBeforeSpawn("/project", {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState({ phase: "blocked", blockers: ["lock missing"] }),
+    registry: [],
+  });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /lock missing/);
+  }
+});
+
+test("ADR-017 (#5707): reconcileBeforeSpawn catches ReconciliationFailedError → ok=false", async () => {
+  const persistent: DriftRecord = { kind: "stale-sketch-flag", mid: "M001", sid: "S02" };
+  const handler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => [persistent],
+    repair: () => { /* no-op: drift cannot be cleared, persists past cap=2 */ },
+  };
+
+  const result = await reconcileBeforeSpawn("/project", {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+    registry: [handler],
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /stale-sketch-flag/);
+  }
+});
+
+test("ADR-017 (#5707): reconcileBeforeSpawn reports repaired drift in ok=true reason", async () => {
+  let detectCalls = 0;
+  const handler: DriftHandler = {
+    kind: "stale-sketch-flag",
+    detect: () => {
+      detectCalls++;
+      return detectCalls === 1
+        ? [{ kind: "stale-sketch-flag", mid: "M001", sid: "S02" }]
+        : [];
+    },
+    repair: () => { /* repair "succeeds" — second detect returns empty */ },
+  };
+
+  const result = await reconcileBeforeSpawn("/project", {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+    registry: [handler],
+  });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.match(result.reason ?? "", /stale-sketch-flag/);
+  }
 });
 
 // ─── Lifecycle and classification ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the "strict closure" seam ADR-017 names: every parent process that spawns auto-loop workers must reconcile first, otherwise each spawned worker independently detects+repairs the same drift, racing on shared state.

- Adds `reconcileBeforeSpawn(basePath, deps?)` helper in `state-reconciliation/spawn-gate.ts`. Wraps `reconcileBeforeDispatch` with catch-and-translate: clean → ok; blockers → ok=false; `ReconciliationFailedError` → ok=false; other errors propagate.
- Wires into both production spawn sites:
  - `commands/handlers/parallel.ts` (`/gsd parallel start` → `startParallel`)
  - `auto/phases.ts` (slice-parallel-dispatch → `startSliceParallel`)
- On gate failure, `parallel.ts` emits a customMessage to the user; `phases.ts` notifies via `ctx.ui.notify` and returns `{ action: "break", reason: "slice-parallel-reconciliation-failed: ..." }`.
- Spawned workers continue to reconcile independently inside their auto-loop (existing wire via `auto/orchestrator.ts:42`). The new gate ensures the parent reconciles **before** fanning out, so workers start from clean state.

> **Stacked on #5709 → #5711 → #5718 → #5720 → #5721 → #5722 → #5723.** This is the final piece of the ADR-017 implementation series.

## Test plan

- [x] `npm run typecheck:extensions` clean for new code
- [x] Full gsd unit suite — 7584 passed, 0 failed, 8 skipped (4 new contract tests on `reconcileBeforeSpawn` directly)
- [x] Tests cover all four return paths: clean reconciliation, terminal blockers, repair-failure throw, and successful repair-then-retry cascade

Closes #5707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pre-spawn state reconciliation validation to parallel operations, ensuring system state consistency before starting workers. If validation fails, users receive error messages with details about the blocking issue.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5724)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->