### PR TITLE
fix(issue): auto-mode: require_slice_discussion stop uses level:"info" instead of "warning", creating orphaned worktrees

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -782,7 +782,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       return {
         action: "stop" as const,
         reason: `Slice ${state.activeSlice.id} requires discussion before planning (require_slice_discussion is enabled). Run /gsd discuss to discuss this slice, then /gsd auto to resume.`,
-        level: "info" as const,
+        level: "warning" as const,
       };
     },
   },

--- a/src/resources/extensions/gsd/tests/require-slice-discussion-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/require-slice-discussion-dispatch.test.ts
@@ -80,7 +80,7 @@ describe("require_slice_discussion dispatch rule (#3454)", () => {
         assert.match(action!.reason, /S01/);
         assert.match(action!.reason, /require_slice_discussion/);
         assert.match(action!.reason, /\/gsd discuss/);
-        assert.strictEqual(action!.level, "info");
+        assert.strictEqual(action!.level, "warning");
       }
     } finally {
       rmSync(basePath, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Switched the require_slice_discussion stop level to warning and verified with the targeted dispatch regression test (7/7 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6152
- [#6152 auto-mode: require_slice_discussion stop uses level:"info" instead of "warning", creating orphaned worktrees](https://github.com/gsd-build/gsd-2/issues/6152)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6152-auto-mode-require-slice-discussion-stop--1778886244`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted notification severity level for missing context file scenarios when slice discussion is required, ensuring appropriate alert prominence for users.

* **Tests**
  * Updated regression tests to reflect alert severity level changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->