### PR TITLE
fix(issue): Worktree safety guard blocks execute-task when isolationMode=none

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -139,7 +139,7 @@ You can also tune sandbox behavior with `context_mode.exec_timeout_ms`, `context
 
 GSD isolates milestone work using one of three modes (configured via `git.isolation` in preferences):
 
-- **`none`** (default): Work happens directly on your current branch. No worktree, no milestone branch. Ideal for hot-reload workflows where file isolation breaks dev tooling.
+- **`none`** (default): Work happens directly on your current branch. No worktree, no milestone branch, and pre-dispatch unit-root safety checks do not enforce milestone branch matching. Ideal for hot-reload workflows where file isolation breaks dev tooling.
 - **`worktree`**: Each milestone runs in its own git worktree at `.gsd/worktrees/<MID>/` on a `milestone/<MID>` branch. Worktree mode requires at least one commit; in a zero-commit repo with no committed `HEAD`, GSD temporarily runs as `none` until the first commit exists. All slice work commits sequentially, and the milestone is squash-merged to main as one clean commit.
 - **`branch`**: Work happens in the project root on a `milestone/<MID>` branch. Useful for submodule-heavy repos where worktrees don't work well.
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2024,6 +2024,7 @@ export function createWiredAutoOrchestrationModule(
           projectRoot: runtimeBasePath,
           unitRoot: dispatchBasePath,
           milestoneId,
+          isolationMode: getIsolationMode(runtimeBasePath),
           expectedBranch,
         });
         if (!result.ok) {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2003,16 +2003,14 @@ export function createWiredAutoOrchestrationModule(
             reason: `No Unit manifest is registered for ${unitType}`,
           };
         }
-        if (getIsolationMode(runtimeBasePath) !== "worktree") {
-          return { ok: true, reason: "not-required" };
-        }
         const writeScope =
           manifest.tools.mode === "all" || manifest.tools.mode === "docs"
             ? "source-writing"
             : "planning-only";
-        if (getIsolationMode(runtimeBasePath) !== "worktree") {
-          return { ok: true, reason: "isolation-not-worktree" };
+        if (writeScope === "planning-only") {
+          return { ok: true, reason: "not-required" };
         }
+        const isolationMode = getIsolationMode(runtimeBasePath);
         const safety = createWorktreeSafetyModule();
         const snapshot = await deriveState(dispatchBasePath);
         const milestoneId = snapshot.activeMilestone?.id ?? null;
@@ -2024,7 +2022,7 @@ export function createWiredAutoOrchestrationModule(
           projectRoot: runtimeBasePath,
           unitRoot: dispatchBasePath,
           milestoneId,
-          isolationMode: getIsolationMode(runtimeBasePath),
+          isolationMode,
           expectedBranch,
         });
         if (!result.ok) {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2014,7 +2014,8 @@ export function createWiredAutoOrchestrationModule(
         const safety = createWorktreeSafetyModule();
         const snapshot = await deriveState(dispatchBasePath);
         const milestoneId = snapshot.activeMilestone?.id ?? null;
-        const expectedBranch = milestoneId ? autoWorktreeBranch(milestoneId) : null;
+        const expectedBranch =
+          isolationMode === "none" ? null : milestoneId ? autoWorktreeBranch(milestoneId) : null;
         const result = safety.validateUnitRoot({
           unitType,
           unitId,

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -222,6 +222,7 @@ async function validateSourceWriteWorktreeSafety(
     projectRoot,
     unitRoot: s.basePath,
     milestoneId,
+    isolationMode: deps.getIsolationMode(projectRoot),
     expectedBranch: milestoneId ? deps.autoWorktreeBranch(milestoneId) : null,
     emptyWorktreeWithProjectContent: resolveEmptyWorktreeWithProjectContent(s.basePath, projectRoot),
     lease: s.workerId

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -213,6 +213,8 @@ async function validateSourceWriteWorktreeSafety(
 
   const projectRoot = s.canonicalProjectRoot ?? resolveWorktreeProjectRoot(s.basePath, s.originalBasePath);
   const isolationMode = deps.getIsolationMode(projectRoot);
+  const expectedBranch =
+    isolationMode === "none" ? null : milestoneId ? deps.autoWorktreeBranch(milestoneId) : null;
 
   const safety = createWorktreeSafetyModule();
   const result = safety.validateUnitRoot({
@@ -223,7 +225,7 @@ async function validateSourceWriteWorktreeSafety(
     unitRoot: s.basePath,
     milestoneId,
     isolationMode,
-    expectedBranch: milestoneId ? deps.autoWorktreeBranch(milestoneId) : null,
+    expectedBranch,
     emptyWorktreeWithProjectContent: resolveEmptyWorktreeWithProjectContent(s.basePath, projectRoot),
     lease: s.workerId
       ? {

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -212,7 +212,7 @@ async function validateSourceWriteWorktreeSafety(
   if (!writesSource) return null;
 
   const projectRoot = s.canonicalProjectRoot ?? resolveWorktreeProjectRoot(s.basePath, s.originalBasePath);
-  if (deps.getIsolationMode(projectRoot) !== "worktree") return null;
+  const isolationMode = deps.getIsolationMode(projectRoot);
 
   const safety = createWorktreeSafetyModule();
   const result = safety.validateUnitRoot({
@@ -222,7 +222,7 @@ async function validateSourceWriteWorktreeSafety(
     projectRoot,
     unitRoot: s.basePath,
     milestoneId,
-    isolationMode: deps.getIsolationMode(projectRoot),
+    isolationMode,
     expectedBranch: milestoneId ? deps.autoWorktreeBranch(milestoneId) : null,
     emptyWorktreeWithProjectContent: resolveEmptyWorktreeWithProjectContent(s.basePath, projectRoot),
     lease: s.workerId

--- a/src/resources/extensions/gsd/tests/worktree-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-safety.test.ts
@@ -151,6 +151,31 @@ describe("Worktree Safety module", () => {
     assert.equal(result.kind, "safe");
   });
 
+  test("accepts project root for source-writing Unit when isolation mode is branch", () => {
+    const safety = createWorktreeSafetyModule({
+      existsSync: () => {
+        throw new Error("should not probe worktree in isolation:branch");
+      },
+      lstatSync: () => ({ isFile: () => true }),
+      getCurrentBranch: () => "milestone/M001",
+    });
+
+    const result = safety.validateUnitRoot({
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      writeScope: "source-writing",
+      projectRoot,
+      unitRoot: projectRoot,
+      milestoneId: "M001",
+      isolationMode: "branch",
+      expectedBranch: "milestone/M001",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.kind, "safe");
+    assert.equal(result.branch, "milestone/M001");
+  });
+
   test("rejects a standalone repository masquerading as a worktree", () => {
     unlinkSync(join(unitRoot, ".git"));
     mkdirSync(join(unitRoot, ".git"), { recursive: true });

--- a/src/resources/extensions/gsd/tests/worktree-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-safety.test.ts
@@ -129,6 +129,28 @@ describe("Worktree Safety module", () => {
     assert.equal(result.details?.expectedRoot, unitRoot);
   });
 
+  test("accepts project root for source-writing Unit when isolation mode is none", () => {
+    const safety = createWorktreeSafetyModule({
+      existsSync: () => {
+        throw new Error("should not probe worktree in isolation:none");
+      },
+      lstatSync: () => ({ isFile: () => true }),
+    });
+
+    const result = safety.validateUnitRoot({
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      writeScope: "source-writing",
+      projectRoot,
+      unitRoot: projectRoot,
+      milestoneId: "M001",
+      isolationMode: "none",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.kind, "safe");
+  });
+
   test("rejects a standalone repository masquerading as a worktree", () => {
     unlinkSync(join(unitRoot, ".git"));
     mkdirSync(join(unitRoot, ".git"), { recursive: true });

--- a/src/resources/extensions/gsd/worktree-safety.ts
+++ b/src/resources/extensions/gsd/worktree-safety.ts
@@ -158,7 +158,8 @@ export function createWorktreeSafetyModule(
       const projectRoot = resolve(input.projectRoot);
       const unitRoot = resolve(input.unitRoot);
       const isolationMode = input.isolationMode ?? "worktree";
-      if (isolationMode === "none" || isolationMode === "branch") {
+      const worktreeIsolation = isolationMode === "worktree";
+      if (!worktreeIsolation) {
         if (!samePath(unitRoot, projectRoot)) {
           return failure(
             "invalid-root",
@@ -167,17 +168,10 @@ export function createWorktreeSafetyModule(
             { expectedRoot: projectRoot, unitRoot, isolationMode },
           );
         }
-        return {
-          ok: true,
-          kind: "safe",
-          projectRoot,
-          unitRoot,
-          milestoneId,
-        };
       }
 
       const expectedRoot = join(projectRoot, ".gsd", "worktrees", milestoneId);
-      if (!samePath(unitRoot, expectedRoot)) {
+      if (worktreeIsolation && !samePath(unitRoot, expectedRoot)) {
         return failure(
           "invalid-root",
           `Unit root ${unitRoot} is not the expected worktree root for ${milestoneId}.`,
@@ -186,7 +180,7 @@ export function createWorktreeSafetyModule(
         );
       }
 
-      if (!deps.existsSync(unitRoot)) {
+      if (worktreeIsolation && !deps.existsSync(unitRoot)) {
         return failure(
           "worktree-missing",
           `Worktree root ${unitRoot} does not exist.`,
@@ -196,7 +190,7 @@ export function createWorktreeSafetyModule(
       }
 
       const gitMarker = join(unitRoot, ".git");
-      if (!deps.existsSync(gitMarker)) {
+      if (worktreeIsolation && !deps.existsSync(gitMarker)) {
         return failure(
           "worktree-git-marker-missing",
           `Worktree root ${unitRoot} has no .git marker.`,
@@ -206,18 +200,20 @@ export function createWorktreeSafetyModule(
       }
 
       let gitMarkerStat: Pick<Stats, "isFile">;
-      try {
-        gitMarkerStat = deps.lstatSync(gitMarker);
-      } catch (error) {
-        return failure(
-          "worktree-git-probe-failed",
-          `Unable to inspect .git marker for worktree root ${unitRoot}.`,
-          "Recover or recreate the milestone worktree before dispatching the source-writing Unit.",
-          { gitMarker, error: errorMessage(error) },
-        );
+      if (worktreeIsolation) {
+        try {
+          gitMarkerStat = deps.lstatSync(gitMarker);
+        } catch (error) {
+          return failure(
+            "worktree-git-probe-failed",
+            `Unable to inspect .git marker for worktree root ${unitRoot}.`,
+            "Recover or recreate the milestone worktree before dispatching the source-writing Unit.",
+            { gitMarker, error: errorMessage(error) },
+          );
+        }
       }
 
-      if (!gitMarkerStat.isFile()) {
+      if (worktreeIsolation && !gitMarkerStat.isFile()) {
         return failure(
           "worktree-git-marker-not-file",
           `Worktree root ${unitRoot} has a .git directory, not a registered worktree .git file.`,
@@ -227,17 +223,19 @@ export function createWorktreeSafetyModule(
       }
 
       let registered: readonly RegisteredWorktree[] | undefined;
-      try {
-        registered = deps.listRegisteredWorktrees?.(projectRoot);
-      } catch (error) {
-        return failure(
-          "worktree-git-probe-failed",
-          `Unable to list registered worktrees for project root ${projectRoot}.`,
-          "Recover or recreate the milestone worktree before dispatching the source-writing Unit.",
-          { projectRoot, error: errorMessage(error) },
-        );
+      if (worktreeIsolation) {
+        try {
+          registered = deps.listRegisteredWorktrees?.(projectRoot);
+        } catch (error) {
+          return failure(
+            "worktree-git-probe-failed",
+            `Unable to list registered worktrees for project root ${projectRoot}.`,
+            "Recover or recreate the milestone worktree before dispatching the source-writing Unit.",
+            { projectRoot, error: errorMessage(error) },
+          );
+        }
       }
-      if (registered && !registered.some((worktree) => samePath(worktree.path, unitRoot))) {
+      if (worktreeIsolation && registered && !registered.some((worktree) => samePath(worktree.path, unitRoot))) {
         const wasPreviouslyTracked = unregisteredRecoveryFailed.has(unitRoot);
         let attemptedPrune = false;
 
@@ -275,7 +273,7 @@ export function createWorktreeSafetyModule(
         }
       }
 
-      if (input.emptyWorktreeWithProjectContent) {
+      if (worktreeIsolation && input.emptyWorktreeWithProjectContent) {
         return failure(
           "empty-worktree-with-project-content",
           `Worktree root ${unitRoot} has no project content, but the project root does.`,

--- a/src/resources/extensions/gsd/worktree-safety.ts
+++ b/src/resources/extensions/gsd/worktree-safety.ts
@@ -54,6 +54,7 @@ export interface WorktreeSafetyInput {
   unitRoot: string;
   milestoneId?: string | null;
   expectedBranch?: string | null;
+  isolationMode?: "none" | "worktree" | "branch";
   emptyWorktreeWithProjectContent?: boolean;
   lease?: {
     required: boolean;
@@ -156,6 +157,25 @@ export function createWorktreeSafetyModule(
 
       const projectRoot = resolve(input.projectRoot);
       const unitRoot = resolve(input.unitRoot);
+      const isolationMode = input.isolationMode ?? "worktree";
+      if (isolationMode === "none" || isolationMode === "branch") {
+        if (!samePath(unitRoot, projectRoot)) {
+          return failure(
+            "invalid-root",
+            `Unit root ${unitRoot} is not the project root for isolation mode ${isolationMode}.`,
+            "Dispatch source-writing Units from the project root when worktree isolation is disabled.",
+            { expectedRoot: projectRoot, unitRoot, isolationMode },
+          );
+        }
+        return {
+          ok: true,
+          kind: "safe",
+          projectRoot,
+          unitRoot,
+          milestoneId,
+        };
+      }
+
       const expectedRoot = join(projectRoot, ".gsd", "worktrees", milestoneId);
       if (!samePath(unitRoot, expectedRoot)) {
         return failure(


### PR DESCRIPTION
## Summary
- Updated worktree safety root validation to honor isolation mode (`none`/`branch` use project root, `worktree` keeps milestone worktree root) and verified with the targeted worktree-safety test suite.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5923
- [#5923 Worktree safety guard blocks execute-task when isolationMode=none](https://github.com/gsd-build/gsd-2/issues/5923)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5923-worktree-safety-guard-blocks-execute-tas-1778925425`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation now supports configurable isolation modes (none, worktree, branch), letting project-root safety checks adapt behavior and enforcement based on the selected mode.

* **Tests**
  * Added tests covering isolation-mode-specific validation paths to ensure correct safety results for none and branch modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->