### PR TITLE
fix(issue): isLikelyCommand() treats Chinese/non-ASCII prose as shell command - verification gate false failure

### DIFF
--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -445,6 +445,10 @@ test("isLikelyCommand: prose descriptions are rejected", () => {
   assert.equal(isLikelyCommand("Build succeeds without errors or warnings"), false);
 });
 
+test("isLikelyCommand: non-ASCII prose descriptions are rejected", () => {
+  assert.equal(isLikelyCommand("所有 命令 输出 一行 JSONL go test ./... 通过"), false);
+});
+
 test("isLikelyCommand: empty or whitespace-only strings are rejected", () => {
   assert.equal(isLikelyCommand(""), false);
   assert.equal(isLikelyCommand("   "), false);

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -182,6 +182,7 @@ const KNOWN_COMMAND_PREFIXES = new Set([
  * Heuristics (any true → prose-like):
  *   1. First token starts with an uppercase letter and the string has 4+ words
  *   2. String contains commas followed by spaces (prose clause structure)
+ *   3. First token has no ASCII letters or digits and the string has 4+ words
  */
 export function isLikelyCommand(cmd: string): boolean {
   const trimmed = cmd.trim();
@@ -207,6 +208,9 @@ export function isLikelyCommand(cmd: string): boolean {
 
   // First token has uppercase letters and no path separators → prose
   if (/[A-Z]/.test(firstToken) && !firstToken.includes("/")) return false;
+
+  // Non-ASCII prose with multiple words should not be executed as a command.
+  if (!/[A-Za-z0-9]/.test(firstToken) && tokens.length >= 4) return false;
 
   return true;
 }


### PR DESCRIPTION
## Summary
- Fixed non-ASCII prose command detection in verification-gate and verified with the focused verification-gate test file.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5510
- [#5510 isLikelyCommand() treats Chinese/non-ASCII prose as shell command - verification gate false failure](https://github.com/gsd-build/gsd-2/issues/5510)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5510-islikelycommand-treats-chinese-non-ascii-1778624561`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command detection accuracy for non-ASCII text.

* **Tests**
  * Added test coverage for non-ASCII command handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5868)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->