### PR TITLE
fix(issue): Resolve task-plan artifact checks against active milestone worktree

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -31,6 +31,8 @@ import {
   relSliceFile,
   buildMilestoneFileName,
   buildSliceFileName,
+  buildTaskFileName,
+  gsdProjectionRoot,
 } from "./paths.js";
 import { parseRoadmap } from "./parsers-legacy.js";
 import { validateArtifact } from "./schemas/validate.js";
@@ -84,6 +86,7 @@ import { annotateBackgroundable } from "./delegation-policy.js";
 import { invalidateAllCaches } from "./cache.js";
 import { insertMilestoneValidationGates } from "./milestone-validation-gates.js";
 import { nativeHasChanges } from "./native-git-bridge.js";
+import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -1163,14 +1166,24 @@ export const DISPATCH_RULES: DispatchRule[] = [
       const sid = state.activeSlice!.id;
       const sTitle = state.activeSlice!.title;
       const tid = state.activeTask.id;
+      const milestoneRoot = resolveCanonicalMilestoneRoot(basePath, mid);
 
       // Guard: if the slice plan exists but the individual task plan files are
       // missing, the planner created S##-PLAN.md with task entries but never
       // wrote the tasks/ directory files. Dispatch plan-slice to regenerate
       // them rather than hard-stopping — fixes the infinite-loop described in
       // issue #909.
-      const taskPlanPath = resolveTaskFile(basePath, mid, sid, tid, "PLAN");
-      if (!taskPlanPath || !existsSync(taskPlanPath)) {
+      const taskPlanPath = resolveTaskFile(milestoneRoot, mid, sid, tid, "PLAN");
+      const projectionTaskPlanPath = join(
+        gsdProjectionRoot(milestoneRoot),
+        "milestones",
+        mid,
+        "slices",
+        sid,
+        "tasks",
+        buildTaskFileName(tid, "PLAN"),
+      );
+      if ((!taskPlanPath || !existsSync(taskPlanPath)) && !existsSync(projectionTaskPlanPath)) {
         return {
           action: "dispatch",
           unitType: "plan-slice",

--- a/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
@@ -118,6 +118,30 @@ test("dispatch: present task plan proceeds to execute-task normally", async (t) 
     `unitId should be M002/S03/T01, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`);
 });
 
+test("dispatch: executing recovery checks active milestone worktree task plans before re-dispatching plan-slice", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-6192-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  scaffoldMilestoneContext(tmp, "M002");
+  scaffoldSlicePlan(tmp, "M002", "S03");
+
+  const worktreeRoot = join(tmp, ".gsd", "worktrees", "M002");
+  mkdirSync(worktreeRoot, { recursive: true });
+  writeFileSync(join(worktreeRoot, ".git"), "gitdir: /tmp/fake-worktree-gitdir\n");
+  scaffoldMilestoneContext(worktreeRoot, "M002");
+  scaffoldSlicePlan(worktreeRoot, "M002", "S03");
+  scaffoldTaskPlan(worktreeRoot, "M002", "S03", "T01");
+
+  const ctx = makeContext(tmp);
+  const result = await resolveDispatch(ctx);
+
+  assert.equal(result.action, "dispatch");
+  assert.ok(result.action === "dispatch" && result.unitType === "execute-task",
+    `unitType should be execute-task, got: ${result.action === "dispatch" ? result.unitType : "(stop)"}`);
+  assert.ok(result.action === "dispatch" && result.unitId === "M002/S03/T01",
+    `unitId should be M002/S03/T01, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`);
+});
+
 test("dispatch: plan-slice recovery loop — second call after plan-slice still recovers cleanly", async (t) => {
   // Simulate: plan-slice ran but T01-PLAN.md is still missing (e.g. agent crashed mid-write).
   // Dispatch should still re-dispatch plan-slice, not hard-stop.


### PR DESCRIPTION
## Summary
- Fixed execute-task recovery to check task-plan artifacts in the active milestone worktree projection and added regression coverage for the root/worktree split.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6192
- [#6192 Resolve task-plan artifact checks against active milestone worktree](https://github.com/gsd-build/gsd-2/issues/6192)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6192-resolve-task-plan-artifact-checks-agains-1778901935`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task execution recovery when task plan files are missing in alternate locations. The system now checks multiple paths and regenerates missing task artifacts instead of hard-stopping, increasing reliability during task execution.

* **Tests**
  * Added regression test for task plan recovery scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->