### PR TITLE
Default interactive tool output to expanded

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode-ordering.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode-ordering.test.ts
@@ -2,8 +2,12 @@
 // File Purpose: Regression tests for interactive assistant replay ordering.
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import stripAnsi from "strip-ansi";
 
-import { buildAssistantReplaySegments } from "./interactive-mode.js";
+import { buildAssistantReplaySegments, getToolExpansionStartupHint } from "./interactive-mode.js";
+import { initTheme } from "./theme/theme.js";
+
+initTheme("dark", false);
 
 test("buildAssistantReplaySegments preserves tool-first ordering", () => {
 	const segments = buildAssistantReplaySegments([
@@ -55,4 +59,15 @@ test("buildAssistantReplaySegments skips empty GPT reasoning blocks before tools
 	assert.deepEqual(segments, [
 		{ kind: "tool", contentIndex: 2 },
 	]);
+});
+
+test("tool expansion startup hint reflects the default expansion state", () => {
+	const keybindings = {
+		getKeys(action: string) {
+			return action === "expandTools" ? ["ctrl+o"] : [];
+		},
+	} as any;
+
+	assert.match(stripAnsi(getToolExpansionStartupHint(true, keybindings)), /ctrl\+o.*collapse tools/);
+	assert.match(stripAnsi(getToolExpansionStartupHint(false, keybindings)), /ctrl\+o.*expand tools/);
 });

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -184,6 +184,10 @@ export function buildAssistantReplaySegments(contentBlocks: Array<any>): Assista
 	return segments;
 }
 
+export function getToolExpansionStartupHint(toolOutputExpanded: boolean, keybindings: KeybindingsManager): string {
+	return appKeyHint(keybindings, "expandTools", toolOutputExpanded ? "to collapse tools" : "to expand tools");
+}
+
 type CompactionQueuedMessage = {
 	text: string;
 	mode: "steer" | "followUp";
@@ -308,7 +312,7 @@ export class InteractiveMode {
 	private pendingTools = new Map<string, ToolExecutionComponent>();
 
 	// Tool output expansion state
-	private toolOutputExpanded = false;
+	private toolOutputExpanded = true;
 
 	// Pasted image tracking
 	private pendingImages: ImageContent[] = [];
@@ -560,7 +564,7 @@ export class InteractiveMode {
 				hint("cycleThinkingLevel", "to cycle thinking level"),
 				rawKeyHint(`${appKey(kb, "cycleModelForward")}/${appKey(kb, "cycleModelBackward")}`, "to cycle models"),
 				hint("selectModel", "to select model"),
-				hint("expandTools", "to expand tools"),
+				getToolExpansionStartupHint(this.toolOutputExpanded, kb),
 				hint("toggleThinking", "to expand thinking"),
 				hint("externalEditor", "for external editor"),
 				rawKeyHint("/", "for commands"),


### PR DESCRIPTION
## TL;DR

**What:** Interactive mode now defaults tool output to expanded, and the startup hint reflects the toggle as a collapse action.
**Why:** Tool results should be visible by default instead of rolled up behind an extra keypress.
**How:** Flip the interactive-mode default, route the startup hint through a small helper, and cover the new hint behavior with a regression test.

## What

- Set the interactive-mode tool output default to expanded.
- Updated the startup keybinding hint to describe collapsing tools.
- Added regression coverage for the startup hint state mapping.

## Why

Closes #6069

## How

The interactive-mode host now initializes `toolOutputExpanded` to `true`, so newly rendered tool cards start expanded. A helper keeps the header copy aligned with that state, and the test suite exercises both the expanded and collapsed hint text.

AI-assisted contribution.

## Verification

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/modes/interactive/interactive-mode-ordering.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool outputs now expand by default in interactive mode
  * Startup hints dynamically display relevant keyboard shortcuts based on tool expansion state

* **Tests**
  * Added regression tests for tool expansion startup hint functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6070)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->