### PR TITLE
fix(pi-coding-agent): resolve discovery model-list URLs relative to baseUrl

### DIFF
--- a/packages/pi-coding-agent/src/core/model-discovery.test.ts
+++ b/packages/pi-coding-agent/src/core/model-discovery.test.ts
@@ -325,4 +325,61 @@ describe("discovery fetchModels — list URL resolution", () => {
 		await adapter.fetchModels("k", "https://api.custom.example");
 		assert.equal(requestedUrl, "https://api.custom.example/v1/models");
 	});
+
+	it("OpenAI adapter: rejects discovery base URL with query string", async () => {
+		globalThis.fetch = (async () => {
+			throw new Error("fetch should not run");
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("openai");
+		await assert.rejects(adapter.fetchModels("sk-test", "https://api.openai.com/v1?x=1"), /query string or hash fragment/i);
+	});
+
+	it("Google: rejects discovery base URL with hash fragment", async () => {
+		globalThis.fetch = (async () => {
+			throw new Error("fetch should not run");
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("google");
+		await assert.rejects(
+			adapter.fetchModels("google-key", "https://generativelanguage.googleapis.com/v1beta#bad"),
+			/query string or hash fragment/i,
+		);
+	});
+
+	it("OpenAI adapter: non-array payload.data yields empty DiscoveredModel list", async () => {
+		globalThis.fetch = (async () => {
+			return new Response(JSON.stringify({ data: { not: "an-array" } }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("openai");
+		const models = await adapter.fetchModels("sk-test");
+		assert.deepEqual(models, []);
+	});
+
+	it("OpenRouter: invalid pricing strings omit cost (no NaN)", async () => {
+		globalThis.fetch = (async () => {
+			return new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "m1",
+							name: "M1",
+							pricing: { prompt: "not-a-number", completion: "0.000001" },
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("openrouter");
+		const models = await adapter.fetchModels("sk-test");
+		assert.equal(models.length, 1);
+		assert.equal(models[0].id, "m1");
+		assert.equal(models[0].cost, undefined);
+	});
 });

--- a/packages/pi-coding-agent/src/core/model-discovery.test.ts
+++ b/packages/pi-coding-agent/src/core/model-discovery.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import {
 	DISCOVERY_TTLS,
 	getDefaultTTL,
@@ -140,5 +140,189 @@ describe("supportsDiscoveryForApi", () => {
 	it("returns false for non-discoverable APIs", () => {
 		assert.equal(supportsDiscoveryForApi("anthropic-messages"), false);
 		assert.equal(supportsDiscoveryForApi(undefined), false);
+	});
+});
+
+// ─── discovery list URL resolution (regression: no doubled /v1 or /api/v1) ─────
+
+describe("discovery fetchModels — list URL resolution", () => {
+	let prevFetch: typeof fetch;
+
+	beforeEach(() => {
+		prevFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = prevFetch;
+	});
+
+	it("OpenRouter: registry-style base does not double /api/v1", async () => {
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("openrouter");
+		await adapter.fetchModels("sk-test", "https://openrouter.ai/api/v1");
+		assert.equal(requestedUrl, "https://openrouter.ai/api/v1/models");
+	});
+
+	it("OpenRouter: host-only base gets /api/v1/models", async () => {
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("openrouter");
+		await adapter.fetchModels("sk-test", "https://openrouter.example");
+		assert.equal(requestedUrl, "https://openrouter.example/api/v1/models");
+	});
+
+	it("OpenRouter: default base when baseUrl omitted", async () => {
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("openrouter");
+		await adapter.fetchModels("sk-test", undefined);
+		assert.equal(requestedUrl, "https://openrouter.ai/api/v1/models");
+	});
+
+	it("OpenAI adapter: registry-style base does not double /v1", async () => {
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("openai");
+		await adapter.fetchModels("sk-test", "https://api.openai.com/v1");
+		assert.equal(requestedUrl, "https://api.openai.com/v1/models");
+	});
+
+	it("OpenAI adapter: proxy path preserves single /v1 segment", async () => {
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("openai");
+		await adapter.fetchModels("sk-test", "https://proxy.example.com/route/v1");
+		assert.equal(requestedUrl, "https://proxy.example.com/route/v1/models");
+	});
+
+	it("OpenAI adapter: host-only base gets /v1/models", async () => {
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("openai");
+		await adapter.fetchModels("sk-test", "https://api.minimax.example");
+		assert.equal(requestedUrl, "https://api.minimax.example/v1/models");
+	});
+
+	it("OpenAI adapter: default base when baseUrl omitted", async () => {
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("openai");
+		await adapter.fetchModels("sk-test", undefined);
+		assert.equal(requestedUrl, "https://api.openai.com/v1/models");
+	});
+
+	it("Google: registry-style base does not double /v1beta", async () => {
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return new Response(JSON.stringify({ models: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("google");
+		await adapter.fetchModels("google-key", "https://generativelanguage.googleapis.com/v1beta");
+		const parsed = new URL(requestedUrl);
+		assert.equal(parsed.pathname, "/v1beta/models");
+		assert.equal(parsed.searchParams.get("key"), "google-key");
+	});
+
+	it("Google: default base when baseUrl omitted", async () => {
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return new Response(JSON.stringify({ models: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("google");
+		await adapter.fetchModels("gk", undefined);
+		const parsed = new URL(requestedUrl);
+		assert.equal(parsed.origin, "https://generativelanguage.googleapis.com");
+		assert.equal(parsed.pathname, "/v1beta/models");
+		assert.equal(parsed.searchParams.get("key"), "gk");
+	});
+
+	it("Ollama: default base when baseUrl omitted", async () => {
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return new Response(JSON.stringify({ models: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("ollama");
+		await adapter.fetchModels("", undefined);
+		assert.equal(requestedUrl, "http://localhost:11434/api/tags");
+	});
+
+	it("OpenAI-compat custom provider: host-only base gets /v1/models", async () => {
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const adapter = getDiscoveryAdapter("my-proxy", ["openai-completions"]);
+		await adapter.fetchModels("k", "https://api.custom.example");
+		assert.equal(requestedUrl, "https://api.custom.example/v1/models");
 	});
 });

--- a/packages/pi-coding-agent/src/core/model-discovery.ts
+++ b/packages/pi-coding-agent/src/core/model-discovery.ts
@@ -88,11 +88,21 @@ function joinUnderBase(base: string, resourcePath: string): string {
 }
 
 /**
- * When `trimmedBase` has no path (origin only), use `${origin}${hostOnlyPathPrefix}` as the API root.
+ * Normalize a discovery base URL to a stable API root for joining list paths.
+ *
+ * Requires an API-root style URL: no query string or hash (those would make joined list URLs ambiguous).
+ * When `trimmedBase` has no path (origin only), returns `${origin}${hostOnlyPathPrefix}`.
  * `hostOnlyPathPrefix` must start with `/` (e.g. `/v1`, `/api/v1`, `/v1beta`).
+ *
+ * @throws If the URL includes a query or fragment.
  */
 function resolveDiscoveryRoot(trimmedBase: string, hostOnlyPathPrefix: string): string {
 	const u = parseUrlOrThrow(trimmedBase);
+	if (u.search !== "" || u.hash !== "") {
+		throw new Error(
+			`Discovery base URL must not include a query string or hash fragment (use an API-root style base only): ${trimmedBase}`,
+		);
+	}
 	const pathNoSlash = u.pathname.replace(/\/+$/, "") || "/";
 	const isHostOnly = pathNoSlash === "/";
 	return isHostOnly ? `${u.origin}${hostOnlyPathPrefix}` : trimmedBase;
@@ -225,10 +235,15 @@ class OpenAIDiscoveryAdapter extends BearerJsonDiscoveryAdapter {
 		return "OpenAI models API";
 	}
 
+	/**
+	 * Parses an OpenAI-compatible `GET .../models` JSON body (`{ data: [...] }`).
+	 * If `data` is missing or not an array, returns an empty list instead of failing.
+	 */
 	parseBody(data: unknown): DiscoveredModel[] {
-		const payload = data as { data?: Array<Record<string, unknown>> };
-		return (payload.data ?? [])
-			.map((m) => parseOpenAICompatibleModel(m))
+		const payload = data as { data?: unknown };
+		const rows: unknown[] = Array.isArray(payload.data) ? payload.data : [];
+		return rows
+			.map((m) => parseOpenAICompatibleModel(m as Record<string, unknown>))
 			.filter((m): m is DiscoveredModel => !!m);
 	}
 }
@@ -285,6 +300,11 @@ class OpenRouterDiscoveryAdapter extends BearerJsonDiscoveryAdapter {
 		return "OpenRouter models API";
 	}
 
+	/**
+	 * Parses OpenRouter model list JSON. Builds per-model `cost` from `m.pricing` prompt/completion
+	 * strings (scaled by 1e6 into `input` / `output`; `cacheRead` / `cacheWrite` are 0).
+	 * Omits `cost` when parsing yields non-finite numbers (avoids NaN in `DiscoveredModel`).
+	 */
 	parseBody(data: unknown): DiscoveredModel[] {
 		const payload = data as {
 			data: Array<{
@@ -296,15 +316,19 @@ class OpenRouterDiscoveryAdapter extends BearerJsonDiscoveryAdapter {
 			}>;
 		};
 		return (payload.data ?? []).map((m) => {
-			const cost =
-				m.pricing?.prompt !== undefined && m.pricing?.completion !== undefined
-					? {
-							input: parseFloat(m.pricing.prompt) * 1_000_000,
-							output: parseFloat(m.pricing.completion) * 1_000_000,
-							cacheRead: 0,
-							cacheWrite: 0,
-						}
-					: undefined;
+			let cost: DiscoveredModel["cost"] | undefined;
+			if (m.pricing?.prompt !== undefined && m.pricing?.completion !== undefined) {
+				const promptCost = Number.parseFloat(m.pricing.prompt) * 1_000_000;
+				const completionCost = Number.parseFloat(m.pricing.completion) * 1_000_000;
+				if (Number.isFinite(promptCost) && Number.isFinite(completionCost)) {
+					cost = {
+						input: promptCost,
+						output: completionCost,
+						cacheRead: 0,
+						cacheWrite: 0,
+					};
+				}
+			}
 
 			return {
 				id: m.id,

--- a/packages/pi-coding-agent/src/core/model-discovery.ts
+++ b/packages/pi-coding-agent/src/core/model-discovery.ts
@@ -57,6 +57,86 @@ async function fetchWithTimeout(url: string, options: RequestInit = {}, timeoutM
 	}
 }
 
+const DEFAULT_OPENAI_DISCOVERY_BASE = "https://api.openai.com/v1";
+const DEFAULT_OPENROUTER_DISCOVERY_BASE = "https://openrouter.ai/api/v1";
+const DEFAULT_GOOGLE_DISCOVERY_BASE = "https://generativelanguage.googleapis.com/v1beta";
+const DEFAULT_OLLAMA_DISCOVERY_BASE = "http://localhost:11434";
+
+function trimTrailingSlashes(base: string): string {
+	return base.replace(/\/+$/, "");
+}
+
+function parseUrlOrThrow(raw: string): URL {
+	try {
+		return new URL(raw);
+	} catch {
+		throw new Error(`Invalid discovery base URL: ${raw}`);
+	}
+}
+
+function ensureTrailingSlash(base: string): string {
+	const trimmed = trimTrailingSlashes(base);
+	return `${trimmed}/`;
+}
+
+function joinUnderBase(base: string, resourcePath: string): string {
+	try {
+		return new URL(resourcePath, ensureTrailingSlash(base)).href;
+	} catch {
+		throw new Error(`Invalid discovery base URL: ${base}`);
+	}
+}
+
+/**
+ * When `trimmedBase` has no path (origin only), use `${origin}${hostOnlyPathPrefix}` as the API root.
+ * `hostOnlyPathPrefix` must start with `/` (e.g. `/v1`, `/api/v1`, `/v1beta`).
+ */
+function resolveDiscoveryRoot(trimmedBase: string, hostOnlyPathPrefix: string): string {
+	const u = parseUrlOrThrow(trimmedBase);
+	const pathNoSlash = u.pathname.replace(/\/+$/, "") || "/";
+	const isHostOnly = pathNoSlash === "/";
+	return isHostOnly ? `${u.origin}${hostOnlyPathPrefix}` : trimmedBase;
+}
+
+function openAiStyleModelsListUrl(trimmedRoot: string, hostOnlyPathPrefix: string): string {
+	return joinUnderBase(resolveDiscoveryRoot(trimmedRoot, hostOnlyPathPrefix), "models");
+}
+
+function googleDiscoveryListUrl(apiKey: string, trimmedRoot: string): string {
+	const root = resolveDiscoveryRoot(trimmedRoot, "/v1beta");
+	const list = new URL("models", ensureTrailingSlash(root));
+	list.searchParams.set("key", apiKey);
+	return list.href;
+}
+
+// ─── HTTP discovery base ─────────────────────────────────────────────────────
+
+abstract class JsonDiscoveryAdapter implements ProviderDiscoveryAdapter {
+	supportsDiscovery = true;
+	abstract readonly provider: string;
+
+	abstract defaultBase(): string;
+	abstract resolveListUrl(apiKey: string, baseUrl?: string): string;
+	abstract requestInit(apiKey: string): RequestInit;
+	abstract httpErrorApiName(): string;
+	abstract parseBody(data: unknown): DiscoveredModel[];
+
+	async fetchModels(apiKey: string, baseUrl?: string): Promise<DiscoveredModel[]> {
+		const url = this.resolveListUrl(apiKey, baseUrl);
+		const response = await fetchWithTimeout(url, this.requestInit(apiKey));
+		if (!response.ok) {
+			throw new Error(`${this.httpErrorApiName()} returned ${response.status}: ${response.statusText}`);
+		}
+		return this.parseBody(await response.json());
+	}
+}
+
+abstract class BearerJsonDiscoveryAdapter extends JsonDiscoveryAdapter {
+	requestInit(apiKey: string): RequestInit {
+		return { headers: { Authorization: `Bearer ${apiKey}` } };
+	}
+}
+
 // ─── OpenAI Adapter ──────────────────────────────────────────────────────────
 
 const OPENAI_EXCLUDED_PREFIXES = ["embedding", "tts", "dall-e", "whisper", "text-embedding", "davinci", "babbage"];
@@ -124,26 +204,30 @@ function parseOpenAICompatibleModel(rawModel: Record<string, unknown>): Discover
 	};
 }
 
-class OpenAIDiscoveryAdapter implements ProviderDiscoveryAdapter {
-	provider: string;
-	supportsDiscovery = true;
+class OpenAIDiscoveryAdapter extends BearerJsonDiscoveryAdapter {
+	readonly provider: string;
 
 	constructor(provider: string) {
+		super();
 		this.provider = provider;
 	}
 
-	async fetchModels(apiKey: string, baseUrl?: string): Promise<DiscoveredModel[]> {
-		const url = `${baseUrl ?? "https://api.openai.com"}/v1/models`;
-		const response = await fetchWithTimeout(url, {
-			headers: { Authorization: `Bearer ${apiKey}` },
-		});
+	defaultBase(): string {
+		return DEFAULT_OPENAI_DISCOVERY_BASE;
+	}
 
-		if (!response.ok) {
-			throw new Error(`OpenAI models API returned ${response.status}: ${response.statusText}`);
-		}
+	resolveListUrl(_apiKey: string, baseUrl?: string): string {
+		const root = trimTrailingSlashes(baseUrl ?? this.defaultBase());
+		return openAiStyleModelsListUrl(root, "/v1");
+	}
 
-		const data = (await response.json()) as { data?: Array<Record<string, unknown>> };
-		return (data.data ?? [])
+	httpErrorApiName(): string {
+		return "OpenAI models API";
+	}
+
+	parseBody(data: unknown): DiscoveredModel[] {
+		const payload = data as { data?: Array<Record<string, unknown>> };
+		return (payload.data ?? [])
 			.map((m) => parseOpenAICompatibleModel(m))
 			.filter((m): m is DiscoveredModel => !!m);
 	}
@@ -151,23 +235,31 @@ class OpenAIDiscoveryAdapter implements ProviderDiscoveryAdapter {
 
 // ─── Ollama Adapter ──────────────────────────────────────────────────────────
 
-class OllamaDiscoveryAdapter implements ProviderDiscoveryAdapter {
-	provider = "ollama";
-	supportsDiscovery = true;
+class OllamaDiscoveryAdapter extends JsonDiscoveryAdapter {
+	readonly provider = "ollama";
 
-	async fetchModels(_apiKey: string, baseUrl?: string): Promise<DiscoveredModel[]> {
-		const url = `${baseUrl ?? "http://localhost:11434"}/api/tags`;
-		const response = await fetchWithTimeout(url);
+	defaultBase(): string {
+		return DEFAULT_OLLAMA_DISCOVERY_BASE;
+	}
 
-		if (!response.ok) {
-			throw new Error(`Ollama tags API returned ${response.status}: ${response.statusText}`);
-		}
+	resolveListUrl(_apiKey: string, baseUrl?: string): string {
+		const root = trimTrailingSlashes(baseUrl ?? this.defaultBase());
+		return joinUnderBase(root, "api/tags");
+	}
 
-		const data = (await response.json()) as {
+	requestInit(): RequestInit {
+		return {};
+	}
+
+	httpErrorApiName(): string {
+		return "Ollama tags API";
+	}
+
+	parseBody(data: unknown): DiscoveredModel[] {
+		const payload = data as {
 			models: Array<{ name: string; size: number; details?: { parameter_size?: string } }>;
 		};
-
-		return (data.models ?? []).map((m) => ({
+		return (payload.models ?? []).map((m) => ({
 			id: m.name,
 			name: m.name,
 			input: ["text" as const],
@@ -177,21 +269,24 @@ class OllamaDiscoveryAdapter implements ProviderDiscoveryAdapter {
 
 // ─── OpenRouter Adapter ──────────────────────────────────────────────────────
 
-class OpenRouterDiscoveryAdapter implements ProviderDiscoveryAdapter {
-	provider = "openrouter";
-	supportsDiscovery = true;
+class OpenRouterDiscoveryAdapter extends BearerJsonDiscoveryAdapter {
+	readonly provider = "openrouter";
 
-	async fetchModels(apiKey: string, baseUrl?: string): Promise<DiscoveredModel[]> {
-		const url = `${baseUrl ?? "https://openrouter.ai"}/api/v1/models`;
-		const response = await fetchWithTimeout(url, {
-			headers: { Authorization: `Bearer ${apiKey}` },
-		});
+	defaultBase(): string {
+		return DEFAULT_OPENROUTER_DISCOVERY_BASE;
+	}
 
-		if (!response.ok) {
-			throw new Error(`OpenRouter models API returned ${response.status}: ${response.statusText}`);
-		}
+	resolveListUrl(_apiKey: string, baseUrl?: string): string {
+		const root = trimTrailingSlashes(baseUrl ?? this.defaultBase());
+		return openAiStyleModelsListUrl(root, "/api/v1");
+	}
 
-		const data = (await response.json()) as {
+	httpErrorApiName(): string {
+		return "OpenRouter models API";
+	}
+
+	parseBody(data: unknown): DiscoveredModel[] {
+		const payload = data as {
 			data: Array<{
 				id: string;
 				name: string;
@@ -200,8 +295,7 @@ class OpenRouterDiscoveryAdapter implements ProviderDiscoveryAdapter {
 				pricing?: { prompt: string; completion: string };
 			}>;
 		};
-
-		return (data.data ?? []).map((m) => {
+		return (payload.data ?? []).map((m) => {
 			const cost =
 				m.pricing?.prompt !== undefined && m.pricing?.completion !== undefined
 					? {
@@ -226,19 +320,28 @@ class OpenRouterDiscoveryAdapter implements ProviderDiscoveryAdapter {
 
 // ─── Google/Gemini Adapter ───────────────────────────────────────────────────
 
-class GoogleDiscoveryAdapter implements ProviderDiscoveryAdapter {
-	provider = "google";
-	supportsDiscovery = true;
+class GoogleDiscoveryAdapter extends JsonDiscoveryAdapter {
+	readonly provider = "google";
 
-	async fetchModels(apiKey: string, baseUrl?: string): Promise<DiscoveredModel[]> {
-		const url = `${baseUrl ?? "https://generativelanguage.googleapis.com"}/v1beta/models?key=${apiKey}`;
-		const response = await fetchWithTimeout(url);
+	defaultBase(): string {
+		return DEFAULT_GOOGLE_DISCOVERY_BASE;
+	}
 
-		if (!response.ok) {
-			throw new Error(`Google models API returned ${response.status}: ${response.statusText}`);
-		}
+	resolveListUrl(apiKey: string, baseUrl?: string): string {
+		const root = trimTrailingSlashes(baseUrl ?? this.defaultBase());
+		return googleDiscoveryListUrl(apiKey, root);
+	}
 
-		const data = (await response.json()) as {
+	requestInit(): RequestInit {
+		return {};
+	}
+
+	httpErrorApiName(): string {
+		return "Google models API";
+	}
+
+	parseBody(data: unknown): DiscoveredModel[] {
+		const payload = data as {
 			models: Array<{
 				name: string;
 				displayName: string;
@@ -247,8 +350,7 @@ class GoogleDiscoveryAdapter implements ProviderDiscoveryAdapter {
 				outputTokenLimit?: number;
 			}>;
 		};
-
-		return (data.models ?? [])
+		return (payload.models ?? [])
 			.filter((m) => m.supportedGenerationMethods?.includes("generateContent"))
 			.map((m) => ({
 				id: m.name.replace("models/", ""),


### PR DESCRIPTION
Discovery appended /v1 and /api/v1 segments to bases that already included them, causing list endpoints to 404 (notably OpenRouter). Resolve paths with WHATWG URL rules, normalize host-only bases for OpenAI-compat and Gemini roots, and dedupe HTTP adapters via JsonDiscoveryAdapter and BearerJsonDiscoveryAdapter.

Add regression tests that stub fetch and assert the outgoing discovery URL for OpenRouter, OpenAI, Google, Ollama, and custom OpenAI-compat providers.

## Linked issue

<!--
PRs without a linked issue will be closed.
Open or find an issue first: https://github.com/gsd-build/gsd-2/issues
-->

Closes #6141 

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Fixes provider model-discovery list URLs so paths are resolved under each provider’s configured API root instead of concatenating duplicate `/v1` / `/api/v1` / `/v1beta` segments.  
**Why:** Discovery called endpoints like `…/api/v1/api/v1/models`, which returned 404 (notably breaking OpenRouter discovery when using registry `baseUrl`s).  
**How:** WHATWG `URL` resolution + shared host-only normalization; HTTP adapters share behavior via `JsonDiscoveryAdapter` / `BearerJsonDiscoveryAdapter`; regression tests stub `fetch` and assert requested URLs.

## What

- [`packages/pi-coding-agent/src/core/model-discovery.ts`](packages/pi-coding-agent/src/core/model-discovery.ts) — Discovery URL helpers (`resolveDiscoveryRoot`, `openAiStyleModelsListUrl`, `googleDiscoveryListUrl`, etc.), default bases aligned with shipped models, adapters refactored to extend abstract discovery bases.  
- [`packages/pi-coding-agent/src/core/model-discovery.test.ts`](packages/pi-coding-agent/src/core/model-discovery.test.ts) — New suite asserting outgoing discovery URLs for OpenRouter, OpenAI (including proxy-style bases), Google, Ollama, and OpenAI-compat custom providers; `fetch` restored with `beforeEach`/`afterEach`.

## Why

Built-in models already store full API roots (e.g. `https://openrouter.ai/api/v1`). Appending `/api/v1/models` again doubled the path and broke discovery. The same pattern affected OpenAI and Google list URLs.

## How

- Trim/normalize bases, detect host-only origins, apply provider-specific defaults (`/v1`, `/api/v1`, `/v1beta`), then append `models` (or `api/tags` for Ollama) with `new URL(…)` under that root so proxy paths stay correct.  
- Centralize fetch → status check → JSON → parse in `JsonDiscoveryAdapter`; Bearer auth in `BearerJsonDiscoveryAdapter` for OpenAI/OpenRouter.

## Change type

- [ ] `feat` — New feature or capability  
- [x] `fix` — Bug fix  
- [ ] `refactor` — Code restructuring (no behavior change)  
- [x] `test` — Adding or updating tests  
- [ ] `docs` — Documentation only  
- [ ] `chore` — Build, CI, or tooling changes  

## Scope

- [ ] `pi-tui` — Terminal UI  
- [ ] `pi-ai` — AI/LLM layer  
- [ ] `pi-agent-core` — Agent orchestration  
- [x] `pi-coding-agent` — Coding agent  
- [ ] `gsd extension` — GSD workflow  
- [ ] `native` — Native bindings  
- [ ] `ci/build` — Workflows, scripts, config  

## Breaking changes

- [x] No breaking changes  
- [ ] Yes — described above  

## Test plan

- [ ] CI passes  
- [x] New/updated tests included (`model-discovery.test.ts`; existing `model-registry-discovery` integration still covers custom OpenAI-compat discovery)  
- [ ] Manual testing — steps described above  
- [ ] No tests needed — explained above  

_local verification_: `npm run test:compile` and `node --test dist-test/packages/pi-coding-agent/src/core/model-discovery.test.js dist-test/packages/pi-coding-agent/src/core/model-registry-discovery.test.js`

## AI disclosure

- [x] This PR includes AI-assisted code <!-- Cursor agent; discovery URL behavior verified via compiled tests above and optional full CI -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded regression tests for model list URL resolution across providers and base URL shapes to prevent incorrect endpoint construction.

* **Refactor**
  * Reworked model discovery to standardize URL handling, fetching, and parsing for OpenAI, OpenRouter, Google, and Ollama.

* **Bug Fixes**
  * Safer handling of malformed responses and base URLs (avoids calling invalid endpoints, prevents invalid model lists or NaN cost values).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6142)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->