### PR TITLE
fix(pi-tui): four-pass flicker fix for bottom-anchored render path

### DIFF
--- a/packages/pi-tui/src/__tests__/tui.test.ts
+++ b/packages/pi-tui/src/__tests__/tui.test.ts
@@ -7,11 +7,11 @@ import { Container, CURSOR_MARKER, TUI } from "../tui.js";
 import type { Component } from "../tui.js";
 import type { Terminal } from "../terminal.js";
 
-function makeTerminal(writes?: string[]): Terminal {
+function makeTerminal(writes?: string[], rows = 24): Terminal {
 	return {
 		isTTY: true,
 		columns: 80,
-		rows: 24,
+		rows,
 		kittyProtocolActive: false,
 		start() {},
 		stop() {},
@@ -69,6 +69,63 @@ describe("TUI", () => {
 		const renderWrite = writes[writeCountAfterFirstRender];
 		assert.ok(renderWrite.startsWith("\x1b[?2026h\r"), "editor diff should start at the current cursor row");
 		assert.ok(!renderWrite.startsWith("\x1b[?2026h\x1b[1A\r"), "editor diff must not move above the cursor row");
+	});
+
+	it("does not full-clear when a tall buffer shrinks (flicker regression #6130)", () => {
+		// Tall-buffer-shrink path: both prev and new exceed viewport height. The fix
+		// falls through to differential render instead of emitting \x1b[2J, which used
+		// to cause the bottom panel to flash on every shrink.
+		const writes: string[] = [];
+		const terminal = makeTerminal(writes, 10);
+		const tui = new TUI(terminal);
+		let lines = Array.from({ length: 20 }, (_, i) => `line-${i}`);
+		tui.addChild({
+			render: () => lines,
+			invalidate() {},
+		});
+		const anyTui = tui as any;
+
+		anyTui.doRender();
+		const writeCountAfterFirstRender = writes.length;
+
+		// Shrink: still taller than viewport, but smaller than before.
+		lines = Array.from({ length: 15 }, (_, i) => `line-${i}`);
+		anyTui.doRender();
+
+		const shrinkWrites = writes.slice(writeCountAfterFirstRender).join("");
+		assert.ok(
+			!shrinkWrites.includes("\x1b[2J"),
+			"tall buffer shrink must not emit \\x1b[2J — that causes the bottom panel to flash",
+		);
+	});
+
+	it("does not full-clear when firstChanged is above the viewport (flicker regression #6130)", () => {
+		// firstChanged-above-viewport path: a line above the current viewport changes.
+		// The fix clamps firstChanged to the viewport top and repaints in place instead
+		// of emitting \x1b[2J + full repaint, which used to cause a bottom-panel flash.
+		const writes: string[] = [];
+		const terminal = makeTerminal(writes, 10);
+		const tui = new TUI(terminal);
+		let lines = Array.from({ length: 20 }, (_, i) => `line-${i}`);
+		tui.addChild({
+			render: () => lines,
+			invalidate() {},
+		});
+		const anyTui = tui as any;
+
+		anyTui.doRender();
+		const writeCountAfterFirstRender = writes.length;
+
+		// Change a line above the viewport (viewportTop = 20 - 10 = 10, so line 0 is above).
+		lines = lines.slice();
+		lines[0] = "changed-above-viewport";
+		anyTui.doRender();
+
+		const clampWrites = writes.slice(writeCountAfterFirstRender).join("");
+		assert.ok(
+			!clampWrites.includes("\x1b[2J"),
+			"firstChanged-above-viewport must not emit \\x1b[2J — that causes the bottom panel to flash",
+		);
 	});
 
 	it("does not swallow a bare Escape keypress while waiting for the cell-size response", () => {

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -741,9 +741,54 @@ export class TUI extends Container {
 			return;
 		}
 
-		// Tall buffer shrinks: fall through to differential render instead of full-clearing.
-		// Ghost lines will be handled below; the viewport shift means old ghost rows get
-		// overwritten by the differential render, so no \x1b[2J flash is needed.
+		// Tall→tall shrink with viewport baseline shift. Both buffers fill the
+		// viewport, but newLines is shorter, so the viewport baseline must move
+		// from (previousLines.length - height) down to (newLines.length - height).
+		// The differential render below would see no diff in the overlapping
+		// indices (content[20..39] is identical between frames) and would leave
+		// the screen showing stale rows from the old viewport.
+		//
+		// Repaint the visible viewport in place without \x1b[2J — the four-pass
+		// flicker fix exists exactly to avoid that full-screen clear — then reset
+		// maxLinesRendered and previousViewportTop so subsequent diffs anchor
+		// against the new baseline.
+		if (
+			this.previousLines.length > height &&
+			newLines.length > height &&
+			newLines.length < this.previousLines.length &&
+			this.overlayStack.length === 0
+		) {
+			logRedraw(`tall→tall shrink viewport realign (${this.previousLines.length} -> ${newLines.length})`);
+			const newViewportTop = getViewportTop(newLines.length);
+			const currentScreenRow = Math.max(0, hardwareCursorRow - prevViewportTop);
+			let buffer = "\x1b[?2026h";
+			if (currentScreenRow > 0) {
+				buffer += `\x1b[${currentScreenRow}A`;
+			}
+			buffer += "\r";
+			for (let i = 0; i < height; i++) {
+				const idx = newViewportTop + i;
+				if (i > 0) buffer += "\r\n";
+				buffer += "\x1b[2K";
+				let line = newLines[idx] ?? "";
+				if (!isImageLine(line) && visibleWidth(line) > width) {
+					line = truncateToWidth(line, width);
+				}
+				buffer += line;
+			}
+			buffer += "\x1b[?2026l";
+			this.terminal.write(buffer);
+			this.cursorRow = newLines.length - 1;
+			this.hardwareCursorRow = newLines.length - 1;
+			this.maxLinesRendered = newLines.length;
+			this.previousViewportTop = newViewportTop;
+			this.positionHardwareCursor(cursorPos, newLines.length);
+			this.previousLines = newLines;
+			this.previousWidth = width;
+			this.previousHeight = height;
+			this._shrinkDebounceActive = false;
+			return;
+		}
 
 		// Content shrunk below the working area and no overlays - re-render to clear empty rows
 		// (overlays need the padding, so only do this when no overlays are active)

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -741,11 +741,9 @@ export class TUI extends Container {
 			return;
 		}
 
-		if (newLines.length < this.previousLines.length && newLines.length > height) {
-			logRedraw(`bottom-anchored tall block shrunk (${this.previousLines.length} -> ${newLines.length})`);
-			fullRender(true);
-			return;
-		}
+		// Tall buffer shrinks: fall through to differential render instead of full-clearing.
+		// Ghost lines will be handled below; the viewport shift means old ghost rows get
+		// overwritten by the differential render, so no \x1b[2J flash is needed.
 
 		// Content shrunk below the working area and no overlays - re-render to clear empty rows
 		// (overlays need the padding, so only do this when no overlays are active)
@@ -794,7 +792,7 @@ export class TUI extends Container {
 			}
 			lastChanged = newLines.length - 1;
 		}
-		const appendStart = appendedLines && firstChanged === this.previousLines.length && firstChanged > 0;
+		let appendStart = appendedLines && firstChanged === this.previousLines.length && firstChanged > 0;
 
 		// No changes - but still need to update hardware cursor position if it moved
 		if (firstChanged === -1) {
@@ -844,14 +842,29 @@ export class TUI extends Container {
 			return;
 		}
 
-		// Check if firstChanged is above what was previously visible
-		// Use previousLines.length (not maxLinesRendered) to avoid false positives after content shrinks
+		// Check if firstChanged is above what was previously visible.
+		// Use previousLines.length (not maxLinesRendered) to avoid false positives after content shrinks.
 		const previousContentViewportTop = getViewportTop(this.previousLines.length);
+		let clampedToViewport = false;
 		if (firstChanged < previousContentViewportTop) {
-			// First change is above previous viewport - need full re-render
-			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${previousContentViewportTop})`);
-			fullRender(true);
-			return;
+			// First change is above the viewport. Avoid a full screen clear (\x1b[2J)
+			// which causes the bottom panel to flicker. Instead redraw from the actual
+			// viewport top down through the bottom of new content so every visible row
+			// gets the correct line, even if the viewport shifted (content shrank).
+			//
+			// Pick the smaller of the two viewport tops so any row currently on screen
+			// is covered. Force lastChanged to the end of new content so the render loop
+			// repaints the bottom rows that may now hold stale content from the previous
+			// frame (the case that caused "empty screen until next tick" after the clamp).
+			const newViewportTop = getViewportTop(newLines.length);
+			const clampedFirst = Math.max(0, Math.min(previousContentViewportTop, newViewportTop));
+			logRedraw(
+				`firstChanged < viewportTop (${firstChanged} < ${previousContentViewportTop}) — repaint from ${clampedFirst}`,
+			);
+			firstChanged = clampedFirst;
+			lastChanged = Math.max(lastChanged, newLines.length - 1);
+			appendStart = false;
+			clampedToViewport = true;
 		}
 
 		// Render from first changed line to end
@@ -899,20 +912,35 @@ export class TUI extends Container {
 		// Track where cursor ended up after rendering
 		let finalCursorRow = renderEnd;
 
-		// If we had more lines before, clear them and move cursor back
-		if (this.previousLines.length > newLines.length) {
-			// Move to end of new content first if we stopped before it
-			if (renderEnd < newLines.length - 1) {
-				const moveDown = newLines.length - 1 - renderEnd;
-				buffer += `\x1b[${moveDown}B`;
-				finalCursorRow = newLines.length - 1;
+		// If we had more lines before, clear ghost lines — but only when they are
+		// actually visible. For tall buffers (both counts > height) the viewport shifts
+		// up so the differential render already overwrites the old bottom rows; emitting
+		// \r\n at screen-bottom would cause spurious terminal scrolling.
+		//
+		// Also skip ghost clearing when the clamp-to-viewport path was taken: that path
+		// renders from clampedFirst through newLines.length-1, filling the entire visible
+		// viewport. There are no ghost lines below renderEnd, and the local `viewportTop`
+		// is based on the stale (larger) maxLinesRendered, so the renderEndScreenRow
+		// check below would compute a negative value and incorrectly fire the cleanup —
+		// which then emits \r\n past screen-bottom and scrolls correct lines into
+		// scrollback while filling the viewport with blanks.
+		if (this.previousLines.length > newLines.length && !clampedToViewport) {
+			const renderEndScreenRow = renderEnd - viewportTop;
+			const ghostLinesVisible = renderEndScreenRow < height - 1;
+			if (ghostLinesVisible) {
+				// Move to end of new content first if we stopped before it
+				if (renderEnd < newLines.length - 1) {
+					const moveDown = newLines.length - 1 - renderEnd;
+					buffer += `\x1b[${moveDown}B`;
+					finalCursorRow = newLines.length - 1;
+				}
+				const extraLines = this.previousLines.length - newLines.length;
+				for (let i = newLines.length; i < this.previousLines.length; i++) {
+					buffer += "\r\n\x1b[2K";
+				}
+				// Move cursor back to end of new content
+				buffer += `\x1b[${extraLines}A`;
 			}
-			const extraLines = this.previousLines.length - newLines.length;
-			for (let i = newLines.length; i < this.previousLines.length; i++) {
-				buffer += "\r\n\x1b[2K";
-			}
-			// Move cursor back to end of new content
-			buffer += `\x1b[${extraLines}A`;
 		}
 
 		buffer += "\x1b[?2026l"; // End synchronized output
@@ -954,8 +982,16 @@ export class TUI extends Container {
 		// hardwareCursorRow tracks actual terminal cursor position (for movement)
 		this.cursorRow = Math.max(0, newLines.length - 1);
 		this.hardwareCursorRow = finalCursorRow;
-		// Track terminal's working area (grows but doesn't shrink unless cleared)
-		this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
+		// Track terminal's working area (grows but doesn't shrink unless cleared).
+		// Exception: when the clamp-to-viewport path repainted shrunk content, the
+		// visible viewport now anchors to newLines.length, so subsequent
+		// computeLineDiff calls need viewportTop = newLines.length - height.
+		// Without this reset, hardwareCursorRow's physical row goes negative.
+		if (clampedToViewport && newLines.length < this.maxLinesRendered) {
+			this.maxLinesRendered = newLines.length;
+		} else {
+			this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
+		}
 		this.previousViewportTop = getViewportTop(this.maxLinesRendered);
 
 		// Position hardware cursor for IME

--- a/src/tests/tui-pin-to-bottom-on-clear.test.ts
+++ b/src/tests/tui-pin-to-bottom-on-clear.test.ts
@@ -162,7 +162,15 @@ describe("TUI pin-to-bottom on clear", () => {
     );
   });
 
-  it("re-anchors tall shrinks so the latest turn end remains visible", () => {
+  it("re-anchors tall shrinks so the latest turn end remains visible without a full-screen clear", () => {
+    // Tall→tall shrink (60 → 40 on a 20-row terminal). The viewport baseline
+    // must move from 40 down to 20, repainting visible rows with content
+    // indices 20..39 in place. The renderer must NOT emit \x1b[2J — that
+    // full-screen clear is what causes the bottom-panel flicker the four-pass
+    // fix exists to avoid. The earlier byte-level assertion `\x1b[2J\x1b[1;1H`
+    // captured the spirit (new bottom visible, baseline reset) via the only
+    // mechanism available at the time; the fix replaces that mechanism with an
+    // in-place viewport repaint that preserves both intents.
     const terminal = new ResizableMockTerminal(20);
     const tui = new TUI(terminal, false);
     const lines = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`);
@@ -177,8 +185,19 @@ describe("TUI pin-to-bottom on clear", () => {
 
     const frame = terminal.writtenData.join("");
     assert.ok(
-      frame.includes("\x1b[2J\x1b[1;1H"),
-      `expected tall shrink to force a bottom-visible redraw, got ${JSON.stringify(frame.slice(0, 120))}`,
+      !frame.includes("\x1b[2J"),
+      `tall→tall shrink must not emit \\x1b[2J (causes bottom-panel flicker), got ${JSON.stringify(frame.slice(0, 160))}`,
+    );
+    // New viewport content (indices 20..39 → "line 21".."line 40") must be
+    // painted into the visible rows. Check the top and bottom of the new
+    // viewport are both present.
+    assert.ok(
+      frame.includes("line 21"),
+      `expected new viewport top "line 21" to be repainted, got ${JSON.stringify(frame.slice(0, 200))}`,
+    );
+    assert.ok(
+      frame.includes("line 40"),
+      `expected new viewport bottom "line 40" to be repainted, got ${JSON.stringify(frame.slice(0, 200))}`,
     );
     assert.strictEqual(
       (tui as any).previousViewportTop,


### PR DESCRIPTION
Fixes #6130.

## Summary

Eliminates `\x1b[2J` full-screen clears from the differential render path in `packages/pi-tui/src/tui.ts` so the bottom panel no longer flashes on every frame. Four independent paths each used to force a screen-clear-then-repaint; this PR layers four passes that fall through to the existing differential renderer instead.

## The four passes

1. **Tall-buffer-shrink path** — fall through to differential render instead of full-clearing. The viewport shift overwrites old ghost rows naturally.
2. **`firstChanged`-above-viewport** — clamp to the actual viewport top, force `lastChanged` to end of new content, redraw visible rows in-place instead of `\x1b[2J` + full repaint.
3. **`maxLinesRendered` reset after content shrinks** — so the next frame's diff anchors against the new content length, not stale state.
4. **Skip ghost-line clearing when the differential write already covered those rows** — avoids a redundant clear that itself caused a flash.

## Out of scope

The "chat empties on pause / `auto_compaction_end`" symptom is **not** fixed here. Diagnosis traced it upstream to `chatContainer.clear()` in `chat-controller.ts` — the renderer is faithfully drawing what `Container.render()` returns. Will file separately.

## Test plan

- [ ] Start pi, trigger streaming assistant output, watch for flicker on the bottom panel — should be gone.
- [ ] Resize terminal while content is streaming — no flash on shrink.
- [ ] Scroll back through long history and then jump to bottom — no full-screen repaint flash.
- [ ] Pause + resume an auto-mode session — flicker is gone (the chat-empties-on-pause symptom is a separate issue, see *Out of scope*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoided unnecessary full-screen clears during tall-buffer shrinks to eliminate flicker.
  * Added viewport clamping so only the visible overlap is repainted, preventing stray clears and scrolling artifacts.
  * Tightened ghost-line cleanup and adjusted post-render tracking to prevent negative cursor movements and out-of-view output.

* **Tests**
  * Added regression tests for flicker on tall-buffer shrink and made terminal row size configurable in tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6131)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->