### PR TITLE
fix(issue): manage_gitignore: false not respected by guided-flow, init-wizard, and doctor

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -15,6 +15,7 @@ import { readAllSessionStatuses, isSessionStale, removeSessionStatus } from "./s
 import { recoverFailedMigration } from "./migrate-external.js";
 import { splitCompletedKey } from "./forensics.js";
 import { findMilestoneIds } from "./milestone-ids.js";
+import { loadEffectiveGSDPreferences } from "./preferences.js";
 
 const MAX_UAT_ATTEMPTS = 3;
 
@@ -35,6 +36,8 @@ export async function checkRuntimeHealth(
   shouldFix: (code: DoctorIssueCode) => boolean,
 ): Promise<void> {
   const root = gsdRoot(basePath);
+  const gitPrefs = loadEffectiveGSDPreferences(basePath)?.preferences?.git;
+  const manageGitignore = gitPrefs?.manage_gitignore;
 
   // ── Stale crash lock ──────────────────────────────────────────────────
   // Phase C pt 2: the lock state lives in the workers + unit_dispatches
@@ -414,7 +417,7 @@ export async function checkRuntimeHealth(
           });
 
           if (shouldFix("gitignore_missing_patterns")) {
-            ensureGitignore(basePath);
+            ensureGitignore(basePath, { manageGitignore });
             fixesApplied.push("added missing GSD runtime patterns to .gitignore");
           }
         }
@@ -482,7 +485,7 @@ export async function checkRuntimeHealth(
           });
 
           if (shouldFix("symlinked_gsd_unignored")) {
-            const modified = ensureGitignore(basePath);
+            const modified = ensureGitignore(basePath, { manageGitignore });
             if (modified) fixesApplied.push("added .gsd to .gitignore (symlinked external state)");
           }
         }

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -1287,9 +1287,11 @@ function bootstrapGsdProject(basePath: string): void {
   mkdirSync(join(root, "milestones"), { recursive: true });
   mkdirSync(join(root, "runtime"), { recursive: true });
 
-  ensureGitignore(basePath);
+  const gitPrefs = loadEffectiveGSDPreferences(basePath)?.preferences?.git;
+  const manageGitignore = gitPrefs?.manage_gitignore;
+  ensureGitignore(basePath, { manageGitignore });
   ensurePreferences(basePath);
-  untrackRuntimeFiles(basePath);
+  if (manageGitignore !== false) untrackRuntimeFiles(basePath);
 }
 
 /**
@@ -2036,8 +2038,10 @@ export async function showSmartEntry(
 
   // ── Ensure .gitignore has baseline patterns ──────────────────────────
   if (!skipGitBootstrap && nativeIsRepo(basePath)) {
-    ensureGitignore(basePath);
-    untrackRuntimeFiles(basePath);
+    const gitPrefs = loadEffectiveGSDPreferences(basePath)?.preferences?.git;
+    const manageGitignore = gitPrefs?.manage_gitignore;
+    ensureGitignore(basePath, { manageGitignore });
+    if (manageGitignore !== false) untrackRuntimeFiles(basePath);
   }
 
   // Deep setup can pre-create .gsd/PREFERENCES.md before the normal init

--- a/src/resources/extensions/gsd/init-wizard.ts
+++ b/src/resources/extensions/gsd/init-wizard.ts
@@ -18,6 +18,7 @@ import type { ProjectDetection, ProjectSignals } from "./detection.js";
 import { runSkillInstallStep } from "./skill-catalog.js";
 import { generateCodebaseMap, writeCodebaseMap } from "./codebase-generator.js";
 import { handlePrefsWizard, writePreferencesFile } from "./commands-prefs-wizard.js";
+import { loadEffectiveGSDPreferences } from "./preferences.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────────
 
@@ -304,8 +305,10 @@ export async function showProjectInit(
   // Ensure .gitignore only when git is active. A user who selected "Skip"
   // should not have git initialized or git-related files mutated later.
   if (shouldWriteGitFiles(gitEnabled)) {
-    ensureGitignore(basePath);
-    untrackRuntimeFiles(basePath);
+    const gitPrefs = loadEffectiveGSDPreferences(basePath)?.preferences?.git;
+    const manageGitignore = gitPrefs?.manage_gitignore;
+    ensureGitignore(basePath, { manageGitignore });
+    if (manageGitignore !== false) untrackRuntimeFiles(basePath);
   }
 
   // Create initial commit so git log and git worktree work immediately (#4530).

--- a/src/resources/extensions/gsd/tests/doctor-runtime-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-runtime-checks.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runGSDDoctor } from "../doctor.ts";
+
+function runGit(cwd: string, args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function createGitProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-doctor-runtime-checks-"));
+  runGit(dir, ["init"]);
+  runGit(dir, ["config", "user.email", "test@test.com"]);
+  runGit(dir, ["config", "user.name", "Test"]);
+  writeFileSync(join(dir, "README.md"), "# test\n", "utf-8");
+  runGit(dir, ["add", "."]);
+  runGit(dir, ["commit", "-m", "init"]);
+  return dir;
+}
+
+test("doctor fix respects git.manage_gitignore false (#4161)", async (t) => {
+  const dir = createGitProject();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  writeFileSync(
+    join(dir, ".gsd", "PREFERENCES.md"),
+    "---\nversion: 1\ngit:\n  manage_gitignore: false\n---\n",
+    "utf-8",
+  );
+  writeFileSync(join(dir, ".gitignore"), "node_modules/\n", "utf-8");
+
+  const detect = await runGSDDoctor(dir);
+  assert.ok(
+    detect.issues.some((issue) => issue.code === "gitignore_missing_patterns"),
+    "doctor still reports missing runtime ignore patterns so users can decide how to handle them",
+  );
+
+  await runGSDDoctor(dir, { fix: true });
+
+  assert.equal(readFileSync(join(dir, ".gitignore"), "utf-8"), "node_modules/\n");
+  assert.equal(existsSync(join(dir, ".gsd", "PREFERENCES.md")), true);
+});


### PR DESCRIPTION
## Summary
- Passed `manage_gitignore` preference through guided-flow, init-wizard, and doctor runtime `.gitignore` paths and verified with focused tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #4161
- [#4161 manage_gitignore: false not respected by guided-flow, init-wizard, and doctor](https://github.com/gsd-build/gsd-2/issues/4161)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/4161-manage-gitignore-false-not-respected-by--1778746166`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gitignore auto-management is now configurable through user preferences instead of always being enabled. Users can disable automatic .gitignore pattern updates and runtime file untracking during project initialization, guided setup flows, and system health diagnostics. This enhancement provides greater flexibility in controlling how the extension manages git-related files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6041)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->