### PR TITLE
fix(issue): fix(error-classifier): classify 'Schema overload' as tool-schema, not unknown/provider-error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3980,7 +3980,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4541,7 +4540,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6300,7 +6298,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6418,7 +6415,6 @@
     "packages/pi-coding-agent": {
       "name": "@gsd/pi-coding-agent",
       "version": "3.0.0",
-      "peer": true,
       "dependencies": {
         "@gsd-build/contracts": "^2.80.0",
         "@mariozechner/jiti": "^2.6.2",
@@ -6448,7 +6444,6 @@
     "packages/pi-tui": {
       "name": "@gsd/pi-tui",
       "version": "3.0.0",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.6.2",
         "get-east-asian-width": "^1.3.0",

--- a/src/resources/extensions/gsd/auto/types.ts
+++ b/src/resources/extensions/gsd/auto/types.ts
@@ -56,7 +56,7 @@ export interface AgentEndEvent {
  */
 export interface ErrorContext {
   message: string;
-  category: "provider" | "timeout" | "idle" | "network" | "aborted" | "session-failed" | "unknown";
+  category: "provider" | "tool-schema" | "timeout" | "idle" | "network" | "aborted" | "session-failed" | "unknown";
   stopReason?: string;
   isTransient?: boolean;
   retryAfterMs?: number;

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -521,6 +521,19 @@ export async function handleAgentEnd(
       return;
     }
 
+    if (cls.kind === "tool-schema") {
+      await pauseAutoForProviderError(ctx.ui, errorDetail, () => pauseAuto(ctx, pi, {
+        message: `Tool schema error${errorDetail}`,
+        category: "tool-schema",
+        isTransient: false,
+      }), {
+        isRateLimit: false,
+        isTransient: false,
+        retryAfterMs: 0,
+      });
+      return;
+    }
+
     // Cap rate-limit backoff for CLI-style providers (openai-codex, google-gemini-cli)
     // which use per-user quotas with shorter windows (#2922).
     if (cls.kind === "rate-limit") {

--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -94,7 +94,8 @@ const UNSUPPORTED_MODEL_SCOPE_RE = /\b(?:account|plan|tier|subscription)\b/i;
  *  7. Unknown
  */
 export function classifyError(errorMsg: string, retryAfterMs?: number): ErrorClass {
-  // 0. Tool-schema overload from repeated invalid tool args in preparation phase.
+  // Tool-schema overload from repeated invalid tool args in preparation phase.
+  // Checked early to prevent misclassification as unknown/provider error.
   if (TOOL_SCHEMA_RE.test(errorMsg)) {
     return { kind: "tool-schema", retryAfterMs: 0 };
   }

--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -13,6 +13,7 @@
 // ── ErrorClass discriminated union ──────────────────────────────────────────
 
 export type ErrorClass =
+  | { kind: "tool-schema";  retryAfterMs: 0 }
   | { kind: "network";      retryAfterMs: number }
   | { kind: "rate-limit";   retryAfterMs: number }
   | { kind: "server";       retryAfterMs: number }
@@ -66,6 +67,7 @@ const CONNECTION_RE = /terminated|connection.?(?:refused|error)|other side close
 // This eliminates the need to enumerate every error message variant individually.
 const STREAM_RE = /in JSON at position \d+|Unexpected end of JSON|SyntaxError.*JSON/i;
 const RESET_DELAY_RE = /reset in (\d+)s/i;
+const TOOL_SCHEMA_RE = /schema overload|consecutive tool validation failures/i;
 
 // Provider-side model entitlement rejection: the SDK accepted the model switch,
 // but the provider refused at request time because the current account/plan/tier
@@ -92,6 +94,11 @@ const UNSUPPORTED_MODEL_SCOPE_RE = /\b(?:account|plan|tier|subscription)\b/i;
  *  7. Unknown
  */
 export function classifyError(errorMsg: string, retryAfterMs?: number): ErrorClass {
+  // 0. Tool-schema overload from repeated invalid tool args in preparation phase.
+  if (TOOL_SCHEMA_RE.test(errorMsg)) {
+    return { kind: "tool-schema", retryAfterMs: 0 };
+  }
+
   const isPermanent = PERMANENT_RE.test(errorMsg);
   const isRateLimit = RATE_LIMIT_RE.test(errorMsg) || AFFORDABILITY_RE.test(errorMsg);
   const isUnsupportedModel =

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -157,6 +157,12 @@ test("classifyError treats unknown error as not transient", () => {
   assert.equal(result.kind, "unknown");
 });
 
+test("classifyError treats schema overload as tool-schema (non-transient)", () => {
+  const result = classifyError("Schema overload: consecutive tool validation failures exceeded cap");
+  assert.equal(result.kind, "tool-schema");
+  assert.ok(!isTransient(result));
+});
+
 test("classifyError treats empty string as not transient", () => {
   const result = classifyError("");
   assert.ok(!isTransient(result));


### PR DESCRIPTION
## Summary
- Classified schema-overload errors as `tool-schema` and routed recovery to a non-provider tool-schema pause path, verified by focused provider error tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5779
- [#5779 fix(error-classifier): classify 'Schema overload' as tool-schema, not unknown/provider-error](https://github.com/gsd-build/gsd-2/issues/5779)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5779-fix-error-classifier-classify-schema-ove-1778728521`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error classification for schema validation failures
  * Auto-mode now pauses when schema errors are detected, preventing immediate retry attempts

* **Tests**
  * Added test coverage for schema validation error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->