### PR TITLE
fix(issue): [Bug]: Auto-mode can get stuck retrying a unit when the underlying milestone worktree is no longer a valid Git worktree.

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -41,6 +41,7 @@ import {
   resolveExpectedArtifactPath,
   writeBlockerPlaceholder,
   diagnoseExpectedArtifact,
+  diagnoseWorktreeIntegrityFailure,
 } from "./auto-recovery.js";
 import { regenerateIfMissing } from "./workflow-projections.js";
 import { WorktreeStateProjection } from "./worktree-state-projection.js";
@@ -430,6 +431,11 @@ function artifactValidationKind(unitType: string): "project" | "requirements" | 
 }
 
 function describeArtifactVerificationFailure(unitType: string, unitId: string, basePath: string): string {
+  const worktreeFailure = diagnoseWorktreeIntegrityFailure(basePath);
+  if (worktreeFailure) {
+    return `${worktreeFailure} Unit: ${unitType} ${unitId}.`;
+  }
+
   const artifactPath = resolveExpectedArtifactPath(unitType, unitId, basePath);
   if (!artifactPath) {
     return `Artifact verification failed: ${unitType} "${unitId}" has no resolvable artifact path.`;
@@ -1175,6 +1181,24 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           "warning",
         );
         // Fall through to "continue" — do NOT enter the retry or db-unavailable paths.
+      } else if (!triggerArtifactVerified && diagnoseWorktreeIntegrityFailure(s.basePath)) {
+        const retryKey = `${s.currentUnit.type}:${s.currentUnit.id}`;
+        const worktreeFailure = diagnoseWorktreeIntegrityFailure(s.basePath)!;
+        s.pendingVerificationRetry = null;
+        s.verificationRetryCount.delete(retryKey);
+        s.verificationRetryFailureHashes.delete(retryKey);
+        debugLog("postUnit", {
+          phase: "worktree-integrity-failure",
+          unitType: s.currentUnit.type,
+          unitId: s.currentUnit.id,
+          basePath: s.basePath,
+        });
+        ctx.ui.notify(
+          `${worktreeFailure} Retry ${s.currentUnit.id} after repair.`,
+          "error",
+        );
+        await pauseAuto(ctx, pi);
+        return "dispatched";
       } else if (!triggerArtifactVerified && !isDbAvailable()) {
         debugLog("postUnit", { phase: "artifact-verify-skip-db-unavailable", unitType: s.currentUnit.type, unitId: s.currentUnit.id });
         const dbSkipDiag = diagnoseExpectedArtifact(s.currentUnit.type, s.currentUnit.id, s.basePath);

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -46,6 +46,7 @@ import {
 import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
 import { validateArtifact } from "./schemas/validate.js";
 import { getProjectResearchStatus } from "./project-research-policy.js";
+import { isGsdWorktreePath } from "./worktree-root.js";
 
 // Re-export so existing consumers of auto-recovery.ts keep working.
 export { resolveExpectedArtifactPath, diagnoseExpectedArtifact };
@@ -55,6 +56,26 @@ export {
 } from "./milestone-summary-classifier.js";
 
 // ─── Artifact Resolution & Verification ───────────────────────────────────────
+
+export function diagnoseWorktreeIntegrityFailure(basePath: string): string | null {
+  if (!isGsdWorktreePath(basePath) || !existsSync(basePath)) return null;
+
+  const gitPath = join(basePath, ".git");
+  if (!existsSync(gitPath)) {
+    return `Worktree integrity failure: ${basePath} is not a valid git worktree (.git missing). Repair or recreate the worktree before retrying.`;
+  }
+
+  try {
+    execFileSync("git", ["rev-parse", "--git-dir"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    return null;
+  } catch (err) {
+    return `Worktree integrity failure: ${basePath} is not a valid git worktree (git rev-parse failed: ${getErrorMessage(err).split("\n")[0]}). Repair or recreate the worktree before retrying.`;
+  }
+}
 
 export type ArtifactRecoveryDbRefreshResult =
   | { ok: true }
@@ -752,6 +773,11 @@ export function verifyExpectedArtifact(
     return false;
   }
   if (!existsSync(absPath)) {
+    const worktreeFailure = diagnoseWorktreeIntegrityFailure(base);
+    if (worktreeFailure) {
+      logError("recovery", `${worktreeFailure} Unit: ${unitType} ${unitId}.`);
+      return false;
+    }
     logWarning("recovery", `verify-fail ${unitType} ${unitId}: existsSync false for ${absPath}`);
     return false;
   }

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -58,7 +58,10 @@ export {
 // ─── Artifact Resolution & Verification ───────────────────────────────────────
 
 export function diagnoseWorktreeIntegrityFailure(basePath: string): string | null {
-  if (!isGsdWorktreePath(basePath) || !existsSync(basePath)) return null;
+  if (!isGsdWorktreePath(basePath)) return null;
+  if (!existsSync(basePath)) {
+    return `Worktree integrity failure: ${basePath} does not exist. Repair or recreate the worktree before retrying.`;
+  }
 
   const gitPath = join(basePath, ".git");
   if (!existsSync(gitPath)) {

--- a/src/resources/extensions/gsd/state-reconciliation/drift/merge-state.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/merge-state.ts
@@ -23,6 +23,7 @@ import {
 } from "../../native-git-bridge.js";
 import type { GSDState } from "../../types.js";
 import { logError, logWarning } from "../../workflow-logger.js";
+import { isGsdWorktreePath } from "../../worktree-root.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
 
 export type MergeReconcileResult = "clean" | "reconciled" | "blocked";
@@ -46,7 +47,13 @@ function resolveGitDir(basePath: string): string {
       return isAbsolute(gitDir) ? gitDir : resolve(basePath, gitDir);
     }
   } catch (err) {
-    logWarning("recovery", `gitdir resolution failed: ${getErrorMessage(err)}`);
+    const message = getErrorMessage(err);
+    logWarning("recovery", `gitdir resolution failed: ${message}`);
+    if (isGsdWorktreePath(basePath)) {
+      throw new Error(
+        `Worktree integrity failure: ${basePath} is not a valid git worktree (git rev-parse failed: ${message.split("\n")[0]}). Repair or recreate the worktree before retrying.`,
+      );
+    }
   }
 
   return join(basePath, ".git");

--- a/src/resources/extensions/gsd/tests/auto-deterministic-error-classification-4973.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-deterministic-error-classification-4973.test.ts
@@ -42,6 +42,14 @@ function makeTmpBase(): string {
   return base;
 }
 
+function makeBrokenIsolatedWorktree(): string {
+  const root = mkdtempSync(join(tmpdir(), `gsd-test-5848-${randomUUID().slice(0, 8)}-`));
+  tmpDirs.push(root);
+  const base = join(root, ".gsd", "projects", "project-id", "worktrees", "M003");
+  mkdirSync(join(base, ".gsd", "milestones", "M003", "slices", "S03"), { recursive: true });
+  return base;
+}
+
 function resetAutoState(): void {
   _setAutoActiveForTest(false);
 }
@@ -227,6 +235,58 @@ describe("Test 5 — postUnitPreVerification short-circuits on deterministic err
     assert.ok(
       existsSync(placeholderPath),
       `blocker placeholder must be written at ${placeholderPath}`,
+    );
+  });
+});
+
+describe("Test 5b — broken isolated worktree short-circuits artifact retry (#5848)", () => {
+  test("pauses with worktree integrity failure instead of setting pendingVerificationRetry", async () => {
+    const { postUnitPreVerification } = await import("../auto-post-unit.ts");
+
+    const base = makeBrokenIsolatedWorktree();
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = base;
+    s.currentUnit = { type: "research-slice", id: "M003/S03", startedAt: Date.now() };
+    s.verificationRetryCount.set("research-slice:M003/S03", 2);
+
+    const notifications: string[] = [];
+    let pauseCalled = false;
+    const pctx = {
+      s,
+      ctx: {
+        ui: {
+          notify: (message: string) => {
+            notifications.push(message);
+          },
+        },
+      },
+      pi: {},
+      buildSnapshotOpts: () => ({}) as any,
+      lockBase: () => base,
+      stopAuto: async () => {},
+      pauseAuto: async () => {
+        pauseCalled = true;
+      },
+      updateProgressWidget: () => {},
+    } as any;
+
+    const result = await postUnitPreVerification(pctx, {
+      skipSettleDelay: true,
+      skipWorktreeSync: true,
+    });
+
+    assert.strictEqual(result, "dispatched", "worktree integrity failure must pause instead of retrying");
+    assert.strictEqual(pauseCalled, true, "pauseAuto must be called for a broken isolated worktree");
+    assert.strictEqual(s.pendingVerificationRetry, null, "pendingVerificationRetry must NOT be set");
+    assert.strictEqual(s.verificationRetryCount.has("research-slice:M003/S03"), false, "stale retry count must be cleared");
+    assert.ok(
+      notifications.some((message) => message.includes("Worktree integrity failure") && message.includes(".git missing")),
+      `expected worktree integrity notification, got: ${notifications.join("\n")}`,
+    );
+    assert.ok(
+      notifications.every((message) => !message.includes("Artifact verification failed")),
+      `must not surface artifact retry messaging, got: ${notifications.join("\n")}`,
     );
   });
 });

--- a/src/resources/extensions/gsd/tests/auto-deterministic-error-classification-4973.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-deterministic-error-classification-4973.test.ts
@@ -50,6 +50,12 @@ function makeBrokenIsolatedWorktree(): string {
   return base;
 }
 
+function makeBrokenIsolatedWorktreeRevParse(): string {
+  const base = makeBrokenIsolatedWorktree();
+  mkdirSync(join(base, ".git"));
+  return base;
+}
+
 function resetAutoState(): void {
   _setAutoActiveForTest(false);
 }
@@ -283,6 +289,56 @@ describe("Test 5b — broken isolated worktree short-circuits artifact retry (#5
     assert.ok(
       notifications.some((message) => message.includes("Worktree integrity failure") && message.includes(".git missing")),
       `expected worktree integrity notification, got: ${notifications.join("\n")}`,
+    );
+    assert.ok(
+      notifications.every((message) => !message.includes("Artifact verification failed")),
+      `must not surface artifact retry messaging, got: ${notifications.join("\n")}`,
+    );
+  });
+
+  test("pauses when git rev-parse cannot validate an isolated worktree", async () => {
+    const { postUnitPreVerification } = await import("../auto-post-unit.ts");
+
+    const base = makeBrokenIsolatedWorktreeRevParse();
+    const s = new AutoSession();
+    s.active = true;
+    s.basePath = base;
+    s.currentUnit = { type: "research-slice", id: "M003/S03", startedAt: Date.now() };
+    s.verificationRetryCount.set("research-slice:M003/S03", 2);
+
+    const notifications: string[] = [];
+    let pauseCalled = false;
+    const pctx = {
+      s,
+      ctx: {
+        ui: {
+          notify: (message: string) => {
+            notifications.push(message);
+          },
+        },
+      },
+      pi: {},
+      buildSnapshotOpts: () => ({}) as any,
+      lockBase: () => base,
+      stopAuto: async () => {},
+      pauseAuto: async () => {
+        pauseCalled = true;
+      },
+      updateProgressWidget: () => {},
+    } as any;
+
+    const result = await postUnitPreVerification(pctx, {
+      skipSettleDelay: true,
+      skipWorktreeSync: true,
+    });
+
+    assert.strictEqual(result, "dispatched", "worktree integrity failure must pause instead of retrying");
+    assert.strictEqual(pauseCalled, true, "pauseAuto must be called for a broken isolated worktree");
+    assert.strictEqual(s.pendingVerificationRetry, null, "pendingVerificationRetry must NOT be set");
+    assert.strictEqual(s.verificationRetryCount.has("research-slice:M003/S03"), false, "stale retry count must be cleared");
+    assert.ok(
+      notifications.some((message) => message.includes("Worktree integrity failure") && message.includes("git rev-parse")),
+      `expected git rev-parse worktree integrity notification, got: ${notifications.join("\n")}`,
     );
     assert.ok(
       notifications.every((message) => !message.includes("Artifact verification failed")),

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
-import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArtifactPath, diagnoseExpectedArtifact, buildLoopRemediationSteps, writeBlockerPlaceholder, refreshRecoveryDbForArtifact } from "../auto-recovery.ts";
+import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArtifactPath, diagnoseExpectedArtifact, diagnoseWorktreeIntegrityFailure, buildLoopRemediationSteps, writeBlockerPlaceholder, refreshRecoveryDbForArtifact } from "../auto-recovery.ts";
 import { resolveMilestoneFile } from "../paths.ts";
 import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask, getMilestoneCommitAttributionShas } from "../gsd-db.ts";
 import { clearParseCache } from "../files.ts";
@@ -139,6 +139,20 @@ test("resolveExpectedArtifactPath returns null for unknown type", () => {
   } finally {
     cleanup(base);
   }
+});
+
+test("diagnoseWorktreeIntegrityFailure reports missing GSD worktree paths only", () => {
+  const missingWorktreePath = join(tmpdir(), `gsd-test-${randomUUID()}`, ".gsd", "worktrees", "M001-S01");
+  assert.equal(
+    diagnoseWorktreeIntegrityFailure(join(tmpdir(), `gsd-test-${randomUUID()}`)),
+    null,
+    "non-GSD paths should keep falling through to artifact recovery",
+  );
+  assert.equal(
+    diagnoseWorktreeIntegrityFailure(missingWorktreePath),
+    `Worktree integrity failure: ${missingWorktreePath} does not exist. Repair or recreate the worktree before retrying.`,
+    "missing GSD worktree paths should fail terminally before artifact retry",
+  );
 });
 
 test("resolveExpectedArtifactPath returns correct path for all milestone-level types", () => {


### PR DESCRIPTION
## Summary
- Fixed invalid isolated worktree handling to fail fast with a worktree integrity message and verified with focused auto-post-unit and drift tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5848
- [#5848 [Bug]: Auto-mode can get stuck retrying a unit when the underlying milestone worktree is no longer a valid Git worktree.](https://github.com/gsd-build/gsd-2/issues/5848)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5848-bug-auto-mode-can-get-stuck-retrying-a-u-1778614715`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and clearer diagnostics for worktree integrity failures during artifact verification.
  * Pre-verification retry now short-circuits on worktree integrity failures: clears pending retry counters, pauses auto-mode, notifies with a repair-focused message, and exits the pre-verification flow.
  * Distinguishes worktree integrity failures from other verification errors.

* **Tests**
  * Added integration tests covering missing or invalid worktree metadata and retry short-circuit behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5852)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->