### PR TITLE
fix(gsd): verify migration imports

### DIFF
--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -306,7 +306,7 @@ function importRequirements(gsdDir: string): number {
 // ─── Hierarchy Artifact Walker ─────────────────────────────────────────────
 
 /** Artifact suffixes to look for at each hierarchy level */
-const MILESTONE_SUFFIXES = ['ROADMAP', 'CONTEXT', 'RESEARCH', 'ASSESSMENT'];
+const MILESTONE_SUFFIXES = ['ROADMAP', 'CONTEXT', 'RESEARCH', 'ASSESSMENT', 'SUMMARY', 'VALIDATION'];
 const SLICE_SUFFIXES = ['PLAN', 'SUMMARY', 'RESEARCH', 'CONTEXT', 'ASSESSMENT', 'UAT'];
 const TASK_SUFFIXES = ['PLAN', 'SUMMARY', 'CONTINUE', 'CONTEXT', 'RESEARCH'];
 

--- a/src/resources/extensions/gsd/migrate/command.ts
+++ b/src/resources/extensions/gsd/migrate/command.ts
@@ -34,6 +34,9 @@ export type MigrationImportCounts = ReturnType<typeof migrateFromMarkdown>;
 
 function assertMigrationImportMatchesPreview(imported: MigrationImportCounts, preview: MigrationPreview): void {
   const mismatches: string[] = [];
+  if (imported.decisions !== preview.decisions.total) {
+    mismatches.push(`decisions ${imported.decisions}/${preview.decisions.total}`);
+  }
   if (imported.hierarchy.milestones !== preview.milestoneCount) {
     mismatches.push(`milestones ${imported.hierarchy.milestones}/${preview.milestoneCount}`);
   }
@@ -73,6 +76,7 @@ export async function importWrittenMigrationToDb(
 /** Format preview stats for embedding in the review prompt. */
 function formatPreviewStats(preview: MigrationPreview): string {
   const lines = [
+    `- Decisions: ${preview.decisions.total}`,
     `- Milestones: ${preview.milestoneCount}`,
     `- Slices: ${preview.totalSlices} (${preview.doneSlices} done — ${preview.sliceCompletionPct}%)`,
     `- Tasks: ${preview.totalTasks} (${preview.doneTasks} done — ${preview.taskCompletionPct}%)`,
@@ -179,6 +183,7 @@ export async function handleMigrate(
 
   // ── Build preview text ─────────────────────────────────────────────────────
   const lines: string[] = [
+    `Decisions: ${preview.decisions.total}`,
     `Milestones: ${preview.milestoneCount}`,
     `Slices: ${preview.totalSlices} (${preview.doneSlices} done — ${preview.sliceCompletionPct}%)`,
     `Tasks: ${preview.totalTasks} (${preview.doneTasks} done — ${preview.taskCompletionPct}%)`,

--- a/src/resources/extensions/gsd/migrate/preview.ts
+++ b/src/resources/extensions/gsd/migrate/preview.ts
@@ -4,6 +4,13 @@
 import type { GSDProject } from './types.js';
 import type { MigrationPreview } from './writer.js';
 
+function countCanonicalDecisionRows(content: string): number {
+  return content
+    .split('\n')
+    .filter((line) => /^\|\s*D\d+\s*\|/.test(line.trim()))
+    .length;
+}
+
 /**
  * Compute pre-write statistics from a GSDProject without performing I/O.
  * Used to show the user what a migration will produce before writing anything.
@@ -36,6 +43,9 @@ export function generatePreview(project: GSDProject): MigrationPreview {
   }
 
   return {
+    decisions: {
+      total: countCanonicalDecisionRows(project.decisionsContent),
+    },
     milestoneCount: project.milestones.length,
     totalSlices,
     totalTasks,

--- a/src/resources/extensions/gsd/migrate/transformer.ts
+++ b/src/resources/extensions/gsd/migrate/transformer.ts
@@ -238,16 +238,53 @@ function normalizeStatus(status: string): 'active' | 'validated' | 'deferred' {
   return 'active';
 }
 
+function normalizeRequirementId(id: string): string | null {
+  const match = id.trim().match(/^R(\d+)$/i);
+  if (!match) return null;
+  return `R${match[1].padStart(3, '0')}`;
+}
+
 function mapRequirements(reqs: PlanningRequirement[]): GSDRequirement[] {
   let autoId = 0;
+  const reservedIds = new Set(
+    reqs
+      .map((req) => normalizeRequirementId(req.id))
+      .filter((id): id is string => id !== null),
+  );
+  const usedIds = new Set<string>();
+
+  function nextRequirementId(): string {
+    let id = '';
+    do {
+      autoId++;
+      id = padId('R', autoId, 3);
+    } while (usedIds.has(id) || reservedIds.has(id));
+    usedIds.add(id);
+    return id;
+  }
+
   return reqs.map((req) => {
-    autoId++;
+    const originalId = req.id.trim();
+    const canonicalId = normalizeRequirementId(originalId);
+    let id: string;
+    let description = req.description;
+
+    if (canonicalId && !usedIds.has(canonicalId)) {
+      id = canonicalId;
+      usedIds.add(id);
+    } else {
+      id = nextRequirementId();
+      if (originalId) {
+        description = `Legacy ID: ${originalId}\n\n${description}`;
+      }
+    }
+
     return {
-      id: req.id && req.id.trim() !== '' ? req.id : padId('R', autoId, 3),
+      id,
       title: req.title,
       class: 'core-capability',
       status: normalizeStatus(req.status),
-      description: req.description,
+      description,
       source: 'inferred',
       primarySlice: 'none yet',
     };
@@ -286,7 +323,24 @@ function deriveDecisions(parsed: PlanningProject): string {
     }
   }
   if (decisions.length === 0) return '';
-  return decisions.map((d) => `- ${d}`).join('\n');
+  const lines = [
+    '# Decisions Register',
+    '',
+    '<!-- Append-only. Never edit or remove existing rows.',
+    '     To reverse a decision, add a new row that supersedes it.',
+    '     Read this file at the start of any planning or research phase. -->',
+    '',
+    '| # | When | Scope | Decision | Choice | Rationale | Revisable? | Made By |',
+    '|---|------|-------|----------|--------|-----------|------------|---------|',
+  ];
+
+  decisions.forEach((decision, index) => {
+    const id = padId('D', index + 1, 3);
+    const escaped = decision.replace(/\|/g, '\\|');
+    lines.push(`| ${id} | migration | migrated-summary | ${escaped} | ${escaped} | Migrated from legacy summary key-decisions | Yes | agent |`);
+  });
+
+  return lines.join('\n') + '\n';
 }
 
 // ─── Main Entry Point ──────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/migrate/writer.ts
+++ b/src/resources/extensions/gsd/migrate/writer.ts
@@ -37,6 +37,9 @@ export interface WrittenFiles {
 
 /** Pre-write statistics computed from a GSDProject without I/O. */
 export interface MigrationPreview {
+  decisions: {
+    total: number;
+  };
   milestoneCount: number;
   totalSlices: number;
   totalTasks: number;
@@ -374,7 +377,17 @@ export function formatProject(content: string): string {
  */
 export function formatDecisions(content: string): string {
   if (!content || !content.trim()) {
-    return '# Decisions\n\n<!-- Append-only register of architectural and pattern decisions -->\n\n| ID | Decision | Rationale | Date |\n|----|----------|-----------|------|\n';
+    return [
+      '# Decisions Register',
+      '',
+      '<!-- Append-only. Never edit or remove existing rows.',
+      '     To reverse a decision, add a new row that supersedes it.',
+      '     Read this file at the start of any planning or research phase. -->',
+      '',
+      '| # | When | Scope | Decision | Choice | Rationale | Revisable? | Made By |',
+      '|---|------|-------|----------|--------|-----------|------------|---------|',
+      '',
+    ].join('\n');
   }
   return content.endsWith('\n') ? content : content + '\n';
 }

--- a/src/resources/extensions/gsd/tests/integration/migrate-command.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/migrate-command.test.ts
@@ -14,7 +14,9 @@ import {
   generatePreview,
   writeGSDDirectory,
 } from '../../migrate/index.ts';
+import { importWrittenMigrationToDb } from '../../migrate/command.ts';
 import { deriveState } from '../../state.ts';
+import { closeDatabase, getDecisionById, getRequirementCounts } from '../../gsd-db.ts';
 import { describe, test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -50,6 +52,16 @@ const SAMPLE_REQUIREMENTS = `# Requirements
 ### R002 — Output Format
 - Status: validated
 - Description: Output matches GSD format.
+`;
+
+const SAMPLE_REQUIREMENTS_LEGACY_IDS = `# Requirements
+
+## Active
+
+- [ ] **CORE-PIPELINE**: Pipeline must work end-to-end.
+- [ ] **OUTPUT-FORMAT**: Output matches GSD format.
+- [ ] **IMPORT-DB**: Migration imports requirements into the DB.
+- [ ] **STATUS-WIDGET**: Status can query migrated requirements.
 `;
 
 const SAMPLE_STATE = `# State
@@ -166,14 +178,14 @@ Depends on foundation work.
 </context>
 `;
 
-function createCompleteFixture(): string {
+function createCompleteFixture(requirementsContent: string = SAMPLE_REQUIREMENTS): string {
   const base = mkdtempSync(join(tmpdir(), 'gsd-cmd-test-'));
   const planning = join(base, '.planning');
   mkdirSync(planning, { recursive: true });
 
   writeFileSync(join(planning, 'PROJECT.md'), SAMPLE_PROJECT);
   writeFileSync(join(planning, 'ROADMAP.md'), SAMPLE_ROADMAP);
-  writeFileSync(join(planning, 'REQUIREMENTS.md'), SAMPLE_REQUIREMENTS);
+  writeFileSync(join(planning, 'REQUIREMENTS.md'), requirementsContent);
   writeFileSync(join(planning, 'STATE.md'), SAMPLE_STATE);
   writeFileSync(join(planning, 'config.json'), SAMPLE_CONFIG);
 
@@ -303,6 +315,7 @@ test('Full pipeline: parse → transform → preview → write → deriveState',
       const expectedTaskPct = totalTasks > 0 ? Math.round((doneTasks / totalTasks) * 100) : 0;
       assert.deepStrictEqual(preview.sliceCompletionPct, expectedSlicePct, 'pipeline: preview sliceCompletionPct');
       assert.deepStrictEqual(preview.taskCompletionPct, expectedTaskPct, 'pipeline: preview taskCompletionPct');
+      assert.deepStrictEqual(preview.decisions.total, 1, 'pipeline: preview decisions total');
 
       // Requirements in preview
       assert.deepStrictEqual(preview.requirements.active, 1, 'pipeline: preview requirements active');
@@ -342,6 +355,39 @@ test('Full pipeline: parse → transform → preview → write → deriveState',
     }
 });
 
+test('Full pipeline: legacy requirement IDs import into DB with canonical IDs', async () => {
+    const base = createCompleteFixture(SAMPLE_REQUIREMENTS_LEGACY_IDS);
+    const writeTarget = mkdtempSync(join(tmpdir(), 'gsd-cmd-legacy-reqs-'));
+    try {
+      const parsed = await parsePlanningDirectory(join(base, '.planning'));
+      const project = transformToGSD(parsed);
+      const preview = generatePreview(project);
+
+      assert.deepStrictEqual(
+        project.requirements.map((req) => req.id),
+        ['R001', 'R002', 'R003', 'R004'],
+        'legacy-reqs: transform assigns canonical R IDs',
+      );
+      assert.ok(
+        project.requirements[0]?.description.includes('Legacy ID: CORE-PIPELINE'),
+        'legacy-reqs: original ID survives in migrated requirement content',
+      );
+
+      await writeGSDDirectory(project, writeTarget);
+      const imported = await importWrittenMigrationToDb(writeTarget, preview);
+      const counts = getRequirementCounts();
+
+      assert.deepStrictEqual(imported.decisions, 1, 'legacy-reqs: DB import includes migrated decisions');
+      assert.deepStrictEqual(imported.requirements, 4, 'legacy-reqs: DB import count matches preview');
+      assert.ok(getDecisionById('D001') !== null, 'legacy-reqs: migrated decision is queryable');
+      assert.deepStrictEqual(counts.total, 4, 'legacy-reqs: DB stores all migrated requirements');
+    } finally {
+      closeDatabase();
+      rmSync(base, { recursive: true, force: true });
+      rmSync(writeTarget, { recursive: true, force: true });
+    }
+});
+
   // ─── Test 6: .gsd/ exists detection ────────────────────────────────────
 
 test('.gsd/ exists detection', () => {
@@ -357,4 +403,3 @@ test('.gsd/ exists detection', () => {
       rmSync(base, { recursive: true, force: true });
     }
 });
-

--- a/src/resources/extensions/gsd/tests/migrate-transformer.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-transformer.test.ts
@@ -497,6 +497,7 @@ test('Scenario 11: Requirements edge cases', () => {
       makeRequirement('', 'Another No ID', 'validated'),
       makeRequirement('R005', 'Has ID', 'something-weird'),
       makeRequirement('R006', 'Deferred One', 'DEFERRED'),
+      makeRequirement('AUTH-7', 'Legacy ID', 'active'),
     ],
     phases: {
       '1-req-edge': makePhase('1-req-edge', 1, 'req-edge'),
@@ -510,6 +511,8 @@ test('Scenario 11: Requirements edge cases', () => {
   assert.deepStrictEqual(result.requirements[2]?.id, 'R005', 'req-edge: existing id preserved');
   assert.deepStrictEqual(result.requirements[2]?.status, 'active', 'req-edge: unknown status normalized to active');
   assert.deepStrictEqual(result.requirements[3]?.status, 'deferred', 'req-edge: uppercase DEFERRED normalized');
+  assert.deepStrictEqual(result.requirements[4]?.id, 'R003', 'req-edge: non-R legacy id gets next canonical id');
+  assert.ok(result.requirements[4]?.description.includes('Legacy ID: AUTH-7'), 'req-edge: original legacy id is preserved in description');
 });
 
 // ─── Scenario 12: Vision derivation ────────────────────────────────────────
@@ -553,6 +556,8 @@ test('Scenario 13: Decisions content', () => {
   const result = transformToGSD(project);
 
   assert.ok(result.decisionsContent.includes('decision-01'), 'decisions: extracts key-decisions from summaries');
+  assert.ok(result.decisionsContent.includes('| D001 |'), 'decisions: writes DB-importable decision ID');
+  assert.ok(result.decisionsContent.includes('| # | When | Scope | Decision | Choice | Rationale | Revisable? | Made By |'), 'decisions: writes canonical table header');
 });
 
 // ─── Scenario 14: No undefined values in output ───────────────────────────
@@ -616,4 +621,3 @@ test('Scenario 15: Empty research', () => {
 });
 
 // ─── Results ───────────────────────────────────────────────────────────────
-

--- a/src/resources/extensions/gsd/tests/migrate-writer-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-writer-integration.test.ts
@@ -14,7 +14,7 @@ import { parseSummary } from '../files.ts';
 import { deriveState } from '../state.ts';
 import { invalidateAllCaches } from '../cache.ts';
 import { ensureDbOpen } from '../bootstrap/dynamic-tools.ts';
-import { closeDatabase, getAllMilestones } from '../gsd-db.ts';
+import { closeDatabase, getAllMilestones, getArtifact } from '../gsd-db.ts';
 import { importWrittenMigrationToDb } from '../migrate/command.ts';
 import type {
   GSDProject,
@@ -336,7 +336,12 @@ test('Scenario 2: Fully complete project — deriveState phase', async () => {
       assert.deepStrictEqual(preview.taskCompletionPct, 100, 'complete: preview taskCompletionPct');
       assert.deepStrictEqual(preview.requirements.total, 0, 'complete: preview requirements total');
 
+      const imported = await importWrittenMigrationToDb(base, preview);
+      assert.ok(imported.artifacts >= 6, 'complete: imports generated milestone artifacts');
+      assert.ok(getArtifact('milestones/M001/M001-VALIDATION.md') !== null, 'complete: M001-VALIDATION.md imported as artifact');
+      assert.ok(getArtifact('milestones/M001/M001-SUMMARY.md') !== null, 'complete: M001-SUMMARY.md imported as artifact');
     } finally {
+      closeDatabase();
       rmSync(base, { recursive: true, force: true });
     }
 });


### PR DESCRIPTION
## TL;DR

**What:** Canonicalize migrated requirement/decision imports and verify decision counts during `/gsd migrate`.
**Why:** Migration could write files successfully while DB import silently dropped requirements, decisions, or generated milestone artifacts.
**How:** Emit DB-importable IDs/tables, import completed-milestone summary/validation artifacts, and add regression coverage at the migration import seam.

## What

- Canonicalizes non-`R###` legacy requirement IDs during migration while preserving the original ID in the migrated description.
- Emits migrated key decisions as canonical `D###` decision table rows and includes decision totals in the migration preview/import verification.
- Imports generated milestone `SUMMARY` and `VALIDATION` files into the artifacts table.
- Adds regression tests for legacy requirement IDs, migrated decisions, and generated milestone artifacts.

## Why

The migration command compared DB import counts against the preview for hierarchy and requirements only. Legacy requirement IDs could produce `requirements 0/4`, and migrated decisions or generated milestone artifacts could be written to disk without landing in DB-backed state.

## How

The transformer now assigns canonical IDs before writing `.gsd/REQUIREMENTS.md`, formats summary key decisions as canonical `DECISIONS.md` rows, and the importer includes milestone summary/validation artifacts. The command checks imported decision counts alongside the existing hierarchy and requirement checks.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/migrate-transformer.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/migrate-command.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/migrate-writer-integration.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/migrate-writer.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/md-importer.test.ts`
- `npm run typecheck:extensions`

## Change type checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Decision tracking is now included in migration previews with total counts displayed
  * VALIDATION milestone artifact files are now imported alongside existing milestone types

* **Improvements**
  * Legacy requirement IDs are normalized to canonical format while preserving original identifiers
  * Migration validation enhanced to verify consistency between preview and database import

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5802)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->