### PR TITLE
fix(issue): /gsd doctor command crashes/exits prematurely during health checks

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -80,17 +80,29 @@ export async function checkRuntimeHealth(
         // heartbeat for this project?" — readCrashLock returns null for
         // healthy live workers (it surfaces stale ones only), so we must
         // consult getActiveAutoWorkers directly.
-        const projectRoot = normalizeRealPath(basePath);
-        const activeWorkers = getActiveAutoWorkers().filter(
-          (w) => w.project_root_realpath === projectRoot && isLockProcessAlive({
-            pid: w.pid,
-            startedAt: w.started_at,
-            unitType: "starting",
-            unitId: "bootstrap",
-            unitStartedAt: w.started_at,
-          }),
-        );
-        const lockHolderAlive = activeWorkers.length > 0;
+        let lockHolderAlive = false;
+        try {
+          const projectRoot = normalizeRealPath(basePath);
+          for (const worker of getActiveAutoWorkers()) {
+            if (worker.project_root_realpath !== projectRoot) continue;
+            try {
+              if (isLockProcessAlive({
+                pid: worker.pid,
+                startedAt: worker.started_at,
+                unitType: "starting",
+                unitId: "bootstrap",
+                unitStartedAt: worker.started_at,
+              })) {
+                lockHolderAlive = true;
+                break;
+              }
+            } catch {
+              // Ignore malformed worker rows or transient PID probe failures.
+            }
+          }
+        } catch {
+          // If worker lookup fails, continue with the stranded lock diagnosis.
+        }
         if (!lockHolderAlive) {
           issues.push({
             severity: "error",

--- a/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
@@ -446,6 +446,26 @@ node_modules/
       const strandedIssues = detect.issues.filter(i => i.code === "stranded_lock_directory");
       assert.deepStrictEqual(strandedIssues.length, 0, "live lock holder: stranded_lock_directory NOT detected");
     });
+
+    test('stranded_lock_directory still reports when worker lookup fails', async () => {
+      const dir = createMinimalProject();
+      cleanups.push(dir);
+
+      const lockDir = join(dir, ".gsd.lock");
+      mkdirSync(lockDir, { recursive: true });
+      const { openDatabase, _getAdapter, closeDatabase } = await import("../../gsd-db.ts");
+      openDatabase(join(dir, ".gsd", "gsd.db"));
+      const db = _getAdapter()!;
+      db.exec("DROP TABLE workers");
+
+      try {
+        const detect = await runGSDDoctor(dir);
+        const strandedIssues = detect.issues.filter(i => i.code === "stranded_lock_directory");
+        assert.ok(strandedIssues.length > 0, "reports stranded lock directory even when active worker lookup fails");
+      } finally {
+        closeDatabase();
+      }
+    });
     } else {
     }
 


### PR DESCRIPTION
## Summary
- Fixed stranded lock health checks to tolerate worker lookup/liveness failures and verified with focused doctor runtime integration tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5882
- [#5882 /gsd doctor command crashes/exits prematurely during health checks](https://github.com/gsd-build/gsd-2/issues/5882)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5882-gsd-doctor-command-crashes-exits-prematu-1778630242`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the stranded lock directory diagnostic to be more resilient when worker information is unavailable, ensuring lock issues are still properly detected and reported even under degraded conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5883)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->