### PR TITLE
fix(issue): MCP status shows 'disconnected' for host-connected servers

### DIFF
--- a/src/resources/extensions/gsd/commands-mcp-status.ts
+++ b/src/resources/extensions/gsd/commands-mcp-status.ts
@@ -32,6 +32,11 @@ export interface McpServerDetail extends McpServerStatus {
   tools: string[];
 }
 
+export function hasHostMcpTool(systemPrompt: string, serverName: string): boolean {
+  const marker = `mcp__${serverName}__`;
+  return systemPrompt.includes(marker);
+}
+
 export function formatMcpInitResult(
   status: "created" | "updated" | "unchanged",
   configPath: string,
@@ -184,6 +189,7 @@ export async function handleMcpStatus(
   const trimmed = args.trim();
   const lowered = trimmed.toLowerCase();
   const configs = readMcpConfigs();
+  const systemPrompt = ctx.getSystemPrompt();
 
   // /gsd mcp init [dir]
   if (!lowered || lowered === "status") {
@@ -233,6 +239,7 @@ export async function handleMcpStatus(
     } catch {
       // mcp-client may not expose status helpers — that's fine
     }
+    if (!connected && !error && hasHostMcpTool(systemPrompt, serverName)) connected = true;
 
     ctx.ui.notify(
       formatMcpServerDetail({
@@ -270,6 +277,7 @@ export async function handleMcpStatus(
       } catch {
         // Fall back to unknown state
       }
+      if (!connected && !error && hasHostMcpTool(systemPrompt, config.name)) connected = true;
 
       statuses.push({
         name: config.name,

--- a/src/resources/extensions/gsd/tests/mcp-status.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-status.test.ts
@@ -5,6 +5,7 @@ import {
   formatMcpInitResult,
   formatMcpStatusReport,
   formatMcpServerDetail,
+  hasHostMcpTool,
   type McpServerStatus,
 } from "../commands-mcp-status.ts";
 
@@ -114,5 +115,15 @@ describe("formatMcpInitResult", () => {
   test("shows unchanged message when config is current", () => {
     const result = formatMcpInitResult("unchanged", "/tmp/project/.mcp.json", "/tmp/project");
     assert.match(result, /already up to date/i);
+  });
+});
+
+describe("hasHostMcpTool", () => {
+  test("detects host-provided MCP tool prefix for a server", () => {
+    assert.equal(hasHostMcpTool("tools: mcp__gsd-workflow__*", "gsd-workflow"), true);
+  });
+
+  test("does not match other servers", () => {
+    assert.equal(hasHostMcpTool("tools: mcp__other-server__*", "gsd-workflow"), false);
   });
 });


### PR DESCRIPTION
## Summary
- Added a minimal `/gsd mcp` fallback that treats servers as connected when host MCP tools (`mcp__<server>__*`) are present in the system prompt, with targeted tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5300
- [#5300 MCP status shows 'disconnected' for host-connected servers](https://github.com/gsd-build/gsd-2/issues/5300)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5300-mcp-status-shows-disconnected-for-host-c-1778736442`