### PR TITLE
fix(issue): Premature auto-compaction with claude-code provider: SDK result.usage is cumulative across agentic loop, mistaken for current context size

### DIFF
--- a/src/resources/extensions/claude-code-cli/partial-builder.ts
+++ b/src/resources/extensions/claude-code-cli/partial-builder.ts
@@ -134,10 +134,11 @@ export function mapUsage(sdkUsage: NonNullableUsage, totalCostUsd: number): Usag
 		output: sdkUsage.output_tokens,
 		cacheRead: sdkUsage.cache_read_input_tokens,
 		cacheWrite: sdkUsage.cache_creation_input_tokens,
+		// Claude Agent SDK result usage is cumulative across its internal loop;
+		// repeated cache reads do not represent additional live context.
 		totalTokens:
 			sdkUsage.input_tokens +
 			sdkUsage.output_tokens +
-			sdkUsage.cache_read_input_tokens +
 			sdkUsage.cache_creation_input_tokens,
 		cost: {
 			input: 0,

--- a/src/resources/extensions/claude-code-cli/tests/partial-builder.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/partial-builder.test.ts
@@ -1,7 +1,24 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { mapContentBlock, parseMcpToolName, PartialMessageBuilder } from "../partial-builder.ts";
-import type { BetaContentBlock, BetaRawMessageStreamEvent } from "../sdk-types.ts";
+import { mapContentBlock, mapUsage, parseMcpToolName, PartialMessageBuilder } from "../partial-builder.ts";
+import type { BetaContentBlock, BetaRawMessageStreamEvent, NonNullableUsage } from "../sdk-types.ts";
+
+describe("mapUsage", () => {
+	test("excludes cumulative cache reads from context-sized totalTokens (#5243)", () => {
+		const usage: NonNullableUsage = {
+			input_tokens: 150_000,
+			output_tokens: 2_000,
+			cache_read_input_tokens: 900_000,
+			cache_creation_input_tokens: 3_000,
+		};
+
+		const mapped = mapUsage(usage, 1.23);
+
+		assert.equal(mapped.cacheRead, 900_000);
+		assert.equal(mapped.totalTokens, 155_000);
+		assert.equal(mapped.cost.total, 1.23);
+	});
+});
 
 describe("PartialMessageBuilder — malformed tool arguments (#2574)", () => {
 	/**


### PR DESCRIPTION
## Summary
- Excluded Claude Code cumulative cache-read usage from context-sized totalTokens and verified with the focused partial-builder test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5243
- [#5243 Premature auto-compaction with claude-code provider: SDK result.usage is cumulative across agentic loop, mistaken for current context size](https://github.com/gsd-build/gsd-2/issues/5243)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5243-premature-auto-compaction-with-claude-co-1778561544`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Corrected token usage calculations to prevent cache read tokens from being incorrectly included in total token counts.

## Tests
- Added test coverage for token usage calculations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5833)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->