### PR TITLE
fix(issue): isClosedStatus misses "closed" DB value — infinite discuss-milestone loop

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1615,7 +1615,7 @@ export function updateMilestoneStatus(milestoneId: string, status: string, compl
 export function getActiveMilestoneFromDb(): MilestoneRow | null {
   if (!currentDb) return null;
   const row = currentDb.prepare(
-    "SELECT * FROM milestones WHERE status NOT IN ('complete', 'parked') ORDER BY id LIMIT 1",
+    "SELECT * FROM milestones WHERE status NOT IN ('complete', 'done', 'skipped', 'closed', 'parked') ORDER BY id LIMIT 1",
   ).get();
   if (!row) return null;
   return rowToMilestone(row);
@@ -1671,7 +1671,7 @@ export function getArtifact(path: string): ArtifactRow | null {
 export function getActiveMilestoneIdFromDb(): IdStatusSummary | null {
   if (!currentDb) return null;
   const row = currentDb.prepare(
-    "SELECT id, status FROM milestones WHERE status NOT IN ('complete', 'parked') ORDER BY id LIMIT 1",
+    "SELECT id, status FROM milestones WHERE status NOT IN ('complete', 'done', 'skipped', 'closed', 'parked') ORDER BY id LIMIT 1",
   ).get();
   if (!row) return null;
   return rowToIdStatusSummary(row);
@@ -1886,16 +1886,16 @@ export function reconcileWorktreeDb(
           )
           SELECT w.id, w.title,
                  CASE
-                   WHEN m.status IN ('complete', 'done') AND w.status NOT IN ('complete', 'done')
+                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
                    THEN m.status ELSE w.status
                  END,
                  w.depends_on,
                  CASE
-                   WHEN m.status IN ('complete', 'done') AND w.status NOT IN ('complete', 'done')
+                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
                    THEN m.created_at ELSE w.created_at
                  END,
                  CASE
-                   WHEN m.status IN ('complete', 'done') AND w.status NOT IN ('complete', 'done')
+                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
                    THEN m.completed_at ELSE w.completed_at
                  END,
                  w.vision, w.success_criteria, w.key_risks, w.proof_strategy,
@@ -1919,12 +1919,12 @@ export function reconcileWorktreeDb(
           )
           SELECT w.milestone_id, w.id, w.title,
                  CASE
-                   WHEN m.status IN ('complete', 'done') AND w.status NOT IN ('complete', 'done')
+                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
                    THEN m.status ELSE w.status
                  END,
                  w.risk, w.depends, w.demo, w.created_at,
                  CASE
-                   WHEN m.status IN ('complete', 'done') AND w.status NOT IN ('complete', 'done')
+                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
                    THEN m.completed_at ELSE w.completed_at
                  END,
                  w.full_summary_md, w.full_uat_md, w.goal, w.success_criteria, w.proof_level,
@@ -1950,13 +1950,13 @@ export function reconcileWorktreeDb(
           )
           SELECT w.milestone_id, w.slice_id, w.id, w.title,
                  CASE
-                   WHEN m.status IN ('complete', 'done') AND w.status NOT IN ('complete', 'done')
+                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
                    THEN m.status ELSE w.status
                  END,
                  w.one_liner, w.narrative,
                  w.verification_result, w.duration,
                  CASE
-                   WHEN m.status IN ('complete', 'done') AND w.status NOT IN ('complete', 'done')
+                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
                    THEN m.completed_at ELSE w.completed_at
                  END,
                  w.blocker_discovered,

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -110,6 +110,7 @@ const providerLoader = createSqliteProviderLoader({
 });
 
 export const SCHEMA_VERSION = 28;
+const TERMINAL_STATUS_SQL = "'complete', 'done', 'skipped', 'closed'";
 
 function initSchema(db: DbAdapter, fileBacked: boolean, dbPath: string | null): void {
   const conservativeFilePragmas = fileBacked && _isLikelyWslDrvFsPathForTest(dbPath);
@@ -1092,7 +1093,7 @@ export function insertSlice(s: {
     )
     ON CONFLICT (milestone_id, id) DO UPDATE SET
       title = CASE WHEN :raw_title IS NOT NULL THEN excluded.title ELSE slices.title END,
-      status = CASE WHEN slices.status IN ('complete', 'done') THEN slices.status ELSE excluded.status END,
+      status = CASE WHEN slices.status IN (${TERMINAL_STATUS_SQL}) THEN slices.status ELSE excluded.status END,
       risk = CASE WHEN :raw_risk IS NOT NULL THEN excluded.risk ELSE slices.risk END,
       depends = excluded.depends,
       demo = CASE WHEN :raw_demo IS NOT NULL THEN excluded.demo ELSE slices.demo END,
@@ -1886,16 +1887,16 @@ export function reconcileWorktreeDb(
           )
           SELECT w.id, w.title,
                  CASE
-                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
+                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
                    THEN m.status ELSE w.status
                  END,
                  w.depends_on,
                  CASE
-                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
+                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
                    THEN m.created_at ELSE w.created_at
                  END,
                  CASE
-                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
+                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
                    THEN m.completed_at ELSE w.completed_at
                  END,
                  w.vision, w.success_criteria, w.key_risks, w.proof_strategy,
@@ -1919,12 +1920,12 @@ export function reconcileWorktreeDb(
           )
           SELECT w.milestone_id, w.id, w.title,
                  CASE
-                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
+                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
                    THEN m.status ELSE w.status
                  END,
                  w.risk, w.depends, w.demo, w.created_at,
                  CASE
-                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
+                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
                    THEN m.completed_at ELSE w.completed_at
                  END,
                  w.full_summary_md, w.full_uat_md, w.goal, w.success_criteria, w.proof_level,
@@ -1950,13 +1951,13 @@ export function reconcileWorktreeDb(
           )
           SELECT w.milestone_id, w.slice_id, w.id, w.title,
                  CASE
-                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
+                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
                    THEN m.status ELSE w.status
                  END,
                  w.one_liner, w.narrative,
                  w.verification_result, w.duration,
                  CASE
-                   WHEN m.status IN ('complete', 'done', 'skipped', 'closed') AND w.status NOT IN ('complete', 'done', 'skipped', 'closed')
+                   WHEN m.status IN (${TERMINAL_STATUS_SQL}) AND w.status NOT IN (${TERMINAL_STATUS_SQL})
                    THEN m.completed_at ELSE w.completed_at
                  END,
                  w.blocker_discovered,

--- a/src/resources/extensions/gsd/status-guards.ts
+++ b/src/resources/extensions/gsd/status-guards.ts
@@ -2,7 +2,8 @@
  * Status predicates for GSD state-machine guards.
  *
  * The DB stores status as free-form strings. Three values indicate
- * "closed": "complete" (canonical), "done" (legacy / alias), and
+ * "closed": "complete" (canonical), "done" (legacy / alias),
+ * "closed" (legacy/imported), and
  * "skipped" (user-directed skip via rethink or backtrack).
  * Every inline `status === "complete" || status === "done"` should
  * use isClosedStatus() instead.
@@ -10,7 +11,7 @@
 
 /** Returns true when a milestone, slice, or task status indicates closure. */
 export function isClosedStatus(status: string): boolean {
-  return status === "complete" || status === "done" || status === "skipped";
+  return status === "complete" || status === "done" || status === "skipped" || status === "closed";
 }
 
 /** Returns true when a slice status indicates it was deferred by a decision. */

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -30,6 +30,7 @@ import {
   insertTask,
   getTask,
   getSliceTasks,
+  getActiveMilestoneFromDb,
   deleteMilestone,
   clearEngineHierarchy,
   recordMilestoneCommitAttribution,
@@ -215,6 +216,22 @@ describe('gsd-db', () => {
     // Non-existent
     const missing = getRequirementById('R999');
     assert.deepStrictEqual(missing, null, 'non-existent requirement returns null');
+
+    closeDatabase();
+  });
+
+  test("gsd-db: getActiveMilestoneFromDb excludes closed statuses", () => {
+    openDatabase(":memory:");
+
+    insertMilestone({ id: "M001", title: "Done", status: "complete" });
+    insertMilestone({ id: "M002", title: "Legacy done", status: "done" });
+    insertMilestone({ id: "M003", title: "Skipped", status: "skipped" });
+    insertMilestone({ id: "M004", title: "Closed", status: "closed" });
+    insertMilestone({ id: "M005", title: "Parked", status: "parked" });
+    insertMilestone({ id: "M006", title: "Active", status: "active" });
+
+    const active = getActiveMilestoneFromDb();
+    assert.equal(active?.id, "M006", "closed/complete/done/skipped/parked should be excluded from active milestone selection");
 
     closeDatabase();
   });

--- a/src/resources/extensions/gsd/tests/status-guards.test.ts
+++ b/src/resources/extensions/gsd/tests/status-guards.test.ts
@@ -17,6 +17,10 @@ test('isClosedStatus: "skipped" returns true', () => {
   assert.equal(isClosedStatus('skipped'), true);
 });
 
+test('isClosedStatus: "closed" returns true', () => {
+  assert.equal(isClosedStatus('closed'), true);
+});
+
 test('isClosedStatus: "pending" returns false', () => {
   assert.equal(isClosedStatus('pending'), false);
 });


### PR DESCRIPTION
## Summary
- Added `"closed"` as a terminal status across guard/query/merge paths and verified with focused status-guard and gsd-db tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6064
- [#6064 isClosedStatus misses "closed" DB value — infinite discuss-milestone loop](https://github.com/gsd-build/gsd-2/issues/6064)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6064-isclosedstatus-misses-closed-db-value-in-1778816093`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved active milestone filtering to exclude additional terminal statuses (complete, done, skipped, closed, parked).
  * Enhanced status preservation logic during milestone, slice, and task data reconciliation.
  * "Closed" status now properly recognized as a terminal status.

* **Tests**
  * Added test coverage for milestone active status filtering and closed status recognition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6103)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->