### PR TITLE
feat(gsd): add /gsd verdict command for milestone override recovery

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1340,7 +1340,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           if (verdict !== "pass") {
             return {
               action: "stop",
-              reason: `Cannot complete milestone ${mid}: VALIDATION verdict is "${verdict}". Address the validation findings and re-run validation, or update the verdict manually.`,
+              reason: `Cannot complete milestone ${mid}: VALIDATION verdict is "${verdict}". Address the validation findings and re-run validation, or run \`/gsd verdict pass --rationale "..."\` to override.`,
               level: "warning",
             };
           }

--- a/src/resources/extensions/gsd/commands-verdict.ts
+++ b/src/resources/extensions/gsd/commands-verdict.ts
@@ -1,0 +1,202 @@
+import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+
+import { loadFile } from "./files.js";
+import { resolveMilestoneFile } from "./paths.js";
+import { deriveState } from "./state.js";
+import { executeValidateMilestone } from "./tools/workflow-tool-executors.js";
+import {
+  VALIDATION_VERDICTS,
+  extractVerdict,
+  isValidMilestoneVerdict,
+  type ValidationVerdict,
+} from "./verdict-parser.js";
+
+const USAGE =
+  'Usage: /gsd verdict <pass|needs-attention|needs-remediation> [--milestone Mxxx] [--rationale "..."]';
+
+interface ParsedArgs {
+  verdict?: ValidationVerdict;
+  milestoneId?: string;
+  rationale?: string;
+}
+
+interface ParsedValidation {
+  verdict: string | undefined;
+  remediationRound: number;
+  successCriteriaChecklist: string;
+  sliceDeliveryAudit: string;
+  crossSliceIntegration: string;
+  requirementCoverage: string;
+  verificationClasses?: string;
+  verdictRationale: string;
+  remediationPlan?: string;
+}
+
+function tokenize(raw: string): string[] {
+  const tokens: string[] = [];
+  const re = /"([^"]*)"|(\S+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(raw)) !== null) {
+    tokens.push(match[1] ?? match[2]);
+  }
+  return tokens;
+}
+
+function parseArgs(raw: string): ParsedArgs | { error: string } {
+  const tokens = tokenize(raw);
+  const out: ParsedArgs = {};
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t === "--milestone") {
+      const next = tokens[++i];
+      if (!next) return { error: "--milestone requires a milestone ID" };
+      out.milestoneId = next;
+    } else if (t === "--rationale") {
+      const next = tokens[++i];
+      if (next == null) return { error: "--rationale requires a value" };
+      out.rationale = next;
+    } else if (!out.verdict) {
+      if (!isValidMilestoneVerdict(t)) {
+        return {
+          error: `Invalid verdict "${t}". Must be one of: ${VALIDATION_VERDICTS.join(", ")}`,
+        };
+      }
+      out.verdict = t;
+    } else {
+      return { error: `Unexpected argument: ${t}` };
+    }
+  }
+  return out;
+}
+
+function extractRemediationRound(content: string): number {
+  const fm = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fm) return 0;
+  const m = fm[1].match(/^remediation_round:\s*(\d+)/im);
+  return m ? Number.parseInt(m[1], 10) : 0;
+}
+
+function extractSection(content: string, heading: string): string | undefined {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Match section bodies bounded by the next "## " heading or end-of-string.
+  // Leading "\n" prefix lets a single pattern handle first-line headings too.
+  // No /m flag — we want `$` to mean end-of-string, not end-of-line.
+  const re = new RegExp(`\\n## ${escaped}\\s*\\n([\\s\\S]*?)(?=\\n## |$)`);
+  const m = ("\n" + content).match(re);
+  if (!m) return undefined;
+  return m[1].replace(/\s+$/, "");
+}
+
+export function parseValidationFile(content: string): ParsedValidation {
+  return {
+    verdict: extractVerdict(content),
+    remediationRound: extractRemediationRound(content),
+    successCriteriaChecklist: extractSection(content, "Success Criteria Checklist") ?? "",
+    sliceDeliveryAudit: extractSection(content, "Slice Delivery Audit") ?? "",
+    crossSliceIntegration: extractSection(content, "Cross-Slice Integration") ?? "",
+    requirementCoverage: extractSection(content, "Requirement Coverage") ?? "",
+    verificationClasses: extractSection(content, "Verification Class Compliance"),
+    verdictRationale: extractSection(content, "Verdict Rationale") ?? "",
+    remediationPlan: extractSection(content, "Remediation Plan"),
+  };
+}
+
+export async function handleVerdict(
+  rawArgs: string,
+  ctx: ExtensionCommandContext,
+  basePath: string,
+): Promise<void> {
+  if (!rawArgs.trim()) {
+    ctx.ui.notify(USAGE, "warning");
+    return;
+  }
+
+  const parsed = parseArgs(rawArgs);
+  if ("error" in parsed) {
+    ctx.ui.notify(`${parsed.error}\n${USAGE}`, "warning");
+    return;
+  }
+  if (!parsed.verdict) {
+    ctx.ui.notify(USAGE, "warning");
+    return;
+  }
+
+  let milestoneId = parsed.milestoneId;
+  if (!milestoneId) {
+    const state = await deriveState(basePath);
+    if (!state.activeMilestone) {
+      ctx.ui.notify(
+        "No active milestone — pass --milestone Mxxx to target a specific milestone.",
+        "warning",
+      );
+      return;
+    }
+    milestoneId = state.activeMilestone.id;
+  }
+
+  const validationPath = resolveMilestoneFile(basePath, milestoneId, "VALIDATION");
+  if (!validationPath) {
+    ctx.ui.notify(
+      `No VALIDATION file found for ${milestoneId}. Run gsd_validate_milestone first to produce one.`,
+      "warning",
+    );
+    return;
+  }
+  const existing = await loadFile(validationPath);
+  if (!existing) {
+    ctx.ui.notify(
+      `Could not read VALIDATION file for ${milestoneId} (${validationPath}).`,
+      "warning",
+    );
+    return;
+  }
+
+  const current = parseValidationFile(existing);
+
+  if (parsed.verdict !== "pass" && !parsed.rationale) {
+    ctx.ui.notify(
+      `--rationale is required when overriding to ${parsed.verdict}.`,
+      "warning",
+    );
+    return;
+  }
+
+  const verdictRationale =
+    parsed.rationale ?? "Manually overridden via /gsd verdict";
+
+  const result = await executeValidateMilestone(
+    {
+      milestoneId,
+      verdict: parsed.verdict,
+      remediationRound: current.remediationRound,
+      successCriteriaChecklist: current.successCriteriaChecklist,
+      sliceDeliveryAudit: current.sliceDeliveryAudit,
+      crossSliceIntegration: current.crossSliceIntegration,
+      requirementCoverage: current.requirementCoverage,
+      verificationClasses: current.verificationClasses,
+      verdictRationale,
+      remediationPlan: current.remediationPlan,
+    },
+    basePath,
+  );
+
+  if (result.isError) {
+    const msg =
+      result.content[0]?.type === "text" ? result.content[0].text : "Unknown error";
+    ctx.ui.notify(msg, "error");
+    return;
+  }
+
+  const prevVerdict = current.verdict ?? "unknown";
+  ctx.ui.notify(
+    `Milestone ${milestoneId} verdict: ${prevVerdict} -> ${parsed.verdict}`,
+    "success",
+  );
+
+  if (parsed.verdict === "needs-remediation") {
+    ctx.ui.notify(
+      "Follow up with gsd_reassess_roadmap to add remediation slices, then re-run /gsd auto.",
+      "info",
+    );
+  }
+}

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -14,7 +14,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|fast|mcp|rethink|workflow|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
+  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|brief|queue|quick|discuss|capture|triage|dispatch|verdict|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|new-project|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|fast|mcp|rethink|workflow|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language|worktree|eval-review";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -33,6 +33,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "changelog", desc: "Show categorized release notes" },
   { cmd: "triage", desc: "Manually trigger triage of pending captures" },
   { cmd: "dispatch", desc: "Dispatch a specific phase directly" },
+  { cmd: "verdict", desc: "Override the recorded milestone validation verdict (pass|needs-attention|needs-remediation)" },
   { cmd: "history", desc: "View execution history" },
   { cmd: "undo", desc: "Revert last completed unit" },
   { cmd: "undo-task", desc: "Reset a specific task's completion state (DB + markdown)" },
@@ -247,6 +248,11 @@ const NESTED_COMPLETIONS: CompletionMap = {
     { cmd: "reassess", desc: "Reassess current progress" },
     { cmd: "uat", desc: "Run user acceptance testing" },
     { cmd: "replan", desc: "Replan the current slice" },
+  ],
+  verdict: [
+    { cmd: "pass", desc: "Override the milestone validation verdict to pass" },
+    { cmd: "needs-attention", desc: "Override the verdict to needs-attention (requires --rationale)" },
+    { cmd: "needs-remediation", desc: "Override the verdict to needs-remediation (requires --rationale)" },
   ],
   rate: [
     { cmd: "over", desc: "Model was overqualified for this task" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -71,6 +71,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd new-project    Bootstrap a new project (use --deep for staged project-level discovery)",
     "  /gsd quick          Execute a quick task without full planning overhead",
     "  /gsd dispatch       Dispatch a specific phase directly  [research|plan|execute|complete|uat|replan]",
+    "  /gsd verdict <v>    Override milestone validation verdict  [pass|needs-attention|needs-remediation] [--milestone Mxxx] [--rationale \"...\"]",
     "  /gsd parallel       Parallel milestone orchestration  [start|status|stop|pause|resume|merge|watch]",
     "  /gsd workflow       Custom workflow lifecycle  [new|run|list|validate|pause|resume]",
     "",

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -188,6 +188,11 @@ Examples:
     await dispatchDirectPhase(ctx, pi, phase, projectRoot());
     return true;
   }
+  if (trimmed === "verdict" || trimmed.startsWith("verdict ")) {
+    const { handleVerdict } = await import("../../commands-verdict.js");
+    await handleVerdict(trimmed.replace(/^verdict\s*/, "").trim(), ctx, projectRoot());
+    return true;
+  }
   if (trimmed === "notifications" || trimmed.startsWith("notifications ")) {
     const { handleNotificationsCommand } = await import("./notifications-handler.js");
     await handleNotificationsCommand(trimmed.replace(/^notifications\s*/, "").trim(), ctx, pi);

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -591,7 +591,7 @@ async function handleAllSlicesDone(
       recentDecisions: [],
       blockers: [
         `Milestone ${activeMilestone.id} validation verdict is needs-remediation but all slices are complete. ` +
-          `Add remediation slices via gsd_reassess_roadmap or override the verdict manually.`,
+          `Add remediation slices via gsd_reassess_roadmap, or run \`/gsd verdict pass --rationale "..."\` to override.`,
       ],
       nextAction: `Resolve ${activeMilestone.id} remediation before proceeding.`,
       registry, requirements,
@@ -1314,7 +1314,7 @@ export async function _deriveStateImpl(
         recentDecisions: [],
         blockers: [
           `Milestone ${activeMilestone.id} validation verdict is needs-remediation but all slices are complete. ` +
-            `Add remediation slices via gsd_reassess_roadmap or override the verdict manually.`,
+            `Add remediation slices via gsd_reassess_roadmap, or run \`/gsd verdict pass --rationale "..."\` to override.`,
         ],
         nextAction: `Resolve ${activeMilestone.id} remediation before proceeding.`,
         registry,

--- a/src/resources/extensions/gsd/tests/commands-verdict.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-verdict.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for /gsd verdict — manual override of milestone validation verdict.
+ *
+ * Covers parseValidationFile section extraction and handleVerdict end-to-end:
+ * pass override, needs-remediation override with rationale, missing rationale
+ * rejection, active-milestone fallback, missing VALIDATION rejection.
+ *
+ * Also asserts the three paused-state messages reference /gsd verdict so the
+ * user has a discoverable recovery path.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { handleVerdict, parseValidationFile } from "../commands-verdict.ts";
+import { openDatabase, closeDatabase, _getAdapter } from "../gsd-db.ts";
+import { invalidateStateCache } from "../state.ts";
+
+interface NotifyCall {
+  message: string;
+  kind: string;
+}
+
+function makeMockCtx(): { ctx: any; calls: NotifyCall[] } {
+  const calls: NotifyCall[] = [];
+  const ctx = {
+    ui: {
+      notify: (message: string, kind: string) => {
+        calls.push({ message, kind });
+      },
+    },
+  };
+  return { ctx, calls };
+}
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-verdict-${randomUUID()}-`));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* swallow */ }
+}
+
+function openTestDb(base: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+}
+
+function seedMilestone(milestoneId: string, title: string, status = "active"): void {
+  const db = _getAdapter();
+  if (!db) throw new Error("DB not open");
+  db.prepare(
+    "INSERT OR REPLACE INTO milestones (id, title, status, created_at) VALUES (?, ?, ?, ?)",
+  ).run(milestoneId, title, status, new Date().toISOString());
+}
+
+function seedSlice(milestoneId: string, sliceId: string, status: string): void {
+  const db = _getAdapter();
+  if (!db) throw new Error("DB not open");
+  db.prepare(
+    "INSERT OR REPLACE INTO slices (milestone_id, id, title, status, created_at) VALUES (?, ?, ?, ?, ?)",
+  ).run(milestoneId, sliceId, `Slice ${sliceId}`, status, new Date().toISOString());
+}
+
+function writeValidation(base: string, milestoneId: string, verdict: string, round = 0): string {
+  const milestoneDir = join(base, ".gsd", "milestones", milestoneId);
+  mkdirSync(milestoneDir, { recursive: true });
+  const path = join(milestoneDir, `${milestoneId}-VALIDATION.md`);
+  const md = [
+    "---",
+    `verdict: ${verdict}`,
+    `remediation_round: ${round}`,
+    "---",
+    "",
+    `# Milestone Validation: ${milestoneId}`,
+    "",
+    "## Success Criteria Checklist",
+    "- [x] Criterion A met",
+    "- [x] Criterion B met",
+    "",
+    "## Slice Delivery Audit",
+    "| Slice | Result |",
+    "| --- | --- |",
+    "| S01 | delivered |",
+    "",
+    "## Cross-Slice Integration",
+    "No cross-slice mismatches detected.",
+    "",
+    "## Requirement Coverage",
+    "All requirements covered.",
+    "",
+    "## Verdict Rationale",
+    `Initial verdict was ${verdict}.`,
+    "",
+  ].join("\n");
+  writeFileSync(path, md);
+  return path;
+}
+
+// ─── parseValidationFile ────────────────────────────────────────────────
+
+test("parseValidationFile extracts all standard sections and frontmatter", () => {
+  const md = [
+    "---",
+    "verdict: needs-attention",
+    "remediation_round: 2",
+    "---",
+    "",
+    "# Milestone Validation: M001",
+    "",
+    "## Success Criteria Checklist",
+    "- [x] First",
+    "- [ ] Second",
+    "",
+    "## Slice Delivery Audit",
+    "| Slice | Delivered |",
+    "",
+    "## Cross-Slice Integration",
+    "Boundary intact.",
+    "",
+    "## Requirement Coverage",
+    "R001 covered.",
+    "",
+    "## Verification Class Compliance",
+    "Operational: MET",
+    "",
+    "## Verdict Rationale",
+    "Acceptance proof incomplete.",
+    "",
+    "## Remediation Plan",
+    "Address acceptance proof.",
+    "",
+  ].join("\n");
+
+  const parsed = parseValidationFile(md);
+
+  assert.equal(parsed.verdict, "needs-attention");
+  assert.equal(parsed.remediationRound, 2);
+  assert.match(parsed.successCriteriaChecklist, /First/);
+  assert.match(parsed.successCriteriaChecklist, /Second/);
+  assert.match(parsed.sliceDeliveryAudit, /Delivered/);
+  assert.match(parsed.crossSliceIntegration, /Boundary intact/);
+  assert.match(parsed.requirementCoverage, /R001 covered/);
+  assert.match(parsed.verificationClasses ?? "", /Operational: MET/);
+  assert.match(parsed.verdictRationale, /Acceptance proof incomplete/);
+  assert.match(parsed.remediationPlan ?? "", /Address acceptance proof/);
+});
+
+test("parseValidationFile omits optional sections when absent", () => {
+  const md = [
+    "---",
+    "verdict: pass",
+    "remediation_round: 0",
+    "---",
+    "",
+    "## Success Criteria Checklist",
+    "- [x] All met",
+    "",
+    "## Slice Delivery Audit",
+    "Done.",
+    "",
+    "## Cross-Slice Integration",
+    "Clean.",
+    "",
+    "## Requirement Coverage",
+    "Complete.",
+    "",
+    "## Verdict Rationale",
+    "All criteria met.",
+  ].join("\n");
+
+  const parsed = parseValidationFile(md);
+
+  assert.equal(parsed.verdict, "pass");
+  assert.equal(parsed.remediationRound, 0);
+  assert.equal(parsed.verificationClasses, undefined);
+  assert.equal(parsed.remediationPlan, undefined);
+});
+
+// ─── handleVerdict — argument validation ────────────────────────────────
+
+test("handleVerdict rejects missing verdict", async () => {
+  const { ctx, calls } = makeMockCtx();
+  await handleVerdict("", ctx, "/tmp/unused");
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].message, /Usage: \/gsd verdict/);
+  assert.equal(calls[0].kind, "warning");
+});
+
+test("handleVerdict rejects invalid verdict", async () => {
+  const { ctx, calls } = makeMockCtx();
+  await handleVerdict("yolo", ctx, "/tmp/unused");
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].message, /Invalid verdict "yolo"/);
+  assert.equal(calls[0].kind, "warning");
+});
+
+test("handleVerdict rejects needs-remediation without --rationale", async () => {
+  const base = makeBase();
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Test Milestone");
+    seedSlice("M001", "S01", "complete");
+    writeValidation(base, "M001", "pass");
+
+    const { ctx, calls } = makeMockCtx();
+    await handleVerdict("needs-remediation --milestone M001", ctx, base);
+
+    assert.ok(
+      calls.some((c) => /--rationale is required/.test(c.message)),
+      `expected rationale-required warning, got: ${JSON.stringify(calls)}`,
+    );
+  } finally {
+    closeDatabase();
+    invalidateStateCache();
+    cleanup(base);
+  }
+});
+
+test("handleVerdict rejects when VALIDATION file is missing", async () => {
+  const base = makeBase();
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Test Milestone");
+    seedSlice("M001", "S01", "complete");
+    mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+
+    const { ctx, calls } = makeMockCtx();
+    await handleVerdict("pass --milestone M001", ctx, base);
+
+    assert.ok(
+      calls.some((c) => /No VALIDATION file found/.test(c.message)),
+      `expected missing-VALIDATION warning, got: ${JSON.stringify(calls)}`,
+    );
+  } finally {
+    closeDatabase();
+    invalidateStateCache();
+    cleanup(base);
+  }
+});
+
+// ─── handleVerdict — pass override flow ─────────────────────────────────
+
+test("handleVerdict pass override flips verdict and preserves sections", async () => {
+  const base = makeBase();
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Test Milestone");
+    seedSlice("M001", "S01", "complete");
+    const validationPath = writeValidation(base, "M001", "needs-attention");
+
+    const { ctx, calls } = makeMockCtx();
+    await handleVerdict("pass --milestone M001", ctx, base);
+
+    const rewritten = readFileSync(validationPath, "utf-8");
+    assert.match(rewritten, /^verdict: pass$/m, "verdict should flip to pass");
+    assert.match(rewritten, /Criterion A met/, "success criteria preserved");
+    assert.match(rewritten, /S01 \| delivered/, "slice audit preserved");
+    assert.match(rewritten, /Manually overridden via \/gsd verdict/, "default rationale applied");
+
+    assert.ok(
+      calls.some((c) => c.kind === "success" && /needs-attention.*->.*pass/.test(c.message)),
+      `expected success notification, got: ${JSON.stringify(calls)}`,
+    );
+  } finally {
+    closeDatabase();
+    invalidateStateCache();
+    cleanup(base);
+  }
+});
+
+test("handleVerdict needs-remediation override with --rationale rewrites verdict", async () => {
+  const base = makeBase();
+  try {
+    openTestDb(base);
+    seedMilestone("M001", "Test Milestone");
+    seedSlice("M001", "S01", "complete");
+    const validationPath = writeValidation(base, "M001", "pass");
+
+    const { ctx, calls } = makeMockCtx();
+    await handleVerdict(
+      'needs-remediation --milestone M001 --rationale "found missing slice"',
+      ctx,
+      base,
+    );
+
+    const rewritten = readFileSync(validationPath, "utf-8");
+    assert.match(rewritten, /^verdict: needs-remediation$/m);
+    assert.match(rewritten, /found missing slice/);
+
+    assert.ok(
+      calls.some((c) => /gsd_reassess_roadmap/.test(c.message)),
+      "needs-remediation override should suggest gsd_reassess_roadmap follow-up",
+    );
+  } finally {
+    closeDatabase();
+    invalidateStateCache();
+    cleanup(base);
+  }
+});
+
+test("handleVerdict resolves active milestone when --milestone omitted", async () => {
+  const base = makeBase();
+  try {
+    openTestDb(base);
+    seedMilestone("M042", "Active Milestone");
+    seedSlice("M042", "S01", "complete");
+    const validationPath = writeValidation(base, "M042", "needs-attention");
+
+    const { ctx, calls } = makeMockCtx();
+    invalidateStateCache();
+    await handleVerdict("pass", ctx, base);
+
+    const rewritten = readFileSync(validationPath, "utf-8");
+    assert.match(rewritten, /^verdict: pass$/m);
+    assert.ok(
+      calls.some((c) => c.kind === "success" && /M042/.test(c.message)),
+      `expected success notification naming M042, got: ${JSON.stringify(calls)}`,
+    );
+  } finally {
+    closeDatabase();
+    invalidateStateCache();
+    cleanup(base);
+  }
+});
+
+// ─── Pause messages reference /gsd verdict ─────────────────────────────
+
+test("auto-dispatch needs-attention pause message references /gsd verdict", async () => {
+  const { DISPATCH_RULES } = await import("../auto-dispatch.ts");
+  const rule = DISPATCH_RULES.find((r) => r.name === "completing-milestone → complete-milestone");
+  assert.ok(rule, "completing-milestone rule should exist");
+
+  const base = mkdtempSync(join(tmpdir(), "gsd-verdict-paused-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  try {
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-VALIDATION.md"),
+      "---\nverdict: needs-attention\nremediation_round: 0\n---\n\n# Validation\nNeeds work.\n",
+    );
+
+    const result = await rule!.match({
+      mid: "M001",
+      midTitle: "Test",
+      basePath: base,
+      state: { phase: "completing-milestone" } as any,
+      prefs: {} as any,
+      session: undefined,
+    } as any);
+
+    assert.ok(result !== null);
+    assert.equal(result!.action, "stop");
+    if (result!.action === "stop") {
+      assert.match(result!.reason, /\/gsd verdict/);
+    }
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("state.ts needs-remediation blocker messages reference /gsd verdict", async () => {
+  // We don't need to invoke deriveState — just assert the substring is in the
+  // source. The blocker strings are constructed inline and shipped to the user
+  // verbatim, so a static check is sufficient and avoids fragile DB setup.
+  const stateSource = readFileSync(
+    new URL("../state.ts", import.meta.url).pathname,
+    "utf-8",
+  );
+  const occurrences = stateSource.match(/`\/gsd verdict /g) ?? [];
+  assert.ok(
+    occurrences.length >= 2,
+    `expected at least 2 references to /gsd verdict in state.ts blockers, found ${occurrences.length}`,
+  );
+});


### PR DESCRIPTION
## Summary

- New `/gsd verdict <pass|needs-attention|needs-remediation> [--milestone Mxxx] [--rationale \"...\"]` slash command that wraps `gsd_validate_milestone` to override the recorded verdict while preserving every other section of the existing `VALIDATION.md`.
- Resolves the active milestone when `--milestone` is omitted; requires `--rationale` for non-pass overrides; suggests `gsd_reassess_roadmap` follow-up when overriding to `needs-remediation`.
- The three paused-state messages now reference the new command instead of "update the verdict manually" — recovery is discoverable without doc-diving:
  - `auto-dispatch.ts:1343` (completing-milestone non-pass guard)
  - `state.ts:594` (handleAllSlicesDone needs-remediation blocker)
  - `state.ts:1317` (\_deriveStateImpl needs-remediation blocker)

Closes #6071

## Test plan

- [x] `parseValidationFile` extracts all standard sections + frontmatter, omits absent optional sections
- [x] `/gsd verdict pass --milestone M001` flips a `needs-attention` milestone to `pass` and preserves every other section
- [x] `/gsd verdict needs-remediation --rationale \"...\"` rewrites the verdict and surfaces the `gsd_reassess_roadmap` follow-up hint
- [x] `/gsd verdict needs-remediation` without `--rationale` is rejected
- [x] `/gsd verdict` with no `--milestone` resolves to the active milestone
- [x] Missing VALIDATION file is rejected with a clear message
- [x] Invalid verdict string is rejected
- [x] Both `auto-dispatch.ts` pause-reason and `state.ts` blocker messages reference `/gsd verdict` (asserted by tests)
- [x] `remediation-completion-guard` regression tests still pass (existing needs-remediation/needs-attention/fail guards untouched)
- [x] `tsc --noEmit` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/gsd verdict` command to set milestone validation verdicts to `pass`, `needs-attention`, or `needs-remediation`. The `--rationale` flag is required when setting non-pass verdicts, and the optional `--milestone` flag allows targeting specific milestones.
  * Updated error messages and guidance text throughout the system to reference the new `/gsd verdict` command for milestone validation changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6073)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->