### PR TITLE
fix(issue): [Bug]: auto-mode: milestone completed without user UAT — needs-attention verdict not guarded in dispatch

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1330,16 +1330,16 @@ export const DISPATCH_RULES: DispatchRule[] = [
         }
       }
 
-      // Safety guard (#2675, #5747): block completion when VALIDATION
-      // verdict is non-passing. The state machine treats these verdicts as
-      // terminal, but completing-milestone should NOT proceed — remediation
-      // or human attention is needed.
+      // Safety guard (#2675, #5747, #5920): block completion when VALIDATION
+      // verdict is anything other than pass. The state machine treats these
+      // verdicts as terminal, but completing-milestone should NOT proceed —
+      // remediation or human attention is needed.
       const validationFile = resolveMilestoneFile(basePath, mid, "VALIDATION");
       if (validationFile) {
         const validationContent = await loadFile(validationFile);
         if (validationContent) {
           const verdict = extractVerdict(validationContent);
-          if (verdict === "needs-remediation" || verdict === "needs-attention") {
+          if (verdict !== "pass") {
             return {
               action: "stop",
               reason: `Cannot complete milestone ${mid}: VALIDATION verdict is "${verdict}". Address the validation findings and re-run validation, or update the verdict manually.`,

--- a/src/resources/extensions/gsd/tests/remediation-completion-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/remediation-completion-guard.test.ts
@@ -110,6 +110,49 @@ test("completing-milestone blocks when VALIDATION verdict is needs-attention (#5
   }
 });
 
+test("completing-milestone blocks when VALIDATION verdict is fail (#5920)", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-fail-verdict-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+
+  try {
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-VALIDATION.md"),
+      [
+        "---",
+        "verdict: fail",
+        "---",
+        "",
+        "# Validation Report",
+        "",
+        "Blocking failures remain unresolved.",
+      ].join("\n"),
+    );
+
+    const ctx = {
+      mid: "M001",
+      midTitle: "Test Milestone",
+      basePath: base,
+      state: { phase: "completing-milestone" } as any,
+      prefs: {} as any,
+      session: undefined,
+    };
+
+    const result = await completingRule!.match(ctx);
+
+    assert.ok(result !== null, "rule should match");
+    assert.equal(result!.action, "stop", "should return stop action");
+    if (result!.action === "stop") {
+      assert.equal(result!.level, "warning", "should be warning level (pausable)");
+      assert.ok(
+        result!.reason.includes('verdict is "fail"'),
+        "reason should mention fail verdict",
+      );
+    }
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("completing-milestone proceeds normally when VALIDATION verdict is pass (#2675 guard)", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-remediation-"));
   mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });


### PR DESCRIPTION
## Summary
- Guard now blocks complete-milestone dispatch unless VALIDATION verdict is pass, verified by focused regression tests including needs-attention and fail.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5920
- [#5920 [Bug]: auto-mode: milestone completed without user UAT — needs-attention verdict not guarded in dispatch](https://github.com/gsd-build/gsd-2/issues/5920)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5920-bug-auto-mode-milestone-completed-withou-1778725767`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Milestone completion validation now stops whenever the validation verdict is not "pass," rather than only for specific verdict types.

* **Tests**
  * Added regression test for validation verdict handling during milestone completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5958)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->