### PR TITLE
fix(issue): fix(notification-widget): multiline messages cause UI layout shift in belowEditor widget

### DIFF
--- a/src/resources/extensions/gsd/notification-widget.ts
+++ b/src/resources/extensions/gsd/notification-widget.ts
@@ -12,6 +12,7 @@ import { formattedShortcutPair } from "./shortcut-defs.js";
 // Key chosen to sort after alphabetic extension keys so the chip lands on the
 // far right of the extension-status block.
 const STATUS_KEY = "zz-notifications";
+const WIDGET_MAX_WIDTH = 80;
 
 export function buildNotificationChip(): string {
   const unread = getUnreadCount();
@@ -23,7 +24,12 @@ export function buildNotificationChip(): string {
 // that still expected a line-array widget. Returns empty when no unread.
 export function buildNotificationWidgetLines(): string[] {
   const chip = buildNotificationChip();
-  return chip ? [`  ${chip}`] : [];
+  if (!chip) return [];
+  const singleLine = chip.replace(/\s+/g, " ").trim();
+  const truncated = singleLine.length > WIDGET_MAX_WIDTH
+    ? `${singleLine.slice(0, WIDGET_MAX_WIDTH - 1)}…`
+    : singleLine;
+  return [`  ${truncated}`];
 }
 
 const REFRESH_INTERVAL_MS = 30_000;

--- a/src/resources/extensions/gsd/tests/notification-widget.test.ts
+++ b/src/resources/extensions/gsd/tests/notification-widget.test.ts
@@ -28,6 +28,25 @@ test("buildNotificationWidgetLines shows unread count with shortcut pair", () =>
   }
 });
 
+test("buildNotificationWidgetLines keeps multiline notifications on one bounded widget row", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-notification-widget-"));
+  try {
+    mkdirSync(join(tmp, ".gsd"), { recursive: true });
+    _resetNotificationStore();
+    initNotificationStore(tmp);
+    appendNotification("Line one\nLine two\nLine three", "warning");
+
+    const lines = buildNotificationWidgetLines();
+    assert.equal(lines.length, 1, "belowEditor fallback must not grow extra rows for multiline messages");
+    const row = lines[0] ?? "";
+    assert.equal(row.includes("\n"), false, "widget row must not contain embedded line breaks");
+    assert.ok(row.length <= 82, `widget row should stay bounded, got ${row.length} chars`);
+  } finally {
+    _resetNotificationStore();
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("initNotificationWidget replaces prior interval and store subscription", () => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-notification-widget-"));
   const firstStatuses: Array<string | undefined> = [];


### PR DESCRIPTION
## Summary
- Normalized notification widget lines to single-line 80-char output with ellipsis and verified via notification-widget unit tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #4239
- [#4239 fix(notification-widget): multiline messages cause UI layout shift in belowEditor widget](https://github.com/gsd-build/gsd-2/issues/4239)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/4239-fix-notification-widget-multiline-messag-1778746045`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification widget text is now normalized to a single line and automatically truncated to prevent display overflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6040)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->