### PR TITLE
fix(issue): bug: /gsd auto requires two invocations when isolation is 'none' — resume path exits on false-positive guard-block

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1953,6 +1953,9 @@ export function createWiredAutoOrchestrationModule(
             reason: `No Unit manifest is registered for ${unitType}`,
           };
         }
+        if (getIsolationMode(runtimeBasePath) !== "worktree") {
+          return { ok: true, reason: "not-required" };
+        }
         const writeScope =
           manifest.tools.mode === "all" || manifest.tools.mode === "docs"
             ? "source-writing"
@@ -2637,10 +2640,13 @@ export async function startAuto(
 
     try {
       const resumeResult = await s.orchestration?.resume();
-      if (resumeResult?.kind === "blocked") {
+      if (resumeResult?.kind === "blocked" && resumeResult.action === "stop") {
         notifyResumeBlocked(ctx, resumeResult);
         await cleanupAfterLoopExit(ctx);
         return;
+      }
+      if (resumeResult?.kind === "blocked") {
+        notifyResumeBlocked(ctx, resumeResult);
       }
     } catch (err) {
       debugLog("resume-orchestration-resume", { error: err instanceof Error ? err.message : String(err) });

--- a/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
+++ b/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
@@ -291,3 +291,36 @@ test("discussion auto-start waits for the current command context to become idle
   assert.equal(launches[0][2], "/tmp/gsd-auto-start-idle-test");
   assert.deepEqual(launches[0][4], { step: true });
 });
+
+test("resume path only hard-exits on blocked stop, not blocked pause (#6154)", () => {
+  const autoSrc = readGsdFile("auto.ts");
+  const startAutoIdx = autoSrc.indexOf("export async function startAuto(");
+  const startAutoBody = autoSrc.slice(startAutoIdx);
+  const resumeSectionIdx = startAutoBody.indexOf("if (s.paused) {");
+  const freshStartSectionIdx = startAutoBody.indexOf("// ── Fresh start path — delegated to auto-start.ts ──");
+  const resumeBody = startAutoBody.slice(resumeSectionIdx, freshStartSectionIdx);
+
+  assert.ok(startAutoIdx > -1, "startAuto should exist");
+  assert.ok(resumeSectionIdx > -1, "resume path should exist");
+  assert.ok(freshStartSectionIdx > resumeSectionIdx, "resume assertions should be scoped before fresh start");
+  assert.ok(
+    resumeBody.includes('if (resumeResult?.kind === "blocked" && resumeResult.action === "stop")'),
+    "resume path should only hard-stop blocked resume when action is stop",
+  );
+  assert.ok(
+    resumeBody.includes('if (resumeResult?.kind === "blocked")'),
+    "resume path should still notify blocked resume results",
+  );
+});
+
+test("prepareForUnit skips worktree safety when isolation is not worktree (#6154)", () => {
+  const autoSrc = readGsdFile("auto.ts");
+  const prepareForUnitIdx = autoSrc.indexOf("async prepareForUnit(unitType, unitId) {");
+  const prepareForUnitBody = autoSrc.slice(prepareForUnitIdx, autoSrc.indexOf("async syncAfterUnit() {}", prepareForUnitIdx));
+
+  assert.ok(prepareForUnitIdx > -1, "prepareForUnit should exist");
+  assert.ok(
+    prepareForUnitBody.includes('if (getIsolationMode(runtimeBasePath) !== "worktree")'),
+    "prepareForUnit should bypass worktree safety validation outside worktree isolation mode",
+  );
+});


### PR DESCRIPTION
## Summary
- Fixed false-positive non-worktree resume blocking and resume-path hard-exit logic, with targeted regression tests passing.

## Bugs Addressed
- [x] **`prepareForUnit` missing isolation mode guard (`auto.ts`)**
- [x] **Resume path hard-exits on any `"blocked"` result (`auto.ts`)**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6154
- [#6154 bug: /gsd auto requires two invocations when isolation is 'none' — resume path exits on false-positive guard-block](https://github.com/gsd-build/gsd-2/issues/6154)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6154-bug-gsd-auto-requires-two-invocations-wh-1778883840`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-mode orchestration to handle blocked resume states more intelligently—now only hard-exits when explicitly stopped, while properly handling other blocked scenarios.
  * Auto-mode now skips unnecessary worktree validation when not in worktree isolation mode.

* **Tests**
  * Added tests to validate auto-mode resume behavior and worktree handling logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->