### PR TITLE
fix(issue): Slice title with '/' causes empty ROADMAP.md + TypeError 'Cannot read properties of undefined (reading indexOf)' stuck loop

### DIFF
--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -100,6 +100,8 @@ After writing the file, GSD attempts to open it in a browser using the local pla
 | `/gsd unpark` | Reactivate a parked milestone |
 | Discard milestone | Available via `/gsd` wizard → "Milestone actions" → "Discard" |
 
+Milestone and slice titles created during planning must not contain forward slash (`/`), en dash, or em dash characters. GSD reserves those characters as state-document delimiters, so `plan-milestone` rejects titles that include them.
+
 ## Parallel Orchestration
 
 | Command | Description |

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -615,10 +615,11 @@ export async function selectAndApplyModel(
  * Handles formats: "provider/model", "bare-id", "org/model-name" (OpenRouter).
  */
 export function resolveModelId<T extends { id: string; provider: string }>(
-  modelId: string,
+  modelId: string | undefined,
   availableModels: T[],
   currentProvider: string | undefined,
 ): T | undefined {
+  if (!modelId) return undefined;
   const slashIdx = modelId.indexOf("/");
 
   if (slashIdx !== -1) {

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -487,17 +487,18 @@ export function registerDbTools(pi: ExtensionAPI): void {
     promptGuidelines: [
       "Use gsd_plan_milestone for milestone planning instead of writing ROADMAP.md directly.",
       "Keep parameters flat and provide the full milestone planning payload, including slices.",
+      "Milestone and slice titles must not contain forward slash (/), en dash, or em dash characters.",
       "The tool validates input, writes milestone and slice planning data transactionally, renders ROADMAP.md from DB, and clears both state and parse caches after success.",
       "Use the canonical name gsd_plan_milestone; gsd_milestone_plan is only an alias.",
     ],
     parameters: Type.Object({
       // ── Core identification + content (required) ──────────────────────
       milestoneId: Type.String({ description: "Milestone ID (e.g. M001)" }),
-      title: Type.String({ description: "Milestone title" }),
+      title: Type.String({ description: "Milestone title; must not contain forward slash (/), en dash, or em dash characters" }),
       vision: Type.String({ description: "Milestone vision" }),
       slices: Type.Array(Type.Object({
         sliceId: Type.String({ description: "Slice ID (e.g. S01)" }),
-        title: Type.String({ description: "Slice title" }),
+        title: Type.String({ description: "Slice title; must not contain forward slash (/), en dash, or em dash characters" }),
         risk: Type.String({ description: "Slice risk" }),
         depends: Type.Array(Type.String(), { description: "Slice dependency IDs" }),
         demo: Type.String({ description: "Roadmap demo text / After this" }),

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -16,6 +16,7 @@ import type { RoadmapSliceEntry } from "./types.js";
 import { checkGitHealth, checkRuntimeHealth, checkGlobalHealth, checkEngineHealth } from "./doctor-checks.js";
 import { checkEnvironmentHealth } from "./doctor-environment.js";
 import { runProviderChecks } from "./doctor-providers.js";
+import { validateTitle } from "./validation.js";
 
 // ── Re-exports ─────────────────────────────────────────────────────────────
 // All public types and functions from extracted modules are re-exported here
@@ -25,33 +26,7 @@ export { summarizeDoctorIssues, filterDoctorIssues, formatDoctorReport, formatDo
 export { runEnvironmentChecks, runFullEnvironmentChecks, formatEnvironmentReport, type EnvironmentCheckResult } from "./doctor-environment.js";
 export { computeProgressScore, computeProgressScoreWithContext, formatProgressLine, formatProgressReport, type ProgressScore, type ProgressLevel } from "./progress-score.js";
 
-/**
- * Characters that are used as delimiters in GSD state management documents
- * and should not appear in milestone or slice titles.
- *
- * - "\u2014" (em dash, U+2014): used as a display separator in STATE.md and other docs.
- *   A title containing "\u2014" makes the separator ambiguous, corrupting state display
- *   and confusing the LLM agent that reads and writes these files.
- * - "\u2013" (en dash, U+2013): visually similar to em dash; same ambiguity risk.
- * - "/" (forward slash, U+002F): used as the path separator in unit IDs (M001/S01)
- *   and git branch names (gsd/M001/S01). A slash in a title can break path resolution.
- */
-const TITLE_DELIMITER_RE = /[\u2014\u2013\/]/; // em dash, en dash, forward slash
-
-/**
- * Check whether a milestone or slice title contains characters that conflict
- * with GSD's state document delimiter conventions.
- * Returns a human-readable description of the problem, or null if the title is safe.
- */
-export function validateTitle(title: string): string | null {
-  if (TITLE_DELIMITER_RE.test(title)) {
-    const found: string[] = [];
-    if (/[\u2014\u2013]/.test(title)) found.push("em/en dash (\u2014 or \u2013)");
-    if (/\//.test(title)) found.push("forward slash (/)");
-    return `title contains ${found.join(" and ")}, which conflict with GSD state document delimiters`;
-  }
-  return null;
-}
+export { validateTitle } from "./validation.js";
 
 function validatePreferenceShape(preferences: GSDPreferences): string[] {
   const issues: string[] = [];

--- a/src/resources/extensions/gsd/tests/hook-model-resolution.test.ts
+++ b/src/resources/extensions/gsd/tests/hook-model-resolution.test.ts
@@ -92,6 +92,11 @@ test("resolveModelId: returns undefined for unknown model", () => {
   assert.equal(match, undefined);
 });
 
+test("resolveModelId: returns undefined for missing model ID", () => {
+  const match = resolveModelId(undefined, AVAILABLE_MODELS, "anthropic");
+  assert.equal(match, undefined);
+});
+
 test("resolveModelId: returns undefined for unknown provider/model combo", () => {
   const match = resolveModelId("fakeprovider/fake-model", AVAILABLE_MODELS, undefined);
   assert.equal(match, undefined);

--- a/src/resources/extensions/gsd/tests/plan-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-milestone.test.ts
@@ -116,6 +116,32 @@ test('handlePlanMilestone rejects invalid payloads', async () => {
   }
 });
 
+test('handlePlanMilestone rejects delimiter characters in milestone and slice titles', async () => {
+  const base = makeTmpBase();
+  const dbPath = join(base, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+
+  try {
+    const milestoneResult = await handlePlanMilestone({ ...validParams(), title: 'Client/Server split' }, base);
+    assert.ok('error' in milestoneResult);
+    assert.match(milestoneResult.error, /validation failed: title is invalid: .*forward slash/);
+    assert.equal(getMilestone('M001'), null, 'invalid milestone title must not persist');
+
+    const sliceResult = await handlePlanMilestone({
+      ...validParams(),
+      slices: [
+        validParams().slices[0],
+        { ...validParams().slices[1], title: 'Client/Server migration' },
+      ],
+    }, base);
+    assert.ok('error' in sliceResult);
+    assert.match(sliceResult.error, /validation failed: slices\[1\]\.title is invalid: .*forward slash/);
+    assert.equal(getMilestoneSlices('M001').length, 0, 'invalid slice title must not persist partial roadmap state');
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handlePlanMilestone surfaces render failures and does not clear parse-visible state on failure', async () => {
   const base = makeTmpBase();
   const dbPath = join(base, '.gsd', 'gsd.db');

--- a/src/resources/extensions/gsd/tools/plan-milestone.ts
+++ b/src/resources/extensions/gsd/tools/plan-milestone.ts
@@ -1,6 +1,6 @@
 import { clearParseCache } from "../files.js";
 import { isClosedStatus } from "../status-guards.js";
-import { isNonEmptyString, validateStringArray } from "../validation.js";
+import { isNonEmptyString, validateStringArray, validateTitle } from "../validation.js";
 import {
   transaction,
   getMilestone,
@@ -148,6 +148,8 @@ function validateSlices(value: unknown): PlanMilestoneSliceInput[] {
     if (seen.has(sliceId)) throw new Error(`slices[${index}].sliceId must be unique`);
     seen.add(sliceId);
     if (!isNonEmptyString(title)) throw new Error(`slices[${index}].title must be a non-empty string`);
+    const titleIssue = validateTitle(title);
+    if (titleIssue) throw new Error(`slices[${index}].title is invalid: ${titleIssue}`);
     if (!isNonEmptyString(risk)) throw new Error(`slices[${index}].risk must be a non-empty string`);
     if (!Array.isArray(depends) || depends.some((item) => !isNonEmptyString(item))) {
       throw new Error(`slices[${index}].depends must be an array of non-empty strings`);
@@ -190,6 +192,8 @@ function validateParams(params: PlanMilestoneParams): PlanMilestoneParams {
   if (!isNonEmptyString(params?.milestoneId)) throw new Error("milestoneId is required");
   if (!isNonEmptyString(params?.title)) throw new Error("title is required");
   if (!isNonEmptyString(params?.vision)) throw new Error("vision is required");
+  const milestoneTitleIssue = validateTitle(params.title);
+  if (milestoneTitleIssue) throw new Error(`title is invalid: ${milestoneTitleIssue}`);
 
   return {
     ...params,

--- a/src/resources/extensions/gsd/validation.ts
+++ b/src/resources/extensions/gsd/validation.ts
@@ -8,6 +8,27 @@ export function isNonEmptyString(value: unknown): value is string {
 }
 
 /**
+ * Characters that are used as delimiters in GSD state management documents
+ * and should not appear in milestone or slice titles.
+ */
+const TITLE_DELIMITER_RE = /[\u2014\u2013\/]/; // em dash, en dash, forward slash
+
+/**
+ * Check whether a milestone or slice title contains characters that conflict
+ * with GSD's state document delimiter conventions.
+ * Returns a human-readable description of the problem, or null if the title is safe.
+ */
+export function validateTitle(title: string): string | null {
+  if (TITLE_DELIMITER_RE.test(title)) {
+    const found: string[] = [];
+    if (/[\u2014\u2013]/.test(title)) found.push("em/en dash (\u2014 or \u2013)");
+    if (/\//.test(title)) found.push("forward slash (/)");
+    return `title contains ${found.join(" and ")}, which conflict with GSD state document delimiters`;
+  }
+  return null;
+}
+
+/**
  * Validate that `value` is an array of non-empty strings.
  * Throws with a message referencing `field` on failure.
  * Returns the validated array (narrowed to string[]).


### PR DESCRIPTION
## Summary
- Rejected delimiter characters in milestone slice titles before persistence and guarded missing model IDs, with focused planning/model/doctor tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5506
- [#5506 Slice title with '/' causes empty ROADMAP.md + TypeError 'Cannot read properties of undefined (reading indexOf)' stuck loop](https://github.com/gsd-build/gsd-2/issues/5506)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5506-slice-title-with-causes-empty-roadmap-md-1778624681`