### PR TITLE
fix(gsd): keep markdown projections subordinate to db

### DIFF
--- a/docs/dev/ADR-017-state-reconciliation-drift-driven.md
+++ b/docs/dev/ADR-017-state-reconciliation-drift-driven.md
@@ -45,12 +45,12 @@ type DriftRecord =
 ```
 
 `roadmap-divergence` means the milestone `ROADMAP.md` projection and DB slice
-rows no longer agree on slice presence, sequence, or declared `depends` values.
-Its repair treats `ROADMAP.md` as the source of truth: the markdown hierarchy is
-re-imported into the DB, then each parsed slice's `depends` list is synced into
-the `slice_dependencies` junction table. This keeps both the JSON `slices.depends`
-column and the relational dependency view aligned before Dispatch decides which
-slice or task can run.
+rows no longer agree on slice presence, sequence, checkbox state, or declared
+`depends` values. Runtime repair treats the DB as authoritative: the ROADMAP
+projection is regenerated from DB rows. It must not import slice presence,
+sequence, dependencies, or completion state from rendered markdown during
+Dispatch or worker-spawn reconciliation. Markdown hierarchy import remains
+available only through explicit recovery/migration commands.
 
 ### Lifecycle
 
@@ -134,7 +134,7 @@ Add new `RecoveryFailureKind: "reconciliation-drift"` with action `escalate` and
 
 - `gsd-db.ts:1156` `autoHealSketchFlags` relocates to `state-reconciliation/drift/sketch-flag.ts`. `gsd-db.ts` keeps `setSliceSketchFlag` and the SELECT primitive.
 - `auto-recovery.ts:1118` `reconcileMergeState` and supporting helpers relocate to `state-reconciliation/drift/merge-state.ts`. `auto-recovery.ts` shrinks; remaining post-failure helpers (`verifyExpectedArtifact`, `writeBlockerPlaceholder`) stay.
-- Four new repair functions land: stale-worker, PROJECT.md sync, ROADMAP.md sync, completion-timestamp backfill.
+- Four new repair functions land: stale-worker, PROJECT.md blocker/recovery guidance, ROADMAP.md projection regeneration, completion-timestamp backfill.
 - `state.ts` `blockers: string[]` is unchanged; existing call sites that read `s.blockers` are unaffected.
 - Detector cost is paid on every `advance()` tick. Cheap detectors (DB queries, `existsSync`) run unconditionally; markdown-parsing detectors must be designed to short-circuit when artifacts are unchanged.
 - Every drift kind has a contract test: seeded drift → reconcile → assert repaired. Persistent-drift cases are tested with non-idempotent fixture setups.

--- a/docs/dev/ADR-018-project-authority-contract.md
+++ b/docs/dev/ADR-018-project-authority-contract.md
@@ -1,0 +1,42 @@
+<!-- Project/App: GSD-2 -->
+<!-- File Purpose: ADR for PROJECT.md authority and projection semantics. -->
+
+# ADR-018: PROJECT Authority Contract
+
+**Status:** Accepted
+**Date:** 2026-05-13
+**Author:** GSD architecture review
+**Related:** ADR-013 (memory store consolidation), ADR-015 (runtime invariant modules), ADR-017 (drift-driven state reconciliation), issues #5911 and #5912
+
+## Context
+
+The DB-authoritative runtime model treats `.gsd/**` markdown files as projections unless an explicit recovery or migration command says otherwise. `PROJECT.md` was still ambiguous: prompts described it as a file agents could write directly, while `gsd_summary_save(PROJECT)` also persisted the artifact into the database and registered milestone rows from its Milestone Sequence.
+
+That ambiguity makes future prompt and write-gate work hard to reason about. If direct `PROJECT.md` writes are valid, then markdown can silently become a second authority for project state. If direct writes are invalid, agents need one tool path that records the artifact, updates the disk projection, and performs any DB registration side effects.
+
+## Decision
+
+`PROJECT.md` is a DB-backed project artifact whose disk file is a projection. The canonical write path is `gsd_summary_save` with `artifact_type: "PROJECT"`.
+
+The accepted contract is:
+
+- The artifact content is persisted in the DB artifacts table before projection writes are attempted.
+- The disk file `.gsd/PROJECT.md` is a human-readable projection of the DB-backed artifact content.
+- Milestone registration side effects are owned by the PROJECT tool path. A valid PROJECT save may parse the submitted project content to register milestone rows, but that parsing is part of the DB-backed tool surface, not a direct markdown import.
+- Normal runtime, dispatch, reconciliation, and guided startup must not treat hand-edited `PROJECT.md` as authoritative DB state.
+- Direct `PROJECT.md` edits are only valid as explicit recovery/migration input, or as operator-authored draft material before it is persisted through the DB-backed tool.
+- When disk and DB disagree, runtime keeps DB authority and should either regenerate the projection or surface explicit recovery guidance. It must not silently import the disk file.
+
+## Consequences
+
+- Prompts should instruct agents to call `gsd_summary_save(PROJECT)`, not to use generic write/edit tools on `.gsd/PROJECT.md`.
+- Write gates and tool contracts may block or warn on direct PROJECT writes during normal workflow units.
+- Queue, discussion, and completion flows need prompt cleanup so PROJECT updates use the tool contract.
+- Tests should prove direct PROJECT projection changes do not mutate runtime DB state outside explicit recovery/import commands.
+- Existing explicit recovery/import commands can continue to read markdown as operator-selected recovery input.
+
+## Alternatives considered
+
+- **Keep PROJECT as a hand-authored source of truth.** Rejected because it preserves split-brain behavior between markdown and DB state.
+- **Make PROJECT a pure generated projection with no submitted content.** Rejected for now because project setup and discussion flows still need a human-authored narrative artifact. The DB-backed tool path preserves that narrative while keeping one authoritative write path.
+- **Hybrid without a tool boundary.** Rejected because it leaves callers guessing which fields are canonical and which writes are projections.

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -2124,18 +2124,18 @@ export async function showSmartEntry(
 
   if (interrupted.classification !== "recoverable") {
     try {
-      const { autoImportMarkdownHierarchyIfDbMismatch } = await import("./migration-auto-check.js");
-      const result = await autoImportMarkdownHierarchyIfDbMismatch(basePath);
-      if (result.action === "imported") {
+      const { checkMarkdownHierarchyAgainstDb } = await import("./migration-auto-check.js");
+      const result = await checkMarkdownHierarchyAgainstDb(basePath);
+      if (result.action === "recovery-required") {
         ctx.ui.notify(
-          `Recovered migrated planning state into gsd.db (${result.reason}): ${result.afterDb.milestones} milestone(s), ${result.afterDb.slices} slice(s), ${result.afterDb.tasks} task(s).`,
-          "info",
+          `${result.message ?? "Markdown planning artifacts do not match the authoritative DB."} Run \`${result.recoveryCommand ?? "gsd recover"}\` to import markdown explicitly.`,
+          "warning",
         );
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.ui.notify(`GSD could not auto-import existing planning state into gsd.db: ${message}`, "warning");
-      logWarning("guided", `planning state auto-import failed: ${message}`, { file: "guided-flow.ts" });
+      ctx.ui.notify(`GSD could not compare markdown planning artifacts with gsd.db: ${message}`, "warning");
+      logWarning("guided", `planning state DB/markdown comparison failed: ${message}`, { file: "guided-flow.ts" });
     }
   }
 

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -2128,7 +2128,8 @@ export async function showSmartEntry(
       const result = await checkMarkdownHierarchyAgainstDb(basePath);
       if (result.action === "recovery-required") {
         ctx.ui.notify(
-          `${result.message ?? "Markdown planning artifacts do not match the authoritative DB."} Run \`${result.recoveryCommand ?? "gsd recover"}\` to import markdown explicitly.`,
+          result.message ??
+            `Markdown planning artifacts do not match the authoritative DB. Run \`${result.recoveryCommand ?? "gsd recover"}\` to import markdown explicitly.`,
           "warning",
         );
       }

--- a/src/resources/extensions/gsd/migration-auto-check.ts
+++ b/src/resources/extensions/gsd/migration-auto-check.ts
@@ -2,21 +2,17 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 
 import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
 import {
-  clearEngineHierarchy,
   getAllMilestones,
   getMilestoneSlices,
   getSliceTasks,
   isDbAvailable,
-  transaction,
 } from "./gsd-db.js";
-import { migrateHierarchyToDb } from "./md-importer.js";
 import { parsePlan, parseRoadmap } from "./parsers-legacy.js";
 import {
   milestonesDir,
   resolveMilestoneFile,
   resolveSliceFile,
 } from "./paths.js";
-import { invalidateStateCache } from "./state.js";
 
 export interface HierarchyCounts {
   milestones: number;
@@ -25,11 +21,13 @@ export interface HierarchyCounts {
 }
 
 export interface MigrationAutoCheckResult {
-  action: "none" | "imported";
+  action: "none" | "recovery-required";
   reason: "no-markdown" | "in-sync" | "db-empty" | "count-mismatch";
   markdown: HierarchyCounts;
   beforeDb: HierarchyCounts;
   afterDb: HierarchyCounts;
+  recoveryCommand?: string;
+  message?: string;
 }
 
 function zeroCounts(): HierarchyCounts {
@@ -83,7 +81,7 @@ export function countDbHierarchy(): HierarchyCounts {
   return counts;
 }
 
-export async function autoImportMarkdownHierarchyIfDbMismatch(
+export async function checkMarkdownHierarchyAgainstDb(
   basePath: string,
 ): Promise<MigrationAutoCheckResult> {
   const markdown = countMarkdownHierarchy(basePath);
@@ -108,22 +106,16 @@ export async function autoImportMarkdownHierarchyIfDbMismatch(
   }
 
   const reason = sameCounts(beforeDb, zeroCounts()) ? "db-empty" : "count-mismatch";
-  const imported = transaction(() => {
-    clearEngineHierarchy();
-    return migrateHierarchyToDb(basePath);
-  });
-  invalidateStateCache();
-
-  const afterDb = {
-    milestones: imported.milestones,
-    slices: imported.slices,
-    tasks: imported.tasks,
+  return {
+    action: "recovery-required",
+    reason,
+    markdown,
+    beforeDb,
+    afterDb: beforeDb,
+    recoveryCommand: "gsd recover",
+    message:
+      `Markdown planning artifacts (${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T) ` +
+      `do not match the authoritative DB (${beforeDb.milestones}M/${beforeDb.slices}S/${beforeDb.tasks}T). ` +
+      "Runtime startup will not import markdown automatically; run explicit GSD recovery if markdown should repopulate the database.",
   };
-  if (!sameCounts(markdown, afterDb)) {
-    throw new Error(
-      `migration auto-import verification failed: markdown ${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T, db ${afterDb.milestones}M/${afterDb.slices}S/${afterDb.tasks}T`,
-    );
-  }
-
-  return { action: "imported", reason, markdown, beforeDb, afterDb };
 }

--- a/src/resources/extensions/gsd/state-reconciliation/drift/project-md.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/project-md.ts
@@ -1,14 +1,13 @@
 // Project/App: GSD-2
 // File Purpose: ADR-017 unregistered-milestone drift handler. Detects
 // milestones whose on-disk directory has meaningful content (ROADMAP/
-// CONTEXT/SUMMARY) but no DB row, then runs the markdown importer to
-// reconcile. PROJECT.md is the human-facing index — the importer's source
-// of truth is the .gsd/milestones/ directory tree.
+// CONTEXT/SUMMARY) but no DB row, then fails closed with an explicit recovery
+// instruction. Markdown hierarchy import is reserved for operator-controlled
+// migration/recovery commands, not automatic runtime reconciliation.
 
 import { existsSync } from "node:fs";
 
 import { getMilestone, isDbAvailable } from "../../gsd-db.js";
-import { migrateHierarchyToDb } from "../../md-importer.js";
 import { findMilestoneIds } from "../../milestone-ids.js";
 import { resolveMilestoneFile } from "../../paths.js";
 import type { GSDState } from "../../types.js";
@@ -46,20 +45,18 @@ export function detectUnregisteredMilestoneDrift(
 }
 
 /**
- * Repair: invoke the markdown importer. migrateHierarchyToDb walks the same
- * findMilestoneIds list the detector uses and INSERTs OR IGNOREs every
- * missing milestone (and its slices/tasks) — idempotent under cap=2 retry.
- *
- * Note: even though we receive one record at a time, the importer is a
- * project-wide operation. Repeated invocation across multiple drift records
- * in the same pass is wasteful but safe; a future optimization could
- * coalesce by checking whether the importer has already run this pass.
+ * Repair intentionally fails closed. The project-root DB is authoritative at
+ * runtime; markdown-only milestones must be imported through an explicit
+ * migration/recovery command so operators opt into changing canonical state.
  */
 export function repairUnregisteredMilestone(
-  _record: UnregisteredMilestoneDrift,
-  ctx: DriftContext,
+  record: UnregisteredMilestoneDrift,
+  _ctx: DriftContext,
 ): void {
-  migrateHierarchyToDb(ctx.basePath);
+  throw new Error(
+    `Milestone ${record.milestoneId} exists only as markdown projection. ` +
+      "Runtime reconciliation will not import markdown into the authoritative DB; run explicit GSD recovery/migration if this markdown should repopulate the database.",
+  );
 }
 
 export const unregisteredMilestoneHandler: DriftHandler<UnregisteredMilestoneDrift> = {

--- a/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
+++ b/src/resources/extensions/gsd/state-reconciliation/drift/roadmap.ts
@@ -1,8 +1,8 @@
 // Project/App: GSD-2
 // File Purpose: ADR-017 roadmap-divergence drift handler. Detects mismatches
-// between ROADMAP.md (parsed slice sequence + depends declarations) and the
-// DB slice rows for that milestone, then reconciles via the markdown
-// importer plus an explicit junction-table sync.
+// between ROADMAP.md (parsed slice sequence, depends declarations, and
+// checkboxes) and the DB slice rows for that milestone, then re-renders the
+// ROADMAP projection from the authoritative DB rows.
 
 import { existsSync, readFileSync } from "node:fs";
 
@@ -10,12 +10,12 @@ import {
   getMilestone,
   getMilestoneSlices,
   isDbAvailable,
-  syncSliceDependencies,
 } from "../../gsd-db.js";
-import { migrateHierarchyToDb } from "../../md-importer.js";
+import { renderRoadmapFromDb } from "../../markdown-renderer.js";
 import { findMilestoneIds } from "../../milestone-ids.js";
 import { parseRoadmap } from "../../parsers-legacy.js";
 import { resolveMilestoneFile } from "../../paths.js";
+import { isClosedStatus } from "../../status-guards.js";
 import type { GSDState } from "../../types.js";
 import type { DriftContext, DriftHandler, DriftRecord } from "../types.js";
 
@@ -46,14 +46,20 @@ function milestoneHasDivergence(
 
   const dbSlices = getMilestoneSlices(milestoneId);
   const dbSliceMap = new Map(dbSlices.map((s) => [s.id, s]));
+  const roadmapSliceIds = new Set<string>();
 
   for (let i = 0; i < roadmap.slices.length; i++) {
     const roadmapSlice = roadmap.slices[i]!;
+    roadmapSliceIds.add(roadmapSlice.id);
     const expectedSequence = i + 1;
     const dbSlice = dbSliceMap.get(roadmapSlice.id);
     if (!dbSlice) return true; // Roadmap has a slice the DB doesn't.
     if (dbSlice.sequence !== expectedSequence) return true;
     if (!arraysEqual(dbSlice.depends, roadmapSlice.depends)) return true;
+    if (isClosedStatus(dbSlice.status) !== roadmapSlice.done) return true;
+  }
+  for (const dbSlice of dbSlices) {
+    if (!roadmapSliceIds.has(dbSlice.id)) return true;
   }
   return false;
 }
@@ -77,29 +83,15 @@ export function detectRoadmapDivergenceDrift(
 }
 
 /**
- * Repair a milestone's roadmap divergence:
- *   1. migrateHierarchyToDb upserts slice rows (sequence + depends JSON
- *      update via ON CONFLICT DO UPDATE).
- *   2. syncSliceDependencies updates the junction table per slice — the
- *      importer only writes the JSON column, not the relational view.
+ * Repair a milestone's roadmap divergence by regenerating the projection from
+ * DB rows. ROADMAP.md is a projection; runtime reconciliation must not import
+ * slice presence, sequence, dependencies, or checkbox state from markdown.
  */
-export function repairRoadmapDivergence(
+export async function repairRoadmapDivergence(
   record: RoadmapDivergenceDrift,
   ctx: DriftContext,
-): void {
-  migrateHierarchyToDb(ctx.basePath);
-
-  const roadmapPath = resolveMilestoneFile(ctx.basePath, record.milestoneId, "ROADMAP");
-  if (!roadmapPath || !existsSync(roadmapPath)) return;
-
-  try {
-    const roadmap = parseRoadmap(readFileSync(roadmapPath, "utf-8"));
-    for (const slice of roadmap.slices) {
-      syncSliceDependencies(record.milestoneId, slice.id, slice.depends);
-    }
-  } catch {
-    /* parse failure: detector will fire again next pass */
-  }
+): Promise<void> {
+  await renderRoadmapFromDb(ctx.basePath, record.milestoneId);
 }
 
 export const roadmapDivergenceHandler: DriftHandler<RoadmapDivergenceDrift> = {

--- a/src/resources/extensions/gsd/tests/db-authority-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/db-authority-regression.test.ts
@@ -1,0 +1,208 @@
+// Project/App: GSD-2
+// File Purpose: Regression tests for DB authority over markdown projections.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  closeDatabase,
+  getAllMilestones,
+  getSliceTasks,
+  insertMilestone,
+  insertRequirement,
+  insertSlice,
+  openDatabase,
+} from "../gsd-db.ts";
+import { migrateHierarchyToDb } from "../md-importer.ts";
+import { checkMarkdownHierarchyAgainstDb } from "../migration-auto-check.ts";
+import { queryDecisions } from "../context-store.ts";
+import { deriveStateFromDb, invalidateStateCache } from "../state.ts";
+import type { Requirement } from "../types.ts";
+
+function makeBase(prefix = "gsd-db-authority-"): string {
+  const base = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try {
+    closeDatabase();
+  } catch {
+    /* noop */
+  }
+  rmSync(base, { recursive: true, force: true });
+}
+
+function openProjectDb(base: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+}
+
+function activeRequirement(id: string): Requirement {
+  return {
+    id,
+    class: "functional",
+    status: "active",
+    description: `${id} from DB`,
+    why: "DB authority regression fixture",
+    source: "test",
+    primary_owner: "M999/S01",
+    supporting_slices: "",
+    validation: "derive state",
+    notes: "",
+    full_content: `${id} from DB`,
+    superseded_by: null,
+  };
+}
+
+test("DB authority: PROJECT.md and QUEUE-ORDER projections do not choose runtime milestone", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "PROJECT.md"),
+    [
+      "# Projection Project",
+      "",
+      "## Milestone Sequence",
+      "- [ ] M001: Projection Only -- should not become active",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(base, ".gsd", "QUEUE-ORDER.json"),
+    JSON.stringify({ order: ["M001", "M999"], updatedAt: new Date().toISOString() }),
+  );
+
+  openProjectDb(base);
+  insertMilestone({ id: "M999", title: "DB Milestone", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M999", title: "DB Slice", status: "pending", risk: "low", depends: [], demo: "DB demo", sequence: 1 });
+
+  invalidateStateCache();
+  const state = await deriveStateFromDb(base);
+
+  assert.equal(state.activeMilestone?.id, "M999");
+  assert.equal(state.registry.some((entry) => entry.id === "M001"), false);
+});
+
+test("DB authority: REQUIREMENTS.md and DECISIONS.md projections do not populate DB reads", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+
+  writeFileSync(
+    join(base, ".gsd", "REQUIREMENTS.md"),
+    [
+      "# Requirements",
+      "",
+      "## Active",
+      "### R001 - Projection-only requirement",
+      "- Class: functional",
+      "- Status: active",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(base, ".gsd", "DECISIONS.md"),
+    [
+      "# Decisions",
+      "",
+      "| # | When / Context | Scope | Decision | Choice | Rationale | Revisable | Made By |",
+      "|---|----------------|-------|----------|--------|-----------|----------|---------|",
+      "| D001 | Now | global | Projection-only decision | Ignore | DB is authority | Yes | human |",
+      "",
+    ].join("\n"),
+  );
+
+  openProjectDb(base);
+  insertMilestone({ id: "M999", title: "DB Milestone", status: "active" });
+
+  invalidateStateCache();
+  const state = await deriveStateFromDb(base);
+
+  assert.deepEqual(state.requirements, {
+    active: 0,
+    validated: 0,
+    deferred: 0,
+    outOfScope: 0,
+    blocked: 0,
+    total: 0,
+  });
+  assert.deepEqual(queryDecisions(), []);
+});
+
+test("DB authority: DB requirements remain canonical when REQUIREMENTS.md disagrees", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+
+  writeFileSync(
+    join(base, ".gsd", "REQUIREMENTS.md"),
+    [
+      "# Requirements",
+      "",
+      "## Active",
+      "### R999 - Projection-only requirement",
+      "- Class: functional",
+      "- Status: active",
+      "",
+    ].join("\n"),
+  );
+
+  openProjectDb(base);
+  insertMilestone({ id: "M999", title: "DB Milestone", status: "active" });
+  insertRequirement(activeRequirement("R001"));
+
+  invalidateStateCache();
+  const state = await deriveStateFromDb(base);
+
+  assert.ok(state.requirements);
+  assert.equal(state.requirements.active, 1);
+  assert.equal(state.requirements.total, 1);
+});
+
+test("explicit markdown import remains opt-in and is not run by startup mismatch check", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  const sliceDir = join(milestoneDir, "slices", "S01");
+  const tasksDir = join(sliceDir, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  writeFileSync(
+    join(milestoneDir, "M001-ROADMAP.md"),
+    [
+      "# M001: Imported Explicitly",
+      "",
+      "**Vision:** Explicit recovery import only",
+      "",
+      "## Slices",
+      "- [ ] **S01: Slice** `risk:low` `depends:[]`",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(sliceDir, "S01-PLAN.md"),
+    [
+      "# S01: Slice",
+      "",
+      "**Goal:** prove explicit import",
+      "",
+      "## Tasks",
+      "- [ ] **T01: Task** `est:5m`",
+      "",
+    ].join("\n"),
+  );
+
+  openProjectDb(base);
+  const check = await checkMarkdownHierarchyAgainstDb(base);
+  assert.equal(check.action, "recovery-required");
+  assert.equal(getAllMilestones().length, 0, "startup mismatch check must not import markdown");
+
+  const imported = migrateHierarchyToDb(base);
+  assert.deepEqual(imported, { milestones: 1, slices: 1, tasks: 1 });
+  assert.equal(getAllMilestones().length, 1);
+  assert.equal(getSliceTasks("M001", "S01").length, 1);
+});

--- a/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
+++ b/src/resources/extensions/gsd/tests/migration-auto-check.test.ts
@@ -6,13 +6,15 @@ import test from "node:test";
 
 import { ensureDbOpen } from "../bootstrap/dynamic-tools.ts";
 import {
-  _getAdapter,
   closeDatabase,
   getAllMilestones,
+  insertMilestone,
+  insertSlice,
+  insertTask,
   getSliceTasks,
 } from "../gsd-db.ts";
 import {
-  autoImportMarkdownHierarchyIfDbMismatch,
+  checkMarkdownHierarchyAgainstDb,
   countMarkdownHierarchy,
 } from "../migration-auto-check.ts";
 import { writeGSDDirectory } from "../migrate/writer.ts";
@@ -70,7 +72,7 @@ function projectFixture(): GSDProject {
   };
 }
 
-test("migration auto-check imports markdown hierarchy when DB is empty", async () => {
+test("migration auto-check preserves empty DB and reports explicit recovery", async () => {
   const base = makeBase();
   try {
     await writeGSDDirectory(projectFixture(), base);
@@ -79,32 +81,35 @@ test("migration auto-check imports markdown hierarchy when DB is empty", async (
     assert.equal(await ensureDbOpen(base), true);
     assert.equal(getAllMilestones().length, 0, "fresh authoritative DB starts empty");
 
-    const result = await autoImportMarkdownHierarchyIfDbMismatch(base);
-    assert.equal(result.action, "imported");
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "recovery-required");
     assert.equal(result.reason, "db-empty");
-    assert.deepEqual(result.afterDb, { milestones: 1, slices: 1, tasks: 1 });
-    assert.equal(getAllMilestones().length, 1);
-    assert.equal(getSliceTasks("M001", "S01").length, 1);
+    assert.deepEqual(result.afterDb, { milestones: 0, slices: 0, tasks: 0 });
+    assert.equal(result.recoveryCommand, "gsd recover");
+    assert.match(result.message ?? "", /will not import markdown automatically/);
+    assert.equal(getAllMilestones().length, 0);
+    assert.equal(getSliceTasks("M001", "S01").length, 0);
   } finally {
     cleanup(base);
   }
 });
 
-test("migration auto-check repairs DB hierarchy count mismatch", async () => {
+test("migration auto-check preserves DB on hierarchy count mismatch", async () => {
   const base = makeBase();
   try {
     await writeGSDDirectory(projectFixture(), base);
-    await autoImportMarkdownHierarchyIfDbMismatch(base);
-
-    _getAdapter()!.prepare("DELETE FROM tasks WHERE milestone_id = ? AND slice_id = ? AND id = ?").run("M001", "S01", "T01");
+    assert.equal(await ensureDbOpen(base), true);
+    insertMilestone({ id: "M001", title: "Legacy Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Legacy Slice", status: "pending", risk: "medium", depends: [], demo: "Legacy slice demo", sequence: 1 });
     assert.equal(getSliceTasks("M001", "S01").length, 0, "test fixture simulates stale DB task count");
 
-    const result = await autoImportMarkdownHierarchyIfDbMismatch(base);
-    assert.equal(result.action, "imported");
+    const result = await checkMarkdownHierarchyAgainstDb(base);
+    assert.equal(result.action, "recovery-required");
     assert.equal(result.reason, "count-mismatch");
     assert.deepEqual(result.beforeDb, { milestones: 1, slices: 1, tasks: 0 });
-    assert.deepEqual(result.afterDb, { milestones: 1, slices: 1, tasks: 1 });
-    assert.equal(getSliceTasks("M001", "S01").length, 1);
+    assert.deepEqual(result.afterDb, { milestones: 1, slices: 1, tasks: 0 });
+    assert.equal(result.recoveryCommand, "gsd recover");
+    assert.equal(getSliceTasks("M001", "S01").length, 0);
   } finally {
     cleanup(base);
   }
@@ -114,9 +119,12 @@ test("migration auto-check leaves matching DB hierarchy alone", async () => {
   const base = makeBase();
   try {
     await writeGSDDirectory(projectFixture(), base);
-    await autoImportMarkdownHierarchyIfDbMismatch(base);
+    assert.equal(await ensureDbOpen(base), true);
+    insertMilestone({ id: "M001", title: "Legacy Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Legacy Slice", status: "pending", risk: "medium", depends: [], demo: "Legacy slice demo", sequence: 1 });
+    insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Legacy Task", status: "pending" });
 
-    const result = await autoImportMarkdownHierarchyIfDbMismatch(base);
+    const result = await checkMarkdownHierarchyAgainstDb(base);
     assert.equal(result.action, "none");
     assert.equal(result.reason, "in-sync");
     assert.deepEqual(result.markdown, { milestones: 1, slices: 1, tasks: 1 });

--- a/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
+++ b/src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts
@@ -544,7 +544,7 @@ test("ADR-017 (#5703): live worker lock is not cleared", async (t) => {
 
 // ─── #5704: unregistered-milestone drift ────────────────────────────────────
 
-test("ADR-017 (#5704): unregistered-milestone drift detected and DB row inserted", async (t) => {
+test("ADR-017 (#5704): unregistered-milestone drift fails closed without importing markdown", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-adr017-projmd-"));
   const milestoneDir = join(base, ".gsd", "milestones", "M042");
   mkdirSync(milestoneDir, { recursive: true });
@@ -571,20 +571,22 @@ test("ADR-017 (#5704): unregistered-milestone drift detected and DB row inserted
   // Pre-condition: filesystem has the milestone, DB does NOT.
   assert.equal(getMilestone("M042"), null, "pre: DB has no row for M042");
 
-  const result = await reconcileBeforeDispatch(base, {
-    invalidateStateCache: () => {},
-    deriveState: async () => makeState(),
-  });
-
-  assert.equal(result.ok, true);
-  assert.ok(getMilestone("M042"), "post: DB row inserted for M042");
-  const milestoneRepaired = result.repaired.find(
-    (d) => d.kind === "unregistered-milestone",
+  await assert.rejects(
+    reconcileBeforeDispatch(base, {
+      invalidateStateCache: () => {},
+      deriveState: async () => makeState(),
+    }),
+    (err: unknown) => {
+      assert.ok(err instanceof ReconciliationFailedError);
+      assert.match(String(err.message), /unregistered-milestone/);
+      assert.equal(err.failures[0]?.drift.kind, "unregistered-milestone");
+      assert.match(String(err.failures[0]?.cause), /M042/);
+      assert.match(String(err.failures[0]?.cause), /markdown projection/);
+      assert.match(String(err.failures[0]?.cause), /recovery\/migration/);
+      return true;
+    },
   );
-  assert.ok(milestoneRepaired, "repaired list should include the unregistered-milestone drift");
-  if (milestoneRepaired?.kind === "unregistered-milestone") {
-    assert.equal(milestoneRepaired.milestoneId, "M042");
-  }
+  assert.equal(getMilestone("M042"), null, "post: DB still has no row for M042");
 });
 
 test("ADR-017 (#5704): registered milestone (DB row present) → no drift", async (t) => {
@@ -627,13 +629,14 @@ test("ADR-017 (#5704): registered milestone (DB row present) → no drift", asyn
 
 // ─── #5705: roadmap-divergence drift ─────────────────────────────────────────
 
-test("ADR-017 (#5705): roadmap-divergence drift detected and DB depends synced", async (t) => {
+test("ADR-017 (#5705): roadmap-divergence re-renders projection without syncing depends into DB", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-"));
   const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  const roadmapPath = join(milestoneDir, "M001-ROADMAP.md");
   mkdirSync(milestoneDir, { recursive: true });
   // ROADMAP.md declares S02 depends on [S01]
   writeFileSync(
-    join(milestoneDir, "M001-ROADMAP.md"),
+    roadmapPath,
     [
       "# M001: Test",
       "",
@@ -665,7 +668,12 @@ test("ADR-017 (#5705): roadmap-divergence drift detected and DB depends synced",
   });
 
   assert.equal(result.ok, true);
-  assert.deepEqual(getSlice("M001", "S02")?.depends, ["S01"], "post: DB depends matches ROADMAP.md");
+  assert.deepEqual(getSlice("M001", "S02")?.depends, [], "post: DB depends remains authoritative");
+  assert.match(
+    readFileSync(roadmapPath, "utf-8"),
+    /- \[ \] \*\*S02: Feature\*\* `risk:medium` `depends:\[\]`/,
+    "post: ROADMAP projection is regenerated from DB depends",
+  );
   const roadmapRepaired = result.repaired.find((d) => d.kind === "roadmap-divergence");
   assert.ok(roadmapRepaired, "repaired list should include the roadmap-divergence drift");
   if (roadmapRepaired?.kind === "roadmap-divergence") {
@@ -673,13 +681,14 @@ test("ADR-017 (#5705): roadmap-divergence drift detected and DB depends synced",
   }
 });
 
-test("ADR-017 (#5705): ROADMAP declares slice missing from DB → slice inserted and drift reported", async (t) => {
+test("ADR-017 (#5705): ROADMAP-only slice is removed from projection and not inserted into DB", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-newslice-"));
   const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  const roadmapPath = join(milestoneDir, "M001-ROADMAP.md");
   mkdirSync(milestoneDir, { recursive: true });
   // ROADMAP.md declares S01 and S02; DB will only have S01.
   writeFileSync(
-    join(milestoneDir, "M001-ROADMAP.md"),
+    roadmapPath,
     [
       "# M001: Test",
       "",
@@ -710,15 +719,102 @@ test("ADR-017 (#5705): ROADMAP declares slice missing from DB → slice inserted
   });
 
   assert.equal(result.ok, true);
-  const s02 = getSlice("M001", "S02");
-  assert.ok(s02, "post: S02 inserted into DB after repair");
-  assert.equal(s02?.sequence, 2, "post: S02 sequence matches ROADMAP order");
-  assert.deepEqual(s02?.depends, ["S01"], "post: S02 depends matches ROADMAP");
+  assert.equal(getSlice("M001", "S02"), null, "post: S02 still has no DB row");
+  const rendered = readFileSync(roadmapPath, "utf-8");
+  assert.match(rendered, /- \[ \] \*\*S01: Foundation\*\*/);
+  assert.doesNotMatch(rendered, /S02: Feature/, "post: ROADMAP-only S02 removed from projection");
   const roadmapRepaired = result.repaired.find((d) => d.kind === "roadmap-divergence");
   assert.ok(roadmapRepaired, "repaired list should include the roadmap-divergence drift");
   if (roadmapRepaired?.kind === "roadmap-divergence") {
     assert.equal(roadmapRepaired.milestoneId, "M001");
   }
+});
+
+test("ADR-017 (#5705): ROADMAP sequence drift re-renders from DB order without mutating DB", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-sequence-"));
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  const roadmapPath = join(milestoneDir, "M001-ROADMAP.md");
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(
+    roadmapPath,
+    [
+      "# M001: Test",
+      "",
+      "**Vision:** Verify sequence drift",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S02: Feature** `risk:medium` `depends:[]`",
+      "- [ ] **S01: Foundation** `risk:medium` `depends:[]`",
+      "",
+    ].join("\n"),
+  );
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Foundation", status: "pending", risk: "medium", depends: [], demo: "", sequence: 1 });
+  insertSlice({ id: "S02", milestoneId: "M001", title: "Feature", status: "pending", risk: "medium", depends: [], demo: "", sequence: 2 });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(getSlice("M001", "S01")?.sequence, 1, "post: S01 DB sequence remains authoritative");
+  assert.equal(getSlice("M001", "S02")?.sequence, 2, "post: S02 DB sequence remains authoritative");
+  const rendered = readFileSync(roadmapPath, "utf-8");
+  assert.ok(
+    rendered.indexOf("S01: Foundation") < rendered.indexOf("S02: Feature"),
+    "post: ROADMAP projection follows DB sequence",
+  );
+  assert.ok(result.repaired.some((d) => d.kind === "roadmap-divergence"));
+});
+
+test("ADR-017 (#5705): ROADMAP checkbox drift re-renders from DB status without mutating DB", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr017-roadmap-checkbox-"));
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  const roadmapPath = join(milestoneDir, "M001-ROADMAP.md");
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(
+    roadmapPath,
+    [
+      "# M001: Test",
+      "",
+      "**Vision:** Verify checkbox drift",
+      "",
+      "## Slices",
+      "",
+      "- [x] **S01: Foundation** `risk:medium` `depends:[]`",
+      "",
+    ].join("\n"),
+  );
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Foundation", status: "pending", risk: "medium", depends: [], demo: "", sequence: 1 });
+
+  const result = await reconcileBeforeDispatch(base, {
+    invalidateStateCache: () => {},
+    deriveState: async () => makeState(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(getSlice("M001", "S01")?.status, "pending", "post: DB status remains authoritative");
+  assert.match(
+    readFileSync(roadmapPath, "utf-8"),
+    /- \[ \] \*\*S01: Foundation\*\*/,
+    "post: ROADMAP checkbox reflects DB status",
+  );
+  assert.ok(result.repaired.some((d) => d.kind === "roadmap-divergence"));
 });
 
 test("ADR-017 (#5705): in-sync ROADMAP and DB → no roadmap-divergence drift", async (t) => {


### PR DESCRIPTION
## TL;DR

**What:** Makes GSD runtime reconciliation treat markdown planning files as projections and keeps DB state authoritative.
**Why:** ROADMAP/PROJECT markdown drift could previously import or mutate runtime DB state outside explicit recovery paths.
**How:** Replaces runtime markdown import/repair paths with DB-backed projection rendering, adds the PROJECT authority ADR, and adds regression coverage for DB-vs-markdown authority.

## What

- Changes ROADMAP drift repair to re-render from DB instead of syncing markdown into DB.
- Changes PROJECT markdown-only runtime drift to fail closed with recovery guidance instead of importing.
- Replaces guided startup auto-import with mismatch detection and explicit recovery instructions.
- Records the PROJECT authority contract in ADR-018 and updates ADR-017 language.
- Adds regression coverage for DB authority over PROJECT, QUEUE, REQUIREMENTS, DECISIONS, and explicit recovery/migration boundaries.

## Why

The DB should be the source of truth for runtime state, while markdown files under `.gsd/` are human-readable projections unless an explicit migration or recovery path says otherwise.

Closes #5908
Closes #5909
Closes #5910
Closes #5911
Refs #5913

## How

Runtime reconciliation now detects markdown drift but repairs it by rendering DB state back to disk. Markdown-only hierarchy recovery remains available through explicit migration/recovery tooling, while guided startup reports `gsd recover` guidance instead of silently mutating DB rows.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/state-reconciliation-drift.test.ts src/resources/extensions/gsd/tests/migration-auto-check.test.ts src/resources/extensions/gsd/tests/migrate-hierarchy.test.ts src/resources/extensions/gsd/tests/gsd-recover.test.ts src/resources/extensions/gsd/tests/db-authority-regression.test.ts` — 46 passed, 0 failed
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/db-authority-regression.test.ts` — 4 passed, 0 failed
- `npm run verify:pr` — 9240 passed, 0 failed, 9 skipped

## Change Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking Changes

This changes recovery semantics: runtime startup/reconciliation no longer silently imports markdown hierarchy drift into the DB. Operators should use explicit recovery/migration paths when markdown is the intended source for recovery.

## Assistance

AI-assisted contribution; no AI tool is credited as author or co-author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown/projection mismatches now fail closed and require explicit recovery (e.g. `gsd recover`) instead of auto-importing; ROADMAP and PROJECT projections no longer overwrite DB authority.

* **Documentation**
  * Added ADR describing PROJECT.md as DB-backed projection and canonical write path.
  * Updated ADR clarifying ROADMAP regeneration from DB during reconciliation.

* **Tests**
  * Added and updated tests covering DB-authority, startup checks, and explicit recovery workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5914)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->