### PR TITLE
fix(issue): dispatch-guard.js has no consecutive same-unit cap for complete-milestone/validate-milestone/research-slice

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -179,6 +179,10 @@ GSD uses a sliding-window analysis to detect stuck loops. Instead of a simple "s
 
 The sliding-window approach reduces false positives on legitimate retries (e.g., verification failures that self-correct) while catching genuine stuck loops faster.
 
+### Consecutive Dispatch Blocker
+
+Auto mode also enforces a same-unit consecutive dispatch cap for `complete-milestone`, `validate-milestone`, and `research-slice`. The loop allows two consecutive dispatches of the same unit in the same phase and stops before a third attempt with a repeat-cap warning that instructs you to run `/gsd resume` after intervention.
+
 ### Artifact Verification Retries
 
 After each unit, GSD verifies that the expected artifact exists on disk. If the artifact is missing, auto mode re-dispatches the unit with explicit failure context and records an `artifact-verification-retry` journal event.

--- a/mintlify-docs/guides/auto-mode.mdx
+++ b/mintlify-docs/guides/auto-mode.mdx
@@ -110,6 +110,10 @@ Auto mode persists worker state, unit-dispatch state, and paused-session metadat
 
 A sliding-window analysis detects stuck loops — catching cycles like A→B→A→B as well as single-unit repeats. On detection, GSD retries once with a diagnostic prompt. If it fails again, auto mode stops with the exact file it expected.
 
+### Consecutive dispatch blocker
+
+Auto mode also enforces a same-unit consecutive dispatch cap for `complete-milestone`, `validate-milestone`, and `research-slice`. The loop allows two consecutive dispatches of the same unit in the same phase and stops before a third attempt with a repeat-cap warning that instructs you to run `/gsd resume` after intervention.
+
 ### Timeout supervision
 
 | Timeout | Default | Behavior                   |

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -284,6 +284,9 @@ export async function autoLoop(
     recentUnits: persisted.recentUnits,
     stuckRecoveryAttempts: persisted.stuckRecoveryAttempts,
     consecutiveFinalizeTimeouts: 0,
+    consecutiveDispatchCount: new Map<string, number>(),
+    lastDispatchedKey: null,
+    lastDispatchPhase: null,
   };
   let consecutiveErrors = 0;
   let consecutiveCooldowns = 0;

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -78,6 +78,7 @@ import { createWorktreeSafetyModule, type WorktreeSafetyResult } from "../worktr
 import { isSuspiciousGhostCompletion } from "../auto-unit-closeout.js";
 import { decideVerificationRetry, verificationRetryKey } from "./verification-retry-policy.js";
 import { buildPhaseHandoffOutcome, setAutoOutcomeWidget } from "../auto-dashboard.js";
+import { getConsecutiveDispatchBlocker } from "../dispatch-guard.js";
 
 // ─── Path Comparison Helper ───────────────────────────────────────────────
 /** Compare two paths for physical identity, tolerating trailing slashes and symlinks. */
@@ -1351,6 +1352,18 @@ export async function runDispatch(
     await deps.stopAuto(ctx, pi, priorSliceBlocker);
     debugLog("autoLoop", { phase: "exit", reason: "prior-slice-blocker" });
     return { action: "break", reason: "prior-slice-blocker" };
+  }
+
+  const consecutiveDispatchBlocker = getConsecutiveDispatchBlocker(
+    loopState,
+    state.phase,
+    unitType,
+    unitId,
+  );
+  if (consecutiveDispatchBlocker) {
+    await deps.stopAuto(ctx, pi, consecutiveDispatchBlocker);
+    debugLog("autoLoop", { phase: "exit", reason: "consecutive-dispatch-blocker" });
+    return { action: "break", reason: "consecutive-dispatch-blocker" };
   }
 
   const worktreeSafetyBlock = await validateSourceWriteWorktreeSafety(

--- a/src/resources/extensions/gsd/auto/types.ts
+++ b/src/resources/extensions/gsd/auto/types.ts
@@ -97,6 +97,9 @@ export interface LoopState {
   stuckRecoveryAttempts: number;
   /** Consecutive finalize timeout count — stops auto-mode after threshold. */
   consecutiveFinalizeTimeouts: number;
+  consecutiveDispatchCount?: Map<string, number>;
+  lastDispatchedKey?: string | null;
+  lastDispatchPhase?: string | null;
 }
 
 /** Max consecutive finalize timeouts before hard-stopping auto-mode. */

--- a/src/resources/extensions/gsd/dispatch-guard.ts
+++ b/src/resources/extensions/gsd/dispatch-guard.ts
@@ -17,6 +17,50 @@ const SLICE_DISPATCH_TYPES = new Set([
   "complete-slice",
 ]);
 
+const CONSECUTIVE_SAME_UNIT_CAP_TYPES = new Set([
+  "complete-milestone",
+  "validate-milestone",
+  "research-slice",
+]);
+const CONSECUTIVE_SAME_UNIT_CAP = 2;
+
+type ConsecutiveDispatchState = {
+  consecutiveDispatchCount?: Map<string, number>;
+  lastDispatchedKey?: string | null;
+  lastDispatchPhase?: string | null;
+};
+
+export function getConsecutiveDispatchBlocker(
+  state: ConsecutiveDispatchState,
+  phase: string,
+  unitType: string,
+  unitId: string,
+): string | null {
+  if (!CONSECUTIVE_SAME_UNIT_CAP_TYPES.has(unitType)) return null;
+  if (!state.consecutiveDispatchCount) state.consecutiveDispatchCount = new Map<string, number>();
+
+  const key = `${unitType}:${unitId}`;
+  const phaseChanged = state.lastDispatchPhase !== phase;
+  const switchedUnit = state.lastDispatchedKey !== key;
+  if (phaseChanged || switchedUnit) {
+    state.consecutiveDispatchCount.clear();
+    state.consecutiveDispatchCount.set(key, 1);
+    state.lastDispatchedKey = key;
+    state.lastDispatchPhase = phase;
+    return null;
+  }
+
+  const count = state.consecutiveDispatchCount.get(key) ?? 0;
+  if (count >= CONSECUTIVE_SAME_UNIT_CAP) {
+    return `Cannot dispatch ${unitType} ${unitId}: dispatched ${count} consecutive times; same-unit repeat cap reached. Resolve via /gsd resume.`;
+  }
+
+  state.consecutiveDispatchCount.set(key, count + 1);
+  state.lastDispatchedKey = key;
+  state.lastDispatchPhase = phase;
+  return null;
+}
+
 export function getPriorSliceCompletionBlocker(
   base: string,
   _mainBranch: string,

--- a/src/resources/extensions/gsd/dispatch-guard.ts
+++ b/src/resources/extensions/gsd/dispatch-guard.ts
@@ -8,6 +8,7 @@ import { parseRoadmap } from "./parsers-legacy.js";
 import { isClosedStatus, isSkippedForDispatch } from "./status-guards.js";
 import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
 import { readFileSync } from "node:fs";
+import type { LoopState } from "./auto/types.js";
 
 const SLICE_DISPATCH_TYPES = new Set([
   "research-slice",
@@ -24,12 +25,25 @@ const CONSECUTIVE_SAME_UNIT_CAP_TYPES = new Set([
 ]);
 const CONSECUTIVE_SAME_UNIT_CAP = 2;
 
-type ConsecutiveDispatchState = {
-  consecutiveDispatchCount?: Map<string, number>;
-  lastDispatchedKey?: string | null;
-  lastDispatchPhase?: string | null;
-};
+type ConsecutiveDispatchState = Pick<
+  LoopState,
+  "consecutiveDispatchCount" | "lastDispatchedKey" | "lastDispatchPhase"
+>;
 
+/**
+ * Prevent repeated dispatches of the same unit within the same phase.
+ *
+ * Applies only to unit types in `CONSECUTIVE_SAME_UNIT_CAP_TYPES`. The first
+ * dispatch for a unit/phase pair starts a counter, unit or phase changes reset
+ * tracking, and dispatch is blocked once the counter reaches
+ * `CONSECUTIVE_SAME_UNIT_CAP`.
+ *
+ * Side effects: mutates `state.consecutiveDispatchCount`,
+ * `state.lastDispatchedKey`, and `state.lastDispatchPhase`.
+ *
+ * Returns `null` when dispatch is allowed, or a blocker message (including
+ * guidance to run `/gsd resume`) when the cap is reached.
+ */
 export function getConsecutiveDispatchBlocker(
   state: ConsecutiveDispatchState,
   phase: string,

--- a/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
@@ -282,6 +282,7 @@ test("dispatch guard does not skip prior milestone from SUMMARY projection when 
 });
 
 test("consecutive dispatch guard blocks complete-milestone after repeat cap", () => {
+  // REPEAT_CAP = 2: two same-unit dispatches are allowed; the third is blocked.
   const state = {
     consecutiveDispatchCount: new Map<string, number>(),
     lastDispatchedKey: null as string | null,

--- a/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { getPriorSliceCompletionBlocker } from "../dispatch-guard.ts";
+import { getConsecutiveDispatchBlocker, getPriorSliceCompletionBlocker } from "../dispatch-guard.ts";
 import { openDatabase, closeDatabase, insertMilestone, insertSlice } from "../gsd-db.ts";
 
 /** Helper: create temp dir and open an in-dir DB for dispatch-guard tests */
@@ -279,6 +279,45 @@ test("dispatch guard does not skip prior milestone from SUMMARY projection when 
     getPriorSliceCompletionBlocker(repo, "main", "plan-slice", "M002/S01"),
     "Cannot dispatch plan-slice M002/S01: earlier slice M001/S03-R is not complete.",
   );
+});
+
+test("consecutive dispatch guard blocks complete-milestone after repeat cap", () => {
+  const state = {
+    consecutiveDispatchCount: new Map<string, number>(),
+    lastDispatchedKey: null as string | null,
+    lastDispatchPhase: null as string | null,
+  };
+
+  assert.equal(getConsecutiveDispatchBlocker(state, "completing-milestone", "complete-milestone", "M009"), null);
+  assert.equal(getConsecutiveDispatchBlocker(state, "completing-milestone", "complete-milestone", "M009"), null);
+  assert.match(
+    getConsecutiveDispatchBlocker(state, "completing-milestone", "complete-milestone", "M009") ?? "",
+    /same-unit repeat cap reached/,
+  );
+});
+
+test("consecutive dispatch guard resets when unit changes", () => {
+  const state = {
+    consecutiveDispatchCount: new Map<string, number>(),
+    lastDispatchedKey: null as string | null,
+    lastDispatchPhase: null as string | null,
+  };
+
+  assert.equal(getConsecutiveDispatchBlocker(state, "validating-milestone", "validate-milestone", "M001"), null);
+  assert.equal(getConsecutiveDispatchBlocker(state, "validating-milestone", "research-slice", "M001/parallel-research"), null);
+  assert.equal(getConsecutiveDispatchBlocker(state, "validating-milestone", "validate-milestone", "M001"), null);
+});
+
+test("consecutive dispatch guard resets when phase changes", () => {
+  const state = {
+    consecutiveDispatchCount: new Map<string, number>(),
+    lastDispatchedKey: null as string | null,
+    lastDispatchPhase: null as string | null,
+  };
+
+  assert.equal(getConsecutiveDispatchBlocker(state, "validating-milestone", "validate-milestone", "M001"), null);
+  assert.equal(getConsecutiveDispatchBlocker(state, "validating-milestone", "validate-milestone", "M001"), null);
+  assert.equal(getConsecutiveDispatchBlocker(state, "completing-milestone", "validate-milestone", "M001"), null);
 });
 
 test("dispatch guard does not skip failed milestone SUMMARY without blocker prose", (t) => {


### PR DESCRIPTION
## Summary
- Added a dispatch-time consecutive same-unit cap for complete-milestone/validate-milestone/research-slice and verified with focused guard and lifecycle tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5663
- [#5663 dispatch-guard.js has no consecutive same-unit cap for complete-milestone/validate-milestone/research-slice](https://github.com/gsd-build/gsd-2/issues/5663)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5663-dispatch-guard-js-has-no-consecutive-sam-1778725365`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguard to prevent excessive repeated consecutive dispatches of the same unit in auto-mode, improving execution stability and preventing unintended repeated actions. Consecutive dispatch tracking automatically resets when switching units or dispatch phases.

* **Tests**
  * Added tests for the consecutive dispatch prevention mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5953)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->