### PR TITLE
fix(issue): gsd_slice_complete idempotent-overwrite loses optional requirement data on re-call

### DIFF
--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -448,6 +448,14 @@ console.log('\n=== complete-slice: backfills omitted requirements from rendered 
     const summary = fs.readFileSync(backfilled.summaryPath, 'utf-8');
     assertMatch(summary, /## Requirements Advanced/, 'summary should include advanced requirements heading');
     assertMatch(summary, /- R001 — Handler validates task completion/, 'advanced requirement should be backfilled from summary markdown');
+
+    const sliceAfterBackfill = getSlice('M001', 'S01');
+    assertTrue(sliceAfterBackfill !== null, 'slice should exist after backfill');
+    assertMatch(
+      sliceAfterBackfill!.full_summary_md,
+      /- R001 — Handler validates task completion/,
+      'DB full_summary_md should persist the backfilled advanced requirement',
+    );
   }
 
   cleanupDir(basePath);

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -13,6 +13,7 @@ import {
   getSlice,
   updateSliceStatus,
   getSliceTasks,
+  setSliceSummaryMd,
   SCHEMA_VERSION,
 } from '../gsd-db.ts';
 import { handleCompleteSlice } from '../tools/complete-slice.ts';
@@ -401,6 +402,52 @@ console.log('\n=== complete-slice: handler with missing roadmap ===');
   if (!('error' in result)) {
     assertTrue(fs.existsSync(result.summaryPath), 'summary should be written even without roadmap');
     assertTrue(fs.existsSync(result.uatPath), 'UAT should be written even without roadmap');
+  }
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-slice: backfills omitted requirements from rendered summary
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-slice: backfills omitted requirements from rendered summary ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+
+  const { basePath } = createTempProject();
+
+  insertMilestone({ id: 'M001' });
+  insertSlice({ id: 'S01', milestoneId: 'M001' });
+  insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', status: 'complete', title: 'Task 1' });
+
+  const seedParams = makeValidSliceParams();
+  const seeded = await handleCompleteSlice(seedParams, basePath);
+  assertTrue(!('error' in seeded), 'seed completion should succeed');
+  if ('error' in seeded) {
+    cleanupDir(basePath);
+    cleanup(dbPath);
+    throw new Error('seed completion unexpectedly failed');
+  }
+
+  const seededSummary = fs.readFileSync(seeded.summaryPath, 'utf-8');
+  transaction(() => {
+    updateSliceStatus('M001', 'S01', 'pending', null);
+    setSliceSummaryMd('M001', 'S01', seededSummary, '');
+  });
+
+  const backfillParams = makeValidSliceParams();
+  delete (backfillParams as Partial<CompleteSliceParams>).requirementsAdvanced;
+  delete (backfillParams as Partial<CompleteSliceParams>).requirementsValidated;
+  delete (backfillParams as Partial<CompleteSliceParams>).requirementsInvalidated;
+  const backfilled = await handleCompleteSlice(backfillParams as CompleteSliceParams, basePath);
+  assertTrue(!('error' in backfilled), 'backfill completion should succeed');
+  if (!('error' in backfilled)) {
+    const summary = fs.readFileSync(backfilled.summaryPath, 'utf-8');
+    assertMatch(summary, /## Requirements Advanced/, 'summary should include advanced requirements heading');
+    assertMatch(summary, /- R001 — Handler validates task completion/, 'advanced requirement should be backfilled from summary markdown');
   }
 
   cleanupDir(basePath);

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -434,7 +434,7 @@ console.log('\n=== complete-slice: backfills omitted requirements from rendered 
 
   const seededSummary = fs.readFileSync(seeded.summaryPath, 'utf-8');
   transaction(() => {
-    updateSliceStatus('M001', 'S01', 'pending', null);
+    updateSliceStatus('M001', 'S01', 'pending', undefined);
     setSliceSummaryMd('M001', 'S01', seededSummary, '');
   });
 

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -146,6 +146,78 @@ test("executeTaskComplete coerces string verificationEvidence entries", async ()
   }
 });
 
+test("executeSliceComplete preserves omitted optional requirement arrays", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    await inProjectDir(base, () => executePlanMilestone({
+      milestoneId: "M001",
+      title: "Requirement preservation",
+      vision: "Ensure omitted arrays are not coerced to empties.",
+      slices: [
+        {
+          sliceId: "S01",
+          title: "Slice",
+          risk: "medium",
+          depends: [],
+          demo: "demo",
+          goal: "goal",
+          successCriteria: "done",
+          proofLevel: "integration",
+          integrationClosure: "closed",
+          observabilityImpact: "covered",
+        },
+      ],
+    }, base));
+    await inProjectDir(base, () => executePlanSlice({
+      milestoneId: "M001",
+      sliceId: "S01",
+      goal: "goal",
+      tasks: [
+        {
+          taskId: "T01",
+          title: "Task",
+          description: "desc",
+          estimate: "5m",
+          files: ["src/a.ts"],
+          verify: "node --test",
+          inputs: ["in"],
+          expectedOutput: ["out"],
+        },
+      ],
+    }, base));
+    await inProjectDir(base, () => executeTaskComplete({
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      oneLiner: "done",
+      narrative: "done",
+      verification: "ok",
+    }, base));
+
+    const result = await inProjectDir(base, () => executeSliceComplete({
+      milestoneId: "M001",
+      sliceId: "S01",
+      sliceTitle: "Slice",
+      oneLiner: "done",
+      narrative: "done",
+      verification: "ok",
+      uatContent: "ok",
+      requirementsAdvanced: [{ id: "R010", how: "advanced" }],
+      requirementsValidated: [{ id: "R010", proof: "validated" }],
+    }, base));
+
+    assert.equal(result.details.operation, "complete_slice");
+    const summaryPath = String(result.details.summaryPath);
+    const summary = readFileSync(summaryPath, "utf-8");
+    assert.match(summary, /R010 — advanced/);
+    assert.match(summary, /R010 — validated/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeMilestoneStatus returns milestone metadata and slice counts", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -26,6 +26,7 @@ import {
   executeTaskComplete,
   executeMilestoneStatus,
   executeSliceComplete,
+  executeSliceReopen,
   executeValidateMilestone,
 } from "../tools/workflow-tool-executors.ts";
 
@@ -212,6 +213,45 @@ test("executeSliceComplete preserves omitted optional requirement arrays", async
     const summary = readFileSync(summaryPath, "utf-8");
     assert.match(summary, /R010 — advanced/);
     assert.match(summary, /R010 — validated/);
+
+    const reopenResult = await inProjectDir(base, () => executeSliceReopen({
+      milestoneId: "M001",
+      sliceId: "S01",
+      reason: "validate idempotent overwrite behavior",
+    }, base));
+    assert.equal(reopenResult.details.operation, "reopen_slice");
+    await inProjectDir(base, () => executeTaskComplete({
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      oneLiner: "done (updated)",
+      narrative: "done (updated)",
+      verification: "ok",
+    }, base));
+
+    const recallResult = await inProjectDir(base, () => executeSliceComplete({
+      milestoneId: "M001",
+      sliceId: "S01",
+      sliceTitle: "Slice",
+      oneLiner: "done (updated)",
+      narrative: "done (updated)",
+      verification: "ok",
+      uatContent: "ok",
+    }, base));
+
+    assert.equal(recallResult.details.operation, "complete_slice");
+    const recallSummaryPath = String(recallResult.details.summaryPath);
+    const recallSummary = readFileSync(recallSummaryPath, "utf-8");
+    assert.match(
+      recallSummary,
+      /R010 — advanced/,
+      "requirementsAdvanced should be preserved from first call",
+    );
+    assert.match(
+      recallSummary,
+      /R010 — validated/,
+      "requirementsValidated should be preserved from first call",
+    );
   } finally {
     closeDatabase();
     cleanup(base);

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -237,10 +237,15 @@ function parseRequirementSection(
   heading: "Requirements Advanced" | "Requirements Validated" | "Requirements Invalidated or Re-scoped",
   field: "how" | "proof" | "what",
 ): Array<{ id: string; how?: string; proof?: string; what?: string }> {
-  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = summaryMd.match(new RegExp(`## ${escaped}\\n\\n([\\s\\S]*?)(?:\\n\\n## |$)`));
-  if (!match) return [];
-  return match[1]
+  const headingLine = `## ${heading}\n\n`;
+  const start = summaryMd.indexOf(headingLine);
+  if (start === -1) return [];
+  const contentStart = start + headingLine.length;
+  const nextHeading = summaryMd.indexOf("\n\n## ", contentStart);
+  const content = nextHeading === -1
+    ? summaryMd.slice(contentStart)
+    : summaryMd.slice(contentStart, nextHeading);
+  return content
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.startsWith("- "))
@@ -374,6 +379,9 @@ export async function handleCompleteSlice(
 
   const effectiveParams: CompleteSliceParams = { ...params };
   if (existingSummaryMd) {
+    // Keep these heading names in lock-step with renderSliceSummaryMarkdown's
+    // section titles so omitted CompleteSliceParams requirement fields can be
+    // backfilled from previously rendered summary markdown.
     if (effectiveParams.requirementsAdvanced === undefined) {
       const parsed = parseRequirementSection(existingSummaryMd, "Requirements Advanced", "how");
       if (parsed.length > 0) effectiveParams.requirementsAdvanced = parsed as Array<{ id: string; how: string }>;

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -232,6 +232,29 @@ ${params.uatContent}
 `;
 }
 
+function parseRequirementSection(
+  summaryMd: string,
+  heading: "Requirements Advanced" | "Requirements Validated" | "Requirements Invalidated or Re-scoped",
+  field: "how" | "proof" | "what",
+): Array<{ id: string; how?: string; proof?: string; what?: string }> {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = summaryMd.match(new RegExp(`## ${escaped}\\n\\n([\\s\\S]*?)(?:\\n\\n## |$)`));
+  if (!match) return [];
+  return match[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "))
+    .map((line) => line.slice(2).trim())
+    .map((line) => {
+      const pair = line.match(/^(.+?)\s*(?:—|-)\s+(.+)$/);
+      const id = pair ? pair[1].trim() : line.trim();
+      const detail = pair ? pair[2].trim() : "";
+      if (!id || !detail) return null;
+      return { id, [field]: detail };
+    })
+    .filter((entry): entry is { id: string; how?: string; proof?: string; what?: string } => entry !== null);
+}
+
 /**
  * Handle the complete_slice operation end-to-end.
  *
@@ -277,6 +300,7 @@ export async function handleCompleteSlice(
   // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───
   const completedAt = new Date().toISOString();
   let guardError: string | null = null;
+  let existingSummaryMd = "";
 
   transaction(() => {
     // State machine preconditions (inside txn for atomicity).
@@ -289,6 +313,7 @@ export async function handleCompleteSlice(
     }
 
     const slice = getSlice(params.milestoneId, params.sliceId);
+    existingSummaryMd = slice?.full_summary_md?.trim() ?? "";
     if (slice && isClosedStatus(slice.status)) {
       if (isStaleWrite("complete-slice")) {
         guardError = "__stale_duplicate__";
@@ -347,8 +372,24 @@ export async function handleCompleteSlice(
     return { error: guardError };
   }
 
+  const effectiveParams: CompleteSliceParams = { ...params };
+  if (existingSummaryMd) {
+    if (effectiveParams.requirementsAdvanced === undefined) {
+      const parsed = parseRequirementSection(existingSummaryMd, "Requirements Advanced", "how");
+      if (parsed.length > 0) effectiveParams.requirementsAdvanced = parsed as Array<{ id: string; how: string }>;
+    }
+    if (effectiveParams.requirementsValidated === undefined) {
+      const parsed = parseRequirementSection(existingSummaryMd, "Requirements Validated", "proof");
+      if (parsed.length > 0) effectiveParams.requirementsValidated = parsed as Array<{ id: string; proof: string }>;
+    }
+    if (effectiveParams.requirementsInvalidated === undefined) {
+      const parsed = parseRequirementSection(existingSummaryMd, "Requirements Invalidated or Re-scoped", "what");
+      if (parsed.length > 0) effectiveParams.requirementsInvalidated = parsed as Array<{ id: string; what: string }>;
+    }
+  }
+
   // Render summary markdown
-  const summaryMd = renderSliceSummaryMarkdown(params);
+  const summaryMd = renderSliceSummaryMarkdown(effectiveParams);
 
   // Resolve and write summary to disk
   let summaryPath: string;
@@ -363,7 +404,7 @@ export async function handleCompleteSlice(
     summaryPath = join(manualSliceDir, `${params.sliceId}-SUMMARY.md`);
   }
 
-  const uatMd = renderUatMarkdown(params);
+  const uatMd = renderUatMarkdown(effectiveParams);
   const uatPath = summaryPath.replace(/-SUMMARY\.md$/, "-UAT.md");
   setSliceSummaryMd(params.milestoneId, params.sliceId, summaryMd, uatMd);
   let projectionStale = false;

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -549,7 +549,9 @@ export async function executeSliceComplete(
         .filter((entry): entry is { id: string; how?: string; proof?: string; what?: string } => entry !== null);
     };
 
-    const coerced = { ...params } as CompleteSliceParams & Record<string, unknown>;
+    const coerced = Object.fromEntries(
+      Object.entries(params).filter(([, value]) => value !== undefined && value !== null),
+    ) as CompleteSliceParams & Record<string, unknown>;
     const provides = wrapOptionalArray(params.provides);
     if (provides !== undefined) coerced.provides = provides as string[];
     const keyFiles = wrapOptionalArray(params.keyFiles);

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -8,6 +8,7 @@ import {
   getActiveRequirements,
   insertMilestone,
   getMilestone,
+  getSlice,
   getSliceStatusSummary,
   getSliceTaskCounts,
   readTransaction,
@@ -527,16 +528,44 @@ export async function executeSliceComplete(
       v == null ? [] : Array.isArray(v) ? v : [v];
     const wrapOptionalArray = (v: unknown): unknown[] | undefined =>
       v == null ? undefined : Array.isArray(v) ? v : [v];
+    const parseRequirementSection = (
+      summaryMd: string,
+      heading: "Requirements Advanced" | "Requirements Validated" | "Requirements Invalidated or Re-scoped",
+      field: "how" | "proof" | "what",
+    ): Array<{ id: string; how?: string; proof?: string; what?: string }> => {
+      const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const match = summaryMd.match(new RegExp(`## ${escaped}\\n\\n([\\s\\S]*?)(?:\\n\\n## |$)`));
+      if (!match) return [];
+      return match[1]
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith("- "))
+        .map((line) => line.slice(2).trim())
+        .map((line) => {
+          const [id, detail] = splitPair(line);
+          if (!id || !detail) return null;
+          return { id, [field]: detail };
+        })
+        .filter((entry): entry is { id: string; how?: string; proof?: string; what?: string } => entry !== null);
+    };
 
     const coerced = { ...params } as CompleteSliceParams & Record<string, unknown>;
-    if (params.provides !== undefined) coerced.provides = wrapArray(params.provides) as string[];
-    if (params.keyFiles !== undefined) coerced.keyFiles = wrapArray(params.keyFiles) as string[];
-    if (params.keyDecisions !== undefined) coerced.keyDecisions = wrapArray(params.keyDecisions) as string[];
-    if (params.patternsEstablished !== undefined) coerced.patternsEstablished = wrapArray(params.patternsEstablished) as string[];
-    if (params.observabilitySurfaces !== undefined) coerced.observabilitySurfaces = wrapArray(params.observabilitySurfaces) as string[];
-    if (params.requirementsSurfaced !== undefined) coerced.requirementsSurfaced = wrapArray(params.requirementsSurfaced) as string[];
-    if (params.drillDownPaths !== undefined) coerced.drillDownPaths = wrapArray(params.drillDownPaths) as string[];
-    if (params.affects !== undefined) coerced.affects = wrapArray(params.affects) as string[];
+    const provides = wrapOptionalArray(params.provides);
+    if (provides !== undefined) coerced.provides = provides as string[];
+    const keyFiles = wrapOptionalArray(params.keyFiles);
+    if (keyFiles !== undefined) coerced.keyFiles = keyFiles as string[];
+    const keyDecisions = wrapOptionalArray(params.keyDecisions);
+    if (keyDecisions !== undefined) coerced.keyDecisions = keyDecisions as string[];
+    const patternsEstablished = wrapOptionalArray(params.patternsEstablished);
+    if (patternsEstablished !== undefined) coerced.patternsEstablished = patternsEstablished as string[];
+    const observabilitySurfaces = wrapOptionalArray(params.observabilitySurfaces);
+    if (observabilitySurfaces !== undefined) coerced.observabilitySurfaces = observabilitySurfaces as string[];
+    const requirementsSurfaced = wrapOptionalArray(params.requirementsSurfaced);
+    if (requirementsSurfaced !== undefined) coerced.requirementsSurfaced = requirementsSurfaced as string[];
+    const drillDownPaths = wrapOptionalArray(params.drillDownPaths);
+    if (drillDownPaths !== undefined) coerced.drillDownPaths = drillDownPaths as string[];
+    const affects = wrapOptionalArray(params.affects);
+    if (affects !== undefined) coerced.affects = affects as string[];
     const filesModified = wrapOptionalArray(params.filesModified);
     if (filesModified !== undefined) coerced.filesModified = filesModified.map((f) => {
       if (typeof f !== "string") return f;
@@ -567,6 +596,28 @@ export async function executeSliceComplete(
       const [id, what] = splitPair(r);
       return { id, what };
     }) as Array<{ id: string; what: string }>;
+    if (
+      requirementsAdvanced === undefined ||
+      requirementsValidated === undefined ||
+      requirementsInvalidated === undefined
+    ) {
+      const existing = getSlice(params.milestoneId, params.sliceId);
+      const summaryMd = existing?.full_summary_md?.trim() ?? "";
+      if (summaryMd) {
+        if (requirementsAdvanced === undefined) {
+          const parsed = parseRequirementSection(summaryMd, "Requirements Advanced", "how");
+          if (parsed.length > 0) coerced.requirementsAdvanced = parsed as Array<{ id: string; how: string }>;
+        }
+        if (requirementsValidated === undefined) {
+          const parsed = parseRequirementSection(summaryMd, "Requirements Validated", "proof");
+          if (parsed.length > 0) coerced.requirementsValidated = parsed as Array<{ id: string; proof: string }>;
+        }
+        if (requirementsInvalidated === undefined) {
+          const parsed = parseRequirementSection(summaryMd, "Requirements Invalidated or Re-scoped", "what");
+          if (parsed.length > 0) coerced.requirementsInvalidated = parsed as Array<{ id: string; what: string }>;
+        }
+      }
+    }
 
     const result = await handleCompleteSlice(coerced as CompleteSliceParams, basePath);
     if ("error" in result) {

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -525,37 +525,44 @@ export async function executeSliceComplete(
     };
     const wrapArray = (v: unknown): unknown[] =>
       v == null ? [] : Array.isArray(v) ? v : [v];
+    const wrapOptionalArray = (v: unknown): unknown[] | undefined =>
+      v == null ? undefined : Array.isArray(v) ? v : [v];
 
     const coerced = { ...params } as CompleteSliceParams & Record<string, unknown>;
-    coerced.provides = wrapArray(params.provides) as string[];
-    coerced.keyFiles = wrapArray(params.keyFiles) as string[];
-    coerced.keyDecisions = wrapArray(params.keyDecisions) as string[];
-    coerced.patternsEstablished = wrapArray(params.patternsEstablished) as string[];
-    coerced.observabilitySurfaces = wrapArray(params.observabilitySurfaces) as string[];
-    coerced.requirementsSurfaced = wrapArray(params.requirementsSurfaced) as string[];
-    coerced.drillDownPaths = wrapArray(params.drillDownPaths) as string[];
-    coerced.affects = wrapArray(params.affects) as string[];
-    coerced.filesModified = wrapArray(params.filesModified).map((f) => {
+    if (params.provides !== undefined) coerced.provides = wrapArray(params.provides) as string[];
+    if (params.keyFiles !== undefined) coerced.keyFiles = wrapArray(params.keyFiles) as string[];
+    if (params.keyDecisions !== undefined) coerced.keyDecisions = wrapArray(params.keyDecisions) as string[];
+    if (params.patternsEstablished !== undefined) coerced.patternsEstablished = wrapArray(params.patternsEstablished) as string[];
+    if (params.observabilitySurfaces !== undefined) coerced.observabilitySurfaces = wrapArray(params.observabilitySurfaces) as string[];
+    if (params.requirementsSurfaced !== undefined) coerced.requirementsSurfaced = wrapArray(params.requirementsSurfaced) as string[];
+    if (params.drillDownPaths !== undefined) coerced.drillDownPaths = wrapArray(params.drillDownPaths) as string[];
+    if (params.affects !== undefined) coerced.affects = wrapArray(params.affects) as string[];
+    const filesModified = wrapOptionalArray(params.filesModified);
+    if (filesModified !== undefined) coerced.filesModified = filesModified.map((f) => {
       if (typeof f !== "string") return f;
       const [path, description] = splitPair(f);
       return { path, description };
     }) as Array<{ path: string; description: string }>;
-    coerced.requires = wrapArray(params.requires).map((r) => {
+    const requires = wrapOptionalArray(params.requires);
+    if (requires !== undefined) coerced.requires = requires.map((r) => {
       if (typeof r !== "string") return r;
       const [slice, provides] = splitPair(r);
       return { slice, provides };
     }) as Array<{ slice: string; provides: string }>;
-    coerced.requirementsAdvanced = wrapArray(params.requirementsAdvanced).map((r) => {
+    const requirementsAdvanced = wrapOptionalArray(params.requirementsAdvanced);
+    if (requirementsAdvanced !== undefined) coerced.requirementsAdvanced = requirementsAdvanced.map((r) => {
       if (typeof r !== "string") return r;
       const [id, how] = splitPair(r);
       return { id, how };
     }) as Array<{ id: string; how: string }>;
-    coerced.requirementsValidated = wrapArray(params.requirementsValidated).map((r) => {
+    const requirementsValidated = wrapOptionalArray(params.requirementsValidated);
+    if (requirementsValidated !== undefined) coerced.requirementsValidated = requirementsValidated.map((r) => {
       if (typeof r !== "string") return r;
       const [id, proof] = splitPair(r);
       return { id, proof };
     }) as Array<{ id: string; proof: string }>;
-    coerced.requirementsInvalidated = wrapArray(params.requirementsInvalidated).map((r) => {
+    const requirementsInvalidated = wrapOptionalArray(params.requirementsInvalidated);
+    if (requirementsInvalidated !== undefined) coerced.requirementsInvalidated = requirementsInvalidated.map((r) => {
       if (typeof r !== "string") return r;
       const [id, what] = splitPair(r);
       return { id, what };

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -528,27 +528,6 @@ export async function executeSliceComplete(
       v == null ? [] : Array.isArray(v) ? v : [v];
     const wrapOptionalArray = (v: unknown): unknown[] | undefined =>
       v == null ? undefined : Array.isArray(v) ? v : [v];
-    const parseRequirementSection = (
-      summaryMd: string,
-      heading: "Requirements Advanced" | "Requirements Validated" | "Requirements Invalidated or Re-scoped",
-      field: "how" | "proof" | "what",
-    ): Array<{ id: string; how?: string; proof?: string; what?: string }> => {
-      const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const match = summaryMd.match(new RegExp(`## ${escaped}\\n\\n([\\s\\S]*?)(?:\\n\\n## |$)`));
-      if (!match) return [];
-      return match[1]
-        .split("\n")
-        .map((line) => line.trim())
-        .filter((line) => line.startsWith("- "))
-        .map((line) => line.slice(2).trim())
-        .map((line) => {
-          const [id, detail] = splitPair(line);
-          if (!id || !detail) return null;
-          return { id, [field]: detail };
-        })
-        .filter((entry): entry is { id: string; how?: string; proof?: string; what?: string } => entry !== null);
-    };
-
     const coerced = Object.fromEntries(
       Object.entries(params).filter(([, value]) => value !== undefined && value !== null),
     ) as CompleteSliceParams & Record<string, unknown>;
@@ -598,28 +577,6 @@ export async function executeSliceComplete(
       const [id, what] = splitPair(r);
       return { id, what };
     }) as Array<{ id: string; what: string }>;
-    if (
-      requirementsAdvanced === undefined ||
-      requirementsValidated === undefined ||
-      requirementsInvalidated === undefined
-    ) {
-      const existing = getSlice(params.milestoneId, params.sliceId);
-      const summaryMd = existing?.full_summary_md?.trim() ?? "";
-      if (summaryMd) {
-        if (requirementsAdvanced === undefined) {
-          const parsed = parseRequirementSection(summaryMd, "Requirements Advanced", "how");
-          if (parsed.length > 0) coerced.requirementsAdvanced = parsed as Array<{ id: string; how: string }>;
-        }
-        if (requirementsValidated === undefined) {
-          const parsed = parseRequirementSection(summaryMd, "Requirements Validated", "proof");
-          if (parsed.length > 0) coerced.requirementsValidated = parsed as Array<{ id: string; proof: string }>;
-        }
-        if (requirementsInvalidated === undefined) {
-          const parsed = parseRequirementSection(summaryMd, "Requirements Invalidated or Re-scoped", "what");
-          if (parsed.length > 0) coerced.requirementsInvalidated = parsed as Array<{ id: string; what: string }>;
-        }
-      }
-    }
 
     const result = await handleCompleteSlice(coerced as CompleteSliceParams, basePath);
     if ("error" in result) {

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -8,7 +8,6 @@ import {
   getActiveRequirements,
   insertMilestone,
   getMilestone,
-  getSlice,
   getSliceStatusSummary,
   getSliceTaskCounts,
   readTransaction,
@@ -524,8 +523,6 @@ export async function executeSliceComplete(
       const m = s.match(/^(.+?)\s*(?:—|-)\s+(.+)$/);
       return m ? [m[1].trim(), m[2].trim()] : [s.trim(), ""];
     };
-    const wrapArray = (v: unknown): unknown[] =>
-      v == null ? [] : Array.isArray(v) ? v : [v];
     const wrapOptionalArray = (v: unknown): unknown[] | undefined =>
       v == null ? undefined : Array.isArray(v) ? v : [v];
     const coerced = Object.fromEntries(


### PR DESCRIPTION
## Summary
- Preserved omitted optional slice-completion requirement arrays during executor coercion and verified with the workflow-tool-executors test suite.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6122
- [#6122 gsd_slice_complete idempotent-overwrite loses optional requirement data on re-call](https://github.com/gsd-build/gsd-2/issues/6122)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6122-gsd-slice-complete-idempotent-overwrite--1778851670`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests to verify slice completion preserves previously recorded requirement labels when optional requirement arrays are omitted, including reopen-and-complete and direct-summary-backfill scenarios.

* **Refactor**
  * Optional collection parameters now remain unset when not provided; missing requirement sections are repopulated from existing slice summaries so prior requirement data is retained.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6127)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->