### PR TITLE
feat(gsd): move stuck-loop detection into Auto Orchestration (#5787)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,7 +16,7 @@
 
 ## Architecture terms adopted for this area
 
-- **Auto Orchestration module**: the module that owns unit lifecycle control-flow.
+- **Auto Orchestration module**: the module that owns the pre-dispatch invariant pipeline and lifecycle telemetry. It gates whether a Unit may dispatch (State Reconciliation → Dispatch decision → Tool Contract → Worktree Safety) and journals lifecycle transitions, but does not execute the Unit or own runtime recovery for Unit-execution failures. The auto-loop runs the Unit and calls Recovery Classification directly when it fails.
 - **Dispatch adapter**: adapter behind the Dispatch seam.
 - **Recovery adapter**: adapter behind the Recovery seam.
 - **Worktree adapter**: adapter behind the Worktree seam.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,7 +2,7 @@
 
 ## Domain glossary
 
-- **Auto Orchestration**: runtime coordination of GSD auto-mode units from start to completion, including dispatch and stop/resume behavior; the auto-loop runs Units and calls Recovery Classification for Unit-execution failure recovery.
+- **Auto Orchestration**: runtime coordination of GSD auto-mode units from start to completion, including dispatch and stop/resume behavior; unit-execution failure recovery is classified by the Recovery Classification module.
 - **Unit**: the smallest executable workflow step (e.g., plan slice, execute task, complete slice).
 - **Unit progression**: movement from one Unit to the next under orchestration rules.
 - **Dispatch decision**: selection of the next Unit plus rationale and preconditions.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,7 +2,7 @@
 
 ## Domain glossary
 
-- **Auto Orchestration**: runtime coordination of GSD auto-mode units from start to completion, including dispatch, recovery, and stop/resume behavior.
+- **Auto Orchestration**: runtime coordination of GSD auto-mode units from start to completion, including dispatch and stop/resume behavior; the auto-loop runs Units and calls Recovery Classification for Unit-execution failure recovery.
 - **Unit**: the smallest executable workflow step (e.g., plan slice, execute task, complete slice).
 - **Unit progression**: movement from one Unit to the next under orchestration rules.
 - **Dispatch decision**: selection of the next Unit plus rationale and preconditions.

--- a/src/resources/extensions/gsd/auto/contracts.ts
+++ b/src/resources/extensions/gsd/auto/contracts.ts
@@ -8,21 +8,24 @@ export interface AutoSessionContext {
   trigger: "guided-flow" | "resume" | "auto-loop" | "manual";
 }
 
+export interface UnitRef {
+  unitType: string;
+  unitId: string;
+}
+
 export interface AutoStatus {
   phase: "idle" | "running" | "paused" | "stopped" | "error";
-  activeUnit?: {
-    unitType: string;
-    unitId: string;
-  };
+  activeUnit?: UnitRef;
   lastTransitionAt?: number;
   transitionCount: number;
 }
 
-export interface AutoAdvanceResult {
-  kind: "advanced" | "blocked" | "paused" | "stopped" | "error";
-  reason?: string;
-  stateSnapshot?: GSDState;
-}
+export type AutoAdvanceResult =
+  | { kind: "advanced"; unit: UnitRef; stateSnapshot: GSDState }
+  | { kind: "blocked"; reason: string; action: "pause" | "stop"; stateSnapshot?: GSDState }
+  | { kind: "stopped"; reason: string; stateSnapshot?: GSDState }
+  | { kind: "paused"; reason: string }
+  | { kind: "error"; reason: string };
 
 export interface AutoOrchestrationModule {
   start(sessionContext: AutoSessionContext): Promise<AutoAdvanceResult>;

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -7,6 +7,16 @@ function now(): number {
   return Date.now();
 }
 
+/**
+ * Size of the dispatch-decision ring buffer used by the Auto Orchestration
+ * module's stuck-loop detector. When the same `${unitType}:${unitId}` key
+ * fills the window, advance() blocks with `action: "stop"`.
+ *
+ * Mirrors the legacy `STUCK_WINDOW_SIZE` in auto/phases.ts so behaviour is
+ * preserved across the eventual cutover (issue #5791).
+ */
+export const STUCK_WINDOW_SIZE = 6;
+
 export class AutoOrchestrator implements AutoOrchestrationModule {
   private status: AutoStatus = {
     phase: "idle",
@@ -14,6 +24,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
   };
   private readonly deps: AutoOrchestratorDeps;
   private lastAdvanceKey: string | null = null;
+  private dispatchKeyWindow: string[] = [];
 
   public constructor(deps: AutoOrchestratorDeps) {
     this.deps = deps;
@@ -21,6 +32,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
 
   public async start(_sessionContext: AutoSessionContext): Promise<AutoAdvanceResult> {
     this.lastAdvanceKey = null;
+    this.dispatchKeyWindow = [];
     this.status.phase = "running";
     this.bumpTransition();
     await this.deps.runtime.journalTransition({ name: "start" });
@@ -58,6 +70,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         this.status.phase = "stopped";
         this.status.activeUnit = undefined;
         this.lastAdvanceKey = null;
+        this.dispatchKeyWindow = [];
         this.bumpTransition();
         await this.deps.runtime.journalTransition({ name: "advance-stopped", reason: stopped.reason });
         await this.deps.health.postAdvanceRecord(stopped);
@@ -65,8 +78,45 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       }
 
       const nextKey = `${decision.unitType}:${decision.unitId}`;
-      if (this.lastAdvanceKey === nextKey) {
+
+      // Record every dispatch decision in the ring buffer before pre-flight
+      // checks so the stuck-loop detector observes the full decision history
+      // (including decisions that idempotency would otherwise short-circuit).
+      // The ring is capped at STUCK_WINDOW_SIZE and evicts oldest-first.
+      this.dispatchKeyWindow.push(nextKey);
+      if (this.dispatchKeyWindow.length > STUCK_WINDOW_SIZE) {
+        this.dispatchKeyWindow.shift();
+      }
+
+      // Idempotency: same key as immediately previous successful advance.
+      // This is the soft, fast-path block kept from #5786. It only fires when
+      // the ring is NOT yet saturated for this key — once the ring is full of
+      // `nextKey`, the stuck-loop verdict takes precedence (see below). Both
+      // checks coexist: idempotency for the common immediate-repeat case,
+      // stuck-loop for the saturated-window case.
+      const matchingCount = this.dispatchKeyWindow.filter((k) => k === nextKey).length;
+      if (this.lastAdvanceKey === nextKey && matchingCount < STUCK_WINDOW_SIZE) {
         const blocked: AutoAdvanceResult = { kind: "blocked", reason: "idempotent advance: unit already active", action: "stop" };
+        await this.deps.runtime.journalTransition({
+          name: "advance-blocked",
+          reason: blocked.reason,
+          unitType: decision.unitType,
+          unitId: decision.unitId,
+        });
+        await this.deps.health.postAdvanceRecord(blocked);
+        return blocked;
+      }
+
+      // Stuck-loop detection: when the ring is saturated with copies of
+      // `nextKey` (count >= STUCK_WINDOW_SIZE), the orchestrator has been
+      // picking the same unit across the whole window and must hard-stop with
+      // a diagnosable reason.
+      if (matchingCount >= STUCK_WINDOW_SIZE) {
+        const blocked: AutoAdvanceResult = {
+          kind: "blocked",
+          reason: `stuck-loop: ${nextKey} picked ${matchingCount} times`,
+          action: "stop",
+        };
         await this.deps.runtime.journalTransition({
           name: "advance-blocked",
           reason: blocked.reason,
@@ -155,6 +205,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
 
       if (result.kind === "stopped") {
         this.lastAdvanceKey = null;
+        this.dispatchKeyWindow = [];
         this.status.activeUnit = undefined;
       }
       this.bumpTransition();
@@ -180,6 +231,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
 
   public async resume(): Promise<AutoAdvanceResult> {
     this.lastAdvanceKey = null;
+    this.dispatchKeyWindow = [];
     this.status.phase = "running";
     this.bumpTransition();
     await this.deps.runtime.journalTransition({ name: "resume" });
@@ -195,6 +247,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     this.status.phase = "stopped";
     this.status.activeUnit = undefined;
     this.lastAdvanceKey = null;
+    this.dispatchKeyWindow = [];
     this.bumpTransition();
     await this.deps.runtime.journalTransition({ name: "stop", reason });
     await this.deps.notifications.notifyLifecycle({ name: "stop", detail: reason });

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -33,7 +33,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       await this.deps.runtime.ensureLockOwnership();
       const gate = await this.deps.health.preAdvanceGate();
       if (!gate.allow) {
-        const blocked: AutoAdvanceResult = { kind: "blocked", reason: gate.reason ?? "health gate blocked" };
+        const blocked: AutoAdvanceResult = { kind: "blocked", reason: gate.reason ?? "health gate blocked", action: "pause" };
         await this.deps.runtime.journalTransition({ name: "advance-blocked", reason: blocked.reason });
         await this.deps.health.postAdvanceRecord(blocked);
         return blocked;
@@ -43,7 +43,8 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       if (!reconciliation.ok || !reconciliation.stateSnapshot) {
         const blocked: AutoAdvanceResult = {
           kind: "blocked",
-          reason: reconciliation.reason,
+          reason: reconciliation.reason ?? "state reconciliation produced no snapshot",
+          action: "pause",
           stateSnapshot: reconciliation.stateSnapshot,
         };
         await this.deps.runtime.journalTransition({ name: "advance-blocked", reason: blocked.reason });
@@ -65,7 +66,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
 
       const nextKey = `${decision.unitType}:${decision.unitId}`;
       if (this.lastAdvanceKey === nextKey) {
-        const blocked: AutoAdvanceResult = { kind: "blocked", reason: "idempotent advance: unit already active" };
+        const blocked: AutoAdvanceResult = { kind: "blocked", reason: "idempotent advance: unit already active", action: "stop" };
         await this.deps.runtime.journalTransition({
           name: "advance-blocked",
           reason: blocked.reason,
@@ -81,6 +82,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         const blocked: AutoAdvanceResult = {
           kind: "blocked",
           reason: contract.reason,
+          action: "pause",
           stateSnapshot: reconciliation.stateSnapshot,
         };
         await this.deps.runtime.journalTransition({
@@ -98,6 +100,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
         const blocked: AutoAdvanceResult = {
           kind: "blocked",
           reason: worktree.reason,
+          action: "pause",
           stateSnapshot: reconciliation.stateSnapshot,
         };
         await this.deps.runtime.journalTransition({
@@ -123,7 +126,11 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
       });
       await this.deps.worktree.syncAfterUnit(decision.unitType, decision.unitId);
 
-      const advanced: AutoAdvanceResult = { kind: "advanced", stateSnapshot: reconciliation.stateSnapshot };
+      const advanced: AutoAdvanceResult = {
+        kind: "advanced",
+        unit: { unitType: decision.unitType, unitId: decision.unitId },
+        stateSnapshot: reconciliation.stateSnapshot,
+      };
       await this.deps.health.postAdvanceRecord(advanced);
       return advanced;
     } catch (error) {

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -4,7 +4,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { createAutoOrchestrator } from "../auto/orchestrator.js";
+import { createAutoOrchestrator, STUCK_WINDOW_SIZE } from "../auto/orchestrator.js";
 import type { AutoOrchestratorDeps } from "../auto/contracts.js";
 import type { GSDState } from "../types.js";
 
@@ -475,4 +475,152 @@ test("stop() cleans up worktree and transitions to stopped", async () => {
   assert.ok(calls.includes("worktree.cleanup"));
   assert.ok(calls.includes("journal:stop"));
   assert.ok(calls.includes("notify:stop"));
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Stuck-loop ring buffer (issue #5787)
+// ────────────────────────────────────────────────────────────────────────
+
+test("STUCK_WINDOW_SIZE matches the legacy auto/phases.ts constant", () => {
+  assert.equal(STUCK_WINDOW_SIZE, 6);
+});
+
+test("stuck-loop: empty ring on a freshly constructed orchestrator advances normally", async () => {
+  const { deps } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.advance();
+
+  assert.equal(result.kind, "advanced");
+});
+
+test("stuck-loop: partial fill of mixed units does not block", async () => {
+  // Alternate A/B for STUCK_WINDOW_SIZE rounds. No single key saturates the
+  // window, so neither idempotency nor stuck-loop should fire.
+  let i = 0;
+  const sequence = ["A", "B", "A", "B", "A", "B"];
+  const { deps } = makeDeps({
+    dispatch: {
+      async decideNextUnit() {
+        const id = sequence[i++ % sequence.length];
+        return { unitType: "execute-task", unitId: id, reason: "ready", preconditions: [] };
+      },
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  for (let round = 0; round < STUCK_WINDOW_SIZE; round++) {
+    const result = await orchestrator.advance();
+    assert.equal(result.kind, "advanced", `round ${round} should advance, got ${result.kind}`);
+  }
+});
+
+test("stuck-loop: ring saturated with same unit blocks with action 'stop' and stuck-loop reason", async () => {
+  // Dispatch picks the same unit every time. The first advance succeeds.
+  // Calls 2..STUCK_WINDOW_SIZE-1 are idempotency-blocked while the ring fills.
+  // The STUCK_WINDOW_SIZE'th call sees a saturated ring and returns stuck-loop.
+  const { deps } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const results: Awaited<ReturnType<typeof orchestrator.advance>>[] = [];
+  for (let i = 0; i < STUCK_WINDOW_SIZE; i++) {
+    results.push(await orchestrator.advance());
+  }
+
+  // First call advances.
+  assert.equal(results[0].kind, "advanced");
+
+  // Intermediate calls are blocked by idempotency (not stuck-loop yet).
+  for (let i = 1; i < STUCK_WINDOW_SIZE - 1; i++) {
+    const r = results[i];
+    assert.equal(r.kind, "blocked", `round ${i} should be blocked`);
+    if (r.kind !== "blocked") return;
+    assert.equal(r.reason, "idempotent advance: unit already active");
+    assert.equal(r.action, "stop");
+  }
+
+  // The final call (ring now holds STUCK_WINDOW_SIZE copies) returns stuck-loop.
+  const last = results[STUCK_WINDOW_SIZE - 1];
+  assert.equal(last.kind, "blocked");
+  if (last.kind !== "blocked") return;
+  assert.equal(last.action, "stop");
+  assert.equal(last.reason, `stuck-loop: execute-task:T01 picked ${STUCK_WINDOW_SIZE} times`);
+});
+
+test("stuck-loop: idempotency block continues to fire with its own reason before saturation", async () => {
+  // Two identical calls should produce idempotent (not stuck-loop). Ensures the
+  // existing idempotency block is not absorbed by the new check.
+  const { deps } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const first = await orchestrator.advance();
+  const second = await orchestrator.advance();
+
+  assert.equal(first.kind, "advanced");
+  assert.equal(second.kind, "blocked");
+  assert.equal(second.reason, "idempotent advance: unit already active");
+  assert.equal(second.action, "stop");
+});
+
+test("stuck-loop: start() resets the ring so a fresh saturation cycle is required", async () => {
+  // Fill the ring to one short of saturation, then start() — the ring should
+  // be cleared, and the next advance must succeed instead of going stuck.
+  const { deps } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  for (let i = 0; i < STUCK_WINDOW_SIZE - 1; i++) {
+    await orchestrator.advance();
+  }
+
+  const restarted = await orchestrator.start({ basePath: "/tmp/project", trigger: "manual" });
+  assert.equal(restarted.kind, "advanced");
+
+  // Immediately after start(), the next advance is idempotent (one element in
+  // ring), not stuck-loop, confirming the ring was reset.
+  const next = await orchestrator.advance();
+  assert.equal(next.kind, "blocked");
+  assert.equal(next.reason, "idempotent advance: unit already active");
+});
+
+test("stuck-loop: resume() resets the ring", async () => {
+  const { deps } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  for (let i = 0; i < STUCK_WINDOW_SIZE - 1; i++) {
+    await orchestrator.advance();
+  }
+
+  const resumed = await orchestrator.resume();
+  assert.equal(resumed.kind, "advanced");
+
+  const next = await orchestrator.advance();
+  assert.equal(next.kind, "blocked");
+  assert.equal(next.reason, "idempotent advance: unit already active");
+});
+
+test("stuck-loop: stop() resets the ring", async () => {
+  const { deps } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  for (let i = 0; i < STUCK_WINDOW_SIZE - 1; i++) {
+    await orchestrator.advance();
+  }
+
+  const stopped = await orchestrator.stop("user-request");
+  assert.equal(stopped.kind, "stopped");
+
+  // Ring is cleared by stop(). A subsequent advance is a fresh first-touch.
+  const next = await orchestrator.advance();
+  assert.equal(next.kind, "advanced");
+});
+
+test("stuck-loop: journal records the stuck-loop reason on advance-blocked", async () => {
+  const { deps, calls } = makeDeps();
+  const orchestrator = createAutoOrchestrator(deps);
+
+  for (let i = 0; i < STUCK_WINDOW_SIZE; i++) {
+    await orchestrator.advance();
+  }
+
+  assert.ok(calls.includes("journal:advance-blocked"));
 });

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -87,6 +87,7 @@ test("start() advances and records active unit", async () => {
   const result = await orchestrator.start({ basePath: "/tmp/project", trigger: "manual" });
 
   assert.equal(result.kind, "advanced");
+  assert.deepEqual(result.unit, { unitType: "execute-task", unitId: "T01" });
   const status = orchestrator.getStatus();
   assert.equal(status.phase, "running");
   assert.deepEqual(status.activeUnit, { unitType: "execute-task", unitId: "T01" });
@@ -107,6 +108,7 @@ test("advance() returns blocked when health gate denies", async () => {
 
   assert.equal(result.kind, "blocked");
   assert.equal(result.reason, "doctor-block");
+  assert.equal(result.action, "pause");
 });
 
 test("advance() follows the ADR-015 invariant sequence before journaling advance", async () => {
@@ -116,6 +118,7 @@ test("advance() follows the ADR-015 invariant sequence before journaling advance
   const result = await orchestrator.advance();
 
   assert.equal(result.kind, "advanced");
+  assert.deepEqual(result.unit, { unitType: "execute-task", unitId: "T01" });
   assert.deepEqual(calls, [
     "runtime.lock",
     "health.pre",
@@ -144,6 +147,7 @@ test("advance() blocks before dispatch when State Reconciliation blocks", async 
 
   assert.equal(result.kind, "blocked");
   assert.equal(result.reason, "state drift blocked");
+  assert.equal(result.action, "pause");
   assert.ok(!calls.includes("dispatch.decide"));
   assert.ok(calls.includes("journal:advance-blocked"));
 });
@@ -163,6 +167,7 @@ test("advance() blocks before Runtime persistence when Tool Contract fails", asy
 
   assert.equal(result.kind, "blocked");
   assert.equal(result.reason, "unknown Unit");
+  assert.equal(result.action, "pause");
   assert.ok(!calls.includes("worktree.prepare"));
   assert.ok(!calls.includes("journal:advance"));
   assert.ok(calls.includes("journal:advance-blocked"));
@@ -185,6 +190,7 @@ test("advance() blocks before Runtime persistence when Worktree Safety fails", a
 
   assert.equal(result.kind, "blocked");
   assert.equal(result.reason, "worktree invalid");
+  assert.equal(result.action, "pause");
   assert.ok(!calls.includes("journal:advance"));
   assert.ok(!calls.includes("worktree.sync"));
   assert.ok(calls.includes("journal:advance-blocked"));
@@ -232,8 +238,10 @@ test("advance() is idempotent for the same active unit", async () => {
   const second = await orchestrator.advance();
 
   assert.equal(first.kind, "advanced");
+  assert.deepEqual(first.unit, { unitType: "execute-task", unitId: "T01" });
   assert.equal(second.kind, "blocked");
   assert.equal(second.reason, "idempotent advance: unit already active");
+  assert.equal(second.action, "stop");
 
   const prepareCalls = calls.filter((c) => c === "worktree.prepare").length;
   assert.equal(prepareCalls, 1);

--- a/src/resources/extensions/gsd/tests/auto-runtime-state.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-runtime-state.test.ts
@@ -12,10 +12,10 @@ test("getAutoRuntimeSnapshot includes orchestration phase when available", () =>
   autoSession.active = true;
   autoSession.basePath = "/tmp/project";
   autoSession.orchestration = {
-    async start() { return { kind: "advanced" as const }; },
-    async advance() { return { kind: "advanced" as const }; },
-    async resume() { return { kind: "advanced" as const }; },
-    async stop() { return { kind: "stopped" as const }; },
+    async start() { return { kind: "stopped" as const, reason: "test" }; },
+    async advance() { return { kind: "stopped" as const, reason: "test" }; },
+    async resume() { return { kind: "stopped" as const, reason: "test" }; },
+    async stop() { return { kind: "stopped" as const, reason: "test" }; },
     getStatus() {
       return { phase: "running" as const, transitionCount: 3, lastTransitionAt: 123 };
     },


### PR DESCRIPTION
## Summary

Phase 1 / slice 2 of the "Wire the Auto Orchestration module into the real auto-loop" series. Promote the single-slot `lastAdvanceKey` idempotency check to a fixed-window ring of the last 6 dispatch decisions. When the same unit appears 6 times in the window, `advance()` returns `kind: "blocked"` with `action: "stop"` and a stuck-loop reason.

- `STUCK_WINDOW_SIZE = 6` exported from `auto/orchestrator.ts`, matching the legacy `STUCK_WINDOW_SIZE` in `auto/phases.ts`.
- Ring is recorded on every dispatch decision; idempotency block gated by `matchingCount < STUCK_WINDOW_SIZE` so stuck-loop dominates when both would fire.
- Ring resets on `start()` / `resume()` / `stop()` / no-remaining-units / recovery-stopped (mirroring `lastAdvanceKey` reset points).

## Scope guarantees

- `auto/phases.ts` untouched — legacy stuck detection stays until #5791 deletes `runDispatch`.
- 34/34 tests pass in `auto-orchestrator.test.js` (25 existing + 9 new).

## Design note worth a glance

The issue body says "stuck-loop check **after** idempotency." Strict ordering would make stuck-loop unreachable (idempotency would fire on call #2 forever). Resolution in this PR: ring records on every dispatch decision (before either check) and idempotency is gated by `matchingCount < STUCK_WINDOW_SIZE`. Functional equivalent of stuck-loop-before-idempotency; the only deviation from the issue is the count gate on idempotency. A reverse-order refactor (stuck check first, idempotency second) is a 2-line equivalent and may be cleaner — open to either before #5791 cuts over.

## Test plan

- [ ] `npm run build` — green.
- [ ] `auto-orchestrator.test.js` — 34/34 pass.
- [ ] Manual: confirm same-unit dispatch in a real auto-loop session reaches the stuck-loop block exactly at the 6th iteration.

## Blocked by

- #5786 — adds `action: "pause" | "stop"` to `AutoAdvanceResult.blocked`, which this slice consumes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stuck-loop detection to prevent repetitive unit selection during auto-orchestration; orchestrator now signals clearer blocked outcomes.

* **Refactor**
  * Orchestration result shapes made more explicit—results include unit, action (pause|stop), reason, and state snapshot where applicable.

* **Documentation**
  * Clarified Auto Orchestration responsibilities, ownership boundaries, and failure/recovery classification.

* **Tests**
  * Strengthened tests for stuck-loop behavior, action/result details, and ring-buffer resets.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5796)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->