### PR TITLE
fix(issue): ask_user_questions single-select returns "cancelled" after user completes full selection flow (WSL2)

### DIFF
--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -310,8 +310,8 @@ export async function showInterviewRound(
 					const selected = sorted.map((idx) => q.options[idx].label);
 					if (selected.length > 0 || notes) answers[q.id] = { selected, notes };
 				} else {
+					if (st.committedIndex === null && !notes) continue;
 					const effectiveCommittedIndex = st.committedIndex ?? st.cursorIndex;
-					if (effectiveCommittedIndex === null && !notes) continue;
 					let selected = OTHER_OPTION_LABEL;
 					if (effectiveCommittedIndex !== null) {
 						const idx = effectiveCommittedIndex;
@@ -485,9 +485,10 @@ export async function showInterviewRound(
 					const selected = Array.from(st.checkedIndices).sort((a, b) => a - b).map((idx) => q.options[idx].label);
 					for (const label of selected) push(ui.answer(`    ${INDENT.cursor}${label}`));
 				} else {
+					const effectiveCommittedIndex = st.committedIndex ?? st.cursorIndex;
 					let label = OTHER_OPTION_LABEL;
-					if (st.committedIndex !== null && st.committedIndex < q.options.length) {
-						label = q.options[st.committedIndex].label;
+					if (effectiveCommittedIndex < q.options.length) {
+						label = q.options[effectiveCommittedIndex].label;
 					}
 					push(ui.answer(`    ${INDENT.cursor}${label}`));
 				}

--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -310,10 +310,11 @@ export async function showInterviewRound(
 					const selected = sorted.map((idx) => q.options[idx].label);
 					if (selected.length > 0 || notes) answers[q.id] = { selected, notes };
 				} else {
-					if (st.committedIndex === null && !notes) continue;
+					const effectiveCommittedIndex = st.committedIndex ?? st.cursorIndex;
+					if (effectiveCommittedIndex === null && !notes) continue;
 					let selected = OTHER_OPTION_LABEL;
-					if (st.committedIndex !== null) {
-						const idx = st.committedIndex;
+					if (effectiveCommittedIndex !== null) {
+						const idx = effectiveCommittedIndex;
 						if (idx < q.options.length) selected = q.options[idx].label;
 						else if (idx === noneOrDoneIdx(i)) selected = OTHER_OPTION_LABEL;
 					}

--- a/src/resources/extensions/shared/tests/interview-notes-loop.test.ts
+++ b/src/resources/extensions/shared/tests/interview-notes-loop.test.ts
@@ -21,6 +21,7 @@ import { showInterviewRound, type Question, type RoundResult } from "../intervie
 const ENTER = "\r";
 const DOWN = "\x1b[B";
 const TAB = "\t";
+const SPACE = " ";
 
 /**
  * Drive showInterviewRound with a scripted sequence of key inputs.
@@ -138,6 +139,20 @@ describe("interview-ui notes loop regression (#3502)", () => {
 		const answer = result.answers.q1;
 		assert.ok(answer, "answer for q1 should exist");
 		assert.equal(answer.selected, "Web App");
+	});
+
+	it("single-select returns the committed option label as a string", async () => {
+		const result = await runWithInputs(questions, [
+			DOWN,        // cursor -> "CLI Tool"
+			SPACE,       // commit current selection without advancing
+			ENTER,       // advance to review
+			ENTER,       // submit from review
+		]);
+
+		const answer = result.answers.q1;
+		assert.ok(answer, "answer for q1 should exist");
+		assert.equal(typeof answer.selected, "string");
+		assert.equal(answer.selected, "CLI Tool");
 	});
 
 	it("ignores abort signals after a submitted answer", async () => {


### PR DESCRIPTION
## Summary
- Single-select answer building now falls back to cursor selection when committedIndex is null, and the shared interview UI regression tests pass.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5455
- [#5455 ask_user_questions single-select returns "cancelled" after user completes full selection flow (WSL2)](https://github.com/gsd-build/gsd-2/issues/5455)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5455-ask-user-questions-single-select-returns-1778727227`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced single-select question response handling in interviews to ensure answers are properly recorded when notes are present or cursor-based selection is used.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5967)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->