### PR TITLE
fix(issue): /gsd auto on completed registry opens interactive Next-Action menu instead of terminal stop (guided-flow.js:1888)

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -191,6 +191,11 @@ async function runQuickTaskChoice(ctx: ExtensionCommandContext, pi: ExtensionAPI
   await handleQuick(task, ctx, pi);
 }
 
+function isNonInteractiveContext(ctx: ExtensionCommandContext): boolean {
+  if (!ctx.hasUI) return true;
+  return process.env.GSD_HEADLESS === "1" || process.env.GSD_WEB_BRIDGE_TUI === "1";
+}
+
 /**
  * Scope-based overload of isGhostMilestone.
  * Binds basePath and milestoneId from the scope, ensuring path resolution
@@ -2217,6 +2222,10 @@ export async function showSmartEntry(
         basePath
       ), "gsd-run", ctx, "discuss-milestone", { basePath });
     } else {
+      if (isNonInteractiveContext(ctx)) {
+        ctx.ui.notify(`Auto-mode stopped — ${state.nextAction || "No active milestone."}`, "info");
+        return;
+      }
       const choice = await showNextAction(ctx, {
         title: "GSD — Get Shit Done",
         summary: ["No active milestone."],
@@ -2273,6 +2282,10 @@ export async function showSmartEntry(
 
   // ── All milestones complete → New milestone ──────────────────────────
   if (state.phase === "complete") {
+    if (isNonInteractiveContext(ctx)) {
+      ctx.ui.notify("Auto-mode stopped — all milestones complete.", "info");
+      return;
+    }
     const choice = await showNextAction(ctx, {
       title: `GSD — ${milestoneId}: ${milestoneTitle}`,
       summary: ["All milestones complete."],

--- a/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
+++ b/src/resources/extensions/gsd/tests/smart-entry-complete.test.ts
@@ -7,6 +7,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { deriveState } from "../state.js";
+import { showSmartEntry } from "../guided-flow.js";
+import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../gsd-db.js";
 
 function writeCompleteMilestone(base: string): void {
   const milestoneDir = join(base, ".gsd", "milestones", "M001");
@@ -32,6 +34,43 @@ test("deriveState reports the last completed milestone when all milestone slices
     assert.equal(state.phase, "complete");
     assert.equal(state.lastCompletedMilestone?.id, "M001");
   } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("showSmartEntry stops instead of opening next-action choices when complete and non-interactive", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-smart-entry-complete-"));
+  const notifications: Array<{ message: string; level: string }> = [];
+  try {
+    writeCompleteMilestone(base);
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Complete Milestone", status: "complete" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Done slice", status: "complete", risk: "low", depends: [] });
+
+    await showSmartEntry(
+      {
+        hasUI: false,
+        ui: {
+          notify: (message: string, level: string) => notifications.push({ message, level }),
+          setStatus: () => {},
+        },
+      } as any,
+      {
+        sendMessage: () => {
+          throw new Error("complete non-interactive smart entry must not dispatch a prompt");
+        },
+        getActiveTools: () => [],
+        setActiveTools: () => {},
+      } as any,
+      base,
+    );
+
+    assert.deepEqual(notifications.at(-1), {
+      message: "Auto-mode stopped — All milestones complete.",
+      level: "info",
+    });
+  } finally {
+    closeDatabase();
     rmSync(base, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- Added non-interactive guards in guided-flow complete/no-active-milestone paths to stop auto-mode with terminal notifications, verified by focused headless and guided-flow tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5735
- [#5735 /gsd auto on completed registry opens interactive Next-Action menu instead of terminal stop (guided-flow.js:1888)](https://github.com/gsd-build/gsd-2/issues/5735)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5735-gsd-auto-on-completed-registry-opens-int-1778892827`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed interactive menus appearing in headless and web-bridge environments
  * Improved notifications when there are no active milestones or when all milestones are complete

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->