### PR TITLE
fix(test): prefer compiled package tests

### DIFF
--- a/scripts/__tests__/run-package-tests.test.mjs
+++ b/scripts/__tests__/run-package-tests.test.mjs
@@ -1,0 +1,61 @@
+// Project/App: GSD-2
+// File Purpose: Regression tests for workspace package test file selection.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { selectPackageTestFiles } = require('../run-package-tests.cjs');
+
+function withTempPackage(callback) {
+  const root = mkdtempSync(join(tmpdir(), 'gsd-run-package-tests-'));
+  try {
+    return callback(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function touch(path) {
+  mkdirSync(path.slice(0, path.lastIndexOf('/')), { recursive: true });
+  writeFileSync(path, 'test("placeholder", () => {});\n', 'utf-8');
+}
+
+test('selectPackageTestFiles prefers compiled src tests over copied package dist tests', () => {
+  withTempPackage((root) => {
+    const distTestPkg = join(root, 'dist-test-package');
+    const pkgDist = join(root, 'package-dist');
+    const srcTest = join(distTestPkg, 'src', 'workflow-tools.test.js');
+    const copiedDistTest = join(distTestPkg, 'dist', 'workflow-tools.test.js');
+    touch(srcTest);
+    touch(copiedDistTest);
+
+    assert.deepEqual(selectPackageTestFiles(distTestPkg, pkgDist), [srcTest]);
+  });
+});
+
+test('selectPackageTestFiles falls back to copied dist-test package files when no compiled src tests exist', () => {
+  withTempPackage((root) => {
+    const distTestPkg = join(root, 'dist-test-package');
+    const pkgDist = join(root, 'package-dist');
+    const copiedDistTest = join(distTestPkg, 'dist', 'legacy.test.js');
+    touch(copiedDistTest);
+
+    assert.deepEqual(selectPackageTestFiles(distTestPkg, pkgDist), [copiedDistTest]);
+  });
+});
+
+test('selectPackageTestFiles falls back to package-local dist when test:compile has no package output', () => {
+  withTempPackage((root) => {
+    const distTestPkg = join(root, 'missing-dist-test-package');
+    const pkgDist = join(root, 'package-dist');
+    const packageDistTest = join(pkgDist, 'package-script.test.js');
+    touch(packageDistTest);
+
+    assert.deepEqual(selectPackageTestFiles(distTestPkg, pkgDist), [packageDistTest]);
+  });
+});

--- a/scripts/__tests__/run-package-tests.test.mjs
+++ b/scripts/__tests__/run-package-tests.test.mjs
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createRequire } from 'node:module';
 
@@ -20,9 +20,9 @@ function withTempPackage(callback) {
   }
 }
 
-function touch(path) {
-  mkdirSync(path.slice(0, path.lastIndexOf('/')), { recursive: true });
-  writeFileSync(path, 'test("placeholder", () => {});\n', 'utf-8');
+function touch(filePath) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, 'test("placeholder", () => {});\n', 'utf-8');
 }
 
 test('selectPackageTestFiles prefers compiled src tests over copied package dist tests', () => {

--- a/scripts/run-package-tests.cjs
+++ b/scripts/run-package-tests.cjs
@@ -25,13 +25,18 @@ function findTestFiles(dir) {
 	return out
 }
 
-function findDistTestFiles(pkgDir) {
-	const distTestPkg = join(REPO_ROOT, 'dist-test', 'packages', relative(join(REPO_ROOT, 'packages'), pkgDir))
+function selectPackageTestFiles(distTestPkg, pkgDist) {
+	const fromCompiledSrc = findTestFiles(join(distTestPkg, 'src'))
+	if (fromCompiledSrc.length > 0) return fromCompiledSrc
 	const fromDistTest = findTestFiles(distTestPkg)
 	if (fromDistTest.length > 0) return fromDistTest
 	// Fall back to package-local build outputs when test:compile does not cover a package yet.
-	const pkgDist = join(pkgDir, 'dist')
 	return findTestFiles(pkgDist)
+}
+
+function findDistTestFiles(pkgDir) {
+	const distTestPkg = join(REPO_ROOT, 'dist-test', 'packages', relative(join(REPO_ROOT, 'packages'), pkgDir))
+	return selectPackageTestFiles(distTestPkg, join(pkgDir, 'dist'))
 }
 
 function commandExists(command, args = ['--version']) {
@@ -120,62 +125,73 @@ function runPackageScript(command, args, cwd = REPO_ROOT, label = command) {
 	return result.status ?? 1
 }
 
-const packages = getLinkablePackages()
-const summary = []
-for (const pkg of packages) {
-	if (pkg.packageName === '@gsd/native') {
-		const canRunNative = hasNativeAddon() || commandExists('cargo')
-		summary.push({
-			pkg: pkg.packageName,
-			dir: pkg.dir,
-			count: canRunNative ? 'package-script' : 'skipped',
-		})
-		continue
-	}
-
-	const files = findDistTestFiles(pkg.path)
-	summary.push({ pkg: pkg.packageName, dir: pkg.dir, count: files.length })
-}
-
-process.stderr.write('Workspace package tests:\n')
-for (const row of summary) {
-	if (typeof row.count === 'number') {
-		process.stderr.write(`  ${row.pkg} (${row.dir}): ${row.count} file${row.count === 1 ? '' : 's'}\n`)
-		continue
-	}
-	process.stderr.write(`  ${row.pkg} (${row.dir}): ${row.count}\n`)
-}
-
-let failureCount = 0
-
-for (const pkg of packages) {
-	if (pkg.packageName === '@gsd/native') {
-		if (!hasNativeAddon() && !commandExists('cargo')) {
-			process.stderr.write(
-				`Skipping ${pkg.packageName}: no native addon present and \`cargo\` is unavailable in this environment.\n`
-			)
+function main() {
+	const packages = getLinkablePackages()
+	const summary = []
+	for (const pkg of packages) {
+		if (pkg.packageName === '@gsd/native') {
+			const canRunNative = hasNativeAddon() || commandExists('cargo')
+			summary.push({
+				pkg: pkg.packageName,
+				dir: pkg.dir,
+				count: canRunNative ? 'package-script' : 'skipped',
+			})
 			continue
 		}
-		process.stderr.write(`\nRunning ${pkg.packageName} package tests via workspace script...\n`)
-		if (
-			runPackageScript(getNpmCommand(), ['run', 'test', '-w', pkg.packageName], REPO_ROOT, pkg.packageName) !==
-			0
-		) {
+
+		const files = findDistTestFiles(pkg.path)
+		summary.push({ pkg: pkg.packageName, dir: pkg.dir, count: files.length })
+	}
+
+	process.stderr.write('Workspace package tests:\n')
+	for (const row of summary) {
+		if (typeof row.count === 'number') {
+			process.stderr.write(`  ${row.pkg} (${row.dir}): ${row.count} file${row.count === 1 ? '' : 's'}\n`)
+			continue
+		}
+		process.stderr.write(`  ${row.pkg} (${row.dir}): ${row.count}\n`)
+	}
+
+	let failureCount = 0
+
+	for (const pkg of packages) {
+		if (pkg.packageName === '@gsd/native') {
+			if (!hasNativeAddon() && !commandExists('cargo')) {
+				process.stderr.write(
+					`Skipping ${pkg.packageName}: no native addon present and \`cargo\` is unavailable in this environment.\n`
+				)
+				continue
+			}
+			process.stderr.write(`\nRunning ${pkg.packageName} package tests via workspace script...\n`)
+			if (
+				runPackageScript(getNpmCommand(), ['run', 'test', '-w', pkg.packageName], REPO_ROOT, pkg.packageName) !==
+				0
+			) {
+				failureCount += 1
+			}
+			continue
+		}
+
+		const files = findDistTestFiles(pkg.path)
+		if (files.length === 0) {
+			process.stderr.write(`Skipping ${pkg.packageName}: no compiled test files found.\n`)
+			continue
+		}
+
+		process.stderr.write(`\nRunning ${pkg.packageName} package tests...\n`)
+		if (runCommand(process.execPath, ['--test', ...files], REPO_ROOT, pkg.packageName) !== 0) {
 			failureCount += 1
 		}
-		continue
 	}
 
-	const files = findDistTestFiles(pkg.path)
-	if (files.length === 0) {
-		process.stderr.write(`Skipping ${pkg.packageName}: no compiled test files found.\n`)
-		continue
-	}
-
-	process.stderr.write(`\nRunning ${pkg.packageName} package tests...\n`)
-	if (runCommand(process.execPath, ['--test', ...files], REPO_ROOT, pkg.packageName) !== 0) {
-		failureCount += 1
-	}
+	return failureCount === 0 ? 0 : 1
 }
 
-process.exit(failureCount === 0 ? 0 : 1)
+if (require.main === module) {
+	process.exit(main())
+}
+
+module.exports = {
+	findTestFiles,
+	selectPackageTestFiles,
+}

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -378,6 +378,10 @@ export function applyModeDefaults(mode: WorkflowMode, prefs: GSDPreferences): GS
 
 function mergePreferences(base: GSDPreferences, override: GSDPreferences): GSDPreferences {
   return {
+    // Preserve validated preference keys that do not need custom merge logic.
+    // The explicit fields below still own defaults, arrays, and deep merges.
+    ...base,
+    ...override,
     version: override.version ?? base.version,
     mode: override.mode ?? base.mode,
     always_use_skills: mergeStringLists(base.always_use_skills, override.always_use_skills),


### PR DESCRIPTION
## TL;DR

**What:** Fixes package test discovery so compiled package source tests win over copied/stale package `dist` tests, and preserves validated top-level GSD preferences during preference merging.
**Why:** `npm run test:packages` could run stale copied `dist` tests, and Context Mode-disabled preferences could be dropped during merge.
**How:** Adds ordered package test selection with regression coverage, and spreads validated preference objects before explicit field-specific merge logic.

## What

- Updates `scripts/run-package-tests.cjs` to choose package test files in this order:
  1. `dist-test/packages/<pkg>/src`
  2. other tests under `dist-test/packages/<pkg>`
  3. package-local `packages/<pkg>/dist`
- Wraps the package test runner body in `main()` so helper selection logic can be imported safely in tests.
- Adds `scripts/__tests__/run-package-tests.test.mjs` covering the package test selection order.
- Updates `src/resources/extensions/gsd/preferences.ts` so `mergePreferences()` preserves validated top-level keys that do not need custom merge logic.

## Why

Closes #6227

While stabilizing the repo test suite, `npm run test:packages` was selecting stale copied tests from `dist-test/packages/<pkg>/dist` instead of the freshly compiled `dist-test/packages/<pkg>/src` tests. That produced false failures in MCP workflow tests and OAuth source-reading tests.

Separately, Context Mode-disabled tests showed that `context_mode.enabled: false` parsed and validated correctly, but was dropped by `mergePreferences()`, making callers treat Context Mode as enabled.

## How

The package runner now prefers compiled source tests when they exist, preserving the existing fallback behavior for packages not covered by `test:compile`.

Preference merging now starts with `...base` and `...override` so validated top-level keys survive. Existing explicit fields still own defaults, array merging, and deep merges.

## Change type checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Test plan

- [x] `node --test scripts/__tests__/run-package-tests.test.mjs`
- [x] `npm run test:compile && node scripts/run-package-tests.cjs`
- [x] Targeted Context Mode/preference regression tests:
  - `guided-flow-prompt-consolidation.test.ts`
  - `register-hooks-compaction-checkpoint.test.ts`
  - `unit-context-composer.test.ts`
  - `uok-gitops-turn-action.test.ts`
- [x] `npm run verify:pr`

## AI-assisted contribution

This PR was AI-assisted. No AI co-author trailer is included in the commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preference merging so validated user preferences are preserved and combined correctly with defaults and array-based settings.

* **Tests**
  * Added regression tests to ensure reliable test-file discovery across different project layouts and compiled vs. source test setups.
  * Made test-runner behavior safer to avoid unintended execution when the script is reused, improving predictable test orchestration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->