### PR TITLE
fix(issue): auto-worktree: postflightPopStash crashes auto-mode when .gsd/ metadata files conflict during stash apply

### DIFF
--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -90,6 +90,10 @@ function readZeroDelimitedPaths(output: string): string[] {
   return output.split("\0").filter(Boolean);
 }
 
+function isGsdOwnedPath(path: string): boolean {
+  return path === ".gsd" || path.startsWith(".gsd/");
+}
+
 function listDirtyPaths(basePath: string): string[] | null {
   try {
     const paths = new Set<string>();
@@ -396,6 +400,26 @@ export function postflightPopStash(
         restored: false,
         needsManualRecovery: true,
         message: msg,
+      };
+    }
+    const trackedPaths = listStashTrackedPaths(basePath, stashRef);
+    const untrackedPaths = listStashUntrackedPaths(basePath, stashRef);
+    const stashPaths = [...(trackedPaths ?? []), ...(untrackedPaths ?? [])];
+    if (stashPaths.length > 0 && stashPaths.every((path) => isGsdOwnedPath(path))) {
+      execFileSync("git", ["stash", "drop", stashRef], {
+        cwd: basePath,
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf-8",
+        env: GIT_NO_PROMPT_ENV,
+      });
+      const msg = `Skipped restoring GSD metadata-only preflight stash after milestone ${milestoneId} merge.`;
+      notify(msg, "info");
+      return {
+        restored: true,
+        needsManualRecovery: false,
+        message: msg,
+        stashRef,
+        resolution: "already-present-dropped",
       };
     }
     execFileSync("git", ["stash", "apply", stashRef], {

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -427,30 +427,30 @@ export function postflightPopStash(
     if (trackedPaths !== null && untrackedPaths !== null) {
       const stashPaths = [...trackedPaths, ...untrackedPaths];
       if (stashPaths.length > 0 && stashPaths.every((path) => isGsdOwnedPath(path))) {
-      let dropped = true;
-      try {
-        execFileSync("git", ["stash", "drop", stashRef], {
-          cwd: basePath,
-          stdio: ["ignore", "pipe", "pipe"],
-          encoding: "utf-8",
-          env: GIT_NO_PROMPT_ENV,
-        });
-      } catch (err) {
-        dropped = false;
-        logWarning("preflight", `git stash drop ${stashRef} failed after skipping GSD metadata-only restore: ${err instanceof Error ? err.message : String(err)}`);
+        let dropped = true;
+        try {
+          execFileSync("git", ["stash", "drop", stashRef], {
+            cwd: basePath,
+            stdio: ["ignore", "pipe", "pipe"],
+            encoding: "utf-8",
+            env: GIT_NO_PROMPT_ENV,
+          });
+        } catch (err) {
+          dropped = false;
+          logWarning("preflight", `git stash drop ${stashRef} failed after skipping GSD metadata-only restore: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        const msg = dropped
+          ? `Skipped restoring GSD metadata-only preflight stash after milestone ${milestoneId} merge.`
+          : `Skipped restoring GSD metadata-only preflight stash after milestone ${milestoneId} merge, but ${stashRef} could not be dropped and remains as a backup.`;
+        notify(msg, dropped ? "info" : "warning");
+        return {
+          restored: true,
+          needsManualRecovery: false,
+          message: msg,
+          stashRef,
+          resolution: dropped ? "already-present-dropped" : "already-present-preserved",
+        };
       }
-      const msg = dropped
-        ? `Skipped restoring GSD metadata-only preflight stash after milestone ${milestoneId} merge.`
-        : `Skipped restoring GSD metadata-only preflight stash after milestone ${milestoneId} merge, but ${stashRef} could not be dropped and remains as a backup.`;
-      notify(msg, dropped ? "info" : "warning");
-      return {
-        restored: true,
-        needsManualRecovery: false,
-        message: msg,
-        stashRef,
-        resolution: dropped ? "already-present-dropped" : "already-present-preserved",
-      };
-    }
     }
     execFileSync("git", ["stash", "apply", stashRef], {
       cwd: basePath,

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -154,7 +154,6 @@ function findOverlappingDirtyMilestonePaths(basePath: string, milestoneId: strin
     .sort();
 }
 
-
 function listStashUntrackedPaths(basePath: string, stashRef: string): string[] | null {
   const hasUntrackedParent = hasStashUntrackedParent(basePath, stashRef);
   if (hasUntrackedParent === false) return [];

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -94,6 +94,21 @@ function isGsdOwnedPath(path: string): boolean {
   return path === ".gsd" || path.startsWith(".gsd/");
 }
 
+function hasStashUntrackedParent(basePath: string, stashRef: string): boolean | null {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", "-q", `${stashRef}^3`], {
+      cwd: basePath,
+      stdio: ["ignore", "ignore", "ignore"],
+      env: GIT_NO_PROMPT_ENV,
+    });
+    return true;
+  } catch (err) {
+    const status = typeof err === "object" && err && "status" in err ? (err as { status?: unknown }).status : null;
+    if (typeof status === "number" && status === 1) return false;
+    return null;
+  }
+}
+
 function listDirtyPaths(basePath: string): string[] | null {
   try {
     const paths = new Set<string>();
@@ -139,7 +154,11 @@ function findOverlappingDirtyMilestonePaths(basePath: string, milestoneId: strin
     .sort();
 }
 
+
 function listStashUntrackedPaths(basePath: string, stashRef: string): string[] | null {
+  const hasUntrackedParent = hasStashUntrackedParent(basePath, stashRef);
+  if (hasUntrackedParent === false) return [];
+  if (hasUntrackedParent === null) return null;
   try {
     const output = gitText(basePath, ["ls-tree", "-r", "-z", "--name-only", `${stashRef}^3`]);
     return readZeroDelimitedPaths(output);
@@ -404,22 +423,33 @@ export function postflightPopStash(
     }
     const trackedPaths = listStashTrackedPaths(basePath, stashRef);
     const untrackedPaths = listStashUntrackedPaths(basePath, stashRef);
+    if (trackedPaths === null || untrackedPaths === null) {
+      throw new Error(`Could not inspect stash contents for ${stashRef}; preserving stash for manual recovery.`);
+    }
     const stashPaths = [...(trackedPaths ?? []), ...(untrackedPaths ?? [])];
     if (stashPaths.length > 0 && stashPaths.every((path) => isGsdOwnedPath(path))) {
-      execFileSync("git", ["stash", "drop", stashRef], {
-        cwd: basePath,
-        stdio: ["ignore", "pipe", "pipe"],
-        encoding: "utf-8",
-        env: GIT_NO_PROMPT_ENV,
-      });
-      const msg = `Skipped restoring GSD metadata-only preflight stash after milestone ${milestoneId} merge.`;
-      notify(msg, "info");
+      let dropped = true;
+      try {
+        execFileSync("git", ["stash", "drop", stashRef], {
+          cwd: basePath,
+          stdio: ["ignore", "pipe", "pipe"],
+          encoding: "utf-8",
+          env: GIT_NO_PROMPT_ENV,
+        });
+      } catch (err) {
+        dropped = false;
+        logWarning("preflight", `git stash drop ${stashRef} failed after skipping GSD metadata-only restore: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      const msg = dropped
+        ? `Skipped restoring GSD metadata-only preflight stash after milestone ${milestoneId} merge.`
+        : `Skipped restoring GSD metadata-only preflight stash after milestone ${milestoneId} merge, but ${stashRef} could not be dropped and remains as a backup.`;
+      notify(msg, dropped ? "info" : "warning");
       return {
         restored: true,
         needsManualRecovery: false,
         message: msg,
         stashRef,
-        resolution: "already-present-dropped",
+        resolution: dropped ? "already-present-dropped" : "already-present-preserved",
       };
     }
     execFileSync("git", ["stash", "apply", stashRef], {

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -423,11 +423,11 @@ export function postflightPopStash(
     }
     const trackedPaths = listStashTrackedPaths(basePath, stashRef);
     const untrackedPaths = listStashUntrackedPaths(basePath, stashRef);
-    if (trackedPaths === null || untrackedPaths === null) {
-      throw new Error(`Could not inspect stash contents for ${stashRef}; preserving stash for manual recovery.`);
-    }
-    const stashPaths = [...(trackedPaths ?? []), ...(untrackedPaths ?? [])];
-    if (stashPaths.length > 0 && stashPaths.every((path) => isGsdOwnedPath(path))) {
+    // Only classify as metadata-only when both inspections succeeded.
+    // If either is null, fall through to `git stash apply` as the safe default.
+    if (trackedPaths !== null && untrackedPaths !== null) {
+      const stashPaths = [...trackedPaths, ...untrackedPaths];
+      if (stashPaths.length > 0 && stashPaths.every((path) => isGsdOwnedPath(path))) {
       let dropped = true;
       try {
         execFileSync("git", ["stash", "drop", stashRef], {
@@ -451,6 +451,7 @@ export function postflightPopStash(
         stashRef,
         resolution: dropped ? "already-present-dropped" : "already-present-preserved",
       };
+    }
     }
     execFileSync("git", ["stash", "apply", stashRef], {
       cwd: basePath,

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -448,3 +448,25 @@ test("postflightPopStash requires manual recovery when an untracked stash path i
     try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
   }
 });
+
+test("postflightPopStash skips apply and drops stash when payload is .gsd metadata only", () => {
+  const repo = createTempRepo();
+  try {
+    writeFileSync(join(repo, ".gsd", "notifications.jsonl"), '{"msg":"before"}\n');
+    const preflight = preflightCleanRoot(repo, "M013", () => {});
+    assert.equal(preflight.stashPushed, true, "preflight must stash .gsd metadata changes");
+
+    writeFileSync(join(repo, ".gsd", "notifications.jsonl"), '{"msg":"after"}\n');
+    run("git add .gsd/notifications.jsonl", repo);
+    run('git commit -m "chore: update metadata"', repo);
+
+    const postflight = postflightPopStash(repo, "M013", preflight.stashMarker, () => {});
+    assert.equal(postflight.needsManualRecovery, false, ".gsd-only stash must not stop auto-mode");
+    assert.equal(postflight.restored, true, ".gsd-only stash should be treated as successfully handled");
+
+    const stashList = run("git stash list", repo);
+    assert.ok(!stashList.includes(preflight.stashMarker ?? ""), ".gsd-only stash must be dropped");
+  } finally {
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -463,6 +463,12 @@ test("postflightPopStash skips apply and drops stash when payload is .gsd metada
     const postflight = postflightPopStash(repo, "M013", preflight.stashMarker, () => {});
     assert.equal(postflight.needsManualRecovery, false, ".gsd-only stash must not stop auto-mode");
     assert.equal(postflight.restored, true, ".gsd-only stash should be treated as successfully handled");
+    assert.equal(postflight.resolution, "already-present-dropped");
+    assert.equal(
+      readFileSync(join(repo, ".gsd", "notifications.jsonl"), "utf-8"),
+      '{"msg":"after"}\n',
+      "post-merge metadata must remain untouched when the stash is skipped",
+    );
 
     const stashList = run("git stash list", repo);
     assert.ok(!stashList.includes(preflight.stashMarker ?? ""), ".gsd-only stash must be dropped");


### PR DESCRIPTION
## Summary
- Added `.gsd`-only preflight stash auto-handling in postflight restore and verified with the targeted clean-root-preflight test suite.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6123
- [#6123 auto-worktree: postflightPopStash crashes auto-mode when .gsd/ metadata files conflict during stash apply](https://github.com/gsd-build/gsd-2/issues/6123)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6123-auto-worktree-postflightpopstash-crashes-1778852253`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Preflight stash recovery now detects stashes that contain only internal metadata and skips restoring them, attempting to drop the stash and reporting the result (restored with "dropped" or "preserved" resolution).

* **Bug Fixes**
  - Avoids unnecessary stash apply when metadata is already present, reducing manual recovery and merge noise.

* **Tests**
  - Added a regression test ensuring metadata-only stashes are skipped, dropped when possible, and leave metadata intact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->