### PR TITLE
fix(issue): auto-loop marks successful unit dispatch as failed when pauseAuto fires during runFinalize

### DIFF
--- a/src/resources/extensions/gsd/auto/workflow-kernel.ts
+++ b/src/resources/extensions/gsd/auto/workflow-kernel.ts
@@ -276,7 +276,7 @@ export function decideEngineDispatch(input: EngineDispatchInput): EngineDispatch
   return { action: "dispatch" };
 }
 
-const COMPLETE_AND_BREAK_REASONS = new Set([
+const COMPLETE_AND_BREAK_REASONS = [
   "step-wizard",
   "post-verification-stopped",
   "pre-verification-dispatched",
@@ -284,12 +284,20 @@ const COMPLETE_AND_BREAK_REASONS = new Set([
   "verification-pause",
   "finalize-pre-timeout",
   "finalize-post-timeout",
-] as const);
+] as const;
+
+function isCompleteAndBreakReason(
+  reason: string,
+): reason is (typeof COMPLETE_AND_BREAK_REASONS)[number] {
+  return COMPLETE_AND_BREAK_REASONS.includes(
+    reason as (typeof COMPLETE_AND_BREAK_REASONS)[number],
+  );
+}
 
 export function decideFinalizeResult(input: FinalizeInput): FinalizeDecision {
   if (input.action === "break") {
     const reason = input.reason ?? "unknown";
-    if (COMPLETE_AND_BREAK_REASONS.has(reason)) {
+    if (isCompleteAndBreakReason(reason)) {
       return { action: "complete-and-break" };
     }
     return {

--- a/src/resources/extensions/gsd/auto/workflow-kernel.ts
+++ b/src/resources/extensions/gsd/auto/workflow-kernel.ts
@@ -276,18 +276,20 @@ export function decideEngineDispatch(input: EngineDispatchInput): EngineDispatch
   return { action: "dispatch" };
 }
 
+const COMPLETE_AND_BREAK_REASONS = new Set([
+  "step-wizard",
+  "post-verification-stopped",
+  "pre-verification-dispatched",
+  "uat-pause",
+  "verification-pause",
+  "finalize-pre-timeout",
+  "finalize-post-timeout",
+] as const);
+
 export function decideFinalizeResult(input: FinalizeInput): FinalizeDecision {
   if (input.action === "break") {
     const reason = input.reason ?? "unknown";
-    if (
-      reason === "step-wizard"
-      || reason === "post-verification-stopped"
-      || reason === "pre-verification-dispatched"
-      || reason === "uat-pause"
-      || reason === "verification-pause"
-      || reason === "finalize-pre-timeout"
-      || reason === "finalize-post-timeout"
-    ) {
+    if (COMPLETE_AND_BREAK_REASONS.has(reason)) {
       return { action: "complete-and-break" };
     }
     return {

--- a/src/resources/extensions/gsd/auto/workflow-kernel.ts
+++ b/src/resources/extensions/gsd/auto/workflow-kernel.ts
@@ -279,7 +279,15 @@ export function decideEngineDispatch(input: EngineDispatchInput): EngineDispatch
 export function decideFinalizeResult(input: FinalizeInput): FinalizeDecision {
   if (input.action === "break") {
     const reason = input.reason ?? "unknown";
-    if (reason === "step-wizard") {
+    if (
+      reason === "step-wizard"
+      || reason === "post-verification-stopped"
+      || reason === "pre-verification-dispatched"
+      || reason === "uat-pause"
+      || reason === "verification-pause"
+      || reason === "finalize-pre-timeout"
+      || reason === "finalize-post-timeout"
+    ) {
       return { action: "complete-and-break" };
     }
     return {

--- a/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-kernel.test.ts
@@ -172,6 +172,22 @@ test("decideFinalizeResult maps step-wizard breaks to completed step exits", () 
   );
 });
 
+test("decideFinalizeResult maps finalize pause breaks to completed exits", () => {
+  for (const reason of [
+    "post-verification-stopped",
+    "pre-verification-dispatched",
+    "uat-pause",
+    "verification-pause",
+    "finalize-pre-timeout",
+    "finalize-post-timeout",
+  ]) {
+    assert.deepEqual(
+      decideFinalizeResult({ action: "break", reason }),
+      { action: "complete-and-break" },
+    );
+  }
+});
+
 test("decideFinalizeResult maps continue and next results", () => {
   assert.deepEqual(
     decideFinalizeResult({ action: "continue" }),


### PR DESCRIPTION
## Summary
- Finalize break reasons that represent pause/stop-after-success now exit as complete-and-break (not failed), verified by targeted workflow-kernel tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5715
- [#5715 auto-loop marks successful unit dispatch as failed when pauseAuto fires during runFinalize](https://github.com/gsd-build/gsd-2/issues/5715)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5715-auto-loop-marks-successful-unit-dispatch-1778892832`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workflow finalization behavior to handle pause and timeout conditions more comprehensively.

* **Tests**
  * Added test coverage for additional finalization edge cases to ensure reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->