### PR TITLE
fix(issue): GSD auto-mode loops completing milestone when validation verdict is needs-attention

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1322,19 +1322,19 @@ export const DISPATCH_RULES: DispatchRule[] = [
         }
       }
 
-      // Safety guard (#2675): block completion when VALIDATION verdict is
-      // needs-remediation. The state machine treats needs-remediation as
-      // terminal (to prevent validate-milestone loops per #832), but
-      // completing-milestone should NOT proceed — remediation work is needed.
+      // Safety guard (#2675, #5747): block completion when VALIDATION
+      // verdict is non-passing. The state machine treats these verdicts as
+      // terminal, but completing-milestone should NOT proceed — remediation
+      // or human attention is needed.
       const validationFile = resolveMilestoneFile(basePath, mid, "VALIDATION");
       if (validationFile) {
         const validationContent = await loadFile(validationFile);
         if (validationContent) {
           const verdict = extractVerdict(validationContent);
-          if (verdict === "needs-remediation") {
+          if (verdict === "needs-remediation" || verdict === "needs-attention") {
             return {
               action: "stop",
-              reason: `Cannot complete milestone ${mid}: VALIDATION verdict is "needs-remediation". Address the remediation findings and re-run validation, or update the verdict manually.`,
+              reason: `Cannot complete milestone ${mid}: VALIDATION verdict is "${verdict}". Address the validation findings and re-run validation, or update the verdict manually.`,
               level: "warning",
             };
           }

--- a/src/resources/extensions/gsd/tests/remediation-completion-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/remediation-completion-guard.test.ts
@@ -1,6 +1,6 @@
 /**
- * Regression test for #2675: completing-milestone dispatch rule must
- * block completion when VALIDATION verdict is "needs-remediation".
+ * Regression tests for non-passing VALIDATION verdicts: completing-milestone
+ * dispatch must block completion when VALIDATION needs remediation or attention.
  *
  * Without this guard, needs-remediation + allSlicesDone causes a loop:
  * complete-milestone dispatched → agent refuses (correct) → no SUMMARY
@@ -59,6 +59,50 @@ test("completing-milestone blocks when VALIDATION verdict is needs-remediation (
       assert.ok(
         result!.reason.includes("needs-remediation"),
         "reason should mention needs-remediation",
+      );
+    }
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("completing-milestone blocks when VALIDATION verdict is needs-attention (#5747)", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-attention-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+
+  try {
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-VALIDATION.md"),
+      [
+        "---",
+        "verdict: needs-attention",
+        "remediation_round: 0",
+        "---",
+        "",
+        "# Validation Report",
+        "",
+        "Acceptance proof is incomplete and needs human attention.",
+      ].join("\n"),
+    );
+
+    const ctx = {
+      mid: "M001",
+      midTitle: "Test Milestone",
+      basePath: base,
+      state: { phase: "completing-milestone" } as any,
+      prefs: {} as any,
+      session: undefined,
+    };
+
+    const result = await completingRule!.match(ctx);
+
+    assert.ok(result !== null, "rule should match");
+    assert.equal(result!.action, "stop", "should return stop action");
+    if (result!.action === "stop") {
+      assert.equal(result!.level, "warning", "should be warning level (pausable)");
+      assert.ok(
+        result!.reason.includes("needs-attention"),
+        "reason should mention needs-attention",
       );
     }
   } finally {


### PR DESCRIPTION
## Summary
- Blocked complete-milestone dispatch for needs-attention validation verdicts and verified with focused dispatch tests plus git diff --check.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5747
- [#5747 GSD auto-mode loops completing milestone when validation verdict is needs-attention](https://github.com/gsd-build/gsd-2/issues/5747)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5747-gsd-auto-mode-loops-completing-milestone-1778561582`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation safety checks to prevent milestone completion when additional warning conditions are detected, ensuring comprehensive oversight before proceeding with milestone progression.

* **Tests**
  * Expanded test coverage to verify validation checks properly block completion and return appropriate warnings for identified validation issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5834)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->