### PR TITLE
fix(issue): step mode exits after complete-milestone before mergeAndExit, orphaning milestone branch/worktree

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -381,6 +381,13 @@ export function buildStepCompleteMessage(nextState: import("./types.js").GSDStat
     + `Run /clear, then /gsd to continue (or /gsd auto to run continuously).`;
 }
 
+export function shouldReturnStepWizardAfterUnit(
+  currentUnitType: string | null | undefined,
+  phaseAfterUnit: string | null | undefined,
+): boolean {
+  return currentUnitType !== "complete-milestone" && phaseAfterUnit !== "complete";
+}
+
 export interface PreVerificationOpts {
   skipSettleDelay?: boolean;
   skipWorktreeSync?: boolean;
@@ -1668,14 +1675,18 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
   // Without this notify(), /gsd in step mode finishes a unit and silently
   // exits the loop, leaving the user with no hint to /clear and /gsd again.
   if (s.stepMode) {
+    let phaseAfterUnit: string | null = null;
     try {
       const nextState = await deriveState(s.canonicalProjectRoot);
+      phaseAfterUnit = nextState.phase;
       ctx.ui.notify(buildStepCompleteMessage(nextState), "info");
     } catch (e) {
       debugLog("postUnit", { phase: "step-wizard-notify", error: String(e) });
       ctx.ui.notify(STEP_COMPLETE_FALLBACK_MESSAGE, "info");
     }
-    return "step-wizard";
+    return shouldReturnStepWizardAfterUnit(s.currentUnit?.type, phaseAfterUnit)
+      ? "step-wizard"
+      : "continue";
   }
 
   return "continue";

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -381,6 +381,16 @@ export function buildStepCompleteMessage(nextState: import("./types.js").GSDStat
     + `Run /clear, then /gsd to continue (or /gsd auto to run continuously).`;
 }
 
+/**
+ * Decide whether step mode should stop at the step wizard after a unit finishes.
+ *
+ * @param currentUnitType The just-finished unit type, such as "execute-task" or
+ *   "complete-milestone"; may be null/undefined when no current unit is known.
+ * @param phaseAfterUnit The freshly derived next phase, such as "executing" or
+ *   "complete"; may be null/undefined if state derivation failed.
+ * @returns true to show the step wizard; false to keep the loop running so
+ *   terminal milestone completion can reach the merge/finalization path.
+ */
 export function shouldReturnStepWizardAfterUnit(
   currentUnitType: string | null | undefined,
   phaseAfterUnit: string | null | undefined,

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -818,14 +818,18 @@ export async function bootstrapAutoSession(
     // worktree cleanup) was never run — the survivor branch must be merged.
     // Applies to both worktree and branch isolation modes.
     let hasSurvivorBranch = false;
+    let survivorMilestoneId = state.activeMilestone?.id ?? null;
+    if (!survivorMilestoneId && state.phase === "complete") {
+      survivorMilestoneId = findUnmergedCompletedMilestone(base, getIsolationMode(base));
+    }
     if (
-      state.activeMilestone &&
+      survivorMilestoneId &&
       (state.phase === "pre-planning" || state.phase === "complete") &&
       getIsolationMode(base) !== "none" &&
       !detectWorktreeName(base) &&
       !base.includes(`${pathSep}.gsd${pathSep}worktrees${pathSep}`)
     ) {
-      const milestoneBranch = `milestone/${state.activeMilestone.id}`;
+      const milestoneBranch = `milestone/${survivorMilestoneId}`;
       const { nativeBranchExists } = await import("./native-git-bridge.js");
       hasSurvivorBranch = nativeBranchExists(base, milestoneBranch);
       if (hasSurvivorBranch) {
@@ -869,7 +873,7 @@ export async function bootstrapAutoSession(
     // Re-evaluate via the helper — the discuss branch above may have cleared
     // hasSurvivorBranch after a successful promotion.
     if (decideSurvivorAction(hasSurvivorBranch, state.phase) === "finalize") {
-      const mid = state.activeMilestone!.id;
+      const mid = survivorMilestoneId!;
       // Commit 68ef58a3c made `_mergeBranchMode` throw on wrong-branch
       // instead of returning false silently. Wrap the call so the throw is
       // converted into an error notify + clean bootstrap abort, not an

--- a/src/resources/extensions/gsd/tests/auto-post-unit-step-message.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-post-unit-step-message.test.ts
@@ -3,7 +3,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { buildStepCompleteMessage, STEP_COMPLETE_FALLBACK_MESSAGE } from "../auto-post-unit.ts";
+import {
+  buildStepCompleteMessage,
+  shouldReturnStepWizardAfterUnit,
+  STEP_COMPLETE_FALLBACK_MESSAGE,
+} from "../auto-post-unit.ts";
 import type { GSDState } from "../types.ts";
 
 function makeState(overrides: Partial<GSDState>): GSDState {
@@ -50,4 +54,11 @@ test("buildStepCompleteMessage: unknown phase falls back to generic continue lab
 test("STEP_COMPLETE_FALLBACK_MESSAGE: used when deriveState throws, still points users at /clear + /gsd", () => {
   assert.match(STEP_COMPLETE_FALLBACK_MESSAGE, /\/clear/);
   assert.match(STEP_COMPLETE_FALLBACK_MESSAGE, /\/gsd/);
+});
+
+test("shouldReturnStepWizardAfterUnit: terminal milestone completion continues to merge-back path", () => {
+  assert.equal(shouldReturnStepWizardAfterUnit("complete-milestone", "complete"), false);
+  assert.equal(shouldReturnStepWizardAfterUnit("complete-milestone", null), false);
+  assert.equal(shouldReturnStepWizardAfterUnit("execute-task", "complete"), false);
+  assert.equal(shouldReturnStepWizardAfterUnit("execute-task", "executing"), true);
 });


### PR DESCRIPTION
## Summary
- Fixed step-mode milestone completion to reach merge-back finalization and verified with focused post-unit, survivor recovery, and lifecycle tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5844
- [#5844 step mode exits after complete-milestone before mergeAndExit, orphaning milestone branch/worktree](https://github.com/gsd-build/gsd-2/issues/5844)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5844-step-mode-exits-after-complete-milestone-1778594104`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined step completion workflow to conditionally show the step wizard based on unit and next-phase state.
  * Improved milestone recovery to handle cases where active milestone data is temporarily unavailable.

* **Tests**
  * Added test coverage for step completion behavior across different state scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5845)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->