### PR TITLE
fix(issue): auto-mode: git-closeout-failure after verified task causes hard stop with no recovery retry

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -469,6 +469,13 @@ export async function autoCommitUnit(
   }
 }
 
+/**
+ * Execute the turn-level git action (commit, snapshot, or status-only).
+ *
+ * @param opts.softFailure - Defaults to false. When true, retry git failures,
+ * warn, and continue without pausing auto-mode; use for best-effort deferred
+ * closeout work where a git failure should not block the run.
+ */
 async function runCloseoutGitAction(
   pctx: PostUnitContext,
   unit: NonNullable<AutoSession["currentUnit"]>,
@@ -601,7 +608,7 @@ async function runCloseoutGitAction(
     s.lastGitActionFailure = message;
     s.lastGitActionStatus = "failed";
     debugLog("postUnit", { phase: "git-action", error: message, action: turnAction });
-    ctx.ui.notify(`Git ${turnAction} failed: ${message.split("\n")[0]}`, uokFlags.gitops && !opts?.softFailure ? "error" : "warning");
+    ctx.ui.notify(`Git ${turnAction} failed: ${message.split("\n")[0]}`, opts?.softFailure ? "warning" : "error");
     if (opts?.softFailure) {
       return "continue";
     }

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -472,6 +472,7 @@ export async function autoCommitUnit(
 async function runCloseoutGitAction(
   pctx: PostUnitContext,
   unit: NonNullable<AutoSession["currentUnit"]>,
+  opts?: { softFailure?: boolean },
 ): Promise<"continue" | "dispatched"> {
   const { s, ctx, pi, pauseAuto } = pctx;
   const prefs = loadEffectiveGSDPreferences()?.preferences;
@@ -506,13 +507,24 @@ async function runCloseoutGitAction(
         unitId: unit.id,
       });
     } else {
-      const gitResult = runTurnGitAction({
+      const maxAttempts = opts?.softFailure ? 3 : 1;
+      let gitResult = runTurnGitAction({
         basePath: s.basePath,
         action: turnAction,
         unitType: unit.type,
         unitId: unit.id,
         taskContext,
       });
+      for (let attempt = 1; gitResult.status === "failed" && attempt < maxAttempts; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
+        gitResult = runTurnGitAction({
+          basePath: s.basePath,
+          action: turnAction,
+          unitType: unit.type,
+          unitId: unit.id,
+          taskContext,
+        });
+      }
 
       if (uokFlags.gitops) {
         writeTurnGitTransaction({
@@ -563,12 +575,15 @@ async function runCloseoutGitAction(
         }
 
         const failureMsg = `Git ${turnAction} failed: ${(gitResult.error ?? "unknown error").split("\n")[0]}`;
-        ctx.ui.notify(failureMsg, "error");
+        ctx.ui.notify(failureMsg, opts?.softFailure ? "warning" : "error");
         debugLog("postUnit", {
-          phase: "git-action-failed-blocking",
+          phase: opts?.softFailure ? "git-action-failed-soft" : "git-action-failed-blocking",
           action: turnAction,
           error: gitResult.error ?? "unknown error",
         });
+        if (opts?.softFailure) {
+          return "continue";
+        }
         await pauseAuto(ctx, pi);
         return "dispatched";
       }
@@ -586,7 +601,10 @@ async function runCloseoutGitAction(
     s.lastGitActionFailure = message;
     s.lastGitActionStatus = "failed";
     debugLog("postUnit", { phase: "git-action", error: message, action: turnAction });
-    ctx.ui.notify(`Git ${turnAction} failed: ${message.split("\n")[0]}`, uokFlags.gitops ? "error" : "warning");
+    ctx.ui.notify(`Git ${turnAction} failed: ${message.split("\n")[0]}`, uokFlags.gitops && !opts?.softFailure ? "error" : "warning");
+    if (opts?.softFailure) {
+      return "continue";
+    }
     if (uokFlags.gitops) {
       await pauseAuto(ctx, pi);
       return "dispatched";
@@ -1220,7 +1238,7 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
 
   if (s.currentUnit) {
     if (shouldDeferCloseoutGitAction(s.currentUnit.type)) {
-      const gitActionResult = await runCloseoutGitAction(pctx, s.currentUnit);
+      const gitActionResult = await runCloseoutGitAction(pctx, s.currentUnit, { softFailure: true });
       if (gitActionResult === "dispatched") {
         return "stopped";
       }

--- a/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -10,7 +10,7 @@ import { runDispatch, runPreDispatch } from "../auto/phases.ts";
 import { AutoSession } from "../auto/session.ts";
 import { resolveUnitSupervisionTimeouts } from "../auto-timers.ts";
 import { bootstrapAutoSession } from "../auto-start.ts";
-import { postUnitPreVerification } from "../auto-post-unit.ts";
+import { postUnitPostVerification, postUnitPreVerification } from "../auto-post-unit.ts";
 import { resolveDispatch, setResearchProjectPromptBuilderForTest } from "../auto-dispatch.ts";
 import { resolveExpectedArtifactPath, verifyExpectedArtifact, writeBlockerPlaceholder } from "../auto-recovery.ts";
 import { finalizeProjectResearchTimeout } from "../project-research-policy.ts";
@@ -1581,6 +1581,61 @@ test("deep project setup: discuss-milestone question failure pauses instead of a
     assert.ok(
       notifications.some((message) => message.includes("waiting for your input")),
       "should notify that the discuss unit is waiting for user input",
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("verified task git closeout failure retries and continues auto-mode", async () => {
+  const base = makeBase();
+  try {
+    execFileSync("git", ["init"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: base, stdio: "ignore" });
+    const hookPath = join(base, ".git", "hooks", "pre-commit");
+    writeFileSync(
+      hookPath,
+      [
+        "#!/bin/sh",
+        "count_file=.git/pre-commit-count",
+        "count=0",
+        "if [ -f \"$count_file\" ]; then count=$(cat \"$count_file\"); fi",
+        "count=$((count + 1))",
+        "printf \"%s\" \"$count\" > \"$count_file\"",
+        "echo blocked by test hook >&2",
+        "exit 1",
+      ].join("\n"),
+    );
+    chmodSync(hookPath, 0o755);
+    writeFileSync(join(base, "work.txt"), "changed\n");
+
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = base;
+    s.originalBasePath = base;
+    s.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+
+    let pauseCalled = false;
+    const notifications: Array<{ message: string; severity?: string }> = [];
+    const result = await postUnitPostVerification({
+      s,
+      ctx: { ui: { notify: (message: string, severity?: string) => notifications.push({ message, severity }) } } as any,
+      pi: {} as any,
+      buildSnapshotOpts: () => ({}) as any,
+      lockBase: () => base,
+      stopAuto: async () => {},
+      pauseAuto: async () => { pauseCalled = true; },
+      updateProgressWidget: () => {},
+    });
+
+    assert.equal(result, "continue");
+    assert.equal(pauseCalled, false);
+    assert.equal(s.lastGitActionStatus, "failed");
+    assert.equal(readFileSync(join(base, ".git", "pre-commit-count"), "utf-8"), "3");
+    assert.ok(
+      notifications.some((entry) => entry.severity === "warning" && entry.message.includes("Git commit failed")),
+      "verified task git closeout failure should warn instead of stopping auto-mode",
     );
   } finally {
     rmSync(base, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/post-unit-git-failure.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-git-failure.test.ts
@@ -11,7 +11,7 @@ const source = readFileSync(
 
 test("postUnitPreVerification blocks on git action failure", () => {
   const failureBlock = extractSourceRegion(source, 'if (gitResult.status === "failed")');
-  assert.ok(failureBlock.includes('ctx.ui.notify(failureMsg, "error")'));
+  assert.ok(failureBlock.includes('ctx.ui.notify(failureMsg, opts?.softFailure ? "warning" : "error")'));
   assert.ok(failureBlock.includes("await pauseAuto(ctx, pi)"));
   assert.ok(failureBlock.includes('return "dispatched"'));
   assert.ok(!failureBlock.includes("git-action-failed-nonblocking"));


### PR DESCRIPTION
## Summary
- Fixed verified task git closeout failures to retry then warn-and-continue, verified with the targeted regression test and diff check.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5846
- [#5846 auto-mode: git-closeout-failure after verified task causes hard stop with no recovery retry](https://github.com/gsd-build/gsd-2/issues/5846)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5846-auto-mode-git-closeout-failure-after-ver-1778597566`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git closeout now supports a soft-failure mode: retries failed actions a few times, downgrades severity to warnings, and proceeds without pausing automation for best-effort closeouts.

* **Tests**
  * Added/updated tests to verify automation continues on git closeout failures and that notifications use conditional severity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5847)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->