### PR TITLE
fix(issue): GSD 3.0 auto-mode immediately pauses on needs-attention validation

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -463,9 +463,8 @@ async function buildRegistryAndFindActive(
       }
 
       if (allSlicesDone) {
-        const validationFile = resolveMilestoneFile(basePath, m.id, "VALIDATION");
-        const validationContent = validationFile ? await loadFile(validationFile) : null;
-        const verdict = validationContent ? extractVerdict(validationContent) : undefined;
+        const validation = getLatestAssessmentByScope(m.id, "milestone-validation");
+        const verdict = typeof validation?.status === "string" ? validation.status : undefined;
         if (verdict === "needs-attention") {
           registry.push({ id: m.id, title, status: "parked", ...(deps.length > 0 ? { dependsOn: deps } : {}) });
           continue;

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -463,6 +463,14 @@ async function buildRegistryAndFindActive(
       }
 
       if (allSlicesDone) {
+        const validationFile = resolveMilestoneFile(basePath, m.id, "VALIDATION");
+        const validationContent = validationFile ? await loadFile(validationFile) : null;
+        const verdict = validationContent ? extractVerdict(validationContent) : undefined;
+        if (verdict === "needs-attention") {
+          registry.push({ id: m.id, title, status: "parked", ...(deps.length > 0 ? { dependsOn: deps } : {}) });
+          continue;
+        }
+
         activeMilestone = { id: m.id, title };
         activeMilestoneSlices = slices;
         activeMilestoneFound = true;
@@ -1074,6 +1082,10 @@ export async function _deriveStateImpl(
       const validationContent = validationFile ? await cachedLoadFile(validationFile) : null;
       const validationTerminal = validationContent ? isValidationTerminal(validationContent) : false;
       const verdict = validationContent ? extractVerdict(validationContent) : undefined;
+      if (verdict === "needs-attention") {
+        registry.push({ id: mid, title, status: "parked" });
+        continue;
+      }
       // needs-remediation is terminal but requires re-validation (#3596)
       const needsRevalidation = !validationTerminal || verdict === 'needs-remediation';
 
@@ -1091,7 +1103,7 @@ export async function _deriveStateImpl(
         // Needs (re-)validation, but another milestone is already active
         registry.push({ id: mid, title, status: 'pending' });
       } else if (!activeMilestoneFound) {
-        // Terminal validation (pass/needs-attention) but no summary → completing-milestone
+        // Terminal passing validation but no summary → completing-milestone
         activeMilestone = { id: mid, title };
         activeRoadmap = roadmap;
         activeMilestoneFound = true;

--- a/src/resources/extensions/gsd/tests/validate-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone.test.ts
@@ -205,6 +205,22 @@ test("deriveState returns blocked when needs-remediation has no incomplete slice
   }
 });
 
+test("deriveState parks milestone when validation verdict is needs-attention and no summary (#6136)", async () => {
+  const base = makeTmpBase();
+  try {
+    writeRoadmap(base, "M001", ALL_DONE_ROADMAP);
+    writeValidation(base, "M001", "---\nverdict: needs-attention\nremediation_round: 0\n---\n\n# Validation\nNeeds attention.");
+
+    const state = await deriveState(base);
+    assert.equal(state.phase, "pre-planning");
+    assert.equal(state.activeMilestone, null);
+    assert.equal(state.registry.find(entry => entry.id === "M001")?.status, "parked");
+    assert.ok(state.nextAction.includes("parked"));
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("deriveState returns complete when both VALIDATION and SUMMARY exist", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tests/validate-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone.test.ts
@@ -13,7 +13,7 @@ import { buildCompleteMilestonePrompt, buildValidateMilestonePrompt } from "../a
 import type { GSDState } from "../types.ts";
 import { clearPathCache } from "../paths.ts";
 import { clearParseCache } from "../files.ts";
-import { closeDatabase, insertMilestone, insertSlice, openDatabase, getMilestone } from "../gsd-db.ts";
+import { closeDatabase, insertAssessment, insertMilestone, insertSlice, openDatabase, getMilestone } from "../gsd-db.ts";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -210,6 +210,31 @@ test("deriveState parks milestone when validation verdict is needs-attention and
   try {
     writeRoadmap(base, "M001", ALL_DONE_ROADMAP);
     writeValidation(base, "M001", "---\nverdict: needs-attention\nremediation_round: 0\n---\n\n# Validation\nNeeds attention.");
+
+    const state = await deriveState(base);
+    assert.equal(state.phase, "pre-planning");
+    assert.equal(state.activeMilestone, null);
+    assert.equal(state.registry.find(entry => entry.id === "M001")?.status, "parked");
+    assert.ok(state.nextAction.includes("parked"));
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("deriveState parks DB-backed milestone when validation verdict is needs-attention (#6136)", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "First slice", status: "complete", depends: [] });
+    writeRoadmap(base, "M001", ALL_DONE_ROADMAP);
+    insertAssessment({
+      path: join(".gsd", "milestones", "M001", "M001-VALIDATION.md"),
+      milestoneId: "M001",
+      status: "needs-attention",
+      scope: "milestone-validation",
+      fullContent: "---\nverdict: needs-attention\nremediation_round: 0\n---\n\n# Validation\nNeeds attention.",
+    });
 
     const state = await deriveState(base);
     assert.equal(state.phase, "pre-planning");


### PR DESCRIPTION
## Summary
- Treated `needs-attention` validation milestones as parked in state derivation and verified with targeted validate-milestone tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6136
- [#6136 GSD 3.0 auto-mode immediately pauses on needs-attention validation](https://github.com/gsd-build/gsd-2/issues/6136)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6136-gsd-3-0-auto-mode-immediately-pauses-on--1778871048`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Milestones validated as "needs-attention" are now consistently parked and prevented from auto-advancing across both current and legacy data sources, preserving workflow state and avoiding premature activation.

* **Tests**
  * Added coverage verifying milestones are paused, registry entries marked parked, active milestone cleared, and next-action reflects the parked status when validation requires attention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6144)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->