### PR TITLE
fix(issue): Auto-mode artifact retry budget resets across pause/resume, causing repeated execute-task redispatch

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1731,7 +1731,6 @@ export async function pauseAuto(
   restoreProjectRootEnv();
   restoreMilestoneLockEnv();
   s.pendingVerificationRetry = null;
-  s.verificationRetryCount.clear();
   ctx?.ui.setStatus("gsd-auto", "paused");
   ctx?.ui.setWidget("gsd-progress", undefined);
   const resumeCmd = s.stepMode ? "/gsd next" : "/gsd auto";

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -6,7 +6,7 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { cleanupAfterLoopExit, rerootCommandSession, stopAuto } from "../auto.ts";
+import { cleanupAfterLoopExit, pauseAuto, rerootCommandSession, stopAuto } from "../auto.ts";
 import { autoSession } from "../auto-runtime-state.ts";
 import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
 import { WorktreeLifecycle } from "../worktree-lifecycle.ts";
@@ -114,6 +114,34 @@ test("cleanupAfterLoopExit clears progress widget after stopAuto reset", async (
     assert.equal(autoSession.completionStopInProgress, false);
   } finally {
     autoSession.reset();
+  }
+});
+
+test("pauseAuto preserves artifact retry counts across pause/resume", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-pause-retry-count-"));
+  const previousCwd = process.cwd();
+  const retryKey = "execute-task:M001/S01/T01";
+
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.verificationRetryCount.set(retryKey, 2);
+  autoSession.pendingVerificationRetry = {
+    unitId: "M001/S01/T01",
+    failureContext: "Missing expected artifact (attempt 2/3).",
+    attempt: 2,
+  };
+
+  try {
+    process.chdir(base);
+    await pauseAuto();
+
+    assert.equal(autoSession.paused, true);
+    assert.equal(autoSession.pendingVerificationRetry, null);
+    assert.equal(autoSession.verificationRetryCount.get(retryKey), 2);
+  } finally {
+    autoSession.reset();
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- Preserved auto-mode artifact retry counters across pause/resume by removing the pause-time `verificationRetryCount` clear and verified with `auto-loop.test.ts` passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5207
- [#5207 Auto-mode artifact retry budget resets across pause/resume, causing repeated execute-task redispatch](https://github.com/gsd-build/gsd-2/issues/5207)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5207-auto-mode-artifact-retry-budget-resets-a-1778753727`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state cleanup during pause operations to ensure proper retry state management and prevent residual verification data from affecting subsequent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6053)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->