### PR TITLE
fix(issue): Auto-mode commit failures surface only "Command failed: git commit -F -" with no stderr

### DIFF
--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -42,8 +42,9 @@ It checks:
 - `.gsd/runtime/<unit-type>/<unit-id>.json` shows the latest runtime phase, timeout timestamp, recovery attempts, and progress marker. Timeout recovery uses progress kinds such as `idle-recovery-retry`, `hard-recovery-retry`, `finalize-pre-timeout`, `finalize-post-timeout`, and `finalize-success`.
 - `.gsd/journal/` shows the ordered loop events. Look for `unit-end`, then `post-unit-finalize-start`, `post-unit-finalize-end`, and `iteration-end`.
 - `post-unit-finalize-end.status` tells you whether closeout completed, retried, stopped, or failed. `iteration-end.status` and `iteration-end.reason` show the final loop outcome that caused auto mode to continue, retry, pause, or stop.
+- `.gsd/git-action-failures.log` appends each failed post-unit git action with timestamp and action mode (`commit` or `merge`) so you can inspect the exact git error that paused auto mode.
 
-**Fix:** If the runtime record shows fresh recovery progress, resume with `/gsd auto`; the failsafe defers cancellation while recovery is actively producing durable output. If the journal shows a stopped finalize reason such as a git closeout failure or repeated finalize timeout, resolve that underlying issue first, then resume.
+**Fix:** If the runtime record shows fresh recovery progress, resume with `/gsd auto`; the failsafe defers cancellation while recovery is actively producing durable output. If the journal shows a stopped finalize reason such as a git closeout failure or repeated finalize timeout, inspect `.gsd/git-action-failures.log`, resolve the underlying git issue, then resume.
 
 ### Wrong files in worktree
 

--- a/mintlify-docs/guides/troubleshooting.mdx
+++ b/mintlify-docs/guides/troubleshooting.mdx
@@ -28,6 +28,17 @@ It checks file structure, referential integrity, completion state consistency, g
     **Fix:** Check the task plan for clarity. Refine it manually, then `/gsd auto`.
   </Accordion>
 
+  <Accordion title="Auto mode pauses after a timeout or finalize failure">
+    **Symptoms:** Auto mode reports a hard timeout, finalize timeout, or post-unit closeout failure.
+
+    **What to inspect:**
+    - `.gsd/runtime/<unit-type>/<unit-id>.json` for recovery progress markers and timeout phase
+    - `.gsd/journal/` for `post-unit-finalize-start`, `post-unit-finalize-end`, and `iteration-end`
+    - `.gsd/git-action-failures.log` for timestamped failed git closeout actions (`commit` or `merge`) and the exact git error
+
+    **Fix:** If recovery is still progressing, resume with `/gsd auto`. If finalize stopped on git closeout, inspect `.gsd/git-action-failures.log`, fix the git issue, then resume.
+  </Accordion>
+
   <Accordion title="command not found: gsd">
     **Cause:** npm's global bin directory isn't in `$PATH`.
 

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -109,6 +109,18 @@ function formatPreExecutionCheckDetail(check: PreExecutionCheckJSON): string {
 
 const COMPLETE_MILESTONE_DB_SETTLE_MS = 1500;
 const COMPLETE_MILESTONE_DB_SETTLE_POLL_MS = 100;
+const GIT_ACTION_FAILURE_LOG_REL_PATH = ".gsd/git-action-failures.log";
+
+function persistGitActionFailure(basePath: string, action: TurnGitActionMode, message: string): string {
+  const logPath = join(basePath, GIT_ACTION_FAILURE_LOG_REL_PATH);
+  const logDir = join(basePath, ".gsd");
+  const timestamp = new Date().toISOString();
+  const body = message.trim() || "unknown git failure";
+  const entry = `[${timestamp}] action=${action}\n${body}\n\n`;
+  mkdirSync(logDir, { recursive: true });
+  appendFileSync(logPath, entry, "utf-8");
+  return logPath;
+}
 
 function stripKnownIdPrefix(value: string | undefined | null, id: string): string | undefined {
   const raw = String(value ?? "").trim();
@@ -241,7 +253,7 @@ import {
   unitVerb,
   describeNextUnit,
 } from "./auto-dashboard.js";
-import { existsSync, unlinkSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { join, relative } from "node:path";
 import { _resetHasChangesCache } from "./native-git-bridge.js";
 import { autoCommitCurrentBranch } from "./worktree.js";
@@ -579,6 +591,8 @@ async function runCloseoutGitAction(
       if (gitResult.status === "failed") {
         s.lastGitActionFailure = gitResult.error ?? `git ${turnAction} failed`;
         s.lastGitActionStatus = "failed";
+        const fullError = gitResult.error ?? "unknown error";
+        const failureLogPath = persistGitActionFailure(s.basePath, turnAction, fullError);
         if (uokFlags.gitops && uokFlags.gates) {
           const parsed = parseUnitId(unit.id);
           const gateRunner = new UokGateRunner();
@@ -589,7 +603,7 @@ async function runCloseoutGitAction(
               outcome: "fail",
               failureClass: "git",
               rationale: `turn git action "${turnAction}" failed`,
-              findings: gitResult.error ?? "unknown git failure",
+              findings: fullError,
             }),
           });
           await gateRunner.run("closeout-git-action", {
@@ -604,12 +618,13 @@ async function runCloseoutGitAction(
           });
         }
 
-        const failureMsg = `Git ${turnAction} failed: ${(gitResult.error ?? "unknown error").split("\n")[0]}`;
+        const failureMsg = `Git ${turnAction} failed: ${fullError.split("\n")[0]} (full details: ${failureLogPath})`;
         ctx.ui.notify(failureMsg, opts?.softFailure ? "warning" : "error");
         debugLog("postUnit", {
           phase: opts?.softFailure ? "git-action-failed-soft" : "git-action-failed-blocking",
           action: turnAction,
-          error: gitResult.error ?? "unknown error",
+          error: fullError,
+          failureLogPath,
         });
         if (opts?.softFailure) {
           return "continue";

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -1197,10 +1197,11 @@ export function handleTurnGitActionError(action: TurnGitActionMode, err: unknown
   if (isInfrastructureError(err)) {
     throw err;
   }
+  const errorWithStreams = err as { stderr?: string; message?: string };
   return {
     action,
     status: "failed",
-    error: getErrorMessage(err),
+    error: errorWithStreams.stderr?.trim() || errorWithStreams.message || getErrorMessage(err),
   };
 }
 

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -991,7 +991,11 @@ export function nativeCommit(
     if (combined.includes("nothing to commit") || combined.includes("nothing added to commit") || combined.includes("no changes added")) {
       return null;
     }
-    throw err;
+    const commitDetail = errObj.stderr?.trim() || errObj.message || "git commit failed";
+    const wrapped = new Error(`git commit failed: ${commitDetail}`);
+    (wrapped as Error & { stdout?: string; stderr?: string }).stdout = errObj.stdout;
+    (wrapped as Error & { stdout?: string; stderr?: string }).stderr = errObj.stderr;
+    throw wrapped;
   }
 }
 

--- a/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gitops-turn-action.test.ts
@@ -97,3 +97,13 @@ test("uok gitops turn action keeps non-infrastructure git failures recoverable",
   assert.equal(result.status, "failed");
   assert.equal(result.error, "nothing to commit");
 });
+
+test("uok gitops turn action prefers stderr details for git failures", () => {
+  const err = Object.assign(new Error("Command failed: git commit -F -"), {
+    stderr: "fatal: unable to auto-detect email address",
+  });
+
+  const result = handleTurnGitActionError("commit", err);
+  assert.equal(result.status, "failed");
+  assert.equal(result.error, "fatal: unable to auto-detect email address");
+});


### PR DESCRIPTION
## Summary
- Surfaced git commit stderr through native and turn-level error paths, and now logs full multiline closeout git failures to `.gsd/git-action-failures.log` while keeping notifications concise.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5896
- [#5896 Auto-mode commit failures surface only "Command failed: git commit -F -" with no stderr](https://github.com/gsd-build/gsd-2/issues/5896)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5896-auto-mode-commit-failures-surface-only-c-1778729361`