### PR TITLE
fix(issue): forensics: false-positive stuck-loop warning for parallel-research sentinel

### DIFF
--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -720,8 +720,10 @@ export function detectStuckLoops(units: UnitMetrics[], anomalies: ForensicAnomal
     const count = hasSessionAwareData
       ? Math.max(...Array.from(sessionBuckets.values(), (starts) => starts.size))
       : (sessionBuckets.get("__legacy__")?.size ?? 0);
+    const isParallelResearchSentinel = key.endsWith("/parallel-research");
+    const dispatchThreshold = isParallelResearchSentinel ? 2 : 1;
 
-    if (count > 1) {
+    if (count > dispatchThreshold) {
       const [unitType, ...idParts] = key.split("/");
       anomalies.push({
         type: "stuck-loop",

--- a/src/resources/extensions/gsd/tests/forensics-stuck-loops.test.ts
+++ b/src/resources/extensions/gsd/tests/forensics-stuck-loops.test.ts
@@ -165,6 +165,31 @@ test("#3760 detectStuckLoops still flags repeated dispatches within one auto ses
   );
 });
 
+test("#5072 detectStuckLoops allows two parallel-research sentinel dispatches", () => {
+  const anomalies: ForensicAnomaly[] = [];
+
+  const units: UnitMetrics[] = [
+    makeUnit({
+      type: "research-slice",
+      id: "M052/parallel-research",
+      startedAt: 1000,
+      finishedAt: 2000,
+      autoSessionKey: "session-a",
+    }),
+    makeUnit({
+      type: "research-slice",
+      id: "M052/parallel-research",
+      startedAt: 5000,
+      finishedAt: 6000,
+      autoSessionKey: "session-a",
+    }),
+  ];
+
+  detectStuckLoops(units, anomalies);
+
+  assert.equal(anomalies.length, 0, "two parallel-research sentinel dispatches should not be flagged as a stuck loop");
+});
+
 test("#4711 detectWorktreeOrphans suggests doctor fix for completed unmerged branches", () => {
   const anomalies: ForensicAnomaly[] = [];
   const summary: WorktreeTelemetrySummary = {


### PR DESCRIPTION
## Summary
- Raised stuck-loop tolerance for the `parallel-research` sentinel and added/passed a regression test confirming two dispatches are treated as expected behavior.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5072
- [#5072 forensics: false-positive stuck-loop warning for parallel-research sentinel](https://github.com/gsd-build/gsd-2/issues/5072)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5072-forensics-false-positive-stuck-loop-warn-1778733203`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stuck-loop anomaly detection accuracy for parallel operations. The system now requires more activity before triggering anomalies in certain scenarios, reducing false positives while maintaining proper alert severity classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->