### PR TITLE
fix(issue): ENOBUFS from spawnSync git is not treated as transient — git commit fails with no retry

### DIFF
--- a/src/resources/extensions/gsd/auto/infra-errors.ts
+++ b/src/resources/extensions/gsd/auto/infra-errors.ts
@@ -7,9 +7,14 @@
  */
 
 /**
- * Error codes indicating infrastructure failures that cannot be recovered by
- * retrying. Each retry re-dispatches the unit at full LLM cost, so we bail
- * immediately rather than burning budget on guaranteed failures.
+ * Error codes indicating infrastructure-level failures from the OS,
+ * filesystem, or network. This set includes permanent resource failures
+ * (ENOSPC, ENOMEM, EROFS), transient resource exhaustion (EAGAIN, ENOBUFS),
+ * and network/offline errors (ECONNREFUSED, ENOTFOUND, ENETUNREACH).
+ *
+ * Transient git failures are retried separately through
+ * TRANSIENT_GIT_RETRY_CODES in native-git-bridge.ts before escalating to the
+ * auto-loop.
  */
 export const INFRA_ERROR_CODES: ReadonlySet<string> = new Set([
   "ENOSPC",   // disk full

--- a/src/resources/extensions/gsd/auto/infra-errors.ts
+++ b/src/resources/extensions/gsd/auto/infra-errors.ts
@@ -19,6 +19,7 @@ export const INFRA_ERROR_CODES: ReadonlySet<string> = new Set([
   "EMFILE",   // too many open files (process)
   "ENFILE",   // too many open files (system)
   "EAGAIN",       // resource temporarily unavailable (resource exhaustion)
+  "ENOBUFS",      // no buffer space available (transient pipe exhaustion)
   "ECONNREFUSED", // connection refused (offline / local server down)
   "ENOTFOUND",    // DNS lookup failed (offline / no network)
   "ENETUNREACH",  // network unreachable (offline / no route)

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -6,6 +6,7 @@
 // execSync calls because git2 credential handling is too complex.
 
 import { execSync, execFileSync } from "node:child_process";
+import type { ExecFileSyncOptionsWithStringEncoding } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { GSDError, GSD_GIT_ERROR } from "./errors.js";
@@ -16,6 +17,8 @@ import { isInfrastructureError } from "./auto/infra-errors.js";
 // Issue #453: keep auto-mode bookkeeping on the stable git CLI path unless a
 // caller explicitly opts into the native helper.
 const NATIVE_GSD_GIT_ENABLED = process.env.GSD_ENABLE_NATIVE_GSD_GIT === "1";
+const TRANSIENT_GIT_RETRY_CODES = new Set(["ENOBUFS", "EAGAIN"]);
+const GIT_RETRY_DELAY_MS = 200;
 
 // ─── Native Module Types ──────────────────────────────────────────────────
 
@@ -147,6 +150,42 @@ function gitExec(basePath: string, args: string[], allowFailure = false): string
   } catch {
     if (allowFailure) return "";
     throw new GSDError(GSD_GIT_ERROR, `git ${args.join(" ")} failed in ${basePath}`);
+  }
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function isRetryableGitError(err: unknown): boolean {
+  const code = isInfrastructureError(err)
+    ?? isInfrastructureError((err as { stderr?: string })?.stderr ?? "");
+  return code !== null && TRANSIENT_GIT_RETRY_CODES.has(code);
+}
+
+function execGitFileSyncWithRetry(
+  basePath: string,
+  args: string[],
+  options: Partial<ExecFileSyncOptionsWithStringEncoding>,
+): string {
+  try {
+    return execFileSync("git", args, {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      env: GIT_NO_PROMPT_ENV,
+      ...options,
+    }).trim();
+  } catch (err) {
+    if (!isRetryableGitError(err)) throw err;
+    sleepSync(GIT_RETRY_DELAY_MS);
+    return execFileSync("git", args, {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      env: GIT_NO_PROMPT_ENV,
+      ...options,
+    }).trim();
   }
 }
 
@@ -940,13 +979,10 @@ export function nativeCommit(
   try {
     const args = ["commit", "-F", "-"];
     if (options?.allowEmpty) args.push("--allow-empty");
-    const result = execFileSync("git", args, {
-      cwd: basePath,
+    const result = execGitFileSyncWithRetry(basePath, args, {
       stdio: ["pipe", "pipe", "pipe"],
-      encoding: "utf-8",
-      env: GIT_NO_PROMPT_ENV,
       input: message,
-    }).trim();
+    });
     return result;
   } catch (err: unknown) {
     const errObj = err as { stdout?: string; stderr?: string; message?: string };

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -153,6 +153,7 @@ function gitExec(basePath: string, args: string[], allowFailure = false): string
   }
 }
 
+/** sleepSync uses Atomics.wait for a blocking pause without busy-waiting; it blocks the current thread and requires Atomics.wait support. */
 function sleepSync(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }

--- a/src/resources/extensions/gsd/tests/infra-error.test.ts
+++ b/src/resources/extensions/gsd/tests/infra-error.test.ts
@@ -9,11 +9,11 @@ import { isInfrastructureError, INFRA_ERROR_CODES } from "../auto/infra-errors.j
 test("INFRA_ERROR_CODES contains the expected codes", () => {
   for (const code of [
     "ENOSPC", "ENOMEM", "EROFS", "EDQUOT", "EMFILE", "ENFILE",
-    "EAGAIN", "ECONNREFUSED", "ENOTFOUND", "ENETUNREACH",
+    "EAGAIN", "ENOBUFS", "ECONNREFUSED", "ENOTFOUND", "ENETUNREACH",
   ]) {
     assert.ok(INFRA_ERROR_CODES.has(code), `missing ${code}`);
   }
-  assert.equal(INFRA_ERROR_CODES.size, 10, "unexpected extra codes");
+  assert.equal(INFRA_ERROR_CODES.size, 11, "unexpected extra codes");
 });
 
 // ── isInfrastructureError: code property detection ───────────────────────────

--- a/src/resources/extensions/gsd/tests/infra-errors-cooldown.test.ts
+++ b/src/resources/extensions/gsd/tests/infra-errors-cooldown.test.ts
@@ -5,6 +5,8 @@ import test, { describe } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  INFRA_ERROR_CODES,
+  isInfrastructureError,
   isTransientCooldownError,
   getCooldownRetryAfterMs,
   MAX_COOLDOWN_RETRIES,
@@ -12,6 +14,13 @@ import {
 } from "../auto/infra-errors.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
+
+describe("infra error classification", () => {
+  test("ENOBUFS is treated as infrastructure exhaustion", () => {
+    assert.equal(INFRA_ERROR_CODES.has("ENOBUFS"), true);
+    assert.equal(isInfrastructureError(Object.assign(new Error("spawnSync git ENOBUFS"), { code: "ENOBUFS" })), "ENOBUFS");
+  });
+});
 
 describe("infra-errors cooldown constants", () => {
   test("COOLDOWN_FALLBACK_WAIT_MS is a positive number greater than the 30s rate-limit backoff", () => {

--- a/src/resources/extensions/gsd/tests/integration/state-machine-runtime-failures.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/state-machine-runtime-failures.test.ts
@@ -195,6 +195,11 @@ describe("infrastructure error detection", () => {
     assert.equal(isInfrastructureError(err), "EAGAIN");
   });
 
+  test("ENOBUFS (no buffer space available) is detected", () => {
+    const err = Object.assign(new Error("spawnSync git ENOBUFS"), { code: "ENOBUFS" });
+    assert.equal(isInfrastructureError(err), "ENOBUFS");
+  });
+
   test("SQLite WAL corruption is detected via message scan", () => {
     const err = new Error("database disk image is malformed");
     assert.equal(isInfrastructureError(err), "SQLITE_CORRUPT");
@@ -223,7 +228,7 @@ describe("infrastructure error detection", () => {
   test("all INFRA_ERROR_CODES are covered", () => {
     const expectedCodes = [
       "ENOSPC", "ENOMEM", "EROFS", "EDQUOT", "EMFILE",
-      "ENFILE", "EAGAIN", "ECONNREFUSED", "ENOTFOUND", "ENETUNREACH",
+      "ENFILE", "EAGAIN", "ENOBUFS", "ECONNREFUSED", "ENOTFOUND", "ENETUNREACH",
     ];
     for (const code of expectedCodes) {
       assert.ok(INFRA_ERROR_CODES.has(code), `${code} should be in INFRA_ERROR_CODES`);

--- a/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
@@ -112,15 +112,16 @@ process.exit(result.status ?? 1);
     git(["add", "."], repo);
 
     const originalPath = process.env.PATH ?? "";
-    const originalGitEnvPath = GIT_NO_PROMPT_ENV.PATH;
+    const gitEnv = GIT_NO_PROMPT_ENV as NodeJS.ProcessEnv;
+    const originalGitEnvPath = gitEnv.PATH;
     try {
       process.env.PATH = `${bin}${delimiter}${originalPath}`;
-      GIT_NO_PROMPT_ENV.PATH = process.env.PATH;
+      gitEnv.PATH = process.env.PATH;
       const result = nativeCommit(repo, "test: retry ENOBUFS commit");
       assert.ok(result !== null, "commit should succeed after retry");
     } finally {
       process.env.PATH = originalPath;
-      GIT_NO_PROMPT_ENV.PATH = originalGitEnvPath;
+      gitEnv.PATH = originalGitEnvPath;
     }
 
     assert.equal(readFileSync(attempts, "utf-8").length, 2);

--- a/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
@@ -13,7 +13,7 @@
 import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { chmodSync, existsSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import {
@@ -24,6 +24,7 @@ import {
   nativeResetHard,
   nativeWorktreeAdd,
 } from "../native-git-bridge.js";
+import { GIT_NO_PROMPT_ENV } from "../git-constants.js";
 
 // Note: prior static-analysis tests that scanned native-git-bridge.ts for
 // the raw shell-spawn pattern were removed under #4827 — the integration
@@ -76,6 +77,54 @@ describe("native-git-bridge #4180: fallback runtime behaviour", () => {
 
     const subject = git(["log", "-1", "--format=%s"], repo);
     assert.equal(subject, "test: regression commit #4180");
+  });
+
+  test("nativeCommit retries once after transient ENOBUFS from git", (t) => {
+    const bin = mkdtempSync(join(tmpdir(), "ngb-enobufs-bin-"));
+    t.after(() => rmSync(bin, { recursive: true, force: true }));
+
+    const realGit = execFileSync("git", ["--exec-path"], { encoding: "utf-8" }).trim();
+    const attempts = join(bin, "attempts.txt");
+    const fakeGit = join(bin, "fake-git.cjs");
+    writeFileSync(fakeGit, `
+const { appendFileSync, readFileSync } = require("node:fs");
+const { spawnSync } = require("node:child_process");
+const attempts = ${JSON.stringify(attempts)};
+const realGit = ${JSON.stringify(join(realGit, process.platform === "win32" ? "git.exe" : "git"))};
+appendFileSync(attempts, "1");
+if (process.argv[2] === "commit" && readFileSync(attempts, "utf-8").length === 1) {
+  console.error("spawnSync git ENOBUFS");
+  process.exit(1);
+}
+const result = spawnSync(realGit, process.argv.slice(2), { stdio: "inherit" });
+process.exit(result.status ?? 1);
+`, "utf-8");
+
+    if (process.platform === "win32") {
+      writeFileSync(join(bin, "git.cmd"), `@echo off\r\nnode "${fakeGit}" %*\r\n`, "utf-8");
+    } else {
+      const shim = join(bin, "git");
+      writeFileSync(shim, `#!/bin/sh\nexec node "${fakeGit}" "$@"\n`, "utf-8");
+      chmodSync(shim, 0o755);
+    }
+
+    writeFileSync(join(repo, "file.txt"), "retry commit\n");
+    git(["add", "."], repo);
+
+    const originalPath = process.env.PATH ?? "";
+    const originalGitEnvPath = GIT_NO_PROMPT_ENV.PATH;
+    try {
+      process.env.PATH = `${bin}${delimiter}${originalPath}`;
+      GIT_NO_PROMPT_ENV.PATH = process.env.PATH;
+      const result = nativeCommit(repo, "test: retry ENOBUFS commit");
+      assert.ok(result !== null, "commit should succeed after retry");
+    } finally {
+      process.env.PATH = originalPath;
+      GIT_NO_PROMPT_ENV.PATH = originalGitEnvPath;
+    }
+
+    assert.equal(readFileSync(attempts, "utf-8").length, 2);
+    assert.equal(git(["log", "-1", "--format=%s"], repo), "test: retry ENOBUFS commit");
   });
 
   test("nativeCommit runs commit hooks", () => {


### PR DESCRIPTION
## Summary
- Treated ENOBUFS as transient infrastructure exhaustion and verified native git commit retries once after a simulated ENOBUFS failure.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5518
- [#5518 ENOBUFS from spawnSync git is not treated as transient — git commit fails with no retry](https://github.com/gsd-build/gsd-2/issues/5518)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5518-enobufs-from-spawnsync-git-is-not-treate-1778624303`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transient OS resource errors (ENOBUFS/EAGAIN): git operations now detect these as infrastructure failures and automatically retry once, improving commit reliability.

* **Tests**
  * Added and updated tests to cover the expanded infrastructure-error classification and the git retry behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5867)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->