### PR TITLE
fix(issue): [Bug]: git stash pop fails after milestone merge — uncommitted completion-unit files conflict with squash-merged artifacts

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -179,6 +179,26 @@ function stashRefFromError(err: unknown): string | null {
   return typeof stashRef === "string" && stashRef.length > 0 ? stashRef : null;
 }
 
+function stashAlreadyExistsFilesFromError(err: unknown): string[] {
+  if (!err || typeof err !== "object") return [];
+  const stderr = (err as { stderr?: unknown }).stderr;
+  const stderrText = typeof stderr === "string"
+    ? stderr
+    : stderr instanceof Uint8Array
+      ? Buffer.from(stderr).toString("utf-8")
+      : "";
+  const message = err instanceof Error ? err.message : String(err);
+  const text = `${stderrText}\n${message}`;
+  const files = new Set<string>();
+  for (const line of text.split("\n")) {
+    const m = line.match(/^(.*?)\s+already exists, no checkout\s*$/i);
+    if (!m) continue;
+    const filePath = m[1]?.trim();
+    if (filePath) files.add(filePath);
+  }
+  return [...files];
+}
+
 /**
  * Check if two filesystem paths resolve to the same real location.
  * Returns false if either path cannot be resolved (e.g. doesn't exist).
@@ -2134,6 +2154,9 @@ export function mergeMilestoneToMain(
       const uu = nativeConflictFiles(originalBasePath_);
       const gsdUU = uu.filter((f) => f.startsWith(".gsd/"));
       const nonGsdUU = uu.filter((f) => !f.startsWith(".gsd/"));
+      const alreadyExists = stashAlreadyExistsFilesFromError(e);
+      const gsdAlreadyExists = alreadyExists.filter((f) => f.startsWith(".gsd/"));
+      const nonGsdAlreadyExists = alreadyExists.filter((f) => !f.startsWith(".gsd/"));
 
       if (gsdUU.length > 0) {
         for (const f of gsdUU) {
@@ -2168,10 +2191,35 @@ export function mergeMilestoneToMain(
         } else {
           logWarning("worktree", "recorded stash entry could not be resolved; skipping automatic drop");
         }
+      } else if (
+        gsdUU.length === 0 &&
+        nonGsdUU.length === 0 &&
+        gsdAlreadyExists.length > 0 &&
+        nonGsdAlreadyExists.length === 0
+      ) {
+        // Untracked-file restore failure from stash pop where all collided
+        // paths are .gsd/ artifacts that already exist after merge.
+        if (stashRefForDrop) {
+          try {
+            execFileSync("git", ["stash", "drop", stashRefForDrop], {
+              cwd: originalBasePath_,
+              stdio: ["ignore", "pipe", "pipe"],
+              encoding: "utf-8",
+            });
+          } catch (err) { /* stash may already be consumed */
+            logWarning("worktree", `git stash drop failed: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        } else {
+          logWarning("worktree", "recorded stash entry could not be resolved; skipping automatic drop");
+        }
       } else if (nonGsdUU.length > 0) {
         // Non-.gsd conflicts remain — leave stash for manual resolution
         logWarning("reconcile", "Stash pop conflict on non-.gsd files after merge", {
           files: nonGsdUU.join(", "),
+        });
+      } else if (nonGsdAlreadyExists.length > 0) {
+        logWarning("reconcile", "Stash pop restore collision on non-.gsd files after merge", {
+          files: nonGsdAlreadyExists.join(", "),
         });
       } else {
         logWarning(

--- a/src/resources/extensions/gsd/tests/stash-pop-gsd-conflict.test.ts
+++ b/src/resources/extensions/gsd/tests/stash-pop-gsd-conflict.test.ts
@@ -150,3 +150,50 @@ test("#2766: stash pop conflict on non-.gsd files preserves stash for manual res
     cleanupTempRepo(repo);
   }
 });
+
+test("#4766: stash pop untracked already-exists collisions on .gsd files drop stash", () => {
+  const repo = createTempRepo();
+  try {
+    const wtPath = createAutoWorktree(repo, "M302");
+
+    const normalizedPath = wtPath.replaceAll("\\", "/");
+    const worktreeName = normalizedPath.split("/").pop() || "M302";
+    const sliceBranch = `slice/${worktreeName}/S01`;
+    run(`git checkout -b "${sliceBranch}"`, wtPath);
+    writeFileSync(join(wtPath, "feature-302.ts"), "export const feature302 = true;\n");
+    run("git add feature-302.ts", wtPath);
+    run('git commit -m "add feature 302"', wtPath);
+    run("git checkout milestone/M302", wtPath);
+    run(`git merge --no-ff "${sliceBranch}" -m "merge S01: feature 302"`, wtPath);
+
+    // Create an untracked milestone artifact in root so pre-merge auto-stash
+    // captures it. The squash merge then writes the same path, and stash pop
+    // fails with "<path> already exists, no checkout".
+    const artifactDir = join(repo, ".gsd", "milestones", "M302");
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(join(artifactDir, "M302-SUMMARY.md"), "summary from working tree\n");
+
+    // Commit same artifact path on milestone branch so merge brings it in.
+    const wtArtifactDir = join(wtPath, ".gsd", "milestones", "M302");
+    mkdirSync(wtArtifactDir, { recursive: true });
+    writeFileSync(join(wtArtifactDir, "M302-SUMMARY.md"), "summary from milestone branch\n");
+    run("git add .gsd/milestones/M302/M302-SUMMARY.md", wtPath);
+    run('git commit -m "add milestone artifact"', wtPath);
+
+    const roadmap = makeRoadmap("M302", "Stash pop already-exists regression", [
+      { id: "S01", title: "Feature 302" },
+    ]);
+
+    const result = mergeMilestoneToMain(repo, "M302", roadmap);
+    assert.ok(
+      result.commitMessage.includes("GSD-Milestone: M302"),
+      "merge succeeds despite untracked .gsd stash-pop restore collision",
+    );
+
+    let stashList = "";
+    try { stashList = run("git stash list", repo); } catch { /* empty stash */ }
+    assert.strictEqual(stashList, "", "stash is empty after .gsd already-exists collision");
+  } finally {
+    cleanupTempRepo(repo);
+  }
+});


### PR DESCRIPTION
## Summary
- Added `.gsd`-only stash-pop already-exists collision handling in milestone merge recovery and verified with a new focused regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #4766
- [#4766 [Bug]: git stash pop fails after milestone merge — uncommitted completion-unit files conflict with squash-merged artifacts](https://github.com/gsd-build/gsd-2/issues/4766)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/4766-bug-git-stash-pop-fails-after-milestone--1778735723`