### PR TITLE
fix(issue): run-uat false-completes on pre-existing reassessment ASSESSMENT.md, then re-dispatches

### DIFF
--- a/docs/prompt-map.md
+++ b/docs/prompt-map.md
@@ -219,6 +219,8 @@ run-uat  (user acceptance tests)
 | `validate-milestone.md` | 3 parallel reviewers: (A) requirements, (B) integration, (C) acceptance. | `subagent` × 3, `gsd_validate_milestone` |
 | `run-uat.md` | Execute UAT. Modes: artifact-driven, runtime, browser, human-experience. Runs under `verification` tools policy, so Bash is limited to read-only inspection and build/test verification commands. | `gsd_summary_save(ASSESSMENT)`, verification Bash |
 
+`run-uat` completion verification requires a canonical verdict in the written `S##-ASSESSMENT.md` (for example `verdict: PASS | FAIL | PARTIAL`). A pre-existing assessment file without `verdict` does not satisfy artifact verification.
+
 ### 5f. Completion Flow
 
 ```

--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -183,6 +183,8 @@ The sliding-window approach reduces false positives on legitimate retries (e.g.,
 
 After each unit, GSD verifies that the expected artifact exists on disk. If the artifact is missing, auto mode re-dispatches the unit with explicit failure context and records an `artifact-verification-retry` journal event.
 
+For `run-uat`, existence alone is not sufficient: a pre-existing `S##-ASSESSMENT.md` only counts as completed when it contains a canonical verdict field (for example frontmatter `verdict: PASS | FAIL | PARTIAL`). If the file exists but has no verdict, artifact verification fails and `run-uat` is redispatched.
+
 Artifact verification retries are capped at 3 attempts. If the expected artifact is still missing after those retries, GSD pauses auto mode with an "Artifact still missing..." error instead of relying on loop detection or an unbounded dispatch counter.
 
 ### Post-Mortem Investigation (v2.40)

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -44,6 +44,7 @@ import {
   diagnoseExpectedArtifact,
 } from "./auto-artifact-paths.js";
 import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
+import { hasVerdict } from "./verdict-parser.js";
 import { validateArtifact } from "./schemas/validate.js";
 import { getProjectResearchStatus } from "./project-research-policy.js";
 import { isGsdWorktreePath } from "./worktree-root.js";
@@ -789,6 +790,14 @@ export function verifyExpectedArtifact(
     const validationContent = readFileSync(absPath, "utf-8");
     if (!isValidationTerminal(validationContent)) {
       logWarning("recovery", `verify-fail ${unitType} ${unitId}: validation not terminal (len=${validationContent.length}) at ${absPath}`);
+      return false;
+    }
+  }
+
+  if (unitType === "run-uat") {
+    const assessmentContent = readFileSync(absPath, "utf-8");
+    if (!hasVerdict(assessmentContent)) {
+      logWarning("recovery", `verify-fail ${unitType} ${unitId}: assessment missing verdict at ${absPath}`);
       return false;
     }
   }

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -461,6 +461,44 @@ test("verifyExpectedArtifact rejects complete-slice when roadmap checkbox is sti
   }
 });
 
+test("verifyExpectedArtifact rejects run-uat when ASSESSMENT has no verdict", () => {
+  const base = makeTmpBase();
+  try {
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(join(sliceDir, "S01-ASSESSMENT.md"), "# Reassessment\n\nNo canonical verdict field.\n");
+
+    assert.equal(
+      verifyExpectedArtifact("run-uat", "M001/S01", base),
+      false,
+      "run-uat should not verify from a pre-existing ASSESSMENT without verdict",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("verifyExpectedArtifact accepts run-uat when ASSESSMENT has verdict", () => {
+  const base = makeTmpBase();
+  try {
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(join(sliceDir, "S01-ASSESSMENT.md"), [
+      "---",
+      "verdict: pass",
+      "---",
+      "",
+      "# UAT Assessment",
+    ].join("\n"));
+
+    assert.equal(
+      verifyExpectedArtifact("run-uat", "M001/S01", base),
+      true,
+      "run-uat should verify when ASSESSMENT contains a canonical verdict",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
 
 // ─── verifyExpectedArtifact: plan-slice task plan check (#739) ────────────
 


### PR DESCRIPTION
## Summary
- Tightened `run-uat` artifact verification to require an ASSESSMENT verdict and added regression tests, with the targeted auto-recovery test suite passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #4993
- [#4993 run-uat false-completes on pre-existing reassessment ASSESSMENT.md, then re-dispatches](https://github.com/gsd-build/gsd-2/issues/4993)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/4993-run-uat-false-completes-on-pre-existing--1778735362`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verification now requires assessment artifacts to include a canonical verdict; missing verdicts cause verification to fail and re-dispatch.

* **Tests**
  * Added tests covering verdict-present and verdict-missing scenarios for assessment verification.

* **Documentation**
  * Updated docs to clarify that assessments must include a canonical verdict (PASS | FAIL | PARTIAL) for verification to succeed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6011)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->