### PR TITLE
fix(issue): prepareForUnit runs worktree validation unconditionally, blocks branch/none isolation

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1936,6 +1936,9 @@ export function createWiredAutoOrchestrationModule(
           manifest.tools.mode === "all" || manifest.tools.mode === "docs"
             ? "source-writing"
             : "planning-only";
+        if (getIsolationMode(runtimeBasePath) !== "worktree") {
+          return { ok: true, reason: "isolation-not-worktree" };
+        }
         const safety = createWorktreeSafetyModule();
         const snapshot = await deriveState(dispatchBasePath);
         const milestoneId = snapshot.activeMilestone?.id ?? null;

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -274,6 +274,26 @@ test("advance() blocks before Runtime persistence when Worktree Safety fails", a
   assert.ok(calls.includes("journal:advance-blocked"));
 });
 
+test("advance() allows non-worktree isolation prepare result", async () => {
+  const { deps, calls } = makeDeps({
+    worktree: {
+      async prepareForUnit() {
+        calls.push("worktree.prepare");
+        return { ok: true, reason: "isolation-not-worktree" };
+      },
+      async syncAfterUnit() { calls.push("worktree.sync"); },
+      async cleanupOnStop() { calls.push("worktree.cleanup"); },
+    },
+  });
+  const orchestrator = createAutoOrchestrator(deps);
+
+  const result = await orchestrator.advance();
+
+  assert.equal(result.kind, "advanced");
+  assert.ok(calls.includes("journal:advance"));
+  assert.ok(calls.includes("worktree.sync"));
+});
+
 test("advance() stops when dispatch has no next unit", async () => {
   const { deps } = makeDeps({
     dispatch: {


### PR DESCRIPTION
## Summary
- Added a non-worktree isolation guard in `prepareForUnit` and verified isolation behavior tests pass while noting unrelated existing typecheck failures.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6084
- [#6084 prepareForUnit runs worktree validation unconditionally, blocks branch/none isolation](https://github.com/gsd-build/gsd-2/issues/6084)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6084-prepareforunit-runs-worktree-validation--1778810486`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime isolation handling by skipping unnecessary worktree preparation when not in worktree mode, reducing false failures and improving advance flow.

* **Tests**
  * Added a test validating successful advance behavior when non-worktree isolation is reported, ensuring correct journal and sync actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6085)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->