### PR TITLE
feat(web): update /gsd visualize surfaces

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -157,7 +157,7 @@ Phase skipping (from token profile) gates steps 2-3: if a phase is skipped, the 
 | `triage-resolution.ts` | Capture resolution (inject, defer, replan, quick-task) |
 | `visualizer-overlay.ts` | Workflow visualizer TUI overlay |
 | `visualizer-data.ts` | Data loading for visualizer tabs |
-| `visualizer-views.ts` | Tab renderers (progress, deps, metrics, timeline, discussion status) |
+| `visualizer-views.ts` | Tab renderers (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export) |
 | `metrics.ts` | Token and cost tracking ledger |
 | `state.ts` | DB-authoritative state derivation with explicit legacy markdown fallback for tests/recovery |
 | `session-lock.ts` | OS-level exclusive session locking (proper-lockfile) |

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -27,7 +27,7 @@
 | `/gsd forensics` | Full-access GSD debugger — structured anomaly detection, unit traces, and LLM-guided root-cause analysis for auto-mode failures |
 | `/gsd cleanup` | Clean up GSD state files and stale worktrees |
 | `/gsd worktree` (`/gsd wt`) | Manage GSD worktrees from the TUI |
-| `/gsd visualize` | Open workflow visualizer (progress, deps, metrics, timeline) |
+| `/gsd visualize` | Open workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export) |
 | `/gsd export --html` | Generate self-contained HTML report for current or completed milestone |
 | `/gsd export --html --all` | Generate retrospective reports for all milestones at once |
 | `/gsd update` | Update GSD to the latest version in-session |

--- a/docs/user-docs/visualizer.md
+++ b/docs/user-docs/visualizer.md
@@ -2,7 +2,7 @@
 
 *Introduced in v2.19.0*
 
-The workflow visualizer is a full-screen TUI overlay that shows project progress, dependencies, cost metrics, and execution timeline in an interactive four-tab view.
+The workflow visualizer is an interactive view for project progress, execution history, dependencies, metrics, health, agent activity, changes, knowledge, captures, and exports.
 
 ## Opening the Visualizer
 
@@ -18,7 +18,7 @@ auto_visualize: true
 
 ## Tabs
 
-Switch tabs with `Tab`, `1`-`4`, or arrow keys.
+Switch tabs with `Tab`, `Shift+Tab`, or `1`-`9` and `0`.
 
 ### 1. Progress
 
@@ -40,28 +40,7 @@ Shows checkmarks for completed items, spinners for in-progress, and empty boxes 
 
 **Discussion status** is also shown when milestones have been through a discussion phase — indicates whether requirements were captured and what state the discussion left off in.
 
-### 2. Dependencies
-
-An ASCII dependency graph showing slice relationships:
-
-```
-S01 ──→ S02 ──→ S04
-  └───→ S03 ──↗
-```
-
-Visualizes the `depends:` field from the roadmap, making it easy to see which slices are blocked and which can proceed.
-
-### 3. Metrics
-
-Bar charts showing cost and token usage breakdowns:
-
-- **By phase** — research, planning, execution, completion, reassessment
-- **By slice** — cost per slice with running totals
-- **By model** — which models consumed the most budget
-
-Uses data from `.gsd/metrics.json`.
-
-### 4. Timeline
+### 2. Timeline
 
 Chronological execution history showing:
 
@@ -71,7 +50,51 @@ Chronological execution history showing:
 - Model used
 - Token counts
 
-Ordered by execution time, showing the full history of auto-mode dispatches.
+### 3. Dependencies
+
+An ASCII dependency graph showing slice relationships:
+
+```
+S01 ──→ S02 ──→ S04
+  └───→ S03 ──↗
+```
+
+Visualizes the `depends:` field from the roadmap, making it easy to see which slices are blocked and which can proceed. Slice verification artifacts also surface data flow between completed slices.
+
+### 4. Metrics
+
+Bar charts showing cost and token usage breakdowns:
+
+- **By phase** — research, planning, execution, completion, reassessment
+- **By slice** — cost per slice with running totals
+- **By model** — which models consumed the most budget
+- **By routing tier** — light, standard, heavy, and downgraded unit counts
+
+Uses data from `.gsd/metrics.json`.
+
+### 5. Health
+
+Budget pressure, token pressure, environment issues, provider checks, skill-health summary, progress score, and persisted doctor history.
+
+### 6. Agent
+
+Current agent activity, completion rate, session cost/tokens, pressure signals, pending captures, and recent completed units.
+
+### 7. Changes
+
+Completed slice summaries, modified files, verification decisions, and established patterns.
+
+### 8. Knowledge
+
+Persistent project rules, patterns, and lessons from `.gsd/KNOWLEDGE.md`.
+
+### 9. Captures
+
+Captured notes grouped by pending, triaged, and resolved state.
+
+### 0. Export
+
+Download Markdown, JSON, or a current-view snapshot from the visualizer data.
 
 ## Controls
 
@@ -79,8 +102,10 @@ Ordered by execution time, showing the full history of auto-mode dispatches.
 |-----|--------|
 | `Tab` | Next tab |
 | `Shift+Tab` | Previous tab |
-| `1`-`4` | Jump to tab |
+| `1`-`9`, `0` | Jump to tab |
 | `↑`/`↓` | Scroll within tab |
+| `/` | Search/filter |
+| `?` | Show keyboard help |
 | `Escape` / `q` | Close visualizer |
 
 ## Auto-Refresh

--- a/gitbook/features/visualizer.md
+++ b/gitbook/features/visualizer.md
@@ -1,6 +1,6 @@
 # Workflow Visualizer
 
-The workflow visualizer is a full-screen terminal overlay showing project progress, dependencies, cost metrics, and execution timeline.
+The workflow visualizer is an interactive view for project progress, execution history, dependencies, metrics, health, agent activity, changes, knowledge, captures, and export.
 
 ## Opening
 
@@ -16,7 +16,7 @@ auto_visualize: true
 
 ## Tabs
 
-Switch tabs with `Tab`, `1`-`4`, or arrow keys.
+Switch tabs with `Tab`, `Shift+Tab`, or `1`-`9` and `0`.
 
 ### 1. Progress
 
@@ -33,7 +33,11 @@ M001: User Management                        3/6 tasks
     ⬜ T02: Profile page
 ```
 
-### 2. Dependencies
+### 2. Timeline
+
+Chronological execution history: unit type, timestamps, duration, model, and token counts.
+
+### 3. Dependencies
 
 An ASCII dependency graph showing slice relationships:
 
@@ -42,17 +46,40 @@ S01 ──→ S02 ──→ S04
   └───→ S03 ──↗
 ```
 
-### 3. Metrics
+Slice verification artifacts also surface data flow between completed slices.
+
+### 4. Metrics
 
 Bar charts showing cost and token usage:
 
 - By phase (research, planning, execution, completion)
 - By slice (with running totals)
 - By model (which models consumed the most budget)
+- By routing tier (including downgraded unit counts)
 
-### 4. Timeline
+### 5. Health
 
-Chronological execution history: unit type, timestamps, duration, model, and token counts.
+Budget pressure, token pressure, environment issues, provider checks, skill-health summary, progress score, and doctor history.
+
+### 6. Agent
+
+Current agent activity, completion rate, session cost/tokens, pressure signals, pending captures, and recent completed units.
+
+### 7. Changes
+
+Completed slice summaries, modified files, verification decisions, and established patterns.
+
+### 8. Knowledge
+
+Persistent project rules, patterns, and lessons.
+
+### 9. Captures
+
+Captured notes grouped by pending, triaged, and resolved state.
+
+### 0. Export
+
+Download Markdown, JSON, or a current-view snapshot.
 
 ## Controls
 
@@ -60,8 +87,10 @@ Chronological execution history: unit type, timestamps, duration, model, and tok
 |-----|--------|
 | `Tab` | Next tab |
 | `Shift+Tab` | Previous tab |
-| `1`-`4` | Jump to tab |
+| `1`-`9`, `0` | Jump to tab |
 | `↑`/`↓` | Scroll |
+| `/` | Search/filter |
+| `?` | Show keyboard help |
 | `Escape` / `q` | Close |
 
 The visualizer auto-refreshes every 2 seconds, staying current alongside running auto mode.

--- a/gitbook/reference/commands.md
+++ b/gitbook/reference/commands.md
@@ -26,7 +26,7 @@
 | `/gsd forensics` | Full debugger for auto-mode failures (includes worktree lifecycle telemetry) |
 | `/gsd cleanup` | Clean up state files and stale worktrees |
 | `/gsd worktree` (`/gsd wt`) | Manage GSD worktrees from the TUI |
-| `/gsd visualize` | Open workflow visualizer |
+| `/gsd visualize` | Open workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export) |
 | `/gsd export --html` | Generate HTML report for current milestone |
 | `/gsd export --html --all` | Generate reports for all milestones |
 | `/gsd update` | Update GSD to the latest version |

--- a/mintlify-docs/guides/commands.mdx
+++ b/mintlify-docs/guides/commands.mdx
@@ -31,7 +31,7 @@ description: "Every GSD command, keyboard shortcut, and CLI flag."
 | `/gsd history` | View execution history (supports `--cost`, `--phase`, `--model` filters) |
 | `/gsd forensics` | Full-access debugger for auto-mode failures |
 | `/gsd cleanup` | Clean up GSD state files and stale worktrees |
-| `/gsd visualize` | Open workflow visualizer |
+| `/gsd visualize` | Open workflow visualizer (progress, timeline, deps, metrics, health, agent, changes, knowledge, captures, export) |
 | `/gsd export --html` | Generate self-contained HTML report |
 | `/gsd export --html --all` | Generate reports for all milestones |
 | `/gsd update` | Update GSD to the latest version in-session |

--- a/mintlify-docs/guides/visualizer.mdx
+++ b/mintlify-docs/guides/visualizer.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Workflow visualizer"
-description: "Interactive TUI overlay for progress, dependencies, metrics, and timeline."
+description: "Interactive workflow view for progress, timeline, dependencies, metrics, health, agent activity, changes, knowledge, captures, and export."
 ---
 
-The workflow visualizer is a full-screen TUI overlay with four tabs showing project progress, dependencies, cost metrics, and execution timeline.
+The workflow visualizer is an interactive view for progress, execution history, dependencies, metrics, health, agent activity, changes, knowledge, captures, and export.
 
 ## Opening
 
@@ -19,7 +19,7 @@ auto_visualize: true
 
 ## Tabs
 
-Switch tabs with `Tab`, `1`-`4`, or arrow keys.
+Switch tabs with `Tab`, `Shift+Tab`, or `1`-`9` and `0`.
 
 ### 1. Progress
 
@@ -36,7 +36,11 @@ M001: User Management                        3/6 tasks ⏳
     ⬜ T02: Profile page
 ```
 
-### 2. Dependencies
+### 2. Timeline
+
+Chronological execution history with unit type, timestamps, duration, model, and token counts.
+
+### 3. Dependencies
 
 ASCII dependency graph showing slice relationships:
 
@@ -45,13 +49,35 @@ S01 ──→ S02 ──→ S04
   └───→ S03 ──↗
 ```
 
-### 3. Metrics
+Slice verification artifacts also surface data flow between completed slices.
 
-Bar charts showing cost and token usage by phase, slice, and model.
+### 4. Metrics
 
-### 4. Timeline
+Bar charts showing cost and token usage by phase, slice, model, and routing tier.
 
-Chronological execution history with unit type, timestamps, duration, model, and token counts.
+### 5. Health
+
+Budget pressure, token pressure, environment issues, provider checks, skill-health summary, progress score, and doctor history.
+
+### 6. Agent
+
+Current agent activity, completion rate, session cost/tokens, pressure signals, pending captures, and recent completed units.
+
+### 7. Changes
+
+Completed slice summaries, modified files, verification decisions, and established patterns.
+
+### 8. Knowledge
+
+Persistent project rules, patterns, and lessons.
+
+### 9. Captures
+
+Captured notes grouped by pending, triaged, and resolved state.
+
+### 0. Export
+
+Download Markdown, JSON, or a current-view snapshot.
 
 ## Controls
 
@@ -59,8 +85,10 @@ Chronological execution history with unit type, timestamps, duration, model, and
 |-----|--------|
 | `Tab` | Next tab |
 | `Shift+Tab` | Previous tab |
-| `1`-`4` | Jump to tab |
+| `1`-`9`, `0` | Jump to tab |
 | `↑`/`↓` | Scroll |
+| `/` | Search/filter |
+| `?` | Show keyboard help |
 | `Escape` / `q` | Close |
 
 The visualizer refreshes from disk every 2 seconds, staying current alongside a running auto-mode session.

--- a/src/web/visualizer-service.ts
+++ b/src/web/visualizer-service.ts
@@ -1,3 +1,5 @@
+// GSD-2 Web — Collects workflow visualizer data for browser API routes.
+
 import { execFile } from "node:child_process"
 import { existsSync } from "node:fs"
 import { join } from "node:path"
@@ -23,6 +25,8 @@ export interface SerializedVisualizerData {
   byPhase: unknown[]
   bySlice: unknown[]
   byModel: unknown[]
+  byTier: unknown[]
+  tierSavingsLine: string
   units: unknown[]
   criticalPath: {
     milestonePath: string[]
@@ -33,6 +37,12 @@ export interface SerializedVisualizerData {
   remainingSliceCount: number
   agentActivity: unknown | null
   changelog: unknown
+  sliceVerifications: unknown[]
+  knowledge: unknown
+  captures: unknown
+  health: unknown
+  discussion: unknown[]
+  stats: unknown
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {

--- a/web/components/gsd/visualizer-view.tsx
+++ b/web/components/gsd/visualizer-view.tsx
@@ -2,7 +2,7 @@
 
 "use client"
 
-import { useEffect, useRef, useState, useCallback } from "react"
+import { useEffect, useMemo, useRef, useState, useCallback } from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 import {
   CheckCircle2,
@@ -135,6 +135,91 @@ function verificationTone(result: string) {
   if (result === "passed") return "text-success border-success/25 bg-success/10"
   if (result === "failed") return "text-destructive border-destructive/25 bg-destructive/10"
   return "text-muted-foreground border-border bg-muted/50"
+}
+
+function matchesQuery(value: unknown, query: string): boolean {
+  if (value == null) return false
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value).toLowerCase().includes(query)
+  }
+  if (Array.isArray(value)) return value.some((item) => matchesQuery(item, query))
+  if (typeof value === "object") return Object.values(value).some((item) => matchesQuery(item, query))
+  return false
+}
+
+function filterRecord<T>(items: T[], query: string): T[] {
+  return items.filter((item) => matchesQuery(item, query))
+}
+
+function filterVisualizerData(data: VisualizerData, rawQuery: string): VisualizerData {
+  const query = rawQuery.trim().toLowerCase()
+  if (!query) return data
+
+  const milestones = data.milestones
+    .map((milestone) => {
+      if (matchesQuery({ ...milestone, slices: [] }, query)) return milestone
+
+      const slices = milestone.slices
+        .map((slice) => {
+          if (matchesQuery({ ...slice, tasks: [] }, query)) return slice
+          const tasks = filterRecord(slice.tasks, query)
+          return tasks.length > 0 ? { ...slice, tasks } : null
+        })
+        .filter((slice): slice is VisualizerSlice => slice != null)
+
+      return slices.length > 0 ? { ...milestone, slices } : null
+    })
+    .filter((milestone): milestone is VisualizerData["milestones"][number] => milestone != null)
+
+  const missingSlices = filterRecord(data.stats.missingSlices, query)
+  const updatedSlices = filterRecord(data.stats.updatedSlices, query)
+  const recentEntries = filterRecord(data.stats.recentEntries, query)
+  const captureEntries = filterRecord(data.captures.entries, query)
+
+  return {
+    ...data,
+    milestones,
+    byPhase: filterRecord(data.byPhase, query),
+    bySlice: filterRecord(data.bySlice, query),
+    byModel: filterRecord(data.byModel, query),
+    byTier: filterRecord(data.byTier, query),
+    units: filterRecord(data.units, query),
+    changelog: {
+      ...data.changelog,
+      entries: filterRecord(data.changelog.entries, query),
+    },
+    sliceVerifications: filterRecord(data.sliceVerifications, query),
+    knowledge: {
+      ...data.knowledge,
+      rules: filterRecord(data.knowledge.rules, query),
+      patterns: filterRecord(data.knowledge.patterns, query),
+      lessons: filterRecord(data.knowledge.lessons, query),
+    },
+    captures: {
+      ...data.captures,
+      entries: captureEntries,
+      pendingCount: captureEntries.filter((entry) => entry.status === "pending").length,
+      totalCount: captureEntries.length,
+    },
+    health: {
+      ...data.health,
+      tierBreakdown: filterRecord(data.health.tierBreakdown, query),
+      providers: filterRecord(data.health.providers, query),
+      environmentIssues: filterRecord(data.health.environmentIssues, query),
+      doctorHistory: data.health.doctorHistory
+        ? filterRecord(data.health.doctorHistory, query)
+        : data.health.doctorHistory,
+    },
+    discussion: filterRecord(data.discussion, query),
+    stats: {
+      ...data.stats,
+      missingCount: missingSlices.length,
+      missingSlices,
+      updatedCount: updatedSlices.length,
+      updatedSlices,
+      recentEntries,
+    },
+  }
 }
 
 /** Prominent section label with left accent bar */
@@ -1864,6 +1949,10 @@ export function VisualizerView() {
   const [filterQuery, setFilterQuery] = useState("")
   const [helpOpen, setHelpOpen] = useState(false)
   const searchInputRef = useRef<HTMLInputElement>(null)
+  const filteredData = useMemo(
+    () => (data ? filterVisualizerData(data, filterQuery) : null),
+    [data, filterQuery],
+  )
 
   const fetchData = useCallback(async () => {
     try {
@@ -1902,6 +1991,12 @@ export function VisualizerView() {
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (helpOpen && (event.key === "Escape" || event.key.toLowerCase() === "q")) {
+        event.preventDefault()
+        setHelpOpen(false)
+        return
+      }
+
       if (isFormFieldFocused()) return
 
       if (event.key >= "1" && event.key <= "9") {
@@ -1928,12 +2023,6 @@ export function VisualizerView() {
       if (event.key === "?") {
         event.preventDefault()
         setHelpOpen(true)
-        return
-      }
-
-      if (helpOpen && (event.key === "Escape" || event.key.toLowerCase() === "q")) {
-        event.preventDefault()
-        setHelpOpen(false)
       }
     }
 
@@ -1978,6 +2067,7 @@ export function VisualizerView() {
   }
 
   if (!data) return null
+  const visibleData = filteredData ?? data
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -2046,34 +2136,34 @@ export function VisualizerView() {
         <div className="flex-1 overflow-y-auto">
           <div className="mx-auto max-w-5xl px-7 py-7">
             <TabsPrimitive.Content value="progress" className="outline-none">
-              <ProgressTab data={data} />
+              <ProgressTab data={visibleData} />
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="deps" className="outline-none">
-              <DepsTab data={data} />
+              <DepsTab data={visibleData} />
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="metrics" className="outline-none">
-              <MetricsTab data={data} />
+              <MetricsTab data={visibleData} />
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="health" className="outline-none">
-              <HealthTab data={data} />
+              <HealthTab data={visibleData} />
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="timeline" className="outline-none">
-              <TimelineTab data={data} />
+              <TimelineTab data={visibleData} />
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="agent" className="outline-none">
-              <AgentTab data={data} />
+              <AgentTab data={visibleData} />
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="changes" className="outline-none">
-              <ChangesTab data={data} />
+              <ChangesTab data={visibleData} />
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="knowledge" className="outline-none">
-              <KnowledgeTab data={data} />
+              <KnowledgeTab data={visibleData} />
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="captures" className="outline-none">
-              <CapturesTab data={data} />
+              <CapturesTab data={visibleData} />
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="export" className="outline-none">
-              <ExportTab data={data} />
+              <ExportTab data={visibleData} />
             </TabsPrimitive.Content>
           </div>
         </div>

--- a/web/components/gsd/visualizer-view.tsx
+++ b/web/components/gsd/visualizer-view.tsx
@@ -2,7 +2,7 @@
 
 "use client"
 
-import { useEffect, useState, useCallback } from "react"
+import { useEffect, useRef, useState, useCallback } from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 import {
   CheckCircle2,
@@ -1789,14 +1789,20 @@ function ExportTab({ data }: { data: VisualizerData }) {
 // ─── Custom Tab Bar ────────────────────────────────────────────────────────────
 
 function VisualizerTabs({
-  defaultValue,
+  value,
+  onValueChange,
   children,
 }: {
-  defaultValue: TabValue
+  value: TabValue
+  onValueChange: (value: TabValue) => void
   children: React.ReactNode
 }) {
   return (
-    <TabsPrimitive.Root defaultValue={defaultValue} className="flex h-full flex-col overflow-hidden">
+    <TabsPrimitive.Root
+      value={value}
+      onValueChange={(next) => onValueChange(next as TabValue)}
+      className="flex h-full flex-col overflow-hidden"
+    >
       {children}
     </TabsPrimitive.Root>
   )
@@ -1854,6 +1860,10 @@ export function VisualizerView() {
   const [data, setData] = useState<VisualizerData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [selectedTab, setSelectedTab] = useState<TabValue>("progress")
+  const [filterQuery, setFilterQuery] = useState("")
+  const [helpOpen, setHelpOpen] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement>(null)
 
   const fetchData = useCallback(async () => {
     try {
@@ -1877,6 +1887,59 @@ export function VisualizerView() {
     const interval = setInterval(fetchData, 10_000)
     return () => clearInterval(interval)
   }, [fetchData])
+
+  useEffect(() => {
+    const isFormFieldFocused = () => {
+      const activeElement = document.activeElement
+      if (!activeElement) return false
+      const tagName = activeElement.tagName.toLowerCase()
+      return (
+        tagName === "input" ||
+        tagName === "textarea" ||
+        tagName === "select" ||
+        activeElement.getAttribute("contenteditable") === "true"
+      )
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isFormFieldFocused()) return
+
+      if (event.key >= "1" && event.key <= "9") {
+        const tab = TABS[Number(event.key) - 1]
+        if (tab) {
+          event.preventDefault()
+          setSelectedTab(tab.value)
+        }
+        return
+      }
+
+      if (event.key === "0") {
+        event.preventDefault()
+        setSelectedTab(TABS[TABS.length - 1].value)
+        return
+      }
+
+      if (event.key === "/") {
+        event.preventDefault()
+        searchInputRef.current?.focus()
+        return
+      }
+
+      if (event.key === "?") {
+        event.preventDefault()
+        setHelpOpen(true)
+        return
+      }
+
+      if (helpOpen && (event.key === "Escape" || event.key.toLowerCase() === "q")) {
+        event.preventDefault()
+        setHelpOpen(false)
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [helpOpen])
 
   // Loading
   if (loading && !data) {
@@ -1919,7 +1982,7 @@ export function VisualizerView() {
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Header */}
-      <div className="flex shrink-0 items-center justify-between border-b border-border px-7 py-5">
+      <div className="flex shrink-0 items-center justify-between gap-5 border-b border-border px-7 py-5">
         <div>
           <h1 className="text-xl font-bold tracking-tight">Workflow Visualizer</h1>
           <div className="mt-1.5 flex items-center gap-3 text-sm text-muted-foreground">
@@ -1955,10 +2018,29 @@ export function VisualizerView() {
             )}
           </div>
         </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <input
+            ref={searchInputRef}
+            type="search"
+            value={filterQuery}
+            onChange={(event) => setFilterQuery(event.target.value)}
+            placeholder="Search"
+            aria-label="Search visualizer"
+            className="h-9 w-48 rounded-lg border border-border bg-background px-3 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-foreground/40"
+          />
+          <button
+            type="button"
+            onClick={() => setHelpOpen(true)}
+            aria-label="Show keyboard shortcuts"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-card text-sm font-semibold transition-colors hover:bg-accent"
+          >
+            ?
+          </button>
+        </div>
       </div>
 
       {/* Tabs */}
-      <VisualizerTabs defaultValue="progress">
+      <VisualizerTabs value={selectedTab} onValueChange={setSelectedTab}>
         <VisualizerTabList />
 
         <div className="flex-1 overflow-y-auto">
@@ -1996,6 +2078,43 @@ export function VisualizerView() {
           </div>
         </div>
       </VisualizerTabs>
+
+      {helpOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="visualizer-shortcuts-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 p-6 backdrop-blur-sm"
+          onClick={() => setHelpOpen(false)}
+        >
+          <div
+            className="w-full max-w-sm rounded-xl border border-border bg-card p-5 shadow-lg"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-center justify-between gap-4">
+              <h2 id="visualizer-shortcuts-title" className="text-sm font-semibold">
+                Keyboard Shortcuts
+              </h2>
+              <button
+                type="button"
+                onClick={() => setHelpOpen(false)}
+                aria-label="Close keyboard shortcuts"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              >
+                <XCircle className="h-4 w-4" />
+              </button>
+            </div>
+            <dl className="mt-4 grid grid-cols-[auto_1fr] gap-x-4 gap-y-3 text-sm">
+              <dt className="font-mono text-xs text-muted-foreground">1-9, 0</dt>
+              <dd>Jump to tab</dd>
+              <dt className="font-mono text-xs text-muted-foreground">/</dt>
+              <dd>Focus search</dd>
+              <dt className="font-mono text-xs text-muted-foreground">?</dt>
+              <dd>Show this help</dd>
+            </dl>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/web/components/gsd/visualizer-view.tsx
+++ b/web/components/gsd/visualizer-view.tsx
@@ -1,3 +1,5 @@
+// GSD-2 Web — Workflow visualizer browser view.
+
 "use client"
 
 import { useEffect, useState, useCallback } from "react"
@@ -22,6 +24,11 @@ import {
   ChevronRight,
   AlertCircle,
   SkipForward,
+  HeartPulse,
+  BookOpen,
+  Inbox,
+  XCircle,
+  MessageSquare,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useGSDWorkspaceState, buildProjectUrl } from "@/lib/gsd-workspace-store"
@@ -35,6 +42,7 @@ import {
   formatCost,
   formatTokenCount,
   formatDuration,
+  getCaptureStatusCounts,
 } from "@/lib/visualizer-types"
 import { authFetch } from "@/lib/auth"
 
@@ -43,11 +51,14 @@ import { authFetch } from "@/lib/auth"
 // Tab definitions — single source of truth
 const TABS = [
   { value: "progress", label: "Progress",     Icon: Layers    },
+  { value: "timeline", label: "Timeline",     Icon: Clock     },
   { value: "deps",     label: "Dependencies", Icon: GitBranch },
   { value: "metrics",  label: "Metrics",      Icon: BarChart3 },
-  { value: "timeline", label: "Timeline",     Icon: Clock     },
+  { value: "health",   label: "Health",       Icon: HeartPulse },
   { value: "agent",    label: "Agent",        Icon: Bot       },
   { value: "changes",  label: "Changes",      Icon: Activity  },
+  { value: "knowledge", label: "Knowledge",   Icon: BookOpen  },
+  { value: "captures", label: "Captures",     Icon: Inbox     },
   { value: "export",   label: "Export",       Icon: Download  },
 ] as const
 
@@ -107,6 +118,23 @@ function formatRelative(isoDate: string): string {
 function formatTime(ts: number): string {
   const d = new Date(ts)
   return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`
+}
+
+function formatDate(isoDate: string | null | undefined): string {
+  if (!isoDate) return "unknown"
+  const date = new Date(isoDate)
+  if (Number.isNaN(date.getTime())) return isoDate
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+}
+
+function findVerification(data: VisualizerData, milestoneId: string, sliceId: string) {
+  return data.sliceVerifications.find((v) => v.milestoneId === milestoneId && v.sliceId === sliceId)
+}
+
+function verificationTone(result: string) {
+  if (result === "passed") return "text-success border-success/25 bg-success/10"
+  if (result === "failed") return "text-destructive border-destructive/25 bg-destructive/10"
+  return "text-muted-foreground border-border bg-muted/50"
 }
 
 /** Prominent section label with left accent bar */
@@ -194,6 +222,120 @@ function ProgressBar({
   )
 }
 
+function FeatureSnapshot({ data }: { data: VisualizerData }) {
+  const stats = data.stats
+  const hasPreview =
+    stats.missingSlices.length > 0 ||
+    stats.updatedSlices.length > 0 ||
+    stats.recentEntries.length > 0
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-6">
+      <SectionLabel>Feature Snapshot</SectionLabel>
+      <div className="mt-5 grid gap-4 sm:grid-cols-3">
+        <StatCard label="Missing Slices" value={String(stats.missingCount)} accent={stats.missingCount > 0 ? "amber" : "emerald"} />
+        <StatCard label="Updated This Week" value={String(stats.updatedCount)} accent="sky" />
+        <StatCard label="Recent Completions" value={String(stats.recentEntries.length)} accent="emerald" />
+      </div>
+
+      {hasPreview && (
+        <div className="mt-6 grid gap-5 lg:grid-cols-3">
+          {stats.missingSlices.length > 0 && (
+            <div>
+              <p className="mb-3 text-xs font-semibold text-muted-foreground">Missing</p>
+              <div className="space-y-2">
+                {stats.missingSlices.map((slice) => (
+                  <div key={`${slice.milestoneId}-${slice.sliceId}`} className="rounded-lg bg-muted/50 px-3 py-2">
+                    <p className="font-mono text-xs font-semibold">{slice.milestoneId}/{slice.sliceId}</p>
+                    <p className="mt-0.5 truncate text-xs text-muted-foreground">{slice.title}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {stats.updatedSlices.length > 0 && (
+            <div>
+              <p className="mb-3 text-xs font-semibold text-muted-foreground">Updated</p>
+              <div className="space-y-2">
+                {stats.updatedSlices.map((slice) => (
+                  <div key={`${slice.milestoneId}-${slice.sliceId}`} className="rounded-lg bg-muted/50 px-3 py-2">
+                    <p className="font-mono text-xs font-semibold">{slice.milestoneId}/{slice.sliceId}</p>
+                    <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                      {formatDate(slice.completedAt)} · {slice.title}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {stats.recentEntries.length > 0 && (
+            <div>
+              <p className="mb-3 text-xs font-semibold text-muted-foreground">Recent</p>
+              <div className="space-y-2">
+                {stats.recentEntries.map((entry) => (
+                  <div key={`${entry.milestoneId}-${entry.sliceId}`} className="rounded-lg bg-muted/50 px-3 py-2">
+                    <p className="font-mono text-xs font-semibold">{entry.milestoneId}/{entry.sliceId}</p>
+                    <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                      {entry.oneLiner || entry.title}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function DiscussionStatus({ data }: { data: VisualizerData }) {
+  if (data.discussion.length === 0) return null
+
+  const counts = data.discussion.reduce(
+    (acc, item) => {
+      acc[item.state] += 1
+      return acc
+    },
+    { discussed: 0, draft: 0, undiscussed: 0 },
+  )
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <SectionLabel>Discussion Status</SectionLabel>
+        <div className="flex flex-wrap gap-2 text-xs font-medium">
+          <span className="rounded-md bg-success/10 px-2 py-1 text-success">Discussed {counts.discussed}</span>
+          <span className="rounded-md bg-warning/10 px-2 py-1 text-warning">Draft {counts.draft}</span>
+          <span className="rounded-md bg-muted px-2 py-1 text-muted-foreground">Pending {counts.undiscussed}</span>
+        </div>
+      </div>
+      <div className="mt-5 grid gap-2 md:grid-cols-2">
+        {data.discussion.map((item) => {
+          const tone =
+            item.state === "discussed"
+              ? "text-success bg-success/10"
+              : item.state === "draft"
+                ? "text-warning bg-warning/10"
+                : "text-muted-foreground bg-muted"
+          return (
+            <div key={item.milestoneId} className="flex items-center gap-3 rounded-lg bg-muted/40 px-3 py-2.5">
+              <MessageSquare className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="font-mono text-xs font-semibold">{item.milestoneId}</span>
+              <span className="min-w-0 flex-1 truncate text-sm">{item.title}</span>
+              <span className={cn("rounded-md px-2 py-0.5 text-[11px] font-semibold", tone)}>
+                {item.state}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 // ─── Progress Tab ─────────────────────────────────────────────────────────────
 
 function ProgressTab({ data }: { data: VisualizerData }) {
@@ -259,6 +401,9 @@ function ProgressTab({ data }: { data: VisualizerData }) {
         </div>
       )}
 
+      <FeatureSnapshot data={data} />
+      <DiscussionStatus data={data} />
+
       {/* Milestone tree */}
       <div className="space-y-4">
         {data.milestones.map((ms) => (
@@ -298,6 +443,7 @@ function ProgressTab({ data }: { data: VisualizerData }) {
                 {ms.slices.map((sl) => {
                   const doneTasks = sl.tasks.filter((t) => t.done).length
                   const slStatus = sl.done ? "done" : sl.active ? "active" : "pending"
+                  const verification = findVerification(data, ms.id, sl.id)
                   return (
                     <div key={sl.id} className="px-5 py-4">
                       <div className="flex items-center gap-3">
@@ -305,6 +451,15 @@ function ProgressTab({ data }: { data: VisualizerData }) {
                         <span className="font-mono text-xs font-medium text-muted-foreground">{sl.id}</span>
                         <span className="min-w-0 flex-1 truncate text-sm font-medium">{sl.title}</span>
                         <div className="flex shrink-0 items-center gap-2.5">
+                          {verification && (
+                            <span className={cn(
+                              "rounded-md border px-2 py-0.5 text-[11px] font-semibold",
+                              verificationTone(verification.verificationResult),
+                            )}>
+                              {verification.verificationResult || "untested"}
+                              {verification.blockerDiscovered ? " · blocker" : ""}
+                            </span>
+                          )}
                           {sl.depends.length > 0 && (
                             <span className="text-xs text-muted-foreground">
                               deps: {sl.depends.join(", ")}
@@ -344,8 +499,11 @@ function ProgressTab({ data }: { data: VisualizerData }) {
                               >
                                 {task.title}
                               </span>
+                              {task.estimate && (
+                                <span className="ml-auto font-mono text-xs text-muted-foreground">{task.estimate}</span>
+                              )}
                               {task.active && (
-                                <span className="ml-auto rounded-md bg-info/15 px-2 py-0.5 text-[11px] font-bold uppercase tracking-wider text-info">
+                                <span className="rounded-md bg-info/15 px-2 py-0.5 text-[11px] font-bold uppercase tracking-wider text-info">
                                   running
                                 </span>
                               )}
@@ -366,6 +524,54 @@ function ProgressTab({ data }: { data: VisualizerData }) {
 }
 
 // ─── Deps Tab ─────────────────────────────────────────────────────────────────
+
+function DataFlowSection({ data }: { data: VisualizerData }) {
+  const provided = data.sliceVerifications.filter((v) => v.provides.length > 0)
+  const required = data.sliceVerifications.filter((v) => v.requires.length > 0)
+
+  if (provided.length === 0 && required.length === 0) return null
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-6">
+      <SectionLabel>Data Flow</SectionLabel>
+      <div className="mt-5 grid gap-5 lg:grid-cols-2">
+        {provided.length > 0 && (
+          <div>
+            <p className="mb-3 text-xs font-semibold text-muted-foreground">Provides</p>
+            <div className="space-y-2">
+              {provided.flatMap((verification) =>
+                verification.provides.map((artifact) => (
+                  <div key={`${verification.milestoneId}-${verification.sliceId}-${artifact}`} className="flex items-center gap-3 rounded-lg bg-muted/50 px-3 py-2.5">
+                    <span className="font-mono text-xs font-semibold">{verification.sliceId}</span>
+                    <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span className="truncate text-sm text-muted-foreground">{artifact}</span>
+                  </div>
+                )),
+              )}
+            </div>
+          </div>
+        )}
+
+        {required.length > 0 && (
+          <div>
+            <p className="mb-3 text-xs font-semibold text-muted-foreground">Requires</p>
+            <div className="space-y-2">
+              {required.flatMap((verification) =>
+                verification.requires.map((requirement) => (
+                  <div key={`${verification.milestoneId}-${verification.sliceId}-${requirement.slice}-${requirement.provides}`} className="flex items-center gap-3 rounded-lg bg-muted/50 px-3 py-2.5">
+                    <span className="truncate text-sm text-muted-foreground">{requirement.provides}</span>
+                    <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span className="font-mono text-xs font-semibold">{requirement.slice}</span>
+                  </div>
+                )),
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
 
 function DepsTab({ data }: { data: VisualizerData }) {
   const cp = data.criticalPath
@@ -434,6 +640,8 @@ function DepsTab({ data }: { data: VisualizerData }) {
           )}
         </div>
       </div>
+
+      <DataFlowSection data={data} />
 
       {/* Critical Path */}
       <div className="rounded-xl border border-border bg-card p-6">
@@ -627,6 +835,37 @@ function MetricsTab({ data }: { data: VisualizerData }) {
         </div>
       )}
 
+      {/* By Tier */}
+      {data.byTier.length > 0 && (
+        <div className="rounded-xl border border-border bg-card p-6">
+          <SectionLabel>Cost by Routing Tier</SectionLabel>
+          <div className="mt-5 space-y-5">
+            {data.byTier.map((tier) => {
+              const pct = totals.cost > 0 ? (tier.cost / totals.cost) * 100 : 0
+              return (
+                <div key={tier.tier}>
+                  <div className="mb-2 flex items-center justify-between">
+                    <span className="font-mono text-sm font-medium">{tier.tier}</span>
+                    <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                      <span className="font-mono font-medium text-foreground">{formatCost(tier.cost)}</span>
+                      <span>{pct.toFixed(1)}%</span>
+                      <span>{tier.units} units</span>
+                      {tier.downgraded > 0 && <span>{tier.downgraded} downgraded</span>}
+                    </div>
+                  </div>
+                  <ProgressBar value={pct} max={100} color="amber" />
+                </div>
+              )
+            })}
+          </div>
+          {data.tierSavingsLine && (
+            <div className="mt-5 rounded-lg border border-success/20 bg-success/8 px-4 py-3 text-sm text-success">
+              {data.tierSavingsLine}
+            </div>
+          )}
+        </div>
+      )}
+
       {/* By Slice */}
       {data.bySlice.length > 0 && (
         <div className="rounded-xl border border-border bg-card p-6">
@@ -699,6 +938,208 @@ function ProjectionsSection({
         <div className="mt-4 flex items-center gap-2.5 rounded-lg border border-warning/20 bg-warning/8 px-4 py-3 text-sm text-warning">
           <AlertTriangle className="h-4 w-4 shrink-0" />
           Projected total {formatCost(projectedTotal)} exceeds 2× current spend
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Health Tab ───────────────────────────────────────────────────────────────
+
+function HealthTab({ data }: { data: VisualizerData }) {
+  const health = data.health
+  const currentSpend = data.totals?.cost ?? 0
+  const budgetPct = health.budgetCeiling && health.budgetCeiling > 0
+    ? Math.min(100, (currentSpend / health.budgetCeiling) * 100)
+    : 0
+  const failedProviders = health.providers.filter((provider) => !provider.ok)
+  const doctorHistory = health.doctorHistory ?? []
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard label="Budget" value={health.budgetCeiling !== undefined ? formatCost(health.budgetCeiling) : "unset"} sub={formatCost(currentSpend)} accent={budgetPct >= 90 ? "amber" : "emerald"} />
+        <StatCard label="Token Profile" value={health.tokenProfile} accent="sky" />
+        <StatCard label="Tool Calls" value={String(health.toolCalls)} />
+        <StatCard label="Pending Captures" value={String(data.captures.pendingCount)} accent={data.captures.pendingCount > 0 ? "amber" : "default"} />
+      </div>
+
+      <div className="rounded-xl border border-border bg-card p-6">
+        <SectionLabel>Budget Pressure</SectionLabel>
+        <div className="mt-5 space-y-5">
+          {health.budgetCeiling !== undefined ? (
+            <div>
+              <div className="mb-2 flex items-center justify-between text-sm">
+                <span className="font-medium">Spend</span>
+                <span className="font-mono text-xs text-muted-foreground">
+                  {formatCost(currentSpend)} / {formatCost(health.budgetCeiling)}
+                </span>
+              </div>
+              <ProgressBar value={budgetPct} max={100} color={budgetPct >= 90 ? "amber" : "emerald"} />
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No budget ceiling set.</p>
+          )}
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <div className="mb-2 flex items-center justify-between text-sm">
+                <span className="font-medium">Truncation</span>
+                <span className="font-mono text-xs text-muted-foreground">{health.truncationRate.toFixed(1)}%</span>
+              </div>
+              <ProgressBar value={Math.min(health.truncationRate, 100)} max={100} color={health.truncationRate >= 30 ? "amber" : "sky"} />
+            </div>
+            <div>
+              <div className="mb-2 flex items-center justify-between text-sm">
+                <span className="font-medium">Continue-here</span>
+                <span className="font-mono text-xs text-muted-foreground">{health.continueHereRate.toFixed(1)}%</span>
+              </div>
+              <ProgressBar value={Math.min(health.continueHereRate, 100)} max={100} color={health.continueHereRate >= 30 ? "amber" : "sky"} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {health.tierBreakdown.length > 0 && (
+        <div className="rounded-xl border border-border bg-card p-6">
+          <SectionLabel>Routing</SectionLabel>
+          <div className="mt-5 space-y-3">
+            {health.tierBreakdown.map((tier) => (
+              <div key={tier.tier} className="flex items-center gap-4 rounded-lg bg-muted/50 px-4 py-3">
+                <span className="w-24 font-mono text-xs font-semibold">{tier.tier}</span>
+                <span className="text-sm text-muted-foreground">{tier.units} units</span>
+                <span className="ml-auto font-mono text-sm font-medium">{formatCost(tier.cost)}</span>
+                {tier.downgraded > 0 && (
+                  <span className="rounded-md bg-warning/10 px-2 py-0.5 text-xs text-warning">
+                    {tier.downgraded} downgraded
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+          {health.tierSavingsLine && <p className="mt-4 text-sm text-success">{health.tierSavingsLine}</p>}
+        </div>
+      )}
+
+      {(health.environmentIssues.length > 0 || failedProviders.length > 0 || health.skillSummary.total > 0) && (
+        <div className="rounded-xl border border-border bg-card p-6">
+          <SectionLabel>Readiness</SectionLabel>
+          <div className="mt-5 grid gap-5 lg:grid-cols-3">
+            <div>
+              <p className="mb-3 text-xs font-semibold text-muted-foreground">Environment</p>
+              {health.environmentIssues.length === 0 ? (
+                <p className="text-sm text-success">No environment issues.</p>
+              ) : (
+                <div className="space-y-2">
+                  {health.environmentIssues.map((issue) => (
+                    <div key={`${issue.name}-${issue.message}`} className="rounded-lg bg-muted/50 px-3 py-2">
+                      <p className={cn("text-sm font-medium", issue.status === "error" ? "text-destructive" : "text-warning")}>
+                        {issue.message}
+                      </p>
+                      {issue.detail && <p className="mt-1 text-xs text-muted-foreground">{issue.detail}</p>}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <p className="mb-3 text-xs font-semibold text-muted-foreground">Providers</p>
+              {health.providers.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No provider checks available.</p>
+              ) : (
+                <div className="space-y-2">
+                  {health.providers.map((provider) => (
+                    <div key={provider.name} className="flex items-start gap-2 rounded-lg bg-muted/50 px-3 py-2">
+                      {provider.ok ? (
+                        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-success" />
+                      ) : (
+                        <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+                      )}
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">{provider.label}</p>
+                        <p className="truncate text-xs text-muted-foreground">{provider.message}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <p className="mb-3 text-xs font-semibold text-muted-foreground">Skills</p>
+              {health.skillSummary.total === 0 ? (
+                <p className="text-sm text-muted-foreground">No skill report available.</p>
+              ) : (
+                <div className="rounded-lg bg-muted/50 px-3 py-3">
+                  <p className="text-sm font-medium">{health.skillSummary.total} skills tracked</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {health.skillSummary.criticalCount} critical · {health.skillSummary.warningCount} warning
+                  </p>
+                  {health.skillSummary.topIssue && (
+                    <p className="mt-3 text-xs text-warning">{health.skillSummary.topIssue}</p>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {health.progressScore && (
+        <div className="rounded-xl border border-border bg-card p-6">
+          <SectionLabel>Progress Score</SectionLabel>
+          <div className="mt-5 flex items-start gap-4">
+            <div className={cn(
+              "mt-1 h-3 w-3 rounded-full",
+              health.progressScore.level === "green"
+                ? "bg-success"
+                : health.progressScore.level === "yellow"
+                  ? "bg-warning"
+                  : "bg-destructive",
+            )} />
+            <div>
+              <p className="text-sm font-semibold">{health.progressScore.summary}</p>
+              <div className="mt-3 space-y-1.5">
+                {health.progressScore.signals.map((signal, index) => (
+                  <p key={`${signal.kind}-${index}`} className="text-sm text-muted-foreground">
+                    {signal.label}
+                  </p>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {doctorHistory.length > 0 && (
+        <div className="rounded-xl border border-border bg-card p-6">
+          <SectionLabel>Doctor History</SectionLabel>
+          <div className="mt-5 space-y-3">
+            {doctorHistory.slice(0, 10).map((entry) => (
+              <div key={`${entry.ts}-${entry.codes.join("-")}`} className="rounded-lg bg-muted/50 px-4 py-3">
+                <div className="flex items-center gap-3">
+                  {entry.ok ? (
+                    <CheckCircle2 className="h-4 w-4 shrink-0 text-success" />
+                  ) : (
+                    <AlertTriangle className="h-4 w-4 shrink-0 text-warning" />
+                  )}
+                  <span className="font-mono text-xs text-muted-foreground">{entry.ts.replace("T", " ").slice(0, 19)}</span>
+                  {entry.scope && <span className="rounded-md bg-info/10 px-2 py-0.5 text-xs text-info">{entry.scope}</span>}
+                  <span className="min-w-0 truncate text-sm">{entry.summary || `${entry.errors} errors, ${entry.warnings} warnings, ${entry.fixes} fixes`}</span>
+                </div>
+                {entry.issues && entry.issues.length > 0 && (
+                  <div className="mt-3 space-y-1">
+                    {entry.issues.slice(0, 3).map((issue) => (
+                      <p key={`${issue.code}-${issue.unitId}-${issue.message}`} className="text-xs text-muted-foreground">
+                        {issue.message}
+                      </p>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
         </div>
       )}
     </div>
@@ -859,6 +1300,24 @@ function AgentTab({ data }: { data: VisualizerData }) {
         )}
       </div>
 
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatCard
+          label="Truncation"
+          value={`${data.health.truncationRate.toFixed(1)}%`}
+          accent={data.health.truncationRate >= 30 ? "amber" : "default"}
+        />
+        <StatCard
+          label="Continue-here"
+          value={`${data.health.continueHereRate.toFixed(1)}%`}
+          accent={data.health.continueHereRate >= 30 ? "amber" : "default"}
+        />
+        <StatCard
+          label="Pending Captures"
+          value={String(data.captures.pendingCount)}
+          accent={data.captures.pendingCount > 0 ? "amber" : "default"}
+        />
+      </div>
+
       {/* Completion progress */}
       {total > 0 && (
         <div className="rounded-xl border border-border bg-card p-6">
@@ -929,7 +1388,10 @@ function ChangesTab({ data }: { data: VisualizerData }) {
 
   return (
     <div className="space-y-4">
-      {sorted.map((entry, i) => (
+      {sorted.map((entry, i) => {
+        const verification = findVerification(data, entry.milestoneId, entry.sliceId)
+
+        return (
         <div key={`${entry.milestoneId}-${entry.sliceId}-${i}`} className="overflow-hidden rounded-xl border border-border bg-card">
           {/* Header */}
           <div className="flex items-center justify-between border-b border-border bg-muted/50 px-6 py-4">
@@ -972,9 +1434,179 @@ function ChangesTab({ data }: { data: VisualizerData }) {
                 </div>
               </div>
             )}
+
+            {verification && (verification.keyDecisions.length > 0 || verification.patternsEstablished.length > 0) && (
+              <div className="grid gap-4 md:grid-cols-2">
+                {verification.keyDecisions.length > 0 && (
+                  <div>
+                    <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                      Decisions
+                    </p>
+                    <div className="space-y-2">
+                      {verification.keyDecisions.map((decision, idx) => (
+                        <p key={idx} className="rounded-lg bg-muted/50 px-4 py-2.5 text-xs text-muted-foreground">
+                          {decision}
+                        </p>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {verification.patternsEstablished.length > 0 && (
+                  <div>
+                    <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                      Patterns
+                    </p>
+                    <div className="space-y-2">
+                      {verification.patternsEstablished.map((pattern, idx) => (
+                        <p key={idx} className="rounded-lg bg-muted/50 px-4 py-2.5 text-xs text-muted-foreground">
+                          {pattern}
+                        </p>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
-      ))}
+        )
+      })}
+    </div>
+  )
+}
+
+// ─── Knowledge Tab ────────────────────────────────────────────────────────────
+
+function KnowledgeTab({ data }: { data: VisualizerData }) {
+  const knowledge = data.knowledge
+
+  if (!knowledge.exists) {
+    return <EmptyState message="No project knowledge file found." icon={BookOpen} />
+  }
+
+  if (knowledge.rules.length === 0 && knowledge.patterns.length === 0 && knowledge.lessons.length === 0) {
+    return <EmptyState message="Project knowledge exists but has no entries yet." icon={BookOpen} />
+  }
+
+  return (
+    <div className="space-y-6">
+      {knowledge.rules.length > 0 && (
+        <div className="rounded-xl border border-border bg-card p-6">
+          <SectionLabel>Rules</SectionLabel>
+          <div className="mt-5 space-y-3">
+            {knowledge.rules.map((rule) => (
+              <div key={rule.id} className="rounded-lg bg-muted/50 px-4 py-3">
+                <div className="flex items-center gap-3">
+                  <span className="font-mono text-xs font-semibold text-info">{rule.id}</span>
+                  <span className="rounded-md bg-muted px-2 py-0.5 text-xs text-muted-foreground">{rule.scope}</span>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">{rule.content}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {knowledge.patterns.length > 0 && (
+        <div className="rounded-xl border border-border bg-card p-6">
+          <SectionLabel>Patterns</SectionLabel>
+          <div className="mt-5 space-y-3">
+            {knowledge.patterns.map((pattern) => (
+              <div key={pattern.id} className="rounded-lg bg-muted/50 px-4 py-3">
+                <p className="font-mono text-xs font-semibold text-info">{pattern.id}</p>
+                <p className="mt-2 text-sm text-muted-foreground">{pattern.content}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {knowledge.lessons.length > 0 && (
+        <div className="rounded-xl border border-border bg-card p-6">
+          <SectionLabel>Lessons Learned</SectionLabel>
+          <div className="mt-5 space-y-3">
+            {knowledge.lessons.map((lesson) => (
+              <div key={lesson.id} className="rounded-lg bg-muted/50 px-4 py-3">
+                <p className="font-mono text-xs font-semibold text-info">{lesson.id}</p>
+                <p className="mt-2 text-sm text-muted-foreground">{lesson.content}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Captures Tab ─────────────────────────────────────────────────────────────
+
+function captureClassTone(classification: string | undefined) {
+  if (classification === "inject" || classification === "stop") return "text-warning bg-warning/10"
+  if (classification === "replan" || classification === "backtrack") return "text-destructive bg-destructive/10"
+  if (classification === "quick-task") return "text-info bg-info/10"
+  return "text-muted-foreground bg-muted"
+}
+
+function CapturesTab({ data }: { data: VisualizerData }) {
+  const captures = data.captures
+  const counts = getCaptureStatusCounts(captures)
+  const sorted = [...captures.entries].sort((a, b) => {
+    const order = { pending: 0, triaged: 1, resolved: 2 }
+    return order[a.status] - order[b.status]
+  })
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard label="Total" value={String(captures.totalCount)} />
+        <StatCard label="Pending" value={String(counts.pending)} accent={counts.pending > 0 ? "amber" : "default"} />
+        <StatCard label="Triaged" value={String(counts.triaged)} accent="sky" />
+        <StatCard label="Resolved" value={String(counts.resolved)} accent="emerald" />
+      </div>
+
+      {sorted.length === 0 ? (
+        <EmptyState message="No captures recorded yet." icon={Inbox} />
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-border bg-card">
+          <div className="border-b border-border bg-muted/50 px-6 py-4">
+            <SectionLabel>Captured Notes</SectionLabel>
+          </div>
+          <div className="divide-y divide-border/40">
+            {sorted.map((entry) => {
+              const statusTone =
+                entry.status === "pending"
+                  ? "text-warning bg-warning/10"
+                  : entry.status === "triaged"
+                    ? "text-info bg-info/10"
+                    : "text-success bg-success/10"
+
+              return (
+                <div key={entry.id} className="px-6 py-4">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span className="font-mono text-xs font-bold text-info">{entry.id}</span>
+                    <span className={cn("rounded-md px-2 py-0.5 text-[11px] font-semibold", statusTone)}>
+                      {entry.status}
+                    </span>
+                    {entry.classification && (
+                      <span className={cn("rounded-md px-2 py-0.5 text-[11px] font-semibold", captureClassTone(entry.classification))}>
+                        {entry.classification}
+                      </span>
+                    )}
+                    <span className="ml-auto text-xs text-muted-foreground">{formatDate(entry.timestamp)}</span>
+                  </div>
+                  <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{entry.text}</p>
+                  {(entry.rationale || entry.resolution) && (
+                    <div className="mt-3 rounded-lg bg-muted/50 px-4 py-3 text-xs text-muted-foreground">
+                      {entry.rationale && <p>Rationale: {entry.rationale}</p>}
+                      {entry.resolution && <p className="mt-1">Resolution: {entry.resolution}</p>}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -1032,12 +1664,52 @@ function ExportTab({ data }: { data: VisualizerData }) {
       lines.push(`| Tokens | ${formatTokenCount(data.totals.tokens.total)} |`)
       lines.push("")
     }
+    if (data.byTier.length > 0) {
+      lines.push("## Routing Tiers")
+      lines.push("")
+      lines.push("| Tier | Units | Cost | Downgraded |")
+      lines.push("|------|-------|------|------------|")
+      for (const tier of data.byTier) {
+        lines.push(`| ${tier.tier} | ${tier.units} | ${formatCost(tier.cost)} | ${tier.downgraded} |`)
+      }
+      if (data.tierSavingsLine) lines.push(`\n${data.tierSavingsLine}`)
+      lines.push("")
+    }
+    lines.push("## Health")
+    lines.push("")
+    lines.push(`| Signal | Value |`)
+    lines.push(`|--------|-------|`)
+    lines.push(`| Token profile | ${data.health.tokenProfile} |`)
+    lines.push(`| Truncation | ${data.health.truncationRate.toFixed(1)}% |`)
+    lines.push(`| Continue-here | ${data.health.continueHereRate.toFixed(1)}% |`)
+    lines.push(`| Pending captures | ${data.captures.pendingCount} |`)
+    if (data.health.progressScore) {
+      lines.push(`| Progress score | ${data.health.progressScore.level}: ${data.health.progressScore.summary} |`)
+    }
+    lines.push("")
     if (data.criticalPath.milestonePath.length > 0) {
       lines.push("## Critical Path")
       lines.push("")
       lines.push(`Milestone: ${data.criticalPath.milestonePath.join(" → ")}`)
       if (data.criticalPath.slicePath.length > 0) {
         lines.push(`Slice: ${data.criticalPath.slicePath.join(" → ")}`)
+      }
+      lines.push("")
+    }
+    if (data.knowledge.exists) {
+      lines.push("## Knowledge")
+      lines.push("")
+      for (const rule of data.knowledge.rules) lines.push(`- Rule ${rule.id} [${rule.scope}]: ${rule.content}`)
+      for (const pattern of data.knowledge.patterns) lines.push(`- Pattern ${pattern.id}: ${pattern.content}`)
+      for (const lesson of data.knowledge.lessons) lines.push(`- Lesson ${lesson.id}: ${lesson.content}`)
+      lines.push("")
+    }
+    if (data.captures.entries.length > 0) {
+      lines.push("## Captures")
+      lines.push("")
+      for (const capture of data.captures.entries) {
+        const classification = capture.classification ? `, ${capture.classification}` : ""
+        lines.push(`- **${capture.id}** (${capture.status}${classification}): ${capture.text}`)
       }
       lines.push("")
     }
@@ -1052,6 +1724,15 @@ function ExportTab({ data }: { data: VisualizerData }) {
           for (const f of entry.filesModified) lines.push(`- \`${f.path}\` — ${f.description}`)
         }
         if (entry.completedAt) lines.push(`Completed: ${entry.completedAt}`)
+        const verification = findVerification(data, entry.milestoneId, entry.sliceId)
+        if (verification?.keyDecisions.length) {
+          lines.push("Decisions:")
+          for (const decision of verification.keyDecisions) lines.push(`- ${decision}`)
+        }
+        if (verification?.patternsEstablished.length) {
+          lines.push("Patterns:")
+          for (const pattern of verification.patternsEstablished) lines.push(`- ${pattern}`)
+        }
         lines.push("")
       }
     }
@@ -1067,8 +1748,8 @@ function ExportTab({ data }: { data: VisualizerData }) {
         <SectionLabel>Export Project Data</SectionLabel>
         <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
           Download the current visualizer data as a structured report. Markdown includes
-          milestones, metrics, critical path, and changelog in a readable format.
-          JSON contains the full raw data payload.
+          milestones, health, knowledge, captures, metrics, critical path, and changelog
+          in a readable format. JSON contains the full raw data payload.
         </p>
 
         <div className="mt-7 grid gap-4 sm:grid-cols-2">
@@ -1123,14 +1804,14 @@ function VisualizerTabs({
 
 function VisualizerTabList() {
   return (
-    <TabsPrimitive.List className="flex shrink-0 justify-center border-b border-border bg-background px-6">
+    <TabsPrimitive.List className="flex shrink-0 overflow-x-auto border-b border-border bg-background px-6">
       {TABS.map(({ value, label, Icon }) => (
         <TabsPrimitive.Trigger
           key={value}
           value={value}
           className={cn(
             // Base
-            "group relative flex items-center gap-2 px-4 py-3.5 text-sm font-medium outline-none",
+            "group relative flex shrink-0 items-center gap-2 px-3.5 py-3.5 text-sm font-medium outline-none",
             "text-muted-foreground transition-colors duration-150",
             // Hover
             "hover:text-foreground",
@@ -1291,6 +1972,9 @@ export function VisualizerView() {
             <TabsPrimitive.Content value="metrics" className="outline-none">
               <MetricsTab data={data} />
             </TabsPrimitive.Content>
+            <TabsPrimitive.Content value="health" className="outline-none">
+              <HealthTab data={data} />
+            </TabsPrimitive.Content>
             <TabsPrimitive.Content value="timeline" className="outline-none">
               <TimelineTab data={data} />
             </TabsPrimitive.Content>
@@ -1299,6 +1983,12 @@ export function VisualizerView() {
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="changes" className="outline-none">
               <ChangesTab data={data} />
+            </TabsPrimitive.Content>
+            <TabsPrimitive.Content value="knowledge" className="outline-none">
+              <KnowledgeTab data={data} />
+            </TabsPrimitive.Content>
+            <TabsPrimitive.Content value="captures" className="outline-none">
+              <CapturesTab data={data} />
             </TabsPrimitive.Content>
             <TabsPrimitive.Content value="export" className="outline-none">
               <ExportTab data={data} />

--- a/web/lib/__tests__/visualizer-types-contract.test.ts
+++ b/web/lib/__tests__/visualizer-types-contract.test.ts
@@ -1,0 +1,161 @@
+// GSD-2 Web — Tests for browser visualizer data helpers and current payload shape.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getCaptureStatusCounts,
+  type VisualizerData,
+} from "../visualizer-types.ts";
+
+function makeVisualizerData(overrides: Partial<VisualizerData> = {}): VisualizerData {
+  return {
+    milestones: [],
+    phase: "executing",
+    totals: null,
+    byPhase: [],
+    bySlice: [],
+    byModel: [],
+    byTier: [],
+    tierSavingsLine: "",
+    units: [],
+    criticalPath: {
+      milestonePath: [],
+      slicePath: [],
+      milestoneSlack: {},
+      sliceSlack: {},
+    },
+    remainingSliceCount: 0,
+    agentActivity: null,
+    changelog: { entries: [] },
+    sliceVerifications: [],
+    knowledge: { rules: [], patterns: [], lessons: [], exists: false },
+    captures: { entries: [], pendingCount: 0, totalCount: 0 },
+    health: {
+      budgetCeiling: undefined,
+      tokenProfile: "standard",
+      truncationRate: 0,
+      continueHereRate: 0,
+      tierBreakdown: [],
+      tierSavingsLine: "",
+      toolCalls: 0,
+      assistantMessages: 0,
+      userMessages: 0,
+      providers: [],
+      skillSummary: { total: 0, warningCount: 0, criticalCount: 0, topIssue: null },
+      environmentIssues: [],
+    },
+    discussion: [],
+    stats: {
+      missingCount: 0,
+      missingSlices: [],
+      updatedCount: 0,
+      updatedSlices: [],
+      recentEntries: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("visualizer browser payload contract", () => {
+  test("accepts the recent visualizer additions used by the browser view", () => {
+    const data = makeVisualizerData({
+      byTier: [
+        {
+          tier: "light",
+          units: 2,
+          tokens: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, total: 15 },
+          cost: 0.02,
+          downgraded: 1,
+        },
+      ],
+      tierSavingsLine: "Dynamic routing: 1/2 units downgraded",
+      sliceVerifications: [
+        {
+          milestoneId: "M001",
+          sliceId: "S01",
+          verificationResult: "passed",
+          blockerDiscovered: false,
+          keyDecisions: ["Keep browser data browser-safe"],
+          patternsEstablished: ["Mirror terminal visualizer tabs"],
+          provides: ["visualizer-contract"],
+          requires: [],
+        },
+      ],
+      knowledge: {
+        exists: true,
+        rules: [{ id: "K001", scope: "web", content: "Keep UI parity with terminal data." }],
+        patterns: [],
+        lessons: [],
+      },
+      captures: {
+        pendingCount: 1,
+        totalCount: 3,
+        entries: [
+          { id: "CAP-1", text: "Needs follow-up", timestamp: "2026-05-11T12:00:00Z", status: "pending" },
+          { id: "CAP-2", text: "Triaged", timestamp: "2026-05-11T12:01:00Z", status: "triaged" },
+          { id: "CAP-3", text: "Done", timestamp: "2026-05-11T12:02:00Z", status: "resolved" },
+        ],
+      },
+      health: {
+        budgetCeiling: 10,
+        tokenProfile: "standard",
+        truncationRate: 5,
+        continueHereRate: 0,
+        tierBreakdown: [],
+        tierSavingsLine: "",
+        toolCalls: 4,
+        assistantMessages: 3,
+        userMessages: 2,
+        providers: [],
+        skillSummary: { total: 1, warningCount: 0, criticalCount: 0, topIssue: null },
+        environmentIssues: [],
+        doctorHistory: [],
+        progressScore: { level: "green", summary: "healthy", signals: [] },
+      },
+      discussion: [
+        {
+          milestoneId: "M001",
+          title: "Visualizer",
+          state: "discussed",
+          hasContext: true,
+          hasDraft: false,
+          lastUpdated: "2026-05-11T12:00:00Z",
+        },
+      ],
+      stats: {
+        missingCount: 1,
+        missingSlices: [{ milestoneId: "M001", sliceId: "S02", title: "Remaining work" }],
+        updatedCount: 1,
+        updatedSlices: [{ milestoneId: "M001", sliceId: "S01", title: "Browser parity", completedAt: "2026-05-11T12:00:00Z" }],
+        recentEntries: [],
+      },
+    });
+
+    assert.equal(data.byTier[0]?.downgraded, 1);
+    assert.equal(data.health.progressScore?.level, "green");
+    assert.equal(data.knowledge.rules[0]?.scope, "web");
+    assert.equal(data.discussion[0]?.state, "discussed");
+  });
+
+  test("counts empty and populated capture states without relying on totals", () => {
+    assert.deepEqual(
+      getCaptureStatusCounts({ entries: [], pendingCount: 0, totalCount: 0 }),
+      { pending: 0, triaged: 0, resolved: 0 },
+    );
+
+    assert.deepEqual(
+      getCaptureStatusCounts({
+        pendingCount: 1,
+        totalCount: 4,
+        entries: [
+          { id: "CAP-1", text: "One", timestamp: "2026-05-11T12:00:00Z", status: "pending" },
+          { id: "CAP-2", text: "Two", timestamp: "2026-05-11T12:01:00Z", status: "triaged" },
+          { id: "CAP-3", text: "Three", timestamp: "2026-05-11T12:02:00Z", status: "resolved" },
+          { id: "CAP-4", text: "Four", timestamp: "2026-05-11T12:03:00Z", status: "resolved" },
+        ],
+      }),
+      { pending: 1, triaged: 1, resolved: 2 },
+    );
+  });
+});

--- a/web/lib/visualizer-types.ts
+++ b/web/lib/visualizer-types.ts
@@ -1,4 +1,4 @@
-// Browser-safe TypeScript interfaces for the workflow visualizer.
+// GSD-2 Web — Browser-safe TypeScript interfaces for the workflow visualizer.
 // Mirrors upstream types from src/resources/extensions/gsd/visualizer-data.ts
 // and src/resources/extensions/gsd/metrics.ts — do NOT import from those
 // modules directly, as they use Node.js APIs unavailable in the browser.
@@ -10,6 +10,7 @@ export interface VisualizerTask {
   title: string
   done: boolean
   active: boolean
+  estimate?: string
 }
 
 export interface VisualizerSlice {
@@ -68,6 +69,133 @@ export interface ChangelogInfo {
   entries: ChangelogEntry[]
 }
 
+export interface VisualizerSliceRef {
+  milestoneId: string
+  sliceId: string
+  title: string
+}
+
+export interface VisualizerSliceActivity extends VisualizerSliceRef {
+  completedAt: string
+}
+
+export interface VisualizerStats {
+  missingCount: number
+  missingSlices: VisualizerSliceRef[]
+  updatedCount: number
+  updatedSlices: VisualizerSliceActivity[]
+  recentEntries: ChangelogEntry[]
+}
+
+export type DiscussionState = "undiscussed" | "draft" | "discussed"
+
+export interface VisualizerDiscussionState {
+  milestoneId: string
+  title: string
+  state: DiscussionState
+  hasContext: boolean
+  hasDraft: boolean
+  lastUpdated: string | null
+}
+
+export interface SliceVerification {
+  milestoneId: string
+  sliceId: string
+  verificationResult: string
+  blockerDiscovered: boolean
+  keyDecisions: string[]
+  patternsEstablished: string[]
+  provides: string[]
+  requires: { slice: string; provides: string }[]
+}
+
+export interface KnowledgeInfo {
+  rules: { id: string; scope: string; content: string }[]
+  patterns: { id: string; content: string }[]
+  lessons: { id: string; content: string }[]
+  exists: boolean
+}
+
+export type CaptureClassification = "quick-task" | "inject" | "defer" | "replan" | "note" | "stop" | "backtrack"
+
+export interface CaptureEntry {
+  id: string
+  text: string
+  timestamp: string
+  status: "pending" | "triaged" | "resolved"
+  classification?: CaptureClassification
+  resolution?: string
+  rationale?: string
+  resolvedAt?: string
+  resolvedInMilestone?: string
+  executed?: boolean
+}
+
+export interface CapturesInfo {
+  entries: CaptureEntry[]
+  pendingCount: number
+  totalCount: number
+}
+
+export interface ProviderStatusSummary {
+  name: string
+  label: string
+  category: string
+  ok: boolean
+  required: boolean
+  message: string
+}
+
+export interface SkillSummaryInfo {
+  total: number
+  warningCount: number
+  criticalCount: number
+  topIssue: string | null
+}
+
+export interface EnvironmentCheckResult {
+  name: string
+  status: "ok" | "warning" | "error"
+  message: string
+  detail?: string
+}
+
+export interface VisualizerDoctorEntry {
+  ts: string
+  ok: boolean
+  errors: number
+  warnings: number
+  fixes: number
+  codes: string[]
+  issues?: Array<{ severity: string; code: string; message: string; unitId: string }>
+  fixDescriptions?: string[]
+  scope?: string
+  summary?: string
+}
+
+export interface VisualizerProgressScore {
+  level: "green" | "yellow" | "red"
+  summary: string
+  signals: Array<{ kind: "positive" | "negative" | "neutral"; label: string }>
+}
+
+export interface HealthInfo {
+  budgetCeiling: number | undefined
+  tokenProfile: string
+  truncationRate: number
+  continueHereRate: number
+  tierBreakdown: TierAggregate[]
+  tierSavingsLine: string
+  toolCalls: number
+  assistantMessages: number
+  userMessages: number
+  providers: ProviderStatusSummary[]
+  skillSummary: SkillSummaryInfo
+  environmentIssues: EnvironmentCheckResult[]
+  doctorHistory?: VisualizerDoctorEntry[]
+  progressScore?: VisualizerProgressScore | null
+}
+
 // ─── Metrics ──────────────────────────────────────────────────────────────────
 
 export interface TokenCounts {
@@ -84,15 +212,23 @@ export interface UnitMetrics {
   model: string
   startedAt: number
   finishedAt: number
+  autoSessionKey?: string
   tokens: TokenCounts
   cost: number
   toolCalls: number
   assistantMessages: number
   userMessages: number
+  apiRequests?: number
   contextWindowTokens?: number
   truncationSections?: number
   continueHereFired?: boolean
   promptCharCount?: number
+  baselineCharCount?: number
+  tier?: string
+  modelDowngraded?: boolean
+  skills?: string[]
+  cacheHitRate?: number
+  compressionSavings?: number
 }
 
 export interface PhaseAggregate {
@@ -119,6 +255,14 @@ export interface ModelAggregate {
   contextWindowTokens?: number
 }
 
+export interface TierAggregate {
+  tier: string
+  units: number
+  tokens: TokenCounts
+  cost: number
+  downgraded: number
+}
+
 export interface ProjectTotals {
   units: number
   tokens: TokenCounts
@@ -127,6 +271,7 @@ export interface ProjectTotals {
   toolCalls: number
   assistantMessages: number
   userMessages: number
+  apiRequests: number
   totalTruncationSections: number
   continueHereFiredCount: number
 }
@@ -140,11 +285,19 @@ export interface VisualizerData {
   byPhase: PhaseAggregate[]
   bySlice: SliceAggregate[]
   byModel: ModelAggregate[]
+  byTier: TierAggregate[]
+  tierSavingsLine: string
   units: UnitMetrics[]
   criticalPath: CriticalPathInfo
   remainingSliceCount: number
   agentActivity: AgentActivityInfo | null
   changelog: ChangelogInfo
+  sliceVerifications: SliceVerification[]
+  knowledge: KnowledgeInfo
+  captures: CapturesInfo
+  health: HealthInfo
+  discussion: VisualizerDiscussionState[]
+  stats: VisualizerStats
 }
 
 // ─── Formatting Utilities ─────────────────────────────────────────────────────
@@ -176,4 +329,19 @@ export function formatDuration(ms: number): string {
   const hours = Math.floor(minutes / 60)
   const remainingMinutes = minutes % 60
   return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`
+}
+
+/** Count captures by status for visualizer summary surfaces. */
+export function getCaptureStatusCounts(captures: CapturesInfo): Record<CaptureEntry["status"], number> {
+  const counts: Record<CaptureEntry["status"], number> = {
+    pending: 0,
+    triaged: 0,
+    resolved: 0,
+  }
+
+  for (const entry of captures.entries) {
+    counts[entry.status] += 1
+  }
+
+  return counts
 }


### PR DESCRIPTION
## TL;DR

**What:** Updates `/gsd visualize` in web mode and docs to cover the current 10-tab visualizer surface.
**Why:** The browser visualizer and docs were behind the terminal visualizer’s recent additions.
**How:** Mirrors the newer payload fields in browser-safe types, adds the missing web tabs/sections, and updates docs plus focused tests.

Closes #5825

## What

- Adds browser visualizer surfaces for Health, Knowledge, and Captures, and expands existing tabs with feature snapshot, discussion status, data flow, routing-tier metrics, pressure signals, and verification details.
- Updates the browser-safe visualizer data contract to include recent payload additions from the terminal visualizer data loader.
- Adds a `node:test` contract for the browser payload additions and capture status counting.
- Refreshes user, GitBook, Mintlify, and architecture docs to describe the 10-tab visualizer.

## Why

`/gsd visualize` had drifted between surfaces: terminal command help referenced the newer visualizer, but the web visualizer and docs still described the older four/seven-tab shape. That made recent additions harder to discover and left web mode behind the underlying visualizer data.

## How

The web view now consumes the same recent visualizer fields already returned by the API and renders them with the existing dashboard/card patterns. Docs now list the current tab order and controls. The new test locks the browser-safe payload shape so future visualizer data additions are less likely to be missed.

## Validation

- [x] `npm --prefix web run test`
- [x] `npm --prefix web run build`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/visualizer-data.test.ts src/resources/extensions/gsd/tests/visualizer-views.test.ts src/resources/extensions/gsd/tests/visualizer-overlay.test.ts`
- [x] Playwright browser smoke against local web dev server
- [x] `git diff --cached --check`

## Notes

`npx tsc --noEmit --project web/tsconfig.json` is currently blocked by an unrelated existing `src/resources/extensions/gsd/git-constants.ts` `ProcessEnv` error.

Disclosure: AI-assisted. No AI author or co-author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Workflow Visualizer: added Health, Knowledge, and Captures tabs; richer Progress, Dependencies, Metrics, Changes, and Export content; verification-derived badges/decisions, optional task estimates, header search, and keyboard help with `/`, `?`, and `0–9` tab jumps.

* **Documentation**
  * Updated architecture, command reference, user guides, and site docs to reflect visualizer UI, controls, metrics, and export changes.

* **Tests**
  * Added contract tests validating visualizer payload shape and capture-status counting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5826)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->