### PR TITLE
fix(gsd): preserve paused cleanup and verify guidance

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -371,7 +371,7 @@ export function detectRogueFileWrites(
 export const MAX_ARTIFACT_VERIFICATION_RETRIES = 3;
 
 export const STEP_COMPLETE_FALLBACK_MESSAGE =
-  "Step complete. Run /clear, then /gsd to continue (or /gsd auto to run continuously).";
+  "Step complete. Run /clear if you want a clean view, then /gsd next to continue one step (or /gsd auto to run continuously).";
 
 export function buildStepCompleteMessage(nextState: import("./types.js").GSDState): string {
   if (nextState.phase === "complete") {
@@ -379,7 +379,7 @@ export function buildStepCompleteMessage(nextState: import("./types.js").GSDStat
   }
   const next = describeNextUnit(nextState);
   return `Step complete. Next: ${next.label}\n`
-    + `Run /clear, then /gsd to continue (or /gsd auto to run continuously).`;
+    + `Run /clear if you want a clean view, then /gsd next to continue one step (or /gsd auto to run continuously).`;
 }
 
 /**
@@ -1731,8 +1731,8 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
   }
 
   // Step mode → show wizard instead of dispatch.
-  // Without this notify(), /gsd in step mode finishes a unit and silently
-  // exits the loop, leaving the user with no hint to /clear and /gsd again.
+  // Without this notify(), /gsd next finishes a unit and silently exits the
+  // loop, leaving the user with no next-step command.
   if (s.stepMode) {
     let phaseAfterUnit: string | null = null;
     try {

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -47,7 +47,7 @@ import { regenerateIfMissing } from "./workflow-projections.js";
 import { WorktreeStateProjection } from "./worktree-state-projection.js";
 import { createWorkspace, scopeMilestone } from "./workspace.js";
 import { normalizeWorktreePathForCompare } from "./worktree-root.js";
-import { isDbAvailable, getTask, getSlice, getMilestone, updateTaskStatus, _getAdapter, getVerificationEvidence } from "./gsd-db.js";
+import { isDbAvailable, getDbPath, refreshOpenDatabaseFromDisk, getTask, getSlice, getMilestone, updateTaskStatus, _getAdapter, getVerificationEvidence } from "./gsd-db.js";
 import { renderPlanCheckboxes } from "./markdown-renderer.js";
 import { consumeSignal } from "./session-status-io.js";
 import {
@@ -684,6 +684,14 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
   // Small delay to let files settle (skipped for sidecars where latency matters more)
   if (!opts?.skipSettleDelay) {
     await new Promise(r => setTimeout(r, 100));
+  }
+
+  const dbPath = getDbPath();
+  if (isDbAvailable() && dbPath && dbPath !== ":memory:") {
+    const refreshed = refreshOpenDatabaseFromDisk();
+    if (!refreshed) {
+      logWarning("db", "post-unit database refresh failed; derived state may be stale");
+    }
   }
 
   // Turn-level git action (commit | snapshot | status-only)

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1029,6 +1029,7 @@ export async function rerootCommandSession(
 }
 
 export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void> {
+  const preserveStepSurface = s.preserveStepSurfaceAfterLoopExit;
   s.currentUnit = null;
   s.active = false;
   deactivateGSD();
@@ -1051,12 +1052,16 @@ export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void>
   // A transient provider-error pause intentionally leaves the paused badge
   // visible so the user still has a resumable auto-mode signal on screen.
   if (!s.paused) {
-    ctx.ui.setStatus("gsd-auto", undefined);
-    ctx.ui.setWidget("gsd-progress", undefined);
-    if (s.completionStopInProgress) {
-      s.completionStopInProgress = false;
+    if (preserveStepSurface) {
+      s.preserveStepSurfaceAfterLoopExit = false;
+    } else {
+      ctx.ui.setStatus("gsd-auto", undefined);
+      ctx.ui.setWidget("gsd-progress", undefined);
+      if (s.completionStopInProgress) {
+        s.completionStopInProgress = false;
+      }
+      initHealthWidget(ctx);
     }
-    initHealthWidget(ctx);
   }
 
   // ADR-016 phase 3 (#5693): the stop-path basePath restore + chdir routes
@@ -1064,7 +1069,7 @@ export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void>
   // `s.basePath` mutation and the paired `process.chdir` for auto-loop
   // transitions. The verb assigns `s.basePath` before any throwable work, so
   // a thrown error still leaves basePath restored.
-  if (s.originalBasePath) {
+  if (s.originalBasePath && !preserveStepSurface) {
     try {
       buildLifecycle().restoreToProjectRoot();
     } catch (err) {
@@ -1076,7 +1081,7 @@ export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void>
     }
   }
 
-  if (s.originalBasePath && s.cmdCtx) {
+  if (s.originalBasePath && s.cmdCtx && !preserveStepSurface) {
     const result = await rerootCommandSession(s.cmdCtx, s.originalBasePath);
     if (result.status === "cancelled") {
       logWarning("engine", "post-loop session re-root was cancelled", { file: "auto.ts", basePath: s.originalBasePath });

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1030,6 +1030,7 @@ export async function rerootCommandSession(
 
 export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void> {
   const preserveStepSurface = s.preserveStepSurfaceAfterLoopExit;
+  const preservePausedSurface = s.paused;
   s.currentUnit = null;
   s.active = false;
   deactivateGSD();
@@ -1069,7 +1070,7 @@ export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void>
   // `s.basePath` mutation and the paired `process.chdir` for auto-loop
   // transitions. The verb assigns `s.basePath` before any throwable work, so
   // a thrown error still leaves basePath restored.
-  if (s.originalBasePath && !preserveStepSurface) {
+  if (s.originalBasePath && !preserveStepSurface && !preservePausedSurface) {
     try {
       buildLifecycle().restoreToProjectRoot();
     } catch (err) {
@@ -1081,7 +1082,7 @@ export async function cleanupAfterLoopExit(ctx: ExtensionContext): Promise<void>
     }
   }
 
-  if (s.originalBasePath && s.cmdCtx && !preserveStepSurface) {
+  if (s.originalBasePath && s.cmdCtx && !preserveStepSurface && !preservePausedSurface) {
     const result = await rerootCommandSession(s.cmdCtx, s.originalBasePath);
     if (result.status === "cancelled") {
       logWarning("engine", "post-loop session re-root was cancelled", { file: "auto.ts", basePath: s.originalBasePath });

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Main auto-mode execution loop.
 /**
  * auto/loop.ts — Main auto-mode execution loop.
  *
@@ -945,11 +947,18 @@ export async function autoLoop(
         unitId: iterData.unitId,
       });
       const finalizeReason = finalizeResult.action === "break" ? finalizeResult.reason : undefined;
+      const finalizeStatus = finalizeReason === "step-wizard"
+        ? "completed"
+        : finalizeResult.action === "next"
+          ? "completed"
+          : finalizeResult.action === "continue"
+            ? "retry"
+            : "stopped";
       journalReporter.emit("post-unit-finalize-end", {
         iteration,
         unitType: iterData.unitType,
         unitId: iterData.unitId,
-        status: finalizeResult.action === "next" ? "completed" : finalizeResult.action === "continue" ? "retry" : "stopped",
+        status: finalizeStatus,
         action: finalizeResult.action,
         ...(finalizeReason ? { reason: finalizeReason } : {}),
       });
@@ -996,6 +1005,10 @@ export async function autoLoop(
       }) || dispatchSettled;
       completeIteration();
       finishTurn("completed");
+      if (finalizeDecision.action === "complete-and-break") {
+        s.preserveStepSurfaceAfterLoopExit = true;
+        break;
+      }
     } catch (loopErr) {
       // ── Blanket catch: absorb unexpected exceptions, apply graduated recovery ──
       const msg = loopErr instanceof Error ? loopErr.message : String(loopErr);

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Mutable auto-mode session state container.
 /**
  * AutoSession — encapsulates all mutable auto-mode state into a single instance.
  *
@@ -89,6 +91,7 @@ export class AutoSession {
   active = false;
   paused = false;
   completionStopInProgress = false;
+  preserveStepSurfaceAfterLoopExit = false;
   stepMode = false;
   verbose = false;
   activeEngineId: string | null = null;
@@ -289,6 +292,7 @@ export class AutoSession {
     this.active = false;
     this.paused = false;
     this.completionStopInProgress = false;
+    this.preserveStepSurfaceAfterLoopExit = false;
     this.stepMode = false;
     this.verbose = false;
     this.activeEngineId = null;

--- a/src/resources/extensions/gsd/auto/workflow-kernel.ts
+++ b/src/resources/extensions/gsd/auto/workflow-kernel.ts
@@ -48,7 +48,8 @@ export type FinalizeDecision =
       action: "retry";
       ledgerErrorSummary: "finalize-retry";
     }
-  | { action: "complete" };
+  | { action: "complete" }
+  | { action: "complete-and-break" };
 
 export type EngineReconcileInput =
   | { outcome: "milestone-complete" }
@@ -278,6 +279,9 @@ export function decideEngineDispatch(input: EngineDispatchInput): EngineDispatch
 export function decideFinalizeResult(input: FinalizeInput): FinalizeDecision {
   if (input.action === "break") {
     const reason = input.reason ?? "unknown";
+    if (reason === "step-wizard") {
+      return { action: "complete-and-break" };
+    }
     return {
       action: "stop",
       failureClass: reason === "git-closeout-failure" ? "git" : "closeout",

--- a/src/resources/extensions/gsd/templates/plan.md
+++ b/src/resources/extensions/gsd/templates/plan.md
@@ -132,6 +132,7 @@
   Verify field rules:
   - MUST be a mechanically executable command: `npm test`, `grep -q "pattern" file`, `test -f path`
   - MUST NOT use shell pipes, redirects, semicolons, backticks, command substitution, or output trimming
+  - MUST NOT use inline `node -e` assertions for verification; put assertions in a real test file and run it with `node --test` or a package test script
   - For content/document tasks: verify file existence, section count, YAML validity, or word count
     NOT exact phrasing, specific formulas, or "zero TBD" aspirational criteria
   - If no command can verify the output, write: "Manual review — file exists and is non-empty"

--- a/src/resources/extensions/gsd/templates/task-plan.md
+++ b/src/resources/extensions/gsd/templates/task-plan.md
@@ -57,6 +57,12 @@ skills_used:
 - {{howToVerifyThisTaskIsActuallyDone}}
 - {{commandToRun_OR_behaviorToCheck}}
 
+## Verify Rules
+
+- Use a real executable check, not prose.
+- If the check needs file-content assertions, write a `node:test` file and run it with `node --test` or a package test script.
+- Do not use inline `node -e` assertions for verification.
+
 ## Observability Impact
 
 <!-- OMIT THIS SECTION ENTIRELY for simple tasks that don't touch runtime boundaries,

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -145,6 +145,70 @@ test("pauseAuto preserves artifact retry counts across pause/resume", async () =
   }
 });
 
+test("cleanupAfterLoopExit preserves step-mode surface and worktree session after completed step", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-step-surface-"));
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  const previousCwd = process.cwd();
+  const statusCalls: unknown[] = [];
+  const widgetCalls: unknown[] = [];
+  const newSessionWorkspaces: string[] = [];
+  let restoreCalls = 0;
+
+  t.mock.method(WorktreeLifecycle.prototype, "restoreToProjectRoot", function () {
+    restoreCalls += 1;
+  });
+
+  mkdirSync(worktree, { recursive: true });
+  process.chdir(worktree);
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.paused = false;
+  autoSession.stepMode = true;
+  autoSession.preserveStepSurfaceAfterLoopExit = true;
+  autoSession.basePath = worktree;
+  autoSession.originalBasePath = base;
+  autoSession.cmdCtx = {
+    newSession: async ({ workspaceRoot }: { workspaceRoot: string }) => {
+      newSessionWorkspaces.push(workspaceRoot);
+      return { cancelled: false };
+    },
+  } as any;
+
+  try {
+    await cleanupAfterLoopExit({
+      hasUI: true,
+      ui: {
+        setStatus: (...args: unknown[]) => statusCalls.push(args),
+        setWidget: (...args: unknown[]) => widgetCalls.push(args),
+        setHeader: () => {},
+        notify: () => {},
+      },
+    } as any);
+
+    assert.deepEqual(statusCalls, [], "step-mode cleanup must leave the NEXT badge visible");
+    assert.equal(
+      widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-progress" && args[1] === undefined),
+      false,
+      "step-mode cleanup must not clear the completed step progress surface",
+    );
+    assert.equal(
+      widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-health"),
+      false,
+      "step-mode cleanup must not replace the progress surface with idle health",
+    );
+    assert.deepEqual(newSessionWorkspaces, [], "step-mode cleanup must not re-root the visible command session");
+    assert.equal(restoreCalls, 0, "step-mode cleanup must not restore out of the active worktree");
+    assert.equal(autoSession.active, false);
+    assert.equal(autoSession.preserveStepSurfaceAfterLoopExit, false);
+    assert.equal(autoSession.basePath, worktree);
+    assert.equal(realpathSync(process.cwd()), realpathSync(worktree));
+  } finally {
+    autoSession.reset();
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("cleanupAfterLoopExit restores project root through lifecycle and preserves chdir", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-cleanup-lifecycle-"));
   const worktree = join(base, ".gsd", "worktrees", "M001");

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -43,6 +43,52 @@ test("cleanupAfterLoopExit preserves paused auto badge after provider pause", as
   }
 });
 
+test("cleanupAfterLoopExit preserves paused worktree session and visible failure output", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-paused-session-preserve-"));
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  const previousCwd = process.cwd();
+  const newSessionWorkspaces: string[] = [];
+  let restoreCalls = 0;
+
+  t.mock.method(WorktreeLifecycle.prototype, "restoreToProjectRoot", function () {
+    restoreCalls += 1;
+  });
+
+  mkdirSync(worktree, { recursive: true });
+  process.chdir(worktree);
+  autoSession.reset();
+  autoSession.active = true;
+  autoSession.paused = true;
+  autoSession.basePath = worktree;
+  autoSession.originalBasePath = base;
+  autoSession.cmdCtx = {
+    newSession: async ({ workspaceRoot }: { workspaceRoot: string }) => {
+      newSessionWorkspaces.push(workspaceRoot);
+      return { cancelled: false };
+    },
+  } as any;
+
+  try {
+    await cleanupAfterLoopExit({
+      ui: {
+        setStatus: () => {},
+        setWidget: () => {},
+        notify: () => {},
+      },
+    } as any);
+
+    assert.equal(restoreCalls, 0, "paused cleanup must not restore out of the active worktree");
+    assert.deepEqual(newSessionWorkspaces, [], "paused cleanup must not start a blank rerooted session");
+    assert.equal(autoSession.basePath, worktree);
+    assert.equal(realpathSync(process.cwd()), realpathSync(worktree));
+    assert.equal(autoSession.paused, true);
+  } finally {
+    autoSession.reset();
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("cleanupAfterLoopExit clears status and progress widget without replacing outcome surface", async () => {
   const statusCalls: unknown[] = [];
   const widgetCalls: unknown[] = [];

--- a/src/resources/extensions/gsd/tests/auto-post-unit-step-message.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-post-unit-step-message.test.ts
@@ -1,4 +1,5 @@
-// GSD-2 — Tests for step-mode completion messages in auto-post-unit
+// Project/App: GSD-2
+// File Purpose: Tests for step-mode completion messages in auto-post-unit.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -31,7 +32,7 @@ test("buildStepCompleteMessage: milestone complete surfaces review guidance", ()
   assert.doesNotMatch(msg, /Next:/);
 });
 
-test("buildStepCompleteMessage: mid-flight step includes next unit label and /clear hint", () => {
+test("buildStepCompleteMessage: mid-flight step includes next unit label and /gsd next hint", () => {
   const state = makeState({
     phase: "executing",
     activeSlice: { id: "S01", title: "Core" },
@@ -40,7 +41,7 @@ test("buildStepCompleteMessage: mid-flight step includes next unit label and /cl
   const msg = buildStepCompleteMessage(state);
   assert.match(msg, /Next: Execute T03: Wire notify/);
   assert.match(msg, /\/clear/);
-  assert.match(msg, /\/gsd to continue/);
+  assert.match(msg, /\/gsd next to continue one step/);
 });
 
 test("buildStepCompleteMessage: unknown phase falls back to generic continue label", () => {
@@ -51,9 +52,9 @@ test("buildStepCompleteMessage: unknown phase falls back to generic continue lab
   assert.match(msg, /\/clear/);
 });
 
-test("STEP_COMPLETE_FALLBACK_MESSAGE: used when deriveState throws, still points users at /clear + /gsd", () => {
+test("STEP_COMPLETE_FALLBACK_MESSAGE: used when deriveState throws, still points users at /clear + /gsd next", () => {
   assert.match(STEP_COMPLETE_FALLBACK_MESSAGE, /\/clear/);
-  assert.match(STEP_COMPLETE_FALLBACK_MESSAGE, /\/gsd/);
+  assert.match(STEP_COMPLETE_FALLBACK_MESSAGE, /\/gsd next/);
 });
 
 test("shouldReturnStepWizardAfterUnit: terminal milestone completion continues to merge-back path", () => {

--- a/src/resources/extensions/gsd/tests/post-unit-state-rebuild.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-state-rebuild.test.ts
@@ -8,8 +8,32 @@ import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { createRequire } from "node:module";
 import { AutoSession } from "../auto/session.ts";
 import { postUnitPreVerification } from "../auto-post-unit.ts";
+import {
+  _getAdapter,
+  closeDatabase,
+  getTask,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  openDatabase,
+} from "../gsd-db.ts";
+
+const _require = createRequire(import.meta.url);
+
+function openRawSqliteForTest(dbPath: string): { exec(sql: string): void; close(): void } {
+  try {
+    const mod = _require("node:sqlite") as { DatabaseSync: new (path: string) => { exec(sql: string): void; close(): void } };
+    return new mod.DatabaseSync(dbPath);
+  } catch {
+    type SqliteCtor = new (path: string) => { exec(sql: string): void; close(): void };
+    const mod = _require("better-sqlite3") as SqliteCtor | { default: SqliteCtor };
+    const DatabaseCtor: SqliteCtor = typeof mod === "function" ? mod : mod.default;
+    return new DatabaseCtor(dbPath);
+  }
+}
 
 test("postUnitPreVerification rebuilds STATE.md after a completed unit", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-post-unit-state-"));
@@ -44,6 +68,66 @@ test("postUnitPreVerification rebuilds STATE.md after a completed unit", async (
     assert.equal(existsSync(statePath), true);
     assert.ok(readFileSync(statePath, "utf-8").includes("M001"));
   } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("postUnitPreVerification refreshes DB before checking execute-task completion", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-post-unit-db-refresh-"));
+  try {
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    const tasksDir = join(sliceDir, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+      "# Roadmap\n\n## Slices\n\n- [ ] **S01: Slice** `risk:low` `depends:[]`\n",
+    );
+    writeFileSync(
+      join(sliceDir, "S01-PLAN.md"),
+      "# S01: Slice\n\n## Tasks\n\n- [ ] **T01: Do work** `est:30m`\n",
+    );
+    writeFileSync(
+      join(tasksDir, "T01-SUMMARY.md"),
+      "---\nid: T01\nparent: S01\nmilestone: M001\n---\n# T01\nDone.\n",
+    );
+
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M001", title: "Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "pending" });
+    insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Do work", status: "pending" });
+    const adapterBefore = _getAdapter();
+
+    const externalDb = openRawSqliteForTest(dbPath);
+    try {
+      externalDb.exec("UPDATE tasks SET status = 'complete', completed_at = '2026-05-14T00:00:00.000Z' WHERE milestone_id = 'M001' AND slice_id = 'S01' AND id = 'T01'");
+    } finally {
+      externalDb.close();
+    }
+
+    const s = new AutoSession();
+    s.basePath = base;
+    s.originalBasePath = base;
+    s.currentMilestoneId = "M001";
+    s.currentUnit = { type: "execute-task", id: "M001/S01/T01", startedAt: Date.now() };
+
+    const result = await postUnitPreVerification({
+      s,
+      ctx: { ui: { notify() {} } } as any,
+      pi: {} as any,
+      buildSnapshotOpts: () => ({}),
+      lockBase: () => base,
+      stopAuto: async () => {},
+      pauseAuto: async () => {},
+      updateProgressWidget: () => {},
+    }, { skipSettleDelay: true, skipWorktreeSync: true });
+
+    assert.equal(result, "continue");
+    assert.notEqual(_getAdapter(), adapterBefore, "post-unit flow must reopen the DB before deriving state");
+    assert.equal(getTask("M001", "S01", "T01")?.status, "complete");
+    assert.equal(s.pendingVerificationRetry, null);
+  } finally {
+    closeDatabase();
     rmSync(base, { recursive: true, force: true });
   }
 });

--- a/src/resources/extensions/gsd/tests/quality-gates.test.ts
+++ b/src/resources/extensions/gsd/tests/quality-gates.test.ts
@@ -1,3 +1,6 @@
+// Project/App: GSD-2
+// File Purpose: Validates planning and task template quality-gate content.
+
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -27,11 +30,14 @@ console.log("\n=== Level 1: Templates contain quality gate headings ===");
   const plan = loadTemplate("plan");
   assertTrue(plan.includes("## Threat Surface"), "plan.md contains ## Threat Surface");
   assertTrue(plan.includes("## Requirement Impact"), "plan.md contains ## Requirement Impact");
+  assertTrue(plan.includes("node --test"), "plan.md instructs using node --test for verification");
 
   const taskPlan = loadTemplate("task-plan");
   assertTrue(taskPlan.includes("## Failure Modes"), "task-plan.md contains ## Failure Modes");
   assertTrue(taskPlan.includes("## Load Profile"), "task-plan.md contains ## Load Profile");
   assertTrue(taskPlan.includes("## Negative Tests"), "task-plan.md contains ## Negative Tests");
+  assertTrue(taskPlan.includes("node --test"), "task-plan.md instructs using node --test for verification");
+  assertTrue(taskPlan.includes("node -e"), "task-plan.md mentions inline node -e as disallowed guidance");
 
   const sliceSummary = loadTemplate("slice-summary");
   assertTrue(sliceSummary.includes("## Operational Readiness"), "slice-summary.md contains ## Operational Readiness");

--- a/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
@@ -165,6 +165,13 @@ test("decideFinalizeResult maps break results to stop decisions", () => {
   );
 });
 
+test("decideFinalizeResult maps step-wizard breaks to completed step exits", () => {
+  assert.deepEqual(
+    decideFinalizeResult({ action: "break", reason: "step-wizard" }),
+    { action: "complete-and-break" },
+  );
+});
+
 test("decideFinalizeResult maps continue and next results", () => {
   assert.deepEqual(
     decideFinalizeResult({ action: "continue" }),

--- a/src/tests/integration/web-command-parity-contract.test.ts
+++ b/src/tests/integration/web-command-parity-contract.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Browser slash command parity tests for built-in and GSD command routing.
 import test from "node:test"
 import assert from "node:assert/strict"
 
@@ -170,15 +172,17 @@ test("registered GSD command roots stay on the prompt/extension path", async () 
     assertPromptPassthrough(`/${root}`)
   }
 
-  // Bare /gsd passes through to bridge (equivalent to /gsd next)
+  // Bare /gsd passes through to the extension-owned Smart Entry wizard.
   const bareGsd = dispatchBrowserSlashCommand("/gsd")
   assert.equal(bareGsd.kind, "prompt", "bare /gsd should pass through to bridge")
   assert.equal(bareGsd.command.message, "/gsd", "bare /gsd should preserve exact input")
 })
 
 test("current GSD command family samples dispatch to correct outcomes after S02", async (t) => {
-  await t.test("/gsd (bare) still passes through to bridge", () => {
-    assertPromptPassthrough("/gsd")
+  await t.test("/gsd (bare) stays on Smart Entry prompt path", () => {
+    const outcome = dispatchBrowserSlashCommand("/gsd")
+    assert.equal(outcome.kind, "prompt", "bare /gsd should stay on the Smart Entry prompt path")
+    assert.equal(outcome.command.message, "/gsd", "bare /gsd should preserve exact input")
   })
 
   await t.test("/gsd status now dispatches to surface", () => {
@@ -289,10 +293,11 @@ test("every registered /gsd subcommand has an explicit browser dispatch outcome"
 })
 
 test("GSD dispatch edge cases", async (t) => {
-  await t.test("/gsd (bare, no subcommand) passes through to bridge", () => {
+  await t.test("/gsd (bare, no subcommand) passes through to Smart Entry instead of status", () => {
     const outcome = dispatchBrowserSlashCommand("/gsd")
     assert.equal(outcome.kind, "prompt")
     assert.equal(outcome.command.message, "/gsd")
+    assert.notEqual(outcome.kind, "surface", "bare /gsd must not open the status surface")
   })
 
   await t.test("/gsd help dispatches to local gsd_help action", () => {

--- a/src/tests/integration/web-workflow-controls-contract.test.ts
+++ b/src/tests/integration/web-workflow-controls-contract.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Contract tests for browser workflow action derivation.
 import test from "node:test";
 import assert from "node:assert/strict";
 
@@ -56,6 +58,22 @@ test("auto paused → primary is /gsd auto with label Resume Auto", () => {
   assert.equal(result.primary.command, "/gsd auto");
   assert.equal(result.primary.label, "Resume Auto");
   assert.equal(result.primary.variant, "default");
+});
+
+test("step mode → primary is /gsd next with label Next Step", () => {
+  const result = deriveWorkflowAction(baseInput({ stepMode: true }));
+  assert.ok(result.primary);
+  assert.equal(result.primary.command, "/gsd next");
+  assert.equal(result.primary.label, "Next Step");
+  assert.equal(result.primary.variant, "default");
+  assert.equal(result.secondaries.some((action) => action.command === "/gsd next"), false);
+});
+
+test("paused step mode → primary remains /gsd next", () => {
+  const result = deriveWorkflowAction(baseInput({ autoPaused: true, stepMode: true }));
+  assert.ok(result.primary);
+  assert.equal(result.primary.command, "/gsd next");
+  assert.equal(result.primary.label, "Next Step");
 });
 
 test("pre-planning + no milestones → primary is /gsd with label Initialize Project", () => {

--- a/web/components/gsd/chat-mode.tsx
+++ b/web/components/gsd/chat-mode.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+// Project/App: GSD-2
+// File Purpose: Browser chat mode shell with workflow actions and bridge-backed input.
+
 import Image from "next/image"
 import { useEffect, useRef, useCallback, useState, useMemo, KeyboardEvent, DragEvent, ClipboardEvent } from "react"
 import { MessagesSquare, SendHorizonal, Check, Eye, EyeOff, Play, Loader2, Milestone, X, MessageCircle, FileEdit, FilePlus, Terminal, ChevronDown, ChevronRight, MoreHorizontal, Zap, Square, Pause, BarChart3, LayoutGrid, ListOrdered, History, Compass, PenLine, Inbox, SkipForward, Undo2, BookOpen, Settings, SlidersHorizontal, Stethoscope, FileOutput, Trash2, Globe, type LucideIcon } from "lucide-react"
@@ -179,6 +182,7 @@ function ChatModeHeader({ onPrimaryAction, onSecondaryAction }: ChatModeHeaderPr
     commandInFlight: state.commandInFlight,
     bootStatus: state.bootStatus,
     hasMilestones: (workspace?.milestones.length ?? 0) > 0,
+    stepMode: auto?.stepMode ?? false,
     projectDetectionKind: boot?.projectDetection?.kind ?? null,
   })
 
@@ -2037,6 +2041,7 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
     commandInFlight: state.commandInFlight,
     bootStatus: state.bootStatus,
     hasMilestones: (state.boot?.workspace?.milestones.length ?? 0) > 0,
+    stepMode: state.boot?.auto?.stepMode ?? false,
     projectDetectionKind: state.boot?.projectDetection?.kind ?? null,
   })
 

--- a/web/components/gsd/dashboard.tsx
+++ b/web/components/gsd/dashboard.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+// Project/App: GSD-2
+// File Purpose: Browser dashboard for live GSD workspace progress and actions.
+
 import { useEffect, useState, useCallback } from "react"
 import {
   Activity,
@@ -176,6 +179,7 @@ export function Dashboard({ onSwitchView, onExpandTerminal }: DashboardProps = {
     commandInFlight: state.commandInFlight,
     bootStatus: state.bootStatus,
     hasMilestones: (workspace?.milestones.length ?? 0) > 0,
+    stepMode: auto?.stepMode ?? false,
     projectDetectionKind: boot?.projectDetection?.kind ?? null,
   })
 

--- a/web/components/gsd/sidebar.tsx
+++ b/web/components/gsd/sidebar.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+// Project/App: GSD-2
+// File Purpose: Browser sidebar and milestone navigation with workflow controls.
+
 import { useMemo, useState, useSyncExternalStore } from "react"
 import {
   ChevronRight,
@@ -348,6 +351,7 @@ export function MilestoneExplorer({ isConnecting = false, width, onCollapse }: {
     commandInFlight: workspace.commandInFlight,
     bootStatus: workspace.bootStatus,
     hasMilestones: milestones.length > 0,
+    stepMode: auto?.stepMode ?? false,
     projectDetectionKind: workspace.boot?.projectDetection?.kind ?? null,
   })
 
@@ -643,6 +647,7 @@ export function CollapsedMilestoneSidebar({ onExpand }: { onExpand: () => void }
     commandInFlight: workspace.commandInFlight,
     bootStatus: workspace.bootStatus,
     hasMilestones: milestones.length > 0,
+    stepMode: auto?.stepMode ?? false,
     projectDetectionKind: workspace.boot?.projectDetection?.kind ?? null,
   })
 

--- a/web/lib/browser-slash-command-dispatch.ts
+++ b/web/lib/browser-slash-command-dispatch.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Route browser slash commands to local surfaces, RPC calls, or extension prompts.
 import { BUILTIN_SLASH_COMMANDS } from "../../packages/pi-coding-agent/src/core/slash-commands.ts"
 
 export type BrowserSlashCommandSurface =
@@ -169,7 +171,8 @@ function dispatchGSDSubcommand(
   const subcommand = spaceIndex === -1 ? trimmedArgs : trimmedArgs.slice(0, spaceIndex)
   const subArgs = spaceIndex === -1 ? "" : trimmedArgs.slice(spaceIndex + 1).trim()
 
-  // Bare `/gsd` — equivalent to `/gsd next`, pass through to bridge
+  // Bare `/gsd` opens the extension-owned Smart Entry wizard. Keep it on the
+  // bridge path so it never aliases to browser-native `/gsd status`.
   if (!subcommand) {
     return {
       kind: "prompt",

--- a/web/lib/workflow-actions.ts
+++ b/web/lib/workflow-actions.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Derive browser workflow action labels and commands from workspace state.
 /**
  * Pure derivation of the primary workflow action based on workspace state.
  * No React dependencies — fully testable with plain imports.
@@ -11,6 +13,7 @@ export interface WorkflowActionInput {
   commandInFlight: string | null
   bootStatus: string
   hasMilestones: boolean
+  stepMode?: boolean
   /** When set, suppresses the action bar if the welcome screen is handling initialization. */
   projectDetectionKind?: string | null
 }
@@ -31,7 +34,7 @@ export interface WorkflowActionResult {
 }
 
 export function deriveWorkflowAction(input: WorkflowActionInput): WorkflowActionResult {
-  const { phase, autoActive, autoPaused, onboardingLocked, commandInFlight, bootStatus, hasMilestones, projectDetectionKind } = input
+  const { phase, autoActive, autoPaused, onboardingLocked, commandInFlight, bootStatus, hasMilestones, stepMode = false, projectDetectionKind } = input
 
   // When the project welcome screen is active, it handles the initialization CTA.
   // Suppress the action bar to avoid duplicate/confusing buttons.
@@ -65,6 +68,8 @@ export function deriveWorkflowAction(input: WorkflowActionInput): WorkflowAction
 
   if (autoActive && !autoPaused) {
     primary = { label: "Stop Auto", command: "/gsd stop", variant: "destructive" }
+  } else if (stepMode && hasMilestones && phase !== "complete" && phase !== "blocked") {
+    primary = { label: "Next Step", command: "/gsd next", variant: "default" }
   } else if (autoPaused) {
     primary = { label: "Resume Auto", command: "/gsd auto", variant: "default" }
   } else {


### PR DESCRIPTION
## Summary

- Preserve paused auto-mode cleanup so a pre-execution failure stays visible instead of rerooting to a blank session.
- Tighten planning templates so verification commands are real executable tests instead of inline `node -e` assertions.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/quality-gates.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/plan-slice-prompt.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Step-mode now displays "Next Step" as the primary workflow action.
  * Step surface UI is preserved after completing steps in step-mode.

* **Bug Fixes**
  * Database is refreshed from disk during verification to ensure accuracy.

* **Documentation**
  * Updated template verification rules to require assertions in proper test files instead of inline commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6066)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->