### PR TITLE
fix(issue): auto-mode: verification-retry treats yielded turn as completion

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -983,6 +983,7 @@ export async function autoLoop(
         finishIncompleteIteration({
           status: "retry",
           reason: "finalize-retry",
+          retry: true,
           unitType: iterData.unitType,
           unitId: iterData.unitId,
         });

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -2378,7 +2378,11 @@ export async function runUnitPhase(
     }
   }
 
-  deps.emitJournalEvent({ ts: new Date().toISOString(), flowId: ic.flowId, seq: ic.nextSeq(), eventType: "unit-end", data: { unitType, unitId, status: unitResult.status, artifactVerified, ...(unitResult.errorContext ? { errorContext: unitResult.errorContext } : {}) }, causedBy: { flowId: ic.flowId, seq: unitStartSeq } });
+  const unitEndStatus =
+    !artifactVerified && unitResult.status === "completed"
+      ? "no-artifact"
+      : unitResult.status;
+  deps.emitJournalEvent({ ts: new Date().toISOString(), flowId: ic.flowId, seq: ic.nextSeq(), eventType: "unit-end", data: { unitType, unitId, status: unitEndStatus, artifactVerified, ...(unitResult.errorContext ? { errorContext: unitResult.errorContext } : {}) }, causedBy: { flowId: ic.flowId, seq: unitStartSeq } });
 
   // ── Safety harness: checkpoint cleanup or rollback ──
   if (s.checkpointSha) {

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -825,7 +825,7 @@ test("runUnitPhase emits unit-start and unit-end with causedBy reference", async
   assert.equal(endEvents[0].flowId, ic.flowId);
   assert.equal((endEvents[0].data as any).unitType, "execute-task");
   assert.equal((endEvents[0].data as any).unitId, "M001/S01/T01");
-  assert.equal((endEvents[0].data as any).status, "completed");
+  assert.equal((endEvents[0].data as any).status, "no-artifact");
 
   // Verify causedBy: unit-end references unit-start's seq
   assert.ok(endEvents[0].causedBy, "unit-end must have a causedBy reference");


### PR DESCRIPTION
## Summary
- Changed verification-retry telemetry to mark artifact-missing unit ends as `no-artifact` (not completed) and tagged finalize retry iteration-end events with `retry: true`, verified by focused auto-loop/journal tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5360
- [#5360 auto-mode: verification-retry treats yielded turn as completion](https://github.com/gsd-build/gsd-2/issues/5360)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5360-auto-mode-verification-retry-treats-yiel-1778736203`