### PR TITLE
fix(issue): [Bug]: Queue reorder overlay does not scroll with arrow keys

### DIFF
--- a/src/resources/extensions/gsd/queue-reorder-ui.ts
+++ b/src/resources/extensions/gsd/queue-reorder-ui.ts
@@ -43,6 +43,7 @@ export async function showQueueReorder(
     const items = [...pending];
     let cursor = 0;
     let grabbed = false;
+    let scrollOffset = 0;
     let cachedLines: string[] | undefined;
     let validation: DependencyValidation;
 
@@ -154,8 +155,10 @@ export async function showQueueReorder(
 
       const ui = makeUI(theme, width);
       const lines: string[] = [];
+      const queueRows: string[] = [];
       const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
       const add = (s: string) => truncateToWidth(s, width);
+      let cursorQueueRow = 0;
 
       const headerText = grabbed ? "  Queue Reorder — Moving Item" : "  Queue Reorder";
       push(ui.bar(), ui.blank(), ui.header(headerText), ui.blank());
@@ -188,11 +191,13 @@ export async function showQueueReorder(
         const label = item.title && item.title !== item.id ? `${item.id}  ${item.title}` : item.id;
 
         if (isCursor && grabbed) {
-          lines.push(add(`  ${theme.fg("warning", `▸▸ ${num}. ${label}`)}`));
+          cursorQueueRow = queueRows.length;
+          queueRows.push(add(`  ${theme.fg("warning", `▸▸ ${num}. ${label}`)}`));
         } else if (isCursor) {
-          lines.push(add(`  ${theme.fg("accent", `${GLYPH.cursor} ${num}. ${label}`)}`));
+          cursorQueueRow = queueRows.length;
+          queueRows.push(add(`  ${theme.fg("accent", `${GLYPH.cursor} ${num}. ${label}`)}`));
         } else {
-          lines.push(add(`    ${theme.fg("text", `${num}. ${label}`)}`));
+          queueRows.push(add(`    ${theme.fg("text", `${num}. ${label}`)}`));
         }
 
         // depends_on annotations
@@ -201,36 +206,37 @@ export async function showQueueReorder(
           if (completedIds.has(dep)) continue;
           const pairKey = `${item.id}:${dep}`;
           if (violatedPairs.has(pairKey)) {
-            lines.push(add(`       ${theme.fg("warning", `${GLYPH.statusWarning} depends_on: ${dep} — auto-removed on confirm`)}`));
+            queueRows.push(add(`       ${theme.fg("warning", `${GLYPH.statusWarning} depends_on: ${dep} — auto-removed on confirm`)}`));
           } else if (redundantPairs.has(pairKey)) {
-            lines.push(add(`       ${theme.fg("dim", `↳ depends_on: ${dep} (redundant)`)}`));
+            queueRows.push(add(`       ${theme.fg("dim", `↳ depends_on: ${dep} (redundant)`)}`));
           } else {
-            lines.push(add(`       ${theme.fg("dim", `↳ depends_on: ${dep}`)}`));
+            queueRows.push(add(`       ${theme.fg("dim", `↳ depends_on: ${dep}`)}`));
           }
         }
 
         // Missing deps
         for (const v of validation.violations.filter(v => v.milestone === item.id && v.type === 'missing_dep')) {
-          lines.push(add(`       ${theme.fg("error", `${GLYPH.statusWarning} depends_on: ${v.dependsOn} (does not exist)`)}`));
+          queueRows.push(add(`       ${theme.fg("error", `${GLYPH.statusWarning} depends_on: ${v.dependsOn} (does not exist)`)}`));
         }
       }
 
       // Removed deps feedback
+      const trailingLines: string[] = [];
       if (removedDeps.length > 0) {
-        push(ui.blank());
+        trailingLines.push(...ui.blank());
         for (const r of removedDeps) {
-          lines.push(add(`  ${theme.fg("success", `${GLYPH.statusDone} Removed: ${r.milestone} depends_on ${r.dep}`)}`));
+          trailingLines.push(add(`  ${theme.fg("success", `${GLYPH.statusDone} Removed: ${r.milestone} depends_on ${r.dep}`)}`));
         }
       }
 
       // Circular warning
       const circ = validation.violations.find(v => v.type === 'circular');
       if (circ) {
-        push(ui.blank());
-        lines.push(add(`  ${theme.fg("error", `${GLYPH.statusWarning} ${circ.message}`)}`));
+        trailingLines.push(...ui.blank());
+        trailingLines.push(add(`  ${theme.fg("error", `${GLYPH.statusWarning} ${circ.message}`)}`));
       }
 
-      push(ui.blank());
+      trailingLines.push(...ui.blank());
 
       // Hints — context-sensitive based on grab state
       const hints: string[] = [];
@@ -250,7 +256,19 @@ export async function showQueueReorder(
       }
       hints.push("esc");
 
-      push(ui.hints(hints), ui.bar());
+      trailingLines.push(...ui.hints(hints), ...ui.bar());
+
+      const maxOverlayRows = Math.max(10, process.stdout.rows ? Math.floor(process.stdout.rows * 0.8) : 24);
+      const availableQueueRows = Math.max(1, maxOverlayRows - lines.length - trailingLines.length);
+      const maxScroll = Math.max(0, queueRows.length - availableQueueRows);
+      if (cursorQueueRow < scrollOffset) {
+        scrollOffset = cursorQueueRow;
+      } else if (cursorQueueRow >= scrollOffset + availableQueueRows) {
+        scrollOffset = cursorQueueRow - availableQueueRows + 1;
+      }
+      scrollOffset = Math.min(Math.max(scrollOffset, 0), maxScroll);
+
+      lines.push(...queueRows.slice(scrollOffset, scrollOffset + availableQueueRows), ...trailingLines);
 
       cachedLines = lines;
       return lines;

--- a/src/resources/extensions/gsd/tests/queue-reorder-ui.test.ts
+++ b/src/resources/extensions/gsd/tests/queue-reorder-ui.test.ts
@@ -1,0 +1,54 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { showQueueReorder } from "../queue-reorder-ui.ts";
+
+const fakeTheme = {
+  fg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+};
+
+describe("queue-reorder-ui", () => {
+  test("keeps cursor visible while scrolling long queue with arrow keys (#4656)", async () => {
+    const originalRowsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+    Object.defineProperty(process.stdout, "rows", { value: 20, configurable: true });
+
+    try {
+      const pending = Array.from({ length: 20 }, (_, idx) => ({
+        id: `M${String(idx + 1).padStart(3, "0")}`,
+        title: `Milestone ${idx + 1}`,
+      }));
+
+      let resolved: { order: string[]; depsToRemove: Array<{ milestone: string; dep: string }> } | null = null;
+      let lastRender: string[] = [];
+
+      const ctx = {
+        hasUI: true,
+        ui: {
+          custom: async (factory: any) => {
+            const component = factory({ requestRender() {} }, fakeTheme, null, (value: any) => {
+              resolved = value;
+            });
+
+            for (let i = 0; i < 15; i++) component.handleInput("\u001b[B");
+            lastRender = component.render(100);
+            component.handleInput("\r");
+            return resolved;
+          },
+        },
+      } as any;
+
+      await showQueueReorder(ctx, [], pending);
+
+      const joined = lastRender.join("\n");
+      assert.ok(joined.includes("M016"), "selected item should stay visible after scrolling");
+      assert.ok(lastRender.length <= 16, `overlay should fit terminal max-height, got ${lastRender.length}`);
+    } finally {
+      if (originalRowsDescriptor) {
+        Object.defineProperty(process.stdout, "rows", originalRowsDescriptor);
+      } else {
+        delete (process.stdout as { rows?: number }).rows;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Added queue reorder viewport scrolling with cursor-follow behavior and verified with a focused regression test for arrow-key navigation in long queues.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #4656
- [#4656 [Bug]: Queue reorder overlay does not scroll with arrow keys](https://github.com/gsd-build/gsd-2/issues/4656)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/4656-bug-queue-reorder-overlay-does-not-scrol-1778739204`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queue reordering interface now supports vertical scrolling, improving navigation when working with large queues
  * Cursor selection properly maintains visibility when scrolling through queue items and dependencies
  * Improved display of queue dependencies and validation information throughout the interface
  * Enhanced handling of queue item removal feedback and related status messages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6025)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->