### PR TITLE
fix(issue): bug(plan-slice): stuck loop in refining phase because handlePlanSlice never clears is_sketch

### DIFF
--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -260,6 +260,7 @@ test('handlePlanSlice clears sketch flag so DB-derived state leaves refining', a
     const result = await handlePlanSlice(validParams(), base);
     assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
     assert.equal(getSlice('M001', 'S02')?.is_sketch, 0, 'planned slice must no longer be treated as a sketch');
+    assert.equal(getSlice('M001', 'S02')?.goal, 'Persist slice planning through the DB.');
 
     invalidateStateCache();
     const after = await deriveState(base);

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -329,7 +329,6 @@ export async function handlePlanSlice(
       if (isDeferredStatus(parentSlice.status)) {
         updateSliceStatus(params.milestoneId, params.sliceId, "pending");
       }
-      setSliceSketchFlag(params.milestoneId, params.sliceId, false);
 
       upsertSlicePlanning(params.milestoneId, params.sliceId, {
         goal: params.goal,
@@ -339,6 +338,7 @@ export async function handlePlanSlice(
         observabilityImpact: params.observabilityImpact,
         targetRepositories: params.targetRepositories ?? ["project"],
       });
+      setSliceSketchFlag(params.milestoneId, params.sliceId, false);
 
       for (const taskId of omittedTaskIds) {
         deleteTask(params.milestoneId, params.sliceId, taskId);


### PR DESCRIPTION
## Summary
- Moved sketch-flag clearing to immediately follow slice-plan persistence in `handlePlanSlice` and verified the refining-exit regression test passes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5917
- [#5917 bug(plan-slice): stuck loop in refining phase because handlePlanSlice never clears is_sketch](https://github.com/gsd-build/gsd-2/issues/5917)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5917-bug-plan-slice-stuck-loop-in-refining-ph-1778894304`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred slices now transition to pending when replanned; status updates occur before the new plan is saved.
  * Clearing of the sketch flag now happens after the plan is persisted to ensure derived state updates correctly.

* **Tests**
  * Added a test confirming the sketch flag is cleared and the slice goal is stored immediately after handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->