### PR TITLE
fix(gsd): recover empty milestone worktrees

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -317,6 +317,13 @@ import { normalizeRealPath } from "./paths.js";
 /** Throttle STATE.md rebuilds — at most once per 30 seconds */
 const STATE_REBUILD_MIN_INTERVAL_MS = 30_000;
 
+export function formatAutoStopNotification(prefix: string, totals: { cost: number; tokens: { total: number } }, unitCount: number): string {
+  return [
+    `${prefix}.`,
+    `Session: ${formatCost(totals.cost)} · ${formatTokenCount(totals.tokens.total)} tokens · ${unitCount} units`,
+  ].join("\n");
+}
+
 /**
  * Phase B — register this auto-mode process in the workers table so other
  * workers and janitors can detect liveness via heartbeat. Best-effort: if
@@ -1417,7 +1424,7 @@ export async function stopAuto(
       if (ledger && ledger.units.length > 0) {
         const totals = getProjectTotals(ledger.units);
         ctx?.ui.notify(
-          `${notificationPrefix}. Session: ${formatCost(totals.cost)} · ${formatTokenCount(totals.tokens.total)} tokens · ${ledger.units.length} units`,
+          formatAutoStopNotification(notificationPrefix, totals, ledger.units.length),
           "info",
         );
       } else {

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -155,6 +155,13 @@ function formatWorktreeSafetyFailure(result: Extract<WorktreeSafetyResult, { ok:
   return `Worktree Safety failed (${result.kind}): ${result.reason} ${result.remediation}`;
 }
 
+function formatWorktreeSafetyStopReason(result: Extract<WorktreeSafetyResult, { ok: false }>): string {
+  if (result.kind === "empty-worktree-with-project-content") {
+    return `Worktree Safety failed (${result.kind}). Run /gsd doctor fix, then /gsd auto.`;
+  }
+  return `Worktree Safety failed (${result.kind}).`;
+}
+
 function resolveEmptyWorktreeWithProjectContent(
   unitRoot: string,
   projectRoot: string,
@@ -237,7 +244,7 @@ async function validateSourceWriteWorktreeSafety(
     projectRoot,
   });
   ctx.ui.notify(msg, "error");
-  await deps.stopAuto(ctx, pi, msg);
+  await deps.stopAuto(ctx, pi, formatWorktreeSafetyStopReason(result));
   return { action: "break", reason: result.kind };
 }
 

--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -9,7 +9,7 @@ import { parseRoadmap as parseLegacyRoadmap } from "./parsers-legacy.js";
 import { isDbAvailable, getMilestone } from "./gsd-db.js";
 import { resolveMilestoneFile } from "./paths.js";
 import { deriveState, isMilestoneComplete } from "./state.js";
-import { listWorktrees, resolveGitDir, worktreesDir } from "./worktree-manager.js";
+import { createWorktree, listWorktrees, resolveGitDir, worktreesDir } from "./worktree-manager.js";
 import { abortAndReset } from "./git-self-heal.js";
 import { RUNTIME_EXCLUSION_PATHS, resolveMilestoneIntegrationBranch, writeIntegrationBranch } from "./git-service.js";
 import { nativeIsRepo, nativeWorktreeList, nativeWorktreeRemove, nativeBranchList, nativeBranchDelete, nativeLsFiles, nativeRmCached, nativeHasChanges, nativeLastCommitEpoch, nativeGetCurrentBranch, nativeAddTracked, nativeCommit } from "./native-git-bridge.js";
@@ -52,6 +52,19 @@ function isSameOrNestedPath(candidate: string, container: string): boolean {
   const normalizedContainer = normalizePathForComparison(container);
   return normalizedCandidate === normalizedContainer ||
     normalizedCandidate.startsWith(`${normalizedContainer}/`);
+}
+
+function hasProjectContentOnDisk(dirPath: string): boolean {
+  try {
+    for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+      if (entry.name === ".git" || entry.name === ".gsd") continue;
+      if (entry.name === ".DS_Store") continue;
+      return true;
+    }
+  } catch {
+    return false;
+  }
+  return false;
 }
 
 function getSnapshotDiffCheckFailure(basePath: string): string | null {
@@ -122,6 +135,37 @@ export async function checkGitHealth(
       const isComplete = milestoneEntry
         ? await isCompletedMilestoneTerminal(basePath, milestoneId)
         : false;
+
+      if (!isComplete && !hasProjectContentOnDisk(wt.path) && hasProjectContentOnDisk(basePath)) {
+        issues.push({
+          severity: "error",
+          code: "worktree_empty_with_project_content",
+          scope: "milestone",
+          unitId: milestoneId,
+          message: `Worktree ${wt.path} has no project content, but project root ${basePath} does. Run doctor --fix to recreate the worktree.`,
+          fixable: true,
+        });
+
+        if (shouldFix("worktree_empty_with_project_content")) {
+          try {
+            nativeWorktreeRemove(basePath, wt.path, true);
+            const recreated = createWorktree(basePath, milestoneId, {
+              branch: wt.branch,
+              reuseExistingBranch: true,
+            });
+            const reset = spawnSync("git", ["reset", "--hard"], {
+              cwd: recreated.path,
+              encoding: "utf-8",
+            });
+            if (reset.status !== 0) {
+              throw new Error(reset.stderr || reset.error?.message || "git reset --hard failed");
+            }
+            fixesApplied.push(`recreated empty worktree ${wt.path}`);
+          } catch {
+            fixesApplied.push(`failed to recreate empty worktree ${wt.path}`);
+          }
+        }
+      }
 
       if (isComplete) {
         issues.push({

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -51,6 +51,7 @@ export type DoctorIssueCode =
   // Git / worktree integrity checks
   | "integration_branch_missing"
   | "worktree_directory_orphaned"
+  | "worktree_empty_with_project_content"
   // GSD state structural checks
   | "circular_slice_dependency"
   | "orphaned_slice_directory"

--- a/src/resources/extensions/gsd/tests/auto-stop-notification.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-stop-notification.test.ts
@@ -1,0 +1,20 @@
+// Project/App: GSD-2
+// File Purpose: Regression tests for auto-mode stop notification formatting.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { formatAutoStopNotification } from "../auto.ts";
+
+test("auto stop notification keeps session totals on a separate line", () => {
+  const message = formatAutoStopNotification(
+    "Auto-mode stopped",
+    { cost: 0.652, tokens: { total: 87000 } },
+    2,
+  );
+
+  assert.equal(
+    message,
+    "Auto-mode stopped.\nSession: $0.652 · 87.0k tokens · 2 units",
+  );
+});

--- a/src/resources/extensions/gsd/tests/doctor-empty-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-empty-worktree.test.ts
@@ -1,0 +1,65 @@
+// Project/App: GSD-2
+// File Purpose: Regression tests for doctor repair of empty milestone worktrees.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runGSDDoctor } from "../doctor.ts";
+import { createWorktree, worktreePath } from "../worktree-manager.ts";
+
+function runGit(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  }).trim();
+}
+
+function makeRepo(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-empty-worktree-"));
+  runGit(["init", "-b", "main"], base);
+  runGit(["config", "user.name", "Test User"], base);
+  runGit(["config", "user.email", "test@example.com"], base);
+  writeFileSync(join(base, "package.json"), "{\"scripts\":{}}\n", "utf-8");
+  runGit(["add", "."], base);
+  runGit(["commit", "-m", "chore: init"], base);
+  return base;
+}
+
+test("doctor fix recreates an empty registered milestone worktree", async (t) => {
+  const base = makeRepo();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  createWorktree(base, "M001", { branch: "milestone/M001" });
+  const wtPath = worktreePath(base, "M001");
+  writeFileSync(join(wtPath, "milestone-note.txt"), "worktree branch content\n", "utf-8");
+  runGit(["add", "milestone-note.txt"], wtPath);
+  runGit(["commit", "-m", "test: add milestone content"], wtPath);
+  for (const entry of readdirSync(wtPath)) {
+    if (entry === ".git") continue;
+    rmSync(join(wtPath, entry), { recursive: true, force: true });
+  }
+  assert.ok(existsSync(join(wtPath, ".git")), "test setup keeps registered worktree marker");
+  assert.equal(existsSync(join(wtPath, "package.json")), false, "test setup removes project content");
+
+  const report = await runGSDDoctor(base, {
+    fix: true,
+    fixLevel: "all",
+    isolationMode: "worktree",
+  });
+
+  assert.ok(
+    report.issues.some((issue) => issue.code === "worktree_empty_with_project_content"),
+    "doctor reports the empty worktree",
+  );
+  assert.ok(
+    report.fixesApplied.some((fix) => fix.includes("recreated empty worktree")),
+    "doctor applies the repair",
+  );
+  assert.ok(existsSync(join(wtPath, "package.json")), "worktree content is restored");
+  assert.ok(existsSync(join(wtPath, "milestone-note.txt")), "branch content is restored");
+});


### PR DESCRIPTION
## TL;DR

**What:** Adds doctor recovery for empty milestone worktrees and tightens auto-mode stop messaging.
**Why:** Source-writing units can get stuck when the milestone worktree has no project content while the project root does.
**How:** Doctor now detects the broken worktree, recreates it from the existing milestone branch, and auto-mode points users at `/gsd doctor fix` without duplicating the long Worktree Safety error.

## What

- Adds `worktree_empty_with_project_content` as a doctor issue code.
- Repairs empty milestone worktrees by removing and recreating the registered worktree, then hard-resetting the recreated checkout.
- Splits auto stop session totals onto a separate notification line so boxed/menu surfaces keep the text contained.
- Shortens Worktree Safety stop reasons while preserving the detailed immediate error notification.
- Adds regression tests for doctor repair and stop notification formatting.

## Why

Closes #5941.

Users can hit `empty-worktree-with-project-content` and get stuck because the source-writing unit cannot safely run in an empty isolated worktree. The previous remediation was manual, and the full error could be repeated into UI/status surfaces.

## How

Doctor checks registered milestone worktrees in worktree isolation mode. If an active milestone worktree has no project content while the project root does, it reports a fixable error. In fix mode, it removes and recreates the worktree against the milestone branch and verifies checkout content with `git reset --hard`.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-stop-notification.test.ts src/resources/extensions/gsd/tests/doctor-empty-worktree.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/worktree-safety.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern "Worktree Safety" src/resources/extensions/gsd/tests/auto-loop.test.ts`
- `npm run typecheck:extensions`

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GSD Doctor now detects and repairs empty milestone worktrees when the project root contains content, automatically recreating and restoring affected worktrees to full functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5942)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->