### PR TITLE
feat(adr-013): /gsd knowledge routes pattern + lesson to memories (stage 2c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ Every dispatch is carefully constructed. The LLM never wastes tool calls on orie
 | `PROJECT.md`       | Living doc — what the project is right now                      |
 | `REQUIREMENTS.md`  | Project-level capability contract and out-of-scope list         |
 | `DECISIONS.md`     | Append-only register of architectural decisions                 |
-| `KNOWLEDGE.md`     | Cross-session rules, patterns, and lessons learned              |
+| `KNOWLEDGE.md`     | Hybrid knowledge projection: manual Rules plus memory-backed Patterns/Lessons |
 | `RUNTIME.md`       | Runtime context — API endpoints, env vars, services (v2.39)     |
 | `runtime/research-decision.json` | Deep-mode marker for project research vs skip       |
 | `research/*.md`    | Optional deep-mode project research: stack, features, architecture, pitfalls |
@@ -584,6 +584,12 @@ Every task has must-haves — mechanically checkable outcomes:
 - **Key Links** — Imports and wiring between artifacts
 
 The verification ladder: static checks → command execution → behavioral testing → human review (only when the agent genuinely can't verify itself).
+
+### Project Knowledge
+
+`.gsd/KNOWLEDGE.md` remains the human-readable register for durable project knowledge, but the memory store is now authoritative for generated Patterns and Lessons. On startup, GSD backfills existing `## Patterns` and `## Lessons Learned` rows into `gsd.db` memories, then rewrites `KNOWLEDGE.md` as a hybrid projection: the manual `## Rules` section is preserved from the file, while Patterns and Lessons are rendered from the backfilled memory rows.
+
+Keep hand-authored operating rules in `## Rules` or add them with `/gsd knowledge rule`. Patterns and Lessons that agents discover are retrieved through the memory system for prompts and projected back into `KNOWLEDGE.md` for review, reports, and git history.
 
 ### Dashboard
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,8 @@ Auto mode is a state machine driven by the GSD database at the project root. It 
 
 The database is authoritative for milestones, slices, tasks, requirements, decisions, summaries, and completion status. Markdown under `.gsd/` is a rendered projection for review, prompts, and git-friendly history; it is not a runtime fallback unless you explicitly run a recovery/import command. In worktree mode, project-root DB state remains authoritative and worktree markdown projections are not synced back as state.
 
+`KNOWLEDGE.md` is hybrid: rules remain file-canonical, while patterns and lessons are stored in the `memories` table and rendered back into `KNOWLEDGE.md` on the next session-start projection. Existing pattern and lesson rows are backfilled into memories before projection, so newly captured patterns and lessons may appear in memory-backed prompt context before the file view refreshes.
+
 **What happens under the hood:**
 
 1. **Fresh session per unit** — Every task, every research phase, every planning step gets a clean 200k-token context window. No accumulated garbage. No "I'll be more concise now."
@@ -543,7 +545,7 @@ Every dispatch is carefully constructed. The LLM never wastes tool calls on orie
 | `PROJECT.md`       | Living doc — what the project is right now                      |
 | `REQUIREMENTS.md`  | Project-level capability contract and out-of-scope list         |
 | `DECISIONS.md`     | Append-only register of architectural decisions                 |
-| `KNOWLEDGE.md`     | Cross-session rules, patterns, and lessons learned              |
+| `KNOWLEDGE.md`     | Cross-session rules plus projected memory-backed patterns and lessons learned |
 | `RUNTIME.md`       | Runtime context — API endpoints, env vars, services (v2.39)     |
 | `runtime/research-decision.json` | Deep-mode marker for project research vs skip       |
 | `research/*.md`    | Optional deep-mode project research: stack, features, architecture, pitfalls |
@@ -829,7 +831,7 @@ gsd (CLI binary)
 - **`pkg/` shim directory** — `PI_PACKAGE_DIR` points here (not project root) to avoid Pi's theme resolution collision with our `src/` directory. Contains only `piConfig` and theme assets.
 - **Two-file loader pattern** — `loader.ts` sets all env vars with zero SDK imports, then dynamic-imports `cli.ts` which does static SDK imports. This ensures `PI_PACKAGE_DIR` is set before any SDK code evaluates.
 - **Always-overwrite sync** — `npm update -g` takes effect immediately. Bundled extensions and agents are synced to `~/.gsd/agent/` on every launch, not just first run.
-- **DB-authoritative state** — the project-root GSD database is the runtime source of truth. `.gsd/` markdown files are rendered projections for review, prompt context, and git history. No in-memory state survives across sessions.
+- **DB-authoritative state** — the project-root GSD database is the runtime source of truth. `.gsd/` markdown files are rendered projections for review, prompt context, and git history. `KNOWLEDGE.md` keeps rules file-canonical and projects patterns/lessons from `memories` at session start. No in-memory state survives across sessions.
 
 ---
 

--- a/docs/db-map.md
+++ b/docs/db-map.md
@@ -666,7 +666,7 @@ runtime_kv  (soft state KV)
 
 | Tool | Tables READ | Tables WRITTEN | Disk Artifacts |
 |------|------------|----------------|----------------|
-| `gsd_decision_save` | decisions | decisions | DECISIONS.md (regenerated) |
+| `gsd_decision_save` | decisions | decisions, memories | DECISIONS.md (regenerated from memories) |
 | `gsd_requirement_save` | requirements | requirements | REQUIREMENTS.md |
 | `gsd_requirement_update` | requirements | requirements | REQUIREMENTS.md |
 | `gsd_summary_save` | milestones, slices, tasks | artifacts | M##/S##/T## artifact files |
@@ -685,7 +685,7 @@ runtime_kv  (soft state KV)
 | `gsd_slice_reopen` | slices, tasks, milestones | slices, tasks | deletes S##-SUMMARY.md, UAT, all T##-SUMMARY.md |
 | `gsd_milestone_reopen` | milestones, slices, tasks | milestones, slices, tasks | deletes all summaries |
 | `gsd_save_gate_result` | quality_gates | quality_gates, gate_runs | — |
-| `capture_thought` | memories | memories | KNOWLEDGE.md |
+| `capture_thought` | memories | memories | KNOWLEDGE.md projection for backfilled Patterns/Lessons |
 | `memory_query` | memories, memories_fts, memory_embeddings | memories (hit_count++) | — |
 
 ---

--- a/docs/dev/ADR-013-memory-store-consolidation.md
+++ b/docs/dev/ADR-013-memory-store-consolidation.md
@@ -36,7 +36,7 @@ The two surfaces are not just redundant; they fragment durable knowledge across 
 |---|---|
 | `memories` table | **Canonical** durable knowledge store. All `capture_thought` writes land here. All `memory_query` reads come from here. Auto-injected via a new `loadMemoryBlock` analogous to `loadKnowledgeBlock`. |
 | `.gsd/DECISIONS.md` | **Read-only projection** rendered from `memories` rows where `category = "architecture"`. Continues to satisfy human review and external MCP consumers. |
-| `.gsd/KNOWLEDGE.md` | **Read-only projection** rendered from `memories` rows where `category in ("pattern", "convention", "gotcha")`. Continues to satisfy human review and external MCP consumers. Rules table (manually authored via `/gsd knowledge`) is a separate concern and is **not** migrated. |
+| `.gsd/KNOWLEDGE.md` | **Hybrid projection**. The Rules table remains manually authored and preserved from the file. Existing Patterns and Lessons are backfilled into `memories`, then projected from memory rows that carry `structuredFields.sourceKnowledgeId`. Continues to satisfy human review, reports, and external MCP consumers. |
 | `.gsd/milestones/*/M*-LEARNINGS.md` | **Audit trail** of each extraction. Unchanged — written by `buildExtractionStepsBlock` Step 2; never read back by automation. |
 | `decisions` table | **Removed** in step 6 after backfill into `memories` completes. |
 
@@ -47,7 +47,13 @@ The two surfaces are not just redundant; they fragment durable knowledge across 
 3. **Register `capture_thought` and `memory_query` in `packages/mcp-server/src/server.ts`.** Resolve the `gsd_graph` name collision by renaming the memory variant to `gsd_memory_graph` (or namespacing similarly). External MCP clients (studio, vscode-extension) gain access to the new surface before any cutover removes their current sources.
 4. **Auto-injection parity in `src/resources/extensions/gsd/bootstrap/system-context.ts`.** Implement `loadMemoryBlock` mirroring `loadKnowledgeBlock`: query top-N highest-confidence and most-reinforced memories scoped to the project, inject on `before_agent_start`. After this lands, `memory_query` becomes a discretionary refinement, not the only path to retrieval.
 5. **Backfill `decisions` -> `memories`.** Idempotent migration runs on the next `session_start` after a migration version bump. Each `decisions` row produces a `memories` row with `category = "architecture"`, `content` synthesised from `decision + choice + rationale`, and `structuredFields` populated verbatim. Re-running the migration is a no-op (matched on `structuredFields.sourceDecisionId`).
-6. **Cutover.** Remove KNOWLEDGE.md / DECISIONS.md / `gsd_save_decision` write paths from `buildExtractionStepsBlock`, `execute-task.md`, `complete-slice.md`. Replace with single `capture_thought` calls. Re-render DECISIONS.md and KNOWLEDGE.md from the `memories` table on every project mutation that touches them. Update remaining #4429 regression tests. Deprecate the `decisions` table (read-only for one minor version, then drop).
+6. **Cutover.** Remove KNOWLEDGE.md / DECISIONS.md / `gsd_save_decision` write paths from `buildExtractionStepsBlock`, `execute-task.md`, `complete-slice.md`. Replace with single `capture_thought` calls. Re-render DECISIONS.md and KNOWLEDGE.md from the `memories` table through the projection hooks that own those files. Update remaining #4429 regression tests. Deprecate the `decisions` table (read-only for one minor version, then drop).
+
+### Stage 2b startup projection
+
+The Stage 2b cutover is intentionally conservative for `KNOWLEDGE.md`. During `before_agent_start`, GSD runs an idempotent backfill that copies existing `## Patterns` rows into `memories` with `category = "pattern"` and existing `## Lessons Learned` rows into `memories` with `category = "gotcha"`. Each backfilled row carries `structuredFields.sourceKnowledgeId` so repeated startups do not duplicate memories.
+
+After the backfill, GSD rewrites `.gsd/KNOWLEDGE.md` as a hybrid projection. Intro prose and the `## Rules` section are preserved from the file because Rules remain manual operating constraints. The `## Patterns` and `## Lessons Learned` sections are rendered from memory rows with `sourceKnowledgeId`; memories captured directly through `capture_thought` stay available through memory injection and `memory_query` but are not automatically dumped into `KNOWLEDGE.md`.
 
 ### Cutover criteria
 
@@ -81,14 +87,14 @@ If step 6 must be rolled back after the `decisions` table is dropped, a forward 
 
 ### Caveats
 
-- KNOWLEDGE.md and DECISIONS.md become projections. Manual edits are already overwritten today (DECISIONS.md is DB-projected) — the change extends that contract to KNOWLEDGE.md, which currently accepts manual appends. Anyone hand-editing KNOWLEDGE.md after step 6 will see their changes discarded on the next render. The migration commits include a one-time scan that warns if any KNOWLEDGE.md row in the working tree has no corresponding `memories` row at cutover time.
+- DECISIONS.md becomes a DB projection, and KNOWLEDGE.md becomes a hybrid projection. Manual edits to KNOWLEDGE.md Rules are preserved; manual edits to Patterns or Lessons should be made through the memory-backed knowledge tools because those sections are regenerated from `memories` on startup projection.
 - `category` enum is fixed at six values (`architecture | convention | gotcha | pattern | preference | environment`). Adding a seventh requires a schema change. The current set is adequate for the migration; future categories are out of scope for this ADR.
 - The `structuredFields` blob is intentionally schemaless inside the JSON. Schema for `architecture`-category memories is documented in step 2's commit; future categories may grow their own structured shapes.
 
 ### Excluded from scope
 
 - `src/resources/agents/scout.md` keeps its read-only contract — orchestrator captures, scout doesn't. The audit confirmed adding `capture_thought` to scout would violate the agent's stated purpose.
-- The `## Rules` table inside `.gsd/KNOWLEDGE.md` is manually authored via `/gsd knowledge` and is a different concern; not migrated.
+- The `## Rules` table inside `.gsd/KNOWLEDGE.md` is manually authored via `/gsd knowledge rule` and is a different concern; not migrated.
 - The auto-extraction memory pipeline at `packages/pi-coding-agent/src/resources/extensions/memory/` (a separate `memory_summary.md` injection from session transcripts) is independent of this consolidation. Whether to merge those two memory surfaces is a follow-up ADR.
 
 ### Follow-ups

--- a/docs/prompt-map.md
+++ b/docs/prompt-map.md
@@ -79,8 +79,8 @@ Static section
     └── DECISIONS.md
 
 Semi-static section
-    ├── KNOWLEDGE.md  (manual rules projection)
-    ├── memories      (prompt-relevant patterns, gotchas, decisions)
+    ├── KNOWLEDGE.md  (hybrid file: manual rules plus projected patterns/lessons from memories)
+    ├── memories      (prompt-relevant patterns, gotchas, decisions; may overlap the projected KNOWLEDGE.md entries)
     ├── PREFERENCES.md
     └── Prior slice/milestone RESEARCH.md
 
@@ -92,6 +92,11 @@ Dynamic section
     ├── Carry-forward captures
     └── Gate list to close
 ```
+
+Before this map is assembled, `buildBeforeAgentStartResult()` runs the
+session-start KNOWLEDGE backfill/projection path and then calls
+`loadKnowledgeBlock()`. That helper inlines the current hybrid
+`.gsd/KNOWLEDGE.md` file, not only the manual Rules section.
 
 Budget enforcement: `context-budget.ts` computes `preambleBudgetChars`, `summaryBudgetChars`, `verificationBudgetChars` from the model's context window. Sections are truncated at markdown section boundaries, not mid-sentence.
 

--- a/docs/prompt-map.md
+++ b/docs/prompt-map.md
@@ -79,7 +79,8 @@ Static section
     └── DECISIONS.md
 
 Semi-static section
-    ├── KNOWLEDGE.md  (patterns, gotchas)
+    ├── KNOWLEDGE.md  (manual rules projection)
+    ├── memories      (prompt-relevant patterns, gotchas, decisions)
     ├── PREFERENCES.md
     └── Prior slice/milestone RESEARCH.md
 
@@ -419,9 +420,9 @@ LLM sees: "load these skill files and follow their rules for this unit"
 | `gsd_requirement_save` | requirements table |
 | `gsd_requirement_update` | requirements table |
 | `gsd_summary_save` | artifact files + DB reference |
-| `gsd_decision_save` | DECISIONS.md + DB |
-| `capture_thought` | KNOWLEDGE.md (patterns, gotchas, arch) |
-| `memory_query` | READ — queries KNOWLEDGE.md + summaries |
+| `gsd_decision_save` | decisions table + mirrored architecture memory; DECISIONS.md projection reads memories |
+| `capture_thought` | memories (patterns, gotchas, arch) |
+| `memory_query` | READ — queries memories |
 | `ask_user_questions` | blocks until user responds; no DB write |
 | `subagent` | spins up child Pi session with given prompt |
 

--- a/docs/prompt-map.md
+++ b/docs/prompt-map.md
@@ -79,8 +79,8 @@ Static section
     └── DECISIONS.md
 
 Semi-static section
-    ├── KNOWLEDGE.md  (hybrid file: manual rules plus projected patterns/lessons from memories)
-    ├── memories      (prompt-relevant patterns, gotchas, decisions; may overlap the projected KNOWLEDGE.md entries)
+    ├── KNOWLEDGE.md  (manual rules only — patterns/lessons stripped; ADR-013 Stage 2c)
+    ├── memories      (prompt-relevant patterns, gotchas, decisions — canonical for patterns/lessons)
     ├── PREFERENCES.md
     └── Prior slice/milestone RESEARCH.md
 
@@ -95,8 +95,9 @@ Dynamic section
 
 Before this map is assembled, `buildBeforeAgentStartResult()` runs the
 session-start KNOWLEDGE backfill/projection path and then calls
-`loadKnowledgeBlock()`. That helper inlines the current hybrid
-`.gsd/KNOWLEDGE.md` file, not only the manual Rules section.
+`loadKnowledgeBlock()`. That helper inlines only manual Rules from the project
+`.gsd/KNOWLEDGE.md` file; projected patterns and lessons are supplied through
+the memories layer.
 
 Budget enforcement: `context-budget.ts` computes `preambleBudgetChars`, `summaryBudgetChars`, `verificationBudgetChars` from the model's context window. Sections are truncated at markdown section boundaries, not mid-sentence.
 

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -157,7 +157,9 @@ No manual intervention needed for transient errors — the session pauses briefl
 
 ### Incremental Memory (v2.26)
 
-GSD maintains a `KNOWLEDGE.md` file — an append-only register of project-specific rules, patterns, and lessons learned. The agent reads it at the start of every unit and appends to it when discovering recurring issues, non-obvious patterns, or rules that future sessions should follow. This gives auto-mode cross-session memory that survives context window boundaries.
+GSD maintains durable project memory in `gsd.db` and projects the reviewable subset into `.gsd/KNOWLEDGE.md`. On startup, existing `KNOWLEDGE.md` Patterns and Lessons are backfilled into memories, then the file is rewritten as a hybrid projection: manual Rules remain in the file, while generated Patterns and Lessons are rendered from memory rows.
+
+Agents use the memory system when deciding what project knowledge to inject into prompts, so cross-session memory survives context window boundaries without depending on manual markdown edits. Use `/gsd knowledge rule` for hand-authored operating rules; recurring patterns and lessons discovered during work are stored as memories and shown in `KNOWLEDGE.md` for review.
 
 ### Context Pressure Monitor (v2.26)
 

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -31,9 +31,9 @@
 | `/gsd export --html` | Generate self-contained HTML report for current or completed milestone |
 | `/gsd export --html --all` | Generate retrospective reports for all milestones at once |
 | `/gsd update` | Update GSD to the latest version in-session |
-| `/gsd knowledge` | Add persistent project knowledge. Rules remain manually maintained in `KNOWLEDGE.md`; patterns and lessons are memory-backed and projected into the file. |
+| `/gsd knowledge` | Add persistent project knowledge. Rules remain manually maintained in `KNOWLEDGE.md`; pattern and lesson updates are deferred and appear in the file on the next session start. |
 | `/gsd eval-review <sliceId>` | Audit a slice's AI evaluation strategy and write a scored `<sliceId>-EVAL-REVIEW.md`. Flags: `--force` overwrites; `--show` prints the existing audit. See [eval-review](eval-review.md). |
-| `/gsd extract-learnings <MID>` | Extract structured Decisions, Lessons, Patterns, and Surprises from a completed milestone — writes `<MID>-LEARNINGS.md` audit trail, persists durable knowledge through the memory/decision stores, and projects reviewable knowledge into `.gsd/KNOWLEDGE.md`. Runs automatically at milestone completion. |
+| `/gsd extract-learnings <MID>` | Extract structured Decisions, Lessons, Patterns, and Surprises from a completed milestone — writes `<MID>-LEARNINGS.md` audit trail and persists durable knowledge through the memory/decision stores. `.gsd/KNOWLEDGE.md` updates are deferred and appear on the next session start. Runs automatically at milestone completion. |
 | `/gsd fast` | Toggle service tier for supported models (prioritized API routing) |
 | `/gsd rate` | Rate last unit's model tier (over/ok/under) — improves adaptive routing |
 | `/gsd changelog` | Show categorized release notes |

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -31,9 +31,9 @@
 | `/gsd export --html` | Generate self-contained HTML report for current or completed milestone |
 | `/gsd export --html --all` | Generate retrospective reports for all milestones at once |
 | `/gsd update` | Update GSD to the latest version in-session |
-| `/gsd knowledge` | Add persistent project knowledge (rule, pattern, or lesson) |
+| `/gsd knowledge` | Add persistent project knowledge. Rules remain manually maintained in `KNOWLEDGE.md`; patterns and lessons are memory-backed and projected into the file. |
 | `/gsd eval-review <sliceId>` | Audit a slice's AI evaluation strategy and write a scored `<sliceId>-EVAL-REVIEW.md`. Flags: `--force` overwrites; `--show` prints the existing audit. See [eval-review](eval-review.md). |
-| `/gsd extract-learnings <MID>` | Extract structured Decisions, Lessons, Patterns, and Surprises from a completed milestone — writes `<MID>-LEARNINGS.md` audit trail, appends Patterns and Lessons to `.gsd/KNOWLEDGE.md`, and persists Decisions via the DECISIONS database. Runs automatically at milestone completion. |
+| `/gsd extract-learnings <MID>` | Extract structured Decisions, Lessons, Patterns, and Surprises from a completed milestone — writes `<MID>-LEARNINGS.md` audit trail, persists durable knowledge through the memory/decision stores, and projects reviewable knowledge into `.gsd/KNOWLEDGE.md`. Runs automatically at milestone completion. |
 | `/gsd fast` | Toggle service tier for supported models (prioritized API routing) |
 | `/gsd rate` | Rate last unit's model tier (over/ok/under) — improves adaptive routing |
 | `/gsd changelog` | Show categorized release notes |

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -31,9 +31,9 @@
 | `/gsd export --html` | Generate self-contained HTML report for current or completed milestone |
 | `/gsd export --html --all` | Generate retrospective reports for all milestones at once |
 | `/gsd update` | Update GSD to the latest version in-session |
-| `/gsd knowledge` | Add persistent project knowledge. Rules remain manually maintained in `KNOWLEDGE.md`; pattern and lesson updates are deferred and appear in the file on the next session start. |
+| `/gsd knowledge` | Add persistent project knowledge. Rules remain manually maintained in `KNOWLEDGE.md`; patterns and lessons are memory-backed and projected into the file on the next session start. |
 | `/gsd eval-review <sliceId>` | Audit a slice's AI evaluation strategy and write a scored `<sliceId>-EVAL-REVIEW.md`. Flags: `--force` overwrites; `--show` prints the existing audit. See [eval-review](eval-review.md). |
-| `/gsd extract-learnings <MID>` | Extract structured Decisions, Lessons, Patterns, and Surprises from a completed milestone — writes `<MID>-LEARNINGS.md` audit trail and persists durable knowledge through the memory/decision stores. `.gsd/KNOWLEDGE.md` updates are deferred and appear on the next session start. Runs automatically at milestone completion. |
+| `/gsd extract-learnings <MID>` | Extract structured Decisions, Lessons, Patterns, and Surprises from a completed milestone — writes `<MID>-LEARNINGS.md` audit trail, persists durable knowledge through the memory/decision stores, and projects reviewable knowledge into `.gsd/KNOWLEDGE.md` on the next session start. Runs automatically at milestone completion. |
 | `/gsd fast` | Toggle service tier for supported models (prioritized API routing) |
 | `/gsd rate` | Rate last unit's model tier (over/ok/under) — improves adaptive routing |
 | `/gsd changelog` | Show categorized release notes |

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -752,7 +752,7 @@ custom_instructions:
   - "Prefer functional patterns over classes"
 ```
 
-For project-specific knowledge (patterns, gotchas, lessons learned), use `.gsd/KNOWLEDGE.md` instead — it's injected into every agent prompt automatically. Add entries with `/gsd knowledge rule|pattern|lesson <description>`.
+For project-specific knowledge, use the GSD knowledge and memory surfaces instead. `.gsd/KNOWLEDGE.md` is a hybrid projection: manually maintained Rules stay in the file, while generated Patterns and Lessons are backed by the `memories` table and rendered back into the file for review. Add durable operating rules with `/gsd knowledge rule <description>`; agent-discovered patterns and lessons are stored as memories and selected for prompt injection automatically.
 
 ### `RUNTIME.md` — Runtime Context (v2.39)
 

--- a/docs/user-docs/getting-started.md
+++ b/docs/user-docs/getting-started.md
@@ -382,7 +382,7 @@ GSD keeps authoritative runtime state in the project-root SQLite database and re
   PROJECT.md          — what the project is right now
   REQUIREMENTS.md     — requirement contract
   DECISIONS.md        — append-only architectural decisions
-  KNOWLEDGE.md        — cross-session rules and patterns
+  KNOWLEDGE.md        — manual Rules plus memory-backed Patterns/Lessons
   STATE.md            — quick-glance status rendered from the database
   milestones/
     M001/

--- a/docs/zh-CN/user-docs/auto-mode.md
+++ b/docs/zh-CN/user-docs/auto-mode.md
@@ -87,7 +87,9 @@ GSD 会对 provider 错误分类，并在安全时自动恢复：
 
 ### 增量记忆（v2.26）
 
-GSD 会维护一个 `KNOWLEDGE.md` 文件，作为项目特有规则、模式和经验的追加式记录。agent 在每个工作单元开始时都会读取它；当发现反复出现的问题、非显而易见的模式或未来会话需要遵循的规则时，也会把内容追加进去。这样一来，自动模式就有了跨会话、跨上下文窗口的持久记忆。
+GSD 会把持久项目记忆保存在 `gsd.db` 中，并把可审阅的部分投影到 `.gsd/KNOWLEDGE.md`。启动时，已有的 `KNOWLEDGE.md` Patterns 和 Lessons 会回填到 memories，然后文件会被重写为混合投影：手写 Rules 仍保留在文件中，生成的 Patterns 和 Lessons 则从 memory 行渲染出来。
+
+agent 会通过 memory 系统选择要注入 prompt 的项目知识，因此跨会话记忆不依赖手工维护 markdown。手写的操作规则请用 `/gsd knowledge rule`；工作中发现的重复模式和经验会存入 memories，并显示在 `KNOWLEDGE.md` 中方便审阅。
 
 ### 上下文压力监视器（v2.26）
 

--- a/docs/zh-CN/user-docs/commands.md
+++ b/docs/zh-CN/user-docs/commands.md
@@ -30,7 +30,7 @@
 | `/gsd export --html` | 为当前或已完成的 milestone 生成自包含 HTML 报告 |
 | `/gsd export --html --all` | 一次性为所有 milestones 生成回顾报告 |
 | `/gsd update` | 在会话内更新到最新版本 |
-| `/gsd knowledge` | 添加持久化项目知识（规则、模式或经验） |
+| `/gsd knowledge` | 添加持久化项目知识。Rules 仍手动维护在 `KNOWLEDGE.md` 中；patterns 和 lessons 由 memories 承载，并投影回文件。 |
 | `/gsd fast` | 为支持的模型切换 service tier（优先级 API 路由） |
 | `/gsd rate` | 评价上一个单元所用模型层级（over / ok / under），帮助改进自适应路由 |
 | `/gsd changelog` | 查看分类后的发行说明 |

--- a/docs/zh-CN/user-docs/configuration.md
+++ b/docs/zh-CN/user-docs/configuration.md
@@ -682,7 +682,7 @@ custom_instructions:
   - "Prefer functional patterns over classes"
 ```
 
-如果是项目特有知识（模式、坑点、经验），请优先放到 `.gsd/KNOWLEDGE.md` 中，因为它会自动注入每个 agent prompt。你也可以通过 `/gsd knowledge rule|pattern|lesson <description>` 添加。
+如果是项目特有知识，请使用 GSD 的 knowledge 和 memory 机制。`.gsd/KNOWLEDGE.md` 是混合投影：手动维护的 Rules 保留在文件里，生成的 Patterns 和 Lessons 由 `memories` 表承载，并渲染回文件方便审阅。持久操作规则用 `/gsd knowledge rule <description>` 添加；agent 发现的模式和经验会作为 memories 保存，并自动参与 prompt 注入。
 
 ### `RUNTIME.md`：运行时上下文（v2.39）
 

--- a/docs/zh-CN/user-docs/getting-started.md
+++ b/docs/zh-CN/user-docs/getting-started.md
@@ -381,7 +381,7 @@ Milestone  →  一个可交付版本（4-10 个 slice）
   PROJECT.md          — 项目当前是什么
   REQUIREMENTS.md     — 需求契约
   DECISIONS.md        — 追加式架构决策记录
-  KNOWLEDGE.md        — 跨会话规则与模式
+  KNOWLEDGE.md        — 手写 Rules，加上 memory 支撑的 Patterns/Lessons
   STATE.md            — 一眼可见的状态摘要
   milestones/
     M001/

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -263,7 +263,7 @@ custom_instructions:
   - "Prefer functional patterns over classes"
 ```
 
-For project-specific patterns, use `.gsd/KNOWLEDGE.md` instead — it's injected into every agent prompt automatically.
+For project-specific durable guidance, use `.gsd/KNOWLEDGE.md` instead. Rules are read from the file; patterns and lessons are persisted to the `memories` table and projected back into `KNOWLEDGE.md` on the next session start.
 
 ### `context_pause_threshold`
 

--- a/gitbook/getting-started/first-project.md
+++ b/gitbook/getting-started/first-project.md
@@ -106,7 +106,7 @@ GSD keeps authoritative runtime state in the project-root SQLite database and re
   PROJECT.md          — what the project is
   REQUIREMENTS.md     — requirement contract
   DECISIONS.md        — architectural decisions
-  KNOWLEDGE.md        — cross-session rules and patterns
+  KNOWLEDGE.md        — rules plus projected memory-backed patterns and lessons
   STATE.md            — quick-glance status rendered from the database
   milestones/
     M001/
@@ -121,6 +121,8 @@ GSD keeps authoritative runtime state in the project-root SQLite database and re
             T01-PLAN.md
             T01-SUMMARY.md
 ```
+
+`KNOWLEDGE.md` has a split source of truth. Rules stay in the file. Patterns and lessons are persisted to the `memories` table, then rendered into `KNOWLEDGE.md` the next time a GSD session starts; existing pattern and lesson rows are backfilled into memories during that startup path.
 
 ## Next Steps
 

--- a/gitbook/getting-started/first-project.md
+++ b/gitbook/getting-started/first-project.md
@@ -106,7 +106,7 @@ GSD keeps authoritative runtime state in the project-root SQLite database and re
   PROJECT.md          — what the project is
   REQUIREMENTS.md     — requirement contract
   DECISIONS.md        — architectural decisions
-  KNOWLEDGE.md        — rules plus projected memory-backed patterns and lessons
+  KNOWLEDGE.md        — rules plus patterns and lessons synced from the database
   STATE.md            — quick-glance status rendered from the database
   milestones/
     M001/
@@ -122,7 +122,9 @@ GSD keeps authoritative runtime state in the project-root SQLite database and re
             T01-SUMMARY.md
 ```
 
-`KNOWLEDGE.md` has a split source of truth. Rules stay in the file. Patterns and lessons are persisted to the `memories` table, then rendered into `KNOWLEDGE.md` the next time a GSD session starts; existing pattern and lesson rows are backfilled into memories during that startup path.
+`KNOWLEDGE.md` has a split source of truth. Rules stay in the file and are visible immediately. Patterns and lessons added through `/gsd knowledge` are persisted to the `memories` table, then rendered into `KNOWLEDGE.md` the next time a GSD session starts, so they will not appear in the file immediately.
+
+Existing pattern and lesson rows are backfilled into `memories` during that startup path. The Patterns and Lessons sections in `KNOWLEDGE.md` are generated projections, so manual edits to those generated sections may be overwritten on regeneration.
 
 ## Next Steps
 

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -169,6 +169,10 @@ export async function buildBeforeAgentStartResult(
   // re-render the hybrid projection (manual Rules + projected Patterns +
   // projected Lessons). Both are idempotent and best-effort — failures here
   // can't block agent startup.
+  const ctxProjectRoot = (ctx as { projectRoot?: unknown }).projectRoot;
+  const basePath = typeof ctxProjectRoot === "string" && ctxProjectRoot.length > 0
+    ? ctxProjectRoot
+    : process.cwd();
   try {
     const { backfillKnowledgeToMemories } = await import("../knowledge-backfill.js");
     const writtenK = backfillKnowledgeToMemories(basePath);

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -131,9 +131,11 @@ export async function buildBeforeAgentStartResult(
     logWarning("bootstrap", `cmux prompt setup skipped: ${(e as Error).message}`);
   }
 
+  const basePath = process.cwd();
+
   let preferenceBlock = "";
   if (loadedPreferences) {
-    const cwd = process.cwd();
+    const cwd = basePath;
     const report = resolveAllSkillReferences(loadedPreferences.preferences, cwd);
     preferenceBlock = `\n\n${renderPreferencesForSystemPrompt(loadedPreferences.preferences, report.resolutions)}`;
     if (report.warnings.length > 0) {
@@ -142,14 +144,6 @@ export async function buildBeforeAgentStartResult(
         "warning",
       );
     }
-  }
-
-  const { block: knowledgeBlock, globalSizeKb } = loadKnowledgeBlock(gsdHome(), process.cwd());
-  if (globalSizeKb > 4) {
-    ctx.ui.notify(
-      `GSD: ~/.gsd/agent/KNOWLEDGE.md is ${globalSizeKb.toFixed(1)}KB — consider trimming to keep system prompt lean.`,
-      "warning",
-    );
   }
 
   // ADR-013 step 5: opportunistic decisions->memories backfill. Idempotent
@@ -183,6 +177,14 @@ export async function buildBeforeAgentStartResult(
     renderKnowledgeProjection(basePath);
   } catch (e) {
     logWarning("bootstrap", `KNOWLEDGE.md projection render failed: ${(e as Error).message}`);
+  }
+
+  const { block: knowledgeBlock, globalSizeKb } = loadKnowledgeBlock(gsdHome(), basePath);
+  if (globalSizeKb > 4) {
+    ctx.ui.notify(
+      `GSD: ~/.gsd/agent/KNOWLEDGE.md is ${globalSizeKb.toFixed(1)}KB — consider trimming to keep system prompt lean.`,
+      "warning",
+    );
   }
 
   let newSkillsBlock = "";

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -159,10 +159,30 @@ export async function buildBeforeAgentStartResult(
     const { backfillDecisionsToMemories } = await import("../memory-backfill.js");
     const written = backfillDecisionsToMemories();
     if (written > 0) {
-      ctx.ui.notify(`GSD: backfilled ${written} decision${written === 1 ? "" : "s"} into the memory store (ADR-013).`, "info");
+      ctx.ui.notify(`GSD: backfilled ${written} decision${written === 1 ? "" : "s"} into the memory store.`, "info");
     }
   } catch (e) {
     logWarning("bootstrap", `decisions backfill failed: ${(e as Error).message}`);
+  }
+
+  // ADR-013 Stage 2b: KNOWLEDGE.md Patterns + Lessons backfill, then
+  // re-render the hybrid projection (manual Rules + projected Patterns +
+  // projected Lessons). Both are idempotent and best-effort — failures here
+  // can't block agent startup.
+  try {
+    const { backfillKnowledgeToMemories } = await import("../knowledge-backfill.js");
+    const writtenK = backfillKnowledgeToMemories(basePath);
+    if (writtenK > 0) {
+      ctx.ui.notify(`GSD: backfilled ${writtenK} KNOWLEDGE.md row${writtenK === 1 ? "" : "s"} into the memory store.`, "info");
+    }
+  } catch (e) {
+    logWarning("bootstrap", `KNOWLEDGE.md backfill failed: ${(e as Error).message}`);
+  }
+  try {
+    const { renderKnowledgeProjection } = await import("../knowledge-projection.js");
+    renderKnowledgeProjection(basePath);
+  } catch (e) {
+    logWarning("bootstrap", `KNOWLEDGE.md projection render failed: ${(e as Error).message}`);
   }
 
   let newSkillsBlock = "";

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -404,6 +404,27 @@ export async function loadMemoryBlock(
   }
 }
 
+/**
+ * Extracts intro prose plus the `## Rules` section from project KNOWLEDGE.md,
+ * dropping projected patterns and lessons that are injected through memory.
+ */
+function extractRulesSection(content: string): string {
+  const rulesHeading = "## Rules";
+  const rulesIdx = content.indexOf(rulesHeading);
+  if (rulesIdx === -1) {
+    const firstSection = content.search(/^## /m);
+    return firstSection === -1 ? content : content.slice(0, firstSection).trim();
+  }
+
+  const intro = content.slice(0, rulesIdx).trim();
+  const afterRules = content.slice(rulesIdx);
+  const nextSection = afterRules.match(/\n## /);
+  const rulesSection =
+    nextSection && nextSection.index !== undefined ? afterRules.slice(0, nextSection.index).trim() : afterRules.trim();
+
+  return intro ? `${intro}\n\n${rulesSection}` : rulesSection;
+}
+
 export function loadKnowledgeBlock(gsdHomeDir: string, cwd: string): { block: string; globalSizeKb: number } {
   // 1. Global knowledge (~/.gsd/agent/KNOWLEDGE.md) — cross-project, user-maintained
   let globalKnowledge = "";
@@ -427,7 +448,7 @@ export function loadKnowledgeBlock(gsdHomeDir: string, cwd: string): { block: st
   if (existsSync(knowledgePath)) {
     try {
       const content = readFileSync(knowledgePath, "utf-8").trim();
-      if (content) projectKnowledge = content;
+      if (content) projectKnowledge = extractRulesSection(content);
     } catch (e) {
       logWarning("bootstrap", `project knowledge file read failed: ${(e as Error).message}`);
     }
@@ -446,7 +467,7 @@ export function loadKnowledgeBlock(gsdHomeDir: string, cwd: string): { block: st
   }
   const body = limitKnowledgeBlock(parts.join("\n\n"), getKnowledgeCharLimit());
   return {
-    block: `\n\n[KNOWLEDGE — Rules, patterns, and lessons learned]\n\n${body}`,
+    block: `\n\n[KNOWLEDGE — Manual Rules]\n\n${body}`,
     globalSizeKb,
   };
 }

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -131,7 +131,10 @@ export async function buildBeforeAgentStartResult(
     logWarning("bootstrap", `cmux prompt setup skipped: ${(e as Error).message}`);
   }
 
-  const basePath = process.cwd();
+  const ctxProjectRoot = (ctx as { projectRoot?: unknown }).projectRoot;
+  const basePath = typeof ctxProjectRoot === "string" && ctxProjectRoot.length > 0
+    ? ctxProjectRoot
+    : process.cwd();
 
   let preferenceBlock = "";
   if (loadedPreferences) {
@@ -163,10 +166,6 @@ export async function buildBeforeAgentStartResult(
   // re-render the hybrid projection (manual Rules + projected Patterns +
   // projected Lessons). Both are idempotent and best-effort — failures here
   // can't block agent startup.
-  const ctxProjectRoot = (ctx as { projectRoot?: unknown }).projectRoot;
-  const basePath = typeof ctxProjectRoot === "string" && ctxProjectRoot.length > 0
-    ? ctxProjectRoot
-    : process.cwd();
   try {
     const { backfillKnowledgeToMemories } = await import("../knowledge-backfill.js");
     const writtenK = backfillKnowledgeToMemories(basePath);

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -368,8 +368,25 @@ export async function handleKnowledge(args: string, ctx: ExtensionCommandContext
     ? `${state.activeMilestone.id}${state.activeSlice ? `/${state.activeSlice.id}` : ""}`
     : "global";
 
-  await appendKnowledge(basePath, type, entryText, scope);
-  ctx.ui.notify(`Added ${type} to KNOWLEDGE.md: "${entryText}"`, "success");
+  // ADR-013 Stage 2c: Patterns and Lessons land in the memories table; the
+  // next session-start projection render emits them back into KNOWLEDGE.md.
+  // Rules stay file-canonical per ADR-013 line 39 — Rules are not migrated.
+  if (type === "rule") {
+    await appendKnowledge(basePath, type, entryText, scope);
+    ctx.ui.notify(`Added rule to KNOWLEDGE.md: "${entryText}"`, "success");
+    return;
+  }
+
+  const { captureKnowledgeEntry } = await import("./knowledge-capture.js");
+  const { id, written } = captureKnowledgeEntry(basePath, type, entryText, scope);
+  if (!written) {
+    ctx.ui.notify(`Could not persist ${type} — see logs for details.`, "error");
+    return;
+  }
+  ctx.ui.notify(
+    `Captured ${type} ${id} to memories; KNOWLEDGE.md will render it on next session start.`,
+    "success",
+  );
 }
 
 export async function handleRunHook(args: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -96,7 +96,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd unpark [id]    Reactivate a parked milestone",
     "",
     "PROJECT KNOWLEDGE",
-    "  /gsd knowledge <type> <text>   Add rule, pattern, or lesson to KNOWLEDGE.md",
+    "  /gsd knowledge <type> <text>   Add a rule to KNOWLEDGE.md or capture a pattern/lesson to memories",
     "  /gsd codebase [generate|update|stats]   Manage the CODEBASE.md cache used in prompt context",
     "",
     "SHIPPING & BACKLOG",

--- a/src/resources/extensions/gsd/context-store.ts
+++ b/src/resources/extensions/gsd/context-store.ts
@@ -91,10 +91,6 @@ function readDecisionsFromMemories(
     ];
     const params: Record<string, unknown> = {};
 
-    if (!includeSuperseded) {
-      clauses.push("superseded_by IS NULL");
-    }
-
     if (opts?.milestoneId) {
       // when_context is a free-text JSON value; substring match preserves the
       // semantics of `when_context LIKE '%milestoneId%'` on the legacy table.

--- a/src/resources/extensions/gsd/context-store.ts
+++ b/src/resources/extensions/gsd/context-store.ts
@@ -67,40 +67,33 @@ export function queryDecisions(opts?: DecisionQueryOpts): Decision[] {
 }
 
 /**
- * ADR-013 Phase 6 cutover (Stage 1): read active decisions from the `memories`
- * table instead of the legacy `decisions` table. Returns the same `Decision[]`
- * shape as `queryDecisions` so downstream formatters work unchanged.
+ * Internal: shared core for the two memory-sourced decision queries. Reads
+ * memory rows tagged with `sourceDecisionId` and reconstructs `Decision[]`
+ * from their `structured_fields` JSON.
  *
- * Filter semantics match `queryDecisions` exactly:
- * - active only (memory's own `superseded_by IS NULL`)
- * - `milestoneId`: matches when the JSON value of `structured_fields.when_context`
- *   contains the milestone token, mirroring `when_context LIKE '%milestoneId%'`
- *   on the legacy table
- * - `scope`: exact match on `structured_fields.scope`, mirroring `scope = :scope`
- *
- * Both surfaces filter to active rows, so once the Phase 5 dual-write is
- * caught up (PR #5765's scanner reading zero gaps), `queryDecisions` and
- * `queryDecisionsFromMemories` return byte-equivalent results.
- *
- * `superseded_by` is always `null` here: the `decisions` table's
- * supersedes-chain is not preserved by today's backfill (only active rows
- * are migrated), so the field has no source in memories. Acceptable for
- * prompt inlining, which never reads superseded entries.
+ * @param includeSuperseded — when false, drops rows whose
+ *   `structured_fields.superseded_by` is non-null. The supersedes-chain is
+ *   captured by the backfill (`memory-backfill.ts`) and kept in sync by
+ *   the backfill's drift auto-heal pass.
  */
-export function queryDecisionsFromMemories(opts?: DecisionQueryOpts): Decision[] {
+function readDecisionsFromMemories(
+  opts: DecisionQueryOpts | undefined,
+  includeSuperseded: boolean,
+): Decision[] {
   if (!isDbAvailable()) return [];
   const adapter = _getAdapter();
   if (!adapter) return [];
 
   try {
-    // Anchor each pattern with the closing `"` so prefix collisions don't
-    // produce false matches (e.g. scope=M001 must not match "scope":"M001-S01").
     const clauses: string[] = [
       "category = 'architecture'",
       "structured_fields LIKE '%\"sourceDecisionId\":\"%'",
-      "superseded_by IS NULL",
     ];
     const params: Record<string, unknown> = {};
+
+    if (!includeSuperseded) {
+      clauses.push("superseded_by IS NULL");
+    }
 
     if (opts?.milestoneId) {
       // when_context is a free-text JSON value; substring match preserves the
@@ -110,6 +103,8 @@ export function queryDecisionsFromMemories(opts?: DecisionQueryOpts): Decision[]
     }
 
     if (opts?.scope) {
+      // Anchored with the closing `"` so prefix collisions don't produce
+      // false matches (e.g. scope=M001 must not match "scope":"M001-S01").
       clauses.push("structured_fields LIKE :scope_pattern");
       params[':scope_pattern'] = `%"scope":"${opts.scope}"%`;
     }
@@ -131,6 +126,12 @@ export function queryDecisionsFromMemories(opts?: DecisionQueryOpts): Decision[]
       const sourceId = sf['sourceDecisionId'];
       if (typeof sourceId !== 'string' || sourceId.length === 0) continue;
 
+      // Decision-level supersedes lives in structuredFields.superseded_by
+      // (populated by the backfill / drift auto-heal). Skip when the caller
+      // wants active-only and the chain has been recorded there.
+      const supersededBy = typeof sf['superseded_by'] === 'string' ? (sf['superseded_by'] as string) : null;
+      if (!includeSuperseded && supersededBy) continue;
+
       decisions.push({
         seq,
         id: sourceId,
@@ -141,7 +142,7 @@ export function queryDecisionsFromMemories(opts?: DecisionQueryOpts): Decision[]
         rationale: typeof sf['rationale'] === 'string' ? (sf['rationale'] as string) : '',
         revisable: typeof sf['revisable'] === 'string' ? (sf['revisable'] as string) : '',
         made_by: ((typeof sf['made_by'] === 'string' ? sf['made_by'] : 'agent') as DecisionMadeBy),
-        superseded_by: null,
+        superseded_by: supersededBy,
       });
     }
 
@@ -149,6 +150,41 @@ export function queryDecisionsFromMemories(opts?: DecisionQueryOpts): Decision[]
   } catch {
     return [];
   }
+}
+
+/**
+ * ADR-013 Phase 6 cutover (Stage 1): read **active** decisions from the
+ * `memories` table instead of the legacy `decisions` table. Returns the
+ * same `Decision[]` shape as `queryDecisions` so downstream formatters
+ * work unchanged.
+ *
+ * Filter semantics match `queryDecisions` exactly:
+ * - active only (skips rows where `structured_fields.superseded_by` is set)
+ * - `milestoneId`: substring match on `structured_fields.when_context`
+ * - `scope`: exact match on `structured_fields.scope`
+ *
+ * Used by the prompt-inline path (`inlineDecisionsFromDb` in
+ * `auto-prompts.ts`). For the projection regen (which renders superseded
+ * rows too), see `getAllDecisionsFromMemories`.
+ */
+export function queryDecisionsFromMemories(opts?: DecisionQueryOpts): Decision[] {
+  return readDecisionsFromMemories(opts, /* includeSuperseded */ false);
+}
+
+/**
+ * ADR-013 Phase 6 cutover (Stage 2a): read **all** decisions (active +
+ * superseded) from the `memories` table. Used by the DECISIONS.md
+ * projection regen in `saveDecisionToDb`, which must render the full
+ * supersedes-chain for the canonical register format.
+ *
+ * Equivalent to `SELECT * FROM decisions ORDER BY seq` over the legacy
+ * table — but sourced from memories so the legacy table can be retired
+ * in Stage 3. Includes `superseded_by` reconstructed from
+ * `structured_fields.superseded_by` (populated by the backfill's drift
+ * auto-heal pass).
+ */
+export function getAllDecisionsFromMemories(): Decision[] {
+  return readDecisionsFromMemories(undefined, /* includeSuperseded */ true);
 }
 
 /**

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -471,7 +471,10 @@ export async function saveDecisionToDb(
     // happen before the projection regen below, because the regen now sources
     // from memories. If the dual-write ran after, the just-saved decision
     // would be missing from its own projection.
-    await mirrorDecisionToMemory(id, fields);
+    const mirrored = await mirrorDecisionToMemory(id, fields);
+    if (!mirrored) {
+      throw new Error(`Decision ${id} saved to DB but failed to mirror into memories`);
+    }
 
     // Fetch all decisions (including superseded for the full register).
     // ADR-013 Stage 2a: source from the `memories` table. The Phase 5
@@ -548,7 +551,8 @@ export async function saveDecisionToDb(
  * table so the memory store remains the single source of truth for the
  * DECISIONS.md projection (Stage 2a) and for prompt-inline reads (Stage 1).
  *
- * Best-effort: never throws, never rolls back the decision on failure.
+ * Never throws directly; returns false so the caller can avoid reporting a
+ * successful save when memory-sourced projections would miss the decision.
  * Caller invokes this AFTER the decisions-table write completes and
  * BEFORE the projection regen — the regen sources from memories and would
  * otherwise miss the just-saved decision.
@@ -556,7 +560,7 @@ export async function saveDecisionToDb(
 async function mirrorDecisionToMemory(
   id: string,
   fields: SaveDecisionFields,
-): Promise<void> {
+): Promise<boolean> {
   try {
     const { createMemory } = await import('./memory-store.js');
     const decisionText = (fields.decision ?? '').trim();
@@ -567,7 +571,7 @@ async function mirrorDecisionToMemory(
     if (choiceText) contentParts.push(`Chose: ${choiceText}.`);
     if (rationaleText) contentParts.push(`Rationale: ${rationaleText}.`);
     const content = contentParts.join(' ').slice(0, 600);
-    if (!content) return;
+    if (!content) return false;
 
     createMemory({
       category: 'architecture',
@@ -589,12 +593,14 @@ async function mirrorDecisionToMemory(
         superseded_by: null,
       },
     });
+    return true;
   } catch (mirrorErr) {
-    logError('manifest', 'memory-store mirror write failed (non-fatal)', {
+    logError('manifest', 'memory-store mirror write failed', {
       fn: 'saveDecisionToDb',
       decisionId: id,
       error: String((mirrorErr as Error).message),
     });
+    return false;
   }
 }
 

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -548,7 +548,7 @@ export async function saveDecisionToDb(
  * table so the memory store remains the single source of truth for the
  * DECISIONS.md projection (Stage 2a) and for prompt-inline reads (Stage 1).
  *
- * Best-effort: never throws, never rolls back the decision on failure.
+ * Required save contract: throws when the memory mirror cannot be written.
  * Caller invokes this AFTER the decisions-table write completes and
  * BEFORE the projection regen — the regen sources from memories and would
  * otherwise miss the just-saved decision.
@@ -557,44 +557,48 @@ async function mirrorDecisionToMemory(
   id: string,
   fields: SaveDecisionFields,
 ): Promise<void> {
-  try {
-    const { createMemory } = await import('./memory-store.js');
-    const decisionText = (fields.decision ?? '').trim();
-    const choiceText = (fields.choice ?? '').trim();
-    const rationaleText = (fields.rationale ?? '').trim();
-    const contentParts: string[] = [];
-    if (decisionText) contentParts.push(decisionText);
-    if (choiceText) contentParts.push(`Chose: ${choiceText}.`);
-    if (rationaleText) contentParts.push(`Rationale: ${rationaleText}.`);
-    const content = contentParts.join(' ').slice(0, 600);
-    if (!content) return;
+  const { createMemory } = await import('./memory-store.js');
+  const decisionText = (fields.decision ?? '').trim();
+  const choiceText = (fields.choice ?? '').trim();
+  const rationaleText = (fields.rationale ?? '').trim();
+  const contentParts: string[] = [];
+  if (decisionText) contentParts.push(decisionText);
+  if (choiceText) contentParts.push(`Chose: ${choiceText}.`);
+  if (rationaleText) contentParts.push(`Rationale: ${rationaleText}.`);
+  const content = contentParts.join(' ').slice(0, 600);
+  if (!content) {
+    throw new Error(`memory-store mirror write failed for ${id}: empty decision content`);
+  }
 
-    createMemory({
-      category: 'architecture',
-      content,
-      scope: fields.scope || 'project',
-      confidence: 0.85,
-      structuredFields: {
-        sourceDecisionId: id,
-        when_context: fields.when_context ?? '',
-        scope: fields.scope,
-        decision: fields.decision,
-        choice: fields.choice,
-        rationale: fields.rationale,
-        made_by: fields.made_by ?? 'agent',
-        revisable: fields.revisable ?? '',
-        // New decisions are always written as active; md-importer can later
-        // set superseded_by on the source decision row, and the backfill's
-        // drift auto-heal pass propagates that update to this memory.
-        superseded_by: null,
-      },
-    });
-  } catch (mirrorErr) {
-    logError('manifest', 'memory-store mirror write failed (non-fatal)', {
+  const memoryId = createMemory({
+    category: 'architecture',
+    content,
+    scope: fields.scope || 'project',
+    confidence: 0.85,
+    structuredFields: {
+      sourceDecisionId: id,
+      when_context: fields.when_context ?? '',
+      scope: fields.scope,
+      decision: fields.decision,
+      choice: fields.choice,
+      rationale: fields.rationale,
+      made_by: fields.made_by ?? 'agent',
+      revisable: fields.revisable ?? 'Yes',
+      // New decisions are always written as active; md-importer can later
+      // set superseded_by on the source decision row, and the backfill's
+      // drift auto-heal pass propagates that update to this memory.
+      superseded_by: null,
+    },
+  });
+
+  if (!memoryId) {
+    const mirrorErr = new Error(`memory-store mirror write failed for ${id}: memory store unavailable`);
+    logError('manifest', 'memory-store mirror write failed', {
       fn: 'saveDecisionToDb',
       decisionId: id,
-      error: String((mirrorErr as Error).message),
+      error: mirrorErr.message,
     });
+    throw mirrorErr;
   }
 }
 

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -467,23 +467,19 @@ export async function saveDecisionToDb(
       return nextId;
     });
 
-    // Fetch all decisions (including superseded for the full register)
-    let allDecisions: Decision[] = [];
-    if (adapter) {
-      const rows = adapter.prepare('SELECT * FROM decisions ORDER BY seq').all();
-      allDecisions = rows.map(row => ({
-        seq: row['seq'] as number,
-        id: row['id'] as string,
-        when_context: row['when_context'] as string,
-        scope: row['scope'] as string,
-        decision: row['decision'] as string,
-        choice: row['choice'] as string,
-        rationale: row['rationale'] as string,
-        revisable: row['revisable'] as string,
-        made_by: (row['made_by'] as string as import('./types.js').DecisionMadeBy) ?? 'agent',
-        superseded_by: (row['superseded_by'] as string) ?? null,
-      }));
-    }
+    // ADR-013 Stage 2a (PR #5767 → #5755): the dual-write to memories MUST
+    // happen before the projection regen below, because the regen now sources
+    // from memories. If the dual-write ran after, the just-saved decision
+    // would be missing from its own projection.
+    await mirrorDecisionToMemory(id, fields);
+
+    // Fetch all decisions (including superseded for the full register).
+    // ADR-013 Stage 2a: source from the `memories` table. The Phase 5
+    // dual-write keeps memories in sync with each decision save; the backfill
+    // (memory-backfill.ts) absorbs the historical chain and drift-heals
+    // superseded_by on every session start.
+    const { getAllDecisionsFromMemories } = await import('./context-store.js');
+    let allDecisions: Decision[] = getAllDecisionsFromMemories();
 
     const filePath = resolveGsdRootFile(basePath, 'DECISIONS');
 
@@ -538,54 +534,67 @@ export async function saveDecisionToDb(
     clearPathCache();
     clearParseCache();
 
-    // ADR-013 dual-write: keep the memory store in sync with every decision
-    // persisted via the legacy gsd_save_decision path. Without this, prompts
-    // that still call gsd_save_decision (discuss.md, plan-milestone.md,
-    // plan-slice.md, et al.) would create decisions rows invisible to
-    // memory_query and loadMemoryBlock.
-    // Best-effort — never throw, never roll back the decision on failure.
-    try {
-      const { createMemory } = await import('./memory-store.js');
-      const decisionText = (fields.decision ?? '').trim();
-      const choiceText = (fields.choice ?? '').trim();
-      const rationaleText = (fields.rationale ?? '').trim();
-      const contentParts: string[] = [];
-      if (decisionText) contentParts.push(decisionText);
-      if (choiceText) contentParts.push(`Chose: ${choiceText}.`);
-      if (rationaleText) contentParts.push(`Rationale: ${rationaleText}.`);
-      const content = contentParts.join(' ').slice(0, 600);
-      if (content) {
-        createMemory({
-          category: 'architecture',
-          content,
-          scope: fields.scope || 'project',
-          confidence: 0.85,
-          structuredFields: {
-            sourceDecisionId: id,
-            when_context: fields.when_context ?? '',
-            scope: fields.scope,
-            decision: fields.decision,
-            choice: fields.choice,
-            rationale: fields.rationale,
-            made_by: fields.made_by ?? 'agent',
-            revisable: fields.revisable ?? '',
-          },
-        });
-      }
-    } catch (mirrorErr) {
-      logError('manifest', 'memory-store mirror write failed (non-fatal)', {
-        fn: 'saveDecisionToDb',
-        decisionId: id,
-        error: String((mirrorErr as Error).message),
-      });
-    }
-
     return { id };
   } catch (err) {
     logError('manifest', 'saveDecisionToDb failed', { fn: 'saveDecisionToDb', error: String((err as Error).message) });
     throw err;
   } finally {
     release!();
+  }
+}
+
+/**
+ * ADR-013 dual-write — mirror a freshly-saved decision into the `memories`
+ * table so the memory store remains the single source of truth for the
+ * DECISIONS.md projection (Stage 2a) and for prompt-inline reads (Stage 1).
+ *
+ * Best-effort: never throws, never rolls back the decision on failure.
+ * Caller invokes this AFTER the decisions-table write completes and
+ * BEFORE the projection regen — the regen sources from memories and would
+ * otherwise miss the just-saved decision.
+ */
+async function mirrorDecisionToMemory(
+  id: string,
+  fields: SaveDecisionFields,
+): Promise<void> {
+  try {
+    const { createMemory } = await import('./memory-store.js');
+    const decisionText = (fields.decision ?? '').trim();
+    const choiceText = (fields.choice ?? '').trim();
+    const rationaleText = (fields.rationale ?? '').trim();
+    const contentParts: string[] = [];
+    if (decisionText) contentParts.push(decisionText);
+    if (choiceText) contentParts.push(`Chose: ${choiceText}.`);
+    if (rationaleText) contentParts.push(`Rationale: ${rationaleText}.`);
+    const content = contentParts.join(' ').slice(0, 600);
+    if (!content) return;
+
+    createMemory({
+      category: 'architecture',
+      content,
+      scope: fields.scope || 'project',
+      confidence: 0.85,
+      structuredFields: {
+        sourceDecisionId: id,
+        when_context: fields.when_context ?? '',
+        scope: fields.scope,
+        decision: fields.decision,
+        choice: fields.choice,
+        rationale: fields.rationale,
+        made_by: fields.made_by ?? 'agent',
+        revisable: fields.revisable ?? '',
+        // New decisions are always written as active; md-importer can later
+        // set superseded_by on the source decision row, and the backfill's
+        // drift auto-heal pass propagates that update to this memory.
+        superseded_by: null,
+      },
+    });
+  } catch (mirrorErr) {
+    logError('manifest', 'memory-store mirror write failed (non-fatal)', {
+      fn: 'saveDecisionToDb',
+      decisionId: id,
+      error: String((mirrorErr as Error).message),
+    });
   }
 }
 

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -510,13 +510,13 @@ export async function saveDecisionToDb(
       const fallback: Decision = {
         seq: nextSeq,
         id,
-        when_context: fields.when_context ?? '',
-        scope: fields.scope,
-        decision: fields.decision,
-        choice: fields.choice,
-        rationale: fields.rationale,
-        revisable: fields.revisable ?? 'Yes',
-        made_by: fields.made_by ?? 'agent',
+        when_context: normalized.when_context,
+        scope: normalized.scope,
+        decision: normalized.decision,
+        choice: normalized.choice,
+        rationale: normalized.rationale,
+        revisable: normalized.revisable,
+        made_by: normalized.made_by,
         superseded_by: null,
       };
       allDecisions = [...allDecisions, fallback];
@@ -589,35 +589,35 @@ export async function saveDecisionToDb(
  * table so the memory store remains the single source of truth for the
  * DECISIONS.md projection (Stage 2a) and for prompt-inline reads (Stage 1).
  *
- * Required save contract: throws when the memory mirror cannot be written.
+ * Best-effort mirror: logs failures without throwing to avoid blocking saves.
  * Caller invokes this AFTER the decisions-table write completes and
  * BEFORE the projection regen — the regen sources from memories and would
  * otherwise miss the just-saved decision.
  */
 async function mirrorDecisionToMemory(
   id: string,
-  fields: NormalizedSaveDecisionFields,
+  normalizedFields: NormalizedSaveDecisionFields,
 ): Promise<void> {
   try {
     const { createMemory } = await import('./memory-store.js');
     const { synthesizeDecisionMemoryContent } = await import('./memory-backfill.js');
-    const content = synthesizeDecisionMemoryContent(fields);
+    const content = synthesizeDecisionMemoryContent(normalizedFields);
     if (!content) return;
 
     createMemory({
       category: 'architecture',
       content,
-      scope: fields.scope || 'project',
+      scope: normalizedFields.scope || 'project',
       confidence: 0.85,
       structuredFields: {
         sourceDecisionId: id,
-        when_context: fields.when_context,
-        scope: fields.scope,
-        decision: fields.decision,
-        choice: fields.choice,
-        rationale: fields.rationale,
-        made_by: fields.made_by,
-        revisable: fields.revisable,
+        when_context: normalizedFields.when_context,
+        scope: normalizedFields.scope,
+        decision: normalizedFields.decision,
+        choice: normalizedFields.choice,
+        rationale: normalizedFields.rationale,
+        made_by: normalizedFields.made_by,
+        revisable: normalizedFields.revisable,
         // New decisions are always written as active; md-importer can later
         // set superseded_by on the source decision row, and the backfill's
         // drift auto-heal pass propagates that update to this memory.

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -416,6 +416,16 @@ export interface SaveDecisionFields {
   source?: string;
 }
 
+type NormalizedSaveDecisionFields = Omit<
+  SaveDecisionFields,
+  'when_context' | 'revisable' | 'made_by' | 'source'
+> & {
+  when_context: string;
+  revisable: string;
+  made_by: NonNullable<SaveDecisionFields['made_by']>;
+  source: string;
+};
+
 /**
  * Save a new decision to DB and regenerate DECISIONS.md.
  * Auto-assigns the next ID via nextDecisionId().
@@ -447,19 +457,26 @@ export async function saveDecisionToDb(
     const db = await import('./gsd-db.js');
 
     const adapter = db._getAdapter();
+    const normalized: NormalizedSaveDecisionFields = {
+      ...fields,
+      when_context: fields.when_context ?? '',
+      revisable: fields.revisable ?? 'Yes',
+      made_by: fields.made_by ?? 'agent',
+      source: fields.source ?? 'discussion',
+    };
 
     const id = db.transaction(() => {
       const nextId = nextDecisionIdSync(adapter);
       db.upsertDecision({
         id: nextId,
-        when_context: fields.when_context ?? '',
-        scope: fields.scope,
-        decision: fields.decision,
-        choice: fields.choice,
-        rationale: fields.rationale,
-        revisable: fields.revisable ?? 'Yes',
-        made_by: fields.made_by ?? 'agent',
-        source: fields.source ?? 'discussion',
+        when_context: normalized.when_context,
+        scope: normalized.scope,
+        decision: normalized.decision,
+        choice: normalized.choice,
+        rationale: normalized.rationale,
+        revisable: normalized.revisable,
+        made_by: normalized.made_by,
+        source: normalized.source,
         superseded_by: null,
       });
 
@@ -471,7 +488,7 @@ export async function saveDecisionToDb(
     // happen before the projection regen below, because the regen now sources
     // from memories. If the dual-write ran after, the just-saved decision
     // would be missing from its own projection.
-    await mirrorDecisionToMemory(id, fields);
+    await mirrorDecisionToMemory(id, normalized);
 
     // Fetch all decisions (including superseded for the full register).
     // ADR-013 Stage 2a: source from the `memories` table. The Phase 5
@@ -555,18 +572,12 @@ export async function saveDecisionToDb(
  */
 async function mirrorDecisionToMemory(
   id: string,
-  fields: SaveDecisionFields,
+  fields: NormalizedSaveDecisionFields,
 ): Promise<void> {
   try {
     const { createMemory } = await import('./memory-store.js');
-    const decisionText = (fields.decision ?? '').trim();
-    const choiceText = (fields.choice ?? '').trim();
-    const rationaleText = (fields.rationale ?? '').trim();
-    const contentParts: string[] = [];
-    if (decisionText) contentParts.push(decisionText);
-    if (choiceText) contentParts.push(`Chose: ${choiceText}.`);
-    if (rationaleText) contentParts.push(`Rationale: ${rationaleText}.`);
-    const content = contentParts.join(' ').slice(0, 600);
+    const { synthesizeDecisionMemoryContent } = await import('./memory-backfill.js');
+    const content = synthesizeDecisionMemoryContent(fields);
     if (!content) return;
 
     createMemory({
@@ -576,13 +587,13 @@ async function mirrorDecisionToMemory(
       confidence: 0.85,
       structuredFields: {
         sourceDecisionId: id,
-        when_context: fields.when_context ?? '',
+        when_context: fields.when_context,
         scope: fields.scope,
         decision: fields.decision,
         choice: fields.choice,
         rationale: fields.rationale,
-        made_by: fields.made_by ?? 'agent',
-        revisable: fields.revisable ?? '',
+        made_by: fields.made_by,
+        revisable: fields.revisable,
         // New decisions are always written as active; md-importer can later
         // set superseded_by on the source decision row, and the backfill's
         // drift auto-heal pass propagates that update to this memory.

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -471,7 +471,15 @@ export async function saveDecisionToDb(
     // happen before the projection regen below, because the regen now sources
     // from memories. If the dual-write ran after, the just-saved decision
     // would be missing from its own projection.
-    await mirrorDecisionToMemory(id, fields);
+    try {
+      await mirrorDecisionToMemory(id, fields);
+    } catch (mirrorErr) {
+      logWarning('projection', 'decision memory mirror failed; projection fallback will use the committed decision row', {
+        fn: 'saveDecisionToDb',
+        decisionId: id,
+        error: String((mirrorErr as Error).message),
+      });
+    }
 
     // Fetch all decisions (including superseded for the full register).
     // ADR-013 Stage 2a: source from the `memories` table. The Phase 5
@@ -480,6 +488,26 @@ export async function saveDecisionToDb(
     // superseded_by on every session start.
     const { getAllDecisionsFromMemories } = await import('./context-store.js');
     let allDecisions: Decision[] = getAllDecisionsFromMemories();
+    if (!allDecisions.some(d => d.id === id)) {
+      logWarning('projection', 'just-saved decision missing from memories after mirror; injecting fallback for projection', {
+        fn: 'saveDecisionToDb',
+        decisionId: id,
+      });
+      const nextSeq = allDecisions.reduce((max, d) => Math.max(max, d.seq ?? 0), 0) + 1;
+      const fallback: Decision = {
+        seq: nextSeq,
+        id,
+        when_context: fields.when_context ?? '',
+        scope: fields.scope,
+        decision: fields.decision,
+        choice: fields.choice,
+        rationale: fields.rationale,
+        revisable: fields.revisable ?? 'Yes',
+        made_by: fields.made_by ?? 'agent',
+        superseded_by: null,
+      };
+      allDecisions = [...allDecisions, fallback];
+    }
 
     const filePath = resolveGsdRootFile(basePath, 'DECISIONS');
 

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -597,12 +597,12 @@ export async function saveDecisionToDb(
 async function mirrorDecisionToMemory(
   id: string,
   normalizedFields: NormalizedSaveDecisionFields,
-): Promise<void> {
+): Promise<boolean> {
   try {
     const { createMemory } = await import('./memory-store.js');
     const { synthesizeDecisionMemoryContent } = await import('./memory-backfill.js');
     const content = synthesizeDecisionMemoryContent(normalizedFields);
-    if (!content) return;
+    if (!content) return false;
 
     createMemory({
       category: 'architecture',

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -100,7 +100,7 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
 
 - `skill_rules`: situational rules with a human-readable `when` trigger and one or more of `use`, `prefer`, or `avoid`.
 
-- `custom_instructions`: extra durable instructions related to skill use. For operational project knowledge (recurring rules, gotchas, patterns), use `.gsd/KNOWLEDGE.md` instead — it's injected into every agent prompt automatically and agents can append to it during execution.
+- `custom_instructions`: extra durable instructions related to skill use. For operational project knowledge, use `.gsd/KNOWLEDGE.md` instead. Rules are file-canonical; patterns and lessons are persisted to the `memories` table and projected back into `KNOWLEDGE.md` on the next session start.
 
 - `language`: preferred response language for all GSD interactions. Accepts any language name or code — `"Chinese"`, `"zh"`, `"German"`, `"de"`, `"日本語"`, etc. When set, GSD injects "Always respond in \<language\>" into every agent's system prompt, including after `/clear`. Quickest way to set it: `/gsd language <name>`. To clear: `/gsd language off`.
 

--- a/src/resources/extensions/gsd/knowledge-backfill.ts
+++ b/src/resources/extensions/gsd/knowledge-backfill.ts
@@ -48,13 +48,13 @@ export function backfillKnowledgeToMemories(basePath: string): number {
   const adapter = _getAdapter();
   if (!adapter) return 0;
 
-  const content = readKnowledgeMd(basePath);
-  if (!content.trim()) return 0;
-
-  const rows = parseKnowledgeRows(content);
-  if (rows.length === 0) return 0;
-
   try {
+    const content = readKnowledgeMd(basePath);
+    if (!content.trim()) return 0;
+
+    const rows = parseKnowledgeRows(content);
+    if (rows.length === 0) return 0;
+
     const checkExisting = adapter.prepare(
       "SELECT 1 FROM memories WHERE structured_fields LIKE :pattern LIMIT 1",
     );
@@ -82,7 +82,7 @@ export function backfillKnowledgeToMemories(basePath: string): number {
     return written;
   } catch (e) {
     logWarning(
-      "knowledge-backfill",
+      "memory-backfill",
       `KNOWLEDGE.md -> memories backfill failed: ${(e as Error).message}`,
     );
     return 0;

--- a/src/resources/extensions/gsd/knowledge-backfill.ts
+++ b/src/resources/extensions/gsd/knowledge-backfill.ts
@@ -1,0 +1,164 @@
+// GSD2 — KNOWLEDGE.md -> memories backfill (ADR-013 Stage 2b).
+//
+// Idempotent migration of `.gsd/KNOWLEDGE.md` Patterns and Lessons rows into
+// the `memories` table. Patterns become memories with `category: "pattern"`;
+// Lessons become memories with `category: "gotcha"` (mirroring the ADR-013
+// line 38 contract). Rules (K###) are NOT migrated — they remain manually
+// maintained in `KNOWLEDGE.md` per ADR-013 line 39.
+//
+// Idempotency is enforced by tagging each backfilled memory with
+// `structured_fields.sourceKnowledgeId = "<P|L>NNN"`. The
+// memory-consolidation-scanner (PR #5765) checks for the same marker.
+//
+// Triggered opportunistically by `buildBeforeAgentStartResult` so the cost
+// only ever fires once per project. Costs O(N) inserts on first run where N
+// is the row count; subsequent runs are an O(N) lookup that finds existing
+// markers and exits.
+
+import { _getAdapter, isDbAvailable } from "./gsd-db.js";
+import { createMemory } from "./memory-store.js";
+import { parseKnowledgeRows, readKnowledgeMd, type KnowledgeRow } from "./knowledge-parser.js";
+import { logWarning } from "./workflow-logger.js";
+
+interface SynthesizedRow {
+  table: "patterns" | "lessons";
+  id: string;
+  category: "pattern" | "gotcha";
+  content: string;
+  scope: string;
+  structuredFields: Record<string, unknown>;
+}
+
+/**
+ * Backfill KNOWLEDGE.md Patterns + Lessons rows into the memories table.
+ *
+ * - Idempotent (per-row): each migrated memory carries
+ *   `structured_fields.sourceKnowledgeId = "<P|L>NNN"`. Rows whose ID is
+ *   already present in the memory store are skipped.
+ * - Best-effort: never throws. Logs and returns 0 on failure so a broken
+ *   backfill cannot block agent startup.
+ * - Rules (K###) are intentionally skipped — they remain manually maintained
+ *   in `KNOWLEDGE.md` per ADR-013.
+ *
+ * Returns the number of memories written (0 when there's nothing to migrate
+ * or when the file is absent).
+ */
+export function backfillKnowledgeToMemories(basePath: string): number {
+  if (!isDbAvailable()) return 0;
+  const adapter = _getAdapter();
+  if (!adapter) return 0;
+
+  const content = readKnowledgeMd(basePath);
+  if (!content.trim()) return 0;
+
+  const rows = parseKnowledgeRows(content);
+  if (rows.length === 0) return 0;
+
+  try {
+    const checkExisting = adapter.prepare(
+      "SELECT 1 FROM memories WHERE structured_fields LIKE :pattern LIMIT 1",
+    );
+
+    let written = 0;
+    for (const row of rows) {
+      const synth = synthesize(row);
+      if (!synth) continue;
+
+      // Pattern is anchored on both sides of the value to avoid prefix
+      // collisions (e.g. P1 vs P10).
+      const matchPattern = `%"sourceKnowledgeId":"${synth.id}"%`;
+      if (checkExisting.get({ ":pattern": matchPattern })) continue;
+
+      const id = createMemory({
+        category: synth.category,
+        content: synth.content,
+        scope: synth.scope,
+        confidence: 0.85,
+        structuredFields: synth.structuredFields,
+      });
+      if (id) written += 1;
+    }
+
+    return written;
+  } catch (e) {
+    logWarning(
+      "knowledge-backfill",
+      `KNOWLEDGE.md -> memories backfill failed: ${(e as Error).message}`,
+    );
+    return 0;
+  }
+}
+
+/**
+ * Convert a parsed KNOWLEDGE.md row into the memory payload we insert.
+ * Returns `null` for Rules (K###) which are not migrated, or for rows whose
+ * primary content cell is empty (defensive against malformed manual edits).
+ */
+function synthesize(row: KnowledgeRow): SynthesizedRow | null {
+  if (row.table === "rules") return null;
+
+  if (row.table === "patterns") {
+    // Cells: [P###, Pattern, Where, Notes]
+    const [, pattern, where, notes] = row.cells;
+    const cleaned = (pattern ?? "").trim();
+    if (!cleaned) return null;
+
+    const contentParts: string[] = [cleaned];
+    if (where && where.trim() && where.trim() !== "—") {
+      contentParts.push(`Where: ${where.trim()}.`);
+    }
+    if (notes && notes.trim() && notes.trim() !== "—") {
+      contentParts.push(`Notes: ${notes.trim()}.`);
+    }
+
+    return {
+      table: "patterns",
+      id: row.id,
+      category: "pattern",
+      content: trim(contentParts.join(" "), 600),
+      scope: (where ?? "").trim() || "project",
+      structuredFields: {
+        sourceKnowledgeId: row.id,
+        sourceKnowledgeTable: "patterns",
+        pattern: cleaned,
+        where: (where ?? "").trim(),
+        notes: (notes ?? "").trim(),
+      },
+    };
+  }
+
+  // table === "lessons"
+  // Cells: [L###, What Happened, Root Cause, Fix, Scope]
+  const [, whatHappened, rootCause, fix, scope] = row.cells;
+  const cleanedWhat = (whatHappened ?? "").trim();
+  if (!cleanedWhat) return null;
+
+  const contentParts: string[] = [cleanedWhat];
+  if (rootCause && rootCause.trim() && rootCause.trim() !== "—") {
+    contentParts.push(`Root cause: ${rootCause.trim()}.`);
+  }
+  if (fix && fix.trim() && fix.trim() !== "—") {
+    contentParts.push(`Fix: ${fix.trim()}.`);
+  }
+
+  return {
+    table: "lessons",
+    id: row.id,
+    category: "gotcha",
+    content: trim(contentParts.join(" "), 600),
+    scope: (scope ?? "").trim() || "project",
+    structuredFields: {
+      sourceKnowledgeId: row.id,
+      sourceKnowledgeTable: "lessons",
+      whatHappened: cleanedWhat,
+      rootCause: (rootCause ?? "").trim(),
+      fix: (fix ?? "").trim(),
+      scopeText: (scope ?? "").trim(),
+    },
+  };
+}
+
+function trim(value: string, max: number): string {
+  const cleaned = value.replace(/\s+/g, " ").trim();
+  return cleaned.length > max ? cleaned.slice(0, max - 1) + "…" : cleaned;
+}

--- a/src/resources/extensions/gsd/knowledge-capture.ts
+++ b/src/resources/extensions/gsd/knowledge-capture.ts
@@ -1,0 +1,160 @@
+// GSD2 — KNOWLEDGE.md write-side cutover (ADR-013 Stage 2c).
+//
+// Replaces the legacy `appendKnowledge` file-append path for Patterns and
+// Lessons with `createMemory` calls. Rules (K###) continue to flow through
+// the legacy file-append because they are intentionally not migrated to
+// memories per ADR-013 line 39.
+//
+// Next-ID assignment is the cross-surface stable rule: read the existing
+// `.gsd/KNOWLEDGE.md` for the highest <prefix>### in that section, AND read
+// the memories table for the highest `sourceKnowledgeId` with the matching
+// prefix, take the max, and increment. This stays stable across the
+// knowledge backfill mid-run (when some rows exist only in the file and
+// others only in memories) and on a fresh project where neither has any
+// entries yet.
+
+import { _getAdapter, isDbAvailable } from "./gsd-db.js";
+import { createMemory } from "./memory-store.js";
+import { parseKnowledgeRows, readKnowledgeMd } from "./knowledge-parser.js";
+import { logWarning } from "./workflow-logger.js";
+
+export type PatternLessonType = "pattern" | "lesson";
+
+export interface CaptureKnowledgeResult {
+  /** The assigned <prefix>### identifier (e.g. "P004"). */
+  id: string;
+  /** Whether the memory row was actually written. False only when the
+   *  DB is unavailable or the createMemory call returned undefined. */
+  written: boolean;
+}
+
+/**
+ * Append a new Pattern or Lesson by writing it as a memory row carrying a
+ * `sourceKnowledgeId` marker. The next session's KNOWLEDGE.md projection
+ * render (`knowledge-projection.ts`) picks it up and emits the row into the
+ * appropriate section.
+ *
+ * `entryText` is treated as the row's primary description cell (Pattern for
+ * patterns, "What Happened" for lessons). Auxiliary cells (Where/Notes for
+ * patterns; Root Cause/Fix/Scope for lessons) are left empty — the projection
+ * renders `—` for empty cells. Users who need richer structure can call
+ * `capture_thought` directly with a fuller `structuredFields` payload.
+ */
+export function captureKnowledgeEntry(
+  basePath: string,
+  type: PatternLessonType,
+  entryText: string,
+  scope: string,
+): CaptureKnowledgeResult {
+  const cleaned = entryText.trim();
+  const idPrefix = type === "pattern" ? "P" : "L";
+  const id = nextKnowledgeId(basePath, idPrefix);
+
+  if (!cleaned) {
+    return { id, written: false };
+  }
+
+  if (!isDbAvailable()) {
+    logWarning("knowledge-capture", "DB unavailable; cannot persist knowledge entry");
+    return { id, written: false };
+  }
+
+  try {
+    const category = type === "pattern" ? "pattern" : "gotcha";
+    const structuredFields: Record<string, unknown> =
+      type === "pattern"
+        ? {
+            sourceKnowledgeId: id,
+            sourceKnowledgeTable: "patterns",
+            pattern: cleaned,
+            where: "",
+            notes: "",
+          }
+        : {
+            sourceKnowledgeId: id,
+            sourceKnowledgeTable: "lessons",
+            whatHappened: cleaned,
+            rootCause: "",
+            fix: "",
+            scopeText: scope,
+          };
+
+    const memoryId = createMemory({
+      category,
+      content: cleaned,
+      scope: scope || "project",
+      confidence: 0.85,
+      structuredFields,
+    });
+
+    return { id, written: !!memoryId };
+  } catch (e) {
+    logWarning(
+      "knowledge-capture",
+      `failed to persist ${type} entry as memory: ${(e as Error).message}`,
+    );
+    return { id, written: false };
+  }
+}
+
+/**
+ * Compute the next <prefix>### identifier across both the legacy
+ * `.gsd/KNOWLEDGE.md` and the `memories.structured_fields.sourceKnowledgeId`
+ * surface. Takes the max numeric suffix from either side and increments.
+ *
+ * Padded to three digits to match the existing `appendKnowledge` convention.
+ * Exported for tests; production callers go through `captureKnowledgeEntry`.
+ */
+export function nextKnowledgeId(basePath: string, prefix: "K" | "P" | "L"): string {
+  const fromFile = maxIdInFile(basePath, prefix);
+  const fromMemories = maxIdInMemories(prefix);
+  const next = Math.max(fromFile, fromMemories) + 1;
+  return `${prefix}${String(next).padStart(3, "0")}`;
+}
+
+function maxIdInFile(basePath: string, prefix: "K" | "P" | "L"): number {
+  const content = readKnowledgeMd(basePath);
+  if (!content.trim()) return 0;
+  const expectedTable =
+    prefix === "K" ? "rules" : prefix === "P" ? "patterns" : "lessons";
+
+  let max = 0;
+  for (const row of parseKnowledgeRows(content)) {
+    if (row.table !== expectedTable) continue;
+    const num = parseInt(row.id.slice(1), 10);
+    if (Number.isFinite(num) && num > max) max = num;
+  }
+  return max;
+}
+
+function maxIdInMemories(prefix: "K" | "P" | "L"): number {
+  if (!isDbAvailable()) return 0;
+  const adapter = _getAdapter();
+  if (!adapter) return 0;
+  try {
+    const rows = adapter
+      .prepare(
+        "SELECT structured_fields FROM memories WHERE structured_fields LIKE :pattern",
+      )
+      .all({ ":pattern": `%"sourceKnowledgeId":"${prefix}%` }) as Array<{
+      structured_fields: string | null;
+    }>;
+    let max = 0;
+    for (const row of rows) {
+      if (!row.structured_fields) continue;
+      let sf: Record<string, unknown>;
+      try {
+        sf = JSON.parse(row.structured_fields) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      const sourceId = sf["sourceKnowledgeId"];
+      if (typeof sourceId !== "string" || !sourceId.startsWith(prefix)) continue;
+      const num = parseInt(sourceId.slice(1), 10);
+      if (Number.isFinite(num) && num > max) max = num;
+    }
+    return max;
+  } catch {
+    return 0;
+  }
+}

--- a/src/resources/extensions/gsd/knowledge-parser.ts
+++ b/src/resources/extensions/gsd/knowledge-parser.ts
@@ -1,0 +1,139 @@
+// GSD-2 — KNOWLEDGE.md parsing helpers shared by the consolidation scanner,
+// the Patterns/Lessons backfill, and the hybrid projection renderer
+// (ADR-013 Stage 2a/2b).
+//
+// The KNOWLEDGE.md format is locked in `files.ts:appendKnowledge`:
+//
+//   # Project Knowledge
+//
+//   <optional intro prose>
+//
+//   ## Rules
+//
+//   | # | Scope | Rule | Why | Added |
+//   |---|-------|------|-----|-------|
+//   | K001 | project | <rule text> | <reason> | <date> |
+//
+//   ## Patterns
+//
+//   | # | Pattern | Where | Notes |
+//   |---|---------|-------|-------|
+//   | P001 | <pattern> | <location> | <notes> |
+//
+//   ## Lessons Learned
+//
+//   | # | What Happened | Root Cause | Fix | Scope |
+//   |---|--------------|------------|-----|-------|
+//   | L001 | <what> | <cause> | <fix> | <scope> |
+//
+// Row IDs use a strict <prefix><digits> format (K001, P001, L001 …). Parsers
+// skip the column-title and separator rows; only rows whose first cell
+// matches the expected prefix are emitted.
+
+import { existsSync, readFileSync } from "node:fs";
+
+import { resolveGsdRootFile } from "./paths.js";
+
+export type KnowledgeTable = "rules" | "patterns" | "lessons";
+
+export interface KnowledgeRow {
+  table: KnowledgeTable;
+  id: string;
+  /** Full table row, trimmed. Useful as a sample for diagnostic surfaces. */
+  raw: string;
+  /** Pipe-split cell values (excluding the leading/trailing empty cells from `| ... |`). */
+  cells: string[];
+}
+
+export const KNOWLEDGE_SECTIONS: ReadonlyArray<{
+  table: KnowledgeTable;
+  heading: string;
+  idPrefix: string;
+}> = [
+  { table: "rules", heading: "## Rules", idPrefix: "K" },
+  { table: "patterns", heading: "## Patterns", idPrefix: "P" },
+  { table: "lessons", heading: "## Lessons Learned", idPrefix: "L" },
+];
+
+/** Read `.gsd/KNOWLEDGE.md` content if present. Returns "" when absent or unreadable. */
+export function readKnowledgeMd(basePath: string): string {
+  const path = resolveGsdRootFile(basePath, "KNOWLEDGE");
+  if (!existsSync(path)) return "";
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+/** Resolve the canonical `.gsd/KNOWLEDGE.md` path. */
+export function knowledgeMdPath(basePath: string): string {
+  return resolveGsdRootFile(basePath, "KNOWLEDGE");
+}
+
+/**
+ * Parse KNOWLEDGE.md into row records. Skips intro prose, table headers,
+ * separator lines, and rows from unrecognized sections. Each row's first
+ * cell must match the section's expected prefix (K/P/L + digits).
+ */
+export function parseKnowledgeRows(content: string): KnowledgeRow[] {
+  const rows: KnowledgeRow[] = [];
+  if (!content.trim()) return rows;
+
+  const lines = content.split("\n");
+  let activeSection: (typeof KNOWLEDGE_SECTIONS)[number] | undefined;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("## ")) {
+      activeSection = KNOWLEDGE_SECTIONS.find((s) => s.heading === trimmed);
+      continue;
+    }
+    if (!activeSection) continue;
+    if (!trimmed.startsWith("|")) continue;
+
+    const idMatch = new RegExp(`^\\|\\s*(${activeSection.idPrefix}\\d+)\\s*\\|`).exec(trimmed);
+    if (!idMatch) continue;
+
+    rows.push({
+      table: activeSection.table,
+      id: idMatch[1] ?? "",
+      raw: trimmed,
+      cells: splitPipeRow(trimmed),
+    });
+  }
+
+  return rows;
+}
+
+/**
+ * Split a Markdown table row on un-escaped pipes. Returns the cell values
+ * (without the leading/trailing empty fragments from `| ... |`), each
+ * trimmed. Escaped pipes (`\|`) inside a cell are preserved as `|` in the
+ * output.
+ */
+export function splitPipeRow(row: string): string[] {
+  const cells: string[] = [];
+  let current = "";
+  for (let i = 0; i < row.length; i++) {
+    const ch = row[i];
+    if (ch === "\\" && row[i + 1] === "|") {
+      current += "|";
+      i += 1;
+      continue;
+    }
+    if (ch === "|") {
+      cells.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim().length > 0) {
+    cells.push(current.trim());
+  }
+  // Drop the leading empty fragment from `|<cell>|...|` — the first split
+  // produces an empty string before the first pipe.
+  if (cells.length > 0 && cells[0] === "") cells.shift();
+  return cells;
+}

--- a/src/resources/extensions/gsd/knowledge-projection.ts
+++ b/src/resources/extensions/gsd/knowledge-projection.ts
@@ -71,7 +71,7 @@ function readKnowledgeMemories(category: "pattern" | "gotcha"): KnowledgeMemoryR
   try {
     const rows = adapter
       .prepare(
-        "SELECT structured_fields FROM memories WHERE category = :cat AND structured_fields LIKE '%\"sourceKnowledgeId\":\"%' ORDER BY seq",
+        "SELECT structured_fields FROM memories WHERE category = :cat AND structured_fields IS NOT NULL",
       )
       .all({ ":cat": category }) as Array<{ structured_fields: string | null }>;
 
@@ -88,6 +88,7 @@ function readKnowledgeMemories(category: "pattern" | "gotcha"): KnowledgeMemoryR
       if (typeof sourceId !== "string" || sourceId.length === 0) continue;
       out.push({ sourceId, structured: sf });
     }
+    out.sort((a, b) => a.sourceId.localeCompare(b.sourceId));
     return out;
   } catch {
     return [];

--- a/src/resources/extensions/gsd/knowledge-projection.ts
+++ b/src/resources/extensions/gsd/knowledge-projection.ts
@@ -1,0 +1,219 @@
+// GSD2 — KNOWLEDGE.md hybrid projection renderer (ADR-013 Stage 2b).
+//
+// Renders `.gsd/KNOWLEDGE.md` as a hybrid file:
+//   - Rules section: read directly from the existing KNOWLEDGE.md (manual,
+//     per ADR-013 line 39 — Rules are not migrated to memories).
+//   - Patterns section: read from `memories` where `category = "pattern"`
+//     AND `structured_fields.sourceKnowledgeId` is set (matches the marker
+//     written by knowledge-backfill.ts).
+//   - Lessons Learned section: read from `memories` where
+//     `category = "gotcha"` AND `structured_fields.sourceKnowledgeId` is set.
+//
+// Triggered opportunistically by `buildBeforeAgentStartResult` after the
+// knowledge backfill runs. Output is byte-stable when nothing has changed
+// (atomic write). The Rules section is preserved verbatim — including
+// indentation, trailing whitespace, and comments — so manual edits to that
+// section continue to round-trip through `/gsd knowledge`.
+//
+// Memories captured directly via `capture_thought` (without a
+// `sourceKnowledgeId` marker) are intentionally NOT rendered into
+// KNOWLEDGE.md. They remain accessible via the loadMemoryBlock auto-injection
+// surface; KNOWLEDGE.md projects only the KNOWLEDGE.md-originating subset.
+
+import { writeFileSync } from "node:fs";
+
+import { _getAdapter, isDbAvailable } from "./gsd-db.js";
+import {
+  KNOWLEDGE_SECTIONS,
+  knowledgeMdPath,
+  readKnowledgeMd,
+} from "./knowledge-parser.js";
+import { logWarning } from "./workflow-logger.js";
+
+const RULES_HEADING = "## Rules";
+const PATTERNS_HEADING = "## Patterns";
+const LESSONS_HEADING = "## Lessons Learned";
+
+const PATTERNS_HEADER = "| # | Pattern | Where | Notes |";
+const PATTERNS_SEPARATOR = "|---|---------|-------|-------|";
+
+const LESSONS_HEADER = "| # | What Happened | Root Cause | Fix | Scope |";
+const LESSONS_SEPARATOR = "|---|--------------|------------|-----|-------|";
+
+const DEFAULT_INTRO = [
+  "# Project Knowledge",
+  "",
+  "Append-only register of project-specific rules, patterns, and lessons learned.",
+  "Agents read this before every unit. Add entries when you discover something worth remembering.",
+  "",
+].join("\n");
+
+interface KnowledgeMemoryRow {
+  sourceId: string;
+  structured: Record<string, unknown>;
+}
+
+export interface KnowledgeProjectionResult {
+  written: boolean;
+  content: string;
+}
+
+/**
+ * Read pattern memories that originated from KNOWLEDGE.md, ordered by
+ * `sourceKnowledgeId` (lexicographic — P001 < P002 < P010). Memories whose
+ * structuredFields fail to parse are skipped silently; they are diagnosed
+ * separately by the memory-consolidation scanner.
+ */
+function readKnowledgeMemories(category: "pattern" | "gotcha"): KnowledgeMemoryRow[] {
+  if (!isDbAvailable()) return [];
+  const adapter = _getAdapter();
+  if (!adapter) return [];
+  try {
+    const rows = adapter
+      .prepare(
+        "SELECT structured_fields FROM memories WHERE category = :cat AND structured_fields LIKE '%\"sourceKnowledgeId\":\"%' ORDER BY seq",
+      )
+      .all({ ":cat": category }) as Array<{ structured_fields: string | null }>;
+
+    const out: KnowledgeMemoryRow[] = [];
+    for (const row of rows) {
+      if (!row.structured_fields) continue;
+      let sf: Record<string, unknown>;
+      try {
+        sf = JSON.parse(row.structured_fields) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      const sourceId = sf["sourceKnowledgeId"];
+      if (typeof sourceId !== "string" || sourceId.length === 0) continue;
+      out.push({ sourceId, structured: sf });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+function escapeCell(value: string | undefined): string {
+  return (value ?? "").replace(/\|/g, "\\|");
+}
+
+function renderPatternsSection(memories: KnowledgeMemoryRow[]): string[] {
+  const lines = [PATTERNS_HEADING, "", PATTERNS_HEADER, PATTERNS_SEPARATOR];
+  for (const m of memories) {
+    const pattern = escapeCell(typeof m.structured["pattern"] === "string" ? (m.structured["pattern"] as string) : "");
+    const where = escapeCell(typeof m.structured["where"] === "string" ? (m.structured["where"] as string) : "");
+    const notes = escapeCell(typeof m.structured["notes"] === "string" ? (m.structured["notes"] as string) : "");
+    lines.push(`| ${m.sourceId} | ${pattern} | ${where || "—"} | ${notes || "—"} |`);
+  }
+  lines.push("");
+  return lines;
+}
+
+function renderLessonsSection(memories: KnowledgeMemoryRow[]): string[] {
+  const lines = [LESSONS_HEADING, "", LESSONS_HEADER, LESSONS_SEPARATOR];
+  for (const m of memories) {
+    const what = escapeCell(typeof m.structured["whatHappened"] === "string" ? (m.structured["whatHappened"] as string) : "");
+    const rootCause = escapeCell(typeof m.structured["rootCause"] === "string" ? (m.structured["rootCause"] as string) : "");
+    const fix = escapeCell(typeof m.structured["fix"] === "string" ? (m.structured["fix"] as string) : "");
+    const scope = escapeCell(typeof m.structured["scopeText"] === "string" ? (m.structured["scopeText"] as string) : "");
+    lines.push(`| ${m.sourceId} | ${what} | ${rootCause || "—"} | ${fix || "—"} | ${scope || "project"} |`);
+  }
+  lines.push("");
+  return lines;
+}
+
+/**
+ * Extract the Rules section (heading + table) from the existing
+ * `KNOWLEDGE.md` content, verbatim. Returns an empty default section
+ * (heading + empty table) when the source has no `## Rules` heading.
+ */
+function extractRulesSection(existing: string): string[] {
+  const lines = existing.split("\n");
+  const startIdx = lines.findIndex((l) => l.trim() === RULES_HEADING);
+  if (startIdx === -1) {
+    return [
+      RULES_HEADING,
+      "",
+      "| # | Scope | Rule | Why | Added |",
+      "|---|-------|------|-----|-------|",
+      "",
+    ];
+  }
+
+  // Find the next H2 heading that ends the Rules section.
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (lines[i]!.startsWith("## ")) {
+      endIdx = i;
+      break;
+    }
+  }
+
+  // Strip trailing blank lines from the captured slice — the assembled
+  // output adds its own separator blank line between sections.
+  const slice = lines.slice(startIdx, endIdx);
+  while (slice.length > 0 && slice[slice.length - 1]!.trim() === "") {
+    slice.pop();
+  }
+  slice.push("");
+  return slice;
+}
+
+/**
+ * Extract the intro prose (anything before `## Rules`) verbatim, preserving
+ * any title (`# Project Knowledge`), comments, and description text. Falls
+ * back to the `DEFAULT_INTRO` template when the source has no Rules heading
+ * yet.
+ */
+function extractIntro(existing: string): string {
+  if (!existing.trim()) return DEFAULT_INTRO;
+  const lines = existing.split("\n");
+  const rulesIdx = lines.findIndex((l) => l.trim() === RULES_HEADING);
+  if (rulesIdx === -1) return DEFAULT_INTRO;
+  // Trim trailing blank lines so the assembly adds its own separator.
+  const slice = lines.slice(0, rulesIdx);
+  while (slice.length > 0 && slice[slice.length - 1]!.trim() === "") {
+    slice.pop();
+  }
+  slice.push("");
+  return slice.join("\n");
+}
+
+/**
+ * Render the hybrid `KNOWLEDGE.md`: manual Rules + projected Patterns +
+ * projected Lessons. Returns the rendered content and a flag indicating
+ * whether the file was written (skipped when content is byte-identical to
+ * what's on disk).
+ *
+ * Best-effort: catches all errors and returns `{ written: false, content: "" }`.
+ */
+export function renderKnowledgeProjection(basePath: string): KnowledgeProjectionResult {
+  try {
+    const existing = readKnowledgeMd(basePath);
+    const intro = extractIntro(existing);
+    const rules = extractRulesSection(existing);
+    const patterns = renderPatternsSection(readKnowledgeMemories("pattern"));
+    const lessons = renderLessonsSection(readKnowledgeMemories("gotcha"));
+
+    const content = [intro, ...rules, ...patterns, ...lessons]
+      .join("\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .replace(/\s+$/g, "")
+      + "\n";
+
+    if (content === existing) {
+      return { written: false, content };
+    }
+
+    writeFileSync(knowledgeMdPath(basePath), content, "utf-8");
+    return { written: true, content };
+  } catch (e) {
+    logWarning("knowledge-projection", `render failed: ${(e as Error).message}`);
+    return { written: false, content: "" };
+  }
+}
+
+// Re-export the section headings so tests can assert on the canonical
+// structure without re-defining the strings.
+export { KNOWLEDGE_SECTIONS };

--- a/src/resources/extensions/gsd/knowledge-projection.ts
+++ b/src/resources/extensions/gsd/knowledge-projection.ts
@@ -53,6 +53,11 @@ interface KnowledgeMemoryRow {
   structured: Record<string, unknown>;
 }
 
+interface KnowledgeMemoryReadResult {
+  ok: boolean;
+  rows: KnowledgeMemoryRow[];
+}
+
 export interface KnowledgeProjectionResult {
   written: boolean;
   content: string;
@@ -64,10 +69,10 @@ export interface KnowledgeProjectionResult {
  * structuredFields fail to parse are skipped silently; they are diagnosed
  * separately by the memory-consolidation scanner.
  */
-function readKnowledgeMemories(category: "pattern" | "gotcha"): KnowledgeMemoryRow[] {
-  if (!isDbAvailable()) return [];
+function readKnowledgeMemories(category: "pattern" | "gotcha"): KnowledgeMemoryReadResult {
+  if (!isDbAvailable()) return { ok: false, rows: [] };
   const adapter = _getAdapter();
-  if (!adapter) return [];
+  if (!adapter) return { ok: false, rows: [] };
   try {
     const rows = adapter
       .prepare(
@@ -88,14 +93,17 @@ function readKnowledgeMemories(category: "pattern" | "gotcha"): KnowledgeMemoryR
       if (typeof sourceId !== "string" || sourceId.length === 0) continue;
       out.push({ sourceId, structured: sf });
     }
-    return out;
+    return { ok: true, rows: out };
   } catch {
-    return [];
+    return { ok: false, rows: [] };
   }
 }
 
 function escapeCell(value: string | undefined): string {
-  return (value ?? "").replace(/\|/g, "\\|");
+  return (value ?? "")
+    .replace(/\s+/g, " ")
+    .replace(/\|/g, "\\|")
+    .trim();
 }
 
 function renderPatternsSection(memories: KnowledgeMemoryRow[]): string[] {
@@ -193,12 +201,23 @@ export function renderKnowledgeProjection(basePath: string): KnowledgeProjection
     const existing = readKnowledgeMd(basePath);
     const intro = extractIntro(existing);
     const rules = extractRulesSection(existing);
-    const patterns = renderPatternsSection(readKnowledgeMemories("pattern"));
-    const lessons = renderLessonsSection(readKnowledgeMemories("gotcha"));
+    const patternMemories = readKnowledgeMemories("pattern");
+    const lessonMemories = readKnowledgeMemories("gotcha");
+    if (!patternMemories.ok || !lessonMemories.ok) {
+      return { written: false, content: existing };
+    }
+    const patterns = renderPatternsSection(patternMemories.rows);
+    const lessons = renderLessonsSection(lessonMemories.rows);
 
-    const content = [intro, ...rules, ...patterns, ...lessons]
+    const introText = intro
+      .replace(/\n{3,}/g, "\n\n")
+      .replace(/\s+$/g, "");
+    const projectedText = [...patterns, ...lessons]
       .join("\n")
       .replace(/\n{3,}/g, "\n\n")
+      .replace(/\s+$/g, "");
+    const content = [introText, rules.join("\n"), projectedText]
+      .join("\n")
       .replace(/\s+$/g, "")
       + "\n";
 
@@ -209,7 +228,7 @@ export function renderKnowledgeProjection(basePath: string): KnowledgeProjection
     writeFileSync(knowledgeMdPath(basePath), content, "utf-8");
     return { written: true, content };
   } catch (e) {
-    logWarning("knowledge-projection", `render failed: ${(e as Error).message}`);
+    logWarning("renderer", `KNOWLEDGE.md projection render failed: ${(e as Error).message}`);
     return { written: false, content: "" };
   }
 }

--- a/src/resources/extensions/gsd/memory-backfill.ts
+++ b/src/resources/extensions/gsd/memory-backfill.ts
@@ -1,9 +1,10 @@
 // GSD2 — Decisions -> memories backfill (ADR-013 step 5)
 //
-// Idempotent one-shot migration that copies every active decisions row into
-// the memories table with category="architecture" and a structured_fields
-// payload preserving the original gsd_save_decision schema (when_context,
-// scope, decision, choice, rationale, made_by, revisable, sourceDecisionId).
+// Idempotent migration that copies every decisions row (active and
+// superseded — see Stage 2a note below) into the memories table with
+// category="architecture" and a structured_fields payload preserving the
+// original gsd_save_decision schema (when_context, scope, decision, choice,
+// rationale, made_by, revisable, superseded_by, sourceDecisionId).
 //
 // The backfill exists so the cutover in ADR-013 step 6 can drop the
 // decisions table without losing schema fidelity. Idempotency is enforced
@@ -14,6 +15,13 @@
 // only ever fires once per project. Costs O(N) inserts on first run where
 // N is the active-decisions count; subsequent runs are an O(N) lookup that
 // finds existing markers and exits.
+//
+// ADR-013 Stage 2a (PR #5755): backfill now includes superseded rows so the
+// DECISIONS.md projection regen can source from memories without losing
+// historical entries. An auto-heal pass runs after the initial migration to
+// pick up superseded_by changes that occurred after the source decision was
+// already migrated (e.g. a fresh md-importer run that introduced a new
+// supersedes-chain).
 
 import { isDbAvailable, _getAdapter } from "./gsd-db.js";
 import { createMemory } from "./memory-store.js";
@@ -32,7 +40,7 @@ interface DecisionRow {
 }
 
 /**
- * Backfill active decisions rows into the memories table.
+ * Backfill decisions rows into the memories table.
  *
  * - Idempotent (per-row): every row written carries
  *   `structured_fields.sourceDecisionId = "<decisionId>"`. Each candidate
@@ -41,13 +49,18 @@ interface DecisionRow {
  *   their own `sourceDecisionId` does NOT abort the backfill.
  * - Best-effort: never throws. Logs and returns 0 on failure so a broken
  *   backfill cannot block agent startup.
- * - Active-only: skips rows where `superseded_by IS NOT NULL`. Superseded
- *   decisions are historical record; the memory store is for active
- *   knowledge.
+ * - Full migration (ADR-013 Stage 2a): both active and superseded rows are
+ *   migrated. `structured_fields.superseded_by` preserves the supersedes
+ *   chain so the DECISIONS.md projection regen can source from memories
+ *   without losing historical entries.
+ * - Drift auto-heal: after the initial insert pass, the function updates
+ *   any pre-existing memory whose `structured_fields.superseded_by` drifted
+ *   from the source decision (e.g. a fresh md-importer run introduced a
+ *   new supersedes annotation after the initial migration).
  *
  * Returns the number of memories written (0 when already backfilled or
- * when the DB has no decisions). Callers can log the result or surface it
- * to the user.
+ * when the DB has no decisions). Drift-heal updates are not counted in
+ * this return — they are logged separately.
  */
 export function backfillDecisionsToMemories(): number {
   if (!isDbAvailable()) return 0;
@@ -56,7 +69,7 @@ export function backfillDecisionsToMemories(): number {
 
   try {
     const decisions = adapter
-      .prepare("SELECT id, when_context, scope, decision, choice, rationale, made_by, revisable, superseded_by FROM decisions WHERE superseded_by IS NULL")
+      .prepare("SELECT id, when_context, scope, decision, choice, rationale, made_by, revisable, superseded_by FROM decisions")
       .all() as Array<Record<string, unknown>>;
 
     if (decisions.length === 0) return 0;
@@ -67,10 +80,14 @@ export function backfillDecisionsToMemories(): number {
     // sentinel would silently abort the backfill if a user manually called
     // capture_thought with their own structuredFields.sourceDecisionId.
     const checkExisting = adapter.prepare(
-      "SELECT 1 FROM memories WHERE structured_fields LIKE :pattern LIMIT 1",
+      "SELECT structured_fields FROM memories WHERE structured_fields LIKE :pattern LIMIT 1",
+    );
+    const updateStructuredFields = adapter.prepare(
+      "UPDATE memories SET structured_fields = :sf, updated_at = :ts WHERE structured_fields LIKE :pattern",
     );
 
     let written = 0;
+    let healed = 0;
     for (const raw of decisions) {
       const row: DecisionRow = {
         id: String(raw["id"] ?? ""),
@@ -85,9 +102,38 @@ export function backfillDecisionsToMemories(): number {
       };
       if (!row.id) continue;
 
-      // Pattern is anchored to the JSON-stringified shape and the exact
-      // decision id to avoid prefix collisions (e.g. "D1" vs "D10").
-      if (checkExisting.get({ ":pattern": `%"sourceDecisionId":"${row.id}"%` })) continue;
+      const pattern = `%"sourceDecisionId":"${row.id}"%`;
+      const existing = checkExisting.get({ ":pattern": pattern }) as
+        | { structured_fields: string | null }
+        | undefined;
+
+      if (existing) {
+        // Drift auto-heal: if the source decision's superseded_by has changed
+        // since the original migration, update the memory in place. Read-side
+        // queries reconstruct Decision.superseded_by from this field, so the
+        // DECISIONS.md projection stays accurate without us having to track
+        // supersedes events at the write site.
+        const currentSf = existing.structured_fields
+          ? (safeParse(existing.structured_fields) ?? {})
+          : {};
+        const memorySuperseded =
+          typeof currentSf["superseded_by"] === "string" || currentSf["superseded_by"] === null
+            ? (currentSf["superseded_by"] as string | null | undefined)
+            : null;
+        if (memorySuperseded !== row.superseded_by) {
+          const merged = {
+            ...currentSf,
+            superseded_by: row.superseded_by,
+          };
+          updateStructuredFields.run({
+            ":sf": JSON.stringify(merged),
+            ":ts": new Date().toISOString(),
+            ":pattern": pattern,
+          });
+          healed += 1;
+        }
+        continue;
+      }
 
       const content = synthesizeContent(row);
       const id = createMemory({
@@ -104,15 +150,31 @@ export function backfillDecisionsToMemories(): number {
           rationale: row.rationale,
           made_by: row.made_by,
           revisable: row.revisable,
+          superseded_by: row.superseded_by,
         },
       });
       if (id) written += 1;
+    }
+
+    if (healed > 0) {
+      logWarning(
+        "memory-backfill",
+        `decisions->memories drift healed: ${healed} row${healed === 1 ? "" : "s"} updated superseded_by`,
+      );
     }
 
     return written;
   } catch (e) {
     logWarning("memory-backfill", `decisions->memories backfill failed: ${(e as Error).message}`);
     return 0;
+  }
+}
+
+function safeParse(raw: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
   }
 }
 

--- a/src/resources/extensions/gsd/memory-backfill.ts
+++ b/src/resources/extensions/gsd/memory-backfill.ts
@@ -82,10 +82,10 @@ export function backfillDecisionsToMemories(): number {
     // sentinel would silently abort the backfill if a user manually called
     // capture_thought with their own structuredFields.sourceDecisionId.
     const checkExisting = adapter.prepare(
-      "SELECT structured_fields FROM memories WHERE structured_fields LIKE :pattern LIMIT 1",
+      "SELECT id, structured_fields FROM memories WHERE structured_fields LIKE :pattern LIMIT 1",
     );
     const updateStructuredFields = adapter.prepare(
-      "UPDATE memories SET structured_fields = :sf, updated_at = :ts WHERE structured_fields LIKE :pattern",
+      "UPDATE memories SET structured_fields = :sf, updated_at = :ts WHERE id = :id",
     );
 
     let written = 0;
@@ -106,7 +106,7 @@ export function backfillDecisionsToMemories(): number {
 
       const pattern = `%"sourceDecisionId":"${row.id}"%`;
       const existing = checkExisting.get({ ":pattern": pattern }) as
-        | { structured_fields: string | null }
+        | { id: string; structured_fields: string | null }
         | undefined;
 
       if (existing) {
@@ -128,9 +128,9 @@ export function backfillDecisionsToMemories(): number {
             superseded_by: row.superseded_by,
           };
           updateStructuredFields.run({
+            ":id": existing.id,
             ":sf": JSON.stringify(merged),
             ":ts": new Date().toISOString(),
-            ":pattern": pattern,
           });
           healed += 1;
         }

--- a/src/resources/extensions/gsd/memory-backfill.ts
+++ b/src/resources/extensions/gsd/memory-backfill.ts
@@ -69,7 +69,7 @@ export function backfillDecisionsToMemories(): number {
 
   try {
     const decisions = adapter
-      .prepare("SELECT id, when_context, scope, decision, choice, rationale, made_by, revisable, superseded_by FROM decisions")
+      .prepare("SELECT id, when_context, scope, decision, choice, rationale, made_by, revisable, superseded_by FROM decisions ORDER BY seq")
       .all() as Array<Record<string, unknown>>;
 
     if (decisions.length === 0) return 0;

--- a/src/resources/extensions/gsd/memory-backfill.ts
+++ b/src/resources/extensions/gsd/memory-backfill.ts
@@ -39,6 +39,8 @@ interface DecisionRow {
   superseded_by: string | null;
 }
 
+type DecisionContentFields = Pick<DecisionRow, "decision" | "choice" | "rationale">;
+
 /**
  * Backfill decisions rows into the memories table.
  *
@@ -69,7 +71,7 @@ export function backfillDecisionsToMemories(): number {
 
   try {
     const decisions = adapter
-      .prepare("SELECT id, when_context, scope, decision, choice, rationale, made_by, revisable, superseded_by FROM decisions")
+      .prepare("SELECT id, when_context, scope, decision, choice, rationale, made_by, revisable, superseded_by FROM decisions ORDER BY seq")
       .all() as Array<Record<string, unknown>>;
 
     if (decisions.length === 0) return 0;
@@ -135,7 +137,7 @@ export function backfillDecisionsToMemories(): number {
         continue;
       }
 
-      const content = synthesizeContent(row);
+      const content = synthesizeDecisionMemoryContent(row);
       const id = createMemory({
         category: "architecture",
         content,
@@ -186,7 +188,7 @@ function safeParse(raw: string): Record<string, unknown> | null {
  * Truncates each field to keep the synthesized line under ~600 chars so
  * memory_query rendering stays readable.
  */
-function synthesizeContent(row: DecisionRow): string {
+export function synthesizeDecisionMemoryContent(row: DecisionContentFields): string {
   const trim = (value: string, max: number): string => {
     const cleaned = value.replace(/\s+/g, " ").trim();
     return cleaned.length > max ? cleaned.slice(0, max - 1) + "\u2026" : cleaned;

--- a/src/resources/extensions/gsd/memory-backfill.ts
+++ b/src/resources/extensions/gsd/memory-backfill.ts
@@ -113,9 +113,17 @@ export function backfillDecisionsToMemories(): number {
         // queries reconstruct Decision.superseded_by from this field, so the
         // DECISIONS.md projection stays accurate without us having to track
         // supersedes events at the write site.
-        const currentSf = existing.structured_fields
-          ? (safeParse(existing.structured_fields) ?? {})
+        const parsedSf = existing.structured_fields
+          ? safeParse(existing.structured_fields)
           : {};
+        if (existing.structured_fields && !parsedSf) {
+          logWarning(
+            "memory-backfill",
+            `decisions->memories drift heal skipped for ${row.id}: invalid structured_fields JSON`,
+          );
+          continue;
+        }
+        const currentSf = parsedSf ?? {};
         const memorySuperseded =
           typeof currentSf["superseded_by"] === "string" || currentSf["superseded_by"] === null
             ? (currentSf["superseded_by"] as string | null | undefined)

--- a/src/resources/extensions/gsd/templates/knowledge.md
+++ b/src/resources/extensions/gsd/templates/knowledge.md
@@ -1,7 +1,7 @@
 # Project Knowledge
 
-Append-only register of project-specific rules, patterns, and lessons learned.
-Agents read this before every unit. Add entries when you discover something worth remembering.
+Project-specific rules plus projected patterns and lessons learned.
+Rules are maintained in this file. Patterns and lessons are persisted to the memories table and rendered here on the next session-start projection.
 
 ## Rules
 

--- a/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
+++ b/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
@@ -187,6 +187,64 @@ test("backfill auto-heals when a source decision's superseded_by changes after m
   }
 });
 
+test("backfill drift auto-heal updates only the selected memory row", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001",
+      scope: "M001",
+      decision: "Original",
+      choice: "A",
+      rationale: "r",
+    });
+    backfillDecisionsToMemories();
+
+    const adapter = _getAdapter();
+    if (!adapter) throw new Error("DB adapter unavailable");
+    const now = new Date().toISOString();
+    adapter
+      .prepare(
+        `INSERT INTO memories (
+          id, category, content, confidence, created_at, updated_at, scope, tags, structured_fields
+        ) VALUES (
+          :id, 'architecture', 'duplicate marker', 0.8, :created_at, :updated_at, 'project', '[]', :structured_fields
+        )`,
+      )
+      .run({
+        ":id": "manual-duplicate-D001",
+        ":created_at": now,
+        ":updated_at": now,
+        ":structured_fields": JSON.stringify({
+          sourceDecisionId: "D001",
+          superseded_by: null,
+          note: "manual duplicate should not be healed as a side effect",
+        }),
+      });
+
+    setDecisionSupersededBy("D001", "D002");
+    backfillDecisionsToMemories();
+
+    const rows = adapter
+      .prepare("SELECT id, structured_fields FROM memories WHERE structured_fields LIKE :pattern ORDER BY seq")
+      .all({ ":pattern": '%"sourceDecisionId":"D001"%' }) as Array<{
+        id: string;
+        structured_fields: string;
+      }>;
+    assert.equal(rows.length, 2);
+    const healed = rows.find((row) => row.id !== "manual-duplicate-D001");
+    const duplicate = rows.find((row) => row.id === "manual-duplicate-D001");
+    assert.equal(JSON.parse(healed?.structured_fields ?? "{}").superseded_by, "D002");
+    assert.equal(
+      JSON.parse(duplicate?.structured_fields ?? "{}").superseded_by,
+      null,
+      "drift auto-heal must not update every memory matching the sourceDecisionId pattern",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
 // ─── queryDecisionsFromMemories: active-only via structuredFields ──────────
 
 test("queryDecisionsFromMemories filters out rows whose structuredFields.superseded_by is set", () => {

--- a/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
+++ b/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
@@ -1,0 +1,372 @@
+// ADR-013 Phase 6 cutover (Stage 2a) — locks in the four behavioral changes:
+//
+//   1. memory-backfill includes superseded decisions + preserves
+//      structuredFields.superseded_by
+//   2. memory-backfill drift auto-heal: when a decision's superseded_by
+//      changes after migration, the memory's structuredFields update
+//   3. context-store.queryDecisionsFromMemories filters out rows whose
+//      structuredFields.superseded_by is set (active-only)
+//   4. context-store.getAllDecisionsFromMemories returns the full register
+//      including superseded rows, and the saveDecisionToDb projection regen
+//      uses it — producing byte-equivalent DECISIONS.md to the legacy path
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  _getAdapter,
+  closeDatabase,
+  insertDecision,
+  openDatabase,
+} from "../gsd-db.ts";
+import { saveDecisionToDb, generateDecisionsMd } from "../db-writer.ts";
+import {
+  getAllDecisionsFromMemories,
+  queryDecisionsFromMemories,
+} from "../context-store.ts";
+import { backfillDecisionsToMemories } from "../memory-backfill.ts";
+import type { Decision } from "../types.ts";
+
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-decisions-stage2a-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  return base;
+}
+
+function cleanup(base: string): void {
+  try {
+    closeDatabase();
+  } catch {
+    /* noop */
+  }
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* noop */
+  }
+}
+
+function seedRawDecision(args: {
+  id: string;
+  when_context: string;
+  scope: string;
+  decision: string;
+  choice: string;
+  rationale: string;
+  revisable?: string;
+  made_by?: "human" | "agent" | "collaborative";
+  superseded_by?: string | null;
+}): void {
+  insertDecision({
+    id: args.id,
+    when_context: args.when_context,
+    scope: args.scope,
+    decision: args.decision,
+    choice: args.choice,
+    rationale: args.rationale,
+    revisable: args.revisable ?? "Yes",
+    made_by: args.made_by ?? "agent",
+    superseded_by: args.superseded_by ?? null,
+  });
+}
+
+function setDecisionSupersededBy(id: string, supersededBy: string): void {
+  const adapter = _getAdapter();
+  if (!adapter) throw new Error("DB adapter unavailable");
+  adapter
+    .prepare("UPDATE decisions SET superseded_by = :s WHERE id = :id")
+    .run({ ":s": supersededBy, ":id": id });
+}
+
+// ─── Backfill: superseded inclusion + structuredFields preservation ────────
+
+test("backfill migrates superseded decisions (no active-only filter)", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001 discuss",
+      scope: "M001",
+      decision: "Use A",
+      choice: "A",
+      rationale: "first idea",
+      superseded_by: "D002",
+    });
+    seedRawDecision({
+      id: "D002",
+      when_context: "M001 discuss",
+      scope: "M001",
+      decision: "Switch to B",
+      choice: "B",
+      rationale: "second thought",
+      superseded_by: null,
+    });
+
+    const written = backfillDecisionsToMemories();
+    assert.equal(written, 2, "both active and superseded rows should be migrated");
+
+    const all = getAllDecisionsFromMemories();
+    assert.equal(all.length, 2);
+    const d001 = all.find((d) => d.id === "D001");
+    const d002 = all.find((d) => d.id === "D002");
+    assert.ok(d001 && d002);
+    assert.equal(d001.superseded_by, "D002", "structuredFields.superseded_by must be preserved");
+    assert.equal(d002.superseded_by, null);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("backfill is idempotent — re-running over migrated rows is a no-op", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001",
+      scope: "M001",
+      decision: "x",
+      choice: "y",
+      rationale: "z",
+    });
+
+    const first = backfillDecisionsToMemories();
+    assert.equal(first, 1);
+    const second = backfillDecisionsToMemories();
+    assert.equal(second, 0, "already-migrated rows must not be re-inserted");
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── Drift auto-heal ───────────────────────────────────────────────────────
+
+test("backfill auto-heals when a source decision's superseded_by changes after migration", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001",
+      scope: "M001",
+      decision: "Original",
+      choice: "A",
+      rationale: "r",
+    });
+    // Initial migration: D001 is active.
+    backfillDecisionsToMemories();
+    const beforeHeal = getAllDecisionsFromMemories().find((d) => d.id === "D001");
+    assert.equal(beforeHeal?.superseded_by, null);
+
+    // Simulate md-importer setting superseded_by on the existing decision row.
+    seedRawDecision({
+      id: "D002",
+      when_context: "M001",
+      scope: "M001",
+      decision: "New",
+      choice: "B",
+      rationale: "newer",
+    });
+    setDecisionSupersededBy("D001", "D002");
+
+    // Second backfill pass: should heal D001's memory + migrate D002.
+    backfillDecisionsToMemories();
+
+    const afterHeal = getAllDecisionsFromMemories().find((d) => d.id === "D001");
+    assert.equal(
+      afterHeal?.superseded_by,
+      "D002",
+      "drift auto-heal must update structuredFields.superseded_by on existing migrated memories",
+    );
+    const d002 = getAllDecisionsFromMemories().find((d) => d.id === "D002");
+    assert.equal(d002?.superseded_by, null, "newly-migrated D002 stays active");
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── queryDecisionsFromMemories: active-only via structuredFields ──────────
+
+test("queryDecisionsFromMemories filters out rows whose structuredFields.superseded_by is set", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001",
+      scope: "M001",
+      decision: "Old",
+      choice: "A",
+      rationale: "r1",
+      superseded_by: "D002",
+    });
+    seedRawDecision({
+      id: "D002",
+      when_context: "M001",
+      scope: "M001",
+      decision: "New",
+      choice: "B",
+      rationale: "r2",
+    });
+    backfillDecisionsToMemories();
+
+    const active = queryDecisionsFromMemories();
+    assert.equal(active.length, 1, "only the non-superseded decision should appear");
+    assert.equal(active[0]?.id, "D002");
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── getAllDecisionsFromMemories: full register including superseded ───────
+
+test("getAllDecisionsFromMemories returns the full register including superseded", () => {
+  const base = makeTmpBase();
+  try {
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001",
+      scope: "M001",
+      decision: "First",
+      choice: "A",
+      rationale: "r1",
+      superseded_by: "D002",
+    });
+    seedRawDecision({
+      id: "D002",
+      when_context: "M001",
+      scope: "M001",
+      decision: "Second",
+      choice: "B",
+      rationale: "r2",
+    });
+    backfillDecisionsToMemories();
+
+    const all = getAllDecisionsFromMemories();
+    assert.equal(all.length, 2);
+    assert.deepEqual(
+      all.map((d) => ({ id: d.id, superseded_by: d.superseded_by })),
+      [
+        { id: "D001", superseded_by: "D002" },
+        { id: "D002", superseded_by: null },
+      ],
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── Projection parity: legacy table source vs memories source ─────────────
+
+function decisionFromLegacyRow(row: Record<string, unknown>): Decision {
+  return {
+    seq: row["seq"] as number,
+    id: row["id"] as string,
+    when_context: row["when_context"] as string,
+    scope: row["scope"] as string,
+    decision: row["decision"] as string,
+    choice: row["choice"] as string,
+    rationale: row["rationale"] as string,
+    revisable: row["revisable"] as string,
+    made_by: ((row["made_by"] as string) ?? "agent") as Decision["made_by"],
+    superseded_by: (row["superseded_by"] as string) ?? null,
+  };
+}
+
+test("DECISIONS.md projection from memories matches the legacy decisions-table render", async () => {
+  const base = makeTmpBase();
+  try {
+    // Seed three decisions with mixed superseded chains directly into the
+    // decisions table to ensure the legacy-side fixture is realistic.
+    seedRawDecision({
+      id: "D001",
+      when_context: "M001 discuss",
+      scope: "M001",
+      decision: "Initial direction",
+      choice: "A",
+      rationale: "rationale-1",
+      superseded_by: "D003",
+    });
+    seedRawDecision({
+      id: "D002",
+      when_context: "M001 plan",
+      scope: "M001-S01",
+      decision: "Active call",
+      choice: "B",
+      rationale: "rationale-2",
+    });
+    seedRawDecision({
+      id: "D003",
+      when_context: "M002 review",
+      scope: "M002",
+      decision: "Replacement for D001",
+      choice: "C",
+      rationale: "rationale-3",
+    });
+
+    // Run backfill so memories carries the full chain.
+    backfillDecisionsToMemories();
+
+    // Legacy render: read the decisions table directly, render via the
+    // existing generateDecisionsMd helper.
+    const adapter = _getAdapter();
+    if (!adapter) throw new Error("DB adapter unavailable");
+    const legacyRows = adapter.prepare("SELECT * FROM decisions ORDER BY seq").all() as Array<
+      Record<string, unknown>
+    >;
+    const legacyDecisions = legacyRows.map(decisionFromLegacyRow);
+    const legacyMd = generateDecisionsMd(legacyDecisions);
+
+    // Memory-sourced render: same generator, but Decision[] from memories.
+    const memoryDecisions = getAllDecisionsFromMemories();
+    const memoryMd = generateDecisionsMd(memoryDecisions);
+
+    assert.equal(memoryMd, legacyMd, "memory-sourced projection must match decisions-table render byte-for-byte");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("saveDecisionToDb writes a DECISIONS.md projection sourced from memories that round-trips", async () => {
+  const base = makeTmpBase();
+  try {
+    // Use the public write path so dual-write + projection happen end-to-end.
+    await saveDecisionToDb(
+      {
+        when_context: "M001 discuss",
+        scope: "M001",
+        decision: "Adopt SQLite",
+        choice: "better-sqlite3",
+        rationale: "synchronous + native",
+        revisable: "Yes",
+        made_by: "agent",
+      },
+      base,
+    );
+    await saveDecisionToDb(
+      {
+        when_context: "M001 plan",
+        scope: "M001-S01",
+        decision: "Schema versioning",
+        choice: "header column",
+        rationale: "simplest to read",
+        revisable: "Yes",
+        made_by: "agent",
+      },
+      base,
+    );
+
+    const md = readFileSync(join(base, ".gsd", "DECISIONS.md"), "utf-8");
+    // The projection must include both rows by ID — proving the regen
+    // sourced from memories (where dual-write landed them) rather than
+    // silently skipping anything.
+    assert.match(md, /\| D001 \|/);
+    assert.match(md, /\| D002 \|/);
+    assert.match(md, /Adopt SQLite/);
+    assert.match(md, /Schema versioning/);
+    assert.match(md, /# Decisions Register/);
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
+++ b/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
@@ -351,8 +351,6 @@ test("saveDecisionToDb writes a DECISIONS.md projection sourced from memories th
         decision: "Schema versioning",
         choice: "header column",
         rationale: "simplest to read",
-        revisable: "Yes",
-        made_by: "agent",
       },
       base,
     );
@@ -366,6 +364,7 @@ test("saveDecisionToDb writes a DECISIONS.md projection sourced from memories th
     assert.match(md, /Adopt SQLite/);
     assert.match(md, /Schema versioning/);
     assert.match(md, /# Decisions Register/);
+    assert.match(md, /\| D002 \|[^\n]*\| Yes \| agent \|/);
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
+++ b/src/resources/extensions/gsd/tests/decisions-projection-from-memories.test.ts
@@ -370,3 +370,27 @@ test("saveDecisionToDb writes a DECISIONS.md projection sourced from memories th
     cleanup(base);
   }
 });
+
+test("saveDecisionToDb injects a projection fallback when memory mirror is absent", async () => {
+  const base = makeTmpBase();
+  try {
+    const result = await saveDecisionToDb(
+      {
+        when_context: "M001 fallback",
+        scope: "M001",
+        decision: "",
+        choice: "",
+        rationale: "",
+      },
+      base,
+    );
+
+    assert.equal(result.id, "D001");
+    assert.equal(getAllDecisionsFromMemories().some((d) => d.id === "D001"), false);
+
+    const md = readFileSync(join(base, ".gsd", "DECISIONS.md"), "utf-8");
+    assert.match(md, /\| D001 \| M001 fallback \| M001 \|  \|  \|  \| Yes \| agent \|/);
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/knowledge-backfill-projection.test.ts
+++ b/src/resources/extensions/gsd/tests/knowledge-backfill-projection.test.ts
@@ -1,0 +1,323 @@
+// ADR-013 Stage 2b — KNOWLEDGE.md backfill + hybrid projection tests.
+//
+// Covers four behaviors:
+//   1. parser: splits cells correctly, skips header/separator rows, respects
+//      section boundaries
+//   2. backfill: Patterns -> memories(category=pattern), Lessons ->
+//      memories(category=gotcha), Rules NOT migrated, idempotent
+//   3. projection: hybrid output preserves manual Rules verbatim while
+//      projecting Patterns + Lessons from memories
+//   4. bootstrap path: backfill + projection round-trip produces a stable
+//      file that re-reading reconstitutes the same memory set
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  _getAdapter,
+  closeDatabase,
+  openDatabase,
+} from "../gsd-db.ts";
+import { backfillKnowledgeToMemories } from "../knowledge-backfill.ts";
+import {
+  knowledgeMdPath,
+  parseKnowledgeRows,
+  splitPipeRow,
+} from "../knowledge-parser.ts";
+import { renderKnowledgeProjection } from "../knowledge-projection.ts";
+
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-knowledge-stage2b-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  return base;
+}
+
+function cleanup(base: string): void {
+  try {
+    closeDatabase();
+  } catch {
+    /* noop */
+  }
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* noop */
+  }
+}
+
+function writeKnowledgeMd(base: string, body: string): void {
+  writeFileSync(join(base, ".gsd", "KNOWLEDGE.md"), body, "utf-8");
+}
+
+const FIXTURE = `# Project Knowledge
+
+Append-only register of project-specific rules, patterns, and lessons learned.
+Agents read this before every unit. Add entries when you discover something worth remembering.
+
+## Rules
+
+| # | Scope | Rule | Why | Added |
+|---|-------|------|-----|-------|
+| K001 | project | All timestamps in UTC | clarity | 2026-01-01 |
+| K002 | M001 | Never trust user input | safety | 2026-01-02 |
+
+## Patterns
+
+| # | Pattern | Where | Notes |
+|---|---------|-------|-------|
+| P001 | Repository pattern | services/ | guards |
+| P002 | Adapter at the seam | packages/pi-ai/ | observability |
+
+## Lessons Learned
+
+| # | What Happened | Root Cause | Fix | Scope |
+|---|--------------|------------|-----|-------|
+| L001 | Cache poisoning | reused key | versioned key | project |
+`;
+
+// ─── splitPipeRow ──────────────────────────────────────────────────────────
+
+test("splitPipeRow extracts cells from a standard table row", () => {
+  const cells = splitPipeRow("| K001 | project | All timestamps in UTC | clarity | 2026-01-01 |");
+  assert.deepEqual(cells, ["K001", "project", "All timestamps in UTC", "clarity", "2026-01-01"]);
+});
+
+test("splitPipeRow preserves escaped pipes inside a cell", () => {
+  const cells = splitPipeRow(`| K001 | project | Use A \\| B operator | safety | 2026-01-01 |`);
+  assert.equal(cells[2], "Use A | B operator");
+});
+
+// ─── parseKnowledgeRows ────────────────────────────────────────────────────
+
+test("parseKnowledgeRows returns rows per section with the correct table tag", () => {
+  const rows = parseKnowledgeRows(FIXTURE);
+  assert.equal(rows.length, 5, "two rules + two patterns + one lesson");
+  const tables = rows.map((r) => r.table);
+  assert.deepEqual(tables, ["rules", "rules", "patterns", "patterns", "lessons"]);
+});
+
+test("parseKnowledgeRows captures cell values aligned with the section schema", () => {
+  const rows = parseKnowledgeRows(FIXTURE);
+  const p1 = rows.find((r) => r.id === "P001");
+  assert.ok(p1);
+  assert.equal(p1.cells[1], "Repository pattern");
+  assert.equal(p1.cells[2], "services/");
+});
+
+// ─── backfillKnowledgeToMemories ───────────────────────────────────────────
+
+test("backfill migrates Patterns + Lessons but skips Rules", () => {
+  const base = makeTmpBase();
+  try {
+    writeKnowledgeMd(base, FIXTURE);
+    const written = backfillKnowledgeToMemories(base);
+    assert.equal(written, 3, "P001 + P002 + L001 should migrate; K rows skipped");
+
+    const adapter = _getAdapter();
+    assert.ok(adapter);
+
+    const knowledgeMemories = adapter
+      .prepare(
+        "SELECT category, structured_fields FROM memories WHERE structured_fields LIKE '%\"sourceKnowledgeId\":\"%' ORDER BY seq",
+      )
+      .all() as Array<{ category: string; structured_fields: string }>;
+
+    assert.equal(knowledgeMemories.length, 3);
+    const categoriesById: Record<string, string> = {};
+    for (const m of knowledgeMemories) {
+      const sf = JSON.parse(m.structured_fields) as { sourceKnowledgeId: string };
+      categoriesById[sf.sourceKnowledgeId] = m.category;
+    }
+    assert.equal(categoriesById["P001"], "pattern");
+    assert.equal(categoriesById["P002"], "pattern");
+    assert.equal(categoriesById["L001"], "gotcha");
+    assert.equal(categoriesById["K001"], undefined, "K001 must NOT be in memories");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("backfill is idempotent — second run on the same file is a no-op", () => {
+  const base = makeTmpBase();
+  try {
+    writeKnowledgeMd(base, FIXTURE);
+    const first = backfillKnowledgeToMemories(base);
+    assert.equal(first, 3);
+    const second = backfillKnowledgeToMemories(base);
+    assert.equal(second, 0, "already-migrated rows must not be re-inserted");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("backfill returns 0 when KNOWLEDGE.md is absent", () => {
+  const base = makeTmpBase();
+  try {
+    assert.equal(backfillKnowledgeToMemories(base), 0);
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── renderKnowledgeProjection ─────────────────────────────────────────────
+
+test("projection preserves the manual Rules section verbatim", () => {
+  const base = makeTmpBase();
+  try {
+    writeKnowledgeMd(base, FIXTURE);
+    backfillKnowledgeToMemories(base);
+    renderKnowledgeProjection(base);
+
+    const rendered = readFileSync(knowledgeMdPath(base), "utf-8");
+    // Both K-rows must appear unchanged.
+    assert.match(rendered, /\| K001 \| project \| All timestamps in UTC \| clarity \| 2026-01-01 \|/);
+    assert.match(rendered, /\| K002 \| M001 \| Never trust user input \| safety \| 2026-01-02 \|/);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("projection renders Patterns + Lessons from memories", () => {
+  const base = makeTmpBase();
+  try {
+    writeKnowledgeMd(base, FIXTURE);
+    backfillKnowledgeToMemories(base);
+    // Wipe the original Patterns/Lessons table rows from the file so the
+    // projection's output can ONLY come from memories. Keep Rules intact.
+    writeKnowledgeMd(
+      base,
+      `# Project Knowledge
+
+## Rules
+
+| # | Scope | Rule | Why | Added |
+|---|-------|------|-----|-------|
+| K001 | project | All timestamps in UTC | clarity | 2026-01-01 |
+| K002 | M001 | Never trust user input | safety | 2026-01-02 |
+`,
+    );
+
+    renderKnowledgeProjection(base);
+    const rendered = readFileSync(knowledgeMdPath(base), "utf-8");
+
+    assert.match(rendered, /\| P001 \| Repository pattern \| services\/ \| guards \|/);
+    assert.match(rendered, /\| P002 \| Adapter at the seam \| packages\/pi-ai\/ \| observability \|/);
+    assert.match(rendered, /\| L001 \| Cache poisoning \| reused key \| versioned key \| project \|/);
+
+    // Section structure must still be the canonical three headings, in order.
+    const rulesIdx = rendered.indexOf("## Rules");
+    const patternsIdx = rendered.indexOf("## Patterns");
+    const lessonsIdx = rendered.indexOf("## Lessons Learned");
+    assert.ok(rulesIdx >= 0 && patternsIdx > rulesIdx && lessonsIdx > patternsIdx, "headings must appear in canonical order");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("projection is idempotent when nothing has changed", () => {
+  const base = makeTmpBase();
+  try {
+    // Seed a file the projection will *change* (no canonical headers yet, so
+    // the first render must rewrite to add structure).
+    writeKnowledgeMd(
+      base,
+      `# Project Knowledge
+
+## Rules
+
+| # | Scope | Rule | Why | Added |
+|---|-------|------|-----|-------|
+| K001 | project | manual rule | reason | 2026-01-01 |
+`,
+    );
+
+    const first = renderKnowledgeProjection(base);
+    assert.equal(first.written, true, "first render adds the missing Patterns + Lessons section scaffolding");
+
+    const second = renderKnowledgeProjection(base);
+    assert.equal(second.written, false, "second render is a no-op when content already matches");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("projection emits empty section tables when no rows exist for that category", () => {
+  const base = makeTmpBase();
+  try {
+    writeKnowledgeMd(
+      base,
+      `# Project Knowledge
+
+## Rules
+
+| # | Scope | Rule | Why | Added |
+|---|-------|------|-----|-------|
+`,
+    );
+    renderKnowledgeProjection(base);
+    const rendered = readFileSync(knowledgeMdPath(base), "utf-8");
+
+    assert.match(rendered, /## Patterns/);
+    assert.match(rendered, /## Lessons Learned/);
+    // The empty-table headers must be present.
+    assert.match(rendered, /\| # \| Pattern \| Where \| Notes \|/);
+    assert.match(rendered, /\| # \| What Happened \| Root Cause \| Fix \| Scope \|/);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("projection escapes pipes in memory content", () => {
+  const base = makeTmpBase();
+  try {
+    writeKnowledgeMd(
+      base,
+      `## Patterns
+
+| # | Pattern | Where | Notes |
+|---|---------|-------|-------|
+| P001 | Use A \\| B fallback | adapters/ | watch out |
+`,
+    );
+    backfillKnowledgeToMemories(base);
+    renderKnowledgeProjection(base);
+    const rendered = readFileSync(knowledgeMdPath(base), "utf-8");
+
+    // Pipe MUST stay escaped in the rendered output so the table doesn't break.
+    assert.match(rendered, /\| P001 \| Use A \\\| B fallback \| adapters\/ \| watch out \|/);
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── End-to-end round-trip ─────────────────────────────────────────────────
+
+test("backfill + projection round-trip: re-running backfill on rendered file is a no-op", () => {
+  const base = makeTmpBase();
+  try {
+    writeKnowledgeMd(base, FIXTURE);
+    const initial = backfillKnowledgeToMemories(base);
+    assert.equal(initial, 3);
+
+    renderKnowledgeProjection(base);
+    assert.ok(existsSync(knowledgeMdPath(base)));
+
+    // The rendered file contains the same P/L IDs as the source. A second
+    // backfill pass must NOT re-insert them.
+    const second = backfillKnowledgeToMemories(base);
+    assert.equal(second, 0, "round-trip rendered file must remain idempotent for backfill");
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/knowledge-capture.test.ts
+++ b/src/resources/extensions/gsd/tests/knowledge-capture.test.ts
@@ -1,0 +1,242 @@
+// ADR-013 Stage 2c — /gsd knowledge write-side redirect tests.
+//
+// Locks in four properties of captureKnowledgeEntry / nextKnowledgeId:
+//   1. Pattern entries write a memory row with category="pattern" and a
+//      sourceKnowledgeId marker — but do NOT touch KNOWLEDGE.md.
+//   2. Lesson entries write a memory row with category="gotcha" — same
+//      file-vs-memory split.
+//   3. Next-ID is monotonic across both surfaces: a P004 in the file plus a
+//      P007 in memories yields P008 next.
+//   4. The legacy appendKnowledge stays the canonical path for Rules
+//      (covered indirectly via no-memory side effect on type="rule").
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  _getAdapter,
+  closeDatabase,
+  openDatabase,
+} from "../gsd-db.ts";
+import { captureKnowledgeEntry, nextKnowledgeId } from "../knowledge-capture.ts";
+import { knowledgeMdPath } from "../knowledge-parser.ts";
+
+function makeTmpBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-knowledge-capture-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  return base;
+}
+
+function cleanup(base: string): void {
+  try {
+    closeDatabase();
+  } catch {
+    /* noop */
+  }
+  try {
+    rmSync(base, { recursive: true, force: true });
+  } catch {
+    /* noop */
+  }
+}
+
+function readMemoriesWithMarker(prefix: "P" | "L"): Array<{ category: string; sf: Record<string, unknown> }> {
+  const adapter = _getAdapter();
+  if (!adapter) return [];
+  const rows = adapter
+    .prepare(
+      "SELECT category, structured_fields FROM memories WHERE structured_fields LIKE :pattern ORDER BY seq",
+    )
+    .all({ ":pattern": `%"sourceKnowledgeId":"${prefix}%` }) as Array<{
+    category: string;
+    structured_fields: string;
+  }>;
+  return rows.map((r) => ({ category: r.category, sf: JSON.parse(r.structured_fields) }));
+}
+
+// ─── Pattern path ───────────────────────────────────────────────────────────
+
+test("pattern entry creates a memory and assigns the next P### id", () => {
+  const base = makeTmpBase();
+  try {
+    const result = captureKnowledgeEntry(base, "pattern", "Repository pattern at the seam", "M001");
+    assert.equal(result.id, "P001", "first pattern on a fresh project should be P001");
+    assert.equal(result.written, true);
+
+    const memories = readMemoriesWithMarker("P");
+    assert.equal(memories.length, 1);
+    assert.equal(memories[0]?.category, "pattern");
+    assert.equal(memories[0]?.sf.sourceKnowledgeId, "P001");
+    assert.equal(memories[0]?.sf.pattern, "Repository pattern at the seam");
+    assert.equal(memories[0]?.sf.where, "");
+    assert.equal(memories[0]?.sf.notes, "");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("pattern entry does NOT write to KNOWLEDGE.md (memory-only)", () => {
+  const base = makeTmpBase();
+  try {
+    captureKnowledgeEntry(base, "pattern", "Adapter at the seam", "project");
+    assert.equal(
+      existsSync(knowledgeMdPath(base)),
+      false,
+      "KNOWLEDGE.md should remain untouched — projection re-renders on next session start",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("repeated pattern captures advance the ID monotonically", () => {
+  const base = makeTmpBase();
+  try {
+    const a = captureKnowledgeEntry(base, "pattern", "First", "project");
+    const b = captureKnowledgeEntry(base, "pattern", "Second", "project");
+    const c = captureKnowledgeEntry(base, "pattern", "Third", "project");
+    assert.deepEqual([a.id, b.id, c.id], ["P001", "P002", "P003"]);
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── Lesson path ────────────────────────────────────────────────────────────
+
+test("lesson entry creates a memory with category=gotcha and L### id", () => {
+  const base = makeTmpBase();
+  try {
+    const result = captureKnowledgeEntry(base, "lesson", "Cache poisoning via reused key", "M001/S01");
+    assert.equal(result.id, "L001");
+    assert.equal(result.written, true);
+
+    const memories = readMemoriesWithMarker("L");
+    assert.equal(memories.length, 1);
+    assert.equal(memories[0]?.category, "gotcha");
+    assert.equal(memories[0]?.sf.sourceKnowledgeId, "L001");
+    assert.equal(memories[0]?.sf.whatHappened, "Cache poisoning via reused key");
+    assert.equal(memories[0]?.sf.scopeText, "M001/S01");
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── Empty input ────────────────────────────────────────────────────────────
+
+test("empty entry text does NOT create a memory but still assigns an id", () => {
+  const base = makeTmpBase();
+  try {
+    const result = captureKnowledgeEntry(base, "pattern", "   ", "project");
+    assert.equal(result.written, false);
+    assert.equal(readMemoriesWithMarker("P").length, 0);
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── nextKnowledgeId — cross-surface monotonicity ───────────────────────────
+
+test("nextKnowledgeId takes max of file and memory surfaces", () => {
+  const base = makeTmpBase();
+  try {
+    // Pre-existing patterns in KNOWLEDGE.md and one new pattern in memories.
+    // The legacy appendKnowledge format starts P at 001 — we simulate higher
+    // existing IDs to verify the take-max-then-+1 rule.
+    writeFileSync(
+      knowledgeMdPath(base),
+      `## Patterns
+
+| # | Pattern | Where | Notes |
+|---|---------|-------|-------|
+| P004 | Legacy pattern | services/ | preserved |
+`,
+      "utf-8",
+    );
+
+    // Capture jumps the memory ID forward.
+    captureKnowledgeEntry(base, "pattern", "Memory-only pattern", "project");
+    captureKnowledgeEntry(base, "pattern", "Another memory-only pattern", "project");
+    captureKnowledgeEntry(base, "pattern", "And another", "project");
+
+    // After: file has P004 (max=4); memories have P005, P006, P007 (max=7).
+    // Next must be P008.
+    assert.equal(nextKnowledgeId(base, "P"), "P008");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("nextKnowledgeId works per-prefix without cross-talk", () => {
+  const base = makeTmpBase();
+  try {
+    captureKnowledgeEntry(base, "pattern", "P entry", "project");
+    captureKnowledgeEntry(base, "pattern", "P entry 2", "project");
+    captureKnowledgeEntry(base, "lesson", "L entry", "project");
+
+    assert.equal(nextKnowledgeId(base, "P"), "P003");
+    assert.equal(nextKnowledgeId(base, "L"), "L002");
+    // K has no entries on this project — first one should be K001.
+    assert.equal(nextKnowledgeId(base, "K"), "K001");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("nextKnowledgeId pads to three digits even at the rollover", () => {
+  const base = makeTmpBase();
+  try {
+    writeFileSync(
+      knowledgeMdPath(base),
+      `## Patterns
+
+| # | Pattern | Where | Notes |
+|---|---------|-------|-------|
+| P099 | high water mark | — | — |
+`,
+      "utf-8",
+    );
+    assert.equal(nextKnowledgeId(base, "P"), "P100");
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── Sanity: file-side reads still see existing rows after capture ─────────
+
+test("after pattern capture, KNOWLEDGE.md untouched but next id reflects memory state", () => {
+  const base = makeTmpBase();
+  try {
+    captureKnowledgeEntry(base, "pattern", "First", "project");
+    // KNOWLEDGE.md still absent.
+    assert.equal(existsSync(knowledgeMdPath(base)), false);
+    // Next-ID logic sees the new memory.
+    assert.equal(nextKnowledgeId(base, "P"), "P002");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("rule writes still flow through appendKnowledge (file-canonical) — memory unchanged", async () => {
+  const base = makeTmpBase();
+  try {
+    // We invoke the legacy file path directly here; the command handler
+    // dispatch is verified separately at the integration level. The point
+    // of this test is to lock in that captureKnowledgeEntry is NOT the
+    // rule path — rules must go through appendKnowledge.
+    const { appendKnowledge } = await import("../files.ts");
+    await appendKnowledge(base, "rule", "Always pin SQLite version", "project");
+
+    const md = readFileSync(knowledgeMdPath(base), "utf-8");
+    assert.match(md, /\| K001 \| project \| Always pin SQLite version /);
+
+    // No pattern/lesson memories should exist as a side effect.
+    assert.equal(readMemoriesWithMarker("P").length, 0);
+    assert.equal(readMemoriesWithMarker("L").length, 0);
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/knowledge.test.ts
+++ b/src/resources/extensions/gsd/tests/knowledge.test.ts
@@ -187,7 +187,7 @@ test('loadKnowledgeBlock: uses project knowledge alone when no global file', () 
   writeFileSync(join(cwd, '.gsd', 'KNOWLEDGE.md'), 'K001: Use real DB');
 
   const result = loadKnowledgeBlock(gsdHome, cwd);
-  assert.ok(result.block.includes('[KNOWLEDGE — Rules, patterns, and lessons learned]'));
+  assert.ok(result.block.includes('[KNOWLEDGE — Manual Rules]'));
   assert.ok(result.block.includes('## Project Knowledge'));
   assert.ok(result.block.includes('K001: Use real DB'));
   assert.ok(!result.block.includes('## Global Knowledge'));
@@ -205,7 +205,7 @@ test('loadKnowledgeBlock: uses global knowledge alone when no project file', () 
   writeFileSync(join(gsdHome, 'agent', 'KNOWLEDGE.md'), 'G001: Respond in English');
 
   const result = loadKnowledgeBlock(gsdHome, cwd);
-  assert.ok(result.block.includes('[KNOWLEDGE — Rules, patterns, and lessons learned]'));
+  assert.ok(result.block.includes('[KNOWLEDGE — Manual Rules]'));
   assert.ok(result.block.includes('## Global Knowledge'));
   assert.ok(result.block.includes('G001: Respond in English'));
   assert.ok(!result.block.includes('## Project Knowledge'));
@@ -230,6 +230,51 @@ test('loadKnowledgeBlock: merges global before project when both exist', () => {
   assert.ok(result.block.includes('K001: Project rule'));
   // Global section appears before project section
   assert.ok(result.block.indexOf('## Global Knowledge') < result.block.indexOf('## Project Knowledge'));
+
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('loadKnowledgeBlock: strips patterns and lessons from project knowledge', () => {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'gsd-kb-strip-')));
+  const gsdHome = join(tmp, 'home');
+  const cwd = join(tmp, 'project');
+  mkdirSync(join(cwd, '.gsd'), { recursive: true });
+  mkdirSync(join(gsdHome, 'agent'), { recursive: true });
+  writeFileSync(
+    join(cwd, '.gsd', 'KNOWLEDGE.md'),
+    [
+      '# Project Knowledge',
+      '',
+      'Intro note that should stay with manual rules.',
+      '',
+      '## Rules',
+      '',
+      '| ID | Rule | Notes |',
+      '|---|---|---|',
+      '| K001 | Use real DB | - |',
+      '',
+      '## Patterns',
+      '',
+      '| ID | Pattern | Where | Notes |',
+      '|---|---|---|---|',
+      '| P001 | Prefer async | server | - |',
+      '',
+      '## Lessons Learned',
+      '',
+      '| ID | What Happened | Root Cause | Fix | Scope |',
+      '|---|---|---|---|---|',
+      '| L001 | Missed cache | N/A | Add TTL | project |',
+    ].join('\n'),
+  );
+
+  const result = loadKnowledgeBlock(gsdHome, cwd);
+  assert.ok(result.block.includes('[KNOWLEDGE — Manual Rules]'));
+  assert.ok(result.block.includes('Intro note that should stay with manual rules.'));
+  assert.ok(result.block.includes('K001'), 'rules entry should be present');
+  assert.ok(!result.block.includes('P001'), 'patterns should be stripped and injected via memories');
+  assert.ok(!result.block.includes('L001'), 'lessons should be stripped and injected via memories');
+  assert.ok(!result.block.includes('## Patterns'), 'Patterns heading should not appear');
+  assert.ok(!result.block.includes('## Lessons Learned'), 'Lessons heading should not appear');
 
   rmSync(tmp, { recursive: true, force: true });
 });

--- a/src/resources/extensions/gsd/workflow-logger.ts
+++ b/src/resources/extensions/gsd/workflow-logger.ts
@@ -65,6 +65,7 @@ export type LogComponent =
   | "memory-embeddings" // Memory layer embedding generation
   | "memory-ingest"     // Memory layer ingestion pipeline
   | "memory-backfill"   // ADR-013: decisions->memories backfill
+  | "knowledge-capture" // ADR-013: KNOWLEDGE.md capture pipeline
   | "memory-store"      // Memory CRUD layer — surfaces SQLite/store-level faults (#4967)
   | "context-mode"     // Context-mode exec sandbox and compaction snapshot
   | "preflight"        // Clean-root preflight gate at milestone completion

--- a/src/resources/extensions/gsd/workflow-logger.ts
+++ b/src/resources/extensions/gsd/workflow-logger.ts
@@ -65,6 +65,8 @@ export type LogComponent =
   | "memory-embeddings" // Memory layer embedding generation
   | "memory-ingest"     // Memory layer ingestion pipeline
   | "memory-backfill"   // ADR-013: decisions->memories backfill
+  | "knowledge-backfill" // ADR-013: KNOWLEDGE.md->memories backfill
+  | "knowledge-projection" // ADR-013: KNOWLEDGE.md projection renderer
   | "memory-store"      // Memory CRUD layer — surfaces SQLite/store-level faults (#4967)
   | "context-mode"     // Context-mode exec sandbox and compaction snapshot
   | "preflight"        // Clean-root preflight gate at milestone completion


### PR DESCRIPTION
## Summary

Stage 2c of 3 for ADR-013 Phase 6 cutover (#5755). Closes the **KNOWLEDGE.md write-side loop**.

> **Builds on PR #5770** (Stage 2b) which builds on #5769 (Stage 2a) which builds on #5767 (Stage 1). Merge order: 5767 → 5769 → 5770 → this.

Before this PR, the `/gsd knowledge` command file-appended every entry — including patterns and lessons that Stage 2b had just begun rendering as projections from `memories`. That meant new patterns/lessons added via the command were *only* in the file until the next session-start backfill caught them. After this PR, patterns and lessons land in `memories` directly, and the existing projection render (Stage 2b) picks them up on next session start.

**Rules stay manual** per ADR-013 line 39 — `type="rule"` still calls `appendKnowledge`.

## Three pieces

### 1. New module `knowledge-capture.ts`

`captureKnowledgeEntry(basePath, type, text, scope)` writes a memory row:

- `type="pattern"` → `category: "pattern"`, `structuredFields.sourceKnowledgeTable: "patterns"`
- `type="lesson"` → `category: "gotcha"`, `structuredFields.sourceKnowledgeTable: "lessons"`

Empty entry text returns `{ written: false }` with the next ID allocated (so the user sees what would have been assigned). DB unavailability is non-fatal: logs a warning, returns `{ written: false }`.

### 2. `nextKnowledgeId(basePath, prefix)`

Cross-surface monotonic next-ID assignment. Scans **both** the legacy `KNOWLEDGE.md` file (for `<prefix>###` rows in the matching section) **and** the `memories` table (for `structured_fields.sourceKnowledgeId` values), takes the max numeric suffix, increments, three-digit pads.

This stays stable mid-backfill: when some rows exist only in the file and others only in memories, the next ID skips both ranges instead of colliding.

### 3. Command handler dispatch (`commands-handlers.ts:handleKnowledge`)

```diff
- await appendKnowledge(basePath, type, entryText, scope);
- ctx.ui.notify(`Added ${type} to KNOWLEDGE.md: "${entryText}"`, "success");
+ if (type === "rule") {
+   await appendKnowledge(basePath, type, entryText, scope);
+   ctx.ui.notify(`Added rule to KNOWLEDGE.md: "${entryText}"`, "success");
+   return;
+ }
+ const { captureKnowledgeEntry } = await import("./knowledge-capture.js");
+ const { id, written } = captureKnowledgeEntry(basePath, type, entryText, scope);
+ // ... notify with the assigned ID + reminder that projection renders next session start
```

## Test plan

- [x] 10 new tests in `knowledge-capture.test.ts` covering pattern path, lesson path, ID monotonicity across surfaces, per-prefix isolation, three-digit padding, empty-text guard, and Rules-path-still-file-appends
- [x] No regression — combined run with Stage 1, Stage 2a, Stage 2b, and `memory-store`: 51/51

## Sequencing

| Stage | Issue | PR |
|---|---|---|
| 1 — Prompt-inline read switch | #5755 | #5767 |
| 2a — DECISIONS.md projection switch | #5755 | #5769 |
| 2b — KNOWLEDGE.md backfill + projection | #5755 | #5770 |
| **2c — /gsd knowledge redirect (this PR)** | **#5755** | **this** |
| 3 — Destructive: stop decisions-table writes | #5755 | final |
| Drop decisions table | #5756 | gated on Stage 3 baking |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KNOWLEDGE.md is now a hybrid: manual Rules remain file-canonical; Patterns/Lessons are persisted to project memory and projected into the file at session start.
  * Capturing knowledge stores Patterns/Lessons in memory (Rules still append to the file).
  * Decisions are mirrored into memory and projections are generated from memory with conservative, non‑blocking startup backfill/projection and notifications when available.

* **Tests**
  * Added suites covering backfill, projection, capture, ID allocation, drift‑heal, and projection parity.

* **Documentation**
  * Updated docs and templates to reflect the hybrid KNOWLEDGE.md model and new workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5771)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->