### PR TITLE
fix(issue): plan-slice stuck loop: gsdProjectionRoot vs gsdRoot divergence in worktree mode writes to worktree .gsd but verifies against project .gsd

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -22,6 +22,7 @@ import { isClosedStatus } from "./status-guards.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 
 import {
+  gsdProjectionRoot,
   gsdRoot,
   resolveMilestoneFile,
   resolveMilestonePath,
@@ -1168,8 +1169,16 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // wrote the tasks/ directory files. Dispatch plan-slice to regenerate
       // them rather than hard-stopping — fixes the infinite-loop described in
       // issue #909.
-      const taskPlanPath = resolveTaskFile(basePath, mid, sid, tid, "PLAN");
-      if (!taskPlanPath || !existsSync(taskPlanPath)) {
+      const taskPlanPath = join(
+        gsdProjectionRoot(basePath),
+        "milestones",
+        mid,
+        "slices",
+        sid,
+        "tasks",
+        `${tid}-PLAN.md`,
+      );
+      if (!existsSync(taskPlanPath)) {
         return {
           action: "dispatch",
           unitType: "plan-slice",

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -20,6 +20,7 @@ import { logWarning, logError } from "./workflow-logger.js";
 import { readIntegrationBranch } from "./git-service.js";
 import { isClosedStatus } from "./status-guards.js";
 import {
+  gsdProjectionRoot,
   resolveSlicePath,
   resolveSliceFile,
   resolveTasksDir,
@@ -880,9 +881,9 @@ export function verifyExpectedArtifact(
         }
 
         if (taskIds && taskIds.length > 0) {
-          const tasksDir = resolveTasksDir(base, mid, sid);
-          if (!tasksDir) {
-            logWarning("recovery", `verify-fail ${unitType} ${unitId}: resolveTasksDir returned null for ${mid}/${sid}`);
+          const tasksDir = join(gsdProjectionRoot(base), "milestones", mid, "slices", sid, "tasks");
+          if (!existsSync(tasksDir)) {
+            logWarning("recovery", `verify-fail ${unitType} ${unitId}: projected tasks dir missing ${tasksDir}`);
             return false;
           }
           for (const tid of taskIds) {

--- a/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
@@ -138,3 +138,28 @@ test("dispatch: plan-slice recovery loop — second call after plan-slice still 
   assert.ok(r2.action === "dispatch" && r2.unitType === "plan-slice",
     "should keep dispatching plan-slice until task plans appear");
 });
+
+test("dispatch: worktree projection task plan is honored for execute-task dispatch", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-909-wt-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const projectRoot = join(tmp, "project");
+  const worktreeBase = join(projectRoot, ".gsd", "worktrees", "M002");
+
+  scaffoldMilestoneContext(projectRoot, "M002");
+  scaffoldSlicePlan(projectRoot, "M002", "S03");
+  scaffoldTaskPlan(worktreeBase, "M002", "S03", "T01");
+
+  const ctx = makeContext(worktreeBase);
+  const result = await resolveDispatch(ctx);
+
+  assert.equal(result.action, "dispatch");
+  assert.ok(
+    result.action === "dispatch" && result.unitType === "execute-task",
+    `unitType should be execute-task, got: ${result.action === "dispatch" ? result.unitType : "(stop)"}`,
+  );
+  assert.ok(
+    result.action === "dispatch" && result.unitId === "M002/S03/T01",
+    `unitId should be M002/S03/T01, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`,
+  );
+});


### PR DESCRIPTION
## Summary
- Updated plan-slice verification and dispatch task-plan path checks to use gsdProjectionRoot and confirmed with focused auto-recovery/integration tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6125
- [#6125 plan-slice stuck loop: gsdProjectionRoot vs gsdRoot divergence in worktree mode writes to worktree .gsd but verifies against project .gsd](https://github.com/gsd-build/gsd-2/issues/6125)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6125-plan-slice-stuck-loop-gsdprojectionroot--1778863138`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and recovery when task plan files are missing during execution recovery.
  * Enhanced verification of projected task-plan locations to align with the updated projected directory layout.
* **Tests**
  * Added a regression test verifying dispatch behavior against the projected worktree task-plan structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->