### PR TITLE
fix(issue): Bug: Milestone completion blocked by 'no implementation files' check for planning-only milestones

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -28,6 +28,10 @@ When progressive planning is enabled, GSD fully plans the first slice and may le
 
 Milestone completion is safe to retry. If a `complete-milestone` unit is redispatched after the database already marks the milestone as closed, GSD treats the call as successful instead of returning an error. The existing summary projection is left intact, no duplicate completion event is appended, and the tool response includes `alreadyComplete: true` in its details so operators and integrations can distinguish a retry from the first completion.
 
+### Planning-Only Milestone Closeout
+
+When milestone history contains only `.gsd/` artifact changes (for example planning-only or documentation-only closeout), auto mode now continues `complete-milestone` dispatch instead of blocking completion for missing implementation files outside `.gsd/`. GSD emits a warning so operators can distinguish this path from implementation-bearing milestones.
+
 ### State Authority
 
 The SQLite database is the runtime source of truth for milestones, slices, tasks, requirements, summaries, and completion status. Durable decisions and project knowledge use the same database through the `memories` table: decisions are stored as `architecture` memories, and KNOWLEDGE patterns/lessons are stored as `pattern`/`gotcha` memories.

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1359,16 +1359,12 @@ export const DISPATCH_RULES: DispatchRule[] = [
         };
       }
 
-      // Safety guard (#1703): verify the milestone produced implementation
-      // artifacts (non-.gsd/ files). A milestone with only plan files and
-      // zero implementation code should not be marked complete.
+      // Safety signal (#1703, #5097): detect milestones with only .gsd/
+      // artifacts. This no longer hard-blocks completion because some
+      // milestones are intentionally planning/documentation-only.
       const artifactCheck = hasImplementationArtifacts(basePath, mid);
       if (artifactCheck === "absent") {
-        return {
-          action: "stop",
-          reason: `Cannot complete milestone ${mid}: no implementation files found outside .gsd/. The milestone has only plan files — actual code changes are required.`,
-          level: "error",
-        };
+        logWarning("dispatch", `Milestone ${mid} has no implementation files outside .gsd/ — continuing complete-milestone dispatch (planning-only/documentation-only milestone).`);
       }
       if (artifactCheck === "unknown") {
         logWarning("dispatch", `Implementation artifact check inconclusive for ${mid} — proceeding (git context unavailable)`);

--- a/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
@@ -90,7 +90,6 @@ describe("completing-milestone dispatch guard (#4324)", () => {
     base = makeBase();
     rmSync(join(base, "implementation.txt"), { force: true });
     initGitRepo(base);
-    execFileSync("git", ["checkout", "-b", "feat/planning-only"], { cwd: base, stdio: "ignore" });
     writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-SUMMARY.md"), "# Milestone Summary\n");
     execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
     execFileSync("git", ["commit", "-m", "chore: planning artifacts only"], { cwd: base, stdio: "ignore" });

--- a/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
@@ -25,7 +25,7 @@ function makeBase(): string {
 }
 
 function initGitRepo(base: string): void {
-  execFileSync("git", ["init", "--initial-branch=main"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["init"], { cwd: base, stdio: "ignore" });
   execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: base, stdio: "ignore" });
   execFileSync("git", ["config", "user.name", "Test"], { cwd: base, stdio: "ignore" });
   execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });

--- a/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
@@ -10,6 +10,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
 
 import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
 import { closeDatabase, insertMilestone, openDatabase } from "../gsd-db.ts";
@@ -21,6 +22,14 @@ function makeBase(): string {
   writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "SUMMARY.md"), "# Summary\n");
   writeFileSync(join(base, "implementation.txt"), "done\n");
   return base;
+}
+
+function initGitRepo(base: string): void {
+  execFileSync("git", ["init", "--initial-branch=main"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: base, stdio: "ignore" });
 }
 
 function buildDispatchCtx(basePath: string): DispatchContext {
@@ -67,6 +76,25 @@ describe("completing-milestone dispatch guard (#4324)", () => {
 
   test("dispatches complete-milestone when the DB milestone is still active", async () => {
     base = makeBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
+
+    const result = await rule.match(buildDispatchCtx(base));
+
+    assert.equal(result?.action, "dispatch");
+    assert.equal(result?.unitType, "complete-milestone");
+    assert.equal(result?.unitId, "M001");
+  });
+
+  test("dispatches complete-milestone when only .gsd/ files exist in git history (#5097)", async () => {
+    base = makeBase();
+    rmSync(join(base, "implementation.txt"), { force: true });
+    initGitRepo(base);
+    execFileSync("git", ["checkout", "-b", "feat/planning-only"], { cwd: base, stdio: "ignore" });
+    writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-SUMMARY.md"), "# Milestone Summary\n");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "chore: planning artifacts only"], { cwd: base, stdio: "ignore" });
+
     openDatabase(join(base, ".gsd", "gsd.db"));
     insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
 


### PR DESCRIPTION
## Summary
- Updated complete-milestone dispatch to warn (not block) on planning-only `.gsd/` artifacts and added a focused regression test that passes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5097
- [#5097 Bug: Milestone completion blocked by 'no implementation files' check for planning-only milestones](https://github.com/gsd-build/gsd-2/issues/5097)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5097-bug-milestone-completion-blocked-by-no-i-1778725299`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Milestones that only contain planning/documentation artifacts can now be completed; the process emits a warning instead of blocking completion.

* **Tests**
  * Added regression test covering milestone completion when only documentation/planning artifacts are present.

* **Documentation**
  * New guidance clarifying the planning-only milestone closeout behavior and the warning path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5950)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->