### PR TITLE
fix(gsd): import plan slice validator

### DIFF
--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -219,6 +219,28 @@ test('handlePlanSlice explains string task IO fields must be arrays', async () =
   }
 });
 
+test('handlePlanSlice validates task files with the shared string-array helper', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+    const result = await handlePlanSlice({
+      ...validParams(),
+      tasks: [
+        {
+          ...validParams().tasks[0],
+          files: 'src/index.ts' as unknown as string[],
+        },
+      ],
+    }, base);
+    assert.ok('error' in result);
+    assert.match(result.error, /validation failed: tasks\[0\]\.files must be an array of strings, not string/);
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handlePlanSlice rejects absolute task IO paths outside the active worktree', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -447,3 +447,45 @@ test('handlePlanSlice rejects omitted completed tasks without changing slice or 
     cleanup(base);
   }
 });
+
+test('regression: validateTasks surfaces clean per-field errors for non-array IO inputs', async () => {
+  // Regression for the bug this PR fixes: an earlier refactor (0b0e1a901)
+  // re-added validateStringArray() calls inside validateTasks without
+  // re-adding its import. The catch around validateParams swallowed the
+  // ReferenceError into a generic "validation failed: validateStringArray
+  // is not defined" message, so silent runtime breakage was possible.
+  //
+  // Exercise every validateStringArray call site (files, inputs, expectedOutput)
+  // so a future missing-import would surface as a per-field assertion failure
+  // here, not a deep ReferenceError that's easy to mis-diagnose.
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+
+    for (const field of ['files', 'inputs', 'expectedOutput'] as const) {
+      const result = await handlePlanSlice({
+        ...validParams(),
+        tasks: [{
+          ...validParams().tasks[0],
+          [field]: 'not-an-array' as unknown as string[],
+        }],
+      }, base);
+      assert.ok('error' in result, `${field}: expected validation error, got success`);
+      assert.match(
+        result.error,
+        new RegExp(`tasks\\[0\\]\\.${field} must be an array`),
+        `${field}: expected per-field validation message, got: ${result.error}`,
+      );
+      assert.doesNotMatch(
+        result.error,
+        /is not defined/,
+        `${field}: validation surfaced ReferenceError — likely a missing import in plan-slice.ts`,
+      );
+      assert.equal(getSliceTasks('M001', 'S02').length, 0, `${field}: invalid input must not persist`);
+    }
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -2,7 +2,7 @@ import { existsSync, rmSync } from "node:fs";
 import { join, relative } from "node:path";
 import { clearParseCache } from "../files.js";
 import { isClosedStatus, isDeferredStatus } from "../status-guards.js";
-import { isNonEmptyString } from "../validation.js";
+import { isNonEmptyString, validateStringArray } from "../validation.js";
 import {
   transaction,
   getMilestone,


### PR DESCRIPTION
## TL;DR

**What:** Import the existing `validateStringArray` helper in `plan-slice.ts`.
**Why:** Dev Publish failed during `build:core` because `plan-slice.ts` referenced `validateStringArray` without importing it.
**How:** Adds the missing named import from `../validation.js`.

## What

Updates `src/resources/extensions/gsd/tools/plan-slice.ts` so the existing task IO validation calls resolve during TypeScript compilation.

## Why

The Dev Publish workflow failed on `TS2304: Cannot find name 'validateStringArray'` for the `files`, `inputs`, and `expectedOutput` validation paths.

## How

This reuses the existing shared validation helper already exported by `validation.ts`; no behavior change beyond restoring the intended compile-time reference.

## Validation

- `npm run build:core`
- `npm run typecheck:extensions`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/plan-slice.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code organization updates to improve maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5890)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->