### PR TITLE
fix(headless): keep workflow runs alive across steps

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -93,12 +93,11 @@ export interface HeadlessOptions {
  * than grepping the source for identifier names.
  */
 export function isMultiTurnHeadlessCommand(command: string): boolean {
-  return (
-    command === 'auto' ||
-    command === 'next' ||
-    command === 'discuss' ||
-    command === 'plan'
-  )
+  // With --bare, the entire subcommand string lands as a single argument
+  // (e.g. "workflow run test-workflow --params ..."), so prefix-match in
+  // addition to exact match.
+  const multiTurnPrefixes = ['auto', 'next', 'discuss', 'plan', 'workflow']
+  return multiTurnPrefixes.some(p => command === p || command.startsWith(p + ' '))
 }
 
 interface TrackedEvent {
@@ -510,6 +509,10 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   })
 
   // Idle timeout — fallback completion detection
+  // Multi-turn commands (auto, workflow, etc.) manage their own lifecycle via
+  // terminal notifications. Arming the idle timer after their agent_end causes
+  // a closeout race: auto-loop reconcile + next-step dispatch takes longer than
+  // the idle window, so headless resolves before the next step starts.
   let idleTimer: ReturnType<typeof setTimeout> | null = null
   let effectiveIdleTimeout = isNewMilestone
     ? NEW_MILESTONE_IDLE_TIMEOUT_MS
@@ -519,6 +522,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
   function resetIdleTimer(): void {
     if (idleTimer) clearTimeout(idleTimer)
+    if (isMultiTurnCommand) return // auto-loop manages its own completion
     if (
       effectiveIdleTimeout > 0 &&
       shouldArmHeadlessIdleTimeout(toolCallCount, interactiveToolCallIds.size)
@@ -781,7 +785,6 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
       resolveCompletion()
       return
     }
-
     // Long-running commands: agent_end after tool execution — possible completion
     // The idle timer + terminal notification handle this case.
   })

--- a/src/tests/headless-multi-turn.test.ts
+++ b/src/tests/headless-multi-turn.test.ts
@@ -29,6 +29,27 @@ test('next is classified as multi-turn', () => {
   assert.equal(isMultiTurnHeadlessCommand('next'), true)
 })
 
+test('workflow is classified as multi-turn', () => {
+  assert.equal(isMultiTurnHeadlessCommand('workflow'), true)
+})
+
+test('compound workflow run command is classified as multi-turn', () => {
+  assert.equal(
+    isMultiTurnHeadlessCommand('workflow run test-workflow --params input=demo'),
+    true,
+  )
+})
+
+test('compound multi-turn commands require a word boundary', () => {
+  for (const cmd of ['automation', 'workflowish', 'planner', 'nextgen']) {
+    assert.equal(
+      isMultiTurnHeadlessCommand(cmd),
+      false,
+      `${cmd} should not be multi-turn`,
+    )
+  }
+})
+
 test('single-turn commands are not multi-turn', () => {
   for (const cmd of ['ask', 'chat', 'help', 'version', '', 'random-cmd']) {
     assert.equal(


### PR DESCRIPTION
## Summary

Fixes #6203.

`gsd headless workflow run ...` is a multi-turn command, but the headless classifier only treated `auto`, `next`, `discuss`, and `plan` as multi-turn. That allowed a per-step `execution_complete` event to resolve the whole headless process after the first custom workflow step.

This PR:

- classifies `workflow` as multi-turn,
- handles compound command strings such as `workflow run test-workflow --params ...`,
- keeps multi-turn commands terminal-notification-driven instead of generic idle-fallback-driven,
- adds regression tests for exact workflow commands, compound workflow commands, and false-prefix negatives.

## Test plan

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
  --experimental-strip-types \
  --test src/tests/headless-multi-turn.test.ts
```

Result locally:

```text
# tests 8
# pass 8
# fail 0
```

## Notes

This is intentionally scoped to issue #6203. It does not include custom workflow artifact-dir verification changes or local debugging notes from the broader investigation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved idle-timeout handling in headless mode for multi-turn commands to prevent race conditions during completion detection.
  * Enhanced classification of multi-turn workflow subcommands using prefix-based matching for more accurate command recognition.

* **Tests**
  * Added test coverage for multi-turn headless command classification validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->