### PR TITLE
fix(issue): artifact verification retry counter wiped on overflow allows fresh budget on next dispatch

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1651,7 +1651,18 @@ export async function resolveDispatch(
   // Delegate to registry when available
   try {
     const registry = getRegistry();
-    return annotateBackgroundable(await registry.evaluateDispatch(ctx));
+    const action = annotateBackgroundable(await registry.evaluateDispatch(ctx));
+    if (
+      action.action === "dispatch" &&
+      ctx.session?.exhaustedVerificationUnits.has(`${action.unitType}:${action.unitId}`)
+    ) {
+      return {
+        action: "stop",
+        reason: `Unit ${action.unitId} exhausted verification retries this session.`,
+        level: "error",
+      };
+    }
+    return action;
   } catch (err) {
     // Registry not initialized — fall back to inline loop
     logWarning("dispatch", `registry dispatch failed, falling back to inline rules: ${err instanceof Error ? err.message : String(err)}`);
@@ -1661,7 +1672,19 @@ export async function resolveDispatch(
     const result = await rule.match(ctx);
     if (result) {
       if (result.action !== "skip") result.matchedRule = rule.name;
-      return annotateBackgroundable(result);
+      const action = annotateBackgroundable(result);
+      if (
+        action.action === "dispatch" &&
+        ctx.session?.exhaustedVerificationUnits.has(`${action.unitType}:${action.unitId}`)
+      ) {
+        return {
+          action: "stop",
+          reason: `Unit ${action.unitId} exhausted verification retries this session.`,
+          level: "error",
+          matchedRule: rule.name,
+        };
+      }
+      return action;
     }
   }
 

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1654,7 +1654,7 @@ export async function resolveDispatch(
     const action = annotateBackgroundable(await registry.evaluateDispatch(ctx));
     if (
       action.action === "dispatch" &&
-      ctx.session?.exhaustedVerificationUnits.has(`${action.unitType}:${action.unitId}`)
+      ctx.session?.exhaustedVerificationUnits?.has(`${action.unitType}:${action.unitId}`)
     ) {
       return {
         action: "stop",
@@ -1675,7 +1675,7 @@ export async function resolveDispatch(
       const action = annotateBackgroundable(result);
       if (
         action.action === "dispatch" &&
-        ctx.session?.exhaustedVerificationUnits.has(`${action.unitType}:${action.unitId}`)
+        ctx.session?.exhaustedVerificationUnits?.has(`${action.unitType}:${action.unitId}`)
       ) {
         return {
           action: "stop",

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1321,8 +1321,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
             s.basePath,
           );
           if (attempt > MAX_ARTIFACT_VERIFICATION_RETRIES) {
-            s.verificationRetryCount.delete(retryKey);
-            s.verificationRetryFailureHashes.delete(retryKey);
+            s.exhaustedVerificationUnits.add(retryKey);
             debugLog("postUnit", { phase: "artifact-verify-exhausted", unitType: s.currentUnit.type, unitId: s.currentUnit.id, attempt });
             ctx.ui.notify(
               `${failureDetails} Pausing auto-mode after ${MAX_ARTIFACT_VERIFICATION_RETRIES} retries.`,

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -173,6 +173,7 @@ export class AutoSession {
   pendingVerificationRetry: PendingVerificationRetry | null = null;
   readonly verificationRetryCount = new Map<string, number>();
   readonly verificationRetryFailureHashes = new Map<string, string>();
+  readonly exhaustedVerificationUnits = new Set<string>();
   pausedSessionFile: string | null = null;
   pausedUnitType: string | null = null;
   pausedUnitId: string | null = null;
@@ -353,6 +354,7 @@ export class AutoSession {
     this.pendingVerificationRetry = null;
     this.verificationRetryCount.clear();
     this.verificationRetryFailureHashes.clear();
+    this.exhaustedVerificationUnits.clear();
     this.pausedSessionFile = null;
     this.pausedUnitType = null;
     this.pausedUnitId = null;

--- a/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
@@ -12,7 +12,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 
-import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
+import { DISPATCH_RULES, resolveDispatch, type DispatchContext } from "../auto-dispatch.ts";
+import { AutoSession } from "../auto/session.ts";
 import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
 
 function makeBase(): string {
@@ -88,6 +89,23 @@ describe("completing-milestone dispatch guard (#4324)", () => {
     assert.equal(result?.action, "dispatch");
     assert.equal(result?.unitType, "complete-milestone");
     assert.equal(result?.unitId, "M001");
+  });
+
+  test("resolveDispatch stops complete-milestone when unit is exhausted in-session (#5662)", async () => {
+    base = makeBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Milestone One", status: "active" });
+
+    const ctx = buildDispatchCtx(base);
+    ctx.state.phase = "complete";
+
+    const session = new AutoSession();
+    session.exhaustedVerificationUnits.add("complete-milestone:M001");
+
+    const result = await resolveDispatch({ ...ctx, session });
+
+    assert.equal(result.action, "stop");
+    assert.match(result.reason, /exhausted verification retries this session/i);
   });
 
   test("dispatches complete-milestone when only .gsd/ files exist in git history (#5097)", async () => {


### PR DESCRIPTION
## Summary
- Persisted exhausted verification units and added a dispatch-time stop guard, verified by focused dispatch and retry-cap test suites.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5662
- [#5662 artifact verification retry counter wiped on overflow allows fresh budget on next dispatch](https://github.com/gsd-build/gsd-2/issues/5662)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5662-artifact-verification-retry-counter-wipe-1778940904`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevents redundant dispatch attempts on verification units that have exhausted retries within the same session, reducing unnecessary processing and improving error handling.

* **Tests**
  * Added test coverage for the exhausted verification unit guard behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->