### PR TITLE
fix(issue): [Bug]: incorrect branching/merging. Planned M002 for a empty codebase instead post-M002

### DIFF
--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -598,7 +598,10 @@ export function nativeBranchList(basePath: string, pattern?: string): string[] {
   const result = gitFileExec(basePath, args, true);
   if (!result) return [];
 
-  return result.split("\n").map(b => b.trim().replace(/^\* /, "")).filter(Boolean);
+  return result
+    .split("\n")
+    .map(b => b.trim().replace(/^[*+]\s+/, ""))
+    .filter(Boolean);
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import {
   assertWorktreeMaterialized,
+  nativeBranchList,
   nativeBranchDelete,
   nativeCommit,
   nativeGetCurrentBranch,
@@ -206,6 +207,22 @@ process.exit(result.status ?? 1);
       existsSync(join(wtPath, ".git")),
       true,
       "created worktree must have the .git file required by later health checks",
+    );
+  });
+
+  test("nativeBranchList strips linked-worktree '+' marker from fallback output", (t) => {
+    const wtPath = join(repo, ".gsd", "worktrees", "M001");
+    t.after(() => {
+      try { git(["worktree", "remove", "--force", wtPath], repo); } catch { /* noop */ }
+    });
+
+    git(["branch", "milestone/M001"], repo);
+    git(["worktree", "add", wtPath, "milestone/M001"], repo);
+
+    const listed = nativeBranchList(repo, "milestone/*");
+    assert.ok(
+      listed.includes("milestone/M001"),
+      `expected clean milestone branch name, got: ${JSON.stringify(listed)}`,
     );
   });
 });


### PR DESCRIPTION
## Summary
- Normalized fallback branch-list parsing to remove linked-worktree `+` prefixes and verified with a targeted passing regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5180
- [#5180 [Bug]: incorrect branching/merging. Planned M002 for a empty codebase instead post-M002](https://github.com/gsd-build/gsd-2/issues/5180)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5180-bug-incorrect-branching-merging-planned--1778731881`