### PR TITLE
fix(issue): [Bug]: With Gemini 3.1 GSD Next get stuck at last task

### DIFF
--- a/src/resources/extensions/gsd/auto/unit-runner-events.ts
+++ b/src/resources/extensions/gsd/auto/unit-runner-events.ts
@@ -9,7 +9,11 @@ export function isInternalSessionTransitionAbortEvent(
 }
 
 export function shouldIgnoreAgentEndForActiveUnit(
-  event: Pick<AgentEndEvent, "abortOrigin">,
+  event: Pick<AgentEndEvent, "abortOrigin" | "messages">,
 ): boolean {
-  return isInternalSessionTransitionAbortEvent(event);
+  if (!isInternalSessionTransitionAbortEvent(event)) return false;
+  const lastMsg = event.messages[event.messages.length - 1];
+  if (!lastMsg || typeof lastMsg !== "object") return true;
+  const stopReason = (lastMsg as { stopReason?: unknown }).stopReason;
+  return stopReason === "aborted" || stopReason === "error";
 }

--- a/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
+++ b/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
@@ -117,19 +117,29 @@ test("typed session-transition abort events are classified as internal", () => {
   assert.equal(
     shouldIgnoreAgentEndForActiveUnit({
       abortOrigin: "session-transition",
+      messages: [{ stopReason: "aborted" }],
     }),
     true,
   );
 
   assert.equal(
     shouldIgnoreAgentEndForActiveUnit({
-      abortOrigin: "user",
+      abortOrigin: "session-transition",
+      messages: [{ stopReason: "end_turn" }],
     }),
     false,
   );
 
   assert.equal(
-    shouldIgnoreAgentEndForActiveUnit({}),
+    shouldIgnoreAgentEndForActiveUnit({
+      abortOrigin: "user",
+      messages: [{ stopReason: "aborted" }],
+    }),
+    false,
+  );
+
+  assert.equal(
+    shouldIgnoreAgentEndForActiveUnit({ messages: [] }),
     false,
   );
 });


### PR DESCRIPTION
## Summary
- Tightened session-transition agent_end filtering so completed turns are no longer ignored, and verified with the targeted regression test suite.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5887
- [#5887 [Bug]: With Gemini 3.1 GSD Next get stuck at last task](https://github.com/gsd-build/gsd-2/issues/5887)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5887-bug-with-gemini-3-1-gsd-next-get-stuck-a-1778892809`