### PR TITLE
fix(issue): Branch-mode milestone entry fails on dirty working tree (no stash guard)

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -42,7 +42,6 @@ import {
   nativeCommit,
   nativeGetCurrentBranch,
   nativeDetectMainBranch,
-  nativeCheckoutBranch,
   nativeBranchList,
   nativeBranchExists,
   nativeBranchListMerged,
@@ -56,7 +55,7 @@ import {
   detectWorktreeName,
   setActiveMilestoneId,
 } from "./worktree.js";
-import { getAutoWorktreePath, isInAutoWorktree } from "./auto-worktree.js";
+import { getAutoWorktreePath, isInAutoWorktree, checkoutBranchWithStashGuard } from "./auto-worktree.js";
 import { readResourceVersion, cleanStaleRuntimeUnits } from "./auto-worktree.js";
 import { worktreePath as getWorktreeDir, isInsideWorktreesDir } from "./worktree-manager.js";
 import { emitWorktreeOrphaned } from "./worktree-telemetry.js";
@@ -1170,7 +1169,7 @@ export async function bootstrapAutoSession(
           isRepo,
         );
         if (branchToCheckout) {
-          nativeCheckoutBranch(base, branchToCheckout);
+          checkoutBranchWithStashGuard(base, branchToCheckout, "isolation-none-recovery");
           logWarning("bootstrap", `Returned to "${branchToCheckout}" — HEAD was on stale milestone branch "${currentBranch}" (isolation: none does not use milestone branches).`);
         }
       } catch (err) {

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1007,7 +1007,45 @@ export function enterBranchModeForMilestone(
     });
   }
 
-  nativeCheckoutBranch(basePath, branch);
+  checkoutBranchWithStashGuard(basePath, branch, `enter-branch-mode:${milestoneId}`);
+}
+
+export function checkoutBranchWithStashGuard(
+  basePath: string,
+  branch: string,
+  reason: string,
+): void {
+  let stashMarker: string | null = null;
+  let stashed = false;
+  try {
+    const status = nativeWorkingTreeStatus(basePath).trim();
+    if (status.length > 0) {
+      stashMarker = `gsd-checkout-stash:${reason}:${process.pid}:${Date.now()}:${process.hrtime.bigint().toString(36)}`;
+      const output = execFileSync(
+        "git",
+        ["stash", "push", "--include-untracked", "-m", `gsd: checkout stash [${stashMarker}]`],
+        {
+          cwd: basePath,
+          stdio: ["ignore", "pipe", "pipe"],
+          encoding: "utf-8",
+        },
+      );
+      stashed = !output.includes("No local changes to save");
+    }
+
+    nativeCheckoutBranch(basePath, branch);
+
+    if (stashed) popStashByRef(basePath, stashMarker);
+  } catch (err) {
+    if (stashed) {
+      try {
+        popStashByRef(basePath, stashMarker);
+      } catch (restoreErr) {
+        logWarning("worktree", `git stash pop failed during checkout restore: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`);
+      }
+    }
+    throw err;
+  }
 }
 
 // ─── Public API ────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1021,7 +1021,12 @@ export function checkoutBranchWithStashGuard(
   const status = nativeWorkingTreeStatus(basePath).trim();
   if (status.length > 0) {
     stashMarker = `gsd-checkout-stash:${reason}:${process.pid}:${Date.now()}:${process.hrtime.bigint().toString(36)}`;
-    const output = execFileSync(
+    const stashListBefore = execFileSync("git", ["stash", "list"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    execFileSync(
       "git",
       ["stash", "push", "--include-untracked", "-m", `gsd: checkout stash [${stashMarker}]`],
       {
@@ -1030,7 +1035,12 @@ export function checkoutBranchWithStashGuard(
         encoding: "utf-8",
       },
     );
-    stashed = !output.includes("No local changes to save");
+    const stashListAfter = execFileSync("git", ["stash", "list"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    stashed = stashListAfter !== stashListBefore;
   }
 
   // Checkout and stash-restore are split so we can distinguish two failure

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1017,26 +1017,30 @@ export function checkoutBranchWithStashGuard(
 ): void {
   let stashMarker: string | null = null;
   let stashed = false;
+
+  const status = nativeWorkingTreeStatus(basePath).trim();
+  if (status.length > 0) {
+    stashMarker = `gsd-checkout-stash:${reason}:${process.pid}:${Date.now()}:${process.hrtime.bigint().toString(36)}`;
+    const output = execFileSync(
+      "git",
+      ["stash", "push", "--include-untracked", "-m", `gsd: checkout stash [${stashMarker}]`],
+      {
+        cwd: basePath,
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf-8",
+      },
+    );
+    stashed = !output.includes("No local changes to save");
+  }
+
+  // Checkout and stash-restore are split so we can distinguish two failure
+  // modes: (a) checkout failed → HEAD did not move, restore stash and rethrow;
+  // (b) checkout succeeded but stash pop failed → HEAD moved to `branch` but
+  // the working-tree changes remain in the stash list. We surface a distinct
+  // error in case (b) so callers don't assume the branch switch was rolled back.
   try {
-    const status = nativeWorkingTreeStatus(basePath).trim();
-    if (status.length > 0) {
-      stashMarker = `gsd-checkout-stash:${reason}:${process.pid}:${Date.now()}:${process.hrtime.bigint().toString(36)}`;
-      const output = execFileSync(
-        "git",
-        ["stash", "push", "--include-untracked", "-m", `gsd: checkout stash [${stashMarker}]`],
-        {
-          cwd: basePath,
-          stdio: ["ignore", "pipe", "pipe"],
-          encoding: "utf-8",
-        },
-      );
-      stashed = !output.includes("No local changes to save");
-    }
-
     nativeCheckoutBranch(basePath, branch);
-
-    if (stashed) popStashByRef(basePath, stashMarker);
-  } catch (err) {
+  } catch (checkoutErr) {
     if (stashed) {
       try {
         popStashByRef(basePath, stashMarker);
@@ -1044,7 +1048,21 @@ export function checkoutBranchWithStashGuard(
         logWarning("worktree", `git stash pop failed during checkout restore: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`);
       }
     }
-    throw err;
+    throw checkoutErr;
+  }
+
+  if (stashed) {
+    try {
+      popStashByRef(basePath, stashMarker);
+    } catch (popErr) {
+      const msg = popErr instanceof Error ? popErr.message : String(popErr);
+      const wrapped = new Error(
+        `checkout to '${branch}' succeeded but stash restore failed; working tree changes remain in the stash list. Original error: ${msg}`,
+      );
+      const ref = (popErr as { stashRef?: string } | null)?.stashRef;
+      if (ref) (wrapped as { stashRef?: string }).stashRef = ref;
+      throw wrapped;
+    }
   }
 }
 

--- a/src/resources/extensions/gsd/tests/checkout-branch-stash-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/checkout-branch-stash-guard.test.ts
@@ -1,0 +1,62 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { checkoutBranchWithStashGuard } from "../auto-worktree.ts";
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  });
+}
+
+function createRepo(t: { after: (fn: () => void) => void }): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "checkout-stash-guard-")));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  git(["init"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "Test User"], dir);
+  writeFileSync(join(dir, "note.txt"), "base\n");
+  git(["add", "note.txt"], dir);
+  git(["commit", "-m", "init"], dir);
+  git(["branch", "-M", "main"], dir);
+  return dir;
+}
+
+describe("checkoutBranchWithStashGuard", () => {
+  test("restores dirty working tree after successful checkout", (t) => {
+    const repo = createRepo(t);
+    git(["checkout", "-b", "milestone/M001"], repo);
+    git(["checkout", "main"], repo);
+
+    writeFileSync(join(repo, "note.txt"), "dirty\n");
+
+    checkoutBranchWithStashGuard(repo, "milestone/M001", "test-success");
+
+    const branch = git(["branch", "--show-current"], repo).trim();
+    assert.equal(branch, "milestone/M001");
+    const content = git(["show", "HEAD:note.txt"], repo).trim();
+    assert.equal(content, "base");
+    const wtContent = git(["status", "--porcelain"], repo);
+    assert.match(wtContent, /note\.txt/);
+  });
+
+  test("restores dirty working tree when checkout throws", (t) => {
+    const repo = createRepo(t);
+    writeFileSync(join(repo, "note.txt"), "dirty\n");
+
+    assert.throws(
+      () => checkoutBranchWithStashGuard(repo, "milestone/DOES-NOT-EXIST", "test-failure"),
+    );
+
+    const status = git(["status", "--porcelain"], repo);
+    assert.match(status, /note\.txt/);
+    const stashList = git(["stash", "list"], repo).trim();
+    assert.equal(stashList, "");
+  });
+});

--- a/src/resources/extensions/gsd/tests/checkout-branch-stash-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/checkout-branch-stash-guard.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -42,8 +42,10 @@ describe("checkoutBranchWithStashGuard", () => {
     assert.equal(branch, "milestone/M001");
     const content = git(["show", "HEAD:note.txt"], repo).trim();
     assert.equal(content, "base");
-    const wtContent = git(["status", "--porcelain"], repo);
-    assert.match(wtContent, /note\.txt/);
+    const wtContent = readFileSync(join(repo, "note.txt"), "utf8");
+    assert.equal(wtContent, "dirty\n");
+    const status = git(["status", "--porcelain"], repo);
+    assert.match(status, /note\.txt/);
   });
 
   test("restores dirty working tree when checkout throws", (t) => {

--- a/src/resources/extensions/gsd/tests/checkout-branch-stash-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/checkout-branch-stash-guard.test.ts
@@ -59,4 +59,27 @@ describe("checkoutBranchWithStashGuard", () => {
     const stashList = git(["stash", "list"], repo).trim();
     assert.equal(stashList, "");
   });
+
+  test("surfaces distinct error when checkout succeeds but stash pop conflicts", (t) => {
+    const repo = createRepo(t);
+    // Branch B has a divergent version of note.txt so popping a stash made
+    // against main will conflict after the checkout to B.
+    git(["checkout", "-b", "milestone/B"], repo);
+    writeFileSync(join(repo, "note.txt"), "B-version\n");
+    git(["add", "note.txt"], repo);
+    git(["commit", "-m", "B"], repo);
+    git(["checkout", "main"], repo);
+
+    writeFileSync(join(repo, "note.txt"), "local\n");
+
+    assert.throws(
+      () => checkoutBranchWithStashGuard(repo, "milestone/B", "test-pop-failure"),
+      /checkout to 'milestone\/B' succeeded but stash restore failed/,
+    );
+
+    const branch = git(["branch", "--show-current"], repo).trim();
+    assert.equal(branch, "milestone/B");
+    const stashList = git(["stash", "list"], repo).trim();
+    assert.match(stashList, /gsd: checkout stash/);
+  });
 });


### PR DESCRIPTION
## Summary
- Added stash-protected branch checkout for milestone entry and isolation:none recovery, with focused regression tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5927
- [#5927 Branch-mode milestone entry fails on dirty working tree (no stash guard)](https://github.com/gsd-build/gsd-2/issues/5927)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5927-branch-mode-milestone-entry-fails-on-dir-1778725001`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch switching reliability with enhanced safeguards that preserve working directory state during checkout operations and provide better recovery mechanisms when issues occur.

* **Tests**
  * Added comprehensive test coverage for branch checkout safety and working directory state preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5948)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->