### PR TITLE
fix(issue): [Bug]: auto-mode aborts on provider 500 errors instead of pausing and retrying

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -100,6 +100,14 @@ export function isUserInitiatedAbortMessage(message: string | undefined | null):
   return /\b(?:claude code process aborted by user|request aborted by user|process aborted by user)\b/i.test(message);
 }
 
+export function shouldDeferTransientErrorToCoreRetry(
+  cls: ErrorClass,
+  rawErrorMsg: string,
+): boolean {
+  if (!isTransient(cls) || cls.kind === "rate-limit") return false;
+  return !/retry failed after \d+ attempts:/i.test(rawErrorMsg);
+}
+
 function isBareClaudeCodeSessionSwitchAbortMarker(message: string | undefined | null): boolean {
   if (!message) return false;
   const normalized = message.trim().replace(/\s+/g, " ").toLowerCase();
@@ -488,7 +496,7 @@ export async function handleAgentEnd(
     // Core retries transient failures in-session after this handler.
     // Keep that behavior for non-rate-limit classes to avoid pause/retry races,
     // but let rate-limit continue into model fallback logic below (#4373).
-    if (isTransient(cls) && cls.kind !== "rate-limit") {
+    if (shouldDeferTransientErrorToCoreRetry(cls, rawErrorMsg)) {
       return;
     }
 

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -10,7 +10,12 @@ import assert from "node:assert/strict";
 import { classifyError, isTransient, isTransientNetworkError } from "../error-classifier.ts";
 import { pauseAutoForProviderError } from "../provider-error-pause.ts";
 import { resumeAutoAfterProviderDelay } from "../bootstrap/provider-error-resume.ts";
-import { MAX_TRANSIENT_AUTO_RESUMES, isTerminalDeletedWorktreeProviderError, resetTransientRetryState } from "../bootstrap/agent-end-recovery.ts";
+import {
+  MAX_TRANSIENT_AUTO_RESUMES,
+  isTerminalDeletedWorktreeProviderError,
+  resetTransientRetryState,
+  shouldDeferTransientErrorToCoreRetry,
+} from "../bootstrap/agent-end-recovery.ts";
 import { _buildCancelledUnitStopReason } from "../auto/phases.ts";
 import { getNextFallbackModel } from "../preferences.ts";
 // Zero-import module — imported by path rather than through the package
@@ -677,4 +682,16 @@ test("agent-session retryable error regex matches server_error (underscore)", ()
   assert.ok(!RETRYABLE_ERROR_RE.test("model not found"));
   // "temporarily backed off" must NOT be matched (intentional exclusion #3429)
   assert.ok(!RETRYABLE_ERROR_RE.test("temporarily backed off"));
+});
+
+test("exhausted retry errors are not deferred back to core retry handling", () => {
+  const cls = classifyError("Retry failed after 3 attempts: 500 empty_stream: upstream stream closed before first payload");
+  assert.equal(cls.kind, "server");
+  assert.equal(
+    shouldDeferTransientErrorToCoreRetry(
+      cls,
+      "Retry failed after 3 attempts: 500 empty_stream: upstream stream closed before first payload",
+    ),
+    false,
+  );
 });


### PR DESCRIPTION
## Summary
- Adjusted agent-end transient retry deferral so exhausted 500 retry errors route into provider pause/recovery, and verified with the provider-errors test suite.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #4707
- [#4707 [Bug]: auto-mode aborts on provider 500 errors instead of pausing and retrying](https://github.com/gsd-build/gsd-2/issues/4707)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/4707-bug-auto-mode-aborts-on-provider-500-err-1778740044`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transient error handling logic to more accurately determine which errors should be deferred to the system's retry handler versus handled through local fallback mechanisms.

* **Tests**
  * Added test coverage for scenarios where retries have been exhausted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6031)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->