### PR TITLE
fix(workflow): bypass guided discuss for custom workflow bootstrap

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -1024,7 +1024,12 @@ export async function bootstrapAutoSession(
       s.currentMilestoneId = null;
     }
 
-    if (!hasSurvivorBranch && !deepProjectStagePending) {
+    // Custom workflow runs do not require an active milestone. They manage
+    // progression from GRAPH.yaml/runDir state instead of milestone planning
+    // state, so guided-flow discussion must not preempt them.
+    const isCustomWorkflowRun = !!s.activeEngineId && s.activeEngineId !== "dev";
+
+    if (!hasSurvivorBranch && !deepProjectStagePending && !isCustomWorkflowRun) {
       // No active work — start a new milestone via discuss flow
       if (!state.activeMilestone || state.phase === "complete") {
         // Guard against recursive dialog loop (#1348):
@@ -1099,8 +1104,8 @@ export async function bootstrapAutoSession(
       }
     }
 
-    // Unreachable safety check
-    if (!state.activeMilestone && !deepProjectStagePending) {
+    // Unreachable safety check (also guarded by isCustomWorkflowRun above)
+    if (!state.activeMilestone && !deepProjectStagePending && !isCustomWorkflowRun) {
       const { showSmartEntry } = await import("./guided-flow.js");
       await showSmartEntry(ctx, pi, base, { step: requestedStepMode });
       return releaseLockAndReturn();

--- a/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
@@ -140,6 +140,18 @@ function makeRepo(): string {
   return base;
 }
 
+function makeLightRepo(): string {
+  const base = join(tmpdir(), `gsd-custom-workflow-bootstrap-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  execFileSync("git", ["init"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: base });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: base });
+  writeFileSync(join(base, "README.md"), "# test\n");
+  execFileSync("git", ["add", "-A"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: base, stdio: "ignore" });
+  return base;
+}
+
 function makeCtx(sessionId = "test-session") {
   const model = { provider: "claude-code", id: "claude-sonnet-4-6", contextWindow: 128000 };
   return {
@@ -303,6 +315,70 @@ test("deep project setup: bootstrap can start auto-mode without an active milest
     assert.equal(s.active, true);
     assert.equal(s.currentMilestoneId, null);
   } finally {
+    try {
+      const { closeDatabase } = await import("../gsd-db.ts");
+      closeDatabase();
+    } catch {}
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("custom workflow bootstrap: no active milestone does not enter guided discuss", async () => {
+  const base = makeLightRepo();
+  const previousCwd = process.cwd();
+  const messages: unknown[] = [];
+  try {
+    process.chdir(base);
+    const s = new AutoSession();
+    s.activeEngineId = "custom";
+    s.activeRunDir = join(base, ".gsd", "workflow-runs", "test", "run");
+
+    const ready = await bootstrapAutoSession(
+      s,
+      makeCtx(`custom-${randomUUID()}`) as any,
+      {
+        ...makePi(messages),
+        getThinkingLevel: () => "medium",
+      } as any,
+      base,
+      false,
+      false,
+      {
+        shouldUseWorktreeIsolation: () => false,
+        registerSigtermHandler: () => {},
+        registerAutoWorkerForSession: () => {},
+        lockBase: () => base,
+        buildLifecycle: () => ({
+          adoptSessionRoot: (sessionBase: string, originalBase?: string) => {
+            s.basePath = sessionBase;
+            if (originalBase !== undefined) {
+              s.originalBasePath = originalBase;
+            } else if (!s.originalBasePath) {
+              s.originalBasePath = sessionBase;
+            }
+          },
+        }) as any,
+      },
+      {
+        classification: "none",
+        lock: null,
+        pausedSession: null,
+        state: null,
+        recovery: null,
+        recoveryPrompt: null,
+        recoveryToolCallCount: 0,
+        artifactSatisfied: false,
+        hasResumableDiskState: false,
+        isBootstrapCrash: false,
+      },
+    );
+
+    assert.equal(ready, true);
+    assert.equal(s.active, true);
+    assert.equal(s.currentMilestoneId, null);
+    assert.deepEqual(messages, [], "custom workflow bootstrap must not dispatch guided discuss");
+  } finally {
+    process.chdir(previousCwd);
     try {
       const { closeDatabase } = await import("../gsd-db.ts");
       closeDatabase();


### PR DESCRIPTION
## Summary

Follow-up to #3188.

Custom workflow runs are driven by `activeEngineId`/`activeRunDir` and `GRAPH.yaml`, not by the standard milestone state. During bootstrap, a custom workflow can legitimately have no active milestone, but the no-active-milestone gates still route into guided milestone discussion via `showSmartEntry()` before the custom engine loop gets a chance to dispatch.

This PR:

- detects non-dev custom workflow runs during auto bootstrap,
- skips the guided discuss/no-active-milestone branches for those custom runs,
- still preserves the existing deep-project setup exception,
- adds a regression test proving custom workflow bootstrap continues without dispatching guided discuss when no active milestone exists.

## Test plan

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
  --experimental-strip-types \
  --test --test-name-pattern "custom workflow bootstrap: no active milestone" \
  src/resources/extensions/gsd/tests/deep-project-auto-loop.test.ts
```

Result locally:

```text
# tests 1
# pass 1
# fail 0
```

```bash
npm run build:core
```

Result locally: build completed successfully.

## Notes

Running the entire `deep-project-auto-loop.test.ts` file in this local environment still has unrelated existing model-policy fixture failures in other subtests (`no candidate models`). The new regression itself passes when run by name, and `npm run build:core` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Custom workflows no longer trigger unintended auto-start guided flows when active.

## Tests
* Added test coverage validating that custom workflow initialization properly prevents guided flow execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->