### PR TITLE
fix(issue): fix(tui): collapsed tool card truncates command at hard cap instead of terminal width

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
@@ -39,6 +39,7 @@ function renderToolCollapsed(
 		details?: Record<string, unknown>;
 	},
 	toolDefinition?: { label?: string; renderCall?: (...args: any[]) => any; renderResult?: (...args: any[]) => any },
+	width = 120,
 ): string {
 	const component = new ToolExecutionComponent(
 		toolName,
@@ -48,7 +49,7 @@ function renderToolCollapsed(
 		{ requestRender() {} } as any,
 	);
 	if (result) component.updateResult(result);
-	return stripAnsi(component.render(120).join("\n"));
+	return stripAnsi(component.render(width).join("\n"));
 }
 
 describe("ToolExecutionComponent", () => {
@@ -292,6 +293,21 @@ describe("ToolExecutionComponent", () => {
 		assert.match(rendered, /\$ npm run typecheck -- --watch false/);
 		assert.doesNotMatch(rendered, /├/, "collapsed command cards should not include internal divider lines");
 		assert.doesNotMatch(rendered, /\bok\b/);
+	});
+
+	test("uses available row width for compact bash command text", () => {
+		const rendered = renderToolCollapsed(
+			"bash",
+			{
+				command:
+					'grep -n "expanded\\|toolOutputExpanded\\|setExpanded\\|defaultExpanded" /tmp/project/src/tool-execution.ts',
+			},
+			{ content: [{ type: "text", text: "ok" }], isError: false, details: { cwd: "/tmp/project" } },
+			undefined,
+			200,
+		);
+
+		assert.match(rendered, /defaultExpanded/);
 	});
 
 	test("keeps failed tools expanded and error visible", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -117,7 +117,7 @@ function formatElapsed(ms: number): string {
 }
 
 function formatCommandPreview(command: string): string {
-	return truncateToWidth(command.replace(/\s+/g, " ").trim(), 64, "");
+	return command.replace(/\s+/g, " ").trim();
 }
 
 function appendLineOrRange(displayPath: string | undefined, target: ToolTargetMetadata): string | undefined {


### PR DESCRIPTION
## Summary
- Removed hard-capped collapsed bash command truncation and added a wide-width regression test, verified by targeted tool-execution tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6157
- [#6157 fix(tui): collapsed tool card truncates command at hard cap instead of terminal width](https://github.com/gsd-build/gsd-2/issues/6157)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6157-fix-tui-collapsed-tool-card-truncates-co-1778883640`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced command preview formatting in the interactive coding agent interface for improved whitespace handling.

* **Tests**
  * Expanded test coverage for command rendering across different display widths to ensure consistent formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->