### PR TITLE
docs(adr): mark ADR-001 superseded, fill ADR-002/006 stubs, ADR-007 implemented

### DIFF
--- a/docs/dev/ADR-001-branchless-worktree-architecture.md
+++ b/docs/dev/ADR-001-branchless-worktree-architecture.md
@@ -1,11 +1,12 @@
 # ADR-001: Branchless Worktree Architecture
 
-**Status:** Proposed
+**Status:** Superseded
 **Date:** 2026-03-15
+**Superseded:** 2026-05-08 by the ADR-016 trio (worktree lifecycle split, fail-closed safety, phase-2 design) and ADR-017 (drift-driven state reconciliation)
 **Deciders:** Lex Christopherson
 **Advisors:** Claude Opus 4.6, Gemini 2.5 Pro, GPT-5.4 (Codex)
 
-> **Current state model:** This ADR predates the DB-authoritative runtime model. Its git/worktree decision still applies, but current GSD treats the project-root database as authoritative and uses markdown files as rendered projections. The database is not silently rebuilt from markdown during normal runtime; use explicit recovery commands when importing markdown state is required.
+> **Superseded — read this first.** The DB-authoritative runtime model took the place of this ADR's primary motivation (`.gsd/` merge conflicts, planning-artifact visibility): the project-root database is canonical, markdown files are projections, and cross-branch state clobbering is no longer the failure mode this ADR was trying to fix. The remaining worktree concerns (lifecycle ownership, fail-closed source-writing, drift repair) were consolidated by **ADR-014** (deep Auto Orchestration), **ADR-015** (runtime invariant modules), the **ADR-016 trio** (worktree lifecycle/projection split, fail-closed safety), and **ADR-017** (drift-driven reconciliation). Slice branches inside milestone worktrees were retained. The historical analysis below is preserved for context; the decisions in §Decision were not adopted.
 
 ## Context
 

--- a/docs/dev/ADR-002-external-state-directory.md
+++ b/docs/dev/ADR-002-external-state-directory.md
@@ -1,0 +1,24 @@
+# ADR-002: External State Directory
+
+**Status:** Not Adopted
+**Date:** 2026-03-16 (proposed window)
+**Closed:** 2026-05-10
+**Related:** ADR-001 (branchless worktree, superseded), ADR-016 trio, ADR-017 (drift-driven reconciliation)
+
+## Context
+
+ADR-001 and ADR-003 reference an "external state directory" ADR-002 that was never written as a standalone document. The idea, as carried in those ADRs, was to move `.gsd/` runtime state out of the working tree so that branch checkouts, slice merges, and worktree teardown could not clobber in-flight planning artifacts.
+
+## Decision
+
+**Not adopted.** GSD instead moved to a **DB-authoritative runtime model**: the project-root database is canonical, and `.gsd/**` markdown files are rendered projections of that database. With the database living outside the per-worktree working set and projections regenerated on demand, the cross-branch state-clobbering problem an external state directory was meant to solve no longer presents the same shape.
+
+The worktree-level concerns this ADR would have touched were addressed by:
+
+- **ADR-016 trio** — split worktree handling into Worktree Lifecycle and State Projection modules, with fail-closed safety for source-writing units.
+- **ADR-017** — drift-driven State Reconciliation module, which detects and repairs the specific state classes (sketch flags, merge state, roadmap divergence, completion timestamps, stale workers) that an external state directory would have tried to keep out of the working tree entirely.
+
+## Consequences
+
+- Cross-references to "ADR-002" from ADR-001 and ADR-003 should be read as "the work that became ADR-016/017."
+- No external state directory exists or is planned. `.gsd/` artifacts remain inside the working tree as projections.

--- a/docs/dev/ADR-006-extension-modularization.md
+++ b/docs/dev/ADR-006-extension-modularization.md
@@ -1,0 +1,16 @@
+# ADR-006: Extension Modularization & Install Infrastructure
+
+**Status:** Proposed (canonical text on GitHub)
+**Date:** 2026-03-28
+**Deciders:** Jeremy McSpadden
+**Canonical location:** [Issue #2995](https://github.com/gsd-build/gsd-2/issues/2995)
+
+## Pointer
+
+This ADR's full text lives on the GitHub issue tracker so the discussion thread, label state (`accepted`, `priority: high`, `area: gsd-extension`), and milestone progress stay in one place. This file exists only so the local ADR sequence has no gap and cross-references from ADR-007 resolve to a real path.
+
+## One-line summary
+
+Modularize GSD2 across 7 milestones (v1.3–v1.9): split the 177K-LOC core `gsd` extension, introduce an `npm`-package-based extension install/uninstall/update surface, lazy-load provider SDKs, and ship a `~450 MB` default install instead of `~842 MB`.
+
+See [Issue #2995](https://github.com/gsd-build/gsd-2/issues/2995) for the full Context / Decision / Milestone breakdown / Success Metrics / Risks / Consequences.

--- a/docs/dev/ADR-007-model-catalog-split.md
+++ b/docs/dev/ADR-007-model-catalog-split.md
@@ -1,9 +1,10 @@
 # ADR-007: Model Catalog Split and Provider API Encapsulation
 
-**Status:** Proposed
+**Status:** Accepted (implemented)
 **Date:** 2026-04-03
+**Implemented:** 2026-04 (catalog split landed; `models.generated.ts` replaced by `packages/pi-ai/src/models/generated/` per-provider files; barrel exports cleaned)
 **Deciders:** Jeremy McSpadden
-**Related:** ADR-004 (capability-aware model routing), [ADR-005](https://github.com/gsd-build/gsd-2/issues/2790), [ADR-006](https://github.com/gsd-build/gsd-2/issues/2995), `packages/pi-ai/src/providers/`, `packages/pi-ai/src/models.ts`
+**Related:** ADR-004 (capability-aware model routing), [ADR-005](https://github.com/gsd-build/gsd-2/issues/2790), [ADR-006](./ADR-006-extension-modularization.md), `packages/pi-ai/src/providers/`, `packages/pi-ai/src/models.ts`
 
 ## Context
 


### PR DESCRIPTION
## Summary

ADR house-cleaning identified during a completion audit of all previous ADRs:

- **ADR-001 → Superseded.** Branchless worktree decision never shipped; its motivation was overtaken by the DB-authoritative runtime model and the ADR-014/015/016/017 consolidation. Status header updated with a forward-pointing note so future readers don't try to implement a stale plan.
- **ADR-002 → new file, "Not Adopted."** Referenced from ADR-001 and ADR-003 as "external state directory" but never written. New stub closes the dangling reference and records that the DB-authoritative model addressed the same concern differently.
- **ADR-006 → new file, "Proposed (canonical text on GitHub)."** Referenced from ADR-007 but the full text lives on issue #2995 (Extension Modularization). New stub points to the canonical location so cross-references resolve locally.
- **ADR-007 → Accepted (implemented).** Catalog split shipped (`packages/pi-ai/src/models/generated/` exists; barrel exports cleaned); status header brought in line with code.

## Test plan

- [ ] Render the four ADR files in a markdown viewer to confirm headings, links, and admonition blocks display correctly.
- [ ] Verify the local `ADR-006-extension-modularization.md` link in ADR-007 resolves.
- [ ] Verify the ADR-014/015/016/017 references in ADR-001's supersession note all resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural decision records to reflect current design approaches.
  * Documented extension modularization strategy and installation infrastructure plans.
  * Consolidated architectural guidance with updated status references and implementation timelines.
  * Clarified decisions on runtime state management and provider API architecture.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5757)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->