### PR TITLE
fix(issue): Auto-orchestrator and main loop emit colliding journal events, masking stuck state in forensics

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2000,22 +2000,22 @@ export function createWiredAutoOrchestrationModule(
       },
       async journalTransition(event) {
         const eventType = event.name === "start"
-          ? "iteration-start"
+          ? "orchestrator-iteration-start"
           : event.name === "resume"
-            ? "iteration-start"
+            ? "orchestrator-iteration-start"
             : event.name === "advance"
-              ? "dispatch-match"
+              ? "orchestrator-dispatch-match"
               : event.name === "advance-blocked"
-                ? "guard-block"
+                ? "orchestrator-guard-block"
                 : event.name === "advance-stopped"
-                  ? "dispatch-stop"
+                  ? "orchestrator-dispatch-stop"
                   : event.name === "advance-error"
-                    ? "iteration-end"
+                    ? "orchestrator-iteration-end"
                     : event.name === "advance-paused" || event.name === "advance-retry"
-                      ? "guard-block"
+                      ? "orchestrator-guard-block"
                       : event.name === "stop"
-                      ? "terminal"
-                      : "iteration-end";
+                      ? "orchestrator-terminal"
+                      : "orchestrator-iteration-end";
 
         _emitJournalEvent(runtimeBasePath, {
           ts: new Date().toISOString(),

--- a/src/resources/extensions/gsd/journal.ts
+++ b/src/resources/extensions/gsd/journal.ts
@@ -65,7 +65,14 @@ export type JournalEventType =
   | "milestone-resquash"
   // dispatch telemetry — measure agent/subagent invocation frequency and shape
   | "subagent-invoked"
-  | "subagent-completed";
+  | "subagent-completed"
+  // auto orchestrator telemetry namespace (kept separate from auto-loop events)
+  | "orchestrator-iteration-start"
+  | "orchestrator-dispatch-match"
+  | "orchestrator-dispatch-stop"
+  | "orchestrator-guard-block"
+  | "orchestrator-terminal"
+  | "orchestrator-iteration-end";
 
 /** A single structured event in the journal. */
 export interface JournalEntry {

--- a/src/resources/extensions/gsd/prompts/forensics.md
+++ b/src/resources/extensions/gsd/prompts/forensics.md
@@ -50,11 +50,11 @@ GSD extension source: `{{gsdSourceDir}}`
 
 The journal is a structured event log for auto-mode iterations. Daily files contain JSONL:
 
-```
-{ ts: "ISO-8601", flowId: "UUID", seq: 0, eventType: "iteration-start", rule?: "rule-name", causedBy?: { flowId, seq }, data?: { unitId, status, ... } }
+```json
+{ ts: "ISO-8601", flowId: "UUID", seq: 0, eventType: "orchestrator-iteration-start", rule?: "rule-name", causedBy?: { flowId, seq }, data?: { unitId, status, ... } }
 ```
 
-Key events: `iteration-start/end`, `dispatch-match/stop`, `unit-start/end`, `terminal`, `guard-block`, `stuck-detected`, `milestone-transition`, worktree events. `flowId` groups one loop; `causedBy` links causal events; `seq` orders events. Trace stuck loops with `stuck-detected` -> `flowId`; guard blocks with `guard-block` and `data.reason`.
+Key orchestrator events: `orchestrator-iteration-start/end`, `orchestrator-dispatch-match/stop`, `orchestrator-guard-block`, `orchestrator-terminal`. Legacy loop and phase events (`iteration-start/end`, `dispatch-match/stop`, `unit-start/end`, `terminal`, `guard-block`, `stuck-detected`, `milestone-transition`) still appear for non-orchestrator paths, along with worktree events. `flowId` groups one loop; `causedBy` links causal events; `seq` orders events. Trace orchestrator stalls with `orchestrator-guard-block`/`orchestrator-dispatch-stop` and `data.reason`.
 
 ### Crash Lock Format (`auto.lock`)
 

--- a/src/resources/extensions/gsd/tests/journal.test.ts
+++ b/src/resources/extensions/gsd/tests/journal.test.ts
@@ -206,6 +206,38 @@ describe("queryJournal", () => {
     assert.ok(results.every(e => e.eventType === "dispatch-match"));
   });
 
+  test("keeps auto-orchestrator events separate from auto-loop events", () => {
+    emitJournalEvent(base, makeEntry({ eventType: "iteration-start", seq: 0 }));
+    emitJournalEvent(base, makeEntry({ eventType: "dispatch-match", seq: 1 }));
+    emitJournalEvent(
+      base,
+      makeEntry({
+        eventType: "orchestrator-iteration-start",
+        seq: 2,
+        data: { source: "auto-orchestrator", name: "start" },
+      }),
+    );
+    emitJournalEvent(
+      base,
+      makeEntry({
+        eventType: "orchestrator-dispatch-match",
+        seq: 3,
+        data: { source: "auto-orchestrator", name: "advance" },
+      }),
+    );
+
+    const loopMatches = queryJournal(base, { eventType: "dispatch-match" });
+    const orchestratorMatches = queryJournal(base, { eventType: "orchestrator-dispatch-match" });
+
+    assert.equal(loopMatches.length, 1, "loop dispatch telemetry should not include orchestrator advances");
+    assert.equal(orchestratorMatches.length, 1, "forensics needs orchestrator advances under their own type");
+    assert.equal(orchestratorMatches[0].seq, 3);
+    assert.deepEqual(orchestratorMatches[0].data, {
+      source: "auto-orchestrator",
+      name: "advance",
+    });
+  });
+
   test("filters by unitId (from data.unitId)", () => {
     emitJournalEvent(
       base,

--- a/src/resources/skills/forensics/SKILL.md
+++ b/src/resources/skills/forensics/SKILL.md
@@ -11,7 +11,7 @@ Turn scattered GSD runtime artifacts into one coherent cause chain. The delivera
 GSD persists a lot of runtime evidence under `.gsd/`:
 
 - `activity/{seq}-{unitType}-{unitId}.jsonl` — full tool-call and message stream per unit
-- `journal/YYYY-MM-DD.jsonl` — iteration-level events (dispatch-match, stuck-detected, guard-block, unit-start/end, terminal)
+- `journal/YYYY-MM-DD.jsonl` — iteration-level events. Orchestrator path emits `orchestrator-*` events (`orchestrator-dispatch-match`, `orchestrator-guard-block`, `orchestrator-terminal`, etc.); legacy loop events (`dispatch-match`, `stuck-detected`, `guard-block`, `unit-start/end`, `terminal`) can still appear on non-orchestrator paths.
 - `metrics.json` — token/cost ledger; duplicate `type/id` entries indicate a stuck loop
 - `auto.lock` — JSON snapshot of the currently-owning PID; stale lock = crash mid-unit
 - `forensics/` — saved prior reports


### PR DESCRIPTION
## Summary
- Namespaced auto-orchestrator journal event types to prevent collisions with main-loop telemetry, and verified with focused orchestrator/journal tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5732
- [#5732 Auto-orchestrator and main loop emit colliding journal events, masking stuck state in forensics](https://github.com/gsd-build/gsd-2/issues/5732)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5732-auto-orchestrator-and-main-loop-emit-col-1778728641`