### PR TITLE
fix(issue): Milestone status drift makes planned future milestones inconsistently discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ On first run, GSD launches a branded setup wizard that walks you through LLM pro
 | `/gsd mcp`              | MCP server status and connectivity                                            |
 | `/gsd status`           | Progress dashboard                                                            |
 | `/gsd brief <mode>`     | Generate a visual HTML brief (diagram, plan, diff, recap, table, slides)      |
-| `/gsd queue`            | Queue future milestones (safe during auto mode)                               |
+| `/gsd queue`            | Queue/reorder future milestones (`pending`, `queued`, or legacy `planned`; safe during auto mode) |
 | `/gsd prefs`            | Model selection, timeouts, budget ceiling                                     |
 | `/gsd migrate`          | Migrate a v1 `.planning` directory to `.gsd` format                           |
 | `/gsd help`             | Categorized command reference for all GSD subcommands                         |

--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -14,7 +14,7 @@
 | `/gsd discuss` | Discuss architecture and decisions (works alongside auto mode) |
 | `/gsd status` | Progress dashboard |
 | `/gsd widget` | Cycle dashboard widget: full / small / min / off |
-| `/gsd queue` | Queue and reorder future milestones (safe during auto mode) |
+| `/gsd queue` | Queue and reorder future milestones (`pending`, `queued`, and legacy `planned`; safe during auto mode) |
 | `/gsd capture` | Fire-and-forget thought capture (works during auto mode) |
 | `/gsd triage` | Manually trigger triage of pending captures |
 | `/gsd debug` | Create and inspect persistent /gsd debug sessions |

--- a/mintlify-docs/guides/commands.mdx
+++ b/mintlify-docs/guides/commands.mdx
@@ -19,7 +19,7 @@ description: "Every GSD command, keyboard shortcut, and CLI flag."
 | `/gsd mcp` | MCP server status and connectivity |
 | `/gsd status` | Progress dashboard |
 | `/gsd widget` | Cycle dashboard widget: full / small / min / off |
-| `/gsd queue` | Queue and reorder future milestones (safe during auto mode) |
+| `/gsd queue` | Queue and reorder future milestones (`pending`, `queued`, and legacy `planned`; safe during auto mode) |
 | `/gsd capture` | Fire-and-forget thought capture (works during auto mode) |
 | `/gsd triage` | Manually trigger triage of pending captures |
 | `/gsd debug` | Create and inspect persistent /gsd debug sessions |

--- a/src/resources/extensions/gsd/guided-flow-queue.ts
+++ b/src/resources/extensions/gsd/guided-flow-queue.ts
@@ -23,6 +23,7 @@ import { nativeAddPaths, nativeCommit } from "./native-git-bridge.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { loadQueueOrder, sortByQueueOrder, saveQueueOrder } from "./queue-order.js";
 import { findMilestoneIds, nextMilestoneId } from "./milestone-ids.js";
+import { isFutureMilestoneStatus } from "./status-guards.js";
 
 // ─── Queue Entry Point ──────────────────────────────────────────────────────
 
@@ -63,7 +64,7 @@ export async function showQueue(
 
   // ── Count pending milestones ────────────────────────────────────────
   const pendingMilestones = state.registry.filter(
-    m => m.status === "pending" || m.status === "active",
+    m => isFutureMilestoneStatus(m.status) || m.status === "active",
   );
   const completeCount = state.registry.filter(m => m.status === "complete").length;
   const parkedCount = state.registry.filter(m => m.status === "parked").length;
@@ -182,7 +183,7 @@ export async function showQueueAdd(
     ? `Currently executing: ${state.activeMilestone.id} — ${state.activeMilestone.title} (phase: ${state.phase}).`
     : "No milestone currently active.";
 
-  const pendingCount = state.registry.filter(m => m.status === "pending").length;
+  const pendingCount = state.registry.filter(m => isFutureMilestoneStatus(m.status)).length;
   const completeCount = state.registry.filter(m => m.status === "complete").length;
 
   const preamble = [
@@ -284,7 +285,7 @@ export async function buildExistingMilestonesContext(
 
     // For active/pending/parked milestones, include the roadmap if it exists
     // (shows what's planned but not yet built)
-    if (status === "active" || status === "pending" || status === "parked") {
+    if (status === "active" || isFutureMilestoneStatus(status) || status === "parked") {
       const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
       if (roadmapFile) {
         const content = await loadFile(roadmapFile);

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -48,6 +48,7 @@ import { getIsolationMode, loadEffectiveGSDPreferences } from "./preferences.js"
 import { resolveUokFlags } from "./uok/flags.js";
 import { ensurePlanV2Graph, isMissingFinalizedContextResult } from "./uok/plan-v2.js";
 import { detectProjectState, hasGsdBootstrapArtifacts } from "./detection.js";
+import { isFutureMilestoneStatus } from "./status-guards.js";
 import { showProjectInit, offerMigration } from "./init-wizard.js";
 import { validateDirectory } from "./validate-directory.js";
 import { showConfirm } from "../shared/tui.js";
@@ -1471,7 +1472,7 @@ export async function showDiscuss(
   // No active milestone (or corrupted milestone with undefined id) —
   // check for pending milestones to discuss instead
   if (!state.activeMilestone?.id) {
-    const pendingMilestones = state.registry.filter(m => m.status === "pending");
+    const pendingMilestones = state.registry.filter(m => isFutureMilestoneStatus(m.status));
     if (pendingMilestones.length === 0) {
       ctx.ui.notify("No active milestone. Run /gsd to create one first.", "warning");
       return;
@@ -1583,7 +1584,7 @@ export async function showDiscuss(
 
   if (pendingSlices.length === 0) {
     // All slices complete — but queued milestones may still need discussion (#3150)
-    const pendingMilestones = state.registry.filter(m => m.status === "pending");
+    const pendingMilestones = state.registry.filter(m => isFutureMilestoneStatus(m.status));
     if (pendingMilestones.length > 0) {
       await showDiscussQueuedMilestone(ctx, pi, basePath, pendingMilestones);
       return;
@@ -1607,7 +1608,7 @@ export async function showDiscuss(
     // If all pending slices are discussed, check for queued milestones before exiting (#3150)
     const allDiscussed = pendingSlices.every(s => discussedMap.get(s.id));
     if (allDiscussed) {
-      const pendingMilestones = state.registry.filter(m => m.status === "pending");
+      const pendingMilestones = state.registry.filter(m => isFutureMilestoneStatus(m.status));
       if (pendingMilestones.length > 0) {
         await showDiscussQueuedMilestone(ctx, pi, basePath, pendingMilestones);
         return;
@@ -1643,7 +1644,7 @@ export async function showDiscuss(
     });
 
     // Offer access to queued milestones when any exist
-    const pendingMilestones = state.registry.filter(m => m.status === "pending");
+    const pendingMilestones = state.registry.filter(m => isFutureMilestoneStatus(m.status));
     if (pendingMilestones.length > 0) {
       actions.push({
         id: "discuss_queued_milestone",
@@ -1718,10 +1719,11 @@ async function showDiscussQueuedMilestone(
     const hasContext = !!resolveMilestoneFile(basePath, m.id, "CONTEXT");
     const hasDraft = !hasContext && !!resolveMilestoneFile(basePath, m.id, "CONTEXT-DRAFT");
     const contextStatus = hasContext ? "context ✓" : hasDraft ? "draft context" : "no context yet";
+    const statusLabel = m.status === "planned" ? "planned" : "queued";
     return {
       id: m.id,
       label: `${m.id}: ${m.title}`,
-      description: `[queued] · ${contextStatus}`,
+      description: `[${statusLabel}] · ${contextStatus}`,
       recommended: i === 0,
     };
   });

--- a/src/resources/extensions/gsd/status-guards.ts
+++ b/src/resources/extensions/gsd/status-guards.ts
@@ -30,3 +30,11 @@ export function isInactiveStatus(status: string): boolean {
 export function isSkippedForDispatch(status: string): boolean {
   return isClosedStatus(status) || status === "parked" || isDeferredStatus(status);
 }
+
+/**
+ * Returns true when a milestone is future/backlog work (not currently executing).
+ * Includes legacy/project-specific alias "planned" for compatibility.
+ */
+export function isFutureMilestoneStatus(status: string): boolean {
+  return status === "pending" || status === "queued" || status === "planned";
+}

--- a/src/resources/extensions/gsd/tests/status-guards.test.ts
+++ b/src/resources/extensions/gsd/tests/status-guards.test.ts
@@ -3,7 +3,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isClosedStatus } from '../status-guards.ts';
+import { isClosedStatus, isFutureMilestoneStatus } from '../status-guards.ts';
 
 test('isClosedStatus: "complete" returns true', () => {
   assert.equal(isClosedStatus('complete'), true);
@@ -31,4 +31,16 @@ test('isClosedStatus: "active" returns false', () => {
 
 test('isClosedStatus: "" (empty string) returns false', () => {
   assert.equal(isClosedStatus(''), false);
+});
+
+test('isFutureMilestoneStatus includes future milestone aliases', () => {
+  assert.equal(isFutureMilestoneStatus('pending'), true);
+  assert.equal(isFutureMilestoneStatus('queued'), true);
+  assert.equal(isFutureMilestoneStatus('planned'), true);
+});
+
+test('isFutureMilestoneStatus excludes active and closed milestones', () => {
+  assert.equal(isFutureMilestoneStatus('active'), false);
+  assert.equal(isFutureMilestoneStatus('complete'), false);
+  assert.equal(isFutureMilestoneStatus('parked'), false);
 });


### PR DESCRIPTION
## Summary
- Added a future-status compatibility predicate (`planned` included) and wired it into discuss/queue filtering with targeted tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5473
- [#5473 Milestone status drift makes planned future milestones inconsistently discoverable](https://github.com/gsd-build/gsd-2/issues/5473)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5473-milestone-status-drift-makes-planned-fut-1778725224`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal consistency by standardizing the evaluation and categorization of milestone statuses throughout the queue system, queue display, milestone context-building, and future milestone identification.
  * Enhanced user visibility with refined labels for queued items that more clearly indicate whether items are marked as planned or are currently queued.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5951)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->