### PR TITLE
fix(issue): auto-mode self-pauses mid-transition: agent-end-recovery falls through to pauseAuto when stream-abort content isn't exactly the placeholder

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -51,7 +51,15 @@ function isObjectRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export function _hasEmptyAgentEndContent(content: unknown): boolean {
-  return content == null || (Array.isArray(content) && content.length === 0);
+  if (content == null) return true;
+  if (!Array.isArray(content)) return false;
+  if (content.length === 0) return true;
+  return content.every((block) => {
+    if (!block || typeof block !== "object") return true;
+    const typedBlock = block as { type?: unknown; text?: unknown };
+    if (typedBlock.type !== "text") return false;
+    return typeof typedBlock.text !== "string" || typedBlock.text.trim() === "";
+  });
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
+++ b/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
@@ -205,6 +205,8 @@ test("missing agent_end content is classified as empty abort content", () => {
   assert.equal(_hasEmptyAgentEndContent(undefined), true);
   assert.equal(_hasEmptyAgentEndContent(null), true);
   assert.equal(_hasEmptyAgentEndContent([]), true);
+  assert.equal(_hasEmptyAgentEndContent([{ type: "text", text: "" }]), true);
+  assert.equal(_hasEmptyAgentEndContent([{ type: "text", text: "   " }]), true);
   assert.equal(_hasEmptyAgentEndContent([{ type: "text", text: "partial" }]), false);
 });
 


### PR DESCRIPTION
## Summary
- Expanded empty-abort content detection and added regression tests, with the targeted session-switch abort test file passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6202
- [#6202 auto-mode self-pauses mid-transition: agent-end-recovery falls through to pauseAuto when stream-abort content isn't exactly the placeholder](https://github.com/gsd-build/gsd-2/issues/6202)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6202-auto-mode-self-pauses-mid-transition-age-1778930377`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced empty response detection during agent termination to properly handle whitespace-only text and empty strings, improving reliability of session handling and recovery processes.

* **Tests**
  * Expanded test coverage to validate proper treatment of empty strings and whitespace in content evaluation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->