### PR TITLE
fix(issue): [Bug]: Auto-commit fails when keyFiles are inside git submodule — git add throws 'pathspec is in submodule'

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -270,16 +270,26 @@ function isExcludedScopedPath(path: string, exclusions: readonly string[]): bool
   return false;
 }
 
-function isInsideSubmodule(basePath: string, path: string): boolean {
-  const normalizedPath = path.replace(/\\/g, "/");
-  const output = runGit(basePath, ["ls-files", "--stage"], { allowFailure: true });
-  if (!output) return false;
+function submodulePathsFromLsFiles(output: string): Set<string> {
+  const submodulePaths = new Set<string>();
+  if (!output) return submodulePaths;
 
   for (const line of output.split("\n")) {
     const match = line.match(/^160000\s+\S+\s+\d+\t(.+)$/);
     if (!match) continue;
-    const submodulePath = match[1].replace(/\\/g, "/").replace(/\/+$/, "");
-    if (normalizedPath.startsWith(`${submodulePath}/`)) return true;
+    submodulePaths.add(match[1].replace(/\\/g, "/").replace(/\/+$/, ""));
+  }
+  return submodulePaths;
+}
+
+function isInsideSubmodule(path: string, submodulePaths: ReadonlySet<string>): boolean {
+  const normalizedPath = path.replace(/\\/g, "/");
+  if (submodulePaths.has(normalizedPath)) return true;
+
+  let slashIndex = normalizedPath.lastIndexOf("/");
+  while (slashIndex > 0) {
+    if (submodulePaths.has(normalizedPath.slice(0, slashIndex))) return true;
+    slashIndex = normalizedPath.lastIndexOf("/", slashIndex - 1);
   }
   return false;
 }
@@ -780,8 +790,11 @@ export class GitServiceImpl {
 
     const scopedPaths: string[] = [];
     const submodulePaths: string[] = [];
+    const repoSubmodules = submodulePathsFromLsFiles(
+      runGit(this.basePath, ["ls-files", "--stage"], { allowFailure: true }),
+    );
     for (const path of normalized) {
-      if (isInsideSubmodule(this.basePath, path)) {
+      if (isInsideSubmodule(path, repoSubmodules)) {
         submodulePaths.push(path);
       } else {
         scopedPaths.push(path);

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -270,6 +270,20 @@ function isExcludedScopedPath(path: string, exclusions: readonly string[]): bool
   return false;
 }
 
+function isInsideSubmodule(basePath: string, path: string): boolean {
+  const normalizedPath = path.replace(/\\/g, "/");
+  const output = runGit(basePath, ["ls-files", "--stage"], { allowFailure: true });
+  if (!output) return false;
+
+  for (const line of output.split("\n")) {
+    const match = line.match(/^160000\s+\S+\s+\d+\t(.+)$/);
+    if (!match) continue;
+    const submodulePath = match[1].replace(/\\/g, "/").replace(/\/+$/, "");
+    if (normalizedPath.startsWith(`${submodulePath}/`)) return true;
+  }
+  return false;
+}
+
 /**
  * Thrown when a slice merge hits code conflicts in non-.gsd files.
  * The working tree is left in a conflicted state (no reset) so the
@@ -764,6 +778,23 @@ export class GitServiceImpl {
       .filter(file => !nativeIsIgnored(this.basePath, file))
       .filter(file => !isExcludedScopedPath(file, allExclusions));
 
+    const scopedPaths: string[] = [];
+    const submodulePaths: string[] = [];
+    for (const path of normalized) {
+      if (isInsideSubmodule(this.basePath, path)) {
+        submodulePaths.push(path);
+      } else {
+        scopedPaths.push(path);
+      }
+    }
+    if (submodulePaths.length > 0) {
+      logWarning(
+        "engine",
+        `scoped stage: dropping ${submodulePaths.length} keyFile(s) inside git submodule(s): ${submodulePaths.join(", ")}`,
+        { file: "git-service.ts" },
+      );
+    }
+
     // Drop entries that don't exist on disk. The LLM occasionally lists files
     // it intended to write but didn't (or names them with wrong casing/path).
     // Pre-`b304f738b` `git add -A` swallowed these silently; the scoped
@@ -771,7 +802,7 @@ export class GitServiceImpl {
     // the whole commit fail (see #5500). Filter so valid paths still commit.
     const missing: string[] = [];
     const existing: string[] = [];
-    for (const path of normalized) {
+    for (const path of scopedPaths) {
       if (existsSync(join(this.basePath, path))) {
         existing.push(path);
       } else {

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -470,6 +470,51 @@ describe('git-service', async () => {
     }
   });
 
+  test('GitServiceImpl: all keyFiles inside submodules falls back to smartStage', () => {
+    const repo = initTempRepo();
+    const subSrc = mkdtempSync(join(tmpdir(), "gsd-git-all-submodule-src-"));
+
+    try {
+      gitRun(["init", "-b", "main"], subSrc);
+      gitRun(["config", "user.name", "Pi Test"], subSrc);
+      gitRun(["config", "user.email", "pi@example.com"], subSrc);
+      createFile(subSrc, "tracked.txt", "initial\n");
+      gitRun(["add", "-A"], subSrc);
+      gitRun(["commit", "-m", "init submodule"], subSrc);
+
+      gitRun(["-c", "protocol.file.allow=always", "submodule", "add", `file://${subSrc}`, "sub"], repo);
+      gitRun(["commit", "-m", "add submodule"], repo);
+
+      createFile(repo, "sub/file1.txt", "inside submodule\n");
+      createFile(repo, "sub/file2.txt", "also inside\n");
+      createFile(repo, "src/real.ts", "export const real = true;\n");
+
+      const svc = new GitServiceImpl(repo);
+      const taskContext: TaskCommitContext = {
+        taskId: "S01/T02",
+        taskDisplayId: "T02",
+        taskTitle: "all keyFiles inside submodule",
+        milestoneId: "M001",
+        milestoneTitle: "Submodule auto commit",
+        sliceId: "S01",
+        sliceTitle: "Commit scoped files",
+        oneLiner: "Fell back when all key files are inside submodules",
+        keyFiles: ["sub", "sub/file1.txt", "sub/file2.txt"],
+      };
+
+      const result = svc.autoCommit("execute-task", "M001/S01/T02", [], taskContext);
+
+      assert.ok(result !== null, "autoCommit falls back to smartStage when all keyFiles are filtered");
+      const committed = gitRun(["show", "--name-only", "--format=", "HEAD"], repo);
+      assert.ok(!committed.includes("sub/file1.txt"), "submodule keyFile is not committed");
+      assert.ok(!committed.includes("sub/file2.txt"), "submodule keyFile is not committed");
+      assert.ok(committed.includes("src/real.ts"), "smartStage fallback commits other dirty files");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(subSrc, { recursive: true, force: true });
+    }
+  });
+
   // ─── GitServiceImpl: smart staging excludes tracked runtime files ──────
 
   test('GitServiceImpl: smart staging excludes tracked runtime files', () => {

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 
 import {
   inferCommitType,
@@ -371,6 +371,18 @@ describe('git-service', async () => {
     return dir;
   }
 
+  function gitRun(args: string[], cwd: string): string {
+    return execFileSync("git", args, {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        GIT_ALLOW_PROTOCOL: "file",
+      },
+    }).trim();
+  }
+
   // ─── GitServiceImpl: smart staging ─────────────────────────────────────
 
   test('GitServiceImpl: smart staging', () => {
@@ -411,6 +423,51 @@ describe('git-service', async () => {
     assert.ok(statusOut.includes(".gsd/STATE.md"), "STATE.md still untracked after commit");
 
     rmSync(repo, { recursive: true, force: true });
+  });
+
+  test('GitServiceImpl: task autoCommit skips keyFiles inside submodules', () => {
+    const repo = initTempRepo();
+    const subSrc = mkdtempSync(join(tmpdir(), "gsd-git-submodule-src-"));
+
+    try {
+      gitRun(["init", "-b", "main"], subSrc);
+      gitRun(["config", "user.name", "Pi Test"], subSrc);
+      gitRun(["config", "user.email", "pi@example.com"], subSrc);
+      createFile(subSrc, "tracked.txt", "initial\n");
+      gitRun(["add", "-A"], subSrc);
+      gitRun(["commit", "-m", "init submodule"], subSrc);
+
+      gitRun(["-c", "protocol.file.allow=always", "submodule", "add", `file://${subSrc}`, "sub"], repo);
+      gitRun(["commit", "-m", "add submodule"], repo);
+
+      createFile(repo, "sub/copied.txt", "copied from source\n");
+      createFile(repo, "src/feature.ts", "export const feature = true;\n");
+      createFile(repo, "src/unrelated.ts", "export const unrelated = true;\n");
+
+      const svc = new GitServiceImpl(repo);
+      const taskContext: TaskCommitContext = {
+        taskId: "S01/T01",
+        taskDisplayId: "T01",
+        taskTitle: "fix submodule staging",
+        milestoneId: "M001",
+        milestoneTitle: "Submodule auto commit",
+        sliceId: "S01",
+        sliceTitle: "Commit scoped files",
+        oneLiner: "Fixed auto commit when key files include submodule paths",
+        keyFiles: ["sub/copied.txt", "src/feature.ts"],
+      };
+
+      const result = svc.autoCommit("execute-task", "M001/S01/T01", [], taskContext);
+
+      assert.ok(result !== null, "autoCommit should commit non-submodule changes");
+      const committed = gitRun(["show", "--name-only", "--format=", "HEAD"], repo);
+      assert.ok(committed.includes("src/feature.ts"), "non-submodule keyFile is committed");
+      assert.ok(!committed.includes("sub/copied.txt"), "submodule inner keyFile is not pathspec-staged");
+      assert.ok(!committed.includes("src/unrelated.ts"), "scoped staging does not fall back to smartStage");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(subSrc, { recursive: true, force: true });
+    }
   });
 
   // ─── GitServiceImpl: smart staging excludes tracked runtime files ──────


### PR DESCRIPTION
## Summary
- Fixed scoped auto-commit staging to skip submodule-internal keyFiles and verified with the focused git-service integration test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5466
- [#5466 [Bug]: Auto-commit fails when keyFiles are inside git submodule — git add throws 'pathspec is in submodule'](https://github.com/gsd-build/gsd-2/issues/5466)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5466-bug-auto-commit-fails-when-keyfiles-are--1778626240`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Task staging now excludes files located inside git submodules to avoid unintended staging; a warning is logged listing skipped submodule-contained key files.
* **Tests**
  * Added integration tests verifying commit behavior when key files point into submodules, including mixed and all-submodule scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5874)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->