### PR TITLE
fix(prefs-wizard): call getAllWithDiscovered as a method to keep `this` bound

### DIFF
--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -587,10 +587,13 @@ async function configureModels(ctx: ExtensionCommandContext, prefs: Record<strin
   const models: Record<string, unknown> = (prefs.models as Record<string, unknown>) ?? {};
 
   const availableModels = ctx.modelRegistry.getAvailable();
-  const getAllWithDiscovered = (ctx.modelRegistry as { getAllWithDiscovered?: () => typeof availableModels }).getAllWithDiscovered;
+  // Call getAllWithDiscovered as a method so `this` stays bound to the
+  // registry — invoking a detached reference loses `this` and the method's
+  // internal `this.models` access throws.
+  const registry = ctx.modelRegistry as { getAllWithDiscovered?: () => typeof availableModels };
   const availableProviders = new Set(availableModels.map((m) => m.provider));
-  const selectableModels = typeof getAllWithDiscovered === "function"
-    ? getAllWithDiscovered().filter((m) => availableProviders.has(m.provider))
+  const selectableModels = typeof registry.getAllWithDiscovered === "function"
+    ? registry.getAllWithDiscovered().filter((m) => availableProviders.has(m.provider))
     : availableModels;
   if (selectableModels.length > 0) {
     // Group models by provider, sorted alphabetically

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -169,13 +169,21 @@ test("models wizard offers discovered models for enabled providers", async () =>
     "(keep current)",
   ];
   const ctx = {
+    // `getAllWithDiscovered` reads `this._all` so the wizard must call it as a
+    // method — invoking a detached reference would lose `this` and throw,
+    // mirroring the real ModelRegistry implementation.
     modelRegistry: {
-      getAvailable: () => [{ provider: "local", id: "baseline-model" }],
-      getAllWithDiscovered: () => [
+      _all: [
         { provider: "local", id: "baseline-model" },
         { provider: "local", id: "discovered-model" },
         { provider: "disabled", id: "hidden-model" },
       ],
+      getAvailable() {
+        return [{ provider: "local", id: "baseline-model" }];
+      },
+      getAllWithDiscovered() {
+        return this._all;
+      },
     },
     ui: {
       notify() {},


### PR DESCRIPTION
## Summary
The prefs wizard pulled `getAllWithDiscovered` off `ctx.modelRegistry` into a local variable, then called the detached reference. That lost the `this` binding, so the method's internal `this.models` access threw.

Fix: call it through the registry object — `registry.getAllWithDiscovered()`.

## Tests
- Updated `prefs-wizard-coverage.test.ts` mock to mirror the real `ModelRegistry` (method reads `this._all`), so the test actually catches the binding regression.
- All 3 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a binding issue in the models preferences wizard that was affecting the proper retrieval and configuration of available models during the setup process.

* **Tests**
  * Enhanced test coverage by updating mock implementations to more accurately reflect actual model registry behavior, ensuring comprehensive validation of the preferences wizard's model configuration and selection functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->