### PR TITLE
fix(issue): fix(gsd): pre-exec checks resolve files against worktree path only

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1494,7 +1494,9 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
         // s.canonicalProjectRoot is the project root and lacks files that a
         // prior slice wrote to the worktree but hasn't merged to main yet.
         const preExecutionBasePath = s.basePath;
-        const result: PreExecutionResult = await runPreExecutionChecks(tasks, preExecutionBasePath);
+        const result: PreExecutionResult = await runPreExecutionChecks(tasks, preExecutionBasePath, {
+          additionalRoots: [s.canonicalProjectRoot],
+        });
 
         // Log summary to stderr in existing verification output format
         const emoji = result.status === "pass" ? "✅" : result.status === "warn" ? "⚠️" : "❌";
@@ -1511,12 +1513,12 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
         }
 
         // Write evidence JSON to slice artifacts directory
-        const slicePath = resolveSlicePath(preExecutionBasePath, mid, sid);
+        const slicePath = resolveSlicePath(s.canonicalProjectRoot, mid, sid);
         const evidenceFileName = `${sid}-PRE-EXEC-VERIFY.json`;
         let evidencePath = join(".gsd", "milestones", mid, "slices", sid, evidenceFileName);
         if (slicePath) {
           writePreExecutionEvidence(result, slicePath, mid, sid);
-          evidencePath = relative(preExecutionBasePath, join(slicePath, evidenceFileName)) || evidenceFileName;
+          evidencePath = relative(s.canonicalProjectRoot, join(slicePath, evidenceFileName)) || evidenceFileName;
         }
 
         if (uokFlags.gates) {

--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -38,6 +38,10 @@ export interface PreExecutionResult {
   durationMs: number;
 }
 
+export interface PreExecutionCheckContext {
+  additionalRoots?: string[];
+}
+
 export function checkVerificationCommands(tasks: TaskRow[]): PreExecutionCheckJSON[] {
   const results: PreExecutionCheckJSON[] = [];
 
@@ -480,9 +484,11 @@ function getExpectedOutputsUpTo(tasks: TaskRow[], taskIndex: number): Set<string
  */
 export function checkFilePathConsistency(
   tasks: TaskRow[],
-  basePath: string
+  basePath: string,
+  context?: PreExecutionCheckContext,
 ): PreExecutionCheckJSON[] {
   const results: PreExecutionCheckJSON[] = [];
+  const resolutionRoots = [basePath, ...(context?.additionalRoots ?? [])];
 
   // Build a set of all files created by any task at any position (normalized).
   // Used to suppress consistency errors for files that will be caught with a
@@ -510,8 +516,7 @@ export function checkFilePathConsistency(
       if (containsGlobPattern(normalizedFile)) continue;
 
       // Check if file exists on disk
-      const absolutePath = resolve(basePath, normalizedFile);
-      const existsOnDisk = existsSync(absolutePath);
+      const existsOnDisk = resolutionRoots.some((root) => existsSync(resolve(root, normalizedFile)));
 
       // Check if file is in prior expected outputs (priorOutputs already normalized)
       const inPriorOutputs = priorOutputs.has(normalizedFile);
@@ -557,9 +562,11 @@ export function checkFilePathConsistency(
  */
 export function checkTaskOrdering(
   tasks: TaskRow[],
-  basePath: string
+  basePath: string,
+  context?: PreExecutionCheckContext,
 ): PreExecutionCheckJSON[] {
   const results: PreExecutionCheckJSON[] = [];
+  const resolutionRoots = [basePath, ...(context?.additionalRoots ?? [])];
 
   // Build map: normalized file → task index that creates it
   const fileCreators = new Map<string, { taskId: string; index: number; originalPath: string; completed: boolean }>();
@@ -597,8 +604,7 @@ export function checkTaskOrdering(
       // files, and a same-task output under the directory satisfies it.
       if (isDirectoryReference(file)) continue;
       const creator = fileCreators.get(normalizedFile);
-      const absolutePath = resolve(basePath, normalizedFile);
-      const existsOnDisk = existsSync(absolutePath);
+      const existsOnDisk = resolutionRoots.some((root) => existsSync(resolve(root, normalizedFile)));
       // Skip if the creating task has already completed — its output is available
       // regardless of disk state (e.g. file was a temp artifact cleaned up after
       // the task ran, or a replan introduced a new earlier-sequence task that
@@ -778,14 +784,15 @@ export function checkInterfaceContracts(
  */
 export async function runPreExecutionChecks(
   tasks: TaskRow[],
-  basePath: string
+  basePath: string,
+  context?: PreExecutionCheckContext,
 ): Promise<PreExecutionResult> {
   const startTime = Date.now();
   const allChecks: PreExecutionCheckJSON[] = [];
 
   // Run sync checks first
-  const fileChecks = checkFilePathConsistency(tasks, basePath);
-  const orderingChecks = checkTaskOrdering(tasks, basePath);
+  const fileChecks = checkFilePathConsistency(tasks, basePath, context);
+  const orderingChecks = checkTaskOrdering(tasks, basePath, context);
   const contractChecks = checkInterfaceContracts(tasks, basePath);
   const verificationChecks = checkVerificationCommands(tasks);
 

--- a/src/resources/extensions/gsd/tests/pre-execution-pause-wiring.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-pause-wiring.test.ts
@@ -556,6 +556,60 @@ describe("Pre-execution checks → pauseAuto wiring", () => {
     );
   });
 
+  test("files absent from s.basePath but present in canonicalProjectRoot do not block", async () => {
+    writePreferences({
+      enhanced_verification: true,
+      enhanced_verification_pre: true,
+      enhanced_verification_strict: false,
+    });
+
+    const worktreeDir = join(tempDir, "worktree-missing-src");
+    mkdirSync(join(worktreeDir, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+
+    mkdirSync(join(tempDir, "src", "engine"), { recursive: true });
+    writeFileSync(join(tempDir, "src", "engine", "bus.ts"), "export const bus = {};");
+
+    insertMilestone({ id: "M001" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Test Slice", risk: "low" });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M001",
+      title: "Task that reads canonical-root source files",
+      status: "pending",
+      planning: {
+        description: "Reads src/engine/bus.ts from canonical root",
+        estimate: "1h",
+        files: [],
+        verify: "npm test",
+        inputs: ["`src/engine/bus.ts` — lifecycle helper subscription API"],
+        expectedOutput: ["src/engine/helper.ts"],
+        observabilityImpact: "",
+      },
+      sequence: 0,
+    });
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(worktreeDir, { type: "plan-slice", id: "M001/S01" });
+    Object.defineProperty(s, "canonicalProjectRoot", { get: () => tempDir });
+
+    const pctx = makePostUnitContext(s, ctx, pi, pauseAutoMock);
+    const result = await postUnitPostVerification(pctx);
+
+    assert.equal(
+      pauseAutoMock.mock.callCount(),
+      0,
+      "pauseAuto should NOT be called when referenced files exist in canonicalProjectRoot",
+    );
+    assert.equal(
+      result,
+      "continue",
+      "postUnitPostVerification should return 'continue' when canonical root files satisfy pre-exec inputs",
+    );
+  });
+
   test("uok gate runner persists pre-execution gate outcomes when enabled", async () => {
     writePreferences({
       enhanced_verification: true,


### PR DESCRIPTION
## Summary
- Pre-exec checks now resolve inputs against both worktree basePath and canonical project root, with regression coverage and targeted tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5688
- [#5688 fix(gsd): pre-exec checks resolve files against worktree path only](https://github.com/gsd-build/gsd-2/issues/5688)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5688-fix-gsd-pre-exec-checks-resolve-files-ag-1778728760`