### PR TITLE
fix(issue): auto-mode false stuck stop: persisted 20-entry recentUnits window bypasses 6-entry detector cap

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -26,6 +26,7 @@ import {
   runDispatch,
   runGuards,
   runFinalize,
+  STUCK_WINDOW_SIZE,
 } from "./phases.js";
 import { debugLog } from "../debug-logger.js";
 import { isInfrastructureError, isTransientCooldownError, getCooldownRetryAfterMs, COOLDOWN_FALLBACK_WAIT_MS, MAX_COOLDOWN_RETRIES } from "./infra-errors.js";
@@ -111,7 +112,6 @@ import { handleCustomEngineReconcileOutcome } from "./workflow-custom-engine-rec
 // helpers degrade to the empty-state fallback that #3704 already
 // tolerates — same behavior as a fresh session.
 const STUCK_RECOVERY_ATTEMPTS_KEY = "stuck_recovery_attempts";
-const RECENT_UNIT_KEYS_LIMIT = 20;
 
 function stableStuckStateScopeId(s: AutoSession): string {
   return normalizeRealPath(s.scope?.workspace.projectRoot ?? (s.originalBasePath || s.basePath));
@@ -121,7 +121,7 @@ function loadStuckState(s: AutoSession): { recentUnits: Array<{ key: string }>; 
   const scopeId = stableStuckStateScopeId(s);
   if (!scopeId) return { recentUnits: [], stuckRecoveryAttempts: 0 };
   try {
-    const recentUnits = getRecentUnitKeysForProjectRoot(scopeId, RECENT_UNIT_KEYS_LIMIT);
+    const recentUnits = getRecentUnitKeysForProjectRoot(scopeId, STUCK_WINDOW_SIZE);
     const stuckRecoveryAttempts =
       getRuntimeKv<number>("global", scopeId, STUCK_RECOVERY_ATTEMPTS_KEY) ?? 0;
     return { recentUnits, stuckRecoveryAttempts };

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -80,6 +80,8 @@ import { decideVerificationRetry, verificationRetryKey } from "./verification-re
 import { buildPhaseHandoffOutcome, setAutoOutcomeWidget } from "../auto-dashboard.js";
 import { getConsecutiveDispatchBlocker } from "../dispatch-guard.js";
 
+export const STUCK_WINDOW_SIZE = 6;
+
 // ─── Path Comparison Helper ───────────────────────────────────────────────
 /** Compare two paths for physical identity, tolerating trailing slashes and symlinks. */
 function isSamePathLocal(a: string, b: string): boolean {
@@ -1248,7 +1250,6 @@ export async function runDispatch(
 ): Promise<PhaseResult<IterationData>> {
   const { ctx, pi, s, deps, prefs } = ic;
   const { state, mid, midTitle } = preData;
-  const STUCK_WINDOW_SIZE = 6;
   const provider = ctx.model?.provider;
   const authMode = provider && typeof ctx.modelRegistry?.getProviderAuthMode === "function"
     ? ctx.modelRegistry.getProviderAuthMode(provider)
@@ -1389,7 +1390,9 @@ export async function runDispatch(
   // Rules 1/3/4 can catch retry loops with repeated failure content (#5719).
   // Rules 2/2b suppress legitimate retry backoff through the dispatch ledger.
   loopState.recentUnits.push({ key: derivedKey });
-  if (loopState.recentUnits.length > STUCK_WINDOW_SIZE) loopState.recentUnits.shift();
+  while (loopState.recentUnits.length > STUCK_WINDOW_SIZE) {
+    loopState.recentUnits.shift();
+  }
 
   const stuckSignal = detectStuck(loopState.recentUnits);
   if (stuckSignal) {

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -3652,6 +3652,81 @@ test("runDispatch falls back to main when dispatch guard cannot read main branch
   assert.equal(result.action, "next");
 });
 
+test("runDispatch clamps oversized stuck window before detection (#6216)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+  const deps = makeMockDeps({
+    resolveDispatch: async () => {
+      deps.callLog.push("resolveDispatch");
+      return {
+        action: "dispatch" as const,
+        unitType: "complete-slice",
+        unitId: "M006/S03",
+        prompt: "close out slice",
+      };
+    },
+  });
+  const loopState = {
+    recentUnits: [
+      { key: "complete-slice/M006/S03" },
+      { key: "execute-task/M006/S03/T01" },
+      { key: "complete-slice/M006/S03" },
+      { key: "execute-task/M006/S03/T01" },
+      { key: "execute-task/M006/S03/T02" },
+      { key: "execute-task/M006/S03/T03" },
+      { key: "execute-task/M006/S03/T04" },
+      { key: "execute-task/M006/S03/T05" },
+      { key: "execute-task/M006/S03/T06" },
+      { key: "execute-task/M006/S03/T07" },
+      { key: "execute-task/M006/S03/T08" },
+      { key: "execute-task/M006/S03/T09" },
+      { key: "execute-task/M006/S03/T10" },
+      { key: "execute-task/M006/S03/T11" },
+      { key: "execute-task/M006/S03/T12" },
+      { key: "complete-slice/M006/S03" },
+      { key: "execute-task/M006/S03/T13" },
+      { key: "execute-task/M006/S03/T14" },
+      { key: "execute-task/M006/S03/T15" },
+      { key: "execute-task/M006/S03/T16" },
+    ],
+    stuckRecoveryAttempts: 0,
+    consecutiveFinalizeTimeouts: 0,
+  };
+
+  const result = await runDispatch(
+    {
+      ctx,
+      pi,
+      s,
+      deps,
+      prefs: undefined,
+      iteration: 1,
+      flowId: "test-flow",
+      nextSeq: () => 1,
+    },
+    {
+      state: {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Test", status: "active" },
+        activeSlice: { id: "S01", title: "Slice 1" },
+        activeTask: { id: "T01" },
+        registry: [{ id: "M001", status: "active" }],
+        blockers: [],
+      } as any,
+      mid: "M001",
+      midTitle: "Test",
+    },
+    loopState,
+  );
+
+  assert.equal(result.action, "next");
+  assert.equal(loopState.recentUnits.length, 6, "stuck window should be capped to the active detector size");
+  assert.ok(!deps.callLog.includes("stopAuto"), "oversized persisted history should not trigger a false stuck stop");
+});
+
 test("dispatch Worktree Safety stops unknown unit types with missing Tool Contract", async (t) => {
   _resetPendingResolve();
 


### PR DESCRIPTION
## Summary
- Shared and enforced the 6-entry stuck window across load and dispatch paths, and verified with a targeted auto-loop regression test pass.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6216
- [#6216 auto-mode false stuck stop: persisted 20-entry recentUnits window bypasses 6-entry detector cap](https://github.com/gsd-build/gsd-2/issues/6216)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6216-auto-mode-false-stuck-stop-persisted-20--1778932702`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stuck-detection algorithm to properly manage and cap operation history window sizes, preventing false stuck detection triggers and enhancing system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->