### PR TITLE
fix(issue): recordToolCall misses PowerShell and async_bash, producing false-positive "no bash evidence" warnings

### DIFF
--- a/src/resources/extensions/gsd/safety/evidence-collector.ts
+++ b/src/resources/extensions/gsd/safety/evidence-collector.ts
@@ -53,6 +53,8 @@ export type EvidenceEntry = BashEvidence | FileWriteEvidence | FileEditEvidence;
 const EXECUTION_TOOL_NAMES = new Set([
   "bash",
   "Bash",
+  "PowerShell",
+  "async_bash",
   "gsd_exec",
   "gsd_exec_search",
   "mcp__gsd-workflow__gsd_exec",

--- a/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
@@ -83,4 +83,16 @@ describe("evidence-collector: toolCallId-based matching (A-3)", () => {
     assert.equal(entries[1].kind, "edit");
     assert.equal(entries[1].toolCallId, "tc-edit");
   });
+
+  it("treats PowerShell and async_bash as execution evidence", () => {
+    recordToolCall("tc-ps", "PowerShell", { command: "Get-ChildItem" });
+    recordToolCall("tc-async", "async_bash", { command: "npm run build" });
+
+    const entries = getEvidence() as readonly BashEvidence[];
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].kind, "bash");
+    assert.equal(entries[0].command, "Get-ChildItem");
+    assert.equal(entries[1].kind, "bash");
+    assert.equal(entries[1].command, "npm run build");
+  });
 });


### PR DESCRIPTION
## Summary
- Added PowerShell and async_bash to execution evidence collection and verified with a targeted passing unit test run.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5353
- [#5353 recordToolCall misses PowerShell and async_bash, producing false-positive "no bash evidence" warnings](https://github.com/gsd-build/gsd-2/issues/5353)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5353-recordtoolcall-misses-powershell-and-asy-1778729601`