### PR TITLE
fix(issue): buildTaskCommitMessage overshoots 72-byte subject limit by 2-3 bytes (UTF-8 ellipsis + char-based truncation)

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -158,14 +158,26 @@ export interface TaskCommitContext {
 export function buildTaskCommitMessage(ctx: TaskCommitContext): string {
   const description = sanitizeCommitSubjectDescription(ctx.oneLiner || ctx.taskTitle);
   const type = inferCommitType(ctx.taskTitle, ctx.oneLiner);
+  const subjectPrefix = `${type}: `;
+  const maxSubjectBytes = 72;
+  const ellipsis = "...";
+  const maxDescBytes = maxSubjectBytes - Buffer.byteLength(subjectPrefix, "utf8");
+  const maxTruncatedDescBytes = maxDescBytes - Buffer.byteLength(ellipsis, "utf8");
 
-  // Truncate description to ~72 chars for subject line (full budget without scope)
-  const maxDescLen = 70 - type.length;
-  const truncated = description.length > maxDescLen
-    ? description.slice(0, maxDescLen - 1).trimEnd() + "…"
-    : description;
+  let truncated = description;
+  if (Buffer.byteLength(description, "utf8") > maxDescBytes) {
+    let bytes = 0;
+    let cut = "";
+    for (const ch of description) {
+      const chBytes = Buffer.byteLength(ch, "utf8");
+      if (bytes + chBytes > maxTruncatedDescBytes) break;
+      cut += ch;
+      bytes += chBytes;
+    }
+    truncated = cut.trimEnd() + ellipsis;
+  }
 
-  const subject = `${type}: ${truncated}`;
+  const subject = `${subjectPrefix}${truncated}`;
 
   // Build body with key files if available
   const bodyParts: string[] = [];

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -247,6 +247,27 @@ describe('git-service', async () => {
     assert.equal(subject.includes("\u0007"), false, "subject does not include control characters");
   });
 
+  test('buildTaskCommitMessage truncates long ASCII subject to <=72 UTF-8 bytes', () => {
+    const msg = buildTaskCommitMessage({
+      taskId: "S01/T05",
+      taskTitle: "implement lint metadata",
+      oneLiner: "Added the core lint contract, seven-rule metadata catalogue, and parse-derived mechanical lint mappings with structured suggested_fix objects.",
+    });
+    const subject = msg.split("\n")[0] ?? "";
+    assert.ok(Buffer.byteLength(subject, "utf8") <= 72, "subject is capped at 72 UTF-8 bytes");
+  });
+
+  test('buildTaskCommitMessage truncates multibyte subject without breaking UTF-8 boundaries', () => {
+    const msg = buildTaskCommitMessage({
+      taskId: "S01/T06",
+      taskTitle: "implement emoji handling",
+      oneLiner: "Added emoji support 😀😀😀😀😀😀😀😀😀😀 with robust UTF-8 truncation guards for commit subject generation across locales.",
+    });
+    const subject = msg.split("\n")[0] ?? "";
+    assert.ok(Buffer.byteLength(subject, "utf8") <= 72, "multibyte subject is capped at 72 UTF-8 bytes");
+    assert.ok(subject.endsWith("..."), "truncated subject uses ASCII ellipsis");
+  });
+
   {
     const msg = buildTaskCommitMessage({
       taskId: "S02/T01",


### PR DESCRIPTION
## Summary
- Fixed `buildTaskCommitMessage` to enforce a UTF-8-safe 72-byte subject limit and verified with targeted git-service integration tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5907
- [#5907 buildTaskCommitMessage overshoots 72-byte subject limit by 2-3 bytes (UTF-8 ellipsis + char-based truncation)](https://github.com/gsd-build/gsd-2/issues/5907)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5907-buildtaskcommitmessage-overshoots-72-byt-1778753970`