### PR TITLE
fix(issue): Post-exec import checker treats import-looking strings as blocking missing imports

### DIFF
--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -132,6 +132,10 @@ export function extractRelativeImports(
         continue;
       }
 
+      if (isInsideStringOrTemplateLiteral(line, match.index)) {
+        continue;
+      }
+
       imports.push({
         importPath: match[2],
         lineNum: i + 1,
@@ -144,6 +148,38 @@ export function extractRelativeImports(
   }
 
   return imports;
+}
+
+function isInsideStringOrTemplateLiteral(line: string, index: number): boolean {
+  let quote: "'" | '"' | "`" | null = null;
+  let escaped = false;
+
+  for (let i = 0; i < index; i++) {
+    const char = line[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+
+    if (quote !== null) {
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+    }
+  }
+
+  return quote !== null;
 }
 
 /**

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -62,13 +62,22 @@ export function extractRelativeImports(
   //   import './path'
   //   require('./path')
   //   require("../path")
-  const importPattern = /(?:import\s+(?:.*?\s+from\s+)?|require\s*\(\s*)(['"])(\.\.?\/[^'"]+)\1/g;
+  const importPattern = /(?:^|[;{}]\s*)import\s+(?:.*?\s+from\s+)?(['"])(\.\.?\/[^'"]+)\1/g;
+  const requirePattern = /require\s*\(\s*(['"])(\.\.?\/[^'"]+)\1/g;
 
   // Track if we're inside a block comment
   let inBlockComment = false;
+  let inTemplateLiteral = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+
+    if (inTemplateLiteral) {
+      if ((line.match(/(?<!\\)`/g) ?? []).length % 2 === 1) {
+        inTemplateLiteral = false;
+      }
+      continue;
+    }
 
     // Handle block comment boundaries
     if (inBlockComment) {
@@ -101,6 +110,7 @@ export function extractRelativeImports(
 
     // Reset lastIndex for each line
     importPattern.lastIndex = 0;
+    requirePattern.lastIndex = 0;
 
     while ((match = importPattern.exec(line)) !== null) {
       // Check if this match is after a // comment marker on the same line
@@ -113,6 +123,23 @@ export function extractRelativeImports(
         importPath: match[2],
         lineNum: i + 1,
       });
+    }
+
+    while ((match = requirePattern.exec(line)) !== null) {
+      // Check if this match is after a // comment marker on the same line
+      const beforeMatch = line.substring(0, match.index);
+      if (beforeMatch.includes("//")) {
+        continue;
+      }
+
+      imports.push({
+        importPath: match[2],
+        lineNum: i + 1,
+      });
+    }
+
+    if ((line.match(/(?<!\\)`/g) ?? []).length % 2 === 1) {
+      inTemplateLiteral = true;
     }
   }
 

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -47,6 +47,46 @@ export interface PostExecutionResult {
 // ─── Import Resolution Check ─────────────────────────────────────────────────
 
 /**
+ * Replace the contents of single- and double-quoted string literals on a single
+ * source line with spaces so import patterns do not match text inside strings.
+ * Template-literal spans are handled separately via the inTemplateLiteral flag.
+ */
+function stripStringLiterals(line: string): string {
+  let result = "";
+  let i = 0;
+
+  while (i < line.length) {
+    const ch = line[i];
+
+    if (ch === '"' || ch === "'") {
+      result += ch;
+      i++;
+
+      while (i < line.length) {
+        const c = line[i];
+
+        if (c === "\\" && i + 1 < line.length) {
+          result += "  ";
+          i += 2;
+        } else if (c === ch) {
+          result += ch;
+          i++;
+          break;
+        } else {
+          result += " ";
+          i++;
+        }
+      }
+    } else {
+      result += ch;
+      i++;
+    }
+  }
+
+  return result;
+}
+
+/**
  * Extract relative import paths from TypeScript/JavaScript source code.
  * Returns array of { importPath, lineNum } for relative imports.
  */
@@ -112,9 +152,20 @@ export function extractRelativeImports(
     importPattern.lastIndex = 0;
     requirePattern.lastIndex = 0;
 
+    const strippedLine = stripStringLiterals(line);
+
     while ((match = importPattern.exec(line)) !== null) {
+      const importOffset = match[0].indexOf("import");
+      const importStart = match.index + importOffset;
+      if (
+        strippedLine.slice(importStart, importStart + "import".length) !==
+        "import"
+      ) {
+        continue;
+      }
+
       // Check if this match is after a // comment marker on the same line
-      const beforeMatch = line.substring(0, match.index);
+      const beforeMatch = strippedLine.substring(0, match.index);
       if (beforeMatch.includes("//")) {
         continue;
       }
@@ -126,13 +177,16 @@ export function extractRelativeImports(
     }
 
     while ((match = requirePattern.exec(line)) !== null) {
-      // Check if this match is after a // comment marker on the same line
-      const beforeMatch = line.substring(0, match.index);
-      if (beforeMatch.includes("//")) {
+      if (
+        strippedLine.slice(match.index, match.index + "require".length) !==
+        "require"
+      ) {
         continue;
       }
 
-      if (isInsideStringOrTemplateLiteral(line, match.index)) {
+      // Check if this match is after a // comment marker on the same line
+      const beforeMatch = strippedLine.substring(0, match.index);
+      if (beforeMatch.includes("//")) {
         continue;
       }
 
@@ -142,44 +196,12 @@ export function extractRelativeImports(
       });
     }
 
-    if ((line.match(/(?<!\\)`/g) ?? []).length % 2 === 1) {
+    if ((strippedLine.match(/(?<!\\)`/g) ?? []).length % 2 === 1) {
       inTemplateLiteral = true;
     }
   }
 
   return imports;
-}
-
-function isInsideStringOrTemplateLiteral(line: string, index: number): boolean {
-  let quote: "'" | '"' | "`" | null = null;
-  let escaped = false;
-
-  for (let i = 0; i < index; i++) {
-    const char = line[i];
-
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-
-    if (char === "\\") {
-      escaped = true;
-      continue;
-    }
-
-    if (quote !== null) {
-      if (char === quote) {
-        quote = null;
-      }
-      continue;
-    }
-
-    if (char === "'" || char === '"' || char === "`") {
-      quote = char;
-    }
-  }
-
-  return quote !== null;
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -156,6 +156,31 @@ import realThing from "./real-thing";
     ]);
   });
 
+  test("ignores require() inside string literals", () => {
+    const source = `
+const fixture = "const x = require('./missing');";
+const real = require('./real');
+`;
+    const imports = extractRelativeImports(source);
+    assert.deepEqual(imports, [
+      { importPath: "./real", lineNum: 3 },
+    ]);
+  });
+
+  test("ignores require() inside template literals", () => {
+    const source = [
+      "const fixture = `",
+      "const x = require('./missing');",
+      "`;",
+      "",
+      "const real = require('./real');",
+    ].join("\n");
+    const imports = extractRelativeImports(source);
+    assert.deepEqual(imports, [
+      { importPath: "./real", lineNum: 5 },
+    ]);
+  });
+
   test("handles empty source", () => {
     const imports = extractRelativeImports("");
     assert.deepEqual(imports, []);

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -127,6 +127,35 @@ import { b } from './b';
     assert.equal(imports.length, 2);
   });
 
+  test("ignores import-looking string literals in test fixtures", () => {
+    const source = `
+const rewritten = source.replace(
+  'import { normalizeZagrebBusinessDeadline } from "./cutoff";',
+  'const helper = true;'
+);
+
+import realThing from "./real-thing";
+`;
+    const imports = extractRelativeImports(source);
+    assert.deepEqual(imports, [
+      { importPath: "./real-thing", lineNum: 7 },
+    ]);
+  });
+
+  test("ignores import-looking lines inside template literals", () => {
+    const source = [
+      "const fixture = `",
+      "import missingThing from './missing-thing';",
+      "`;",
+      "",
+      "import realThing from './real-thing';",
+    ].join("\n");
+    const imports = extractRelativeImports(source);
+    assert.deepEqual(imports, [
+      { importPath: "./real-thing", lineNum: 5 },
+    ]);
+  });
+
   test("handles empty source", () => {
     const imports = extractRelativeImports("");
     assert.deepEqual(imports, []);
@@ -805,6 +834,37 @@ describe("runPostExecutionChecks", () => {
       assert.equal(result.status, "pass");
       assert.equal(result.checks.length, 0);
       assert.ok(result.durationMs >= 0);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not fail on import-looking strings in task key files", () => {
+    tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    mkdirSync(join(tempDir, "tests"), { recursive: true });
+    writeFileSync(join(tempDir, "tests", "real-thing.ts"), "export default true;");
+    writeFileSync(
+      join(tempDir, "tests", "source-verifier.test.ts"),
+      `
+const rewritten = source.replace(
+  'import { normalizeZagrebBusinessDeadline } from "./cutoff";',
+  'const helper = true;'
+);
+
+import realThing from "./real-thing";
+assert.ok(realThing);
+`
+    );
+
+    try {
+      const task = createTask({
+        id: "T03",
+        key_files: ["tests/source-verifier.test.ts"],
+      });
+      const result = runPostExecutionChecks(task, [], tempDir);
+      assert.equal(result.status, "pass");
+      assert.deepEqual(result.checks, []);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -157,10 +157,11 @@ import realThing from "./real-thing";
   });
 
   test("ignores require() inside string literals", () => {
-    const source = `
-const fixture = "const x = require('./missing');";
-const real = require('./real');
-`;
+    const source = [
+      'const fixture = "const x = require(\'./missing\');";',
+      "const otherFixture = 'const y = require(\"./also-missing\");';",
+      "const real = require('./real');",
+    ].join("\n");
     const imports = extractRelativeImports(source);
     assert.deepEqual(imports, [
       { importPath: "./real", lineNum: 3 },


### PR DESCRIPTION
## Summary
- Fixed post-exec import extraction to ignore import-looking fixture strings and verified with the focused post-execution checks test suite.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5482
- [#5482 Post-exec import checker treats import-looking strings as blocking missing imports](https://github.com/gsd-build/gsd-2/issues/5482)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5482-post-exec-import-checker-treats-import-l-1778625760`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of relative import detection by properly ignoring import-like patterns that appear within strings and template literals.

* **Tests**
  * Added test coverage for import detection edge cases in template literals and string content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5873)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->