### PR TITLE
feat(gsd): widen AutoAdvanceResult with unit + action (#5786)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,7 +16,7 @@
 
 ## Architecture terms adopted for this area
 
-- **Auto Orchestration module**: the module that owns unit lifecycle control-flow.
+- **Auto Orchestration module**: the module that owns the pre-dispatch invariant pipeline and lifecycle telemetry. It gates whether a Unit may dispatch (State Reconciliation → Dispatch decision → Tool Contract → Worktree Safety) and journals lifecycle transitions, but does not execute the Unit or own runtime recovery for Unit-execution failures. The auto-loop runs the Unit and calls Recovery Classification directly when it fails.
 - **Dispatch adapter**: adapter behind the Dispatch seam.
 - **Recovery adapter**: adapter behind the Recovery seam.
 - **Worktree adapter**: adapter behind the Worktree seam.

--- a/src/resources/extensions/gsd/auto/contracts.ts
+++ b/src/resources/extensions/gsd/auto/contracts.ts
@@ -8,21 +8,24 @@ export interface AutoSessionContext {
   trigger: "guided-flow" | "resume" | "auto-loop" | "manual";
 }
 
+export interface UnitRef {
+  unitType: string;
+  unitId: string;
+}
+
 export interface AutoStatus {
   phase: "idle" | "running" | "paused" | "stopped" | "error";
-  activeUnit?: {
-    unitType: string;
-    unitId: string;
-  };
+  activeUnit?: UnitRef;
   lastTransitionAt?: number;
   transitionCount: number;
 }
 
-export interface AutoAdvanceResult {
-  kind: "advanced" | "blocked" | "paused" | "stopped" | "error";
-  reason?: string;
-  stateSnapshot?: GSDState;
-}
+export type AutoAdvanceResult =
+  | { kind: "advanced"; unit: UnitRef; stateSnapshot: GSDState }
+  | { kind: "blocked"; reason: string; action: "pause" | "stop"; stateSnapshot?: GSDState }
+  | { kind: "stopped"; reason: string; stateSnapshot?: GSDState }
+  | { kind: "paused"; reason: string }
+  | { kind: "error"; reason: string };
 
 export interface AutoOrchestrationModule {
   start(sessionContext: AutoSessionContext): Promise<AutoAdvanceResult>;

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -33,7 +33,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       await this.deps.runtime.ensureLockOwnership();
       const gate = await this.deps.health.preAdvanceGate();
       if (!gate.allow) {
-        const blocked: AutoAdvanceResult = { kind: "blocked", reason: gate.reason ?? "health gate blocked" };
+        const blocked: AutoAdvanceResult = { kind: "blocked", reason: gate.reason ?? "health gate blocked", action: "pause" };
         await this.deps.runtime.journalTransition({ name: "advance-blocked", reason: blocked.reason });
         await this.deps.health.postAdvanceRecord(blocked);
         return blocked;
@@ -43,7 +43,8 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       if (!reconciliation.ok || !reconciliation.stateSnapshot) {
         const blocked: AutoAdvanceResult = {
           kind: "blocked",
-          reason: reconciliation.reason,
+          reason: reconciliation.reason ?? "state reconciliation produced no snapshot",
+          action: "pause",
           stateSnapshot: reconciliation.stateSnapshot,
         };
         await this.deps.runtime.journalTransition({ name: "advance-blocked", reason: blocked.reason });
@@ -65,7 +66,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
 
       const nextKey = `${decision.unitType}:${decision.unitId}`;
       if (this.lastAdvanceKey === nextKey) {
-        const blocked: AutoAdvanceResult = { kind: "blocked", reason: "idempotent advance: unit already active" };
+        const blocked: AutoAdvanceResult = { kind: "blocked", reason: "idempotent advance: unit already active", action: "stop" };
         await this.deps.runtime.journalTransition({
           name: "advance-blocked",
           reason: blocked.reason,
@@ -81,6 +82,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         const blocked: AutoAdvanceResult = {
           kind: "blocked",
           reason: contract.reason,
+          action: "pause",
           stateSnapshot: reconciliation.stateSnapshot,
         };
         await this.deps.runtime.journalTransition({
@@ -98,6 +100,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         const blocked: AutoAdvanceResult = {
           kind: "blocked",
           reason: worktree.reason,
+          action: "pause",
           stateSnapshot: reconciliation.stateSnapshot,
         };
         await this.deps.runtime.journalTransition({
@@ -123,7 +126,11 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       });
       await this.deps.worktree.syncAfterUnit(decision.unitType, decision.unitId);
 
-      const advanced: AutoAdvanceResult = { kind: "advanced", stateSnapshot: reconciliation.stateSnapshot };
+      const advanced: AutoAdvanceResult = {
+        kind: "advanced",
+        unit: { unitType: decision.unitType, unitId: decision.unitId },
+        stateSnapshot: reconciliation.stateSnapshot,
+      };
       await this.deps.health.postAdvanceRecord(advanced);
       return advanced;
     } catch (error) {

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -87,6 +87,7 @@ test("start() advances and records active unit", async () => {
   const result = await orchestrator.start({ basePath: "/tmp/project", trigger: "manual" });
 
   assert.equal(result.kind, "advanced");
+  assert.deepEqual(result.unit, { unitType: "execute-task", unitId: "T01" });
   const status = orchestrator.getStatus();
   assert.equal(status.phase, "running");
   assert.deepEqual(status.activeUnit, { unitType: "execute-task", unitId: "T01" });
@@ -107,6 +108,7 @@ test("advance() returns blocked when health gate denies", async () => {
 
   assert.equal(result.kind, "blocked");
   assert.equal(result.reason, "doctor-block");
+  assert.equal(result.action, "pause");
 });
 
 test("advance() follows the ADR-015 invariant sequence before journaling advance", async () => {
@@ -116,6 +118,7 @@ test("advance() follows the ADR-015 invariant sequence before journaling advance
   const result = await orchestrator.advance();
 
   assert.equal(result.kind, "advanced");
+  assert.deepEqual(result.unit, { unitType: "execute-task", unitId: "T01" });
   assert.deepEqual(calls, [
     "runtime.lock",
     "health.pre",
@@ -144,6 +147,7 @@ test("advance() blocks before dispatch when State Reconciliation blocks", async 
 
   assert.equal(result.kind, "blocked");
   assert.equal(result.reason, "state drift blocked");
+  assert.equal(result.action, "pause");
   assert.ok(!calls.includes("dispatch.decide"));
   assert.ok(calls.includes("journal:advance-blocked"));
 });
@@ -163,6 +167,7 @@ test("advance() blocks before Runtime persistence when Tool Contract fails", asy
 
   assert.equal(result.kind, "blocked");
   assert.equal(result.reason, "unknown Unit");
+  assert.equal(result.action, "pause");
   assert.ok(!calls.includes("worktree.prepare"));
   assert.ok(!calls.includes("journal:advance"));
   assert.ok(calls.includes("journal:advance-blocked"));
@@ -185,6 +190,7 @@ test("advance() blocks before Runtime persistence when Worktree Safety fails", a
 
   assert.equal(result.kind, "blocked");
   assert.equal(result.reason, "worktree invalid");
+  assert.equal(result.action, "pause");
   assert.ok(!calls.includes("journal:advance"));
   assert.ok(!calls.includes("worktree.sync"));
   assert.ok(calls.includes("journal:advance-blocked"));
@@ -232,8 +238,10 @@ test("advance() is idempotent for the same active unit", async () => {
   const second = await orchestrator.advance();
 
   assert.equal(first.kind, "advanced");
+  assert.deepEqual(first.unit, { unitType: "execute-task", unitId: "T01" });
   assert.equal(second.kind, "blocked");
   assert.equal(second.reason, "idempotent advance: unit already active");
+  assert.equal(second.action, "stop");
 
   const prepareCalls = calls.filter((c) => c === "worktree.prepare").length;
   assert.equal(prepareCalls, 1);

--- a/src/resources/extensions/gsd/tests/auto-runtime-state.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-runtime-state.test.ts
@@ -12,10 +12,10 @@ test("getAutoRuntimeSnapshot includes orchestration phase when available", () =>
   autoSession.active = true;
   autoSession.basePath = "/tmp/project";
   autoSession.orchestration = {
-    async start() { return { kind: "advanced" as const }; },
-    async advance() { return { kind: "advanced" as const }; },
-    async resume() { return { kind: "advanced" as const }; },
-    async stop() { return { kind: "stopped" as const }; },
+    async start() { return { kind: "stopped" as const, reason: "test" }; },
+    async advance() { return { kind: "stopped" as const, reason: "test" }; },
+    async resume() { return { kind: "stopped" as const, reason: "test" }; },
+    async stop() { return { kind: "stopped" as const, reason: "test" }; },
     getStatus() {
       return { phase: "running" as const, transitionCount: 3, lastTransitionAt: 123 };
     },


### PR DESCRIPTION
## Summary

Phase 1 / slice 1 of the "Wire the Auto Orchestration module into the real auto-loop" series (issues #5786–#5791).

Convert `AutoAdvanceResult` from a single interface to a discriminated union so a future cutover of `auto/loop.ts` to `advance()` can read the dispatch decision back from the orchestrator and know which side effect (pause vs stop) to apply on blocked results.

- `AutoAdvanceResult.advanced` carries `unit: UnitRef`.
- `AutoAdvanceResult.blocked` carries `action: "pause" | "stop"`. Health gate, state reconciliation, tool contract, worktree safety map to pause; idempotency-block maps to stop. Refined in slices #5787 and #5788.
- Introduces `UnitRef`, reused on `AutoStatus.activeUnit`.
- Narrows the `CONTEXT.md` Auto Orchestration module glossary entry to "pre-dispatch invariant pipeline and lifecycle telemetry" — the thin-gate, pull-seam scope agreed for this series.

## Scope guarantees

- **No production call site changes.** `auto/loop.ts` continues to use the legacy `runPreDispatch + runDispatch + runGuards` pipeline. The cutover is slice #5790.
- Type-check (`tsconfig.extensions.json`) clean.
- All 25 existing `auto-orchestrator.test.ts` tests pass; 8 new field assertions added to those tests.
- A latent type mismatch in `auto-runtime-state.test.ts` (mocks of the orchestration module that didn't satisfy the new union) is fixed in this slice.

## Test plan

- [ ] `npx tsc --noEmit --project tsconfig.extensions.json` — clean for `auto/contracts.ts`, `auto/orchestrator.ts`, `tests/auto-orchestrator.test.ts`, `tests/auto-runtime-state.test.ts`.
- [ ] `npm run build` — green.
- [ ] `npm run test:unit` — green (9091+ tests pass).
- [ ] Manual: ensure no behavioural change to auto-mode (the loop still drives the same `runPreDispatch + runDispatch + runGuards` path).

## Series

This PR is the foundation. Downstream slices, each blocked by this one:

- #5787 — Move stuck-loop detection into the Auto Orchestration module
- #5788 — Orchestrator parity with `runPreDispatch`
- #5789 — Dispatch adapter receives full session dispatch inputs
- #5790 — Cut over dev path of `auto/loop.ts` to `advance()`
- #5791 — Delete `runPreDispatch` and `runDispatch` from `phases.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured Auto Orchestration module response types for improved clarity with discriminated union types and explicit action fields.
  * Blocked orchestration scenarios now specify required actions (pause or stop).
  * Execution results now include unit identifier alongside state information.

* **Documentation**
  * Expanded glossary entry for Auto Orchestration module with precise responsibility and boundary descriptions.

* **Tests**
  * Updated test assertions to verify new response structure fields.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5795)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->