### PR TITLE
fix(issue): Memory guard blindspot: first 4 iterations of each auto-mode session unprotected from jetsam kill

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -78,7 +78,10 @@ import { createWorkflowTurnReporter } from "./workflow-turn-reporter.js";
 import { validateWorkflowSessionLock } from "./workflow-session-lock.js";
 import { dequeueSidecarItem } from "./workflow-sidecar-queue.js";
 import { maintainWorkerHeartbeat } from "./workflow-worker-heartbeat.js";
-import { measureMemoryPressure } from "./workflow-memory-pressure.js";
+import {
+  measureMemoryPressure,
+  shouldCheckMemoryPressure,
+} from "./workflow-memory-pressure.js";
 import { buildSidecarIterationData } from "./workflow-sidecar-iteration.js";
 import {
   createExecutionGraphUnitDispatchDeps,
@@ -203,9 +206,9 @@ function logCustomVerifyRetrySaveFailure(err: unknown): void {
 }
 
 // ── Memory pressure monitoring (#3331) ──────────────────────────────────
-// Check heap usage every N iterations and trigger graceful shutdown before
-// the OS OOM killer sends SIGKILL. The threshold is 90% of the V8 heap
-// limit (--max-old-space-size or default ~1.5-4GB depending on platform).
+// Check heap usage on session startup, then every N iterations, and trigger
+// graceful shutdown before the OS OOM killer sends SIGKILL. The threshold is
+// 90% of the V8 heap limit (--max-old-space-size or default ~1.5-4GB depending on platform).
 const MEMORY_CHECK_INTERVAL = 5; // check every 5 iterations
 const MAX_CUSTOM_ENGINE_VERIFY_RETRIES = 3;
 
@@ -372,7 +375,7 @@ export async function autoLoop(
 
     // ── Memory pressure check (#3331) ──
     // Graceful shutdown before OOM killer sends SIGKILL.
-    if (iteration % MEMORY_CHECK_INTERVAL === 0) {
+    if (shouldCheckMemoryPressure(iteration, MEMORY_CHECK_INTERVAL)) {
       const mem = measureMemoryPressure();
       debugLog("autoLoop", { phase: "memory-check", ...mem });
       const memoryDecision = decideMemoryPressure({ ...mem, iteration });

--- a/src/resources/extensions/gsd/auto/workflow-memory-pressure.ts
+++ b/src/resources/extensions/gsd/auto/workflow-memory-pressure.ts
@@ -19,6 +19,10 @@ export interface MeasureMemoryPressureDeps {
   heapLimitBytes: () => number;
 }
 
+export function shouldCheckMemoryPressure(iteration: number, interval: number): boolean {
+  return iteration === 1 || iteration % interval === 0;
+}
+
 function defaultHeapLimitBytes(): number {
   const v8 = require("node:v8") as {
     getHeapStatistics?: () => { heap_size_limit?: number };

--- a/src/resources/extensions/gsd/auto/workflow-memory-pressure.ts
+++ b/src/resources/extensions/gsd/auto/workflow-memory-pressure.ts
@@ -19,7 +19,16 @@ export interface MeasureMemoryPressureDeps {
   heapLimitBytes: () => number;
 }
 
+/**
+ * Returns true on auto-mode startup, then every configured interval.
+ *
+ * Iteration 1 is checked explicitly so early session memory pressure cannot
+ * bypass the periodic interval guard.
+ */
 export function shouldCheckMemoryPressure(iteration: number, interval: number): boolean {
+  if (!Number.isInteger(interval) || interval <= 0) {
+    throw new Error("Memory pressure check interval must be a positive integer");
+  }
   return iteration === 1 || iteration % interval === 0;
 }
 

--- a/src/resources/extensions/gsd/tests/workflow-memory-pressure.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-memory-pressure.test.ts
@@ -78,3 +78,14 @@ test("shouldCheckMemoryPressure covers the first auto-mode iteration", () => {
   assert.equal(shouldCheckMemoryPressure(2, 5), false);
   assert.equal(shouldCheckMemoryPressure(5, 5), true);
 });
+
+test("shouldCheckMemoryPressure rejects invalid intervals", () => {
+  assert.throws(
+    () => shouldCheckMemoryPressure(1, 0),
+    /positive integer/,
+  );
+  assert.throws(
+    () => shouldCheckMemoryPressure(1, 1.5),
+    /positive integer/,
+  );
+});

--- a/src/resources/extensions/gsd/tests/workflow-memory-pressure.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-memory-pressure.test.ts
@@ -4,7 +4,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { measureMemoryPressure } from "../auto/workflow-memory-pressure.ts";
+import {
+  measureMemoryPressure,
+  shouldCheckMemoryPressure,
+} from "../auto/workflow-memory-pressure.ts";
 
 const mb = 1024 * 1024;
 
@@ -68,4 +71,10 @@ test("measureMemoryPressure falls back when heap limit cannot be read", () => {
     limitMB: 4096,
     pct: 0.25,
   });
+});
+
+test("shouldCheckMemoryPressure covers the first auto-mode iteration", () => {
+  assert.equal(shouldCheckMemoryPressure(1, 5), true);
+  assert.equal(shouldCheckMemoryPressure(2, 5), false);
+  assert.equal(shouldCheckMemoryPressure(5, 5), true);
 });


### PR DESCRIPTION
## Summary
- Fixed auto-mode memory pressure checks to run on iteration 1 and verified with focused memory/auto-loop tests plus extension typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5421
- [#5421 Memory guard blindspot: first 4 iterations of each auto-mode session unprotected from jetsam kill](https://github.com/gsd-build/gsd-2/issues/5421)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5421-memory-guard-blindspot-first-4-iteration-1778625040`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory-pressure monitoring to check on session startup and then periodically, enabling graceful shutdown handling before critical system conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5871)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->