### PR TITLE
fix(issue): gsd_plan_slice leaves omitted stale tasks in DB, causing pre-exec to validate old task plans

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -2082,6 +2082,9 @@ export function deleteTask(milestoneId: string, sliceId: string, taskId: string)
       `DELETE FROM verification_evidence WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid`,
     ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
     currentDb!.prepare(
+      `DELETE FROM quality_gates WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid`,
+    ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+    currentDb!.prepare(
       `DELETE FROM tasks WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
     ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
   });

--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -6,7 +6,7 @@ import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync, writeFileSync
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { openDatabase, closeDatabase, insertMilestone, insertSlice, getSlice, getSliceTasks, getTask, getGateResults } from '../gsd-db.ts';
+import { openDatabase, closeDatabase, insertMilestone, insertSlice, getSlice, getSliceTasks, getTask, getGateResults, updateTaskStatus } from '../gsd-db.ts';
 import { handlePlanSlice } from '../tools/plan-slice.ts';
 import { parsePlan } from '../parsers-legacy.ts';
 import { parseTaskPlanFile } from '../files.ts';
@@ -359,6 +359,46 @@ test('handlePlanSlice removes omitted pending tasks when replanning a smaller ta
     assert.deepEqual(getSliceTasks('M001', 'S02').map((task) => task.id), ['T01', 'T02', 'T03']);
     assert.equal(getGateResults('M001', 'S02', 'task').some((gate) => gate.task_id === 'T04'), false);
     assert.equal(existsSync(staleTaskPlanPath), false, 'omitted task plan artifact should be removed');
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('handlePlanSlice rejects omitted completed tasks without changing slice or task state', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+    const fourTaskPlan = {
+      ...validParams(),
+      tasks: [
+        ...validParams().tasks,
+        { ...validParams().tasks[0], taskId: 'T03', title: 'Third task' },
+        { ...validParams().tasks[0], taskId: 'T04', title: 'Stale task', inputs: ['stale-input.py'] },
+      ],
+    };
+
+    const first = await handlePlanSlice(fourTaskPlan, base);
+    assert.ok(!('error' in first), `unexpected error: ${'error' in first ? first.error : ''}`);
+    const staleTaskPlanPath = join(base, '.gsd', 'milestones', 'M001', 'slices', 'S02', 'tasks', 'T04-PLAN.md');
+    assert.ok(existsSync(staleTaskPlanPath), 'initial plan should render T04');
+
+    updateTaskStatus('M001', 'S02', 'T04', 'complete', '2026-05-12T00:00:00.000Z');
+    const tasksBefore = getSliceTasks('M001', 'S02');
+    const gatesBefore = getGateResults('M001', 'S02', 'task');
+
+    const second = await handlePlanSlice({
+      ...validParams(),
+      goal: 'Rejected replan should not persist.',
+      tasks: fourTaskPlan.tasks.filter((task) => task.taskId !== 'T04'),
+    }, base);
+    assert.deepEqual(second, { error: 'cannot remove completed task T04' });
+
+    assert.equal(getSlice('M001', 'S02')?.goal, 'Persist slice planning through the DB.');
+    assert.deepEqual(getSliceTasks('M001', 'S02'), tasksBefore);
+    assert.deepEqual(getGateResults('M001', 'S02', 'task'), gatesBefore);
+    assert.ok(existsSync(staleTaskPlanPath), 'completed task plan artifact should remain after rejected replan');
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -6,7 +6,7 @@ import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync, writeFileSync
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { openDatabase, closeDatabase, insertMilestone, insertSlice, getSlice, getSliceTasks, getTask } from '../gsd-db.ts';
+import { openDatabase, closeDatabase, insertMilestone, insertSlice, getSlice, getSliceTasks, getTask, getGateResults } from '../gsd-db.ts';
 import { handlePlanSlice } from '../tools/plan-slice.ts';
 import { parsePlan } from '../parsers-legacy.ts';
 import { parseTaskPlanFile } from '../files.ts';
@@ -325,6 +325,40 @@ test('handlePlanSlice reruns idempotently and refreshes parse-visible state', as
     assert.equal(parsedAfter.goal, 'Updated goal from rerun.');
     const task = getTask('M001', 'S02', 'T01');
     assert.equal(task?.description, 'Updated slice handler description.');
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('handlePlanSlice removes omitted pending tasks when replanning a smaller task set', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+    const fourTaskPlan = {
+      ...validParams(),
+      tasks: [
+        ...validParams().tasks,
+        { ...validParams().tasks[0], taskId: 'T03', title: 'Third task' },
+        { ...validParams().tasks[0], taskId: 'T04', title: 'Stale task', inputs: ['stale-input.py'] },
+      ],
+    };
+
+    const first = await handlePlanSlice(fourTaskPlan, base);
+    assert.ok(!('error' in first), `unexpected error: ${'error' in first ? first.error : ''}`);
+    const staleTaskPlanPath = join(base, '.gsd', 'milestones', 'M001', 'slices', 'S02', 'tasks', 'T04-PLAN.md');
+    assert.ok(existsSync(staleTaskPlanPath), 'initial plan should render T04');
+
+    const second = await handlePlanSlice({
+      ...validParams(),
+      tasks: fourTaskPlan.tasks.filter((task) => task.taskId !== 'T04'),
+    }, base);
+    assert.ok(!('error' in second), `unexpected error: ${'error' in second ? second.error : ''}`);
+
+    assert.deepEqual(getSliceTasks('M001', 'S02').map((task) => task.id), ['T01', 'T02', 'T03']);
+    assert.equal(getGateResults('M001', 'S02', 'task').some((gate) => gate.task_id === 'T04'), false);
+    assert.equal(existsSync(staleTaskPlanPath), false, 'omitted task plan artifact should be removed');
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -189,19 +189,6 @@ export async function handlePlanSlice(
         return;
       }
 
-      if (isDeferredStatus(parentSlice.status)) {
-        updateSliceStatus(params.milestoneId, params.sliceId, "pending");
-      }
-      setSliceSketchFlag(params.milestoneId, params.sliceId, false);
-
-      upsertSlicePlanning(params.milestoneId, params.sliceId, {
-        goal: params.goal,
-        successCriteria: params.successCriteria,
-        proofLevel: params.proofLevel,
-        integrationClosure: params.integrationClosure,
-        observabilityImpact: params.observabilityImpact,
-      });
-
       const newTaskIds = new Set(params.tasks.map((task) => task.taskId));
       const existingTasks = getSliceTasks(params.milestoneId, params.sliceId);
       omittedTaskIds = existingTasks
@@ -214,6 +201,19 @@ export async function handlePlanSlice(
           return;
         }
       }
+
+      if (isDeferredStatus(parentSlice.status)) {
+        updateSliceStatus(params.milestoneId, params.sliceId, "pending");
+      }
+      setSliceSketchFlag(params.milestoneId, params.sliceId, false);
+
+      upsertSlicePlanning(params.milestoneId, params.sliceId, {
+        goal: params.goal,
+        successCriteria: params.successCriteria,
+        proofLevel: params.proofLevel,
+        integrationClosure: params.integrationClosure,
+        observabilityImpact: params.observabilityImpact,
+      });
 
       for (const taskId of omittedTaskIds) {
         deleteTask(params.milestoneId, params.sliceId, taskId);

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -1,16 +1,21 @@
+import { existsSync, rmSync } from "node:fs";
+import { join, relative } from "node:path";
 import { clearParseCache } from "../files.js";
 import { isClosedStatus, isDeferredStatus } from "../status-guards.js";
-import { isNonEmptyString, validateStringArray } from "../validation.js";
+import { isNonEmptyString } from "../validation.js";
 import {
   transaction,
   getMilestone,
   getSlice,
+  getSliceTasks,
   insertTask,
   upsertSlicePlanning,
   upsertTaskPlanning,
   insertGateRow,
   updateSliceStatus,
   setSliceSketchFlag,
+  deleteTask,
+  deleteArtifactByPath,
 } from "../gsd-db.js";
 import type { GateId } from "../types.js";
 import { invalidateStateCache } from "../state.js";
@@ -20,6 +25,7 @@ import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning } from "../workflow-logger.js";
 import { validatePlanningPathScope } from "../planning-path-scope.js";
+import { buildTaskFileName, gsdRoot, resolveTasksDir } from "../paths.js";
 
 export interface PlanSliceTaskInput {
   taskId: string;
@@ -159,6 +165,7 @@ export async function handlePlanSlice(
   // Guards must be inside the transaction so the state they check cannot
   // change between the read and the write (#2723).
   let guardError: string | null = null;
+  let omittedTaskIds: string[] = [];
 
   try {
     transaction(() => {
@@ -194,6 +201,23 @@ export async function handlePlanSlice(
         integrationClosure: params.integrationClosure,
         observabilityImpact: params.observabilityImpact,
       });
+
+      const newTaskIds = new Set(params.tasks.map((task) => task.taskId));
+      const existingTasks = getSliceTasks(params.milestoneId, params.sliceId);
+      omittedTaskIds = existingTasks
+        .filter((task) => !newTaskIds.has(task.id))
+        .map((task) => task.id);
+
+      for (const task of existingTasks) {
+        if (!newTaskIds.has(task.id) && isClosedStatus(task.status)) {
+          guardError = `cannot remove completed task ${task.id}`;
+          return;
+        }
+      }
+
+      for (const taskId of omittedTaskIds) {
+        deleteTask(params.milestoneId, params.sliceId, taskId);
+      }
 
       for (const task of params.tasks) {
         insertTask({
@@ -239,6 +263,15 @@ export async function handlePlanSlice(
   }
 
   try {
+    const tasksDir = resolveTasksDir(basePath, params.milestoneId, params.sliceId);
+    for (const taskId of omittedTaskIds) {
+      if (!tasksDir) continue;
+      const taskPlanPath = join(tasksDir, buildTaskFileName(taskId, "PLAN"));
+      if (existsSync(taskPlanPath)) rmSync(taskPlanPath, { force: true });
+      const artifactPath = relative(gsdRoot(basePath), taskPlanPath).replace(/\\/g, "/");
+      deleteArtifactByPath(artifactPath);
+    }
+
     const renderResult = await renderPlanFromDb(basePath, params.milestoneId, params.sliceId);
     invalidateStateCache();
     clearParseCache();


### PR DESCRIPTION
## Summary
- Fixed gsd_plan_slice stale task reconciliation and verified with focused plan-slice and DB tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5557
- [#5557 gsd_plan_slice leaves omitted stale tasks in DB, causing pre-exec to validate old task plans](https://github.com/gsd-build/gsd-2/issues/5557)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5557-gsd-plan-slice-leaves-omitted-stale-task-1778623339`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Delete now also cleans up related quality-gate records when a task is removed.
  * Replanning will not remove tasks that are already completed; an error prevents their deletion and preserves state.
  * Stale task artifacts are removed from disk after successful replans that omit tasks.

* **Tests**
  * Added integration tests covering omitted-task deletion, artifact cleanup, and the protected-completed-task case.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5862)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->