### PR TITLE
fix(gsd): harden GSD HTML shell and brief flow

### DIFF
--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@gsd/pi-coding-agent";
 import type { Model } from "@gsd/pi-ai";
 import type { GSDState } from "../../types.js";
+import { createRequire } from "node:module";
 
 import { computeProgressScore, formatProgressLine } from "../../progress-score.js";
 import { loadEffectiveGSDPreferences, getGlobalGSDPreferencesPath, getProjectGSDPreferencesPath } from "../../preferences.js";
@@ -220,7 +221,22 @@ export async function handleBrief(args: string, ctx: ExtensionCommandContext, pi
   }
 
   const outputDir = getVisualBriefOutputDir();
-  pi.sendUserMessage(buildVisualBriefPrompt(request, { outputDir }));
+  const version = resolveGsdVersion();
+  pi.sendUserMessage(buildVisualBriefPrompt(request, { outputDir, version }));
+}
+
+const briefRequire = createRequire(import.meta.url);
+
+function resolveGsdVersion(): string | undefined {
+  const envVersion = process.env.GSD_VERSION?.trim();
+  if (envVersion) return envVersion;
+  try {
+    const pkg = briefRequire("../../../../../../package.json") as { version?: unknown };
+    const fromPkg = typeof pkg.version === "string" ? pkg.version.trim() : "";
+    return fromPkg || undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export async function handleSetup(args: string, ctx: ExtensionCommandContext, pi?: ExtensionAPI): Promise<void> {

--- a/src/resources/extensions/shared/html-shell.ts
+++ b/src/resources/extensions/shared/html-shell.ts
@@ -359,8 +359,15 @@ export const HTML_SHELL_JS = `
     }
   });
 })();
+function safeLocalStorageSet(key,value){
+  try{localStorage.setItem(key,value)}catch(e){}
+}
+function safeLocalStorageGet(key){
+  try{return localStorage.getItem(key)}catch(e){return null}
+}
 (function(){
-  var saved=JSON.parse(localStorage.getItem('gsd-collapsed')||'{}');
+  var saved={};
+  try{saved=JSON.parse(safeLocalStorageGet('gsd-collapsed')||'{}')}catch(e){}
   document.querySelectorAll('section[id]').forEach(function(sec){
     var h2=sec.querySelector('h2');
     if(!h2)return;
@@ -376,7 +383,7 @@ export const HTML_SHELL_JS = `
       toggleSection(sec,collapsed);
       btn.textContent=collapsed?'+':'-';
       saved[sec.id]=collapsed;
-      localStorage.setItem('gsd-collapsed',JSON.stringify(saved));
+      safeLocalStorageSet('gsd-collapsed',JSON.stringify(saved));
     });
   });
   function toggleSection(sec,hide){
@@ -389,15 +396,16 @@ export const HTML_SHELL_JS = `
 (function(){
   var hr=document.querySelector('.header-right');
   if(!hr)return;
+  var stored=safeLocalStorageGet('gsd-theme');
   var btn=document.createElement('button');
   btn.className='theme-toggle';
-  btn.textContent=localStorage.getItem('gsd-theme')==='light'?'Dark':'Light';
-  if(localStorage.getItem('gsd-theme')==='light')document.documentElement.classList.add('light-theme');
+  btn.textContent=stored==='light'?'Dark':'Light';
+  if(stored==='light')document.documentElement.classList.add('light-theme');
   btn.addEventListener('click',function(){
     document.documentElement.classList.toggle('light-theme');
     var isLight=document.documentElement.classList.contains('light-theme');
     btn.textContent=isLight?'Dark':'Light';
-    localStorage.setItem('gsd-theme',isLight?'light':'dark');
+    safeLocalStorageSet('gsd-theme',isLight?'light':'dark');
   });
   hr.prepend(btn);
 })();

--- a/src/resources/extensions/visual-brief/page-contract.ts
+++ b/src/resources/extensions/visual-brief/page-contract.ts
@@ -126,6 +126,8 @@ export function getVisualBriefModeProfile(mode: VisualBriefMode, slides: boolean
 					"Assumptions, limitations, and source references",
 				],
 			};
+		default:
+			throw new Error(`Unknown visual brief mode: ${mode as string}`);
 	}
 }
 

--- a/src/resources/extensions/visual-brief/prompts.ts
+++ b/src/resources/extensions/visual-brief/prompts.ts
@@ -98,18 +98,26 @@ export function parseVisualBriefArgs(args: string): VisualBriefRequest | null {
 	};
 }
 
+export interface VisualBriefPromptOptions {
+	outputDir: string;
+	/** GSD version rendered in the shell header/footer. Falls back to "0.0.0" when not provided. */
+	version?: string;
+}
+
 export function buildVisualBriefPrompt(
 	request: VisualBriefRequest,
-	options: { outputDir: string },
+	options: VisualBriefPromptOptions,
 ): string {
 	const profile = getVisualBriefModeProfile(request.mode, request.slides);
 	const artifactPolicy = createVisualBriefArtifactPolicy(options.outputDir);
 	const outputFormat = request.slides ? "slide deck" : "scrollable explanation page";
+	const version = options.version?.trim() || undefined;
 	const shell = renderHtmlShellTemplate({
 		title: request.subject,
 		documentTitle: `GSD ${VISUAL_BRIEF_KIND[request.mode]} - ${request.subject}`,
 		subtitle: "Visual brief",
 		kind: VISUAL_BRIEF_KIND[request.mode],
+		version,
 		mainPlaceholder: "{{MAIN_HTML}}",
 		footerNote: request.subject,
 	});

--- a/src/resources/extensions/visual-brief/tests/visual-brief.test.ts
+++ b/src/resources/extensions/visual-brief/tests/visual-brief.test.ts
@@ -181,6 +181,32 @@ test("artifact output directory is under the configured GSD agent directory", ()
 	assert.equal(getVisualBriefOutputDir("/tmp/gsd-agent-test"), join("/tmp/gsd-agent-test", "diagrams"));
 });
 
+test("prompt embeds the GSD version in the shell when provided", () => {
+	const request = parseVisualBriefArgs("diff release branch changes");
+	assert.ok(request, "request should parse");
+
+	const prompt = buildVisualBriefPrompt(request, { outputDir: "/tmp/visual-brief", version: "9.9.9" });
+	assert.match(prompt, /v9\.9\.9/);
+});
+
+test("prompt omits the version chip when version is missing or blank", () => {
+	const request = parseVisualBriefArgs("diff release branch changes");
+	assert.ok(request, "request should parse");
+
+	const blank = buildVisualBriefPrompt(request, { outputDir: "/tmp/visual-brief", version: "   " });
+	assert.doesNotMatch(blank, /class="version"/);
+
+	const missing = buildVisualBriefPrompt(request, { outputDir: "/tmp/visual-brief" });
+	assert.doesNotMatch(missing, /class="version"/);
+});
+
+test("getVisualBriefModeProfile throws on an unknown mode", () => {
+	assert.throws(
+		() => getVisualBriefModeProfile("not-a-real-mode" as unknown as Parameters<typeof getVisualBriefModeProfile>[0], false),
+		/Unknown visual brief mode: not-a-real-mode/,
+	);
+});
+
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }


### PR DESCRIPTION
## Linked issue

Refs #5850 (the canonical implementation shipped in #5855; this PR adds polish on top).

---

## TL;DR

**What:** Three small follow-ups to #5855 — localStorage-safety in the shell JS, an exhaustive switch guard in the brief mode profile, and wiring the GSD version through the visual-brief prompt.
**Why:** All three are edge cases that were noticed while testing the merged shell but were not part of #5855.
**How:** Surgical edits + 3 new test cases. No new modules; no behavior change in the happy path.

## What

- `src/resources/extensions/shared/html-shell.ts` — wrap `localStorage.getItem` / `setItem` calls in a tiny `safeLocalStorageGet` / `safeLocalStorageSet` helper inside the embedded shell JS. The theme toggle and section-collapse handlers no longer throw when storage is unavailable (private mode, sandboxed iframes, storage full).
- `src/resources/extensions/visual-brief/page-contract.ts` — add a `default:` arm to `getVisualBriefModeProfile` that throws `Unknown visual brief mode: …` instead of returning `undefined`.
- `src/resources/extensions/visual-brief/prompts.ts` — `buildVisualBriefPrompt` now accepts an optional `version` and passes it to `renderHtmlShellTemplate`. Blank/whitespace versions are treated as absent so the shell's optional `version` chip is omitted cleanly.
- `src/resources/extensions/gsd/commands/handlers/core.ts` — `handleBrief` resolves the version once via a new `resolveGsdVersion()` helper: `GSD_VERSION` env var first (trimmed), then `package.json#version`, then `undefined`. Mirrors how `/gsd export --html` already populates the shell.
- `src/resources/extensions/visual-brief/tests/visual-brief.test.ts` — three new cases: `version` present → `v9.9.9` appears in the shell; blank/missing `version` → no `class=\"version\"` chip; unknown mode → throws.

## Why

While verifying #5855's merged implementation:

1. The embedded shell JS calls `localStorage.setItem` unconditionally. Browsers in private/incognito mode and sandboxed iframes throw on writes — the theme toggle and section collapse silently break, sometimes taking down the rest of the JS in the handler.
2. `getVisualBriefModeProfile` was an exhaustive `switch` without a `default`. A typo'd or future mode falls through and returns `undefined`, which crashes downstream prompt construction with an opaque \"cannot read properties of undefined (reading 'goal')\".
3. `/gsd brief` renders the canonical shell but did not pass the GSD version, so every brief header/footer was un-versioned even when `/gsd export --html` showed one. Fixing this also paid down `\"0.0.0\"` placeholder noise during local development.

## How

- The `safeLocalStorage*` helpers are inline in the shell JS template string so they remain self-contained (no external file, no module boundary). They cost ~6 lines and are reused by both the collapse and the theme handlers.
- The `default:` arm uses `${mode as string}` to keep the error message useful even when called from JS-land or after a type cast — the type-narrowing inside the switch makes `mode` `never` here.
- `resolveGsdVersion` is defined inside `core.ts` (one caller) rather than a shared util, since it's the only place that needs the package.json lookup. `createRequire(import.meta.url)` keeps it ESM-clean.
- Version chip is skipped when `version` is undefined OR a whitespace string, so callers can pass `process.env.GSD_VERSION` directly without hand-trimming.

## Change type

- [x] `fix` — Bug fix (the localStorage tolerance is the main user-visible fix)
- [x] `feat` — Minor: thread version into brief prompt
- [ ] `refactor`
- [ ] `test`
- [ ] `docs`
- [ ] `chore`

## Scope

- [x] Other extensions — `shared/html-shell.ts`
- [x] Other extensions — `visual-brief`
- [x] `gsd extension` — `handleBrief` version wiring

## Breaking changes

- [x] No breaking changes. `VisualBriefPromptOptions.version` is optional and defaulted; the helper functions are additive; no public API removed.

## Test plan

- [x] New/updated tests: `visual-brief.test.ts` — version-present, version-blank/missing, unknown-mode throws.
- [x] Full visual-brief test suite (16 tests) passes.
- [x] `tsc --noEmit --project tsconfig.extensions.json` clean.
- [x] CI must pass.

## AI disclosure

- [x] AI-assisted (Claude). Implementation reviewed end-to-end; tests written first for the throw guard and version branches. AI is not credited as a commit author per CONTRIBUTING.md.