### PR TITLE
fix(issue): showNextAction !ctx.hasUI guard misses headless RPC mode where hasUI is truthy but no human input is possible (next-action-ui.js:70)

### DIFF
--- a/src/resources/extensions/shared/next-action-ui.ts
+++ b/src/resources/extensions/shared/next-action-ui.ts
@@ -118,11 +118,9 @@ export async function showNextAction(
 		}
 	});
 
-	// Headless guard: when no UI is bound (noOpUIContext), ctx.ui.custom() resolves
-	// to undefined immediately, and ctx.ui.select() does the same. Skip both and
-	// return the safe default so callers don't await two no-op promises before
-	// reaching a deterministic "not_yet". Lockup #5125 root protection.
-	if (!ctx.hasUI) {
+	// Headless/non-interactive guard: avoid emitting interactive select requests
+	// in contexts where no human can answer (no UI, RPC/headless shims).
+	if (!isInteractiveUIContext(ctx)) {
 		return "not_yet";
 	}
 
@@ -217,4 +215,12 @@ export async function showNextAction(
 	}
 
 	return result;
+}
+
+function isInteractiveUIContext(ctx: ExtensionCommandContext): boolean {
+	if (!ctx.hasUI) return false;
+	if (process.env.GSD_HEADLESS === "1") return false;
+	const uiMode = (ctx.ui as { mode?: string } | undefined)?.mode;
+	if (uiMode === "rpc" || uiMode === "headless") return false;
+	return true;
 }

--- a/src/resources/extensions/shared/tests/next-action-ui-hasui.test.ts
+++ b/src/resources/extensions/shared/tests/next-action-ui-hasui.test.ts
@@ -81,6 +81,38 @@ describe("showNextAction ctx.hasUI guard (#5125 lockup root protection)", () => 
     assert.equal(result, "alpha", "fallback should map the picked label back to the chosen action id");
   });
 
+  it("returns 'not_yet' immediately when UI mode is rpc even if ctx.hasUI is true", async () => {
+    let customCalled = 0;
+    let selectCalled = 0;
+
+    const ctx = {
+      hasUI: true,
+      ui: {
+        mode: "rpc",
+        custom: async () => {
+          customCalled++;
+          return undefined as never;
+        },
+        select: async () => {
+          selectCalled++;
+          return undefined;
+        },
+      },
+    };
+
+    const result = await showNextAction(ctx as any, {
+      title: "GSD — test",
+      actions: [
+        { id: "alpha", label: "Alpha", description: "first", recommended: true },
+        { id: "beta", label: "Beta", description: "second" },
+      ],
+    });
+
+    assert.equal(result, "not_yet", "rpc-backed UI is non-interactive for next-action");
+    assert.equal(customCalled, 0, "ctx.ui.custom must not be called in rpc mode");
+    assert.equal(selectCalled, 0, "ctx.ui.select must not be called in rpc mode");
+  });
+
   it("returns the resolved id when ctx.ui.custom completes normally", async () => {
     let selectCalled = 0;
 


### PR DESCRIPTION
## Summary
- Replaced `showNextAction`’s `hasUI`-only guard with an interactivity guard that blocks headless/RPC prompting and verified via targeted unit tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5742
- [#5742 showNextAction !ctx.hasUI guard misses headless RPC mode where hasUI is truthy but no human input is possible (next-action-ui.js:70)](https://github.com/gsd-build/gsd-2/issues/5742)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5742-shownextaction-ctx-hasui-guard-misses-he-1778905572`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactive UI context detection to ensure consistent behavior in headless and RPC modes.

* **Tests**
  * Added test coverage for UI mode validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->