### PR TITLE
fix(issue): auto-mode zero-tool-call execute-task enters artifact verification retry loop

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -681,6 +681,17 @@ export async function autoLoop(
           finishTurn("stopped", "execution", "unit-break");
           break;
         }
+        if (unitPhaseResult.action === "retry") {
+          finishIncompleteIteration({
+            status: "retry",
+            reason: unitPhaseResult.reason,
+            retry: true,
+            unitType: iterData.unitType,
+            unitId: iterData.unitId,
+          });
+          finishTurn("retry", "execution", unitPhaseResult.reason);
+          continue;
+        }
 
         // ── Verify first, then reconcile (only mark complete on pass) ──
         debugLog("autoLoop", { phase: "custom-engine-verify", iteration, unitId: iterData.unitId });
@@ -1052,6 +1063,21 @@ export async function autoLoop(
         });
         finishTurn("stopped", "execution", "unit-break");
         break;
+      }
+      if (unitPhaseResult.action === "retry") {
+        dispatchSettled = settleDispatchFailed(dispatchId, unitPhaseResult.reason, {
+          markFailed: markDispatchFailed,
+          logWriteFailure: logDispatchLedgerWriteFailure,
+        }) || dispatchSettled;
+        finishIncompleteIteration({
+          status: "retry",
+          reason: unitPhaseResult.reason,
+          retry: true,
+          unitType: iterData.unitType,
+          unitId: iterData.unitId,
+        });
+        finishTurn("retry", "execution", unitPhaseResult.reason);
+        continue;
       }
 
       // ── Phase 5: Finalize ───────────────────────────────────────────────

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -876,6 +876,10 @@ export async function autoLoop(
             finishTurn("skipped");
             continue;
           }
+          if (preDispatchResult.action === "retry") {
+            finishTurn("retry", "execution", preDispatchResult.reason);
+            continue;
+          }
           const preData = preDispatchResult.data;
           const guardsResult = await runGuards(ic, preData.mid);
           phaseReporter.report("guard", guardsResult.action);
@@ -891,6 +895,10 @@ export async function autoLoop(
           }
           if (dispatchResult.action === "continue") {
             finishTurn("skipped");
+            continue;
+          }
+          if (dispatchResult.action === "retry") {
+            finishTurn("retry", "execution", dispatchResult.reason);
             continue;
           }
           iterData = dispatchResult.data;

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -2416,9 +2416,14 @@ export async function runUnitPhase(
             `${unitType} ${unitId} completed with 0 tool calls — context exhaustion, will retry`,
             "warning",
           );
-          // Fall through to next iteration where dispatch will re-derive
-          // and re-dispatch this unit.
-          return { action: "next", data: { unitStartedAt: _resolveCurrentUnitStartedAtForTest(s.currentUnit), requestDispatchedAt: unitResult.requestDispatchedAt } };
+          return {
+            action: "retry",
+            reason: "zero-tool-calls",
+            data: {
+              unitStartedAt: _resolveCurrentUnitStartedAtForTest(s.currentUnit),
+              requestDispatchedAt: unitResult.requestDispatchedAt,
+            },
+          };
         }
       }
     }

--- a/src/resources/extensions/gsd/auto/types.ts
+++ b/src/resources/extensions/gsd/auto/types.ts
@@ -77,6 +77,7 @@ export interface UnitResult {
 export type PhaseResult<T = void> =
   | { action: "continue" }
   | { action: "break"; reason: string }
+  | { action: "retry"; reason: string; data?: T }
   | { action: "next"; data: T }
 
 export interface IterationContext {

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -3430,7 +3430,7 @@ test("autoLoop rejects execute-task with 0 tool calls as hallucinated (#1833)", 
   ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
   const pi = makeMockPi();
 
-  let iterationCount = 0;
+  let closeoutCount = 0;
   const notifications: string[] = [];
   ctx.ui.notify = (msg: string) => { notifications.push(msg); };
 
@@ -3465,6 +3465,7 @@ test("autoLoop rejects execute-task with 0 tool calls as hallucinated (#1833)", 
       };
     },
     closeoutUnit: async () => {
+      closeoutCount++;
       // Simulate snapshotUnitMetrics adding a 0-toolCalls entry to ledger
       mockLedger.units.push({
         type: "execute-task",
@@ -3475,15 +3476,9 @@ test("autoLoop rejects execute-task with 0 tool calls as hallucinated (#1833)", 
         tokens: { input: 100, output: 200, total: 300, cacheRead: 0, cacheWrite: 0 },
         cost: 0.50,
       });
+      if (closeoutCount >= 2) s.active = false;
     },
     getLedger: () => mockLedger,
-    postUnitPostVerification: async () => {
-      deps.callLog.push("postUnitPostVerification");
-      iterationCount++;
-      // Deactivate after 2nd iteration
-      s.active = iterationCount < 2;
-      return "continue" as const;
-    },
   });
 
   const loopPromise = autoLoop(ctx, pi, s, deps);
@@ -3496,6 +3491,7 @@ test("autoLoop rejects execute-task with 0 tool calls as hallucinated (#1833)", 
   await new Promise((r) => setTimeout(r, 50));
   mockLedger.units.length = 0; // clear previous entry
   (deps as any).closeoutUnit = async () => {
+    closeoutCount++;
     mockLedger.units.push({
       type: "execute-task",
       id: "M001/S01/T01",
@@ -3505,6 +3501,7 @@ test("autoLoop rejects execute-task with 0 tool calls as hallucinated (#1833)", 
       tokens: { input: 500, output: 800, total: 1300, cacheRead: 0, cacheWrite: 0 },
       cost: 1.00,
     });
+    if (closeoutCount >= 2) s.active = false;
   };
   resolveAgentEnd(makeEvent());
 
@@ -3525,6 +3522,11 @@ test("autoLoop rejects execute-task with 0 tool calls as hallucinated (#1833)", 
   assert.ok(
     deriveCount >= 2,
     `deriveState should be called at least 2 times for retry (got ${deriveCount})`,
+  );
+  assert.equal(
+    deps.callLog.filter((c) => c === "postUnitPreVerification").length,
+    1,
+    "zero-tool retry should bypass finalize on the failed iteration",
   );
 });
 
@@ -3617,7 +3619,7 @@ test("autoLoop rejects complete-slice with 0 tool calls as context-exhausted (#2
   ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
   const pi = makeMockPi();
 
-  let iterationCount = 0;
+  let closeoutCount = 0;
   const notifications: string[] = [];
   ctx.ui.notify = (msg: string) => { notifications.push(msg); };
 
@@ -3651,6 +3653,7 @@ test("autoLoop rejects complete-slice with 0 tool calls as context-exhausted (#2
       };
     },
     closeoutUnit: async () => {
+      closeoutCount++;
       // complete-slice with 0 tool calls — context exhausted, no progress
       mockLedger.units.push({
         type: "complete-slice",
@@ -3661,15 +3664,9 @@ test("autoLoop rejects complete-slice with 0 tool calls as context-exhausted (#2
         tokens: { input: 50, output: 100, total: 150, cacheRead: 0, cacheWrite: 0 },
         cost: 0.10,
       });
+      if (closeoutCount >= 2) s.active = false;
     },
     getLedger: () => mockLedger,
-    postUnitPostVerification: async () => {
-      deps.callLog.push("postUnitPostVerification");
-      iterationCount++;
-      // Deactivate after 2nd iteration
-      s.active = iterationCount < 2;
-      return "continue" as const;
-    },
   });
 
   const loopPromise = autoLoop(ctx, pi, s, deps);
@@ -3682,6 +3679,7 @@ test("autoLoop rejects complete-slice with 0 tool calls as context-exhausted (#2
   await new Promise((r) => setTimeout(r, 50));
   mockLedger.units.length = 0;
   (deps as any).closeoutUnit = async () => {
+    closeoutCount++;
     mockLedger.units.push({
       type: "complete-slice",
       id: "M001/S01",
@@ -3691,6 +3689,7 @@ test("autoLoop rejects complete-slice with 0 tool calls as context-exhausted (#2
       tokens: { input: 200, output: 400, total: 600, cacheRead: 0, cacheWrite: 0 },
       cost: 0.30,
     });
+    if (closeoutCount >= 2) s.active = false;
   };
   resolveAgentEnd(makeEvent());
 
@@ -3710,6 +3709,11 @@ test("autoLoop rejects complete-slice with 0 tool calls as context-exhausted (#2
   assert.ok(
     deriveCount >= 2,
     `deriveState should be called at least 2 times for retry (got ${deriveCount})`,
+  );
+  assert.equal(
+    deps.callLog.filter((c) => c === "postUnitPreVerification").length,
+    1,
+    "zero-tool retry should bypass finalize on the failed iteration",
   );
 });
 


### PR DESCRIPTION
## Summary
- Zero-tool-call unit outcomes now return retry and are handled before finalize, with focused auto-loop regressions passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5885
- [#5885 auto-mode zero-tool-call execute-task enters artifact verification retry loop](https://github.com/gsd-build/gsd-2/issues/5885)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5885-auto-mode-zero-tool-call-execute-task-en-1778892813`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Improved handling of zero tool-call completions through automatic retry mechanism
* Enhanced consistency of retry logic across custom and legacy execution paths
* Strengthened dispatch and pre-dispatch phase retry recognition and handling

**Tests**
* Updated test verification for zero tool-call retry behavior validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->