### PR TITLE
fix(issue): complete-milestone blocked by planning-dispatch tools policy — stuck loop on bash verification commands

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -14,7 +14,10 @@ import {
   type SkillsPolicy,
   type UnitContextManifest,
 } from "../unit-context-manifest.ts";
-import { ALLOWED_PLANNING_DISPATCH_AGENTS } from "../bootstrap/write-gate.ts";
+import {
+  ALLOWED_PLANNING_DISPATCH_AGENTS,
+  shouldBlockPlanningUnit,
+} from "../bootstrap/write-gate.ts";
 import {
   getRequiredWorkflowToolsForAutoUnit,
   getRequiredWorkflowToolsForGuidedUnit,
@@ -243,12 +246,22 @@ test('#4934: only execution units and complete-milestone may use tools.mode "all
 });
 
 test("#5453: complete-milestone uses all tools so bash verification is not planning-dispatch blocked", () => {
-  assert.strictEqual(UNIT_MANIFESTS["complete-milestone"].tools.mode, "all");
+  const manifest = UNIT_MANIFESTS["complete-milestone"];
+
+  assert.strictEqual(manifest.tools.mode, "all");
   assert.deepEqual(resolveSubagentPermissionContract("complete-milestone"), {
     allowed: true,
     allowedSubagents: ["*"],
     toolsMode: "all",
   });
+  const gitVerification = shouldBlockPlanningUnit(
+    "bash",
+    "git diff --name-only",
+    process.cwd(),
+    "complete-milestone",
+    manifest.tools,
+  );
+  assert.strictEqual(gitVerification.block, false, gitVerification.reason);
 });
 
 test('planning-dispatch mode is reserved for slice-level decomposition and completion units', () => {

--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -254,14 +254,22 @@ test("#5453: complete-milestone uses all tools so bash verification is not plann
     allowedSubagents: ["*"],
     toolsMode: "all",
   });
-  const gitVerification = shouldBlockPlanningUnit(
-    "bash",
-    "git diff --name-only",
-    process.cwd(),
-    "complete-milestone",
-    manifest.tools,
-  );
-  assert.strictEqual(gitVerification.block, false, gitVerification.reason);
+  // Runtime gate-level regression: these verification commands were blocked
+  // under planning-dispatch in #5453; complete-milestone must bypass that gate.
+  for (const cmd of ["git diff --name-only HEAD~1", "git log -n1 --oneline"]) {
+    const result = shouldBlockPlanningUnit(
+      "bash",
+      cmd,
+      process.cwd(),
+      "complete-milestone",
+      manifest.tools,
+    );
+    assert.strictEqual(
+      result.block,
+      false,
+      `shouldBlockPlanningUnit must not block ${cmd} for complete-milestone: ${result.reason}`,
+    );
+  }
 });
 
 test('planning-dispatch mode is reserved for slice-level decomposition and completion units', () => {

--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -227,19 +227,28 @@ test("#4934: tools.mode is one of the declared policies", () => {
   }
 });
 
-test('#4934: only execute-task and reactive-execute may use tools.mode "all" (full source-tree write access)', () => {
-  const allowedAllUnits = new Set(["execute-task", "reactive-execute"]);
+test('#4934: only execution units and complete-milestone may use tools.mode "all"', () => {
+  const allowedAllUnits = new Set(["execute-task", "reactive-execute", "complete-milestone"]);
   for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
     const mode = (manifest as { tools: { mode: string } }).tools.mode;
     if (mode === "all") {
       assert.ok(
         allowedAllUnits.has(unitType),
-        `manifest "${unitType}" declares tools.mode = "all" but is not on the execute-track. ` +
-        'Only execute-task and reactive-execute should have full source write access; ' +
+        `manifest "${unitType}" declares tools.mode = "all" but is not explicitly allowed. ` +
+        'Only execute-task, reactive-execute, and complete-milestone should have full source write access; ' +
         'planning/discuss/research units must use "planning" or "planning-dispatch" (or "docs" for rewrite-docs).',
       );
     }
   }
+});
+
+test("#5453: complete-milestone uses all tools so bash verification is not planning-dispatch blocked", () => {
+  assert.strictEqual(UNIT_MANIFESTS["complete-milestone"].tools.mode, "all");
+  assert.deepEqual(resolveSubagentPermissionContract("complete-milestone"), {
+    allowed: true,
+    allowedSubagents: ["*"],
+    toolsMode: "all",
+  });
 });
 
 test('planning-dispatch mode is reserved for slice-level decomposition and completion units', () => {
@@ -248,7 +257,6 @@ test('planning-dispatch mode is reserved for slice-level decomposition and compl
     "research-slice",
     "refine-slice",
     "complete-slice",
-    "complete-milestone",
     "gate-evaluate",
     // Deep planning mode: research-project orchestrates 4 parallel research
     // subagents (stack/features/architecture/pitfalls). Subagent dispatch is

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -406,8 +406,8 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     contextMode: "verification",
     // planning-dispatch: validation is a verification-fan-out unit. It reads
     // the milestone surface and dispatches reviewer/security/tester subagents
-    // to report findings without touching user source. Mirrors
-    // complete-milestone's policy. Write isolation to .gsd/ is preserved.
+    // to report findings without touching user source. Write isolation to
+    // .gsd/ is preserved.
     tools: TOOLS_PLANNING_DISPATCH_REVIEW,
     artifacts: {
       inline: ["roadmap", "slice-summary", "slice-uat", "requirements", "decisions", "templates"],
@@ -423,11 +423,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     codebaseMap: false,
     preferences: "active-only",
     contextMode: "verification",
-    // planning-dispatch: completion is a high-leverage place to fan out to
-    // reviewer / security / tester subagents. They read the diff and report
-    // findings; they do not write user source. Write isolation to .gsd/ is
-    // preserved.
-    tools: TOOLS_PLANNING_DISPATCH_REVIEW,
+    // Milestone closeout must run unrestricted shell verification commands
+    // against the final diff before recording completion.
+    tools: TOOLS_ALL,
     artifacts: {
       // #4780 landed slice-summary as excerpt for this unit; phase 2 of
       // the architecture will read this manifest as the source of truth


### PR DESCRIPTION
## Summary
- Fixed complete-milestone to use TOOLS_ALL and verified with the focused manifest test plus extension typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5453
- [#5453 complete-milestone blocked by planning-dispatch tools policy — stuck loop on bash verification commands](https://github.com/gsd-build/gsd-2/issues/5453)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5453-complete-milestone-blocked-by-planning-d-1778561515`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit tests to allow full-tool access for milestone completion, verify it isn't blocked by shell-gated checks, and adjust planning-dispatch allowlist expectations.
* **Improvements**
  * Milestone closeout operations declared to run with unrestricted verification access; comments clarified to reflect this behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5835)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->