### PR TITLE
fix(issue): [Bug]: VSCode extension, italic/bold output markdown (train-of-thought) is not rendered properly

### DIFF
--- a/vscode-extension/src/chat-participant.ts
+++ b/vscode-extension/src/chat-participant.ts
@@ -95,10 +95,9 @@ export function registerChatParticipant(
 							response.markdown(delta);
 						}
 					} else if (assistantEvent.type === "thinking_delta") {
-						// Thinking shown inline — prefix with italic so it's visually distinct
 						const delta = assistantEvent.delta as string | undefined;
 						if (delta) {
-							response.markdown(`*${delta}*`);
+							response.markdown(delta);
 						}
 					}
 					break;


### PR DESCRIPTION
## Summary
- Removed per-delta italic wrapping in VS Code chat thinking stream to prevent broken raw markdown artifacts, and verified with vscode-extension tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #4705
- [#4705 [Bug]: VSCode extension, italic/bold output markdown (train-of-thought) is not rendered properly](https://github.com/gsd-build/gsd-2/issues/4705)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/4705-bug-vscode-extension-italic-bold-output--1778735962`