### PR TITLE
feat(adr-013): DECISIONS.md projection sources from memories (stage 2a)

### DIFF
--- a/src/resources/extensions/gsd/context-store.ts
+++ b/src/resources/extensions/gsd/context-store.ts
@@ -67,40 +67,33 @@ export function queryDecisions(opts?: DecisionQueryOpts): Decision[] {
 }
 
 /**
- * ADR-013 Phase 6 cutover (Stage 1): read active decisions from the `memories`
- * table instead of the legacy `decisions` table. Returns the same `Decision[]`
- * shape as `queryDecisions` so downstream formatters work unchanged.
+ * Internal: shared core for the two memory-sourced decision queries. Reads
+ * memory rows tagged with `sourceDecisionId` and reconstructs `Decision[]`
+ * from their `structured_fields` JSON.
  *
- * Filter semantics match `queryDecisions` exactly:
- * - active only (memory's own `superseded_by IS NULL`)
- * - `milestoneId`: matches when the JSON value of `structured_fields.when_context`
- *   contains the milestone token, mirroring `when_context LIKE '%milestoneId%'`
- *   on the legacy table
- * - `scope`: exact match on `structured_fields.scope`, mirroring `scope = :scope`
- *
- * Both surfaces filter to active rows, so once the Phase 5 dual-write is
- * caught up (PR #5765's scanner reading zero gaps), `queryDecisions` and
- * `queryDecisionsFromMemories` return byte-equivalent results.
- *
- * `superseded_by` is always `null` here: the `decisions` table's
- * supersedes-chain is not preserved by today's backfill (only active rows
- * are migrated), so the field has no source in memories. Acceptable for
- * prompt inlining, which never reads superseded entries.
+ * @param includeSuperseded — when false, drops rows whose
+ *   `structured_fields.superseded_by` is non-null. The supersedes-chain is
+ *   captured by the backfill (`memory-backfill.ts`) and kept in sync by
+ *   the backfill's drift auto-heal pass.
  */
-export function queryDecisionsFromMemories(opts?: DecisionQueryOpts): Decision[] {
+function readDecisionsFromMemories(
+  opts: DecisionQueryOpts | undefined,
+  includeSuperseded: boolean,
+): Decision[] {
   if (!isDbAvailable()) return [];
   const adapter = _getAdapter();
   if (!adapter) return [];
 
   try {
-    // Anchor each pattern with the closing `"` so prefix collisions don't
-    // produce false matches (e.g. scope=M001 must not match "scope":"M001-S01").
     const clauses: string[] = [
       "category = 'architecture'",
       "structured_fields LIKE '%\"sourceDecisionId\":\"%'",
-      "superseded_by IS NULL",
     ];
     const params: Record<string, unknown> = {};
+
+    if (!includeSuperseded) {
+      clauses.push("superseded_by IS NULL");
+    }
 
     if (opts?.milestoneId) {
       // when_context is a free-text JSON value; substring match preserves the
@@ -110,6 +103,8 @@ export function queryDecisionsFromMemories(opts?: DecisionQueryOpts): Decision[]
     }
 
     if (opts?.scope) {
+      // Anchored with the closing `"` so prefix collisions don't produce
+      // false matches (e.g. scope=M001 must not match "scope":"M001-S01").
       clauses.push("structured_fields LIKE :scope_pattern");
       params[':scope_pattern'] = `%"scope":"${opts.scope}"%`;
     }
@@ -131,6 +126,12 @@ export function queryDecisionsFromMemories(opts?: DecisionQueryOpts): Decision[]
       const sourceId = sf['sourceDecisionId'];
       if (typeof sourceId !== 'string' || sourceId.length === 0) continue;
 
+      // Decision-level supersedes lives in structuredFields.superseded_by
+      // (populated by the backfill / drift auto-heal). Skip when the caller
+      // wants active-only and the chain has been recorded there.
+      const supersededBy = typeof sf['superseded_by'] === 'string' ? (sf['superseded_by'] as string) : null;
+      if (!includeSuperseded && supersededBy) continue;
+
       decisions.push({
         seq,
         id: sourceId,
@@ -141,7 +142,7 @@ export function queryDecisionsFromMemories(opts?: DecisionQueryOpts): Decision[]
         rationale: typeof sf['rationale'] === 'string' ? (sf['rationale'] as string) : '',
         revisable: typeof sf['revisable'] === 'string' ? (sf['revisable'] as string) : '',
         made_by: ((typeof sf['made_by'] === 'string' ? sf['made_by'] : 'agent') as DecisionMadeBy),
-        superseded_by: null,
+        superseded_by: supersededBy,
       });
     }
 
@@ -149,6 +150,41 @@ export function queryDecisionsFromMemories(opts?: DecisionQueryOpts): Decision[]
   } catch {
     return [];
   }
+}
+
+/**
+ * ADR-013 Phase 6 cutover (Stage 1): read **active** decisions from the
+ * `memories` table instead of the legacy `decisions` table. Returns the
+ * same `Decision[]` shape as `queryDecisions` so downstream formatters
+ * work unchanged.
+ *
+ * Filter semantics match `queryDecisions` exactly:
+ * - active only (skips rows where `structured_fields.superseded_by` is set)
+ * - `milestoneId`: substring match on `structured_fields.when_context`
+ * - `scope`: exact match on `structured_fields.scope`
+ *
+ * Used by the prompt-inline path (`inlineDecisionsFromDb` in
+ * `auto-prompts.ts`). For the projection regen (which renders superseded
+ * rows too), see `getAllDecisionsFromMemories`.
+ */
+export function queryDecisionsFromMemories(opts?: DecisionQueryOpts): Decision[] {
+  return readDecisionsFromMemories(opts, /* includeSuperseded */ false);
+}
+
+/**
+ * ADR-013 Phase 6 cutover (Stage 2a): read **all** decisions (active +
+ * superseded) from the `memories` table. Used by the DECISIONS.md
+ * projection regen in `saveDecisionToDb`, which must render the full
+ * supersedes-chain for the canonical register format.
+ *
+ * Equivalent to `SELECT * FROM decisions ORDER BY seq` over the legacy
+ * table — but sourced from memories so the legacy table can be retired
+ * in Stage 3. Includes `superseded_by` reconstructed from
+ * `structured_fields.superseded_by` (populated by the backfill's drift
+ * auto-heal pass).
+ */
+export function getAllDecisionsFromMemories(): Decision[] {
+  return readDecisionsFromMemories(undefined, /* includeSuperseded */ true);
 }
 
 /**

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -467,23 +467,19 @@ export async function saveDecisionToDb(
       return nextId;
     });
 
-    // Fetch all decisions (including superseded for the full register)
-    let allDecisions: Decision[] = [];
-    if (adapter) {
-      const rows = adapter.prepare('SELECT * FROM decisions ORDER BY seq').all();
-      allDecisions = rows.map(row => ({
-        seq: row['seq'] as number,
-        id: row['id'] as string,
-        when_context: row['when_context'] as string,
-        scope: row['scope'] as string,
-        decision: row['decision'] as string,
-        choice: row['choice'] as string,
-        rationale: row['rationale'] as string,
-        revisable: row['revisable'] as string,
-        made_by: (row['made_by'] as string as import('./types.js').DecisionMadeBy) ?? 'agent',
-        superseded_by: (row['superseded_by'] as string) ?? null,
-      }));
-    }
+    // ADR-013 Stage 2a (PR #5767 → #5755): the dual-write to memories MUST
+    // happen before the projection regen below, because the regen now sources
+    // from memories. If the dual-write ran after, the just-saved decision
+    // would be missing from its own projection.
+    await mirrorDecisionToMemory(id, fields);
+
+    // Fetch all decisions (including superseded for the full register).
+    // ADR-013 Stage 2a: source from the `memories` table. The Phase 5
+    // dual-write keeps memories in sync with each decision save; the backfill
+    // (memory-backfill.ts) absorbs the historical chain and drift-heals
+    // superseded_by on every session start.
+    const { getAllDecisionsFromMemories } = await import('./context-store.js');
+    let allDecisions: Decision[] = getAllDecisionsFromMemories();
 
     const filePath = resolveGsdRootFile(basePath, 'DECISIONS');
 
@@ -538,54 +534,67 @@ export async function saveDecisionToDb(
     clearPathCache();
     clearParseCache();
 
-    // ADR-013 dual-write: keep the memory store in sync with every decision
-    // persisted via the legacy gsd_save_decision path. Without this, prompts
-    // that still call gsd_save_decision (discuss.md, plan-milestone.md,
-    // plan-slice.md, et al.) would create decisions rows invisible to
-    // memory_query and loadMemoryBlock.
-    // Best-effort — never throw, never roll back the decision on failure.
-    try {
-      const { createMemory } = await import('./memory-store.js');
-      const decisionText = (fields.decision ?? '').trim();
-      const choiceText = (fields.choice ?? '').trim();
-      const rationaleText = (fields.rationale ?? '').trim();
-      const contentParts: string[] = [];
-      if (decisionText) contentParts.push(decisionText);
-      if (choiceText) contentParts.push(`Chose: ${choiceText}.`);
-      if (rationaleText) contentParts.push(`Rationale: ${rationaleText}.`);
-      const content = contentParts.join(' ').slice(0, 600);
-      if (content) {
-        createMemory({
-          category: 'architecture',
-          content,
-          scope: fields.scope || 'project',
-          confidence: 0.85,
-          structuredFields: {
-            sourceDecisionId: id,
-            when_context: fields.when_context ?? '',
-            scope: fields.scope,
-            decision: fields.decision,
-            choice: fields.choice,
-            rationale: fields.rationale,
-            made_by: fields.made_by ?? 'agent',
-            revisable: fields.revisable ?? '',
-          },
-        });
-      }
-    } catch (mirrorErr) {
-      logError('manifest', 'memory-store mirror write failed (non-fatal)', {
-        fn: 'saveDecisionToDb',
-        decisionId: id,
-        error: String((mirrorErr as Error).message),
-      });
-    }
-
     return { id };
   } catch (err) {
     logError('manifest', 'saveDecisionToDb failed', { fn: 'saveDecisionToDb', error: String((err as Error).message) });
     throw err;
   } finally {
     release!();
+  }
+}
+
+/**
+ * ADR-013 dual-write — mirror a freshly-saved decision into the `memories`
+ * table so the memory store remains the single source of truth for the
+ * DECISIONS.md projection (Stage 2a) and for prompt-inline reads (Stage 1).
+ *
+ * Best-effort: never throws, never rolls back the decision on failure.
+ * Caller invokes this AFTER the decisions-table write completes and
+ * BEFORE the projection regen — the regen sources from memories and would
+ * otherwise miss the just-saved decision.
+ */
+async function mirrorDecisionToMemory(
+  id: string,
+  fields: SaveDecisionFields,
+): Promise<void> {
+  try {
+    const { createMemory } = await import('./memory-store.js');
+    const decisionText = (fields.decision ?? '').trim();
+    const choiceText = (fields.choice ?? '').trim();
+    const rationaleText = (fields.rationale ?? '').trim();
+    const contentParts: string[] = [];
+    if (decisionText) contentParts.push(decisionText);
+    if (choiceText) contentParts.push(`Chose: ${choiceText}.`);
+    if (rationaleText) contentParts.push(`Rationale: ${rationaleText}.`);
+    const content = contentParts.join(' ').slice(0, 600);
+    if (!content) return;
+
+    createMemory({
+      category: 'architecture',
+      content,
+      scope: fields.scope || 'project',
+      confidence: 0.85,
+      structuredFields: {
+        sourceDecisionId: id,
+        when_context: fields.when_context ?? '',
+        scope: fields.scope,
+        decision: fields.decision,
+        choice: fields.choice,
+        rationale: fields.rationale,
+        made_by: fields.made_by ?? 'agent',
+        revisable: fields.revisable ?? '',
+        // New decisions are always written as active; md-importer can later
+        // set superseded_by on the source decision row, and the backfill's
+        // drift auto-heal pass propagates that update to this memory.
+        superseded_by: null,
+      },
+    });
+  } catch (mirrorErr) {
+    logError('manifest', 'memory-store mirror write failed (non-fatal)', {
+      fn: 'saveDecisionToDb',
+      decisionId: id,
+      error: String((mirrorErr as Error).message),
+    });
   }
 }
 

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -416,6 +416,16 @@ export interface SaveDecisionFields {
   source?: string;
 }
 
+type NormalizedSaveDecisionFields = Omit<
+  SaveDecisionFields,
+  'when_context' | 'revisable' | 'made_by' | 'source'
+> & {
+  when_context: string;
+  revisable: string;
+  made_by: NonNullable<SaveDecisionFields['made_by']>;
+  source: string;
+};
+
 /**
  * Save a new decision to DB and regenerate DECISIONS.md.
  * Auto-assigns the next ID via nextDecisionId().
@@ -447,19 +457,26 @@ export async function saveDecisionToDb(
     const db = await import('./gsd-db.js');
 
     const adapter = db._getAdapter();
+    const normalized: NormalizedSaveDecisionFields = {
+      ...fields,
+      when_context: fields.when_context ?? '',
+      revisable: fields.revisable ?? 'Yes',
+      made_by: fields.made_by ?? 'agent',
+      source: fields.source ?? 'discussion',
+    };
 
     const id = db.transaction(() => {
       const nextId = nextDecisionIdSync(adapter);
       db.upsertDecision({
         id: nextId,
-        when_context: fields.when_context ?? '',
-        scope: fields.scope,
-        decision: fields.decision,
-        choice: fields.choice,
-        rationale: fields.rationale,
-        revisable: fields.revisable ?? 'Yes',
-        made_by: fields.made_by ?? 'agent',
-        source: fields.source ?? 'discussion',
+        when_context: normalized.when_context,
+        scope: normalized.scope,
+        decision: normalized.decision,
+        choice: normalized.choice,
+        rationale: normalized.rationale,
+        revisable: normalized.revisable,
+        made_by: normalized.made_by,
+        source: normalized.source,
         superseded_by: null,
       });
 
@@ -471,7 +488,7 @@ export async function saveDecisionToDb(
     // happen before the projection regen below, because the regen now sources
     // from memories. If the dual-write ran after, the just-saved decision
     // would be missing from its own projection.
-    await mirrorDecisionToMemory(id, fields);
+    await mirrorDecisionToMemory(id, normalized);
 
     // Fetch all decisions (including superseded for the full register).
     // ADR-013 Stage 2a: source from the `memories` table. The Phase 5
@@ -555,18 +572,12 @@ export async function saveDecisionToDb(
  */
 async function mirrorDecisionToMemory(
   id: string,
-  fields: SaveDecisionFields,
+  fields: NormalizedSaveDecisionFields,
 ): Promise<void> {
   try {
     const { createMemory } = await import('./memory-store.js');
-    const decisionText = (fields.decision ?? '').trim();
-    const choiceText = (fields.choice ?? '').trim();
-    const rationaleText = (fields.rationale ?? '').trim();
-    const contentParts: string[] = [];
-    if (decisionText) contentParts.push(decisionText);
-    if (choiceText) contentParts.push(`Chose: ${choiceText}.`);
-    if (rationaleText) contentParts.push(`Rationale: ${rationaleText}.`);
-    const content = contentParts.join(' ').slice(0, 600);
+    const { synthesizeDecisionMemoryContent } = await import('./memory-backfill.js');
+    const content = synthesizeDecisionMemoryContent(fields);
     if (!content) return;
 
     createMemory({
@@ -576,13 +587,13 @@ async function mirrorDecisionToMemory(
       confidence: 0.85,
       structuredFields: {
         sourceDecisionId: id,
-        when_context: fields.when_context ?? '',
+        when_context: fields.when_context,
         scope: fields.scope,
         decision: fields.decision,
         choice: fields.choice,
         rationale: fields.rationale,
-        made_by: fields.made_by ?? 'agent',
-        revisable: fields.revisable ?? '',
+        made_by: fields.made_by,
+        revisable: fields.revisable,
         // New decisions are always written as active; md-importer can later
         // set superseded_by on the source decision row, and the backfill's
         // drift auto-heal pass propagates that update to this memory.

--- a/src/resources/extensions/gsd/memory-backfill.ts
+++ b/src/resources/extensions/gsd/memory-backfill.ts
@@ -1,9 +1,10 @@
 // GSD2 — Decisions -> memories backfill (ADR-013 step 5)
 //
-// Idempotent one-shot migration that copies every active decisions row into
-// the memories table with category="architecture" and a structured_fields
-// payload preserving the original gsd_save_decision schema (when_context,
-// scope, decision, choice, rationale, made_by, revisable, sourceDecisionId).
+// Idempotent migration that copies every decisions row (active and
+// superseded — see Stage 2a note below) into the memories table with
+// category="architecture" and a structured_fields payload preserving the
+// original gsd_save_decision schema (when_context, scope, decision, choice,
+// rationale, made_by, revisable, superseded_by, sourceDecisionId).
 //
 // The backfill exists so the cutover in ADR-013 step 6 can drop the
 // decisions table without losing schema fidelity. Idempotency is enforced
@@ -14,6 +15,13 @@
 // only ever fires once per project. Costs O(N) inserts on first run where
 // N is the active-decisions count; subsequent runs are an O(N) lookup that
 // finds existing markers and exits.
+//
+// ADR-013 Stage 2a (PR #5755): backfill now includes superseded rows so the
+// DECISIONS.md projection regen can source from memories without losing
+// historical entries. An auto-heal pass runs after the initial migration to
+// pick up superseded_by changes that occurred after the source decision was
+// already migrated (e.g. a fresh md-importer run that introduced a new
+// supersedes-chain).
 
 import { isDbAvailable, _getAdapter } from "./gsd-db.js";
 import { createMemory } from "./memory-store.js";
@@ -32,7 +40,7 @@ interface DecisionRow {
 }
 
 /**
- * Backfill active decisions rows into the memories table.
+ * Backfill decisions rows into the memories table.
  *
  * - Idempotent (per-row): every row written carries
  *   `structured_fields.sourceDecisionId = "<decisionId>"`. Each candidate
@@ -41,13 +49,18 @@ interface DecisionRow {
  *   their own `sourceDecisionId` does NOT abort the backfill.
  * - Best-effort: never throws. Logs and returns 0 on failure so a broken
  *   backfill cannot block agent startup.
- * - Active-only: skips rows where `superseded_by IS NOT NULL`. Superseded
- *   decisions are historical record; the memory store is for active
- *   knowledge.
+ * - Full migration (ADR-013 Stage 2a): both active and superseded rows are
+ *   migrated. `structured_fields.superseded_by` preserves the supersedes
+ *   chain so the DECISIONS.md projection regen can source from memories
+ *   without losing historical entries.
+ * - Drift auto-heal: after the initial insert pass, the function updates
+ *   any pre-existing memory whose `structured_fields.superseded_by` drifted
+ *   from the source decision (e.g. a fresh md-importer run introduced a
+ *   new supersedes annotation after the initial migration).
  *
  * Returns the number of memories written (0 when already backfilled or
- * when the DB has no decisions). Callers can log the result or surface it
- * to the user.
+ * when the DB has no decisions). Drift-heal updates are not counted in
+ * this return — they are logged separately.
  */
 export function backfillDecisionsToMemories(): number {
   if (!isDbAvailable()) return 0;
@@ -56,7 +69,7 @@ export function backfillDecisionsToMemories(): number {
 
   try {
     const decisions = adapter
-      .prepare("SELECT id, when_context, scope, decision, choice, rationale, made_by, revisable, superseded_by FROM decisions WHERE superseded_by IS NULL")
+      .prepare("SELECT id, when_context, scope, decision, choice, rationale, made_by, revisable, superseded_by FROM decisions")
       .all() as Array<Record<string, unknown>>;
 
     if (decisions.length === 0) return 0;
@@ -67,10 +80,14 @@ export function backfillDecisionsToMemories(): number {
     // sentinel would silently abort the backfill if a user manually called
     // capture_thought with their own structuredFields.sourceDecisionId.
     const checkExisting = adapter.prepare(
-      "SELECT 1 FROM memories WHERE structured_fields LIKE :pattern LIMIT 1",
+      "SELECT structured_fields FROM memories WHERE structured_fields LIKE :pattern LIMIT 1",
+    );
+    const updateStructuredFields = adapter.prepare(
+      "UPDATE memories SET structured_fields = :sf, updated_at = :ts WHERE structured_fields LIKE :pattern",
     );
 
     let written = 0;
+    let healed = 0;
     for (const raw of decisions) {
       const row: DecisionRow = {
         id: String(raw["id"] ?? ""),
@@ -85,9 +102,38 @@ export function backfillDecisionsToMemories(): number {
       };
       if (!row.id) continue;
 
-      // Pattern is anchored to the JSON-stringified shape and the exact
-      // decision id to avoid prefix collisions (e.g. "D1" vs "D10").
-      if (checkExisting.get({ ":pattern": `%"sourceDecisionId":"${row.id}"%` })) continue;
+      const pattern = `%"sourceDecisionId":"${row.id}"%`;
+      const existing = checkExisting.get({ ":pattern": pattern }) as
+        | { structured_fields: string | null }
+        | undefined;
+
+      if (existing) {
+        // Drift auto-heal: if the source decision's superseded_by has changed
+        // since the original migration, update the memory in place. Read-side
+        // queries reconstruct Decision.superseded_by from this field, so the
+        // DECISIONS.md projection stays accurate without us having to track
+        // supersedes events at the write site.
+        const currentSf = existing.structured_fields
+          ? (safeParse(existing.structured_fields) ?? {})
+          : {};
+        const memorySuperseded =
+          typeof currentSf["superseded_by"] === "string" || currentSf["superseded_by"] === null
+            ? (currentSf["superseded_by"] as string | null | undefined)
+            : null;
+        if (memorySuperseded !== row.superseded_by) {
+          const merged = {
+            ...currentSf,
+            superseded_by: row.superseded_by,
+          };
+          updateStructuredFields.run({
+            ":sf": JSON.stringify(merged),
+            ":ts": new Date().toISOString(),
+            ":pattern": pattern,
+          });
+          healed += 1;
+        }
+        continue;
+      }
 
       const content = synthesizeContent(row);
       const id = createMemory({
@@ -104,15 +150,31 @@ export function backfillDecisionsToMemories(): number {
           rationale: row.rationale,
           made_by: row.made_by,
           revisable: row.revisable,
+          superseded_by: row.superseded_by,
         },
       });
       if (id) written += 1;
+    }
+
+    if (healed > 0) {
+      logWarning(
+        "memory-backfill",
+        `decisions->memories drift healed: ${healed} row${healed === 1 ? "" : "s"} updated superseded_by`,
+      );
     }
 
     return written;
   } catch (e) {
     logWarning("memory-backfill", `decisions->memories backfill failed: ${(e as Error).message}`);
     return 0;
+  }
+}
+
+function safeParse(raw: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
   }
 }
 

--- a/src/resources/extensions/gsd/memory-backfill.ts
+++ b/src/resources/extensions/gsd/memory-backfill.ts
@@ -82,10 +82,10 @@ export function backfillDecisionsToMemories(): number {
     // sentinel would silently abort the backfill if a user manually called
     // capture_thought with their own structuredFields.sourceDecisionId.
     const checkExisting = adapter.prepare(
-      "SELECT structured_fields FROM memories WHERE structured_fields LIKE :pattern LIMIT 1",
+      "SELECT id, structured_fields FROM memories WHERE structured_fields LIKE :pattern LIMIT 1",
     );
     const updateStructuredFields = adapter.prepare(
-      "UPDATE memories SET structured_fields = :sf, updated_at = :ts WHERE structured_fields LIKE :pattern",
+      "UPDATE memories SET structured_fields = :sf, updated_at = :ts WHERE id = :id",
     );
 
     let written = 0;
@@ -106,7 +106,7 @@ export function backfillDecisionsToMemories(): number {
 
       const pattern = `%"sourceDecisionId":"${row.id}"%`;
       const existing = checkExisting.get({ ":pattern": pattern }) as
-        | { structured_fields: string | null }
+        | { id: string; structured_fields: string | null }
         | undefined;
 
       if (existing) {
@@ -128,9 +128,9 @@ export function backfillDecisionsToMemories(): number {
             superseded_by: row.superseded_by,
           };
           updateStructuredFields.run({
+            ":id": existing.id,
             ":sf": JSON.stringify(merged),
             ":ts": new Date().toISOString(),
-            ":pattern": pattern,
           });
           healed += 1;
         }

--- a/src/resources/extensions/gsd/memory-backfill.ts
+++ b/src/resources/extensions/gsd/memory-backfill.ts
@@ -39,6 +39,8 @@ interface DecisionRow {
   superseded_by: string | null;
 }
 
+type DecisionContentFields = Pick<DecisionRow, "decision" | "choice" | "rationale">;
+
 /**
  * Backfill decisions rows into the memories table.
  *
@@ -69,7 +71,7 @@ export function backfillDecisionsToMemories(): number {
 
   try {
     const decisions = adapter
-      .prepare("SELECT id, when_context, scope, decision, choice, rationale, made_by, revisable, superseded_by FROM decisions")
+      .prepare("SELECT id, when_context, scope, decision, choice, rationale, made_by, revisable, superseded_by FROM decisions ORDER BY seq")
       .all() as Array<Record<string, unknown>>;
 
     if (decisions.length === 0) return 0;
@@ -135,7 +137,7 @@ export function backfillDecisionsToMemories(): number {
         continue;
       }
 
-      const content = synthesizeContent(row);
+      const content = synthesizeDecisionMemoryContent(row);
       const id = createMemory({
         category: "architecture",
         content,
@@ -186,7 +188,7 @@ function safeParse(raw: string): Record<string, unknown> | null {
  * Truncates each field to keep the synthesized line under ~600 chars so
  * memory_query rendering stays readable.
  */
-function synthesizeContent(row: DecisionRow): string {
+export function synthesizeDecisionMemoryContent(row: DecisionContentFields): string {
   const trim = (value: string, max: number): string => {
     const cleaned = value.replace(/\s+/g, " ").trim();
     return cleaned.length > max ? cleaned.slice(0, max - 1) + "\u2026" : cleaned;

--- a/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
+++ b/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
@@ -187,6 +187,64 @@ test("backfill auto-heals when a source decision's superseded_by changes after m
   }
 });
 
+test("backfill drift auto-heal updates only the selected memory row", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001",
+      scope: "M001",
+      decision: "Original",
+      choice: "A",
+      rationale: "r",
+    });
+    backfillDecisionsToMemories();
+
+    const adapter = _getAdapter();
+    if (!adapter) throw new Error("DB adapter unavailable");
+    const now = new Date().toISOString();
+    adapter
+      .prepare(
+        `INSERT INTO memories (
+          id, category, content, confidence, created_at, updated_at, scope, tags, structured_fields
+        ) VALUES (
+          :id, 'architecture', 'duplicate marker', 0.8, :created_at, :updated_at, 'project', '[]', :structured_fields
+        )`,
+      )
+      .run({
+        ":id": "manual-duplicate-D001",
+        ":created_at": now,
+        ":updated_at": now,
+        ":structured_fields": JSON.stringify({
+          sourceDecisionId: "D001",
+          superseded_by: null,
+          note: "manual duplicate should not be healed as a side effect",
+        }),
+      });
+
+    setDecisionSupersededBy("D001", "D002");
+    backfillDecisionsToMemories();
+
+    const rows = adapter
+      .prepare("SELECT id, structured_fields FROM memories WHERE structured_fields LIKE :pattern ORDER BY seq")
+      .all({ ":pattern": '%"sourceDecisionId":"D001"%' }) as Array<{
+        id: string;
+        structured_fields: string;
+      }>;
+    assert.equal(rows.length, 2);
+    const healed = rows.find((row) => row.id !== "manual-duplicate-D001");
+    const duplicate = rows.find((row) => row.id === "manual-duplicate-D001");
+    assert.equal(JSON.parse(healed?.structured_fields ?? "{}").superseded_by, "D002");
+    assert.equal(
+      JSON.parse(duplicate?.structured_fields ?? "{}").superseded_by,
+      null,
+      "drift auto-heal must not update every memory matching the sourceDecisionId pattern",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
 // ─── queryDecisionsFromMemories: active-only via structuredFields ──────────
 
 test("queryDecisionsFromMemories filters out rows whose structuredFields.superseded_by is set", () => {

--- a/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
+++ b/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
@@ -1,0 +1,372 @@
+// ADR-013 Phase 6 cutover (Stage 2a) — locks in the four behavioral changes:
+//
+//   1. memory-backfill includes superseded decisions + preserves
+//      structuredFields.superseded_by
+//   2. memory-backfill drift auto-heal: when a decision's superseded_by
+//      changes after migration, the memory's structuredFields update
+//   3. context-store.queryDecisionsFromMemories filters out rows whose
+//      structuredFields.superseded_by is set (active-only)
+//   4. context-store.getAllDecisionsFromMemories returns the full register
+//      including superseded rows, and the saveDecisionToDb projection regen
+//      uses it — producing byte-equivalent DECISIONS.md to the legacy path
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  _getAdapter,
+  closeDatabase,
+  insertDecision,
+  openDatabase,
+} from "../gsd-db.ts";
+import { saveDecisionToDb, generateDecisionsMd } from "../db-writer.ts";
+import {
+  getAllDecisionsFromMemories,
+  queryDecisionsFromMemories,
+} from "../context-store.ts";
+import { backfillDecisionsToMemories } from "../memory-backfill.ts";
+import type { Decision } from "../types.ts";
+
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-decisions-stage2a-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  return base;
+}
+
+function cleanup(base: string): void {
+  try {
+    closeDatabase();
+  } catch {
+    /* noop */
+  }
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* noop */
+  }
+}
+
+function seedRawDecision(args: {
+  id: string;
+  when_context: string;
+  scope: string;
+  decision: string;
+  choice: string;
+  rationale: string;
+  revisable?: string;
+  made_by?: "human" | "agent" | "collaborative";
+  superseded_by?: string | null;
+}): void {
+  insertDecision({
+    id: args.id,
+    when_context: args.when_context,
+    scope: args.scope,
+    decision: args.decision,
+    choice: args.choice,
+    rationale: args.rationale,
+    revisable: args.revisable ?? "Yes",
+    made_by: args.made_by ?? "agent",
+    superseded_by: args.superseded_by ?? null,
+  });
+}
+
+function setDecisionSupersededBy(id: string, supersededBy: string): void {
+  const adapter = _getAdapter();
+  if (!adapter) throw new Error("DB adapter unavailable");
+  adapter
+    .prepare("UPDATE decisions SET superseded_by = :s WHERE id = :id")
+    .run({ ":s": supersededBy, ":id": id });
+}
+
+// ─── Backfill: superseded inclusion + structuredFields preservation ────────
+
+test("backfill migrates superseded decisions (no active-only filter)", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001 discuss",
+      scope: "M001",
+      decision: "Use A",
+      choice: "A",
+      rationale: "first idea",
+      superseded_by: "D002",
+    });
+    seedRawDecision({
+      id: "D002",
+      when_context: "M001 discuss",
+      scope: "M001",
+      decision: "Switch to B",
+      choice: "B",
+      rationale: "second thought",
+      superseded_by: null,
+    });
+
+    const written = backfillDecisionsToMemories();
+    assert.equal(written, 2, "both active and superseded rows should be migrated");
+
+    const all = getAllDecisionsFromMemories();
+    assert.equal(all.length, 2);
+    const d001 = all.find((d) => d.id === "D001");
+    const d002 = all.find((d) => d.id === "D002");
+    assert.ok(d001 && d002);
+    assert.equal(d001.superseded_by, "D002", "structuredFields.superseded_by must be preserved");
+    assert.equal(d002.superseded_by, null);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("backfill is idempotent — re-running over migrated rows is a no-op", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001",
+      scope: "M001",
+      decision: "x",
+      choice: "y",
+      rationale: "z",
+    });
+
+    const first = backfillDecisionsToMemories();
+    assert.equal(first, 1);
+    const second = backfillDecisionsToMemories();
+    assert.equal(second, 0, "already-migrated rows must not be re-inserted");
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── Drift auto-heal ───────────────────────────────────────────────────────
+
+test("backfill auto-heals when a source decision's superseded_by changes after migration", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001",
+      scope: "M001",
+      decision: "Original",
+      choice: "A",
+      rationale: "r",
+    });
+    // Initial migration: D001 is active.
+    backfillDecisionsToMemories();
+    const beforeHeal = getAllDecisionsFromMemories().find((d) => d.id === "D001");
+    assert.equal(beforeHeal?.superseded_by, null);
+
+    // Simulate md-importer setting superseded_by on the existing decision row.
+    seedRawDecision({
+      id: "D002",
+      when_context: "M001",
+      scope: "M001",
+      decision: "New",
+      choice: "B",
+      rationale: "newer",
+    });
+    setDecisionSupersededBy("D001", "D002");
+
+    // Second backfill pass: should heal D001's memory + migrate D002.
+    backfillDecisionsToMemories();
+
+    const afterHeal = getAllDecisionsFromMemories().find((d) => d.id === "D001");
+    assert.equal(
+      afterHeal?.superseded_by,
+      "D002",
+      "drift auto-heal must update structuredFields.superseded_by on existing migrated memories",
+    );
+    const d002 = getAllDecisionsFromMemories().find((d) => d.id === "D002");
+    assert.equal(d002?.superseded_by, null, "newly-migrated D002 stays active");
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── queryDecisionsFromMemories: active-only via structuredFields ──────────
+
+test("queryDecisionsFromMemories filters out rows whose structuredFields.superseded_by is set", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001",
+      scope: "M001",
+      decision: "Old",
+      choice: "A",
+      rationale: "r1",
+      superseded_by: "D002",
+    });
+    seedRawDecision({
+      id: "D002",
+      when_context: "M001",
+      scope: "M001",
+      decision: "New",
+      choice: "B",
+      rationale: "r2",
+    });
+    backfillDecisionsToMemories();
+
+    const active = queryDecisionsFromMemories();
+    assert.equal(active.length, 1, "only the non-superseded decision should appear");
+    assert.equal(active[0]?.id, "D002");
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── getAllDecisionsFromMemories: full register including superseded ───────
+
+test("getAllDecisionsFromMemories returns the full register including superseded", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001",
+      scope: "M001",
+      decision: "First",
+      choice: "A",
+      rationale: "r1",
+      superseded_by: "D002",
+    });
+    seedRawDecision({
+      id: "D002",
+      when_context: "M001",
+      scope: "M001",
+      decision: "Second",
+      choice: "B",
+      rationale: "r2",
+    });
+    backfillDecisionsToMemories();
+
+    const all = getAllDecisionsFromMemories();
+    assert.equal(all.length, 2);
+    assert.deepEqual(
+      all.map((d) => ({ id: d.id, superseded_by: d.superseded_by })),
+      [
+        { id: "D001", superseded_by: "D002" },
+        { id: "D002", superseded_by: null },
+      ],
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── Projection parity: legacy table source vs memories source ─────────────
+
+function decisionFromLegacyRow(row: Record<string, unknown>): Decision {
+  return {
+    seq: row["seq"] as number,
+    id: row["id"] as string,
+    when_context: row["when_context"] as string,
+    scope: row["scope"] as string,
+    decision: row["decision"] as string,
+    choice: row["choice"] as string,
+    rationale: row["rationale"] as string,
+    revisable: row["revisable"] as string,
+    made_by: ((row["made_by"] as string) ?? "agent") as Decision["made_by"],
+    superseded_by: (row["superseded_by"] as string) ?? null,
+  };
+}
+
+test("DECISIONS.md projection from memories matches the legacy decisions-table render", async () => {
+  const base = makeTmpBase();
+  try {
+    // Seed three decisions with mixed superseded chains directly into the
+    // decisions table to ensure the legacy-side fixture is realistic.
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001 discuss",
+      scope: "M001",
+      decision: "Initial direction",
+      choice: "A",
+      rationale: "rationale-1",
+      superseded_by: "D003",
+    });
+    seedRawDecision({
+      id: "D002",
+      when_context: "M001 plan",
+      scope: "M001-S01",
+      decision: "Active call",
+      choice: "B",
+      rationale: "rationale-2",
+    });
+    seedRawDecision({
+      id: "D003",
+      when_context: "M002 review",
+      scope: "M002",
+      decision: "Replacement for D001",
+      choice: "C",
+      rationale: "rationale-3",
+    });
+
+    // Run backfill so memories carries the full chain.
+    backfillDecisionsToMemories();
+
+    // Legacy render: read the decisions table directly, render via the
+    // existing generateDecisionsMd helper.
+    const adapter = _getAdapter();
+    if (!adapter) throw new Error("DB adapter unavailable");
+    const legacyRows = adapter.prepare("SELECT * FROM decisions ORDER BY seq").all() as Array<
+      Record<string, unknown>
+    >;
+    const legacyDecisions = legacyRows.map(decisionFromLegacyRow);
+    const legacyMd = generateDecisionsMd(legacyDecisions);
+
+    // Memory-sourced render: same generator, but Decision[] from memories.
+    const memoryDecisions = getAllDecisionsFromMemories();
+    const memoryMd = generateDecisionsMd(memoryDecisions);
+
+    assert.equal(memoryMd, legacyMd, "memory-sourced projection must match decisions-table render byte-for-byte");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("saveDecisionToDb writes a DECISIONS.md projection sourced from memories that round-trips", async () => {
+  const base = makeTmpBase();
+  try {
+    // Use the public write path so dual-write + projection happen end-to-end.
+    await saveDecisionToDb(
+      {
+        when_context: "M001 discuss",
+        scope: "M001",
+        decision: "Adopt SQLite",
+        choice: "better-sqlite3",
+        rationale: "synchronous + native",
+        revisable: "Yes",
+        made_by: "agent",
+      },
+      base,
+    );
+    await saveDecisionToDb(
+      {
+        when_context: "M001 plan",
+        scope: "M001-S01",
+        decision: "Schema versioning",
+        choice: "header column",
+        rationale: "simplest to read",
+        revisable: "Yes",
+        made_by: "agent",
+      },
+      base,
+    );
+
+    const md = readFileSync(join(base, ".gsd", "DECISIONS.md"), "utf-8");
+    // The projection must include both rows by ID — proving the regen
+    // sourced from memories (where dual-write landed them) rather than
+    // silently skipping anything.
+    assert.match(md, /\| D001 \|/);
+    assert.match(md, /\| D002 \|/);
+    assert.match(md, /Adopt SQLite/);
+    assert.match(md, /Schema versioning/);
+    assert.match(md, /# Decisions Register/);
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
+++ b/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
@@ -351,8 +351,6 @@ test("saveDecisionToDb writes a DECISIONS.md projection sourced from memories th
         decision: "Schema versioning",
         choice: "header column",
         rationale: "simplest to read",
-        revisable: "Yes",
-        made_by: "agent",
       },
       base,
     );
@@ -366,6 +364,7 @@ test("saveDecisionToDb writes a DECISIONS.md projection sourced from memories th
     assert.match(md, /Adopt SQLite/);
     assert.match(md, /Schema versioning/);
     assert.match(md, /# Decisions Register/);
+    assert.match(md, /\| D002 \|[^\n]*\| Yes \| agent \|/);
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## Summary

Stage 2a of 3 for ADR-013 Phase 6 cutover (#5755). Completes the **decisions side** of the cutover by sourcing the `DECISIONS.md` projection regen from the `memories` table. Pairs with Stage 1 (#5767, prompt-inline read switch). KNOWLEDGE.md cutover lives in Stage 2b; the actual destructive write removal lives in Stage 3.

> **Builds on PR #5767** — branch is cut from that PR's branch. Merge order: #5767 first, then this. If you want to review them together, the diffs are additive.

## What changes

| File | Change |
|---|---|
| `memory-backfill.ts` | Backfill includes superseded decisions + preserves `superseded_by` in structuredFields + drift auto-heal pass |
| `db-writer.ts` | Mirror-to-memory extracted to `mirrorDecisionToMemory()` and reordered to run **before** the projection regen (otherwise the just-saved decision would be missing from its own projection). Projection regen `SELECT * FROM decisions` → `getAllDecisionsFromMemories()`. |
| `context-store.ts` | `queryDecisionsFromMemories` now reads `superseded_by` from structuredFields (was always null). New `getAllDecisionsFromMemories` for the full register. Both share a `readDecisionsFromMemories` core. |

## Why this is safe to ship now

- **Parity test asserts byte-equivalence** between the memory-sourced projection and the legacy decisions-table-sourced projection over a fixture with mixed active+superseded decisions.
- **Phase 5 dual-write is intact** — every `gsd_save_decision` call still writes to both tables. The change is just where the projection *reads* from.
- **Drift auto-heal** handles the one case where the two surfaces could disagree: an `md-importer` run setting `superseded_by` on a decision after its memory was already migrated. On the next session start, the heal pass updates the memory's structuredFields in place.
- **Reversible** — revert flips the projection back to the decisions-table source. No data loss possible; both surfaces remain populated.

## What this PR does *not* do

- ❌ Stop writes to the `decisions` table — Stage 3.
- ❌ Drop the `decisions` table — #5756, gated on Stage 3 baking.
- ❌ KNOWLEDGE.md cutover — Stage 2b. Has a real design choice (Rules handling per ADR-013 line 39) that's worth its own PR.

## Test plan

- [x] 7 new tests in `decisions-projection-from-memories.test.ts` covering backfill superseded inclusion, idempotency, drift auto-heal, queryDecisionsFromMemories active filter via structuredFields, getAllDecisionsFromMemories full register, projection parity (memory vs legacy), saveDecisionToDb end-to-end
- [x] No regression — combined run: 105/105 across `context-store`, `gsd-tools`, `db-writer`, `freeform-decisions`, `memory-consolidation-scanner`, `memory-store`, Stage 1, and Stage 2a

## Sequencing

| Stage | Issue | PR | State |
|---|---|---|---|
| 1 — Prompt-inline read switch | #5755 | #5767 | Open, review pending |
| **2a — DECISIONS.md projection switch (this PR)** | #5755 | **this** | Open |
| 2b — KNOWLEDGE.md cutover + `/gsd knowledge` redirect | #5755 | follow-up | Not started |
| 3 — Destructive: stop decisions-table writes | #5755 | final | Not started |
| Drop decisions table | #5756 | future | Gated on Stage 3 baking |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View and export both active and superseded decisions as a complete register.

* **Improvements**
  * Unified querying and persistence so projections are generated from the consolidated memory-backed source.
  * Migrations now include superseded entries, are idempotent, and auto-heal drift between sources.
  * Decision saves mirror into context storage before regenerating projections for consistency.

* **Tests**
  * End-to-end suite validating migration, filtering, drift-heal, and projection parity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5769)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->