### PR TITLE
fix(issue): retry context grows unbounded — both failure-prose and diagnostic branches prepend without trimming baseline

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -68,6 +68,7 @@ import { resetEvidence, loadEvidenceFromDisk } from "../safety/evidence-collecto
 import { parseUnitId } from "../unit-id.js";
 import { createCheckpoint, cleanupCheckpoint, rollbackToCheckpoint } from "../safety/git-checkpoint.js";
 import { resolveSafetyHarnessConfig } from "../safety/safety-harness.js";
+import { truncateAtSectionBoundary } from "../context-budget.js";
 import {
   getWorkflowTransportSupportError,
   getRequiredWorkflowToolsForAutoUnit,
@@ -81,6 +82,8 @@ import { buildPhaseHandoffOutcome, setAutoOutcomeWidget } from "../auto-dashboar
 import { getConsecutiveDispatchBlocker } from "../dispatch-guard.js";
 
 export const STUCK_WINDOW_SIZE = 6;
+const INLINE_CONTEXT_RATIO = 0.40;
+const VERIFICATION_RETRY_PREFIX_RE = /^\*\*VERIFICATION FAILED — AUTO-FIX ATTEMPT \d+\*\*[\s\S]*?\n\n---\n\n/;
 
 // ─── Path Comparison Helper ───────────────────────────────────────────────
 /** Compare two paths for physical identity, tolerating trailing slashes and symlinks. */
@@ -1872,6 +1875,7 @@ export async function runUnitPhase(
 
   // Prompt injection
   let finalPrompt = prompt;
+  let prependedRetryContext = false;
 
   if (unitType === "execute-task") {
     projectClassification ??= classifyProject(s.basePath);
@@ -1887,6 +1891,9 @@ export async function runUnitPhase(
   if (s.pendingVerificationRetry) {
     const retryCtx = s.pendingVerificationRetry;
     s.pendingVerificationRetry = null;
+    if (retryCtx.attempt >= 2) {
+      finalPrompt = finalPrompt.replace(VERIFICATION_RETRY_PREFIX_RE, "");
+    }
     const retrySpentChars = s.retryContextChars.get(retryCtx.unitId) ?? 0;
     const remaining = Math.max(0, MAX_RECOVERY_CHARS - retrySpentChars);
     const raw =
@@ -1898,6 +1905,7 @@ export async function runUnitPhase(
       : raw;
     s.retryContextChars.set(retryCtx.unitId, retrySpentChars + raw.length);
     if (raw.length > 0) {
+      prependedRetryContext = true;
       finalPrompt = `**VERIFICATION FAILED — AUTO-FIX ATTEMPT ${retryCtx.attempt}**\n\nThe verification gate ran after your previous attempt and found failures. Fix these issues before completing the task.\n\n${capped}\n\n---\n\n${finalPrompt}`;
     }
   }
@@ -1927,6 +1935,7 @@ export async function runUnitPhase(
           diagnostic.length > remaining
             ? raw + "\n\n[...diagnostic truncated to prevent memory exhaustion]"
             : raw;
+        prependedRetryContext = true;
         finalPrompt = `**RETRY — your previous attempt did not produce the required artifact.**\n\nDiagnostic from previous attempt:\n${cappedDiag}\n\nFix whatever went wrong and make sure you write the required file this time.\n\n---\n\n${finalPrompt}`;
       }
     }
@@ -1961,6 +1970,14 @@ export async function runUnitPhase(
       reorderErr instanceof Error ? reorderErr.message : String(reorderErr);
     logWarning("engine", "Prompt reorder failed", { error: msg });
   }
+  if (prependedRetryContext && (s.lastBaselineCharCount ?? 0) > 0) {
+    const baselineChars = s.lastBaselineCharCount ?? 0;
+    const nonBaselineChars = Math.max(0, finalPrompt.length - baselineChars);
+    const baselineBudget = Math.floor(baselineChars * INLINE_CONTEXT_RATIO);
+    const mergedPromptBudget = nonBaselineChars + baselineBudget;
+    finalPrompt = truncateAtSectionBoundary(finalPrompt, mergedPromptBudget).content;
+  }
+  s.lastPromptCharCount = finalPrompt.length;
 
   // Select and apply model (with tier escalation on retry — normal units only)
   const prevUnitRouting = s.currentUnitRouting;

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1887,12 +1887,19 @@ export async function runUnitPhase(
   if (s.pendingVerificationRetry) {
     const retryCtx = s.pendingVerificationRetry;
     s.pendingVerificationRetry = null;
-    const capped =
-      retryCtx.failureContext.length > MAX_RECOVERY_CHARS
-        ? retryCtx.failureContext.slice(0, MAX_RECOVERY_CHARS) +
-          "\n\n[...failure context truncated]"
+    const retrySpentChars = s.retryContextChars.get(retryCtx.unitId) ?? 0;
+    const remaining = Math.max(0, MAX_RECOVERY_CHARS - retrySpentChars);
+    const raw =
+      retryCtx.failureContext.length > remaining
+        ? retryCtx.failureContext.slice(0, remaining)
         : retryCtx.failureContext;
-    finalPrompt = `**VERIFICATION FAILED — AUTO-FIX ATTEMPT ${retryCtx.attempt}**\n\nThe verification gate ran after your previous attempt and found failures. Fix these issues before completing the task.\n\n${capped}\n\n---\n\n${finalPrompt}`;
+    const capped = retryCtx.failureContext.length > remaining
+      ? `${raw}\n\n[...failure context truncated]`
+      : raw;
+    s.retryContextChars.set(retryCtx.unitId, retrySpentChars + raw.length);
+    if (raw.length > 0) {
+      finalPrompt = `**VERIFICATION FAILED — AUTO-FIX ATTEMPT ${retryCtx.attempt}**\n\nThe verification gate ran after your previous attempt and found failures. Fix these issues before completing the task.\n\n${capped}\n\n---\n\n${finalPrompt}`;
+    }
   }
 
   if (s.pendingCrashRecovery) {
@@ -1906,12 +1913,22 @@ export async function runUnitPhase(
   } else if (nextDispatchCount > 1) {
     const diagnostic = deps.getDeepDiagnostic(s.basePath);
     if (diagnostic) {
-      const cappedDiag =
-        diagnostic.length > MAX_RECOVERY_CHARS
-          ? diagnostic.slice(0, MAX_RECOVERY_CHARS) +
-            "\n\n[...diagnostic truncated to prevent memory exhaustion]"
-          : diagnostic;
-      finalPrompt = `**RETRY — your previous attempt did not produce the required artifact.**\n\nDiagnostic from previous attempt:\n${cappedDiag}\n\nFix whatever went wrong and make sure you write the required file this time.\n\n---\n\n${finalPrompt}`;
+      const retrySpentChars = s.retryContextChars.get(unitId) ?? 0;
+      const remaining = Math.max(0, MAX_RECOVERY_CHARS - retrySpentChars);
+      if (remaining <= 0) {
+        // Shared retry context budget exhausted for this unit; skip extra prepend.
+      } else {
+        const raw =
+          diagnostic.length > remaining
+            ? diagnostic.slice(0, remaining)
+            : diagnostic;
+        s.retryContextChars.set(unitId, retrySpentChars + raw.length);
+        const cappedDiag =
+          diagnostic.length > remaining
+            ? raw + "\n\n[...diagnostic truncated to prevent memory exhaustion]"
+            : raw;
+        finalPrompt = `**RETRY — your previous attempt did not produce the required artifact.**\n\nDiagnostic from previous attempt:\n${cappedDiag}\n\nFix whatever went wrong and make sure you write the required file this time.\n\n---\n\n${finalPrompt}`;
+      }
     }
   }
 
@@ -2414,6 +2431,7 @@ export async function runUnitPhase(
   if (artifactVerified) {
     s.unitDispatchCount.delete(dispatchKey);
     s.unitRecoveryCount.delete(`${unitType}/${unitId}`);
+    s.retryContextChars.delete(unitId);
   }
 
   // Write phase handoff anchor after successful research/planning completion

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -171,6 +171,7 @@ export class AutoSession {
   // ── Recovery ─────────────────────────────────────────────────────────────
   pendingCrashRecovery: string | null = null;
   pendingVerificationRetry: PendingVerificationRetry | null = null;
+  readonly retryContextChars = new Map<string, number>();
   readonly verificationRetryCount = new Map<string, number>();
   readonly verificationRetryFailureHashes = new Map<string, string>();
   pausedSessionFile: string | null = null;
@@ -351,6 +352,7 @@ export class AutoSession {
     // Recovery
     this.pendingCrashRecovery = null;
     this.pendingVerificationRetry = null;
+    this.retryContextChars.clear();
     this.verificationRetryCount.clear();
     this.verificationRetryFailureHashes.clear();
     this.pausedSessionFile = null;

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -898,6 +898,7 @@ function makeLoopSession(overrides?: Partial<Record<string, unknown>>) {
     lastBudgetAlertLevel: 0,
     pendingVerificationRetry: null,
     pendingCrashRecovery: null,
+    retryContextChars: new Map<string, number>(),
     verificationRetryFailureHashes: new Map<string, string>(),
     pendingQuickTasks: [],
     sidecarQueue: [],
@@ -2961,6 +2962,100 @@ test("runUnitPhase records failed routing outcome when expected artifact is miss
     [{ unitType: "execute-task", tier: "light", success: false }],
     "routing history must treat missing artifacts as failed outcomes so retries can escalate",
   );
+});
+
+test("runUnitPhase applies a shared retry-context cap across verification failure and diagnostic prepends", async (t) => {
+  _resetPendingResolve();
+
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-retry-context-cap-"));
+  t.after(() => {
+    _resetPendingResolve();
+    rmSync(basePath, { recursive: true, force: true });
+  });
+
+  const unitType = "execute-task";
+  const unitId = "M001/S01/T01";
+  const dispatchKey = `${unitType}/${unitId}`;
+  const failureContext = "F".repeat(40_000);
+  const diagnostic = "D".repeat(20_000);
+
+  const deps = makeMockDeps({
+    getDeepDiagnostic: () => diagnostic,
+  });
+  const ctx = {
+    ...makeMockCtx(),
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setWorkingMessage: () => {},
+    },
+    sessionManager: {
+      getEntries: () => [],
+    },
+    modelRegistry: {
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => true,
+    },
+  } as any;
+
+  let sentPrompt = "";
+  const pi = {
+    ...makeMockPi(),
+    sendMessage: (payload: { content: string }) => {
+      sentPrompt = payload.content;
+      queueMicrotask(() => resolveAgentEnd({ messages: [{ role: "assistant" }] }));
+    },
+  } as any;
+
+  const s = makeLoopSession({
+    basePath,
+    canonicalProjectRoot: basePath,
+    originalBasePath: basePath,
+    pendingVerificationRetry: {
+      unitId,
+      failureContext,
+      attempt: 1,
+    },
+  });
+  s.unitDispatchCount.set(dispatchKey, 1);
+  let seq = 0;
+
+  await runUnitPhase(
+    { ctx, pi, s, deps, prefs: undefined, iteration: 1, flowId: "flow-retry-cap", nextSeq: () => ++seq },
+    {
+      unitType,
+      unitId,
+      prompt: "base prompt",
+      finalPrompt: "base prompt",
+      pauseAfterUatDispatch: false,
+      state: {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Milestone" },
+        activeSlice: { id: "S01", title: "Slice" },
+        activeTask: { id: "T01", title: "Task" },
+        registry: [{ id: "M001", title: "Milestone", status: "active" }],
+        recentDecisions: [],
+        blockers: [],
+        nextAction: "",
+        progress: { milestones: { done: 0, total: 1 } },
+        requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+      } as any,
+      mid: "M001",
+      midTitle: "Milestone",
+      isRetry: false,
+      previousTier: undefined,
+    },
+    { recentUnits: [], stuckRecoveryAttempts: 0, consecutiveFinalizeTimeouts: 0 },
+  );
+
+  assert.equal(
+    s.retryContextChars.get(unitId),
+    50_000,
+    "shared retry context spend should cap at MAX_RECOVERY_CHARS",
+  );
+  assert.match(sentPrompt, /VERIFICATION FAILED — AUTO-FIX ATTEMPT 1/);
+  assert.match(sentPrompt, /RETRY — your previous attempt did not produce the required artifact/);
+  assert.match(sentPrompt, /\[\.\.\.diagnostic truncated to prevent memory exhaustion\]/);
 });
 
 test("resolveAgentEndCancelled without args produces no errorContext field", async () => {

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2976,11 +2976,18 @@ test("runUnitPhase applies a shared retry-context cap across verification failur
   const unitType = "execute-task";
   const unitId = "M001/S01/T01";
   const dispatchKey = `${unitType}/${unitId}`;
-  const failureContext = "F".repeat(40_000);
-  const diagnostic = "D".repeat(20_000);
+  const failureContext = "F".repeat(10_000);
+  const diagnostic = "D".repeat(35_000);
+
+  mkdirSync(join(basePath, ".gsd"), { recursive: true });
+  const baselineSection = `### Baseline\n${"B".repeat(120)}\n\n`;
+  writeFileSync(join(basePath, ".gsd", "decisions.md"), baselineSection, "utf8");
+  writeFileSync(join(basePath, ".gsd", "requirements.md"), baselineSection, "utf8");
+  writeFileSync(join(basePath, ".gsd", "project.md"), baselineSection, "utf8");
 
   const deps = makeMockDeps({
     getDeepDiagnostic: () => diagnostic,
+    isDbAvailable: () => true,
   });
   const ctx = {
     ...makeMockCtx(),
@@ -2998,11 +3005,11 @@ test("runUnitPhase applies a shared retry-context cap across verification failur
     },
   } as any;
 
-  let sentPrompt = "";
+  const sentPrompts: string[] = [];
   const pi = {
     ...makeMockPi(),
     sendMessage: (payload: { content: string }) => {
-      sentPrompt = payload.content;
+      sentPrompts.push(payload.content);
       queueMicrotask(() => resolveAgentEnd({ messages: [{ role: "assistant" }] }));
     },
   } as any;
@@ -3020,31 +3027,44 @@ test("runUnitPhase applies a shared retry-context cap across verification failur
   s.unitDispatchCount.set(dispatchKey, 1);
   let seq = 0;
 
+  const iterData = {
+    unitType,
+    unitId,
+    prompt: "base prompt",
+    finalPrompt: "base prompt",
+    pauseAfterUatDispatch: false,
+    state: {
+      phase: "executing",
+      activeMilestone: { id: "M001", title: "Milestone" },
+      activeSlice: { id: "S01", title: "Slice" },
+      activeTask: { id: "T01", title: "Task" },
+      registry: [{ id: "M001", title: "Milestone", status: "active" }],
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "",
+      progress: { milestones: { done: 0, total: 1 } },
+      requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+    } as any,
+    mid: "M001",
+    midTitle: "Milestone",
+    isRetry: false,
+    previousTier: undefined,
+  } as const;
+
   await runUnitPhase(
     { ctx, pi, s, deps, prefs: undefined, iteration: 1, flowId: "flow-retry-cap", nextSeq: () => ++seq },
-    {
-      unitType,
-      unitId,
-      prompt: "base prompt",
-      finalPrompt: "base prompt",
-      pauseAfterUatDispatch: false,
-      state: {
-        phase: "executing",
-        activeMilestone: { id: "M001", title: "Milestone" },
-        activeSlice: { id: "S01", title: "Slice" },
-        activeTask: { id: "T01", title: "Task" },
-        registry: [{ id: "M001", title: "Milestone", status: "active" }],
-        recentDecisions: [],
-        blockers: [],
-        nextAction: "",
-        progress: { milestones: { done: 0, total: 1 } },
-        requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
-      } as any,
-      mid: "M001",
-      midTitle: "Milestone",
-      isRetry: false,
-      previousTier: undefined,
-    },
+    iterData,
+    { recentUnits: [], stuckRecoveryAttempts: 0, consecutiveFinalizeTimeouts: 0 },
+  );
+
+  s.pendingVerificationRetry = {
+    unitId,
+    failureContext: "SECOND_FAILURE_CONTEXT",
+    attempt: 2,
+  };
+  await runUnitPhase(
+    { ctx, pi, s, deps, prefs: undefined, iteration: 2, flowId: "flow-retry-cap-2", nextSeq: () => ++seq },
+    iterData,
     { recentUnits: [], stuckRecoveryAttempts: 0, consecutiveFinalizeTimeouts: 0 },
   );
 
@@ -3053,9 +3073,12 @@ test("runUnitPhase applies a shared retry-context cap across verification failur
     50_000,
     "shared retry context spend should cap at MAX_RECOVERY_CHARS",
   );
-  assert.match(sentPrompt, /VERIFICATION FAILED — AUTO-FIX ATTEMPT 1/);
-  assert.match(sentPrompt, /RETRY — your previous attempt did not produce the required artifact/);
-  assert.match(sentPrompt, /\[\.\.\.diagnostic truncated to prevent memory exhaustion\]/);
+  const firstPrompt = sentPrompts[0] ?? "";
+  const secondPrompt = sentPrompts[1] ?? "";
+  assert.match(firstPrompt, /VERIFICATION FAILED — AUTO-FIX ATTEMPT 1/);
+  assert.match(firstPrompt, /RETRY — your previous attempt did not produce the required artifact/);
+  assert.match(secondPrompt, /VERIFICATION FAILED — AUTO-FIX ATTEMPT 2/);
+  assert.doesNotMatch(secondPrompt, /AUTO-FIX ATTEMPT 1/);
 });
 
 test("resolveAgentEndCancelled without args produces no errorContext field", async () => {


### PR DESCRIPTION
## Summary
- Added a shared per-unit retry-context character cap across verification and diagnostic prompt prepends and validated it with a targeted auto-loop regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5669
- [#5669 retry context grows unbounded — both failure-prose and diagnostic branches prepend without trimming baseline](https://github.com/gsd-build/gsd-2/issues/5669)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5669-retry-context-grows-unbounded-both-failu-1778942103`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced per-unit retry character budgeting to cap injected retry context and avoid carrying prior-attempt markers.
  * More careful prompt truncation to preserve baseline content when prepending retry context.
  * Clears per-unit retry budgeting state after successful verification to prevent cross-run carryover.

* **Tests**
  * Added regression coverage verifying capped retry-context spend and correct prompt markers across consecutive retries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->