### PR TITLE
fix(issue): DB-backed stale worker cleanup leaves crashed hook dispatch active

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -58,6 +58,7 @@ import {
 import {
   writeLock,
   clearLock,
+  clearStaleWorkerLock,
   readCrashLock,
   isLockProcessAlive,
   formatCrashInfo,
@@ -2422,7 +2423,7 @@ export async function startAuto(
     // This closes the journal gap reported in #3348 where the worker wrote side
     // effects (SUMMARY.md, DB updates) but died before emitting unit-end.
     emitCrashRecoveredUnitEnd(base, freshStartAssessment.lock);
-    clearLock(base);
+    clearStaleWorkerLock(base);
   }
 
   if (!s.paused) {

--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -30,9 +30,10 @@ import { join } from "node:path";
 import {
   findStaleWorkerForProject,
   getAllAutoWorkers,
+  markWorkerCrashed,
   type AutoWorkerRow,
 } from "./db/auto-workers.js";
-import { getLatestForUnit, type DispatchStatus } from "./db/unit-dispatches.js";
+import { markLatestActiveForWorkerCanceled, type DispatchStatus } from "./db/unit-dispatches.js";
 import { getRuntimeKv, setRuntimeKv, deleteRuntimeKv } from "./db/runtime-kv.js";
 import { _getAdapter, isDbAvailable } from "./gsd-db.js";
 import { gsdRoot, normalizeRealPath } from "./paths.js";
@@ -54,6 +55,15 @@ const SESSION_FILE_KV_KEY = "session_file";
 
 function lockPath(basePath: string): string {
   return join(gsdRoot(basePath), effectiveLockFile());
+}
+
+function clearLegacyLockFile(basePath: string): void {
+  try {
+    const p = lockPath(basePath);
+    if (existsSync(p)) unlinkSync(p);
+  } catch {
+    // Best-effort.
+  }
 }
 
 function readLegacyLock(basePath: string): LockData | null {
@@ -204,18 +214,34 @@ export function writeLock(
  * stale session-file pointer.
  */
 export function clearLock(basePath: string): void {
-  try {
-    const p = lockPath(basePath);
-    if (existsSync(p)) unlinkSync(p);
-  } catch {
-    // Best-effort.
-  }
+  clearLegacyLockFile(basePath);
 
   if (!isDbAvailable()) return;
   try {
     const projectRoot = normalizeRealPath(basePath);
     const worker = findActiveWorkerForCurrentProcess(projectRoot);
     if (!worker) return;
+    deleteRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY);
+  } catch {
+    // Best-effort.
+  }
+}
+
+/**
+ * Clear a stale DB-backed worker lock after readCrashLock/findStaleWorkerForProject
+ * has identified a dead worker. Unlike clearLock(), this targets the stale
+ * worker row instead of the current process's active worker.
+ */
+export function clearStaleWorkerLock(basePath: string): void {
+  clearLegacyLockFile(basePath);
+
+  if (!isDbAvailable()) return;
+  try {
+    const projectRoot = normalizeRealPath(basePath);
+    const worker = findStaleWorkerForProject(projectRoot);
+    if (!worker) return;
+    markLatestActiveForWorkerCanceled(worker.worker_id, "crash-recovered");
+    markWorkerCrashed(worker.worker_id);
     deleteRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY);
   } catch {
     // Best-effort.

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -7,7 +7,7 @@ import { milestonesDir, gsdRoot, resolveGsdRootFile } from "./paths.js";
 import { deriveState, isGhostMilestone, isReusableGhostMilestone } from "./state.js";
 import { saveFile } from "./files.js";
 import { nativeIsRepo, nativeForEachRef, nativeUpdateRef } from "./native-git-bridge.js";
-import { readCrashLock, isLockProcessAlive, clearLock } from "./crash-recovery.js";
+import { readCrashLock, isLockProcessAlive, clearStaleWorkerLock } from "./crash-recovery.js";
 import { getActiveAutoWorkers } from "./db/auto-workers.js";
 import { normalizeRealPath } from "./paths.js";
 import { ensureGitignore, isGsdGitignored } from "./gitignore.js";
@@ -56,7 +56,7 @@ export async function checkRuntimeHealth(
         });
 
         if (shouldFix("stale_crash_lock")) {
-          clearLock(basePath);
+          clearStaleWorkerLock(basePath);
           fixesApplied.push("cleared stale auto-mode worker state");
         }
       }

--- a/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
@@ -19,14 +19,15 @@ import {
   insertMilestone,
   _getAdapter,
 } from "../gsd-db.ts";
-import { registerAutoWorker } from "../db/auto-workers.ts";
+import { getAutoWorker, registerAutoWorker } from "../db/auto-workers.ts";
 import { claimMilestoneLease } from "../db/milestone-leases.ts";
-import { recordDispatchClaim } from "../db/unit-dispatches.ts";
+import { getLatestForUnit, markRunning, recordDispatchClaim } from "../db/unit-dispatches.ts";
 import { setRuntimeKv, getRuntimeKv } from "../db/runtime-kv.ts";
 import {
   writeLock,
   readCrashLock,
   clearLock,
+  clearStaleWorkerLock,
   isLockProcessAlive,
 } from "../crash-recovery.ts";
 import { normalizeRealPath } from "../paths.ts";
@@ -222,4 +223,44 @@ test("clearLock removes the session_file row for the active worker", (t) => {
   clearLock(base);
   assert.equal(getRuntimeKv("worker", workerId, "session_file"), null,
     "session_file row deleted by clearLock");
+});
+
+test("clearStaleWorkerLock crashes stale worker and cancels latest active dispatch", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "T", status: "active" });
+  const projectRoot = normalizeRealPath(base);
+  const workerId = registerAutoWorker({ projectRootRealpath: projectRoot });
+  const lease = claimMilestoneLease(workerId, "M001");
+  assert.equal(lease.ok, true);
+  if (!lease.ok) return;
+  const claim = recordDispatchClaim({
+    traceId: "t1",
+    workerId,
+    milestoneLeaseToken: lease.token,
+    milestoneId: "M001",
+    sliceId: "S01",
+    taskId: "T02",
+    unitType: "hook/codex-review",
+    unitId: "M001/S01/T02",
+  });
+  assert.equal(claim.ok, true);
+  if (!claim.ok) return;
+  markRunning(claim.dispatchId);
+  setRuntimeKv("worker", workerId, "session_file", "/tmp/pi-session-hook.jsonl");
+  setWorkerPid(workerId, 99999);
+  expireWorker(workerId);
+
+  assert.ok(readCrashLock(base), "stale worker is detected before cleanup");
+
+  clearStaleWorkerLock(base);
+
+  assert.equal(getAutoWorker(workerId)?.status, "crashed");
+  const dispatch = getLatestForUnit("M001/S01/T02");
+  assert.ok(dispatch);
+  assert.equal(dispatch!.status, "canceled");
+  assert.equal(dispatch!.exit_reason, "crash-recovered");
+  assert.equal(getRuntimeKv("worker", workerId, "session_file"), null);
+  assert.equal(readCrashLock(base), null);
 });

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -2,7 +2,7 @@ import { existsSync, rmSync } from "node:fs";
 import { join, relative } from "node:path";
 import { clearParseCache } from "../files.js";
 import { isClosedStatus, isDeferredStatus } from "../status-guards.js";
-import { isNonEmptyString } from "../validation.js";
+import { isNonEmptyString, validateStringArray } from "../validation.js";
 import {
   transaction,
   getMilestone,


### PR DESCRIPTION
## Summary
- Fixed stale DB worker cleanup to crash stale workers, cancel active dispatches, clear KV state, and verified with the crash recovery DB regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5269
- [#5269 DB-backed stale worker cleanup leaves crashed hook dispatch active](https://github.com/gsd-build/gsd-2/issues/5269)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5269-db-backed-stale-worker-cleanup-leaves-cr-1778632863`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash recovery and cleanup of stale worker locks to ensure proper resource cleanup and accurate worker status tracking during recovery.
* **Tests**
  * Added end-to-end test validating crash-recovery cleanup: worker marked crashed, dispatch canceled as crash-recovered, session runtime entry removed, and crash lock cleared.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5889)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->