### PR TITLE
refactor(gsd): harden smart entry routing paths

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/footer.ts
@@ -249,7 +249,7 @@ export class FooterComponent implements Component {
 		const footerRight = [rightSide, extStatusText].filter(Boolean).join(" ");
 		const gsdSegment = theme.fg("accent", "● GSD");
 		const dimStatsLeft = theme.fg("dim", statsLeft);
-		const innerWidth = Math.max(1, Math.max(20, width) - 2);
+		const innerWidth = Math.max(1, width - 2);
 		const rightWidth = visibleWidth(footerRight);
 		const leftBudget = footerRight ? Math.max(1, innerWidth - rightWidth - 3) : innerWidth;
 		const sepWidth = visibleWidth("  │  ");

--- a/packages/pi-coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/footer.ts
@@ -20,6 +20,17 @@ function sanitizeStatusText(text: string): string {
 		.trim();
 }
 
+function truncateFooterPath(text: string, width: number): string {
+	if (visibleWidth(text) <= width) return text;
+	const tailMatch = text.match(/( \([^)]+\)(?: • .*)?)$/);
+	if (!tailMatch) return truncateToWidth(text, width, "...");
+	const tail = tailMatch[1];
+	const tailWidth = visibleWidth(tail);
+	if (tailWidth >= width - 4) return truncateToWidth(text, width, "...");
+	const head = text.slice(0, -tail.length);
+	return `${truncateToWidth(head, width - tailWidth, "...")}${tail}`;
+}
+
 /**
  * Format token counts (similar to web-ui)
  */
@@ -222,10 +233,6 @@ export class FooterComponent implements Component {
 			}
 		}
 
-		// Apply dim to the stats group before handing it to the shared footer strip.
-		// statsLeft may contain color codes for context %, so keep coloring local to the group.
-		const dimStatsLeft = theme.fg("dim", statsLeft);
-
 		// Extension statuses right-aligned on the pwd line (sorted by key).
 		// Keeps the footer compact by avoiding a dedicated row when the content
 		// fits alongside pwd. Falls back to pwd-only if the combined line would
@@ -239,12 +246,21 @@ export class FooterComponent implements Component {
 						.join(" ")
 				: "";
 
+		const footerRight = [rightSide, extStatusText].filter(Boolean).join(" ");
+		const gsdSegment = theme.fg("accent", "● GSD");
+		const dimStatsLeft = theme.fg("dim", statsLeft);
+		const innerWidth = Math.max(1, Math.max(20, width) - 2);
+		const rightWidth = visibleWidth(footerRight);
+		const leftBudget = footerRight ? Math.max(1, innerWidth - rightWidth - 3) : innerWidth;
+		const sepWidth = visibleWidth("  │  ");
+		const pwdBudget = Math.max(1, leftBudget - visibleWidth(gsdSegment) - visibleWidth(dimStatsLeft) - sepWidth * 2);
+		const pwdSegment = theme.fg("dim", truncateFooterPath(pwd, pwdBudget));
+
 		const leftSegments = [
-			theme.fg("accent", "● GSD"),
-			theme.fg("dim", pwd),
+			gsdSegment,
+			pwdSegment,
 			dimStatsLeft,
 		];
-		const footerRight = [rightSide, extStatusText].filter(Boolean).join(" ");
 		return renderFooterStrip(leftSegments, footerRight, width);
 	}
 }

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -201,6 +201,14 @@ export function resolveAgentEndErrorDisplay(
   return rawErrorMsg;
 }
 
+export function isTerminalDeletedWorktreeProviderError(
+  message: string | undefined | null,
+): boolean {
+  if (!message) return false;
+  if (!/\bdoes not exist\b/i.test(message)) return false;
+  return /[/\\]\.gsd[/\\](?:projects[/\\][^/\\]+[/\\])?worktrees[/\\][^/\\\s"']+/i.test(message);
+}
+
 async function pauseTransientWithBackoff(
   cls: ErrorClass,
   pi: ExtensionAPI,
@@ -249,9 +257,10 @@ export async function handleAgentEnd(
   // falsely report files as missing — producing a spurious "ready signal
   // rejected" loop even though the files are on disk.
   clearPathCache();
+  const basePath = resolveAgentEndBasePath();
 
   try {
-    if (await checkDeepProjectSetupAfterTurn(event, ctx, resolveAgentEndBasePath())) {
+    if (await checkDeepProjectSetupAfterTurn(event, ctx, basePath)) {
       return;
     }
   } catch (err) {
@@ -259,8 +268,8 @@ export async function handleAgentEnd(
     logWarning("bootstrap", `checkDeepProjectSetupAfterTurn failed: ${message}`);
   }
 
-  if (checkAutoStartAfterDiscuss()) {
-    clearDiscussionFlowState(resolveAgentEndBasePath() ?? process.cwd());
+  if (checkAutoStartAfterDiscuss(basePath)) {
+    clearDiscussionFlowState(basePath ?? process.cwd());
     return;
   }
 
@@ -268,14 +277,14 @@ export async function handleAgentEnd(
   // are missing, `checkAutoStartAfterDiscuss` returns false silently. Surface
   // that and nudge the LLM to complete the writes before the user hits the
   // downstream "All milestones complete" warning loop.
-  if (maybeHandleReadyPhraseWithoutFiles(event)) return;
+  if (maybeHandleReadyPhraseWithoutFiles(event, basePath)) return;
 
   // #4573 — Empty-turn recovery: if the LLM announced intent in prose but
   // emitted no tool calls, nudge it to execute. Fires only when auto-mode is
   // active or a discussion autostart is pending (non-auto interactive discuss
   // is user-driven). Runs before `isAutoActive` early return so pending
   // discussions (where isAutoActive may be false) still get recovered.
-  if (maybeHandleEmptyIntentTurn(event, isAutoActive())) return;
+  if (maybeHandleEmptyIntentTurn(event, isAutoActive(), basePath)) return;
 
   if (!isAutoActive()) return;
 
@@ -360,6 +369,17 @@ export async function handleAgentEnd(
       rawErrorMsg,
       "content" in lastMsg ? lastMsg.content : undefined,
     );
+    if (
+      isAutoCompletionStopInProgress() &&
+      isTerminalDeletedWorktreeProviderError(`${rawErrorMsg}\n${displayMsg}`)
+    ) {
+      resetRetryState(retryState);
+      logWarning(
+        "bootstrap",
+        `Ignoring stale deleted-worktree provider error during terminal completion reroot: ${displayMsg || rawErrorMsg}`,
+      );
+      return;
+    }
     const errorDetail = displayMsg ? `: ${displayMsg}` : "";
     const explicitRetryAfterMs = ("retryAfterMs" in lastMsg && typeof lastMsg.retryAfterMs === "number") ? lastMsg.retryAfterMs : undefined;
 

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -32,6 +32,7 @@ import { shouldIgnoreAgentEndForActiveUnit } from "../auto/unit-runner-events.js
 import { resolveModelId } from "../auto-model-selection.js";
 import { resolveProjectRoot } from "../worktree.js";
 import { clearDiscussionFlowState } from "./write-gate.js";
+import { clearGuidedUnitContext } from "../guided-unit-context.js";
 import { resumeAutoAfterProviderDelay } from "./provider-error-resume.js";
 import {
   classifyError,
@@ -258,6 +259,7 @@ export async function handleAgentEnd(
   // rejected" loop even though the files are on disk.
   clearPathCache();
   const basePath = resolveAgentEndBasePath();
+  clearGuidedUnitContext(basePath);
 
   try {
     if (await checkDeepProjectSetupAfterTurn(event, ctx, basePath)) {

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -31,6 +31,7 @@ import { resolveWorktreeProjectRoot } from "../worktree-root.js";
 import { extractSubagentAgentClasses } from "./subagent-input.js";
 import { approvalGateIdForUnit, isExplicitApprovalResponse, shouldPauseForUserApprovalQuestion } from "../user-input-boundary.js";
 import { resolveSkillManifest } from "../skill-manifest.js";
+import { getGuidedUnitContext } from "../guided-unit-context.js";
 
 let approvalQuestionAbortInFlight = false;
 
@@ -772,7 +773,8 @@ export function registerHooks(
     // subagent dispatch. Closes the b23 bug class where a discuss-milestone
     // turn used the host Edit tool to modify user source files.
     const dash = getAutoRuntimeSnapshot();
-    const activeUnitType = dash.currentUnit?.type;
+    const guidedUnit = getGuidedUnitContext(discussionBasePath);
+    const activeUnitType = dash.currentUnit?.type ?? guidedUnit?.unitType;
     if (activeUnitType) {
       const manifest = resolveManifest(activeUnitType);
       if (manifest) {
@@ -791,7 +793,7 @@ export function registerHooks(
         const planningGuard = shouldBlockPlanningUnit(
           event.toolName,
           planningInput,
-          dash.basePath || discussionBasePath,
+          dash.basePath || guidedUnit?.basePath || discussionBasePath,
           activeUnitType,
           manifest.tools,
           agentClasses,

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -69,8 +69,23 @@ import {
   formatPriorContextBrief,
 } from "./preparation.js";
 import { verifyExpectedArtifact } from "./auto-recovery.js";
-import { createWorkspace, scopeMilestone, type MilestoneScope } from "./workspace.js";
+import type { MilestoneScope } from "./workspace.js";
 import { getPendingGate, extractDepthVerificationMilestoneId } from "./bootstrap/write-gate.js";
+import {
+  _getPendingAutoStart,
+  clearPendingAutoStart,
+  deletePendingAutoStart,
+  getDiscussionMilestoneId,
+  hasPendingAutoStart,
+  setPendingAutoStart,
+} from "./pending-auto-start.js";
+
+export {
+  _getPendingAutoStart,
+  clearPendingAutoStart,
+  getDiscussionMilestoneId,
+  setPendingAutoStart,
+} from "./pending-auto-start.js";
 
 export function shouldSkipGitBootstrapAfterInit(result: { gitEnabled?: boolean }): boolean {
   return result.gitEnabled === false;
@@ -234,26 +249,6 @@ function buildDocsCommitInstruction(_message: string): string {
 
 // ─── Auto-start after discuss ─────────────────────────────────────────────────
 
-/** Pending auto-start context, keyed by basePath for session isolation (#2985). */
-interface PendingAutoStartEntry {
-  ctx: ExtensionCommandContext;
-  pi: ExtensionAPI;
-  basePath: string;
-  milestoneId: string; // the milestone being discussed
-  step?: boolean; // preserve step mode through discuss → auto transition
-  createdAt: number; // timestamp for staleness detection (#3274)
-  // #4573: counter for how many times the LLM emitted the ready phrase
-  // without writing the required artifacts. Cleared on entry delete/recreate.
-  readyRejectCount?: number;
-  // C1: scope is pinned at reservation time so path resolution is immune to
-  // cwd-drift between discuss and checkAutoStartAfterDiscuss.
-  // TODO(C3): basePath becomes redundant once all consumers migrate to scope.
-  scope: MilestoneScope;
-  // H1: retry counter for Gate 1b plan-blocked recovery. Capped at
-  // MAX_PLAN_BLOCKED_RECOVERIES to prevent infinite recovery loops (#5012).
-  planBlockedRecoveryCount: number;
-}
-
 interface PendingDeepProjectSetupEntry {
   ctx: ExtensionCommandContext;
   pi: ExtensionAPI;
@@ -279,7 +274,6 @@ const MAX_PLAN_BLOCKED_RECOVERIES = 3;
 // suffix) with optional trailing punctuation.
 const READY_PHRASE_RE = /\bMilestone\s+M\d{3}[A-Z0-9-]*\s+ready\.?/i;
 
-const pendingAutoStartMap = new Map<string, PendingAutoStartEntry>();
 const pendingDeepProjectSetupMap = new Map<string, PendingDeepProjectSetupEntry>();
 const USER_DRIVEN_DEEP_SETUP_UNITS = new Set([
   "discuss-project",
@@ -305,17 +299,6 @@ This stage is running inside the foreground \`/gsd new-project --deep\` intervie
 
 - Do NOT call \`ask_user_questions\`, \`AskUserQuestion\`, or ToolSearch to discover user-input tools.
 - Ask one focused round, then stop and wait for the user's normal chat response.`;
-
-/**
- * Backward-compat bridge: returns a mutable reference to the entry matching
- * basePath, or the sole entry when only one session exists.
- * Exported for testing — internal use only in production code.
- */
-export function _getPendingAutoStart(basePath?: string): PendingAutoStartEntry | null {
-  if (basePath) return pendingAutoStartMap.get(basePath) ?? null;
-  if (pendingAutoStartMap.size === 1) return pendingAutoStartMap.values().next().value!;
-  return null;
-}
 
 function hasNestedFileOrSymlink(dir: string): boolean {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -350,52 +333,12 @@ function clearEmptyLegacyDeepSetupPseudoMilestones(basePath: string, entries: st
   return remaining;
 }
 
-/**
- * Store pending auto-start state for a project.
- * Exported for testing (#2985).
- */
-export function setPendingAutoStart(basePath: string, entry: { basePath: string; milestoneId: string; ctx?: ExtensionCommandContext; pi?: ExtensionAPI; step?: boolean; createdAt?: number }): void {
-  const ws = createWorkspace(entry.basePath);
-  const scope = scopeMilestone(ws, entry.milestoneId);
-  pendingAutoStartMap.set(basePath, { createdAt: Date.now(), planBlockedRecoveryCount: 0, ...entry, scope } as PendingAutoStartEntry);
-}
-
-/**
- * Clear pending auto-start state.
- * If basePath is given, clears only that project.  Otherwise clears all.
- * Exported for testing (#2985).
- */
-export function clearPendingAutoStart(basePath?: string): void {
-  if (basePath) {
-    pendingAutoStartMap.delete(basePath);
-  } else {
-    pendingAutoStartMap.clear();
-  }
-}
-
 export function clearPendingDeepProjectSetup(basePath?: string): void {
   if (basePath) {
     pendingDeepProjectSetupMap.delete(basePath);
   } else {
     pendingDeepProjectSetupMap.clear();
   }
-}
-
-/**
- * Returns the milestoneId being discussed for the given project.
- * When basePath is omitted and only one session is active, returns that
- * session's milestoneId for backward compatibility.  Returns null when
- * multiple sessions exist and basePath is not specified (#2985 Bug 4).
- */
-export function getDiscussionMilestoneId(basePath?: string): string | null {
-  if (basePath) {
-    return pendingAutoStartMap.get(basePath)?.milestoneId ?? null;
-  }
-  // Backward compat: return the sole entry's milestoneId, or null if ambiguous
-  if (pendingAutoStartMap.size === 1) {
-    return pendingAutoStartMap.values().next().value!.milestoneId;
-  }
-  return null;
 }
 
 function _getPendingDeepProjectSetup(basePath?: string): PendingDeepProjectSetupEntry | null {
@@ -556,8 +499,8 @@ async function dispatchNextDeepProjectSetupStage(entry: PendingDeepProjectSetupE
 }
 
 /** Called from agent_end to check if auto-mode should start after discuss */
-export function checkAutoStartAfterDiscuss(): boolean {
-  const entry = _getPendingAutoStart();
+export function checkAutoStartAfterDiscuss(lookupBasePath?: string): boolean {
+  const entry = _getPendingAutoStart(lookupBasePath);
   if (!entry) return false;
 
   const { ctx, pi, basePath, milestoneId, step } = entry;
@@ -742,7 +685,7 @@ export function checkAutoStartAfterDiscuss(): boolean {
     }
   }
 
-  pendingAutoStartMap.delete(basePath);
+  deletePendingAutoStart(basePath);
   ctx.ui.notify(`Milestone ${milestoneId} ready.`, "success");
   scheduleAutoStartAfterIdle(ctx, pi, basePath, false, { step });
   return true;
@@ -813,8 +756,8 @@ function hasToolUse(msg: any): boolean {
  * Returns true when a nudge (or give-up) was emitted, signaling the caller to
  * skip `resolveAgentEnd`.
  */
-export function maybeHandleReadyPhraseWithoutFiles(event: { messages: any[] }): boolean {
-  const entry = _getPendingAutoStart();
+export function maybeHandleReadyPhraseWithoutFiles(event: { messages: any[] }, lookupBasePath?: string): boolean {
+  const entry = _getPendingAutoStart(lookupBasePath);
   if (!entry) return false;
   const { ctx, pi, basePath, milestoneId } = entry;
 
@@ -861,7 +804,7 @@ export function maybeHandleReadyPhraseWithoutFiles(event: { messages: any[] }): 
   if (entry.readyRejectCount > MAX_READY_REJECTS) {
     // Give up: clear state and tell the user to re-run /gsd. Avoids an
     // infinite nudge loop when the LLM never produces the writes.
-    pendingAutoStartMap.delete(basePath);
+    deletePendingAutoStart(basePath);
     ctx.ui.notify(
       `Milestone ${milestoneId}: LLM signaled "ready" ${entry.readyRejectCount} times without writing files. ` +
       `Stopping auto-nudge. Run /gsd to try again.`,
@@ -942,10 +885,11 @@ export function resetEmptyTurnCounter(basePath?: string): void {
 export function maybeHandleEmptyIntentTurn(
   event: { messages: any[] },
   isAuto: boolean,
+  lookupBasePath?: string,
 ): boolean {
   // Gate: only fire when there is system-driven work in flight. Interactive
   // /gsd discuss (user-driven) produces legitimate text-only turns.
-  if (!isAuto && pendingAutoStartMap.size === 0) return false;
+  if (!isAuto && !hasPendingAutoStart(lookupBasePath)) return false;
 
   const lastMsg = event.messages[event.messages.length - 1];
   if (!lastMsg) return false;
@@ -972,7 +916,7 @@ export function maybeHandleEmptyIntentTurn(
 
   // Resolve the target basePath + pi for injection. Prefer the pending
   // autostart entry (discuss flow); otherwise we cannot inject.
-  const entry = _getPendingAutoStart();
+  const entry = _getPendingAutoStart(lookupBasePath);
   if (!entry) return false;
   const { ctx, pi, basePath } = entry;
 
@@ -2203,17 +2147,17 @@ export async function showSmartEntry(
     // Both /gsd and /gsd auto reach this branch when no milestone exists yet.
     // Without this guard, every subsequent /gsd call overwrites the pending auto-start
     // and fires another dispatchWorkflow, resetting the conversation mid-interview.
-    if (pendingAutoStartMap.has(basePath)) {
+    if (hasPendingAutoStart(basePath)) {
       // #3274: If /clear interrupted the discussion, the pending entry is stale.
       // Detect staleness: no manifest, no milestone CONTEXT artifact, AND entry is older than
       // 30s (avoids race between .set() and LLM writing first artifact).
-      const entry = pendingAutoStartMap.get(basePath)!;
+      const entry = _getPendingAutoStart(basePath)!;
       const ageMs = Date.now() - (entry.createdAt || 0);
       const manifestExists = existsSync(join(gsdRoot(basePath), "DISCUSSION-MANIFEST.json"));
       const milestoneHasContext = !!resolveMilestoneFile(basePath, entry.milestoneId, "CONTEXT");
       if (!manifestExists && !milestoneHasContext && ageMs > 30_000) {
         // Stale entry from an interrupted discussion — clear and continue
-        pendingAutoStartMap.delete(basePath);
+        deletePendingAutoStart(basePath);
       } else {
         ctx.ui.notify("Discussion already in progress — answer the question above to continue.", "info");
         return;

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -1004,12 +1004,13 @@ async function dispatchWorkflow(
   customType = "gsd-run",
   ctx?: ExtensionContext,
   unitType?: string,
-  options: DispatchWorkflowOptions = {},
+  options?: DispatchWorkflowOptions,
 ): Promise<void> {
-  const projectRoot = resolveGuidedDispatchProjectRoot(options.basePath);
-  const loadPreferences = options.deps?.loadPreferences ?? loadEffectiveGSDPreferences;
-  const selectModel = options.deps?.selectModel ?? selectAndApplyModel;
-  const getTransportSupportError = options.deps?.getTransportSupportError ?? getWorkflowTransportSupportError;
+  const resolvedOptions = options ?? {};
+  const projectRoot = resolveGuidedDispatchProjectRoot(resolvedOptions.basePath);
+  const loadPreferences = resolvedOptions.deps?.loadPreferences ?? loadEffectiveGSDPreferences;
+  const selectModel = resolvedOptions.deps?.selectModel ?? selectAndApplyModel;
+  const getTransportSupportError = resolvedOptions.deps?.getTransportSupportError ?? getWorkflowTransportSupportError;
 
   // Route through the dynamic routing pipeline (complexity classification,
   // tier downgrade, fallback chains) — same path as auto-mode dispatches (#2958).

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -2298,7 +2298,7 @@ export async function showSmartEntry(
       await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
         `New milestone ${nextId}.`,
         basePath
-      ), "gsd-run", ctx, "discuss-milestone");
+      ), "gsd-run", ctx, "discuss-milestone", { basePath });
     } else if (choice === "status") {
       const { fireStatusViaCommand } = await import("./commands.js");
       await fireStatusViaCommand(ctx);

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -2721,6 +2721,8 @@ export async function showSmartEntry(
       notYetMessage: "Run /gsd when ready.",
     });
 
+    if (choice === "not_yet") return;
+
     const route = resolveActiveTaskChoiceRoute({
       choice: choice as ActiveTaskChoice,
       isolationMode: getIsolationMode(basePath),

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -92,6 +92,12 @@ import { deleteRuntimeKv } from "./db/runtime-kv.js";
 import { PAUSED_SESSION_KV_KEY } from "./interrupted-session.js";
 import { buildWorkflowDispatchContent } from "./workflow-protocol.js";
 import { isFullGsdToolSurfaceRequested, restoreGsdWorkflowTools, scopeGsdWorkflowToolsForDispatch } from "./bootstrap/register-hooks.js";
+import {
+  resolveActiveTaskChoiceRoute,
+  type ActiveTaskChoice,
+} from "./smart-entry-routing.js";
+
+export { resolveGuidedExecuteLaunchMode } from "./smart-entry-routing.js";
 
 type AutoStartOptions = Parameters<typeof startAutoDetached>[4];
 type AutoStartLauncher = typeof startAutoDetached;
@@ -211,12 +217,6 @@ function runPlanV2Gate(
 
 export const _needsPlanV2GateForTest = needsPlanV2Gate;
 export const _runPlanV2GateForTest = runPlanV2Gate;
-
-export function resolveGuidedExecuteLaunchMode(
-  isolationMode: string,
-): "auto-step" | "guided-dispatch" {
-  return isolationMode === "worktree" ? "auto-step" : "guided-dispatch";
-}
 
 export function _roadmapHasParseableSlicesForTest(
   roadmapContent: string | null | undefined,
@@ -2721,20 +2721,18 @@ export async function showSmartEntry(
       notYetMessage: "Run /gsd when ready.",
     });
 
-    if (choice === "auto") {
-      startAutoDetached(ctx, pi, basePath, false);
+    const route = resolveActiveTaskChoiceRoute({
+      choice: choice as ActiveTaskChoice,
+      isolationMode: getIsolationMode(basePath),
+      milestoneId,
+    });
+
+    if (route.kind === "auto-bootstrap") {
+      startAutoDetached(ctx, pi, basePath, route.verboseMode, route.options);
       return;
     }
 
-    if (choice === "execute") {
-      if (resolveGuidedExecuteLaunchMode(getIsolationMode(basePath)) === "auto-step") {
-        startAutoDetached(ctx, pi, basePath, false, {
-          step: true,
-          milestoneLock: milestoneId,
-        });
-        return;
-      }
-
+    if (route.kind === "guided-dispatch") {
       ctx.ui.setStatus("gsd-step", "Executing Task · follow progress above");
       if (hasInterrupted) {
         await dispatchWorkflow(pi, loadPrompt("guided-resume-task", {
@@ -2757,10 +2755,10 @@ export async function showSmartEntry(
           "execute-task",
         );
       }
-    } else if (choice === "status") {
+    } else if (route.kind === "status") {
       const { fireStatusViaCommand } = await import("./commands.js");
       await fireStatusViaCommand(ctx);
-    } else if (choice === "milestone_actions") {
+    } else if (route.kind === "milestone-actions") {
       const acted = await handleMilestoneActions(ctx, pi, basePath, milestoneId, milestoneTitle, options);
       if (acted) return showSmartEntry(ctx, pi, basePath, options);
     }

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -550,6 +550,7 @@ async function dispatchNextDeepProjectSetupStage(entry: PendingDeepProjectSetupE
     "gsd-run",
     entry.ctx,
     result.unitType,
+    { basePath: entry.basePath },
   );
   return true;
 }
@@ -1030,6 +1031,19 @@ type UIContext = ExtensionContext;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+interface DispatchWorkflowOptions {
+  basePath?: string;
+  deps?: {
+    loadPreferences?: typeof loadEffectiveGSDPreferences;
+    selectModel?: typeof selectAndApplyModel;
+    getTransportSupportError?: typeof getWorkflowTransportSupportError;
+  };
+}
+
+export function resolveGuidedDispatchProjectRoot(basePath?: string): string {
+  return basePath ?? process.cwd();
+}
+
 /**
  * Read GSD-WORKFLOW.md and dispatch it to the LLM with a contextual note.
  * This is the only way the wizard triggers work — everything else is the LLM's job.
@@ -1045,13 +1059,19 @@ async function dispatchWorkflow(
   customType = "gsd-run",
   ctx?: ExtensionContext,
   unitType?: string,
+  options: DispatchWorkflowOptions = {},
 ): Promise<void> {
+  const projectRoot = resolveGuidedDispatchProjectRoot(options.basePath);
+  const loadPreferences = options.deps?.loadPreferences ?? loadEffectiveGSDPreferences;
+  const selectModel = options.deps?.selectModel ?? selectAndApplyModel;
+  const getTransportSupportError = options.deps?.getTransportSupportError ?? getWorkflowTransportSupportError;
+
   // Route through the dynamic routing pipeline (complexity classification,
   // tier downgrade, fallback chains) — same path as auto-mode dispatches (#2958).
   if (ctx && unitType) {
-    const prefs = loadEffectiveGSDPreferences()?.preferences;
-    const result = await selectAndApplyModel(
-      ctx, pi, unitType, /* unitId */ "", /* basePath */ process.cwd(),
+    const prefs = loadPreferences(projectRoot)?.preferences;
+    const result = await selectModel(
+      ctx, pi, unitType, /* unitId */ "", projectRoot,
       prefs, /* verbose */ false, /* autoModeStartModel */ null,
       /* retryContext */ undefined, /* isAutoMode */ false,
     );
@@ -1063,11 +1083,11 @@ async function dispatchWorkflow(
       });
     }
 
-    const compatibilityError = getWorkflowTransportSupportError(
+    const compatibilityError = getTransportSupportError(
       result.appliedModel?.provider ?? ctx.model?.provider,
       getRequiredWorkflowToolsForGuidedUnit(unitType),
       {
-        projectRoot: process.cwd(),
+        projectRoot,
         surface: "guided flow",
         unitType,
         authMode: result.appliedModel?.provider
@@ -1363,7 +1383,7 @@ export async function showHeadlessMilestoneCreation(
   // model/tool routing to skip discuss-flow tool scoping and
   // `checkAutoStartAfterDiscuss` guardrails that rely on the
   // "discuss-"-prefixed unitType.
-  await dispatchWorkflow(pi, prompt, "gsd-run", ctx, "discuss-milestone");
+  await dispatchWorkflow(pi, prompt, "gsd-run", ctx, "discuss-milestone", { basePath });
 }
 
 
@@ -1554,7 +1574,7 @@ export async function showDiscuss(
         ? `${basePrompt}\n\n## Prior Discussion (Draft Seed)\n\n${draftContent}`
         : basePrompt;
       setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId: mid, step: false });
-      await dispatchWorkflow(pi, seed, "gsd-discuss", ctx, "discuss-milestone");
+      await dispatchWorkflow(pi, seed, "gsd-discuss", ctx, "discuss-milestone", { basePath });
     } else if (choice === "discuss_fresh") {
       const discussMilestoneTemplates = inlineTemplate("context", "Context");
       const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
@@ -1564,7 +1584,7 @@ export async function showDiscuss(
         milestoneId: mid, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
         commitInstruction: buildDocsCommitInstruction(`docs(${mid}): milestone context from discuss`),
         fastPathInstruction: "",
-      }), "gsd-discuss", ctx, "discuss-milestone");
+      }), "gsd-discuss", ctx, "discuss-milestone", { basePath });
     } else if (choice === "skip_milestone") {
       const { ensureDbOpen } = await import("./bootstrap/dynamic-tools.js");
       await ensureDbOpen(basePath);
@@ -1572,7 +1592,7 @@ export async function showDiscuss(
       const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
       const nextId = nextMilestoneIdReserved(milestoneIds, uniqueMilestoneIds, basePath);
       setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId: nextId, step: false });
-      await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId, `New milestone ${nextId}.`, basePath), "gsd-run", ctx, "discuss-milestone");
+      await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId, `New milestone ${nextId}.`, basePath), "gsd-run", ctx, "discuss-milestone", { basePath });
     }
     return;
   }
@@ -1720,7 +1740,7 @@ export async function showDiscuss(
 
     const sqAvail = getStructuredQuestionsAvailability(pi, ctx);
     const prompt = await buildDiscussSlicePrompt(mid, chosen.id, chosen.title, basePath, { rediscuss: isRediscuss, structuredQuestionsAvailable: sqAvail });
-    await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-slice");
+    await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-slice", { basePath });
 
     // Wait for the discuss session to finish, then loop back to the picker
     await ctx.waitForIdle();
@@ -1841,7 +1861,7 @@ async function dispatchDiscussForMilestone(
   const prompt = draftContent
     ? `${basePrompt}\n\n## Prior Discussion (Draft Seed)\n\n${draftContent}`
     : basePrompt;
-  await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-milestone");
+  await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "discuss-milestone", { basePath });
 }
 
 // ─── Smart Entry Point ────────────────────────────────────────────────────────
@@ -1984,7 +2004,7 @@ async function handleMilestoneActions(
     await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
       `New milestone ${nextId}.`,
       basePath
-    ), "gsd-run", ctx, "discuss-milestone");
+    ), "gsd-run", ctx, "discuss-milestone", { basePath });
     return true;
   }
 
@@ -2233,7 +2253,7 @@ export async function showSmartEntry(
       await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
         `New project, milestone ${nextId}. Do NOT read or explore .gsd/ — it's empty scaffolding.`,
         basePath
-      ), "gsd-run", ctx, "discuss-milestone");
+      ), "gsd-run", ctx, "discuss-milestone", { basePath });
     } else {
       const choice = await showNextAction(ctx, {
         title: "GSD — Get Shit Done",
@@ -2262,7 +2282,7 @@ export async function showSmartEntry(
         await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
           `New milestone ${nextId}.`,
           basePath
-        ), "gsd-run", ctx, "discuss-milestone");
+        ), "gsd-run", ctx, "discuss-milestone", { basePath });
       }
     }
     return;
@@ -2284,6 +2304,7 @@ export async function showSmartEntry(
       "gsd-discuss",
       ctx,
       "discuss-milestone",
+      { basePath },
     );
     return;
   }
@@ -2375,7 +2396,7 @@ export async function showSmartEntry(
         ? `${basePrompt}\n\n## Prior Discussion (Draft Seed)\n\n${draftContent}`
         : basePrompt;
       setPendingAutoStart(basePath, { ctx, pi, basePath, milestoneId, step: stepMode });
-      await dispatchWorkflow(pi, seed, "gsd-discuss", ctx, "discuss-milestone");
+      await dispatchWorkflow(pi, seed, "gsd-discuss", ctx, "discuss-milestone", { basePath });
     } else if (choice === "discuss_fresh") {
       const discussMilestoneTemplates = inlineTemplate("context", "Context");
       const structuredQuestionsAvailable = getStructuredQuestionsAvailability(pi, ctx);
@@ -2385,7 +2406,7 @@ export async function showSmartEntry(
         milestoneId, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
         commitInstruction: buildDocsCommitInstruction(`docs(${milestoneId}): milestone context from discuss`),
         fastPathInstruction: "",
-      }), "gsd-discuss", ctx, "discuss-milestone");
+      }), "gsd-discuss", ctx, "discuss-milestone", { basePath });
     } else if (choice === "skip_milestone") {
       const milestoneIds = findMilestoneIds(basePath);
       const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
@@ -2394,7 +2415,7 @@ export async function showSmartEntry(
       await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
         `New milestone ${nextId}.`,
         basePath
-      ), "gsd-run", ctx, "discuss-milestone");
+      ), "gsd-run", ctx, "discuss-milestone", { basePath });
     }
     return;
   }
@@ -2469,6 +2490,7 @@ export async function showSmartEntry(
           "gsd-run",
           ctx,
           "plan-milestone",
+          { basePath },
         );
       } else if (choice === "discuss") {
         const discussMilestoneTemplates = inlineTemplate("context", "Context");
@@ -2478,7 +2500,7 @@ export async function showSmartEntry(
           milestoneId, milestoneTitle, inlinedTemplates: discussMilestoneTemplates, structuredQuestionsAvailable,
           commitInstruction: buildDocsCommitInstruction(`docs(${milestoneId}): milestone context from discuss`),
           fastPathInstruction: "",
-        }), "gsd-run", ctx, "discuss-milestone");
+        }), "gsd-run", ctx, "discuss-milestone", { basePath });
       } else if (choice === "skip_milestone") {
         const milestoneIds = findMilestoneIds(basePath);
         const uniqueMilestoneIds = !!loadEffectiveGSDPreferences()?.preferences?.unique_milestone_ids;
@@ -2487,7 +2509,7 @@ export async function showSmartEntry(
         await dispatchWorkflow(pi, await prepareAndBuildDiscussPrompt(ctx, pi, nextId,
           `New milestone ${nextId}.`,
           basePath
-        ), "gsd-run", ctx, "discuss-milestone");
+        ), "gsd-run", ctx, "discuss-milestone", { basePath });
       } else if (choice === "discard_milestone") {
         const confirmed = await showConfirm(ctx, {
           title: "Discard milestone?",
@@ -2602,10 +2624,11 @@ export async function showSmartEntry(
         "gsd-run",
         ctx,
         "plan-slice",
+        { basePath },
       );
     } else if (choice === "discuss") {
       const sqAvail = getStructuredQuestionsAvailability(pi, ctx);
-      await dispatchWorkflow(pi, await buildDiscussSlicePrompt(milestoneId, sliceId, sliceTitle, basePath, { rediscuss: hasContext, structuredQuestionsAvailable: sqAvail }), "gsd-run", ctx, "discuss-slice");
+      await dispatchWorkflow(pi, await buildDiscussSlicePrompt(milestoneId, sliceId, sliceTitle, basePath, { rediscuss: hasContext, structuredQuestionsAvailable: sqAvail }), "gsd-run", ctx, "discuss-slice", { basePath });
     } else if (choice === "research") {
       const researchTemplates = inlineTemplate("research", "Research");
       await dispatchWorkflow(pi, loadPrompt("guided-research-slice", {
@@ -2620,7 +2643,7 @@ export async function showSmartEntry(
           sliceTitle,
           extraContext: [researchTemplates],
         }),
-      }), "gsd-run", ctx, "research-slice");
+      }), "gsd-run", ctx, "research-slice", { basePath });
     } else if (choice === "status") {
       const { fireStatusViaCommand } = await import("./commands.js");
       await fireStatusViaCommand(ctx);
@@ -2665,6 +2688,7 @@ export async function showSmartEntry(
         "gsd-run",
         ctx,
         "complete-slice",
+        { basePath },
       );
     } else if (choice === "status") {
       const { fireStatusViaCommand } = await import("./commands.js");
@@ -2747,7 +2771,7 @@ export async function showSmartEntry(
             taskId,
             taskTitle,
           }),
-        }), "gsd-run", ctx, "execute-task");
+        }), "gsd-run", ctx, "execute-task", { basePath });
       } else {
         await dispatchWorkflow(
           pi,
@@ -2755,6 +2779,7 @@ export async function showSmartEntry(
           "gsd-run",
           ctx,
           "execute-task",
+          { basePath },
         );
       }
     } else if (route.kind === "status") {

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -79,6 +79,7 @@ import {
   hasPendingAutoStart,
   setPendingAutoStart,
 } from "./pending-auto-start.js";
+import { clearGuidedUnitContext, setGuidedUnitContext } from "./guided-unit-context.js";
 
 export {
   _getPendingAutoStart,
@@ -1089,14 +1090,20 @@ async function dispatchWorkflow(
     const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(gsdHome(), "agent", "GSD-WORKFLOW.md");
     const workflow = readFileSync(workflowPath, "utf-8");
 
-    pi.sendMessage(
-      {
-        customType,
-        content: buildWorkflowDispatchContent({ workflow, workflowPath, task: note }),
-        display: false,
-      },
-      { triggerTurn: true },
-    );
+    if (unitType) setGuidedUnitContext(projectRoot, unitType);
+    try {
+      pi.sendMessage(
+        {
+          customType,
+          content: buildWorkflowDispatchContent({ workflow, workflowPath, task: note }),
+          display: false,
+        },
+        { triggerTurn: true },
+      );
+    } catch (err) {
+      clearGuidedUnitContext(projectRoot);
+      throw err;
+    }
   } finally {
     // Restore full tool set after the message is queued. The LLM turn has
     // already captured the scoped set — restoring prevents the narrowed

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -44,7 +44,7 @@ import { readSessionLockData, isSessionLockProcessAlive } from "./session-lock.j
 import { nativeAddAll, nativeCommit, nativeHasCommittedHead, nativeIsRepo, nativeInit } from "./native-git-bridge.js";
 import { isInheritedRepo } from "./repo-identity.js";
 import { ensureGitignore, ensurePreferences, untrackRuntimeFiles } from "./gitignore.js";
-import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { getIsolationMode, loadEffectiveGSDPreferences } from "./preferences.js";
 import { resolveUokFlags } from "./uok/flags.js";
 import { ensurePlanV2Graph, isMissingFinalizedContextResult } from "./uok/plan-v2.js";
 import { detectProjectState, hasGsdBootstrapArtifacts } from "./detection.js";
@@ -211,6 +211,12 @@ function runPlanV2Gate(
 
 export const _needsPlanV2GateForTest = needsPlanV2Gate;
 export const _runPlanV2GateForTest = runPlanV2Gate;
+
+export function resolveGuidedExecuteLaunchMode(
+  isolationMode: string,
+): "auto-step" | "guided-dispatch" {
+  return isolationMode === "worktree" ? "auto-step" : "guided-dispatch";
+}
 
 export function _roadmapHasParseableSlicesForTest(
   roadmapContent: string | null | undefined,
@@ -2721,6 +2727,14 @@ export async function showSmartEntry(
     }
 
     if (choice === "execute") {
+      if (resolveGuidedExecuteLaunchMode(getIsolationMode(basePath)) === "auto-step") {
+        startAutoDetached(ctx, pi, basePath, false, {
+          step: true,
+          milestoneLock: milestoneId,
+        });
+        return;
+      }
+
       ctx.ui.setStatus("gsd-step", "Executing Task · follow progress above");
       if (hasInterrupted) {
         await dispatchWorkflow(pi, loadPrompt("guided-resume-task", {

--- a/src/resources/extensions/gsd/guided-unit-context.ts
+++ b/src/resources/extensions/gsd/guided-unit-context.ts
@@ -1,0 +1,30 @@
+// GSD-2 — Guided workflow Unit context.
+// Tracks the guided Unit whose queued turn should use manifest Tool Contract policy.
+
+export interface GuidedUnitContext {
+  basePath: string;
+  unitType: string;
+  startedAt: number;
+}
+
+const guidedUnitContextByBasePath = new Map<string, GuidedUnitContext>();
+
+export function setGuidedUnitContext(basePath: string, unitType: string): GuidedUnitContext {
+  const context = { basePath, unitType, startedAt: Date.now() };
+  guidedUnitContextByBasePath.set(basePath, context);
+  return context;
+}
+
+export function getGuidedUnitContext(basePath?: string): GuidedUnitContext | null {
+  if (basePath) return guidedUnitContextByBasePath.get(basePath) ?? null;
+  if (guidedUnitContextByBasePath.size === 1) return guidedUnitContextByBasePath.values().next().value!;
+  return null;
+}
+
+export function clearGuidedUnitContext(basePath?: string): void {
+  if (basePath) {
+    guidedUnitContextByBasePath.delete(basePath);
+  } else {
+    guidedUnitContextByBasePath.clear();
+  }
+}

--- a/src/resources/extensions/gsd/pending-auto-start.ts
+++ b/src/resources/extensions/gsd/pending-auto-start.ts
@@ -1,0 +1,74 @@
+// GSD-2 — Pending auto-start handoff state.
+// Stores discuss-to-auto handoff entries keyed by project root.
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import { createWorkspace, scopeMilestone, type MilestoneScope } from "./workspace.js";
+
+export interface PendingAutoStartEntry {
+  ctx: ExtensionCommandContext;
+  pi: ExtensionAPI;
+  basePath: string;
+  milestoneId: string;
+  step?: boolean;
+  createdAt: number;
+  readyRejectCount?: number;
+  scope: MilestoneScope;
+  planBlockedRecoveryCount: number;
+}
+
+export interface PendingAutoStartInput {
+  basePath: string;
+  milestoneId: string;
+  ctx?: ExtensionCommandContext;
+  pi?: ExtensionAPI;
+  step?: boolean;
+  createdAt?: number;
+}
+
+const pendingAutoStartMap = new Map<string, PendingAutoStartEntry>();
+
+export function getPendingAutoStart(basePath?: string): PendingAutoStartEntry | null {
+  if (basePath) return pendingAutoStartMap.get(basePath) ?? null;
+  if (pendingAutoStartMap.size === 1) return pendingAutoStartMap.values().next().value!;
+  return null;
+}
+
+export const _getPendingAutoStart = getPendingAutoStart;
+
+export function hasPendingAutoStart(basePath?: string): boolean {
+  if (basePath) return pendingAutoStartMap.has(basePath);
+  return pendingAutoStartMap.size > 0;
+}
+
+export function setPendingAutoStart(basePath: string, entry: PendingAutoStartInput): void {
+  const ws = createWorkspace(entry.basePath);
+  const scope = scopeMilestone(ws, entry.milestoneId);
+  pendingAutoStartMap.set(basePath, {
+    createdAt: Date.now(),
+    planBlockedRecoveryCount: 0,
+    ...entry,
+    scope,
+  } as PendingAutoStartEntry);
+}
+
+export function deletePendingAutoStart(basePath: string): void {
+  pendingAutoStartMap.delete(basePath);
+}
+
+export function clearPendingAutoStart(basePath?: string): void {
+  if (basePath) {
+    pendingAutoStartMap.delete(basePath);
+  } else {
+    pendingAutoStartMap.clear();
+  }
+}
+
+export function getDiscussionMilestoneId(basePath?: string): string | null {
+  if (basePath) {
+    return pendingAutoStartMap.get(basePath)?.milestoneId ?? null;
+  }
+  if (pendingAutoStartMap.size === 1) {
+    return pendingAutoStartMap.values().next().value!.milestoneId;
+  }
+  return null;
+}

--- a/src/resources/extensions/gsd/pending-auto-start.ts
+++ b/src/resources/extensions/gsd/pending-auto-start.ts
@@ -19,8 +19,8 @@ export interface PendingAutoStartEntry {
 export interface PendingAutoStartInput {
   basePath: string;
   milestoneId: string;
-  ctx?: ExtensionCommandContext;
-  pi?: ExtensionAPI;
+  ctx: ExtensionCommandContext;
+  pi: ExtensionAPI;
   step?: boolean;
   createdAt?: number;
 }

--- a/src/resources/extensions/gsd/pending-auto-start.ts
+++ b/src/resources/extensions/gsd/pending-auto-start.ts
@@ -41,6 +41,9 @@ export function hasPendingAutoStart(basePath?: string): boolean {
 }
 
 export function setPendingAutoStart(basePath: string, entry: PendingAutoStartInput): void {
+  if (!entry.ctx || !entry.pi) {
+    throw new Error("setPendingAutoStart requires ctx and pi");
+  }
   const ws = createWorkspace(entry.basePath);
   const scope = scopeMilestone(ws, entry.milestoneId);
   pendingAutoStartMap.set(basePath, {
@@ -48,7 +51,9 @@ export function setPendingAutoStart(basePath: string, entry: PendingAutoStartInp
     planBlockedRecoveryCount: 0,
     ...entry,
     scope,
-  } as PendingAutoStartEntry);
+    ctx: entry.ctx,
+    pi: entry.pi,
+  });
 }
 
 export function deletePendingAutoStart(basePath: string): void {

--- a/src/resources/extensions/gsd/smart-entry-routing.ts
+++ b/src/resources/extensions/gsd/smart-entry-routing.ts
@@ -1,0 +1,73 @@
+// GSD-2 — Smart entry routing decisions.
+// Pure route selection for /gsd guided wizard choices.
+
+export type SmartEntryIsolationMode = "worktree" | string;
+
+export type ActiveTaskChoice =
+  | "execute"
+  | "auto"
+  | "status"
+  | "milestone_actions";
+
+export type ActiveTaskRoute =
+  | {
+      kind: "auto-bootstrap";
+      verboseMode: false;
+      options?: {
+        step?: true;
+        milestoneLock?: string;
+      };
+    }
+  | {
+      kind: "guided-dispatch";
+      unitType: "execute-task";
+    }
+  | {
+      kind: "status";
+    }
+  | {
+      kind: "milestone-actions";
+    };
+
+export function resolveGuidedExecuteLaunchMode(
+  isolationMode: SmartEntryIsolationMode,
+): "auto-step" | "guided-dispatch" {
+  return isolationMode === "worktree" ? "auto-step" : "guided-dispatch";
+}
+
+export function resolveActiveTaskChoiceRoute(input: {
+  choice: ActiveTaskChoice;
+  isolationMode: SmartEntryIsolationMode;
+  milestoneId: string;
+}): ActiveTaskRoute {
+  if (input.choice === "auto") {
+    return {
+      kind: "auto-bootstrap",
+      verboseMode: false,
+    };
+  }
+
+  if (input.choice === "execute") {
+    if (resolveGuidedExecuteLaunchMode(input.isolationMode) === "auto-step") {
+      return {
+        kind: "auto-bootstrap",
+        verboseMode: false,
+        options: {
+          step: true,
+          milestoneLock: input.milestoneId,
+        },
+      };
+    }
+
+    return {
+      kind: "guided-dispatch",
+      unitType: "execute-task",
+    };
+  }
+
+  if (input.choice === "status") {
+    return { kind: "status" };
+  }
+
+  return { kind: "milestone-actions" };
+}

--- a/src/resources/extensions/gsd/smart-entry-routing.ts
+++ b/src/resources/extensions/gsd/smart-entry-routing.ts
@@ -1,7 +1,7 @@
 // GSD-2 — Smart entry routing decisions.
 // Pure route selection for /gsd guided wizard choices.
 
-export type SmartEntryIsolationMode = "worktree" | string;
+export type SmartEntryIsolationMode = "worktree" | "branch" | "none";
 
 export type ActiveTaskChoice =
   | "execute"
@@ -69,5 +69,9 @@ export function resolveActiveTaskChoiceRoute(input: {
     return { kind: "status" };
   }
 
-  return { kind: "milestone-actions" };
+  if (input.choice === "milestone_actions") {
+    return { kind: "milestone-actions" };
+  }
+
+  throw new Error(`Invalid ActiveTaskChoice: ${input.choice}`);
 }

--- a/src/resources/extensions/gsd/tests/clear-stale-autostart.test.ts
+++ b/src/resources/extensions/gsd/tests/clear-stale-autostart.test.ts
@@ -17,6 +17,15 @@ import {
   setPendingAutoStart,
 } from "../guided-flow.ts";
 
+function pendingInput(basePath: string, milestoneId: string) {
+  return {
+    basePath,
+    milestoneId,
+    ctx: { ui: { notify: () => undefined } } as any,
+    pi: { sendMessage: () => undefined } as any,
+  };
+}
+
 afterEach(() => {
   clearPendingAutoStart();
 });
@@ -28,7 +37,7 @@ describe("clear stale pending auto-start (#3667)", () => {
     mkdirSync(join(base, ".gsd"), { recursive: true });
     const before = Date.now();
 
-    setPendingAutoStart(base, { basePath: base, milestoneId: "M001" });
+    setPendingAutoStart(base, pendingInput(base, "M001"));
 
     const entry = _getPendingAutoStart(base);
     assert.ok(entry);
@@ -41,7 +50,7 @@ describe("clear stale pending auto-start (#3667)", () => {
     t.after(() => rmSync(base, { recursive: true, force: true }));
     mkdirSync(join(base, ".gsd"), { recursive: true });
 
-    setPendingAutoStart(base, { basePath: base, milestoneId: "M001", createdAt: 123 });
+    setPendingAutoStart(base, { ...pendingInput(base, "M001"), createdAt: 123 });
 
     assert.equal(_getPendingAutoStart(base)?.createdAt, 123);
   });

--- a/src/resources/extensions/gsd/tests/guided-dispatch-root.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-dispatch-root.test.ts
@@ -1,0 +1,106 @@
+// GSD-2 — Guided workflow dispatch project-root tests.
+// Verifies smart entry dispatch uses the explicit project root instead of cwd.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  _dispatchWorkflowForTest,
+  resolveGuidedDispatchProjectRoot,
+} from "../guided-flow.ts";
+
+test("guided dispatch falls back to cwd only when no project root is supplied", () => {
+  const cwd = process.cwd();
+  assert.equal(resolveGuidedDispatchProjectRoot(), cwd);
+  assert.equal(resolveGuidedDispatchProjectRoot("/tmp/explicit-root"), "/tmp/explicit-root");
+});
+
+test("guided dispatch passes the explicit project root through model and compatibility checks", async () => {
+  const explicitRoot = mkdtempSync(join(tmpdir(), "gsd-guided-root-explicit-"));
+  const otherRoot = mkdtempSync(join(tmpdir(), "gsd-guided-root-cwd-"));
+  const workflowPath = join(explicitRoot, "GSD-WORKFLOW.md");
+  const originalWorkflowPath = process.env.GSD_WORKFLOW_PATH;
+  const originalCwd = process.cwd();
+  const seen = {
+    prefsRoot: "",
+    modelRoot: "",
+    compatibilityRoot: "",
+    sent: false,
+  };
+
+  const ctx = {
+    model: { provider: "local-provider" },
+    modelRegistry: {
+      getProviderAuthMode: () => "apiKey",
+    },
+    ui: {
+      notify: () => {},
+    },
+  };
+
+  const pi = {
+    getActiveTools: () => ["gsd_plan_slice"],
+    setActiveTools: () => {},
+    sendMessage: () => {
+      seen.sent = true;
+    },
+  };
+
+  try {
+    writeFileSync(workflowPath, "# Workflow\n", "utf-8");
+    process.env.GSD_WORKFLOW_PATH = workflowPath;
+    process.chdir(otherRoot);
+
+    await _dispatchWorkflowForTest(
+      pi as any,
+      "Plan the slice.",
+      "gsd-run",
+      ctx as any,
+      "plan-slice",
+      {
+        basePath: explicitRoot,
+        deps: {
+          loadPreferences: (projectRoot?: string) => {
+            seen.prefsRoot = projectRoot ?? "";
+            return { preferences: {} } as any;
+          },
+          selectModel: async (
+            _ctx: unknown,
+            _pi: unknown,
+            _unitType: string,
+            _unitId: string,
+            projectRoot: string,
+          ) => {
+            seen.modelRoot = projectRoot;
+            return { routing: null, appliedModel: null };
+          },
+          getTransportSupportError: (
+            _provider: string | undefined,
+            _requiredTools: string[],
+            options?: { projectRoot?: string },
+          ) => {
+            seen.compatibilityRoot = options?.projectRoot ?? "";
+            return null;
+          },
+        },
+      },
+    );
+
+    assert.equal(seen.prefsRoot, explicitRoot);
+    assert.equal(seen.modelRoot, explicitRoot);
+    assert.equal(seen.compatibilityRoot, explicitRoot);
+    assert.equal(seen.sent, true);
+  } finally {
+    process.chdir(originalCwd);
+    if (originalWorkflowPath === undefined) {
+      delete process.env.GSD_WORKFLOW_PATH;
+    } else {
+      process.env.GSD_WORKFLOW_PATH = originalWorkflowPath;
+    }
+    rmSync(explicitRoot, { recursive: true, force: true });
+    rmSync(otherRoot, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/guided-flow-session-isolation.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-flow-session-isolation.test.ts
@@ -129,3 +129,44 @@ test("checkAutoStartAfterDiscuss ignores missing manifest for single-milestone d
     rmSync(base, { recursive: true, force: true });
   }
 });
+
+test("checkAutoStartAfterDiscuss(basePath) selects the matching pending entry when multiple sessions exist", () => {
+  const projectA = mkdtempSync(join(tmpdir(), "gsd-auto-start-project-a-"));
+  const projectB = mkdtempSync(join(tmpdir(), "gsd-auto-start-project-b-"));
+
+  function writeReadyArtifacts(base: string, milestoneId: string): void {
+    const gsdDir = join(base, ".gsd");
+    const milestoneDir = join(gsdDir, "milestones", milestoneId);
+    mkdirSync(milestoneDir, { recursive: true });
+    writeFileSync(join(gsdDir, "PROJECT.md"), `# Project\n\n| ${milestoneId} | Milestone | active |\n`);
+    writeFileSync(join(gsdDir, "STATE.md"), "# State\n");
+    writeFileSync(join(milestoneDir, `${milestoneId}-CONTEXT.md`), "# Context\n");
+  }
+
+  try {
+    clearPendingAutoStart();
+    writeReadyArtifacts(projectA, "M001");
+    writeReadyArtifacts(projectB, "M002");
+    setPendingAutoStart(projectA, {
+      basePath: projectA,
+      milestoneId: "M001",
+      ctx: { ui: { notify: () => undefined } } as any,
+      pi: { setActiveTools: () => undefined, getActiveTools: () => [] } as any,
+    });
+    setPendingAutoStart(projectB, {
+      basePath: projectB,
+      milestoneId: "M002",
+      ctx: { ui: { notify: () => undefined } } as any,
+      pi: { setActiveTools: () => undefined, getActiveTools: () => [] } as any,
+    });
+
+    assert.equal(checkAutoStartAfterDiscuss(), false, "ambiguous pending sessions should not auto-start");
+    assert.equal(checkAutoStartAfterDiscuss(projectB), true, "explicit basePath should select projectB");
+    assert.equal(getDiscussionMilestoneId(projectA), "M001", "projectA should remain pending");
+    assert.equal(getDiscussionMilestoneId(projectB), null, "projectB should be cleared after start");
+  } finally {
+    clearPendingAutoStart();
+    rmSync(projectA, { recursive: true, force: true });
+    rmSync(projectB, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/guided-flow-session-isolation.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-flow-session-isolation.test.ts
@@ -21,6 +21,15 @@ import {
   checkAutoStartAfterDiscuss,
 } from "../guided-flow.ts";
 
+function pendingInput(basePath: string, milestoneId: string) {
+  return {
+    basePath,
+    milestoneId,
+    ctx: { ui: { notify: () => undefined } } as any,
+    pi: { setActiveTools: () => undefined, getActiveTools: () => [] } as any,
+  };
+}
+
 // ─── Tests ─────────────────────────────────────────────────────────────────
 
 describe("#2985 Bug 3 — concurrent discuss sessions must be independent", () => {
@@ -34,13 +43,11 @@ describe("#2985 Bug 3 — concurrent discuss sessions must be independent", () =
     const projectB = "/projects/beta";
 
     setPendingAutoStart(projectA, {
-      basePath: projectA,
-      milestoneId: "M001-aaa111",
+      ...pendingInput(projectA, "M001-aaa111"),
     });
 
     setPendingAutoStart(projectB, {
-      basePath: projectB,
-      milestoneId: "M002-bbb222",
+      ...pendingInput(projectB, "M002-bbb222"),
     });
 
     // Both sessions should be retrievable
@@ -55,8 +62,8 @@ describe("#2985 Bug 3 — concurrent discuss sessions must be independent", () =
     const projectA = "/projects/alpha";
     const projectB = "/projects/beta";
 
-    setPendingAutoStart(projectA, { basePath: projectA, milestoneId: "M001-aaa111" });
-    setPendingAutoStart(projectB, { basePath: projectB, milestoneId: "M002-bbb222" });
+    setPendingAutoStart(projectA, pendingInput(projectA, "M001-aaa111"));
+    setPendingAutoStart(projectB, pendingInput(projectB, "M002-bbb222"));
 
     // Clear only projectA
     clearPendingAutoStart(projectA);
@@ -72,8 +79,8 @@ describe("#2985 Bug 4 — getDiscussionMilestoneId must be keyed by basePath", (
   });
 
   test("getDiscussionMilestoneId(basePath) returns correct milestone for each project", () => {
-    setPendingAutoStart("/proj/a", { basePath: "/proj/a", milestoneId: "M001" });
-    setPendingAutoStart("/proj/b", { basePath: "/proj/b", milestoneId: "M002" });
+    setPendingAutoStart("/proj/a", pendingInput("/proj/a", "M001"));
+    setPendingAutoStart("/proj/b", pendingInput("/proj/b", "M002"));
 
     assert.equal(getDiscussionMilestoneId("/proj/a"), "M001");
     assert.equal(getDiscussionMilestoneId("/proj/b"), "M002");
@@ -81,8 +88,8 @@ describe("#2985 Bug 4 — getDiscussionMilestoneId must be keyed by basePath", (
   });
 
   test("getDiscussionMilestoneId() without basePath returns null when multiple sessions exist", () => {
-    setPendingAutoStart("/proj/a", { basePath: "/proj/a", milestoneId: "M001" });
-    setPendingAutoStart("/proj/b", { basePath: "/proj/b", milestoneId: "M002" });
+    setPendingAutoStart("/proj/a", pendingInput("/proj/a", "M001"));
+    setPendingAutoStart("/proj/b", pendingInput("/proj/b", "M002"));
 
     // Without a key, the function should not blindly return the first entry
     const result = getDiscussionMilestoneId();
@@ -92,7 +99,7 @@ describe("#2985 Bug 4 — getDiscussionMilestoneId must be keyed by basePath", (
   });
 
   test("getDiscussionMilestoneId() without basePath returns the milestone when only one session", () => {
-    setPendingAutoStart("/proj/a", { basePath: "/proj/a", milestoneId: "M001" });
+    setPendingAutoStart("/proj/a", pendingInput("/proj/a", "M001"));
 
     // With only one session, backward compat — return it
     const result = getDiscussionMilestoneId();

--- a/src/resources/extensions/gsd/tests/guided-tool-contract.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-tool-contract.test.ts
@@ -1,0 +1,65 @@
+// GSD-2 — Guided Unit Tool Contract tests.
+// Verifies guided workflow turns use manifest tool policy without auto-mode state.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerHooks } from "../bootstrap/register-hooks.ts";
+import {
+  clearGuidedUnitContext,
+  getGuidedUnitContext,
+  setGuidedUnitContext,
+} from "../guided-unit-context.ts";
+
+test("guided Unit context applies Tool Contract policy when auto-mode has no current Unit", async () => {
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-guided-tool-contract-"));
+  const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>();
+  const pi = {
+    on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  };
+
+  try {
+    clearGuidedUnitContext();
+    registerHooks(pi as any, []);
+    setGuidedUnitContext(basePath, "plan-slice");
+
+    let blockResult: { block?: boolean; reason?: string } | undefined;
+    for (const handler of handlers.get("tool_call") ?? []) {
+      const result = await handler({
+        toolName: "edit",
+        input: {
+          path: join(basePath, "src", "main.ts"),
+        },
+      }, { cwd: basePath });
+      if (result?.block) {
+        blockResult = result;
+        break;
+      }
+    }
+
+    assert.equal(blockResult?.block, true);
+    assert.match(blockResult?.reason ?? "", /plan-slice|ToolsPolicy|not allowed|blocked/i);
+  } finally {
+    clearGuidedUnitContext();
+    rmSync(basePath, { recursive: true, force: true });
+  }
+});
+
+test("guided Unit context can be cleared by project root", () => {
+  clearGuidedUnitContext();
+  setGuidedUnitContext("/project/a", "plan-slice");
+  setGuidedUnitContext("/project/b", "complete-slice");
+
+  clearGuidedUnitContext("/project/a");
+
+  assert.equal(getGuidedUnitContext("/project/a"), null);
+  assert.equal(getGuidedUnitContext("/project/b")?.unitType, "complete-slice");
+  clearGuidedUnitContext();
+});

--- a/src/resources/extensions/gsd/tests/headless-milestone-parity.test.ts
+++ b/src/resources/extensions/gsd/tests/headless-milestone-parity.test.ts
@@ -45,7 +45,7 @@ describe("headless milestone bootstrap — parity with interactive flow", () => 
 
     // Match only the actual dispatchWorkflow call — comments in the body
     // may mention "plan-milestone" as part of the fix rationale.
-    const dispatchMatches = [...fnBody.matchAll(/dispatchWorkflow\([\s\S]*?,\s*"([^"]+)"\s*,\s*\{ basePath \}\s*\)/g)];
+    const dispatchMatches = [...fnBody.matchAll(/dispatchWorkflow\([\s\S]*?,\s*"([^"]+)"\s*,\s*\{\s*basePath\s*\}\s*\)/g)];
     assert.strictEqual(
       dispatchMatches.length,
       1,

--- a/src/resources/extensions/gsd/tests/headless-milestone-parity.test.ts
+++ b/src/resources/extensions/gsd/tests/headless-milestone-parity.test.ts
@@ -45,7 +45,7 @@ describe("headless milestone bootstrap — parity with interactive flow", () => 
 
     // Match only the actual dispatchWorkflow call — comments in the body
     // may mention "plan-milestone" as part of the fix rationale.
-    const dispatchMatches = [...fnBody.matchAll(/dispatchWorkflow\([^)]*,\s*"([^"]+)"\s*\)/g)];
+    const dispatchMatches = [...fnBody.matchAll(/dispatchWorkflow\([\s\S]*?,\s*"([^"]+)"\s*,\s*\{ basePath \}\s*\)/g)];
     assert.strictEqual(
       dispatchMatches.length,
       1,

--- a/src/resources/extensions/gsd/tests/pending-autostart-scope.test.ts
+++ b/src/resources/extensions/gsd/tests/pending-autostart-scope.test.ts
@@ -11,6 +11,7 @@ import {
   clearPendingAutoStart,
   _getPendingAutoStart,
 } from "../guided-flow.ts";
+import type { PendingAutoStartInput } from "../pending-auto-start.ts";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -65,7 +66,11 @@ describe("pendingAutoStart scope pinning (C1)", () => {
 
   test("setPendingAutoStart rejects entries without ctx and pi before storing them", () => {
     assert.throws(
-      () => setPendingAutoStart(base, { basePath: base, milestoneId: "M001" }),
+      () =>
+        setPendingAutoStart(base, {
+          basePath: base,
+          milestoneId: "M001",
+        } as PendingAutoStartInput),
       /requires ctx and pi/,
       "pending entries must include the handles later used by auto-start recovery",
     );

--- a/src/resources/extensions/gsd/tests/pending-autostart-scope.test.ts
+++ b/src/resources/extensions/gsd/tests/pending-autostart-scope.test.ts
@@ -20,6 +20,15 @@ function makeProjectDir(): string {
   return dir;
 }
 
+function pendingInput(basePath: string, milestoneId: string) {
+  return {
+    basePath,
+    milestoneId,
+    ctx: { ui: { notify: () => undefined } } as any,
+    pi: { sendMessage: () => undefined } as any,
+  };
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("pendingAutoStart scope pinning (C1)", () => {
@@ -38,7 +47,7 @@ describe("pendingAutoStart scope pinning (C1)", () => {
   });
 
   test("setPendingAutoStart stores a scope whose paths derive from the basePath at reservation time", () => {
-    setPendingAutoStart(base, { basePath: base, milestoneId: "M001" });
+    setPendingAutoStart(base, pendingInput(base, "M001"));
 
     const entry = _getPendingAutoStart(base);
     assert.ok(entry, "entry should exist");
@@ -54,8 +63,18 @@ describe("pendingAutoStart scope pinning (C1)", () => {
     assert.equal(entry.scope.stateFile(), expectedState);
   });
 
+  test("setPendingAutoStart rejects entries without ctx and pi before storing them", () => {
+    assert.throws(
+      () => setPendingAutoStart(base, { basePath: base, milestoneId: "M001" }),
+      /requires ctx and pi/,
+      "pending entries must include the handles later used by auto-start recovery",
+    );
+
+    assert.equal(_getPendingAutoStart(base), null);
+  });
+
   test("scope paths are unaffected by process.chdir after reservation", (t) => {
-    setPendingAutoStart(base, { basePath: base, milestoneId: "M002" });
+    setPendingAutoStart(base, pendingInput(base, "M002"));
 
     const entry = _getPendingAutoStart(base);
     assert.ok(entry, "entry should exist");
@@ -82,7 +101,7 @@ describe("pendingAutoStart scope pinning (C1)", () => {
 
   test("scope identityKey matches the realpath of the original basePath even with trailing slash", () => {
     const baseWithSlash = base + "/";
-    setPendingAutoStart(base, { basePath: baseWithSlash, milestoneId: "M003" });
+    setPendingAutoStart(base, pendingInput(baseWithSlash, "M003"));
 
     const entry = _getPendingAutoStart(base);
     assert.ok(entry, "entry should exist");
@@ -96,7 +115,7 @@ describe("pendingAutoStart scope pinning (C1)", () => {
   });
 
   test("clearPendingAutoStart removes the entry", () => {
-    setPendingAutoStart(base, { basePath: base, milestoneId: "M001" });
+    setPendingAutoStart(base, pendingInput(base, "M001"));
 
     const before = _getPendingAutoStart(base);
     assert.ok(before, "entry should exist before clear");
@@ -108,7 +127,7 @@ describe("pendingAutoStart scope pinning (C1)", () => {
   });
 
   test("_getPendingAutoStart with no basePath argument returns the sole entry", () => {
-    setPendingAutoStart(base, { basePath: base, milestoneId: "M001" });
+    setPendingAutoStart(base, pendingInput(base, "M001"));
 
     // No argument — should return the sole entry
     const entry = _getPendingAutoStart();

--- a/src/resources/extensions/gsd/tests/smart-entry-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/smart-entry-routing.test.ts
@@ -9,11 +9,12 @@ import {
   resolveGuidedExecuteLaunchMode,
   type ActiveTaskChoice,
   type ActiveTaskRoute,
+  type SmartEntryIsolationMode,
 } from "../smart-entry-routing.ts";
 
 test("guided execute route enters auto step bootstrap only for worktree isolation", () => {
   const cases: Array<{
-    isolationMode: string;
+    isolationMode: SmartEntryIsolationMode;
     expectedRoute: ActiveTaskRoute;
   }> = [
     {
@@ -91,6 +92,18 @@ test("active task smart entry choices resolve to explicit routes", () => {
       testCase.expectedRoute,
     );
   }
+});
+
+test("active task route rejects invalid choices from untyped callers", () => {
+  assert.throws(
+    () =>
+      resolveActiveTaskChoiceRoute({
+        choice: "not_yet" as ActiveTaskChoice,
+        isolationMode: "worktree",
+        milestoneId: "M001",
+      }),
+    /Invalid ActiveTaskChoice: not_yet/,
+  );
 });
 
 test("guided execute launch mode remains a small compatibility helper", () => {

--- a/src/resources/extensions/gsd/tests/smart-entry-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/smart-entry-routing.test.ts
@@ -1,0 +1,100 @@
+// GSD-2 — Smart entry routing behavior tests.
+// Verifies guided wizard choices resolve to the correct execution path.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  resolveActiveTaskChoiceRoute,
+  resolveGuidedExecuteLaunchMode,
+  type ActiveTaskChoice,
+  type ActiveTaskRoute,
+} from "../smart-entry-routing.ts";
+
+test("guided execute route enters auto step bootstrap only for worktree isolation", () => {
+  const cases: Array<{
+    isolationMode: string;
+    expectedRoute: ActiveTaskRoute;
+  }> = [
+    {
+      isolationMode: "worktree",
+      expectedRoute: {
+        kind: "auto-bootstrap",
+        verboseMode: false,
+        options: {
+          step: true,
+          milestoneLock: "M001",
+        },
+      },
+    },
+    {
+      isolationMode: "none",
+      expectedRoute: {
+        kind: "guided-dispatch",
+        unitType: "execute-task",
+      },
+    },
+    {
+      isolationMode: "branch",
+      expectedRoute: {
+        kind: "guided-dispatch",
+        unitType: "execute-task",
+      },
+    },
+  ];
+
+  for (const testCase of cases) {
+    assert.deepEqual(
+      resolveActiveTaskChoiceRoute({
+        choice: "execute",
+        isolationMode: testCase.isolationMode,
+        milestoneId: "M001",
+      }),
+      testCase.expectedRoute,
+    );
+  }
+});
+
+test("active task smart entry choices resolve to explicit routes", () => {
+  const cases: Array<{
+    choice: ActiveTaskChoice;
+    expectedRoute: ActiveTaskRoute;
+  }> = [
+    {
+      choice: "auto",
+      expectedRoute: {
+        kind: "auto-bootstrap",
+        verboseMode: false,
+      },
+    },
+    {
+      choice: "status",
+      expectedRoute: {
+        kind: "status",
+      },
+    },
+    {
+      choice: "milestone_actions",
+      expectedRoute: {
+        kind: "milestone-actions",
+      },
+    },
+  ];
+
+  for (const testCase of cases) {
+    assert.deepEqual(
+      resolveActiveTaskChoiceRoute({
+        choice: testCase.choice,
+        isolationMode: "worktree",
+        milestoneId: "M001",
+      }),
+      testCase.expectedRoute,
+    );
+  }
+});
+
+test("guided execute launch mode remains a small compatibility helper", () => {
+  assert.equal(resolveGuidedExecuteLaunchMode("worktree"), "auto-step");
+  assert.equal(resolveGuidedExecuteLaunchMode("none"), "guided-dispatch");
+  assert.equal(resolveGuidedExecuteLaunchMode("branch"), "guided-dispatch");
+});

--- a/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
+++ b/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
@@ -4,7 +4,10 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { _withDetachedAutoKeepaliveForTest } from "../auto.ts";
-import { _scheduleAutoStartAfterIdleForTest } from "../guided-flow.ts";
+import {
+  _scheduleAutoStartAfterIdleForTest,
+  resolveGuidedExecuteLaunchMode,
+} from "../guided-flow.ts";
 
 const gsdDir = resolve(import.meta.dirname, "..");
 
@@ -61,6 +64,24 @@ test("bare /gsd stays in the foreground smart-entry flow (#5125 regression)", ()
   assert.ok(
     !bareCommandBranch.includes("startAutoDetached("),
     "bare /gsd must not enter detached auto bootstrap directly",
+  );
+});
+
+test("guided execute uses auto step bootstrap when worktree isolation is enabled", () => {
+  assert.equal(
+    resolveGuidedExecuteLaunchMode("worktree"),
+    "auto-step",
+    "guided execute must enter auto bootstrap so the milestone worktree is created before execution",
+  );
+  assert.equal(
+    resolveGuidedExecuteLaunchMode("none"),
+    "guided-dispatch",
+    "non-isolated projects can keep the foreground guided dispatch path",
+  );
+  assert.equal(
+    resolveGuidedExecuteLaunchMode("branch"),
+    "guided-dispatch",
+    "this regression fix is scoped to worktree isolation",
   );
 });
 


### PR DESCRIPTION
## TL;DR

**What:** Hardens `/gsd` smart-entry routing so guided choices use explicit routes, roots, handoff state, and Tool Contract context.
**Why:** Smart-entry paths could bypass worktree bootstrap or rely on ambient process state, making configured isolation advisory instead of enforced.
**How:** Adds small routing/context modules, routes worktree execute through auto step bootstrap, passes explicit project roots through guided dispatch, isolates pending auto-start state, and applies manifest Tool Contract policy to guided Units.

Closes #5929
Closes #5931
Closes #5932
Closes #5933
Closes #5934
Closes #5935

## What

- Centralized active-task smart-entry route selection for execute, auto, status, and milestone actions.
- Preserved the worktree-isolated execute path through auto step bootstrap with the active milestone lock.
- Passed the explicit smart-entry project root through guided dispatch preferences, model selection, and workflow compatibility checks.
- Moved pending discuss-to-auto handoff state into a focused project-root-keyed module and made agent-end recovery use the resolved project root.
- Added guided Unit context so non-auto guided workflow turns are enforced by the same manifest Tool Contract policy as auto-mode Units.
- Added behavior tests for the route matrix, root propagation, pending auto-start session selection, and guided Tool Contract enforcement.

## Why

Bare `/gsd` enters a smart wizard, but several paths were encoded inline in `guided-flow.ts`. That made it easy for a foreground guided Unit to skip the deeper Auto Orchestration path that owns worktree lifecycle, or for dispatch/recovery to depend on `process.cwd()` instead of the wizard project root.

## How

The change keeps behavior narrow and incremental: route decisions are pure where practical, runtime handoff state has a dedicated module, and guided dispatch publishes enough Unit context for existing Tool Contract checks to run without inventing a second enforcement model.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/smart-entry-routing.test.ts src/resources/extensions/gsd/tests/guided-dispatch-root.test.ts src/resources/extensions/gsd/tests/guided-tool-contract.test.ts src/resources/extensions/gsd/tests/guided-flow-session-isolation.test.ts src/resources/extensions/gsd/tests/pending-autostart-scope.test.ts src/resources/extensions/gsd/tests/clear-stale-autostart.test.ts src/resources/extensions/gsd/tests/start-auto-detached.test.ts src/resources/extensions/gsd/tests/restore-tools-after-discuss.test.ts src/resources/extensions/gsd/tests/discuss-tool-scoping.test.ts`
- `npm run typecheck:extensions`

## Change type

- [x] `fix` — Bug fix
- [x] `refactor` — Code restructuring, no behavior change except the bug fix
- [x] `test` — Adding or updating tests

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized smart-entry routing for active-task choices and a launch-mode resolver.

* **Improvements**
  * Launch mode respects project isolation (worktree → auto-step; others → guided-dispatch).
  * Session-scoped guided-unit context and per-project pending auto-start to isolate concurrent sessions.
  * Dispatch workflows accept project-scoped options so actions target the correct project.

* **Bug Fixes**
  * Avoid cancelling progress on a stale terminal provider error.

* **Tests**
  * New tests for routing, launch-mode, session isolation, dispatch root propagation, and tool-contract.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5930)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->