### PR TITLE
fix(issue): [Bug]: gsd causes cmux to become unusable after exit

### DIFF
--- a/packages/pi-tui/src/__tests__/terminal.test.ts
+++ b/packages/pi-tui/src/__tests__/terminal.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { describe, it, type TestContext } from "node:test";
+
+import { ProcessTerminal } from "../terminal.js";
+
+function replaceProcessProperty(
+	t: TestContext,
+	target: object,
+	key: string,
+	value: unknown
+): void {
+	const descriptor = Object.getOwnPropertyDescriptor(target, key);
+	Object.defineProperty(target, key, {
+		configurable: true,
+		writable: true,
+		value,
+	});
+	t.after(() => {
+		if (descriptor) {
+			Object.defineProperty(target, key, descriptor);
+			return;
+		}
+		delete (target as Record<string, unknown>)[key];
+	});
+}
+
+describe("ProcessTerminal", () => {
+	it("restores terminal state when the process exits without an explicit stop", (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
+
+		const writes: string[] = [];
+		const rawModes: boolean[] = [];
+		const resizeHandlers = new Set<(...args: unknown[]) => void>();
+		const stdinHandlers = new Set<(data: string) => void>();
+		let resumed = false;
+		let paused = false;
+		let encoding = "";
+		let sigwinchSent = false;
+
+		replaceProcessProperty(t, process.stdout, "isTTY", true);
+		replaceProcessProperty(t, process.stdout, "write", (data: string) => {
+			writes.push(data);
+			return true;
+		});
+		replaceProcessProperty(t, process.stdout, "on", (event: string, handler: (...args: unknown[]) => void) => {
+			if (event === "resize") resizeHandlers.add(handler);
+			return process.stdout;
+		});
+		replaceProcessProperty(
+			t,
+			process.stdout,
+			"removeListener",
+			(event: string, handler: (...args: unknown[]) => void) => {
+				if (event === "resize") resizeHandlers.delete(handler);
+				return process.stdout;
+			}
+		);
+
+		replaceProcessProperty(t, process.stdin, "isRaw", false);
+		replaceProcessProperty(t, process.stdin, "setRawMode", (enabled: boolean) => {
+			rawModes.push(enabled);
+			return process.stdin;
+		});
+		replaceProcessProperty(t, process.stdin, "setEncoding", (nextEncoding: BufferEncoding) => {
+			encoding = nextEncoding;
+			return process.stdin;
+		});
+		replaceProcessProperty(t, process.stdin, "resume", () => {
+			resumed = true;
+			return process.stdin;
+		});
+		replaceProcessProperty(t, process.stdin, "pause", () => {
+			paused = true;
+			return process.stdin;
+		});
+		replaceProcessProperty(t, process.stdin, "on", (event: string, handler: (data: string) => void) => {
+			if (event === "data") stdinHandlers.add(handler);
+			return process.stdin;
+		});
+		replaceProcessProperty(t, process.stdin, "removeListener", (event: string, handler: (data: string) => void) => {
+			if (event === "data") stdinHandlers.delete(handler);
+			return process.stdin;
+		});
+		replaceProcessProperty(t, process, "kill", (pid: number, signal?: NodeJS.Signals | number) => {
+			assert.equal(pid, process.pid);
+			assert.equal(signal, "SIGWINCH");
+			sigwinchSent = true;
+			return true;
+		});
+
+		const terminal = new ProcessTerminal();
+		const exitListenersBeforeStart = process.listeners("exit");
+
+		terminal.start(() => {}, () => {});
+
+		const processExitHandler = process
+			.listeners("exit")
+			.find((listener) => !exitListenersBeforeStart.includes(listener));
+		assert.ok(processExitHandler);
+		assert.deepEqual(rawModes, [true]);
+		assert.equal(encoding, "utf8");
+		assert.equal(resumed, true);
+		assert.equal(sigwinchSent, process.platform !== "win32");
+		assert.equal(resizeHandlers.size, 1);
+		assert.equal(stdinHandlers.size, 1);
+		assert.deepEqual(writes, ["\x1b[?2004h", "\x1b[?u"]);
+
+		processExitHandler(0);
+
+		assert.deepEqual(rawModes, [true, false]);
+		assert.equal(paused, true);
+		assert.equal(resizeHandlers.size, 0);
+		assert.equal(stdinHandlers.size, 0);
+		assert.equal(process.listeners("exit").includes(processExitHandler), false);
+		assert.deepEqual(writes, ["\x1b[?2004h", "\x1b[?u", "\x1b[?2004l"]);
+
+		terminal.stop();
+
+		assert.deepEqual(writes, ["\x1b[?2004h", "\x1b[?u", "\x1b[?2004l"]);
+	});
+});

--- a/packages/pi-tui/src/terminal.ts
+++ b/packages/pi-tui/src/terminal.ts
@@ -58,6 +58,10 @@ export interface Terminal {
 export class ProcessTerminal implements Terminal {
 	private static _vtHandles: { GetConsoleMode: any; SetConsoleMode: any; handle: any } | null = null;
 	private wasRaw = false;
+	private started = false;
+	private readonly processExitHandler = () => {
+		this.stop();
+	};
 	private inputHandler?: (data: string) => void;
 	private resizeHandler?: () => void;
 	private _kittyProtocolActive = false;
@@ -81,6 +85,8 @@ export class ProcessTerminal implements Terminal {
 		if (!this.isTTY) {
 			return;
 		}
+		if (this.started) return;
+		this.started = true;
 
 		this.inputHandler = onInput;
 		this.resizeHandler = onResize;
@@ -115,6 +121,7 @@ export class ProcessTerminal implements Terminal {
 		// The query handler intercepts input temporarily, then installs the user's handler
 		// See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 		this.queryAndEnableKittyProtocol();
+		process.once("exit", this.processExitHandler);
 	}
 
 	/**
@@ -267,6 +274,10 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	stop(): void {
+		if (!this.started) return;
+		this.started = false;
+		process.removeListener("exit", this.processExitHandler);
+
 		// Disable bracketed paste mode
 		process.stdout.write("\x1b[?2004l");
 


### PR DESCRIPTION
## Summary
- Added exit-hook terminal cleanup and idempotent stop in `ProcessTerminal`, then ran focused terminal/cmux and TUI tests successfully.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5145
- [#5145 [Bug]: gsd causes cmux to become unusable after exit](https://github.com/gsd-build/gsd-2/issues/5145)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5145-bug-gsd-causes-cmux-to-become-unusable-a-1778753487`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process terminal stability by preventing duplicate initialization and ensuring proper cleanup when starting and stopping operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6051)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->