### PR TITLE
fix(issue): gsd.db corrupts repeatedly on WSL2 9p mounts (/mnt/d, /mnt/c) — WAL+mmap pragmas unsafe

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -111,8 +111,8 @@ const providerLoader = createSqliteProviderLoader({
 
 export const SCHEMA_VERSION = 28;
 
-function initSchema(db: DbAdapter, fileBacked: boolean): void {
-  const conservativeFilePragmas = fileBacked && _isLikelyWslDrvFsPathForTest(currentPath);
+function initSchema(db: DbAdapter, fileBacked: boolean, dbPath: string | null): void {
+  const conservativeFilePragmas = fileBacked && _isLikelyWslDrvFsPathForTest(dbPath);
   if (fileBacked) db.exec(conservativeFilePragmas ? "PRAGMA journal_mode=DELETE" : "PRAGMA journal_mode=WAL");
   if (fileBacked) db.exec("PRAGMA busy_timeout = 5000");
   if (fileBacked) db.exec(conservativeFilePragmas ? "PRAGMA synchronous = FULL" : "PRAGMA synchronous = NORMAL");
@@ -617,14 +617,14 @@ export function openDatabase(path: string): boolean {
   const adapter = createDbAdapter(rawDb);
   const fileBacked = path !== ":memory:";
   try {
-    initSchema(adapter, fileBacked);
+    initSchema(adapter, fileBacked, path);
   } catch (err) {
     // Corrupt freelist: DDL fails with "malformed" but VACUUM can rebuild.
     // Attempt VACUUM recovery before giving up (see #2519).
     if (fileBacked && err instanceof Error && err.message?.includes("malformed")) {
       try {
         adapter.exec("VACUUM");
-        initSchema(adapter, fileBacked);
+        initSchema(adapter, fileBacked, path);
         process.stderr.write("gsd-db: recovered corrupt database via VACUUM\n");
       } catch (retryErr) {
         _dbOpenState.recordError("vacuum-recovery", retryErr);

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -112,12 +112,13 @@ const providerLoader = createSqliteProviderLoader({
 export const SCHEMA_VERSION = 28;
 
 function initSchema(db: DbAdapter, fileBacked: boolean): void {
-  if (fileBacked) db.exec("PRAGMA journal_mode=WAL");
+  const conservativeFilePragmas = fileBacked && _isLikelyWslDrvFsPathForTest(currentPath);
+  if (fileBacked) db.exec(conservativeFilePragmas ? "PRAGMA journal_mode=DELETE" : "PRAGMA journal_mode=WAL");
   if (fileBacked) db.exec("PRAGMA busy_timeout = 5000");
-  if (fileBacked) db.exec("PRAGMA synchronous = NORMAL");
+  if (fileBacked) db.exec(conservativeFilePragmas ? "PRAGMA synchronous = FULL" : "PRAGMA synchronous = NORMAL");
   if (fileBacked) db.exec("PRAGMA auto_vacuum = INCREMENTAL");
   if (fileBacked) db.exec("PRAGMA cache_size = -8000");   // 8 MB page cache
-  if (fileBacked && process.platform !== "darwin") db.exec("PRAGMA mmap_size = 67108864");  // 64 MB mmap
+  if (fileBacked && !conservativeFilePragmas && process.platform !== "darwin") db.exec("PRAGMA mmap_size = 67108864");  // 64 MB mmap
   db.exec("PRAGMA temp_store = MEMORY");
   db.exec("PRAGMA foreign_keys = ON");
 
@@ -154,6 +155,17 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
   }
 
   migrateSchema(db);
+}
+
+export function _isLikelyWslDrvFsPathForTest(dbPath: string | null): boolean {
+  if (!dbPath || process.platform !== "linux") return false;
+  const drvFsPathPattern = /^\/mnt\/[a-z](?:\/|$)/i;
+  if (drvFsPathPattern.test(dbPath)) return true;
+  try {
+    return drvFsPathPattern.test(realpathSync(dbPath));
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -37,6 +37,7 @@ import {
   checkpointDatabase,
   refreshOpenDatabaseFromDisk,
   tryCreateMemoriesFts,
+  _isLikelyWslDrvFsPathForTest,
 } from '../gsd-db.ts';
 import { _resetLogs, peekLogs, setStderrLoggingEnabled } from '../workflow-logger.ts';
 
@@ -342,6 +343,16 @@ describe('gsd-db', () => {
       const mmap = adapter.prepare('PRAGMA mmap_size').get();
       assert.deepStrictEqual(mmap?.['mmap_size'], 67108864, 'non-darwin should still enable mmap_size');
       cleanup(linuxDbPath);
+    });
+  });
+
+  test('gsd-db: detects WSL DrvFs mount paths for conservative pragmas', () => {
+    withPlatform('linux', () => {
+      assert.equal(_isLikelyWslDrvFsPathForTest('/mnt/d/code/project/.gsd/gsd.db'), true);
+      assert.equal(_isLikelyWslDrvFsPathForTest('/tmp/gsd.db'), false);
+    });
+    withPlatform('darwin', () => {
+      assert.equal(_isLikelyWslDrvFsPathForTest('/mnt/d/code/project/.gsd/gsd.db'), false);
     });
   });
 


### PR DESCRIPTION
## Summary
- Added a Linux `/mnt/<drive>` SQLite pragma downgrade (DELETE/FULL/no mmap) in `gsd-db` with a focused passing regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5106
- [#5106 gsd.db corrupts repeatedly on WSL2 9p mounts (/mnt/d, /mnt/c) — WAL+mmap pragmas unsafe](https://github.com/gsd-build/gsd-2/issues/5106)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5106-gsd-db-corrupts-repeatedly-on-wsl2-9p-mo-1778753378`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database initialization to apply more conservative SQLite settings when a database file appears to live on a WSL-mounted drive, reducing risk in those environments.

* **Tests**
  * Added a regression test verifying WSL path detection and the conditional application of the conservative SQLite settings across platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6050)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->