### PR TITLE
fix(issue): auto-mode retries execute-task after deterministic ESM tool-load failure instead of pausing

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1246,7 +1246,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           const isUserSkip = /queued user message/i.test(s.lastToolInvocationError);
           const errMsg = isUserSkip
             ? `Tool skipped for ${s.currentUnit.type}: ${s.lastToolInvocationError}. Queued user message interrupted the turn — pausing auto-mode.`
-            : `Tool invocation failed for ${s.currentUnit.type}: ${s.lastToolInvocationError}. Structured argument generation failed — pausing auto-mode.`;
+            : `Tool invocation/runtime failed for ${s.currentUnit.type}: ${s.lastToolInvocationError}. Retrying cannot resolve this deterministic failure — pausing auto-mode.`;
           debugLog("postUnit", { phase: "tool-invocation-error-pause", unitType: s.currentUnit.type, unitId: s.currentUnit.id, error: s.lastToolInvocationError });
           ctx.ui.notify(errMsg, "error");
           s.lastToolInvocationError = null;

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -92,7 +92,7 @@ export function clearInFlightTools(): void {
  * from the tool handler. When these errors occur, retrying the same unit will
  * produce the same failure, so the retry loop must be broken.
  */
-const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON/i;
+const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON|does not provide an export named|Named export .* not found|Cannot find module|ERR_MODULE_NOT_FOUND|ERR_MODULE_NOT_EXPORTED|ERR_PACKAGE_PATH_NOT_EXPORTED/i;
 const DETERMINISTIC_POLICY_ERROR_RE = /(?:^|\b)(?:HARD BLOCK:|Blocked: \/gsd queue is a planning tool|Direct writes to \.gsd\/STATE\.md and \.gsd\/gsd\.db are blocked|This is a mechanical gate)/i;
 
 /**

--- a/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
@@ -101,6 +101,19 @@ describe("#2883: isToolInvocationError classification", () => {
     );
   });
 
+  test("detects ESM export-link errors", () => {
+    assert.equal(
+      isToolInvocationError("The requested module '../paths.js' does not provide an export named 'gsdProjectionRoot'"),
+      true,
+    );
+  });
+
+  test("detects module-not-found and package export errors", () => {
+    assert.equal(isToolInvocationError("Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/tmp/x.mjs'"), true);
+    assert.equal(isToolInvocationError("Named export 'x' not found. The requested module 'y' is a CommonJS module"), true);
+    assert.equal(isToolInvocationError("Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './x' is not defined"), true);
+  });
+
   test("detects raw write-gate CONTEXT failures for non-GSD write tools", () => {
     resetWriteGateState(process.cwd());
     const result = shouldBlockContextWrite(


### PR DESCRIPTION
## Summary
- Added deterministic ESM/module-load failures to tool-invocation classification and verified with targeted regression tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6149
- [#6149 auto-mode retries execute-task after deterministic ESM tool-load failure instead of pausing](https://github.com/gsd-build/gsd-2/issues/6149)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6149-auto-mode-retries-execute-task-after-det-1778886414`