### PR TITLE
fix(issue): auto-mode silently disables milestone lease + dispatch ledger because enterMilestone runs before registerAutoWorkerForSession

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -101,6 +101,7 @@ import { getSessionModelOverride } from "./session-model-override.js";
 export interface BootstrapDeps {
   shouldUseWorktreeIsolation: (basePath?: string) => boolean;
   registerSigtermHandler: (basePath: string) => void;
+  registerAutoWorkerForSession: (basePath: string) => void;
   lockBase: () => string;
   buildLifecycle: () => WorktreeLifecycle;
 }
@@ -533,6 +534,7 @@ export async function bootstrapAutoSession(
   const {
     shouldUseWorktreeIsolation,
     registerSigtermHandler,
+    registerAutoWorkerForSession,
     lockBase,
     buildLifecycle,
   } = deps;
@@ -722,6 +724,7 @@ export async function bootstrapAutoSession(
     // consult DB status and avoid clearing runtime units for milestones that
     // only have a failure-path SUMMARY on disk (#4663).
     await openProjectDbIfPresent(base);
+    registerAutoWorkerForSession(base);
 
     // Clean stale runtime unit files for completed milestones (#887).
     // DB-authoritative: when DB is available, require DB status to be closed

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2473,6 +2473,8 @@ export async function startAuto(
     s.unitLifetimeDispatches.clear();
     if (!getLedger()) initMetrics(base);
     if (s.currentMilestoneId) setActiveMilestoneId(base, s.currentMilestoneId);
+    await openProjectDbIfPresent(base);
+    registerAutoWorkerForSession(s, base);
 
     // Re-register health level notification callback lost across process restart
     setLevelChangeCallback((_from, to, summary) => {
@@ -2601,6 +2603,7 @@ export async function startAuto(
   const bootstrapDeps: BootstrapDeps = {
     shouldUseWorktreeIsolation,
     registerSigtermHandler,
+    registerAutoWorkerForSession: (projectRoot) => registerAutoWorkerForSession(s, projectRoot),
     lockBase,
     buildLifecycle,
   };

--- a/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-orphan-bootstrap.test.ts
@@ -98,6 +98,7 @@ test("bootstrap aborts before starting next milestone when completed orphan merg
       {
         shouldUseWorktreeIsolation: () => true,
         registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
         lockBase: () => base,
         buildLifecycle: () => ({
           adoptSessionRoot: (sessionBase: string, originalBase?: string) => {

--- a/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
@@ -272,6 +272,7 @@ test("deep project setup: bootstrap can start auto-mode without an active milest
       {
         shouldUseWorktreeIsolation: () => false,
         registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
         lockBase: () => base,
         buildLifecycle: () => ({
           adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
@@ -386,6 +387,7 @@ test("deep project setup: bootstrap continues queued M002 without milestone cont
       {
         shouldUseWorktreeIsolation: () => false,
         registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
         lockBase: () => base,
         buildLifecycle: () => ({
           adoptSessionRoot: (sessionBase: string, originalBase?: string) => {

--- a/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
+++ b/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
@@ -108,10 +108,12 @@ test("fresh start registers the auto worker before bootstrap enters worktree flo
   const bootstrapCallIdx = startAutoBody.indexOf("const ready = await bootstrapAutoSession(");
   const preBootstrapBody = startAutoBody.slice(0, bootstrapCallIdx);
   const preBootstrapRegisterIdx = preBootstrapBody.lastIndexOf("registerAutoWorkerForSession(s, base);");
-  const resumeSectionIdx = startAutoBody.indexOf("// ── Auto-worktree / branch-mode: re-enter on resume ──");
-  const resumeBody = startAutoBody.slice(0, resumeSectionIdx);
-  const resumeDbOpenIdx = resumeBody.lastIndexOf("await openProjectDbIfPresent(base);");
-  const resumeRegisterIdx = resumeBody.lastIndexOf("registerAutoWorkerForSession(s, base);");
+  const resumeSectionIdx = startAutoBody.indexOf("if (s.paused) {");
+  const freshStartSectionIdx = startAutoBody.indexOf("// ── Fresh start path — delegated to auto-start.ts ──");
+  const resumeBody = startAutoBody.slice(resumeSectionIdx, freshStartSectionIdx);
+  const resumeDbOpenIdx = resumeBody.indexOf("await openProjectDbIfPresent(base);");
+  const resumeRegisterIdx = resumeBody.indexOf("registerAutoWorkerForSession(s, base);");
+  const resumeEnterMilestoneIdx = resumeBody.indexOf("buildLifecycle().enterMilestone");
   const dbOpenIdx = bootstrapBody.indexOf("await openProjectDbIfPresent(base);");
   const bootstrapRegisterIdx = bootstrapBody.indexOf("registerAutoWorkerForSession(base);");
   const enterMilestoneIdx = bootstrapBody.indexOf("buildLifecycle().enterMilestone");
@@ -120,8 +122,10 @@ test("fresh start registers the auto worker before bootstrap enters worktree flo
   assert.ok(preBootstrapRegisterIdx > -1, "startAuto should register worker before bootstrap");
   assert.ok(bootstrapCallIdx > -1, "startAuto should call bootstrapAutoSession");
   assert.ok(resumeSectionIdx > -1, "startAuto should have resume milestone entry flow");
+  assert.ok(freshStartSectionIdx > resumeSectionIdx, "resume assertions should be scoped before fresh start");
   assert.ok(resumeDbOpenIdx > -1, "resume should open DB before milestone entry");
   assert.ok(resumeRegisterIdx > -1, "resume should register worker before milestone entry");
+  assert.ok(resumeEnterMilestoneIdx > -1, "resume should enter milestones through lifecycle");
   assert.ok(bootstrapIdx > -1, "bootstrapAutoSession should exist");
   assert.ok(dbOpenIdx > -1, "bootstrap should open the project DB");
   assert.ok(bootstrapRegisterIdx > -1, "bootstrap should register worker after DB open");
@@ -135,7 +139,7 @@ test("fresh start registers the auto worker before bootstrap enters worktree flo
     "bootstrap must open DB and register worker before first enterMilestone",
   );
   assert.ok(
-    resumeDbOpenIdx < resumeRegisterIdx,
+    resumeDbOpenIdx < resumeRegisterIdx && resumeRegisterIdx < resumeEnterMilestoneIdx,
     "resume must open DB and register worker before first enterMilestone",
   );
 });

--- a/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
+++ b/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
@@ -99,18 +99,44 @@ test("auto bootstrap validates blocked directories before touching .gsd migratio
 
 test("fresh start registers the auto worker before bootstrap enters worktree flow (#5405)", () => {
   const autoSrc = readGsdFile("auto.ts");
+  const autoStartSrc = readGsdFile("auto-start.ts");
   const startAutoIdx = autoSrc.indexOf("export async function startAuto(");
   const startAutoBody = autoSrc.slice(startAutoIdx);
+  const bootstrapIdx = autoStartSrc.indexOf("export async function bootstrapAutoSession(");
+  const bootstrapBody = autoStartSrc.slice(bootstrapIdx);
 
-  const preBootstrapRegisterIdx = startAutoBody.indexOf("registerAutoWorkerForSession(s, base);");
   const bootstrapCallIdx = startAutoBody.indexOf("const ready = await bootstrapAutoSession(");
+  const preBootstrapBody = startAutoBody.slice(0, bootstrapCallIdx);
+  const preBootstrapRegisterIdx = preBootstrapBody.lastIndexOf("registerAutoWorkerForSession(s, base);");
+  const resumeSectionIdx = startAutoBody.indexOf("// ── Auto-worktree / branch-mode: re-enter on resume ──");
+  const resumeBody = startAutoBody.slice(0, resumeSectionIdx);
+  const resumeDbOpenIdx = resumeBody.lastIndexOf("await openProjectDbIfPresent(base);");
+  const resumeRegisterIdx = resumeBody.lastIndexOf("registerAutoWorkerForSession(s, base);");
+  const dbOpenIdx = bootstrapBody.indexOf("await openProjectDbIfPresent(base);");
+  const bootstrapRegisterIdx = bootstrapBody.indexOf("registerAutoWorkerForSession(base);");
+  const enterMilestoneIdx = bootstrapBody.indexOf("buildLifecycle().enterMilestone");
 
   assert.ok(startAutoIdx > -1, "startAuto should exist");
   assert.ok(preBootstrapRegisterIdx > -1, "startAuto should register worker before bootstrap");
   assert.ok(bootstrapCallIdx > -1, "startAuto should call bootstrapAutoSession");
+  assert.ok(resumeSectionIdx > -1, "startAuto should have resume milestone entry flow");
+  assert.ok(resumeDbOpenIdx > -1, "resume should open DB before milestone entry");
+  assert.ok(resumeRegisterIdx > -1, "resume should register worker before milestone entry");
+  assert.ok(bootstrapIdx > -1, "bootstrapAutoSession should exist");
+  assert.ok(dbOpenIdx > -1, "bootstrap should open the project DB");
+  assert.ok(bootstrapRegisterIdx > -1, "bootstrap should register worker after DB open");
+  assert.ok(enterMilestoneIdx > -1, "bootstrap should enter milestones through lifecycle");
   assert.ok(
     preBootstrapRegisterIdx < bootstrapCallIdx,
     "worker registration must happen before bootstrap so enterMilestone can claim milestone leases on first entry",
+  );
+  assert.ok(
+    dbOpenIdx < bootstrapRegisterIdx && bootstrapRegisterIdx < enterMilestoneIdx,
+    "bootstrap must open DB and register worker before first enterMilestone",
+  );
+  assert.ok(
+    resumeDbOpenIdx < resumeRegisterIdx,
+    "resume must open DB and register worker before first enterMilestone",
   );
 });
 

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -23,6 +23,7 @@ import { join } from "node:path";
 
 import type { AutoSession } from "./auto/session.js";
 import { debugLog } from "./debug-logger.js";
+import { logWarning } from "./workflow-logger.js";
 import { emitJournalEvent } from "./journal.js";
 import { emitWorktreeCreated, emitWorktreeMerged } from "./worktree-telemetry.js";
 import {
@@ -532,7 +533,7 @@ export function _enterMilestoneCore(
 
   // Phase B: claim a milestone lease before any worktree mutation. Two
   // workers cannot enter the same milestone concurrently. Best-effort:
-  // skip if no worker registered (single-worker fallback) or DB
+  // warn if no worker registered (single-worker fallback) or skip if DB
   // unavailable; reuse existing lease if we already hold it on this
   // milestone (re-entry within the same session).
   if (s.workerId) {
@@ -625,6 +626,11 @@ export function _enterMilestoneCore(
         });
       }
     }
+  } else {
+    logWarning(
+      "worktree",
+      `enterMilestone(${milestoneId}) ran before auto worker registration; milestone lease was not claimed.`,
+    );
   }
 
   // Resolve the project root for worktree operations via shared helper.


### PR DESCRIPTION
## Summary
- Fixed auto-mode worker registration ordering before milestone entry and verified with focused tests plus extension typecheck.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5268
- [#5268 auto-mode silently disables milestone lease + dispatch ledger because enterMilestone runs before registerAutoWorkerForSession](https://github.com/gsd-build/gsd-2/issues/5268)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5268-auto-mode-silently-disables-milestone-le-1778630265`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured auto-session initialization to explicitly register workers earlier in both fresh-start and resume paths.

* **Bug Fixes**
  * Added warning logging to detect if operations begin before worker registration completes.

* **Tests**
  * Updated test infrastructure to validate worker registration timing within the session initialization sequence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5886)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->