### PR TITLE
fix(issue): [auto] Slice-parallel rapid-exit loop: stale worktrees cause infinite dispatch-and-fail cycle

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1187,6 +1187,8 @@ export async function stopAuto(
         ? "merge-conflict"
         : rawReason.startsWith("Merge error") || rawReason.startsWith("Merge failed")
           ? "merge-failed"
+          : rawReason.startsWith("Slice-parallel dispatched")
+            ? "stop"
           : rawReason.startsWith("slice-merge-conflict")
             ? "slice-merge-conflict"
             : rawReason === "All milestones complete"

--- a/src/resources/extensions/gsd/slice-parallel-orchestrator.ts
+++ b/src/resources/extensions/gsd/slice-parallel-orchestrator.ts
@@ -18,13 +18,15 @@ import { randomUUID } from "node:crypto";
 import {
   appendFileSync,
   existsSync,
+  lstatSync,
+  rmSync,
   writeFileSync,
   readFileSync,
   mkdirSync,
   renameSync,
   unlinkSync,
 } from "node:fs";
-import { join, dirname } from "node:path";
+import { isAbsolute, join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gsdRoot } from "./paths.js";
 import { createWorktree, worktreePath, removeWorktree } from "./worktree-manager.js";
@@ -103,6 +105,37 @@ export function _buildSliceWorkerEnvForTest(
     GSD_PARALLEL_WORKER: "1",
     GSD_SLICE_WORKER_TOKEN: workerToken,
   };
+}
+
+function isValidSliceWorktreePath(basePath: string, wtPath: string): boolean {
+  if (!existsSync(wtPath)) return false;
+  const gitPath = join(wtPath, ".git");
+  if (!existsSync(gitPath)) return false;
+  try {
+    if (!lstatSync(gitPath).isFile()) return false;
+    const content = readFileSync(gitPath, "utf8").trim();
+    if (!content.startsWith("gitdir: ")) return false;
+    const rawGitdir = content.slice("gitdir: ".length).trim();
+    if (!rawGitdir) return false;
+    const resolvedGitdir = isAbsolute(rawGitdir) ? rawGitdir : resolve(wtPath, rawGitdir);
+    const expectedPrefix = join(basePath, ".git", "worktrees").replaceAll("\\", "/");
+    const normalized = resolvedGitdir.replaceAll("\\", "/");
+    return normalized === expectedPrefix || normalized.startsWith(`${expectedPrefix}/`);
+  } catch {
+    return false;
+  }
+}
+
+function isWorkerPidAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "ESRCH") return false;
+    return true;
+  }
 }
 
 interface PersistedSliceWorker {
@@ -427,6 +460,9 @@ export async function startSliceParallel(
       const wtName = `${milestoneId}-${slice.id}`;
       const wtPath = worktreePath(basePath, wtName);
 
+      if (existsSync(wtPath) && !isValidSliceWorktreePath(basePath, wtPath)) {
+        rmSync(wtPath, { recursive: true, force: true });
+      }
       if (!existsSync(wtPath)) {
         createWorktree(basePath, wtName, { branch: wtBranch });
       }
@@ -468,6 +504,21 @@ export async function startSliceParallel(
         removeWorktree(basePath, wtName, { deleteBranch: true, force: true });
       } catch { /* ignore cleanup failures */ }
     }
+  }
+
+  // Guard: if workers died immediately, treat as failed start so callers
+  // don't exit auto-mode and re-dispatch in a rapid loop.
+  for (let i = started.length - 1; i >= 0; i--) {
+    const sid = started[i];
+    const worker = sliceState.workers.get(sid);
+    if (worker && isWorkerPidAlive(worker.pid)) continue;
+    started.splice(i, 1);
+    errors.push({ sid, error: "Worker exited immediately after spawn" });
+    sliceState.workers.delete(sid);
+    const wtName = `${milestoneId}-${sid}`;
+    try {
+      removeWorktree(basePath, wtName, { deleteBranch: true, force: true });
+    } catch { /* ignore cleanup failures */ }
   }
 
   // If nothing started, deactivate

--- a/src/resources/extensions/gsd/tests/slice-parallel-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-parallel-orchestrator.test.ts
@@ -3,7 +3,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -12,8 +12,12 @@ import { validatePreferences } from "../preferences-validation.ts";
 import {
   _buildSliceWorkerEnvForTest,
   _resolveSliceParallelMaxWorkersForTest,
+  getSliceOrchestratorState,
   restoreSliceState,
+  resetSliceOrchestrator,
   SLICE_WORKER_AUTO_ARGS,
+  startSliceParallel,
+  stopSliceParallel,
 } from "../slice-parallel-orchestrator.ts";
 
 function readLinuxProcessStartFingerprint(pid: number): string | null {
@@ -48,6 +52,23 @@ function makeTempProject(): string {
   const basePath = mkdtempSync(join(tmpdir(), "gsd-slice-parallel-"));
   mkdirSync(join(basePath, ".gsd"), { recursive: true });
   return basePath;
+}
+
+function runGit(basePath: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: basePath,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  }).trim();
+}
+
+function initGitProject(basePath: string): void {
+  runGit(basePath, ["init", "--initial-branch=main"]);
+  runGit(basePath, ["config", "user.email", "test@example.com"]);
+  runGit(basePath, ["config", "user.name", "Test User"]);
+  writeFileSync(join(basePath, "README.md"), "initial\n", "utf-8");
+  runGit(basePath, ["add", "README.md"]);
+  runGit(basePath, ["commit", "-m", "initial"]);
 }
 
 function writeSliceOrchestratorState(
@@ -108,6 +129,56 @@ describe("slice worker launch contract", () => {
   it("defaults to two workers unless explicitly configured", () => {
     assert.equal(_resolveSliceParallelMaxWorkersForTest(), 2);
     assert.equal(_resolveSliceParallelMaxWorkersForTest(4), 4);
+  });
+});
+
+describe("slice-parallel stale worktree handling", () => {
+  it("replaces a stale slice worktree before spawning the worker", async () => {
+    const basePath = makeTempProject();
+    const oldGsdBinPath = process.env.GSD_BIN_PATH;
+    try {
+      initGitProject(basePath);
+      const workerBin = join(basePath, "fake-worker.js");
+      writeFileSync(
+        workerBin,
+        [
+          "process.on('SIGTERM', () => process.exit(0));",
+          "setInterval(() => {}, 1000);",
+        ].join("\n"),
+        "utf-8",
+      );
+      process.env.GSD_BIN_PATH = workerBin;
+
+      const staleWorktree = join(basePath, ".gsd", "worktrees", "M900-S01");
+      mkdirSync(staleWorktree, { recursive: true });
+      writeFileSync(join(staleWorktree, ".git"), "gitdir: /tmp/not-this-repo\n", "utf-8");
+      writeFileSync(join(staleWorktree, "stale-marker"), "stale\n", "utf-8");
+
+      const result = await startSliceParallel(basePath, "M900", [{ id: "S01" }], { maxWorkers: 1 });
+
+      assert.deepEqual(result, { started: ["S01"], errors: [] });
+      assert.equal(existsSync(join(staleWorktree, "stale-marker")), false);
+      assert.equal(lstatSync(join(staleWorktree, ".git")).isFile(), true);
+      assert.match(readFileSync(join(staleWorktree, ".git"), "utf-8"), /^gitdir: /);
+      assert.equal(getSliceOrchestratorState()?.active, true);
+    } finally {
+      const child = getSliceOrchestratorState()?.workers.get("S01")?.process;
+      if (child && child.exitCode === null) {
+        await new Promise<void>((resolve) => {
+          const timeout = setTimeout(resolve, 500);
+          child.once("exit", () => {
+            clearTimeout(timeout);
+            resolve();
+          });
+          child.kill("SIGTERM");
+        });
+      }
+      stopSliceParallel();
+      resetSliceOrchestrator();
+      if (oldGsdBinPath === undefined) delete process.env.GSD_BIN_PATH;
+      else process.env.GSD_BIN_PATH = oldGsdBinPath;
+      rmSync(basePath, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixed stale slice worktree reuse, prevented false successful dispatch when workers die immediately, and normalized slice-parallel stop reasons so telemetry no longer reports them as “other”.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5161
- [#5161 [auto] Slice-parallel rapid-exit loop: stale worktrees cause infinite dispatch-and-fail cycle](https://github.com/gsd-build/gsd-2/issues/5161)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5161-auto-slice-parallel-rapid-exit-loop-stal-1778732242`