### PR TITLE
fix(issue): auto-mode blocks on stale needs-remediation verdict after remediation slice completes

### DIFF
--- a/src/resources/extensions/gsd/prompts/validate-milestone.md
+++ b/src/resources/extensions/gsd/prompts/validate-milestone.md
@@ -77,8 +77,9 @@ Extract the `Verification Classes` subsection from Reviewer C and pass it verbat
 **DB access safety:** Do NOT query `.gsd/gsd.db` directly via `sqlite3` or `node -e require('better-sqlite3')` - the engine owns the WAL connection. Use `gsd_milestone_status` for milestone and slice state. Data is already inlined or available via `gsd_*` tools. Direct DB access risks WAL corruption and bypasses validation.
 
 If verdict is `needs-remediation`:
-- Use `gsd_reassess_roadmap` to add remediation slices instead of editing `{{roadmapPath}}` manually.
-- Those slices will be planned and executed before validation re-runs
+- First call `gsd_validate_milestone` to persist this failed validation verdict.
+- Then use `gsd_reassess_roadmap` to add remediation slices instead of editing `{{roadmapPath}}` manually.
+- Those slices will be planned and executed before validation re-runs.
 
 **You MUST call `gsd_validate_milestone` before finishing. Do not manually write `{{validationPath}}`.**
 


### PR DESCRIPTION
## Summary
- Reordered validate-milestone remediation instructions so validation is persisted before roadmap reassessment, and verified with targeted GSD prompt tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6110
- [#6110 auto-mode blocks on stale needs-remediation verdict after remediation slice completes](https://github.com/gsd-build/gsd-2/issues/6110)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6110-auto-mode-blocks-on-stale-needs-remediat-1778821380`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated validation failure handling instructions to clarify the required sequence of remediation operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6111)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->