### PR TITLE
[codex] Ignore completed-content aborts during session switch

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -153,8 +153,7 @@ export function isBareClaudeCodeStreamAbortPlaceholder(lastMsg: unknown): boolea
  * Claude Code abort markers are intentionally ignored when the abort fires
  * while the session-switch is in flight: the abort is the expected side-effect
  * of the transition, not a user signal. Other branches (genuine `stopReason
- * === "aborted"` with diagnostic content/errorMessage) preserve the prior
- * behavior.
+ * === "aborted"` with explicit errorMessage) preserve the prior behavior.
  */
 export function _handleSessionSwitchAgentEnd(
   lastMsg: unknown,
@@ -178,10 +177,8 @@ export function _handleSessionSwitchAgentEnd(
   }
 
   if (m.stopReason === "aborted") {
-    const content = m.content;
-    const hasEmptyContent = Array.isArray(content) && content.length === 0;
     const hasErrorMessage = !!m.errorMessage;
-    if (!hasEmptyContent || hasErrorMessage) {
+    if (hasErrorMessage) {
       resolveCancelled(_buildAbortedPauseContext(m as { errorMessage?: unknown }));
     }
   }

--- a/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
+++ b/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
@@ -188,6 +188,30 @@ test("empty-content aborted during session-switch is silently ignored", () => {
   assert.equal(cancelledWith, null);
 });
 
+test("completed assistant content with aborted stopReason during session-switch is ignored", () => {
+  // newSession() can abort the just-finished provider stream while the last
+  // assistant message still carries the completed unit summary. That is a
+  // session-transition artifact, not a cancellation for the next unit.
+  let cancelledWith: unknown = null;
+  const resolveCancelled = (ctx: ErrorContext) => {
+    cancelledWith = ctx;
+    return true;
+  };
+
+  _handleSessionSwitchAgentEnd(
+    {
+      stopReason: "aborted",
+      content: [{
+        type: "text",
+        text: "Implemented T01 and verified the slice task is complete.",
+      }],
+    },
+    resolveCancelled,
+  );
+
+  assert.equal(cancelledWith, null);
+});
+
 test("non-abort errors during session-switch are not propagated through this helper", () => {
   // Real provider errors (rate-limit, network, unsupported-model) are handled
   // by the post-switch retry pipeline — not by the in-flight switch handler.


### PR DESCRIPTION
## TL;DR

**What:** Ignore session-switch `stopReason: "aborted"` events when they only carry completed assistant content and no explicit error.
**Why:** Auto-mode can otherwise queue a stale `category: "aborted"` cancellation into the next unit and hard-stop before dispatch.
**How:** Narrow `_handleSessionSwitchAgentEnd()` so only `aborted` messages with `errorMessage` propagate cancellation, and add a regression test for the completed-assistant-content shape.

## What

This updates the GSD auto-mode agent-end recovery path for session switches. During `newSession()`, a just-completed provider stream can emit a final `agent_end` with `stopReason: "aborted"` while still carrying the assistant summary content from the completed unit. That content alone is now treated as a session-transition artifact, not as cancellation input for the next unit.

The regression test covers a session-switch `aborted` event with non-empty assistant text and verifies `_handleSessionSwitchAgentEnd()` does not call the cancellation resolver. The existing diagnostic-abort test still verifies that `errorMessage` aborts propagate.

Closes #5728.

## Why

The previous condition treated any non-empty content on `stopReason: "aborted"` as a meaningful abort. At a unit boundary, that can be stale completed-task prose from the prior turn. `resolveAgentEndCancelled()` then stores it as `_pendingSwitchCancellation`, `runUnit()` consumes it for the next unit, and `auto/phases.ts` falls through to the generic cancelled hard-stop path because `category: "aborted"` is not handled as recoverable there.

This makes successful unit handoff look like a cancelled next unit, commonly around `execute-task` → `complete-slice`.

## How

`_handleSessionSwitchAgentEnd()` now preserves cancellation propagation only for `stopReason: "aborted"` messages that include an explicit `errorMessage`. Assistant `content` alone is not used as abort evidence while a session switch is in flight. This keeps real diagnostic aborts visible while dropping stale completed-output artifacts.

## Validation

- PASS: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts` (`10/10` tests)
- FAIL, existing baseline: `npm run typecheck:extensions` fails in unrelated `src/resources/extensions/claude-code-cli/stream-adapter.ts` and `stream-adapter.test.ts` because `SimpleStreamOptions` does not declare `cwd`. This PR does not touch those files.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

## AI-assisted contribution

This PR was AI-assisted. The change was investigated locally, covered by a focused regression test, and manually reviewed before publishing.
