### PR TITLE
fix(issue): headless extension_ui_request select auto-responder picks first option blindly (headless-ui.js:176)

### DIFF
--- a/src/headless-ui.ts
+++ b/src/headless-ui.ts
@@ -217,12 +217,20 @@ export function handleExtensionUIRequest(
       // Lock-guard prompts list "View status" first, but headless needs "Force start"
       // to proceed. Detect by title and pick the force option.
       const title = String(event.title ?? '')
-      let selected = event.options?.[0] ?? ''
-      if (title.includes('Auto-mode is running') && event.options) {
-        const forceOption = event.options.find(o => o.toLowerCase().includes('force start'))
-        if (forceOption) selected = forceOption
+      const options = event.options ?? []
+      if (title.includes('Auto-mode is running')) {
+        const forceOption = options.find(o => o.toLowerCase().includes('force start'))
+        if (forceOption) {
+          client.sendUIResponse(id, { value: forceOption })
+          break
+        }
       }
-      client.sendUIResponse(id, { value: selected })
+      const safeOption = options.find(o => /\b(not yet|cancel|skip|exit|abort)\b/i.test(o))
+      if (safeOption) {
+        client.sendUIResponse(id, { value: safeOption })
+        break
+      }
+      client.sendUIResponse(id, { cancelled: true })
       break
     }
     case 'confirm':

--- a/src/tests/headless-v2-migration.test.ts
+++ b/src/tests/headless-v2-migration.test.ts
@@ -95,12 +95,20 @@ function handleExtensionUIRequest(
   switch (method) {
     case 'select': {
       const title = String(event.title ?? '')
-      let selected = event.options?.[0] ?? ''
-      if (title.includes('Auto-mode is running') && event.options) {
-        const forceOption = event.options.find(o => o.toLowerCase().includes('force start'))
-        if (forceOption) selected = forceOption
+      const options = event.options ?? []
+      if (title.includes('Auto-mode is running')) {
+        const forceOption = options.find(o => o.toLowerCase().includes('force start'))
+        if (forceOption) {
+          client.sendUIResponse(id, { value: forceOption })
+          break
+        }
       }
-      client.sendUIResponse(id, { value: selected })
+      const safeOption = options.find(o => /\b(not yet|cancel|skip|exit|abort)\b/i.test(o))
+      if (safeOption) {
+        client.sendUIResponse(id, { value: safeOption })
+        break
+      }
+      client.sendUIResponse(id, { cancelled: true })
       break
     }
     case 'confirm':
@@ -274,7 +282,7 @@ test('string-matching fallback works when execution_complete never received', ()
 
 // ─── handleExtensionUIRequest uses client.sendUIResponse ────────────────────
 
-test('handleExtensionUIRequest select calls sendUIResponse with value', () => {
+test('handleExtensionUIRequest select cancels when no safe option exists', () => {
   const client = new MockRpcClient()
 
   handleExtensionUIRequest(
@@ -284,7 +292,25 @@ test('handleExtensionUIRequest select calls sendUIResponse with value', () => {
 
   assert.equal(client.sendUICalls.length, 1)
   assert.equal(client.sendUICalls[0].id, 'sel1')
-  assert.equal(client.sendUICalls[0].response.value, 'option-a')
+  assert.equal(client.sendUICalls[0].response.cancelled, true)
+})
+
+test('handleExtensionUIRequest select prefers safe option when present', () => {
+  const client = new MockRpcClient()
+
+  handleExtensionUIRequest(
+    {
+      type: 'extension_ui_request',
+      id: 'sel-safe',
+      method: 'select',
+      options: ['Quick task (recommended)', 'Not yet: Run /gsd when ready.'],
+    },
+    client,
+  )
+
+  assert.equal(client.sendUICalls.length, 1)
+  assert.equal(client.sendUICalls[0].id, 'sel-safe')
+  assert.equal(client.sendUICalls[0].response.value, 'Not yet: Run /gsd when ready.')
 })
 
 test('handleExtensionUIRequest confirm calls sendUIResponse with confirmed', () => {

--- a/src/tests/headless-v2-migration.test.ts
+++ b/src/tests/headless-v2-migration.test.ts
@@ -313,6 +313,25 @@ test('handleExtensionUIRequest select prefers safe option when present', () => {
   assert.equal(client.sendUICalls[0].response.value, 'Not yet: Run /gsd when ready.')
 })
 
+test('handleExtensionUIRequest select prefers force start when Auto-mode is running', () => {
+  const client = new MockRpcClient()
+
+  handleExtensionUIRequest(
+    {
+      type: 'extension_ui_request',
+      id: 'sel-force',
+      method: 'select',
+      title: 'Auto-mode is running — another command is already executing',
+      options: ['View status', 'Force start anyway', 'Cancel'],
+    },
+    client,
+  )
+
+  assert.equal(client.sendUICalls.length, 1)
+  assert.equal(client.sendUICalls[0].id, 'sel-force')
+  assert.equal(client.sendUICalls[0].response.value, 'Force start anyway')
+})
+
 test('handleExtensionUIRequest confirm calls sendUIResponse with confirmed', () => {
   const client = new MockRpcClient()
 


### PR DESCRIPTION
## Summary
- Updated headless select auto-response to prefer safe non-progress options or cancel, and verified with focused headless migration tests (27/27 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5736
- [#5736 headless extension_ui_request select auto-responder picks first option blindly (headless-ui.js:176)](https://github.com/gsd-build/gsd-2/issues/5736)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5736-headless-extension-ui-request-select-aut-1778892826`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved headless mode request handling with enhanced option selection logic and safer fallback behavior for edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->