### PR TITLE
fix(issue): verification-gate: SHELL_INJECTION_PATTERN false positive on semicolons inside python3 -c quoted strings

### DIFF
--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -578,6 +578,7 @@ test("isLikelyCommand: known command prefixes are accepted", () => {
   assert.equal(isLikelyCommand("cargo test"), true);
   assert.equal(isLikelyCommand("go test ./..."), true);
   assert.equal(isLikelyCommand("make test"), true);
+  assert.equal(isLikelyCommand("uv run pytest"), true);
 });
 
 test("isLikelyCommand: path-like first tokens are accepted", () => {
@@ -625,6 +626,11 @@ test("validateVerificationCommand rejects shell control syntax", () => {
   if (!result.ok) {
     assert.match(result.reason, /shell control syntax/);
   }
+});
+
+test("validateVerificationCommand allows semicolons inside quoted python -c code", () => {
+  const result = validateVerificationCommand("uv run python3 -c \"import yaml; yaml.safe_load('x: 1')\"");
+  assert.equal(result.ok, true);
 });
 
 // ─── Additional Preference Validation Tests (T02) ──────────────────────────

--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -633,6 +633,14 @@ test("validateVerificationCommand allows semicolons inside quoted python -c code
   assert.equal(result.ok, true);
 });
 
+test("validateVerificationCommand rejects shell operators after single-quote backslash desync patterns", () => {
+  const result = validateVerificationCommand("echo 'x\\'; ls");
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /shell control syntax/);
+  }
+});
+
 // ─── Additional Preference Validation Tests (T02) ──────────────────────────
 
 test("verification-gate: verification_commands produces no unknown-key warnings", () => {

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -227,6 +227,7 @@ export function formatFailureContext(result: VerificationResult): string {
 /** Characters that indicate shell control syntax when unquoted in a command string. */
 const UNQUOTED_SHELL_CONTROL_CHARS = new Set([";", "|", "<", ">"]);
 
+/** Returns true when command text contains unquoted shell control syntax. */
 function hasUnsafeShellSyntax(cmd: string): boolean {
   // Command substitution remains unsafe even when quoted with double quotes.
   if (cmd.includes("$(") || cmd.includes("`")) return true;
@@ -240,7 +241,7 @@ function hasUnsafeShellSyntax(cmd: string): boolean {
       escaped = false;
       continue;
     }
-    if (ch === "\\") {
+    if (ch === "\\" && !inSingle) {
       escaped = true;
       continue;
     }

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -224,8 +224,41 @@ export function formatFailureContext(result: VerificationResult): string {
 
 // ─── Gate Execution ─────────────────────────────────────────────────────────
 
-/** Characters that indicate shell injection when found in a command string. */
-const SHELL_INJECTION_PATTERN = /[;|`<>]|\$\(/;
+/** Characters that indicate shell control syntax when unquoted in a command string. */
+const UNQUOTED_SHELL_CONTROL_CHARS = new Set([";", "|", "<", ">"]);
+
+function hasUnsafeShellSyntax(cmd: string): boolean {
+  // Command substitution remains unsafe even when quoted with double quotes.
+  if (cmd.includes("$(") || cmd.includes("`")) return true;
+
+  let inSingle = false;
+  let inDouble = false;
+  let escaped = false;
+
+  for (const ch of cmd) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (ch === "\"" && !inSingle) {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (!inSingle && !inDouble && UNQUOTED_SHELL_CONTROL_CHARS.has(ch)) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 /**
  * Known executable first-tokens that are safe to run.
@@ -233,6 +266,7 @@ const SHELL_INJECTION_PATTERN = /[;|`<>]|\$\(/;
  */
 const KNOWN_COMMAND_PREFIXES = new Set([
   "npm", "npx", "yarn", "pnpm", "bun", "bunx", "deno",
+  "uv",
   "node", "ts-node", "tsx", "tsc",
   "sh", "bash", "zsh",
   "echo", "cat", "ls", "test", "true", "false", "pwd", "env",
@@ -301,7 +335,7 @@ export function isLikelyCommand(cmd: string): boolean {
  * Returns the command unchanged if safe, or null if suspicious.
  */
 export function validateVerificationCommand(cmd: string): { ok: true } | { ok: false; reason: string } {
-  if (SHELL_INJECTION_PATTERN.test(cmd)) {
+  if (hasUnsafeShellSyntax(cmd)) {
     return { ok: false, reason: "contains shell control syntax such as pipes, redirects, semicolons, backticks, or command substitution" };
   }
   if (!isLikelyCommand(cmd)) {


### PR DESCRIPTION
## Summary
- Made shell-syntax validation quote-aware and added `uv` prefix support, then verified with the targeted verification-gate test suite (88/88 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6231
- [#6231 verification-gate: SHELL_INJECTION_PATTERN false positive on semicolons inside python3 -c quoted strings](https://github.com/gsd-build/gsd-2/issues/6231)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6231-verification-gate-shell-injection-patter-1778937324`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened command validation to better detect unsafe shell syntax (including command substitution and unquoted control characters) while allowing safe quoted content such as semicolons inside quoted code.
* **Tests**
  * Added tests covering accepted quoted command forms and rejected shell-control injection patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->