### PR TITLE
fix(issue): TUI freezes after every task completion — pauseAuto→stopAuto double-cleanup leaves input disabled

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -575,6 +575,13 @@ export function _buildCancelledUnitStopReason(
   };
 }
 
+export function _isPauseOriginCancelledResult(
+  isPaused: boolean,
+  errorContext?: { message: string; category: string },
+): boolean {
+  return isPaused && !errorContext;
+}
+
 async function failClosedOnFinalizeTimeout(
   ic: IterationContext,
   iterData: IterationData,
@@ -2139,6 +2146,11 @@ export async function runUnitPhase(
   }
 
   if (unitResult.status === "cancelled") {
+    if (_isPauseOriginCancelledResult(s.paused, unitResult.errorContext)) {
+      debugLog("autoLoop", { phase: "cancelled-after-pause", unitType, unitId });
+      return { action: "break", reason: "paused" };
+    }
+
     const errorCategory = unitResult.errorContext?.category;
     // Provider-error pause: agent_end recovery normally pauses before this
     // branch. Provider readiness failures happen before dispatch, so pause here

--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -258,11 +258,13 @@ export async function handleForensics(
   });
 
   ctx.ui.notify(`Forensic report saved: ${relative(basePath, savedPath)}`, "info");
+  ctx.ui.setStatus("gsd-forensics", "running");
 
   pi.sendMessage(
     { customType: "gsd-forensics", content, display: false },
     { triggerTurn: true },
   );
+  ctx.ui.setStatus("gsd-forensics", undefined);
 
   // Persist forensics context so follow-up turns can re-inject it (#2941)
   writeForensicsMarker(basePath, savedPath, content);

--- a/src/resources/extensions/gsd/tests/auto-abort-pause-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-abort-pause-regression.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { _buildAbortedPauseContext, isUserInitiatedAbortMessage } from "../bootstrap/agent-end-recovery.js";
-import { _buildCancelledUnitStopReason } from "../auto/phases.js";
+import { _buildCancelledUnitStopReason, _isPauseOriginCancelledResult } from "../auto/phases.js";
 
 test("aborted agent_end maps errorMessage into structured aborted pause context", () => {
   const withMessage = _buildAbortedPauseContext({ errorMessage: "provider aborted request" });
@@ -35,4 +35,13 @@ test("provider user-abort errors are recognized as cancellations, not provider o
   assert.equal(isUserInitiatedAbortMessage("Claude Code process aborted by user"), true);
   assert.equal(isUserInitiatedAbortMessage("Request aborted by user"), true);
   assert.equal(isUserInitiatedAbortMessage("HTTP 503 Service Unavailable"), false);
+});
+
+test("cancelled-without-errorContext while paused is treated as pause-origin cancellation", () => {
+  assert.equal(_isPauseOriginCancelledResult(true, undefined), true);
+  assert.equal(_isPauseOriginCancelledResult(false, undefined), false);
+  assert.equal(
+    _isPauseOriginCancelledResult(true, { category: "aborted", message: "Operation aborted" }),
+    false,
+  );
 });


### PR DESCRIPTION
## Summary
- Added a pause-origin cancellation guard to prevent double stopAuto cleanup and surfaced visible forensics running status, verified by focused extension tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #4646
- [#4646 TUI freezes after every task completion — pauseAuto→stopAuto double-cleanup leaves input disabled](https://github.com/gsd-build/gsd-2/issues/4646)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/4646-tui-freezes-after-every-task-completion--1778739084`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of paused unit cancellations that lack error context, ensuring proper system state management in pause scenarios

* **UX Improvements**
  * Enhanced UI status visibility with real-time status indicators during forensics message processing

* **Tests**
  * Added regression test coverage for pause-related unit cancellation detection and handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6024)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->