### PR TITLE
fix(issue): Cut over dev path of auto/loop.ts to advance()

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -284,6 +284,7 @@ import type {
   UnitRouting,
   StartModel,
   AutoSession,
+  PendingOrchestrationDispatch,
 } from "./auto/session.js";
 export {
   STUB_RECOVERY_THRESHOLD,
@@ -1801,6 +1802,7 @@ export function createWiredDispatchAdapter(
   ctx: ExtensionContext,
   pi: ExtensionAPI,
   dispatchBasePath: string,
+  session?: AutoSession,
 ): DispatchAdapter {
   return {
     async decideNextUnit(input) {
@@ -1849,13 +1851,29 @@ export function createWiredDispatchAdapter(
       });
 
       if (action.action === "stop") {
+        if (session) session.pendingOrchestrationDispatch = null;
         return {
           kind: "blocked",
           reason: action.reason,
           action: action.level === "warning" ? "pause" : "stop",
         };
       }
-      if (action.action !== "dispatch") return null;
+      if (action.action !== "dispatch") {
+        if (session) session.pendingOrchestrationDispatch = null;
+        return null;
+      }
+      if (session) {
+        const pending: PendingOrchestrationDispatch = {
+          unitType: action.unitType,
+          unitId: action.unitId,
+          prompt: action.prompt,
+          pauseAfterUatDispatch: action.pauseAfterDispatch ?? false,
+          state,
+          mid: active.id,
+          midTitle: active.title,
+        };
+        session.pendingOrchestrationDispatch = pending;
+      }
       return {
         unitType: action.unitType,
         unitId: action.unitId,
@@ -1904,7 +1922,7 @@ export function createWiredAutoOrchestrationModule(
         };
       },
     },
-    dispatch: createWiredDispatchAdapter(ctx, pi, dispatchBasePath),
+    dispatch: createWiredDispatchAdapter(ctx, pi, dispatchBasePath, s),
     recovery: {
       async classifyAndRecover(input) {
         const recovery = classifyFailure(input);

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -729,42 +729,88 @@ export async function autoLoop(
       }
 
       if (!sidecarItem) {
-        // ── Phase 1: Pre-dispatch ─────────────────────────────────────────
-        const preDispatchResult = await runPreDispatch(ic, loopState);
-        phaseReporter.report("pre-dispatch", preDispatchResult.action);
-        if (preDispatchResult.action === "break") {
-          finishTurn("stopped", "manual-attention", "pre-dispatch-break");
-          break;
-        }
-        if (preDispatchResult.action === "continue") {
-          finishTurn("skipped");
-          continue;
-        }
+        const orchestration = s.orchestration;
+        if (orchestration) {
+          const orchestrationResult = await orchestration.advance();
 
-        const preData = preDispatchResult.data;
+          if (orchestrationResult.kind === "blocked") {
+            s.pendingOrchestrationDispatch = null;
+            if (orchestrationResult.action === "pause") {
+              await deps.pauseAuto(ctx, pi, {
+                message: orchestrationResult.reason,
+                category: "unknown",
+              });
+            } else {
+              await deps.stopAuto(ctx, pi, orchestrationResult.reason);
+            }
+            finishTurn("stopped", "manual-attention", "orchestration-blocked");
+            break;
+          }
 
-        // ── Phase 2: Guards ───────────────────────────────────────────────
-        const guardsResult = await runGuards(ic, preData.mid);
-        phaseReporter.report("guard", guardsResult.action);
-        if (guardsResult.action === "break") {
-          finishTurn("stopped", "manual-attention", "guard-break");
-          break;
-        }
+          if (orchestrationResult.kind === "stopped") {
+            s.pendingOrchestrationDispatch = null;
+            await deps.stopAuto(ctx, pi, orchestrationResult.reason);
+            finishTurn("stopped", "manual-attention", "orchestration-stopped");
+            break;
+          }
 
-        // ── Phase 3: Dispatch ─────────────────────────────────────────────
-        const dispatchResult = await runDispatch(ic, preData, loopState);
-        phaseReporter.report("dispatch", dispatchResult.action);
-        if (dispatchResult.action === "break") {
-          finishTurn("stopped", "manual-attention", "dispatch-break");
-          break;
+          if (orchestrationResult.kind !== "advanced") {
+            s.pendingOrchestrationDispatch = null;
+            finishTurn("skipped");
+            continue;
+          }
+          const pendingDispatch = s.pendingOrchestrationDispatch;
+          iterData = {
+            unitType: pendingDispatch?.unitType ?? orchestrationResult.unit.unitType,
+            unitId: pendingDispatch?.unitId ?? orchestrationResult.unit.unitId,
+            prompt: pendingDispatch?.prompt ?? "",
+            finalPrompt: pendingDispatch?.prompt ?? "",
+            pauseAfterUatDispatch: pendingDispatch?.pauseAfterUatDispatch ?? false,
+            state: pendingDispatch?.state ?? orchestrationResult.stateSnapshot,
+            mid: pendingDispatch?.mid ?? s.currentMilestoneId ?? "workflow",
+            midTitle: pendingDispatch?.midTitle ?? orchestrationResult.stateSnapshot.activeMilestone?.title ?? "Workflow",
+            isRetry: false,
+            previousTier: undefined,
+          };
+          s.pendingOrchestrationDispatch = null;
+          phaseReporter.report("dispatch", "next", {
+            unitType: iterData.unitType,
+            unitId: iterData.unitId,
+          });
+          observedUnitType = iterData.unitType;
+          observedUnitId = iterData.unitId;
+        } else {
+          const preDispatchResult = await runPreDispatch(ic, loopState);
+          phaseReporter.report("pre-dispatch", preDispatchResult.action);
+          if (preDispatchResult.action === "break") {
+            finishTurn("stopped", "manual-attention", "pre-dispatch-break");
+            break;
+          }
+          if (preDispatchResult.action === "continue") {
+            finishTurn("skipped");
+            continue;
+          }
+          const preData = preDispatchResult.data;
+          const guardsResult = await runGuards(ic, preData.mid);
+          phaseReporter.report("guard", guardsResult.action);
+          if (guardsResult.action === "break") {
+            finishTurn("stopped", "manual-attention", "guard-break");
+            break;
+          }
+          const dispatchResult = await runDispatch(ic, preData, loopState);
+          phaseReporter.report("dispatch", dispatchResult.action);
+          if (dispatchResult.action === "break") {
+            finishTurn("stopped", "manual-attention", "dispatch-break");
+            break;
+          }
+          if (dispatchResult.action === "continue") {
+            finishTurn("skipped");
+            continue;
+          }
+          iterData = dispatchResult.data;
+          observedUnitType = iterData.unitType;
+          observedUnitId = iterData.unitId;
         }
-        if (dispatchResult.action === "continue") {
-          finishTurn("skipped");
-          continue;
-        }
-        iterData = dispatchResult.data;
-        observedUnitType = iterData.unitType;
-        observedUnitId = iterData.unitId;
       } else {
         iterData = await buildSidecarIterationData({
           sidecarItem,

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -52,6 +52,16 @@ export interface PendingVerificationRetry {
   attempt: number;
 }
 
+export interface PendingOrchestrationDispatch {
+  unitType: string;
+  unitId: string;
+  prompt: string;
+  pauseAfterUatDispatch: boolean;
+  state: import("../types.js").GSDState;
+  mid: string | undefined;
+  midTitle: string | undefined;
+}
+
 /**
  * A typed item enqueued by postUnitPostVerification for the main loop to
  * drain via the standard runUnit path. Replaces inline dispatch
@@ -241,6 +251,7 @@ export class AutoSession {
 
   // ── Orchestration seam ───────────────────────────────────────────────────
   orchestration: AutoOrchestrationModule | null = null;
+  pendingOrchestrationDispatch: PendingOrchestrationDispatch | null = null;
 
   // ── Loop promise state ──────────────────────────────────────────────────
   // Per-unit resolve function and session-switch guard live at module level
@@ -372,6 +383,7 @@ export class AutoSession {
 
     // Orchestration seam
     this.orchestration = null;
+    this.pendingOrchestrationDispatch = null;
 
     // Loop promise state lives in auto-loop.ts module scope
   }

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1401,6 +1401,81 @@ test("autoLoop calls deriveState → resolveDispatch → runUnit in sequence", a
   );
 });
 
+test("autoLoop dev path dispatches orchestration.advance results without legacy resolveDispatch", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  const pi = makeMockPi();
+  const stateSnapshot = {
+    phase: "executing",
+    activeMilestone: { id: "M002", title: "Advance Milestone", status: "active" },
+    activeSlice: { id: "S03", title: "Slice 3" },
+    activeTask: { id: "T05" },
+    registry: [{ id: "M002", status: "active" }],
+    blockers: [],
+  } as any;
+  let advanceCalls = 0;
+  let s: any;
+  s = makeLoopSession({
+    currentMilestoneId: "M002",
+    orchestration: {
+      start: async () => ({ kind: "stopped" as const, reason: "unused" }),
+      advance: async () => {
+        advanceCalls++;
+        s.pendingOrchestrationDispatch = {
+          unitType: "execute-task",
+          unitId: "M002/S03/T05",
+          prompt: "advance prompt",
+          pauseAfterUatDispatch: false,
+          state: stateSnapshot,
+          mid: "M002",
+          midTitle: "Advance Milestone",
+        };
+        return {
+          kind: "advanced" as const,
+          unit: { unitType: "execute-task", unitId: "M002/S03/T05" },
+          stateSnapshot,
+        };
+      },
+      resume: async () => ({ kind: "stopped" as const, reason: "unused" }),
+      stop: async () => ({ kind: "stopped" as const, reason: "unused" }),
+      getStatus: () => ({ phase: "running" as const, transitionCount: 1 }),
+    },
+  });
+
+  const deps = makeMockDeps({
+    resolveDispatch: async () => {
+      deps.callLog.push("resolveDispatch");
+      throw new Error("legacy resolveDispatch must not run when orchestration is wired");
+    },
+    postUnitPostVerification: async () => {
+      deps.callLog.push("postUnitPostVerification");
+      s.active = false;
+      return "continue" as const;
+    },
+  });
+
+  const loopPromise = autoLoop(ctx, pi, s, deps);
+  await waitForMicrotasks(() => pi.calls.length === 1, "orchestration advance dispatch");
+  resolveAgentEnd(makeEvent());
+  await loopPromise;
+
+  assert.equal(advanceCalls, 1);
+  assert.equal(
+    deps.callLog.includes("resolveDispatch"),
+    false,
+    "orchestration.advance owns dev-path dispatch",
+  );
+  assert.equal(
+    (pi.calls[0] as any[])[0].content,
+    "advance prompt",
+    "runUnit should receive the dispatch prompt captured by advance()",
+  );
+  assert.equal(s.pendingOrchestrationDispatch, null, "pending dispatch should be one-shot");
+});
+
 test("autoLoop journals post-unit finalize stop after completed unit", async () => {
   _resetPendingResolve();
 


### PR DESCRIPTION
## Summary
- Switched the dev auto-loop path to drive via `s.orchestration.advance()` (with pause/stop/stopped/advanced mapping) and verified with auto-loop and orchestrator test suites passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5790
- [#5790 Cut over dev path of auto/loop.ts to advance()](https://github.com/gsd-build/gsd-2/issues/5790)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5790-cut-over-dev-path-of-auto-loop-ts-to-adv-1778727509`