### PR TITLE
fix(issue): [Bug]:

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -27,7 +27,15 @@ export { writeCrashLog } from "./crash-log.js";
 
 export function handleRecoverableExtensionProcessError(err: Error): boolean {
   if ((err as NodeJS.ErrnoException).code === "EPIPE") {
-    process.exit(0);
+    writeCrashLog(err, "EPIPE");
+    const stdoutGone = process.stdout.destroyed || process.stdout.writableEnded;
+    if (stdoutGone) {
+      process.exit(0);
+    }
+    process.stderr.write(
+      `[gsd] swallowed EPIPE (syscall=${(err as NodeJS.ErrnoException).syscall ?? "?"}); see ~/.gsd/crash/ for details\n`,
+    );
+    return true;
   }
   if ((err as NodeJS.ErrnoException).code === "ENOENT") {
     const syscall = (err as NodeJS.ErrnoException).syscall;

--- a/src/resources/extensions/gsd/tests/register-extension-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/register-extension-guard.test.ts
@@ -1,5 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 
 import { handleRecoverableExtensionProcessError } from "../bootstrap/register-extension.ts";
 
@@ -56,4 +60,35 @@ test("handleRecoverableExtensionProcessError leaves unrelated errors unhandled",
     }),
   );
   assert.equal(handled, false);
+});
+
+test("handleRecoverableExtensionProcessError swallows EPIPE, warns, and writes crash log when stdout is alive", () => {
+  const tmpHome = join(tmpdir(), `gsd-epipe-test-${randomUUID()}`);
+  const origHome = process.env.GSD_HOME;
+  process.env.GSD_HOME = tmpHome;
+
+  let stderr = "";
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const handled = handleRecoverableExtensionProcessError(
+      Object.assign(new Error("broken pipe"), {
+        code: "EPIPE",
+        syscall: "write",
+      }),
+    );
+    assert.equal(handled, true);
+    assert.match(stderr, /swallowed EPIPE/);
+    const crashDir = join(tmpHome, "crash");
+    assert.equal(existsSync(crashDir), true);
+    assert.equal(readdirSync(crashDir).some((f) => f.endsWith(".log")), true);
+  } finally {
+    process.stderr.write = originalWrite;
+    process.env.GSD_HOME = origHome;
+    rmSync(tmpHome, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- Fixed EPIPE guard to always log and only exit when stdout is gone, with targeted test coverage confirming recoverable EPIPE now warns and continues.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5119
- [#5119 [Bug]:](https://github.com/gsd-build/gsd-2/issues/5119)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5119-bug-1778735483`