### PR TITLE
fix(issue): [Bug]: GSD Time to time Exit 0

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -453,7 +453,9 @@ if (cliFlags.messages[0] === 'headless') {
   initResources(agentDir)
   const { runHeadless, parseHeadlessArgs } = await import('./headless.js')
   await runHeadless(parseHeadlessArgs(process.argv))
-  process.exit(0)
+  // runHeadless is expected to terminate the process. If it returns, fail loud
+  // instead of silently reporting success.
+  process.exit(process.exitCode ?? 1)
 }
 
 /**
@@ -466,7 +468,9 @@ async function runHeadlessFromAuto(headlessArgs: string[]): Promise<never> {
   const { runHeadless, parseHeadlessArgs } = await import('./headless.js')
   const argv = [process.argv[0], process.argv[1], 'headless', ...headlessArgs]
   await runHeadless(parseHeadlessArgs(argv))
-  process.exit(0)
+  // runHeadless should not return; preserve any explicit exitCode and default
+  // to failure if control reaches here.
+  process.exit(process.exitCode ?? 1)
 }
 
 function flushPendingProviderRegistrations(resourceLoader: DefaultResourceLoaderInstance, modelRegistry: ModelRegistryInstance): void {

--- a/src/tests/auto-mode-piped.test.ts
+++ b/src/tests/auto-mode-piped.test.ts
@@ -84,6 +84,7 @@ const modules = new Map([
     }
     export async function runHeadless(options) {
       process.stderr.write('AUTO_REDIRECT_RUN ' + JSON.stringify(options) + '\\\\n')
+      process.exitCode = 0
     }
   \`],
 ])


### PR DESCRIPTION
## Summary
- Prevented `gsd auto` wrapper paths from masking headless failures as exit 0 and verified with focused headless routing/detection tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5202
- [#5202 [Bug]: GSD Time to time Exit 0](https://github.com/gsd-build/gsd-2/issues/5202)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5202-bug-gsd-time-to-time-exit-0-1778753607`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Headless and auto-redirect flows now correctly report failure when they exit unexpectedly, instead of always indicating success.
  * Test coverage updated to ensure the auto-routing path completes successfully when the headless path is intentionally successful.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->