### PR TITLE
fix: run stuck detection during verification retries

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1340,16 +1340,14 @@ export async function runDispatch(
   // ── Sliding-window stuck detection with graduated recovery ──
   const derivedKey = `${unitType}/${unitId}`;
 
-  // Always record this dispatch in the sliding window so detectStuck() has
-  // accurate history. Skipping the push when pendingVerificationRetry is set
-  // caused infinite artifact-retry loops to be invisible to stuck detection
-  // (#2007). Only the *response* to a stuck signal is suppressed during retries.
+  // Always record this dispatch in the sliding window and run detection so
+  // Rules 1/3/4 can catch retry loops with repeated failure content (#5719).
+  // Rules 2/2b suppress legitimate retry backoff through the dispatch ledger.
   loopState.recentUnits.push({ key: derivedKey });
   if (loopState.recentUnits.length > STUCK_WINDOW_SIZE) loopState.recentUnits.shift();
 
-  if (!s.pendingVerificationRetry) {
-    const stuckSignal = detectStuck(loopState.recentUnits);
-    if (stuckSignal) {
+  const stuckSignal = detectStuck(loopState.recentUnits);
+  if (stuckSignal) {
       debugLog("autoLoop", {
         phase: "stuck-check",
         unitType,
@@ -1465,16 +1463,15 @@ export async function runDispatch(
         );
         return { action: "break", reason: "stuck-detected" };
       }
-    } else {
-      // Progress detected — reset recovery counter
-      if (loopState.stuckRecoveryAttempts > 0) {
-        debugLog("autoLoop", {
-          phase: "stuck-counter-reset",
-          from: loopState.recentUnits[loopState.recentUnits.length - 2]?.key ?? "",
-          to: derivedKey,
-        });
-        loopState.stuckRecoveryAttempts = 0;
-      }
+  } else {
+    // Progress detected — reset recovery counter
+    if (loopState.stuckRecoveryAttempts > 0) {
+      debugLog("autoLoop", {
+        phase: "stuck-counter-reset",
+        from: loopState.recentUnits[loopState.recentUnits.length - 2]?.key ?? "",
+        to: derivedKey,
+      });
+      loopState.stuckRecoveryAttempts = 0;
     }
   }
 

--- a/src/resources/extensions/gsd/tests/artifact-retry-cap.test.ts
+++ b/src/resources/extensions/gsd/tests/artifact-retry-cap.test.ts
@@ -62,7 +62,7 @@ test("#2007 bug 2: recentUnits.push is unconditional — not gated on pendingVer
   );
 });
 
-test("#2007 bug 2: detectStuck is still inside the pendingVerificationRetry guard", () => {
+test("#2007 bug 2: pendingVerificationRetry state is available for dispatch regression coverage", () => {
   const s = new AutoSession();
   s.pendingVerificationRetry = {
     unitId: "M001/S01/T01",

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2144,7 +2144,7 @@ test("stuck detection: window resets recovery when deriveState returns a differe
   );
 });
 
-test("stuck detection: does not push to window during verification retry", async () => {
+test("stuck detection: verification retries remain visible to the sliding window", async () => {
   _resetPendingResolve();
   mock.timers.enable({ apis: ["Date", "setTimeout"], now: 20_000 });
 
@@ -2199,8 +2199,9 @@ test("stuck detection: does not push to window during verification retry", async
 
     const loopPromise = autoLoop(ctx, pi, s, deps);
 
-    // Resolve agent_end for 4 iterations (1 initial + 3 retries)
-    for (let i = 1; i <= 4; i++) {
+    // Resolve agent_end for 3 attempts. The 4th iteration should stop before
+    // dispatch because retry dispatches stay visible to stuck detection.
+    for (let i = 1; i <= 3; i++) {
       await waitForMicrotasks(() => pi.calls.length === i, `dispatch ${i}`);
       resolveAgentEnd(makeEvent());
       await drainMicrotasks(100);
@@ -2209,16 +2210,14 @@ test("stuck detection: does not push to window during verification retry", async
 
     await loopPromise;
 
-    // Even though same unit was derived 4 times, verification retries should
-    // not push to the sliding window, so stuck detection should not have fired
     assert.ok(
-      !stopReason.includes("Stuck"),
-      `stuck detection should not fire during verification retries, got: ${stopReason}`,
+      stopReason.includes("Stuck"),
+      `stuck detection should fire during repeated verification retries, got: ${stopReason}`,
     );
     assert.equal(
       verifyCallCount,
-      4,
-      "verification should have been called 4 times (1 initial + 3 retries)",
+      3,
+      "verification should stop before a 4th repeated retry dispatch",
     );
   } finally {
     mock.timers.reset();
@@ -2304,7 +2303,8 @@ test("detectStuck: truncates long error strings", () => {
     { key: "A", error: longError },
   ]);
   assert.ok(result?.stuck);
-  assert.ok(result!.reason.length < 300, "reason should be truncated");
+  assert.ok(result!.reason.includes(longError.slice(0, 200)), "reason should include the truncated error prefix");
+  assert.equal(result!.reason.includes(longError), false, "reason should not include the full long error");
 });
 
 // NOTE: the "stuck-detected" / "stuck-counter-reset" debug-log grep was
@@ -3204,6 +3204,77 @@ test("dispatch Worktree Safety wins before stuck detection for execute-task with
   assert.ok(
     !notifications.some((n) => n.includes("Stuck on execute-task")),
     "stuck-loop message must not mask the worktree health failure",
+  );
+});
+
+test("runDispatch runs stuck detection while artifact verification retry is pending (#5719)", async (t) => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  const pi = makeMockPi();
+  const notifications: string[] = [];
+  ctx.ui.notify = (msg: string) => { notifications.push(msg); };
+
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-5719-retry-stuck-"));
+  t.after(() => rmSync(basePath, { recursive: true, force: true }));
+
+  const s = makeLoopSession({
+    basePath,
+    pendingVerificationRetry: {
+      unitId: "M001/S01/T01",
+      failureContext: "ENOENT: no such file or directory, access '/tmp/missing-plan.md'",
+      attempt: 1,
+    },
+  });
+  const deps = makeMockDeps();
+  const loopState = {
+    recentUnits: [
+      {
+        key: "execute-task/M001/S01/T01",
+        error: "ENOENT: no such file or directory, access '/tmp/missing-plan.md'",
+      },
+      { key: "plan-slice/M001/S02", error: "other failure" },
+      {
+        key: "complete-slice/M001/S01",
+        error: "ENOENT: no such file or directory, access '/tmp/missing-plan.md'",
+      },
+    ],
+    stuckRecoveryAttempts: 0,
+    consecutiveFinalizeTimeouts: 0,
+  };
+
+  const result = await runDispatch(
+    {
+      ctx,
+      pi,
+      s,
+      deps,
+      prefs: undefined,
+      iteration: 1,
+      flowId: "test-flow",
+      nextSeq: () => 1,
+    },
+    {
+      state: {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Test", status: "active" },
+        activeSlice: { id: "S01", title: "Slice 1" },
+        activeTask: { id: "T01" },
+        registry: [{ id: "M001", status: "active" }],
+        blockers: [],
+      } as any,
+      mid: "M001",
+      midTitle: "Test",
+    },
+    loopState,
+  );
+
+  assert.equal(result.action, "next", "level-1 stuck recovery should still allow the recovery dispatch");
+  assert.equal(loopState.stuckRecoveryAttempts, 1, "stuck recovery should record the first recovery attempt");
+  assert.ok(deps.callLog.includes("invalidateAllCaches"), "stuck recovery should invalidate caches");
+  assert.ok(
+    notifications.some((n) => n.includes("Missing file referenced twice")),
+    "notification should surface the repeated ENOENT stuck reason",
   );
 });
 


### PR DESCRIPTION
## TL;DR

**What:** Runs `detectStuck()` even while `pendingVerificationRetry` is set.
**Why:** Rules 1/3/4 were disabled during artifact-verification retry loops, allowing repeated failures such as ENOENT to loop indefinitely.
**How:** Removes the outer retry gate around stuck detection and relies on the rule-level retry-budget suppression already inside `detect-stuck.ts` for legitimate Rule 2/2b backoff.

## What

This updates `src/resources/extensions/gsd/auto/phases.ts` so dispatches are still recorded in the stuck window and `detectStuck()` is always invoked.

It also updates regression coverage in `src/resources/extensions/gsd/tests/auto-loop.test.ts` and `src/resources/extensions/gsd/tests/artifact-retry-cap.test.ts` to assert that verification retries remain visible to stuck detection and that repeated ENOENT content trips recovery while retry state is pending.

## Why

Fixes #5719.

The prior code moved `recentUnits.push(...)` outside the `pendingVerificationRetry` gate, but left `detectStuck()` inside that gate. That meant the sliding window collected retry history, but the detector never evaluated it during the retry loops where Rules 1, 3, and 4 are supposed to fire.

## How

The fix removes the `if (!s.pendingVerificationRetry)` wrapper around `detectStuck(loopState.recentUnits)`. Rule 2 and Rule 2b still suppress legitimate retry backoff through `retryBudgetSuppresses()` in `detect-stuck.ts`, while error-content rules remain active during retries.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern "5719|verification retries remain visible|truncates long error|pendingVerificationRetry state|rule 2b|Missing file" src/resources/extensions/gsd/tests/auto-loop.test.ts src/resources/extensions/gsd/tests/artifact-retry-cap.test.ts src/resources/extensions/gsd/tests/detect-stuck-respects-retry.test.ts src/resources/extensions/gsd/tests/stuck-detection-coverage.test.ts`
- `npm run build:core`
- `npm run typecheck:extensions`
- `npm run test:unit` -> `8988 passed, 0 failed, 9 skipped`
- `git diff --check`

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

## AI-assisted

This PR is AI-assisted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved reliability of stuck detection during artifact verification retries, ensuring recovery signals are consistently detected throughout verification cycles.

## Tests
* Enhanced regression test coverage for stuck detection behavior during artifact verification retries.
* Strengthened error message truncation assertions to ensure accurate error information display.
* Added new test coverage verifying proper recovery attempt handling and user notification delivery during repeated verification retries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5725)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->