### PR TITLE
fix(issue): stuck detection key mismatch: derivedKey uses unitType/unitId but DB persistence uses bare unitId — cross-session stuck detection defeated

### DIFF
--- a/src/resources/extensions/gsd/db/unit-dispatches.ts
+++ b/src/resources/extensions/gsd/db/unit-dispatches.ts
@@ -524,7 +524,7 @@ export function getRecentUnitKeysForProjectRoot(
   if (!isDbAvailable()) return [];
   const db = _getAdapter()!;
   const rows = db.prepare(
-    `SELECT ud.unit_id
+    `SELECT ud.unit_type, ud.unit_id
      FROM unit_dispatches ud
      INNER JOIN workers w ON w.worker_id = ud.worker_id
      WHERE w.project_root_realpath = :project_root_realpath
@@ -533,8 +533,8 @@ export function getRecentUnitKeysForProjectRoot(
   ).all({
     ":project_root_realpath": projectRootRealpath,
     ":limit": limit,
-  }) as Array<{ unit_id: string }>;
-  return rows.reverse().map((r) => ({ key: r.unit_id }));
+  }) as Array<{ unit_type: string; unit_id: string }>;
+  return rows.reverse().map((r) => ({ key: `${r.unit_type}/${r.unit_id}` }));
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/stuck-state-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/stuck-state-via-db.test.ts
@@ -23,9 +23,12 @@ import { registerAutoWorker } from "../db/auto-workers.ts";
 import { claimMilestoneLease } from "../db/milestone-leases.ts";
 import {
   recordDispatchClaim,
+  markCanceled,
   getRecentUnitKeysForWorker,
+  getRecentUnitKeysForProjectRoot,
 } from "../db/unit-dispatches.ts";
 import { setRuntimeKv, getRuntimeKv } from "../db/runtime-kv.ts";
+import { detectStuck } from "../auto/detect-stuck.ts";
 
 function makeBase(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-stuck-state-db-"));
@@ -65,6 +68,42 @@ test("getRecentUnitKeysForWorker reconstructs the recentUnits sliding window", (
   // window semantics that detect-stuck.ts expects.
   const window = getRecentUnitKeysForWorker(worker, 20);
   assert.deepEqual(window.map(w => w.key), ["U1", "U2", "U3"]);
+});
+
+test("getRecentUnitKeysForProjectRoot restores compound keys used by stuck detection", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "T", status: "active" });
+  const worker = registerAutoWorker({ projectRootRealpath: base });
+  const lease = claimMilestoneLease(worker, "M001");
+  assert.equal(lease.ok, true);
+  if (!lease.ok) return;
+
+  for (let i = 0; i < 2; i++) {
+    const claim = recordDispatchClaim({
+      traceId: `t${i}`,
+      workerId: worker,
+      milestoneLeaseToken: lease.token,
+      milestoneId: "M001",
+      sliceId: "S01",
+      unitType: "complete-slice",
+      unitId: "M001/S01",
+    });
+    assert.equal(claim.ok, true);
+    if (!claim.ok) return;
+    markCanceled(claim.dispatchId, "pause");
+  }
+
+  const window = getRecentUnitKeysForProjectRoot(base, 20);
+  assert.deepEqual(window.map(w => w.key), [
+    "complete-slice/M001/S01",
+    "complete-slice/M001/S01",
+  ]);
+
+  const result = detectStuck([...window, { key: "complete-slice/M001/S01" }]);
+  assert.equal(result?.stuck, true);
+  assert.match(result?.reason ?? "", /3 consecutive times/);
 });
 
 test("getRecentUnitKeysForWorker honors the limit parameter", (t) => {


### PR DESCRIPTION
## Summary
- Fixed project-root stuck-state hydration to use compound unit keys and verified the restart regression with focused stuck-state DB tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5839
- [#5839 stuck detection key mismatch: derivedKey uses unitType/unitId but DB persistence uses bare unitId — cross-session stuck detection defeated](https://github.com/gsd-build/gsd-2/issues/5839)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5839-stuck-detection-key-mismatch-derivedkey--1778587948`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated unit identification format in database queries to include both unit type and ID information for more accurate recent unit retrieval.

* **Tests**
  * Added validation tests for stuck-state detection via project-root reconstruction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5840)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->