### PR TITLE
fix(issue): Persist pause reason for warning-level auto-mode dispatch stops

### DIFF
--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2096,6 +2096,7 @@ test("autoLoop pauses instead of stopping for warning-level dispatch stop", asyn
   ctx.ui.setStatus = () => {};
   const pi = makeMockPi();
   const s = makeLoopSession();
+  let pauseContext: unknown;
 
   const deps = makeMockDeps({
     resolveDispatch: async () => {
@@ -2105,6 +2106,10 @@ test("autoLoop pauses instead of stopping for warning-level dispatch stop", asyn
         reason: 'UAT verdict for S01 is "partial" — blocking progression.',
         level: "warning" as const,
       };
+    },
+    pauseAuto: async (_ctx, _pi, errorContext) => {
+      pauseContext = errorContext;
+      deps.callLog.push("pauseAuto");
     },
   });
 
@@ -2121,6 +2126,11 @@ test("autoLoop pauses instead of stopping for warning-level dispatch stop", asyn
   assert.ok(
     !deps.callLog.includes("stopAuto"),
     "warning-level stop should NOT call stopAuto (hard stop)",
+  );
+  assert.equal(
+    (pauseContext as { message?: string } | undefined)?.message,
+    'UAT verdict for S01 is "partial" — blocking progression.',
+    "warning-level stop should pass pause reason into pauseAuto for persisted paused metadata",
   );
 });
 


### PR DESCRIPTION
## Summary
- Added a focused auto-loop regression assertion that warning dispatch-stop reasons are forwarded into pause context and verified via the auto-loop test suite passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5231
- [#5231 Persist pause reason for warning-level auto-mode dispatch stops](https://github.com/gsd-build/gsd-2/issues/5231)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5231-persist-pause-reason-for-warning-level-a-1778742805`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved regression test for the warning-level dispatch stop: captures the pause context provided to the pause handler, stores it for inspection, and adds an assertion that the pause message exactly matches the expected warning reason. Existing assertions still verify that pause is invoked and automatic stop is not triggered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6036?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->