### PR TITLE
fix(auto-dispatch): use worktree for task plan recovery

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -237,6 +237,23 @@ export function shouldRunDeepProjectSetup(
   return hasPendingDeepStage(prefs, basePath);
 }
 
+function resolveArtifactBasePath(
+  basePath: string,
+  mid: string,
+  session: import("./auto/session.js").AutoSession | undefined,
+): string {
+  if (
+    session?.basePath &&
+    session.currentMilestoneId === mid &&
+    session.basePath !== session.originalBasePath &&
+    existsSync(session.basePath)
+  ) {
+    return session.basePath;
+  }
+
+  return resolveCanonicalMilestoneRoot(basePath, mid);
+}
+
 function missingSliceStop(mid: string, phase: string): DispatchAction {
   return {
     action: "stop",
@@ -1168,16 +1185,16 @@ export const DISPATCH_RULES: DispatchRule[] = [
       const sid = state.activeSlice!.id;
       const sTitle = state.activeSlice!.title;
       const tid = state.activeTask.id;
-      const milestoneRoot = resolveCanonicalMilestoneRoot(basePath, mid);
+      const artifactBasePath = resolveArtifactBasePath(basePath, mid, session);
 
       // Guard: if the slice plan exists but the individual task plan files are
       // missing, the planner created S##-PLAN.md with task entries but never
       // wrote the tasks/ directory files. Dispatch plan-slice to regenerate
       // them rather than hard-stopping — fixes the infinite-loop described in
       // issue #909.
-      const taskPlanPath = resolveTaskFile(milestoneRoot, mid, sid, tid, "PLAN");
+      const taskPlanPath = resolveTaskFile(artifactBasePath, mid, sid, tid, "PLAN");
       const projectionTaskPlanPath = join(
-        gsdProjectionRoot(milestoneRoot),
+        gsdProjectionRoot(artifactBasePath),
         "milestones",
         mid,
         "slices",
@@ -1187,14 +1204,14 @@ export const DISPATCH_RULES: DispatchRule[] = [
       );
       if ((!taskPlanPath || !existsSync(taskPlanPath)) && !existsSync(projectionTaskPlanPath)) {
         if (isDebugEnabled()) {
-          const expectedTaskPlanPath = join(basePath, relTaskFile(basePath, mid, sid, tid, "PLAN"));
+          const expectedTaskPlanPath = join(artifactBasePath, relTaskFile(artifactBasePath, mid, sid, tid, "PLAN"));
           const originalProjectRoot = session?.originalBasePath || basePath;
           const activeMilestoneWorktreePath = session?.basePath || basePath;
           const artifactExists = taskPlanPath ? existsSync(taskPlanPath) : false;
           debugLog("dispatch-missing-task-plan-recovery", {
             selectedDispatchRule: "executing → execute-task (recover missing task plan → plan-slice)",
-            basePathUsedForArtifactChecks: basePath,
-            milestoneRoot,
+            basePathUsedForArtifactChecks: artifactBasePath,
+            milestoneRoot: artifactBasePath,
             originalProjectRoot,
             activeMilestoneWorktreePath,
             expectedTaskPlanPath,

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1901,7 +1901,7 @@ export function createWiredDispatchAdapter(
         midTitle: active.title,
         state,
         prefs,
-        session: input.session,
+        session: input.session ?? session,
         structuredQuestionsAvailable,
         sessionContextWindow,
         sessionProvider,

--- a/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-orchestrator.test.ts
@@ -1027,6 +1027,46 @@ test("wired DispatchAdapter prefers caller-supplied dispatch inputs over ctx-der
   }
 });
 
+test("wired DispatchAdapter forwards constructor session when advance input omits session", async () => {
+  const stateSnapshot = makeState();
+  const captured: DispatchContext[] = [];
+  const captureRule: UnifiedRule = {
+    name: "test-session-fallback",
+    when: "dispatch",
+    evaluation: "first-match",
+    where: async (ctx: DispatchContext) => {
+      captured.push(ctx);
+      return {
+        action: "dispatch" as const,
+        unitType: "execute-task",
+        unitId: "T01",
+        prompt: "session-fallback-fixture",
+      };
+    },
+    then: (r: unknown) => r,
+  };
+  setRegistry(new RuleRegistry([captureRule]));
+
+  try {
+    const ctx = { model: {}, modelRegistry: { getAll: () => [] } } as any;
+    const pi = { getActiveTools: () => [] } as any;
+    const session = {
+      basePath: "/tmp/worktree-fixture",
+      originalBasePath: "/tmp/project-fixture",
+      currentMilestoneId: "M001",
+    } as any;
+    const adapter = createWiredDispatchAdapter(ctx, pi, "/tmp/project-fixture", session);
+
+    const result = await adapter.decideNextUnit({ stateSnapshot });
+
+    assert.ok(result);
+    assert.equal(captured.length, 1, "expected one captured dispatch context");
+    assert.equal(captured[0].session, session);
+  } finally {
+    resetRegistry();
+  }
+});
+
 test("wired DispatchAdapter preserves stop reason as a blocked decision", async () => {
   const stateSnapshot = makeState();
   const stopRule: UnifiedRule = {

--- a/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
@@ -16,6 +16,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { resolveDispatch } from "../auto-dispatch.ts";
 import type { DispatchContext } from "../auto-dispatch.ts";
+import type { AutoSession } from "../auto/session.ts";
 import type { GSDState } from "../types.ts";
 import { enableDebug, disableDebug, getDebugLogPath } from "../debug-logger.ts";
 
@@ -40,6 +41,27 @@ function makeContext(basePath: string, stateOverrides?: Partial<GSDState>): Disp
     midTitle: "Test Milestone",
     state: makeState(stateOverrides),
     prefs: undefined,
+  };
+}
+
+function makeContextFor(
+  basePath: string,
+  mid: string,
+  sid: string,
+  tid: string,
+  session?: Partial<AutoSession>,
+): DispatchContext {
+  return {
+    basePath,
+    mid,
+    midTitle: "Test Milestone",
+    state: makeState({
+      activeMilestone: { id: mid, title: "Test Milestone" },
+      activeSlice: { id: sid, title: "Second Slice" },
+      activeTask: { id: tid, title: "First Task" },
+    }),
+    prefs: undefined,
+    session: session as AutoSession | undefined,
   };
 }
 
@@ -141,6 +163,33 @@ test("dispatch: executing recovery checks active milestone worktree task plans b
     `unitType should be execute-task, got: ${result.action === "dispatch" ? result.unitType : "(stop)"}`);
   assert.ok(result.action === "dispatch" && result.unitId === "M002/S03/T01",
     `unitId should be M002/S03/T01, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`);
+});
+
+test("dispatch: active session worktree task plan wins over missing original-root task plan", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-worktree-artifact-root-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  scaffoldMilestoneContext(tmp, "M004");
+  scaffoldSlicePlan(tmp, "M004", "S02");
+
+  const worktreeRoot = join(tmp, ".gsd", "worktrees", "M004");
+  mkdirSync(worktreeRoot, { recursive: true });
+  scaffoldMilestoneContext(worktreeRoot, "M004");
+  scaffoldSlicePlan(worktreeRoot, "M004", "S02");
+  scaffoldTaskPlan(worktreeRoot, "M004", "S02", "T01");
+
+  const ctx = makeContextFor(tmp, "M004", "S02", "T01", {
+    basePath: worktreeRoot,
+    originalBasePath: tmp,
+    currentMilestoneId: "M004",
+  });
+  const result = await resolveDispatch(ctx);
+
+  assert.equal(result.action, "dispatch");
+  assert.ok(result.action === "dispatch" && result.unitType === "execute-task",
+    `unitType should be execute-task, got: ${result.action === "dispatch" ? result.unitType : "(stop)"}`);
+  assert.ok(result.action === "dispatch" && result.unitId === "M004/S02/T01",
+    `unitId should be M004/S02/T01, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`);
 });
 
 test("dispatch: plan-slice recovery loop — second call after plan-slice still recovers cleanly", async (t) => {


### PR DESCRIPTION
## TL;DR

**What:** Resolve missing-task-plan recovery checks against the active milestone worktree before falling back to the original project root.
**Why:** Task plans can exist only in the worktree `.gsd`, causing dispatch to incorrectly re-run `plan-slice` and hit the idempotent unit guard.
**How:** Add a dispatch artifact base resolver that prefers the current session worktree for the active milestone, and cover the root/worktree mismatch with a regression test.

Fixes #6221

## What

This updates the executing-phase missing-task-plan recovery rule in `auto-dispatch.ts` so artifact checks use the active session milestone worktree when the session has entered that milestone. The existing canonical root fallback remains in place for callers without an active session worktree.

It also adds a regression test for `M004/S02/T01` where `T01-PLAN.md` exists only under the milestone worktree `.gsd` tree while the original root lacks the task plan.

## Why

`gsd_plan_slice` can render task plans under the milestone worktree, while the next dispatch decision may still check the original project root. That mismatch makes dispatch think task plans are missing, re-dispatches `plan-slice`, and can lead to an idempotent advance pause because the same unit is already active.

## How

The recovery rule now resolves an `artifactBasePath` from the active session when `session.currentMilestoneId` matches the dispatch milestone and `session.basePath` points at an existing worktree. If that does not apply, it falls back to the existing canonical milestone root lookup.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts`
- `npm run typecheck:extensions`

## Change type checklist

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session object propagation in task dispatch resolution
  * Enhanced task plan discovery to recognize artifacts in active worktree sessions

* **Tests**
  * Added test coverage for session parameter handling in dispatch adapter
  * Added regression test for task plan artifact discovery in session-based scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->