### PR TITLE
fix(issue): [Bug]: complete-slice prompt field-name ambiguity causes TypeBox validation failures (how vs proof)

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -794,6 +794,10 @@ export function registerDbTools(pi: ExtensionAPI): void {
             id: Type.String({ description: "Requirement ID" }),
             proof: Type.String({ description: "What proof validates it" }),
           }),
+          Type.Object({
+            id: Type.String({ description: "Requirement ID" }),
+            how: Type.String({ description: "Alias accepted for proof (normalized internally)" }),
+          }),
           Type.String({ description: "Fallback: 'ID — proof' string" }),
         ]),
         { description: "Requirements validated by this slice" },
@@ -803,6 +807,10 @@ export function registerDbTools(pi: ExtensionAPI): void {
           Type.Object({
             id: Type.String({ description: "Requirement ID" }),
             what: Type.String({ description: "What changed" }),
+          }),
+          Type.Object({
+            id: Type.String({ description: "Requirement ID" }),
+            how: Type.String({ description: "Alias accepted for what (normalized internally)" }),
           }),
           Type.String({ description: "Fallback: 'ID — what' string" }),
         ]),

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -326,6 +326,43 @@ test("executeSliceComplete coerces string enrichment entries and writes summary/
   }
 });
 
+test("executeSliceComplete normalizes requirement object aliases (how -> proof/what)", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Milestone One");
+    seedSlice("M001", "S01", "pending");
+    writeRoadmap(base, "M001", ["S01"]);
+    const db = _getAdapter();
+    db!.prepare(
+      "INSERT OR REPLACE INTO tasks (milestone_id, slice_id, id, title, status) VALUES (?, ?, ?, ?, ?)",
+    ).run("M001", "S01", "T01", "Task T01", "complete");
+
+    const rawParams = {
+      milestoneId: "M001",
+      sliceId: "S01",
+      sliceTitle: "Slice S01",
+      oneLiner: "Completed slice",
+      narrative: "Implemented the slice",
+      verification: "node --test",
+      uatContent: "## UAT\n\nPASS",
+      requirementsValidated: [{ id: "R010", how: "Integration test passed" }],
+      requirementsInvalidated: [{ id: "R011", how: "Scope narrowed" }],
+    } as unknown as Parameters<typeof executeSliceComplete>[0];
+
+    const result = await inProjectDir(base, () => executeSliceComplete(rawParams, base));
+    assert.equal(result.details.operation, "complete_slice");
+    const summaryPath = String(result.details.summaryPath);
+    assert.ok(existsSync(summaryPath), "slice summary should be written to disk");
+    const summary = readFileSync(summaryPath, "utf-8");
+    assert.match(summary, /R010 — Integration test passed/);
+    assert.match(summary, /R011 — Scope narrowed/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeValidateMilestone persists validation artifact and gate records", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -554,11 +554,25 @@ export async function executeSliceComplete(
       if (typeof r !== "string") return r;
       const [id, proof] = splitPair(r);
       return { id, proof };
+    }).map((r) => {
+      if (!r || typeof r !== "object" || Array.isArray(r)) return r;
+      const record = r as Record<string, unknown>;
+      if (typeof record.id === "string" && typeof record.proof !== "string" && typeof record.how === "string") {
+        return { id: record.id, proof: record.how };
+      }
+      return r;
     }) as Array<{ id: string; proof: string }>;
     coerced.requirementsInvalidated = wrapArray(params.requirementsInvalidated).map((r) => {
       if (typeof r !== "string") return r;
       const [id, what] = splitPair(r);
       return { id, what };
+    }).map((r) => {
+      if (!r || typeof r !== "object" || Array.isArray(r)) return r;
+      const record = r as Record<string, unknown>;
+      if (typeof record.id === "string" && typeof record.what !== "string" && typeof record.how === "string") {
+        return { id: record.id, what: record.how };
+      }
+      return r;
     }) as Array<{ id: string; what: string }>;
 
     const result = await handleCompleteSlice(coerced as CompleteSliceParams, basePath);


### PR DESCRIPTION
## Summary
- Added schema alias support and executor normalization for complete-slice requirement fields, verified by focused gsd test suites passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5321
- [#5321 [Bug]: complete-slice prompt field-name ambiguity causes TypeBox validation failures (how vs proof)](https://github.com/gsd-build/gsd-2/issues/5321)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5321-bug-complete-slice-prompt-field-name-amb-1778738843`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Requirement validation now accepts alternative field name aliases that are automatically normalized to standard formats during processing.

* **Tests**
  * Added test coverage for requirement field alias normalization in workflow operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6023)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->