### PR TITLE
fix(issue): Orchestrator parity with runPreDispatch: control-flow translation and UoK gate event emission

### DIFF
--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -145,6 +145,76 @@ test("advance() returns blocked stop when resources are stale", async () => {
   assert.ok(!calls.includes("state.reconcile"));
 });
 
+test("advance() pre-dispatch parity: gate emissions and control-flow action match legacy branches", async () => {
+  type Scenario = {
+    name: string;
+    staleMsg: string | null;
+    gateResult: Awaited<ReturnType<AutoOrchestratorDeps["health"]["preAdvanceGate"]>>;
+    expectedKind: "advanced" | "blocked";
+    expectedAction?: "pause" | "stop";
+    expectedGates: string[];
+  };
+  const scenarios: Scenario[] = [
+    {
+      name: "pass",
+      staleMsg: null,
+      gateResult: { kind: "pass" },
+      expectedKind: "advanced",
+      expectedGates: [
+        "resource-version-guard:policy:pass:none:resource version guard passed:",
+        "pre-dispatch-health-gate:execution:pass:none:pre-dispatch health gate passed:",
+      ],
+    },
+    {
+      name: "resource-stale",
+      staleMsg: "resources changed since session start",
+      gateResult: { kind: "pass" },
+      expectedKind: "blocked",
+      expectedAction: "stop",
+      expectedGates: [
+        "resource-version-guard:policy:fail:policy:resource version guard blocked dispatch:resources changed since session start",
+      ],
+    },
+    {
+      name: "health-gate-fail",
+      staleMsg: null,
+      gateResult: { kind: "fail", reason: "doctor-block" },
+      expectedKind: "blocked",
+      expectedAction: "pause",
+      expectedGates: [
+        "resource-version-guard:policy:pass:none:resource version guard passed:",
+        "pre-dispatch-health-gate:execution:manual-attention:manual-attention:pre-dispatch health gate blocked dispatch:doctor-block",
+      ],
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const gateEvents: string[] = [];
+    const { deps } = makeDeps({
+      health: {
+        checkResourcesStale: () => scenario.staleMsg,
+        async preAdvanceGate() { return scenario.gateResult; },
+        async postAdvanceRecord() {},
+      },
+      uokGate: {
+        async emit(input) {
+          gateEvents.push(
+            `${input.gateId}:${input.gateType}:${input.outcome}:${input.failureClass}:${input.rationale}:${input.findings ?? ""}`,
+          );
+        },
+      },
+    });
+    const orchestrator = createAutoOrchestrator(deps);
+    const result = await orchestrator.advance();
+
+    assert.equal(result.kind, scenario.expectedKind, `${scenario.name} result kind`);
+    if (scenario.expectedKind === "blocked") {
+      assert.equal(result.action, scenario.expectedAction, `${scenario.name} blocked action`);
+    }
+    assert.deepEqual(gateEvents, scenario.expectedGates, `${scenario.name} gate parity`);
+  }
+});
+
 test("advance() continues past pre-dispatch health gate when it throws", async () => {
   const { deps, calls } = makeDeps({
     health: {

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -152,6 +152,7 @@ test("advance() pre-dispatch parity: gate emissions and control-flow action matc
     gateResult: Awaited<ReturnType<AutoOrchestratorDeps["health"]["preAdvanceGate"]>>;
     expectedKind: "advanced" | "blocked";
     expectedAction?: "pause" | "stop";
+    expectedReason?: string;
     expectedGates: string[];
   };
   const scenarios: Scenario[] = [
@@ -171,6 +172,7 @@ test("advance() pre-dispatch parity: gate emissions and control-flow action matc
       gateResult: { kind: "pass" },
       expectedKind: "blocked",
       expectedAction: "stop",
+      expectedReason: "resources changed since session start",
       expectedGates: [
         "resource-version-guard:policy:fail:policy:resource version guard blocked dispatch:resources changed since session start",
       ],
@@ -181,6 +183,7 @@ test("advance() pre-dispatch parity: gate emissions and control-flow action matc
       gateResult: { kind: "fail", reason: "doctor-block" },
       expectedKind: "blocked",
       expectedAction: "pause",
+      expectedReason: "doctor-block",
       expectedGates: [
         "resource-version-guard:policy:pass:none:resource version guard passed:",
         "pre-dispatch-health-gate:execution:manual-attention:manual-attention:pre-dispatch health gate blocked dispatch:doctor-block",
@@ -210,6 +213,7 @@ test("advance() pre-dispatch parity: gate emissions and control-flow action matc
     assert.equal(result.kind, scenario.expectedKind, `${scenario.name} result kind`);
     if (scenario.expectedKind === "blocked") {
       assert.equal(result.action, scenario.expectedAction, `${scenario.name} blocked action`);
+      assert.equal(result.reason, scenario.expectedReason, `${scenario.name} blocked reason`);
     }
     assert.deepEqual(gateEvents, scenario.expectedGates, `${scenario.name} gate parity`);
   }


### PR DESCRIPTION
## Summary
- Added a focused parity test for `AutoOrchestrator.advance()` covering pass/resource-stale/health-gate-fail UoK emissions and blocked action mapping, and the orchestrator test suite passes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5788
- [#5788 Orchestrator parity with runPreDispatch: control-flow translation and UoK gate event emission](https://github.com/gsd-build/gsd-2/issues/5788)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5788-orchestrator-parity-with-runpredispatch--1778727921`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for the orchestrator's health gate scenarios, including successful operations, resource staleness detection, and pre-dispatch validation failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5975)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->