### PR TITLE
fix(issue): plan-slice infinite loop: is_sketch never cleared after full plan written (progressive_planning=OFF)

### DIFF
--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -125,6 +125,31 @@ test('handlePlanSlice advances DB-derived state out of planning immediately', as
   }
 });
 
+test('handlePlanSlice clears sketch flag so DB-derived state leaves refining', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    insertMilestone({ id: 'M001', title: 'Milestone', status: 'active' });
+    insertSlice({ id: 'S02', milestoneId: 'M001', title: 'Planning slice', status: 'pending', demo: 'Rendered plans exist.', isSketch: true });
+
+    invalidateStateCache();
+    const before = await deriveState(base);
+    assert.equal(before.phase, 'refining');
+
+    const result = await handlePlanSlice(validParams(), base);
+    assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+    assert.equal(getSlice('M001', 'S02')?.is_sketch, 0, 'planned slice must no longer be treated as a sketch');
+
+    invalidateStateCache();
+    const after = await deriveState(base);
+    assert.notEqual(after.phase, 'refining');
+    assert.equal(after.progress?.tasks?.total, 2);
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handlePlanSlice leaves omitted enrichment fields empty instead of rendering placeholders', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -10,6 +10,7 @@ import {
   upsertTaskPlanning,
   insertGateRow,
   updateSliceStatus,
+  setSliceSketchFlag,
 } from "../gsd-db.js";
 import type { GateId } from "../types.js";
 import { invalidateStateCache } from "../state.js";
@@ -184,6 +185,7 @@ export async function handlePlanSlice(
       if (isDeferredStatus(parentSlice.status)) {
         updateSliceStatus(params.milestoneId, params.sliceId, "pending");
       }
+      setSliceSketchFlag(params.milestoneId, params.sliceId, false);
 
       upsertSlicePlanning(params.milestoneId, params.sliceId, {
         goal: params.goal,


### PR DESCRIPTION
## Summary
- Cleared the plan-slice sketch flag in the DB transaction and verified with the focused plan-slice test, build:core, and extension typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5830
- [#5830 plan-slice infinite loop: is_sketch never cleared after full plan written (progressive_planning=OFF)](https://github.com/gsd-build/gsd-2/issues/5830)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5830-plan-slice-infinite-loop-is-sketch-never-1778556877`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where sketch slices were not being properly cleared during plan processing, which prevented accurate state transitions and task totals. Slices now correctly transition out of the refining phase when plans are created.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5832)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->