### PR TITLE
fix(issue): Windows: backslash path mangling crashes Claude Code SDK spawn

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -249,8 +249,8 @@ export function normalizeClaudePathForSdk(
 	bundledCliPath: string | null = resolveBundledClaudeCliPath(),
 ): string {
 	if (platform !== "win32") return resolvedPath;
-	if (/\.exe$/i.test(resolvedPath)) return resolvedPath;
-	if (bundledCliPath) return bundledCliPath;
+	if (/\.exe$/i.test(resolvedPath)) return resolvedPath.replaceAll("\\", "/");
+	if (bundledCliPath) return bundledCliPath.replaceAll("\\", "/");
 	return resolvedPath;
 }
 

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1459,8 +1459,8 @@ describe("stream-adapter — Windows Claude path lookup (#3770)", () => {
 	test("normalizeClaudePathForSdk swaps Windows shim paths to bundled cli.js", () => {
 		const shimPath = "C:\\Users\\djeff\\AppData\\Roaming\\npm\\claude";
 		const bundled = "C:\\repo\\node_modules\\@anthropic-ai\\claude-agent-sdk\\cli.js";
-		assert.equal(normalizeClaudePathForSdk(shimPath, "win32", bundled), bundled);
-		assert.equal(normalizeClaudePathForSdk("C:\\Program Files\\Claude\\claude.exe", "win32", bundled), "C:\\Program Files\\Claude\\claude.exe");
+		assert.equal(normalizeClaudePathForSdk(shimPath, "win32", bundled), "C:/repo/node_modules/@anthropic-ai/claude-agent-sdk/cli.js");
+		assert.equal(normalizeClaudePathForSdk("C:\\Program Files\\Claude\\claude.exe", "win32", bundled), "C:/Program Files/Claude/claude.exe");
 	});
 
 	test("resolveBundledClaudeCliPath returns a .js path when SDK package is present", () => {


### PR DESCRIPTION
## Summary
- Normalized Windows Claude SDK executable/fallback paths to forward slashes and verified with the focused stream-adapter test suite passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5222
- [#5222 Windows: backslash path mangling crashes Claude Code SDK spawn](https://github.com/gsd-build/gsd-2/issues/5222)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5222-windows-backslash-path-mangling-crashes--1778729961`