### PR TITLE
fix(issue): [Bug]: /gsd command surface hides milestone/planning/research loop verbs behind dispatch

### DIFF
--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -20,6 +20,22 @@ import { handlePrBranch } from "../../commands-pr-branch.js";
 import { currentDirectoryRoot, projectRoot } from "../context.js";
 
 export async function handleOpsCommand(trimmed: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<boolean> {
+  const directDispatchAlias = new Map<string, string>([
+    ["research-milestone", "research"],
+    ["research-slice", "research"],
+    ["plan-milestone", "plan"],
+    ["plan-slice", "plan"],
+    ["execute-task", "execute"],
+    ["complete-slice", "complete"],
+    ["validate-milestone", "uat"],
+    ["complete-milestone", "complete"],
+  ]);
+  const aliasPhase = directDispatchAlias.get(trimmed);
+  if (aliasPhase) {
+    await dispatchDirectPhase(ctx, pi, aliasPhase, projectRoot());
+    return true;
+  }
+
   if (trimmed === "init") {
     const { detectProjectState } = await import("../../detection.js");
     const { handleReinit, showProjectInit } = await import("../../init-wizard.js");

--- a/src/resources/extensions/gsd/tests/autocomplete-regressions-1675.test.ts
+++ b/src/resources/extensions/gsd/tests/autocomplete-regressions-1675.test.ts
@@ -120,3 +120,24 @@ test("bare /gsd skip shows usage and does not fall through to unknown-command wa
   );
 });
 
+test("direct loop verbs do not fall through to unknown-command warning", async () => {
+  const loopVerbs = [
+    "research-milestone",
+    "research-slice",
+    "plan-milestone",
+    "plan-slice",
+    "execute-task",
+    "complete-slice",
+    "validate-milestone",
+    "complete-milestone",
+  ];
+
+  for (const verb of loopVerbs) {
+    const ctx = createMockCtx();
+    await handleGSDCommand(verb, ctx as any, {} as any);
+    assert.ok(
+      !ctx.notifications.some((n) => n.message.startsWith(`Unknown: /gsd ${verb}`)),
+      `${verb} should be recognized as a valid /gsd command alias`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Added direct /gsd loop-verb aliases to dispatch phases and verified with focused command-surface regression tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #4756
- [#4756 [Bug]: /gsd command surface hides milestone/planning/research loop verbs behind dispatch](https://github.com/gsd-build/gsd-2/issues/4756)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/4756-bug-gsd-command-surface-hides-milestone--1778735843`