### PR TITLE
fix(issue): bug(auto): cross-slice context accumulation violates one-slice-per-context-window contract

### DIFF
--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -197,12 +197,18 @@ export function writeLock(
     // Best-effort — never throw from the lock writer.
   }
 
-  if (!isDbAvailable() || !sessionFile) return;
+  if (!isDbAvailable()) return;
   try {
     const projectRoot = normalizeRealPath(basePath);
     const worker = findActiveWorkerForCurrentProcess(projectRoot);
     if (!worker) return;
-    setRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY, sessionFile);
+    if (sessionFile) {
+      setRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY, sessionFile);
+    } else {
+      // Preliminary unit locks (before runUnit/newSession settles) must clear
+      // any prior pointer so crash recovery cannot ingest stale cross-unit context.
+      deleteRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY);
+    }
   } catch {
     // Best-effort — never throw from the lock writer.
   }

--- a/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
@@ -207,6 +207,24 @@ test("writeLock stores the session_file in runtime_kv (worker scope)", (t) => {
   assert.equal(lock!.sessionFile, "/tmp/session-xyz.jsonl");
 });
 
+test("writeLock without session file clears stale worker session_file pointer", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  const projectRoot = normalizeRealPath(base);
+  const workerId = registerAutoWorker({ projectRootRealpath: projectRoot });
+
+  writeLock(base, "plan-slice", "M001/S01", "/tmp/session-stale.jsonl");
+  assert.equal(getRuntimeKv("worker", workerId, "session_file"), "/tmp/session-stale.jsonl");
+
+  writeLock(base, "execute-task", "M001/S01/T01");
+  assert.equal(
+    getRuntimeKv("worker", workerId, "session_file"),
+    null,
+    "preliminary lock write must clear stale session_file pointer",
+  );
+});
+
 test("clearLock removes the session_file row for the active worker", (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));


### PR DESCRIPTION
## Summary
- Cleared stale worker session-file pointers on preliminary lock writes and added a passing regression test to prevent cross-unit/slice crash-recovery context carryover.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5792
- [#5792 bug(auto): cross-slice context accumulation violates one-slice-per-context-window contract](https://github.com/gsd-build/gsd-2/issues/5792)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5792-bug-auto-cross-slice-context-accumulatio-1778892816`