### PR TITLE
Add resumable isolated subagent orchestration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Simplified Chinese translation: [`zh-CN/`](./zh-CN/).
 | [Cost Management](./user-docs/cost-management.md) | Budget ceilings, cost tracking, projections, and enforcement modes |
 | [Git Strategy](./user-docs/git-strategy.md) | Worktree isolation, branching model, and merge behavior |
 | [Parallel Orchestration](./user-docs/parallel-orchestration.md) | Run multiple milestones simultaneously with worker isolation and coordination |
+| [Subagents](./user-docs/subagents.md) | Delegate, inspect, and resume isolated child-agent runs |
 | [Working in Teams](./user-docs/working-in-teams.md) | Unique milestone IDs, `.gitignore` setup, and shared planning artifacts |
 | [Skills](./user-docs/skills.md) | Bundled skills, skill discovery, and custom skill authoring |
 | [Migration from v1](./user-docs/migration.md) | Migrating `.planning` directories from the original GSD |

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -180,6 +180,12 @@ Install sources are auto-detected: starts with `http(s)://` or ends with `.git` 
 | `/gsd cmux sidebar on/off` | Toggle cmux sidebar metadata |
 | `/gsd cmux splits on/off` | Toggle cmux visual subagent splits |
 
+## Subagents
+
+| Command | Description |
+|---------|-------------|
+| `/subagent` | List available user and project subagents. Run records, status checks, and follow-up resume are handled through the `subagent` tool; see [Subagents](./subagents.md). |
+
 ## GitHub Sync (v2.39)
 
 | Command | Description |

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -359,6 +359,24 @@ Defaults and tuning:
 
 When `enabled` is omitted, reactive execution uses the default-on safety threshold of three ready tasks before it attempts a parallel batch. When `enabled: true` is set explicitly, GSD uses the earlier opt-in threshold of two ready tasks.
 
+### `taskIsolation`
+
+Controls optional filesystem isolation for explicit subagent tool calls that set `isolated: true`. This is a global `~/.gsd/agent/settings.json` setting.
+
+```json
+{
+  "taskIsolation": {
+    "mode": "worktree"
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | string | none | `"worktree"` creates a temporary detached git worktree for the child task. `"fuse-overlay"` uses `fuse-overlayfs` on Linux when installed and falls back to `worktree`. Any other value disables subagent filesystem isolation. |
+
+See [Subagents](./subagents.md#filesystem-isolation) for invocation, merge, and recovery behavior.
+
 ### `skill_discovery`
 
 Controls how GSD finds and applies skills during auto mode.

--- a/docs/user-docs/subagents.md
+++ b/docs/user-docs/subagents.md
@@ -1,0 +1,174 @@
+# Subagents
+
+Subagents delegate focused work to separate agent processes. Each child gets its own context window, model selection, tools, and system prompt, while the parent session receives the final answer, usage data, and a durable run record that can be inspected later.
+
+Use subagents for bounded work such as codebase scouting, implementation, review, security checks, doc writing, or independent task batches. Auto mode may also dispatch subagents during reactive task execution when ready tasks do not depend on each other.
+
+## Available Agents
+
+List agents from an active session:
+
+```text
+/subagent
+```
+
+Agents are Markdown files loaded from:
+
+| Location | Scope |
+|----------|-------|
+| `~/.gsd/agent/agents/` | User-wide agents |
+| `.gsd/agents/` | Project-local agents |
+
+Project-local agents are repository-controlled. For trusted-repo prompts, the parent can set `confirmProjectAgents: true` so GSD asks before running project-local agents.
+
+## Invocation Modes
+
+The `subagent` tool supports three launch shapes:
+
+```json
+{ "agent": "scout", "task": "Find the files involved in auth redirects." }
+```
+
+```json
+{
+  "tasks": [
+    { "agent": "tester", "task": "Run focused API tests and report failures." },
+    { "agent": "reviewer", "task": "Review the changed auth files for regressions." }
+  ]
+}
+```
+
+```json
+{
+  "chain": [
+    { "agent": "scout", "task": "Map the checkout flow." },
+    { "agent": "planner", "task": "Create an implementation plan from this context: {previous}" },
+    { "agent": "worker", "task": "Implement the plan: {previous}" }
+  ]
+}
+```
+
+Single mode runs one child. Parallel mode runs independent tasks concurrently, with a maximum of eight tasks and an execution concurrency cap of four. Chain mode runs steps sequentially and replaces `{previous}` with the prior step's output.
+
+Optional fields:
+
+| Field | Applies to | Description |
+|-------|------------|-------------|
+| `agentScope` | all modes | `"user"`, `"project"`, or `"both"`; default is `"both"` |
+| `model` | all modes | Model override for the child process |
+| `cwd` | single, task, or chain step | Working directory for that child |
+| `context` | all modes, task, or chain step | `"fresh"` or `"fork"`; default is `"fresh"` |
+| `background` | single mode | Return immediately and persist progress for later `status` checks |
+| `isolated` | launch | Run through the configured filesystem isolation backend before merging patches back |
+
+## Context Modes
+
+`context: "fresh"` is the default. The child starts with the agent's prompt and the delegated task, keeping the parent conversation out of the child context.
+
+`context: "fork"` branches from the current parent session. Use it when the child needs the exact conversation state, selected files, or prior decisions. Forked context requires a persisted parent session and a current session leaf; in-memory sessions cannot be forked.
+
+Child processes are marked with `GSD_SUBAGENT_CHILD=1`, which suppresses recursive subagent registration inside the child.
+
+## Background Runs
+
+For a long single-agent task, launch in the background:
+
+```json
+{
+  "agent": "tester",
+  "task": "Run the full regression suite and summarize failures.",
+  "background": true
+}
+```
+
+The tool returns a run id:
+
+```text
+Started background subagent run <runId>. Use action: "status" with runId: "<runId>" to inspect it.
+```
+
+Check the persisted run:
+
+```json
+{ "action": "status", "runId": "<runId>" }
+```
+
+Status output includes the run status, mode, context mode, update time, child status, exit code, output or error, and the child session file when one exists.
+
+## Resume And Follow-Up
+
+Resume follows up inside a child session captured by a previous run:
+
+```json
+{
+  "action": "resume",
+  "runId": "<runId>",
+  "followUp": "Apply the smallest fix for the failing test and report changed files."
+}
+```
+
+If the run has more than one resumable child session, include the agent selector:
+
+```json
+{
+  "action": "resume",
+  "runId": "<runId>",
+  "agent": "tester",
+  "followUp": "Re-run only the failing tests."
+}
+```
+
+Resume requires a run record with exactly one matching child session file. If no run exists, no child session was recorded, or multiple child sessions match without an `agent` selector, GSD returns a hard error instead of guessing.
+
+## Run State
+
+Subagent run records are JSON files stored under:
+
+```text
+~/.gsd/agent/subagent-runs/<runId>.json
+```
+
+`GSD_HOME` and `GSD_CODING_AGENT_DIR` can move this location; the store uses the active GSD agent directory returned by the runtime. Each record contains:
+
+| Field | Meaning |
+|-------|---------|
+| `runId` | Unique dispatch id |
+| `mode` | `single`, `parallel`, or `chain` |
+| `contextMode` | `fresh` or `fork` |
+| `status` | `running`, `succeeded`, `failed`, or `interrupted` |
+| `cwd` | Parent working directory for the dispatch |
+| `children` | Per-child agent, task, cwd, status, session file, output, stderr, usage, model, and merge result |
+| `failure` | Failure category and message when the run did not succeed |
+
+The persisted record is the operational source for `status` and `resume`. The child session JSONL file remains the source for conversation continuation.
+
+## Filesystem Isolation
+
+By default, subagents run in the selected working directory and can edit that checkout according to their tool permissions.
+
+Set `isolated: true` to request task-level filesystem isolation. Isolation only activates when global settings contain a supported backend:
+
+```json
+{
+  "taskIsolation": {
+    "mode": "worktree"
+  }
+}
+```
+
+Supported modes are:
+
+| Mode | Behavior |
+|------|----------|
+| `worktree` | Creates a detached git worktree under `~/.gsd/wt/<encoded-cwd>/<task-id>/`, snapshots parent dirty state into it, captures the child delta, applies the patch back to the parent checkout, then removes the worktree |
+| `fuse-overlay` | Uses `fuse-overlayfs` on Linux when available, otherwise falls back to `worktree` |
+
+If `taskIsolation.mode` is unset or invalid, `isolated: true` is ignored and the child runs in the normal working directory. If patch merge fails, the run is marked failed and the merge result lists applied and failed patches.
+
+## Recovery Behavior
+
+When the parent session shuts down, GSD sends `SIGTERM` to live child processes and then `SIGKILL` to any process that does not exit promptly. Completed, failed, and interrupted child evidence is written to the run record when available.
+
+Use `status` first after an interruption. If a child session file was recorded, use `resume` with a follow-up instruction to continue that child's conversation. If the child never launched far enough to create a session file, relaunch the task from the parent with a new `launch` action.
+
+Subagent run records are local machine state, not a team artifact. They are intended for same-host recovery and inspection; do not rely on them as shared project documentation.

--- a/docs/user-docs/subagents.md
+++ b/docs/user-docs/subagents.md
@@ -95,6 +95,8 @@ Check the persisted run:
 
 Status output includes the run status, mode, context mode, update time, child status, exit code, output or error, and the child session file when one exists.
 
+Each child is also assigned a random tracking name, shown as `<tracking-name> / <agent>`. The name is only for human tracking in status and result output; agent selection still uses the configured agent id.
+
 ## Resume And Follow-Up
 
 Resume follows up inside a child session captured by a previous run:
@@ -137,7 +139,7 @@ Subagent run records are JSON files stored under:
 | `contextMode` | `fresh` or `fork` |
 | `status` | `running`, `succeeded`, `failed`, or `interrupted` |
 | `cwd` | Parent working directory for the dispatch |
-| `children` | Per-child agent, task, cwd, status, session file, output, stderr, usage, model, and merge result |
+| `children` | Per-child tracking name, agent, task, cwd, status, session file, output, stderr, usage, model, and merge result |
 | `failure` | Failure category and message when the run did not succeed |
 
 The persisted record is the operational source for `status` and `resume`. The child session JSONL file remains the source for conversation continuation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "cross-env": "^7.0.3",
         "esbuild": "^0.25.12",
         "jiti": "^2.6.1",
-        "typescript": "^5.4.0"
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -3980,7 +3980,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4541,7 +4540,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6300,7 +6298,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6418,7 +6415,6 @@
     "packages/pi-coding-agent": {
       "name": "@gsd/pi-coding-agent",
       "version": "2.82.0",
-      "peer": true,
       "dependencies": {
         "@gsd-build/contracts": "^2.80.0",
         "@mariozechner/jiti": "^2.6.2",
@@ -6448,7 +6444,6 @@
     "packages/pi-tui": {
       "name": "@gsd/pi-tui",
       "version": "2.82.0",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.6.2",
         "get-east-asian-width": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "cross-env": "^7.0.3",
     "esbuild": "^0.25.12",
     "jiti": "^2.6.1",
-    "typescript": "^5.4.0"
+    "typescript": "^5.9.3"
   },
   "optionalDependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.2.83",

--- a/src/resources/extensions/cmux/index.ts
+++ b/src/resources/extensions/cmux/index.ts
@@ -374,6 +374,12 @@ export class CmuxClient {
     const stdout = await this.runAsync(["send-surface", "--surface", surfaceId, payload]);
     return stdout !== null;
   }
+
+  // Send Ctrl-C (ETX) to a surface to interrupt the running command.
+  async sendInterrupt(surfaceId: string): Promise<boolean> {
+    const stdout = await this.runAsync(["send-surface", "--surface", surfaceId, "\x03"]);
+    return stdout !== null;
+  }
 }
 
 export function syncCmuxSidebar(preferences: CmuxPreferences | undefined, state: CmuxState): void {

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -3197,7 +3197,7 @@ export async function buildParallelResearchSlicesPrompt(
     subagentSections.push([
       `### ${slice.id}: ${slice.title}`,
       "",
-      `Use this as the prompt for a \`subagent\` call${modelSuffix} (agent: \`gsd-executor\` or the default agent):`,
+      `Use this as the prompt for a \`subagent\` call${modelSuffix} (agent: \`scout\`):`,
       "",
       "```",
       slicePrompt,
@@ -3279,7 +3279,7 @@ export async function buildGateEvaluatePrompt(
     subagentSections.push([
       `### ${def.id}: ${def.question}`,
       "",
-      `Use this as the prompt for a \`subagent\` call${modelSuffix}:`,
+      `Use this as the prompt for a \`subagent\` call${modelSuffix} (agent: \`tester\`):`,
       "",
       "```",
       subPrompt,

--- a/src/resources/extensions/gsd/bootstrap/subagent-input.ts
+++ b/src/resources/extensions/gsd/bootstrap/subagent-input.ts
@@ -2,6 +2,7 @@ export function extractSubagentAgentClasses(input: unknown): string[] {
   if (!input || typeof input !== "object") return [];
 
   const agentClasses: string[] = [];
+  const visited = new WeakSet<object>();
   const addAgentClass = (value: unknown): void => {
     if (typeof value === "string" && value.trim().length > 0) agentClasses.push(value.trim());
   };
@@ -15,6 +16,8 @@ export function extractSubagentAgentClasses(input: unknown): string[] {
 
   const visit = (value: unknown): void => {
     if (!value || typeof value !== "object") return;
+    if (visited.has(value)) return;
+    visited.add(value);
     const record = value as Record<string, unknown>;
     addAgentClass(record.agent);
     visitItems(record.tasks);

--- a/src/resources/extensions/gsd/bootstrap/subagent-input.ts
+++ b/src/resources/extensions/gsd/bootstrap/subagent-input.ts
@@ -1,20 +1,27 @@
 export function extractSubagentAgentClasses(input: unknown): string[] {
   if (!input || typeof input !== "object") return [];
 
-  const record = input as Record<string, unknown>;
   const agentClasses: string[] = [];
   const addAgentClass = (value: unknown): void => {
     if (typeof value === "string" && value.trim().length > 0) agentClasses.push(value.trim());
   };
-  const addFromItems = (value: unknown): void => {
+
+  const visitItems = (value: unknown): void => {
     if (!Array.isArray(value)) return;
     for (const item of value) {
-      if (item && typeof item === "object") addAgentClass((item as Record<string, unknown>).agent);
+      visit(item);
     }
   };
 
-  addAgentClass(record.agent);
-  addFromItems(record.tasks);
-  addFromItems(record.chain);
+  const visit = (value: unknown): void => {
+    if (!value || typeof value !== "object") return;
+    const record = value as Record<string, unknown>;
+    addAgentClass(record.agent);
+    visitItems(record.tasks);
+    visitItems(record.chain);
+    visitItems(record.parallel);
+  };
+
+  visit(input);
   return agentClasses;
 }

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -5,7 +5,7 @@ import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { minimatch } from "minimatch";
 
 import { getIsolationMode } from "../preferences.js";
-import type { ToolsPolicy } from "../unit-context-manifest.js";
+import { compileSubagentPermissionContract, type ToolsPolicy } from "../unit-context-manifest.js";
 import { logWarning } from "../workflow-logger.js";
 import { isGsdWorktreePath, resolveWorktreeProjectRoot } from "../worktree-root.js";
 
@@ -811,7 +811,8 @@ export function shouldBlockPlanningUnit(
   if (PLANNING_SUBAGENT_TOOLS.has(tool)) {
     if (policy.mode === "planning-dispatch") {
       const requested = (agentClasses ?? []).map(a => a.trim()).filter(Boolean);
-      const allowedSubagents = Array.isArray(policy.allowedSubagents) ? policy.allowedSubagents : [];
+      const dispatchContract = compileSubagentPermissionContract(policy);
+      const allowedSubagents = dispatchContract.allowedSubagents;
       const allowed = new Set(allowedSubagents);
       // When agentClasses is undefined, the caller has not been updated to extract
       // agent identities yet. Block and warn so stale callers surface in telemetry

--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -7,6 +7,7 @@ import {
   ARTIFACT_KEYS,
   KNOWN_UNIT_TYPES,
   UNIT_MANIFESTS,
+  resolveSubagentPermissionContract,
   resolveManifest,
   type ArtifactKey,
   type ContextModePolicy,
@@ -244,9 +245,11 @@ test('#4934: only execute-task and reactive-execute may use tools.mode "all" (fu
 test('planning-dispatch mode is reserved for slice-level decomposition and completion units', () => {
   const allowedDispatchUnits = new Set([
     "plan-slice",
+    "research-slice",
     "refine-slice",
     "complete-slice",
     "complete-milestone",
+    "gate-evaluate",
     // Deep planning mode: research-project orchestrates 4 parallel research
     // subagents (stack/features/architecture/pitfalls). Subagent dispatch is
     // the unit's core mechanism — without it, the unit cannot do its job.
@@ -263,6 +266,24 @@ test('planning-dispatch mode is reserved for slice-level decomposition and compl
       );
     }
   }
+});
+
+test('Unit Tool Contract exposes subagent dispatch permissions', () => {
+  assert.deepEqual(resolveSubagentPermissionContract("plan-slice"), {
+    allowed: true,
+    allowedSubagents: ["scout", "planner"],
+    toolsMode: "planning-dispatch",
+  });
+  assert.deepEqual(resolveSubagentPermissionContract("gate-evaluate"), {
+    allowed: true,
+    allowedSubagents: ["reviewer", "security", "tester"],
+    toolsMode: "planning-dispatch",
+  });
+  assert.deepEqual(resolveSubagentPermissionContract("discuss-milestone"), {
+    allowed: false,
+    allowedSubagents: [],
+    toolsMode: "planning",
+  });
 });
 
 test('planning-dispatch manifests declare non-empty allowedSubagents lists', () => {

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -172,6 +172,15 @@ test('planning-dispatch: extracts subagent classes from single, parallel, and ch
     extractSubagentAgentClasses({ chain: [{ agent: 'reviewer' }, { agent: 'security' }] }),
     ['reviewer', 'security'],
   );
+  assert.deepEqual(
+    extractSubagentAgentClasses({
+      chain: [
+        { agent: 'scout' },
+        { parallel: [{ agent: 'reviewer' }, { agent: ' security ' }] },
+      ],
+    }),
+    ['scout', 'reviewer', 'security'],
+  );
 });
 
 test('planning-dispatch: blocks subagent dispatch when agentClasses is undefined (stale caller shim)', () => {

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -183,6 +183,13 @@ test('planning-dispatch: extracts subagent classes from single, parallel, and ch
   );
 });
 
+test('planning-dispatch: extracts subagent classes without recursing through cycles', () => {
+  const input: { agent: string; parallel?: unknown[] } = { agent: 'scout' };
+  input.parallel = [input, { agent: 'reviewer' }];
+
+  assert.deepEqual(extractSubagentAgentClasses(input), ['scout', 'reviewer']);
+});
+
 test('planning-dispatch: blocks subagent dispatch when agentClasses is undefined (stale caller shim)', () => {
   const r = shouldBlockPlanningUnit('subagent', '', BASE, 'plan-slice', PLANNING_DISPATCH, undefined);
   assert.strictEqual(r.block, true);

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -447,7 +447,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     codebaseMap: true,
     preferences: "active-only",
     contextMode: "research",
-    tools: TOOLS_PLANNING,
+    // Multi-slice research dispatches use the research-slice unit contract to
+    // fan out scout subagents that write .gsd research artifacts.
+    tools: TOOLS_PLANNING_DISPATCH_RECON,
     artifacts: {
       inline: ["roadmap", "milestone-research", "dependency-summaries", "templates"],
       excerpt: [],
@@ -606,7 +608,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     codebaseMap: false,
     preferences: "active-only",
     contextMode: "verification",
-    tools: TOOLS_PLANNING,
+    // Gate evaluation fans out tester-style subagents, which read the slice
+    // plan and report via the DB-backed gate-result tool.
+    tools: TOOLS_PLANNING_DISPATCH_REVIEW,
     artifacts: {
       inline: ["slice-plan", "prior-task-summaries"],
       excerpt: [],
@@ -733,4 +737,33 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
  */
 export function resolveManifest(unitType: string): UnitContextManifest | null {
   return (UNIT_MANIFESTS as Record<string, UnitContextManifest>)[unitType] ?? null;
+}
+
+export interface SubagentPermissionContract {
+  readonly allowed: boolean;
+  readonly allowedSubagents: readonly string[];
+  readonly toolsMode: ToolsPolicy["mode"] | "unknown";
+}
+
+export function compileSubagentPermissionContract(
+  policy: ToolsPolicy | null | undefined,
+): SubagentPermissionContract {
+  if (!policy) {
+    return { allowed: false, allowedSubagents: [], toolsMode: "unknown" };
+  }
+  if (policy.mode === "all") {
+    return { allowed: true, allowedSubagents: ["*"], toolsMode: policy.mode };
+  }
+  if (policy.mode === "planning-dispatch") {
+    return {
+      allowed: true,
+      allowedSubagents: [...policy.allowedSubagents],
+      toolsMode: policy.mode,
+    };
+  }
+  return { allowed: false, allowedSubagents: [], toolsMode: policy.mode };
+}
+
+export function resolveSubagentPermissionContract(unitType: string): SubagentPermissionContract {
+  return compileSubagentPermissionContract(resolveManifest(unitType)?.tools);
 }

--- a/src/resources/extensions/subagent/index.ts
+++ b/src/resources/extensions/subagent/index.ts
@@ -671,9 +671,25 @@ async function runSingleAgentInCmuxSplit(
 
 		const finished = await waitForFile(exitPath, signal);
 		if (!finished) {
+			// Terminate the child running inside the cmux split: send Ctrl-C
+			// so bash interrupts the pipeline and writes the exit code, instead
+			// of leaving an orphaned subagent that can keep editing after cancel.
+			try {
+				await cmuxClient.sendInterrupt(cmuxSurfaceId);
+			} catch {
+				/* ignore — best-effort */
+			}
+			// Give the shell a brief window to reap the killed child and write exit.code.
+			await waitForFile(exitPath, undefined, 5000);
 			currentResult.exitCode = 1;
 			currentResult.running = false;
 			currentResult.stderr = "cmux split execution timed out or was aborted";
+			if (fs.existsSync(stdoutPath)) {
+				const stdout = fs.readFileSync(stdoutPath, "utf-8");
+				for (const line of stdout.split("\n")) {
+					processSubagentEventLine(line, currentResult, emitUpdate);
+				}
+			}
 			return currentResult;
 		}
 
@@ -892,11 +908,10 @@ export default function (pi: ExtensionAPI) {
 					};
 				}
 				const sessionChildren = record.children.filter((child) => child.sessionFile);
-				const selected = params.agent
-					? sessionChildren.find((child) => child.agent === params.agent)
-					: sessionChildren.length === 1
-						? sessionChildren[0]
-						: undefined;
+				const matches = params.agent
+					? sessionChildren.filter((child) => child.agent === params.agent)
+					: sessionChildren;
+				const selected = matches.length === 1 ? matches[0] : undefined;
 				if (!selected?.sessionFile) {
 					const available = sessionChildren.map((child) => formatAgentLabel(child.agent, child.trackingName)).join(", ") || "none";
 					return {
@@ -988,13 +1003,17 @@ export default function (pi: ExtensionAPI) {
 						? taskParams[index]?.cwd
 						: params.cwd,
 			}));
-			runStore.create(createInitialRunRecord({
-				runId: dispatchId,
-				mode: dispatchMode as SubagentRunMode,
-				contextMode: dispatchContextMode,
-				cwd: ctx.cwd,
-				children: dispatchChildren,
-			}));
+			try {
+				runStore.create(createInitialRunRecord({
+					runId: dispatchId,
+					mode: dispatchMode as SubagentRunMode,
+					contextMode: dispatchContextMode,
+					cwd: ctx.cwd,
+					children: dispatchChildren,
+				}));
+			} catch {
+				// Persistence is observability; execution remains authoritative.
+			}
 
 			const persistRunResults = (results: SingleResult[], completed = false): void => {
 				try {

--- a/src/resources/extensions/subagent/index.ts
+++ b/src/resources/extensions/subagent/index.ts
@@ -38,6 +38,24 @@ import { registerWorker, updateWorker } from "./worker-registry.js";
 import { loadEffectiveGSDPreferences } from "../gsd/preferences.js";
 import { emitJournalEvent } from "../gsd/journal.js";
 import { CmuxClient, shellEscape } from "../cmux/index.js";
+import {
+	buildShellEnvAssignments,
+	buildSubagentProcessArgs,
+	createSubagentLaunchPlan,
+	isSubagentChildProcess,
+	type SubagentContextMode,
+	type SubagentSessionArgs,
+} from "./launch.js";
+import {
+	SubagentRunStore,
+	createInitialRunRecord,
+	deriveRunStatus,
+	type SubagentChildArtifact,
+	type SubagentRunMode,
+	type SubagentRunStatus,
+} from "./run-store.js";
+
+export { buildSubagentProcessArgs } from "./launch.js";
 
 const MAX_PARALLEL_TASKS = 8;
 const MAX_CONCURRENCY = 4;
@@ -196,6 +214,8 @@ interface SingleResult {
 	model?: string;
 	stopReason?: string;
 	errorMessage?: string;
+	sessionFile?: string;
+	mergeResult?: MergeResult;
 	step?: number;
 }
 
@@ -261,21 +281,6 @@ function writePromptToTempFile(agentName: string, prompt: string): { dir: string
 	return { dir: tmpDir, filePath };
 }
 
-export function buildSubagentProcessArgs(
-	agent: AgentConfig,
-	task: string,
-	tmpPromptPath: string | null,
-	modelOverride?: string,
-): string[] {
-	const args: string[] = ["--mode", "json", "-p", "--no-session"];
-	const effectiveModel = modelOverride ?? agent.model;
-	if (effectiveModel) args.push("--model", effectiveModel);
-	if (agent.tools && agent.tools.length > 0) args.push("--tools", agent.tools.join(","));
-	if (tmpPromptPath) args.push("--append-system-prompt", tmpPromptPath);
-	args.push(`Task: ${task}`);
-	return args;
-}
-
 function processSubagentEventLine(
 	line: string,
 	currentResult: SingleResult,
@@ -329,6 +334,65 @@ async function waitForFile(filePath: string, signal: AbortSignal | undefined, ti
 
 type OnUpdateCallback = (partial: AgentToolResult<SubagentDetails>) => void;
 
+interface TaskParam {
+	agent: string;
+	task: string;
+	cwd?: string;
+	model?: string;
+	context?: SubagentContextMode;
+}
+
+interface ChainParam extends TaskParam {}
+
+function resultStatus(result: SingleResult): SubagentRunStatus {
+	if (result.stopReason === "aborted") return "interrupted";
+	return result.exitCode === 0 ? "succeeded" : "failed";
+}
+
+function resultToChildArtifact(result: SingleResult, index: number, cwd?: string): SubagentChildArtifact {
+	return {
+		index,
+		agent: result.agent,
+		task: result.task,
+		status: result.exitCode === -1 ? "running" : resultStatus(result),
+		exitCode: result.exitCode,
+		cwd,
+		sessionFile: result.sessionFile,
+		completedAt: result.exitCode === -1 ? undefined : new Date().toISOString(),
+		output: getFinalOutput(result.messages),
+		stderr: result.stderr || undefined,
+		errorMessage: result.errorMessage,
+		stopReason: result.stopReason,
+		model: result.model,
+		usage: result.usage,
+		merge: result.mergeResult
+			? {
+					success: result.mergeResult.success,
+					appliedPatches: result.mergeResult.appliedPatches,
+					failedPatches: result.mergeResult.failedPatches,
+					error: result.mergeResult.error,
+				}
+			: undefined,
+	};
+}
+
+function formatRunRecord(record: ReturnType<SubagentRunStore["get"]>): string {
+	if (!record) return "Subagent run not found.";
+	const lines = [
+		`Run ${record.runId}: ${record.status}`,
+		`Mode: ${record.mode}`,
+		`Context: ${record.contextMode}`,
+		`Updated: ${record.updatedAt}`,
+	];
+	for (const child of record.children) {
+		const exit = child.exitCode === undefined ? "" : ` (exit ${child.exitCode})`;
+		lines.push(`- [${child.status}] ${child.agent}${exit}: ${child.output || child.errorMessage || child.stderr || child.task}`);
+		if (child.sessionFile) lines.push(`  session: ${child.sessionFile}`);
+	}
+	if (record.failure) lines.push(`Failure: ${record.failure.message}`);
+	return lines.join("\n");
+}
+
 async function runSingleAgent(
 	defaultCwd: string,
 	agents: AgentConfig[],
@@ -340,6 +404,9 @@ async function runSingleAgent(
 	onUpdate: OnUpdateCallback | undefined,
 	makeDetails: (results: SingleResult[]) => SubagentDetails,
 	modelOverride?: string,
+	contextMode: SubagentContextMode = "fresh",
+	parentSessionManager?: Parameters<typeof createSubagentLaunchPlan>[0]["parentSessionManager"],
+	sessionOverride?: SubagentSessionArgs,
 ): Promise<SingleResult> {
 	const agent = agents.find((a) => a.name === agentName);
 
@@ -404,7 +471,18 @@ async function runSingleAgent(
 			tmpPromptDir = tmp.dir;
 			tmpPromptPath = tmp.filePath;
 		}
-		const args = buildSubagentProcessArgs(agent, task, tmpPromptPath, modelOverride);
+		const launch = createSubagentLaunchPlan({
+			agent,
+			task,
+			tmpPromptPath,
+			modelOverride,
+			contextMode,
+			parentSessionManager,
+			session: sessionOverride,
+			cwd,
+			defaultCwd,
+		});
+		if (launch.session.mode === "fork") currentResult.sessionFile = launch.session.sessionFile;
 		let wasAborted = false;
 
 		const exitCode = await new Promise<number>((resolve) => {
@@ -412,8 +490,8 @@ async function runSingleAgent(
 			const extensionArgs = bundledPaths.flatMap(p => ["--extension", p]);
 			const proc = spawn(
 				process.execPath,
-				[process.env.GSD_BIN_PATH!, ...extensionArgs, ...args],
-				{ cwd: cwd ?? defaultCwd, shell: false, stdio: ["ignore", "pipe", "pipe"] },
+				[process.env.GSD_BIN_PATH!, ...extensionArgs, ...launch.args],
+				{ cwd: launch.cwd, env: launch.env, shell: false, stdio: ["ignore", "pipe", "pipe"] },
 			);
 			liveSubagentProcesses.add(proc);
 			let buffer = "";
@@ -485,10 +563,13 @@ async function runSingleAgentInCmuxSplit(
 	onUpdate: OnUpdateCallback | undefined,
 	makeDetails: (results: SingleResult[]) => SubagentDetails,
 	modelOverride?: string,
+	contextMode: SubagentContextMode = "fresh",
+	parentSessionManager?: Parameters<typeof createSubagentLaunchPlan>[0]["parentSessionManager"],
+	sessionOverride?: SubagentSessionArgs,
 ): Promise<SingleResult> {
 	const agent = agents.find((a) => a.name === agentName);
 	if (!agent) {
-		return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride);
+		return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride, contextMode, parentSessionManager, sessionOverride);
 	}
 
 	let tmpPromptDir: string | null = null;
@@ -533,27 +614,41 @@ async function runSingleAgentInCmuxSplit(
 			? await cmuxClient.createSplit(directionOrSurfaceId as "right" | "down" | "left" | "up")
 			: directionOrSurfaceId;
 		if (!cmuxSurfaceId) {
-			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride);
+			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride, contextMode, parentSessionManager, sessionOverride);
 		}
 
 		const bundledPaths = (process.env.GSD_BUNDLED_EXTENSION_PATHS ?? "").split(path.delimiter).map((s) => s.trim()).filter(Boolean);
 		const extensionArgs = bundledPaths.flatMap((p) => ["--extension", p]);
-		const processArgs = [process.env.GSD_BIN_PATH!, ...extensionArgs, ...buildSubagentProcessArgs(agent, task, tmpPromptPath, modelOverride)];
+		const launch = createSubagentLaunchPlan({
+			agent,
+			task,
+			tmpPromptPath,
+			modelOverride,
+			contextMode,
+			parentSessionManager,
+			session: sessionOverride,
+			cwd,
+			defaultCwd,
+		});
+		if (launch.session.mode === "fork") currentResult.sessionFile = launch.session.sessionFile;
+		const processArgs = [process.env.GSD_BIN_PATH!, ...extensionArgs, ...launch.args];
 		// Normalize all paths to forward slashes before embedding in bash strings.
 		// On Windows, backslashes are interpreted as escape characters by bash,
 		// mangling paths like C:\Users\user into C:Useruser (#1436).
 		const bashPath = (p: string) => shellEscape(p.replaceAll("\\", "/"));
+		const envPrefix = buildShellEnvAssignments(launch.env).join(" ");
+		const commandPrefix = envPrefix ? `${envPrefix} ` : "";
 		const innerScript = [
-			`cd ${bashPath(cwd ?? defaultCwd)}`,
+			`cd ${bashPath(launch.cwd)}`,
 			"set -o pipefail",
-			`${bashPath(process.execPath)} ${processArgs.map(a => bashPath(a)).join(" ")} 2> >(tee ${bashPath(stderrPath)} >&2) | tee ${bashPath(stdoutPath)}`,
+			`${commandPrefix}${bashPath(process.execPath)} ${processArgs.map(a => bashPath(a)).join(" ")} 2> >(tee ${bashPath(stderrPath)} >&2) | tee ${bashPath(stdoutPath)}`,
 			"status=${PIPESTATUS[0]}",
 			`printf '%s' "$status" > ${bashPath(exitPath)}`,
 		].join("; ");
 
 		const sent = await cmuxClient.sendSurface(cmuxSurfaceId, `bash -lc ${shellEscape(innerScript)}`);
 		if (!sent) {
-			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride);
+			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride, contextMode, parentSessionManager, sessionOverride);
 		}
 
 		const finished = await waitForFile(exitPath, signal);
@@ -601,6 +696,10 @@ const TaskItem = Type.Object({
 	task: Type.String({ description: "Task to delegate to the agent" }),
 	cwd: Type.Optional(Type.String({ description: "Working directory for the agent process" })),
 	model: Type.Optional(Type.String({ description: "Model override for this task (e.g. 'claude-sonnet-4-6')" })),
+	context: Type.Optional(StringEnum(["fresh", "fork"] as const, {
+		description: 'Context mode for this task. "fresh" keeps the existing isolated context behavior; "fork" branches the parent session.',
+		default: "fresh",
+	})),
 });
 
 const ChainItem = Type.Object({
@@ -608,6 +707,10 @@ const ChainItem = Type.Object({
 	task: Type.String({ description: "Task with optional {previous} placeholder for prior output" }),
 	cwd: Type.Optional(Type.String({ description: "Working directory for the agent process" })),
 	model: Type.Optional(Type.String({ description: "Model override for this step (e.g. 'claude-sonnet-4-6')" })),
+	context: Type.Optional(StringEnum(["fresh", "fork"] as const, {
+		description: 'Context mode for this step. "fresh" keeps the existing isolated context behavior; "fork" branches the parent session.',
+		default: "fresh",
+	})),
 });
 
 const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
@@ -615,12 +718,27 @@ const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
 	default: "both",
 });
 
+const ContextModeSchema = StringEnum(["fresh", "fork"] as const, {
+	description: 'Context mode for delegated work. "fresh" is the default existing behavior; "fork" branches the parent session.',
+	default: "fresh",
+});
+
+const SubagentActionSchema = StringEnum(["launch", "status", "resume"] as const, {
+	description: 'Run action. "launch" starts delegated work, "status" inspects a persisted run, and "resume" follows up a child session from a run.',
+	default: "launch",
+});
+
 const SubagentParams = Type.Object({
+	action: Type.Optional(SubagentActionSchema),
+	runId: Type.Optional(Type.String({ description: "Persisted subagent run id for status or resume actions" })),
 	agent: Type.Optional(Type.String({ description: "Name of the agent to invoke (for single mode)" })),
 	task: Type.Optional(Type.String({ description: "Task to delegate (for single mode)" })),
 	tasks: Type.Optional(Type.Array(TaskItem, { description: "Array of {agent, task} for parallel execution" })),
 	chain: Type.Optional(Type.Array(ChainItem, { description: "Array of {agent, task} for sequential execution" })),
 	agentScope: Type.Optional(AgentScopeSchema),
+	context: Type.Optional(ContextModeSchema),
+	background: Type.Optional(Type.Boolean({ description: "Return after starting the run and keep status in the persisted run record. Default: false.", default: false })),
+	followUp: Type.Optional(Type.String({ description: "Follow-up instruction for resume action. Falls back to task when omitted." })),
 	confirmProjectAgents: Type.Optional(
 		Type.Boolean({ description: "Prompt before running project-local agents. Default: false.", default: false }),
 	),
@@ -638,6 +756,8 @@ const SubagentParams = Type.Object({
 });
 
 export default function (pi: ExtensionAPI) {
+	if (isSubagentChildProcess()) return;
+
 	pi.on("session_shutdown", async () => {
 		await stopLiveSubagents();
 	});
@@ -687,13 +807,18 @@ export default function (pi: ExtensionAPI) {
 			const confirmProjectAgents = params.confirmProjectAgents ?? false;
 			const cmuxClient = CmuxClient.fromPreferences(loadEffectiveGSDPreferences()?.preferences);
 			const cmuxSplitsEnabled = cmuxClient.getConfig().splits;
+			const runStore = new SubagentRunStore();
+			const action = params.action ?? "launch";
+			const contextMode: SubagentContextMode = params.context ?? "fresh";
+			const taskParams: TaskParam[] = Array.isArray(params.tasks) ? params.tasks as TaskParam[] : [];
+			const chainParams: ChainParam[] = Array.isArray(params.chain) ? params.chain as ChainParam[] : [];
 
 			// Resolve isolation mode
 			const isolationMode = readIsolationMode();
 			const useIsolation = Boolean(params.isolated) && isolationMode !== "none";
 
-			const hasChain = (params.chain?.length ?? 0) > 0;
-			const hasTasks = (params.tasks?.length ?? 0) > 0;
+			const hasChain = chainParams.length > 0;
+			const hasTasks = taskParams.length > 0;
 			const hasSingle = Boolean(params.agent && params.task);
 			const modeCount = Number(hasChain) + Number(hasTasks) + Number(hasSingle);
 
@@ -705,6 +830,85 @@ export default function (pi: ExtensionAPI) {
 					projectAgentsDir: discovery.projectAgentsDir,
 					results,
 				});
+
+			if (action === "status") {
+				if (!params.runId) {
+					return {
+						content: [{ type: "text", text: "Status requires runId." }],
+						details: makeDetails("single")([]),
+						isError: true,
+					};
+				}
+				const record = runStore.get(params.runId);
+				return {
+					content: [{ type: "text", text: formatRunRecord(record) }],
+					details: makeDetails("single")([]),
+					...(record ? {} : { isError: true }),
+				};
+			}
+
+			if (action === "resume") {
+				if (!params.runId) {
+					return {
+						content: [{ type: "text", text: "Resume requires runId." }],
+						details: makeDetails("single")([]),
+						isError: true,
+					};
+				}
+				const record = runStore.get(params.runId);
+				if (!record) {
+					return {
+						content: [{ type: "text", text: `Subagent run not found: ${params.runId}` }],
+						details: makeDetails("single")([]),
+						isError: true,
+					};
+				}
+				const followUp = params.followUp ?? params.task;
+				if (!followUp) {
+					return {
+						content: [{ type: "text", text: "Resume requires followUp or task." }],
+						details: makeDetails("single")([]),
+						isError: true,
+					};
+				}
+				const sessionChildren = record.children.filter((child) => child.sessionFile);
+				const selected = params.agent
+					? sessionChildren.find((child) => child.agent === params.agent)
+					: sessionChildren.length === 1
+						? sessionChildren[0]
+						: undefined;
+				if (!selected?.sessionFile) {
+					const available = sessionChildren.map((child) => child.agent).join(", ") || "none";
+					return {
+						content: [{
+							type: "text",
+							text: `Resume requires exactly one child session or an agent selector. Available resumable agents: ${available}`,
+						}],
+						details: makeDetails("single")([]),
+						isError: true,
+					};
+				}
+				const result = await runSingleAgent(
+					ctx.cwd,
+					agents,
+					selected.agent,
+					followUp,
+					selected.cwd,
+					undefined,
+					signal,
+					onUpdate,
+					makeDetails("single"),
+					params.model,
+					"fresh",
+					ctx.sessionManager,
+					{ mode: "fork", sessionFile: selected.sessionFile, sessionDir: path.dirname(selected.sessionFile) },
+				);
+				return {
+					content: [{ type: "text", text: getFinalOutput(result.messages) || result.errorMessage || result.stderr || "(no output)" }],
+					details: makeDetails("single")([result]),
+					...(result.exitCode === 0 ? {} : { isError: true }),
+				};
+			}
 
 			if (modeCount !== 1) {
 				const available = agents.map((a) => `${a.name} (${a.source})`).join(", ") || "none";
@@ -724,16 +928,16 @@ export default function (pi: ExtensionAPI) {
 			// auto-mode flowId; per-dispatch ids still let us measure frequency, batch size, mode).
 			const dispatchMode: "single" | "parallel" | "chain" = hasChain ? "chain" : hasTasks ? "parallel" : "single";
 			const dispatchAgents = hasChain
-				? params.chain!.map((s) => s.agent)
+				? chainParams.map((s) => s.agent)
 				: hasTasks
-					? params.tasks!.map((t) => t.agent)
+					? taskParams.map((t) => t.agent)
 					: params.agent
 						? [params.agent]
 						: [];
 			const dispatchTasks = hasChain
-				? params.chain!.map((s) => s.task)
+				? chainParams.map((s) => s.task)
 				: hasTasks
-					? params.tasks!.map((t) => t.task)
+					? taskParams.map((t) => t.task)
 					: params.task
 						? [params.task]
 						: [];
@@ -741,6 +945,73 @@ export default function (pi: ExtensionAPI) {
 			const dispatchStartMs = Date.now();
 			let finalResults: SingleResult[] = [];
 			let dispatchCompletedEmitted = false;
+			const dispatchContextMode: SubagentContextMode =
+				hasChain && chainParams.some((step) => (step.context ?? contextMode) === "fork")
+					? "fork"
+					: hasTasks && taskParams.some((task) => (task.context ?? contextMode) === "fork")
+						? "fork"
+						: contextMode;
+			const dispatchChildren = dispatchAgents.map((agent, index) => ({
+				agent,
+				task: dispatchTasks[index] ?? "",
+				cwd: hasChain
+					? chainParams[index]?.cwd
+					: hasTasks
+						? taskParams[index]?.cwd
+						: params.cwd,
+			}));
+			runStore.create(createInitialRunRecord({
+				runId: dispatchId,
+				mode: dispatchMode as SubagentRunMode,
+				contextMode: dispatchContextMode,
+				cwd: ctx.cwd,
+				children: dispatchChildren,
+			}));
+
+			const persistRunResults = (results: SingleResult[], completed = false): void => {
+				try {
+					runStore.update(dispatchId, (record) => {
+						const children = [...record.children];
+						for (let index = 0; index < results.length; index++) {
+							const result = results[index];
+							if (!result) continue;
+							children[index] = {
+								...children[index],
+								...resultToChildArtifact(result, index, children[index]?.cwd),
+							};
+						}
+						if (completed) {
+							for (let index = 0; index < children.length; index++) {
+								const child = children[index];
+								if (child.status === "queued" || child.status === "running") {
+									children[index] = {
+										...child,
+										status: "failed",
+										completedAt: new Date().toISOString(),
+										errorMessage: "Subagent run ended before this child completed.",
+									};
+								}
+							}
+						}
+						const status = completed ? deriveRunStatus(children) : "running";
+						const failed = children.find((child) => child.status === "failed");
+						const interrupted = children.find((child) => child.status === "interrupted");
+						return {
+							...record,
+							children,
+							status,
+							...(completed && status !== "running" ? { completedAt: new Date().toISOString() } : {}),
+							...(interrupted
+								? { failure: { type: "interrupted" as const, message: interrupted.errorMessage || interrupted.stderr || "Subagent run was interrupted" } }
+								: failed
+									? { failure: { type: failed.merge?.success === false ? "merge-failed" as const : "child-failed" as const, message: failed.errorMessage || failed.stderr || `Subagent ${failed.agent} failed` } }
+									: {}),
+						};
+					});
+				} catch {
+					// Persistence is observability; execution remains authoritative.
+				}
+			};
 
 			emitJournalEvent(ctx.cwd, {
 				ts: new Date().toISOString(),
@@ -829,6 +1100,7 @@ export default function (pi: ExtensionAPI) {
 				if (dispatchCompletedEmitted) return;
 				finalResults = results;
 				dispatchCompletedEmitted = true;
+				persistRunResults(results, true);
 				const successCount = results.filter((r) => r.exitCode === 0).length;
 				const failureCount = results.filter((r) => r.exitCode !== 0).length;
 				const totalCost = results.reduce((s, r) => s + (r.usage?.cost ?? 0), 0);
@@ -856,8 +1128,8 @@ export default function (pi: ExtensionAPI) {
 			try {
 			if ((agentScope === "project" || agentScope === "both") && confirmProjectAgents && ctx.hasUI) {
 				const requestedAgentNames = new Set<string>();
-				if (params.chain) for (const step of params.chain) requestedAgentNames.add(step.agent);
-				if (params.tasks) for (const t of params.tasks) requestedAgentNames.add(t.agent);
+				if (hasChain) for (const step of chainParams) requestedAgentNames.add(step.agent);
+				if (hasTasks) for (const t of taskParams) requestedAgentNames.add(t.agent);
 				if (params.agent) requestedAgentNames.add(params.agent);
 
 				const projectAgentsRequested = Array.from(requestedAgentNames)
@@ -881,29 +1153,101 @@ export default function (pi: ExtensionAPI) {
 				}
 			}
 
-			if (params.chain && params.chain.length > 0) {
+			if (params.background) {
+				if (!params.agent || !params.task || hasTasks || hasChain) {
+					const failure = makeFailureResult(
+						new Error("Background launch currently requires single mode with agent and task."),
+						params.agent ?? "unknown",
+						params.task ?? "",
+					);
+					finishDispatch([failure]);
+					return {
+						content: [{ type: "text", text: failure.errorMessage ?? failure.stderr }],
+						details: makeDetails("single")([failure]),
+						isError: true,
+					};
+				}
+
+				void (async () => {
+					let isolation: IsolationEnvironment | null = null;
+					try {
+						const effectiveCwd = params.cwd ?? ctx.cwd;
+						if (useIsolation) {
+							const taskId = crypto.randomUUID();
+							isolation = await createIsolation(effectiveCwd, taskId, isolationMode);
+						}
+						const result = await runSingleAgent(
+							ctx.cwd,
+							agents,
+							params.agent!,
+							params.task!,
+							isolation ? isolation.workDir : params.cwd,
+							undefined,
+							signal,
+							(partial) => {
+								if (partial.details?.results[0]) persistRunResults([partial.details.results[0]]);
+							},
+							makeDetails("single"),
+							params.model,
+							contextMode,
+							ctx.sessionManager,
+						);
+						if (isolation && result.exitCode === 0) {
+							const patches = await isolation.captureDelta();
+							if (patches.length > 0) {
+								const mergeResult = await mergeDeltaPatches(effectiveCwd, patches);
+								result.mergeResult = mergeResult;
+								if (!mergeResult.success) {
+									result.exitCode = 1;
+									result.stopReason = "error";
+									result.errorMessage = `Patch merge failed: ${mergeResult.error || "unknown error"}`;
+									result.stderr = result.stderr || result.errorMessage;
+								}
+							}
+						}
+						finalResults = [result];
+						finishDispatch([result]);
+					} catch (err) {
+						finalResults = synthesizeFailureResults(err);
+						finishDispatch(finalResults);
+					} finally {
+						if (isolation) await isolation.cleanup();
+					}
+				})();
+
+				return {
+					content: [{
+						type: "text",
+						text: `Started background subagent run ${dispatchId}. Use action: "status" with runId: "${dispatchId}" to inspect it.`,
+					}],
+					details: makeDetails("single")([]),
+				};
+			}
+
+			if (chainParams.length > 0) {
 				const results: SingleResult[] = [];
 				finalResults = results;
 				let previousOutput = "";
 
-				for (let i = 0; i < params.chain.length; i++) {
-					const step = params.chain[i];
+				for (let i = 0; i < chainParams.length; i++) {
+					const step = chainParams[i];
 					const taskWithContext = step.task.replace(/\{previous\}/g, previousOutput);
 
 					// Create update callback that includes all previous results
-					const chainUpdate: OnUpdateCallback | undefined = onUpdate
-						? (partial) => {
-								// Combine completed results with current streaming result
-								const currentResult = partial.details?.results[0];
-								if (currentResult) {
-									const allResults = [...results, currentResult];
-									onUpdate({
-										content: partial.content,
-										details: makeDetails("chain")(allResults),
-									});
-								}
+					const chainUpdate: OnUpdateCallback = (partial) => {
+						// Combine completed results with current streaming result
+						const currentResult = partial.details?.results[0];
+						if (currentResult) {
+							const allResults = [...results, currentResult];
+							persistRunResults(allResults);
+							if (onUpdate) {
+								onUpdate({
+									content: partial.content,
+									details: makeDetails("chain")(allResults),
+								});
 							}
-						: undefined;
+						}
+					};
 
 					const result = await runSingleAgent(
 						ctx.cwd,
@@ -916,8 +1260,11 @@ export default function (pi: ExtensionAPI) {
 						chainUpdate,
 						makeDetails("chain"),
 						step.model || params.model,
+						step.context ?? contextMode,
+						ctx.sessionManager,
 					);
 					results.push(result);
+					persistRunResults(results);
 
 					const isError =
 						result.exitCode !== 0 || result.stopReason === "error" || result.stopReason === "aborted";
@@ -940,14 +1287,14 @@ export default function (pi: ExtensionAPI) {
 				};
 			}
 
-			if (params.tasks && params.tasks.length > 0) {
-				if (params.tasks.length > MAX_PARALLEL_TASKS) {
+			if (taskParams.length > 0) {
+				if (taskParams.length > MAX_PARALLEL_TASKS) {
 					finishDispatch([]);
 					return {
 						content: [
 							{
 								type: "text",
-								text: `Too many parallel tasks (${params.tasks.length}). Max is ${MAX_PARALLEL_TASKS}.`,
+								text: `Too many parallel tasks (${taskParams.length}). Max is ${MAX_PARALLEL_TASKS}.`,
 							},
 						],
 						details: makeDetails("parallel")([]),
@@ -955,14 +1302,14 @@ export default function (pi: ExtensionAPI) {
 				}
 
 				// Track all results for streaming updates
-				const allResults: SingleResult[] = new Array(params.tasks.length);
+				const allResults: SingleResult[] = new Array(taskParams.length);
 
 				// Initialize placeholder results
-				for (let i = 0; i < params.tasks.length; i++) {
+				for (let i = 0; i < taskParams.length; i++) {
 					allResults[i] = {
-						agent: params.tasks[i].agent,
+						agent: taskParams[i].agent,
 						agentSource: "unknown",
-						task: params.tasks[i].task,
+						task: taskParams[i].task,
 						exitCode: -1, // -1 = still running
 						messages: [],
 						stderr: "",
@@ -986,51 +1333,80 @@ export default function (pi: ExtensionAPI) {
 
 				const MAX_RETRIES = 1; // Retry failed tasks once
 				const batchId = crypto.randomUUID();
-				const batchSize = params.tasks.length;
+				const batchSize = taskParams.length;
 				// Pre-create a grid layout for cmux splits so agents get a clean tiled arrangement
 				const gridSurfaces = cmuxSplitsEnabled
 					? await cmuxClient.createGridLayout(Math.min(batchSize, MAX_CONCURRENCY))
 					: [];
-				const results = await mapWithConcurrencyLimit(params.tasks, MAX_CONCURRENCY, async (t, index) => {
+				const results = await mapWithConcurrencyLimit(taskParams, MAX_CONCURRENCY, async (t, index) => {
 					const workerId = registerWorker(t.agent, t.task, index, batchSize, batchId);
 					const taskModel = t.model || params.model;
-					const runTask = () => cmuxSplitsEnabled
+					const updateParallelResult = (partial: AgentToolResult<SubagentDetails>) => {
+						if (partial.details?.results[0]) {
+							allResults[index] = partial.details.results[0];
+							persistRunResults([...allResults]);
+							emitParallelUpdate();
+						}
+					};
+					const executeOnce = (runCwd: string | undefined) => cmuxSplitsEnabled
 						? runSingleAgentInCmuxSplit(
-							cmuxClient,
-							gridSurfaces[index] ?? (index % 2 === 0 ? "right" : "down"),
-							ctx.cwd,
-							agents,
-							t.agent,
-							t.task,
-							t.cwd,
-							undefined,
-							signal,
-							(partial) => {
-								if (partial.details?.results[0]) {
-									allResults[index] = partial.details.results[0];
-									emitParallelUpdate();
-								}
-							},
-							makeDetails("parallel"),
-							taskModel,
-						)
+								cmuxClient,
+								gridSurfaces[index] ?? (index % 2 === 0 ? "right" : "down"),
+								ctx.cwd,
+								agents,
+								t.agent,
+								t.task,
+								runCwd,
+								undefined,
+								signal,
+								updateParallelResult,
+								makeDetails("parallel"),
+								taskModel,
+								t.context ?? contextMode,
+								ctx.sessionManager,
+							)
 						: runSingleAgent(
-							ctx.cwd,
-							agents,
-							t.agent,
-							t.task,
-							t.cwd,
-							undefined,
-							signal,
-							(partial) => {
-								if (partial.details?.results[0]) {
-									allResults[index] = partial.details.results[0];
-									emitParallelUpdate();
+								ctx.cwd,
+								agents,
+								t.agent,
+								t.task,
+								runCwd,
+								undefined,
+								signal,
+								updateParallelResult,
+								makeDetails("parallel"),
+								taskModel,
+								t.context ?? contextMode,
+								ctx.sessionManager,
+							);
+					const runTask = async () => {
+						let isolation: IsolationEnvironment | null = null;
+						const effectiveCwd = t.cwd ?? ctx.cwd;
+						try {
+							if (useIsolation) {
+								const taskId = crypto.randomUUID();
+								isolation = await createIsolation(effectiveCwd, taskId, isolationMode);
+							}
+
+							const result = await executeOnce(isolation ? isolation.workDir : t.cwd);
+							if (isolation && result.exitCode === 0) {
+								const patches = await isolation.captureDelta();
+								const mergeResult = patches.length > 0
+									? await mergeDeltaPatches(effectiveCwd, patches)
+									: { success: true, appliedPatches: [], failedPatches: [] };
+								result.mergeResult = mergeResult;
+								if (!mergeResult.success) {
+									result.exitCode = 1;
+									result.stopReason = "error";
+									result.errorMessage = `Patch merge failed: ${mergeResult.error || "unknown error"}`;
+									result.stderr = result.stderr || result.errorMessage;
 								}
-							},
-							makeDetails("parallel"),
-							taskModel,
-						);
+							}
+							return result;
+						} finally {
+							if (isolation) await isolation.cleanup();
+						}
+					};
 					let result = await runTask();
 
 					// Auto-retry failed tasks (likely API rate limit or transient error)
@@ -1041,6 +1417,7 @@ export default function (pi: ExtensionAPI) {
 
 					updateWorker(workerId, result.exitCode === 0 ? "completed" : "failed");
 					allResults[index] = result;
+					persistRunResults([...allResults]);
 					emitParallelUpdate();
 					return result;
 				});
@@ -1077,6 +1454,10 @@ export default function (pi: ExtensionAPI) {
 						isolation = await createIsolation(effectiveCwd, taskId, isolationMode);
 					}
 
+					const singleUpdate: OnUpdateCallback = (partial) => {
+						if (partial.details?.results[0]) persistRunResults([partial.details.results[0]]);
+						if (onUpdate) onUpdate(partial);
+					};
 					const result = cmuxSplitsEnabled
 						? await runSingleAgentInCmuxSplit(
 							cmuxClient,
@@ -1088,9 +1469,11 @@ export default function (pi: ExtensionAPI) {
 							isolation ? isolation.workDir : params.cwd,
 							undefined,
 							signal,
-							onUpdate,
+							singleUpdate,
 							makeDetails("single"),
 							params.model,
+							contextMode,
+							ctx.sessionManager,
 						)
 						: await runSingleAgent(
 							ctx.cwd,
@@ -1100,9 +1483,11 @@ export default function (pi: ExtensionAPI) {
 							isolation ? isolation.workDir : params.cwd,
 							undefined,
 							signal,
-							onUpdate,
+							singleUpdate,
 							makeDetails("single"),
 							params.model,
+							contextMode,
+							ctx.sessionManager,
 						);
 					finalResults = [result];
 
@@ -1111,6 +1496,13 @@ export default function (pi: ExtensionAPI) {
 						const patches = await isolation.captureDelta();
 						if (patches.length > 0) {
 							mergeResult = await mergeDeltaPatches(effectiveCwd, patches);
+							result.mergeResult = mergeResult;
+							if (!mergeResult.success) {
+								result.exitCode = 1;
+								result.stopReason = "error";
+								result.errorMessage = `Patch merge failed: ${mergeResult.error || "unknown error"}`;
+								result.stderr = result.stderr || result.errorMessage;
+							}
 						}
 					}
 
@@ -1152,7 +1544,7 @@ export default function (pi: ExtensionAPI) {
 				if (!dispatchCompletedEmitted) finalResults = synthesizeFailureResults(err);
 				throw err;
 			} finally {
-				finishDispatch(finalResults);
+				if (!params.background) finishDispatch(finalResults);
 			}
 		},
 

--- a/src/resources/extensions/subagent/index.ts
+++ b/src/resources/extensions/subagent/index.ts
@@ -49,6 +49,7 @@ import {
 import {
 	SubagentRunStore,
 	createInitialRunRecord,
+	createSubagentTrackingName,
 	deriveRunStatus,
 	type SubagentChildArtifact,
 	type SubagentRunMode,
@@ -205,6 +206,7 @@ interface UsageStats {
 
 interface SingleResult {
 	agent: string;
+	trackingName?: string;
 	agentSource: "user" | "project" | "unknown";
 	task: string;
 	exitCode: number;
@@ -355,6 +357,7 @@ function resultToChildArtifact(result: SingleResult, index: number, cwd?: string
 	return {
 		index,
 		agent: result.agent,
+		trackingName: result.trackingName,
 		task: result.task,
 		status: running ? "running" : resultStatus(result),
 		exitCode: result.exitCode,
@@ -378,6 +381,10 @@ function resultToChildArtifact(result: SingleResult, index: number, cwd?: string
 	};
 }
 
+function formatAgentLabel(agent: string, trackingName?: string): string {
+	return trackingName ? `${trackingName} / ${agent}` : agent;
+}
+
 function formatRunRecord(record: ReturnType<SubagentRunStore["get"]>): string {
 	if (!record) return "Subagent run not found.";
 	const lines = [
@@ -388,7 +395,7 @@ function formatRunRecord(record: ReturnType<SubagentRunStore["get"]>): string {
 	];
 	for (const child of record.children) {
 		const exit = child.exitCode === undefined ? "" : ` (exit ${child.exitCode})`;
-		lines.push(`- [${child.status}] ${child.agent}${exit}: ${child.output || child.errorMessage || child.stderr || child.task}`);
+		lines.push(`- [${child.status}] ${formatAgentLabel(child.agent, child.trackingName)}${exit}: ${child.output || child.errorMessage || child.stderr || child.task}`);
 		if (child.sessionFile) lines.push(`  session: ${child.sessionFile}`);
 	}
 	if (record.failure) lines.push(`Failure: ${record.failure.message}`);
@@ -409,6 +416,7 @@ async function runSingleAgent(
 	contextMode: SubagentContextMode = "fresh",
 	parentSessionManager?: Parameters<typeof createSubagentLaunchPlan>[0]["parentSessionManager"],
 	sessionOverride?: SubagentSessionArgs,
+	trackingName?: string,
 ): Promise<SingleResult> {
 	const agent = agents.find((a) => a.name === agentName);
 
@@ -416,6 +424,7 @@ async function runSingleAgent(
 		const available = agents.map((a) => `"${a.name}"`).join(", ") || "none";
 		return {
 			agent: agentName,
+			trackingName,
 			agentSource: "unknown",
 			task,
 			exitCode: 1,
@@ -432,6 +441,7 @@ async function runSingleAgent(
 		if (activePhase && agent.conflictsWith.includes(activePhase)) {
 			return {
 				agent: agentName,
+				trackingName,
 				agentSource: agent.source,
 				task,
 				exitCode: 1,
@@ -448,6 +458,7 @@ async function runSingleAgent(
 
 	const currentResult: SingleResult = {
 		agent: agentName,
+		trackingName,
 		agentSource: agent.source,
 		task,
 		exitCode: -1,
@@ -570,10 +581,11 @@ async function runSingleAgentInCmuxSplit(
 	contextMode: SubagentContextMode = "fresh",
 	parentSessionManager?: Parameters<typeof createSubagentLaunchPlan>[0]["parentSessionManager"],
 	sessionOverride?: SubagentSessionArgs,
+	trackingName?: string,
 ): Promise<SingleResult> {
 	const agent = agents.find((a) => a.name === agentName);
 	if (!agent) {
-		return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride, contextMode, parentSessionManager, sessionOverride);
+		return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride, contextMode, parentSessionManager, sessionOverride, trackingName);
 	}
 
 	let tmpPromptDir: string | null = null;
@@ -582,6 +594,7 @@ async function runSingleAgentInCmuxSplit(
 
 	const currentResult: SingleResult = {
 		agent: agentName,
+		trackingName,
 		agentSource: agent.source,
 		task,
 		exitCode: -1,
@@ -619,7 +632,7 @@ async function runSingleAgentInCmuxSplit(
 			? await cmuxClient.createSplit(directionOrSurfaceId as "right" | "down" | "left" | "up")
 			: directionOrSurfaceId;
 		if (!cmuxSurfaceId) {
-			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride, contextMode, parentSessionManager, sessionOverride);
+			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride, contextMode, parentSessionManager, sessionOverride, trackingName);
 		}
 
 		const bundledPaths = (process.env.GSD_BUNDLED_EXTENSION_PATHS ?? "").split(path.delimiter).map((s) => s.trim()).filter(Boolean);
@@ -653,7 +666,7 @@ async function runSingleAgentInCmuxSplit(
 
 		const sent = await cmuxClient.sendSurface(cmuxSurfaceId, `bash -lc ${shellEscape(innerScript)}`);
 		if (!sent) {
-			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride, contextMode, parentSessionManager, sessionOverride);
+			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, modelOverride, contextMode, parentSessionManager, sessionOverride, trackingName);
 		}
 
 		const finished = await waitForFile(exitPath, signal);
@@ -885,7 +898,7 @@ export default function (pi: ExtensionAPI) {
 						? sessionChildren[0]
 						: undefined;
 				if (!selected?.sessionFile) {
-					const available = sessionChildren.map((child) => child.agent).join(", ") || "none";
+					const available = sessionChildren.map((child) => formatAgentLabel(child.agent, child.trackingName)).join(", ") || "none";
 					return {
 						content: [{
 							type: "text",
@@ -909,6 +922,7 @@ export default function (pi: ExtensionAPI) {
 					"fresh",
 					ctx.sessionManager,
 					{ mode: "fork", sessionFile: selected.sessionFile, sessionDir: path.dirname(selected.sessionFile) },
+					selected.trackingName,
 				);
 				return {
 					content: [{ type: "text", text: getFinalOutput(result.messages) || result.errorMessage || result.stderr || "(no output)" }],
@@ -952,6 +966,12 @@ export default function (pi: ExtensionAPI) {
 			const dispatchStartMs = Date.now();
 			let finalResults: SingleResult[] = [];
 			let dispatchCompletedEmitted = false;
+			const usedTrackingNames = new Set<string>();
+			const dispatchTrackingNames = dispatchAgents.map(() => {
+				const trackingName = createSubagentTrackingName(usedTrackingNames);
+				usedTrackingNames.add(trackingName);
+				return trackingName;
+			});
 			const dispatchContextMode: SubagentContextMode =
 				hasChain && chainParams.some((step) => (step.context ?? contextMode) === "fork")
 					? "fork"
@@ -960,6 +980,7 @@ export default function (pi: ExtensionAPI) {
 						: contextMode;
 			const dispatchChildren = dispatchAgents.map((agent, index) => ({
 				agent,
+				trackingName: dispatchTrackingNames[index],
 				task: dispatchTasks[index] ?? "",
 				cwd: hasChain
 					? chainParams[index]?.cwd
@@ -1046,10 +1067,20 @@ export default function (pi: ExtensionAPI) {
 			});
 			const errorMessageFor = (err: unknown): string =>
 				err instanceof Error ? err.message : String(err || "subagent dispatch failed");
-			const makeFailureResult = (err: unknown, agent: string, task: string, step?: number): SingleResult => {
+			const makeFailureResult = (
+				err: unknown,
+				agent: string,
+				task: string,
+				step?: number,
+				trackingName?: string,
+			): SingleResult => {
 				const message = errorMessageFor(err);
+				const dispatchIndex = dispatchAgents.findIndex((dispatchAgent, index) =>
+					dispatchAgent === agent && dispatchTasks[index] === task
+				);
 				return {
 					agent,
+					trackingName: trackingName ?? (dispatchIndex >= 0 ? dispatchTrackingNames[dispatchIndex] : undefined),
 					agentSource: "unknown",
 					task,
 					exitCode: 1,
@@ -1088,6 +1119,7 @@ export default function (pi: ExtensionAPI) {
 								dispatchAgents[nextIndex] ?? "unknown",
 								dispatchTasks[nextIndex] ?? "",
 								dispatchMode === "chain" ? nextIndex + 1 : undefined,
+								dispatchTrackingNames[nextIndex],
 							),
 						];
 					}
@@ -1100,6 +1132,7 @@ export default function (pi: ExtensionAPI) {
 						agent,
 						dispatchTasks[index] ?? "",
 						dispatchMode === "chain" ? index + 1 : undefined,
+						dispatchTrackingNames[index],
 					),
 				);
 			};
@@ -1198,6 +1231,8 @@ export default function (pi: ExtensionAPI) {
 							params.model,
 							contextMode,
 							ctx.sessionManager,
+							undefined,
+							dispatchTrackingNames[0],
 						);
 						if (isolation && result.exitCode === 0) {
 							const patches = await isolation.captureDelta();
@@ -1269,6 +1304,8 @@ export default function (pi: ExtensionAPI) {
 						step.model || params.model,
 						step.context ?? contextMode,
 						ctx.sessionManager,
+						undefined,
+						dispatchTrackingNames[i],
 					);
 					results.push(result);
 					persistRunResults(results);
@@ -1315,6 +1352,7 @@ export default function (pi: ExtensionAPI) {
 				for (let i = 0; i < taskParams.length; i++) {
 					allResults[i] = {
 						agent: taskParams[i].agent,
+						trackingName: dispatchTrackingNames[i],
 						agentSource: "unknown",
 						task: taskParams[i].task,
 						exitCode: -1, // -1 = still running
@@ -1371,6 +1409,8 @@ export default function (pi: ExtensionAPI) {
 								taskModel,
 								t.context ?? contextMode,
 								ctx.sessionManager,
+								undefined,
+								dispatchTrackingNames[index],
 							)
 						: runSingleAgent(
 								ctx.cwd,
@@ -1385,6 +1425,8 @@ export default function (pi: ExtensionAPI) {
 								taskModel,
 								t.context ?? contextMode,
 								ctx.sessionManager,
+								undefined,
+								dispatchTrackingNames[index],
 							);
 					const runTask = async () => {
 						let isolation: IsolationEnvironment | null = null;
@@ -1436,7 +1478,7 @@ export default function (pi: ExtensionAPI) {
 					const output = isError
 						? (r.errorMessage || r.stderr || getFinalOutput(r.messages) || "(no output)")
 						: getFinalOutput(r.messages);
-					return `[${r.agent}] ${r.exitCode === 0 ? "completed" : `failed (exit ${r.exitCode})`}: ${output || "(no output)"}`;
+					return `[${formatAgentLabel(r.agent, r.trackingName)}] ${r.exitCode === 0 ? "completed" : `failed (exit ${r.exitCode})`}: ${output || "(no output)"}`;
 				});
 				finishDispatch(results);
 				return {
@@ -1481,6 +1523,8 @@ export default function (pi: ExtensionAPI) {
 							params.model,
 							contextMode,
 							ctx.sessionManager,
+							undefined,
+							dispatchTrackingNames[0],
 						)
 						: await runSingleAgent(
 							ctx.cwd,
@@ -1495,6 +1539,8 @@ export default function (pi: ExtensionAPI) {
 							params.model,
 							contextMode,
 							ctx.sessionManager,
+							undefined,
+							dispatchTrackingNames[0],
 						);
 					finalResults = [result];
 
@@ -1633,7 +1679,7 @@ export default function (pi: ExtensionAPI) {
 
 				if (expanded) {
 					const container = new Container();
-					let header = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
+					let header = `${icon} ${theme.fg("toolTitle", theme.bold(formatAgentLabel(r.agent, r.trackingName)))}${theme.fg("muted", ` (${r.agentSource})`)}`;
 					if (isError && r.stopReason) header += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
 					container.addChild(new Text(header, 0, 0));
 					if (isError && r.errorMessage)
@@ -1669,7 +1715,7 @@ export default function (pi: ExtensionAPI) {
 					return container;
 				}
 
-				let text = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
+				let text = `${icon} ${theme.fg("toolTitle", theme.bold(formatAgentLabel(r.agent, r.trackingName)))}${theme.fg("muted", ` (${r.agentSource})`)}`;
 				if (isError && r.stopReason) text += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
 				if (isError && r.errorMessage) text += `\n${theme.fg("error", `Error: ${r.errorMessage}`)}`;
 				else if (displayItems.length === 0) text += `\n${theme.fg("muted", "(no output)")}`;
@@ -1720,7 +1766,7 @@ export default function (pi: ExtensionAPI) {
 						container.addChild(new Spacer(1));
 						container.addChild(
 							new Text(
-								`${theme.fg("muted", `─── Step ${r.step}: `) + theme.fg("accent", r.agent)} ${rIcon}`,
+								`${theme.fg("muted", `─── Step ${r.step}: `) + theme.fg("accent", formatAgentLabel(r.agent, r.trackingName))} ${rIcon}`,
 								0,
 								0,
 							),
@@ -1767,7 +1813,7 @@ export default function (pi: ExtensionAPI) {
 				for (const r of details.results) {
 					const rIcon = r.exitCode === 0 ? theme.fg("success", "✓") : theme.fg("error", "✗");
 					const displayItems = getDisplayItems(r.messages);
-					text += `\n\n${theme.fg("muted", `─── Step ${r.step}: `)}${theme.fg("accent", r.agent)} ${rIcon}`;
+					text += `\n\n${theme.fg("muted", `─── Step ${r.step}: `)}${theme.fg("accent", formatAgentLabel(r.agent, r.trackingName))} ${rIcon}`;
 					if (displayItems.length === 0) text += `\n${theme.fg("muted", "(no output)")}`;
 					else text += `\n${renderDisplayItems(displayItems, 5)}`;
 				}
@@ -1808,7 +1854,7 @@ export default function (pi: ExtensionAPI) {
 
 						container.addChild(new Spacer(1));
 						container.addChild(
-							new Text(`${theme.fg("muted", "─── ") + theme.fg("accent", r.agent)} ${rIcon}`, 0, 0),
+							new Text(`${theme.fg("muted", "─── ") + theme.fg("accent", formatAgentLabel(r.agent, r.trackingName))} ${rIcon}`, 0, 0),
 						);
 						container.addChild(new Text(theme.fg("muted", "Task: ") + theme.fg("dim", r.task), 0, 0));
 
@@ -1853,7 +1899,7 @@ export default function (pi: ExtensionAPI) {
 								? theme.fg("success", "✓")
 								: theme.fg("error", "✗");
 					const displayItems = getDisplayItems(r.messages);
-					text += `\n\n${theme.fg("muted", "─── ")}${theme.fg("accent", r.agent)} ${rIcon}`;
+					text += `\n\n${theme.fg("muted", "─── ")}${theme.fg("accent", formatAgentLabel(r.agent, r.trackingName))} ${rIcon}`;
 					if (displayItems.length === 0)
 						text += `\n${theme.fg("muted", r.exitCode === -1 ? "(running...)" : "(no output)")}`;
 					else text += `\n${renderDisplayItems(displayItems, 5)}`;

--- a/src/resources/extensions/subagent/index.ts
+++ b/src/resources/extensions/subagent/index.ts
@@ -208,6 +208,7 @@ interface SingleResult {
 	agentSource: "user" | "project" | "unknown";
 	task: string;
 	exitCode: number;
+	running?: boolean;
 	messages: Message[];
 	stderr: string;
 	usage: UsageStats;
@@ -350,15 +351,16 @@ function resultStatus(result: SingleResult): SubagentRunStatus {
 }
 
 function resultToChildArtifact(result: SingleResult, index: number, cwd?: string): SubagentChildArtifact {
+	const running = result.running === true || result.exitCode === -1;
 	return {
 		index,
 		agent: result.agent,
 		task: result.task,
-		status: result.exitCode === -1 ? "running" : resultStatus(result),
+		status: running ? "running" : resultStatus(result),
 		exitCode: result.exitCode,
 		cwd,
 		sessionFile: result.sessionFile,
-		completedAt: result.exitCode === -1 ? undefined : new Date().toISOString(),
+		completedAt: running ? undefined : new Date().toISOString(),
 		output: getFinalOutput(result.messages),
 		stderr: result.stderr || undefined,
 		errorMessage: result.errorMessage,
@@ -448,7 +450,8 @@ async function runSingleAgent(
 		agent: agentName,
 		agentSource: agent.source,
 		task,
-		exitCode: 0,
+		exitCode: -1,
+		running: true,
 		messages: [],
 		stderr: "",
 		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
@@ -532,6 +535,7 @@ async function runSingleAgent(
 		});
 
 		currentResult.exitCode = exitCode;
+		currentResult.running = false;
 		if (wasAborted) throw new Error("Subagent was aborted");
 		return currentResult;
 	} finally {
@@ -580,7 +584,8 @@ async function runSingleAgentInCmuxSplit(
 		agent: agentName,
 		agentSource: agent.source,
 		task,
-		exitCode: 0,
+		exitCode: -1,
+		running: true,
 		messages: [],
 		stderr: "",
 		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
@@ -654,6 +659,7 @@ async function runSingleAgentInCmuxSplit(
 		const finished = await waitForFile(exitPath, signal);
 		if (!finished) {
 			currentResult.exitCode = 1;
+			currentResult.running = false;
 			currentResult.stderr = "cmux split execution timed out or was aborted";
 			return currentResult;
 		}
@@ -668,6 +674,7 @@ async function runSingleAgentInCmuxSplit(
 			currentResult.stderr = fs.readFileSync(stderrPath, "utf-8");
 		}
 		currentResult.exitCode = Number.parseInt(fs.readFileSync(exitPath, "utf-8").trim() || "1", 10) || 0;
+		currentResult.running = false;
 		return currentResult;
 	} finally {
 		if (tmpPromptPath)
@@ -1183,7 +1190,7 @@ export default function (pi: ExtensionAPI) {
 							params.task!,
 							isolation ? isolation.workDir : params.cwd,
 							undefined,
-							signal,
+							undefined,
 							(partial) => {
 								if (partial.details?.results[0]) persistRunResults([partial.details.results[0]]);
 							},

--- a/src/resources/extensions/subagent/launch.ts
+++ b/src/resources/extensions/subagent/launch.ts
@@ -1,0 +1,131 @@
+// GSD-2 + Subagent launch contract and child process safety helpers.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { SessionManager } from "@gsd/pi-coding-agent";
+import type { AgentConfig } from "./agents.js";
+
+export const SUBAGENT_CHILD_ENV_VAR = "GSD_SUBAGENT_CHILD";
+export const SUBAGENT_CHILD_ENV_VALUE = "1";
+
+export type SubagentContextMode = "fresh" | "fork";
+
+export type SubagentSessionArgs =
+	| { mode: "fresh" }
+	| { mode: "fork"; sessionFile: string; sessionDir?: string };
+
+export interface SubagentParentSessionManager {
+	getSessionFile(): string | undefined;
+	getLeafId(): string | null;
+	getSessionDir(): string;
+}
+
+export interface SubagentLaunchInput {
+	agent: AgentConfig;
+	task: string;
+	tmpPromptPath: string | null;
+	modelOverride?: string;
+	contextMode?: SubagentContextMode;
+	parentSessionManager?: SubagentParentSessionManager;
+	session?: SubagentSessionArgs;
+	cwd?: string;
+	defaultCwd: string;
+}
+
+export interface SubagentLaunchPlan {
+	args: string[];
+	env: NodeJS.ProcessEnv;
+	cwd: string;
+	session: SubagentSessionArgs;
+}
+
+export function isSubagentChildProcess(env: NodeJS.ProcessEnv = process.env): boolean {
+	return env[SUBAGENT_CHILD_ENV_VAR] === SUBAGENT_CHILD_ENV_VALUE;
+}
+
+export function buildSubagentProcessEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+	return {
+		...env,
+		[SUBAGENT_CHILD_ENV_VAR]: SUBAGENT_CHILD_ENV_VALUE,
+	};
+}
+
+export function buildShellEnvAssignments(env: NodeJS.ProcessEnv = process.env): string[] {
+	const value = env[SUBAGENT_CHILD_ENV_VAR];
+	return value ? [`${SUBAGENT_CHILD_ENV_VAR}=${JSON.stringify(value)}`] : [];
+}
+
+export function buildSubagentProcessArgs(
+	agent: AgentConfig,
+	task: string,
+	tmpPromptPath: string | null,
+	modelOverride?: string,
+	session: SubagentSessionArgs = { mode: "fresh" },
+): string[] {
+	const args: string[] = ["--mode", "json", "-p"];
+	if (session.mode === "fork") {
+		args.push("--session", session.sessionFile);
+		if (session.sessionDir) args.push("--session-dir", session.sessionDir);
+	} else {
+		args.push("--no-session");
+	}
+	const effectiveModel = modelOverride ?? agent.model;
+	if (effectiveModel) args.push("--model", effectiveModel);
+	if (agent.tools && agent.tools.length > 0) args.push("--tools", agent.tools.join(","));
+	if (tmpPromptPath) args.push("--append-system-prompt", tmpPromptPath);
+	args.push(`Task: ${task}`);
+	return args;
+}
+
+export function resolveSubagentSessionArgs(
+	contextMode: SubagentContextMode = "fresh",
+	parentSessionManager?: SubagentParentSessionManager,
+): SubagentSessionArgs {
+	if (contextMode === "fresh") return { mode: "fresh" };
+
+	if (!parentSessionManager) {
+		throw new Error("Forked subagent context requires a parent session manager.");
+	}
+
+	const parentSessionFile = parentSessionManager.getSessionFile();
+	if (!parentSessionFile) {
+		throw new Error("Forked subagent context requires a persisted parent session file; current session is in-memory.");
+	}
+	if (!fs.existsSync(parentSessionFile)) {
+		throw new Error(`Forked subagent context could not read parent session file: ${parentSessionFile}`);
+	}
+
+	const leafId = parentSessionManager.getLeafId();
+	if (!leafId) {
+		throw new Error("Forked subagent context requires a parent session leaf to branch from.");
+	}
+
+	const sessionDir = parentSessionManager.getSessionDir?.();
+	const parentSession = SessionManager.open(parentSessionFile, sessionDir);
+	const childSessionFile = parentSession.createBranchedSession(leafId);
+	if (!childSessionFile) {
+		throw new Error("Forked subagent context could not create a branched child session.");
+	}
+
+	return {
+		mode: "fork",
+		sessionFile: childSessionFile,
+		...(sessionDir ? { sessionDir: path.resolve(sessionDir) } : {}),
+	};
+}
+
+export function createSubagentLaunchPlan(input: SubagentLaunchInput): SubagentLaunchPlan {
+	const session = input.session ?? resolveSubagentSessionArgs(input.contextMode ?? "fresh", input.parentSessionManager);
+	return {
+		args: buildSubagentProcessArgs(
+			input.agent,
+			input.task,
+			input.tmpPromptPath,
+			input.modelOverride,
+			session,
+		),
+		env: buildSubagentProcessEnv(),
+		cwd: input.cwd ?? input.defaultCwd,
+		session,
+	};
+}

--- a/src/resources/extensions/subagent/run-store.ts
+++ b/src/resources/extensions/subagent/run-store.ts
@@ -1,0 +1,157 @@
+// GSD-2 + Durable subagent run status and result artifact store.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getAgentDir } from "@gsd/pi-coding-agent";
+
+export type SubagentRunMode = "single" | "parallel" | "chain";
+export type SubagentRunStatus = "queued" | "running" | "succeeded" | "failed" | "interrupted";
+
+export interface SubagentChildArtifact {
+	index: number;
+	agent: string;
+	task: string;
+	status: SubagentRunStatus;
+	exitCode?: number;
+	cwd?: string;
+	sessionFile?: string;
+	startedAt?: string;
+	completedAt?: string;
+	output?: string;
+	stderr?: string;
+	errorMessage?: string;
+	stopReason?: string;
+	model?: string;
+	usage?: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+		cost: number;
+		contextTokens: number;
+		turns: number;
+	};
+	merge?: {
+		success: boolean;
+		appliedPatches: string[];
+		failedPatches: string[];
+		error?: string;
+	};
+}
+
+export interface SubagentRunRecord {
+	schemaVersion: 1;
+	runId: string;
+	mode: SubagentRunMode;
+	contextMode: "fresh" | "fork";
+	status: SubagentRunStatus;
+	cwd: string;
+	startedAt: string;
+	updatedAt: string;
+	completedAt?: string;
+	children: SubagentChildArtifact[];
+	failure?: {
+		type: "child-failed" | "merge-failed" | "interrupted" | "launch-failed";
+		message: string;
+	};
+}
+
+export function defaultSubagentRunStoreDir(): string {
+	return path.join(getAgentDir(), "subagent-runs");
+}
+
+export class SubagentRunStore {
+	private readonly baseDir: string;
+
+	constructor(baseDir: string = defaultSubagentRunStoreDir()) {
+		this.baseDir = baseDir;
+	}
+
+	getBaseDir(): string {
+		return this.baseDir;
+	}
+
+	create(record: SubagentRunRecord): SubagentRunRecord {
+		this.write(record);
+		return record;
+	}
+
+	get(runId: string): SubagentRunRecord | null {
+		const filePath = this.pathFor(runId);
+		if (!fs.existsSync(filePath)) return null;
+		try {
+			return JSON.parse(fs.readFileSync(filePath, "utf-8")) as SubagentRunRecord;
+		} catch {
+			return null;
+		}
+	}
+
+	update(runId: string, updater: (record: SubagentRunRecord) => SubagentRunRecord): SubagentRunRecord {
+		const current = this.get(runId);
+		if (!current) throw new Error(`Subagent run not found: ${runId}`);
+		const next = updater({
+			...current,
+			children: current.children.map((child) => ({ ...child })),
+		});
+		next.updatedAt = new Date().toISOString();
+		this.write(next);
+		return next;
+	}
+
+	list(): SubagentRunRecord[] {
+		if (!fs.existsSync(this.baseDir)) return [];
+		return fs.readdirSync(this.baseDir)
+			.filter((name) => name.endsWith(".json"))
+			.map((name) => this.get(path.basename(name, ".json")))
+			.filter((record): record is SubagentRunRecord => record !== null)
+			.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+	}
+
+	private pathFor(runId: string): string {
+		const safeRunId = runId.replace(/[^a-zA-Z0-9._-]/g, "_");
+		return path.join(this.baseDir, `${safeRunId}.json`);
+	}
+
+	private write(record: SubagentRunRecord): void {
+		fs.mkdirSync(this.baseDir, { recursive: true });
+		const filePath = this.pathFor(record.runId);
+		const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+		fs.writeFileSync(tmpPath, `${JSON.stringify(record, null, 2)}\n`, "utf-8");
+		fs.renameSync(tmpPath, filePath);
+	}
+}
+
+export function createInitialRunRecord(input: {
+	runId: string;
+	mode: SubagentRunMode;
+	contextMode: "fresh" | "fork";
+	cwd: string;
+	children: Array<{ agent: string; task: string; cwd?: string }>;
+	now?: string;
+}): SubagentRunRecord {
+	const now = input.now ?? new Date().toISOString();
+	return {
+		schemaVersion: 1,
+		runId: input.runId,
+		mode: input.mode,
+		contextMode: input.contextMode,
+		status: "running",
+		cwd: input.cwd,
+		startedAt: now,
+		updatedAt: now,
+		children: input.children.map((child, index) => ({
+			index,
+			agent: child.agent,
+			task: child.task,
+			cwd: child.cwd,
+			status: "queued",
+		})),
+	};
+}
+
+export function deriveRunStatus(children: readonly SubagentChildArtifact[]): SubagentRunStatus {
+	if (children.some((child) => child.status === "interrupted")) return "interrupted";
+	if (children.some((child) => child.status === "failed")) return "failed";
+	if (children.length > 0 && children.every((child) => child.status === "succeeded")) return "succeeded";
+	return "running";
+}

--- a/src/resources/extensions/subagent/run-store.ts
+++ b/src/resources/extensions/subagent/run-store.ts
@@ -1,7 +1,8 @@
-// GSD-2 + Durable subagent run status and result artifact store.
+// GSD-2 + Durable subagent run status, tracking names, and result artifact store.
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { randomInt } from "node:crypto";
 import { getAgentDir } from "@gsd/pi-coding-agent";
 
 export type SubagentRunMode = "single" | "parallel" | "chain";
@@ -10,6 +11,7 @@ export type SubagentRunStatus = "queued" | "running" | "succeeded" | "failed" | 
 export interface SubagentChildArtifact {
 	index: number;
 	agent: string;
+	trackingName?: string;
 	task: string;
 	status: SubagentRunStatus;
 	exitCode?: number;
@@ -58,6 +60,54 @@ export interface SubagentRunRecord {
 
 export function defaultSubagentRunStoreDir(): string {
 	return path.join(getAgentDir(), "subagent-runs");
+}
+
+const TRACKING_ADJECTIVES = [
+	"amber",
+	"bright",
+	"calm",
+	"clear",
+	"crisp",
+	"daring",
+	"keen",
+	"lucky",
+	"quiet",
+	"steady",
+	"swift",
+	"vivid",
+] as const;
+
+const TRACKING_NOUNS = [
+	"anchor",
+	"atlas",
+	"beacon",
+	"canvas",
+	"compass",
+	"forge",
+	"harbor",
+	"lantern",
+	"ledger",
+	"mesa",
+	"quartz",
+	"ridge",
+	"signal",
+	"summit",
+	"vector",
+	"vista",
+] as const;
+
+export function createSubagentTrackingName(existingNames: ReadonlySet<string> = new Set()): string {
+	const maxCombinations = TRACKING_ADJECTIVES.length * TRACKING_NOUNS.length;
+	for (let attempt = 0; attempt < maxCombinations * 2; attempt++) {
+		const adjective = TRACKING_ADJECTIVES[randomInt(TRACKING_ADJECTIVES.length)];
+		const noun = TRACKING_NOUNS[randomInt(TRACKING_NOUNS.length)];
+		const name = `${adjective}-${noun}`;
+		if (!existingNames.has(name)) return name;
+	}
+
+	let suffix = existingNames.size + 1;
+	while (existingNames.has(`agent-${suffix}`)) suffix++;
+	return `agent-${suffix}`;
 }
 
 export class SubagentRunStore {
@@ -126,7 +176,7 @@ export function createInitialRunRecord(input: {
 	mode: SubagentRunMode;
 	contextMode: "fresh" | "fork";
 	cwd: string;
-	children: Array<{ agent: string; task: string; cwd?: string }>;
+	children: Array<{ agent: string; trackingName?: string; task: string; cwd?: string }>;
 	now?: string;
 }): SubagentRunRecord {
 	const now = input.now ?? new Date().toISOString();
@@ -142,6 +192,7 @@ export function createInitialRunRecord(input: {
 		children: input.children.map((child, index) => ({
 			index,
 			agent: child.agent,
+			trackingName: child.trackingName,
 			task: child.task,
 			cwd: child.cwd,
 			status: "queued",

--- a/src/resources/extensions/subagent/run-store.ts
+++ b/src/resources/extensions/subagent/run-store.ts
@@ -130,7 +130,17 @@ export class SubagentRunStore {
 		const filePath = this.pathFor(runId);
 		if (!fs.existsSync(filePath)) return null;
 		try {
-			return JSON.parse(fs.readFileSync(filePath, "utf-8")) as SubagentRunRecord;
+			const parsed = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Partial<SubagentRunRecord>;
+			if (
+				!parsed ||
+				typeof parsed !== "object" ||
+				typeof parsed.runId !== "string" ||
+				typeof parsed.updatedAt !== "string" ||
+				!Array.isArray(parsed.children)
+			) {
+				return null;
+			}
+			return parsed as SubagentRunRecord;
 		} catch {
 			return null;
 		}

--- a/src/resources/extensions/subagent/tests/launch.test.ts
+++ b/src/resources/extensions/subagent/tests/launch.test.ts
@@ -1,0 +1,115 @@
+// GSD-2 + Subagent launch module regression tests.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, afterEach } from "node:test";
+
+import { SessionManager } from "@gsd/pi-coding-agent";
+import subagentExtension from "../index.js";
+import type { AgentConfig } from "../agents.js";
+import {
+	SUBAGENT_CHILD_ENV_VAR,
+	SUBAGENT_CHILD_ENV_VALUE,
+	buildSubagentProcessEnv,
+	createSubagentLaunchPlan,
+	isSubagentChildProcess,
+	resolveSubagentSessionArgs,
+} from "../launch.js";
+
+function makeAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+	return {
+		name: "test-agent",
+		description: "A test agent",
+		systemPrompt: "",
+		source: "project",
+		filePath: "test-agent.md",
+		tools: ["read", "write"],
+		...overrides,
+	};
+}
+
+function makeAssistantMessage() {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "ok" }],
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			total: 2,
+			cost: { total: 0 },
+		},
+	} as any;
+}
+
+describe("subagent launch module", () => {
+	let dir: string | undefined;
+
+	afterEach(() => {
+		if (dir) rmSync(dir, { recursive: true, force: true });
+		dir = undefined;
+	});
+
+	it("builds fresh child process args with child environment", () => {
+		const agent = makeAgent({ model: "local-model" });
+		const plan = createSubagentLaunchPlan({
+			agent,
+			task: "inspect the API",
+			tmpPromptPath: "/tmp/prompt.md",
+			defaultCwd: "/repo",
+		});
+
+		assert.ok(plan.args.includes("--no-session"));
+		assert.equal(plan.args.includes("--session"), false);
+		assert.equal(plan.env[SUBAGENT_CHILD_ENV_VAR], SUBAGENT_CHILD_ENV_VALUE);
+		assert.equal(plan.cwd, "/repo");
+		assert.deepEqual(plan.session, { mode: "fresh" });
+		assert.deepEqual(plan.args.slice(plan.args.indexOf("--tools"), plan.args.indexOf("--tools") + 2), ["--tools", "read,write"]);
+	});
+
+	it("creates a real branched session for forked context", () => {
+		dir = mkdtempSync(join(tmpdir(), "gsd-subagent-launch-"));
+		const manager = SessionManager.create(dir, dir);
+		manager.appendMessage({ role: "user", content: [{ type: "text", text: "hello" }] } as any);
+		manager.appendMessage(makeAssistantMessage());
+
+		const session = resolveSubagentSessionArgs("fork", manager);
+
+		assert.equal(session.mode, "fork");
+		assert.ok(session.sessionFile);
+		assert.notEqual(session.sessionFile, manager.getSessionFile());
+		assert.equal(session.sessionDir, dir);
+	});
+
+	it("fails forked context loudly without a persisted parent session", () => {
+		const manager = SessionManager.inMemory("/repo");
+		assert.throws(
+			() => resolveSubagentSessionArgs("fork", manager),
+			/persisted parent session file/,
+		);
+	});
+
+	it("marks child env and suppresses recursive tool registration", () => {
+		const env = buildSubagentProcessEnv({});
+		assert.equal(isSubagentChildProcess(env), true);
+
+		const previous = process.env[SUBAGENT_CHILD_ENV_VAR];
+		process.env[SUBAGENT_CHILD_ENV_VAR] = SUBAGENT_CHILD_ENV_VALUE;
+		const calls: string[] = [];
+		try {
+			subagentExtension({
+				on: () => calls.push("on"),
+				registerCommand: () => calls.push("command"),
+				registerTool: () => calls.push("tool"),
+			} as any);
+		} finally {
+			if (previous === undefined) delete process.env[SUBAGENT_CHILD_ENV_VAR];
+			else process.env[SUBAGENT_CHILD_ENV_VAR] = previous;
+		}
+
+		assert.deepEqual(calls, []);
+	});
+});

--- a/src/resources/extensions/subagent/tests/run-store.test.ts
+++ b/src/resources/extensions/subagent/tests/run-store.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, it } from "node:test";
 import {
 	SubagentRunStore,
 	createInitialRunRecord,
+	createSubagentTrackingName,
 	deriveRunStatus,
 } from "../run-store.js";
 
@@ -28,7 +29,7 @@ describe("SubagentRunStore", () => {
 			mode: "single",
 			contextMode: "fresh",
 			cwd: "/repo",
-			children: [{ agent: "scout", task: "inspect" }],
+			children: [{ agent: "scout", trackingName: "clear-beacon", task: "inspect" }],
 			now: "2026-01-01T00:00:00.000Z",
 		}));
 
@@ -46,8 +47,19 @@ describe("SubagentRunStore", () => {
 
 		const loaded = store.get("run-1");
 		assert.equal(loaded?.status, "succeeded");
+		assert.equal(loaded?.children[0]?.trackingName, "clear-beacon");
 		assert.equal(loaded?.children[0]?.output, "done");
 		assert.equal(store.list()[0]?.runId, "run-1");
+	});
+
+	it("generates unique tracking names for child agents", () => {
+		const names = new Set<string>();
+		for (let i = 0; i < 24; i++) {
+			const name = createSubagentTrackingName(names);
+			assert.match(name, /^[a-z]+-[a-z]+$|^agent-\d+$/);
+			assert.equal(names.has(name), false);
+			names.add(name);
+		}
 	});
 
 	it("persists failed and interrupted child evidence", () => {

--- a/src/resources/extensions/subagent/tests/run-store.test.ts
+++ b/src/resources/extensions/subagent/tests/run-store.test.ts
@@ -1,0 +1,99 @@
+// GSD-2 + Subagent durable run-store tests.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import {
+	SubagentRunStore,
+	createInitialRunRecord,
+	deriveRunStatus,
+} from "../run-store.js";
+
+describe("SubagentRunStore", () => {
+	let dir: string | undefined;
+
+	afterEach(() => {
+		if (dir) rmSync(dir, { recursive: true, force: true });
+		dir = undefined;
+	});
+
+	it("persists launch and successful completion evidence", () => {
+		dir = mkdtempSync(join(tmpdir(), "gsd-subagent-runs-"));
+		const store = new SubagentRunStore(dir);
+		store.create(createInitialRunRecord({
+			runId: "run-1",
+			mode: "single",
+			contextMode: "fresh",
+			cwd: "/repo",
+			children: [{ agent: "scout", task: "inspect" }],
+			now: "2026-01-01T00:00:00.000Z",
+		}));
+
+		store.update("run-1", (record) => ({
+			...record,
+			status: "succeeded",
+			completedAt: "2026-01-01T00:00:01.000Z",
+			children: [{
+				...record.children[0],
+				status: "succeeded",
+				exitCode: 0,
+				output: "done",
+			}],
+		}));
+
+		const loaded = store.get("run-1");
+		assert.equal(loaded?.status, "succeeded");
+		assert.equal(loaded?.children[0]?.output, "done");
+		assert.equal(store.list()[0]?.runId, "run-1");
+	});
+
+	it("persists failed and interrupted child evidence", () => {
+		dir = mkdtempSync(join(tmpdir(), "gsd-subagent-runs-"));
+		const store = new SubagentRunStore(dir);
+		store.create(createInitialRunRecord({
+			runId: "run-2",
+			mode: "parallel",
+			contextMode: "fork",
+			cwd: "/repo",
+			children: [
+				{ agent: "tester", task: "verify" },
+				{ agent: "reviewer", task: "review" },
+			],
+		}));
+
+		store.update("run-2", (record) => ({
+			...record,
+			status: "interrupted",
+			children: [
+				{
+					...record.children[0],
+					status: "failed",
+					exitCode: 1,
+					errorMessage: "verification failed",
+				},
+				{
+					...record.children[1],
+					status: "interrupted",
+					exitCode: 1,
+					stopReason: "aborted",
+				},
+			],
+			failure: { type: "interrupted", message: "run aborted" },
+		}));
+
+		const loaded = store.get("run-2");
+		assert.equal(loaded?.status, "interrupted");
+		assert.equal(loaded?.children[0]?.errorMessage, "verification failed");
+		assert.equal(loaded?.children[1]?.stopReason, "aborted");
+		assert.equal(loaded?.failure?.type, "interrupted");
+	});
+
+	it("derives failed and interrupted status from child artifacts", () => {
+		assert.equal(deriveRunStatus([{ index: 0, agent: "a", task: "t", status: "failed" }]), "failed");
+		assert.equal(deriveRunStatus([{ index: 0, agent: "a", task: "t", status: "interrupted" }]), "interrupted");
+		assert.equal(deriveRunStatus([{ index: 0, agent: "a", task: "t", status: "succeeded" }]), "succeeded");
+	});
+});


### PR DESCRIPTION
## Summary
- add subagent child-process recursion guard, launch planning, and forked-context session branching
- persist subagent run status/artifacts with status/resume/background support
- support isolated parallel child work with merge failure reporting
- enforce planning-dispatch subagent permission contracts
- assign random per-child tracking names for status/result output
- document subagent launch, status, resume, isolation, and recovery behavior

## Tests
- npm run build:core
- npm run typecheck:extensions
- npm run test:unit
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/subagent/tests/model-override.test.ts src/resources/extensions/subagent/tests/launch.test.ts src/resources/extensions/subagent/tests/run-store.test.ts src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts src/resources/extensions/gsd/tests/unit-context-manifest.test.ts

Closes #5817
Closes #5818
Closes #5819
Closes #5820
Closes #5821
Closes #5822
Closes #5823

Replaces #5824 after its head branch was reset and the PR was closed unmerged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Subagents workflow: dispatch modes (single/parallel/chain), background launches with status/resume, persistent run tracking with human-friendly tracking names, and improved agent labeling in UI.
  * New interrupt API for terminal multiplexing surfaces.

* **Documentation**
  * New Subagents docs, command reference, and taskIsolation configuration guide.

* **Tests**
  * Added launch and run-store test suites.

* **Chores**
  * Updated TypeScript devDependency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5829)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->