### PR TITLE
fix(issue): Worktree Safety fail-closes on hook/* units: missing-tool-contract for hook/session-context

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -150,6 +150,7 @@ export function shouldDegradeEmptyWorktreeToProjectRoot(
 }
 
 function unitWritesSource(unitType: string): boolean | null {
+  if (unitType.startsWith("hook/")) return false;
   // Backward compatibility: sidecar queues from older builds may persist
   // prefixed unit types (e.g. "sidecar/quick-task").
   const normalizedUnitType = unitType.startsWith("sidecar/")

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -4164,6 +4164,74 @@ test("dispatch Worktree Safety accepts sidecar-prefixed known unit types", async
   assert.ok(!deps.callLog.includes("stopAuto"), "should not stop for sidecar-prefixed known unit types");
 });
 
+test("dispatch Worktree Safety allows hook units without Unit Tool Contract manifests", async (t) => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  const pi = makeMockPi();
+  const notifications: string[] = [];
+  ctx.ui.notify = (msg: string) => { notifications.push(msg); };
+
+  const projectRoot = mkdtempSync(join(tmpdir(), "gsd-wt-safety-hook-contract-"));
+  const worktreeRoot = join(projectRoot, ".gsd", "worktrees", "M001");
+  mkdirSync(worktreeRoot, { recursive: true });
+  t.after(() => rmSync(projectRoot, { recursive: true, force: true }));
+
+  const s = makeLoopSession({
+    basePath: worktreeRoot,
+    originalBasePath: projectRoot,
+    canonicalProjectRoot: projectRoot,
+  });
+  const deps = makeMockDeps({
+    getIsolationMode: () => "worktree",
+    resolveDispatch: async () => {
+      deps.callLog.push("resolveDispatch");
+      return {
+        action: "dispatch" as const,
+        unitType: "hook/session-context",
+        unitId: "M001/S01/T01",
+        prompt: "do the thing",
+      };
+    },
+  });
+
+  const result = await runDispatch(
+    {
+      ctx,
+      pi,
+      s,
+      deps,
+      prefs: undefined,
+      iteration: 1,
+      flowId: "test-flow",
+      nextSeq: () => 1,
+    },
+    {
+      state: {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Test", status: "active" },
+        activeSlice: { id: "S01", title: "Slice 1" },
+        activeTask: { id: "T01" },
+        registry: [{ id: "M001", status: "active" }],
+        blockers: [],
+      } as any,
+      mid: "M001",
+      midTitle: "Test",
+    },
+    {
+      recentUnits: [],
+      stuckRecoveryAttempts: 0,
+      consecutiveFinalizeTimeouts: 0,
+    },
+  );
+
+  assert.equal(result.action, "next");
+  assert.ok(
+    !notifications.some((n) => n.includes("missing Tool Contract for hook/session-context")),
+    "hook units should not fail closed with missing-tool-contract",
+  );
+});
+
 test("pre-dispatch skip resolves before dispatch health and stuck accounting", async () => {
   _resetPendingResolve();
 


### PR DESCRIPTION
## Summary
- Hook units now bypass missing-tool-contract in worktree safety, verified by adding and passing a targeted auto-loop regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6059
- [#6059 Worktree Safety fail-closes on hook/* units: missing-tool-contract for hook/session-context](https://github.com/gsd-build/gsd-2/issues/6059)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6059-worktree-safety-fail-closes-on-hook-unit-1778817484`