### PR TITLE
fix(issue): auto-mode: pauseAuto and SIGTERM handler leak workers DB row (status='active') causing stale_crash_lock false positive

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -660,7 +660,17 @@ function registerSigtermHandler(currentBasePath: string): void {
   s.sigtermHandler = _registerSigtermHandler(
     currentBasePath,
     s.sigtermHandler,
-    () => closeOutSignalInterruptedUnit(currentBasePath),
+    () => {
+      closeOutSignalInterruptedUnit(currentBasePath);
+      try {
+        if (s.workerId) {
+          markWorkerStopping(s.workerId);
+          s.workerId = null;
+        }
+      } catch (err) {
+        logWarning("engine", `signal worker cleanup failed: ${getErrorMessage(err)}`, { file: "auto.ts" });
+      }
+    },
   );
 }
 
@@ -1761,6 +1771,15 @@ export async function pauseAuto(
   if (lockBase()) {
     releaseSessionLock(lockBase());
     clearLock(lockBase());
+  }
+
+  if (s.workerId) {
+    try {
+      markWorkerStopping(s.workerId);
+    } catch {
+      // best-effort cleanup; pause must still complete
+    }
+    s.workerId = null;
   }
 
   deregisterSigtermHandler();

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1776,8 +1776,8 @@ export async function pauseAuto(
   if (s.workerId) {
     try {
       markWorkerStopping(s.workerId);
-    } catch {
-      // best-effort cleanup; pause must still complete
+    } catch (err) {
+      logWarning("engine", `pause worker cleanup failed: ${getErrorMessage(err)}`, { file: "auto.ts" });
     }
     s.workerId = null;
   }

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import { cleanupAfterLoopExit, pauseAuto, rerootCommandSession, stopAuto } from "../auto.ts";
 import { autoSession } from "../auto-runtime-state.ts";
 import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
+import { getAutoWorker, registerAutoWorker } from "../db/auto-workers.ts";
 import { WorktreeLifecycle } from "../worktree-lifecycle.ts";
 
 test("cleanupAfterLoopExit preserves paused auto badge after provider pause", async () => {
@@ -186,6 +187,33 @@ test("pauseAuto preserves artifact retry counts across pause/resume", async () =
     assert.equal(autoSession.verificationRetryCount.get(retryKey), 2);
   } finally {
     autoSession.reset();
+    process.chdir(previousCwd);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("pauseAuto marks active worker as stopping and clears workerId", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-pause-worker-stop-"));
+  const previousCwd = process.cwd();
+  const dbPath = join(base, ".gsd", "gsd.db");
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+
+  autoSession.reset();
+  autoSession.active = true;
+
+  try {
+    openDatabase(dbPath);
+    const workerId = registerAutoWorker({ projectRootRealpath: base });
+    autoSession.workerId = workerId;
+    process.chdir(base);
+
+    await pauseAuto();
+
+    assert.equal(autoSession.workerId, null);
+    assert.equal(getAutoWorker(workerId)?.status, "stopping");
+  } finally {
+    autoSession.reset();
+    try { closeDatabase(); } catch { /* noop */ }
     process.chdir(previousCwd);
     rmSync(base, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Added `markWorkerStopping` cleanup to both `pauseAuto` and signal shutdown paths and verified with targeted auto/signal tests (14/14 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5768
- [#5768 auto-mode: pauseAuto and SIGTERM handler leak workers DB row (status='active') causing stale_crash_lock false positive](https://github.com/gsd-build/gsd-2/issues/5768)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5768-auto-mode-pauseauto-and-sigterm-handler--1778833889`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup and state management when auto-mode is interrupted or paused: the session worker ID is now cleared and the worker is marked as stopping on best-effort shutdown, preventing stale liveness state and improving shutdown reliability.
* **Tests**
  * Added a behavioral test that verifies pausing auto-mode clears the session worker ID and transitions the worker to a stopping state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->