### PR TITLE
fix(issue): UAT verdict gate misclassifies roadmap reassessment verdicts from S##-ASSESSMENT.md

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -17,7 +17,7 @@ import type { GSDPreferences } from "./preferences.js";
 import type { UatType } from "./files.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
-import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, insertAssessment, transaction } from "./gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, insertAssessment, transaction, getAssessment } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 
@@ -177,6 +177,16 @@ async function readUatGateVerdict(
 
   const assessmentContent = assessmentFile ? await loadFile(assessmentFile) : null;
   if (assessmentContent) {
+    // `reassess-roadmap` writes roadmap-scoped assessments to the same
+    // S##-ASSESSMENT artifact path; those verdicts must not be treated as UAT.
+    const assessmentRow = getAssessment(relSliceFile(basePath, mid, sliceId, "ASSESSMENT"));
+    const assessmentScope = typeof assessmentRow?.["scope"] === "string"
+      ? String(assessmentRow["scope"]).trim().toLowerCase()
+      : "";
+    if (assessmentScope === "roadmap") {
+      return null;
+    }
+
     const assessmentVerdict = extractVerdict(assessmentContent);
     if (assessmentVerdict) {
       return {

--- a/src/resources/extensions/gsd/tests/integration/state-machine-edge-cases.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/state-machine-edge-cases.test.ts
@@ -915,6 +915,39 @@ describe("dispatch failure modes", () => {
     );
   });
 
+  test("UAT verdict gate: roadmap-scoped ASSESSMENT verdict is ignored", async () => {
+    base = createFullFixture();
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Active", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "First", status: "complete" });
+    insertSlice({ id: "S02", milestoneId: "M001", title: "Second", status: "pending" });
+
+    const s01Dir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    const assessmentRelPath = join(".gsd", "milestones", "M001", "slices", "S01", "S01-ASSESSMENT.md");
+    writeFileSync(
+      join(s01Dir, "S01-ASSESSMENT.md"),
+      "---\nverdict: roadmap-adjusted\n---\n# Reassessment\n",
+    );
+    insertAssessment({
+      path: assessmentRelPath,
+      milestoneId: "M001",
+      sliceId: "S01",
+      status: "roadmap-adjusted",
+      scope: "roadmap",
+      fullContent: "---\nverdict: roadmap-adjusted\n---\n# Reassessment\n",
+    });
+
+    const ctx = buildDispatchCtx(base, "M001", {
+      phase: "planning",
+      activeSlice: { id: "S02", title: "Second" },
+      activeTask: null,
+    });
+    ctx.prefs = { uat_dispatch: true } as any;
+
+    const result = await getUatVerdictGate().match(ctx);
+    assert.equal(result, null, "roadmap scoped assessment verdict should not be treated as UAT");
+  });
+
   test("UAT verdict gate: ROADMAP fallback gates done slices when DB is unavailable", async () => {
     base = createFullFixture();
     const mDir = join(base, ".gsd", "milestones", "M001");


### PR DESCRIPTION
## Summary
- UAT verdict gating now ignores roadmap-scoped assessment verdicts, and a regression test verifies `roadmap-adjusted` no longer blocks progression.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5727
- [#5727 UAT verdict gate misclassifies roadmap reassessment verdicts from S##-ASSESSMENT.md](https://github.com/gsd-build/gsd-2/issues/5727)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5727-uat-verdict-gate-misclassifies-roadmap-r-1778892826`