### PR TITLE
fix(issue): Clear stale paused-session replay after completed planning unit

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -179,6 +179,7 @@ import { debugLog, isDebugEnabled, writeDebugSummary } from "./debug-logger.js";
 import {
   buildLoopRemediationSteps,
   reconcileMergeState,
+  verifyExpectedArtifact,
 } from "./auto-recovery.js";
 import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
 import { resolveDispatch, DISPATCH_RULES } from "./auto-dispatch.js";
@@ -2608,10 +2609,21 @@ export async function startAuto(
     invalidateAllCaches();
 
     if (s.pausedSessionFile) {
+      const pausedRecoveryUnitType = s.currentUnit?.type ?? s.pausedUnitType ?? "unknown";
+      const pausedRecoveryUnitId = s.currentUnit?.id ?? s.pausedUnitId ?? "unknown";
+      const completedPausedUnit = verifyExpectedArtifact(
+        pausedRecoveryUnitType,
+        pausedRecoveryUnitId,
+        s.basePath,
+      );
+
+      if (completedPausedUnit) {
+        s.pausedSessionFile = null;
+      } else {
       const recovery = synthesizePausedSessionRecovery(
         s.basePath,
-        s.currentUnit?.type ?? s.pausedUnitType ?? "unknown",
-        s.currentUnit?.id ?? s.pausedUnitId ?? "unknown",
+        pausedRecoveryUnitType,
+        pausedRecoveryUnitId,
         s.pausedSessionFile,
       );
       if (recovery && recovery.trace.toolCallCount > 0) {
@@ -2622,6 +2634,7 @@ export async function startAuto(
         );
       }
       s.pausedSessionFile = null;
+      }
     }
 
     captureProjectRootEnv(s.originalBasePath || s.basePath);

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -471,6 +471,55 @@ export function _synthesizePausedSessionRecoveryForTest(
   return synthesizePausedSessionRecovery(basePath, unitType, unitId, sessionFile);
 }
 
+type PausedResumeRecoverySessionState = {
+  pausedSessionFile: string | null;
+  currentUnit: { type: string; id: string } | null;
+  pausedUnitType: string | null;
+  pausedUnitId: string | null;
+  pendingCrashRecovery: string | null;
+};
+
+function handlePausedSessionResumeRecovery(
+  basePath: string,
+  state: PausedResumeRecoverySessionState,
+  notify: (message: string) => void,
+): { skippedReplay: boolean } {
+  if (!state.pausedSessionFile) return { skippedReplay: false };
+
+  const pausedRecoveryUnitType = state.currentUnit?.type ?? state.pausedUnitType ?? "unknown";
+  const pausedRecoveryUnitId = state.currentUnit?.id ?? state.pausedUnitId ?? "unknown";
+  const completedPausedUnit = verifyExpectedArtifact(
+    pausedRecoveryUnitType,
+    pausedRecoveryUnitId,
+    basePath,
+  );
+
+  if (completedPausedUnit) {
+    state.pausedSessionFile = null;
+    return { skippedReplay: true };
+  }
+
+  const recovery = synthesizePausedSessionRecovery(
+    basePath,
+    pausedRecoveryUnitType,
+    pausedRecoveryUnitId,
+    state.pausedSessionFile,
+  );
+  if (recovery && recovery.trace.toolCallCount > 0) {
+    state.pendingCrashRecovery = recovery.prompt;
+    notify(`Recovered ${recovery.trace.toolCallCount} tool calls from paused session. Resuming with context.`);
+  }
+  state.pausedSessionFile = null;
+  return { skippedReplay: false };
+}
+
+export function _handlePausedSessionResumeRecoveryForTest(
+  basePath: string,
+  state: PausedResumeRecoverySessionState,
+): { skippedReplay: boolean } {
+  return handlePausedSessionResumeRecovery(basePath, state, () => {});
+}
+
 // `_resolvePausedResumeBasePathForTest` was retired in ADR-016 phase 2 / B3
 // (#5621). Production callers go through
 // `WorktreeLifecycle.resumeFromPausedSession`; the pure helper for tests is
@@ -2608,34 +2657,11 @@ export async function startAuto(
     }
     invalidateAllCaches();
 
-    if (s.pausedSessionFile) {
-      const pausedRecoveryUnitType = s.currentUnit?.type ?? s.pausedUnitType ?? "unknown";
-      const pausedRecoveryUnitId = s.currentUnit?.id ?? s.pausedUnitId ?? "unknown";
-      const completedPausedUnit = verifyExpectedArtifact(
-        pausedRecoveryUnitType,
-        pausedRecoveryUnitId,
-        s.basePath,
-      );
-
-      if (completedPausedUnit) {
-        s.pausedSessionFile = null;
-      } else {
-      const recovery = synthesizePausedSessionRecovery(
-        s.basePath,
-        pausedRecoveryUnitType,
-        pausedRecoveryUnitId,
-        s.pausedSessionFile,
-      );
-      if (recovery && recovery.trace.toolCallCount > 0) {
-        s.pendingCrashRecovery = recovery.prompt;
-        ctx.ui.notify(
-          `Recovered ${recovery.trace.toolCallCount} tool calls from paused session. Resuming with context.`,
-          "info",
-        );
-      }
-      s.pausedSessionFile = null;
-      }
-    }
+    handlePausedSessionResumeRecovery(
+      s.basePath,
+      s,
+      (message) => ctx.ui.notify(message, "info"),
+    );
 
     captureProjectRootEnv(s.originalBasePath || s.basePath);
     registerAutoWorkerForSession(s);

--- a/src/resources/extensions/gsd/tests/interrupted-session-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/interrupted-session-auto.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
+import { _handlePausedSessionResumeRecoveryForTest } from "../auto.ts";
 import { assessInterruptedSession } from "../interrupted-session.ts";
 import {
   openDatabase,
@@ -186,13 +187,41 @@ test("direct /gsd auto source only resumes paused-session metadata for recoverab
   assert.ok(source.includes('|| !!freshStartAssessment.lock'));
 });
 
-test("direct /gsd auto source skips paused-session replay when recovered unit already completed", async () => {
-  const source = await import(`node:fs/promises`).then((fs) =>
-    fs.readFile(new URL("../auto.ts", import.meta.url), "utf-8")
-  );
-  assert.ok(source.includes("const completedPausedUnit = verifyExpectedArtifact("));
-  assert.ok(source.includes("if (completedPausedUnit) {"));
-  assert.ok(source.includes("s.pausedSessionFile = null;"));
+test("direct /gsd auto skips paused-session replay when recovered unit already completed", async () => {
+  const base = makeTmpBase();
+  try {
+    writeRoadmap(base, false);
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    const tasksDir = join(sliceDir, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(
+      join(sliceDir, "S01-PLAN.md"),
+      [
+        "# S01: Test Slice",
+        "",
+        "## Tasks",
+        "",
+        "- [ ] **T01: First task** `est:1h`",
+      ].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan\n\nDo the thing.\n", "utf-8");
+
+    const state = {
+      pausedSessionFile: join(base, ".gsd", "activity", "paused-session.jsonl"),
+      currentUnit: { type: "plan-slice", id: "M001/S01" },
+      pausedUnitType: null,
+      pausedUnitId: null,
+      pendingCrashRecovery: null,
+    };
+
+    const result = _handlePausedSessionResumeRecoveryForTest(base, state);
+    assert.equal(result.skippedReplay, true);
+    assert.equal(state.pausedSessionFile, null);
+    assert.equal(state.pendingCrashRecovery, null);
+  } finally {
+    cleanup(base);
+  }
 });
 
 test("auto module imports successfully after interrupted-session changes", async () => {

--- a/src/resources/extensions/gsd/tests/interrupted-session-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/interrupted-session-auto.test.ts
@@ -186,6 +186,15 @@ test("direct /gsd auto source only resumes paused-session metadata for recoverab
   assert.ok(source.includes('|| !!freshStartAssessment.lock'));
 });
 
+test("direct /gsd auto source skips paused-session replay when recovered unit already completed", async () => {
+  const source = await import(`node:fs/promises`).then((fs) =>
+    fs.readFile(new URL("../auto.ts", import.meta.url), "utf-8")
+  );
+  assert.ok(source.includes("const completedPausedUnit = verifyExpectedArtifact("));
+  assert.ok(source.includes("if (completedPausedUnit) {"));
+  assert.ok(source.includes("s.pausedSessionFile = null;"));
+});
+
 test("auto module imports successfully after interrupted-session changes", async () => {
   const mod = await import(`../auto.ts?ts=${Date.now()}-${Math.random()}`);
   assert.equal(typeof mod.startAuto, "function");


### PR DESCRIPTION
## Summary
- Resume now clears stale paused-session recovery replay for already-completed units (including plan-slice), with targeted regression coverage passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6193
- [#6193 Clear stale paused-session replay after completed planning unit](https://github.com/gsd-build/gsd-2/issues/6193)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6193-clear-stale-paused-session-replay-after--1778901950`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session resume now detects when a paused unit's output is already present and skips redundant replay, avoiding unnecessary recovery prompts.

* **Tests**
  * Added test coverage to ensure paused-session replays are skipped when the expected unit is already completed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->