### PR TITLE
fix(pi-tui): stop streaming-write flicker by trimming fullRender to visible window

### DIFF
--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -674,7 +674,16 @@ export class TUI extends Container {
 		const fullRender = (clear: boolean): void => {
 			this.fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
-			const startRow = Math.max(1, height - Math.max(1, newLines.length) + 1);
+			// Only emit lines that will actually fit in the viewport. When the
+			// content block exceeds the terminal height, writing the entire
+			// buffer forces the terminal to physically scroll through every
+			// off-screen line on each full redraw — that is what produces the
+			// top-to-bottom scroll storm during streaming tool calls. The
+			// off-screen head was not visible anyway; once `\x1b[2J` clears the
+			// viewport, the visible window at the end is all that matters.
+			const visibleStart = Math.max(0, newLines.length - height);
+			const visibleLineCount = newLines.length - visibleStart;
+			const startRow = Math.max(1, height - visibleLineCount + 1);
 			if (clear) {
 				// Clear viewport (scrollback preserved) and anchor the rendered
 				// block to the terminal bottom so the editor / belowEditor
@@ -685,8 +694,8 @@ export class TUI extends Container {
 			} else if (startRow > 1) {
 				buffer += `\x1b[${startRow};1H`;
 			}
-			for (let i = 0; i < newLines.length; i++) {
-				if (i > 0) buffer += "\r\n";
+			for (let i = visibleStart; i < newLines.length; i++) {
+				if (i > visibleStart) buffer += "\r\n";
 				let line = newLines[i];
 				if (!isImageLine(line) && visibleWidth(line) > width) {
 					line = truncateToWidth(line, width);
@@ -848,6 +857,20 @@ export class TUI extends Container {
 		// Use previousLines.length (not maxLinesRendered) to avoid false positives after content shrinks
 		const previousContentViewportTop = getViewportTop(this.previousLines.length);
 		if (firstChanged < previousContentViewportTop) {
+			// If every change is above the viewport, nothing visible moved.
+			// Refreshing here would otherwise emit a fullRender that writes the
+			// entire buffer (potentially thousands of lines of scrolled-up
+			// transcript), and any ticking off-screen widget would re-trigger it
+			// every second. Update bookkeeping and skip the write.
+			if (lastChanged < previousContentViewportTop) {
+				this.positionHardwareCursor(cursorPos, newLines.length);
+				this.previousLines = newLines;
+				this.previousWidth = width;
+				this.previousHeight = height;
+				this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
+				this.previousViewportTop = getViewportTop(this.maxLinesRendered);
+				return;
+			}
 			// First change is above previous viewport - need full re-render
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${previousContentViewportTop})`);
 			fullRender(true);

--- a/src/tests/tui-pin-to-bottom-on-clear.test.ts
+++ b/src/tests/tui-pin-to-bottom-on-clear.test.ts
@@ -224,6 +224,129 @@ describe("TUI pin-to-bottom on clear", () => {
     );
   });
 
+  it("skips fullRender when off-screen content above the viewport mutates", () => {
+    // Regression: a ticking timer (e.g. `running · Ns`) on a tool-execution
+    // card that has scrolled out of view above the viewport must NOT cause
+    // a fullRender(true) — that path writes the entire buffer (thousands of
+    // lines of transcript) to the terminal every second, producing the
+    // top-to-bottom scroll-storm visible during streaming responses.
+    const terminal = new ResizableMockTerminal(20);
+    const tui = new TUI(terminal, false);
+    // Build a transcript that vastly exceeds the viewport (20 rows).
+    const initial = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`);
+    const component = new StaticLinesComponent(initial);
+    tui.addChild(component);
+    (tui as any).doRender();
+
+    terminal.writtenData = [];
+
+    // Simulate an off-screen mutation: line 10 (well above viewport top at
+    // index 180) changes its content. previousLines length stays at 200.
+    const mutated = initial.slice();
+    mutated[10] = "line 11 tick";
+    component.lines = mutated;
+    (tui as any).doRender();
+
+    const frame = terminal.writtenData.join("");
+    // Must not clear the viewport or reposition to top.
+    assert.ok(
+      !frame.includes("\x1b[2J"),
+      `off-screen mutation must not trigger \\x1b[2J, got ${JSON.stringify(frame.slice(0, 200))}`,
+    );
+    // Must not emit the mutated line itself (it is off-screen).
+    assert.ok(
+      !frame.includes("line 11 tick"),
+      `off-screen mutated line must not be written, got ${JSON.stringify(frame.slice(0, 200))}`,
+    );
+    // Bookkeeping must be updated so the next render's diff baseline is the
+    // mutated buffer. applyLineResets appends ANSI reset/OSC suffixes, so we
+    // assert substring rather than equality.
+    assert.ok(
+      (tui as any).previousLines[10].includes("line 11 tick"),
+      `previousLines should track the mutated buffer even when no write occurs, got ${JSON.stringify((tui as any).previousLines[10])}`,
+    );
+  });
+
+  it("fullRender only emits the visible window when content exceeds viewport", () => {
+    // Regression: when a tool-execution panel (e.g. streaming Write) grows
+    // past the terminal height AND its header timer ticks once per second,
+    // the diff sees firstChanged above the viewport (header) and lastChanged
+    // inside it (new body line). That triggers fullRender(true) — which
+    // previously wrote every off-screen line to the terminal, forcing it to
+    // physically scroll through the entire buffer each second.
+    const terminal = new ResizableMockTerminal(20);
+    const tui = new TUI(terminal, false);
+    // 200-line block on a 20-row viewport. The first ~180 lines are off-screen.
+    const initial = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`);
+    const component = new StaticLinesComponent(initial);
+    tui.addChild(component);
+    (tui as any).doRender();
+
+    terminal.writtenData = [];
+
+    // Mutate both an off-screen line (10, simulating a header timer tick) and
+    // an on-screen line (195, simulating new streaming content) — this forces
+    // the fullRender path because the change spans across the viewport edge.
+    const mutated = initial.slice();
+    mutated[10] = "header tick";
+    mutated[195] = "new streamed line";
+    component.lines = mutated;
+    (tui as any).doRender();
+
+    const frame = terminal.writtenData.join("");
+    assert.ok(
+      frame.includes("\x1b[2J"),
+      `expected fullRender to clear the viewport, got ${JSON.stringify(frame.slice(0, 200))}`,
+    );
+    // Off-screen content must NOT be written to the terminal.
+    assert.ok(
+      !frame.includes("header tick"),
+      `off-screen header mutation must not be emitted, got frame of length ${frame.length}`,
+    );
+    assert.ok(
+      !frame.includes("line 1\r\n"),
+      `off-screen line 1 must not be emitted, got ${JSON.stringify(frame.slice(0, 200))}`,
+    );
+    // On-screen content must be present.
+    assert.ok(
+      frame.includes("new streamed line"),
+      `on-screen mutated line must be emitted, got ${JSON.stringify(frame.slice(-200))}`,
+    );
+    // The total number of newlines emitted in the body should be height-1 (19),
+    // not newLines.length-1 (199). Count "\r\n" separators between lines.
+    const separatorCount = (frame.match(/\r\n/g) || []).length;
+    assert.strictEqual(
+      separatorCount,
+      19,
+      `expected ${20 - 1} line separators (one viewport's worth), got ${separatorCount}`,
+    );
+  });
+
+  it("still fullRenders when the change extends from above the viewport into it", () => {
+    // Guard rail: if a change starts above the viewport but reaches into it,
+    // the visible region really did move and we still need a full redraw.
+    const terminal = new ResizableMockTerminal(20);
+    const tui = new TUI(terminal, false);
+    const initial = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`);
+    const component = new StaticLinesComponent(initial);
+    tui.addChild(component);
+    (tui as any).doRender();
+
+    terminal.writtenData = [];
+
+    // Mutate a range that spans from above-viewport (line 10) into the
+    // visible region (last 20 lines start at index 180).
+    const mutated = initial.map((line, i) => (i >= 10 && i <= 190 ? `${line}!` : line));
+    component.lines = mutated;
+    (tui as any).doRender();
+
+    const frame = terminal.writtenData.join("");
+    assert.ok(
+      frame.includes("\x1b[2J"),
+      `visible change spanning above-viewport must trigger fullRender, got ${JSON.stringify(frame.slice(0, 200))}`,
+    );
+  });
+
   it("positions hardware cursor correctly within a short bottom-anchored block", () => {
     // Gap B: verify positionHardwareCursor emits correct relative moves when
     // content is short (negative previousViewportTop) and a CURSOR_MARKER is


### PR DESCRIPTION
## Summary

Streaming tool calls (most visibly `Write` of long files) cause the entire TUI viewport to scroll top-to-bottom on every render tick — the whole rendered block appears to repaint from line 1 every second, making the streaming output unreadable. `PI_DEBUG_REDRAW=1` reveals `fullRender` running ~once per second emitting thousands of lines (`prev=7908, new=7909, height=70`).

Two interacting issues are responsible:

1. **Off-screen mutations force a full-buffer redraw.** When a `running · Ns` timer ticks inside a tool-execution card that has scrolled above the viewport, the diff sees `firstChanged < previousContentViewportTop` and falls through to `fullRender(true)` — even though nothing visible moved.

2. **`fullRender` emits every line, not just the visible window.** For oversized blocks (streaming Write panel taller than the terminal, or a long transcript), this forces the terminal to physically scroll through thousands of off-screen lines on each redraw. The off-screen head is invisible after `\x1b[2J` anyway.

Either issue alone produces visible flicker. Together — a ticking timer above the viewport (issue 1) combined with streaming body growth inside it (driving `lastChanged` into the viewport, which keeps issue 1's skip from triggering) — they produce the per-second 8000-line repaint.

## Changes

`packages/pi-tui/src/tui.ts`:

- When `firstChanged < previousContentViewportTop` **and** `lastChanged < previousContentViewportTop` (every change is off-screen), update bookkeeping and return without writing to the terminal.
- `fullRender` now emits only `newLines.slice(newLines.length - height)` instead of the full buffer. Anchor row math (`startRow`) uses `visibleLineCount` so short blocks still bottom-anchor correctly.

The `fullRender` change is intentionally width-preserving: short blocks (`newLines.length < height`) emit exactly the same bytes as before — `visibleStart = 0`, `visibleLineCount = newLines.length`, identical `startRow`. Only oversized blocks behave differently, and there the previously-emitted off-screen prefix was unobservable anyway.

## Origin

The off-screen `fullRender` branch was introduced in eaf73e4d3 (`fix(pi-tui): keep auto-mode tui anchored to bottom`) to re-anchor the rendered block to the terminal bottom when its size changes. The intent was correct; the side effect of redrawing the entire buffer on every off-screen tick was not.

## Test plan

Regression coverage added in `src/tests/tui-pin-to-bottom-on-clear.test.ts`:

- [x] `skips fullRender when off-screen content above the viewport mutates` — mutates line 10 of a 200-line block on a 20-row terminal; asserts no `\x1b[2J` is emitted and the mutated content is not written.
- [x] `fullRender only emits the visible window when content exceeds viewport` — mutates an off-screen header line and an on-screen body line simultaneously (forcing the fullRender path); asserts exactly `height - 1` line separators are emitted and the off-screen content is absent.
- [x] `still fullRenders when the change extends from above the viewport into it` — guardrail: when a change spans across the viewport edge, the fullRender path is still taken.

Existing tests preserved:
- [x] `anchors short first renders to the terminal bottom`
- [x] `appends short auto-mode frames without feeding blank rows downward`
- [x] `anchors a short block to the terminal bottom when a height change triggers fullRender(clear)`
- [x] `falls back to row 1 when the block is taller than the viewport`
- [x] `re-anchors tall shrinks so the latest turn end remains visible`
- [x] `uses differential render for same-line-count edit on short content`
- [x] `positions hardware cursor correctly within a short bottom-anchored block`

Sibling renderer suites (`tui-autocomplete-ghost-lines`, `tui-content-cursor-desync`, `tui-non-tty-render-loop`, `tui-classic-theme`, `pi-tui/__tests__/tui`) all green: 26/26 total across these suites.

## Manual repro

Before: open a chat session, ask the assistant to write a long file with the `Write` tool. As the streamed content grows past the terminal height, the entire screen repaints top-to-bottom every second. `PI_DEBUG_REDRAW=1` log fills with `fullRender: firstChanged < viewportTop (... < ...)` entries at one-per-second cadence.

After: the panel updates incrementally without visible repaint of the whole viewport. `PI_DEBUG_REDRAW=1` log shows the `firstChanged < viewportTop` branch is taken much less often, and when it is taken, only the visible window's worth of lines is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Optimized viewport rendering to display only content visible within terminal height, reducing unnecessary scrolling and screen updates.
  * Improved differential rendering to skip off-screen content changes without triggering terminal buffer writes.

* **Tests**
  * Added regression tests verifying correct behavior when content changes outside the visible viewport.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6133)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->