### PR TITLE
fix(gsd): tolerate verification retries in evidence cross-reference

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -987,6 +987,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
                     command: row.command,
                     exitCode: row.exit_code,
                     verdict: row.verdict,
+                    createdAt: row.created_at,
                   }))
                   .filter((row) => typeof row.command === "string" && row.command.trim().length > 0);
                 const mismatches = crossReferenceEvidence(claimedEvidence, actual);

--- a/src/resources/extensions/gsd/safety/evidence-cross-ref.ts
+++ b/src/resources/extensions/gsd/safety/evidence-cross-ref.ts
@@ -1,3 +1,4 @@
+
 /**
  * Evidence cross-reference for auto-mode safety harness.
  * Compares the LLM's claimed verification evidence (command + exitCode)
@@ -14,6 +15,7 @@ export interface ClaimedEvidence {
   command: string;
   exitCode: number;
   verdict: string;
+  createdAt?: string;
 }
 
 export interface EvidenceMismatch {
@@ -40,7 +42,7 @@ export function crossReferenceEvidence(
   );
   const mismatches: EvidenceMismatch[] = [];
 
-  for (const claimed of claimedEvidence) {
+  for (const claimed of latestClaimBatch(claimedEvidence)) {
     // Skip coerced entries — they're already flagged with exitCode: -1
     // and verdict: "unknown (coerced from string)" by db-tools.ts
     if (claimed.verdict?.includes("coerced from string")) continue;
@@ -49,10 +51,12 @@ export function crossReferenceEvidence(
     // Skip entries with empty or generic commands
     if (!claimed.command || claimed.command.length < 3) continue;
 
-    // Find matching bash call by command substring match
-    const match = findBestMatch(claimed.command, bashCalls);
+    // Find matching bash calls by command similarity. A command may be retried
+    // after a failed first run; the newest matching execution is the one that
+    // supports or rejects a claimed pass.
+    const matches = findMatches(claimed.command, bashCalls);
 
-    if (!match) {
+    if (matches.length === 0) {
       mismatches.push({
         severity: "warning",
         claimed,
@@ -63,6 +67,7 @@ export function crossReferenceEvidence(
     }
 
     // Exit code mismatch: LLM claims success but actual command failed
+    const match = latestMatch(matches);
     if (claimed.exitCode === 0 && match.exitCode !== 0) {
       mismatches.push({
         severity: "error",
@@ -79,42 +84,72 @@ export function crossReferenceEvidence(
 // ─── Internals ──────────────────────────────────────────────────────────────
 
 /**
- * Find the best matching bash evidence entry for a claimed command.
+ * Verification evidence rows are append-only across retries, but a task
+ * completion inserts one batch at a single created_at timestamp. When that
+ * timestamp is present, safety should judge the newest completion claim only.
+ */
+function latestClaimBatch(
+  claimedEvidence: readonly ClaimedEvidence[],
+): readonly ClaimedEvidence[] {
+  const dated = claimedEvidence
+    .map((claim) => ({
+      claim,
+      time: typeof claim.createdAt === "string" ? Date.parse(claim.createdAt) : Number.NaN,
+    }))
+    .filter((entry) => Number.isFinite(entry.time));
+
+  if (dated.length === 0) return claimedEvidence;
+
+  const latestTime = Math.max(...dated.map((entry) => entry.time));
+  return claimedEvidence.filter((claim) => (
+    typeof claim.createdAt === "string" && Date.parse(claim.createdAt) === latestTime
+  ));
+}
+
+/**
+ * Find bash evidence entries matching a claimed command.
  * Uses substring matching — the claimed command may be a shortened version
  * of the actual command, or vice versa.
  */
-function findBestMatch(
+function findMatches(
   claimedCommand: string,
   bashCalls: readonly BashEvidence[],
-): BashEvidence | null {
+): BashEvidence[] {
   const normalized = claimedCommand.trim();
 
-  // Exact match first
-  const exact = bashCalls.find(b => b.command.trim() === normalized);
-  if (exact) return exact;
+  // Exact matches first
+  const exact = bashCalls.filter(b => b.command.trim() === normalized);
+  if (exact.length > 0) return exact;
 
   // Substring match: claimed is contained in actual or actual in claimed
-  const substring = bashCalls.find(
+  const substring = bashCalls.filter(
     b => b.command.includes(normalized) || normalized.includes(b.command),
   );
-  if (substring) return substring;
+  if (substring.length > 0) return substring;
 
   // Token match: split on whitespace and check significant overlap
   const claimedTokens = normalized.split(/\s+/).filter(t => t.length > 2);
-  if (claimedTokens.length === 0) return null;
+  if (claimedTokens.length === 0) return [];
 
-  let bestMatch: BashEvidence | null = null;
-  let bestScore = 0;
+  const scoredMatches: Array<{ call: BashEvidence; score: number }> = [];
 
   for (const call of bashCalls) {
     const callTokens = new Set(call.command.split(/\s+/));
     const matchCount = claimedTokens.filter(t => callTokens.has(t)).length;
     const score = matchCount / claimedTokens.length;
-    if (score > bestScore && score >= 0.5) {
-      bestScore = score;
-      bestMatch = call;
+    if (score >= 0.5) {
+      scoredMatches.push({ call, score });
     }
   }
 
-  return bestMatch;
+  const bestScore = Math.max(0, ...scoredMatches.map((match) => match.score));
+  return scoredMatches
+    .filter((match) => match.score === bestScore)
+    .map((match) => match.call);
+}
+
+function latestMatch(matches: readonly BashEvidence[]): BashEvidence {
+  return matches.reduce((latest, match) => (
+    match.timestamp > latest.timestamp ? match : latest
+  ));
 }

--- a/src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts
+++ b/src/resources/extensions/gsd/tests/evidence-cross-ref.test.ts
@@ -27,6 +27,65 @@ test("claims of passing verification become errors when recorded bash evidence f
   assert.match(mismatches[0].reason, /Claimed exitCode=0/);
 });
 
+test("passing retry evidence is not invalidated by an earlier failed run of the same command", () => {
+  const command = "node todo.js add 'Task A' && node todo.js add 'Task B' && node todo.js done 1";
+  const mismatches = crossReferenceEvidence(
+    [{ command, exitCode: 0, verdict: "passed after retry" }],
+    [
+      {
+        kind: "bash",
+        toolCallId: "call-1",
+        command,
+        exitCode: 1,
+        outputSnippet: "Task #1 not found",
+        timestamp: 1,
+      },
+      {
+        kind: "bash",
+        toolCallId: "call-2",
+        command,
+        exitCode: 0,
+        outputSnippet: "Marked #1 done.",
+        timestamp: 2,
+      },
+    ] as EvidenceEntry[],
+  );
+
+  assert.deepEqual(mismatches, []);
+});
+
+test("stale verification evidence batches are ignored when a newer completion batch exists", () => {
+  const command = "node todo.js add 'Task A' && node todo.js add 'Task B' && node todo.js done 1";
+  const resetCommand = `rm -f "$HOME/.config/todo/data.json" && ${command}`;
+  const mismatches = crossReferenceEvidence(
+    [
+      { command, exitCode: 0, verdict: "pass", createdAt: "2026-05-14T11:16:48.588Z" },
+      { command, exitCode: 1, verdict: "fail before reset", createdAt: "2026-05-14T11:28:36.952Z" },
+      { command: resetCommand, exitCode: 0, verdict: "pass after reset", createdAt: "2026-05-14T11:28:36.952Z" },
+    ],
+    [
+      {
+        kind: "bash",
+        toolCallId: "call-1",
+        command,
+        exitCode: 1,
+        outputSnippet: "Task #1 not found",
+        timestamp: 1,
+      },
+      {
+        kind: "bash",
+        toolCallId: "call-2",
+        command: resetCommand,
+        exitCode: 0,
+        outputSnippet: "Marked #1 done.",
+        timestamp: 2,
+      },
+    ] as EvidenceEntry[],
+  );
+
+  assert.deepEqual(mismatches, []);
+});
+
 test("missing recorded bash evidence remains a warning", () => {
   const mismatches = crossReferenceEvidence(
     [{ command: "npm test", exitCode: 0, verdict: "passed" }],


### PR DESCRIPTION
## Summary

When the auto-mode safety harness compares the LLM's claimed verification evidence against actual recorded bash calls, a verify command that failed once and was retried successfully would still trigger a mismatch. \`findBestMatch\` returned the first matching call (the failure), so a legitimate recovery was rejected by the harness as a false claim.

- \`findMatches\` returns every matching bash call; \`latestMatch\` picks the newest by timestamp, so retries dominate.
- \`latestClaimBatch\` filters claimed evidence to the newest \`created_at\` batch when timestamps are present. Verification evidence is append-only across retries, but a completion records one batch at one moment — only that batch reflects the unit's terminal claim.
- \`auto-post-unit.ts\` now threads \`row.created_at\` into the \`ClaimedEvidence\` shape so the new filter actually fires.

## Test plan

- [x] \`passing retry evidence is not invalidated by an earlier failed run of the same command\` — covers the retry within one batch
- [x] \`stale verification evidence batches are ignored when a newer completion batch exists\` — covers the multi-completion case (failed batch followed by reset + pass batch)
- [x] Existing \`claims of passing verification become errors when recorded bash evidence failed\` still passes (the harness still rejects an outright failed-then-claimed-pass)
- [x] Existing \`missing recorded bash evidence remains a warning\` unchanged
- [x] \`tsc --noEmit\` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Verification system now uses only the most recent evidence batches, preventing outdated data from invalidating valid verifications.
  * Enhanced command matching to evaluate all matching bash calls and prioritize the most recent match, improving accuracy in retry scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6074)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->