### PR TITLE
fix(gsd): reject unsafe verify commands before execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ The database is authoritative for milestones, slices, tasks, requirements, summa
 
 10. **Adaptive replanning** — After each slice completes, the roadmap is reassessed. If the work revealed new information that changes the plan, slices are reordered, added, or removed before continuing.
 
-11. **Verification enforcement** — Configure shell commands (`npm run lint`, `npm run test`, etc.) that run automatically after task execution. Failures trigger auto-fix retries before advancing. Execute-task commits and snapshots are deferred until verification passes; failed or incomplete verification blocks closeout instead of publishing changes. Auto-discovered checks from `package.json` run in advisory mode — they log warnings but don't block on pre-existing errors. Configurable via `verification_commands`, `verification_auto_fix`, and `verification_max_retries` preferences.
+11. **Verification enforcement** — Configure simple executable commands (`npm run lint`, `npm run test`, etc.) that run automatically after task execution. Verification commands must not use shell composition or control syntax such as pipes, redirects, semicolons, backticks, or command substitution. Failures trigger auto-fix retries before advancing. Execute-task commits and snapshots are deferred until verification passes; failed or incomplete verification blocks closeout instead of publishing changes. Auto-discovered checks from `package.json` and Python pytest project markers (`python-project`) run in advisory mode — they log warnings but don't block on pre-existing errors. Configurable via `verification_commands`, `verification_auto_fix`, and `verification_max_retries` preferences.
 
 12. **Milestone validation** — After all slices complete, a `validate-milestone` gate compares roadmap success criteria against actual results before sealing the milestone.
 
@@ -670,7 +670,7 @@ auto_report: true
 | `context_mode.exec_stdout_cap_bytes` | Persisted stdout cap for `gsd_exec` output (default: 1048576)                                      |
 | `context_mode.exec_digest_chars`  | Trailing stdout characters returned to the agent context (default: 300)                              |
 | `context_mode.exec_env_allowlist` | Environment variables forwarded to sandboxed `gsd_exec` runs in addition to `PATH` and `HOME`        |
-| `verification_commands`           | Array of shell commands to run after task execution (e.g., `["npm run lint", "npm run test"]`)        |
+| `verification_commands`           | Array of simple executable commands to run after task execution (e.g., `["npm run lint", "npm run test"]`); avoid pipes, redirects, semicolons, backticks, and command substitution |
 | `verification_auto_fix`           | Auto-retry on verification failures (default: true)                                                   |
 | `verification_max_retries`        | Max retries for verification failures (default: 2)                                                    |
 | `phases.require_slice_discussion` | Pause auto-mode before each slice for human discussion review                                         |

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -251,6 +251,10 @@ verification_max_retries: 2    # max retry attempts (default: 2)
 
 Failures trigger auto-fix retries — the agent sees the verification output and attempts to fix the issues before advancing. This ensures code quality gates are enforced mechanically, not by LLM compliance.
 
+Commands must be directly runnable checks such as `npm run lint`, `npm run test`, or `python3 -m pytest`. GSD rejects shell composition and control syntax in verification commands, including pipes, redirects, semicolons, backticks, and command substitution, so a piped command like `python3 -m pytest 2>&1 | tail -5` must be replaced with the underlying test command.
+
+If you do not configure commands and the task plan does not provide a `verify` command, GSD attempts project discovery. It checks `package.json` scripts first, then Python pytest markers through the `python-project` discovery source: test files under `tests/`, `pytest.ini`, or pytest configuration in `pyproject.toml`.
+
 ### Slice Discussion Gate (v2.26)
 
 For projects where you want human review before each slice begins:

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -465,7 +465,7 @@ verification_max_retries: 2       # max retry attempts (default: 2)
 
 Verification commands must be simple executable commands, not shell pipelines or scripts packed into one line. GSD rejects pipes (`|`), redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`) because verification is run as a controlled command list, not as an arbitrary shell program. Use `python3 -m pytest tests -q` instead of `python3 -m pytest tests -q 2>&1 | tail -5`.
 
-When `verification_commands` is empty and no task-level `verify` command is available, GSD can auto-discover project checks. JavaScript projects use `package.json` scripts in this order: `typecheck`, `lint`, `test`. Python projects use the `python-project` discovery source and run `python3 -m pytest` when GSD finds Python test files under `tests/`, `pytest.ini`, or pytest configuration in `pyproject.toml`.
+When `verification_commands` is empty and no task-level `verify` command is available, GSD can auto-discover project checks. JavaScript projects use `package.json` scripts in this order: `typecheck`, `lint`, `test`. Python projects use the `python-project` discovery source and run `python3 -m pytest` when GSD finds files matching pytest's default test file patterns (`test_*.py` or `*_test.py`) under `tests/` or an explicit pytest configuration marker: `pytest.ini`, `[tool.pytest]`, `[tool.pytest.*]`, `[pytest]`, or `[tool:pytest]` in `pyproject.toml`.
 
 ### URL Blocking (`fetch_page`)
 

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -459,9 +459,13 @@ verification_max_retries: 2       # max retry attempts (default: 2)
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `verification_commands` | string[] | `[]` | Shell commands to run after task execution |
+| `verification_commands` | string[] | `[]` | Simple executable commands to run after task execution |
 | `verification_auto_fix` | boolean | `true` | Auto-retry when verification fails |
 | `verification_max_retries` | number | `2` | Maximum auto-fix retry attempts |
+
+Verification commands must be simple executable commands, not shell pipelines or scripts packed into one line. GSD rejects pipes (`|`), redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`) because verification is run as a controlled command list, not as an arbitrary shell program. Use `python3 -m pytest tests -q` instead of `python3 -m pytest tests -q 2>&1 | tail -5`.
+
+When `verification_commands` is empty and no task-level `verify` command is available, GSD can auto-discover project checks. JavaScript projects use `package.json` scripts in this order: `typecheck`, `lint`, `test`. Python projects use the `python-project` discovery source and run `python3 -m pytest` when GSD finds Python test files under `tests/`, `pytest.ini`, or pytest configuration in `pyproject.toml`.
 
 ### URL Blocking (`fetch_page`)
 

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -400,6 +400,14 @@ For non-TTY environments (CI, cron, scripted automation), v2.79 adds `gsd headle
 
 **Fix:** Updated in v2.29+ to filter preference commands through `isLikelyCommand()`. Ensure `verification_commands` in preferences contains only valid shell commands, not descriptions.
 
+### Verification command is rejected as unsafe or non-runnable
+
+**Symptoms:** Pre-execution checks fail with `Unsafe or non-runnable Verify command`, often for a command that works in an interactive shell.
+
+**Cause:** GSD only accepts mechanically executable verification commands. Shell control syntax such as pipes (`|`), redirects (`>` or `<`), semicolons, backticks, and command substitution (`$(...)`) is rejected so verification cannot hide failures by trimming or reshaping output.
+
+**Fix:** Put the direct check in the verify field or `verification_commands`. For example, use `python3 -m pytest tests -q --tb=short` instead of `python3 -m pytest tests -q --tb=short 2>&1 | tail -5`.
+
 ## LSP (Language Server Protocol)
 
 ### "LSP isn't available in this workspace"

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -162,7 +162,7 @@ verification_max_retries: 2       # max attempts (default: 2)
 
 Verification commands must be simple executable commands, not shell pipelines or scripts packed into one line. GSD rejects pipes (`|`), redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`) because verification is run as a controlled command list, not as an arbitrary shell program. Use `python3 -m pytest tests -q` instead of `python3 -m pytest tests -q 2>&1 | tail -5`.
 
-When `verification_commands` is empty and no task-level `verify` command is available, GSD can auto-discover project checks. JavaScript projects use `package.json` scripts in this order: `typecheck`, `lint`, `test`. Python projects use the `python-project` discovery source and run `python3 -m pytest` when GSD finds Python test files under `tests/`, `pytest.ini`, or pytest configuration in `pyproject.toml`.
+When `verification_commands` is empty and no task-level `verify` command is available, GSD can auto-discover project checks. JavaScript projects use `package.json` scripts in this order: `typecheck`, `lint`, `test`. Python projects use the `python-project` discovery source and run `python3 -m pytest` when GSD finds explicit pytest evidence: `pytest.ini`, a pytest configuration section in `pyproject.toml` such as `[tool.pytest.ini_options]`, or files matching pytest's default test file patterns (`test_*.py` or `*_test.py`) under `tests/`.
 
 ### `phases`
 

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -160,6 +160,10 @@ verification_auto_fix: true       # auto-retry on failure (default)
 verification_max_retries: 2       # max attempts (default: 2)
 ```
 
+Verification commands must be simple executable commands, not shell pipelines or scripts packed into one line. GSD rejects pipes (`|`), redirects (`>` and `<`), semicolons, backticks, and command substitution (`$(...)`) because verification is run as a controlled command list, not as an arbitrary shell program. Use `python3 -m pytest tests -q` instead of `python3 -m pytest tests -q 2>&1 | tail -5`.
+
+When `verification_commands` is empty and no task-level `verify` command is available, GSD can auto-discover project checks. JavaScript projects use `package.json` scripts in this order: `typecheck`, `lint`, `test`. Python projects use the `python-project` discovery source and run `python3 -m pytest` when GSD finds Python test files under `tests/`, `pytest.ini`, or pytest configuration in `pyproject.toml`.
+
 ### `phases`
 
 Fine-grained control over which phases run:

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -209,7 +209,7 @@ If verification fails, the AI sees the output and attempts to fix the issues bef
 
 Commands must be directly runnable checks such as `npm run lint`, `npm run test`, or `python3 -m pytest`. GSD rejects shell composition and control syntax in verification commands, including pipes, redirects, semicolons, backticks, and command substitution, so a piped command like `python3 -m pytest 2>&1 | tail -5` must be replaced with the underlying test command.
 
-If no verification commands are configured and the task plan does not provide a `verify` command, GSD attempts project discovery. It checks `package.json` scripts first, then Python pytest markers through the `python-project` discovery source: test files under `tests/`, `pytest.ini`, or pytest configuration in `pyproject.toml`.
+If no verification commands are configured and the task plan does not provide a `verify` command, GSD attempts project discovery. It checks `package.json` scripts first, then Python pytest markers through the `python-project` discovery source: a `tests/` directory containing files that match `test_*.py` or `*_test.py` at any nested depth, `pytest.ini`, or pytest configuration sections in `pyproject.toml` such as `[tool.pytest.ini_options]`; equivalent pytest markers under `[tool.pytest]`, `[tool.pytest.*]`, `[pytest]`, or `[tool:pytest]` are also treated as explicit pytest evidence.
 
 ## Slice Discussion Gate
 

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -207,6 +207,10 @@ verification_max_retries: 2    # max retry attempts
 
 If verification fails, the AI sees the output and attempts to fix the issues before advancing. This ensures quality gates are enforced mechanically.
 
+Commands must be directly runnable checks such as `npm run lint`, `npm run test`, or `python3 -m pytest`. GSD rejects shell composition and control syntax in verification commands, including pipes, redirects, semicolons, backticks, and command substitution, so a piped command like `python3 -m pytest 2>&1 | tail -5` must be replaced with the underlying test command.
+
+If no verification commands are configured and the task plan does not provide a `verify` command, GSD attempts project discovery. It checks `package.json` scripts first, then Python pytest markers through the `python-project` discovery source: test files under `tests/`, `pytest.ini`, or pytest configuration in `pyproject.toml`.
+
 ## Slice Discussion Gate
 
 For projects requiring human review before each slice:

--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -23,6 +23,7 @@ import { homedir } from "node:os";
 import { resolve } from "node:path";
 import type { TaskRow } from "./db-task-slice-rows.js";
 import type { PreExecutionCheckJSON } from "./verification-evidence.ts";
+import { validateVerificationCommand } from "./verification-gate.js";
 
 const NPM_COMMAND = process.platform === "win32" ? "npm.cmd" : "npm";
 
@@ -35,6 +36,35 @@ export interface PreExecutionResult {
   checks: PreExecutionCheckJSON[];
   /** Total duration in milliseconds */
   durationMs: number;
+}
+
+export function checkVerificationCommands(tasks: TaskRow[]): PreExecutionCheckJSON[] {
+  const results: PreExecutionCheckJSON[] = [];
+
+  for (const task of tasks) {
+    const verify = task.verify.trim();
+    if (!verify) continue;
+
+    const commands = verify
+      .split("&&")
+      .map((command) => command.trim())
+      .filter(Boolean);
+
+    for (const command of commands) {
+      const validation = validateVerificationCommand(command);
+      if (!validation.ok) {
+        results.push({
+          category: "tool",
+          target: `${task.id} Verify`,
+          passed: false,
+          message: `Unsafe or non-runnable Verify command: ${command} (${validation.reason})`,
+          blocking: true,
+        });
+      }
+    }
+  }
+
+  return results;
 }
 
 // ─── Package Existence Check ─────────────────────────────────────────────────
@@ -757,8 +787,9 @@ export async function runPreExecutionChecks(
   const fileChecks = checkFilePathConsistency(tasks, basePath);
   const orderingChecks = checkTaskOrdering(tasks, basePath);
   const contractChecks = checkInterfaceContracts(tasks, basePath);
+  const verificationChecks = checkVerificationCommands(tasks);
 
-  allChecks.push(...fileChecks, ...orderingChecks, ...contractChecks);
+  allChecks.push(...fileChecks, ...orderingChecks, ...contractChecks, ...verificationChecks);
 
   // Run async package checks
   const packageChecks = await checkPackageExistence(tasks, basePath);

--- a/src/resources/extensions/gsd/templates/plan.md
+++ b/src/resources/extensions/gsd/templates/plan.md
@@ -131,10 +131,13 @@
 
   Verify field rules:
   - MUST be a mechanically executable command: `npm test`, `grep -q "pattern" file`, `test -f path`
+  - MUST NOT use shell pipes, redirects, semicolons, backticks, command substitution, or output trimming
   - For content/document tasks: verify file existence, section count, YAML validity, or word count
     NOT exact phrasing, specific formulas, or "zero TBD" aspirational criteria
   - If no command can verify the output, write: "Manual review — file exists and is non-empty"
+  - BAD: `python3 -m pytest tests/ -q --tb=short 2>&1 | tail -5`
   - BAD: "Sections 3.1 and 3.2 exist with exact formulas. Zero TBD/TODO."
+  - GOOD: `python3 -m pytest tests/ -q --tb=short`
   - GOOD: `grep -c "^## " doc.md` returns >= 4 (4+ sections), `! grep -q "TBD\|TODO" doc.md`
 
   Integration closure rule:

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -9,6 +9,7 @@
  *   2. File path consistency — files exist vs prior expected_output
  *   3. Task ordering — detect impossible read-before-create
  *   4. Interface contracts — contradictory function signatures
+ *   5. Verify commands — reject unsafe or non-runnable task verification
  */
 
 import { describe, test, mock } from "node:test";
@@ -22,6 +23,7 @@ import {
   checkFilePathConsistency,
   checkTaskOrdering,
   checkInterfaceContracts,
+  checkVerificationCommands,
   runPreExecutionChecks,
   normalizeFilePath,
   type PreExecutionResult,
@@ -812,6 +814,33 @@ function process(a: number): number
   });
 });
 
+describe("checkVerificationCommands", () => {
+  test("accepts pipe-free pytest Verify command", () => {
+    const results = checkVerificationCommands([
+      createTask({
+        id: "T01",
+        verify: "python3 -m pytest tests/ -q --tb=short",
+      }),
+    ]);
+
+    assert.deepEqual(results, []);
+  });
+
+  test("rejects piped pytest Verify command", () => {
+    const results = checkVerificationCommands([
+      createTask({
+        id: "T01",
+        verify: "python3 -m pytest tests/ -q --tb=short 2>&1 | tail -5",
+      }),
+    ]);
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.category, "tool");
+    assert.equal(results[0]?.blocking, true);
+    assert.match(results[0]?.message ?? "", /shell control syntax/);
+  });
+});
+
 // ─── runPreExecutionChecks Integration Tests ─────────────────────────────────
 
 describe("runPreExecutionChecks", () => {
@@ -842,6 +871,30 @@ describe("runPreExecutionChecks", () => {
       assert.equal(result.status, "pass");
       assert.equal(result.checks.length, 0);
       assert.ok(result.durationMs >= 0);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns fail status for unsafe Verify command before execution", async () => {
+    tempDir = join(tmpdir(), `pre-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+
+    try {
+      const tasks = [
+        createTask({
+          id: "T01",
+          verify: "python3 -m pytest tests/ -q --tb=short 2>&1 | tail -5",
+        }),
+      ];
+
+      const result = await runPreExecutionChecks(tasks, tempDir);
+
+      assert.equal(result.status, "fail");
+      assert.equal(result.checks.length, 1);
+      assert.equal(result.checks[0]?.category, "tool");
+      assert.equal(result.checks[0]?.blocking, true);
+      assert.match(result.checks[0]?.message ?? "", /Unsafe or non-runnable Verify command/);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -22,7 +22,7 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { discoverCommands, runVerificationGate, formatFailureContext, captureRuntimeErrors, runDependencyAudit, isLikelyCommand } from "../verification-gate.ts";
+import { discoverCommands, runVerificationGate, formatFailureContext, captureRuntimeErrors, runDependencyAudit, isLikelyCommand, validateVerificationCommand } from "../verification-gate.ts";
 import type { CaptureRuntimeErrorsOptions, DependencyAuditOptions } from "../verification-gate.ts";
 import { validatePreferences } from "../preferences.ts";
 
@@ -214,6 +214,33 @@ describe("verification-gate: discovery", () => {
     // "npm run test" is a valid command
     assert.equal(result.source, "task-plan");
     assert.deepStrictEqual(result.commands, ["npm run test"]);
+  });
+
+  test("taskPlanVerify rejects piped pytest command", () => {
+    const result = discoverCommands({
+      taskPlanVerify: "python3 -m pytest tests/ -q --tb=short 2>&1 | tail -5",
+      cwd: tmp,
+    });
+    assert.equal(result.source, "none");
+    assert.deepStrictEqual(result.commands, []);
+  });
+
+  test("Python project with tests discovers pytest when package.json is absent", () => {
+    mkdirSync(join(tmp, "tests"));
+    writeFileSync(
+      join(tmp, "pyproject.toml"),
+      `[project]
+name = "sample"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+`,
+    );
+
+    const result = discoverCommands({ cwd: tmp });
+
+    assert.equal(result.source, "python-project");
+    assert.deepStrictEqual(result.commands, ["python3 -m pytest"]);
   });
 });
 
@@ -457,6 +484,15 @@ test("isLikelyCommand: empty or whitespace-only strings are rejected", () => {
 test("isLikelyCommand: short lowercase tokens without flags are accepted (could be custom scripts)", () => {
   assert.equal(isLikelyCommand("custom-verify"), true);
   assert.equal(isLikelyCommand("mycheck"), true);
+});
+
+test("validateVerificationCommand rejects shell control syntax", () => {
+  assert.deepEqual(validateVerificationCommand("python3 -m pytest tests/ -q --tb=short").ok, true);
+  const result = validateVerificationCommand("python3 -m pytest tests/ -q --tb=short 2>&1 | tail -5");
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /shell control syntax/);
+  }
 });
 
 // ─── Additional Preference Validation Tests (T02) ──────────────────────────

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -280,8 +280,6 @@ pythonpath = ["."]
   test("Python project markers without pytest evidence do not discover pytest", () => {
     mkdirSync(join(tmp, "tests"));
     writeFileSync(join(tmp, "tests", "README.md"), "# tests\n");
-    writeFileSync(join(tmp, "tox.ini"), "[tox]\nenvlist = py\n");
-    writeFileSync(join(tmp, "setup.cfg"), "[metadata]\nname = sample\n");
     writeFileSync(
       join(tmp, "pyproject.toml"),
       `[project]
@@ -289,6 +287,24 @@ name = "sample"
 dependencies = ["pytest-cov"]
 `,
     );
+
+    const result = discoverCommands({ cwd: tmp });
+
+    assert.equal(result.source, "none");
+    assert.deepStrictEqual(result.commands, []);
+  });
+
+  test("Python project with setup.cfg alone does not discover pytest", () => {
+    writeFileSync(join(tmp, "setup.cfg"), "[tool:pytest]\npythonpath = .\n");
+
+    const result = discoverCommands({ cwd: tmp });
+
+    assert.equal(result.source, "none");
+    assert.deepStrictEqual(result.commands, []);
+  });
+
+  test("Python project with tox.ini alone does not discover pytest", () => {
+    writeFileSync(join(tmp, "tox.ini"), "[pytest]\npythonpath = .\n");
 
     const result = discoverCommands({ cwd: tmp });
 

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -227,6 +227,7 @@ describe("verification-gate: discovery", () => {
 
   test("Python project with tests discovers pytest when package.json is absent", () => {
     mkdirSync(join(tmp, "tests"));
+    writeFileSync(join(tmp, "tests", "test_sample.py"), "def test_sample():\n    assert True\n");
     writeFileSync(
       join(tmp, "pyproject.toml"),
       `[project]
@@ -241,6 +242,58 @@ pythonpath = ["."]
 
     assert.equal(result.source, "python-project");
     assert.deepStrictEqual(result.commands, ["python3 -m pytest"]);
+  });
+
+  test("Python project with nested Python test file discovers pytest", () => {
+    mkdirSync(join(tmp, "tests", "unit"), { recursive: true });
+    writeFileSync(join(tmp, "tests", "unit", "sample_test.py"), "def test_sample():\n    assert True\n");
+
+    const result = discoverCommands({ cwd: tmp });
+
+    assert.equal(result.source, "python-project");
+    assert.deepStrictEqual(result.commands, ["python3 -m pytest"]);
+  });
+
+  test("Python project with pytest.ini discovers pytest", () => {
+    writeFileSync(join(tmp, "pytest.ini"), "[pytest]\npythonpath = .\n");
+
+    const result = discoverCommands({ cwd: tmp });
+
+    assert.equal(result.source, "python-project");
+    assert.deepStrictEqual(result.commands, ["python3 -m pytest"]);
+  });
+
+  test("Python project with explicit pyproject pytest marker discovers pytest", () => {
+    writeFileSync(
+      join(tmp, "pyproject.toml"),
+      `[tool.pytest]
+pythonpath = ["."]
+`,
+    );
+
+    const result = discoverCommands({ cwd: tmp });
+
+    assert.equal(result.source, "python-project");
+    assert.deepStrictEqual(result.commands, ["python3 -m pytest"]);
+  });
+
+  test("Python project markers without pytest evidence do not discover pytest", () => {
+    mkdirSync(join(tmp, "tests"));
+    writeFileSync(join(tmp, "tests", "README.md"), "# tests\n");
+    writeFileSync(join(tmp, "tox.ini"), "[tox]\nenvlist = py\n");
+    writeFileSync(join(tmp, "setup.cfg"), "[metadata]\nname = sample\n");
+    writeFileSync(
+      join(tmp, "pyproject.toml"),
+      `[project]
+name = "sample"
+dependencies = ["pytest-cov"]
+`,
+    );
+
+    const result = discoverCommands({ cwd: tmp });
+
+    assert.equal(result.source, "none");
+    assert.deepStrictEqual(result.commands, []);
   });
 });
 

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -106,7 +106,7 @@ export interface AuditWarning {
 export interface VerificationResult {
   passed: boolean; // true if all checks passed (or no checks discovered)
   checks: VerificationCheck[]; // per-command results
-  discoverySource: "preference" | "task-plan" | "package-json" | "none";
+  discoverySource: "preference" | "task-plan" | "package-json" | "python-project" | "none";
   timestamp: number; // Date.now() at gate start
   runtimeErrors?: RuntimeError[]; // optional — populated by captureRuntimeErrors()
   auditWarnings?: AuditWarning[]; // optional — populated by runDependencyAudit()

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -4,7 +4,7 @@
 // First non-empty source wins.
 
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, type Dirent } from "node:fs";
 import { join, basename } from "node:path";
 import type { AuditWarning, RuntimeError, VerificationCheck, VerificationResult } from "./types.js";
 import { DEFAULT_COMMAND_TIMEOUT_MS } from "./constants.js";
@@ -102,25 +102,27 @@ export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCo
 }
 
 function discoverPythonPytestCommand(cwd: string): string | null {
-  const hasTestsDir = existsSync(join(cwd, "tests"));
-  const hasPytestConfig =
-    existsSync(join(cwd, "pytest.ini")) ||
-    existsSync(join(cwd, "tox.ini")) ||
-    existsSync(join(cwd, "setup.cfg"));
+  const hasPythonTestFiles = hasPythonTests(join(cwd, "tests"));
+  const hasPytestConfig = existsSync(join(cwd, "pytest.ini"));
   const pyprojectPath = join(cwd, "pyproject.toml");
   const hasPyproject = existsSync(pyprojectPath);
 
-  if (!hasTestsDir && !hasPytestConfig && !hasPyproject) {
+  if (!hasPythonTestFiles && !hasPytestConfig && !hasPyproject) {
     return null;
   }
 
-  if (hasPytestConfig || hasTestsDir) {
+  if (hasPytestConfig || hasPythonTestFiles) {
     return "python3 -m pytest";
   }
 
   try {
     const pyproject = readFileSync(pyprojectPath, "utf-8");
-    if (pyproject.includes("[tool.pytest") || pyproject.includes("pytest")) {
+    if (
+      pyproject.includes("[tool.pytest]") ||
+      pyproject.includes("[tool.pytest.") ||
+      pyproject.includes("[pytest]") ||
+      pyproject.includes("[tool:pytest]")
+    ) {
       return "python3 -m pytest";
     }
   } catch {
@@ -128,6 +130,27 @@ function discoverPythonPytestCommand(cwd: string): string | null {
   }
 
   return null;
+}
+
+function hasPythonTests(dir: string): boolean {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory() && hasPythonTests(path)) {
+      return true;
+    }
+    if (entry.isFile() && /^test_.*\.py$|^.*_test\.py$/.test(entry.name)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 // ─── Failure Context Formatting ──────────────────────────────────────────────

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -44,7 +44,8 @@ const PACKAGE_SCRIPT_KEYS = ["typecheck", "lint", "test"] as const;
  *   1. Explicit preference commands
  *   2. Task plan verify field (split on &&)
  *   3. package.json scripts (typecheck, lint, test)
- *   4. None found
+ *   4. Python pytest project markers
+ *   5. None found
  */
 export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCommands {
   // 1. Preference commands
@@ -91,8 +92,42 @@ export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCo
     }
   }
 
-  // 4. Nothing found
+  const pythonCommand = discoverPythonPytestCommand(options.cwd);
+  if (pythonCommand) {
+    return { commands: [pythonCommand], source: "python-project" };
+  }
+
+  // 5. Nothing found
   return { commands: [], source: "none" };
+}
+
+function discoverPythonPytestCommand(cwd: string): string | null {
+  const hasTestsDir = existsSync(join(cwd, "tests"));
+  const hasPytestConfig =
+    existsSync(join(cwd, "pytest.ini")) ||
+    existsSync(join(cwd, "tox.ini")) ||
+    existsSync(join(cwd, "setup.cfg"));
+  const pyprojectPath = join(cwd, "pyproject.toml");
+  const hasPyproject = existsSync(pyprojectPath);
+
+  if (!hasTestsDir && !hasPytestConfig && !hasPyproject) {
+    return null;
+  }
+
+  if (hasPytestConfig || hasTestsDir) {
+    return "python3 -m pytest";
+  }
+
+  try {
+    const pyproject = readFileSync(pyprojectPath, "utf-8");
+    if (pyproject.includes("[tool.pytest") || pyproject.includes("pytest")) {
+      return "python3 -m pytest";
+    }
+  } catch {
+    // Ignore unreadable pyproject.toml and fall through.
+  }
+
+  return null;
 }
 
 // ─── Failure Context Formatting ──────────────────────────────────────────────
@@ -144,7 +179,7 @@ export function formatFailureContext(result: VerificationResult): string {
 // ─── Gate Execution ─────────────────────────────────────────────────────────
 
 /** Characters that indicate shell injection when found in a command string. */
-const SHELL_INJECTION_PATTERN = /[;|`]|\$\(/;
+const SHELL_INJECTION_PATTERN = /[;|`<>]|\$\(/;
 
 /**
  * Known executable first-tokens that are safe to run.
@@ -219,9 +254,19 @@ export function isLikelyCommand(cmd: string): boolean {
  * Validate a command string for obvious shell injection patterns.
  * Returns the command unchanged if safe, or null if suspicious.
  */
+export function validateVerificationCommand(cmd: string): { ok: true } | { ok: false; reason: string } {
+  if (SHELL_INJECTION_PATTERN.test(cmd)) {
+    return { ok: false, reason: "contains shell control syntax such as pipes, redirects, semicolons, backticks, or command substitution" };
+  }
+  if (!isLikelyCommand(cmd)) {
+    return { ok: false, reason: "does not look like a runnable command" };
+  }
+  return { ok: true };
+}
+
 function sanitizeCommand(cmd: string): string | null {
-  if (SHELL_INJECTION_PATTERN.test(cmd)) return null;
-  if (!isLikelyCommand(cmd)) return null;
+  const validation = validateVerificationCommand(cmd);
+  if (!validation.ok) return null;
   return cmd;
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Reject unsafe task-plan Verify commands during pre-execution and discover pytest for Python projects.
**Why:** Piped Verify commands were being rejected only after task execution, causing a late fail-closed pause with no runnable host-owned checks.
**How:** Reuse verifier command validation in pre-exec checks, add Python pytest fallback discovery, and tighten plan-template guidance.

## What

- Adds a shared `validateVerificationCommand` helper for task Verify command safety.
- Adds `checkVerificationCommands` to pre-execution checks so pipes, redirects, semicolons, backticks, and command substitution block before task execution.
- Adds Python pytest fallback discovery for projects with `tests/`, pytest config, or pytest-related `pyproject.toml` when no explicit/project JS verification command exists.
- Updates the plan template to forbid output-trimming Verify commands like `... | tail -5`.
- Adds regression tests for pipe-free pytest acceptance, piped pytest rejection, pre-exec blocking, and Python pytest discovery.

Closes #5892

## Why

A task plan generated this Verify command:

```text
python3 -m pytest tests/ -q --tb=short 2>&1 | tail -5
```

The post-task verification gate correctly rejected the pipe as unsafe shell syntax, but because the rejection happened late, auto-mode paused after the task completed with `discoverySource: none` and no checks.

## How

Task-plan Verify command validation now runs in pre-execution checks. The same validation remains used by verification-gate discovery, so planning and execution agree on what is runnable. Python projects also get a host-owned fallback command of `python3 -m pytest` when no higher-priority verification source exists.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/verification-gate.test.ts src/resources/extensions/gsd/tests/pre-execution-checks.test.ts` — 174 passed, 0 failed
- `npm run typecheck:extensions` — passed
- `npm run verify:pr` — build + typecheck + unit tests passed; 9227 passed, 0 failed, 9 skipped
- `git diff --check` — passed

## Change Type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verification commands are validated before execution; unsafe or non-runnable commands produce blocking "tool" checks and can cause runs to fail.
  * Auto-discovery now detects Python projects and suggests pytest-based verification commands (reported as a Python-project discovery).

* **Documentation**
  * Verification guidance tightened: disallow shell composition/control syntax (pipes, redirects, semicolons, backticks, command substitution).

* **Tests**
  * Added coverage for verification-command safety, Python discovery, and end-to-end failure on unsafe commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5893)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->