### PR TITLE
fix(workflow): pass artifact dir to shell verification

### DIFF
--- a/src/resources/extensions/gsd/custom-verification.ts
+++ b/src/resources/extensions/gsd/custom-verification.ts
@@ -166,13 +166,28 @@ function handleShellCommand(
     return "pause";
   }
 
+  // Load artifact_dir from PARAMS.json so ${GSD_ARTIFACT_DIR} resolves in
+  // shell-command verification commands.
+  let artifactDir = process.env.GSD_ARTIFACT_DIR ?? ".";
+  const paramsPath = join(runDir, "PARAMS.json");
+  if (existsSync(paramsPath) && !process.env.GSD_ARTIFACT_DIR) {
+    try {
+      const params = JSON.parse(readFileSync(paramsPath, "utf-8"));
+      if (params.artifact_dir && typeof params.artifact_dir === "string") {
+        artifactDir = params.artifact_dir;
+      }
+    } catch {
+      // Best effort — fall through to default
+    }
+  }
+
   const rewrittenCommand = rewriteCommandWithRtk(verify.command);
   const result = spawnSync("sh", ["-c", rewrittenCommand], {
     cwd: runDir,
     timeout: 30_000,
     encoding: "utf-8",
     stdio: "pipe",
-    env: { ...process.env, PATH: process.env.PATH },
+    env: { ...process.env, PATH: process.env.PATH, GSD_ARTIFACT_DIR: artifactDir },
   });
 
   if (result.status === 0) {

--- a/src/resources/extensions/gsd/tests/custom-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-verification.test.ts
@@ -258,6 +258,81 @@ describe("shell-command policy", () => {
       fake.cleanup();
     }
   });
+
+  it("sets GSD_ARTIFACT_DIR from PARAMS.json when the environment omits it", () => {
+    const artifactDir = mkdtempSync(join(tmpdir(), "cv-artifacts-"));
+    writeFileSync(join(artifactDir, "artifact.txt"), "content", "utf-8");
+
+    const def = makeDef([
+      {
+        id: "step-1",
+        name: "Build external artifact",
+        prompt: "Build the artifact outside the run directory",
+        requires: [],
+        produces: ["artifact.txt"],
+        verify: {
+          policy: "shell-command",
+          command: 'test -f "$GSD_ARTIFACT_DIR/artifact.txt"',
+        },
+      },
+    ]);
+
+    const previous = process.env.GSD_ARTIFACT_DIR;
+    delete process.env.GSD_ARTIFACT_DIR;
+
+    try {
+      const runDir = makeTempRun(def);
+      writeFileSync(
+        join(runDir, "PARAMS.json"),
+        JSON.stringify({ artifact_dir: artifactDir }),
+        "utf-8",
+      );
+
+      const result = runCustomVerification(runDir, "step-1");
+      assert.equal(result, "continue");
+    } finally {
+      if (previous === undefined) delete process.env.GSD_ARTIFACT_DIR;
+      else process.env.GSD_ARTIFACT_DIR = previous;
+    }
+  });
+
+  it("preserves an explicit GSD_ARTIFACT_DIR environment override", () => {
+    const paramsArtifactDir = mkdtempSync(join(tmpdir(), "cv-params-artifacts-"));
+    const envArtifactDir = mkdtempSync(join(tmpdir(), "cv-env-artifacts-"));
+    writeFileSync(join(envArtifactDir, "artifact.txt"), "content", "utf-8");
+
+    const def = makeDef([
+      {
+        id: "step-1",
+        name: "Build external artifact",
+        prompt: "Build the artifact outside the run directory",
+        requires: [],
+        produces: ["artifact.txt"],
+        verify: {
+          policy: "shell-command",
+          command: 'test -f "$GSD_ARTIFACT_DIR/artifact.txt"',
+        },
+      },
+    ]);
+
+    const previous = process.env.GSD_ARTIFACT_DIR;
+    process.env.GSD_ARTIFACT_DIR = envArtifactDir;
+
+    try {
+      const runDir = makeTempRun(def);
+      writeFileSync(
+        join(runDir, "PARAMS.json"),
+        JSON.stringify({ artifact_dir: paramsArtifactDir }),
+        "utf-8",
+      );
+
+      const result = runCustomVerification(runDir, "step-1");
+      assert.equal(result, "continue");
+    } finally {
+      if (previous === undefined) delete process.env.GSD_ARTIFACT_DIR;
+      else process.env.GSD_ARTIFACT_DIR = previous;
+    }
+  });
 });
 
 // ─── prompt-verify tests ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #6205.

Custom workflow shell-command verification can reference `$GSD_ARTIFACT_DIR`, but the verifier did not populate that variable from the workflow run's `PARAMS.json`. As a result, workflows using an external `artifact_dir` could create artifacts successfully while verification checked the wrong path and retried/paused.

This PR:

- reads `artifact_dir` from `PARAMS.json` when `GSD_ARTIFACT_DIR` is not already set,
- passes `GSD_ARTIFACT_DIR` into the shell verification environment,
- preserves explicit caller-provided `GSD_ARTIFACT_DIR` values,
- adds regression tests for both fallback and override behavior.

## Test plan

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
  --experimental-strip-types \
  --test src/resources/extensions/gsd/tests/custom-verification.test.ts
```

Result locally:

```text
# tests 18
# pass 18
# fail 0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced artifact directory resolution for shell command verification.

* **Tests**
  * Added test coverage for artifact directory resolution behavior in shell command verification scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->