### PR TITLE
fix(issue): [Bug]: Split-brain project identity — verifier resolves to a stale `~/.gsd/projects/<hash>/` while symlink, marker, and notifications use the correct hash

### DIFF
--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -430,19 +430,35 @@ function hasProjectState(externalPath: string): boolean {
 function resolveExternalPathWithRecovery(projectPath: string): string {
   const computedPath = externalGsdRoot(projectPath);
   const computedId = repoIdentity(projectPath);
+  const computedHasState = hasProjectState(computedPath);
+  const markerId = readGsdIdMarker(projectPath);
+  const base = process.env.GSD_STATE_DIR || gsdHome();
+  const markerPath = markerId ? join(base, "projects", markerId) : null;
+  const markerHasState = markerPath ? hasProjectState(markerPath) : false;
+
+  // Split-brain guard: when marker and computed identities disagree and both
+  // directories contain state, prefer the marker-backed directory. This keeps
+  // all writers anchored to a single canonical project identity even if a
+  // transient identity computation produced a stale computed hash.
+  if (
+    markerId
+    && markerPath
+    && markerId !== computedId
+    && markerHasState
+    && computedHasState
+  ) {
+    return markerPath;
+  }
 
   // Check if computed path already has state — fast path, no recovery needed.
-  if (hasProjectState(computedPath)) {
+  if (computedHasState) {
     return computedPath;
   }
 
   // Check for .gsd-id marker from a previous location.
-  const markerId = readGsdIdMarker(projectPath);
-  if (markerId && markerId !== computedId) {
+  if (markerId && markerPath && markerId !== computedId) {
     // The marker points to a different identity — the repo was likely moved.
-    const base = process.env.GSD_STATE_DIR || gsdHome();
-    const markerPath = join(base, "projects", markerId);
-    if (hasProjectState(markerPath)) {
+    if (markerHasState) {
       // Recover: use the old state directory and update the marker to the new identity.
       // Move the state from the old hash dir to the new one so future lookups work
       // without the marker.

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -427,12 +427,12 @@ function hasProjectState(externalPath: string): boolean {
  *
  * Returns the resolved external path (may differ from the computed identity).
  */
-function resolveExternalPathWithRecovery(projectPath: string): string {
-  const computedPath = externalGsdRoot(projectPath);
+function resolveExternalPathWithRecovery(projectPath: string): { path: string; identity: string } {
+  const base = process.env.GSD_STATE_DIR || gsdHome();
   const computedId = repoIdentity(projectPath);
+  const computedPath = join(base, "projects", computedId);
   const computedHasState = hasProjectState(computedPath);
   const markerId = readGsdIdMarker(projectPath);
-  const base = process.env.GSD_STATE_DIR || gsdHome();
   const markerPath = markerId ? join(base, "projects", markerId) : null;
   const markerHasState = markerPath ? hasProjectState(markerPath) : false;
 
@@ -447,12 +447,12 @@ function resolveExternalPathWithRecovery(projectPath: string): string {
     && markerHasState
     && computedHasState
   ) {
-    return markerPath;
+    return { path: markerPath, identity: markerId };
   }
 
   // Check if computed path already has state — fast path, no recovery needed.
   if (computedHasState) {
-    return computedPath;
+    return { path: computedPath, identity: computedId };
   }
 
   // Check for .gsd-id marker from a previous location.
@@ -481,12 +481,12 @@ function resolveExternalPathWithRecovery(projectPath: string): string {
         try { rmSync(markerPath, { recursive: true, force: true }); } catch { /* non-fatal */ }
       } catch {
         // If migration fails, just point at the old directory.
-        return markerPath;
+        return { path: markerPath, identity: markerId };
       }
     }
   }
 
-  return computedPath;
+  return { path: computedPath, identity: computedId };
 }
 
 // ─── Symlink Management ─────────────────────────────────────────────────────
@@ -505,20 +505,21 @@ function resolveExternalPathWithRecovery(projectPath: string): string {
  * Returns the resolved external path.
  */
 export function ensureGsdSymlink(projectPath: string): string {
-  const result = ensureGsdSymlinkCore(projectPath);
+  const { path: result, identity } = ensureGsdSymlinkCore(projectPath);
 
   // Write .gsd-id marker so future relocations can recover this state (#2750).
   // Only write for the project root (not subdirectories or worktrees that
   // delegate to a parent .gsd).
   if (!isInsideWorktree(projectPath)) {
-    writeGsdIdMarker(projectPath, repoIdentity(projectPath));
+    writeGsdIdMarker(projectPath, identity);
   }
 
   return result;
 }
 
-function ensureGsdSymlinkCore(projectPath: string): string {
-  const externalPath = resolveExternalPathWithRecovery(projectPath);
+function ensureGsdSymlinkCore(projectPath: string): { path: string; identity: string } {
+  const resolved = resolveExternalPathWithRecovery(projectPath);
+  const externalPath = resolved.path;
   const localGsd = join(projectPath, ".gsd");
   const inWorktree = isInsideWorktree(projectPath);
 
@@ -535,7 +536,7 @@ function ensureGsdSymlinkCore(projectPath: string): string {
   const localGsdNormalized = normalizeForGuard(localGsd);
   const gsdHomeNorm = normalizeForGuard(gsdHome());
   if (localGsdNormalized === gsdHomeNorm) {
-    return localGsd;
+    return { path: localGsd, identity: resolved.identity };
   }
 
   // Guard: If projectPath is a plain subdirectory (not a worktree) of a git
@@ -554,7 +555,10 @@ function ensureGsdSymlinkCore(projectPath: string): string {
           try {
             const rootStat = lstatSync(rootGsd);
             if (rootStat.isSymbolicLink() || rootStat.isDirectory()) {
-              return rootStat.isSymbolicLink() ? realpathSync(rootGsd) : rootGsd;
+              return {
+                path: rootStat.isSymbolicLink() ? realpathSync(rootGsd) : rootGsd,
+                identity: resolved.identity,
+              };
             }
           } catch {
             // Fall through to normal logic if we can't stat root .gsd
@@ -576,12 +580,12 @@ function ensureGsdSymlinkCore(projectPath: string): string {
   // Write repo metadata once so cleanup commands can identify this directory later.
   writeRepoMeta(externalPath, getRemoteUrl(projectPath), resolveGitRoot(projectPath));
 
-  const replaceWithSymlink = (): string => {
+  const replaceWithSymlink = (): { path: string; identity: string } => {
     rmSync(localGsd, { recursive: true, force: true });
     // Defensive: remove any residual entry (e.g. dangling symlink) before creating.
     try { unlinkSync(localGsd); } catch { /* already gone */ }
     symlinkSync(externalPath, localGsd, "junction");
-    return externalPath;
+    return resolved;
   };
 
   // Check for dangling symlinks (e.g. after relocation recovery removed the old
@@ -601,7 +605,7 @@ function ensureGsdSymlinkCore(projectPath: string): string {
     // Defensive: remove any residual entry to avoid EEXIST race (#2750).
     try { unlinkSync(localGsd); } catch { /* nothing to remove */ }
     symlinkSync(externalPath, localGsd, "junction");
-    return externalPath;
+    return resolved;
   }
 
   try {
@@ -611,7 +615,7 @@ function ensureGsdSymlinkCore(projectPath: string): string {
       // Already a symlink — verify it points to the right place
       const target = realpathSync(localGsd);
       if (target === externalPath) {
-        return externalPath; // correct symlink, no-op
+        return resolved; // correct symlink, no-op
       }
       // In a worktree, mismatched symlinks are always stale. Heal them so
       // the worktree points at the same external state dir as the main repo.
@@ -636,11 +640,11 @@ function ensureGsdSymlinkCore(projectPath: string): string {
           return replaceWithSymlink();
         } catch {
           // Migration failed — preserve old symlink
-          return target;
+          return { path: target, identity: resolved.identity };
         }
       }
       // Outside worktrees, preserve custom overrides or legacy symlinks.
-      return target;
+      return { path: target, identity: resolved.identity };
     }
 
     if (stat.isDirectory()) {
@@ -648,13 +652,13 @@ function ensureGsdSymlinkCore(projectPath: string): string {
       // In worktrees, keep the directory in place and let syncGsdStateToWorktree
       // refresh its contents. Replacing a git-tracked .gsd directory with a
       // symlink makes git think tracked planning files were deleted.
-      return localGsd;
+      return { path: localGsd, identity: resolved.identity };
     }
   } catch {
     // lstat failed — path exists but we can't stat it
   }
 
-  return localGsd;
+  return { path: localGsd, identity: resolved.identity };
 }
 
 // ─── Worktree Detection ─────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
@@ -228,4 +228,30 @@ test('validateProjectId accepts valid values', () => {
     }
 });
 
+test('ensureGsdSymlink prefers marker directory when marker/computed identities diverge and both have state (#5685)', () => {
+    const repo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-split-brain-")));
+    run("git init -b main", repo);
+    run('git config user.name "Pi Test"', repo);
+    run('git config user.email "pi@example.com"', repo);
+    writeFileSync(join(repo, "README.md"), "# Split Brain Test\n", "utf-8");
+    run("git add README.md", repo);
+    run('git commit -m "init"', repo);
+
+    const computedPath = externalGsdRoot(repo);
+    mkdirSync(computedPath, { recursive: true });
+    writeFileSync(join(computedPath, "computed-state.txt"), "computed\n", "utf-8");
+
+    const markerId = "marker-state-id";
+    const markerPath = join(stateDir, "projects", markerId);
+    mkdirSync(markerPath, { recursive: true });
+    writeFileSync(join(markerPath, "marker-state.txt"), "marker\n", "utf-8");
+    writeFileSync(join(repo, ".gsd-id"), `${markerId}\n`, "utf-8");
+
+    const resolved = ensureGsdSymlink(repo);
+    assert.deepStrictEqual(resolved, markerPath, "marker-backed state directory is preferred in split-brain condition");
+    assert.deepStrictEqual(realpathSync(join(repo, ".gsd")), realpathSync(markerPath), ".gsd symlink resolves to marker-backed state directory");
+
+    rmSync(repo, { recursive: true, force: true });
+});
+
 });

--- a/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, existsSync, lstatSync, realpathSync, mkdirSync, symlinkSync, renameSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, lstatSync, realpathSync, mkdirSync, symlinkSync, renameSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
@@ -250,6 +250,7 @@ test('ensureGsdSymlink prefers marker directory when marker/computed identities 
     const resolved = ensureGsdSymlink(repo);
     assert.deepStrictEqual(resolved, markerPath, "marker-backed state directory is preferred in split-brain condition");
     assert.deepStrictEqual(realpathSync(join(repo, ".gsd")), realpathSync(markerPath), ".gsd symlink resolves to marker-backed state directory");
+    assert.deepStrictEqual(readFileSync(join(repo, ".gsd-id"), "utf-8").trim(), markerId, ".gsd-id marker persists the marker-backed identity");
 
     rmSync(repo, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- Added a marker-preference guard in external state resolution and a regression test, then verified with the focused repo-identity worktree test suite (13 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5685
- [#5685 [Bug]: Split-brain project identity — verifier resolves to a stale `~/.gsd/projects/<hash>/` while symlink, marker, and notifications use the correct hash](https://github.com/gsd-build/gsd-2/issues/5685)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5685-bug-split-brain-project-identity-verifie-1778934523`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository identity recovery: when a stored identity marker and a computed identity both have repo state but differ, the marker-backed identity is now chosen to avoid split-brain and ensure symlinks and directories resolve consistently. Resolution now returns both the selected path and its confirmed identity.
* **Tests**
  * Added a unit test covering the marker-vs-computed identity divergence scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->