### PR TITLE
fix(gsd): pre-validate commit subjects against documented type list

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -148,7 +148,7 @@ export interface TaskCommitContext {
  */
 export function buildTaskCommitMessage(ctx: TaskCommitContext): string {
   const description = sanitizeCommitSubjectDescription(ctx.oneLiner || ctx.taskTitle);
-  const type = inferCommitType(ctx.taskTitle, ctx.oneLiner);
+  const type = coerceCommitType(inferCommitType(ctx.taskTitle, ctx.oneLiner));
 
   // Truncate description to ~72 chars for subject line (full budget without scope)
   const maxDescLen = 70 - type.length;
@@ -1124,6 +1124,51 @@ export function runTurnGitAction(args: {
 }
 
 // ─── Commit Type Inference ─────────────────────────────────────────────────
+
+/**
+ * Conventional Commits types accepted by GSD's commit-message builders.
+ *
+ * Matches the set documented in GSD-WORKFLOW.md and aligns with the
+ * Conventional Commits standard. `inferCommitType` only ever produces a
+ * subset of these ("feat" plus the types listed in COMMIT_TYPE_RULES);
+ * `style` is included for compatibility with externally supplied types.
+ *
+ * Used by `coerceCommitType` to harden every code path that composes a
+ * `<type>: <subject>` line against malformed or unknown types — e.g. a
+ * future caller passing the type in directly, or a refactor of
+ * `inferCommitType` that accidentally widens its return set. Without this
+ * guard, an invalid type silently slips into `git commit` and a strict
+ * commit-msg hook rejects the commit with no actionable diagnostic.
+ */
+export const ALLOWED_COMMIT_TYPES = Object.freeze([
+  "feat",
+  "fix",
+  "docs",
+  "style",
+  "refactor",
+  "perf",
+  "test",
+  "chore",
+] as const);
+
+export type AllowedCommitType = typeof ALLOWED_COMMIT_TYPES[number];
+
+const ALLOWED_COMMIT_TYPE_SET: ReadonlySet<string> = new Set(ALLOWED_COMMIT_TYPES);
+
+/**
+ * Validate a commit type against ALLOWED_COMMIT_TYPES. Unknown types fall
+ * back to "chore" and a warning is logged to stderr so the substitution is
+ * visible in auto-mode logs. This keeps commit construction crash-free
+ * while preventing invalid types from reaching `git commit`.
+ */
+export function coerceCommitType(type: string): AllowedCommitType {
+  if (ALLOWED_COMMIT_TYPE_SET.has(type)) return type as AllowedCommitType;
+  console.warn(
+    `[gsd] Unknown commit type "${type}"; falling back to "chore". ` +
+    `Allowed types: ${ALLOWED_COMMIT_TYPES.join(", ")}`,
+  );
+  return "chore";
+}
 
 /**
  * Infer a conventional commit type from a title (and optional one-liner).

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -8,6 +8,8 @@ import { execSync } from "node:child_process";
 import {
   inferCommitType,
   buildTaskCommitMessage,
+  coerceCommitType,
+  ALLOWED_COMMIT_TYPES,
   GitServiceImpl,
   MergeConflictError,
   RUNTIME_EXCLUSION_PATHS,
@@ -254,6 +256,65 @@ describe('git-service', async () => {
     assert.ok(msg.startsWith("test:"), "infers test type");
     assert.ok(msg.includes("GSD-Task: S01/T03"), "GSD-Task trailer present");
   }
+
+  // ─── coerceCommitType ──────────────────────────────────────────────────
+
+  test('coerceCommitType: passes through allowed types unchanged', () => {
+    for (const type of ALLOWED_COMMIT_TYPES) {
+      assert.equal(coerceCommitType(type), type, `${type} is allowed`);
+    }
+  });
+
+  test('coerceCommitType: rewrites unknown types to chore with warning', () => {
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (msg: string) => { warnings.push(msg); };
+    try {
+      assert.equal(coerceCommitType("wip"), "chore", "wip rewrites to chore");
+      assert.equal(coerceCommitType("cleanup"), "chore", "cleanup rewrites to chore");
+      assert.equal(coerceCommitType(""), "chore", "empty rewrites to chore");
+      assert.equal(coerceCommitType("FEAT"), "chore", "uppercase rewrites to chore (allowlist is lowercase)");
+      assert.equal(warnings.length, 4, "one warning per unknown type");
+      assert.ok(warnings[0]!.includes("wip"), "warning names the bad type");
+      assert.ok(warnings[0]!.includes("chore"), "warning names the fallback");
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test('coerceCommitType: inferCommitType output is always allowed', () => {
+    // Every type COMMIT_TYPE_RULES can produce — plus the "feat" default —
+    // must be in ALLOWED_COMMIT_TYPES so coerceCommitType is a no-op on the
+    // normal path. Guards against future drift where a new rule adds a type
+    // that the allowlist doesn't know about.
+    const inferredTypes = [
+      inferCommitType("Implement user authentication"), // feat (default)
+      inferCommitType("Fix login redirect bug"),         // fix
+      inferCommitType("Refactor state management"),      // refactor
+      inferCommitType("Update API documentation"),       // docs
+      inferCommitType("Add tests for auth"),             // test
+      inferCommitType("Optimize cache performance"),     // perf
+      inferCommitType("Bump dependencies"),              // chore
+    ];
+    for (const t of inferredTypes) {
+      assert.ok((ALLOWED_COMMIT_TYPES as readonly string[]).includes(t), `inferCommitType produced "${t}" — must be in ALLOWED_COMMIT_TYPES`);
+    }
+  });
+
+  test('buildTaskCommitMessage: invalid synthesized type would fall back to chore', () => {
+    // Defense-in-depth: if a caller (or future refactor of inferCommitType)
+    // produced an invalid type, buildTaskCommitMessage must not emit it into
+    // the subject line — strict commit-msg hooks would reject the commit
+    // with no actionable diagnostic. Exercised here via coerceCommitType
+    // directly since inferCommitType always returns an allowed type today.
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      assert.equal(coerceCommitType("wip"), "chore", "wip → chore prevents `wip: ...` subject");
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
 
   // ─── RUNTIME_EXCLUSION_PATHS ───────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds defense-in-depth so an unexpected commit type can't slip through to `git commit` and trip a Conventional Commits hook:

- Exports `ALLOWED_COMMIT_TYPES` tuple as the single source of truth.
- Adds `coerceCommitType(type)`: returns the type if valid, otherwise warns and falls back to `chore`.
- Wires it into `buildTaskCommitMessage` so the commit subject's type is guaranteed-valid before assembly.

## Files

- `src/resources/extensions/gsd/git-service.ts`
- `src/resources/extensions/gsd/tests/integration/git-service.test.ts` (4 new tests)

## Test plan

- [x] 62/62 git-service integration tests pass
- [x] New tests cover: passthrough of valid types, unknown-type warning+fallback, `inferCommitType ⊆ ALLOWED_COMMIT_TYPES` invariant, defense-in-depth at build-message layer
- [x] `npm run typecheck:extensions` clean on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened commit type validation to prevent malformed commits from being generated
  * Invalid or unknown commit types are now automatically corrected to "chore" with logged warnings
  * Added safeguards to ensure generated commits use only approved, supported types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5901)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->