### PR TITLE
fix(gsd): surface commit stderr in auto-mode git-action failures

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -36,6 +36,7 @@ import {
   type TaskCommitContext,
   type TurnGitActionMode,
 } from "./git-service.js";
+import { appendGitActionFailureLog } from "./git-action-failure-log.js";
 import {
   verifyExpectedArtifact,
   resolveExpectedArtifactPath,
@@ -604,12 +605,23 @@ async function runCloseoutGitAction(
           });
         }
 
-        const failureMsg = `Git ${turnAction} failed: ${(gitResult.error ?? "unknown error").split("\n")[0]}`;
+        const fullError = gitResult.error ?? "unknown error";
+        const logPath = appendGitActionFailureLog({
+          action: turnAction,
+          unitType: unit.type,
+          unitId: unit.id,
+          basePath: s.basePath,
+          error: fullError,
+        });
+        const firstLine = fullError.split("\n")[0];
+        const failureMsg = logPath
+          ? `Git ${turnAction} failed: ${firstLine} — see ${logPath}`
+          : `Git ${turnAction} failed: ${firstLine}`;
         ctx.ui.notify(failureMsg, opts?.softFailure ? "warning" : "error");
         debugLog("postUnit", {
           phase: opts?.softFailure ? "git-action-failed-soft" : "git-action-failed-blocking",
           action: turnAction,
-          error: gitResult.error ?? "unknown error",
+          error: fullError,
         });
         if (opts?.softFailure) {
           return "continue";
@@ -627,11 +639,29 @@ async function runCloseoutGitAction(
       }
     }
   } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
+    const errAny = e as { stderr?: unknown; stdout?: unknown };
+    const baseMessage = e instanceof Error ? e.message : String(e);
+    const stderrStr = typeof errAny.stderr === "string" ? errAny.stderr.trim() : "";
+    const stdoutStr = typeof errAny.stdout === "string" ? errAny.stdout.trim() : "";
+    const detailParts = [baseMessage];
+    if (stderrStr && !baseMessage.includes(stderrStr)) detailParts.push(stderrStr);
+    if (stdoutStr && !baseMessage.includes(stdoutStr) && !stderrStr.includes(stdoutStr)) detailParts.push(stdoutStr);
+    const message = detailParts.join("\n");
     s.lastGitActionFailure = message;
     s.lastGitActionStatus = "failed";
     debugLog("postUnit", { phase: "git-action", error: message, action: turnAction });
-    ctx.ui.notify(`Git ${turnAction} failed: ${message.split("\n")[0]}`, opts?.softFailure ? "warning" : "error");
+    const logPath = appendGitActionFailureLog({
+      action: turnAction,
+      unitType: unit.type,
+      unitId: unit.id,
+      basePath: s.basePath,
+      error: message,
+    });
+    const firstLine = message.split("\n")[0];
+    const notifyMsg = logPath
+      ? `Git ${turnAction} failed: ${firstLine} — see ${logPath}`
+      : `Git ${turnAction} failed: ${firstLine}`;
+    ctx.ui.notify(notifyMsg, opts?.softFailure ? "warning" : "error");
     if (opts?.softFailure) {
       return "continue";
     }

--- a/src/resources/extensions/gsd/git-action-failure-log.ts
+++ b/src/resources/extensions/gsd/git-action-failure-log.ts
@@ -1,0 +1,54 @@
+/**
+ * git-action-failure-log.ts — Persist multi-line git-action failures to
+ * ~/.gsd/git-action-failures.log (or $GSD_HOME/git-action-failures.log).
+ *
+ * Auto-mode's inline `ui.notify` is intentionally compact (single line), but
+ * the underlying git failure — hook stderr, signer error, etc. — is usually
+ * multi-line and load-bearing for the user. We append the full detail here
+ * and surface the log path in the UI so users have a stable place to look.
+ *
+ * Zero cross-dependencies beyond Node built-ins so it stays safe to call from
+ * any error path. Never throws.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Resolve the on-disk path of the git-action failure log. */
+export function gitActionFailureLogPath(): string {
+  const gsdHome = process.env.GSD_HOME ?? join(homedir(), ".gsd");
+  return join(gsdHome, "git-action-failures.log");
+}
+
+/**
+ * Append a git-action failure entry. Returns the log path on success,
+ * or `null` if the write failed (caller should still surface the inline
+ * one-liner — we never want to silently swallow the failure).
+ */
+export function appendGitActionFailureLog(entry: {
+  action: string;
+  unitType?: string;
+  unitId?: string;
+  basePath?: string;
+  error: string;
+}): string | null {
+  try {
+    const logPath = gitActionFailureLogPath();
+    mkdirSync(join(logPath, ".."), { recursive: true });
+    const lines = [
+      `[${new Date().toISOString()}] git ${entry.action} failed`,
+      ...(entry.unitType ? [`unit-type: ${entry.unitType}`] : []),
+      ...(entry.unitId ? [`unit-id: ${entry.unitId}`] : []),
+      ...(entry.basePath ? [`base-path: ${entry.basePath}`] : []),
+      "error:",
+      entry.error,
+      "",
+      "",
+    ];
+    appendFileSync(logPath, lines.join("\n"));
+    return logPath;
+  } catch {
+    return null;
+  }
+}

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -1200,8 +1200,31 @@ export function handleTurnGitActionError(action: TurnGitActionMode, err: unknown
   return {
     action,
     status: "failed",
-    error: getErrorMessage(err),
+    error: formatGitActionError(err),
   };
+}
+
+/**
+ * Build a multi-line error string that includes the underlying command's
+ * stderr (and any meaningful stdout) when available — git CLI failures from
+ * `execFileSync` populate `err.stderr` with the real reason (hook rejection,
+ * signer failure, etc.) while `err.message` is only "Command failed: …".
+ * Without this, auto-mode users see the bare command string with no clue why.
+ */
+function formatGitActionError(err: unknown): string {
+  const baseMessage = getErrorMessage(err);
+  if (!(err instanceof Error)) return baseMessage;
+  const extra = err as Error & { stdout?: unknown; stderr?: unknown };
+  const stderrStr = typeof extra.stderr === "string" ? extra.stderr : "";
+  const stdoutStr = typeof extra.stdout === "string" ? extra.stdout : "";
+  // If `nativeCommit` already folded stderr into `.message`, return as-is.
+  if (stderrStr && baseMessage.includes(stderrStr.trim())) return baseMessage;
+  const parts = [baseMessage];
+  const stderrTrim = stderrStr.trim();
+  const stdoutTrim = stdoutStr.trim();
+  if (stderrTrim) parts.push(stderrTrim);
+  if (stdoutTrim && !stderrTrim.includes(stdoutTrim)) parts.push(stdoutTrim);
+  return parts.join("\n");
 }
 
 export function runTurnGitAction(args: {

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -986,12 +986,33 @@ export function nativeCommit(
     });
     return result;
   } catch (err: unknown) {
-    const errObj = err as { stdout?: string; stderr?: string; message?: string };
-    const combined = [errObj.stdout, errObj.stderr, errObj.message].filter(Boolean).join(" ");
+    const errObj = err as { stdout?: string | Buffer; stderr?: string | Buffer; message?: string };
+    const stdoutStr = typeof errObj.stdout === "string" ? errObj.stdout : errObj.stdout?.toString("utf-8") ?? "";
+    const stderrStr = typeof errObj.stderr === "string" ? errObj.stderr : errObj.stderr?.toString("utf-8") ?? "";
+    const combined = [stdoutStr, stderrStr, errObj.message].filter(Boolean).join(" ");
     if (combined.includes("nothing to commit") || combined.includes("nothing added to commit") || combined.includes("no changes added")) {
       return null;
     }
-    throw err;
+    // Surface stderr (and any meaningful stdout) on the thrown error so
+    // downstream consumers — `handleTurnGitActionError`, auto-mode UI — can
+    // explain *why* the commit failed (hook rejection, signer failure, etc.)
+    // instead of just echoing "Command failed: git commit -F -".
+    const origMessage = errObj.message ?? "git commit failed";
+    const stderrTrim = stderrStr.trim();
+    const stdoutTrim = stdoutStr.trim();
+    const detailParts: string[] = [];
+    if (stderrTrim) detailParts.push(stderrTrim);
+    if (stdoutTrim && !stderrTrim.includes(stdoutTrim)) detailParts.push(stdoutTrim);
+    const detail = detailParts.join("\n");
+    const wrapped = new Error(detail ? `${origMessage}\n${detail}` : origMessage) as Error & {
+      stdout?: string;
+      stderr?: string;
+      cause?: unknown;
+    };
+    wrapped.stdout = stdoutStr;
+    wrapped.stderr = stderrStr;
+    wrapped.cause = err;
+    throw wrapped;
   }
 }
 

--- a/src/resources/extensions/gsd/tests/git-service-error-formatting.test.ts
+++ b/src/resources/extensions/gsd/tests/git-service-error-formatting.test.ts
@@ -1,0 +1,48 @@
+// git-service-error-formatting.test.ts — regression for #1
+//
+// `handleTurnGitActionError` used to call `getErrorMessage(err)` which only
+// reads `.message`. When `nativeCommit` failed under a rejecting hook, the
+// real reason lived on `err.stderr` and was dropped. Now the handler combines
+// `.message` with `.stderr` / `.stdout` so auto-mode's `runTurnGitAction`
+// result carries the user-actionable detail.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { handleTurnGitActionError } from "../git-service.js";
+
+describe("handleTurnGitActionError surfaces stderr", () => {
+  test("combines err.message with err.stderr when both are present", () => {
+    const err = new Error("Command failed: git commit -F -") as Error & {
+      stderr?: string;
+      stdout?: string;
+    };
+    err.stderr = "hook rejected: subject must start with feat|fix|…";
+    const result = handleTurnGitActionError("commit", err);
+    assert.equal(result.status, "failed");
+    assert.equal(result.action, "commit");
+    assert.ok(
+      result.error?.includes("Command failed: git commit -F -"),
+      `error should preserve original message; got: ${result.error}`,
+    );
+    assert.ok(
+      result.error?.includes("hook rejected: subject must start with feat|fix|…"),
+      `error should include stderr; got: ${result.error}`,
+    );
+  });
+
+  test("does not duplicate stderr already folded into message", () => {
+    const err = new Error(
+      "Command failed: git commit -F -\nhook rejected: bad subject",
+    ) as Error & { stderr?: string };
+    err.stderr = "hook rejected: bad subject";
+    const result = handleTurnGitActionError("commit", err);
+    const matches = result.error?.match(/hook rejected: bad subject/g) ?? [];
+    assert.equal(matches.length, 1, `stderr should not be duplicated; got: ${result.error}`);
+  });
+
+  test("falls back to plain message when no stderr/stdout present", () => {
+    const result = handleTurnGitActionError("commit", new Error("boom"));
+    assert.equal(result.status, "failed");
+    assert.equal(result.error, "boom");
+  });
+});

--- a/src/resources/extensions/gsd/tests/native-git-bridge-commit-stderr.test.ts
+++ b/src/resources/extensions/gsd/tests/native-git-bridge-commit-stderr.test.ts
@@ -1,0 +1,85 @@
+// native-git-bridge-commit-stderr.test.ts — regression for #1
+//
+// Before the fix, `nativeCommit` rethrew the raw error from `execFileSync`
+// whose `.message` is "Command failed: git commit -F -" — the actual reason
+// (hook stderr, signer failure, …) lived only on `err.stderr`. Downstream
+// consumers (`handleTurnGitActionError`, auto-mode's `ui.notify`) propagated
+// `err.message` and left users staring at a useless one-liner.
+//
+// The fix folds stderr into the thrown error's `.message` while preserving
+// `.stderr` / `.stdout` for structured consumers. This test installs a
+// commit-msg hook that rejects with a recognisable token and asserts the
+// thrown error carries that token in both `.message` and `.stderr`.
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { nativeCommit } from "../native-git-bridge.js";
+
+function git(args: string[], cwd: string): string {
+  // -c core.hooksPath=/dev/null neutralises the developer's global hookspath
+  // (e.g. a strict commit-msg validator) which would otherwise reject the
+  // sentinel "init" commit used to seed the test repo.
+  return execFileSync("git", ["-c", "core.hooksPath=/dev/null", ...args], {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  }).trim();
+}
+
+describe("nativeCommit surfaces hook stderr on failure", () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), "ngb-commit-stderr-"));
+    git(["init"], repo);
+    // Pin the hooks path to the repo's own .git/hooks so a developer's global
+    // core.hooksPath (e.g. a strict commit-msg validator) can't interfere with
+    // either the seed commit or the deliberately-rejecting hook installed below.
+    git(["config", "core.hooksPath", join(repo, ".git", "hooks")], repo);
+    git(["config", "user.email", "test@test.com"], repo);
+    git(["config", "user.name", "Test"], repo);
+    writeFileSync(join(repo, "file.txt"), "initial\n");
+    git(["add", "."], repo);
+    git(["commit", "-m", "init"], repo);
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  test("rejecting commit-msg hook stderr is surfaced on the thrown error", () => {
+    const REJECT_TOKEN = "GSD_TEST_HOOK_REJECTED_COMMIT_42";
+    const hookPath = join(repo, ".git", "hooks", "commit-msg");
+    writeFileSync(
+      hookPath,
+      `#!/bin/sh\necho "${REJECT_TOKEN}" 1>&2\nexit 1\n`,
+      "utf-8",
+    );
+    chmodSync(hookPath, 0o755);
+
+    writeFileSync(join(repo, "file.txt"), "modified\n");
+    git(["add", "."], repo);
+
+    let captured: unknown = null;
+    try {
+      nativeCommit(repo, "test: hook should reject");
+    } catch (e) {
+      captured = e;
+    }
+
+    assert.ok(captured instanceof Error, "nativeCommit should throw an Error");
+    const err = captured as Error & { stderr?: string; stdout?: string };
+    assert.ok(
+      err.message.includes(REJECT_TOKEN),
+      `error.message must include hook stderr; got: ${err.message}`,
+    );
+    assert.ok(
+      typeof err.stderr === "string" && err.stderr.includes(REJECT_TOKEN),
+      `error.stderr must be preserved; got: ${String(err.stderr)}`,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #5896.

## Summary

Surfaces `err.stderr` (and a slice of `err.stdout`) through three layers that were swallowing the real cause of "Git commit failed: Command failed: git commit -F -":

- `nativeCommit` (native-git-bridge): wraps the `execFileSync` error so `.message` includes stderr; preserves `.stderr`/`.stdout` on the wrapped error.
- `handleTurnGitActionError` (git-service): surfaces both `err.message` and `err.stderr` in `gitResult.error`.
- `auto-post-unit`: keeps UI notification compact (first line) but persists the full multi-line error to `~/.gsd/git-action-failures.log` and references the path in the notification.

## Files

- `src/resources/extensions/gsd/native-git-bridge.ts`
- `src/resources/extensions/gsd/git-service.ts`
- `src/resources/extensions/gsd/auto-post-unit.ts`
- `src/resources/extensions/gsd/git-action-failure-log.ts` (new — shared log writer)
- `src/resources/extensions/gsd/tests/native-git-bridge-commit-stderr.test.ts` (new)
- `src/resources/extensions/gsd/tests/git-service-error-formatting.test.ts` (new)

## Test plan

- [x] New unit tests assert wrapped error message contains hook stderr
- [x] `npm run typecheck:extensions` clean on touched files
- [x] New tests pass; pre-existing failures unchanged

## Caveats

- Subject line is 64 chars; passes upstream hook but exceeds the 50-char target.
- 180 pre-existing test failures from the host's global `core.hooksPath` rejecting test-fixture `git commit -m init` calls — same on `main`, worth filing as a separate test-isolation issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git action failures are now logged to a persistent file with diagnostic details.
  * Error notifications now include a path to access detailed failure logs.

* **Bug Fixes**
  * Improved error messages to include stderr and stdout from git operations for better troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5899)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->