### PR TITLE
fix(gsd): clean orphan worktree dirs whose milestone branch was already deleted

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -64,7 +64,7 @@ import { initRoutingHistory } from "./routing-history.js";
 import { restoreHookState, resetHookState } from "./post-unit-hooks.js";
 import { resetProactiveHealing, setLevelChangeCallback } from "./doctor-proactive.js";
 import { snapshotSkills } from "./skill-discovery.js";
-import { isDbAvailable, getMilestone, openDatabase, getDbStatus } from "./gsd-db.js";
+import { isDbAvailable, getMilestone, getAllMilestones, openDatabase, getDbStatus } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
 import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
 import { auditOrphanedPreflightStashes } from "./orphan-stash-audit.js";
@@ -216,11 +216,10 @@ export function auditOrphanedMilestoneBranches(
   try {
     milestoneBranches = nativeBranchList(basePath, "milestone/*");
   } catch {
-    // git branch list failed — skip audit
-    return { recovered, warnings };
+    // git branch list failed — fall through with an empty branch set so the
+    // branch-less orphan pass at the bottom of this function can still run.
+    milestoneBranches = [];
   }
-
-  if (milestoneBranches.length === 0) return { recovered, warnings };
 
   // Detect main branch for merge-check
   let mainBranch: string;
@@ -351,6 +350,64 @@ export function auditOrphanedMilestoneBranches(
       } catch (err) {
         logWarning("engine", `worktree-orphaned telemetry failed for ${milestoneId}: ${err instanceof Error ? err.message : String(err)}`);
       }
+    }
+  }
+
+  // Second pass (#5879): catch worktree directories stranded by a previous
+  // audit that deleted the milestone/* branch but failed to remove the
+  // directory (or the dir was orphaned by a separate path entirely, e.g.
+  // postflight-stash-restore-failed during closeout). The branch-keyed loop
+  // above is invisible to these cases — `nativeBranchList` returns nothing
+  // for the milestone, so the dir-cleanup block at line ~310 is never
+  // reached.
+  //
+  // Keyed on milestones whose DB status is `complete`. We do not iterate
+  // over arbitrary directories under .gsd/worktrees/ to avoid touching
+  // dirs that belong to an in-progress milestone whose branch was deleted
+  // separately — those are handled by the in-progress orphan path above
+  // when the branch is present, and by `/gsd doctor` when it is not.
+  const seenMilestoneIds = new Set(
+    milestoneBranches.map((branch) => branch.replace(/^milestone\//, "")),
+  );
+  let completedMilestones: readonly { id: string; status: string }[] = [];
+  try {
+    completedMilestones = getAllMilestones();
+  } catch {
+    // DB read failure — skip the second pass; the first pass is still useful.
+    completedMilestones = [];
+  }
+  for (const m of completedMilestones) {
+    if (m.status !== "complete") continue;
+    if (seenMilestoneIds.has(m.id)) continue; // already processed in the branch loop
+    const wtDir = getWorktreeDir(basePath, m.id);
+    if (!existsSync(wtDir)) continue;
+    if (!isInsideWorktreesDir(basePath, wtDir)) {
+      warnings.push(
+        `Orphaned worktree directory for ${m.id} is outside .gsd/worktrees/ — skipping removal for safety.`,
+      );
+      continue;
+    }
+    // Try `git worktree remove` first in case the dir is still registered
+    // (defensive — usually it is not when we reach this branch-less pass).
+    try {
+      nativeWorktreeRemove(basePath, wtDir, true);
+    } catch (e) {
+      logWarning(
+        "engine",
+        `worktree remove failed (expected for branch-less orphans): ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+    if (existsSync(wtDir)) {
+      try {
+        rmSync(wtDir, { recursive: true, force: true });
+        recovered.push(`Removed orphaned worktree directory for ${m.id} (branch already deleted).`);
+      } catch (err) {
+        warnings.push(
+          `Failed to remove orphaned worktree directory for ${m.id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    } else {
+      recovered.push(`Removed orphaned worktree directory for ${m.id} (branch already deleted).`);
     }
   }
 

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -44,6 +44,7 @@ import {
   nativeDetectMainBranch,
   nativeCheckoutBranch,
   nativeBranchList,
+  nativeBranchExists,
   nativeBranchListMerged,
   nativeBranchDelete,
   nativeWorktreeRemove,
@@ -202,9 +203,15 @@ export function decideSurvivorAction(
 export function auditOrphanedMilestoneBranches(
   basePath: string,
   isolationMode: "worktree" | "branch" | "none",
+  gitDeps: {
+    branchList?: typeof nativeBranchList;
+    branchExists?: typeof nativeBranchExists;
+  } = {},
 ): { recovered: string[]; warnings: string[] } {
   const recovered: string[] = [];
   const warnings: string[] = [];
+  const branchList = gitDeps.branchList ?? nativeBranchList;
+  const branchExists = gitDeps.branchExists ?? nativeBranchExists;
 
   // Skip in none mode — no milestone branches are created
   if (isolationMode === "none") return { recovered, warnings };
@@ -213,11 +220,13 @@ export function auditOrphanedMilestoneBranches(
   if (!isDbAvailable()) return { recovered, warnings };
 
   let milestoneBranches: string[];
+  let milestoneBranchListAvailable = true;
   try {
-    milestoneBranches = nativeBranchList(basePath, "milestone/*");
+    milestoneBranches = branchList(basePath, "milestone/*");
   } catch {
+    milestoneBranchListAvailable = false;
     // git branch list failed — fall through with an empty branch set so the
-    // branch-less orphan pass at the bottom of this function can still run.
+    // branch-less orphan pass can still run after per-milestone verification.
     milestoneBranches = [];
   }
 
@@ -379,6 +388,16 @@ export function auditOrphanedMilestoneBranches(
   for (const m of completedMilestones) {
     if (m.status !== "complete") continue;
     if (seenMilestoneIds.has(m.id)) continue; // already processed in the branch loop
+    if (!milestoneBranchListAvailable) {
+      try {
+        if (branchExists(basePath, `milestone/${m.id}`)) continue;
+      } catch (err) {
+        warnings.push(
+          `Could not verify whether milestone/${m.id} still exists; skipping branch-less worktree cleanup for safety: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        continue;
+      }
+    }
     const wtDir = getWorktreeDir(basePath, m.id);
     if (!existsSync(wtDir)) continue;
     if (!isInsideWorktreesDir(basePath, wtDir)) {

--- a/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
@@ -243,12 +243,67 @@ describe("auditOrphanedMilestoneBranches", () => {
     );
   });
 
-  test("handles milestone in DB but no branch (no-op)", () => {
+  test("milestone in DB, no branch, no worktree dir → no-op", () => {
     insertMilestone({ id: "M001", title: "Test", status: "complete" });
 
     const result = auditOrphanedMilestoneBranches(dir, "worktree");
 
     assert.deepStrictEqual(result.recovered, []);
     assert.deepStrictEqual(result.warnings, []);
+  });
+
+  test("#5879 — cleans orphaned worktree dir for complete milestone whose branch was already deleted", () => {
+    // Reproduces the postflight-stash-restore-failed scenario:
+    // 1. An earlier audit deleted milestone/M001 (merged + complete).
+    // 2. The worktree dir cleanup failed silently (logWarning only).
+    // 3. On the next startup the branch is gone, so the existing branch-keyed
+    //    loop is invisible to the orphan dir. Without the second pass, the
+    //    directory lives forever.
+    insertMilestone({ id: "M001", title: "Test", status: "complete" });
+
+    const wtDir = join(dir, ".gsd", "worktrees", "M001");
+    mkdirSync(wtDir, { recursive: true });
+    writeFileSync(join(wtDir, "leftover.txt"), "stranded from a prior session\n");
+
+    // No milestone/M001 branch — already deleted on a previous run.
+    const branches = run("git branch --list milestone/M001", dir);
+    assert.equal(branches, "", "test fixture: branch should not exist");
+
+    const result = auditOrphanedMilestoneBranches(dir, "worktree");
+
+    assert.ok(
+      result.recovered.some((r) => r.includes("M001") && r.includes("branch already deleted")),
+      `should report branch-less orphan cleanup; got: ${JSON.stringify(result.recovered)}`,
+    );
+    assert.ok(!existsSync(wtDir), "branch-less orphan worktree dir should be removed");
+  });
+
+  test("#5879 — skips branch-less orphan for milestone that is not complete", () => {
+    // Defensive: only `complete` milestones get the branch-less cleanup. An
+    // `active` milestone with no branch but a worktree dir is a different
+    // state (probably mid-recovery) and should not be silently wiped.
+    insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+    const wtDir = join(dir, ".gsd", "worktrees", "M001");
+    mkdirSync(wtDir, { recursive: true });
+    writeFileSync(join(wtDir, "live-work.txt"), "do not delete\n");
+
+    const result = auditOrphanedMilestoneBranches(dir, "worktree");
+
+    assert.deepStrictEqual(result.recovered, []);
+    assert.ok(existsSync(wtDir), "active milestone worktree dir must be preserved");
+  });
+
+  test("#5879 — skips branch-less orphan in 'none' isolation mode", () => {
+    insertMilestone({ id: "M001", title: "Test", status: "complete" });
+
+    const wtDir = join(dir, ".gsd", "worktrees", "M001");
+    mkdirSync(wtDir, { recursive: true });
+    writeFileSync(join(wtDir, "leftover.txt"), "stranded\n");
+
+    const result = auditOrphanedMilestoneBranches(dir, "none");
+
+    assert.deepStrictEqual(result.recovered, []);
+    assert.ok(existsSync(wtDir), "'none' mode must not touch worktree dirs");
   });
 });

--- a/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
@@ -278,6 +278,51 @@ describe("auditOrphanedMilestoneBranches", () => {
     assert.ok(!existsSync(wtDir), "branch-less orphan worktree dir should be removed");
   });
 
+  test("#5879 — branch list failure still cleans complete orphan only after branch absence is verified", () => {
+    insertMilestone({ id: "M001", title: "Test", status: "complete" });
+
+    const wtDir = join(dir, ".gsd", "worktrees", "M001");
+    mkdirSync(wtDir, { recursive: true });
+    writeFileSync(join(wtDir, "leftover.txt"), "stranded from a prior session\n");
+
+    const result = auditOrphanedMilestoneBranches(dir, "worktree", {
+      branchList: () => {
+        throw new Error("branch list failed");
+      },
+      branchExists: (_basePath, branch) => {
+        assert.equal(branch, "milestone/M001");
+        return false;
+      },
+    });
+
+    assert.ok(
+      result.recovered.some((r) => r.includes("M001") && r.includes("branch already deleted")),
+      `should report verified branch-less orphan cleanup; got: ${JSON.stringify(result.recovered)}`,
+    );
+    assert.ok(!existsSync(wtDir), "verified branch-less orphan worktree dir should be removed");
+  });
+
+  test("#5879 — branch list failure preserves complete worktree when branch still exists", () => {
+    insertMilestone({ id: "M001", title: "Test", status: "complete" });
+
+    const wtDir = join(dir, ".gsd", "worktrees", "M001");
+    mkdirSync(wtDir, { recursive: true });
+    writeFileSync(join(wtDir, "live-work.txt"), "do not delete\n");
+
+    const result = auditOrphanedMilestoneBranches(dir, "worktree", {
+      branchList: () => {
+        throw new Error("branch list failed");
+      },
+      branchExists: (_basePath, branch) => {
+        assert.equal(branch, "milestone/M001");
+        return true;
+      },
+    });
+
+    assert.deepStrictEqual(result.recovered, []);
+    assert.ok(existsSync(wtDir), "worktree dir must be preserved when branch existence is verified");
+  });
+
   test("#5879 — skips branch-less orphan for milestone that is not complete", () => {
     // Defensive: only `complete` milestones get the branch-less cleanup. An
     // `active` milestone with no branch but a worktree dir is a different
@@ -289,6 +334,26 @@ describe("auditOrphanedMilestoneBranches", () => {
     writeFileSync(join(wtDir, "live-work.txt"), "do not delete\n");
 
     const result = auditOrphanedMilestoneBranches(dir, "worktree");
+
+    assert.deepStrictEqual(result.recovered, []);
+    assert.ok(existsSync(wtDir), "active milestone worktree dir must be preserved");
+  });
+
+  test("#5879 — branch list failure does not delete worktree for milestone that is not complete", () => {
+    insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+    const wtDir = join(dir, ".gsd", "worktrees", "M001");
+    mkdirSync(wtDir, { recursive: true });
+    writeFileSync(join(wtDir, "live-work.txt"), "do not delete\n");
+
+    const result = auditOrphanedMilestoneBranches(dir, "worktree", {
+      branchList: () => {
+        throw new Error("branch list failed");
+      },
+      branchExists: () => {
+        throw new Error("branchExists should not be called for active milestones");
+      },
+    });
 
     assert.deepStrictEqual(result.recovered, []);
     assert.ok(existsSync(wtDir), "active milestone worktree dir must be preserved");


### PR DESCRIPTION
## Linked issue

Closes #5879

- [x] I have linked an issue above.

---

## TL;DR

**What:** `auditOrphanedMilestoneBranches()` now cleans `.gsd/worktrees/<id>/` directories whose milestone branch was already deleted by an earlier pass.
**Why:** Before this fix, the dir-cleanup block only ran inside a `for (branch of milestone/*)` loop. Once an earlier audit deleted the branch, the orphan directory was invisible to every subsequent audit — it stayed on disk forever.
**How:** Drop the early `return` when there are no `milestone/*` branches; after the branch-keyed loop, enumerate completed milestones from the DB and remove any leftover worktree dir.

## What

- `src/resources/extensions/gsd/auto-start.ts` — `auditOrphanedMilestoneBranches()`:
  - Replace `if (milestoneBranches.length === 0) return …` with a fall-through so the function continues to the branch-less pass.
  - On the failure path of `nativeBranchList`, fall through with `milestoneBranches = []` instead of returning, so a transient git error doesn't suppress the branch-less cleanup either.
  - Add a second pass after the existing branch-keyed loop: enumerate `getAllMilestones()`, keep those with `status === "complete"` that weren't already touched by the branch loop, and for each, if `existsSync(getWorktreeDir(basePath, id))` and `isInsideWorktreesDir(basePath, …)`, try `nativeWorktreeRemove`, then `rmSync` as fallback. Surface success/failure via `recovered` / `warnings`.
- `src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts`:
  - Rename the pre-existing "no branch" no-op test to make the precondition explicit (no worktree dir).
  - **`#5879 — cleans orphaned worktree dir for complete milestone whose branch was already deleted`** — the primary regression. Setup: DB row `M001 status=complete`, `.gsd/worktrees/M001/leftover.txt` on disk, no branch. Assert: dir is removed and `recovered` mentions "branch already deleted".
  - **`#5879 — skips branch-less orphan for milestone that is not complete`** — defensive: an `active` milestone's worktree must be preserved.
  - **`#5879 — skips branch-less orphan in 'none' isolation mode`** — `none` mode never touches worktrees.

## Why

Real session that surfaced this:

1. `2026-05-11T22:11:24Z` — milestone M008 closeout. `git worktree-merged` succeeded (no conflicts). Auto-mode stopped with `reason: postflight-stash-restore-failed` from `auto/phases.ts:403`. State DB marked M008 `status=complete`. The `.gsd/worktrees/M008/` directory was left on disk.
2. Next run — `auditOrphanedMilestoneBranches()` ran at bootstrap. The branch loop matched `milestone/M008`, deleted it, then tried to remove the worktree dir. Removal failed silently (the only signal is `logWarning("engine", …)`, no `recovered` / `warnings` entry).
3. Subsequent run — `git branch --list 'milestone/*'` returned only `milestone/M009`. The branch loop never saw M008. The orphan directory stayed.
4. New milestones started anyway; the empty shell accumulated.

`doctor-git-checks.ts:384` (`worktree_directory_orphaned`) catches this — but it only runs on demand via `/gsd doctor`, not at session startup.

## How

The fix is purely additive on the happy path. The branch-keyed loop is unchanged; the new pass only runs over completed milestones that the first loop did NOT process (`seenMilestoneIds` set), so it cannot double-touch. The dir cleanup uses the same `nativeWorktreeRemove` → `rmSync` fallback as the existing block.

Decision notes:

- Keyed on **completed milestones** from the DB, not on arbitrary `.gsd/worktrees/*` directories. A dir for an in-progress milestone (e.g. mid-recovery) is a different case and is intentionally out of scope.
- Surface `recovered` / `warnings` so the bootstrap notification reflects the cleanup instead of silently calling `logWarning`. Matches the existing block's behavior.
- The early-return removal is the smaller of two options. The alternative — lifting the second pass above the branch loop — would have required restructuring `seenMilestoneIds` and didn't simplify anything.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat`
- [ ] `refactor`
- [ ] `test`
- [ ] `docs`
- [ ] `chore`

## Scope

- [x] `gsd extension` — `auto-start.ts` bootstrap audit

## Breaking changes

- [x] No breaking changes. The first pass behaves identically; the second pass only triggers for completed milestones with stranded directories — a state that previously had no remediation outside `/gsd doctor`.

## Test plan

- [x] New regression tests cover: primary branch-less orphan path, active-milestone safety, `none`-mode skip.
- [x] Existing 11 tests in `orphaned-worktree-audit.test.ts` pass unchanged.
- [x] `tsc --noEmit --project tsconfig.extensions.json` clean.
- [x] CI must pass.

## AI disclosure

- [x] AI-assisted (Claude). Bug was diagnosed end-to-end from the user's session logs (journal + state-manifest + notifications), the regression test was written first to reproduce, then the fix made it pass. AI is not credited as a commit author per CONTRIBUTING.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Orphaned milestone cleanup now proceeds when branch listing fails, recovers leftover worktree directories for completed milestones, and records clear warnings. Removal uses safer fallback deletion attempts.
* **Tests**
  * Added regression tests covering branch-less worktree cleanup across branch-list failures, branch existence checks, milestone statuses, and isolation modes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5881)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->