### PR TITLE
fix(issue): [Bug]: run-uat stuck in dispatched loop — slice already complete but runtime unit never resolves

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -457,9 +457,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       const attempts = incrementUatCount(basePath, mid, sliceId);
       if (attempts > MAX_UAT_ATTEMPTS) {
         return {
-          action: "stop" as const,
-          reason: `run-uat for ${mid}/${sliceId} has been dispatched ${attempts - 1} times without producing a verdict. Verification commands may be broken — fix the UAT spec or manually write an ASSESSMENT verdict.`,
-          level: "warning" as const,
+          action: "skip" as const,
         };
       }
       const uatFile = resolveSliceFile(basePath, mid, sliceId, "UAT")!;

--- a/src/resources/extensions/gsd/tests/run-uat-replay-cap.test.ts
+++ b/src/resources/extensions/gsd/tests/run-uat-replay-cap.test.ts
@@ -36,7 +36,7 @@ function makeUatProject(): string {
   return base;
 }
 
-test("run-uat dispatch stops after three attempts without a verdict", async () => {
+test("run-uat dispatch skips after three attempts without a verdict", async () => {
   const basePath = makeUatProject();
   const rule = DISPATCH_RULES.find((r) => r.name === "run-uat (post-completion)");
   assert.ok(rule, "run-uat dispatch rule is registered");
@@ -58,8 +58,7 @@ test("run-uat dispatch stops after three attempts without a verdict", async () =
     }
 
     const capped = await rule.match(ctx as any);
-    assert.equal(capped?.action, "stop");
-    assert.match(capped?.reason ?? "", /dispatched 3 times/);
+    assert.equal(capped?.action, "skip");
     assert.equal(getUatCount(basePath, "M001", "S01"), 4);
   } finally {
     rmSync(basePath, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Capped `run-uat` retries now skip instead of pause-stop, and the replay-cap regression test passes with the new behavior.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5229
- [#5229 [Bug]: run-uat stuck in dispatched loop — slice already complete but runtime unit never resolves](https://github.com/gsd-build/gsd-2/issues/5229)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5229-bug-run-uat-stuck-in-dispatched-loop-sli-1778729841`