### PR TITLE
feat(adr-011): ROADMAP shows [sketch] badge on unrefined slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ Plan (with integrated research) → Execute (per task) → Complete → Reassess
 
 **Plan** scouts the codebase, researches relevant docs, and decomposes the slice into tasks with must-haves (mechanically verifiable outcomes). **Execute** runs each task in a fresh context window with only the relevant files pre-loaded — then runs configured verification commands (lint, test, etc.) with auto-fix retries. **Complete** writes the summary, UAT script, marks the roadmap, and commits with meaningful messages derived from task summaries. **Reassess** checks if the roadmap still makes sense given what was learned. **Validate Milestone** runs a reconciliation gate after all slices complete — comparing roadmap success criteria against actual results before sealing the milestone.
 
+When progressive planning is enabled, the first slice is fully planned up front while later slices may appear in `M###-ROADMAP.md` with a `` `[sketch]` `` badge. A sketch slice has an approved title, dependency shape, demo line, and scope boundary, but it has not yet been expanded into task plans; auto mode runs `refine-slice` just before execution to turn the sketch into a full slice plan using the latest prior-slice summaries.
+
 ### `/gsd auto` — The Main Event
 
 This is what makes GSD different. Run it, walk away, come back to built software.
@@ -548,7 +550,7 @@ Every dispatch is carefully constructed. The LLM never wastes tool calls on orie
 | `runtime/research-decision.json` | Deep-mode marker for project research vs skip       |
 | `research/*.md`    | Optional deep-mode project research: stack, features, architecture, pitfalls |
 | `STATE.md`         | Quick-glance dashboard rendered from the database                |
-| `M001-ROADMAP.md`  | Milestone plan with slice checkboxes, risk levels, dependencies |
+| `M001-ROADMAP.md`  | Milestone plan with slice checkboxes, risk levels, dependencies, and `` `[sketch]` `` badges for slices awaiting `refine-slice` |
 | `M001-CONTEXT.md`  | User decisions from the discuss phase                           |
 | `M001-RESEARCH.md` | Codebase and ecosystem research                                 |
 | `S01-PLAN.md`      | Slice task decomposition with must-haves                        |

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -22,6 +22,8 @@ Plan (with integrated research) → Execute (per task) → Complete → Reassess
 - **Reassess** — checks if the roadmap still makes sense
 - **Validate Milestone** — reconciliation gate after all slices complete; compares roadmap success criteria against actual results, catches gaps before sealing the milestone
 
+When progressive planning is enabled, GSD fully plans the first slice and may leave later slices as sketches. Those slices render in `M###-ROADMAP.md` with a `` `[sketch]` `` badge, meaning the slice has an approved scope boundary but has not yet been expanded into task plans. Auto mode runs `refine-slice` just before execution to convert the sketch into a full slice plan using the current codebase and prior slice summaries.
+
 ### Idempotent Milestone Completion
 
 Milestone completion is safe to retry. If a `complete-milestone` unit is redispatched after the database already marks the milestone as closed, GSD treats the call as successful instead of returning an error. The existing summary projection is left intact, no duplicate completion event is appended, and the tool response includes `alreadyComplete: true` in its details so operators and integrations can distinguish a retry from the first completion.
@@ -61,7 +63,7 @@ Workflow Preferences -> Project Context -> Requirements -> Research Decision -> 
 | `.gsd/REQUIREMENTS.md` | `discuss-requirements` | Capability contract using `R###` requirements grouped by Active, Validated, Deferred, and Out of Scope |
 | `.gsd/runtime/research-decision.json` | `research-decision` | Records `research` or `skip`; this unit only asks the question and writes the marker |
 | `.gsd/research/STACK.md`, `FEATURES.md`, `ARCHITECTURE.md`, `PITFALLS.md` | `research-project`, only when the decision is `research` | Four parallel project-level research outputs for stack, feature norms, architecture, and pitfalls |
-| `.gsd/milestones/<MID>/M###-CONTEXT.md` and `M###-ROADMAP.md` | Normal milestone discussion/planning | Milestone-specific context and executable roadmap |
+| `.gsd/milestones/<MID>/M###-CONTEXT.md` and `M###-ROADMAP.md` | Normal milestone discussion/planning | Milestone-specific context and executable roadmap; `` `[sketch]` `` marks slices awaiting `refine-slice` |
 
 `REQUIREMENTS.md` is rendered from the requirements stored in the GSD database. Agents should save individual requirements with `gsd_requirement_save`; a final `gsd_summary_save` for `REQUIREMENTS` will fail if no active requirement rows exist instead of treating caller-supplied markdown as canonical.
 

--- a/mintlify-docs/guides/auto-mode.mdx
+++ b/mintlify-docs/guides/auto-mode.mdx
@@ -19,6 +19,8 @@ Plan → Execute (per task) → Complete → Reassess Roadmap → Next Slice
 - **Reassess** — checks if the roadmap still makes sense
 - **Validate** — reconciliation gate after all slices; catches gaps before sealing the milestone
 
+When progressive planning is enabled, GSD fully plans the first slice and may leave later slices as sketches. Those slices render in `M###-ROADMAP.md` with a `` `[sketch]` `` badge, meaning the slice has an approved scope boundary but has not yet been expanded into task plans. Auto mode runs `refine-slice` just before execution to convert the sketch into a full slice plan using the current codebase and prior slice summaries.
+
 ## Deep planning mode
 
 Enable project-level deep planning with `/gsd new-project --deep`, `/gsd new-milestone --deep`, or this project preference:
@@ -40,6 +42,7 @@ Workflow Preferences -> Project Context -> Requirements -> Research Decision -> 
 | `.gsd/REQUIREMENTS.md`                                                    | `discuss-requirements`            | Capability contract with Active, Validated, Deferred, and Out of Scope requirements |
 | `.gsd/runtime/research-decision.json`                                     | `research-decision`               | Records whether to run project research or skip it                                  |
 | `.gsd/research/STACK.md`, `FEATURES.md`, `ARCHITECTURE.md`, `PITFALLS.md` | `research-project`                | Optional four-way project research when the decision is `research`                  |
+| `.gsd/milestones/<MID>/M###-ROADMAP.md`                                   | `plan-milestone`                  | Executable roadmap; `` `[sketch]` `` marks slices awaiting `refine-slice`           |
 
 The research-decision unit only records the choice. If the decision is `research`, the next gate fans out four project research passes. Those outputs inform planning and requirement review; they do not silently create binding requirements.
 

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -157,7 +157,12 @@ function renderRoadmapMarkdown(milestone: MilestoneRow, slices: SliceRow[]): str
   for (const slice of slices) {
     const done = isClosedStatus(slice.status) ? "x" : " ";
     const depends = `[${(slice.depends ?? []).join(",")}]`;
-    lines.push(`- [${done}] **${slice.id}: ${slice.title}** \`risk:${slice.risk}\` \`depends:${depends}\``);
+    // ADR-011: sketch slices get a `[sketch]` badge so the roadmap shows at a
+    // glance which slices are still pending refine-slice expansion. The badge
+    // sits in front of `risk:` so it's visible in narrow terminals that may
+    // truncate the line.
+    const sketchBadge = slice.is_sketch === 1 ? "`[sketch]` " : "";
+    lines.push(`- [${done}] **${slice.id}: ${slice.title}** ${sketchBadge}\`risk:${slice.risk}\` \`depends:${depends}\``);
     lines.push(`  > After this: ${slice.demo}`);
     lines.push("");
   }

--- a/src/resources/extensions/gsd/tests/plan-milestone-sketch-render.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-milestone-sketch-render.test.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { openDatabase, closeDatabase } from "../gsd-db.ts";
-import { handlePlanMilestone } from "../tools/plan-milestone.ts";
+import { handlePlanMilestone, type PlanMilestoneParams } from "../tools/plan-milestone.ts";
 
 function makeTmpBase(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-plan-sketch-render-"));
@@ -34,7 +34,7 @@ function cleanup(base: string): void {
   }
 }
 
-function planMilestoneWithSketches() {
+function planMilestoneWithSketches(): PlanMilestoneParams {
   return {
     milestoneId: "M001",
     title: "Progressive Planning Demo",
@@ -70,6 +70,10 @@ function planMilestoneWithSketches() {
         depends: ["S01"],
         demo: "Sketched until S01 ships.",
         goal: "Refine into a full plan after S01 lands.",
+        successCriteria: "",
+        proofLevel: "",
+        integrationClosure: "",
+        observabilityImpact: "",
         isSketch: true,
         sketchScope: "Pick up the scaffold from S01 and add the demo behavior. Stay inside the existing module boundaries.",
       },
@@ -81,7 +85,7 @@ test("ROADMAP renders sketch slices with [sketch] badge and full slices without"
   const base = makeTmpBase();
   try {
     const params = planMilestoneWithSketches();
-    const result = await handlePlanMilestone(params as Parameters<typeof handlePlanMilestone>[0], base);
+    const result = await handlePlanMilestone(params, base);
     if ("error" in result) {
       assert.fail(`handlePlanMilestone failed: ${result.error}`);
     }
@@ -130,9 +134,9 @@ test("ROADMAP omits sketch badge when no slices are sketches", async () => {
       proofLevel: "unit" as const,
       integrationClosure: "S02 closes the demo behavior.",
       observabilityImpact: "No new telemetry.",
-    } as typeof params.slices[1];
+    };
 
-    const result = await handlePlanMilestone(params as Parameters<typeof handlePlanMilestone>[0], base);
+    const result = await handlePlanMilestone(params, base);
     if ("error" in result) {
       assert.fail(`handlePlanMilestone failed: ${result.error}`);
     }

--- a/src/resources/extensions/gsd/tests/plan-milestone-sketch-render.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-milestone-sketch-render.test.ts
@@ -1,0 +1,153 @@
+// ADR-011 #5750: ROADMAP.md renders sketch slices with a `[sketch]` badge.
+//
+// Locks in the visual distinction so an auditor scanning the rendered roadmap
+// can tell which slices are sketches awaiting refine-slice expansion vs which
+// already carry a full plan. Sits alongside `plan-milestone.test.ts` which
+// covers the full-plan render path.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openDatabase, closeDatabase } from "../gsd-db.ts";
+import { handlePlanMilestone } from "../tools/plan-milestone.ts";
+
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-plan-sketch-render-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  return base;
+}
+
+function cleanup(base: string): void {
+  try {
+    closeDatabase();
+  } catch {
+    /* noop */
+  }
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* noop */
+  }
+}
+
+function planMilestoneWithSketches() {
+  return {
+    milestoneId: "M001",
+    title: "Progressive Planning Demo",
+    vision: "Demonstrate sketch slices in ROADMAP rendering.",
+    successCriteria: ["S01 full, S02 sketch", "ROADMAP distinguishes them"],
+    keyRisks: [{ risk: "Visual collision", whyItMatters: "Auditors need to spot sketches." }],
+    proofStrategy: [{ riskOrUnknown: "Render correctness", retireIn: "S01", whatWillBeProven: "Roadmap shows the badge." }],
+    verificationContract: "Contract verification text",
+    verificationIntegration: "Integration verification text",
+    verificationOperational: "Operational verification text",
+    verificationUat: "UAT verification text",
+    definitionOfDone: ["Renderer emits badge", "Test asserts it"],
+    requirementCoverage: "Covers ADR-011 #5750.",
+    boundaryMapMarkdown: "| From | To | Produces | Consumes |\n|------|----|----------|----------|\n| S01 | S02 | scaffold | nothing |",
+    slices: [
+      {
+        sliceId: "S01",
+        title: "Fully planned scaffold",
+        risk: "medium" as const,
+        depends: [],
+        demo: "Scaffold is in place.",
+        goal: "Lay down the structural foundation.",
+        successCriteria: "Scaffold tests pass.",
+        proofLevel: "integration" as const,
+        integrationClosure: "Downstream slices depend on this scaffold.",
+        observabilityImpact: "No new telemetry.",
+        // No isSketch flag — defaults to full plan.
+      },
+      {
+        sliceId: "S02",
+        title: "Refinement candidate",
+        risk: "low" as const,
+        depends: ["S01"],
+        demo: "Sketched until S01 ships.",
+        goal: "Refine into a full plan after S01 lands.",
+        isSketch: true,
+        sketchScope: "Pick up the scaffold from S01 and add the demo behavior. Stay inside the existing module boundaries.",
+      },
+    ],
+  };
+}
+
+test("ROADMAP renders sketch slices with [sketch] badge and full slices without", async () => {
+  const base = makeTmpBase();
+  try {
+    const params = planMilestoneWithSketches();
+    const result = await handlePlanMilestone(params as Parameters<typeof handlePlanMilestone>[0], base);
+    if ("error" in result) {
+      assert.fail(`handlePlanMilestone failed: ${result.error}`);
+    }
+
+    const roadmapPath = join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md");
+    const roadmap = readFileSync(roadmapPath, "utf-8");
+
+    // S01 is a full slice — no sketch badge.
+    const s01Line = roadmap.split("\n").find((line) => line.includes("**S01:"));
+    assert.ok(s01Line, "S01 slice line must exist in roadmap");
+    assert.equal(
+      s01Line.includes("`[sketch]`"),
+      false,
+      "fully-planned S01 must NOT carry the sketch badge",
+    );
+    assert.match(s01Line, /`risk:medium`/);
+
+    // S02 is a sketch — badge required, positioned before risk.
+    const s02Line = roadmap.split("\n").find((line) => line.includes("**S02:"));
+    assert.ok(s02Line, "S02 slice line must exist in roadmap");
+    assert.ok(
+      s02Line.includes("`[sketch]`"),
+      `sketch slice S02 must carry the sketch badge, got: ${s02Line}`,
+    );
+    // Badge sits before risk so it stays visible if the line truncates.
+    const sketchIdx = s02Line.indexOf("`[sketch]`");
+    const riskIdx = s02Line.indexOf("`risk:");
+    assert.ok(
+      sketchIdx >= 0 && riskIdx >= 0 && sketchIdx < riskIdx,
+      "sketch badge must appear before the risk tag",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("ROADMAP omits sketch badge when no slices are sketches", async () => {
+  const base = makeTmpBase();
+  try {
+    const params = planMilestoneWithSketches();
+    // Strip the sketch designation from S02 so both slices are fully planned.
+    params.slices[1] = {
+      ...params.slices[1],
+      isSketch: false,
+      successCriteria: "Demo behavior works.",
+      proofLevel: "unit" as const,
+      integrationClosure: "S02 closes the demo behavior.",
+      observabilityImpact: "No new telemetry.",
+    } as typeof params.slices[1];
+
+    const result = await handlePlanMilestone(params as Parameters<typeof handlePlanMilestone>[0], base);
+    if ("error" in result) {
+      assert.fail(`handlePlanMilestone failed: ${result.error}`);
+    }
+
+    const roadmap = readFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+      "utf-8",
+    );
+
+    assert.equal(
+      roadmap.includes("`[sketch]`"),
+      false,
+      "roadmap must not carry the sketch badge when no slice is a sketch",
+    );
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## Summary

Closes #5750 (scope sharpened after code review revealed most of ADR-011 #1 is already shipped).

ADR-011 Progressive Planning was substantially in place before this issue: schema (\`is_sketch\` / \`sketch_scope\`), prompt (the "Progressive Planning (ADR-011)" section of \`plan-milestone.md\`), executor (\`executePlanMilestone\` accepts and validates \`isSketch\`/\`sketchScope\` with 3-valued ON CONFLICT semantics), preference (\`phases.progressive_planning\`), state derivation (\`is_sketch === 1\` → \`phase: 'refining'\`), dispatch (refining → refine-slice or plan-slice fallback), and the sketch-flag drift handler that auto-clears \`is_sketch=1\` rows whose PLAN already exists.

What was missing: a visible signal in the rendered \`ROADMAP.md\` so a person reading the file can tell which slices are sketches awaiting refinement vs which carry a full plan.

## Change

Renderer: when \`slice.is_sketch === 1\`, emit a \`[sketch]\` backtick badge before the existing \`risk:\` tag. Badge sits before risk so it stays visible if the line truncates in a narrow terminal. Plain ASCII (no emoji rendering variance, no parse impact).

\`\`\`
- [ ] **S02: Add deletion flow** \`[sketch]\` \`risk:medium\` \`depends:[S01]\`
  > After this: users can delete records
\`\`\`

## Test plan

- [x] New \`plan-milestone-sketch-render.test.ts\` — positive case (sketch + full slices side by side, badge appears only on the sketch line) and negative case (no sketches → no badge anywhere)
- [x] Existing \`plan-milestone.test.ts\` / \`plan-milestone-rendering.test.ts\` / \`plan-milestone-artifact-verification.test.ts\` / \`projection-regression.test.ts\` continue to pass (26 tests total)

## Files

- \`src/resources/extensions/gsd/markdown-renderer.ts\` — renderer change (4 lines)
- \`src/resources/extensions/gsd/tests/plan-milestone-sketch-render.test.ts\` *(new)* — 2 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sketch slices in the ROADMAP now display a `[sketch]` badge placed immediately before the existing `risk:` tag, making sketch status more visible and distinguishable.

* **Tests**
  * Added test coverage validating the sketch badge appears for sketch slices, is omitted for non-sketch slices, and is positioned correctly relative to the risk tag.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5763)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->