### PR TITLE
fix(issue): isVerificationNotApplicable regex rejects N/A with trailing explanatory text

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -331,7 +331,7 @@ export function incrementUatCount(basePath: string, mid: string, sid: string): n
 export function isVerificationNotApplicable(value: string): boolean {
   const v = (value ?? "").toLowerCase().trim().replace(/[.\s]+$/, "");
   if (!v || v === "none") return true;
-  return /^(?:none(?:[\s._\u2014-]+[\s\S]*)?|n\/?a|not[\s._-]+(?:applicable|required|needed|provided)|no[\s._-]+operational[\s\S]*)$/i.test(v);
+  return /^(?:none(?:[\s._\u2014-]+[\s\S]*)?|n\/?a(?:[\s._\u2014-]+[\s\S]*)?|not[\s._-]+(?:applicable|required|needed|provided)|no[\s._-]+operational[\s\S]*)$/i.test(v);
 }
 
 // ─── Rules ────────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/verification-operational-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-operational-gate.test.ts
@@ -51,6 +51,10 @@ test("isVerificationNotApplicable: 'n/a' is not applicable", () => {
   assert.equal(isVerificationNotApplicable("n/a"), true);
 });
 
+test("isVerificationNotApplicable: 'N/A — <rationale>' is not applicable", () => {
+  assert.equal(isVerificationNotApplicable("N/A — local-only tool."), true);
+});
+
 test("isVerificationNotApplicable: 'Not applicable' is not applicable", () => {
   assert.equal(isVerificationNotApplicable("Not applicable"), true);
 });


### PR DESCRIPTION
## Summary
- Expanded the `n/a` regex branch to accept trailing rationale text and verified with a new focused regression test that passes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5354
- [#5354 isVerificationNotApplicable regex rejects N/A with trailing explanatory text](https://github.com/gsd-build/gsd-2/issues/5354)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5354-isverificationnotapplicable-regex-reject-1778746405`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded recognition of "not applicable" status text variations to include additional formats with alternative separators and punctuation.

* **Tests**
  * Added test coverage for new "not applicable" format variations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6043)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->