### PR TITLE
fix(issue): OpenAI-compat: reasoning_content echoed back to server causes 400 on TensorRT-LLM / vLLM providers

### DIFF
--- a/docs/user-docs/custom-models.md
+++ b/docs/user-docs/custom-models.md
@@ -36,6 +36,7 @@ For local models (Ollama, LM Studio, vLLM), only `id` is required per model:
 The `apiKey` is required but Ollama ignores it, so any value works.
 
 Some OpenAI-compatible servers do not understand the `developer` role used for reasoning-capable models. For those providers, set `compat.supportsDeveloperRole` to `false` so GSD sends the system prompt as a `system` message instead. If the server also does not support `reasoning_effort`, set `compat.supportsReasoningEffort` to `false` too.
+Some servers (including certain vLLM/TensorRT-LLM deployments) can return 400 errors when prior assistant `reasoning_content` is replayed. Set `compat.stripReasoningContent` to `true` to remove those replayed fields from outbound history.
 
 You can set `compat` at the provider level to apply to all models, or at the model level to override a specific model. This commonly applies to Ollama, vLLM, SGLang, and similar OpenAI-compatible servers.
 
@@ -48,7 +49,8 @@ You can set `compat` at the provider level to apply to all models, or at the mod
       "apiKey": "ollama",
       "compat": {
         "supportsDeveloperRole": false,
-        "supportsReasoningEffort": false
+        "supportsReasoningEffort": false,
+        "stripReasoningContent": true
       },
       "models": [
         {
@@ -300,6 +302,7 @@ For providers with partial OpenAI compatibility, use the `compat` field.
 | `requiresToolResultName` | Include `name` on tool result messages |
 | `requiresAssistantAfterToolResult` | Insert an assistant message before a user message after tool results |
 | `requiresThinkingAsText` | Convert thinking blocks to plain text |
+| `stripReasoningContent` | Strip replayed assistant `reasoning_content` fields from outbound message history (default: `false`; enable for some vLLM/TensorRT-LLM endpoints that otherwise return 400 errors) |
 | `thinkingFormat` | Use `reasoning_effort`, `zai`, `qwen`, or `qwen-chat-template` thinking parameters |
 | `supportsStrictMode` | Include the `strict` field in tool definitions |
 | `openRouterRouting` | OpenRouter routing config passed to OpenRouter for model/provider selection |

--- a/gitbook/configuration/custom-models.md
+++ b/gitbook/configuration/custom-models.md
@@ -52,16 +52,20 @@ Local and non-standard servers often need compatibility adjustments:
   "compat": {
     "supportsDeveloperRole": false,
     "supportsReasoningEffort": false,
+    "stripReasoningContent": true,
     "supportsUsageInStreaming": false,
     "thinkingFormat": "qwen"
   }
 }
 ```
 
+Some OpenAI-compatible servers can return 400 errors when prior assistant `reasoning_content` is replayed (commonly seen on certain vLLM/TensorRT-LLM deployments). Set `compat.stripReasoningContent` to `true` to strip those replayed fields from outbound history.
+
 | Flag | Default | Purpose |
 |------|---------|---------|
 | `supportsDeveloperRole` | `true` | Set `false` if the server doesn't support the `developer` message role |
 | `supportsReasoningEffort` | `true` | Set `false` if the server doesn't support reasoning effort parameters |
+| `stripReasoningContent` | `false` | Set `true` to strip replayed assistant `reasoning_content` fields from outbound history (useful for some vLLM/TensorRT-LLM endpoints that otherwise return 400 errors) |
 | `supportsUsageInStreaming` | `true` | Set `false` if streaming responses don't include token usage |
 | `thinkingFormat` | — | Set `"qwen"` for Qwen thinking mode, `"qwen-chat-template"` for chat template variant |
 

--- a/mintlify-docs/guides/custom-models.mdx
+++ b/mintlify-docs/guides/custom-models.mdx
@@ -29,6 +29,8 @@ For local models (Ollama, LM Studio, vLLM):
 
 The `apiKey` is required but Ollama ignores it — any value works.
 
+Some OpenAI-compatible servers can return 400 errors when prior assistant `reasoning_content` is replayed (commonly seen on certain vLLM/TensorRT-LLM deployments). Set `compat.stripReasoningContent` to `true` to strip those replayed fields from outbound history.
+
 ## Supported APIs
 
 | API | Description |
@@ -101,7 +103,8 @@ For providers with partial OpenAI compatibility, use the `compat` field at provi
       "api": "openai-completions",
       "compat": {
         "supportsDeveloperRole": false,
-        "supportsReasoningEffort": false
+        "supportsReasoningEffort": false,
+        "stripReasoningContent": true
       },
       "models": [...]
     }
@@ -114,6 +117,7 @@ For providers with partial OpenAI compatibility, use the `compat` field at provi
 | `supportsDeveloperRole` | Use `developer` vs `system` role |
 | `supportsReasoningEffort` | Support for `reasoning_effort` parameter |
 | `supportsUsageInStreaming` | Support for `stream_options: { include_usage: true }` |
+| `stripReasoningContent` | Strip replayed assistant `reasoning_content` fields from outbound message history (default: `false`; enable for some vLLM/TensorRT-LLM endpoints that otherwise return 400 errors) |
 | `maxTokensField` | `max_completion_tokens` or `max_tokens` |
 | `thinkingFormat` | `reasoning_effort`, `zai`, `qwen`, or `qwen-chat-template` |
 | `openRouterRouting` | OpenRouter provider selection config |

--- a/packages/pi-ai/src/providers/openai-completions.test.ts
+++ b/packages/pi-ai/src/providers/openai-completions.test.ts
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { convertMessages } from "./openai-completions.ts";
+import type { Context, Model } from "../types.ts";
+
+const baseModel: Model<"openai-completions"> = {
+	id: "local/reasoning-model",
+	name: "Local Reasoning Model",
+	api: "openai-completions",
+	provider: "openai",
+	baseUrl: "http://localhost:8000/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128000,
+	maxTokens: 4096,
+};
+
+test("convertMessages strips reasoning_content replay when compat.stripReasoningContent is enabled", () => {
+	const context: Context = {
+		messages: [
+			{ role: "user", content: "hello", timestamp: 1 },
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "internal chain", thinkingSignature: "reasoning_content" },
+					{ type: "text", text: "Hi" },
+				],
+				api: "openai-completions",
+				provider: "openai",
+				model: "local/reasoning-model",
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: 2,
+			},
+		],
+	};
+
+	const disabledCompat = {
+		supportsStore: false,
+		supportsDeveloperRole: true,
+		supportsReasoningEffort: true,
+		reasoningEffortMap: {},
+		supportsUsageInStreaming: true,
+		maxTokensField: "max_completion_tokens" as const,
+		requiresToolResultName: false,
+		requiresAssistantAfterToolResult: false,
+		requiresThinkingAsText: false,
+		stripReasoningContent: true,
+		thinkingFormat: "openai" as const,
+		openRouterRouting: {},
+		vercelGatewayRouting: {},
+		supportsStrictMode: true,
+	};
+	const enabledCompat = { ...disabledCompat, stripReasoningContent: false };
+
+	const stripped = convertMessages(baseModel, context, disabledCompat);
+	const replayedAssistant = stripped.find((m) => m.role === "assistant") as Record<string, unknown>;
+	assert.equal(replayedAssistant.reasoning_content, undefined);
+
+	const passthrough = convertMessages(baseModel, context, enabledCompat);
+	const replayedAssistantWithReasoning = passthrough.find((m) => m.role === "assistant") as Record<string, unknown>;
+	assert.equal(replayedAssistantWithReasoning.reasoning_content, "internal chain");
+});

--- a/packages/pi-ai/src/providers/openai-completions.test.ts
+++ b/packages/pi-ai/src/providers/openai-completions.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { convertMessages } from "./openai-completions.ts";
-import type { Context, Model } from "../types.ts";
+import { convertMessages } from "./openai-completions.js";
+import type { Context, Model } from "../types.js";
 
 const baseModel: Model<"openai-completions"> = {
 	id: "local/reasoning-model",
@@ -62,10 +62,14 @@ test("convertMessages strips reasoning_content replay when compat.stripReasoning
 	const enabledCompat = { ...disabledCompat, stripReasoningContent: false };
 
 	const stripped = convertMessages(baseModel, context, disabledCompat);
-	const replayedAssistant = stripped.find((m) => m.role === "assistant") as Record<string, unknown>;
-	assert.equal(replayedAssistant.reasoning_content, undefined);
+	const replayedAssistant = stripped.find((m) => m.role === "assistant");
+	assert.ok(replayedAssistant);
+	const replayedAssistantRecord = replayedAssistant as unknown as { reasoning_content?: string };
+	assert.equal(replayedAssistantRecord.reasoning_content, undefined);
 
 	const passthrough = convertMessages(baseModel, context, enabledCompat);
-	const replayedAssistantWithReasoning = passthrough.find((m) => m.role === "assistant") as Record<string, unknown>;
-	assert.equal(replayedAssistantWithReasoning.reasoning_content, "internal chain");
+	const replayedAssistantWithReasoning = passthrough.find((m) => m.role === "assistant");
+	assert.ok(replayedAssistantWithReasoning);
+	const replayedAssistantWithReasoningRecord = replayedAssistantWithReasoning as unknown as { reasoning_content?: string };
+	assert.equal(replayedAssistantWithReasoningRecord.reasoning_content, "internal chain");
 });

--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -474,6 +474,11 @@ function maybeAddOpenRouterAnthropicCacheControl(
 	}
 }
 
+/**
+ * Convert pi-ai Context messages to OpenAI ChatCompletionMessageParam format.
+ * The compat object controls provider-specific behavior (e.g. stripReasoningContent,
+ * requiresThinkingAsText) that affects how assistant thinking blocks are serialized.
+ */
 export function convertMessages(
 	model: Model<"openai-completions">,
 	context: Context,

--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -587,7 +587,7 @@ export function convertMessages(
 				} else {
 					// Use the signature from the first thinking block if available (for llama.cpp server + gpt-oss)
 					const signature = nonEmptyThinkingBlocks[0].thinkingSignature;
-					if (signature && signature.length > 0) {
+					if (!compat.stripReasoningContent && signature && signature.length > 0) {
 						(assistantMsg as any)[signature] = nonEmptyThinkingBlocks.map((b) => b.thinking).join("\n");
 					}
 				}
@@ -789,6 +789,7 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 		requiresToolResultName: false,
 		requiresAssistantAfterToolResult: false,
 		requiresThinkingAsText: false,
+		stripReasoningContent: false,
 		thinkingFormat: isZai ? "zai" : "openai",
 		openRouterRouting: {},
 		vercelGatewayRouting: {},
@@ -815,6 +816,7 @@ function getCompat(model: Model<"openai-completions">): Required<OpenAICompletio
 		requiresAssistantAfterToolResult:
 			model.compat.requiresAssistantAfterToolResult ?? detected.requiresAssistantAfterToolResult,
 		requiresThinkingAsText: model.compat.requiresThinkingAsText ?? detected.requiresThinkingAsText,
+		stripReasoningContent: model.compat.stripReasoningContent ?? detected.stripReasoningContent,
 		thinkingFormat: model.compat.thinkingFormat ?? detected.thinkingFormat,
 		openRouterRouting: model.compat.openRouterRouting ?? {},
 		vercelGatewayRouting: model.compat.vercelGatewayRouting ?? detected.vercelGatewayRouting,

--- a/packages/pi-ai/src/types.ts
+++ b/packages/pi-ai/src/types.ts
@@ -312,6 +312,8 @@ export interface OpenAICompletionsCompat {
 	requiresAssistantAfterToolResult?: boolean;
 	/** Whether thinking blocks must be converted to text blocks with <thinking> delimiters. Default: auto-detected from URL. */
 	requiresThinkingAsText?: boolean;
+	/** Whether to strip replayed `reasoning_content`-style assistant fields from outbound messages. Default: false. */
+	stripReasoningContent?: boolean;
 	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "zai" uses thinking: { type: "enabled" }, "qwen" uses enable_thinking: boolean. Default: "openai". */
 	thinkingFormat?: "openai" | "zai" | "qwen";
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */


### PR DESCRIPTION
## Summary
- Added a model compat flag to strip replayed reasoning_content in openai-completions and verified with a focused regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #4647
- [#4647 OpenAI-compat: reasoning_content echoed back to server causes 400 on TensorRT-LLM / vLLM providers](https://github.com/gsd-build/gsd-2/issues/4647)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/4647-openai-compat-reasoning-content-echoed-b-1778746285`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a provider-level compat option `stripReasoningContent` to control whether assistant reasoning content is preserved or stripped (default: preserve).

* **Tests**
  * Added a Node test validating behavior when reasoning content is preserved vs. stripped.

* **Documentation**
  * Updated user and guides to document the new `compat.stripReasoningContent` flag and examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6042)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->