### PR TITLE
fix(issue): Auto-mode 3-strike hard-stop on git dubious ownership: getMainBranch() uncaught in dispatch guard path

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1327,9 +1327,15 @@ export async function runDispatch(
   }
 
   const guardBasePath = _resolveDispatchGuardBasePath(s);
+  let mainBranch = "main";
+  try {
+    mainBranch = deps.getMainBranch(guardBasePath);
+  } catch (err) {
+    debugLog("autoLoop", { phase: "getMainBranch-failed", error: String(err) });
+  }
   const priorSliceBlocker = deps.getPriorSliceCompletionBlocker(
     guardBasePath,
-    deps.getMainBranch(guardBasePath),
+    mainBranch,
     unitType,
     unitId,
   );

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -144,9 +144,9 @@ function gitExec(basePath: string, args: string[], allowFailure = false): string
       encoding: "utf-8",
       env: GIT_NO_PROMPT_ENV,
     }).trim();
-  } catch {
+  } catch (err) {
     if (allowFailure) return "";
-    throw new GSDError(GSD_GIT_ERROR, `git ${args.join(" ")} failed in ${basePath}`);
+    throw new GSDError(GSD_GIT_ERROR, `git ${args.join(" ")} failed in ${basePath}: ${getErrorMessage(err)}`);
   }
 }
 
@@ -159,9 +159,9 @@ function gitFileExec(basePath: string, args: string[], allowFailure = false): st
       encoding: "utf-8",
       env: GIT_NO_PROMPT_ENV,
     }).trim();
-  } catch {
+  } catch (err) {
     if (allowFailure) return "";
-    throw new GSDError(GSD_GIT_ERROR, `git ${args.join(" ")} failed in ${basePath}`);
+    throw new GSDError(GSD_GIT_ERROR, `git ${args.join(" ")} failed in ${basePath}: ${getErrorMessage(err)}`);
   }
 }
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -3353,6 +3353,60 @@ test("runDispatch runs stuck detection while artifact verification retry is pend
   );
 });
 
+test("runDispatch falls back to main when dispatch guard cannot read main branch (#5530)", async (t) => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  const pi = makeMockPi();
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-5530-main-branch-fallback-"));
+  t.after(() => rmSync(basePath, { recursive: true, force: true }));
+
+  let guardBranch: string | null = null;
+  const s = makeLoopSession({ basePath });
+  const deps = makeMockDeps({
+    getMainBranch: () => {
+      throw new Error("fatal: detected dubious ownership");
+    },
+    getPriorSliceCompletionBlocker: (_basePath, mainBranch) => {
+      guardBranch = mainBranch;
+      return null;
+    },
+  });
+
+  const result = await runDispatch(
+    {
+      ctx,
+      pi,
+      s,
+      deps,
+      prefs: undefined,
+      iteration: 1,
+      flowId: "test-flow",
+      nextSeq: () => 1,
+    },
+    {
+      state: {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Test", status: "active" },
+        activeSlice: { id: "S01", title: "Slice 1" },
+        activeTask: { id: "T01" },
+        registry: [{ id: "M001", status: "active" }],
+        blockers: [],
+      } as any,
+      mid: "M001",
+      midTitle: "Test",
+    },
+    {
+      recentUnits: [],
+      stuckRecoveryAttempts: 0,
+      consecutiveFinalizeTimeouts: 0,
+    },
+  );
+
+  assert.equal(guardBranch, "main");
+  assert.equal(result.action, "next");
+});
+
 test("dispatch Worktree Safety stops unknown unit types with missing Tool Contract", async (t) => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
@@ -20,6 +20,7 @@ import {
   assertWorktreeMaterialized,
   nativeBranchDelete,
   nativeCommit,
+  nativeGetCurrentBranch,
   nativeIsRepo,
   nativeResetHard,
   nativeWorktreeAdd,
@@ -119,7 +120,17 @@ describe("native-git-bridge #4180: fallback runtime behaviour", () => {
   test("nativeBranchDelete throws when git cannot delete the branch", () => {
     assert.throws(
       () => nativeBranchDelete(repo, "does-not-exist"),
-      /GSD_GIT_ERROR|git branch -D does-not-exist failed/,
+      /git branch -D does-not-exist failed[\s\S]*does-not-exist/,
+    );
+  });
+
+  test("nativeGetCurrentBranch preserves git stderr in fallback errors", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "ngb-stderr-notrepo-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+    assert.throws(
+      () => nativeGetCurrentBranch(dir),
+      /git branch --show-current failed[\s\S]*(not a git repository|not a git repo|fatal:)/,
     );
   });
 


### PR DESCRIPTION
## Summary
- Fixed auto-mode dispatch fallback for git main-branch lookup failures and preserved native git stderr, verified with focused regression tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5530
- [#5530 Auto-mode 3-strike hard-stop on git dubious ownership: getMainBranch() uncaught in dispatch guard path](https://github.com/gsd-build/gsd-2/issues/5530)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5530-auto-mode-3-strike-hard-stop-on-git-dubi-1778623823`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of branch detection with automatic fallback to default branch when detection fails.
  * Enhanced error reporting by capturing and displaying detailed error messages when git operations fail.

* **Tests**
  * Added regression tests for branch detection fallback behavior and error message preservation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5865)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->