### PR TITLE
fix(issue): gsd_summary_save always receives empty arguments {} — Type.Union as top-level tool schema is invalid for function-calling APIs (Anthropic, z.ai, others)

### DIFF
--- a/packages/pi-ai/src/providers/anthropic-shared.test.ts
+++ b/packages/pi-ai/src/providers/anthropic-shared.test.ts
@@ -54,6 +54,43 @@ describe("convertTools cache_control", () => {
 		assert.equal(result.length, 1);
 		assert.deepEqual((result[0] as any).cache_control, { type: "ephemeral" });
 	});
+
+	it("merges object variants when parameters is top-level anyOf", () => {
+		const tools = [
+			{
+				name: "gsd_summary_save",
+				description: "desc",
+				parameters: {
+					anyOf: [
+						{
+							type: "object",
+							properties: {
+								milestone_id: { type: "string" },
+								artifact_type: { type: "string" },
+								content: { type: "string" },
+							},
+							required: ["milestone_id", "artifact_type", "content"],
+						},
+						{
+							type: "object",
+							properties: {
+								artifact_type: { type: "string" },
+								content: { type: "string" },
+							},
+							required: ["artifact_type", "content"],
+						},
+					],
+				},
+			},
+		] as any;
+		const result = convertTools(tools, false);
+		assert.deepEqual((result[0] as any).input_schema.properties, {
+			milestone_id: { type: "string" },
+			artifact_type: { type: "string" },
+			content: { type: "string" },
+		});
+		assert.deepEqual((result[0] as any).input_schema.required, ["milestone_id", "artifact_type", "content"]);
+	});
 });
 
 describe("mapThinkingLevelToEffort", () => {

--- a/packages/pi-ai/src/providers/anthropic-shared.ts
+++ b/packages/pi-ai/src/providers/anthropic-shared.ts
@@ -464,14 +464,39 @@ export function convertTools(
 
 	const result = tools.map((tool) => {
 		const jsonSchema = tool.parameters as any;
+		const variants = Array.isArray(jsonSchema?.anyOf)
+			? jsonSchema.anyOf
+			: Array.isArray(jsonSchema?.oneOf)
+				? jsonSchema.oneOf
+				: [];
+		const objectVariants = variants.filter(
+			(schema: any) =>
+				schema && schema.type === "object" && typeof schema.properties === "object" && schema.properties !== null,
+		);
+		const mergedProperties = objectVariants.reduce(
+			(acc: Record<string, unknown>, schema: any) => ({ ...acc, ...schema.properties }),
+			{},
+		);
+		const mergedRequired = Array.from(
+			new Set(
+				objectVariants.flatMap((schema: any) =>
+					Array.isArray(schema.required) ? schema.required.filter((key: unknown) => typeof key === "string") : [],
+				),
+			),
+		);
+		const properties =
+			typeof jsonSchema?.properties === "object" && jsonSchema.properties !== null
+				? jsonSchema.properties
+				: mergedProperties;
+		const required = Array.isArray(jsonSchema?.required) ? jsonSchema.required : mergedRequired;
 
 		return {
 			name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
 			description: tool.description,
 			input_schema: {
 				type: "object" as const,
-				properties: jsonSchema.properties || {},
-				required: jsonSchema.required || [],
+				properties,
+				required,
 			},
 		};
 	});


### PR DESCRIPTION
## Summary
- Fixed Anthropic tool schema conversion to preserve top-level anyOf/oneOf object arguments and verified with targeted provider tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5190
- [#5190 gsd_summary_save always receives empty arguments {} — Type.Union as top-level tool schema is invalid for function-calling APIs (Anthropic, z.ai, others)](https://github.com/gsd-build/gsd-2/issues/5190)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5190-gsd-summary-save-always-receives-empty-a-1778731761`