### PR TITLE
fix(issue): loadPrompt("guided-discuss-milestone") crash: 6 callsites in guided-flow.js missing workingDirectory arg + format-string typo at prompt-loader.js:154

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -1539,6 +1539,7 @@ export async function showDiscuss(
       const discussMilestoneTemplates = inlineTemplate("context", "Context");
       const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
       const basePrompt = loadPrompt("guided-discuss-milestone", {
+        workingDirectory: basePath,
         milestoneId: mid, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
         commitInstruction: buildDocsCommitInstruction(`docs(${mid}): milestone context from discuss`),
         fastPathInstruction: "",
@@ -1553,6 +1554,7 @@ export async function showDiscuss(
       const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
       setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId: mid, step: false });
       await dispatchWorkflow(pi, loadPrompt("guided-discuss-milestone", {
+        workingDirectory: basePath,
         milestoneId: mid, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
         commitInstruction: buildDocsCommitInstruction(`docs(${mid}): milestone context from discuss`),
         fastPathInstruction: "",
@@ -1822,6 +1824,7 @@ async function dispatchDiscussForMilestone(
   const discussMilestoneTemplates = inlineTemplate("context", "Context");
   const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
   const basePrompt = loadPrompt("guided-discuss-milestone", {
+    workingDirectory: basePath,
     milestoneId: mid,
     milestoneTitle,
     inlinedTemplates: discussMilestoneTemplates,
@@ -2356,6 +2359,7 @@ export async function showSmartEntry(
       const discussMilestoneTemplates = inlineTemplate("context", "Context");
       const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
       const basePrompt = loadPrompt("guided-discuss-milestone", {
+        workingDirectory: basePath,
         milestoneId, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
         commitInstruction: buildDocsCommitInstruction(`docs(${milestoneId}): milestone context from discuss`),
         fastPathInstruction: "",
@@ -2370,6 +2374,7 @@ export async function showSmartEntry(
       const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
       setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId, step: stepMode });
       await dispatchWorkflow(pi, loadPrompt("guided-discuss-milestone", {
+        workingDirectory: basePath,
         milestoneId, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
         commitInstruction: buildDocsCommitInstruction(`docs(${milestoneId}): milestone context from discuss`),
         fastPathInstruction: "",
@@ -2462,6 +2467,7 @@ export async function showSmartEntry(
         const discussMilestoneTemplates = inlineTemplate("context", "Context");
         const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
         await dispatchWorkflow(pi, loadPrompt("guided-discuss-milestone", {
+          workingDirectory: basePath,
           milestoneId, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
           commitInstruction: buildDocsCommitInstruction(`docs(${milestoneId}): milestone context from discuss`),
           fastPathInstruction: "",

--- a/src/resources/extensions/gsd/prompt-loader.ts
+++ b/src/resources/extensions/gsd/prompt-loader.ts
@@ -200,7 +200,7 @@ export function loadPrompt(name: string, vars: Record<string, string> = {}): str
     if (missing.length > 0) {
       throw new GSDError(
         GSD_PARSE_ERROR,
-        `loadPrompt("${name}"): template declares {{${missing.join("}}, {{")}}}} but no value was provided. ` +
+        `loadPrompt("${name}"): template declares {{${missing.join("}}, {{")}}} but no value was provided. ` +
         `This usually means the extension code in memory is older than the template on disk. ` +
         `Restart pi to reload the extension.`,
       );

--- a/src/resources/extensions/gsd/tests/guided-flow.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-flow.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test("guided milestone discussion callsites pass workingDirectory to loadPrompt", () => {
+  const source = readFileSync(join(__dirname, "..", "guided-flow.ts"), "utf-8");
+  const calls = [...source.matchAll(/loadPrompt\("guided-discuss-milestone",\s*\{([\s\S]*?)\}\)/g)];
+
+  assert.equal(calls.length, 6, "all guided-flow guided-discuss-milestone callsites should be covered");
+  for (const call of calls) {
+    assert.match(
+      call[1] ?? "",
+      /\bworkingDirectory:\s*basePath\b/,
+      "guided-discuss-milestone prompts need workingDirectory so template validation does not crash",
+    );
+  }
+});

--- a/src/resources/extensions/gsd/tests/prompt-loader.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-loader.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { loadPrompt } from "../prompt-loader.ts";
+
+test("loadPrompt reports missing template variables with balanced braces", () => {
+  assert.throws(
+    () => loadPrompt("guided-discuss-milestone", {
+      milestoneId: "M001",
+      milestoneTitle: "Missing working directory",
+      structuredQuestionsAvailable: "false",
+      fastPathInstruction: "",
+      inlinedTemplates: "context template",
+      commitInstruction: "Do not commit during this test.",
+    }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /template declares \{\{workingDirectory\}\} but no value was provided/);
+      assert.doesNotMatch(error.message, /\{\{workingDirectory\}\}\}/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Fixed guided milestone prompt workingDirectory propagation and loader brace formatting, verified with focused prompt rendering and source checks.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5503
- [#5503 loadPrompt("guided-discuss-milestone") crash: 6 callsites in guided-flow.js missing workingDirectory arg + format-string typo at prompt-loader.js:154](https://github.com/gsd-build/gsd-2/issues/5503)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5503-loadprompt-guided-discuss-milestone-cras-1778624921`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error message formatting for missing template variable placeholders to display the correct number of closing braces.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5870)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->