### PR TITLE
fix(gsd): enforce planning absolute paths within target repo roots

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -724,6 +724,38 @@ github:
 - `/github-sync bootstrap` — initial setup and sync
 - `/github-sync status` — show sync mapping counts
 
+### `workspace` (v2.49)
+
+Multi-repository parent workspace configuration. This lets one `.gsd` state manage multiple child repositories and constrains planning file paths to declared repository roots.
+
+```yaml
+workspace:
+  mode: parent                  # "project" (default) or "parent"
+  repositories:
+    frontend:
+      path: frontend            # relative to project root (or absolute path within project root)
+      role: ui                  # optional
+      verification:             # optional default verification commands
+        - npm run test
+      commit_policy: auto       # optional: "auto" or "skip"
+    backend:
+      path: backend
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | string | `project` | Workspace mode. `parent` enables multi-repo registry behavior. |
+| `repositories` | object | `{}` | Map of repository ids to repository config objects. |
+| `repositories.<id>.path` | string | required | Repository root path. Relative paths resolve from project root and must stay inside project root. |
+| `repositories.<id>.role` | string | (none) | Optional human-oriented label for prompts/reporting. |
+| `repositories.<id>.verification` | string[] | (none) | Optional default verification commands for that repository. |
+| `repositories.<id>.commit_policy` | string | (none) | Optional per-repo auto-mode turn commit policy: `auto` or `skip`. |
+
+**Path-scope behavior:**
+- During planning (`plan-slice`/`replan-slice`), file paths are validated against the selected `targetRepositories`.
+- Absolute and relative paths are both checked; paths that resolve outside declared repository roots are rejected.
+- If no explicit `targetRepositories` are provided, planning defaults to `["project"]`.
+
 ### `notifications`
 
 Control what notifications GSD sends during auto mode:

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1837,7 +1837,6 @@ export function reconcileWorktreeDb(
       const hasEscalationAwaiting = wtTaskInfo.some((col) => col["name"] === "escalation_awaiting_review");
       const hasEscalationArtifact = wtTaskInfo.some((col) => col["name"] === "escalation_artifact_path");
       const hasEscalationOverride = wtTaskInfo.some((col) => col["name"] === "escalation_override_applied_at");
-      const hasTaskTargetRepositories = wtTaskInfo.some((col) => col["name"] === "target_repositories");
       const wtArtifactInfo = adapter.prepare("PRAGMA wt.table_info('artifacts')").all();
       const hasArtifactContentHash = wtArtifactInfo.some((col) => col["name"] === "content_hash");
       const wtMemoryInfo = adapter.prepare("PRAGMA wt.table_info('memories')").all();

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1837,6 +1837,7 @@ export function reconcileWorktreeDb(
       const hasEscalationAwaiting = wtTaskInfo.some((col) => col["name"] === "escalation_awaiting_review");
       const hasEscalationArtifact = wtTaskInfo.some((col) => col["name"] === "escalation_artifact_path");
       const hasEscalationOverride = wtTaskInfo.some((col) => col["name"] === "escalation_override_applied_at");
+      const hasTaskTargetRepositories = wtTaskInfo.some((col) => col["name"] === "target_repositories");
       const wtArtifactInfo = adapter.prepare("PRAGMA wt.table_info('artifacts')").all();
       const hasArtifactContentHash = wtArtifactInfo.some((col) => col["name"] === "content_hash");
       const wtMemoryInfo = adapter.prepare("PRAGMA wt.table_info('memories')").all();

--- a/src/resources/extensions/gsd/planning-path-scope.ts
+++ b/src/resources/extensions/gsd/planning-path-scope.ts
@@ -37,7 +37,7 @@ export function validatePlanningPathScope(
         ? resolve(candidate)
         : resolve(basePath, candidate);
       if (isInsideAnyBase(absoluteRoots, resolvedCandidate)) continue;
-      return `${field} contains path outside allowed repository roots: ${candidate}. Use a path relative to one of: ${absoluteRoots.join(", ")}.`;
+      return `${field} contains path outside allowed repository roots: ${candidate}. Use a path within one of: ${absoluteRoots.join(", ")}.`;
     }
   }
 

--- a/src/resources/extensions/gsd/planning-path-scope.ts
+++ b/src/resources/extensions/gsd/planning-path-scope.ts
@@ -33,9 +33,11 @@ export function validatePlanningPathScope(
   for (const { field, values } of fields) {
     for (const raw of values) {
       const candidate = normalizePlannedFileReference(raw);
-      if (!isAbsolute(candidate)) continue;
-      if (isInsideAnyBase(absoluteRoots, candidate)) continue;
-      return `${field} contains absolute path outside allowed repository roots: ${candidate}. Use a path relative to one of: ${absoluteRoots.join(", ")}.`;
+      const resolvedCandidate = isAbsolute(candidate)
+        ? resolve(candidate)
+        : resolve(basePath, candidate);
+      if (isInsideAnyBase(absoluteRoots, resolvedCandidate)) continue;
+      return `${field} contains path outside allowed repository roots: ${candidate}. Use a path relative to one of: ${absoluteRoots.join(", ")}.`;
     }
   }
 

--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -196,6 +196,50 @@ test('handlePlanSlice enforces absolute path scope to declared target repositori
   }
 });
 
+test('handlePlanSlice rejects relative traversal outside declared target repositories', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    seedParentSlice();
+    mkdirSync(join(base, 'frontend'), { recursive: true });
+    mkdirSync(join(base, 'backend'), { recursive: true });
+    writeFileSync(
+      join(base, '.gsd', 'PREFERENCES.md'),
+      [
+        '---',
+        'workspace:',
+        '  mode: parent',
+        '  repositories:',
+        '    frontend:',
+        '      path: frontend',
+        '    backend:',
+        '      path: backend',
+        '---',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const result = await handlePlanSlice({
+      ...validParams(),
+      targetRepositories: ['frontend'],
+      tasks: [
+        {
+          ...validParams().tasks[0],
+          files: ['../sibling-repo/src/server.ts'],
+          targetRepositories: ['frontend'],
+        },
+      ],
+    }, base);
+
+    assert.ok('error' in result);
+    assert.match(result.error, /outside allowed repository roots/);
+    assert.equal(getSliceTasks('M001', 'S02').length, 0, 'relative traversal outside scope must not persist');
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handlePlanSlice renders plan artifacts under worktree-local .gsd while using project DB', async () => {
   const base = makeTmpBase();
   const worktree = join(base, '.gsd', 'worktrees', 'M001');

--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -380,7 +380,7 @@ test('handlePlanSlice rejects absolute task IO paths outside the active worktree
     }, base);
 
     assert.ok('error' in result);
-    assert.match(result.error, /validation failed: tasks\[0\]\.inputs contains absolute path outside allowed repository roots/);
+    assert.match(result.error, /validation failed: tasks\[0\]\.inputs contains path outside allowed repository roots/);
     assert.equal(getSliceTasks('M001', 'S02').length, 0, 'invalid planning IO must not persist tasks');
   } finally {
     cleanup(base);

--- a/src/resources/extensions/gsd/tests/plan-task.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-task.test.ts
@@ -110,7 +110,7 @@ test('handlePlanTask rejects absolute task IO paths outside the active worktree'
     }, base);
 
     assert.ok('error' in result);
-    assert.match(result.error, /validation failed: inputs contains absolute path outside allowed repository roots/);
+    assert.match(result.error, /validation failed: inputs contains path outside allowed repository roots/);
     assert.equal(getTask('M001', 'S02', 'T02'), null, 'invalid planning IO must not persist the task');
   } finally {
     cleanup(base);


### PR DESCRIPTION
## Summary
- enforce pre-exec absolute path scope against allowed target repository roots
- wire plan-slice path-scope checks to repository registry targets
- add schema/plan-slice coverage for repo-root path validation

Closes #6088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-repository workspace support with per-repo settings and repository-targeted planning; slices/tasks can be assigned target repositories and persist that selection.
  * Path validation now respects declared repository roots when planning.

* **Documentation**
  * Added user docs for workspace preferences and path-scope behavior.

* **Tests**
  * New/updated tests for workspace prefs, repository registry, and target-repositories validation.

* **Bug Fixes**
  * Improved validation and error handling for repository paths and planning inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6095)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->