### PR TITLE
fix(issue): Pre-exec checks treat @/ path aliases as npm packages

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -135,7 +135,7 @@ export function extractPackageReferences(description: string): string[] {
   while ((importMatch = importPattern.exec(description)) !== null) {
     // Skip relative imports and node builtins
     const pkg = importMatch[1];
-    if (!pkg.startsWith(".") && !pkg.startsWith("node:")) {
+    if (!pkg.startsWith(".") && !pkg.startsWith("node:") && !pkg.startsWith("@/")) {
       packages.add(normalizePackageName(pkg));
     }
   }

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -128,6 +128,12 @@ import type { Request } from 'express';
     assert.deepEqual(packages, []);
   });
 
+  test("ignores @/ path alias imports", () => {
+    const desc = `import { handler } from '@/app/api/hello/route';`;
+    const packages = extractPackageReferences(desc);
+    assert.deepEqual(packages, []);
+  });
+
   test("normalizes package subpaths", () => {
     const desc = "npm install lodash/get";
     const packages = extractPackageReferences(desc);


### PR DESCRIPTION
## Summary
- Excluded `@/` alias imports from pre-exec package extraction and verified with the targeted pre-execution checks test suite (98 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6080
- [#6080 Pre-exec checks treat @/ path aliases as npm packages](https://github.com/gsd-build/gsd-2/issues/6080)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6080-pre-exec-checks-treat-path-aliases-as-np-1778811749`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Path aliases starting with `@/` are no longer incorrectly treated as npm packages.

**Tests**
* Added test coverage for path alias handling in package detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6092)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->