### PR TITLE
fix(issue): bug(parallel): headless idle timeout (15s) kills workers during inter-unit gaps + refreshWorkerStatuses overrides stopped→error

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -511,7 +511,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
   // Idle timeout — fallback completion detection
   let idleTimer: ReturnType<typeof setTimeout> | null = null
-  const effectiveIdleTimeout = isNewMilestone
+  let effectiveIdleTimeout = isNewMilestone
     ? NEW_MILESTONE_IDLE_TIMEOUT_MS
     : isAutoMode
       ? 0
@@ -938,6 +938,8 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     completed = false
     milestoneReady = false
     blocked = false
+    effectiveIdleTimeout = 0
+    resetIdleTimer()
     const autoCompletionPromise = new Promise<void>((resolve) => {
       resolveCompletion = resolve
     })

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -511,11 +511,18 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
   // Idle timeout — fallback completion detection
   let idleTimer: ReturnType<typeof setTimeout> | null = null
-  const effectiveIdleTimeout = isNewMilestone ? NEW_MILESTONE_IDLE_TIMEOUT_MS : IDLE_TIMEOUT_MS
+  const effectiveIdleTimeout = isNewMilestone
+    ? NEW_MILESTONE_IDLE_TIMEOUT_MS
+    : isAutoMode
+      ? 0
+      : IDLE_TIMEOUT_MS
 
   function resetIdleTimer(): void {
     if (idleTimer) clearTimeout(idleTimer)
-    if (shouldArmHeadlessIdleTimeout(toolCallCount, interactiveToolCallIds.size)) {
+    if (
+      effectiveIdleTimeout > 0 &&
+      shouldArmHeadlessIdleTimeout(toolCallCount, interactiveToolCallIds.size)
+    ) {
       idleTimer = setTimeout(() => {
         completed = true
         resolveCompletion()

--- a/src/resources/extensions/gsd/parallel-orchestrator.ts
+++ b/src/resources/extensions/gsd/parallel-orchestrator.ts
@@ -1005,6 +1005,9 @@ export function refreshWorkerStatuses(
   for (const [mid, worker] of state.workers) {
     const diskStatus = statusMap.get(mid);
     if (!diskStatus) {
+      if (worker.state === "stopped" || worker.state === "error") {
+        continue;
+      }
       if (!isPidAlive(worker.pid)) {
         worker.cleanup?.();
         worker.cleanup = undefined;

--- a/src/resources/extensions/gsd/tests/parallel-orchestrator-zombie-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-orchestrator-zombie-cleanup.test.ts
@@ -275,3 +275,58 @@ test("#2736: restoreRuntimeState clears stale state when all workers are stopped
   const stateFile = join(base, ".gsd", "orchestrator.json");
   assert.equal(existsSync(stateFile), false, "orchestrator.json should be removed");
 });
+
+test("#3428: refreshWorkerStatuses preserves terminal stopped state when disk status is missing", (t) => {
+  const base = makeTmpBase();
+  t.after(() => {
+    resetOrchestrator();
+    cleanup(base);
+  });
+
+  const persisted: PersistedState = {
+    active: true,
+    workers: [
+      {
+        milestoneId: "M001",
+        title: "Milestone 1",
+        pid: process.pid,
+        worktreePath: join(base, "worktrees", "M001"),
+        startedAt: Date.now() - 60_000,
+        state: "running",
+        cost: 0.4,
+      },
+      {
+        milestoneId: "M002",
+        title: "Milestone 2",
+        pid: process.pid,
+        worktreePath: join(base, "worktrees", "M002"),
+        startedAt: Date.now() - 60_000,
+        state: "running",
+        cost: 0.6,
+      },
+    ],
+    totalCost: 1.0,
+    startedAt: Date.now() - 60_000,
+    configSnapshot: { max_workers: 3 },
+  };
+  writePersistedState(base, persisted);
+
+  // Restore into memory first.
+  getWorkerStatuses(base);
+
+  // Simulate exit handler already marking the worker as stopped while session
+  // status file is missing and pid is dead.
+  const orchestrator = getOrchestratorState();
+  assert.ok(orchestrator, "orchestrator state should be restored");
+  const worker = orchestrator.workers.get("M001");
+  assert.ok(worker, "worker should exist");
+  worker.state = "stopped";
+  worker.pid = DEAD_PID;
+  writeSessionStatusFile(base, "M002", "running", process.pid);
+
+  refreshWorkerStatuses(base);
+
+  const refreshed = getOrchestratorState();
+  assert.ok(refreshed, "state should remain available for inspection");
+  assert.equal(refreshed.workers.get("M001")?.state, "stopped");
+});


### PR DESCRIPTION
## Summary
- Disabled headless idle timeout for auto-mode and prevented refresh logic from overwriting stopped/error workers when status files are missing, verified by targeted passing tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #3428
- [#3428 bug(parallel): headless idle timeout (15s) kills workers during inter-unit gaps + refreshWorkerStatuses overrides stopped→error](https://github.com/gsd-build/gsd-2/issues/3428)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/3428-bug-parallel-headless-idle-timeout-15s-k-1778750849`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed idle timeout handling in headless runs to avoid activating completion timers when idle timeout is disabled.
  * Prevented terminal worker states from being overwritten during status refresh operations.

* **Tests**
  * Added a regression test to ensure worker terminal states are preserved during status reconciliation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6049)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->