### PR TITLE
docs(adr-008): mark Accepted (implemented), record phase evidence

### DIFF
--- a/docs/dev/ADR-008-gsd-tools-over-mcp-for-provider-parity.md
+++ b/docs/dev/ADR-008-gsd-tools-over-mcp-for-provider-parity.md
@@ -1,9 +1,23 @@
 # ADR-008: Expose GSD Workflow Tools Over MCP for Provider Parity
 
-**Status:** Proposed
+**Status:** Accepted (implemented)
 **Date:** 2026-04-09
+**Implemented:** 2026-05 (all six phases + validation parity test)
 **Deciders:** Jeremy McSpadden
 **Related:** ADR-004 (capability-aware model routing), ADR-007 (model catalog split and provider API encapsulation), `src/resources/extensions/gsd/bootstrap/db-tools.ts`, `src/resources/extensions/claude-code-cli/stream-adapter.ts`, `packages/mcp-server/src/server.ts`
+
+## Implementation status
+
+| Phase | Status | Evidence |
+|---|---|---|
+| 1. Extract shared handlers | ✅ | `src/resources/extensions/gsd/tools/workflow-tool-executors.ts` exports 11 transport-neutral executors used by both native (`bootstrap/db-tools.ts`) and MCP (`packages/mcp-server/src/workflow-tools.ts`) registrations |
+| 2. Workflow-tool MCP surface | ✅ | `packages/mcp-server/src/workflow-tools.ts` exposes the canonical set; aliases handled via `logAliasUsage` |
+| 3. Port safety enforcement | ✅ | `enforceWorkflowWriteGate(toolName, projectDir, milestoneId)` runs at the head of every MCP handler |
+| 4. Attach MCP to Claude Code | ✅ | `src/resources/extensions/claude-code-cli/stream-adapter.ts:1318` calls `buildWorkflowMcpServers(sdkCwd)` and passes `mcpServers` to the Anthropic Agent SDK session |
+| 5. Provider capability gating | ✅ | `getWorkflowTransportSupportError(...)` in `src/resources/extensions/gsd/workflow-mcp.ts` fires pre-dispatch from `auto/phases.ts`, `guided-flow.ts`, and `auto-direct-dispatch.ts`. Fails early with an actionable error when the active provider can access neither native tools nor an MCP workflow surface. 27 tests in `workflow-mcp.test.ts` |
+| 6. Prompts and docs transport-neutral | ✅ | Prompts under `src/resources/extensions/gsd/prompts/` reference the "DB-backed canonical write path" without prescribing transport; no manual-summary-fallback language remains anywhere |
+
+Validation criterion #3 ("MCP-invoked workflow tools produce the same DB updates, rendered artifacts, and state transitions as native tool calls") is locked in by `packages/mcp-server/src/workflow-tools-parity.test.ts` (added 2026-05-10 via PR #5760).
 
 ## Context
 


### PR DESCRIPTION
## Summary

Updates ADR-008's status from "Proposed" to "Accepted (implemented)" with a phase-by-phase evidence table. All six phases are shipped:

| Phase | Evidence |
|---|---|
| 1. Shared handlers | `workflow-tool-executors.ts` — 11 executors used by both native + MCP |
| 2. MCP surface | `packages/mcp-server/src/workflow-tools.ts` |
| 3. Safety enforcement | `enforceWorkflowWriteGate` at the head of every MCP handler |
| 4. Claude Code wiring | `stream-adapter.ts:1318` calls `buildWorkflowMcpServers` and passes `mcpServers` to the SDK |
| 5. Capability gating | `getWorkflowTransportSupportError` in `workflow-mcp.ts`, fired pre-dispatch from `auto/phases.ts`, `guided-flow.ts`, `auto-direct-dispatch.ts`. 27 tests |
| 6. Prompts/docs neutral | Prompts use "DB-backed canonical write path" language; no manual-summary fallback remains |

Validation criterion #3 (native vs MCP produce identical state) is locked in by #5760 (the parity test PR).

Audit performed via parallel sub-agents and spot-verified against `workflow-mcp.ts`, `auto/phases.ts:1982-2001`, and the prompt files. Stale audit findings from earlier in this work cycle (e.g., "MCP tools are implemented as separate handlers") are now contradicted by the code and resolved.

## Test plan

- [ ] Render the updated ADR-008 in a markdown viewer to confirm the status table renders.
- [ ] Cross-check each evidence path in the table resolves (links are file paths, no anchors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Finalized and documented an architectural decision regarding implementation approach and validation criteria, including implementation timeline and evidence of completion across all phases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5761)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->