### PR TITLE
fix(issue): bug: milestone integration branch can be corrupted to milestone/* and break complete-milestone artifact checks

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -201,9 +201,12 @@ export function hasImplementationArtifacts(basePath: string, milestoneId?: strin
     // Strategy: check `git diff --name-only` against the merge-base with the
     // main branch. This captures ALL files changed during the milestone's
     // lifetime while running on a milestone branch.
-    const integrationBranch = milestoneId
-      ? readIntegrationBranch(basePath, milestoneId) ?? detectMainBranch(basePath)
-      : detectMainBranch(basePath);
+    const recordedIntegrationBranch = milestoneId
+      ? readIntegrationBranch(basePath, milestoneId)
+      : null;
+    const integrationBranch = recordedIntegrationBranch?.startsWith("milestone/")
+      ? detectMainBranch(basePath)
+      : (recordedIntegrationBranch ?? detectMainBranch(basePath));
     const currentBranch = getCurrentBranch(basePath);
     const branchDiff = getChangedFilesSinceBranch(basePath, integrationBranch);
     if (!branchDiff.ok) return "unknown";

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -204,9 +204,12 @@ export function hasImplementationArtifacts(basePath: string, milestoneId?: strin
     const recordedIntegrationBranch = milestoneId
       ? readIntegrationBranch(basePath, milestoneId)
       : null;
-    const integrationBranch = recordedIntegrationBranch?.startsWith("milestone/")
-      ? detectMainBranch(basePath)
-      : (recordedIntegrationBranch ?? detectMainBranch(basePath));
+    let integrationBranch: string;
+    if (recordedIntegrationBranch?.startsWith("milestone/")) {
+      integrationBranch = detectMainBranch(basePath);
+    } else {
+      integrationBranch = recordedIntegrationBranch ?? detectMainBranch(basePath);
+    }
     const currentBranch = getCurrentBranch(basePath);
     const branchDiff = getChangedFilesSinceBranch(basePath, integrationBranch);
     if (!branchDiff.ok) return "unknown";

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -406,6 +406,9 @@ export function writeIntegrationBranch(
   milestoneId: string,
   branch: string,
 ): void {
+  // Never persist milestone branches as integration targets.
+  // They are ephemeral execution branches and can cause self-diff corruption.
+  if (branch.startsWith("milestone/")) return;
   // Don't record slice branches as the integration target
   if (SLICE_BRANCH_RE.test(branch)) return;
   // Don't record quick-task branches — they are ephemeral and merge back

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -388,6 +388,9 @@ export function readIntegrationBranch(basePath: string, milestoneId: string): st
   }
 }
 
+/** Re-export for backward compatibility — canonical definitions in branch-patterns.ts */
+export { QUICK_BRANCH_RE, WORKFLOW_BRANCH_RE } from "./branch-patterns.js";
+
 /**
  * Persist the integration branch for a milestone.
  *
@@ -398,9 +401,6 @@ export function readIntegrationBranch(basePath: string, milestoneId: string): st
  *
  * The file is committed immediately so the metadata is persisted in git.
  */
-/** Re-export for backward compatibility — canonical definitions in branch-patterns.ts */
-export { QUICK_BRANCH_RE, WORKFLOW_BRANCH_RE } from "./branch-patterns.js";
-
 export function writeIntegrationBranch(
   basePath: string,
   milestoneId: string,

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -807,6 +807,51 @@ test("hasImplementationArtifacts finds integration implementation-only commits w
   }
 });
 
+test("hasImplementationArtifacts ignores corrupted milestone/* integration metadata", () => {
+  const base = makeGitBase();
+  try {
+    mkdirSync(join(base, "src"), { recursive: true });
+    writeFileSync(join(base, "src", "feature.ts"), "export function feature() {}\n");
+    execFileSync("git", ["add", "src/feature.ts"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feat: add milestone feature\n\nGSD-Task: S01/T01"], { cwd: base, stdio: "ignore" });
+
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M001",
+      title: "Slice One",
+      status: "complete",
+      risk: "low",
+      depends: [],
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Task One",
+      status: "complete",
+    });
+
+    execFileSync("git", ["checkout", "-b", "milestone/M001"], { cwd: base, stdio: "ignore" });
+    mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-SUMMARY.md"), "# Milestone Summary\nDone.");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "chore: auto-commit after complete-milestone\n\nGSD-Unit: M001"], { cwd: base, stdio: "ignore" });
+
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-META.json"),
+      JSON.stringify({ integrationBranch: "milestone/M001" }, null, 2) + "\n",
+    );
+
+    const result = hasImplementationArtifacts(base, "M001");
+    assert.equal(result, "present", "corrupted milestone integration metadata should fall back to main branch for artifact detection");
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("hasImplementationArtifacts backfills untagged main implementation commits from completed task file hints", () => {
   const base = makeGitBase();
   try {

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -1168,6 +1168,15 @@ describe('git-service', async () => {
     rmSync(repo, { recursive: true, force: true });
   });
 
+  test('Integration branch: rejects milestone branches', () => {
+    const repo = initBranchTestRepo();
+
+    writeIntegrationBranch(repo, "M001", "milestone/M001");
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M001"), null, "milestone branches are not recorded as integration branch");
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
   // ─── writeIntegrationBranch: still records legitimate branches ────────
 
   test('Integration branch: records non-ephemeral gsd branches', () => {


### PR DESCRIPTION
## Summary
- Prevented milestone branch metadata corruption and added artifact-check fallback for corrupted milestone integration branches, verified with targeted git-service and auto-recovery tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5233
- [#5233 bug: milestone integration branch can be corrupted to milestone/* and break complete-milestone artifact checks](https://github.com/gsd-build/gsd-2/issues/5233)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5233-bug-milestone-integration-branch-can-be--1778724696`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch selection for milestone recovery so the system reliably falls back when milestone integration metadata is invalid or missing.
  * Stopped ephemeral milestone branch names from being recorded as integration targets.

* **Tests**
  * Added tests to validate milestone metadata handling and ensure correct branch integration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5947)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->