### PR TITLE
docs(adr-011): mark Accepted (mostly implemented), record phase evidence

### DIFF
--- a/docs/dev/ADR-011-progressive-planning-escalation.md
+++ b/docs/dev/ADR-011-progressive-planning-escalation.md
@@ -1,10 +1,41 @@
 # ADR-011: Progressive Planning and Mid-Execution Escalation
 
-**Status:** Proposed
+**Status:** Accepted (mostly implemented)
 **Date:** 2026-04-17
+**Implemented:** 2026-04 to 2026-05 (Phase 1 + Phase 2 shipped; outstanding work tracked on #5754)
 **Author:** Alan Alwakeel (@OfficialDelta)
 **Related:** ADR-003 (pipeline simplification), ADR-009 (orchestration kernel refactor)
 **Prior art:** PR #3468 (enhanced verification), PR #3602 (discussion system), PR #3766 (tiered context injection), PR #4079 (layered depth enforcement)
+
+## Implementation status
+
+### Phase 1 — Progressive Planning (sketch in plan-milestone)
+
+| Piece | Status | Evidence |
+|---|---|---|
+| Schema: `is_sketch` + `sketch_scope` columns | ✅ | `src/resources/extensions/gsd/db-base-schema.ts:172-173` |
+| Prompt: progressive-planning section in plan-milestone | ✅ | `src/resources/extensions/gsd/prompts/plan-milestone.md:84-94` ("Progressive Planning (ADR-011)") |
+| Executor: 3-valued `isSketch` ON CONFLICT semantics | ✅ | `src/resources/extensions/gsd/tools/plan-milestone.ts:136-184` |
+| Preference: `phases.progressive_planning` | ✅ | `src/resources/extensions/gsd/types.ts:358`, validated in `preferences-validation.ts:352-354` |
+| State derivation: `is_sketch=1` → `phase: 'refining'` | ✅ | `src/resources/extensions/gsd/state.ts:737-744`; phase union in `types.ts:14` |
+| ROADMAP sketch badge | ✅ | `src/resources/extensions/gsd/markdown-renderer.ts:160` — `[sketch]` backtick badge (PR #5763) |
+
+### Phase 2 — Mid-Execution Escalation
+
+| Piece | Status | Evidence |
+|---|---|---|
+| Escalation artifact type | ✅ | `src/resources/extensions/gsd/types.ts:372` |
+| Escalation artifact I/O | ✅ | `src/resources/extensions/gsd/escalation.ts` |
+| Gate-plane `manual-attention` wiring | ✅ | UOK gate runner |
+| `refine-slice` prompt + builder | ✅ | `src/resources/extensions/gsd/prompts/refine-slice.md`; `auto-prompts.ts:2192-2225` (`buildRefineSlicePrompt`) |
+| Dispatch: `refining` → `refine-slice` (or fallback to `plan-slice`) | ✅ | `src/resources/extensions/gsd/auto-dispatch.ts:880-928` |
+| `is_sketch` auto-clear after PLAN written | ✅ | `src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts` — `sketchFlagHandler` registered in DRIFT_REGISTRY |
+| Test coverage of pieces in isolation | ✅ | `src/resources/extensions/gsd/tests/progressive-planning.test.ts` — 12 tests |
+
+### Outstanding (#5754)
+
+- End-to-end test covering the full sketch → refining → dispatch → PLAN written → drift-clear → execute-task pipeline (pieces tested in isolation today)
+- UOK audit event (`category: "plan"`, `type: "refine-slice-start" / "refine-slice-complete"`) emitted on refine dispatch + completion
 
 ## Context
 

--- a/docs/dev/ADR-011-progressive-planning-escalation.md
+++ b/docs/dev/ADR-011-progressive-planning-escalation.md
@@ -16,7 +16,7 @@
 | Schema: `is_sketch` + `sketch_scope` columns | ✅ | `src/resources/extensions/gsd/db-base-schema.ts:172-173` |
 | Prompt: progressive-planning section in plan-milestone | ✅ | `src/resources/extensions/gsd/prompts/plan-milestone.md:84-94` ("Progressive Planning (ADR-011)") |
 | Executor: 3-valued `isSketch` ON CONFLICT semantics | ✅ | `src/resources/extensions/gsd/tools/plan-milestone.ts:136-184` |
-| Preference: `phases.progressive_planning` | ✅ | `src/resources/extensions/gsd/types.ts:358`, validated in `preferences-validation.ts:352-354` |
+| Preference: `phases.progressive_planning` | ✅ | `src/resources/extensions/gsd/types.ts:358`, validated in `src/resources/extensions/gsd/preferences-validation.ts:352-354` |
 | State derivation: `is_sketch=1` → `phase: 'refining'` | ✅ | `src/resources/extensions/gsd/state.ts:737-744`; phase union in `types.ts:14` |
 | ROADMAP sketch badge | ✅ | `src/resources/extensions/gsd/markdown-renderer.ts:160` — `[sketch]` backtick badge (PR #5763) |
 
@@ -26,7 +26,7 @@
 |---|---|---|
 | Escalation artifact type | ✅ | `src/resources/extensions/gsd/types.ts:372` |
 | Escalation artifact I/O | ✅ | `src/resources/extensions/gsd/escalation.ts` |
-| Gate-plane `manual-attention` wiring | ✅ | UOK gate runner |
+| Gate-plane `manual-attention` wiring | ✅ | `src/resources/extensions/gsd/uok/gate-runner.ts:16-24`, fallback outcome in `src/resources/extensions/gsd/uok/gate-runner.ts:195-204` |
 | `refine-slice` prompt + builder | ✅ | `src/resources/extensions/gsd/prompts/refine-slice.md`; `auto-prompts.ts:2192-2225` (`buildRefineSlicePrompt`) |
 | Dispatch: `refining` → `refine-slice` (or fallback to `plan-slice`) | ✅ | `src/resources/extensions/gsd/auto-dispatch.ts:880-928` |
 | `is_sketch` auto-clear after PLAN written | ✅ | `src/resources/extensions/gsd/state-reconciliation/drift/sketch-flag.ts` — `sketchFlagHandler` registered in DRIFT_REGISTRY |


### PR DESCRIPTION
## Summary

Updates ADR-011's status from "Proposed" to "Accepted (mostly implemented)" with a phase-by-phase evidence table. Mirrors the ADR-008 status update treatment (#5761).

Phase 1 (progressive planning) and Phase 2 (mid-execution escalation + refine-slice) are substantially shipped. Schema, prompts, executors, dispatch, state derivation, drift handler, and 12 isolated tests all live in main. The ROADMAP sketch badge ships in PR #5763 (companion to this PR).

Two narrow follow-ups remain on #5754: a full-loop end-to-end test (current tests cover pieces in isolation), and a UOK audit event for the refine step.

## Test plan

- [ ] Render ADR-011 in a markdown viewer to confirm the status tables render cleanly.
- [ ] Verify each evidence path in the tables resolves to a real file/line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated ADR-011 to "Accepted (mostly implemented)" and added an Implementation Status section documenting completion evidence for Phase 1 (Progressive Planning) and Phase 2 (Mid-Execution Escalation).
  * Added an Outstanding list noting missing end-to-end and audit-event coverage for future work.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5764)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->