### PR TITLE
fix(issue): auto-mode stops on aborted plan-slice after clean complete-slice (two bugs in abort recovery path)

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -48,6 +48,11 @@ const MAX_NETWORK_RETRIES = 2;
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object";
 }
+
+export function _hasEmptyAgentEndContent(content: unknown): boolean {
+  return content == null || (Array.isArray(content) && content.length === 0);
+}
+
 /**
  * Cap on auto-resume attempts for sustained transient-provider errors.
  *
@@ -310,7 +315,7 @@ export async function handleAgentEnd(
     // that carry error context — e.g. errorMessage field or non-empty content
     // indicating a mid-stream failure. (#2695)
     const content = "content" in lastMsg ? lastMsg.content : undefined;
-    const hasEmptyContent = Array.isArray(content) && content.length === 0;
+    const hasEmptyContent = _hasEmptyAgentEndContent(content);
     const hasErrorMessage = "errorMessage" in lastMsg && !!lastMsg.errorMessage;
 
     if (hasEmptyContent && !hasErrorMessage) {

--- a/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
+++ b/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  _hasEmptyAgentEndContent,
   _handleSessionSwitchAgentEnd,
   isBareClaudeCodeStreamAbortPlaceholder,
   isClaudeCodeSessionSwitchAbortMessage,
@@ -186,6 +187,15 @@ test("empty-content aborted during session-switch is silently ignored", () => {
   );
 
   assert.equal(cancelledWith, null);
+});
+
+test("missing agent_end content is classified as empty abort content", () => {
+  // Providers may omit content entirely for a late aborted agent_end. That is
+  // equivalent to empty content and must not pause/cancel the next unit.
+  assert.equal(_hasEmptyAgentEndContent(undefined), true);
+  assert.equal(_hasEmptyAgentEndContent(null), true);
+  assert.equal(_hasEmptyAgentEndContent([]), true);
+  assert.equal(_hasEmptyAgentEndContent([{ type: "text", text: "partial" }]), false);
 });
 
 test("completed assistant content with aborted stopReason during session-switch is ignored", () => {


### PR DESCRIPTION
## Summary
- Fixed missing-content aborted agent_end handling and verified abort recovery tests pass.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5838
- [#5838 auto-mode stops on aborted plan-slice after clean complete-slice (two bugs in abort recovery path)](https://github.com/gsd-build/gsd-2/issues/5838)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5838-auto-mode-stops-on-aborted-plan-slice-af-1778588163`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of agent-end payloads when content is missing or empty, ensuring proper classification of abort scenarios.

* **Tests**
  * Added regression test for agent-end content classification edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5841)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->