### PR TITLE
fix(issue): gsd-progress widget not torn down after step-mode natural loop exit (cleanupAfterLoopExit missing setWidget teardown)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1044,6 +1044,7 @@ export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void>
   // visible so the user still has a resumable auto-mode signal on screen.
   if (!s.paused) {
     ctx.ui.setStatus("gsd-auto", undefined);
+    ctx.ui.setWidget("gsd-progress", undefined);
     if (s.completionStopInProgress) {
       s.completionStopInProgress = false;
     }

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -43,7 +43,7 @@ test("cleanupAfterLoopExit preserves paused auto badge after provider pause", as
   }
 });
 
-test("cleanupAfterLoopExit clears status without replacing the last auto surface", async () => {
+test("cleanupAfterLoopExit clears status and progress widget without replacing outcome surface", async () => {
   const statusCalls: unknown[] = [];
   const widgetCalls: unknown[] = [];
 
@@ -64,8 +64,8 @@ test("cleanupAfterLoopExit clears status without replacing the last auto surface
     assert.deepEqual(statusCalls, [["gsd-auto", undefined]]);
     assert.equal(
       widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-progress" && args[1] === undefined),
-      false,
-      "cleanup must not clear the last meaningful auto progress surface",
+      true,
+      "cleanup must clear the stale auto progress widget",
     );
     assert.equal(
       widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-outcome"),
@@ -79,7 +79,7 @@ test("cleanupAfterLoopExit clears status without replacing the last auto surface
   }
 });
 
-test("cleanupAfterLoopExit preserves completion roll-up after stopAuto reset", async () => {
+test("cleanupAfterLoopExit clears progress widget after stopAuto reset", async () => {
   const statusCalls: unknown[] = [];
   const widgetCalls: unknown[] = [];
 
@@ -103,8 +103,8 @@ test("cleanupAfterLoopExit preserves completion roll-up after stopAuto reset", a
     assert.deepEqual(statusCalls, [["gsd-auto", undefined]]);
     assert.equal(
       widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-progress" && args[1] === undefined),
-      false,
-      "completion cleanup must not clear the roll-up progress widget",
+      true,
+      "completion cleanup must clear the stale progress widget",
     );
     assert.equal(
       widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-outcome"),


### PR DESCRIPTION
## Summary
- Cleared the gsd-progress widget on cleanupAfterLoopExit and verified the focused cleanup test passes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5861
- [#5861 gsd-progress widget not torn down after step-mode natural loop exit (cleanupAfterLoopExit missing setWidget teardown)](https://github.com/gsd-build/gsd-2/issues/5861)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5861-gsd-progress-widget-not-torn-down-after--1778623705`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the progress indicator would incorrectly remain visible on the interface after an auto-loop session completes or exits without being paused. The stale progress display is now properly cleared during cleanup, ensuring the interface accurately reflects the current session state and preventing user confusion.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5864)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->