### PR TITLE
fix(issue): auto-mode infinitely re-dispatches complete-milestone when validation verdict is needs-attention

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -28,6 +28,8 @@ When progressive planning is enabled, GSD fully plans the first slice and may le
 
 Milestone completion is safe to retry. If a `complete-milestone` unit is redispatched after the database already marks the milestone as closed, GSD treats the call as successful instead of returning an error. The existing summary projection is left intact, no duplicate completion event is appended, and the tool response includes `alreadyComplete: true` in its details so operators and integrations can distinguish a retry from the first completion.
 
+`complete-milestone` now also enforces a hard validation prerequisite: the latest `milestone-validation` assessment for that milestone must exist and have verdict `pass`. If the verdict is `fail`, `partial`, or absent, closeout is blocked until `validate-milestone` records a fresh passing verdict.
+
 ### Planning-Only Milestone Closeout
 
 When milestone history contains only `.gsd/` artifact changes (for example planning-only or documentation-only closeout), auto mode now continues `complete-milestone` dispatch instead of blocking completion for missing implementation files outside `.gsd/`. GSD emits a warning so operators can distinguish this path from implementation-bearing milestones.

--- a/mintlify-docs/guides/auto-mode.mdx
+++ b/mintlify-docs/guides/auto-mode.mdx
@@ -21,6 +21,8 @@ Plan → Execute (per task) → Complete → Reassess Roadmap → Next Slice
 
 When progressive planning is enabled, GSD fully plans the first slice and may leave later slices as sketches. Those slices render in `M###-ROADMAP.md` with a `` `[sketch]` `` badge, meaning the slice has an approved scope boundary but has not yet been expanded into task plans. Auto mode runs `refine-slice` just before execution to convert the sketch into a full slice plan using the current codebase and prior slice summaries.
 
+`complete-milestone` enforces a hard validation prerequisite: the latest `milestone-validation` assessment for the milestone must exist with verdict `pass`. If the latest verdict is `fail`, `partial`, or missing, milestone closeout is blocked until `validate-milestone` records a fresh passing verdict.
+
 ## Deep planning mode
 
 Enable project-level deep planning with `/gsd new-project --deep`, `/gsd new-milestone --deep`, or this project preference:

--- a/src/resources/extensions/gsd/tests/complete-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { invalidateAllCaches } from '../cache.ts';
 import { parseUnitId } from "../unit-id.ts";
-import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask } from "../gsd-db.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask, insertAssessment } from "../gsd-db.ts";
 import { clearPathCache } from "../paths.ts";
 import { clearParseCache } from "../files.ts";
 
@@ -503,6 +503,49 @@ describe("complete-milestone", () => {
     }
   });
 
+  test("handleCompleteMilestone refuses closeout when latest validation verdict is needs-attention (#5661)", async () => {
+    const { handleCompleteMilestone } = await import("../tools/complete-milestone.ts");
+    const base = createFixtureBase();
+    const mid = "M001";
+    const dbPath = join(base, ".gsd", "gsd.db");
+    try {
+      openDatabase(dbPath);
+      insertMilestone({ id: mid, title: "Test Milestone", status: "active" });
+      insertSlice({ id: "S01", milestoneId: mid, title: "Slice One", status: "complete" });
+      insertTask({ id: "T01", sliceId: "S01", milestoneId: mid, title: "Task One", status: "complete" });
+      insertAssessment({
+        path: join(".gsd", "milestones", mid, `${mid}-VALIDATION.md`),
+        milestoneId: mid,
+        status: "needs-attention",
+        scope: "milestone-validation",
+        fullContent: "---\nverdict: needs-attention\nremediation_round: 1\n---\n\n# Validation\nNeeds attention.",
+      });
+
+      const result = await handleCompleteMilestone({
+        milestoneId: mid,
+        title: "Test Milestone",
+        oneLiner: "Test",
+        narrative: "Test narrative",
+        successCriteriaResults: "Results",
+        definitionOfDoneResults: "Done",
+        requirementOutcomes: "Outcomes",
+        keyDecisions: [],
+        keyFiles: [],
+        lessonsLearned: [],
+        followUps: "",
+        deviations: "",
+        verificationPassed: true,
+      }, base);
+
+      assert.ok("error" in result, "non-pass validation verdict should block completion");
+      assert.match((result as { error: string }).error, /needs-attention/i);
+      assert.match((result as { error: string }).error, /Only verdict=pass permits closeout/i);
+    } finally {
+      try { closeDatabase(); } catch { /* */ }
+      cleanup(base);
+    }
+  });
+
   test("deriveState completing-milestone integration", async () => {
     const { deriveState, isMilestoneComplete } = await import("../state.ts");
     const { invalidateAllCaches: invalidateAllCachesDynamic } = await import("../cache.ts");
@@ -655,6 +698,13 @@ describe("complete-milestone", () => {
       insertMilestone({ id: mid, title: "Empty Enrichment", status: "active" });
       insertSlice({ id: "S01", milestoneId: mid, title: "Slice", status: "complete" });
       insertTask({ id: "T01", sliceId: "S01", milestoneId: mid, title: "Task", status: "complete" });
+      insertAssessment({
+        path: join(".gsd", "milestones", mid, `${mid}-VALIDATION.md`),
+        milestoneId: mid,
+        status: "pass",
+        scope: "milestone-validation",
+        fullContent: "---\nverdict: pass\nremediation_round: 0\n---\n\n# Validation\nValidated.",
+      });
 
       const result = await handleCompleteMilestone({
         milestoneId: mid,

--- a/src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts
@@ -31,6 +31,7 @@ import {
   openDatabase,
   closeDatabase,
   insertMilestone,
+  insertAssessment,
   insertSlice,
   insertTask,
   getTask,
@@ -280,6 +281,16 @@ function makeMilestoneParams(milestoneId: string): Record<string, unknown> {
   };
 }
 
+function insertPassingMilestoneValidation(milestoneId: string): void {
+  insertAssessment({
+    path: `.gsd/milestones/${milestoneId}/${milestoneId}-VALIDATION.md`,
+    milestoneId,
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "# Validation\n\nverdict: PASS",
+  });
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Test Suite
 // ═══════════════════════════════════════════════════════════════════════════
@@ -424,6 +435,7 @@ describe("state-machine-live-validation", () => {
       insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Impl", status: "complete" });
       insertTask({ id: "T02", sliceId: "S01", milestoneId: "M001", title: "Test", status: "complete" });
       insertTask({ id: "T01", sliceId: "S02", milestoneId: "M001", title: "Impl", status: "complete" });
+      insertPassingMilestoneValidation("M001");
 
       const result = await handleCompleteMilestone(makeMilestoneParams("M001") as any, base);
       assert.ok(!("error" in result), `expected success, got: ${JSON.stringify(result)}`);
@@ -528,6 +540,7 @@ describe("state-machine-live-validation", () => {
       base = createFullFixture();
       openDatabase(join(base, ".gsd", "gsd.db"));
       insertMilestone({ id: "M001", title: "Active", status: "active" });
+      insertPassingMilestoneValidation("M001");
 
       const result = await handleCompleteMilestone(makeMilestoneParams("M001") as any, base);
       assert.ok("error" in result);
@@ -542,6 +555,7 @@ describe("state-machine-live-validation", () => {
       insertSlice({ id: "S02", milestoneId: "M001", status: "in_progress" });
       insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", status: "complete" });
       insertTask({ id: "T01", sliceId: "S02", milestoneId: "M001", status: "pending" });
+      insertPassingMilestoneValidation("M001");
 
       const result = await handleCompleteMilestone(makeMilestoneParams("M001") as any, base);
       assert.ok("error" in result);
@@ -555,6 +569,7 @@ describe("state-machine-live-validation", () => {
       // Slice marked complete but task is still pending — simulates inconsistent state
       insertSlice({ id: "S01", milestoneId: "M001", status: "complete" });
       insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", status: "pending" });
+      insertPassingMilestoneValidation("M001");
 
       const result = await handleCompleteMilestone(makeMilestoneParams("M001") as any, base);
       assert.ok("error" in result);

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -10,6 +10,7 @@ import {
   closeDatabase,
   _getAdapter,
   insertGateRow,
+  insertAssessment,
   upsertRequirement,
   getAllMilestones,
 } from "../gsd-db.ts";
@@ -483,6 +484,13 @@ test("executeCompleteMilestone sanitizes raw params and writes milestone summary
     db!.prepare(
       "INSERT OR REPLACE INTO tasks (milestone_id, slice_id, id, title, status) VALUES (?, ?, ?, ?, ?)",
     ).run("M003", "S03", "T03", "Task T03", "complete");
+    insertAssessment({
+      path: join(".gsd", "milestones", "M003", "M003-VALIDATION.md"),
+      milestoneId: "M003",
+      status: "pass",
+      scope: "milestone-validation",
+      fullContent: "---\nverdict: pass\nremediation_round: 0\n---\n\n# Validation\nValidated.",
+    });
 
     const rawParams = {
       milestoneId: "M003",

--- a/src/resources/extensions/gsd/tools/complete-milestone.ts
+++ b/src/resources/extensions/gsd/tools/complete-milestone.ts
@@ -15,6 +15,7 @@ import {
   getMilestone,
   getMilestoneSlices,
   getSliceTasks,
+  getLatestAssessmentByScope,
   updateMilestoneStatus,
 } from "../gsd-db.js";
 import { resolveMilestonePath, clearPathCache } from "../paths.js";
@@ -153,6 +154,15 @@ export async function handleCompleteMilestone(
     }
     if (isClosedStatus(milestone.status)) {
       alreadyComplete = true;
+      return;
+    }
+
+    // Defense-in-depth: only a passing milestone validation permits closeout.
+    const validation = getLatestAssessmentByScope(params.milestoneId, "milestone-validation");
+    if (validation?.status !== "pass") {
+      guardError =
+        `Refusing to complete ${params.milestoneId}: latest milestone-validation verdict is ` +
+        `"${validation?.status ?? "absent"}". Only verdict=pass permits closeout.`;
       return;
     }
 


### PR DESCRIPTION
## Summary
- Added a complete-milestone tool precondition requiring latest milestone-validation verdict=pass and verified with targeted complete-milestone tests (19/19 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5661
- [#5661 auto-mode infinitely re-dispatches complete-milestone when validation verdict is needs-attention](https://github.com/gsd-build/gsd-2/issues/5661)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5661-auto-mode-infinitely-re-dispatches-compl-1778931508`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Milestone completion now enforces a validation-assessment check and blocks closeout unless the latest assessment verdict is "pass".
* **Tests**
  - Expanded test coverage to verify validation-gated completion behavior, including blocking on non-passing verdicts and allowing completion when a passing assessment exists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->