### PR TITLE
fix(issue): pre-execution-checks: install-command parser produces false-positive package failures from prose (sibling of #4388)

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -86,8 +86,9 @@ export function extractPackageReferences(description: string): string[] {
   ]);
 
   // npm install <pkg> patterns (handles npm i, npm add, yarn add, pnpm add)
-  // Use a global pattern to find all install commands, then parse following tokens
-  const installCmdPattern = /(?:npm\s+(?:install|i|add)|yarn\s+add|pnpm\s+add)\s+/g;
+  // Anchor to start-of-line command shape so prose mentions like
+  // "npm install hits worktree symlink breakage" are not parsed as packages.
+  const installCmdPattern = /(^|\n)\s*(?:[$>]\s*)?(?:npm\s+(?:install|i|add)|yarn\s+add|pnpm\s+add)\s+/g;
   let cmdMatch: RegExpExecArray | null;
   
   while ((cmdMatch = installCmdPattern.exec(description)) !== null) {

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -75,7 +75,7 @@ function createTask(overrides: Partial<TaskRow> = {}): TaskRow {
 
 describe("extractPackageReferences", () => {
   test("extracts npm install patterns", () => {
-    const desc = "Run npm install lodash then npm i axios";
+    const desc = "npm install lodash\nnpm i axios";
     const packages = extractPackageReferences(desc);
     assert.deepEqual(packages.sort(), ["axios", "lodash"]);
   });
@@ -144,6 +144,12 @@ import type { Request } from 'express';
     const packages = extractPackageReferences(desc);
     assert.ok(packages.includes("typescript"));
     assert.ok(!packages.includes("-D"));
+  });
+
+  test("does not parse prose mention of npm install as packages (#5170)", () => {
+    const desc = "- npm install hits worktree symlink breakage → flag blocker; do not `rm node_modules` under the sandbox.";
+    const packages = extractPackageReferences(desc);
+    assert.deepEqual(packages, []);
   });
 
   // Regression tests for #4388: prose containing `from "..."` must not produce false-positive packages


### PR DESCRIPTION
## Summary
- Anchored install-command parsing to command-line context and added a #5170 regression test, verified by the targeted pre-execution checks test suite.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5170
- [#5170 pre-execution-checks: install-command parser produces false-positive package failures from prose (sibling of #4388)](https://github.com/gsd-build/gsd-2/issues/5170)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5170-pre-execution-checks-install-command-par-1778732122`