### PR TITLE
fix(issue): Dispatch adapter receives full session dispatch inputs

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1842,6 +1842,7 @@ export function createWiredDispatchAdapter(
         midTitle: active.title,
         state,
         prefs,
+        session: input.session,
         structuredQuestionsAvailable,
         sessionContextWindow,
         sessionProvider,

--- a/src/resources/extensions/gsd/auto/contracts.ts
+++ b/src/resources/extensions/gsd/auto/contracts.ts
@@ -3,6 +3,7 @@
 
 import type { GSDState } from "../types.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
+import type { AutoSession } from "./session.js";
 
 export interface AutoSessionContext {
   basePath: string;
@@ -39,6 +40,8 @@ export interface AutoOrchestrationModule {
 export interface DispatchAdapter {
   decideNextUnit(input: {
     stateSnapshot: GSDState;
+    /** Optional live session context, forwarded to dispatch rules that need session-derived state. */
+    session?: AutoSession;
     /** Mirrors `DispatchContext.structuredQuestionsAvailable` — "true"/"false" string per the dispatch contract. */
     structuredQuestionsAvailable?: "true" | "false";
     /** Session model context window in tokens, forwarded to the budget engine. */

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -900,9 +900,11 @@ test("wired DispatchAdapter prefers caller-supplied dispatch inputs over ctx-der
       getActiveTools: () => [],
     } as any;
     const adapter = createWiredDispatchAdapter(ctx, pi, "/tmp/parity-fixture");
+    const session = { basePath: "/tmp/session-fixture" } as any;
 
     const result = await adapter.decideNextUnit({
       stateSnapshot,
+      session,
       structuredQuestionsAvailable: "true",
       sessionContextWindow: 500_000,
       sessionProvider: "openai",
@@ -915,6 +917,7 @@ test("wired DispatchAdapter prefers caller-supplied dispatch inputs over ctx-der
     assert.equal(captured[0].sessionContextWindow, 500_000);
     assert.equal(captured[0].sessionProvider, "openai");
     assert.equal(captured[0].modelRegistry, overrideModelRegistry);
+    assert.equal(captured[0].session, session);
   } finally {
     resetRegistry();
   }


### PR DESCRIPTION
## Summary
- Added optional `session` to `DispatchAdapter` input and forwarded it through wired dispatch to `resolveDispatch`, then verified with passing auto-orchestrator parity tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5789
- [#5789 Dispatch adapter receives full session dispatch inputs](https://github.com/gsd-build/gsd-2/issues/5789)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5789-dispatch-adapter-receives-full-session-d-1778727346`