### PR TITLE
fix(issue): clearLock() never marks stale DB worker as stopping — blocks resume after crash

### DIFF
--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -31,6 +31,7 @@ import {
   findStaleWorkerForProject,
   getAllAutoWorkers,
   markWorkerCrashed,
+  markWorkerStopping,
   type AutoWorkerRow,
 } from "./db/auto-workers.js";
 import { markLatestActiveForWorkerCanceled, type DispatchStatus } from "./db/unit-dispatches.js";
@@ -220,8 +221,13 @@ export function clearLock(basePath: string): void {
   try {
     const projectRoot = normalizeRealPath(basePath);
     const worker = findActiveWorkerForCurrentProcess(projectRoot);
-    if (!worker) return;
-    deleteRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY);
+    if (worker) deleteRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY);
+
+    const stale = findStaleWorkerForProject(projectRoot);
+    if (stale) {
+      markWorkerStopping(stale.worker_id);
+      deleteRuntimeKv("worker", stale.worker_id, SESSION_FILE_KV_KEY);
+    }
   } catch {
     // Best-effort.
   }

--- a/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
@@ -225,6 +225,25 @@ test("clearLock removes the session_file row for the active worker", (t) => {
     "session_file row deleted by clearLock");
 });
 
+test("clearLock marks stale worker as stopping when no current-process worker matches", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  const projectRoot = normalizeRealPath(base);
+  const workerId = registerAutoWorker({ projectRootRealpath: projectRoot });
+
+  setRuntimeKv("worker", workerId, "session_file", "/tmp/stale-session.jsonl");
+  setWorkerPid(workerId, 99999);
+  expireWorker(workerId);
+  assert.ok(readCrashLock(base), "stale worker is detected before clearLock");
+
+  clearLock(base);
+
+  assert.equal(getAutoWorker(workerId)?.status, "stopping");
+  assert.equal(getRuntimeKv("worker", workerId, "session_file"), null);
+  assert.equal(readCrashLock(base), null);
+});
+
 test("clearStaleWorkerLock crashes stale worker and cancels latest active dispatch", (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));


### PR DESCRIPTION
## Summary
- `clearLock()` now marks project-scoped stale workers as `stopping` (and clears stale session kv), verified by targeted crash-recovery DB tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5897
- [#5897 clearLock() never marks stale DB worker as stopping — blocks resume after crash](https://github.com/gsd-build/gsd-2/issues/5897)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5897-clearlock-never-marks-stale-db-worker-as-1778754089`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced crash recovery to properly clean up orphaned locks from stale workers, ensuring the system can correctly detect and recover from worker failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6057)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->