### PR TITLE
fix(issue): Auto-mode thrash: retry-loop suppression + split retry keys + fail-closed completion pauses cause repeated redispatch/pause cycles

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -1003,6 +1003,12 @@ export async function autoLoop(
           break;
         }
         finishTurn("skipped", "execution", dispatchDecision.reason);
+        finishIncompleteIteration({
+          status: "skipped",
+          reason: dispatchDecision.reason,
+          unitType: iterData.unitType,
+          unitId: iterData.unitId,
+        });
         continue;
       }
       dispatchId = dispatchDecision.dispatchId;
@@ -1278,6 +1284,10 @@ export async function autoLoop(
         ctx.ui.notify(cooldownDecision.notifyMessage, "warning");
         await new Promise(resolve => setTimeout(resolve, cooldownDecision.waitMs));
         finishTurn("retry", "timeout", msg);
+        finishIncompleteIteration({
+          status: "retry",
+          reason: "cooldown-retry",
+        });
         continue; // Retry iteration without incrementing consecutiveErrors
       }
 

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -862,6 +862,7 @@ export async function autoLoop(
             break;
           }
           if (preDispatchResult.action === "continue") {
+            completeIteration();
             finishTurn("skipped");
             continue;
           }
@@ -879,6 +880,7 @@ export async function autoLoop(
             break;
           }
           if (dispatchResult.action === "continue") {
+            completeIteration();
             finishTurn("skipped");
             continue;
           }

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2163,6 +2163,7 @@ test("autoLoop handles dispatch skip action by continuing", async (t) => {
   ctx.ui.setStatus = () => {};
   const pi = makeMockPi();
   const s = makeLoopSession();
+  const journalEvents: Array<{ eventType: string; data?: any }> = [];
 
   let dispatchCallCount = 0;
   // Pre-queued dispatch responses: first call returns "skip", second returns "stop"
@@ -2176,6 +2177,10 @@ test("autoLoop handles dispatch skip action by continuing", async (t) => {
       dispatchCallCount++;
       deps.callLog.push("resolveDispatch");
       return response;
+    },
+    emitJournalEvent: (entry: any) => {
+      journalEvents.push(entry);
+      deps.callLog.push(`journal:${entry.eventType}`);
     },
   });
 
@@ -2192,6 +2197,16 @@ test("autoLoop handles dispatch skip action by continuing", async (t) => {
   assert.ok(
     deriveCalls.length >= 2,
     "deriveState should be called at least twice (one per iteration)",
+  );
+  const skippedIterationEnd = journalEvents.find((e) => e.eventType === "iteration-end");
+  assert.deepEqual(
+    skippedIterationEnd?.data,
+    { iteration: 1 },
+    "dispatch skip must close the skipped iteration before re-deriving state",
+  );
+  assert.ok(
+    deps.callLog.indexOf("journal:iteration-end") < deps.callLog.lastIndexOf("deriveState"),
+    "dispatch skip must journal iteration-end before the next deriveState",
   );
 });
 


### PR DESCRIPTION
## Summary
- Added `completeIteration()` on both continue fast-paths in auto loop and verified with focused auto retry regression tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5242
- [#5242 Auto-mode thrash: retry-loop suppression + split retry keys + fail-closed completion pauses cause repeated redispatch/pause cycles](https://github.com/gsd-build/gsd-2/issues/5242)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5242-auto-mode-thrash-retry-loop-suppression--1778729729`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured loop iterations properly record completion and finalization when continued, skipped, or retried so loop bookkeeping and iteration status are accurate.

* **Tests**
  * Strengthened regression test to verify iteration-end journaling occurs before the next iteration’s state derivation and to capture per-event journal output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5987)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->