### PR TITLE
fix(issue): [Bug]: Auto-commit fails when keyFiles is empty — 'git add -- (none)' causes GSD_GIT_ERROR

### DIFF
--- a/src/resources/GSD-WORKFLOW.md
+++ b/src/resources/GSD-WORKFLOW.md
@@ -448,6 +448,13 @@ What differed from the plan and why (or "None").
 
 The one-liner must be substantive: "JWT auth with refresh rotation using jose" not "Authentication implemented."
 
+When `key_files` or `key_decisions` are empty, render them as empty YAML lists:
+
+```yaml
+key_files: []
+key_decisions: []
+```
+
 **Slice summary:** Written when all tasks in a slice complete. Compresses all task summaries. Includes `drill_down_paths` to each task summary. During slice completion, review task summaries for `key_decisions` and ensure any significant ones are captured in `.gsd/DECISIONS.md`.
 
 **Milestone summary:** Updated each time a slice completes. Compresses all slice summaries. This is what gets injected into later slice planning instead of loading many individual summaries.

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -164,7 +164,7 @@ async function buildTaskCommitContextForUnit(
     sliceTitle: stripKnownIdPrefix(slice?.title, sid),
     oneLiner: summary?.oneLiner || task?.one_liner || undefined,
     keyFiles:
-      summary?.frontmatter.key_files?.filter(f => !f.includes("{{")) ??
+      summary?.frontmatter.key_files?.filter(f => !f.includes("{{") && f.trim() !== "(none)") ??
       task?.key_files ??
       undefined,
     issueNumber: ghIssueNumber,

--- a/src/resources/extensions/gsd/tests/complete-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone.test.ts
@@ -645,7 +645,7 @@ describe("complete-milestone", () => {
     assert.strictEqual(sanitized.triggerReason, undefined);
   });
 
-  test("rendered SUMMARY.md uses placeholder text for empty enrichment fields", async () => {
+  test("rendered SUMMARY.md uses empty frontmatter lists for empty key fields", async () => {
     const { handleCompleteMilestone } = await import("../tools/complete-milestone.ts");
     const base = createFixtureBase();
     const mid = "M001";
@@ -678,6 +678,9 @@ describe("complete-milestone", () => {
       assert.match(summary, /## Success Criteria Results\n\nNot provided\./);
       assert.match(summary, /## Definition of Done Results\n\nNot provided\./);
       assert.match(summary, /## Requirement Outcomes\n\nNot provided\./);
+      assert.match(summary, /key_decisions:\s*\[\]/);
+      assert.match(summary, /key_files:\s*\[\]/);
+      assert.doesNotMatch(summary, /key_(?:decisions|files):\n  - \(none\)/);
       assert.match(summary, /## Deviations\n\nNone\./);
       assert.match(summary, /## Follow-ups\n\nNone\./);
     } finally {

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -491,7 +491,9 @@ console.log('\n=== complete-task: minimal params (no keyFiles, keyDecisions, ver
     assertTrue(fs.existsSync(result.summaryPath), 'summary file should be written with minimal params');
     const summaryContent = fs.readFileSync(result.summaryPath, 'utf-8');
     assertMatch(summaryContent, /blocker_discovered:\s*false/, 'blocker_discovered should default to false');
-    assertMatch(summaryContent, /\(none\)/, 'key_files/key_decisions should show (none) placeholder');
+    assertMatch(summaryContent, /key_files:\s*\[\]/, 'key_files should render as an empty frontmatter list');
+    assertMatch(summaryContent, /key_decisions:\s*\[\]/, 'key_decisions should render as an empty frontmatter list');
+    assertTrue(!summaryContent.includes('  - (none)'), 'empty frontmatter lists should not render (none) as a list item');
   }
 
   cleanupDir(basePath);

--- a/src/resources/extensions/gsd/tests/summary-render-parity.test.ts
+++ b/src/resources/extensions/gsd/tests/summary-render-parity.test.ts
@@ -175,13 +175,17 @@ const verificationEvidence = [
   );
 }
 
-// Test 11: empty key_files renders YAML placeholder, not empty array
+// Test 11: empty key_files renders an empty YAML list, not a sentinel path
 {
   const noFiles = { ...taskRow, key_files: [] };
   const output = renderSummaryContent(noFiles, SLICE_ID, MILESTONE_ID);
   assertTrue(
-    output.includes("key_files:\n  - (none)"),
-    "empty key_files must render as YAML list with (none) placeholder",
+    output.includes("key_files: []"),
+    "empty key_files must render as an empty YAML list",
+  );
+  assertTrue(
+    !output.includes("key_files:\n  - (none)"),
+    "empty key_files must not render (none) as a path-like list item",
   );
 }
 

--- a/src/resources/extensions/gsd/tools/complete-milestone.ts
+++ b/src/resources/extensions/gsd/tools/complete-milestone.ts
@@ -38,9 +38,9 @@ export interface CompleteMilestoneParams {
   definitionOfDoneResults?: string;
   /** @optional — empty/omitted renders as "Not provided." */
   requirementOutcomes?: string;
-  /** @optional — empty/omitted renders as "(none)" */
+  /** @optional — empty/omitted renders as an empty frontmatter list */
   keyDecisions?: string[];
-  /** @optional — empty/omitted renders as "(none)" */
+  /** @optional — empty/omitted renders as an empty frontmatter list */
   keyFiles?: string[];
   /** @optional — empty/omitted renders as "(none)" */
   lessonsLearned?: string[];
@@ -70,12 +70,12 @@ function renderMilestoneSummaryMarkdown(params: CompleteMilestoneParams, complet
   const lessonsLearned = params.lessonsLearned ?? [];
 
   const keyDecisionsYaml = keyDecisions.length > 0
-    ? keyDecisions.map(d => `  - ${d}`).join("\n")
-    : "  - (none)";
+    ? `\n${keyDecisions.map(d => `  - ${d}`).join("\n")}`
+    : " []";
 
   const keyFilesYaml = keyFiles.length > 0
-    ? keyFiles.map(f => `  - ${f}`).join("\n")
-    : "  - (none)";
+    ? `\n${keyFiles.map(f => `  - ${f}`).join("\n")}`
+    : " []";
 
   const lessonsYaml = lessonsLearned.length > 0
     ? lessonsLearned.map(l => `  - ${l}`).join("\n")
@@ -86,10 +86,8 @@ id: ${params.milestoneId}
 title: "${displayTitle}"
 status: complete
 completed_at: ${completedAt}
-key_decisions:
-${keyDecisionsYaml}
-key_files:
-${keyFilesYaml}
+key_decisions:${keyDecisionsYaml}
+key_files:${keyFilesYaml}
 lessons_learned:
 ${lessonsYaml}
 ---

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -104,12 +104,12 @@ function renderSliceSummaryMarkdown(params: CompleteSliceParams): string {
     : "  []";
 
   const keyFilesYaml = keyFiles.length > 0
-    ? keyFiles.map(f => `  - ${f}`).join("\n")
-    : "  - (none)";
+    ? `\n${keyFiles.map(f => `  - ${f}`).join("\n")}`
+    : " []";
 
   const keyDecisionsYaml = keyDecisions.length > 0
-    ? keyDecisions.map(d => `  - ${d}`).join("\n")
-    : "  - (none)";
+    ? `\n${keyDecisions.map(d => `  - ${d}`).join("\n")}`
+    : " []";
 
   const patternsYaml = patternsEstablished.length > 0
     ? patternsEstablished.map(p => `  - ${p}`).join("\n")
@@ -155,10 +155,8 @@ requires:
 ${requiresYaml}
 affects:
 ${affectsYaml}
-key_files:
-${keyFilesYaml}
-key_decisions:
-${keyDecisionsYaml}
+key_files:${keyFilesYaml}
+key_decisions:${keyDecisionsYaml}
 patterns_established:
 ${patternsYaml}
 observability_surfaces:

--- a/src/resources/extensions/gsd/workflow-projections.ts
+++ b/src/resources/extensions/gsd/workflow-projections.ts
@@ -195,11 +195,11 @@ export function renderSummaryContent(
 
   // ── Frontmatter (YAML list format, matches parseSummary() expectations) ──
   const keyFilesYaml = taskRow.key_files && taskRow.key_files.length > 0
-    ? taskRow.key_files.map(f => `  - ${f}`).join("\n")
-    : "  - (none)";
+    ? `\n${taskRow.key_files.map(f => `  - ${f}`).join("\n")}`
+    : " []";
   const keyDecisionsYaml = taskRow.key_decisions && taskRow.key_decisions.length > 0
-    ? taskRow.key_decisions.map(d => `  - ${d}`).join("\n")
-    : "  - (none)";
+    ? `\n${taskRow.key_decisions.map(d => `  - ${d}`).join("\n")}`
+    : " []";
 
   // Derive verification_result from evidence if available
   const evidenceList = evidence ?? [];
@@ -230,10 +230,8 @@ export function renderSummaryContent(
 id: ${taskRow.id}
 parent: ${sliceId}
 milestone: ${milestoneId}
-key_files:
-${keyFilesYaml}
-key_decisions:
-${keyDecisionsYaml}
+key_files:${keyFilesYaml}
+key_decisions:${keyDecisionsYaml}
 duration: ${taskRow.duration || ""}
 verification_result: ${verificationResult}
 completed_at: ${taskRow.completed_at || ""}


### PR DESCRIPTION
## Summary
- Rendered empty key file/decision frontmatter as YAML empty lists, filtered legacy `(none)` before auto-commit staging, and verified with focused GSD summary tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5298
- [#5298 [Bug]: Auto-commit fails when keyFiles is empty — 'git add -- (none)' causes GSD_GIT_ERROR](https://github.com/gsd-build/gsd-2/issues/5298)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5298-bug-auto-commit-fails-when-keyfiles-is-e-1778627322`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty optional fields (key_files, key_decisions) now render as empty YAML lists instead of placeholder text in generated summaries
  * Enhanced filtering to exclude placeholder syntax and invalid values from milestone and task outputs

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5878)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->