### PR TITLE
fix(issue): claude-code-cli adapter misclassifies SDK abort throws as generic errors, surfacing 'aborted by user' for non-user aborts

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -426,7 +426,7 @@ function makeErrorMessage(model: string, errorMsg: string): AssistantMessage {
 
 export function isClaudeCodeAbortErrorMessage(message: string | undefined | null): boolean {
 	if (!message) return false;
-	return /\b(?:claude code process aborted by user|request aborted by user|process aborted by user)\b/i.test(message);
+	return /\b(?:claude code process aborted by user|request aborted by user|process aborted by user|aborterror|aborted)\b/i.test(message);
 }
 
 function isBareClaudeCodeAbortErrorMessage(message: string | undefined | null): boolean {

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -426,7 +426,7 @@ function makeErrorMessage(model: string, errorMsg: string): AssistantMessage {
 
 export function isClaudeCodeAbortErrorMessage(message: string | undefined | null): boolean {
 	if (!message) return false;
-	return /\b(?:claude code process aborted by user|request aborted by user|process aborted by user|aborterror|aborted)\b/i.test(message);
+	return /\b(?:claude code process aborted by user|request aborted by user|process aborted by user|aborterror)\b/i.test(message);
 }
 
 function isBareClaudeCodeAbortErrorMessage(message: string | undefined | null): boolean {

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1258,6 +1258,7 @@ describe("stream-adapter — abort classification (F2)", () => {
 	test("recognizes Claude Code SDK abort exceptions", () => {
 		assert.equal(isClaudeCodeAbortErrorMessage("Claude Code process aborted by user"), true);
 		assert.equal(isClaudeCodeAbortErrorMessage("Request aborted by user"), true);
+		assert.equal(isClaudeCodeAbortErrorMessage("AbortError: The operation was aborted"), true);
 		assert.equal(isClaudeCodeAbortErrorMessage("rate limit exceeded"), false);
 	});
 

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1262,6 +1262,14 @@ describe("stream-adapter — abort classification (F2)", () => {
 		assert.equal(isClaudeCodeAbortErrorMessage("rate limit exceeded"), false);
 	});
 
+	test("does not misclassify non-user abort contexts", () => {
+		assert.equal(isClaudeCodeAbortErrorMessage("Job aborted due to timeout"), false);
+		assert.equal(isClaudeCodeAbortErrorMessage("Operation aborted: disk full"), false);
+		assert.equal(isClaudeCodeAbortErrorMessage("aborted by system cleanup"), false);
+		assert.equal(isClaudeCodeAbortErrorMessage("Database transaction aborted due to constraint violation"), false);
+		assert.equal(isClaudeCodeAbortErrorMessage("Connection aborted unexpectedly"), false);
+	});
+
 	test("makeAbortedMessage sets stopReason to 'aborted', not 'error'", () => {
 		const message = makeAbortedMessage("claude-sonnet-4-6", "");
 		assert.equal(message.stopReason, "aborted");


### PR DESCRIPTION
## Summary
- Expanded claude-code-cli abort error matching to classify generic SDK abort throws as aborted and verified with targeted stream-adapter tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5140
- [#5140 claude-code-cli adapter misclassifies SDK abort throws as generic errors, surfacing 'aborted by user' for non-user aborts](https://github.com/gsd-build/gsd-2/issues/5140)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5140-claude-code-cli-adapter-misclassifies-sd-1778732482`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced abort error message detection to recognize additional error variations.

* **Tests**
  * Added regression test for abort error classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6001)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->