### PR TITLE
fix(issue): bug: /gsd park refuses active milestone with blocked SUMMARY.md

### DIFF
--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -24,6 +24,7 @@ import { deleteMilestone, getMilestone, isDbAvailable, updateMilestoneStatus } f
 import { removeWorktree } from "./worktree-manager.js";
 import { logWarning } from "./workflow-logger.js";
 import { isAutoActive } from "./auto.js";
+import { isClosedStatus } from "./status-guards.js";
 
 /**
  * Writer-side assert for mutations that race with auto-mode's squash merge (#4704).
@@ -44,7 +45,7 @@ function assertNotAutoActive(action: string): void {
 /**
  * Park a milestone — creates a PARKED.md marker file with reason and timestamp.
  * Parked milestones are skipped during active-milestone discovery but stay on disk.
- * Returns true if successfully parked, false if milestone not found or already parked.
+ * Returns true if successfully parked, false if milestone not found, already parked, or complete.
  */
 export function parkMilestone(basePath: string, milestoneId: string, reason: string): boolean {
   assertNotAutoActive("park milestone");
@@ -52,8 +53,13 @@ export function parkMilestone(basePath: string, milestoneId: string, reason: str
   if (!mDir || !existsSync(mDir)) return false;
 
   // Guard: do not park a completed milestone — it would corrupt depends_on satisfaction
-  const summaryFile = resolveMilestoneFile(basePath, milestoneId, "SUMMARY");
-  if (summaryFile) return false;
+  const dbAvailable = isDbAvailable();
+  const milestone = dbAvailable ? getMilestone(milestoneId) : null;
+  if (milestone && isClosedStatus(milestone.status)) return false;
+  if (!dbAvailable) {
+    const summaryFile = resolveMilestoneFile(basePath, milestoneId, "SUMMARY");
+    if (summaryFile) return false;
+  }
 
   const parkedPath = join(mDir, buildMilestoneFileName(milestoneId, "PARKED"));
   if (existsSync(parkedPath)) return false; // already parked
@@ -72,7 +78,7 @@ export function parkMilestone(basePath: string, milestoneId: string, reason: str
 
   writeFileSync(parkedPath, content, "utf-8");
   // Sync DB status so deriveStateFromDb also skips this milestone (#2694)
-  if (isDbAvailable()) {
+  if (dbAvailable) {
     try {
       updateMilestoneStatus(milestoneId, "parked");
     } catch (err) {

--- a/src/resources/extensions/gsd/tests/park-db-sync.test.ts
+++ b/src/resources/extensions/gsd/tests/park-db-sync.test.ts
@@ -7,7 +7,7 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -42,6 +42,60 @@ test("parkMilestone updates DB status to 'parked' (#2694)", () => {
     assert.equal(getMilestone("M001")!.status, "parked", "DB status should be parked");
 
     closeDatabase();
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("parkMilestone ignores blocked SUMMARY.md when DB milestone is active (#5828)", () => {
+  const base = createBase();
+  try {
+    openDatabase(":memory:");
+    insertMilestone({ id: "M001", title: "Test", status: "active" });
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-SUMMARY.md"),
+      [
+        "---",
+        "status: closeout_blocked",
+        "---",
+        "",
+        "# M001 Summary",
+        "",
+        "Completion was not persisted.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const parked = parkMilestone(base, "M001", "test");
+
+    assert.ok(parked, "active DB row should allow parking despite a blocked SUMMARY.md");
+    assert.ok(
+      existsSync(join(base, ".gsd", "milestones", "M001", "M001-PARKED.md")),
+      "PARKED.md should be written",
+    );
+    assert.equal(getMilestone("M001")!.status, "parked", "DB status should be parked");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("parkMilestone refuses DB-complete milestones (#5828)", () => {
+  const base = createBase();
+  try {
+    openDatabase(":memory:");
+    insertMilestone({ id: "M001", title: "Test", status: "complete" });
+
+    const parked = parkMilestone(base, "M001", "test");
+
+    assert.equal(parked, false, "complete DB row should not be parkable");
+    assert.equal(
+      existsSync(join(base, ".gsd", "milestones", "M001", "M001-PARKED.md")),
+      false,
+      "PARKED.md should not be written",
+    );
+    assert.equal(getMilestone("M001")!.status, "complete", "DB status should remain complete");
   } finally {
     closeDatabase();
     rmSync(base, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Fixed parking to ignore stale blocked SUMMARY files when the DB row is active and verified with build, typecheck, and focused regression tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5828
- [#5828 bug: /gsd park refuses active milestone with blocked SUMMARY.md](https://github.com/gsd-build/gsd-2/issues/5828)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5828-bug-gsd-park-refuses-active-milestone-wi-1778561954`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced milestone parking to prevent parking already-closed milestones when database is available, with filesystem-based fallback protection.
  * Optimized database status synchronization after parking operations.

* **Tests**
  * Added test coverage for milestone parking behavior across various database and file system states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5836)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->