### PR TITLE
fix(issue): Context-budget watchdog uses cumulative session tokens, fires spurious wrap-up at 200-300%

### DIFF
--- a/packages/pi-coding-agent/src/core/compaction/compaction.test.ts
+++ b/packages/pi-coding-agent/src/core/compaction/compaction.test.ts
@@ -9,7 +9,14 @@ import { describe, it, mock } from "node:test";
 import type { AgentMessage } from "@gsd/pi-agent-core";
 import type { Model, AssistantMessage } from "@gsd/pi-ai";
 
-import { generateSummary, estimateTokens, chunkMessages, isDegenerateSummary, CompactionProducedNoSummaryError } from "./compaction.js";
+import {
+	generateSummary,
+	estimateTokens,
+	chunkMessages,
+	isDegenerateSummary,
+	CompactionProducedNoSummaryError,
+	calculateContextTokens,
+} from "./compaction.js";
 import { estimateSerializedTokens } from "./utils.js";
 
 // ---------------------------------------------------------------------------
@@ -184,6 +191,21 @@ describe("chunkMessages", () => {
 			estimateSerializedTokens(hugeAssistant) < 2_000,
 			"assistant thinking + text must each cap; total under 2x TOOL_RESULT_MAX_CHARS/4",
 		);
+	});
+});
+
+describe("calculateContextTokens", () => {
+	it("uses prompt-relevant usage only (input + cacheRead + cacheWrite)", () => {
+		const usage = {
+			input: 65,
+			output: 39_846,
+			cacheRead: 2_945_563,
+			cacheWrite: 243_452,
+			totalTokens: 3_228_926,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		assert.equal(calculateContextTokens(usage), 3_189_080);
 	});
 });
 

--- a/packages/pi-coding-agent/src/core/compaction/compaction.ts
+++ b/packages/pi-coding-agent/src/core/compaction/compaction.ts
@@ -107,10 +107,15 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
 
 /**
  * Calculate total context tokens from usage.
- * Uses the native totalTokens field when available, falls back to computing from components.
+ * Uses prompt-relevant components only:
+ * - input: current user/tool payload sent to model
+ * - cacheRead/cacheWrite: context replay + newly cached context
+ *
+ * Excludes output because output tokens are not part of the current prompt size.
+ * Excludes totalTokens because some providers report cumulative loop/session totals.
  */
 export function calculateContextTokens(usage: Usage): number {
-	return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+	return usage.input + usage.cacheRead + usage.cacheWrite;
 }
 
 /**

--- a/src/resources/extensions/gsd/auto-timers.ts
+++ b/src/resources/extensions/gsd/auto-timers.ts
@@ -318,7 +318,14 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
     if (runtime?.continueHereFired) return;
 
     const contextUsage = s.cmdCtx.getContextUsage();
-    if (!contextUsage || contextUsage.percent == null || contextUsage.percent < continueHereThreshold) return;
+    if (!contextUsage || contextUsage.percent == null) return;
+    const rawPercent = contextUsage.percent;
+    if (rawPercent > 150) {
+      logWarning("timer", `[continue-here] ignoring implausible context percent: ${rawPercent}`);
+      return;
+    }
+    const contextPercent = Math.max(0, Math.min(100, rawPercent));
+    if (contextPercent < continueHereThreshold) return;
 
     writeUnitRuntimeRecord(s.basePath, unitType, unitId, s.currentUnit!.startedAt, {
       continueHereFired: true,
@@ -326,7 +333,7 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
 
     if (s.verbose) {
       ctx.ui.notify(
-        `Context at ${contextUsage.percent}% (threshold: ${continueHereThreshold}%) — sending wrap-up signal.`,
+        `Context at ${contextPercent}% (threshold: ${continueHereThreshold}%) — sending wrap-up signal.`,
         "info",
       );
     }
@@ -339,7 +346,7 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
         display: s.verbose,
         content: [
           "**CONTEXT BUDGET WARNING — wrap up this unit now.**",
-          `Context window is at ${contextUsage.percent}% (threshold: ${continueHereThreshold}%).`,
+          `Context window is at ${contextPercent}% (threshold: ${continueHereThreshold}%).`,
           "The next unit needs a fresh context to work effectively. Wrap up now:",
           "1. Finish any in-progress file writes",
           "2. Write or update the required durable artifacts (summary, checkboxes)",


### PR DESCRIPTION
## Summary
- Corrected context-budget math to avoid cumulative-token inflation and added watchdog guards, verified by focused compaction and continue-here tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5203
- [#5203 Context-budget watchdog uses cumulative session tokens, fires spurious wrap-up at 200-300%](https://github.com/gsd-build/gsd-2/issues/5203)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5203-context-budget-watchdog-uses-cumulative--1778731522`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Context token calculation now accurately measures prompt-relevant usage by excluding output tokens
  * Improved reliability of context pressure monitoring with enhanced validation and edge case handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/5991)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->