### PR TITLE
fix(issue): openai-codex-responses.ts — 429 retries fire inside provider cooldown window, Gemini path handles it correctly

### DIFF
--- a/packages/pi-ai/src/providers/openai-codex-responses.test.ts
+++ b/packages/pi-ai/src/providers/openai-codex-responses.test.ts
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Context, Model } from "../types.js";
+import { streamOpenAICodexResponses } from "./openai-codex-responses.js";
+
+function codexModel(): Model<"openai-codex-responses"> {
+	return {
+		id: "gpt-5.5",
+		name: "GPT-5.5",
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400000,
+		maxTokens: 128000,
+	};
+}
+
+function fakeCodexToken(): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "account-123" } }),
+	).toString("base64");
+	return `header.${payload}.signature`;
+}
+
+test("openai codex responses uses Retry-After as the minimum 429 retry delay (#5677)", async (t) => {
+	const originalFetch = globalThis.fetch;
+	const originalSetTimeout = globalThis.setTimeout;
+	const delays: number[] = [];
+	let requests = 0;
+
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+		globalThis.setTimeout = originalSetTimeout;
+	});
+
+	globalThis.fetch = async () => {
+		requests++;
+		return new Response(JSON.stringify({ error: { code: "rate_limit_exceeded", message: "rate limited" } }), {
+			status: 429,
+			headers: { "Retry-After": "60" },
+		});
+	};
+
+	globalThis.setTimeout = ((callback: (...args: unknown[]) => void, ms?: number, ...args: unknown[]) => {
+		delays.push(Number(ms));
+		queueMicrotask(() => callback(...args));
+		return 0;
+	}) as unknown as typeof setTimeout;
+
+	const context: Context = {
+		messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+	};
+
+	const stream = streamOpenAICodexResponses(codexModel(), context, { apiKey: fakeCodexToken() });
+	const result = await stream.result();
+
+	assert.equal(requests, 4);
+	assert.deepEqual(delays, [60000, 60000, 60000]);
+	assert.equal(result.stopReason, "error");
+});

--- a/packages/pi-ai/src/providers/openai-codex-responses.ts
+++ b/packages/pi-ai/src/providers/openai-codex-responses.ts
@@ -89,6 +89,94 @@ function isRetryableError(status: number, errorText: string): boolean {
 	return /rate.?limit|overloaded|service.?unavailable|upstream.?connect|connection.?refused/i.test(errorText);
 }
 
+function extractRetryDelay(errorText: string, response?: Response | Headers): number | undefined {
+	const normalizeDelay = (ms: number): number | undefined => (ms > 0 ? Math.ceil(ms) : undefined);
+
+	const headers = response instanceof Headers ? response : response?.headers;
+	if (headers) {
+		const retryAfter = headers.get("retry-after");
+		if (retryAfter) {
+			const retryAfterSeconds = Number(retryAfter);
+			if (Number.isFinite(retryAfterSeconds)) {
+				const delay = normalizeDelay(retryAfterSeconds * 1000);
+				if (delay !== undefined) {
+					return delay;
+				}
+			}
+
+			const retryAfterDate = new Date(retryAfter).getTime();
+			if (!Number.isNaN(retryAfterDate)) {
+				const delay = normalizeDelay(retryAfterDate - Date.now());
+				if (delay !== undefined) {
+					return delay;
+				}
+			}
+		}
+
+		const rateLimitReset = headers.get("x-ratelimit-reset");
+		if (rateLimitReset) {
+			const resetSeconds = Number.parseInt(rateLimitReset, 10);
+			if (!Number.isNaN(resetSeconds)) {
+				const delay = normalizeDelay(resetSeconds * 1000 - Date.now());
+				if (delay !== undefined) {
+					return delay;
+				}
+			}
+		}
+
+		const rateLimitResetAfter = headers.get("x-ratelimit-reset-after");
+		if (rateLimitResetAfter) {
+			const resetAfterSeconds = Number(rateLimitResetAfter);
+			if (Number.isFinite(resetAfterSeconds)) {
+				const delay = normalizeDelay(resetAfterSeconds * 1000);
+				if (delay !== undefined) {
+					return delay;
+				}
+			}
+		}
+	}
+
+	const durationMatch = errorText.match(/reset after (?:(\d+)h)?(?:(\d+)m)?(\d+(?:\.\d+)?)s/i);
+	if (durationMatch) {
+		const hours = durationMatch[1] ? parseInt(durationMatch[1], 10) : 0;
+		const minutes = durationMatch[2] ? parseInt(durationMatch[2], 10) : 0;
+		const seconds = parseFloat(durationMatch[3]);
+		if (!Number.isNaN(seconds)) {
+			const totalMs = ((hours * 60 + minutes) * 60 + seconds) * 1000;
+			const delay = normalizeDelay(totalMs);
+			if (delay !== undefined) {
+				return delay;
+			}
+		}
+	}
+
+	const retryInMatch = errorText.match(/Please retry in ([0-9.]+)(ms|s)/i);
+	if (retryInMatch?.[1]) {
+		const value = parseFloat(retryInMatch[1]);
+		if (!Number.isNaN(value) && value > 0) {
+			const ms = retryInMatch[2].toLowerCase() === "ms" ? value : value * 1000;
+			const delay = normalizeDelay(ms);
+			if (delay !== undefined) {
+				return delay;
+			}
+		}
+	}
+
+	const retryDelayMatch = errorText.match(/"retryDelay":\s*"([0-9.]+)(ms|s)"/i);
+	if (retryDelayMatch?.[1]) {
+		const value = parseFloat(retryDelayMatch[1]);
+		if (!Number.isNaN(value) && value > 0) {
+			const ms = retryDelayMatch[2].toLowerCase() === "ms" ? value : value * 1000;
+			const delay = normalizeDelay(ms);
+			if (delay !== undefined) {
+				return delay;
+			}
+		}
+	}
+
+	return undefined;
+}
+
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 	return new Promise((resolve, reject) => {
 		if (signal?.aborted) {
@@ -205,7 +293,9 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 
 					const errorText = await response.text();
 					if (attempt < MAX_RETRIES && isRetryableError(response.status, errorText)) {
-						const delayMs = BASE_DELAY_MS * 2 ** attempt;
+						const backoffMs = BASE_DELAY_MS * 2 ** attempt;
+						const serverDelayMs = extractRetryDelay(errorText, response);
+						const delayMs = Math.max(backoffMs, serverDelayMs ?? 0);
 						await sleep(delayMs, options?.signal);
 						continue;
 					}


### PR DESCRIPTION
## Summary
- Fixed Codex 429 retry delays to honor server retry hints and verified with a focused regression test plus pi-ai build.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5677
- [#5677 openai-codex-responses.ts — 429 retries fire inside provider cooldown window, Gemini path handles it correctly](https://github.com/gsd-build/gsd-2/issues/5677)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5677-openai-codex-responses-ts-429-retries-fi-1778620511`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage to verify the system correctly honors server-provided retry delay suggestions when encountering rate-limit errors.

* **Improvements**
  * Enhanced system resilience by improving request retry logic to intelligently respect server-suggested delay guidance from rate-limit responses, resulting in more effective error recovery and improved overall service reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5859)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->