### PR TITLE
fix(issue): [Bug]: Bedrock models fail with context overflow in --print mode

### DIFF
--- a/packages/pi-ai/src/providers/simple-options.test.ts
+++ b/packages/pi-ai/src/providers/simple-options.test.ts
@@ -1,0 +1,60 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildBaseOptions, defaultMaxTokens } from "./simple-options.js";
+import type { Api, Model } from "../types.js";
+
+function makeModel(overrides: Partial<Model<Api>> = {}): Model<Api> {
+	return {
+		id: "test-model",
+		name: "Test Model",
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 16384,
+		maxTokens: 16384,
+		...overrides,
+	};
+}
+
+describe("defaultMaxTokens", () => {
+	test("leaves prompt room when a non-Anthropic model declares output equal to context", () => {
+		const model = makeModel({
+			id: "qwen.qwen3-32b-v1:0",
+			contextWindow: 16384,
+			maxTokens: 16384,
+		});
+
+		assert.equal(defaultMaxTokens(model), 8192);
+	});
+
+	test("preserves smaller declared output windows", () => {
+		const model = makeModel({
+			contextWindow: 32000,
+			maxTokens: 8192,
+		});
+
+		assert.equal(defaultMaxTokens(model), 8192);
+	});
+
+	test("keeps the native Anthropic 32k ceiling within the context cap", () => {
+		const model = makeModel({
+			api: "anthropic-messages",
+			provider: "anthropic",
+			contextWindow: 200000,
+			maxTokens: 64000,
+		});
+
+		assert.equal(defaultMaxTokens(model), 32000);
+	});
+
+	test("honors explicit maxTokens", () => {
+		const model = makeModel();
+		const options = buildBaseOptions(model, { maxTokens: 12000 });
+
+		assert.equal(options.maxTokens, 12000);
+	});
+});

--- a/packages/pi-ai/src/providers/simple-options.ts
+++ b/packages/pi-ai/src/providers/simple-options.ts
@@ -4,16 +4,15 @@ import type { Api, Model, SimpleStreamOptions, StreamOptions, ThinkingBudgets, T
  * Compute the default maxTokens for a model when no explicit value is provided.
  *
  * The 32 k cap is retained only for native Anthropic models (api === "anthropic-messages")
- * where the Anthropic API historically rejected higher values. Custom and
- * Anthropic-compatible models (e.g. OpenAI-completions, Vertex, etc.) use their
- * declared model.maxTokens directly so that providers with larger output windows
- * (131 072 tokens, etc.) are not silently capped.
+ * where the Anthropic API historically rejected higher values. Defaults also
+ * leave at least half the context window available for prompts.
  */
 export function defaultMaxTokens(model: Model<Api>): number {
+	const contextCappedMaxTokens = Math.max(1, Math.floor(model.contextWindow / 2));
 	if (model.api === "anthropic-messages") {
-		return Math.min(model.maxTokens, 32000);
+		return Math.min(model.maxTokens, 32000, contextCappedMaxTokens);
 	}
-	return model.maxTokens;
+	return Math.min(model.maxTokens, contextCappedMaxTokens);
 }
 
 export function buildBaseOptions(model: Model<Api>, options?: SimpleStreamOptions, apiKey?: string): StreamOptions {


### PR DESCRIPTION
## Summary
- Capped default output tokens to leave prompt room and verified with focused provider tests plus diff whitespace check.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5412
- [#5412 [Bug]: Bedrock models fail with context overflow in --print mode](https://github.com/gsd-build/gsd-2/issues/5412)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5412-bug-bedrock-models-fail-with-context-ove-1778627080`