### PR TITLE
fix(issue): Silent death on Claude Code: agent-end handler swallows stream-abort placeholder mid-unit

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -324,9 +324,22 @@ export async function handleAgentEnd(
   }
 
   if (isBareClaudeCodeStreamAbortPlaceholder(lastMsg)) {
-    // The Claude Code adapter can emit this placeholder after a prior turn has
-    // already completed and the next unit is active. It has no user/provider
-    // diagnostic value and must not cancel the newly-dispatched unit.
+    if (isSessionSwitchAbortGraceActive()) {
+      // Old turn leaking through after a session switch — drop it.
+      return;
+    }
+
+    // Mid-unit stream abort with no diagnostic. Treat as non-fatal so the loop
+    // can continue, but surface it to the user and resolve the in-flight unit.
+    ctx.ui.notify("Claude Code stream aborted mid-unit (no diagnostic). Continuing.", "warning");
+    try {
+      resetRetryState(retryState);
+      resolveAgentEnd(event);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.ui.notify(`Auto-mode error after stream-abort placeholder: ${message}. Stopping auto-mode.`, "error");
+      try { await pauseAuto(ctx, pi); } catch (e) { logWarning("bootstrap", `pauseAuto failed after stream-abort placeholder: ${(e as Error).message}`); }
+    }
     return;
   }
 

--- a/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
+++ b/src/resources/extensions/gsd/tests/session-switch-abort-misclassification.test.ts
@@ -7,11 +7,19 @@ import assert from "node:assert/strict";
 import {
   _hasEmptyAgentEndContent,
   _handleSessionSwitchAgentEnd,
+  handleAgentEnd,
   isBareClaudeCodeStreamAbortPlaceholder,
   isClaudeCodeSessionSwitchAbortMessage,
 } from "../bootstrap/agent-end-recovery.js";
+import { _setAutoActiveForTest } from "../auto.js";
 import { shouldIgnoreAgentEndForActiveUnit } from "../auto/unit-runner-events.js";
+import { _resetPendingResolve, _setCurrentResolve } from "../auto/resolve.js";
 import type { ErrorContext } from "../auto/types.js";
+
+test.afterEach(() => {
+  _setAutoActiveForTest(false);
+  _resetPendingResolve();
+});
 
 test("user-abort message during session-switch is dropped (not propagated as cancellation)", () => {
   // The Anthropic SDK emits this exact string when newSession() aborts an
@@ -111,6 +119,34 @@ test("late bare Claude Code stream-aborted placeholder is classified as internal
     false,
     "user abort markers outside the session-switch path must not be swallowed",
   );
+});
+
+test("mid-unit bare Claude Code stream-aborted placeholder resolves the unit", async () => {
+  // A placeholder without an active session-switch grace window belongs to the
+  // current unit. Resolving it prevents auto-mode from hanging while still
+  // allowing the next unit to run.
+  const results: unknown[] = [];
+  const warnings: string[] = [];
+  _setAutoActiveForTest(true);
+  _setCurrentResolve((result) => results.push(result));
+
+  const event = {
+    messages: [{
+      stopReason: "aborted",
+      content: [{ type: "text", text: "Claude Code stream aborted by caller" }],
+    }],
+  };
+
+  await handleAgentEnd({} as any, event, {
+    ui: {
+      notify: (message: string, level: string) => {
+        if (level === "warning") warnings.push(message);
+      },
+    },
+  } as any);
+
+  assert.deepEqual(results, [{ status: "completed", event }]);
+  assert.deepEqual(warnings, ["Claude Code stream aborted mid-unit (no diagnostic). Continuing."]);
 });
 
 test("typed session-transition abort events are classified as internal", () => {


### PR DESCRIPTION
## Summary
- Fixed bare Claude Code stream-abort handling to resolve active units with user-visible warning instead of silently returning, and verified with the targeted session-switch abort test suite.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5657
- [#5657 Silent death on Claude Code: agent-end handler swallows stream-abort placeholder mid-unit](https://github.com/gsd-build/gsd-2/issues/5657)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5657-silent-death-on-claude-code-agent-end-ha-1778933309`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of abort scenarios with enhanced error notification and auto-mode recovery mechanisms.
  * Better session transition abort handling to prevent misclassification of abort events.

* **Tests**
  * Added regression test coverage for abort classification edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->