### PR TITLE
fix(issue): fix(auto): start/resume double-advance causes permanent idempotent-guard pause loop

### DIFF
--- a/src/resources/extensions/gsd/auto/contracts.ts
+++ b/src/resources/extensions/gsd/auto/contracts.ts
@@ -23,6 +23,8 @@ export interface AutoStatus {
 }
 
 export type AutoAdvanceResult =
+  | { kind: "started" }
+  | { kind: "resumed" }
   | { kind: "advanced"; unit: UnitRef; stateSnapshot: GSDState }
   | { kind: "blocked"; reason: string; action: "pause" | "stop"; stateSnapshot?: GSDState }
   | { kind: "stopped"; reason: string; stateSnapshot?: GSDState }

--- a/src/resources/extensions/gsd/auto/orchestrator.ts
+++ b/src/resources/extensions/gsd/auto/orchestrator.ts
@@ -37,7 +37,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     this.bumpTransition();
     await this.deps.runtime.journalTransition({ name: "start" });
     await this.deps.notifications.notifyLifecycle({ name: "start" });
-    return this.advance();
+    return { kind: "started" };
   }
 
   public async advance(): Promise<AutoAdvanceResult> {
@@ -299,7 +299,7 @@ export class AutoOrchestrator implements AutoOrchestrationModule {
     this.bumpTransition();
     await this.deps.runtime.journalTransition({ name: "resume" });
     await this.deps.notifications.notifyLifecycle({ name: "resume" });
-    return this.advance();
+    return { kind: "resumed" };
   }
 
   public async stop(reason: string): Promise<AutoAdvanceResult> {

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -413,13 +413,15 @@ test("advance() surfaces dispatch blocker reason instead of generic no remaining
 });
 
 test("resume() enters running phase without dispatching", async () => {
-  const { deps } = makeDeps();
+  const { deps, calls } = makeDeps();
   const orchestrator = createAutoOrchestrator(deps);
 
   const result = await orchestrator.resume();
 
   assert.equal(result.kind, "resumed");
   assert.equal(orchestrator.getStatus().phase, "running");
+  assert.ok(!calls.includes("journal:advance"));
+  assert.ok(!calls.includes("dispatch.decide"));
 });
 
 test("advance() uses recovery on error", async () => {

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -98,19 +98,18 @@ function makeDeps(overrides: Partial<AutoOrchestratorDeps> = {}): { deps: AutoOr
   return { deps: { ...deps, ...overrides }, calls };
 }
 
-test("start() advances and records active unit", async () => {
+test("start() enters running phase without dispatching", async () => {
   const { deps, calls } = makeDeps();
   const orchestrator = createAutoOrchestrator(deps);
 
   const result = await orchestrator.start({ basePath: "/tmp/project", trigger: "manual" });
 
-  assert.equal(result.kind, "advanced");
-  assert.deepEqual(result.unit, { unitType: "execute-task", unitId: "T01" });
+  assert.equal(result.kind, "started");
   const status = orchestrator.getStatus();
   assert.equal(status.phase, "running");
-  assert.deepEqual(status.activeUnit, { unitType: "execute-task", unitId: "T01" });
+  assert.equal(status.activeUnit, undefined);
   assert.ok(calls.includes("journal:start"));
-  assert.ok(calls.includes("journal:advance"));
+  assert.ok(!calls.includes("journal:advance"));
 });
 
 test("advance() returns blocked when health gate denies", async () => {
@@ -413,26 +412,14 @@ test("advance() surfaces dispatch blocker reason instead of generic no remaining
   assert.ok(!calls.includes("journal:advance-stopped"));
 });
 
-test("resume() returns blocked when advance detects a dispatch blocker", async () => {
-  const { deps } = makeDeps({
-    dispatch: {
-      async decideNextUnit() {
-        return {
-          kind: "blocked",
-          reason: "remediation required",
-          action: "pause",
-        };
-      },
-    },
-  });
+test("resume() enters running phase without dispatching", async () => {
+  const { deps } = makeDeps();
   const orchestrator = createAutoOrchestrator(deps);
 
   const result = await orchestrator.resume();
 
-  assert.equal(result.kind, "blocked");
-  if (result.kind !== "blocked") return;
-  assert.equal(result.reason, "remediation required");
-  assert.equal(result.action, "pause");
+  assert.equal(result.kind, "resumed");
+  assert.equal(orchestrator.getStatus().phase, "running");
 });
 
 test("advance() uses recovery on error", async () => {
@@ -472,13 +459,13 @@ test("advance() is idempotent for the same active unit", async () => {
   assert.equal(prepareCalls, 1);
 });
 
-test("resume() re-enters running flow via advance", async () => {
+test("resume() re-enters running phase", async () => {
   const { deps } = makeDeps();
   const orchestrator = createAutoOrchestrator(deps);
 
   const result = await orchestrator.resume();
 
-  assert.equal(result.kind, "advanced");
+  assert.equal(result.kind, "resumed");
   assert.equal(orchestrator.getStatus().phase, "running");
 });
 
@@ -489,10 +476,12 @@ test("resume() clears idempotent lock and allows re-advance", async () => {
   const first = await orchestrator.advance();
   const blocked = await orchestrator.advance();
   const resumed = await orchestrator.resume();
+  const next = await orchestrator.advance();
 
   assert.equal(first.kind, "advanced");
   assert.equal(blocked.kind, "blocked");
-  assert.equal(resumed.kind, "advanced");
+  assert.equal(resumed.kind, "resumed");
+  assert.equal(next.kind, "advanced");
 });
 
 test("transitionCount increases across lifecycle transitions", async () => {
@@ -607,9 +596,11 @@ test("start() clears prior idempotent lock", async () => {
   await orchestrator.advance();
   const blocked = await orchestrator.advance();
   const restarted = await orchestrator.start({ basePath: "/tmp/project", trigger: "manual" });
+  const next = await orchestrator.advance();
 
   assert.equal(blocked.kind, "blocked");
-  assert.equal(restarted.kind, "advanced");
+  assert.equal(restarted.kind, "started");
+  assert.equal(next.kind, "advanced");
 });
 
 test("error path emits error notification", async () => {
@@ -798,14 +789,12 @@ test("stuck-loop: start() resets the ring so a fresh saturation cycle is require
   }
 
   const restarted = await orchestrator.start({ basePath: "/tmp/project", trigger: "manual" });
-  assert.equal(restarted.kind, "advanced");
+  assert.equal(restarted.kind, "started");
 
-  // Immediately after start(), the next advance is idempotent (one element in
-  // ring), not stuck-loop, confirming the ring was reset.
+  // Immediately after start(), the next advance should succeed because start()
+  // no longer pre-dispatches and the ring was reset.
   const next = await orchestrator.advance();
-  assert.equal(next.kind, "blocked");
-  assert.equal(next.reason, "idempotent advance: unit already active");
-  assert.equal(next.action, "pause");
+  assert.equal(next.kind, "advanced");
 });
 
 test("stuck-loop: resume() resets the ring", async () => {
@@ -817,12 +806,10 @@ test("stuck-loop: resume() resets the ring", async () => {
   }
 
   const resumed = await orchestrator.resume();
-  assert.equal(resumed.kind, "advanced");
+  assert.equal(resumed.kind, "resumed");
 
   const next = await orchestrator.advance();
-  assert.equal(next.kind, "blocked");
-  assert.equal(next.reason, "idempotent advance: unit already active");
-  assert.equal(next.action, "pause");
+  assert.equal(next.kind, "advanced");
 });
 
 test("stuck-loop: stop() resets the ring", async () => {


### PR DESCRIPTION
## Summary
- Stopped `start()`/`resume()` from pre-dispatching `advance()`, added lifecycle result kinds, and verified with the focused auto orchestrator test suite (44 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6209
- [#6209 fix(auto): start/resume double-advance causes permanent idempotent-guard pause loop](https://github.com/gsd-build/gsd-2/issues/6209)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6209-fix-auto-start-resume-double-advance-cau-1778930982`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Lifecycle changes: start/resume now enter running state and defer further processing to the next advance cycle instead of executing immediately.
* **New Features**
  * Added explicit "started" and "resumed" outcome results to lifecycle responses.
* **Tests**
  * Updated tests to reflect new start/resume semantics and reset behavior for stuck-loop/ring scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->