### PR TITLE
fix(gsd): preserve phase handoff outcome

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -1168,11 +1168,25 @@ function normalizeRollupText(value: string | null | undefined): string | null {
 function extractLastAssistantSummary(messages: unknown[] | null | undefined): string | null {
   if (!messages || messages.length === 0) return null;
   for (let i = messages.length - 1; i >= 0; i--) {
+    if (!isAssistantMessage(messages[i])) continue;
     const text = extractMessageText(messages[i]);
     const clean = normalizeRollupText(text);
     if (clean) return truncateToWidth(clean, 220, "…");
   }
   return null;
+}
+
+function isAssistantMessage(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  if (record.role === "assistant") return true;
+
+  const message = record.message;
+  if (message && typeof message === "object") {
+    return (message as Record<string, unknown>).role === "assistant";
+  }
+
+  return false;
 }
 
 function extractMessageText(value: unknown): string | null {

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -120,6 +120,26 @@ export interface AutoOutcomeSurfaceSnapshot {
   startedAt?: number;
 }
 
+export function buildPhaseHandoffOutcome(input: {
+  unitType: string;
+  unitId: string;
+  agentEndMessages?: unknown[] | null;
+}): AutoOutcomeSurfaceSnapshot {
+  const phase = unitPhaseLabel(input.unitType);
+  const detail =
+    extractLastAssistantSummary(input.agentEndMessages) ??
+    `Completed ${unitVerb(input.unitType)} ${input.unitId}.`;
+
+  return {
+    status: "complete",
+    title: `${phase} complete`,
+    detail,
+    unitLabel: `${unitVerb(input.unitType)} ${input.unitId}`,
+    nextAction: "Preparing the next phase. Review this handoff while the next session starts.",
+    commands: ["/gsd status for overview", "/gsd visualize to inspect", "/gsd notifications for history"],
+  };
+}
+
 // ─── Unit Description Helpers ─────────────────────────────────────────────────
 
 export function unitVerb(unitType: string): string {
@@ -631,7 +651,6 @@ export function updateProgressWidget(
   tierBadge?: string,
 ): void {
   if (!ctx.hasUI) return;
-  ctx.ui.setWidget("gsd-outcome", undefined);
 
   // Welcome header is a startup-only banner — permanently suppress it once
   // auto-mode activates. The dashboard widget owns all status from here.
@@ -1144,4 +1163,42 @@ function normalizeRollupText(value: string | null | undefined): string | null {
     .trim();
   if (!clean || clean === "(none)" || clean === "None." || clean === "Not provided.") return null;
   return clean;
+}
+
+function extractLastAssistantSummary(messages: unknown[] | null | undefined): string | null {
+  if (!messages || messages.length === 0) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const text = extractMessageText(messages[i]);
+    const clean = normalizeRollupText(text);
+    if (clean) return truncateToWidth(clean, 220, "…");
+  }
+  return null;
+}
+
+function extractMessageText(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object") return null;
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.content === "string") return record.content;
+
+  const message = record.message;
+  if (message && typeof message === "object") {
+    return extractMessageText(message);
+  }
+
+  const content = record.content;
+  if (Array.isArray(content)) {
+    const parts = content
+      .map((part) => {
+        if (typeof part === "string") return part;
+        if (!part || typeof part !== "object") return "";
+        const partRecord = part as Record<string, unknown>;
+        return typeof partRecord.text === "string" ? partRecord.text : "";
+      })
+      .filter(Boolean);
+    return parts.length > 0 ? parts.join(" ") : null;
+  }
+
+  return null;
 }

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -1165,17 +1165,6 @@ function normalizeRollupText(value: string | null | undefined): string | null {
   return clean;
 }
 
-function extractLastAssistantSummary(messages: unknown[] | null | undefined): string | null {
-  if (!messages || messages.length === 0) return null;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (!isAssistantMessage(messages[i])) continue;
-    const text = extractMessageText(messages[i]);
-    const clean = normalizeRollupText(text);
-    if (clean) return truncateToWidth(clean, 220, "…");
-  }
-  return null;
-}
-
 function isAssistantMessage(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
   const record = value as Record<string, unknown>;
@@ -1187,6 +1176,17 @@ function isAssistantMessage(value: unknown): boolean {
   }
 
   return false;
+}
+
+function extractLastAssistantSummary(messages: unknown[] | null | undefined): string | null {
+  if (!messages || messages.length === 0) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (!isAssistantMessage(messages[i])) continue;
+    const text = extractMessageText(messages[i]);
+    const clean = normalizeRollupText(text);
+    if (clean) return truncateToWidth(clean, 220, "…");
+  }
+  return null;
 }
 
 function extractMessageText(value: unknown): string | null {

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -77,6 +77,7 @@ import { resolveManifest } from "../unit-context-manifest.js";
 import { createWorktreeSafetyModule, type WorktreeSafetyResult } from "../worktree-safety.js";
 import { isSuspiciousGhostCompletion } from "../auto-unit-closeout.js";
 import { decideVerificationRetry, verificationRetryKey } from "./verification-retry-policy.js";
+import { buildPhaseHandoffOutcome, setAutoOutcomeWidget } from "../auto-dashboard.js";
 
 // ─── Path Comparison Helper ───────────────────────────────────────────────
 /** Compare two paths for physical identity, tolerating trailing slashes and symlinks. */
@@ -2602,6 +2603,20 @@ export async function runFinalize(
       lastProgressAt: Date.now(),
       lastProgressKind: "finalize-success",
     });
+    if (
+      !preUnitSnapshot.type.startsWith("hook/") &&
+      preUnitSnapshot.type !== "custom-step" &&
+      preUnitSnapshot.type !== "complete-milestone"
+    ) {
+      setAutoOutcomeWidget(ctx, {
+        ...buildPhaseHandoffOutcome({
+          unitType: preUnitSnapshot.type,
+          unitId: preUnitSnapshot.id,
+          agentEndMessages: s.lastUnitAgentEndMessages,
+        }),
+        startedAt: s.autoStartTime,
+      });
+    }
   }
   s.currentUnit = null;
   clearCurrentPhase();

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -201,6 +201,14 @@ export function resolveAgentEndErrorDisplay(
   return rawErrorMsg;
 }
 
+export function isTerminalDeletedWorktreeProviderError(
+  message: string | undefined | null,
+): boolean {
+  if (!message) return false;
+  if (!/\bdoes not exist\b/i.test(message)) return false;
+  return /[/\\]\.gsd[/\\](?:projects[/\\][^/\\]+[/\\])?worktrees[/\\][^/\\\s"']+/i.test(message);
+}
+
 async function pauseTransientWithBackoff(
   cls: ErrorClass,
   pi: ExtensionAPI,
@@ -360,6 +368,17 @@ export async function handleAgentEnd(
       rawErrorMsg,
       "content" in lastMsg ? lastMsg.content : undefined,
     );
+    if (
+      isAutoCompletionStopInProgress() &&
+      isTerminalDeletedWorktreeProviderError(`${rawErrorMsg}\n${displayMsg}`)
+    ) {
+      resetRetryState(retryState);
+      logWarning(
+        "bootstrap",
+        `Ignoring stale deleted-worktree provider error during terminal completion reroot: ${displayMsg || rawErrorMsg}`,
+      );
+      return;
+    }
     const errorDetail = displayMsg ? `: ${displayMsg}` : "";
     const explicitRetryAfterMs = ("retryAfterMs" in lastMsg && typeof lastMsg.retryAfterMs === "number") ? lastMsg.retryAfterMs : undefined;
 

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -13,6 +13,7 @@ import {
   formatWidgetTokens,
   estimateTimeRemaining,
   extractUatSliceId,
+  buildPhaseHandoffOutcome,
   updateProgressWidget,
   setAutoOutcomeWidget,
   getRoadmapSlicesSync,
@@ -253,6 +254,60 @@ test("setAutoOutcomeWidget renders a durable next-action handoff", () => {
   assert.match(output, /Paused by user request/);
   assert.match(output, /researching M005\/S01/);
   assert.match(output, /\/gsd auto/);
+});
+
+test("buildPhaseHandoffOutcome summarizes the last phase result", () => {
+  const snapshot = buildPhaseHandoffOutcome({
+    unitType: "plan-slice",
+    unitId: "M005/S01",
+    agentEndMessages: [
+      { message: { role: "assistant", content: "Planned S01 with category-aware filtering and validation steps." } },
+    ],
+  });
+
+  assert.equal(snapshot.status, "complete");
+  assert.equal(snapshot.title, "PLAN complete");
+  assert.match(snapshot.detail ?? "", /category-aware filtering/);
+  assert.equal(snapshot.unitLabel, "planning M005/S01");
+  assert.match(snapshot.nextAction, /next phase/);
+});
+
+test("updateProgressWidget preserves the phase handoff during session switching", () => {
+  const calls: Array<[string, unknown]> = [];
+  updateProgressWidget(
+    {
+      hasUI: true,
+      ui: {
+        setWidget(key: string, factory: unknown) {
+          calls.push([key, factory]);
+        },
+        setHeader() {},
+        setStatus() {},
+      },
+    } as any,
+    "execute-task",
+    "M005/S01/T01",
+    {
+      phase: "executing",
+      activeSlice: { id: "S01", title: "Filter chip bar" },
+      activeTask: { id: "T01", title: "Add category filter" },
+    } as any,
+    {
+      getAutoStartTime: () => Date.now(),
+      isStepMode: () => false,
+      getCmdCtx: () => null,
+      getBasePath: () => "",
+      isVerbose: () => false,
+      isSessionSwitching: () => true,
+      getCurrentDispatchedModelId: () => null,
+    },
+  );
+
+  assert.ok(calls.some(([key]) => key === "gsd-progress"));
+  assert.ok(
+    !calls.some(([key, value]) => key === "gsd-outcome" && value === undefined),
+    "handoff widget should stay visible until the next progress frame renders",
+  );
 });
 
 test("shouldRenderRoadmapProgress hides pre-roadmap zero-slice progress", () => {

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -272,6 +272,22 @@ test("buildPhaseHandoffOutcome summarizes the last phase result", () => {
   assert.match(snapshot.nextAction, /next phase/);
 });
 
+test("buildPhaseHandoffOutcome ignores non-assistant trailing messages", () => {
+  const snapshot = buildPhaseHandoffOutcome({
+    unitType: "plan-slice",
+    unitId: "M005/S01",
+    agentEndMessages: [
+      { message: { role: "assistant", content: "Assistant summary to hand off." } },
+      { role: "tool", content: "Tool output should not be shown." },
+      { role: "user", content: "User follow-up should not be shown." },
+    ],
+  });
+
+  assert.match(snapshot.detail ?? "", /Assistant summary/);
+  assert.doesNotMatch(snapshot.detail ?? "", /Tool output/);
+  assert.doesNotMatch(snapshot.detail ?? "", /User follow-up/);
+});
+
 test("updateProgressWidget preserves the phase handoff during session switching", () => {
   const calls: Array<[string, unknown]> = [];
   updateProgressWidget(

--- a/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts
@@ -62,7 +62,11 @@ async function runSuccessfulFinalize(s: AutoSession) {
   );
 }
 
-async function runFinalizeWithDeps(s: AutoSession, depsOverrides: Record<string, unknown>) {
+async function runFinalizeWithDeps(
+  s: AutoSession,
+  depsOverrides: Record<string, unknown>,
+  ctxOverride?: Record<string, unknown>,
+) {
   const unit = s.currentUnit;
   assert.ok(unit, "test setup must provide currentUnit");
 
@@ -86,7 +90,7 @@ async function runFinalizeWithDeps(s: AutoSession, depsOverrides: Record<string,
 
   return runFinalize(
     {
-      ctx: { ui: { notify() {} } },
+      ctx: ctxOverride ?? { ui: { notify() {} } },
       pi: {},
       s,
       deps,
@@ -222,4 +226,51 @@ test("runFinalize merges a verified complete-milestone immediately and only once
   assert.equal(second.action, "next");
   assert.equal(lifecycleMergeCalls, 1);
   assert.equal(resolverMergeCalls, 0);
+});
+
+test("runFinalize does not render next-phase handoff for complete-milestone", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-finalize-complete-handoff-"));
+  t.after(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const s = new AutoSession();
+  const widgetCalls: Array<[string, unknown]> = [];
+  s.basePath = base;
+  s.originalBasePath = base;
+  s.currentMilestoneId = "M001";
+  s.currentUnit = {
+    type: "complete-milestone",
+    id: "M001",
+    startedAt: Date.now(),
+  };
+
+  const result = await runFinalizeWithDeps(
+    s,
+    {
+      preflightCleanRoot: () => ({ stashPushed: false }),
+      postflightPopStash: () => ({ needsManualRecovery: false }),
+      lifecycle: {
+        exitMilestone() {
+          return { ok: true, merged: true, codeFilesChanged: false };
+        },
+      },
+    },
+    {
+      hasUI: true,
+      ui: {
+        notify() {},
+        setWidget(key: string, value: unknown) {
+          widgetCalls.push([key, value]);
+        },
+      },
+    },
+  );
+
+  assert.equal(result.action, "next");
+  assert.equal(
+    widgetCalls.some(([key]) => key === "gsd-outcome"),
+    false,
+    "complete-milestone finalize should leave terminal completion UI to stopAuto",
+  );
 });

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -10,7 +10,7 @@ import assert from "node:assert/strict";
 import { classifyError, isTransient, isTransientNetworkError } from "../error-classifier.ts";
 import { pauseAutoForProviderError } from "../provider-error-pause.ts";
 import { resumeAutoAfterProviderDelay } from "../bootstrap/provider-error-resume.ts";
-import { MAX_TRANSIENT_AUTO_RESUMES, resetTransientRetryState } from "../bootstrap/agent-end-recovery.ts";
+import { MAX_TRANSIENT_AUTO_RESUMES, isTerminalDeletedWorktreeProviderError, resetTransientRetryState } from "../bootstrap/agent-end-recovery.ts";
 import { _buildCancelledUnitStopReason } from "../auto/phases.ts";
 import { getNextFallbackModel } from "../preferences.ts";
 // Zero-import module — imported by path rather than through the package
@@ -397,6 +397,25 @@ test("pauseAutoForProviderError falls back to indefinite pause when not rate lim
   assert.deepEqual(notifications, [
     { message: "Auto-mode paused due to provider error: connection refused", level: "warning" },
   ]);
+});
+
+test("isTerminalDeletedWorktreeProviderError matches removed auto-worktree paths only", () => {
+  assert.equal(
+    isTerminalDeletedWorktreeProviderError('Path "/Users/dev/.gsd/projects/abc123/worktrees/M005" does not exist'),
+    true,
+  );
+  assert.equal(
+    isTerminalDeletedWorktreeProviderError('Path "/Users/dev/app/.gsd/worktrees/M005" does not exist'),
+    true,
+  );
+  assert.equal(
+    isTerminalDeletedWorktreeProviderError('Path "/Users/dev/app/src/file.ts" does not exist'),
+    false,
+  );
+  assert.equal(
+    isTerminalDeletedWorktreeProviderError('Path "/Users/dev/.gsd/projects/abc123/worktrees/M005" failed with EACCES'),
+    false,
+  );
 });
 
 // ── resumeAutoAfterProviderDelay ────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Preserves a phase handoff outcome widget after successful auto Unit finalization.
**Why:** The dashboard could clear the outcome surface during session switching, hiding the just-completed phase handoff before the next progress frame was useful.
**How:** Builds a concise handoff outcome from the last assistant summary, renders it after normal Unit finalization, preserves it through session-switch progress updates, and keeps complete-milestone terminal UI separate.

Closes #5936

## What

- Added `buildPhaseHandoffOutcome()` to summarize the last completed Unit handoff.
- Rendered the outcome after successful non-terminal `runFinalize()` paths.
- Stopped `updateProgressWidget()` from clearing `gsd-outcome` prematurely.
- Added a deleted-worktree provider-error guard for terminal completion reroot noise.
- Added regression tests for dashboard handoff rendering, finalize lifecycle behavior, and deleted-worktree path matching.

## Why

Auto-mode can switch sessions immediately after a Unit completes. During that transition, the useful completion handoff should remain visible until the next real progress frame owns the dashboard, while final milestone completion should continue to use its terminal completion UI.

## How

The dashboard builds a durable `AutoOutcomeSurfaceSnapshot` from the completed Unit type/id and the last assistant message. Finalize renders that snapshot for normal Units only. Provider errors that refer to an already-deleted auto worktree during terminal completion are recognized and ignored instead of surfacing as stale failure noise.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-dashboard.test.ts src/resources/extensions/gsd/tests/auto-phases-lifecycle.test.ts src/resources/extensions/gsd/tests/provider-errors.test.ts`
- `npm run typecheck:extensions`

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-outcome widget now appears on phase handoff completion, showing phase/unit labels, a summarized handoff detail (preferring the last assistant summary), and next-action guidance.

* **Bug Fixes**
  * Outcome widget is no longer cleared during progress updates, preserving handoff visibility.
  * Complete-milestone and certain hook/custom-step units no longer display the handoff outcome UI.

* **Chores**
  * Improved detection/handling for deleted-worktree provider error scenarios to avoid unnecessary retries.

* **Tests**
  * Added coverage for phase handoff rendering, ignoring non-assistant trailing messages, widget behavior across session switches, and deleted-worktree error detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5937)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->