### PR TITLE
fix(issue): Stale s.currentUnit after finalize-retry causes wrong tool scoping for next unit

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -2481,6 +2481,8 @@ export async function runFinalize(
   const preUnitSnapshot = s.currentUnit
     ? { type: s.currentUnit.type, id: s.currentUnit.id, startedAt: s.currentUnit.startedAt }
     : null;
+  s.currentUnit = null;
+  clearCurrentPhase();
   const preResultGuard = await withTimeout(
     deps.postUnitPreVerification(postUnitCtx, preVerificationOpts),
     FINALIZE_PRE_TIMEOUT_MS,
@@ -2653,9 +2655,6 @@ export async function runFinalize(
       });
     }
   }
-  s.currentUnit = null;
-  clearCurrentPhase();
-
   // Surface accumulated workflow-logger issues for this unit to the user.
   // Warnings/errors logged during the unit are buffered in the logger and
   // drained here so the user sees a single consolidated post-unit alert.

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2787,6 +2787,7 @@ test("autoLoop re-iterates when postUnitPreVerification returns retry (#1571)", 
     const s = makeLoopSession();
 
     let preVerifyCallCount = 0;
+    const currentUnitSnapshotsAtPreVerify: Array<{ type: string; id: string; startedAt: number } | null> = [];
     // Pre-queued responses: first call returns "retry", second returns "continue"
     const preVerifyResponses = ["retry", "continue"] as const;
 
@@ -2804,6 +2805,7 @@ test("autoLoop re-iterates when postUnitPreVerification returns retry (#1571)", 
       },
       postUnitPreVerification: async () => {
         deps.callLog.push("postUnitPreVerification");
+        currentUnitSnapshotsAtPreVerify.push(s.currentUnit);
         const response = preVerifyResponses[preVerifyCallCount++] ?? "continue";
         if (response === "retry") {
           s.pendingVerificationRetry = {
@@ -2834,6 +2836,11 @@ test("autoLoop re-iterates when postUnitPreVerification returns retry (#1571)", 
     await loopPromise;
 
     assert.equal(preVerifyCallCount, 2, "preVerification should be called twice");
+    assert.deepEqual(
+      currentUnitSnapshotsAtPreVerify,
+      [null, null],
+      "currentUnit should be cleared before each preVerification run to prevent stale retry scope",
+    );
 
     const postVerifyCalls = deps.callLog.filter(
       (c: string) => c === "runPostUnitVerification",


### PR DESCRIPTION
## Summary
- Moved `s.currentUnit`/phase cleanup to the top of `runFinalize` so finalize-retry paths cannot leak stale unit tool scoping, verified by passing targeted auto-recovery tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6102
- [#6102 Stale s.currentUnit after finalize-retry causes wrong tool scoping for next unit](https://github.com/gsd-build/gsd-2/issues/6102)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6102-stale-s-currentunit-after-finalize-retry-1778816156`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected timing of session state cleanup to occur before verification runs, preventing stale retry context from persisting across iterations and ensuring reliable retry behavior during phase processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6105)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->