### PR TITLE
fix(issue): Worktree Safety fails hard on unregistered worktree - creates stuck dispatch loop

### DIFF
--- a/src/resources/extensions/gsd/tests/worktree-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-safety.test.ts
@@ -189,6 +189,52 @@ describe("Worktree Safety module", () => {
     assert.equal(result.kind, "worktree-unregistered");
   });
 
+  test("attempts prune recovery once for unregistered worktrees and tracks failed roots", () => {
+    let pruneCalls = 0;
+    let listCalls = 0;
+    const safety = createWorktreeSafetyModule({
+      existsSync: () => true,
+      lstatSync: () => ({ isFile: () => true }),
+      pruneRegisteredWorktrees: () => {
+        pruneCalls += 1;
+      },
+      listRegisteredWorktrees: () => {
+        listCalls += 1;
+        return [];
+      },
+    });
+
+    const first = safety.validateUnitRoot({
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      writeScope: "source-writing",
+      projectRoot,
+      unitRoot,
+      milestoneId: "M001",
+    });
+    assert.equal(first.ok, false);
+    assert.equal(first.kind, "worktree-unregistered");
+    assert.equal(first.details?.attemptedPrune, true);
+    assert.equal(first.details?.trackedAsFailed, true);
+    assert.equal(pruneCalls, 1);
+    assert.equal(listCalls, 2);
+
+    const second = safety.validateUnitRoot({
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      writeScope: "source-writing",
+      projectRoot,
+      unitRoot,
+      milestoneId: "M001",
+    });
+    assert.equal(second.ok, false);
+    assert.equal(second.kind, "worktree-unregistered");
+    assert.equal(second.details?.attemptedPrune, false);
+    assert.equal(second.details?.trackedAsFailed, true);
+    assert.equal(pruneCalls, 1);
+    assert.equal(listCalls, 3);
+  });
+
   test("converts registered worktree list failures into typed failures", () => {
     const safety = createWorktreeSafetyModule({
       existsSync: () => true,

--- a/src/resources/extensions/gsd/worktree-safety.ts
+++ b/src/resources/extensions/gsd/worktree-safety.ts
@@ -2,6 +2,7 @@
 // File Purpose: Worktree Safety module contract for validating source-writing Unit roots.
 
 import { existsSync, lstatSync, type Stats } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join, resolve } from "node:path";
 
 import { normalizeWorktreePathForCompare } from "./worktree-root.js";
@@ -70,6 +71,7 @@ export interface WorktreeSafetyDeps {
   existsSync(path: string): boolean;
   lstatSync(path: string): Pick<Stats, "isFile">;
   listRegisteredWorktrees?(projectRoot: string): readonly RegisteredWorktree[];
+  pruneRegisteredWorktrees?(projectRoot: string): void;
   getCurrentBranch?(unitRoot: string): string;
 }
 
@@ -89,6 +91,12 @@ const defaultDeps: WorktreeSafetyDeps = {
       path: worktree.path,
       branch: worktree.branch,
     }));
+  },
+  pruneRegisteredWorktrees(projectRoot) {
+    execFileSync("git", ["worktree", "prune"], {
+      cwd: projectRoot,
+      stdio: "pipe",
+    });
   },
   getCurrentBranch,
 };
@@ -117,6 +125,8 @@ function errorMessage(error: unknown): string {
 export function createWorktreeSafetyModule(
   deps: WorktreeSafetyDeps = defaultDeps,
 ): WorktreeSafetyModule {
+  const unregisteredRecoveryFailed = new Set<string>();
+
   return {
     validateUnitRoot(input) {
       if (input.writeScope === "planning-only") {
@@ -208,12 +218,41 @@ export function createWorktreeSafetyModule(
         );
       }
       if (registered && !registered.some((worktree) => samePath(worktree.path, unitRoot))) {
-        return failure(
-          "worktree-unregistered",
-          `Worktree root ${unitRoot} is not registered with git worktree list.`,
-          "Recreate or re-register the milestone worktree before dispatching the source-writing Unit.",
-          { unitRoot },
-        );
+        const wasPreviouslyTracked = unregisteredRecoveryFailed.has(unitRoot);
+        let attemptedPrune = false;
+
+        if (!wasPreviouslyTracked && deps.pruneRegisteredWorktrees) {
+          attemptedPrune = true;
+          try {
+            deps.pruneRegisteredWorktrees(projectRoot);
+            const rechecked = deps.listRegisteredWorktrees?.(projectRoot);
+            if (rechecked?.some((worktree) => samePath(worktree.path, unitRoot))) {
+              unregisteredRecoveryFailed.delete(unitRoot);
+              registered = rechecked;
+            } else {
+              unregisteredRecoveryFailed.add(unitRoot);
+            }
+          } catch (error) {
+            unregisteredRecoveryFailed.add(unitRoot);
+            return failure(
+              "worktree-git-probe-failed",
+              `Unable to recover unregistered worktree root ${unitRoot}.`,
+              "Run 'git worktree prune', then recreate the milestone worktree before dispatching the source-writing Unit.",
+              { projectRoot, unitRoot, error: errorMessage(error) },
+            );
+          }
+        }
+
+        if (!registered?.some((worktree) => samePath(worktree.path, unitRoot))) {
+          return failure(
+            "worktree-unregistered",
+            `Worktree root ${unitRoot} is not registered with git worktree list.`,
+            wasPreviouslyTracked
+              ? "Worktree recovery was already attempted for this root. Recreate or re-register the milestone worktree before dispatching the source-writing Unit."
+              : "Run 'git worktree prune'. If still unregistered, recreate or re-register the milestone worktree before dispatching the source-writing Unit.",
+            { unitRoot, attemptedPrune, trackedAsFailed: unregisteredRecoveryFailed.has(unitRoot) },
+          );
+        }
       }
 
       if (input.emptyWorktreeWithProjectContent) {

--- a/src/resources/extensions/gsd/worktree-safety.ts
+++ b/src/resources/extensions/gsd/worktree-safety.ts
@@ -247,8 +247,8 @@ export function createWorktreeSafetyModule(
           return failure(
             "worktree-unregistered",
             `Worktree root ${unitRoot} is not registered with git worktree list.`,
-            wasPreviouslyTracked
-              ? "Worktree recovery was already attempted for this root. Recreate or re-register the milestone worktree before dispatching the source-writing Unit."
+            attemptedPrune || wasPreviouslyTracked
+              ? "Worktree recovery was attempted but the root is still unregistered. Recreate or re-register the milestone worktree before dispatching the source-writing Unit."
               : "Run 'git worktree prune'. If still unregistered, recreate or re-register the milestone worktree before dispatching the source-writing Unit.",
             { unitRoot, attemptedPrune, trackedAsFailed: unregisteredRecoveryFailed.has(unitRoot) },
           );


### PR DESCRIPTION
## Summary
- Added one-pass `git worktree prune` recovery with failed-root tracking in worktree safety and verified via the targeted `worktree-safety` test suite (14/14 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6081
- [#6081 Worktree Safety fails hard on unregistered worktree - creates stuck dispatch loop](https://github.com/gsd-build/gsd-2/issues/6081)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6081-worktree-safety-fails-hard-on-unregister-1778808649`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for missing worktree paths that attempts to restore connectivity.
  * Recovery errors now include contextual information about previously attempted recovery steps.

* **Tests**
  * Added test coverage for unregistered worktree scenarios and recovery behavior across multiple validation attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6083)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->