### PR TITLE
fix(gsd): fail closed execute-task verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Plan (with integrated research) → Execute (per task) → Complete → Reassess
                                                                               Validate Milestone → Complete Milestone
 ```
 
-**Plan** scouts the codebase, researches relevant docs, and decomposes the slice into tasks with must-haves (mechanically verifiable outcomes). **Execute** runs each task in a fresh context window with only the relevant files pre-loaded — then runs configured verification commands (lint, test, etc.) with auto-fix retries. **Complete** writes the summary, UAT script, marks the roadmap, and commits with meaningful messages derived from task summaries. **Reassess** checks if the roadmap still makes sense given what was learned. **Validate Milestone** runs a reconciliation gate after all slices complete — comparing roadmap success criteria against actual results before sealing the milestone.
+**Plan** scouts the codebase, researches relevant docs, and decomposes the slice into tasks with must-haves (mechanically verifiable outcomes). **Execute** runs each task in a fresh context window with only the relevant files pre-loaded, then runs configured verification commands (lint, test, etc.) with auto-fix retries before the task closeout commit or snapshot is published. Failed or incomplete verification blocks execute-task closeout. **Complete** writes the summary, UAT script, marks the roadmap, and commits with meaningful messages derived from task summaries. **Reassess** checks if the roadmap still makes sense given what was learned. **Validate Milestone** runs a reconciliation gate after all slices complete — comparing roadmap success criteria against actual results before sealing the milestone.
 
 ### `/gsd auto` — The Main Event
 
@@ -364,7 +364,7 @@ The database is authoritative for milestones, slices, tasks, requirements, decis
 
 10. **Adaptive replanning** — After each slice completes, the roadmap is reassessed. If the work revealed new information that changes the plan, slices are reordered, added, or removed before continuing.
 
-11. **Verification enforcement** — Configure shell commands (`npm run lint`, `npm run test`, etc.) that run automatically after task execution. Failures trigger auto-fix retries before advancing. Auto-discovered checks from `package.json` run in advisory mode — they log warnings but don't block on pre-existing errors. Configurable via `verification_commands`, `verification_auto_fix`, and `verification_max_retries` preferences.
+11. **Verification enforcement** — Configure shell commands (`npm run lint`, `npm run test`, etc.) that run automatically after task execution. Failures trigger auto-fix retries before advancing. Execute-task commits and snapshots are deferred until verification passes; failed or incomplete verification blocks closeout instead of publishing changes. Auto-discovered checks from `package.json` run in advisory mode — they log warnings but don't block on pre-existing errors. Configurable via `verification_commands`, `verification_auto_fix`, and `verification_max_retries` preferences.
 
 12. **Milestone validation** — After all slices complete, a `validate-milestone` gate compares roadmap success criteria against actual results before sealing the milestone.
 

--- a/src/resources/GSD-WORKFLOW.md
+++ b/src/resources/GSD-WORKFLOW.md
@@ -560,7 +560,7 @@ In all modes, slices and tasks commit sequentially on the active branch; there a
 
 1. **Milestone starts** → capture the current integration branch.
 2. **Optional isolation** → create `milestone/M001` only when `git.isolation` is `worktree` or `branch`.
-3. **Per-task commits** — atomic, descriptive, bisectable.
+3. **Per-task commits** — atomic, descriptive, bisectable, and published only after execute-task verification passes.
 4. **Slice completes** → write slice summary, UAT script, roadmap checkbox, and milestone summary.
 5. **Milestone completes** → if isolated, squash-merge the milestone branch back to the captured integration branch and clean up the worktree/branch.
 
@@ -573,6 +573,8 @@ fix: handle empty state rebuild
 ```
 
 In `none` mode these commits land directly on the current branch. In isolated modes they land on `milestone/<MID>` and are squashed back at milestone completion.
+
+Execute-task closeout is fail-closed: the system writes verification evidence first, defers the task commit or snapshot until verification passes, and pauses instead of publishing changes when verification fails or cannot complete.
 
 ### Commit Conventions
 

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -7,8 +7,8 @@
  *
  * Split into two functions called sequentially by auto-loop with
  * the verification gate between them:
- *   1. postUnitPreVerification() — commit, doctor, state rebuild, worktree sync, artifact verification
- *   2. postUnitPostVerification() — DB dual-write, hooks, triage, quick-tasks
+ *   1. postUnitPreVerification() — closeout git for non-task units, doctor, state rebuild, worktree sync, artifact verification
+ *   2. postUnitPostVerification() — post-verified task git, DB dual-write, hooks, triage, quick-tasks
  *
  * Extracted from the pre-loop agent_end handler in auto.ts.
  */
@@ -62,8 +62,7 @@ import { runSafely } from "./auto-utils.js";
 import type { AutoSession, SidecarItem } from "./auto/session.js";
 import { getEvidence, clearEvidenceFromDisk } from "./safety/evidence-collector.js";
 import { validateFileChanges } from "./safety/file-change-validator.js";
-// crossReferenceEvidence available for future use when verification_evidence is stored in DB
-// import { crossReferenceEvidence, type ClaimedEvidence } from "./safety/evidence-cross-ref.js";
+import { crossReferenceEvidence, type ClaimedEvidence } from "./safety/evidence-cross-ref.js";
 import { validateContent } from "./safety/content-validator.js";
 import { resolveSafetyHarnessConfig } from "./safety/safety-harness.js";
 import { resolveExpectedArtifactPath as resolveArtifactForContent } from "./auto-artifact-paths.js";
@@ -220,6 +219,10 @@ export function _shouldDispatchQuickTaskForTest(
     state.pendingQuickTasks.length > 0 &&
     !!state.currentUnit &&
     state.currentUnit.type !== "quick-task";
+}
+
+export function shouldDeferCloseoutGitAction(unitType: string): boolean {
+  return unitType === "execute-task";
 }
 
 /** Unit types that only touch `.gsd/` internal state files (no code changes).
@@ -466,6 +469,139 @@ export async function autoCommitUnit(
   }
 }
 
+async function runCloseoutGitAction(
+  pctx: PostUnitContext,
+  unit: NonNullable<AutoSession["currentUnit"]>,
+): Promise<"continue" | "dispatched"> {
+  const { s, ctx, pi, pauseAuto } = pctx;
+  const prefs = loadEffectiveGSDPreferences()?.preferences;
+  const uokFlags = resolveUokFlags(prefs);
+  const turnAction: TurnGitActionMode = uokFlags.gitops ? uokFlags.gitopsTurnAction : "commit";
+  const traceId = s.currentTraceId ?? `turn:${unit.startedAt}`;
+  const turnId = s.currentTurnId ?? `${unit.type}/${unit.id}/${unit.startedAt}`;
+
+  s.lastGitActionFailure = null;
+  s.lastGitActionStatus = null;
+
+  try {
+    let taskContext: TaskCommitContext | undefined;
+
+    if (turnAction === "commit" && unit.type === "execute-task") {
+      taskContext = await buildTaskCommitContextForUnit(s.basePath, unit.id);
+    }
+
+    // Invalidate the nativeHasChanges cache before auto-commit (#1853).
+    // The cache has a 10-second TTL and is keyed by basePath. A stale
+    // `false` result causes autoCommit to skip staging entirely.
+    _resetHasChangesCache();
+
+    const skipLifecycleCommit =
+      turnAction === "commit" && LIFECYCLE_ONLY_UNITS.has(unit.type);
+
+    if (skipLifecycleCommit) {
+      debugLog("postUnit", {
+        phase: "git-action-skipped",
+        reason: "lifecycle-only-unit",
+        unitType: unit.type,
+        unitId: unit.id,
+      });
+    } else {
+      const gitResult = runTurnGitAction({
+        basePath: s.basePath,
+        action: turnAction,
+        unitType: unit.type,
+        unitId: unit.id,
+        taskContext,
+      });
+
+      if (uokFlags.gitops) {
+        writeTurnGitTransaction({
+          basePath: s.basePath,
+          traceId,
+          turnId,
+          unitType: unit.type,
+          unitId: unit.id,
+          stage: "publish",
+          action: turnAction,
+          push: uokFlags.gitopsTurnPush,
+          status: gitResult.status,
+          error: gitResult.error,
+          metadata: {
+            dirty: gitResult.dirty,
+            commitMessage: gitResult.commitMessage,
+            snapshotLabel: gitResult.snapshotLabel,
+          },
+        });
+      }
+
+      if (gitResult.status === "failed") {
+        s.lastGitActionFailure = gitResult.error ?? `git ${turnAction} failed`;
+        s.lastGitActionStatus = "failed";
+        if (uokFlags.gitops && uokFlags.gates) {
+          const parsed = parseUnitId(unit.id);
+          const gateRunner = new UokGateRunner();
+          gateRunner.register({
+            id: "closeout-git-action",
+            type: "closeout",
+            execute: async () => ({
+              outcome: "fail",
+              failureClass: "git",
+              rationale: `turn git action "${turnAction}" failed`,
+              findings: gitResult.error ?? "unknown git failure",
+            }),
+          });
+          await gateRunner.run("closeout-git-action", {
+            basePath: s.basePath,
+            traceId,
+            turnId,
+            milestoneId: parsed.milestone ?? undefined,
+            sliceId: parsed.slice ?? undefined,
+            taskId: parsed.task ?? undefined,
+            unitType: unit.type,
+            unitId: unit.id,
+          });
+        }
+
+        const failureMsg = `Git ${turnAction} failed: ${(gitResult.error ?? "unknown error").split("\n")[0]}`;
+        ctx.ui.notify(failureMsg, "error");
+        debugLog("postUnit", {
+          phase: "git-action-failed-blocking",
+          action: turnAction,
+          error: gitResult.error ?? "unknown error",
+        });
+        await pauseAuto(ctx, pi);
+        return "dispatched";
+      }
+
+      s.lastGitActionStatus = "ok";
+
+      if (turnAction === "commit" && gitResult.commitMessage) {
+        ctx.ui.notify(`Committed: ${gitResult.commitMessage.split("\n")[0]}`, "info");
+      } else if (turnAction === "snapshot" && gitResult.snapshotLabel) {
+        ctx.ui.notify(`Snapshot recorded: ${gitResult.snapshotLabel}`, "info");
+      }
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    s.lastGitActionFailure = message;
+    s.lastGitActionStatus = "failed";
+    debugLog("postUnit", { phase: "git-action", error: message, action: turnAction });
+    ctx.ui.notify(`Git ${turnAction} failed: ${message.split("\n")[0]}`, uokFlags.gitops ? "error" : "warning");
+    if (uokFlags.gitops) {
+      await pauseAuto(ctx, pi);
+      return "dispatched";
+    }
+  }
+
+  // GitHub sync (non-blocking, opt-in)
+  await runSafely("postUnit", "github-sync", async () => {
+    const { runGitHubSync } = await import("../github-sync/sync.js");
+    await runGitHubSync(s.basePath, unit.type, unit.id);
+  });
+
+  return "continue";
+}
+
 /**
  * Pre-verification processing: parallel worker signal check, cache invalidation,
  * auto-commit, doctor run, state rebuild, worktree sync, artifact verification.
@@ -476,7 +612,7 @@ export async function autoCommitUnit(
  * - "retry" — artifact verification failed, s.pendingVerificationRetry set for loop re-iteration
  */
 export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreVerificationOpts): Promise<"dispatched" | "continue" | "retry"> {
-  const { s, ctx, pi, buildSnapshotOpts, stopAuto, pauseAuto } = pctx;
+  const { s, ctx, pi, stopAuto, pauseAuto } = pctx;
 
   // ── Parallel worker signal check ──
   const milestoneLock = process.env.GSD_MILESTONE_LOCK;
@@ -502,134 +638,21 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
     await new Promise(r => setTimeout(r, 100));
   }
 
-  const prefs = loadEffectiveGSDPreferences()?.preferences;
-  const uokFlags = resolveUokFlags(prefs);
-
   // Turn-level git action (commit | snapshot | status-only)
   if (s.currentUnit) {
     const unit = s.currentUnit;
-    const turnAction: TurnGitActionMode = uokFlags.gitops ? uokFlags.gitopsTurnAction : "commit";
-    const traceId = s.currentTraceId ?? `turn:${unit.startedAt}`;
-    const turnId = s.currentTurnId ?? `${unit.type}/${unit.id}/${unit.startedAt}`;
-    s.lastGitActionFailure = null;
-    s.lastGitActionStatus = null;
-    try {
-      let taskContext: TaskCommitContext | undefined;
-
-      if (turnAction === "commit" && s.currentUnit.type === "execute-task") {
-        taskContext = await buildTaskCommitContextForUnit(s.basePath, s.currentUnit.id);
-      }
-
-      // Invalidate the nativeHasChanges cache before auto-commit (#1853).
-      // The cache has a 10-second TTL and is keyed by basePath.  A stale
-      // `false` result causes autoCommit to skip staging entirely, leaving
-      // code files only in the working tree where they are destroyed by
-      // `git worktree remove --force` during teardown.
-      _resetHasChangesCache();
-
-      const skipLifecycleCommit =
-        turnAction === "commit" && LIFECYCLE_ONLY_UNITS.has(s.currentUnit.type);
-
-      if (skipLifecycleCommit) {
-        debugLog("postUnit", {
-          phase: "git-action-skipped",
-          reason: "lifecycle-only-unit",
-          unitType: s.currentUnit.type,
-          unitId: s.currentUnit.id,
-        });
-      } else {
-        const gitResult = runTurnGitAction({
-          basePath: s.basePath,
-          action: turnAction,
-          unitType: s.currentUnit.type,
-          unitId: s.currentUnit.id,
-          taskContext,
-        });
-
-        if (uokFlags.gitops) {
-          writeTurnGitTransaction({
-            basePath: s.basePath,
-            traceId,
-            turnId,
-            unitType: unit.type,
-            unitId: unit.id,
-            stage: "publish",
-            action: turnAction,
-            push: uokFlags.gitopsTurnPush,
-            status: gitResult.status,
-            error: gitResult.error,
-            metadata: {
-              dirty: gitResult.dirty,
-              commitMessage: gitResult.commitMessage,
-              snapshotLabel: gitResult.snapshotLabel,
-            },
-          });
-        }
-
-        if (gitResult.status === "failed") {
-          s.lastGitActionFailure = gitResult.error ?? `git ${turnAction} failed`;
-          s.lastGitActionStatus = "failed";
-          if (uokFlags.gitops && uokFlags.gates) {
-            const parsed = parseUnitId(unit.id);
-            const gateRunner = new UokGateRunner();
-            gateRunner.register({
-              id: "closeout-git-action",
-              type: "closeout",
-              execute: async () => ({
-                outcome: "fail",
-                failureClass: "git",
-                rationale: `turn git action "${turnAction}" failed`,
-                findings: gitResult.error ?? "unknown git failure",
-              }),
-            });
-            await gateRunner.run("closeout-git-action", {
-              basePath: s.basePath,
-              traceId,
-              turnId,
-              milestoneId: parsed.milestone ?? undefined,
-              sliceId: parsed.slice ?? undefined,
-              taskId: parsed.task ?? undefined,
-              unitType: unit.type,
-              unitId: unit.id,
-            });
-          }
-
-          const failureMsg = `Git ${turnAction} failed: ${(gitResult.error ?? "unknown error").split("\n")[0]}`;
-          ctx.ui.notify(failureMsg, "error");
-          debugLog("postUnit", {
-            phase: "git-action-failed-blocking",
-            action: turnAction,
-            error: gitResult.error ?? "unknown error",
-          });
-          await pauseAuto(ctx, pi);
-          return "dispatched";
-        }
-
-        s.lastGitActionStatus = "ok";
-
-        if (turnAction === "commit" && gitResult.commitMessage) {
-          ctx.ui.notify(`Committed: ${gitResult.commitMessage.split("\n")[0]}`, "info");
-        } else if (turnAction === "snapshot" && gitResult.snapshotLabel) {
-          ctx.ui.notify(`Snapshot recorded: ${gitResult.snapshotLabel}`, "info");
-        }
-      }
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
-      s.lastGitActionFailure = message;
-      s.lastGitActionStatus = "failed";
-      debugLog("postUnit", { phase: "git-action", error: message, action: turnAction });
-      ctx.ui.notify(`Git ${turnAction} failed: ${message.split("\n")[0]}`, uokFlags.gitops ? "error" : "warning");
-      if (uokFlags.gitops) {
-        await pauseAuto(ctx, pi);
+    if (shouldDeferCloseoutGitAction(unit.type)) {
+      debugLog("postUnit", {
+        phase: "git-action-deferred-until-verification",
+        unitType: unit.type,
+        unitId: unit.id,
+      });
+    } else {
+      const gitActionResult = await runCloseoutGitAction(pctx, unit);
+      if (gitActionResult === "dispatched") {
         return "dispatched";
       }
     }
-
-    // GitHub sync (non-blocking, opt-in)
-    await runSafely("postUnit", "github-sync", async () => {
-      const { runGitHubSync } = await import("../github-sync/sync.js");
-      await runGitHubSync(s.basePath, unit.type, unit.id);
-    });
 
     // Prune dead bg-shell processes
     await runSafely("postUnit", "prune-bg-shell", async () => {
@@ -866,7 +889,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       if (safetyConfig.enabled) {
         const { milestone: sMid, slice: sSid, task: sTid } = parseUnitId(s.currentUnit.id);
 
-        // File change validation (execute-task only, after auto-commit)
+        // File change validation (execute-task only, after unit execution)
         if (safetyConfig.file_change_validation && s.currentUnit.type === "execute-task" && sMid && sSid && sTid && isDbAvailable()) {
           try {
             const taskRow = getTask(sMid, sSid, sTid);
@@ -902,15 +925,42 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
             const bashCalls = actual.filter(e => e.kind === "bash");
             if (sMid && sSid && sTid && isDbAvailable()) {
               const taskRow = getTask(sMid, sSid, sTid);
-              const claimedCommands = getVerificationEvidence(sMid, sSid, sTid)
-                .map((row) => row.command)
-                .filter((command): command is string => typeof command === "string" && command.trim().length > 0);
-              if (taskRow?.status === "complete" && claimedCommands.length > 0 && bashCalls.length === 0) {
-                logWarning("safety", "task claimed verification command evidence but no execution tool calls were recorded");
-                ctx.ui.notify(
-                  `Safety: task ${sTid} claimed command evidence but no execution tool calls were recorded`,
-                  "warning",
-                );
+              if (taskRow?.status === "complete") {
+                const claimedEvidence: ClaimedEvidence[] = getVerificationEvidence(sMid, sSid, sTid)
+                  .map((row) => ({
+                    command: row.command,
+                    exitCode: row.exit_code,
+                    verdict: row.verdict,
+                  }))
+                  .filter((row) => typeof row.command === "string" && row.command.trim().length > 0);
+                const mismatches = crossReferenceEvidence(claimedEvidence, actual);
+
+                for (const mismatch of mismatches) {
+                  const logMessage = `evidence-xref: ${mismatch.reason}`;
+                  if (mismatch.severity === "error") {
+                    logError("safety", logMessage);
+                  } else {
+                    logWarning("safety", logMessage);
+                  }
+                }
+
+                if (claimedEvidence.length > 0 && bashCalls.length === 0) {
+                  logWarning("safety", "task claimed verification command evidence but no execution tool calls were recorded");
+                  ctx.ui.notify(
+                    `Safety: task ${sTid} claimed command evidence but no execution tool calls were recorded`,
+                    "warning",
+                  );
+                }
+
+                const blockingMismatch = mismatches.find((mismatch) => mismatch.severity === "error");
+                if (blockingMismatch) {
+                  ctx.ui.notify(
+                    `Safety: task ${sTid} claimed passing verification that failed in recorded execution`,
+                    "error",
+                  );
+                  await pauseAuto(ctx, pi);
+                  return "dispatched";
+                }
               }
             }
           } catch (e) {
@@ -1169,6 +1219,13 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
   const { s, ctx, pi, buildSnapshotOpts, lockBase, stopAuto, pauseAuto, updateProgressWidget } = pctx;
 
   if (s.currentUnit) {
+    if (shouldDeferCloseoutGitAction(s.currentUnit.type)) {
+      const gitActionResult = await runCloseoutGitAction(pctx, s.currentUnit);
+      if (gitActionResult === "dispatched") {
+        return "stopped";
+      }
+    }
+
     try {
       const codebasePrefs = loadEffectiveGSDPreferences()?.preferences?.codebase;
       const refresh = ensureCodebaseMapFresh(

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -346,6 +346,7 @@ export async function runPostUnitVerification(
           } else {
             const nextAttempt = attempt + 1;
             const includeRetryMetadata =
+              !result.passed &&
               verdict.retryable &&
               autoFixEnabled &&
               nextAttempt <= maxRetries;

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -345,13 +345,17 @@ export async function runPostUnitVerification(
             writeVerificationJSON(result, tasksDir, tid, s.currentUnit.id);
           } else {
             const nextAttempt = attempt + 1;
+            const includeRetryMetadata =
+              verdict.retryable &&
+              autoFixEnabled &&
+              nextAttempt <= maxRetries;
             writeVerificationJSON(
               result,
               tasksDir,
               tid,
               s.currentUnit.id,
-              nextAttempt,
-              maxRetries,
+              includeRetryMetadata ? nextAttempt : undefined,
+              includeRetryMetadata ? maxRetries : undefined,
             );
           }
         }

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -40,6 +40,7 @@ import { join } from "node:path";
 import { resolveUokFlags } from "./uok/flags.js";
 import { UokGateRunner } from "./uok/gate-runner.js";
 import { verificationRetryKey } from "./auto/verification-retry-policy.js";
+import { decideVerificationVerdict } from "./verification-verdict.js";
 
 export interface VerificationContext {
   s: AutoSession;
@@ -48,12 +49,6 @@ export interface VerificationContext {
 }
 
 export type VerificationResult = "continue" | "retry" | "pause";
-
-function isInfraVerificationFailure(stderr: string): boolean {
-  return /\b(ENOENT|ENOTFOUND|ETIMEDOUT|ECONNRESET|EAI_AGAIN|spawn\s+\S+\s+ENOENT|command not found)\b/i.test(
-    stderr,
-  );
-}
 
 /**
  * Post-unit guard for `validate-milestone` units (#4094).
@@ -196,7 +191,7 @@ async function countIncompleteSlices(basePath: string, milestoneId: string): Pro
 /**
  * Run the verification gate for the current execute-task unit.
  * Returns:
- * - "continue" — gate passed (or no checks configured), proceed normally
+ * - "continue" — host-owned verification passed, proceed normally
  * - "retry" — gate failed with retries remaining, s.pendingVerificationRetry set for loop re-iteration
  * - "pause" — gate failed with retries exhausted, pauseAuto already called
  */
@@ -260,6 +255,11 @@ export async function runPostUnitVerification(
       }
     }
 
+    const verdict = decideVerificationVerdict(s.currentUnit.type, result);
+    if (!verdict.passed) {
+      result.passed = false;
+    }
+
     if (uokFlags.gates) {
       const gateRunner = new UokGateRunner();
       gateRunner.register({
@@ -272,10 +272,12 @@ export async function runPostUnitVerification(
             : "verification",
           rationale: result.passed
             ? "verification checks passed"
-            : "verification checks failed",
+            : verdict.reason === "no-host-checks"
+              ? "no runnable host-owned verification checks discovered"
+              : "verification checks failed",
           findings: result.passed
             ? ""
-            : formatFailureContext(result),
+            : verdict.failureContext || formatFailureContext(result),
         }),
       });
 
@@ -356,26 +358,6 @@ export async function runPostUnitVerification(
       } catch (evidenceErr) {
         logWarning("engine", `verification-evidence write error: ${(evidenceErr as Error).message}`);
       }
-    }
-
-    const advisoryFailure =
-      !result.passed &&
-      (result.discoverySource === "package-json" ||
-        result.checks.some((check) =>
-          isInfraVerificationFailure(check.stderr),
-        ));
-
-    if (advisoryFailure) {
-      s.verificationRetryCount.delete(retryKey);
-      s.verificationRetryFailureHashes.delete(retryKey);
-      s.pendingVerificationRetry = null;
-      ctx.ui.notify(
-        result.discoverySource === "package-json"
-          ? "Verification failed in auto-discovered package.json checks — treating as advisory."
-          : "Verification failed due to infrastructure/runtime environment issues — treating as advisory.",
-        "warning",
-      );
-      return "continue";
     }
 
     // ── Post-execution checks (run after main verification passes for execute-task units) ──
@@ -572,6 +554,17 @@ export async function runPostUnitVerification(
       s.verificationRetryFailureHashes.delete(retryKey);
       s.pendingVerificationRetry = null;
       return "continue";
+    } else if (verdict.reason === "no-host-checks") {
+      s.verificationRetryCount.delete(retryKey);
+      s.verificationRetryFailureHashes.delete(retryKey);
+      s.pendingVerificationRetry = null;
+      ctx.ui.notify(
+        "Verification gate FAILED — no runnable host-owned verification checks were discovered. Pausing for human review.",
+        "error",
+      );
+      process.stderr.write(`verification-gate: ${verdict.failureContext}\n`);
+      await pauseAuto(ctx, pi);
+      return "pause";
     } else if (postExecBlockingFailure) {
       // Post-execution failures are cross-task consistency issues — retrying the same task won't fix them.
       // Skip retry and pause immediately for human review.
@@ -589,7 +582,7 @@ export async function runPostUnitVerification(
       s.verificationRetryCount.set(retryKey, nextAttempt);
       s.pendingVerificationRetry = {
         unitId: s.currentUnit.id,
-        failureContext: formatFailureContext(result),
+        failureContext: verdict.failureContext || formatFailureContext(result),
         attempt: nextAttempt,
       };
       const failedCmds = result.checks
@@ -623,9 +616,13 @@ export async function runPostUnitVerification(
       return "pause";
     }
   } catch (err) {
-    // Gate errors are non-fatal
     logWarning("engine", `verification-gate error: ${(err as Error).message}`);
-    return "continue";
+    ctx.ui.notify(
+      `Verification gate errored before producing an authoritative verdict: ${(err as Error).message}`,
+      "error",
+    );
+    await pauseAuto(ctx, pi);
+    return "pause";
   }
 }
 

--- a/src/resources/extensions/gsd/tests/closeout-git-deferral.test.ts
+++ b/src/resources/extensions/gsd/tests/closeout-git-deferral.test.ts
@@ -1,0 +1,16 @@
+// Project/App: GSD-2
+// File Purpose: Tests closeout git action deferral policy for auto-mode units.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldDeferCloseoutGitAction } from "../auto-post-unit.ts";
+
+test("execute-task defers closeout git action until verification passes", () => {
+  assert.equal(shouldDeferCloseoutGitAction("execute-task"), true);
+});
+
+test("non execute-task units keep pre-verification closeout git action", () => {
+  assert.equal(shouldDeferCloseoutGitAction("plan-slice"), false);
+  assert.equal(shouldDeferCloseoutGitAction("complete-slice"), false);
+});

--- a/src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts
+++ b/src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts
@@ -1,0 +1,38 @@
+// Project/App: GSD-2
+// File Purpose: Tests for verification evidence cross-reference mismatch policy.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { crossReferenceEvidence } from "../safety/evidence-cross-ref.ts";
+import type { EvidenceEntry } from "../safety/evidence-collector.ts";
+
+test("claims of passing verification become errors when recorded bash evidence failed", () => {
+  const mismatches = crossReferenceEvidence(
+    [{ command: "npm test", exitCode: 0, verdict: "passed" }],
+    [
+      {
+        kind: "bash",
+        toolCallId: "call-1",
+        command: "npm test",
+        exitCode: 1,
+        outputSnippet: "failed",
+        timestamp: Date.now(),
+      },
+    ] as EvidenceEntry[],
+  );
+
+  assert.equal(mismatches.length, 1);
+  assert.equal(mismatches[0].severity, "error");
+  assert.match(mismatches[0].reason, /Claimed exitCode=0/);
+});
+
+test("missing recorded bash evidence remains a warning", () => {
+  const mismatches = crossReferenceEvidence(
+    [{ command: "npm test", exitCode: 0, verdict: "passed" }],
+    [],
+  );
+
+  assert.equal(mismatches.length, 1);
+  assert.equal(mismatches[0].severity, "warning");
+});

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -11,7 +11,7 @@
 import { describe, test, mock, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { tmpdir } from "node:os";
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 import { runPostUnitVerification, type VerificationContext } from "../auto-verification.ts";
@@ -372,6 +372,13 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.equal(result, "pause");
     assert.equal(pauseAutoMock.mock.callCount(), 1);
     assert.equal(s.pendingVerificationRetry, null);
+
+    const evidencePath = join(tempDir, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-VERIFY.json");
+    const evidence = JSON.parse(readFileSync(evidencePath, "utf-8"));
+    assert.equal(evidence.passed, false);
+    assert.equal(evidence.discoverySource, "none");
+    assert.ok(!("retryAttempt" in evidence), "no-host-checks evidence must not include retryAttempt");
+    assert.ok(!("maxRetries" in evidence), "no-host-checks evidence must not include maxRetries");
   });
 
   test("auto-discovered package.json verification failure retries instead of continuing", async () => {

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Tests for post-execution retry bypass and verification gate failure handling.
 /**
  * post-exec-retry-bypass.test.ts — Tests for post-execution blocking failure retry bypass.
  *
@@ -9,7 +11,7 @@
 import { describe, test, mock, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { tmpdir } from "node:os";
-import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 import { runPostUnitVerification, type VerificationContext } from "../auto-verification.ts";
@@ -71,6 +73,7 @@ function setupTestEnvironment(): void {
   mkdirSync(milestonesDir, { recursive: true });
 
   process.chdir(tempDir);
+  invalidateAllCaches();
   _clearGsdRootCache();
 
   dbPath = join(gsdDir, "gsd.db");
@@ -134,6 +137,34 @@ function createBasicTask(): void {
       verify: "echo pass", // Simple verification that always passes
       inputs: [],
       expectedOutput: ["output.ts"],
+      observabilityImpact: "",
+    },
+    sequence: 0,
+  });
+}
+
+function createTaskWithoutVerify(): void {
+  insertMilestone({ id: "M001" });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Test Slice",
+    risk: "low",
+  });
+
+  insertTask({
+    id: "T01",
+    sliceId: "S01",
+    milestoneId: "M001",
+    title: "Task without host verification",
+    status: "pending",
+    planning: {
+      description: "Task intentionally missing runnable verification",
+      estimate: "1h",
+      files: [],
+      verify: "",
+      inputs: [],
+      expectedOutput: [],
       observabilityImpact: "",
     },
     sequence: 0,
@@ -326,6 +357,46 @@ describe("Post-execution blocking failure retry bypass", () => {
     assert.equal(row?.gate_id, "post-execution-checks");
     assert.equal(row?.outcome, "fail");
     assert.equal(row?.failure_class, "artifact");
+  });
+
+  test("execute-task with no host-owned verification pauses fail-closed", async () => {
+    createTaskWithoutVerify();
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
+
+    const result = await runPostUnitVerification({ s, ctx, pi }, pauseAutoMock);
+
+    assert.equal(result, "pause");
+    assert.equal(pauseAutoMock.mock.callCount(), 1);
+    assert.equal(s.pendingVerificationRetry, null);
+  });
+
+  test("auto-discovered package.json verification failure retries instead of continuing", async () => {
+    createTaskWithoutVerify();
+    writeFileSync(
+      join(tempDir, "package.json"),
+      JSON.stringify({ scripts: { test: "exit 1" } }),
+      "utf-8",
+    );
+    writePreferences({
+      verification_auto_fix: true,
+      verification_max_retries: 2,
+    });
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
+
+    const result = await runPostUnitVerification({ s, ctx, pi }, pauseAutoMock);
+
+    assert.equal(result, "retry");
+    assert.equal(pauseAutoMock.mock.callCount(), 0);
+    assert.equal(s.pendingVerificationRetry?.unitId, "M001/S01/T01");
+    assert.match(s.pendingVerificationRetry?.failureContext ?? "", /npm run test/);
   });
 });
 

--- a/src/resources/extensions/gsd/tests/verification-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-verdict.test.ts
@@ -1,0 +1,78 @@
+// Project/App: GSD-2
+// File Purpose: Tests for host-owned auto-mode verification verdict policy.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { decideVerificationVerdict } from "../verification-verdict.ts";
+import type { VerificationResult } from "../types.ts";
+
+function makeResult(overrides: Partial<VerificationResult> = {}): VerificationResult {
+  return {
+    passed: true,
+    checks: [],
+    discoverySource: "none",
+    timestamp: 1,
+    ...overrides,
+  };
+}
+
+test("execute-task fails closed when no host-owned checks are discovered", () => {
+  const verdict = decideVerificationVerdict("execute-task", makeResult());
+
+  assert.equal(verdict.passed, false);
+  assert.equal(verdict.reason, "no-host-checks");
+  assert.equal(verdict.retryable, false);
+  assert.match(verdict.failureContext, /No runnable host-owned verification command/);
+});
+
+test("non execute-task units preserve no-check pass semantics", () => {
+  const verdict = decideVerificationVerdict("plan-slice", makeResult());
+
+  assert.equal(verdict.passed, true);
+  assert.equal(verdict.reason, "passed");
+});
+
+test("execute-task command failure remains retryable verification failure", () => {
+  const verdict = decideVerificationVerdict(
+    "execute-task",
+    makeResult({
+      passed: false,
+      discoverySource: "package-json",
+      checks: [
+        {
+          command: "npm test",
+          exitCode: 1,
+          stdout: "",
+          stderr: "failed",
+          durationMs: 10,
+        },
+      ],
+    }),
+  );
+
+  assert.equal(verdict.passed, false);
+  assert.equal(verdict.reason, "checks-failed");
+  assert.equal(verdict.retryable, true);
+});
+
+test("execute-task passes when a discovered host check succeeds", () => {
+  const verdict = decideVerificationVerdict(
+    "execute-task",
+    makeResult({
+      discoverySource: "preference",
+      checks: [
+        {
+          command: "npm test",
+          exitCode: 0,
+          stdout: "ok",
+          stderr: "",
+          durationMs: 10,
+        },
+      ],
+    }),
+  );
+
+  assert.equal(verdict.passed, true);
+  assert.equal(verdict.reason, "passed");
+});

--- a/src/resources/extensions/gsd/verification-verdict.ts
+++ b/src/resources/extensions/gsd/verification-verdict.ts
@@ -1,0 +1,47 @@
+// Project/App: GSD-2
+// File Purpose: Host-owned verification verdict policy for auto-mode units.
+
+import type { VerificationResult as VerificationGateResult } from "./types.js";
+
+export type VerificationVerdictReason =
+  | "passed"
+  | "no-host-checks"
+  | "checks-failed";
+
+export interface VerificationVerdict {
+  passed: boolean;
+  reason: VerificationVerdictReason;
+  retryable: boolean;
+  failureContext: string;
+}
+
+export function decideVerificationVerdict(
+  unitType: string,
+  result: VerificationGateResult,
+): VerificationVerdict {
+  if (unitType === "execute-task" && result.discoverySource === "none" && result.checks.length === 0) {
+    return {
+      passed: false,
+      reason: "no-host-checks",
+      retryable: false,
+      failureContext:
+        "No runnable host-owned verification command was discovered. Add project verification_commands or a runnable task-plan Verify command before completing this execute-task.",
+    };
+  }
+
+  if (!result.passed) {
+    return {
+      passed: false,
+      reason: "checks-failed",
+      retryable: true,
+      failureContext: "",
+    };
+  }
+
+  return {
+    passed: true,
+    reason: "passed",
+    retryable: false,
+    failureContext: "",
+  };
+}


### PR DESCRIPTION
## TL;DR

**What:** Fail closed execute-task verification before publish.
**Why:** Auto-mode could otherwise treat failed or missing workflow checks as successful work.
**How:** Defer execute-task closeout git actions until after verification passes, make missing host checks fail closed, keep package.json failures blocking/retryable, and block contradictory claimed evidence.

Closes #5809

## What

This updates the GSD auto-mode verification path so execute-task units require a host-owned passing verification verdict before git closeout/publish runs. It also adds regression coverage for the verdict policy, git deferral, claimed-vs-recorded evidence mismatch, no-host-check fail-closed behavior, and package.json failure retry behavior.

## Why

The workflow investigation found a false-success path: failed checks or absent checks could still allow completed task work to be committed as approved/successful. That undermines build-gate trust and lets broken workflow output move forward.

## How

- Added a host-owned verification verdict policy module.
- Deferred execute-task closeout git action from pre-verification to post-verification.
- Removed advisory continue behavior for package.json/infra verification failures.
- Paused fail-closed when execute-task has no runnable host-owned verification checks.
- Cross-referenced claimed verification evidence against recorded bash evidence and pause on hard conflicts.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/verification-verdict.test.ts src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts src/resources/extensions/gsd/tests/closeout-git-deferral.test.ts src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts`
- `npm run typecheck:extensions`
- `npm run test:compile`
- `npm run verify:pr`

## Change type checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-owned verification verdicts and a centralized closeout flow that defers task commits/snapshots until verification passes.

* **Bug Fixes**
  * Stricter evidence cross-referencing with severity-based blocking, improved pause/continue/retry semantics, and more accurate retry bookkeeping.

* **Documentation**
  * Clarified lifecycle and verification enforcement in user docs and workflow guidance.

* **Tests**
  * Added coverage for deferral, evidence cross-reference, verdict logic, and post-exec retry behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5810)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->