### PR TITLE
fix(issue): worktree-sync: git ls-files cleanup fails on .gsd-managed dirs ("fuera del repositorio")

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -252,7 +252,17 @@ function gitPathspecForWorktreePath(basePath: string, targetPath: string): strin
   let base = basePath;
   let target = targetPath;
   try {
-    base = realpathSync.native(basePath);
+    base = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf-8",
+    }).trim() || basePath;
+  } catch {
+    /* keep original */
+    void base;
+  }
+  try {
+    base = realpathSync.native(base);
   } catch {
     /* keep original */
     void base;
@@ -267,6 +277,10 @@ function gitPathspecForWorktreePath(basePath: string, targetPath: string): strin
   const rel = relative(base, target);
   if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) return null;
   return rel.replaceAll("\\", "/");
+}
+
+export function _gitPathspecForWorktreePath(basePath: string, targetPath: string): string | null {
+  return gitPathspecForWorktreePath(basePath, targetPath);
 }
 
 function gitRemoteExists(basePath: string, remote: string): boolean {

--- a/src/resources/extensions/gsd/tests/worktree-git-pathspec.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-git-pathspec.test.ts
@@ -1,0 +1,39 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
+
+import { _gitPathspecForWorktreePath } from "../auto-worktree.ts";
+
+function run(cmd: string, cwd: string): string {
+  return execSync(cmd, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
+}
+
+describe("worktree git pathspec", () => {
+  test("skips external GSD bookkeeping directories outside the git work-tree", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "gsd-pathspec-")));
+    const repo = join(root, "project");
+    const externalGsd = join(root, ".gsd", "projects", "abc123");
+
+    try {
+      mkdirSync(repo, { recursive: true });
+      mkdirSync(join(externalGsd, "milestones", "M002-wa00fm"), { recursive: true });
+      mkdirSync(join(externalGsd, "runtime", "units"), { recursive: true });
+      run("git init", repo);
+      writeFileSync(join(repo, "README.md"), "# test\n");
+
+      assert.equal(
+        _gitPathspecForWorktreePath(repo, join(externalGsd, "milestones", "M002-wa00fm")),
+        null,
+      );
+      assert.equal(
+        _gitPathspecForWorktreePath(repo, join(externalGsd, "runtime", "units")),
+        null,
+      );
+    } finally {
+      if (existsSync(root)) rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/resources/extensions/gsd/tests/worktree-git-pathspec.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-git-pathspec.test.ts
@@ -3,12 +3,12 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 import { _gitPathspecForWorktreePath } from "../auto-worktree.ts";
 
-function run(cmd: string, cwd: string): string {
-  return execSync(cmd, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
+function run(cmd: string, args: string[], cwd: string): string {
+  return execFileSync(cmd, args, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
 }
 
 describe("worktree git pathspec", () => {
@@ -21,7 +21,7 @@ describe("worktree git pathspec", () => {
       mkdirSync(repo, { recursive: true });
       mkdirSync(join(externalGsd, "milestones", "M002-wa00fm"), { recursive: true });
       mkdirSync(join(externalGsd, "runtime", "units"), { recursive: true });
-      run("git init", repo);
+      run("git", ["init"], repo);
       writeFileSync(join(repo, "README.md"), "# test\n");
 
       assert.equal(


### PR DESCRIPTION
## Summary
- Fixed worktree cleanup pathspec guarding for external GSD bookkeeping dirs and verified with focused pathspec and merge integration tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5260
- [#5260 worktree-sync: git ls-files cleanup fails on .gsd-managed dirs ("fuera del repositorio")](https://github.com/gsd-build/gsd-2/issues/5260)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5260-worktree-sync-git-ls-files-cleanup-fails-1778630259`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved git worktree path resolution with enhanced repository root detection and robust fallback handling.

* **Tests**
  * Added test coverage to validate path handling for Git repositories, including edge cases with external repository directories.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5884)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->