### PR TITLE
fix(issue): [Bug]: Model Preference Selection does not include discovered models

### DIFF
--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -587,10 +587,15 @@ async function configureModels(ctx: ExtensionCommandContext, prefs: Record<strin
   const models: Record<string, unknown> = (prefs.models as Record<string, unknown>) ?? {};
 
   const availableModels = ctx.modelRegistry.getAvailable();
-  if (availableModels.length > 0) {
+  const getAllWithDiscovered = (ctx.modelRegistry as { getAllWithDiscovered?: () => typeof availableModels }).getAllWithDiscovered;
+  const availableProviders = new Set(availableModels.map((m) => m.provider));
+  const selectableModels = typeof getAllWithDiscovered === "function"
+    ? getAllWithDiscovered().filter((m) => availableProviders.has(m.provider))
+    : availableModels;
+  if (selectableModels.length > 0) {
     // Group models by provider, sorted alphabetically
-    const byProvider = new Map<string, typeof availableModels>();
-    for (const m of availableModels) {
+    const byProvider = new Map<string, typeof selectableModels>();
+    for (const m of selectableModels) {
       let group = byProvider.get(m.provider);
       if (!group) {
         group = [];

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -141,3 +141,62 @@ test("category summaries expose the wizard menu surface for configured prefs", (
   assert.match(summaries.integrations, /remote: C123/);
   assert.match(summaries.verification, /1 cmd/);
 });
+
+test("models wizard offers discovered models for enabled providers", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-prefs-wizard-"));
+  const prefsPath = join(dir, "PREFERENCES.md");
+  const choices = [
+    "Models",
+    "local (2 models)",
+    "discovered-model",
+    "(keep current)",
+    "(keep current)",
+    "(keep current)",
+    "(keep current)",
+    "(keep current)",
+    "(keep current)",
+    "(keep current)",
+  ];
+  const ctx = {
+    modelRegistry: {
+      getAvailable: () => [{ provider: "local", id: "baseline-model" }],
+      getAllWithDiscovered: () => [
+        { provider: "local", id: "baseline-model" },
+        { provider: "local", id: "discovered-model" },
+        { provider: "disabled", id: "hidden-model" },
+      ],
+    },
+    ui: {
+      notify() {},
+      select: async (label: string, options: string[]) => {
+        const choice = choices.shift();
+        if (!choice && label === "GSD Preferences") return "── Save & Exit ──";
+        if (!choice && options.includes("(keep current)")) return "(keep current)";
+        if (!choice && options.includes("Done")) return "Done";
+        assert.ok(choice, `Unexpected prompt: ${label}`);
+        if (choice === "Models") {
+          const modelsOption = options.find((option) => option.startsWith("Models"));
+          assert.ok(modelsOption, "Expected Models category option");
+          return modelsOption;
+        }
+        assert.ok(options.includes(choice), `"${choice}" must be offered by "${label}"`);
+        assert.ok(!options.includes("hidden-model"), "models from disabled providers must not be offered");
+        return choice;
+      },
+      input: async () => null,
+    },
+    waitForIdle: async () => {},
+    reload: async () => {},
+  } as any;
+
+  try {
+    await handlePrefsWizard(ctx, "project", {}, { pathOverride: prefsPath });
+
+    assert.equal(choices.length, 0, "Expected all queued wizard choices to be consumed");
+    const saved = readFileSync(prefsPath, "utf-8");
+    assert.match(saved, /research:\s+local\/discovered-model/);
+    assert.doesNotMatch(saved, /hidden-model/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Prefs wizard now includes discovered provider models in model selection, verified with the preferences test suite passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5195
- [#5195 [Bug]: Model Preference Selection does not include discovered models](https://github.com/gsd-build/gsd-2/issues/5195)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5195-bug-model-preference-selection-does-not--1778743405`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The model selection in the preferences wizard now includes discovered models alongside standard options, with intelligent filtering to display only models from providers that are currently enabled.

* **Tests**
  * Added test coverage to verify the preferences wizard displays discovered models correctly, shows only models from enabled providers, and properly persists selected model choices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6038)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->