### PR TITLE
fix(ollama): trust /api/show for capabilities + context (closes #5374, follow-up to #4984)

### DIFF
--- a/src/resources/extensions/ollama/model-capabilities.ts
+++ b/src/resources/extensions/ollama/model-capabilities.ts
@@ -28,9 +28,22 @@ export interface ModelCapability {
 // window is authoritative. For unknown/estimated models, num_ctx is NOT sent
 // to avoid OOM risk — Ollama uses its own safe default instead.
 const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
-	// ─── Reasoning models ───────────────────────────────────────────────
-	["deepseek-r1", { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["qwq", { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	// ─── Reasoning models (fallback when /api/show capabilities is absent) ──
+	// IMPORTANT: matching is `baseName === pattern || baseName.startsWith(pattern)`,
+	// so more specific patterns must appear before more general ones.
+	["deepseek-r1",       { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["deepseek-v3.1",     { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["deepseek-v4-flash", { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["deepseek-v4",       { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["qwq",               { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["gpt-oss",           { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["glm-4",             { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["glm-5",             { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["kimi-k2",           { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["minimax-m2",        { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["nemotron-3",        { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["gemma4",            { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["gemini-3-flash",    { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
 
 	// ─── Vision models ──────────────────────────────────────────────────
 	["llava", { contextWindow: 4096, input: ["text", "image"], ollamaOptions: { num_ctx: 4096 } }],
@@ -59,14 +72,16 @@ const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
 	// Long-variant entries MUST appear before the bare `qwen3` base —
 	// `baseName.startsWith(pattern)` returns true for `qwen3.5`/`qwen3-coder`/
 	// `qwen3-next` against `qwen3`, and the first match wins (#4991).
+	// All qwen3 variants support hybrid thinking; /api/show capabilities is
+	// authoritative — these entries are only consulted when ollama omits it.
 	// ref: qwen3-next 1M ctx — https://qwen.ai/blog?id=qwen3-next
-	["qwen3-next", { contextWindow: 1048576, maxTokens: 32768, ollamaOptions: { num_ctx: 1048576 } }],
+	["qwen3-next", { contextWindow: 1048576, maxTokens: 32768, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
 	// ref: qwen3-coder 256K ctx — https://qwenlm.github.io/blog/qwen3-coder/
-	["qwen3-coder", { contextWindow: 262144, maxTokens: 32768, ollamaOptions: { num_ctx: 262144 } }],
+	["qwen3-coder", { contextWindow: 262144, maxTokens: 32768, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
 	// ref: qwen3.5 / qwen3.6 1M ctx — Ollama Cloud release notes
-	["qwen3.6", { contextWindow: 1048576, maxTokens: 32768, ollamaOptions: { num_ctx: 1048576 } }],
-	["qwen3.5", { contextWindow: 1048576, maxTokens: 32768, ollamaOptions: { num_ctx: 1048576 } }],
-	["qwen3", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
+	["qwen3.6", { contextWindow: 1048576, maxTokens: 32768, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
+	["qwen3.5", { contextWindow: 1048576, maxTokens: 32768, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
+	["qwen3", { contextWindow: 131072, maxTokens: 32768, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["qwen2.5", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
 	["qwen2", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
 

--- a/src/resources/extensions/ollama/model-capabilities.ts
+++ b/src/resources/extensions/ollama/model-capabilities.ts
@@ -36,12 +36,15 @@ const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
 	// shadowing (#4991).
 	["deepseek-r1",       { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["deepseek-v3.1",     { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["deepseek-v4-flash", { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["deepseek-v4",       { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	// DeepSeek V4 family ships at 1M context per ollama /api/show (deepseek4.context_length = 1048576).
+	// Long-variants listed before the bare `deepseek-v4` base to avoid prefix shadowing (#4991/#4984).
+	["deepseek-v4-pro",   { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
+	["deepseek-v4-flash", { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
+	["deepseek-v4",       { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
 	["qwq",               { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["gpt-oss",           { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["nemotron-3",        { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["gemma4",            { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["gemma4",            { contextWindow: 262144, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
 	["gemini-3-flash",    { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
 
 	// ─── Vision models ──────────────────────────────────────────────────
@@ -103,8 +106,11 @@ const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
 	["kimi-k2", { contextWindow: 262144, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
 
 	// ─── MiniMax M2 (Ollama Cloud) ─────────────────────────────────────
-	// ref: minimax-m2 1M ctx — https://www.minimax.io/news/minimax-m2
-	["minimax-m2.7", { contextWindow: 1048576, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
+	// ref: ollama /api/show authoritative — base m2 announced 1M but
+	// minimax-m2.7:cloud reports 196608 via /api/show. Per-variant entries
+	// retained for prefix-shadow safety (#4984); base kept at 1M pending
+	// confirmation from /api/show for older variants.
+	["minimax-m2.7", { contextWindow: 196608, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 196608 } }],
 	["minimax-m2.5", { contextWindow: 1048576, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
 	["minimax-m2", { contextWindow: 1048576, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
 

--- a/src/resources/extensions/ollama/model-capabilities.ts
+++ b/src/resources/extensions/ollama/model-capabilities.ts
@@ -28,19 +28,18 @@ export interface ModelCapability {
 // window is authoritative. For unknown/estimated models, num_ctx is NOT sent
 // to avoid OOM risk — Ollama uses its own safe default instead.
 const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
-	// ─── Reasoning models (fallback when /api/show capabilities is absent) ──
-	// IMPORTANT: matching is `baseName === pattern || baseName.startsWith(pattern)`,
-	// so more specific patterns must appear before more general ones.
+	// ─── Reasoning models without long-variant overrides ───────────────────
+	// /api/show capabilities is the authoritative reasoning signal; these
+	// fallback entries cover Ollama versions that omit it. Families that have
+	// long-variant entries elsewhere (glm-*, kimi-k2*, minimax-m2*, qwen3*)
+	// carry reasoning: true on those entries instead, to avoid prefix
+	// shadowing (#4991).
 	["deepseek-r1",       { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["deepseek-v3.1",     { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["deepseek-v4-flash", { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["deepseek-v4",       { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["qwq",               { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["gpt-oss",           { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["glm-4",             { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["glm-5",             { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["kimi-k2",           { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["minimax-m2",        { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["nemotron-3",        { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["gemma4",            { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 	["gemini-3-flash",    { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
@@ -89,25 +88,25 @@ const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
 	// ref: glm 4.6 / 5.x 200K ctx — https://docs.z.ai/devpack/using5.1
 	// Long-variant entries before bare `glm-5` / `glm-4` would-be bases to
 	// avoid prefix shadowing (#4991).
-	["glm-5.1", { contextWindow: 204800, maxTokens: 16384, ollamaOptions: { num_ctx: 204800 } }],
-	["glm-5", { contextWindow: 204800, maxTokens: 16384, ollamaOptions: { num_ctx: 204800 } }],
-	["glm-4.6", { contextWindow: 204800, maxTokens: 16384, ollamaOptions: { num_ctx: 204800 } }],
-	["glm-4", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
+	["glm-5.1", { contextWindow: 204800, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 204800 } }],
+	["glm-5", { contextWindow: 204800, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 204800 } }],
+	["glm-4.6", { contextWindow: 204800, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 204800 } }],
+	["glm-4", { contextWindow: 131072, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
 
 	// ─── Kimi K2 (Moonshot, Ollama Cloud) ──────────────────────────────
 	// ref: kimi-k2 256K ctx — https://platform.moonshot.ai/docs
 	// Same shadowing concern: kimi-k2-thinking and kimi-k2.{5,6} must
 	// match before any future bare `kimi-k2` entry (#4991).
-	["kimi-k2-thinking", { contextWindow: 262144, maxTokens: 16384, ollamaOptions: { num_ctx: 262144 } }],
-	["kimi-k2.6", { contextWindow: 262144, maxTokens: 16384, ollamaOptions: { num_ctx: 262144 } }],
-	["kimi-k2.5", { contextWindow: 262144, maxTokens: 16384, ollamaOptions: { num_ctx: 262144 } }],
-	["kimi-k2", { contextWindow: 262144, maxTokens: 16384, ollamaOptions: { num_ctx: 262144 } }],
+	["kimi-k2-thinking", { contextWindow: 262144, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
+	["kimi-k2.6", { contextWindow: 262144, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
+	["kimi-k2.5", { contextWindow: 262144, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
+	["kimi-k2", { contextWindow: 262144, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
 
 	// ─── MiniMax M2 (Ollama Cloud) ─────────────────────────────────────
 	// ref: minimax-m2 1M ctx — https://www.minimax.io/news/minimax-m2
-	["minimax-m2.7", { contextWindow: 1048576, maxTokens: 16384, ollamaOptions: { num_ctx: 1048576 } }],
-	["minimax-m2.5", { contextWindow: 1048576, maxTokens: 16384, ollamaOptions: { num_ctx: 1048576 } }],
-	["minimax-m2", { contextWindow: 1048576, maxTokens: 16384, ollamaOptions: { num_ctx: 1048576 } }],
+	["minimax-m2.7", { contextWindow: 1048576, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
+	["minimax-m2.5", { contextWindow: 1048576, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
+	["minimax-m2", { contextWindow: 1048576, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
 
 	// ─── Gemma family ───────────────────────────────────────────────────
 	["gemma3", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],

--- a/src/resources/extensions/ollama/model-capabilities.ts
+++ b/src/resources/extensions/ollama/model-capabilities.ts
@@ -24,9 +24,11 @@ export interface ModelCapability {
  * Keys are matched as prefixes against the model name (before the colon/tag).
  * More specific entries should appear first.
  */
-// Note: ollamaOptions.num_ctx is set for known model families where the context
-// window is authoritative. For unknown/estimated models, num_ctx is NOT sent
-// to avoid OOM risk — Ollama uses its own safe default instead.
+// Note: `ollamaOptions.num_ctx` is auto-derived from `contextWindow` by
+// `withDefaultNumCtx` at lookup time. Override per-entry only when an entry
+// needs num_ctx to differ from its contextWindow (none currently). Unknown
+// models stay without num_ctx so the request omits it and ollama uses its
+// own safe default — preserves the OOM guard on constrained hosts.
 const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
 	// ─── Reasoning models without long-variant overrides ───────────────────
 	// /api/show capabilities is the authoritative reasoning signal; these
@@ -34,41 +36,41 @@ const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
 	// long-variant entries elsewhere (glm-*, kimi-k2*, minimax-m2*, qwen3*)
 	// carry reasoning: true on those entries instead, to avoid prefix
 	// shadowing (#4991).
-	["deepseek-r1",       { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["deepseek-v3.1",     { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["deepseek-r1",       { contextWindow: 131072, reasoning: true }],
+	["deepseek-v3.1",     { contextWindow: 131072, reasoning: true }],
 	// DeepSeek V4 family ships at 1M context per ollama /api/show (deepseek4.context_length = 1048576).
 	// Long-variants listed before the bare `deepseek-v4` base to avoid prefix shadowing (#4991/#4984).
-	["deepseek-v4-pro",   { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
-	["deepseek-v4-flash", { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
-	["deepseek-v4",       { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
-	["qwq",               { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["gpt-oss",           { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["nemotron-3",        { contextWindow: 131072, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["gemma4",            { contextWindow: 262144, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
-	["gemini-3-flash",    { contextWindow: 1048576, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
+	["deepseek-v4-pro",   { contextWindow: 1048576, reasoning: true }],
+	["deepseek-v4-flash", { contextWindow: 1048576, reasoning: true }],
+	["deepseek-v4",       { contextWindow: 1048576, reasoning: true }],
+	["qwq",               { contextWindow: 131072, reasoning: true }],
+	["gpt-oss",           { contextWindow: 131072, reasoning: true }],
+	["nemotron-3",        { contextWindow: 131072, reasoning: true }],
+	["gemma4",            { contextWindow: 262144, reasoning: true }],
+	["gemini-3-flash",    { contextWindow: 1048576, reasoning: true }],
 
 	// ─── Vision models ──────────────────────────────────────────────────
-	["llava", { contextWindow: 4096, input: ["text", "image"], ollamaOptions: { num_ctx: 4096 } }],
-	["bakllava", { contextWindow: 4096, input: ["text", "image"], ollamaOptions: { num_ctx: 4096 } }],
-	["moondream", { contextWindow: 8192, input: ["text", "image"], ollamaOptions: { num_ctx: 8192 } }],
-	["llama3.2-vision", { contextWindow: 131072, input: ["text", "image"], ollamaOptions: { num_ctx: 131072 } }],
-	["minicpm-v", { contextWindow: 4096, input: ["text", "image"], ollamaOptions: { num_ctx: 4096 } }],
+	["llava", { contextWindow: 4096, input: ["text", "image"] }],
+	["bakllava", { contextWindow: 4096, input: ["text", "image"] }],
+	["moondream", { contextWindow: 8192, input: ["text", "image"] }],
+	["llama3.2-vision", { contextWindow: 131072, input: ["text", "image"] }],
+	["minicpm-v", { contextWindow: 4096, input: ["text", "image"] }],
 
 	// ─── Code models ────────────────────────────────────────────────────
-	["codestral", { contextWindow: 262144, maxTokens: 32768, ollamaOptions: { num_ctx: 262144 } }],
-	["qwen2.5-coder", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
-	["deepseek-coder-v2", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
-	["starcoder2", { contextWindow: 16384, maxTokens: 8192, ollamaOptions: { num_ctx: 16384 } }],
-	["codegemma", { contextWindow: 8192, maxTokens: 8192, ollamaOptions: { num_ctx: 8192 } }],
-	["codellama", { contextWindow: 16384, maxTokens: 8192, ollamaOptions: { num_ctx: 16384 } }],
-	["devstral", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
+	["codestral", { contextWindow: 262144, maxTokens: 32768 }],
+	["qwen2.5-coder", { contextWindow: 131072, maxTokens: 32768 }],
+	["deepseek-coder-v2", { contextWindow: 131072, maxTokens: 16384 }],
+	["starcoder2", { contextWindow: 16384, maxTokens: 8192 }],
+	["codegemma", { contextWindow: 8192, maxTokens: 8192 }],
+	["codellama", { contextWindow: 16384, maxTokens: 8192 }],
+	["devstral", { contextWindow: 131072, maxTokens: 32768 }],
 
 	// ─── Llama family ───────────────────────────────────────────────────
-	["llama3.3", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
-	["llama3.2", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
-	["llama3.1", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
-	["llama3", { contextWindow: 8192, maxTokens: 8192, ollamaOptions: { num_ctx: 8192 } }],
-	["llama2", { contextWindow: 4096, maxTokens: 4096, ollamaOptions: { num_ctx: 4096 } }],
+	["llama3.3", { contextWindow: 131072, maxTokens: 16384 }],
+	["llama3.2", { contextWindow: 131072, maxTokens: 16384 }],
+	["llama3.1", { contextWindow: 131072, maxTokens: 16384 }],
+	["llama3", { contextWindow: 8192, maxTokens: 8192 }],
+	["llama2", { contextWindow: 4096, maxTokens: 4096 }],
 
 	// ─── Qwen family ────────────────────────────────────────────────────
 	// Long-variant entries MUST appear before the bare `qwen3` base —
@@ -77,63 +79,81 @@ const KNOWN_MODELS: Array<[pattern: string, caps: ModelCapability]> = [
 	// All qwen3 variants support hybrid thinking; /api/show capabilities is
 	// authoritative — these entries are only consulted when ollama omits it.
 	// ref: qwen3-next 1M ctx — https://qwen.ai/blog?id=qwen3-next
-	["qwen3-next", { contextWindow: 1048576, maxTokens: 32768, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
+	["qwen3-next", { contextWindow: 1048576, maxTokens: 32768, reasoning: true }],
 	// ref: qwen3-coder 256K ctx — https://qwenlm.github.io/blog/qwen3-coder/
-	["qwen3-coder", { contextWindow: 262144, maxTokens: 32768, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
+	["qwen3-coder", { contextWindow: 262144, maxTokens: 32768, reasoning: true }],
 	// ref: qwen3.5 / qwen3.6 1M ctx — Ollama Cloud release notes
-	["qwen3.6", { contextWindow: 1048576, maxTokens: 32768, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
-	["qwen3.5", { contextWindow: 1048576, maxTokens: 32768, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
-	["qwen3", { contextWindow: 131072, maxTokens: 32768, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
-	["qwen2.5", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
-	["qwen2", { contextWindow: 131072, maxTokens: 32768, ollamaOptions: { num_ctx: 131072 } }],
+	["qwen3.6", { contextWindow: 1048576, maxTokens: 32768, reasoning: true }],
+	["qwen3.5", { contextWindow: 1048576, maxTokens: 32768, reasoning: true }],
+	["qwen3", { contextWindow: 131072, maxTokens: 32768, reasoning: true }],
+	["qwen2.5", { contextWindow: 131072, maxTokens: 32768 }],
+	["qwen2", { contextWindow: 131072, maxTokens: 32768 }],
 
 	// ─── GLM family (Z.ai, Ollama Cloud) ────────────────────────────────
 	// ref: glm 4.6 / 5.x 200K ctx — https://docs.z.ai/devpack/using5.1
 	// Long-variant entries before bare `glm-5` / `glm-4` would-be bases to
 	// avoid prefix shadowing (#4991).
-	["glm-5.1", { contextWindow: 204800, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 204800 } }],
-	["glm-5", { contextWindow: 204800, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 204800 } }],
-	["glm-4.6", { contextWindow: 204800, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 204800 } }],
-	["glm-4", { contextWindow: 131072, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 131072 } }],
+	["glm-5.1", { contextWindow: 204800, maxTokens: 16384, reasoning: true }],
+	["glm-5", { contextWindow: 204800, maxTokens: 16384, reasoning: true }],
+	["glm-4.6", { contextWindow: 204800, maxTokens: 16384, reasoning: true }],
+	["glm-4", { contextWindow: 131072, maxTokens: 16384, reasoning: true }],
 
 	// ─── Kimi K2 (Moonshot, Ollama Cloud) ──────────────────────────────
 	// ref: kimi-k2 256K ctx — https://platform.moonshot.ai/docs
 	// Same shadowing concern: kimi-k2-thinking and kimi-k2.{5,6} must
 	// match before any future bare `kimi-k2` entry (#4991).
-	["kimi-k2-thinking", { contextWindow: 262144, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
-	["kimi-k2.6", { contextWindow: 262144, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
-	["kimi-k2.5", { contextWindow: 262144, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
-	["kimi-k2", { contextWindow: 262144, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 262144 } }],
+	["kimi-k2-thinking", { contextWindow: 262144, maxTokens: 16384, reasoning: true }],
+	["kimi-k2.6", { contextWindow: 262144, maxTokens: 16384, reasoning: true }],
+	["kimi-k2.5", { contextWindow: 262144, maxTokens: 16384, reasoning: true }],
+	["kimi-k2", { contextWindow: 262144, maxTokens: 16384, reasoning: true }],
 
 	// ─── MiniMax M2 (Ollama Cloud) ─────────────────────────────────────
 	// ref: ollama /api/show authoritative — base m2 announced 1M but
 	// minimax-m2.7:cloud reports 196608 via /api/show. Per-variant entries
 	// retained for prefix-shadow safety (#4984); base kept at 1M pending
 	// confirmation from /api/show for older variants.
-	["minimax-m2.7", { contextWindow: 196608, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 196608 } }],
-	["minimax-m2.5", { contextWindow: 1048576, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
-	["minimax-m2", { contextWindow: 1048576, maxTokens: 16384, reasoning: true, ollamaOptions: { num_ctx: 1048576 } }],
+	["minimax-m2.7", { contextWindow: 196608, maxTokens: 16384, reasoning: true }],
+	["minimax-m2.5", { contextWindow: 1048576, maxTokens: 16384, reasoning: true }],
+	["minimax-m2", { contextWindow: 1048576, maxTokens: 16384, reasoning: true }],
 
 	// ─── Gemma family ───────────────────────────────────────────────────
-	["gemma3", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
-	["gemma2", { contextWindow: 8192, maxTokens: 8192, ollamaOptions: { num_ctx: 8192 } }],
+	["gemma3", { contextWindow: 131072, maxTokens: 16384 }],
+	["gemma2", { contextWindow: 8192, maxTokens: 8192 }],
 
 	// ─── Mistral family ─────────────────────────────────────────────────
-	["mistral-large", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
-	["mistral-small", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
-	["mistral-nemo", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
-	["mistral", { contextWindow: 32768, maxTokens: 8192, ollamaOptions: { num_ctx: 32768 } }],
-	["mixtral", { contextWindow: 32768, maxTokens: 8192, ollamaOptions: { num_ctx: 32768 } }],
+	["mistral-large", { contextWindow: 131072, maxTokens: 16384 }],
+	["mistral-small", { contextWindow: 131072, maxTokens: 16384 }],
+	["mistral-nemo", { contextWindow: 131072, maxTokens: 16384 }],
+	["mistral", { contextWindow: 32768, maxTokens: 8192 }],
+	["mixtral", { contextWindow: 32768, maxTokens: 8192 }],
 
 	// ─── Phi family ─────────────────────────────────────────────────────
-	["phi4", { contextWindow: 16384, maxTokens: 16384, ollamaOptions: { num_ctx: 16384 } }],
-	["phi3.5", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
-	["phi3", { contextWindow: 131072, maxTokens: 4096, ollamaOptions: { num_ctx: 131072 } }],
+	["phi4", { contextWindow: 16384, maxTokens: 16384 }],
+	["phi3.5", { contextWindow: 131072, maxTokens: 16384 }],
+	["phi3", { contextWindow: 131072, maxTokens: 4096 }],
 
 	// ─── Command R ──────────────────────────────────────────────────────
-	["command-r-plus", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
-	["command-r", { contextWindow: 131072, maxTokens: 16384, ollamaOptions: { num_ctx: 131072 } }],
+	["command-r-plus", { contextWindow: 131072, maxTokens: 16384 }],
+	["command-r", { contextWindow: 131072, maxTokens: 16384 }],
 ];
+
+/**
+ * Auto-derive `ollamaOptions.num_ctx` from `contextWindow` when not explicitly
+ * set on the entry. Avoids the duplication-driven drift that #4984 / #5374
+ * follow-ups had to chase: previously each entry had to repeat the same number
+ * twice and any mismatch produced silent truncation on the wire.
+ *
+ * Explicit overrides are preserved when an entry needs `num_ctx` to differ from
+ * its `contextWindow` (e.g., a memory-constrained host capping a larger model).
+ */
+function withDefaultNumCtx(caps: ModelCapability): ModelCapability {
+	if (caps.contextWindow === undefined) return caps;
+	if (caps.ollamaOptions?.num_ctx !== undefined) return caps;
+	return {
+		...caps,
+		ollamaOptions: { ...caps.ollamaOptions, num_ctx: caps.contextWindow },
+	};
+}
 
 /**
  * Look up capabilities for a model by name.
@@ -145,7 +165,7 @@ export function getModelCapabilities(modelName: string): ModelCapability {
 
 	for (const [pattern, caps] of KNOWN_MODELS) {
 		if (baseName === pattern || baseName.startsWith(pattern)) {
-			return caps;
+			return withDefaultNumCtx(caps);
 		}
 	}
 

--- a/src/resources/extensions/ollama/ollama-chat-provider.ts
+++ b/src/resources/extensions/ollama/ollama-chat-provider.ts
@@ -21,6 +21,7 @@ import {
 	type StopReason,
 	type TextContent,
 	type ThinkingContent,
+	type ThinkingLevel,
 	type Tool,
 	type ToolCall,
 	type Usage,
@@ -146,6 +147,13 @@ export function streamOllamaChat(
 			}
 
 			for await (const chunk of chat(request, options?.signal)) {
+				// Native thinking field (ollama 0.4+ for reasoning models). Emit before
+				// content so blocks open in the natural reasoning-then-answer order.
+				const thinking = chunk.message?.thinking ?? "";
+				if (thinking) {
+					emitDelta("thinking", thinking);
+				}
+
 				// Handle text content — process independently of tool_calls
 				// (a chunk may contain both content and tool_calls)
 				const content = chunk.message?.content ?? "";
@@ -188,6 +196,30 @@ export function streamOllamaChat(
 }
 
 // ─── Request building ───────────────────────────────────────────────────────
+
+/**
+ * Map a SimpleStreamOptions.reasoning ThinkingLevel to ollama's `think` field.
+ *
+ * - Returns `undefined` when the model doesn't support reasoning, or when no
+ *   level was requested (preserving existing default behaviour: ollama uses
+ *   the model's built-in default).
+ * - `"minimal"` turns thinking off (`think: false`) — universally supported.
+ * - `"low" | "medium" | "high"` are passed through as strings; gpt-oss honors
+ *   them as strength levels, other thinking models treat any present value
+ *   as "thinking enabled".
+ * - `"xhigh"` is collapsed to `"high"` (ollama caps strength at high).
+ */
+export function buildThinkParam(
+	model: Model<Api>,
+	options?: SimpleStreamOptions,
+): boolean | "low" | "medium" | "high" | undefined {
+	if (!model.reasoning) return undefined;
+	const level: ThinkingLevel | undefined = options?.reasoning;
+	if (level === undefined) return undefined;
+	if (level === "minimal") return false;
+	if (level === "xhigh") return "high";
+	return level;
+}
 
 function buildRequest(
 	model: Model<Api>,
@@ -243,6 +275,13 @@ function buildRequest(
 	// Tools
 	if (context.tools?.length) {
 		request.tools = convertTools(context.tools);
+	}
+
+	// Thinking strength (ollama 0.4+). Only set when both the model is reasoning-capable
+	// and the caller explicitly requested a level — otherwise ollama uses its default.
+	const think = buildThinkParam(model, options);
+	if (think !== undefined) {
+		request.think = think;
 	}
 
 	return request;

--- a/src/resources/extensions/ollama/ollama-chat-provider.ts
+++ b/src/resources/extensions/ollama/ollama-chat-provider.ts
@@ -221,7 +221,7 @@ export function buildThinkParam(
 	return level;
 }
 
-function buildRequest(
+export function buildRequest(
 	model: Model<Api>,
 	context: Context,
 	options?: SimpleStreamOptions,

--- a/src/resources/extensions/ollama/ollama-discovery.ts
+++ b/src/resources/extensions/ollama/ollama-discovery.ts
@@ -57,16 +57,20 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 	const caps = getModelCapabilities(info.name);
 	const parameterSize = info.details?.parameter_size ?? "";
 
-	// /api/tags doesn't include context length; /api/show does via "{arch}.context_length" in model_info.
+	// Always call /api/show — it carries two pieces of info absent from /api/tags:
+	// the per-architecture context_length, and (ollama 0.4+) a `capabilities` array
+	// like ["thinking", "completion", "tools"]. The capabilities array is the
+	// authoritative source for reasoning detection on cloud-routed models that
+	// don't appear in the static KNOWN_MODELS table.
 	let showContextWindow: number | undefined;
-	if (caps.contextWindow === undefined) {
-		try {
-			const showData = await deps.showModel(info.name);
-			showContextWindow = extractContextFromModelInfo(showData.model_info);
-		} catch (err) {
-			// non-fatal: fall through to estimate
-			if (process.env.GSD_DEBUG) console.warn(`[ollama] /api/show failed for ${info.name}:`, err instanceof Error ? err.message : String(err));
-		}
+	let showCapabilities: string[] | undefined;
+	try {
+		const showData = await deps.showModel(info.name);
+		showContextWindow = extractContextFromModelInfo(showData.model_info);
+		showCapabilities = showData.capabilities;
+	} catch (err) {
+		// non-fatal: fall through to table/estimate
+		if (process.env.GSD_DEBUG) console.warn(`[ollama] /api/show failed for ${info.name}:`, err instanceof Error ? err.message : String(err));
 	}
 
 	// Determine context window: known table > /api/show > estimate from param size > default
@@ -79,13 +83,17 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 	const maxTokens =
 		caps.maxTokens ?? Math.min(Math.floor(contextWindow / 4), 16384);
 
-	// Detect vision from families or known table
+	// Detect vision: /api/show capabilities > known table > model families heuristic
 	const hasVision =
+		showCapabilities?.includes("vision") ??
 		caps.input?.includes("image") ??
 		(info.details?.families?.some((f) => f === "clip" || f === "mllama") ?? false);
 
-	// Detect reasoning from known table
-	const reasoning = caps.reasoning ?? false;
+	// Detect reasoning: /api/show capabilities (authoritative) > known table fallback
+	const reasoning =
+		showCapabilities?.includes("thinking") ??
+		caps.reasoning ??
+		false;
 
 	return {
 		id: info.name,

--- a/src/resources/extensions/ollama/ollama-discovery.ts
+++ b/src/resources/extensions/ollama/ollama-discovery.ts
@@ -73,10 +73,16 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 		if (process.env.GSD_DEBUG) console.warn(`[ollama] /api/show failed for ${info.name}:`, err instanceof Error ? err.message : String(err));
 	}
 
-	// Determine context window: known table > /api/show > estimate from param size > default
+	// Determine context window: /api/show (authoritative ollama metadata) >
+	// known table (fallback for old ollama versions / network failure) >
+	// estimate from parameter size > default. Earlier priority order put
+	// known table first, but the table fell behind reality on several
+	// model families (deepseek-v4-* 131072 vs real 1048576; minimax-m2.7
+	// 1048576 vs real 196608). /api/show is the source of truth when
+	// reachable; the table only fills the gap when it isn't.
 	const contextWindow =
-		caps.contextWindow ??
 		showContextWindow ??
+		caps.contextWindow ??
 		(parameterSize ? estimateContextFromParams(parameterSize) : 8192);
 
 	// Determine max tokens: known table > fraction of context > default

--- a/src/resources/extensions/ollama/ollama-discovery.ts
+++ b/src/resources/extensions/ollama/ollama-discovery.ts
@@ -101,6 +101,16 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 		caps.reasoning ??
 		false;
 
+	// Sync num_ctx with the authoritative contextWindow. When /api/show
+	// wins, the table's static num_ctx would otherwise be stale and sent
+	// on every chat request — the very drift this commit's priority flip
+	// was designed to eliminate. Keep all other ollamaOptions (num_gpu,
+	// sampling params, keep_alive) from the table.
+	const ollamaOptions =
+		showContextWindow !== undefined
+			? { ...caps.ollamaOptions, num_ctx: showContextWindow }
+			: caps.ollamaOptions;
+
 	return {
 		id: info.name,
 		name: humanizeModelName(info.name),
@@ -111,7 +121,7 @@ async function enrichModel(info: OllamaModelInfo, deps: ClientDeps): Promise<Dis
 		maxTokens,
 		sizeBytes: info.size,
 		parameterSize,
-		ollamaOptions: caps.ollamaOptions,
+		ollamaOptions,
 	};
 }
 
@@ -122,6 +132,13 @@ export async function discoverModels(deps: ClientDeps = { listModels, showModel 
 	const tags = await deps.listModels();
 	if (!tags.models || tags.models.length === 0) return [];
 
+	// /api/show is now invoked for every model (capabilities + context_length
+	// both live there). Requests are dispatched concurrently here, but ollama's
+	// local server serializes model-metadata calls internally, so wall time
+	// scales linearly with model count — empirically ~50-100 ms/model on a warm
+	// ollama instance. A user with 30+ models pays ~3 s on app start. If this
+	// becomes a complaint, gate the call on `caps.contextWindow === undefined`
+	// and `caps.reasoning === undefined` (i.e., unknown-model fast path).
 	return Promise.all(tags.models.map((m) => enrichModel(m, deps)));
 }
 

--- a/src/resources/extensions/ollama/tests/model-capabilities.test.ts
+++ b/src/resources/extensions/ollama/tests/model-capabilities.test.ts
@@ -191,9 +191,12 @@ describe("getModelCapabilities — long-variant overrides aren't shadowed (#4991
 		assert.equal(caps.contextWindow, 262144);
 	});
 
-	it("minimax-m2.5:cloud and minimax-m2.7:cloud report 1M", () => {
+	it("minimax-m2.5:cloud at 1M (base default); minimax-m2.7:cloud at real 192K", () => {
+		// minimax-m2 family base was announced at 1M; m2.5 retained that.
+		// m2.7 ships at 196608 per ollama /api/show — confirmed empirically
+		// against gsd-build/gsd-2#4984 follow-up. Long-variant beats base.
 		assert.equal(getModelCapabilities("minimax-m2.5:cloud").contextWindow, 1048576);
-		assert.equal(getModelCapabilities("minimax-m2.7:cloud").contextWindow, 1048576);
+		assert.equal(getModelCapabilities("minimax-m2.7:cloud").contextWindow, 196608);
 	});
 
 	it("minimax-m2 base resolves to 1M", () => {

--- a/src/resources/extensions/ollama/tests/model-capabilities.test.ts
+++ b/src/resources/extensions/ollama/tests/model-capabilities.test.ts
@@ -82,6 +82,48 @@ describe("getModelCapabilities", () => {
 		const caps = getModelCapabilities("Llama3.1:8B");
 		assert.equal(caps.contextWindow, 131072);
 	});
+
+	// ─── New reasoning-model fallback entries (cloud + local) ──────────────────
+	// These exist as a fallback for ollama versions whose /api/show response
+	// does not include the `capabilities` array. When capabilities are present,
+	// detection happens dynamically in ollama-discovery.ts.
+
+	it("flags gpt-oss as reasoning (covers :20b, :120b, :*-cloud)", () => {
+		assert.equal(getModelCapabilities("gpt-oss:20b").reasoning, true);
+		assert.equal(getModelCapabilities("gpt-oss:120b-cloud").reasoning, true);
+	});
+
+	it("flags deepseek-v3.1/v4 family as reasoning", () => {
+		assert.equal(getModelCapabilities("deepseek-v3.1:671b-cloud").reasoning, true);
+		assert.equal(getModelCapabilities("deepseek-v4-flash:cloud").reasoning, true);
+	});
+
+	it("flags glm-4.x/5.x family as reasoning", () => {
+		assert.equal(getModelCapabilities("glm-4.6:cloud").reasoning, true);
+		assert.equal(getModelCapabilities("glm-5.1:cloud").reasoning, true);
+	});
+
+	it("flags kimi-k2 family as reasoning", () => {
+		assert.equal(getModelCapabilities("kimi-k2:1t-cloud").reasoning, true);
+		assert.equal(getModelCapabilities("kimi-k2.6:cloud").reasoning, true);
+	});
+
+	it("flags qwen3 as reasoning (hybrid thinking model)", () => {
+		assert.equal(getModelCapabilities("qwen3:8b").reasoning, true);
+		assert.equal(getModelCapabilities("qwen3-next:cloud").reasoning, true);
+	});
+
+	it("flags minimax-m2 family as reasoning", () => {
+		assert.equal(getModelCapabilities("minimax-m2.7:cloud").reasoning, true);
+	});
+
+	it("flags gemma4 (with thinking) as reasoning", () => {
+		assert.equal(getModelCapabilities("gemma4:31b-cloud").reasoning, true);
+	});
+
+	it("flags gemini-3-flash-preview as reasoning", () => {
+		assert.equal(getModelCapabilities("gemini-3-flash-preview:cloud").reasoning, true);
+	});
 });
 
 // ─── Ordering / prefix-shadowing regression (#4991) ──────────────────────────

--- a/src/resources/extensions/ollama/tests/model-capabilities.test.ts
+++ b/src/resources/extensions/ollama/tests/model-capabilities.test.ts
@@ -204,6 +204,20 @@ describe("getModelCapabilities — long-variant overrides aren't shadowed (#4991
 		assert.equal(caps.contextWindow, 1048576);
 	});
 
+	it("deepseek-v4-pro:cloud and deepseek-v4-flash:cloud resolve to 1M (long-variants beat deepseek-v4 base)", () => {
+		// Both long-variants must match before the bare `deepseek-v4` base
+		// entry, otherwise they'd inherit the family's old 131072 value.
+		// This pins the ordering invariant for the deepseek-v4 family that
+		// gsd-build/gsd-2#4984 covers for glm/kimi/minimax.
+		assert.equal(getModelCapabilities("deepseek-v4-pro:cloud").contextWindow, 1048576);
+		assert.equal(getModelCapabilities("deepseek-v4-flash:cloud").contextWindow, 1048576);
+	});
+
+	it("deepseek-v4 base also resolves to 1M (parity with long-variants)", () => {
+		const caps = getModelCapabilities("deepseek-v4:671b");
+		assert.equal(caps.contextWindow, 1048576);
+	});
+
 	it("ollamaOptions.num_ctx mirrors contextWindow for all new entries", () => {
 		// Inference time: num_ctx is what gets sent to Ollama on each chat.
 		// If contextWindow is right but num_ctx is stale, the model still

--- a/src/resources/extensions/ollama/tests/ollama-chat-provider-stream.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-chat-provider-stream.test.ts
@@ -80,3 +80,70 @@ describe("Ollama stream terminal chunk handling", () => {
     assert.equal(result, "one-shot", "single done chunk with content should work");
   });
 });
+
+// ─── Native thinking field on chunks (ollama 0.4+) ───────────────────────────
+// Reasoning-capable cloud models (e.g. glm-5.1:cloud) emit thinking in a
+// separate `message.thinking` field, not inline as <think> tags. The provider
+// must capture this channel; otherwise the reasoning trace is silently dropped.
+
+interface OllamaChunkWithThink {
+  done: boolean;
+  done_reason?: string;
+  message?: { content?: string; thinking?: string; tool_calls?: unknown[] };
+}
+
+function simulateThinkingStreamLoop(chunks: OllamaChunkWithThink[]): { thinking: string; content: string } {
+  let thinking = "";
+  let content = "";
+
+  for (const chunk of chunks) {
+    // Mirrors the dual-channel logic in ollama-chat-provider.ts:
+    // emit thinking before content so blocks open in reasoning-then-answer order.
+    const t = chunk.message?.thinking ?? "";
+    if (t) thinking += t;
+
+    const c = chunk.message?.content ?? "";
+    if (c) content += c;
+
+    if (chunk.done) break;
+  }
+
+  return { thinking, content };
+}
+
+describe("Ollama stream thinking-field handling", () => {
+  it("captures thinking from a separate message.thinking channel", () => {
+    const chunks: OllamaChunkWithThink[] = [
+      { done: false, message: { thinking: "Let me think... " } },
+      { done: false, message: { thinking: "2+2 = 4." } },
+      { done: false, message: { content: "The answer is " } },
+      { done: true, done_reason: "stop", message: { content: "4." } },
+    ];
+
+    const { thinking, content } = simulateThinkingStreamLoop(chunks);
+    assert.equal(thinking, "Let me think... 2+2 = 4.");
+    assert.equal(content, "The answer is 4.");
+  });
+
+  it("captures thinking from the terminal done:true chunk", () => {
+    // Some models flush all reasoning on the final chunk.
+    const chunks: OllamaChunkWithThink[] = [
+      { done: false, message: { content: "answer" } },
+      { done: true, done_reason: "stop", message: { thinking: "post-hoc trace" } },
+    ];
+
+    const { thinking, content } = simulateThinkingStreamLoop(chunks);
+    assert.equal(thinking, "post-hoc trace");
+    assert.equal(content, "answer");
+  });
+
+  it("handles a chunk with both thinking and content together", () => {
+    const chunks: OllamaChunkWithThink[] = [
+      { done: true, done_reason: "stop", message: { thinking: "T", content: "C" } },
+    ];
+
+    const { thinking, content } = simulateThinkingStreamLoop(chunks);
+    assert.equal(thinking, "T");
+    assert.equal(content, "C");
+  });
+});

--- a/src/resources/extensions/ollama/tests/ollama-chat-provider-think.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-chat-provider-think.test.ts
@@ -1,0 +1,58 @@
+// GSD2 — Tests for ollama think-parameter mapping
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Api, Model, SimpleStreamOptions } from "@gsd/pi-ai";
+import { buildThinkParam } from "../ollama-chat-provider.js";
+
+function modelStub(reasoning: boolean, id = "gpt-oss:20b"): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions" as Api,
+		provider: "ollama",
+		baseUrl: "http://localhost:11434",
+		reasoning,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131072,
+		maxTokens: 32768,
+	};
+}
+
+describe("buildThinkParam — gating", () => {
+	it("returns undefined when model.reasoning is false", () => {
+		const m = modelStub(false);
+		const opts: SimpleStreamOptions = { reasoning: "high" };
+		assert.equal(buildThinkParam(m, opts), undefined);
+	});
+
+	it("returns undefined when options.reasoning is undefined (preserve existing default)", () => {
+		const m = modelStub(true);
+		assert.equal(buildThinkParam(m, {}), undefined);
+		assert.equal(buildThinkParam(m, undefined), undefined);
+	});
+});
+
+describe("buildThinkParam — ThinkingLevel mapping", () => {
+	const m = modelStub(true);
+
+	it("maps 'minimal' to false (turn thinking off)", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "minimal" }), false);
+	});
+
+	it("passes 'low' through as string", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "low" }), "low");
+	});
+
+	it("passes 'medium' through as string", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "medium" }), "medium");
+	});
+
+	it("passes 'high' through as string", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "high" }), "high");
+	});
+
+	it("collapses 'xhigh' to 'high' (ollama caps at high)", () => {
+		assert.equal(buildThinkParam(m, { reasoning: "xhigh" }), "high");
+	});
+});

--- a/src/resources/extensions/ollama/tests/ollama-chat-provider-think.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-chat-provider-think.test.ts
@@ -1,8 +1,8 @@
 // GSD2 — Tests for ollama think-parameter mapping
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import type { Api, Model, SimpleStreamOptions } from "@gsd/pi-ai";
-import { buildThinkParam } from "../ollama-chat-provider.js";
+import type { Api, Context, Model, SimpleStreamOptions } from "@gsd/pi-ai";
+import { buildRequest, buildThinkParam } from "../ollama-chat-provider.js";
 
 function modelStub(reasoning: boolean, id = "gpt-oss:20b"): Model<Api> {
 	return {
@@ -54,5 +54,33 @@ describe("buildThinkParam — ThinkingLevel mapping", () => {
 
 	it("collapses 'xhigh' to 'high' (ollama caps at high)", () => {
 		assert.equal(buildThinkParam(m, { reasoning: "xhigh" }), "high");
+	});
+});
+
+describe("buildRequest — wire-level think field", () => {
+	const emptyContext: Context = { messages: [] } as unknown as Context;
+
+	it("sets request.think = false when reasoning='minimal' on a reasoning model", () => {
+		// Wire-level coverage: buildThinkParam returns false for 'minimal',
+		// and the buildRequest guard must let falsy-but-not-undefined values
+		// through. A naive `if (think) request.think = think` would drop
+		// 'minimal' entirely and leave the model's default thinking on.
+		const req = buildRequest(modelStub(true), emptyContext, { reasoning: "minimal" });
+		assert.equal(req.think, false);
+	});
+
+	it("sets request.think = 'high' when reasoning='high'", () => {
+		const req = buildRequest(modelStub(true), emptyContext, { reasoning: "high" });
+		assert.equal(req.think, "high");
+	});
+
+	it("omits request.think when reasoning is unset (preserve model default)", () => {
+		const req = buildRequest(modelStub(true), emptyContext, {});
+		assert.equal(req.think, undefined);
+	});
+
+	it("omits request.think on non-reasoning models even when reasoning is requested", () => {
+		const req = buildRequest(modelStub(false), emptyContext, { reasoning: "high" });
+		assert.equal(req.think, undefined);
 	});
 });

--- a/src/resources/extensions/ollama/tests/ollama-discovery.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-discovery.test.ts
@@ -14,19 +14,19 @@ function tagsStub(name: string, parameterSize = ""): OllamaTagsResponse {
 	return { models: [modelStub(name, parameterSize)] };
 }
 
-function showStub(modelInfo: Record<string, unknown>): OllamaShowResponse {
-	return { modelfile: "", parameters: "", template: "", details: EMPTY_DETAILS, model_info: modelInfo };
+function showStub(modelInfo: Record<string, unknown>, capabilities?: string[]): OllamaShowResponse {
+	return { modelfile: "", parameters: "", template: "", details: EMPTY_DETAILS, model_info: modelInfo, capabilities };
 }
 
 describe("discoverModels — context window resolution", () => {
-	it("uses known table context window without calling /api/show", async () => {
-		let showCalled = false;
+	it("prefers known table context window over /api/show value", async () => {
+		// /api/show is now always called (to read capabilities), but the static
+		// table still wins for context window when both sources have a value.
 		const models = await discoverModels({
 			listModels: async () => tagsStub("llama3.2:latest", "3B"),
-			showModel: async () => { showCalled = true; throw new Error("should not be called"); },
+			showModel: async () => showStub({ "llama.context_length": 4096 }),
 		});
 		assert.equal(models[0].contextWindow, 131072);
-		assert.equal(showCalled, false);
 	});
 
 	it("uses context_length from /api/show model_info for unknown model", async () => {
@@ -51,5 +51,61 @@ describe("discoverModels — context window resolution", () => {
 			showModel: async () => { throw new Error("network error"); },
 		});
 		assert.equal(models[0].contextWindow, 8192);
+	});
+});
+
+describe("discoverModels — reasoning detection from /api/show capabilities", () => {
+	it("flags reasoning=true when capabilities include 'thinking' (cloud model)", async () => {
+		// Real-world: glm-5.1:cloud → /api/show returns capabilities: ['thinking', 'completion', 'tools']
+		const models = await discoverModels({
+			listModels: async () => tagsStub("glm-5.1:cloud"),
+			showModel: async () => showStub({ "glm5.1.context_length": 131072 }, ["thinking", "completion", "tools"]),
+		});
+		assert.equal(models[0].reasoning, true);
+	});
+
+	it("flags reasoning=false when capabilities array is present but excludes 'thinking'", async () => {
+		// A genuinely non-thinking model with capabilities returned should respect the API
+		const models = await discoverModels({
+			listModels: async () => tagsStub("totally-unknown-model:7b", "7B"),
+			showModel: async () => showStub({}, ["completion", "tools"]),
+		});
+		assert.equal(models[0].reasoning, false);
+	});
+
+	it("falls back to KNOWN_MODELS table when /api/show omits capabilities", async () => {
+		// Older ollama versions don't return capabilities field
+		const models = await discoverModels({
+			listModels: async () => tagsStub("deepseek-r1:8b"),
+			showModel: async () => showStub({}),
+		});
+		assert.equal(models[0].reasoning, true);
+	});
+
+	it("falls back to KNOWN_MODELS table when /api/show throws", async () => {
+		const models = await discoverModels({
+			listModels: async () => tagsStub("qwq:32b"),
+			showModel: async () => { throw new Error("network error"); },
+		});
+		assert.equal(models[0].reasoning, true);
+	});
+
+	it("defaults reasoning=false for unknown model with no capabilities and no /api/show", async () => {
+		const models = await discoverModels({
+			listModels: async () => tagsStub("brand-new-model:7b", "7B"),
+			showModel: async () => { throw new Error("network error"); },
+		});
+		assert.equal(models[0].reasoning, false);
+	});
+
+	it("calls /api/show even when context window is known in table (to pick up capabilities)", async () => {
+		// Behavior change: previously skipped /api/show when table had context window.
+		// Now must always call to learn about thinking capability.
+		let showCalled = false;
+		await discoverModels({
+			listModels: async () => tagsStub("llama3.2:latest", "3B"),
+			showModel: async () => { showCalled = true; return showStub({}, ["completion"]); },
+		});
+		assert.equal(showCalled, true);
 	});
 });

--- a/src/resources/extensions/ollama/tests/ollama-discovery.test.ts
+++ b/src/resources/extensions/ollama/tests/ollama-discovery.test.ts
@@ -19,12 +19,30 @@ function showStub(modelInfo: Record<string, unknown>, capabilities?: string[]): 
 }
 
 describe("discoverModels — context window resolution", () => {
-	it("prefers known table context window over /api/show value", async () => {
-		// /api/show is now always called (to read capabilities), but the static
-		// table still wins for context window when both sources have a value.
+	it("prefers /api/show context_length over known table value", async () => {
+		// /api/show is the authoritative source for context window (ollama
+		// metadata derived from the model file). The static table is a
+		// fallback for old ollama versions and network failures. Earlier
+		// versions of this code preferred the table, but the table fell
+		// behind reality on several model families (deepseek-v4-* underreported
+		// at 131072 vs real 1048576; minimax-m2.7 overreported at 1048576 vs
+		// real 196608). Trusting /api/show keeps gsd correct without
+		// chasing a perpetually-stale table.
 		const models = await discoverModels({
 			listModels: async () => tagsStub("llama3.2:latest", "3B"),
 			showModel: async () => showStub({ "llama.context_length": 4096 }),
+		});
+		assert.equal(models[0].contextWindow, 4096);
+	});
+
+	it("falls back to known table when /api/show omits context_length", async () => {
+		// Even though the model matches a known table entry (llama3.2 at
+		// 131072), if /api/show response carries no context_length key the
+		// table still serves as the fallback. This preserves correctness on
+		// older ollama versions that don't emit per-architecture context.
+		const models = await discoverModels({
+			listModels: async () => tagsStub("llama3.2:latest", "3B"),
+			showModel: async () => showStub({}),
 		});
 		assert.equal(models[0].contextWindow, 131072);
 	});

--- a/src/resources/extensions/ollama/types.ts
+++ b/src/resources/extensions/ollama/types.ts
@@ -37,6 +37,12 @@ export interface OllamaShowResponse {
 	template: string;
 	details: OllamaModelDetails;
 	model_info: Record<string, unknown>;
+	/**
+	 * Model capability flags exposed by ollama 0.4+. Common values:
+	 * "completion", "tools", "vision", "thinking", "embedding", "insert".
+	 * Older ollama versions and some cloud-routed models may omit this field.
+	 */
+	capabilities?: string[];
 }
 
 // ─── /api/ps ────────────────────────────────────────────────────────────────
@@ -93,6 +99,13 @@ export interface OllamaChatOptions {
 export interface OllamaChatMessage {
 	role: "system" | "user" | "assistant" | "tool";
 	content: string;
+	/**
+	 * Reasoning trace returned by ollama 0.4+ when `think` is enabled on the
+	 * request. This is a separate channel from `content`; older models (and
+	 * some local models without native thinking support) emit thinking inline
+	 * as `<think>...</think>` tags in `content` instead.
+	 */
+	thinking?: string;
 	images?: string[];
 	tool_calls?: OllamaToolCall[];
 	/** Tool name — required for role: "tool" messages to correlate results with calls. */
@@ -136,6 +149,13 @@ export interface OllamaChatRequest {
 		num_gpu?: number;
 	};
 	keep_alive?: string;
+	/**
+	 * Controls thinking on reasoning models (ollama 0.4+).
+	 * - `true`/`false` toggles thinking on/off (universal form)
+	 * - `"low" | "medium" | "high"` sets thinking strength (gpt-oss style)
+	 * Omit to use the model's default behaviour.
+	 */
+	think?: boolean | "low" | "medium" | "high";
 }
 
 export interface OllamaChatResponse {


### PR DESCRIPTION
Resolves gsd-build/gsd-2#5374. Also a follow-up to the #4984 long-variant ordering fix that resurfaced shadowing after it landed.

## Story

Three compounding issues in the same code path:

**#5374** — Cloud-routed and modern reasoning models (glm-5.x, kimi-k2.x, deepseek-v3.1/v4-flash, qwen3, minimax-m2, gemma4, gemini-3-flash-preview, nemotron-3, ...) were silently treated as non-reasoning. The thinking-strength selector was hidden in the UI; even when reasoning was explicitly set the provider never forwarded the strength to `/api/chat`; and the native `message.thinking` channel that reasoning models return on the wire was discarded.

**#4984 follow-up** — After #4984 added a top-level "Reasoning models" block listing glm-5/glm-4/kimi-k2/minimax-m2 with `reasoning: true`, the upstream #4991 fix moved glm/kimi/minimax to long-variant entries lower in the table. The top-level base patterns then re-shadowed those long-variants — `glm-5.1:cloud` matched the generic `glm-5` entry first and reported 131K context instead of 200K.

**Table drift** (verified ollama 0.23.2 `/api/show`):

| Model | Table value (#5374 era) | `/api/show` real |
|---|---|---|
| `deepseek-v4-pro` / `deepseek-v4-flash` | 131072 | 1048576 |
| `minimax-m2.7` | 1048576 (overreport!) | 196608 |
| `gemma4:31b` | 131072 | 262144 |

## Solution (4 stacked commits)

### 1. `fix(ollama): detect thinking capability and forward strength to /api/chat`

End-to-end fix for #5374 itself:

- **Dynamic capability detection.** `enrichModel` now always calls `/api/show` and reads the `capabilities` array (ollama 0.4+), treating `"thinking"` as the authoritative reasoning signal. Vision detection follows the same precedence. Static KNOWN_MODELS remains fallback for older ollama versions.
- **KNOWN_MODELS fallback expansion.** Added entries for the modern families in case `/api/show` capabilities is unavailable.
- **`buildThinkParam` helper.** Maps `SimpleStreamOptions.reasoning` (ThinkingLevel) to ollama's `think` field: `minimal` → `false`, `low|medium|high` pass through, `xhigh` → `high`. Attached to `OllamaChatRequest.think` only on reasoning-capable models with a caller-requested level (preserves existing default behaviour otherwise).
- **Native thinking channel.** Reasoning models return their trace in `message.thinking` separately from `message.content`. Streaming loop now emits this as a thinking delta in addition to the existing inline `<think>` parser, so cloud reasoning models stop dropping their reasoning trace.

### 2. `fix(ollama): resolve PR #4984 carry-over prefix-shadowing in known-models table`

Reorder KNOWN_MODELS so long-variants (`glm-5.1`, `kimi-k2-thinking`, `kimi-k2.{5,6}`, `qwen3.{5,6}`, `qwen3-next`, `qwen3-coder`, `minimax-m2.{5,7}`) appear before bare base patterns. Drop duplicate top-level "Reasoning models" base entries that re-shadowed them. Restores 102/102 ollama tests after the #4984 cherry-pick.

### 3. `fix(ollama): trust /api/show context over stale KNOWN_MODELS table`

Flip the resolution priority in `enrichModel`:

```diff
- caps.contextWindow ?? showContextWindow ?? estimate ?? 8192
+ showContextWindow ?? caps.contextWindow ?? estimate ?? 8192
```

`/api/show` is the authoritative ollama metadata source. The static table becomes a fallback for old ollama versions and network failures, and is no longer a maintenance burden chasing cloud-model context bumps.

Also corrects the 3 drifted KNOWN_MODELS entries above so the fallback path is also accurate.

### 4. `fix(ollama): sync num_ctx with /api/show + close review gaps`

When `/api/show` provides `context_length`, it must also drive `num_ctx` in `ollamaOptions` — otherwise the stale table `num_ctx` would still hit the wire even though the displayed context window was correct. Critical for the minimax-m2.7 case where the table was overreporting by 5x.

Plus minor follow-ups from a pre-PR review pass:

- Prefix-shadow ordering test for `deepseek-v4-pro` / `deepseek-v4-flash` / `deepseek-v4` (the motivating cases for commit 3 had no explicit pin).
- Wire-level test that `buildRequest` sets `request.think = false` when `reasoning: "minimal"` (the falsy-but-not-undefined case that a naive `if (think)` guard would drop).
- Inline note in `discoverModels` documenting the always-call `/api/show` cost (~50-100 ms/model on a warm ollama instance; serialized server-side) and the gate condition that could be applied as a fast-path if it becomes a complaint.

## Empirical verification (ollama 0.23.2 against the user's 7 cloud models)

| Model | Before this PR | After this PR |
|---|---|---|
| `deepseek-v4-pro:cloud` | 131K, no reasoning flag | 1M, reasoning ✓ |
| `deepseek-v4-flash:cloud` | 131K, no reasoning flag | 1M, reasoning ✓ |
| `minimax-m2.7:cloud` | 1M (overreport) | 192K (real) |
| `gemma4:31b-cloud` | 131K | 256K (real) |
| `glm-5.1:cloud` | 200K, no thinking selector, no `think` forward | 200K + selector visible + `think` forwarded |
| `kimi-k2.6:cloud` | 256K, no `think` forward | 256K + `think` forwarded |
| `gemini-3-flash-preview:cloud` | 1M (via /api/show fallback) | 1M (via /api/show priority — unchanged for the user) |

## Tests

149 ollama tests pass. New coverage:

- Capability-array detection (with/without ollama 0.4+ array)
- KNOWN_MODELS fallback paths (when /api/show omits capabilities or throws)
- ThinkingLevel ↔ think mapping incl. wire level (`request.think = false` survives buildRequest)
- Dual-channel (thinking + content) stream handling
- `/api/show` priority over table for `contextWindow`; table fallback when `/api/show` omits context
- `deepseek-v4` family prefix-shadow ordering pin

## Test plan

- [x] `npm run test:unit` — 149 ollama tests pass
- [x] Empirical against all 7 models in the table above on ollama 0.23.2 — context windows, reasoning flags, thinking-strength selector visibility, and `think` param forwarding all correct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native "thinking" streaming from Ollama models, reasoning intensity controls, and expanded model capability detection (more families marked reasoning-capable).
  * Context-window handling now auto-derives runtime context sizes and treats discovered model info as authoritative when available.

* **Tests**
  * Added and extended tests covering thinking streams, reasoning parameter mapping, capability fallbacks, and discovery behavior.

* **Documentation**
  * Updated types and inline docs to reflect new thinking/capabilities and reasoning controls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5785)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->