### PR TITLE
fix(issue): validate-milestone unit gets stuck in infinite loop if LLM fails to call gsd_validate_milestone tool

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -105,22 +105,26 @@ async function runValidateMilestonePostCheck(
   const { milestone: mid } = parseUnitId(s.currentUnit.id);
   if (!mid) return "continue";
 
-  const validationFile = resolveMilestoneFile(s.basePath, mid, "VALIDATION");
-  if (!validationFile) {
+  const setToolFailureRetry = (message: string): VerificationResult => {
     s.pendingVerificationRetry = {
-      message: "You must call gsd_validate_milestone to persist the validation results. No VALIDATION.md was created.",
+      message,
       errorClass: "tool-failure",
     };
     return "retry";
+  };
+
+  const validationFile = resolveMilestoneFile(s.basePath, mid, "VALIDATION");
+  if (!validationFile) {
+    return setToolFailureRetry(
+      "You must call gsd_validate_milestone to persist the validation results. No VALIDATION.md was created.",
+    );
   }
 
   const validationContent = await loadFile(validationFile);
   if (!validationContent) {
-    s.pendingVerificationRetry = {
-      message: "You must call gsd_validate_milestone to persist the validation results. No VALIDATION.md was created.",
-      errorClass: "tool-failure",
-    };
-    return "retry";
+    return setToolFailureRetry(
+      "You must call gsd_validate_milestone to persist the validation results. VALIDATION.md exists but is empty.",
+    );
   }
 
   const verdict = extractVerdict(validationContent);

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -106,9 +106,13 @@ async function runValidateMilestonePostCheck(
   if (!mid) return "continue";
 
   const setToolFailureRetry = (message: string): VerificationResult => {
+    const retryKey = verificationRetryKey(s.currentUnit!.type, s.currentUnit!.id);
+    const attempt = (s.verificationRetryCount.get(retryKey) ?? 0) + 1;
+    s.verificationRetryCount.set(retryKey, attempt);
     s.pendingVerificationRetry = {
-      message,
-      errorClass: "tool-failure",
+      unitId: s.currentUnit!.id,
+      failureContext: message,
+      attempt,
     };
     return "retry";
   };

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -106,10 +106,22 @@ async function runValidateMilestonePostCheck(
   if (!mid) return "continue";
 
   const validationFile = resolveMilestoneFile(s.basePath, mid, "VALIDATION");
-  if (!validationFile) return "continue";
+  if (!validationFile) {
+    s.pendingVerificationRetry = {
+      message: "You must call gsd_validate_milestone to persist the validation results. No VALIDATION.md was created.",
+      errorClass: "tool-failure",
+    };
+    return "retry";
+  }
 
   const validationContent = await loadFile(validationFile);
-  if (!validationContent) return "continue";
+  if (!validationContent) {
+    s.pendingVerificationRetry = {
+      message: "You must call gsd_validate_milestone to persist the validation results. No VALIDATION.md was created.",
+      errorClass: "tool-failure",
+    };
+    return "retry";
+  }
 
   const verdict = extractVerdict(validationContent);
   if (verdict !== "needs-remediation") {

--- a/src/resources/extensions/gsd/tests/validate-milestone-stuck-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-stuck-guard.test.ts
@@ -179,4 +179,26 @@ describe("validate-milestone stuck-loop guard (#4094)", () => {
     assert.match(s.pendingVerificationRetry!.message, /gsd_validate_milestone/);
     assert.equal(s.pendingVerificationRetry!.errorClass, "tool-failure");
   });
+
+  test("retries when VALIDATION file exists but is empty", async () => {
+    insertMilestone({ id: "M001" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice 1", status: "complete" });
+
+    const path = join(tempDir, ".gsd", "milestones", "M001", "M001-VALIDATION.md");
+    writeFileSync(path, "", "utf-8");
+    invalidateAllCaches();
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, "validate-milestone", "M001");
+
+    const result = await runPostUnitVerification({ s, ctx, pi } as VerificationContext, pauseAutoMock);
+
+    assert.equal(result, "retry");
+    assert.equal(pauseAutoMock.mock.callCount(), 0);
+    assert.ok(s.pendingVerificationRetry);
+    assert.match(s.pendingVerificationRetry!.message, /exists but is empty/);
+    assert.equal(s.pendingVerificationRetry!.errorClass, "tool-failure");
+  });
 });

--- a/src/resources/extensions/gsd/tests/validate-milestone-stuck-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-stuck-guard.test.ts
@@ -176,8 +176,9 @@ describe("validate-milestone stuck-loop guard (#4094)", () => {
     assert.equal(result, "retry");
     assert.equal(pauseAutoMock.mock.callCount(), 0);
     assert.ok(s.pendingVerificationRetry);
-    assert.match(s.pendingVerificationRetry!.message, /gsd_validate_milestone/);
-    assert.equal(s.pendingVerificationRetry!.errorClass, "tool-failure");
+    assert.equal(s.pendingVerificationRetry!.unitId, "M001");
+    assert.match(s.pendingVerificationRetry!.failureContext, /gsd_validate_milestone/);
+    assert.equal(s.pendingVerificationRetry!.attempt, 1);
   });
 
   test("retries when VALIDATION file exists but is empty", async () => {
@@ -198,7 +199,8 @@ describe("validate-milestone stuck-loop guard (#4094)", () => {
     assert.equal(result, "retry");
     assert.equal(pauseAutoMock.mock.callCount(), 0);
     assert.ok(s.pendingVerificationRetry);
-    assert.match(s.pendingVerificationRetry!.message, /exists but is empty/);
-    assert.equal(s.pendingVerificationRetry!.errorClass, "tool-failure");
+    assert.equal(s.pendingVerificationRetry!.unitId, "M001");
+    assert.match(s.pendingVerificationRetry!.failureContext, /exists but is empty/);
+    assert.equal(s.pendingVerificationRetry!.attempt, 1);
   });
 });

--- a/src/resources/extensions/gsd/tests/validate-milestone-stuck-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-stuck-guard.test.ts
@@ -162,7 +162,7 @@ describe("validate-milestone stuck-loop guard (#4094)", () => {
     assert.equal(pauseAutoMock.mock.callCount(), 0);
   });
 
-  test("continues when no VALIDATION file exists yet", async () => {
+  test("retries when no VALIDATION file exists yet", async () => {
     insertMilestone({ id: "M001" });
     insertSlice({ id: "S01", milestoneId: "M001", title: "Slice 1", status: "complete" });
 
@@ -173,7 +173,10 @@ describe("validate-milestone stuck-loop guard (#4094)", () => {
 
     const result = await runPostUnitVerification({ s, ctx, pi } as VerificationContext, pauseAutoMock);
 
-    assert.equal(result, "continue");
+    assert.equal(result, "retry");
     assert.equal(pauseAutoMock.mock.callCount(), 0);
+    assert.ok(s.pendingVerificationRetry);
+    assert.match(s.pendingVerificationRetry!.message, /gsd_validate_milestone/);
+    assert.equal(s.pendingVerificationRetry!.errorClass, "tool-failure");
   });
 });


### PR DESCRIPTION
## Summary
- Fixed validate-milestone post-check to retry with a tool-failure message when VALIDATION.md is missing/empty, and verified with the targeted stuck-guard unit test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5916
- [#5916 validate-milestone unit gets stuck in infinite loop if LLM fails to call gsd_validate_milestone tool](https://github.com/gsd-build/gsd-2/issues/5916)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5916-validate-milestone-unit-gets-stuck-in-in-1778725395`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved milestone verification flow: missing validation evidence now triggers a retry mechanism with clear guidance instead of silently proceeding. The system instructs users to run validation and marks the issue as a recoverable tool failure, enabling proper error handling and resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5952)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->