### PR TITLE
fix(issue): GSD milestone completion falsely reports no implementation files when .gsd is external/ignored

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -562,7 +562,12 @@ function commitMatchesMilestone(basePath: string, message: string, milestoneId: 
     if (files.some((file) => isMilestoneArtifactPath(file, milestoneId))) return true;
     if (commitMessageMentionsMilestone(message, milestoneId)) return true;
     if (commitTaskTrailerBelongsToMilestone(basePath, message, milestoneId)) return true;
-    if (MILESTONE_ID_RE.test(milestoneId) && classifyImplementationFiles(files) === "present") return true;
+    if (MILESTONE_ID_RE.test(milestoneId) && classifyImplementationFiles(files) === "present") {
+      logWarning(
+        "recovery",
+        `unable to verify GSD-Task trailer ownership for ${milestoneId}; ignoring implementation-only commit evidence`,
+      );
+    }
   }
 
   return false;

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -34,7 +34,6 @@ import {
 import {
   existsSync,
   mkdirSync,
-  readdirSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
@@ -560,65 +559,52 @@ function commitMatchesMilestone(basePath: string, message: string, milestoneId: 
   // names the milestone, local GSD state proves the task belongs here, or the
   // commit is implementation-bearing evidence itself (#5100).
   if (/^GSD-Task:\s*S[^/\s]+\/T\S+/m.test(message)) {
-    const taskTrailerOwnership = getCommitTaskTrailerOwnershipStatus(basePath, message, milestoneId);
     if (files.some((file) => isMilestoneArtifactPath(file, milestoneId))) return true;
     if (commitMessageMentionsMilestone(message, milestoneId)) return true;
+    const taskTrailerOwnership = getTaskOwnershipStatus(basePath, message, milestoneId);
     if (taskTrailerOwnership === true) return true;
-    // Only apply implementation-bearing fallback when the DB has no record of
-    // the milestone (external/gitignored .gsd scenario). If the DB knows this
-    // milestone, a negative ownership check is authoritative and must not be
-    // overridden to avoid cross-milestone attribution.
-    if (
-      taskTrailerOwnership === undefined
-      &&
-      MILESTONE_ID_RE.test(milestoneId)
-      && classifyImplementationFiles(files) === "present"
-      && (!isDbAvailable() || !getMilestone(milestoneId))
-    ) return true;
+    if (taskTrailerOwnership === false) return false;
+    // taskTrailerOwnership === null: unknown ownership. Apply fallback only
+    // in this case to avoid cross-milestone attribution.
+    if (MILESTONE_ID_RE.test(milestoneId) && classifyImplementationFiles(files) === "present") return true;
   }
 
   return false;
 }
 
-function getCommitTaskTrailerOwnershipStatus(
+/**
+ * Tri-state task ownership probe.
+ * true => DB or local files confirm this milestone owns the task.
+ * false => DB is available and this milestone is registered, but task is absent.
+ * null => ownership unknown (milestone not in DB yet, or no DB + no local files).
+ */
+function getTaskOwnershipStatus(
   basePath: string,
   message: string,
   milestoneId: string,
-): true | false | undefined {
+): true | false | null {
   const match = message.match(/^GSD-Task:\s*(S[^/\s]+)\/(T[^\s]+)/m);
-  if (!match) return undefined;
+  if (!match) return null;
   const [, sliceId, taskId] = match;
 
-  if (getTask(milestoneId, sliceId, taskId)) return true;
+  if (isDbAvailable()) {
+    if (!getMilestone(milestoneId)) return null;
+    return getTask(milestoneId, sliceId, taskId) ? true : false;
+  }
 
+  // DB unavailable: fallback to local task-file presence.
   const tasksDir = resolveTasksDir(basePath, milestoneId, sliceId);
-  if (tasksDir) {
-    return existsSync(join(tasksDir, `${taskId}-PLAN.md`))
-      || existsSync(join(tasksDir, `${taskId}-SUMMARY.md`));
+  if (
+    tasksDir
+    && (
+      existsSync(join(tasksDir, `${taskId}-PLAN.md`))
+      || existsSync(join(tasksDir, `${taskId}-SUMMARY.md`))
+    )
+  ) {
+    return true;
   }
 
-  if (taskTrailerExistsInAnyMilestoneOnDisk(basePath, sliceId, taskId)) return false;
-  return undefined;
-}
-
-function taskTrailerExistsInAnyMilestoneOnDisk(basePath: string, sliceId: string, taskId: string): boolean {
-  const milestonesPath = join(basePath, ".gsd", "milestones");
-  if (!existsSync(milestonesPath)) return false;
-
-  let milestoneDirs: string[] = [];
-  try {
-    milestoneDirs = readdirSync(milestonesPath, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name);
-  } catch {
-    return false;
-  }
-
-  return milestoneDirs.some((milestoneDir) => {
-    const tasksDir = join(milestonesPath, milestoneDir, "slices", sliceId, "tasks");
-    return existsSync(join(tasksDir, `${taskId}-PLAN.md`))
-      || existsSync(join(tasksDir, `${taskId}-SUMMARY.md`));
-  });
+  return null;
 }
 
 function commitMessageMentionsMilestone(message: string, milestoneId: string): boolean {

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -556,11 +556,13 @@ function commitMatchesMilestone(basePath: string, message: string, milestoneId: 
   // rather than Mxx/Sxx/Tyy. Bind those commits back to the milestone when
   // either the commit touched this milestone's artifacts, or — for projects
   // where .gsd/ is gitignored/external (#5033) — the message explicitly
-  // names the milestone or local GSD state proves the task belongs here.
+  // names the milestone, local GSD state proves the task belongs here, or the
+  // commit is implementation-bearing evidence itself (#5100).
   if (/^GSD-Task:\s*S[^/\s]+\/T\S+/m.test(message)) {
     if (files.some((file) => isMilestoneArtifactPath(file, milestoneId))) return true;
     if (commitMessageMentionsMilestone(message, milestoneId)) return true;
     if (commitTaskTrailerBelongsToMilestone(basePath, message, milestoneId)) return true;
+    if (MILESTONE_ID_RE.test(milestoneId) && classifyImplementationFiles(files) === "present") return true;
   }
 
   return false;

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -34,6 +34,7 @@ import {
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
@@ -559,14 +560,17 @@ function commitMatchesMilestone(basePath: string, message: string, milestoneId: 
   // names the milestone, local GSD state proves the task belongs here, or the
   // commit is implementation-bearing evidence itself (#5100).
   if (/^GSD-Task:\s*S[^/\s]+\/T\S+/m.test(message)) {
+    const taskTrailerOwnership = getCommitTaskTrailerOwnershipStatus(basePath, message, milestoneId);
     if (files.some((file) => isMilestoneArtifactPath(file, milestoneId))) return true;
     if (commitMessageMentionsMilestone(message, milestoneId)) return true;
-    if (commitTaskTrailerBelongsToMilestone(basePath, message, milestoneId)) return true;
+    if (taskTrailerOwnership === true) return true;
     // Only apply implementation-bearing fallback when the DB has no record of
     // the milestone (external/gitignored .gsd scenario). If the DB knows this
     // milestone, a negative ownership check is authoritative and must not be
     // overridden to avoid cross-milestone attribution.
     if (
+      taskTrailerOwnership === undefined
+      &&
       MILESTONE_ID_RE.test(milestoneId)
       && classifyImplementationFiles(files) === "present"
       && (!isDbAvailable() || !getMilestone(milestoneId))
@@ -576,17 +580,45 @@ function commitMatchesMilestone(basePath: string, message: string, milestoneId: 
   return false;
 }
 
-function commitTaskTrailerBelongsToMilestone(basePath: string, message: string, milestoneId: string): boolean {
+function getCommitTaskTrailerOwnershipStatus(
+  basePath: string,
+  message: string,
+  milestoneId: string,
+): true | false | undefined {
   const match = message.match(/^GSD-Task:\s*(S[^/\s]+)\/(T[^\s]+)/m);
-  if (!match) return false;
+  if (!match) return undefined;
   const [, sliceId, taskId] = match;
 
   if (getTask(milestoneId, sliceId, taskId)) return true;
 
   const tasksDir = resolveTasksDir(basePath, milestoneId, sliceId);
-  if (!tasksDir) return false;
-  return existsSync(join(tasksDir, `${taskId}-PLAN.md`))
-    || existsSync(join(tasksDir, `${taskId}-SUMMARY.md`));
+  if (tasksDir) {
+    return existsSync(join(tasksDir, `${taskId}-PLAN.md`))
+      || existsSync(join(tasksDir, `${taskId}-SUMMARY.md`));
+  }
+
+  if (taskTrailerExistsInAnyMilestoneOnDisk(basePath, sliceId, taskId)) return false;
+  return undefined;
+}
+
+function taskTrailerExistsInAnyMilestoneOnDisk(basePath: string, sliceId: string, taskId: string): boolean {
+  const milestonesPath = join(basePath, ".gsd", "milestones");
+  if (!existsSync(milestonesPath)) return false;
+
+  let milestoneDirs: string[] = [];
+  try {
+    milestoneDirs = readdirSync(milestonesPath, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return false;
+  }
+
+  return milestoneDirs.some((milestoneDir) => {
+    const tasksDir = join(milestonesPath, milestoneDir, "slices", sliceId, "tasks");
+    return existsSync(join(tasksDir, `${taskId}-PLAN.md`))
+      || existsSync(join(tasksDir, `${taskId}-SUMMARY.md`));
+  });
 }
 
 function commitMessageMentionsMilestone(message: string, milestoneId: string): boolean {

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -562,12 +562,15 @@ function commitMatchesMilestone(basePath: string, message: string, milestoneId: 
     if (files.some((file) => isMilestoneArtifactPath(file, milestoneId))) return true;
     if (commitMessageMentionsMilestone(message, milestoneId)) return true;
     if (commitTaskTrailerBelongsToMilestone(basePath, message, milestoneId)) return true;
-    if (MILESTONE_ID_RE.test(milestoneId) && classifyImplementationFiles(files) === "present") {
-      logWarning(
-        "recovery",
-        `unable to verify GSD-Task trailer ownership for ${milestoneId}; ignoring implementation-only commit evidence`,
-      );
-    }
+    // Only apply implementation-bearing fallback when the DB has no record of
+    // the milestone (external/gitignored .gsd scenario). If the DB knows this
+    // milestone, a negative ownership check is authoritative and must not be
+    // overridden to avoid cross-milestone attribution.
+    if (
+      MILESTONE_ID_RE.test(milestoneId)
+      && classifyImplementationFiles(files) === "present"
+      && (!isDbAvailable() || !getMilestone(milestoneId))
+    ) return true;
   }
 
   return false;

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -1043,7 +1043,7 @@ test("hasImplementationArtifacts binds GSD-Task trailer to milestone via DB stat
   }
 });
 
-test("hasImplementationArtifacts does not bind GSD-Task trailer without milestone ownership evidence", () => {
+test("hasImplementationArtifacts accepts implementation-bearing GSD-Task commits when .gsd is gitignored/external (#5100)", () => {
   const base = makeGitBase();
   try {
     writeFileSync(join(base, ".git", "info", "exclude"), ".gsd/\n");
@@ -1059,8 +1059,8 @@ test("hasImplementationArtifacts does not bind GSD-Task trailer without mileston
     const result = hasImplementationArtifacts(base, "M001");
     assert.equal(
       result,
-      "absent",
-      "S01/T01 shape alone must not bind an implementation commit to M001",
+      "present",
+      "GSD-Task commits with implementation changes should count as milestone evidence when .gsd artifacts are unavailable",
     );
   } finally {
     cleanup(base);

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -1043,24 +1043,50 @@ test("hasImplementationArtifacts binds GSD-Task trailer to milestone via DB stat
   }
 });
 
-test("hasImplementationArtifacts accepts implementation-bearing GSD-Task commits when .gsd is gitignored/external (#5100)", () => {
+test("hasImplementationArtifacts does not claim Sxx/Tyy commit trailers across milestones when ownership points elsewhere", () => {
   const base = makeGitBase();
   try {
     writeFileSync(join(base, ".git", "info", "exclude"), ".gsd/\n");
+    mkdirSync(join(base, ".gsd"), { recursive: true });
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
+    insertMilestone({ id: "M002", title: "Milestone Two", status: "active" });
+    insertSlice({
+      id: "S01",
+      milestoneId: "M002",
+      title: "Slice One",
+      status: "complete",
+      risk: "low",
+      depends: [],
+    });
+    insertTask({
+      id: "T01",
+      sliceId: "S01",
+      milestoneId: "M002",
+      title: "Task One",
+      status: "complete",
+    });
+
     mkdirSync(join(base, "src"), { recursive: true });
     writeFileSync(join(base, "src", "feature.ts"), "export function feature() {}\n");
     execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
     execFileSync(
       "git",
-      ["commit", "-m", "feat: add feature\n\nGSD-Task: S01/T01"],
+      ["commit", "-m", "feat: add M002 feature\n\nGSD-Task: S01/T01"],
       { cwd: base, stdio: "ignore" },
     );
 
-    const result = hasImplementationArtifacts(base, "M001");
+    const m001Result = hasImplementationArtifacts(base, "M001");
+    const m002Result = hasImplementationArtifacts(base, "M002");
     assert.equal(
-      result,
+      m001Result,
+      "absent",
+      "Sxx/Tyy commit trailers owned by M002 must not be attributed to M001",
+    );
+    assert.equal(
+      m002Result,
       "present",
-      "GSD-Task commits with implementation changes should count as milestone evidence when .gsd artifacts are unavailable",
+      "the owning milestone should still claim the implementation-bearing commit",
     );
   } finally {
     cleanup(base);

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -1072,7 +1072,7 @@ test("hasImplementationArtifacts does not claim Sxx/Tyy commit trailers across m
     execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
     execFileSync(
       "git",
-      ["commit", "-m", "feat: add M002 feature\n\nGSD-Task: S01/T01"],
+      ["commit", "-m", "feat: add sibling feature\n\nGSD-Task: S01/T01"],
       { cwd: base, stdio: "ignore" },
     );
 


### PR DESCRIPTION
## Summary
- Fixed external/ignored `.gsd` milestone artifact false negatives by accepting implementation-bearing `GSD-Task` commits (with valid milestone IDs) and verified via `auto-recovery.test.ts` passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5100
- [#5100 GSD milestone completion falsely reports no implementation files when .gsd is external/ignored](https://github.com/gsd-build/gsd-2/issues/5100)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5100-gsd-milestone-completion-falsely-reports-1778742565`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved milestone attribution: task-scoped trailers now use a tri-state ownership probe with a DB-gated fallback so commits with non-.gsd implementation changes are correctly attributed when milestone records are missing or the DB is unavailable, reducing incorrect cross-milestone attribution.

* **Tests**
  * Updated tests to verify cross-milestone attribution and present/absent detection when implementation artifacts are excluded from tracked paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6034)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->