### PR TITLE
fix(issue): Dispatch guard ignores DB status "parked"/"deferred", blocks newer milestones with no escape in DB-mode

### DIFF
--- a/src/resources/extensions/gsd/dispatch-guard.ts
+++ b/src/resources/extensions/gsd/dispatch-guard.ts
@@ -5,7 +5,7 @@ import { findMilestoneIds } from "./guided-flow.js";
 import { parseUnitId } from "./unit-id.js";
 import { isDbAvailable, getMilestoneSlices, getMilestone } from "./gsd-db.js";
 import { parseRoadmap } from "./parsers-legacy.js";
-import { isClosedStatus } from "./status-guards.js";
+import { isClosedStatus, isSkippedForDispatch } from "./status-guards.js";
 import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
 import { readFileSync } from "node:fs";
 
@@ -58,7 +58,7 @@ export function getPriorSliceCompletionBlocker(
     //      DB-backed projects must not treat SUMMARY.md as authoritative.
     if (isDbAvailable()) {
       const milestoneRow = getMilestone(mid);
-      if (milestoneRow && isClosedStatus(milestoneRow.status)) continue;
+      if (milestoneRow && isSkippedForDispatch(milestoneRow.status)) continue;
     } else {
       const summaryPath = resolveMilestoneFile(base, mid, "SUMMARY");
       let summaryContent: string | null = null;

--- a/src/resources/extensions/gsd/status-guards.ts
+++ b/src/resources/extensions/gsd/status-guards.ts
@@ -25,3 +25,8 @@ export function isDeferredStatus(status: string): boolean {
 export function isInactiveStatus(status: string): boolean {
   return isClosedStatus(status) || isDeferredStatus(status);
 }
+
+/** Returns true when a prior milestone should not block dispatch ordering. */
+export function isSkippedForDispatch(status: string): boolean {
+  return isClosedStatus(status) || status === "parked" || isDeferredStatus(status);
+}

--- a/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
@@ -47,6 +47,33 @@ test("dispatch guard blocks when prior milestone has incomplete slices", (t) => 
   );
 });
 
+test("dispatch guard skips prior DB parked or deferred milestones without marker files", (t) => {
+  const repo = setupRepo();
+  t.after(() => teardownRepo(repo));
+
+  mkdirSync(join(repo, ".gsd", "milestones", "M001"), { recursive: true });
+  mkdirSync(join(repo, ".gsd", "milestones", "M002"), { recursive: true });
+  mkdirSync(join(repo, ".gsd", "milestones", "M003"), { recursive: true });
+
+  insertMilestone({ id: "M001", title: "Parked", status: "parked" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Incomplete", status: "pending", depends: [], sequence: 1 });
+
+  insertMilestone({ id: "M002", title: "Deferred", status: "deferred" });
+  insertSlice({ id: "S01", milestoneId: "M002", title: "Incomplete", status: "pending", depends: [], sequence: 1 });
+
+  insertMilestone({ id: "M003", title: "Current", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M003", title: "First", status: "pending", depends: [], sequence: 1 });
+
+  writeFileSync(join(repo, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# M001\n");
+  writeFileSync(join(repo, ".gsd", "milestones", "M002", "M002-ROADMAP.md"), "# M002\n");
+  writeFileSync(join(repo, ".gsd", "milestones", "M003", "M003-ROADMAP.md"), "# M003\n");
+
+  assert.equal(
+    getPriorSliceCompletionBlocker(repo, "main", "plan-slice", "M003/S01"),
+    null,
+  );
+});
+
 test("dispatch guard blocks later slice in same milestone when earlier incomplete", (t) => {
   const repo = setupRepo();
   t.after(() => teardownRepo(repo));


### PR DESCRIPTION
## Summary
- Fixed dispatch guard DB-mode skipping for parked/deferred milestones and verified with focused dispatch-guard tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5458
- [#5458 Dispatch guard ignores DB status "parked"/"deferred", blocks newer milestones with no escape in DB-mode](https://github.com/gsd-build/gsd-2/issues/5458)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5458-dispatch-guard-ignores-db-status-parked--1778626480`