### PR TITLE
test(plan-slice): regression for missing validateStringArray import

### DIFF
--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -486,3 +486,45 @@ test('handlePlanSlice rejects omitted completed tasks without changing slice or 
     cleanup(base);
   }
 });
+
+test('regression: validateTasks surfaces clean per-field errors for non-array IO inputs', async () => {
+  // Regression for the bug fixed in PR #5872: an earlier refactor on main
+  // (0b0e1a901) re-added validateStringArray() calls inside validateTasks
+  // without re-adding its import. The catch around validateParams swallowed
+  // the ReferenceError into a generic "validation failed: validateStringArray
+  // is not defined" message, so silent runtime breakage was possible.
+  //
+  // Exercise every validateStringArray call site (files, inputs, expectedOutput)
+  // so a future missing-import would surface as a per-field assertion failure
+  // here, not a deep ReferenceError that's easy to mis-diagnose.
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+
+    for (const field of ['files', 'inputs', 'expectedOutput'] as const) {
+      const result = await handlePlanSlice({
+        ...validParams(),
+        tasks: [{
+          ...validParams().tasks[0],
+          [field]: 'not-an-array' as unknown as string[],
+        }],
+      }, base);
+      assert.ok('error' in result, `${field}: expected validation error, got success`);
+      assert.match(
+        result.error,
+        new RegExp(`tasks\\[0\\]\\.${field} must be an array`),
+        `${field}: expected per-field validation message, got: ${result.error}`,
+      );
+      assert.doesNotMatch(
+        result.error,
+        /is not defined/,
+        `${field}: validation surfaced ReferenceError — likely a missing import in plan-slice.ts`,
+      );
+      assert.equal(getSliceTasks('M001', 'S02').length, 0, `${field}: invalid input must not persist`);
+    }
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## Summary
- Adds a focused regression test that exercises every `validateStringArray` call site in `plan-slice.ts` (`files`, `inputs`, `expectedOutput`) with non-array inputs.
- Locks in clean per-field validation errors so a future repeat of the `0b0e1a901` regression (call sites re-added without the import) fails this test with a clear `validateStringArray is not defined` diagnostic instead of being swallowed by `validateParams`'s catch.

## Why
Commit `0b0e1a901` re-added `validateStringArray()` calls inside `validateTasks` without re-adding its import. `tsc --noEmit` caught it, but the runtime path was masked: `validateParams`'s catch wrapped the `ReferenceError` into a generic `"validation failed: validateStringArray is not defined"` and most tests on the buggy commit weren't asserting on the message text, so a silent regression was possible. PR #5872 fixed the import; this test prevents recurrence.

## Test plan
- [x] `node --test src/resources/extensions/gsd/tests/plan-slice.test.ts` — all 17 tests pass
- [x] Re-introduced the bug locally (dropped `validateStringArray` from the import) and confirmed the new test fails with `expected per-field validation message, got: validation failed: validateStringArray is not defined`
- [x] Restored the import — full suite green again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to verify validation error handling for task input/output fields with non-array values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5891)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->