### PR TITLE
fix(issue): complete-slice/complete-milestone blocked by planning-dispatch tools policy — cannot run verification bash commands

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -230,15 +230,21 @@ test("#4934: tools.mode is one of the declared policies", () => {
   }
 });
 
-test('#4934: only execution units and complete-milestone may use tools.mode "all"', () => {
-  const allowedAllUnits = new Set(["execute-task", "reactive-execute", "complete-milestone"]);
+test('#4934: only execution units and closeout units may use tools.mode "all"', () => {
+  const allowedAllUnits = new Set([
+    "execute-task",
+    "reactive-execute",
+    "validate-milestone",
+    "complete-milestone",
+    "complete-slice",
+  ]);
   for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
     const mode = (manifest as { tools: { mode: string } }).tools.mode;
     if (mode === "all") {
       assert.ok(
         allowedAllUnits.has(unitType),
         `manifest "${unitType}" declares tools.mode = "all" but is not explicitly allowed. ` +
-        'Only execute-task, reactive-execute, and complete-milestone should have full source write access; ' +
+        'Only execute-task/reactive-execute and closeout units should have full source write access; ' +
         'planning/discuss/research units must use "planning" or "planning-dispatch" (or "docs" for rewrite-docs).',
       );
     }
@@ -268,6 +274,25 @@ test("#5453: complete-milestone uses all tools so bash verification is not plann
       result.block,
       false,
       `shouldBlockPlanningUnit must not block ${cmd} for complete-milestone: ${result.reason}`,
+    );
+  }
+});
+
+test("#5731: validate-milestone and complete-slice use all tools so closeout verification is not planning-dispatch blocked", () => {
+  for (const unitType of ["validate-milestone", "complete-slice"] as const) {
+    const manifest = UNIT_MANIFESTS[unitType];
+    assert.strictEqual(manifest.tools.mode, "all");
+    const result = shouldBlockPlanningUnit(
+      "bash",
+      "go test -short -count=1 ./...",
+      process.cwd(),
+      unitType,
+      manifest.tools,
+    );
+    assert.strictEqual(
+      result.block,
+      false,
+      `${unitType} must allow verification bash commands: ${result.reason}`,
     );
   }
 });
@@ -306,13 +331,11 @@ test('planning-dispatch mode is reserved for slice-level decomposition and compl
     "plan-slice",
     "research-slice",
     "refine-slice",
-    "complete-slice",
     "gate-evaluate",
     // Deep planning mode: research-project orchestrates 4 parallel research
     // subagents (stack/features/architecture/pitfalls). Subagent dispatch is
     // the unit's core mechanism — without it, the unit cannot do its job.
     "research-project",
-    "validate-milestone",
   ]);
   for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
     const mode = (manifest as { tools: { mode: string } }).tools.mode;

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -409,11 +409,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     codebaseMap: false,
     preferences: "active-only",
     contextMode: "verification",
-    // planning-dispatch: validation is a verification-fan-out unit. It reads
-    // the milestone surface and dispatches reviewer/security/tester subagents
-    // to report findings without touching user source. Write isolation to
-    // .gsd/ is preserved.
-    tools: TOOLS_PLANNING_DISPATCH_REVIEW,
+    // Validation may need to run shell verification commands and apply source
+    // fixes before milestone closeout can proceed.
+    tools: TOOLS_ALL,
     artifacts: {
       inline: ["roadmap", "slice-summary", "slice-uat", "requirements", "decisions", "templates"],
       excerpt: [],
@@ -518,10 +516,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     codebaseMap: false,
     preferences: "active-only",
     contextMode: "verification",
-    // See complete-milestone — same rationale: dispatch to reviewer / security /
-    // tester subagents to fan out review work without bloating this unit's
-    // context.
-    tools: TOOLS_PLANNING_DISPATCH_REVIEW,
+    // Slice closeout may need to run shell verification commands and apply
+    // source fixes before completion can be recorded.
+    tools: TOOLS_ALL,
     artifacts: {
       // Phase 3 migration (#4782): matches today's actual
       // buildCompleteSlicePrompt inlining order. Overrides prepend +


### PR DESCRIPTION
## Summary
- Switched validate-milestone and complete-slice to TOOLS_ALL and verified with the focused unit-context-manifest test suite (24 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5731
- [#5731 complete-slice/complete-milestone blocked by planning-dispatch tools policy — cannot run verification bash commands](https://github.com/gsd-build/gsd-2/issues/5731)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5731-complete-slice-complete-milestone-blocke-1778727376`