### PR TITLE
fix(issue): Auto-mode stops with postflight-stash-restore-failed: stale nativeHasChanges cache after autoCommit + unverified stash push (mode=none)

### DIFF
--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -244,10 +244,13 @@ export function preflightCleanRoot(
       encoding: "utf-8",
       env: GIT_NO_PROMPT_ENV,
     });
+    const stashCreated = findPreflightStashRef(basePath, milestoneId, stashMarker) !== null;
     return {
-      stashPushed: true,
-      stashMarker,
-      summary: `Stashed uncommitted changes before merge (milestone ${milestoneId}).`,
+      stashPushed: stashCreated,
+      stashMarker: stashCreated ? stashMarker : undefined,
+      summary: stashCreated
+        ? `Stashed uncommitted changes before merge (milestone ${milestoneId}).`
+        : `No stashable changes found before merge (milestone ${milestoneId}).`,
     };
   } catch (err) {
     // Stash failure is non-fatal — log and let the merge attempt proceed

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -924,6 +924,9 @@ export class GitServiceImpl {
       if (!nativeHasStagedChanges(this.basePath)) throw err;
       nativeCommit(this.basePath, message, { allowEmpty: false });
     }
+    // nativeHasChanges() uses a short TTL cache in fallback mode; invalidate it
+    // after a successful commit so post-commit checks observe a clean tree.
+    _resetHasChangesCache();
 
     // Absorb any preceding gsd snapshot commits into this real commit.
     // Walk backwards from HEAD~1 counting consecutive snapshot subjects,

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -69,6 +69,7 @@ test("preflightCleanRoot — dirty tree warns user and auto-stashes", () => {
     });
 
     assert.equal(result.stashPushed, true, "stashPushed must be true when tree was dirty");
+    assert.ok(result.stashMarker, "stashMarker must be set when a stash entry is created");
     assert.ok(result.summary.length > 0, "summary must be non-empty when stash was pushed");
 
     // A warning notification must have been emitted before stashing
@@ -84,6 +85,7 @@ test("preflightCleanRoot — dirty tree warns user and auto-stashes", () => {
     // The stash entry must exist
     const stashList = run("git stash list", repo);
     assert.ok(stashList.includes("gsd-preflight-stash"), "stash entry must be named gsd-preflight-stash");
+    assert.ok(stashList.includes(result.stashMarker!), "stash list must include the generated stash marker");
   } finally {
     try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
   }

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -23,7 +23,7 @@ import {
   type PreMergeCheckResult,
   type TaskCommitContext,
 } from "../../git-service.ts";
-import { nativeAddAllWithExclusions } from "../../native-git-bridge.ts";
+import { nativeAddAllWithExclusions, nativeHasChanges, _resetHasChangesCache } from "../../native-git-bridge.ts";
 function run(command: string, cwd: string): string {
   return execSync(command, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
 }
@@ -1947,6 +1947,19 @@ describe('git-service', async () => {
     // No gsd snapshot commits in log
     const log = run("git log --oneline", repo);
     assert.ok(!log.includes("gsd snapshot"), "no gsd snapshot commits remain in history");
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  test('autoCommit: resets nativeHasChanges cache after successful commit', () => {
+    const repo = initTempRepo();
+    createFile(repo, "cache-reset.ts", "before");
+
+    _resetHasChangesCache();
+    const svc = new GitServiceImpl(repo);
+    const message = svc.autoCommit("execute-task", "S01/T-cache");
+    assert.ok(message !== null, "autoCommit should commit dirty changes");
+    assert.equal(nativeHasChanges(repo), false, "post-commit has-changes check should observe a clean tree");
 
     rmSync(repo, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
- Fixed post-commit dirty-cache invalidation and verified preflight stash creation, with targeted tests passing.

## Bugs Addressed
- [x] **Stale nativeHasChanges cache after successful autoCommit**
- [x] **preflightCleanRoot assumes stash created on exit code 0**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5776
- [#5776 Auto-mode stops with postflight-stash-restore-failed: stale nativeHasChanges cache after autoCommit + unverified stash push (mode=none)](https://github.com/gsd-build/gsd-2/issues/5776)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5776-auto-mode-stops-with-postflight-stash-re-1778892822`