### PR TITLE
fix(gsd): clamp task commit subjects to 72 bytes (not chars)

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -146,6 +146,62 @@ export interface TaskCommitContext {
 }
 
 /**
+ * De-facto Git commit-subject byte budget. Conventional Commits / `commit-msg`
+ * hooks (e.g. commitlint with `header-max-length: 72`) enforce a 72-character
+ * limit, but most hooks count bytes (not Unicode code points), so the budget
+ * is most accurately treated as a *byte* limit.
+ */
+const GIT_SUBJECT_MAX_BYTES = 72;
+
+/**
+ * Compose `<prefix><descriptor>` and clamp the result to a 72-byte budget,
+ * truncating on a UTF-8 character boundary and appending an ASCII `...`
+ * marker when truncation occurs.
+ *
+ * Byte-aware (not char-aware): the ellipsis is the 3-byte ASCII `"..."`
+ * rather than U+2026 `"…"` (which is 1 char / 3 bytes in UTF-8), so the
+ * char→byte mismatch that produced over-length subjects (see #5907) is
+ * avoided. Multi-byte input is truncated on a code-point boundary, never
+ * mid-char.
+ *
+ * `prefix` is expected to be ASCII (e.g. `"feat: "`) and is included
+ * verbatim. The descriptor takes whatever byte budget remains.
+ */
+function truncateUtf8ForGitSubject(prefix: string, descriptor: string): string {
+  const prefixBytes = Buffer.byteLength(prefix, "utf8");
+  const descBudget = GIT_SUBJECT_MAX_BYTES - prefixBytes;
+  if (descBudget <= 0) {
+    // Pathological: prefix already at/over budget. Return prefix clamped by
+    // byte length on a char boundary.
+    return clampToByteBudget(prefix, GIT_SUBJECT_MAX_BYTES);
+  }
+  if (Buffer.byteLength(descriptor, "utf8") <= descBudget) {
+    return `${prefix}${descriptor}`;
+  }
+  const ellipsis = "...";
+  const ellipsisBytes = ellipsis.length; // ASCII → bytes == length
+  const cutBudget = descBudget - ellipsisBytes;
+  if (cutBudget <= 0) {
+    return `${prefix}${ellipsis}`.slice(0, prefix.length + ellipsisBytes);
+  }
+  const cut = clampToByteBudget(descriptor, cutBudget).trimEnd();
+  return `${prefix}${cut}${ellipsis}`;
+}
+
+/** Truncate `value` to at most `maxBytes` UTF-8 bytes on a code-point boundary. */
+function clampToByteBudget(value: string, maxBytes: number): string {
+  let bytes = 0;
+  let out = "";
+  for (const ch of value) {
+    const chBytes = Buffer.byteLength(ch, "utf8");
+    if (bytes + chBytes > maxBytes) break;
+    out += ch;
+    bytes += chBytes;
+  }
+  return out;
+}
+
+/**
  * Build a meaningful conventional commit message from task execution context.
  * Format: `{type}: {description}` (clean conventional commit — no GSD IDs in subject).
  *
@@ -159,13 +215,7 @@ export function buildTaskCommitMessage(ctx: TaskCommitContext): string {
   const description = sanitizeCommitSubjectDescription(ctx.oneLiner || ctx.taskTitle);
   const type = inferCommitType(ctx.taskTitle, ctx.oneLiner);
 
-  // Truncate description to ~72 chars for subject line (full budget without scope)
-  const maxDescLen = 70 - type.length;
-  const truncated = description.length > maxDescLen
-    ? description.slice(0, maxDescLen - 1).trimEnd() + "…"
-    : description;
-
-  const subject = `${type}: ${truncated}`;
+  const subject = truncateUtf8ForGitSubject(`${type}: `, description);
 
   // Build body with key files if available
   const bodyParts: string[] = [];

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -235,6 +235,69 @@ describe('git-service', async () => {
     assert.ok(!msg.includes("chore: auto-commit after execute-task"), "message does not use generic fallback");
   });
 
+  // Regression test for #5907: subjects produced by `buildTaskCommitMessage`
+  // were truncated on a *character* boundary, then had a 3-byte UTF-8 ellipsis
+  // appended, which overshot the 72-byte git-subject limit by 2-3 bytes for
+  // any description ≥66 chars and caused strict `commit-msg` hooks to fail.
+  test('buildTaskCommitMessage clamps subject to 72 bytes (ASCII, ≥66-char descriptor)', () => {
+    // Verbatim repro from issue #5907.
+    const oneLiner =
+      "Added the core lint contract, seven-rule metadata catalogue, and parse-derived mechanical lint mappings with structured suggested_fix objects.";
+    const msg = buildTaskCommitMessage({
+      taskId: "S01/T01",
+      taskTitle: "implement lint contract",
+      oneLiner,
+    });
+    const subject = msg.split("\n")[0];
+    assert.ok(
+      Buffer.byteLength(subject, "utf8") <= 72,
+      `subject is ${Buffer.byteLength(subject, "utf8")} bytes (limit 72): ${JSON.stringify(subject)}`,
+    );
+    assert.ok(subject.startsWith("feat:"), "preserves inferred type prefix");
+  });
+
+  test('buildTaskCommitMessage clamps subject to 72 bytes (multi-byte / emoji descriptor)', () => {
+    // Multi-byte chars must not be split mid-codepoint and the result must
+    // still fit in 72 bytes.
+    const oneLiner =
+      "Added 🚀 rocket-fast caching layer with 中文支持 and é-accented identifiers across the entire pipeline end-to-end";
+    const msg = buildTaskCommitMessage({
+      taskId: "S01/T02",
+      taskTitle: "add caching layer",
+      oneLiner,
+    });
+    const subject = msg.split("\n")[0];
+    assert.ok(
+      Buffer.byteLength(subject, "utf8") <= 72,
+      `subject is ${Buffer.byteLength(subject, "utf8")} bytes (limit 72): ${JSON.stringify(subject)}`,
+    );
+    // Round-trip through Buffer to confirm no replacement chars from a
+    // mid-codepoint truncation.
+    assert.equal(
+      Buffer.from(subject, "utf8").toString("utf8"),
+      subject,
+      "subject is valid UTF-8 (not truncated mid-codepoint)",
+    );
+  });
+
+  test('buildTaskCommitMessage clamps subject to 72 bytes across descriptor lengths 1..200', () => {
+    // Boundary fuzz: every length around the 66-char trigger should still
+    // produce a ≤72-byte subject.
+    for (let n = 1; n <= 200; n++) {
+      const msg = buildTaskCommitMessage({
+        taskId: "S01/T03",
+        taskTitle: "implement feature x",
+        oneLiner: "x".repeat(n),
+      });
+      const subject = msg.split("\n")[0];
+      const bytes = Buffer.byteLength(subject, "utf8");
+      assert.ok(
+        bytes <= 72,
+        `descriptor length ${n}: subject is ${bytes} bytes (limit 72): ${JSON.stringify(subject)}`,
+      );
+    }
+  });
+
   test('buildTaskCommitMessage sanitizes subject text', () => {
     const msg = buildTaskCommitMessage({
       taskId: "S01/T03",


### PR DESCRIPTION
## Summary

Fixes #5907.

`buildTaskCommitMessage` in `src/resources/extensions/gsd/git-service.ts` truncated the description on a **character** boundary at `70 - type.length` chars, then appended a 3-byte UTF-8 ellipsis `\"…\"` (U+2026). For any description ≥66 chars this produces a subject **2–3 bytes over** the 72-byte de-facto Git / Conventional Commits limit, deterministically failing strict `commit-msg` hooks with the operator-visible (and unhelpful) `Git commit failed: Command failed: git commit -F -`.

Repro (verbatim from #5907):

- One-liner: `Added the core lint contract, seven-rule metadata catalogue, and parse-derived mechanical lint mappings with structured suggested_fix objects.` (142 chars)
- Pre-fix subject: `feat: Added the core lint contract, seven-rule metadata catalogue, an…` — 71 chars / **73 bytes**

## Approach

- Introduce an internal `truncateUtf8ForGitSubject(prefix, descriptor)` helper that:
  - Budgets in **UTF-8 bytes** (`Buffer.byteLength`) against `GIT_SUBJECT_MAX_BYTES = 72`, not characters.
  - Uses an ASCII `\"...\"` marker (3 bytes / 3 chars — no char/byte mismatch) instead of `\"…\"`.
  - Truncates on a code-point boundary so multi-byte input is never split mid-character.
- Route `buildTaskCommitMessage` through it. No other call sites touched.

## Coordination with #5903

PR #5903 (`fix/auto-commit-subject-truncation`) is still open and adds an exported `buildAutoCommitSubject(prefix, descriptor)` for the `chore: auto-commit after <unitType>` fallback path. That helper has the **same char-vs-byte bug** (`descriptor.length > maxDescLen`, then appends `\"…\"`) — its 72-char clamp is not byte-aware. To avoid stepping on #5903, this PR does **not** edit #5903's helper; instead it ships a parallel byte-aware helper only for the task-context path that #5907 specifically reports.

Suggested follow-up (either tacked onto #5903 before it merges, or filed as a separate fix once both land): consolidate to a single byte-aware helper used by both call sites. I'm happy to do that consolidation in a follow-up PR once the merge order is decided.

## Tests

`src/resources/extensions/gsd/tests/integration/git-service.test.ts`:

- `buildTaskCommitMessage clamps subject to 72 bytes (ASCII, ≥66-char descriptor)` — verbatim 142-char one-liner from the issue body; asserts `Buffer.byteLength(subject, \"utf8\") <= 72`.
- `buildTaskCommitMessage clamps subject to 72 bytes (multi-byte / emoji descriptor)` — rocket emoji + CJK + accented Latin; asserts ≤72 bytes and valid UTF-8 (no mid-codepoint split).
- `buildTaskCommitMessage clamps subject to 72 bytes across descriptor lengths 1..200` — boundary sweep that fails at descriptor length 67 on unpatched code (`74 bytes`).

All three fail on the pre-fix code (verified by stashing the production change and re-running) and pass after the fix.

## Test plan

- [x] All 6 `buildTaskCommitMessage` tests pass (3 new + 3 existing) — verified locally with `GIT_CONFIG_GLOBAL=/dev/null node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern='buildTaskCommitMessage' src/resources/extensions/gsd/tests/integration/git-service.test.ts`.
- [x] New tests fail on unpatched code (confirmed by stash-pop sandwich).
- [x] No new `tsc --noEmit` errors in `git-service.ts` / `git-service.test.ts` (pre-existing workspace-build prerequisite errors in unrelated `@gsd/pi-*` files are unchanged from baseline).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)