### PR TITLE
fix(issue): state.js treats needs-attention as pass for phase derivation — creates dead-end completing-milestone phase

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -582,18 +582,22 @@ async function handleAllSlicesDone(
   }
 
   // All roadmap slices are done (enforced by caller) and verdict is
-  // needs-remediation — remediation cannot progress without new slices.
-  // Return blocked instead of re-dispatching validate-milestone (#4506).
-  if (verdict === 'needs-remediation') {
+  // non-passing. Return blocked instead of entering completing-milestone.
+  if (verdict === 'needs-remediation' || verdict === 'needs-attention') {
+    const remediation = verdict === 'needs-remediation';
     return {
       activeMilestone, activeSlice: null, activeTask: null,
       phase: 'blocked',
       recentDecisions: [],
       blockers: [
-        `Milestone ${activeMilestone.id} validation verdict is needs-remediation but all slices are complete. ` +
-          `Add remediation slices via gsd_reassess_roadmap, or run \`/gsd verdict pass --rationale "..."\` to override.`,
+        `Milestone ${activeMilestone.id} validation verdict is ${verdict} but all slices are complete. ` +
+          (remediation
+            ? `Add remediation slices via gsd_reassess_roadmap, or run \`/gsd verdict pass --rationale "..."\` to override.`
+            : `Address validation findings and re-run validation, or run \`/gsd verdict pass --rationale "..."\` to override.`),
       ],
-      nextAction: `Resolve ${activeMilestone.id} remediation before proceeding.`,
+      nextAction: remediation
+        ? `Resolve ${activeMilestone.id} remediation before proceeding.`
+        : `Resolve ${activeMilestone.id} validation findings before proceeding.`,
       registry, requirements,
       progress: { milestones: milestoneProgress, slices: sliceProgress },
     };
@@ -1074,8 +1078,9 @@ export async function _deriveStateImpl(
       const validationContent = validationFile ? await cachedLoadFile(validationFile) : null;
       const validationTerminal = validationContent ? isValidationTerminal(validationContent) : false;
       const verdict = validationContent ? extractVerdict(validationContent) : undefined;
-      // needs-remediation is terminal but requires re-validation (#3596)
-      const needsRevalidation = !validationTerminal || verdict === 'needs-remediation';
+      // needs-remediation / needs-attention are terminal but require
+      // re-validation before completion.
+      const needsRevalidation = !validationTerminal || verdict === 'needs-remediation' || verdict === 'needs-attention';
 
       if (summaryFile && await isTerminalMilestoneSummaryFile(summaryFile, cachedLoadFile)) {
         // Summary exists → milestone is complete regardless of validation state.
@@ -1305,7 +1310,8 @@ export async function _deriveStateImpl(
       };
     }
 
-    if (verdict === 'needs-remediation') {
+    if (verdict === 'needs-remediation' || verdict === 'needs-attention') {
+      const remediation = verdict === 'needs-remediation';
       return {
         activeMilestone,
         activeSlice: null,
@@ -1313,10 +1319,14 @@ export async function _deriveStateImpl(
         phase: 'blocked',
         recentDecisions: [],
         blockers: [
-          `Milestone ${activeMilestone.id} validation verdict is needs-remediation but all slices are complete. ` +
-            `Add remediation slices via gsd_reassess_roadmap, or run \`/gsd verdict pass --rationale "..."\` to override.`,
+          `Milestone ${activeMilestone.id} validation verdict is ${verdict} but all slices are complete. ` +
+            (remediation
+              ? `Add remediation slices via gsd_reassess_roadmap, or run \`/gsd verdict pass --rationale "..."\` to override.`
+              : `Address validation findings and re-run validation, or run \`/gsd verdict pass --rationale "..."\` to override.`),
         ],
-        nextAction: `Resolve ${activeMilestone.id} remediation before proceeding.`,
+        nextAction: remediation
+          ? `Resolve ${activeMilestone.id} remediation before proceeding.`
+          : `Resolve ${activeMilestone.id} validation findings before proceeding.`,
         registry,
         requirements,
         progress: {

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -902,6 +902,54 @@ describe('derive-state-db', async () => {
     }
   });
 
+  test('derive-state-db: needs-attention with all slices done returns blocked (#6137)', async () => {
+    const base = createFixtureBase();
+    try {
+      const doneRoadmap = `# M001: Stuck Attention
+
+**Vision:** Test needs-attention dead-end guard.
+
+## Slices
+
+- [x] **S01: Done Slice** \`risk:low\` \`depends:[]\`
+  > After this: Done.
+`;
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', doneRoadmap);
+      writeFile(base, 'milestones/M001/M001-VALIDATION.md',
+        '---\nverdict: needs-attention\nremediation_round: 0\n---\n\n# Validation\nNeeds attention.');
+
+      invalidateStateCache();
+      const fileState = await _deriveStateImpl(base);
+
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'Stuck Attention', status: 'active' });
+      insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Done Slice', status: 'complete', risk: 'low', depends: [] });
+      insertAssessment({
+        path: 'milestones/M001/M001-VALIDATION.md',
+        milestoneId: 'M001',
+        status: 'needs-attention',
+        scope: 'milestone-validation',
+        fullContent: 'verdict: needs-attention',
+      });
+
+      invalidateStateCache();
+      const dbState = await deriveStateFromDb(base);
+
+      assert.deepStrictEqual(dbState.phase, 'blocked', 'attention-stuck-db: phase is blocked');
+      assert.deepStrictEqual(dbState.phase, fileState.phase, 'attention-stuck-db: phase matches filesystem');
+      assert.deepStrictEqual(dbState.activeMilestone?.id, 'M001', 'attention-stuck-db: activeMilestone is M001');
+      assert.ok(
+        dbState.blockers.some(b => b.includes('needs-attention') && b.includes('M001')),
+        'attention-stuck-db: blocker message mentions milestone and verdict',
+      );
+
+      closeDatabase();
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
   // ─── Test 15: Completing-milestone — terminal validation, no summary ──
   test('derive-state-db: completing-milestone via DB', async () => {
     const base = createFixtureBase();

--- a/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
@@ -532,6 +532,40 @@ describe('derive-state-helpers', () => {
     }
   });
 
+  test('handleAllSlicesDone: needs-attention with all slices done returns blocked', async () => {
+    const base = createFixtureBase();
+    try {
+      const doneRoadmap = `# M001: Attention Test\n\n**Vision:** Test.\n\n## Slices\n\n- [x] **S01: Done** \`risk:low\` \`depends:[]\`\n  > Done.\n`;
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', doneRoadmap);
+      writeFile(base, 'milestones/M001/M001-VALIDATION.md',
+        '---\nverdict: needs-attention\nremediation_round: 0\n---\n\n# Validation\nNeeds attention.');
+
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'Attention Test', status: 'active' });
+      insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Done', status: 'complete', risk: 'low', depends: [] });
+      insertAssessment({
+        path: 'milestones/M001/M001-VALIDATION.md',
+        milestoneId: 'M001',
+        status: 'needs-attention',
+        scope: 'milestone-validation',
+        fullContent: 'verdict: needs-attention',
+      });
+
+      invalidateStateCache();
+      const state = await deriveStateFromDb(base);
+
+      assert.equal(state.phase, 'blocked', 'attention-stuck: phase is blocked (no dead-end completion phase)');
+      assert.equal(state.activeMilestone?.id, 'M001', 'attention-stuck: activeMilestone is M001');
+      assert.ok(
+        state.blockers.some(b => b.includes('needs-attention') && b.includes('M001')),
+        'attention-stuck: blocker message mentions milestone and verdict',
+      );
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
   // ─── Deferred queued shell: shell milestone deferred, real one promoted ──
   test('buildRegistryAndFindActive: queued shell deferred, later real milestone becomes active (#3470)', async () => {
     const base = createFixtureBase();


### PR DESCRIPTION
## Summary
- Fixed state derivation to block `needs-attention` (not `completing-milestone`) and verified with focused derive-state regression tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6137
- [#6137 state.js treats needs-attention as pass for phase derivation — creates dead-end completing-milestone phase](https://github.com/gsd-build/gsd-2/issues/6137)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6137-state-js-treats-needs-attention-as-pass--1778875669`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Milestones with "needs-attention" verdicts now correctly block completion when all roadmap slices are done, preventing premature advancement and displaying appropriate remediation guidance.

* **Tests**
  * Added validation tests for "needs-attention" milestone behavior with completed slices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6148)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->