### PR TITLE
fix(issue): Interactive image paste inserts [Image #1] but drops image attachment in normal mode

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.test.ts
@@ -146,6 +146,20 @@ describe("input-controller pending images", () => {
 		assert.equal(host.pendingImages.length, 0);
 		assert.equal(promptCalls.length, 0); // bash commands don't go through prompt
 	});
+
+	it("preserves pending images when using onInputCallback path", async () => {
+		let callbackText = "";
+		host.onInputCallback = (text: string) => {
+			callbackText = text;
+		};
+		host.pendingImages.push({ ...TEST_IMAGE });
+
+		await host.defaultEditor.onSubmit!("[Image #1] describe");
+
+		assert.equal(callbackText, "[Image #1] describe");
+		assert.equal(host.pendingImages.length, 1);
+		assert.equal(promptCalls.length, 0);
+	});
 });
 
 type HostOptions = {

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.test.ts
@@ -45,7 +45,7 @@ function createMockHost() {
 		toolOutputExpanded: false,
 		hideThinkingBlock: false,
 		isBashMode: false,
-		onInputCallback: undefined,
+		onInputCallback: undefined as ((text: string) => void) | undefined,
 		isInitialized: true,
 		loadingAnimation: undefined,
 		pendingWorkingMessage: undefined,

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.ts
@@ -71,9 +71,6 @@ export function setupEditorSubmitHandler(host: InteractiveModeStateHost & {
 			}
 		}
 
-		// Consume pending images for prompt submissions
-		const images = consumePendingImages(host);
-
 		// Evaluate contextual tips before sending to agent
 		const tip = host.contextualTips.evaluate({
 			input: text,
@@ -84,6 +81,15 @@ export function setupEditorSubmitHandler(host: InteractiveModeStateHost & {
 		if (tip) {
 			host.showTip(tip);
 		}
+
+		if (host.onInputCallback) {
+			host.onInputCallback(text);
+			host.editor.addToHistory?.(text);
+			return;
+		}
+
+		// Consume pending images for prompt submissions
+		const images = consumePendingImages(host);
 
 		if (host.session.isCompacting) {
 			if (host.isExtensionCommand(text)) {
@@ -111,12 +117,6 @@ export function setupEditorSubmitHandler(host: InteractiveModeStateHost & {
 		}
 
 		host.flushPendingBashComponents();
-
-		if (host.onInputCallback) {
-			host.onInputCallback(text);
-			host.editor.addToHistory?.(text);
-			return;
-		}
 
 		if (host.options?.submitPromptsDirectly) {
 			host.editor.addToHistory?.(text);


### PR DESCRIPTION
## Summary
- Deferred pending-image consumption until after callback handling and added a regression test; targeted input-controller tests pass.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5209
- [#5209 Interactive image paste inserts [Image #1] but drops image attachment in normal mode](https://github.com/gsd-build/gsd-2/issues/5209)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5209-interactive-image-paste-inserts-image-1--1778731401`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where pending images were not properly preserved during input submission with callbacks.

* **Tests**
  * Added test coverage to verify pending images remain intact after input submission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5990)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->