### PR TITLE
fix(issue): auto-mode self-pauses mid-transition: agent-end-recovery falls through to pauseAuto when stream-abort content isn't exactly the placeholder

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -51,7 +51,15 @@ function isObjectRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export function _hasEmptyAgentEndContent(content: unknown): boolean {
-  return content == null || (Array.isArray(content) && content.length === 0);
+  if (content == null) return true;
+  if (!Array.isArray(content)) return false;
+  if (content.length === 0) return true;
+  return content.every((block) => {
+    if (!block || typeof block !== "object") return true;
+    if ((block as { type?: unknown }).type !== "text") return false;
+    const text = (block as { text?: unknown }).text;
+    return typeof text !== "string" || text.trim().length === 0;
+  });
 }
 
 /**

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -56,6 +56,7 @@ export function _hasEmptyAgentEndContent(content: unknown): boolean {
   if (content.length === 0) return true;
   return content.every((block) => {
     if (!block || typeof block !== "object") return true;
+    // Non-text blocks indicate agent activity, so this is not empty content.
     if ((block as { type?: unknown }).type !== "text") return false;
     const text = (block as { text?: unknown }).text;
     return typeof text !== "string" || text.trim().length === 0;

--- a/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
+++ b/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
@@ -205,7 +205,10 @@ test("missing agent_end content is classified as empty abort content", () => {
   assert.equal(_hasEmptyAgentEndContent(undefined), true);
   assert.equal(_hasEmptyAgentEndContent(null), true);
   assert.equal(_hasEmptyAgentEndContent([]), true);
+  assert.equal(_hasEmptyAgentEndContent([{ type: "text", text: "" }]), true);
+  assert.equal(_hasEmptyAgentEndContent([{ type: "text", text: "   " }]), true);
   assert.equal(_hasEmptyAgentEndContent([{ type: "text", text: "partial" }]), false);
+  assert.equal(_hasEmptyAgentEndContent([{ type: "thinking", text: "" }]), false);
 });
 
 test("completed assistant content with aborted stopReason during session-switch is ignored", () => {


### PR DESCRIPTION
## Summary
- Broadened aborted-content emptiness detection to include whitespace-only text blocks and verified with the targeted session-switch abort regression test (11 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6202
- [#6202 auto-mode self-pauses mid-transition: agent-end-recovery falls through to pauseAuto when stream-abort content isn't exactly the placeholder](https://github.com/gsd-build/gsd-2/issues/6202)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6202-auto-mode-self-pauses-mid-transition-age-1778930308`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of empty agent-end content by inspecting block structure; whitespace-only or missing text is now treated as empty, while non-text or non-empty text blocks are treated as non-empty.
* **Tests**
  * Updated/added regression tests to cover whitespace-only text, empty strings, and non-text content cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->