### PR TITLE
fix(issue): auto-mode: discuss-milestone always loads interactive prompt in headless mode — CONTEXT.md never written, stuck loop

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -421,6 +421,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           midTitle,
           basePath,
           structuredQuestionsAvailable,
+          { headless: !!process.env.GSD_HEADLESS },
         ),
       };
     },
@@ -566,6 +567,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           midTitle,
           basePath,
           structuredQuestionsAvailable,
+          { headless: !!process.env.GSD_HEADLESS },
         ),
       };
     },
@@ -733,6 +735,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           midTitle,
           basePath,
           structuredQuestionsAvailable,
+          { headless: !!process.env.GSD_HEADLESS },
         ),
       };
     },

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1654,8 +1654,24 @@ export async function buildDiscussMilestonePrompt(
   midTitle: string,
   base: string,
   structuredQuestionsAvailable = "false",
+  { headless = false }: { headless?: boolean } = {},
 ): Promise<string> {
   const discussTemplates = inlineTemplate("context", "Context");
+
+  if (headless) {
+    const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
+    const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
+    return loadPrompt("discuss-headless", {
+      seedContext: roadmapContent ?? "",
+      inlinedTemplates: discussTemplates,
+      workingDirectory: base,
+      milestoneId: mid,
+      contextPath: relMilestoneFile(base, mid, "CONTEXT"),
+      commitInstruction: "Do not commit planning artifacts — .gsd/ is managed externally.",
+      multiMilestoneCommitInstruction: "Do not commit planning artifacts — .gsd/ is managed externally.",
+    });
+  }
+
   const contextModeInstructions = renderContextModeForPrompt("discuss-milestone", base);
 
   const basePrompt = loadPrompt("guided-discuss-milestone", {

--- a/src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts
@@ -81,3 +81,41 @@ test("auto-dispatch uses discuss-headless prompt when GSD_HEADLESS is set", asyn
   assert.match(result.prompt, /This is a \*\*headless\*\* flow/);
   assert.doesNotMatch(result.prompt, /\*\*Structured questions available: true\*\*/);
 });
+
+test("auto-dispatch uses discuss-headless prompt for needs-discussion when GSD_HEADLESS is set", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-discuss-milestone-headless-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const previous = process.env.GSD_HEADLESS;
+  process.env.GSD_HEADLESS = "1";
+  t.after(() => {
+    if (previous === undefined) delete process.env.GSD_HEADLESS;
+    else process.env.GSD_HEADLESS = previous;
+  });
+
+  const result = await resolveDispatch(makeContext(tmp, "needs-discussion", "true"));
+
+  assert.equal(result.action, "dispatch");
+  assert.equal(result.unitType, "discuss-milestone");
+  assert.match(result.prompt, /This is a \*\*headless\*\* flow/);
+  assert.doesNotMatch(result.prompt, /\*\*Structured questions available: true\*\*/);
+});
+
+test("auto-dispatch uses discuss-headless prompt for executing when GSD_HEADLESS is set", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-discuss-milestone-headless-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const previous = process.env.GSD_HEADLESS;
+  process.env.GSD_HEADLESS = "1";
+  t.after(() => {
+    if (previous === undefined) delete process.env.GSD_HEADLESS;
+    else process.env.GSD_HEADLESS = previous;
+  });
+
+  const result = await resolveDispatch(makeContext(tmp, "executing", "true"));
+
+  assert.equal(result.action, "dispatch");
+  assert.equal(result.unitType, "discuss-milestone");
+  assert.match(result.prompt, /This is a \*\*headless\*\* flow/);
+  assert.doesNotMatch(result.prompt, /\*\*Structured questions available: true\*\*/);
+});

--- a/src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts
@@ -62,3 +62,22 @@ test("auto-dispatch preserves structuredQuestionsAvailable=false for discuss-mil
     /\*\*Structured questions available: false\*\*/,
   );
 });
+
+test("auto-dispatch uses discuss-headless prompt when GSD_HEADLESS is set", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-discuss-milestone-headless-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const previous = process.env.GSD_HEADLESS;
+  process.env.GSD_HEADLESS = "1";
+  t.after(() => {
+    if (previous === undefined) delete process.env.GSD_HEADLESS;
+    else process.env.GSD_HEADLESS = previous;
+  });
+
+  const result = await resolveDispatch(makeContext(tmp, "pre-planning", "true"));
+
+  assert.equal(result.action, "dispatch");
+  assert.equal(result.unitType, "discuss-milestone");
+  assert.match(result.prompt, /This is a \*\*headless\*\* flow/);
+  assert.doesNotMatch(result.prompt, /\*\*Structured questions available: true\*\*/);
+});

--- a/src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts
@@ -35,6 +35,15 @@ function makeContext(
   };
 }
 
+function setGsdHeadless(t: { after: (fn: () => void) => void }): void {
+  const previous = process.env.GSD_HEADLESS;
+  process.env.GSD_HEADLESS = "1";
+  t.after(() => {
+    if (previous === undefined) delete process.env.GSD_HEADLESS;
+    else process.env.GSD_HEADLESS = previous;
+  });
+}
+
 test("auto-dispatch passes structuredQuestionsAvailable=true into discuss-milestone prompt", async (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "gsd-discuss-milestone-structured-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));
@@ -67,12 +76,7 @@ test("auto-dispatch uses discuss-headless prompt when GSD_HEADLESS is set", asyn
   const tmp = mkdtempSync(join(tmpdir(), "gsd-discuss-milestone-headless-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));
 
-  const previous = process.env.GSD_HEADLESS;
-  process.env.GSD_HEADLESS = "1";
-  t.after(() => {
-    if (previous === undefined) delete process.env.GSD_HEADLESS;
-    else process.env.GSD_HEADLESS = previous;
-  });
+  setGsdHeadless(t);
 
   const result = await resolveDispatch(makeContext(tmp, "pre-planning", "true"));
 
@@ -86,12 +90,7 @@ test("auto-dispatch uses discuss-headless prompt for needs-discussion when GSD_H
   const tmp = mkdtempSync(join(tmpdir(), "gsd-discuss-milestone-headless-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));
 
-  const previous = process.env.GSD_HEADLESS;
-  process.env.GSD_HEADLESS = "1";
-  t.after(() => {
-    if (previous === undefined) delete process.env.GSD_HEADLESS;
-    else process.env.GSD_HEADLESS = previous;
-  });
+  setGsdHeadless(t);
 
   const result = await resolveDispatch(makeContext(tmp, "needs-discussion", "true"));
 
@@ -105,12 +104,7 @@ test("auto-dispatch uses discuss-headless prompt for executing when GSD_HEADLESS
   const tmp = mkdtempSync(join(tmpdir(), "gsd-discuss-milestone-headless-"));
   t.after(() => rmSync(tmp, { recursive: true, force: true }));
 
-  const previous = process.env.GSD_HEADLESS;
-  process.env.GSD_HEADLESS = "1";
-  t.after(() => {
-    if (previous === undefined) delete process.env.GSD_HEADLESS;
-    else process.env.GSD_HEADLESS = previous;
-  });
+  setGsdHeadless(t);
 
   const result = await resolveDispatch(makeContext(tmp, "executing", "true"));
 


### PR DESCRIPTION
## Summary
- Routed auto-mode discuss-milestone to `discuss-headless` when `GSD_HEADLESS` is set and verified with a targeted regression test passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6126
- [#6126 auto-mode: discuss-milestone always loads interactive prompt in headless mode — CONTEXT.md never written, stuck loop](https://github.com/gsd-build/gsd-2/issues/6126)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6126-auto-mode-discuss-milestone-always-loads-1778851975`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a headless mode for milestone discussions (GSD_HEADLESS). When enabled, roadmap content seeds a streamlined "headless" discuss prompt used across recovery paths.

* **Tests**
  * Added tests verifying the headless prompt is chosen for pre-planning, needs-discussion, and executing phases and that structured-question markers are omitted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->