### PR TITLE
fix(issue): Worktree safety guard blocks execute-task when isolationMode=none

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2024,6 +2024,7 @@ export function createWiredAutoOrchestrationModule(
           projectRoot: runtimeBasePath,
           unitRoot: dispatchBasePath,
           milestoneId,
+          isolationMode: getIsolationMode(runtimeBasePath),
           expectedBranch,
         });
         if (!result.ok) {

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -212,7 +212,8 @@ async function validateSourceWriteWorktreeSafety(
   if (!writesSource) return null;
 
   const projectRoot = s.canonicalProjectRoot ?? resolveWorktreeProjectRoot(s.basePath, s.originalBasePath);
-  if (deps.getIsolationMode(projectRoot) !== "worktree") return null;
+  const isolationMode = deps.getIsolationMode(projectRoot);
+  if (isolationMode !== "worktree") return null;
 
   const safety = createWorktreeSafetyModule();
   const result = safety.validateUnitRoot({
@@ -222,7 +223,7 @@ async function validateSourceWriteWorktreeSafety(
     projectRoot,
     unitRoot: s.basePath,
     milestoneId,
-    isolationMode: deps.getIsolationMode(projectRoot),
+    isolationMode,
     expectedBranch: milestoneId ? deps.autoWorktreeBranch(milestoneId) : null,
     emptyWorktreeWithProjectContent: resolveEmptyWorktreeWithProjectContent(s.basePath, projectRoot),
     lease: s.workerId

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -222,6 +222,7 @@ async function validateSourceWriteWorktreeSafety(
     projectRoot,
     unitRoot: s.basePath,
     milestoneId,
+    isolationMode: deps.getIsolationMode(projectRoot),
     expectedBranch: milestoneId ? deps.autoWorktreeBranch(milestoneId) : null,
     emptyWorktreeWithProjectContent: resolveEmptyWorktreeWithProjectContent(s.basePath, projectRoot),
     lease: s.workerId

--- a/src/resources/extensions/gsd/tests/worktree-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-safety.test.ts
@@ -129,6 +129,50 @@ describe("Worktree Safety module", () => {
     assert.equal(result.details?.expectedRoot, unitRoot);
   });
 
+  test("accepts project root for source-writing Unit when isolation mode is none", () => {
+    const safety = createWorktreeSafetyModule({
+      existsSync: () => true,
+      lstatSync: () => ({ isFile: () => true }),
+      listRegisteredWorktrees: () => [{ path: projectRoot, branch: "main" }],
+    });
+
+    const result = safety.validateUnitRoot({
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      writeScope: "source-writing",
+      projectRoot,
+      unitRoot: projectRoot,
+      milestoneId: "M001",
+      isolationMode: "none",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.kind, "safe");
+  });
+
+  test("rejects non-project root for source-writing Unit when isolation mode is none", () => {
+    const safety = createWorktreeSafetyModule({
+      existsSync: () => true,
+      lstatSync: () => ({ isFile: () => true }),
+      listRegisteredWorktrees: () => [{ path: unitRoot, branch: "main" }],
+    });
+
+    const result = safety.validateUnitRoot({
+      unitType: "execute-task",
+      unitId: "M001/S01/T01",
+      writeScope: "source-writing",
+      projectRoot,
+      unitRoot,
+      milestoneId: "M001",
+      isolationMode: "none",
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.kind, "invalid-root");
+    assert.equal(result.details?.expectedRoot, projectRoot);
+    assert.equal(result.details?.unitRoot, unitRoot);
+  });
+
   test("rejects a standalone repository masquerading as a worktree", () => {
     unlinkSync(join(unitRoot, ".git"));
     mkdirSync(join(unitRoot, ".git"), { recursive: true });

--- a/src/resources/extensions/gsd/worktree-safety.ts
+++ b/src/resources/extensions/gsd/worktree-safety.ts
@@ -53,6 +53,7 @@ export interface WorktreeSafetyInput {
   projectRoot: string;
   unitRoot: string;
   milestoneId?: string | null;
+  isolationMode?: "none" | "branch" | "worktree";
   expectedBranch?: string | null;
   emptyWorktreeWithProjectContent?: boolean;
   lease?: {
@@ -156,12 +157,19 @@ export function createWorktreeSafetyModule(
 
       const projectRoot = resolve(input.projectRoot);
       const unitRoot = resolve(input.unitRoot);
-      const expectedRoot = join(projectRoot, ".gsd", "worktrees", milestoneId);
+      const isolationMode = input.isolationMode ?? "worktree";
+      const expectedRoot = isolationMode === "worktree"
+        ? join(projectRoot, ".gsd", "worktrees", milestoneId)
+        : projectRoot;
       if (!samePath(unitRoot, expectedRoot)) {
         return failure(
           "invalid-root",
-          `Unit root ${unitRoot} is not the expected worktree root for ${milestoneId}.`,
-          "Prepare the Unit in its canonical milestone worktree before allowing source writes.",
+          isolationMode === "worktree"
+            ? `Unit root ${unitRoot} is not the expected worktree root for ${milestoneId}.`
+            : `Unit root ${unitRoot} is not the project root while isolation mode is ${isolationMode}.`,
+          isolationMode === "worktree"
+            ? "Prepare the Unit in its canonical milestone worktree before allowing source writes."
+            : "Run the Unit from the project root when worktree isolation is disabled.",
           { expectedRoot, unitRoot },
         );
       }

--- a/src/resources/extensions/gsd/worktree-safety.ts
+++ b/src/resources/extensions/gsd/worktree-safety.ts
@@ -205,7 +205,7 @@ export function createWorktreeSafetyModule(
         );
       }
 
-      if (!gitMarkerStat.isFile()) {
+      if (isolationMode === "worktree" && !gitMarkerStat.isFile()) {
         return failure(
           "worktree-git-marker-not-file",
           `Worktree root ${unitRoot} has a .git directory, not a registered worktree .git file.`,


### PR DESCRIPTION
## Summary
- Updated worktree safety root validation to honor non-worktree isolation modes and verified with focused worktree-safety tests (16/16 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5923
- [#5923 Worktree safety guard blocks execute-task when isolationMode=none](https://github.com/gsd-build/gsd-2/issues/5923)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5923-worktree-safety-guard-blocks-execute-tas-1778925718`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Worktree safety validation now accepts an explicit isolation mode (none/branch/worktree), applies mode-specific root checks and marker rules, and returns clearer, context-aware failure reasons.

* **Tests**
  * Added unit tests for isolation-mode "none" and invalid-root scenarios to verify correct validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->