### PR TITLE
test(pi-tui): cover mixed shrink + visible-region rewrite path (follow-up to #6131)

### DIFF
--- a/src/tests/tui-pin-to-bottom-on-clear.test.ts
+++ b/src/tests/tui-pin-to-bottom-on-clear.test.ts
@@ -211,6 +211,60 @@ describe("TUI pin-to-bottom on clear", () => {
     );
   });
 
+  it("re-anchors tall shrinks with a visible-region edit without ghost-line leakage", () => {
+    // CodeRabbit follow-up to PR #6131: the existing tall-shrink test only
+    // exercises the pure-shrink path (`firstChanged >= newLines.length`).
+    // This test covers the mixed case — shrink AND a visible-region rewrite
+    // — to confirm the renderer does not emit a full clear and does not leak
+    // ghost-line `\r\n\x1b[2K` sequences past the viewport bottom (which is
+    // what the `!clampedToViewport` + `ghostLinesVisible` gating at
+    // tui.ts:972 protects against). Sizes use the literal CodeRabbit ratio
+    // (3:1.5) but scaled up so both buffers stay > height — on a 20-row
+    // terminal the 20→10 literal scenario flows through the short-block
+    // full-render path instead, which is by design and would emit \x1b[2J.
+    const terminal = new ResizableMockTerminal(20);
+    const tui = new TUI(terminal, false);
+    const lines = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`);
+    const component = new StaticLinesComponent(lines);
+    tui.addChild(component);
+    (tui as any).doRender();
+    terminal.writtenData = [];
+
+    // Shrink 60 → 40 AND edit a line inside the new viewport (indices 20..39
+    // map to "line 21".."line 40"). Index 25 → screen row 5 of the new
+    // viewport.
+    const next = lines.slice(0, 40);
+    next[25] = "EDITED line 26";
+    component.lines = next;
+    (tui as any).doRender();
+
+    const frame = terminal.writtenData.join("");
+
+    // 1. No full-screen clear.
+    assert.ok(
+      !frame.includes("\x1b[2J"),
+      `tall shrink + edit must not emit \\x1b[2J, got ${JSON.stringify(frame.slice(0, 160))}`,
+    );
+    // 2. Edited visible-region line is repainted.
+    assert.ok(
+      frame.includes("EDITED line 26"),
+      `expected visible-region edit "EDITED line 26" to be repainted, got ${JSON.stringify(frame.slice(0, 240))}`,
+    );
+    // 3. No spurious \r\n past screen-bottom. The realign path emits exactly
+    //    (height - 1) row separators inside the viewport repaint. A misfiring
+    //    ghost-line cleanup would add (previousLines.length - newLines.length)
+    //    extra `\r\n\x1b[2K` sequences (20 here), pushing well past 19.
+    const newlineCount = (frame.match(/\r\n/g) ?? []).length;
+    const height = 20;
+    assert.ok(
+      newlineCount <= height - 1,
+      `expected at most ${height - 1} \\r\\n sequences (one per inter-row separator), got ${newlineCount} in ${JSON.stringify(frame.slice(0, 240))}`,
+    );
+    // 4. Baseline invariants — same as the pure-shrink test.
+    assert.strictEqual((tui as any).previousViewportTop, 20);
+    assert.strictEqual((tui as any).maxLinesRendered, 40);
+  });
+
   it("uses differential render for same-line-count edit on short content", () => {
     // Gap C: verify the negative-viewport coordinate math is correct when a
     // same-length edit reaches the differential path (no line count change →


### PR DESCRIPTION
## Summary

Follow-up to #6131. Adds the mixed-path test CodeRabbit requested in its review of that PR — the shrink + visible-region rewrite case (i.e. `firstChanged < newLines.length`) which the existing pure-shrink test does not exercise.

The realign path in `packages/pi-tui/src/tui.ts:915-944` (ghost-line cleanup gating with `!clampedToViewport` and `renderEndScreenRow < height - 1`) is judged correct; this test pins that behavior so a future regression in the mixed path gets caught.

## Notes

- Test uses **60 → 40 lines on a 20-row terminal** rather than CodeRabbit's literal 20 → 10 suggestion. With 10-line buffers the renderer takes the short-block full-render branch (tui.ts:735-741) which intentionally emits `\x1b[2J`, contradicting the no-full-clear assertion. Both sizes must stay > terminal height to reach the realign path under test.
- Pure test addition — no production code changes.
- 8/8 pin-to-bottom tests pass locally.

## Test plan

- [x] `npx vitest run src/tests/tui-pin-to-bottom-on-clear.test.ts` — 8 pass, 0 fail
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test validating TUI behavior during simultaneous viewport resizing and in-viewport line editing, ensuring correct rendering and preventing unnecessary screen redraws.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6135)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->