### PR TITLE
[codex] Clear stale completion roll-up on session switch

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -484,6 +484,8 @@ export function registerHooks(
     }
     await loadToolApiKeysForSession();
     if (!isAutoActive()) {
+      ctx.ui.setWidget("gsd-progress", undefined);
+      ctx.ui.setWidget("gsd-outcome", undefined);
       const { initHealthWidget } = await import("../health-widget.js");
       initHealthWidget(ctx);
     } else {

--- a/src/resources/extensions/gsd/tests/session-start-footer.test.ts
+++ b/src/resources/extensions/gsd/tests/session-start-footer.test.ts
@@ -1,9 +1,11 @@
+// Project/App: GSD-2
+// File Purpose: Verifies GSD session hook widget and footer lifecycle behavior.
+
 /**
- * session-start-footer.test.ts
- *
  * Verifies that register-hooks.ts suppresses the gsd-health widget (not the
- * built-in footer) when isAutoActive() is true, and that setFooter is never
- * called by the extension in either session_start or session_switch.
+ * built-in footer) when isAutoActive() is true, clears stale completion widgets
+ * on inactive session switches, and that setFooter is never called by the
+ * extension in either session_start or session_switch.
  *
  * Testing strategy:
  *   1. Source-code regression guards: structural checks on register-hooks.ts.
@@ -139,6 +141,16 @@ test("session_switch toggles gsd-health from runtime auto state without touching
   widgetCalls.length = 0;
   autoSession.active = false;
   await sessionSwitch!({ reason: "resume" }, ctx);
+  assert.deepEqual(
+    widgetCalls
+      .filter((call) => call.key === "gsd-progress" || call.key === "gsd-outcome")
+      .map((call) => [call.key, call.value]),
+    [
+      ["gsd-progress", undefined],
+      ["gsd-outcome", undefined],
+    ],
+    "session_switch should clear stale GSD completion widgets when auto is inactive",
+  );
   const healthWidgetValues = widgetCalls
     .filter((call) => call.key === "gsd-health")
     .map((call) => call.value);


### PR DESCRIPTION
## TL;DR

**What:** Clear stale GSD completion widgets when a non-auto session switch starts.
**Why:** `/clear` and `/new` could leave the completed milestone roll-up visible in the fresh session.
**How:** The GSD `session_switch` hook now removes `gsd-progress` and `gsd-outcome` before restoring inactive-session health UI.

## What

This updates `src/resources/extensions/gsd/bootstrap/register-hooks.ts` so inactive session switches explicitly clear GSD completion/outcome widgets. It also updates `src/resources/extensions/gsd/tests/session-start-footer.test.ts` with regression coverage for the widget lifecycle.

## Why

Auto-mode intentionally preserves the final roll-up when completion stops. That preserved widget was not cleared by later non-auto session switches, so a cleared session could still display the old “All milestones complete” roll-up.

Closes #5780

## How

The existing inactive `session_switch` path is the right lifecycle point because it covers `/clear`, `/new`, and other session transitions without changing completion stop behavior. The regression test exercises the live session-switch hook and verifies that stale `gsd-progress` and `gsd-outcome` widgets are unset before health UI is initialized.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/session-start-footer.test.ts`
- `npm run typecheck:extensions`

## Checklist

- [x] `fix` — Bug fix
- [x] Tests included
- [x] AI-assisted change disclosed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session switching now properly clears progress and outcome indicators to prevent displaying outdated information from previous sessions.

* **Tests**
  * Added test coverage to verify indicators are cleared when switching between sessions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5781)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->