### PR TITLE
fix(issue): auto-exit reason normalization buckets every real failure to "other", defeating #4761 orphan detection

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -210,7 +210,11 @@ Artifact verification retries are capped at 3 attempts. If the expected artifact
 - **Metrics analysis** — cost, token counts, and execution time breakdowns
 - **Doctor integration** — includes structural health issues from `/gsd doctor`
 - **Journal correlation** — uses `.gsd/journal/` events such as `unit-start`, `unit-end`, `post-unit-finalize-start`, `post-unit-finalize-end`, and `iteration-end` to show where the loop stopped
+- **Worktree exit telemetry contract** — `auto-exit` journal events now include a normalized `reason` bucket plus `rawReason` (original free-form text) for operator debugging and analytics stability
 - **LLM-guided investigation** — an agent session with full tool access to investigate root causes
+
+Normalized `auto-exit` reason buckets are:
+`pause`, `stop`, `blocked`, `merge-conflict`, `merge-failed`, `slice-merge-conflict`, `provider-error`, `session-failed`, `stream-aborted`, `unit-aborted`, `verification-exhausted`, `all-complete`, `no-active-milestone`, `other`.
 
 ```
 /gsd forensics [optional problem description]

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -280,4 +280,6 @@ Two anomaly types surface from telemetry:
 - `worktree-orphan` — one per orphan reason-bucket
 - `worktree-unmerged-exit` — aggregate signal across the window
 
-For per-event detail (specific milestone IDs, timestamps, exit reasons) inspect `.gsd/journal/*.jsonl` directly.
+For per-event detail (specific milestone IDs, timestamps, exit reasons) inspect `.gsd/journal/*.jsonl` directly. `auto-exit` events now include:
+- `reason`: normalized bucket for stable analytics (`pause`, `stop`, `blocked`, `merge-conflict`, `merge-failed`, `slice-merge-conflict`, `provider-error`, `session-failed`, `stream-aborted`, `unit-aborted`, `verification-exhausted`, `all-complete`, `no-active-milestone`, `other`)
+- `rawReason`: original free-form reason text before normalization, preserved for debugging and audit trails

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1238,7 +1238,8 @@ export async function stopAuto(
     const { emitAutoExit } = await import("./worktree-telemetry.js");
     type AutoExitReason =
       | "pause" | "stop" | "blocked" | "merge-conflict" | "merge-failed"
-      | "slice-merge-conflict" | "all-complete" | "no-active-milestone" | "other";
+      | "slice-merge-conflict" | "provider-error" | "session-failed" | "stream-aborted"
+      | "unit-aborted" | "verification-exhausted" | "all-complete" | "no-active-milestone" | "other";
     // Normalize the free-form reason to a closed set so the telemetry
     // aggregator buckets stably. Raw detail is preserved in the phases.ts
     // notification and the notify'd error string.
@@ -1253,6 +1254,16 @@ export async function stopAuto(
             ? "stop"
           : rawReason.startsWith("slice-merge-conflict")
             ? "slice-merge-conflict"
+            : rawReason.startsWith("Provider error")
+              ? "provider-error"
+              : rawReason.startsWith("Session creation")
+                ? "session-failed"
+                : rawReason.startsWith("Operation aborted") || rawReason.includes("stream aborted")
+                  ? "stream-aborted"
+                  : rawReason.startsWith("Auto-mode stopped")
+                    ? "unit-aborted"
+                    : rawReason.includes("Pausing auto-mode after") && rawReason.includes("retries")
+                      ? "verification-exhausted"
             : rawReason === "All milestones complete"
               ? "all-complete"
               : rawReason === "No active milestone"
@@ -1263,6 +1274,7 @@ export async function stopAuto(
     const telemetryBase = s.originalBasePath || s.basePath;
     emitAutoExit(telemetryBase, {
       reason: normalizedReason,
+      rawReason,
       milestoneId: s.currentMilestoneId ?? undefined,
       milestoneMerged: s.milestoneMergedInPhases === true,
       isolationMode: getIsolationMode(telemetryBase),

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1235,42 +1235,12 @@ export async function stopAuto(
   // worktree was active, and whether the current milestone was merged before
   // stopAuto. The unmerged-work warning is only meaningful for real worktrees.
   try {
-    const { emitAutoExit } = await import("./worktree-telemetry.js");
-    type AutoExitReason =
-      | "pause" | "stop" | "blocked" | "merge-conflict" | "merge-failed"
-      | "slice-merge-conflict" | "provider-error" | "session-failed" | "stream-aborted"
-      | "unit-aborted" | "verification-exhausted" | "all-complete" | "no-active-milestone" | "other";
+    const { emitAutoExit, normalizeAutoExitReason } = await import("./worktree-telemetry.js");
     // Normalize the free-form reason to a closed set so the telemetry
     // aggregator buckets stably. Raw detail is preserved in the phases.ts
     // notification and the notify'd error string.
     const rawReason = reason ?? "stop";
-    const normalizedReason: AutoExitReason = rawReason.startsWith("Blocked:")
-      ? "blocked"
-      : rawReason.startsWith("Merge conflict")
-        ? "merge-conflict"
-        : rawReason.startsWith("Merge error") || rawReason.startsWith("Merge failed")
-          ? "merge-failed"
-          : rawReason.startsWith("Slice-parallel dispatched")
-            ? "stop"
-          : rawReason.startsWith("slice-merge-conflict")
-            ? "slice-merge-conflict"
-            : rawReason.startsWith("Provider error")
-              ? "provider-error"
-              : rawReason.startsWith("Session creation")
-                ? "session-failed"
-                : rawReason.startsWith("Operation aborted") || rawReason.includes("stream aborted")
-                  ? "stream-aborted"
-                  : rawReason.startsWith("Auto-mode stopped")
-                    ? "unit-aborted"
-                    : rawReason.includes("Pausing auto-mode after") && rawReason.includes("retries")
-                      ? "verification-exhausted"
-            : rawReason === "All milestones complete"
-              ? "all-complete"
-              : rawReason === "No active milestone"
-                ? "no-active-milestone"
-                : rawReason === "stop" || rawReason === "pause"
-                  ? rawReason
-                  : "other";
+    const normalizedReason = normalizeAutoExitReason(rawReason);
     const telemetryBase = s.originalBasePath || s.basePath;
     emitAutoExit(telemetryBase, {
       reason: normalizedReason,

--- a/src/resources/extensions/gsd/tests/worktree-telemetry.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-telemetry.test.ts
@@ -87,6 +87,7 @@ test("emitAutoExit records reason and unmerged-work signal", () => {
   try {
     emitAutoExit(base, {
       reason: "pause",
+      rawReason: "Operation aborted",
       milestoneId: "M003",
       milestoneMerged: false,
       isolationMode: "worktree",
@@ -95,6 +96,7 @@ test("emitAutoExit records reason and unmerged-work signal", () => {
     const entries = queryJournal(base, { eventType: "auto-exit" });
     assert.equal(entries.length, 1);
     assert.equal(entries[0].data?.reason, "pause");
+    assert.equal(entries[0].data?.rawReason, "Operation aborted");
     assert.equal(entries[0].data?.milestoneMerged, false);
     assert.equal(entries[0].data?.isolationMode, "worktree");
     assert.equal(entries[0].data?.worktreeActive, true);

--- a/src/resources/extensions/gsd/tests/worktree-telemetry.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-telemetry.test.ts
@@ -18,6 +18,7 @@ import {
   emitWorktreeOrphaned,
   emitAutoExit,
   emitCanonicalRootRedirect,
+  normalizeAutoExitReason,
   summarizeWorktreeTelemetry,
   percentile,
 } from "../worktree-telemetry.ts";
@@ -101,6 +102,19 @@ test("emitAutoExit records reason and unmerged-work signal", () => {
     assert.equal(entries[0].data?.isolationMode, "worktree");
     assert.equal(entries[0].data?.worktreeActive, true);
   } finally { cleanup(base); }
+});
+
+test("normalizeAutoExitReason maps new buckets and ignores casing", () => {
+  const cases: Array<{ rawReason: string; expected: string }> = [
+    { rawReason: "Provider Error: timeout", expected: "provider-error" },
+    { rawReason: "SESSION CREATION failed", expected: "session-failed" },
+    { rawReason: "Operation Aborted by upstream", expected: "stream-aborted" },
+    { rawReason: "AUTO-MODE STOPPED by user", expected: "unit-aborted" },
+    { rawReason: "Pausing Auto-Mode after 3 retries", expected: "verification-exhausted" },
+  ];
+  for (const { rawReason, expected } of cases) {
+    assert.equal(normalizeAutoExitReason(rawReason), expected);
+  }
 });
 
 test("summarizeWorktreeTelemetry only counts unmerged exits from active worktrees", (t) => {

--- a/src/resources/extensions/gsd/worktree-telemetry.ts
+++ b/src/resources/extensions/gsd/worktree-telemetry.ts
@@ -59,6 +59,38 @@ export type AutoExitReason =
   | "no-active-milestone"
   | "other";
 
+export function normalizeAutoExitReason(rawReason?: string): AutoExitReason {
+  const reason = rawReason ?? "stop";
+  const reasonLc = reason.toLowerCase();
+  return reasonLc.startsWith("blocked:")
+    ? "blocked"
+    : reasonLc.startsWith("merge conflict")
+      ? "merge-conflict"
+      : reasonLc.startsWith("merge error") || reasonLc.startsWith("merge failed")
+        ? "merge-failed"
+        : reasonLc.startsWith("slice-parallel dispatched")
+          ? "stop"
+          : reasonLc.startsWith("slice-merge-conflict")
+            ? "slice-merge-conflict"
+            : reasonLc.startsWith("provider error")
+              ? "provider-error"
+              : reasonLc.startsWith("session creation")
+                ? "session-failed"
+                : reasonLc.startsWith("operation aborted") || reasonLc.includes("stream aborted")
+                  ? "stream-aborted"
+                  : reasonLc.startsWith("auto-mode stopped")
+                    ? "unit-aborted"
+                    : reasonLc.includes("pausing auto-mode after") && reasonLc.includes("retries")
+                      ? "verification-exhausted"
+                      : reasonLc === "all milestones complete"
+                        ? "all-complete"
+                        : reasonLc === "no active milestone"
+                          ? "no-active-milestone"
+                          : reasonLc === "stop" || reasonLc === "pause"
+                            ? reasonLc
+                            : "other";
+}
+
 // ─── Emitters ────────────────────────────────────────────────────────────
 
 export function emitWorktreeCreated(

--- a/src/resources/extensions/gsd/worktree-telemetry.ts
+++ b/src/resources/extensions/gsd/worktree-telemetry.ts
@@ -50,6 +50,11 @@ export type AutoExitReason =
   | "merge-conflict"
   | "merge-failed"
   | "slice-merge-conflict"
+  | "provider-error"
+  | "session-failed"
+  | "stream-aborted"
+  | "unit-aborted"
+  | "verification-exhausted"
   | "all-complete"
   | "no-active-milestone"
   | "other";
@@ -125,6 +130,7 @@ export function emitAutoExit(
      *  reasons (e.g. stopAuto's `reason?: string` parameter) should map to
      *  the closed set before emitting. */
     reason: AutoExitReason;
+    rawReason?: string;
     milestoneId?: string;
     milestoneMerged: boolean;
     isolationMode?: WorktreeIsolationMode;
@@ -133,6 +139,7 @@ export function emitAutoExit(
 ): void {
   emitJournalEvent(projectRoot, baseEntry("auto-exit", {
     reason: meta.reason,
+    rawReason: meta.rawReason,
     flowId: meta.flowId,
     milestoneId: meta.milestoneId,
     milestoneMerged: meta.milestoneMerged,


### PR DESCRIPTION
## Summary
- Added explicit auto-exit failure buckets plus `rawReason` telemetry and verified with the focused worktree-telemetry test suite (11/11 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5659
- [#5659 auto-exit reason normalization buckets every real failure to "other", defeating #4761 orphan detection](https://github.com/gsd-build/gsd-2/issues/5659)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5659-auto-exit-reason-normalization-buckets-e-1778940298`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Telemetry: auto-exit reasons are now normalized into stable buckets for analytics, while the original free-form raw reason is preserved in emitted events for debugging and audits.
* **Tests**
  * Added/updated tests to validate normalization mapping and ensure raw reason values appear in telemetry.
* **Documentation**
  * Updated user and developer docs to describe normalized reason buckets and rawReason in auto-exit telemetry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->