### PR TITLE
fix(issue): auto: state mutations + journal emission happen before pre-dispatch validation succeeds (Change 4-B from #4959)

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1921,6 +1921,7 @@ export async function runUnitPhase(
   const prevUnitModel = s.currentUnitModel;
   const prevDispatchedModelId = s.currentDispatchedModelId;
   const prevSessionModel = ctx.model;
+  const prevSessionThinkingLevel = pi.getThinkingLevel();
   const modelResult = await deps.selectAndApplyModel(
     ctx,
     pi,
@@ -1993,10 +1994,17 @@ export async function runUnitPhase(
     s.currentUnitRouting = prevUnitRouting;
     s.currentUnitModel = prevUnitModel;
     s.currentDispatchedModelId = prevDispatchedModelId;
+    if (s.checkpointSha) {
+      cleanupCheckpoint(s.basePath, unitId);
+      s.checkpointSha = null;
+    }
     if (prevSessionModel) {
-      await pi.setModel(prevSessionModel, { persist: false });
-      if (s.autoModeStartThinkingLevel) {
-        pi.setThinkingLevel(s.autoModeStartThinkingLevel);
+      const ok = await pi.setModel(prevSessionModel, { persist: false });
+      if (!ok) {
+        ctx.ui.notify("Failed to restore previous session model after compatibility check failure.", "warning");
+      }
+      if (prevSessionThinkingLevel) {
+        pi.setThinkingLevel(prevSessionThinkingLevel);
       }
     }
     ctx.ui.notify(compatibilityError, "error");

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1810,42 +1810,8 @@ export async function runUnitPhase(
     s.currentUnit.id === unitId
   );
   const previousTier = s.currentUnitRouting?.tier;
-
-  // Scope workflow-logger buffer to this unit so post-finalize drains are
-  // per-unit. Without this, the module-level _buffer accumulates across every
-  // unit in the same Node process (see workflow-logger.ts module header).
-  _resetLogs();
   const dispatchKey = `${unitType}/${unitId}`;
-  s.unitDispatchCount.set(dispatchKey, (s.unitDispatchCount.get(dispatchKey) ?? 0) + 1);
-  s.currentUnit = { type: unitType, id: unitId, startedAt: Date.now() };
-  s.lastGitActionFailure = null;
-  s.lastGitActionStatus = null;
-  s.lastUnitAgentEndMessages = null;
-  setCurrentPhase(unitType, {
-    basePath: s.basePath,
-    traceId: ic.flowId,
-    turnId: `iter-${ic.iteration}`,
-    causedBy: "unit-start",
-  });
-  s.lastToolInvocationError = null; // #2883: clear stale error from previous unit
-  const unitStartSeq = ic.nextSeq();
-  deps.emitJournalEvent({ ts: new Date().toISOString(), flowId: ic.flowId, seq: unitStartSeq, eventType: "unit-start", data: { unitType, unitId } });
-  deps.captureAvailableSkills();
-  writeUnitRuntimeRecord(
-    s.basePath,
-    unitType,
-    unitId,
-    s.currentUnit.startedAt,
-    {
-      phase: "dispatched",
-      wrapupWarningSent: false,
-      timeoutAt: null,
-      lastProgressAt: s.currentUnit.startedAt,
-      progressCount: 0,
-      lastProgressKind: "dispatch",
-      recoveryAttempts: 0, // Reset so re-dispatched units get full recovery budget (#2322)
-    },
-  );
+  const nextDispatchCount = (s.unitDispatchCount.get(dispatchKey) ?? 0) + 1;
 
   // Status bar (widget + preconditions deferred until after model selection — see #2899)
   ctx.ui.setStatus("gsd-auto", "auto");
@@ -1908,7 +1874,7 @@ export async function runUnitPhase(
         : s.pendingCrashRecovery;
     finalPrompt = `${capped}\n\n---\n\n${finalPrompt}`;
     s.pendingCrashRecovery = null;
-  } else if ((s.unitDispatchCount.get(dispatchKey) ?? 0) > 1) {
+  } else if (nextDispatchCount > 1) {
     const diagnostic = deps.getDeepDiagnostic(s.basePath);
     if (diagnostic) {
       const cappedDiag =
@@ -2024,6 +1990,42 @@ export async function runUnitPhase(
     await deps.stopAuto(ctx, pi, compatibilityError);
     return { action: "break", reason: "workflow-capability" };
   }
+
+  // Scope workflow-logger buffer to this unit so post-finalize drains are
+  // per-unit. Without this, the module-level _buffer accumulates across every
+  // unit in the same Node process (see workflow-logger.ts module header).
+  _resetLogs();
+  const unitStartedAt = Date.now();
+  s.unitDispatchCount.set(dispatchKey, nextDispatchCount);
+  s.currentUnit = { type: unitType, id: unitId, startedAt: unitStartedAt };
+  s.lastGitActionFailure = null;
+  s.lastGitActionStatus = null;
+  s.lastUnitAgentEndMessages = null;
+  setCurrentPhase(unitType, {
+    basePath: s.basePath,
+    traceId: ic.flowId,
+    turnId: `iter-${ic.iteration}`,
+    causedBy: "unit-start",
+  });
+  s.lastToolInvocationError = null; // #2883: clear stale error from previous unit
+  const unitStartSeq = ic.nextSeq();
+  deps.emitJournalEvent({ ts: new Date().toISOString(), flowId: ic.flowId, seq: unitStartSeq, eventType: "unit-start", data: { unitType, unitId } });
+  deps.captureAvailableSkills();
+  writeUnitRuntimeRecord(
+    s.basePath,
+    unitType,
+    unitId,
+    unitStartedAt,
+    {
+      phase: "dispatched",
+      wrapupWarningSent: false,
+      timeoutAt: null,
+      lastProgressAt: unitStartedAt,
+      progressCount: 0,
+      lastProgressKind: "dispatch",
+      recoveryAttempts: 0, // Reset so re-dispatched units get full recovery budget (#2322)
+    },
+  );
 
   // Progress widget + preconditions — deferred to after model selection so the
   // widget's first render tick shows the correct model (#2899).

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1917,6 +1917,10 @@ export async function runUnitPhase(
   }
 
   // Select and apply model (with tier escalation on retry — normal units only)
+  const prevUnitRouting = s.currentUnitRouting;
+  const prevUnitModel = s.currentUnitModel;
+  const prevDispatchedModelId = s.currentDispatchedModelId;
+  const prevSessionModel = ctx.model;
   const modelResult = await deps.selectAndApplyModel(
     ctx,
     pi,
@@ -1986,6 +1990,15 @@ export async function runUnitPhase(
     },
   );
   if (compatibilityError) {
+    s.currentUnitRouting = prevUnitRouting;
+    s.currentUnitModel = prevUnitModel;
+    s.currentDispatchedModelId = prevDispatchedModelId;
+    if (prevSessionModel) {
+      await pi.setModel(prevSessionModel, { persist: false });
+      if (s.autoModeStartThinkingLevel) {
+        pi.setThinkingLevel(s.autoModeStartThinkingLevel);
+      }
+    }
     ctx.ui.notify(compatibilityError, "error");
     await deps.stopAuto(ctx, pi, compatibilityError);
     return { action: "break", reason: "workflow-capability" };

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -129,6 +129,8 @@ function makeMockPi() {
       setModelCalls.push(args);
       return true;
     },
+    getThinkingLevel: () => "off",
+    setThinkingLevel: () => {},
     calls,
     setModelCalls,
   } as any;

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -98,6 +98,8 @@ function makeMockPi() {
     sendMessage: (...args: unknown[]) => {
       calls.push(args);
     },
+    getThinkingLevel: () => "off",
+    setThinkingLevel: () => {},
     calls,
   } as any;
 }

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -161,6 +161,8 @@ function makeIC(
     pi: {
       sendMessage: () => {},
       setModel: async () => true,
+      getThinkingLevel: () => "off",
+      setThinkingLevel: () => {},
     } as any,
     s: makeSession(),
     deps,

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -22,6 +22,7 @@ import type { IterationContext, LoopState, PreDispatchData, IterationData } from
 import type { SessionLockStatus } from "../session-lock.js";
 import { runDispatch, runUnitPhase, runPreDispatch, runFinalize } from "../auto/phases.js";
 import { readUnitRuntimeRecord } from "../unit-runtime.js";
+import { ModelPolicyDispatchBlockedError } from "../auto-model-selection.js";
 import {
   closeDatabase,
   insertMilestone,
@@ -866,6 +867,49 @@ test("runUnitPhase increments unitDispatchCount for repeated artifact-missing re
   resolveAgentEnd({ messages: [{ role: "assistant" }] });
   await secondRun;
   assert.equal(ic.s.unitDispatchCount.get("execute-task/M001/S01/T01"), 2);
+});
+
+test("runUnitPhase pre-dispatch model validation failures do not emit unit-start or dispatch runtime state", async (t) => {
+  const capture = createEventCapture();
+  const base = mkdtempSync(join(tmpdir(), `gsd-pre-dispatch-block-${randomUUID()}`));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const deps = makeMockDeps(capture, {
+    selectAndApplyModel: async () => {
+      throw new ModelPolicyDispatchBlockedError("execute-task", "M001/S01/T01", []);
+    },
+  });
+  const ic = makeIC(deps, {
+    s: {
+      ...makeSession(),
+      basePath: base,
+    } as any,
+  });
+  const iterData: IterationData = {
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    prompt: "do stuff",
+    finalPrompt: "do stuff",
+    pauseAfterUatDispatch: false,
+    state: { phase: "executing", activeMilestone: { id: "M001" }, activeSlice: { id: "S01" }, registry: [], blockers: [] } as any,
+    mid: "M001",
+    midTitle: "Test",
+    isRetry: false,
+    previousTier: undefined,
+  };
+  const loopState: LoopState = { recentUnits: [{ key: "execute-task/M001/S01/T01" }], stuckRecoveryAttempts: 0, consecutiveFinalizeTimeouts: 0 };
+
+  await assert.rejects(() => runUnitPhase(ic, iterData, loopState), ModelPolicyDispatchBlockedError);
+  await assert.rejects(() => runUnitPhase(ic, iterData, loopState), ModelPolicyDispatchBlockedError);
+
+  const startEvents = capture.events.filter(e => e.eventType === "unit-start");
+  assert.equal(startEvents.length, 0, "pre-dispatch validation failures must not emit unit-start");
+  assert.equal(ic.s.unitDispatchCount.get("execute-task/M001/S01/T01") ?? 0, 0, "dispatch count must not increment on pre-dispatch validation failure");
+  assert.equal(
+    readUnitRuntimeRecord(base, "execute-task", "M001/S01/T01"),
+    null,
+    "pre-dispatch validation failures must not persist a dispatched runtime record",
+  );
 });
 
 test("all events from a mock iteration have monotonically increasing seq and same flowId", async () => {


### PR DESCRIPTION
## Summary
- Deferred `runUnitPhase` dispatch mutations until pre-dispatch checks pass and added regression tests proving no false dispatch state is recorded on validation failure.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #4962
- [#4962 auto: state mutations + journal emission happen before pre-dispatch validation succeeds (Change 4-B from #4959)](https://github.com/gsd-build/gsd-2/issues/4962)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/4962-auto-state-mutations-journal-emission-ha-1778742444`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model/transport compatibility is now validated before any unit-start side effects or dispatch bookkeeping, preventing dispatch records, increments, or emissions when validation fails.

* **Tests**
  * Added integration tests to confirm validation failures halt dispatching, emit no unit-start events, and do not persist runtime records on repeated attempts.
  * Extended test mocks to include thinking-level getters/setters so relevant paths are exercised.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6033)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->