### PR TITLE
fix(issue): Forensic: 5 verifier/dispatcher bugs cause auto-mode to falsely fail completed tasks

### DIFF
--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -81,7 +81,7 @@ describe("verification-gate: discovery", () => {
     assert.equal(result.source, "package-json");
   });
 
-  test("first-non-empty-wins — preference beats task plan and package.json", () => {
+  test("first-non-empty-wins — task plan beats preference and package.json", () => {
     writeFileSync(
       join(tmp, "package.json"),
       JSON.stringify({ scripts: { lint: "eslint ." } }),
@@ -91,8 +91,8 @@ describe("verification-gate: discovery", () => {
       taskPlanVerify: "npm run lint",
       cwd: tmp,
     });
-    assert.deepStrictEqual(result.commands, ["custom-check"]);
-    assert.equal(result.source, "preference");
+    assert.deepStrictEqual(result.commands, ["npm run lint"]);
+    assert.equal(result.source, "task-plan");
   });
 
   test("task plan verify beats package.json", () => {

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -1,6 +1,6 @@
 // GSD Extension — Verification Gate
 // Pure functions for discovering and running verification commands.
-// Discovery order (D003): preference → task plan verify → package.json scripts.
+// Discovery order (D003): task plan verify → preference → package.json scripts.
 // First non-empty source wins.
 
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
@@ -41,25 +41,15 @@ const PACKAGE_SCRIPT_KEYS = ["typecheck", "lint", "test"] as const;
 
 /**
  * Discover verification commands using the first-non-empty-wins strategy (D003):
- *   1. Explicit preference commands
- *   2. Task plan verify field (split on && and newlines)
+ *   1. Task plan verify field (split on && and newlines)
+ *   2. Explicit preference commands
  *   3. package.json scripts (typecheck, lint, test)
  *   4. Python pytest project markers
  *   5. Dependency-free Node test files
  *   6. None found
  */
 export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCommands {
-  // 1. Preference commands
-  if (options.preferenceCommands && options.preferenceCommands.length > 0) {
-    const filtered = options.preferenceCommands
-      .map(c => c.trim())
-      .filter(Boolean);
-    if (filtered.length > 0) {
-      return { commands: filtered, source: "preference" };
-    }
-  }
-
-  // 2. Task plan verify field (commands are untrusted — sanitize)
+  // 1. Task plan verify field (commands are untrusted — sanitize)
   if (options.taskPlanVerify && options.taskPlanVerify.trim()) {
     const commands = options.taskPlanVerify
       .split(/&&|\r?\n/)
@@ -68,6 +58,16 @@ export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCo
       .filter(c => sanitizeCommand(c) !== null);
     if (commands.length > 0) {
       return { commands, source: "task-plan" };
+    }
+  }
+
+  // 2. Preference commands
+  if (options.preferenceCommands && options.preferenceCommands.length > 0) {
+    const filtered = options.preferenceCommands
+      .map(c => c.trim())
+      .filter(Boolean);
+    if (filtered.length > 0) {
+      return { commands: filtered, source: "preference" };
     }
   }
 


### PR DESCRIPTION
## Summary
- Prioritized task-plan verification commands over preference fallback and verified with the targeted verification-gate test suite (85/85 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Addresses part of #6106 (Bug 2, simple-command case — task-plan verify now takes precedence over preference commands for simple commands; `||` fallback chains in task-plan verify are separately blocked by the shell-injection guard and remain a known limitation)
- [#6106 Forensic: 5 verifier/dispatcher bugs cause auto-mode to falsely fail completed tasks](https://github.com/gsd-build/gsd-2/issues/6106)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6106-forensic-5-verifier-dispatcher-bugs-caus-1778817842`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated verification command discovery precedence to prioritize task-plan verify commands ahead of preference commands and package.json scripts.

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->