### PR TITLE
fix(issue): bug(auto): reactive-execute prompt bloat + infinite stuck-loop recovery

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -3095,17 +3095,40 @@ export async function buildReactiveExecutePrompt(
       mid, sid, tid, node?.dependsOn ?? [], base,
     );
 
-    // Build a full execute-task prompt with dependency-based carry-forward
-    const taskPrompt = await buildExecuteTaskPrompt(
-      mid, sid, sTitle, tid, tTitle, base,
-      {
-        carryForwardPaths: depPaths,
-        sessionContextWindow: opts?.sessionContextWindow,
-        modelRegistry: opts?.modelRegistry,
-        sessionProvider: opts?.sessionProvider,
-        contextModeRenderMode: "nested",
-      },
-    );
+    const taskPlanPath = resolveTaskFile(base, mid, sid, tid, "PLAN");
+    const taskPlanContent = taskPlanPath ? await loadFile(taskPlanPath) : null;
+    const taskPlanRelPath = `${relSlicePath(base, mid, sid)}/tasks/${tid}-PLAN.md`;
+    const taskPlanInline = taskPlanContent
+      ? [
+          "## Inlined Task Plan (authoritative local execution contract)",
+          `Source: \`${taskPlanRelPath}\``,
+          "",
+          taskPlanContent.trim(),
+        ].join("\n")
+      : [
+          "## Inlined Task Plan (authoritative local execution contract)",
+          `Task plan not found at dispatch time. Read \`${taskPlanRelPath}\` before executing.`,
+        ].join("\n");
+    const carryForwardSection = await buildCarryForwardSection(depPaths, base);
+    const taskSummaryPath = `${relSlicePath(base, mid, sid)}/tasks/${tid}-SUMMARY.md`;
+    const taskPrompt = [
+      `## UNIT: Execute Task ${tid} ("${tTitle}")`,
+      "",
+      "Work only in the repository root.",
+      "Implement from the inlined task plan below. Verify changes, then call `gsd_task_complete`.",
+      "Do not run git commands.",
+      "",
+      carryForwardSection,
+      "",
+      taskPlanInline,
+      "",
+      "## Completion Contract",
+      `- Call \`gsd_task_complete\` with camelCase fields: \`milestoneId\`, \`sliceId\`, \`taskId\`, \`oneLiner\`, \`narrative\`, \`verification\`, and \`verificationEvidence\`.`,
+      `- Do not manually write \`${taskSummaryPath}\` or edit PLAN checkboxes; the completion tool is canonical.`,
+      `- Use \`blocker_discovered: true\` only if the task cannot be completed due to a real blocker.`,
+      "",
+      `When done, say: "Task ${tid} complete."`,
+    ].join("\n");
 
     const modelSuffix = subagentModel ? ` with model: "${subagentModel}"` : "";
     subagentSections.push([

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1426,7 +1426,6 @@ export async function runDispatch(
           );
           deps.invalidateAllCaches();
           loopState.recentUnits.length = 0;
-          loopState.stuckRecoveryAttempts = 0;
           return { action: "continue" };
         }
         ctx.ui.notify(

--- a/src/resources/extensions/gsd/prompts/reactive-execute.md
+++ b/src/resources/extensions/gsd/prompts/reactive-execute.md
@@ -8,7 +8,7 @@
 
 You are executing **multiple tasks in parallel** for this slice. The task graph below shows which tasks are ready for simultaneous execution based on their input/output dependencies.
 
-**Critical rule:** Use the `subagent` tool in **parallel mode** to dispatch all ready tasks simultaneously. Each subagent gets a full `execute-task` prompt and is responsible for its own implementation, verification, task summary, and completion tool calls. The parent batch agent orchestrates, verifies, and records failures only when a dispatched task failed before it could leave its own summary behind.
+**Critical rule:** Use the `subagent` tool in **parallel mode** to dispatch all ready tasks simultaneously. Each subagent gets a task-specific execution packet (task plan + dependency carry-forward + completion contract) and is responsible for its own implementation, verification, task summary, and completion tool calls. The parent batch agent orchestrates, verifies, and records failures only when a dispatched task failed before it could leave its own summary behind.
 
 ## Task Dependency Graph
 

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -633,7 +633,7 @@ test("runDispatch clears execute-task stuck state when artifacts and DB status a
   assert.equal(stopCalls, 0, "closed DB task should not hard-stop the loop");
   assert.equal(invalidateCalls, 1, "closed DB task recovery should invalidate caches once");
   assert.deepEqual(loopState.recentUnits, [], "closed DB task recovery should clear the stuck window");
-  assert.equal(loopState.stuckRecoveryAttempts, 0, "closed DB task recovery should reset the recovery counter");
+  assert.equal(loopState.stuckRecoveryAttempts, 1, "closed DB task recovery should preserve the recovery counter");
 });
 
 test("runDispatch clears stuck state after Level 1 artifact recovery", async (t) => {
@@ -700,7 +700,7 @@ test("runDispatch clears stuck state after Level 1 artifact recovery", async (t)
   assert.equal(invalidateCalls, 1, "Level 1 artifact recovery should invalidate caches");
   assert.equal(stopCalls, 0, "Level 1 artifact recovery should not hard-stop");
   assert.deepEqual(loopState.recentUnits, [], "Level 1 artifact recovery should clear the stuck window");
-  assert.equal(loopState.stuckRecoveryAttempts, 0, "Level 1 artifact recovery should reset the recovery counter");
+  assert.equal(loopState.stuckRecoveryAttempts, 1, "Level 1 artifact recovery should preserve the recovery counter");
 });
 
 test("runDispatch escapes Level 2 stuck stop when artifact verifies after cache invalidation", async (t) => {

--- a/src/resources/extensions/gsd/tests/subagent-model-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/subagent-model-dispatch.test.ts
@@ -91,8 +91,9 @@ test("buildReactiveExecutePrompt injects subagent model when provided", async (t
   );
 
   assert.match(prompt, /model: "claude-opus-4-6"/);
-  assert.match(prompt, /Context Mode \(execution lane\):/);
+  assert.match(prompt, /Lane: \*\*execution lane\*\*\./);
   assert.match(prompt, /## Context Mode/);
+  assert.doesNotMatch(prompt, /You are executing GSD auto-mode\./);
 });
 
 test("buildReactiveExecutePrompt omits model instruction when subagentModel is omitted", async (t) => {


### PR DESCRIPTION
## Summary
- Replaced reactive subagent prompt inlining with compact task-specific packets and removed Level-1 stuck-recovery counter reset, verified by focused prompt and dispatch-loop tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5926
- [#5926 bug(auto): reactive-execute prompt bloat + infinite stuck-loop recovery](https://github.com/gsd-build/gsd-2/issues/5926)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5926-bug-auto-reactive-execute-prompt-bloat-i-1778725862`