### PR TITLE
fix(issue): complete-milestone worktree sync misses future milestone context drafts

### DIFF
--- a/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
@@ -641,14 +641,47 @@ describe('worktree-sync-milestones', async () => {
         '#5687: future milestone context draft projected into worktree',
       );
       assert.equal(
-        readFileSync(join(wtBase, '.gsd', 'milestones', 'M003', 'M003-ROADMAP.md'), 'utf-8'),
-        '# WT Roadmap',
-        '#5687: existing future-milestone roadmap is not overwritten',
-      );
-      assert.equal(
         readFileSync(join(wtBase, '.gsd', 'milestones', 'M002', 'M002-ROADMAP.md'), 'utf-8'),
         '# Worktree M002 Roadmap',
         '#5687: existing worktree-local files are not overwritten',
+      );
+    } finally {
+      cleanup(mainBase);
+      cleanup(wtBase);
+    }
+  }
+
+  // ─── 17. pre-dispatch sync creates absent worktree milestone dir before projecting artifacts (#5687) ──
+  console.log('\n=== 17. pre-dispatch sync creates absent worktree milestone dir before projecting artifacts (#5687) ===');
+  {
+    const mainBase = createBase('main');
+    const wtBase = createBase('wt');
+
+    try {
+      // Canonical .gsd has a future milestone M004 with a context draft.
+      const mainM004 = join(mainBase, '.gsd', 'milestones', 'M004');
+      mkdirSync(mainM004, { recursive: true });
+      writeFileSync(join(mainM004, 'M004-CONTEXT-DRAFT.md'), '# M004 Context Draft');
+
+      // Active milestone M002 exists in both main and worktree.
+      const mainM002 = join(mainBase, '.gsd', 'milestones', 'M002');
+      mkdirSync(mainM002, { recursive: true });
+      writeFileSync(join(mainM002, 'M002-ROADMAP.md'), '# Main M002 Roadmap');
+      const wtM002 = join(wtBase, '.gsd', 'milestones', 'M002');
+      mkdirSync(wtM002, { recursive: true });
+      writeFileSync(join(wtM002, 'M002-ROADMAP.md'), '# Worktree M002 Roadmap');
+
+      // M004 does NOT exist in the worktree at all before sync.
+      assert.ok(
+        !existsSync(join(wtBase, '.gsd', 'milestones', 'M004')),
+        '#5687: worktree M004 dir must not exist before sync',
+      );
+
+      syncProjectRootToWorktree(mainBase, wtBase, 'M002');
+
+      assert.ok(
+        existsSync(join(wtBase, '.gsd', 'milestones', 'M004', 'M004-CONTEXT-DRAFT.md')),
+        '#5687: context draft projected into worktree even when milestone dir was absent',
       );
     } finally {
       cleanup(mainBase);

--- a/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
@@ -607,4 +607,47 @@ describe('worktree-sync-milestones', async () => {
       rmSync(wtBase, { recursive: true, force: true });
     }
   }
+
+  // ─── 16. pre-dispatch sync projects missing future milestone top-level artifacts (#5687) ──
+  console.log('\n=== 16. pre-dispatch sync projects missing future milestone top-level artifacts (#5687) ===');
+  {
+    const mainBase = createBase('main');
+    const wtBase = createBase('wt');
+
+    try {
+      // Canonical .gsd has M003 context draft that complete-milestone needs.
+      const mainM003 = join(mainBase, '.gsd', 'milestones', 'M003');
+      mkdirSync(mainM003, { recursive: true });
+      writeFileSync(join(mainM003, 'M003-CONTEXT-DRAFT.md'), '# M003 Context Draft');
+      writeFileSync(join(mainM003, 'M003-ROADMAP.md'), '# M003 Roadmap');
+
+      // Worktree only has skeletal roadmap for M003.
+      const wtM003 = join(wtBase, '.gsd', 'milestones', 'M003');
+      mkdirSync(wtM003, { recursive: true });
+      writeFileSync(join(wtM003, 'M003-ROADMAP.md'), '# WT Roadmap');
+
+      // Worktree has current milestone file that must not be overwritten.
+      const mainM002 = join(mainBase, '.gsd', 'milestones', 'M002');
+      mkdirSync(mainM002, { recursive: true });
+      writeFileSync(join(mainM002, 'M002-ROADMAP.md'), '# Main M002 Roadmap');
+      const wtM002 = join(wtBase, '.gsd', 'milestones', 'M002');
+      mkdirSync(wtM002, { recursive: true });
+      writeFileSync(join(wtM002, 'M002-ROADMAP.md'), '# Worktree M002 Roadmap');
+
+      syncProjectRootToWorktree(mainBase, wtBase, 'M002');
+
+      assert.ok(
+        existsSync(join(wtBase, '.gsd', 'milestones', 'M003', 'M003-CONTEXT-DRAFT.md')),
+        '#5687: future milestone context draft projected into worktree',
+      );
+      assert.equal(
+        readFileSync(join(wtBase, '.gsd', 'milestones', 'M002', 'M002-ROADMAP.md'), 'utf-8'),
+        '# Worktree M002 Roadmap',
+        '#5687: existing worktree-local files are not overwritten',
+      );
+    } finally {
+      cleanup(mainBase);
+      cleanup(wtBase);
+    }
+  }
 });

--- a/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
@@ -634,6 +634,11 @@ describe('worktree-sync-milestones', async () => {
       mkdirSync(wtM002, { recursive: true });
       writeFileSync(join(wtM002, 'M002-ROADMAP.md'), '# Worktree M002 Roadmap');
 
+      // Canonical .gsd has M004 with no corresponding worktree directory at all.
+      const mainM004 = join(mainBase, '.gsd', 'milestones', 'M004');
+      mkdirSync(mainM004, { recursive: true });
+      writeFileSync(join(mainM004, 'M004-CONTEXT-DRAFT.md'), '# M004 Context Draft');
+
       syncProjectRootToWorktree(mainBase, wtBase, 'M002');
 
       assert.ok(
@@ -641,9 +646,18 @@ describe('worktree-sync-milestones', async () => {
         '#5687: future milestone context draft projected into worktree',
       );
       assert.equal(
+        readFileSync(join(wtBase, '.gsd', 'milestones', 'M003', 'M003-ROADMAP.md'), 'utf-8'),
+        '# WT Roadmap',
+        '#5687: existing worktree-local M003 file is not overwritten',
+      );
+      assert.equal(
         readFileSync(join(wtBase, '.gsd', 'milestones', 'M002', 'M002-ROADMAP.md'), 'utf-8'),
         '# Worktree M002 Roadmap',
         '#5687: existing worktree-local files are not overwritten',
+      );
+      assert.ok(
+        existsSync(join(wtBase, '.gsd', 'milestones', 'M004', 'M004-CONTEXT-DRAFT.md')),
+        '#5687: future milestone context draft projected into worktree when no wt dir existed',
       );
     } finally {
       cleanup(mainBase);

--- a/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
@@ -641,6 +641,11 @@ describe('worktree-sync-milestones', async () => {
         '#5687: future milestone context draft projected into worktree',
       );
       assert.equal(
+        readFileSync(join(wtBase, '.gsd', 'milestones', 'M003', 'M003-ROADMAP.md'), 'utf-8'),
+        '# WT Roadmap',
+        '#5687: existing future-milestone roadmap is not overwritten',
+      );
+      assert.equal(
         readFileSync(join(wtBase, '.gsd', 'milestones', 'M002', 'M002-ROADMAP.md'), 'utf-8'),
         '# Worktree M002 Roadmap',
         '#5687: existing worktree-local files are not overwritten',

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -136,6 +136,7 @@ function syncTopLevelMilestoneArtifacts(
       const dstMilestoneDir = join(dstMilestonesDir, milestoneEntry.name);
 
       try {
+        mkdirSync(dstMilestoneDir, { recursive: true });
         for (const fileEntry of readdirSync(srcMilestoneDir, { withFileTypes: true })) {
           if (!fileEntry.isFile()) continue;
           if (!fileEntry.name.endsWith(".md") && !fileEntry.name.endsWith(".json")) continue;

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -136,10 +136,11 @@ function syncTopLevelMilestoneArtifacts(
       const dstMilestoneDir = join(dstMilestonesDir, milestoneEntry.name);
 
       try {
+        mkdirSync(dstMilestoneDir, { recursive: true });
         for (const fileEntry of readdirSync(srcMilestoneDir, { withFileTypes: true })) {
           if (!fileEntry.isFile()) continue;
           if (!fileEntry.name.endsWith(".md") && !fileEntry.name.endsWith(".json")) continue;
-          safeCopy(
+
             join(srcMilestoneDir, fileEntry.name),
             join(dstMilestoneDir, fileEntry.name),
             { force: false },

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -123,6 +123,43 @@ function forceOverwriteAssessmentsWithVerdict(
   }
 }
 
+function syncTopLevelMilestoneArtifacts(
+  srcMilestonesDir: string,
+  dstMilestonesDir: string,
+): void {
+  if (!existsSync(srcMilestonesDir)) return;
+
+  try {
+    for (const milestoneEntry of readdirSync(srcMilestonesDir, { withFileTypes: true })) {
+      if (!milestoneEntry.isDirectory()) continue;
+      const srcMilestoneDir = join(srcMilestonesDir, milestoneEntry.name);
+      const dstMilestoneDir = join(dstMilestonesDir, milestoneEntry.name);
+
+      try {
+        for (const fileEntry of readdirSync(srcMilestoneDir, { withFileTypes: true })) {
+          if (!fileEntry.isFile()) continue;
+          if (!fileEntry.name.endsWith(".md") && !fileEntry.name.endsWith(".json")) continue;
+          safeCopy(
+            join(srcMilestoneDir, fileEntry.name),
+            join(dstMilestoneDir, fileEntry.name),
+            { force: false },
+          );
+        }
+      } catch (err) {
+        logWarning(
+          "worktree",
+          `milestone top-level artifact sync failed (${milestoneEntry.name}): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  } catch (err) {
+    logWarning(
+      "worktree",
+      `milestone artifact scan failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 /**
  * Root-level .gsd/ files copied from worktree back to project root for
  * post-merge diagnostics. Markdown projections are NOT in this list — DB
@@ -175,6 +212,10 @@ export function _projectRootToWorktreeImpl(
     join(wtGsd, "milestones", milestoneId),
     { force: false },
   );
+
+  // Additively project missing top-level milestone files for all milestones
+  // so worktree-bound units can verify future-milestone context artifacts.
+  syncTopLevelMilestoneArtifacts(join(prGsd, "milestones"), join(wtGsd, "milestones"));
 
   // Force-sync ASSESSMENT files that have a verdict from project root (#2821).
   // The additive-only copy above preserves worktree-local files, but

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -140,7 +140,7 @@ function syncTopLevelMilestoneArtifacts(
         for (const fileEntry of readdirSync(srcMilestoneDir, { withFileTypes: true })) {
           if (!fileEntry.isFile()) continue;
           if (!fileEntry.name.endsWith(".md") && !fileEntry.name.endsWith(".json")) continue;
-          safeCopy(
+
             join(srcMilestoneDir, fileEntry.name),
             join(dstMilestoneDir, fileEntry.name),
             { force: false },

--- a/src/resources/extensions/gsd/worktree-state-projection.ts
+++ b/src/resources/extensions/gsd/worktree-state-projection.ts
@@ -141,6 +141,7 @@ function syncTopLevelMilestoneArtifacts(
           if (!fileEntry.isFile()) continue;
           if (!fileEntry.name.endsWith(".md") && !fileEntry.name.endsWith(".json")) continue;
 
+          safeCopy(
             join(srcMilestoneDir, fileEntry.name),
             join(dstMilestoneDir, fileEntry.name),
             { force: false },


### PR DESCRIPTION
## Summary
- Added additive all-milestone top-level artifact projection during pre-dispatch worktree sync and verified with a focused regression test for missing future context drafts.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5687
- [#5687 complete-milestone worktree sync misses future milestone context drafts](https://github.com/gsd-build/gsd-2/issues/5687)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5687-complete-milestone-worktree-sync-misses--1778725160`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synchronization of milestone artifacts from project root to worktree, ensuring proper handling of missing directories and preservation of existing worktree-local files.

* **Tests**
  * Added regression test coverage for milestone artifact synchronization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5949)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->