### PR TITLE
feat(gsd): discover Node test files when no other verify source matches

### DIFF
--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -244,6 +244,26 @@ pythonpath = ["."]
     assert.deepStrictEqual(result.commands, ["python3 -m pytest"]);
   });
 
+  test("dependency-free Node project with root test file discovers node test command", () => {
+    writeFileSync(join(tmp, "test-todo-cli.js"), "require('node:test')('ok', () => {});\n");
+
+    const result = discoverCommands({ cwd: tmp });
+
+    assert.equal(result.source, "node-test-file");
+    assert.deepStrictEqual(result.commands, ["node test-todo-cli.js"]);
+  });
+
+  test("dependency-free Node test discovery is lower priority than Python pytest", () => {
+    mkdirSync(join(tmp, "tests"), { recursive: true });
+    writeFileSync(join(tmp, "tests", "test_sample.py"), "def test_sample():\n    assert True\n");
+    writeFileSync(join(tmp, "sample.test.js"), "require('node:test')('ok', () => {});\n");
+
+    const result = discoverCommands({ cwd: tmp });
+
+    assert.equal(result.source, "python-project");
+    assert.deepStrictEqual(result.commands, ["python3 -m pytest"]);
+  });
+
   test("Python project with nested Python test file discovers pytest", () => {
     mkdirSync(join(tmp, "tests", "unit"), { recursive: true });
     writeFileSync(join(tmp, "tests", "unit", "sample_test.py"), "def test_sample():\n    assert True\n");

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -106,7 +106,7 @@ export interface AuditWarning {
 export interface VerificationResult {
   passed: boolean; // true if all checks passed (or no checks discovered)
   checks: VerificationCheck[]; // per-command results
-  discoverySource: "preference" | "task-plan" | "package-json" | "python-project" | "none";
+  discoverySource: "preference" | "task-plan" | "package-json" | "python-project" | "node-test-file" | "none";
   timestamp: number; // Date.now() at gate start
   runtimeErrors?: RuntimeError[]; // optional — populated by captureRuntimeErrors()
   auditWarnings?: AuditWarning[]; // optional — populated by runDependencyAudit()

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -45,7 +45,8 @@ const PACKAGE_SCRIPT_KEYS = ["typecheck", "lint", "test"] as const;
  *   2. Task plan verify field (split on &&)
  *   3. package.json scripts (typecheck, lint, test)
  *   4. Python pytest project markers
- *   5. None found
+ *   5. Dependency-free Node test files
+ *   6. None found
  */
 export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCommands {
   // 1. Preference commands
@@ -97,8 +98,30 @@ export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCo
     return { commands: [pythonCommand], source: "python-project" };
   }
 
-  // 5. Nothing found
+  const nodeTestCommand = discoverNodeTestFileCommand(options.cwd);
+  if (nodeTestCommand) {
+    return { commands: [nodeTestCommand], source: "node-test-file" };
+  }
+
+  // 6. Nothing found
   return { commands: [], source: "none" };
+}
+
+function discoverNodeTestFileCommand(cwd: string): string | null {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(cwd, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const testFile = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => /^test-[A-Za-z0-9._-]+\.js$|^[A-Za-z0-9._-]+\.test\.js$/.test(name))
+    .sort()[0];
+
+  return testFile ? `node ${testFile}` : null;
 }
 
 function discoverPythonPytestCommand(cwd: string): string | null {


### PR DESCRIPTION
## Summary

A dependency-free Node project — one with a \`test-foo.js\` or \`bar.test.js\` file at the root but no \`package.json\` scripts and no pytest markers — previously fell through every tier of \`discoverCommands\` and got a no-op verification. The agent then had no automatic signal that its changes broke anything.

- Add a fifth discovery tier between \`python-project\` and \`none\`: scan the project root for \`test-<name>.js\` or \`<name>.test.js\`, pick the lexically first match, and run \`node <file>\`.
- New \`node-test-file\` value on \`VerificationResult.discoverySource\` so dashboards and forensics can distinguish this path from \"nothing found\".

## Test plan

- [x] \`dependency-free Node project with root test file discovers node test command\` — passes \`node test-todo-cli.js\`
- [x] Other discoverCommands tiers (preference, task-plan, package.json, pytest) still take precedence — covered by existing tests that haven't been modified
- [x] All 85 \`verification-gate\` tests pass
- [x] \`tsc --noEmit\` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of Node test files as a fallback detection mechanism when other test runners are unavailable.
  * Ensured Python pytest discovery maintains higher priority than Node test file detection.

* **Tests**
  * Added unit tests to verify Node test file discovery and test runner precedence behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6075)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->