### PR TITLE
fix(gsd): prefer compiled parser module in markdown renderer

### DIFF
--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -788,11 +788,12 @@ export function detectStaleRenders(basePath: string): StaleEntry[] {
   const _require = createRequire(import.meta.url);
   let parseRoadmap: Function, parsePlan: Function;
   try {
-    const m = _require("./parsers-legacy.ts");
+    // Prefer compiled JS for packaged/runtime installs; TS exists only in source/dev contexts.
+    const m = _require("./parsers-legacy.js");
     parseRoadmap = m.parseRoadmap; parsePlan = m.parsePlan;
   } catch (e) {
-    logWarning("renderer", `parsers-legacy.ts require failed, falling back to .js: ${(e as Error).message}`);
-    const m = _require("./parsers-legacy.js");
+    logWarning("renderer", `parsers-legacy.js require failed, falling back to .ts: ${(e as Error).message}`);
+    const m = _require("./parsers-legacy.ts");
     parseRoadmap = m.parseRoadmap; parsePlan = m.parsePlan;
   }
 


### PR DESCRIPTION
## TL;DR

**What:** Prefer  before  in .
**Why:** npm/dev packaged installs are JS-first; TS-first require path emits noisy fallback warnings.
**How:** Swap load order to  first with  fallback retained for source/dev.

## What

Updates  in  to load  first, then fallback to .

## Why

Installed runtime under  contains  (no ), so TS-first lookup logs avoidable warning:
.

## How

Minimal change: reverse require order and keep fallback path.

## Validation

- 
- Compiling 2200 files to dist-test/...
Copied non-TS assets and .ts source files to dist-test/src/
Rewrote .ts → .js imports in 745 files
[test:compile] {"cacheHit":false,"fileCount":6706,"bytesCopied":68425131,"inputBytes":68425131,"wallMs":9493}
Done in 9.49s
- ✔ ── markdown-renderer: DB accessor basics ── (8.075833ms)
✔ ── markdown-renderer: getArtifact accessor ── (2.8145ms)
✔ ── markdown-renderer: renderRoadmapCheckboxes round-trip ── (16.212625ms)
✔ ── markdown-renderer: renderRoadmapCheckboxes bidirectional ── (10.501792ms)
✔ ── markdown-renderer: renderPlanCheckboxes round-trip ── (17.052125ms)
✔ ── markdown-renderer: renderPlanCheckboxes bidirectional ── (16.696375ms)
✔ ── markdown-renderer: renderPlanFromDb creates parse-compatible slice plan + task plan files ── (19.716083ms)
✔ ── markdown-renderer: slice plan summarizes task descriptions without leaking nested headings ── (16.10675ms)
✔ ── markdown-renderer: renderTaskPlanFromDb throws for missing task ── (12.634292ms)
✔ ── markdown-renderer: renderTaskSummary round-trip ── (17.341416ms)
✔ ── markdown-renderer: renderTaskSummary skips empty ── (11.362625ms)
✔ ── markdown-renderer: renderSliceSummary round-trip ── (15.689375ms)
✔ ── markdown-renderer: renderAllFromDb produces all files ── (39.268833ms)
markdown-renderer: no slices found for milestone M001
markdown-renderer: detected 1 stale render(s):
  - /private/var/folders/6g/1rc940nd6852typ06m4zzk7r0000gn/T/gsd-renderer-AFWwTs/.gsd/milestones/M001/slices/S01/S01-PLAN.md: T02 is done in DB but unchecked in plan
markdown-renderer: detected 2 stale render(s):
  - /private/var/folders/6g/1rc940nd6852typ06m4zzk7r0000gn/T/gsd-renderer-JsONxK/.gsd/milestones/M001/slices/S01/S01-PLAN.md: T01 is done in DB but unchecked in plan
  - /private/var/folders/6g/1rc940nd6852typ06m4zzk7r0000gn/T/gsd-renderer-JsONxK/.gsd/milestones/M001/slices/S01/S01-PLAN.md: T02 is done in DB but unchecked in plan
markdown-renderer: detected 2 stale render(s):
  - /private/var/folders/6g/1rc940nd6852typ06m4zzk7r0000gn/T/gsd-renderer-JsONxK/.gsd/milestones/M001/slices/S01/S01-PLAN.md: T01 is done in DB but unchecked in plan
  - /private/var/folders/6g/1rc940nd6852typ06m4zzk7r0000gn/T/gsd-renderer-JsONxK/.gsd/milestones/M001/slices/S01/S01-PLAN.md: T02 is done in DB but unchecked in plan
✔ ── markdown-renderer: missing artifact regenerates from DB without importing disk projection ── (13.456083ms)
✔ ── markdown-renderer: stderr warning on missing content ── (4.034625ms)
✔ ── markdown-renderer: detectStaleRenders finds plan checkbox mismatch ── (15.58ms)
markdown-renderer: repaired 1 stale render(s)
markdown-renderer: detected 1 stale render(s):
  - /private/var/folders/6g/1rc940nd6852typ06m4zzk7r0000gn/T/gsd-renderer-ZJj77I/.gsd/milestones/M001/M001-ROADMAP.md: S01 is closed in DB but unchecked in roadmap
markdown-renderer: detected 1 stale render(s):
  - /private/var/folders/6g/1rc940nd6852typ06m4zzk7r0000gn/T/gsd-renderer-ffV09H/.gsd/milestones/M001/slices/S01/tasks/T01-SUMMARY.md: T01 is complete with summary in DB but SUMMARY.md missing on disk
markdown-renderer: detected 1 stale render(s):
  - /private/var/folders/6g/1rc940nd6852typ06m4zzk7r0000gn/T/gsd-renderer-V4tdNS/.gsd/milestones/M001/slices/S01/tasks/T01-SUMMARY.md: T01 is complete with summary in DB but SUMMARY.md missing on disk
✔ ── markdown-renderer: repairStaleRenders fixes plan and second detect returns empty ── (23.717584ms)
✔ ── markdown-renderer: detectStaleRenders finds roadmap checkbox mismatch ── (17.558125ms)
✔ ── markdown-renderer: detectStaleRenders finds missing task summary ── (15.227708ms)
markdown-renderer: repaired 1 stale render(s)
markdown-renderer: detected 2 stale render(s):
  - /private/var/folders/6g/1rc940nd6852typ06m4zzk7r0000gn/T/gsd-renderer-nAKI9T/.gsd/milestones/M001/slices/S01/S01-SUMMARY.md: S01 is complete with summary in DB but SUMMARY.md missing on disk
  - /private/var/folders/6g/1rc940nd6852typ06m4zzk7r0000gn/T/gsd-renderer-nAKI9T/.gsd/milestones/M001/slices/S01/S01-UAT.md: S01 is complete with UAT in DB but UAT.md missing on disk
✔ ── markdown-renderer: repairStaleRenders writes missing task summary ── (19.623208ms)
✔ ── markdown-renderer: repairStaleRenders idempotency — fully synced returns 0 ── (12.8665ms)
✔ ── markdown-renderer: detectStaleRenders finds missing slice summary and UAT ── (14.877292ms)
ℹ tests 22
ℹ suites 0
ℹ pass 22
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 519.618583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized module loading strategy with improved fallback handling
  * Updated system warning messages for greater clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->