### PR TITLE
fix(issue): recentDecisions missing from STATE.md and headless query despite decisions existing in DECISIONS.md

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -208,6 +208,43 @@ let _telemetry = { dbDeriveCount: 0, markdownDeriveCount: 0 };
 export function getDeriveTelemetry() { return { ..._telemetry }; }
 export function resetDeriveTelemetry() { _telemetry = { dbDeriveCount: 0, markdownDeriveCount: 0 }; }
 
+async function loadRecentDecisions(basePath: string): Promise<string[]> {
+  const decisionsPath = resolveGsdRootFile(basePath, "DECISIONS");
+  const content = await loadFile(decisionsPath);
+  if (!content) return [];
+
+  const fromTable = content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("|"))
+    .map((line) => {
+      const cells = line
+        .split("|")
+        .map((cell) => cell.trim())
+        .filter((cell) => cell.length > 0);
+      if (cells.length < 6) return null;
+      const id = cells[0];
+      if (!/^D\d+$/i.test(id)) return null;
+      const whenContext = cells[1];
+      const decision = cells[3];
+      const choice = cells[4];
+      if (!decision || !choice) return null;
+      return `${id} (${whenContext}): ${decision} -> ${choice}`;
+    })
+    .filter((value): value is string => value != null);
+
+  if (fromTable.length > 0) return fromTable.slice(-5);
+
+  const fromBullets = content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /^-\s+/.test(line))
+    .map((line) => line.replace(/^-+\s+/, ""))
+    .filter((line) => /^D\d+\b/i.test(line));
+
+  return fromBullets.slice(-5);
+}
+
 /**
  * Invalidate the deriveState() cache. Call this whenever planning files on disk
  * may have changed (unit completion, merges, file writes).
@@ -352,6 +389,7 @@ export async function deriveState(
     };
   }
 
+  result.recentDecisions = await loadRecentDecisions(cacheKey);
   stopTimer({ phase: result.phase, milestone: result.activeMilestone?.id });
   debugCount("deriveStateCalls");
   _stateCache = { basePath: cacheKey, result, timestamp: Date.now() };

--- a/src/resources/extensions/gsd/tests/derive-state.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state.test.ts
@@ -60,6 +60,10 @@ function writeRequirements(base: string, content: string): void {
   writeFileSync(join(base, '.gsd', 'REQUIREMENTS.md'), content);
 }
 
+function writeDecisions(base: string, content: string): void {
+  writeFileSync(join(base, '.gsd', 'DECISIONS.md'), content);
+}
+
 function cleanup(base: string): void {
   rmSync(base, { recursive: true, force: true });
 }
@@ -172,6 +176,35 @@ describe('derive-state', async () => {
       assert.deepStrictEqual(state.activeTask?.id, 'T01', 'activeTask id is T01');
       assert.deepStrictEqual(state.progress?.tasks?.done, 0, 'tasks done = 0');
       assert.deepStrictEqual(state.progress?.tasks?.total, 2, 'tasks total = 2');
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  test('loads recent decisions from DECISIONS.md table', async () => {
+    const base = createFixtureBase();
+    try {
+      writeRoadmap(base, 'M001', `# M001: Test Milestone
+
+**Vision:** Test decisions projection.
+
+## Slices
+
+- [ ] **S01: Test Slice** \`risk:low\` \`depends:[]\`
+  > After this: Slice is done.
+`);
+      writeDecisions(base, `# Decisions
+
+| # | When/Context | Scope | Decision | Choice | Rationale | Revisable? | Made By |
+|---|---|---|---|---|---|---|---|
+| D001 | M001/S01 | architecture | Use queue worker | yes | Needed for scale | yes | agent |
+| D002 | M001/S01 | pattern | Prefer explicit cache key | yes | Prevent stale state | yes | agent |
+`);
+
+      const state = await deriveState(base);
+      assert.deepStrictEqual(state.recentDecisions.length, 2, 'two decisions loaded');
+      assert.ok(state.recentDecisions[0]?.includes('D001'), 'includes first decision id');
+      assert.ok(state.recentDecisions[1]?.includes('D002'), 'includes second decision id');
     } finally {
       cleanup(base);
     }


### PR DESCRIPTION
## Summary
- Centralized recent decision loading in deriveState and verified with new regression test plus focused derive-state/headless-query test run.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5122
- [#5122 recentDecisions missing from STATE.md and headless query despite decisions existing in DECISIONS.md](https://github.com/gsd-build/gsd-2/issues/5122)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5122-recentdecisions-missing-from-state-md-an-1778746646`