### PR TITLE
fix(pi-tui): keep turn end visible after tall shrink

### DIFF
--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -741,6 +741,12 @@ export class TUI extends Container {
 			return;
 		}
 
+		if (newLines.length < this.previousLines.length && newLines.length > height) {
+			logRedraw(`bottom-anchored tall block shrunk (${this.previousLines.length} -> ${newLines.length})`);
+			fullRender(true);
+			return;
+		}
+
 		// Content shrunk below the working area and no overlays - re-render to clear empty rows
 		// (overlays need the padding, so only do this when no overlays are active)
 		// Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var

--- a/src/tests/tui-pin-to-bottom-on-clear.test.ts
+++ b/src/tests/tui-pin-to-bottom-on-clear.test.ts
@@ -162,6 +162,36 @@ describe("TUI pin-to-bottom on clear", () => {
     );
   });
 
+  it("re-anchors tall shrinks so the latest turn end remains visible", () => {
+    const terminal = new ResizableMockTerminal(20);
+    const tui = new TUI(terminal, false);
+    const lines = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`);
+    const component = new StaticLinesComponent(lines);
+    tui.addChild(component);
+
+    (tui as any).doRender();
+    terminal.writtenData = [];
+
+    component.lines = lines.slice(0, 40);
+    (tui as any).doRender();
+
+    const frame = terminal.writtenData.join("");
+    assert.ok(
+      frame.includes("\x1b[2J\x1b[1;1H"),
+      `expected tall shrink to force a bottom-visible redraw, got ${JSON.stringify(frame.slice(0, 120))}`,
+    );
+    assert.strictEqual(
+      (tui as any).previousViewportTop,
+      20,
+      "tall shrink should reset the viewport baseline to the new rendered bottom",
+    );
+    assert.strictEqual(
+      (tui as any).maxLinesRendered,
+      40,
+      "tall shrink should reset the working area to the new content height",
+    );
+  });
+
   it("uses differential render for same-line-count edit on short content", () => {
     // Gap C: verify the negative-viewport coordinate math is correct when a
     // same-length edit reaches the differential path (no line count change →


### PR DESCRIPTION
## TL;DR

**What:** Keep the TUI anchored on the latest rendered turn end after tall content shrinks.
**Why:** Completed planning/research/milestone turns could collapse hidden output and leave users staring at an empty viewport.
**How:** Force a bottom-visible full redraw when rendered content shrinks but remains taller than the terminal, and add a regression test for that path.

## What

This updates the `pi-tui` renderer so tall-to-tall shrink frames reset the rendered working area instead of keeping the old viewport baseline. It also adds a regression test that reproduces a 60-line frame shrinking to 40 lines on a 20-row terminal.

## Why

Turn completion can collapse or roll up output while removing pinned/status content. When that shrink stayed taller than the viewport, the renderer could clear deleted lines while still tracking the previous taller working area, leaving the visible terminal below the new content.

## How

When `newLines.length` is less than the previous render and still exceeds terminal height, the renderer now uses the existing full redraw path. That path clears the viewport, writes from the new visible top, and resets `maxLinesRendered` / `previousViewportTop` to the new content height.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/tui-pin-to-bottom-on-clear.test.ts src/tests/tui-content-cursor-desync.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-tui/src/__tests__/tui.test.ts packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts`
- `npm run build:native-pkg && npm run build:pi-tui`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TUI rendering to properly handle shrinking of tall bottom-anchored content, ensuring the viewport remains anchored to the latest content and visibility is maintained.

* **Tests**
  * Added regression test for TUI bottom-anchoring with tall content shrinking scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5801)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->