### PR TITLE
docs(adr-013): record phase-by-phase implementation status

### DIFF
--- a/docs/dev/ADR-013-memory-store-consolidation.md
+++ b/docs/dev/ADR-013-memory-store-consolidation.md
@@ -2,10 +2,30 @@
 
 # ADR-013: Memory Store Consolidation
 
-**Status:** Accepted
+**Status:** Accepted (mostly implemented — Phase 6 cutover outstanding)
 **Date:** 2026-04-19
+**Implemented:** 2026-04 to 2026-05 (Phases 0–5 + preflight scanner; Phase 6 cutover tracked on #5755 / #5756)
 **Author:** Jeremy (@jeremymcs)
 **Related:** PR #4469 (memory tools Phase 1), commits f4bd65a8 / 59e1f830 / 03f77f36 / 9d9ccfe8 / fc6c93c2 (Phase 2-5), Issue #4495, PR #4496
+
+## Implementation status
+
+| Phase | Scope | Status | Evidence |
+|---|---|---|---|
+| 0 | ADR document | ✅ | This file |
+| 1 | `structuredFields` JSON column on `memories` table | ✅ | Schema present in `src/resources/extensions/gsd/gsd-db.ts` (memories table definition) |
+| 2 | Register `capture_thought`, `memory_query`, `gsd_graph` | ✅ | `src/resources/extensions/gsd/bootstrap/memory-tools.ts` |
+| 3 | Auto-injection of relevant memories at session start | ✅ | `src/resources/extensions/gsd/bootstrap/system-context.ts:213,329` — `loadMemoryBlock` (covered by `tests/load-memory-block.test.ts`) |
+| 4 | Researcher / scout agent frontmatter updated to include memory tools | ✅ | `src/resources/agents/researcher.md:4` (scout intentionally read-only per scope) |
+| 5 | Idempotent `decisions → memories` backfill on session start | ✅ | `src/resources/extensions/gsd/memory-backfill.ts` — `backfillDecisionsToMemories`; wired from `system-context.ts:159` |
+| 6 preflight | Cutover gap scanner (read-only, warns on unmigrated rows) | ✅ | `src/resources/extensions/gsd/memory-consolidation-scanner.ts` — `scanConsolidationGaps` + `reportConsolidationGaps`; wired from `system-context.ts:168` (PR #5765, closes #5751) |
+| 6 cutover | Stop dual-write, memories canonical, `decisions` table read-only | ⏳ | Outstanding — tracked on #5755. Destructive; blocked on scanner reading clean. |
+| 6 drop | Schema migration to drop `decisions` table | ⏳ | Outstanding — tracked on #5756. Blocked on #5755 baking for one minor version. |
+
+### Outstanding work
+
+- **#5755** (HITL, destructive) — stop dual-write of decisions / KNOWLEDGE.md, make `memories` the sole write surface, projections regenerate from `memories`
+- **#5756** (AFK, gated) — drop the `decisions` table; remove the read fallback. Blocked on #5755 baking
 
 ## Context
 

--- a/docs/dev/ADR-013-memory-store-consolidation.md
+++ b/docs/dev/ADR-013-memory-store-consolidation.md
@@ -2,9 +2,9 @@
 
 # ADR-013: Memory Store Consolidation
 
-**Status:** Accepted (mostly implemented — Phase 6 cutover outstanding)
+**Status:** Accepted (mostly implemented — Phase 6 preflight/cutover outstanding)
 **Date:** 2026-04-19
-**Implemented:** 2026-04 to 2026-05 (Phases 0–5 + preflight scanner; Phase 6 cutover tracked on #5755 / #5756)
+**Implemented:** 2026-04 to 2026-05 (Phases 0–5; Phase 6 preflight/cutover tracked on #5751 / #5755 / #5756)
 **Author:** Jeremy (@jeremymcs)
 **Related:** PR #4469 (memory tools Phase 1), commits f4bd65a8 / 59e1f830 / 03f77f36 / 9d9ccfe8 / fc6c93c2 (Phase 2-5), Issue #4495, PR #4496
 
@@ -15,10 +15,10 @@
 | 0 | ADR document | ✅ | This file |
 | 1 | `structuredFields` JSON column on `memories` table | ✅ | Schema present in `src/resources/extensions/gsd/gsd-db.ts` (memories table definition) |
 | 2 | Register `capture_thought`, `memory_query`, `gsd_graph` | ✅ | `src/resources/extensions/gsd/bootstrap/memory-tools.ts` |
-| 3 | Auto-injection of relevant memories at session start | ✅ | `src/resources/extensions/gsd/bootstrap/system-context.ts:213,329` — `loadMemoryBlock` (covered by `tests/load-memory-block.test.ts`) |
-| 4 | Researcher / scout agent frontmatter updated to include memory tools | ✅ | `src/resources/agents/researcher.md:4` (scout intentionally read-only per scope) |
+| 3 | Auto-injection of relevant memories at session start | ✅ | `src/resources/extensions/gsd/bootstrap/system-context.ts:213,329` — `loadMemoryBlock` (covered by `src/resources/extensions/gsd/tests/load-memory-block.test.ts`) |
+| 4 | Researcher agent frontmatter updated with write-capable memory tools; scout unchanged | ✅ | `src/resources/agents/researcher.md:4` includes `capture_thought` / `memory_query` / `gsd_graph`; scout intentionally remains read-only per scope |
 | 5 | Idempotent `decisions → memories` backfill on session start | ✅ | `src/resources/extensions/gsd/memory-backfill.ts` — `backfillDecisionsToMemories`; wired from `system-context.ts:159` |
-| 6 preflight | Cutover gap scanner (read-only, warns on unmigrated rows) | ✅ | `src/resources/extensions/gsd/memory-consolidation-scanner.ts` — `scanConsolidationGaps` + `reportConsolidationGaps`; wired from `system-context.ts:168` (PR #5765, closes #5751) |
+| 6 preflight | Cutover gap scanner (read-only, warns on unmigrated rows) | ⏳ | Outstanding — tracked on #5751 / PR #5765. No scanner module is present in this branch. |
 | 6 cutover | Stop dual-write, memories canonical, `decisions` table read-only | ⏳ | Outstanding — tracked on #5755. Destructive; blocked on scanner reading clean. |
 | 6 drop | Schema migration to drop `decisions` table | ⏳ | Outstanding — tracked on #5756. Blocked on #5755 baking for one minor version. |
 

--- a/docs/dev/ADR-013-memory-store-consolidation.md
+++ b/docs/dev/ADR-013-memory-store-consolidation.md
@@ -16,7 +16,8 @@
 | 1 | `structuredFields` JSON column on `memories` table | ✅ | Schema present in `src/resources/extensions/gsd/gsd-db.ts` (memories table definition) |
 | 2 | Register `capture_thought`, `memory_query`, `gsd_graph` | ✅ | `src/resources/extensions/gsd/bootstrap/memory-tools.ts` |
 | 3 | Auto-injection of relevant memories at session start | ✅ | `src/resources/extensions/gsd/bootstrap/system-context.ts:213,329` — `loadMemoryBlock` (covered by `src/resources/extensions/gsd/tests/load-memory-block.test.ts`) |
-| 4 | Researcher agent frontmatter updated with write-capable memory tools; scout unchanged | ✅ | `src/resources/agents/researcher.md:4` includes `capture_thought` / `memory_query` / `gsd_graph`; scout intentionally remains read-only per scope |
+| 4a | Researcher agent frontmatter updated to include write-capable memory tools (`capture_thought`, `memory_query`, `gsd_graph`) | ✅ | `src/resources/agents/researcher.md:4` |
+| 4b | Scout agent frontmatter intentionally kept read-only — memory tools excluded per scope | ✅ | `src/resources/agents/scout.md:4` (no change; read-only contract preserved) |
 | 5 | Idempotent `decisions → memories` backfill on session start | ✅ | `src/resources/extensions/gsd/memory-backfill.ts` — `backfillDecisionsToMemories`; wired from `system-context.ts:159` |
 | 6 preflight | Cutover gap scanner (read-only, warns on unmigrated rows) | ⏳ | Outstanding — tracked on #5751 / PR #5765. No scanner module is present in this branch. |
 | 6 cutover | Stop dual-write, memories canonical, `decisions` table read-only | ⏳ | Outstanding — tracked on #5755. Destructive; blocked on scanner reading clean. |


### PR DESCRIPTION
## Summary

Updates ADR-013's status header from "Accepted" to "Accepted (mostly implemented — Phase 6 cutover outstanding)" with a phase-by-phase evidence table. Mirrors the ADR-007 / ADR-008 / ADR-011 status update treatment.

Phases 0–5 (schema, tool registration, auto-injection, agent frontmatter, decisions backfill) are shipped. Phase 6 preflight scanner ships via PR #5765 (closes #5751). Phase 6 destructive cutover (#5755) and `decisions` table drop (#5756) remain outstanding.

## Test plan

- [ ] Render ADR-013 in a markdown viewer to confirm the status table renders.
- [ ] Verify each evidence path resolves to a real file (most are file:line references that should be stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded ADR metadata to include granular rollout timing and phase coverage (Phases 0–5 plus preflight), with Phase 6 noted as outstanding.
  * Added an implementation status table linking to source evidence for each phase and scope.
  * Listed outstanding work items and two tracked blockers; removed the prior simplified header block.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5766)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->