### PR TITLE
fix(issue): Widen AutoAdvanceResult to carry dispatch decision and side-effect action

### DIFF
--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -54,7 +54,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
           rationale: "resource version guard blocked dispatch",
           findings: staleMsg,
         });
-        const blocked: AutoAdvanceResult = { kind: "blocked", reason: staleMsg, action: "stop" };
+        const blocked: AutoAdvanceResult = { kind: "blocked", reason: staleMsg, action: "pause" };
         await this.deps.runtime.journalTransition({ name: "advance-blocked", reason: blocked.reason });
         await this.deps.health.postAdvanceRecord(blocked);
         return blocked;

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -125,7 +125,7 @@ test("advance() returns blocked when health gate denies", async () => {
   assert.ok(calls.includes("gate:pre-dispatch-health-gate:manual-attention"));
 });
 
-test("advance() returns blocked stop when resources are stale", async () => {
+test("advance() returns blocked pause when resources are stale", async () => {
   const { deps, calls } = makeDeps({
     health: {
       checkResourcesStale: () => "resources changed since session start",
@@ -139,7 +139,7 @@ test("advance() returns blocked stop when resources are stale", async () => {
 
   assert.equal(result.kind, "blocked");
   assert.equal(result.reason, "resources changed since session start");
-  assert.equal(result.action, "stop");
+  assert.equal(result.action, "pause");
   assert.ok(calls.includes("gate:resource-version-guard:fail"));
   assert.ok(!calls.includes("health.pre"));
   assert.ok(!calls.includes("state.reconcile"));
@@ -331,6 +331,7 @@ test("resume() returns blocked when advance detects a dispatch blocker", async (
   assert.equal(result.kind, "blocked");
   if (result.kind !== "blocked") return;
   assert.equal(result.reason, "remediation required");
+  assert.equal(result.action, "pause");
 });
 
 test("advance() uses recovery on error", async () => {
@@ -703,6 +704,7 @@ test("stuck-loop: start() resets the ring so a fresh saturation cycle is require
   const next = await orchestrator.advance();
   assert.equal(next.kind, "blocked");
   assert.equal(next.reason, "idempotent advance: unit already active");
+  assert.equal(next.action, "stop");
 });
 
 test("stuck-loop: resume() resets the ring", async () => {
@@ -719,6 +721,7 @@ test("stuck-loop: resume() resets the ring", async () => {
   const next = await orchestrator.advance();
   assert.equal(next.kind, "blocked");
   assert.equal(next.reason, "idempotent advance: unit already active");
+  assert.equal(next.action, "stop");
 });
 
 test("stuck-loop: stop() resets the ring", async () => {


### PR DESCRIPTION
## Summary
- Mapped stale-resource blocked results to `action: "pause"` and verified widened blocked-action expectations with the targeted auto-orchestrator test suite (42 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5786
- [#5786 Widen AutoAdvanceResult to carry dispatch decision and side-effect action](https://github.com/gsd-build/gsd-2/issues/5786)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5786-widen-autoadvanceresult-to-carry-dispatc-1778728039`