### PR TITLE
fix(issue): Worktree isolation guard blocks valid relative writes from auto workers and omits root .gsd projections

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -701,7 +701,8 @@ export function syncGsdStateToWorktree(
   // If both resolve to the same directory (symlink), no sync needed
   if (isSamePath(mainGsd, wtGsd)) return { synced };
 
-  if (!existsSync(mainGsd) || !existsSync(wtGsd)) return { synced };
+  if (!existsSync(mainGsd)) return { synced };
+  mkdirSync(wtGsd, { recursive: true });
 
   // Sync root-level .gsd/ files (DECISIONS, REQUIREMENTS, PROJECT, KNOWLEDGE, etc.)
   for (const f of ROOT_STATE_FILES) {

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -807,11 +807,10 @@ export function registerHooks(
     // git.isolation=worktree but auto-mode hasn't created the milestone
     // worktree yet. Without this, writes silently orphan outside git history.
     if (isToolCallEventType("write", event) || isToolCallEventType("edit", event)) {
-      const wtBasePath = resolveWorktreeProjectRoot(dash.basePath ?? discussionBasePath);
       const wtGuard = shouldBlockWorktreeWrite(
         event.toolName,
         event.input.path,
-        wtBasePath,
+        dash.basePath ?? discussionBasePath,
         isAutoActive(),
         dash.currentUnit?.type,
       );

--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -967,9 +967,9 @@ function isPathContained(target: string, container: string): boolean {
  * while `git.isolation: worktree` is in effect and auto-mode hasn't created
  * (or flipped cwd into) the milestone worktree.
  *
- * Pure / unit-testable. Callers in `register-hooks.ts` supply the resolved
- * project root and current auto liveness; this function does no I/O beyond
- * realpath resolution.
+ * Pure / unit-testable. Callers in `register-hooks.ts` supply the effective
+ * execution base path (worker cwd or project root) and current auto liveness;
+ * this function does no I/O beyond realpath resolution.
  *
  * Allow rules (in order):
  *   1. Tool isn't a planning-write (write/edit/multi_edit/notebook_edit).
@@ -1007,10 +1007,11 @@ export function shouldBlockWorktreeWrite(
     };
   }
 
-  // Resolve the target relative to the project root, then realpath to defeat
+  // Resolve relative targets against the effective execution base path, then
+  // canonicalize against the project root to defeat
   // symlink-based escapes and prefix tricks (e.g. .gsd/worktrees-extra/).
   const projectRoot = resolveWorktreeProjectRoot(effectiveBasePath);
-  const absTarget = isAbsolute(targetPath) ? targetPath : resolve(projectRoot, targetPath);
+  const absTarget = isAbsolute(targetPath) ? targetPath : resolve(effectiveBasePath, targetPath);
   const realTarget = realpathOrResolve(absTarget);
   const realRoot = realpathOrResolve(projectRoot);
   const realGsd = realpathOrResolve(join(projectRoot, ".gsd"));

--- a/src/resources/extensions/gsd/tests/worktree-preferences-sync.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-preferences-sync.test.ts
@@ -86,6 +86,31 @@ test("#2684: syncGsdStateToWorktree forward-syncs PREFERENCES.md when missing fr
   );
 });
 
+test("syncGsdStateToWorktree creates missing worktree .gsd and projects DECISIONS.md", (t) => {
+  const mainBase = makeTempDir("main");
+  const wtBase = makeTempDir("wt");
+  t.after(() => cleanup(mainBase, wtBase));
+
+  const decisions = "# Decisions\n\n- D001: Test decision\n";
+  writeFile(mainBase, ".gsd/DECISIONS.md", decisions);
+
+  const result = syncGsdStateToWorktree(mainBase, wtBase);
+
+  assert.ok(
+    existsSync(join(wtBase, ".gsd", "DECISIONS.md")),
+    "DECISIONS.md should be projected into worktree .gsd",
+  );
+  assert.equal(
+    readFileSync(join(wtBase, ".gsd", "DECISIONS.md"), "utf-8"),
+    decisions,
+    "DECISIONS.md content should match project root projection",
+  );
+  assert.ok(
+    result.synced.includes("DECISIONS.md"),
+    "DECISIONS.md should appear in synced list",
+  );
+});
+
 test("syncGsdStateToWorktree still accepts legacy lowercase preferences.md", (t) => {
   const mainBase = makeTempDir("main");
   const wtBase = makeTempDir("wt");

--- a/src/resources/extensions/gsd/tests/worktree-write-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-write-gate.test.ts
@@ -123,11 +123,38 @@ describe("shouldBlockWorktreeWrite (#5199)", () => {
     assert.equal(result.block, false);
   });
 
+  test("Case 6b: relative write from active worktree cwd is allowed", () => {
+    projectRoot = makeProject("worktree");
+    const inside = join(projectRoot, ".gsd", "worktrees", "M001");
+    mkdirSync(inside, { recursive: true });
+    const result = shouldBlockWorktreeWrite(
+      "write",
+      "DESIGN.md",
+      inside,
+      /* isAutoLive */ true,
+      null,
+    );
+    assert.equal(result.block, false);
+  });
+
   test("Case 7: isolation=worktree, auto active, effectiveBasePath is project root (cwd never flipped) → block", () => {
     projectRoot = makeProject("worktree");
     const result = shouldBlockWorktreeWrite(
       "write",
       join(projectRoot, "app.js"),
+      projectRoot,
+      /* isAutoLive */ true,
+      null,
+    );
+    assert.equal(result.block, true);
+    assert.match(result.reason ?? "", /HARD BLOCK/);
+  });
+
+  test("Case 7b: relative write from project root cwd is blocked", () => {
+    projectRoot = makeProject("worktree");
+    const result = shouldBlockWorktreeWrite(
+      "write",
+      "DESIGN.md",
       projectRoot,
       /* isAutoLive */ true,
       null,


### PR DESCRIPTION
## Summary
- Fixed worktree-relative write guard path handling and ensured missing worktree `.gsd` is created so root projections like `DECISIONS.md` sync, with targeted tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5686
- [#5686 Worktree isolation guard blocks valid relative writes from auto workers and omits root .gsd projections](https://github.com/gsd-build/gsd-2/issues/5686)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5686-worktree-isolation-guard-blocks-valid-re-1778728882`