### PR TITLE
feat(adr-005): declare producesImages on always-image browser tools

### DIFF
--- a/src/resources/extensions/browser-tools/tools/screenshot.ts
+++ b/src/resources/extensions/browser-tools/tools/screenshot.ts
@@ -9,6 +9,7 @@ export function registerScreenshotTools(pi: ExtensionAPI, deps: ToolDeps): void 
 		label: "Browser Screenshot",
 		description:
 			"Take a screenshot of the current browser page and return it as an inline image. Uses JPEG for viewport/fullpage (smaller, configurable quality) and PNG for element crops (preserves transparency). Optionally crop to a specific element by CSS selector.",
+		compatibility: { producesImages: true },
 		parameters: Type.Object({
 			fullPage: Type.Optional(
 				Type.Boolean({ description: "Capture the full scrollable page (default: false)" })

--- a/src/resources/extensions/browser-tools/tools/zoom.ts
+++ b/src/resources/extensions/browser-tools/tools/zoom.ts
@@ -14,6 +14,7 @@ export function registerZoomTools(pi: ExtensionAPI, deps: ToolDeps): void {
 			"Capture and optionally upscale a specific rectangular region of the page for detailed inspection. " +
 			"Useful for dense UIs where full-page screenshots have text too small to read. " +
 			"Returns the region as an inline image, same as browser_screenshot.",
+		compatibility: { producesImages: true },
 		parameters: Type.Object({
 			x: Type.Number({ description: "Left coordinate of the region in CSS pixels." }),
 			y: Type.Number({ description: "Top coordinate of the region in CSS pixels." }),

--- a/src/resources/extensions/gsd/tests/browser-tools-compatibility-declarations.test.ts
+++ b/src/resources/extensions/gsd/tests/browser-tools-compatibility-declarations.test.ts
@@ -1,0 +1,62 @@
+// GSD-2 — ADR-005 Phase 2: Verify browser tool compatibility declarations.
+//
+// Locks in the declarations that always-image-producing browser tools
+// (browser_screenshot, browser_zoom_region) carry `producesImages: true` so
+// the model-router filters them out on providers without imageToolResults
+// (OpenAI completions/responses, Azure, Mistral, Ollama). Conditional-image
+// browser tools (navigation, forms, refs, intent, interaction) must NOT
+// declare producesImages — they only attach error screenshots and filtering
+// them would lose the whole tool surface for OpenAI users.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+
+import { registerScreenshotTools } from "../../browser-tools/tools/screenshot.ts";
+import { registerZoomTools } from "../../browser-tools/tools/zoom.ts";
+
+interface CapturedToolDef {
+  name: string;
+  compatibility?: { producesImages?: boolean; schemaFeatures?: string[] };
+}
+
+function makeCapturingPi(): { pi: ExtensionAPI; tools: CapturedToolDef[] } {
+  const tools: CapturedToolDef[] = [];
+  const pi = {
+    registerTool(def: CapturedToolDef): void {
+      tools.push({ name: def.name, compatibility: def.compatibility });
+    },
+  } as unknown as ExtensionAPI;
+  return { pi, tools };
+}
+
+// Browser tool registration functions accept a `deps` object. None of the
+// declarations under test reach for these deps at registration time — they
+// only run inside execute(), which we never invoke. A bare object satisfies
+// the type signature.
+const stubDeps = {} as Parameters<typeof registerScreenshotTools>[1];
+
+test("browser_screenshot declares producesImages: true", () => {
+  const { pi, tools } = makeCapturingPi();
+  registerScreenshotTools(pi, stubDeps);
+  const screenshot = tools.find((t) => t.name === "browser_screenshot");
+  assert.ok(screenshot, "browser_screenshot should be registered");
+  assert.equal(
+    screenshot.compatibility?.producesImages,
+    true,
+    "browser_screenshot must declare producesImages so it is filtered on providers without imageToolResults",
+  );
+});
+
+test("browser_zoom_region declares producesImages: true", () => {
+  const { pi, tools } = makeCapturingPi();
+  registerZoomTools(pi, stubDeps);
+  const zoom = tools.find((t) => t.name === "browser_zoom_region");
+  assert.ok(zoom, "browser_zoom_region should be registered");
+  assert.equal(
+    zoom.compatibility?.producesImages,
+    true,
+    "browser_zoom_region must declare producesImages so it is filtered on providers without imageToolResults",
+  );
+});


### PR DESCRIPTION
## Summary

ADR-005 Phase 2 (tool compatibility metadata) shipped the `compatibility` field on `ToolDefinition` plus auto-registration in the extension loader, but no tool was actually declaring it. This PR closes that gap for the two browser tools that always return an image on the success path.

- **`browser_screenshot`** — always returns an image; declare `producesImages: true`
- **`browser_zoom_region`** — always returns an image; declare `producesImages: true`

With the declaration in place, the existing model-router `filterToolsForProvider` hard-filters these tools when routing to providers without `imageToolResults` (openai-completions, openai-responses, azure-openai-responses, openai-codex-responses, mistral-conversations, ollama-chat).

## Intentionally NOT declared (rationale)

- **Conditional-image browser tools** (`browser_navigate`, `browser_fill_form`, `browser_get_ref`, `browser_find_best`, `browser_click`, etc.) — only attach error screenshots on failure. Hard-filtering would lose the whole tool surface for OpenAI users.
- **Tools using `Type.Record` or `Type.Literal`** (`gsd_save_decision`, `browser_fill_form`, `browser_network_mock`, `browser_extract`, etc.) — Google's `sanitizeSchemaForGoogle` strips `patternProperties` and converts `const → enum` losslessly. Declaring `schemaFeatures: [\"patternProperties\"]` or `[\"const\"]` would cause unnecessary over-filtering.
- **MCP tools** — already covered by `MCP_TOOL_DEFAULTS` in `tool-compatibility-registry.ts`.

## Test plan

- [x] New `browser-tools-compatibility-declarations.test.ts` — locks in both declarations by capturing tool definitions via a stub `pi.registerTool`. 2 tests.
- [x] Existing `tool-compatibility.test.ts` — 28/28 pass, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added compatibility declarations for image-producing browser tools to improve system integration.
  * Expanded test coverage for tool compatibility specifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5759)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->