### PR TITLE
fix(issue): verification retry budget is count-only — no per-unit cost cap allows 6× cost spikes

### DIFF
--- a/src/resources/extensions/gsd/auto-budget.ts
+++ b/src/resources/extensions/gsd/auto-budget.ts
@@ -30,3 +30,14 @@ export function getBudgetEnforcementAction(
   if (enforcement === "pause") return "pause";
   return "warn";
 }
+
+export function getUnitCostSpikeAction(
+  unitCostUsd: number,
+  rollingAvgUsd: number,
+  multiplier = 3.0,
+): "none" | "pause" {
+  if (!Number.isFinite(unitCostUsd) || unitCostUsd < 0) return "none";
+  if (!Number.isFinite(rollingAvgUsd) || rollingAvgUsd <= 0) return "none";
+  if (!Number.isFinite(multiplier) || multiplier <= 0) return "none";
+  return unitCostUsd >= (rollingAvgUsd * multiplier) ? "pause" : "none";
+}

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -84,6 +84,8 @@ import {
 } from "./project-research-policy.js";
 import { validateArtifact } from "./schemas/validate.js";
 import { verificationRetryKey } from "./auto/verification-retry-policy.js";
+import { getLedger } from "./metrics.js";
+import { getUnitCostSpikeAction } from "./auto-budget.js";
 
 // ─── Path Comparison Helper ───────────────────────────────────────────────
 /** Compare two paths for physical identity, tolerating trailing slashes and symlinks. */
@@ -110,6 +112,28 @@ function formatPreExecutionCheckDetail(check: PreExecutionCheckJSON): string {
 const COMPLETE_MILESTONE_DB_SETTLE_MS = 1500;
 const COMPLETE_MILESTONE_DB_SETTLE_POLL_MS = 100;
 const GIT_ACTION_FAILURE_LOG_REL_PATH = ".gsd/git-action-failures.log";
+const DEFAULT_PER_UNIT_COST_CAP_USD = 5.0;
+
+function getCurrentUnitCostStats(unitId: string): { unitCostUsd: number; rollingAvgUsd: number } {
+  const ledger = getLedger();
+  if (!ledger || !Array.isArray(ledger.units) || ledger.units.length === 0) {
+    return { unitCostUsd: 0, rollingAvgUsd: 0 };
+  }
+  let unitCostUsd = 0;
+  let totalCost = 0;
+  let totalUnits = 0;
+  for (const unit of ledger.units) {
+    const cost = typeof unit?.cost === "number" ? unit.cost : 0;
+    if (!Number.isFinite(cost) || cost < 0) continue;
+    totalCost += cost;
+    totalUnits++;
+    if (unit?.id === unitId) unitCostUsd += cost;
+  }
+  return {
+    unitCostUsd,
+    rollingAvgUsd: totalUnits > 0 ? totalCost / totalUnits : 0,
+  };
+}
 
 function persistGitActionFailure(basePath: string, action: TurnGitActionMode, message: string): string {
   const logPath = join(basePath, GIT_ACTION_FAILURE_LOG_REL_PATH);
@@ -1257,6 +1281,34 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         const hasExpectedArtifact = resolveExpectedArtifactPath(s.currentUnit.type, s.currentUnit.id, s.basePath) !== null;
         if (hasExpectedArtifact) {
           const retryKey = `${s.currentUnit.type}:${s.currentUnit.id}`;
+          const prefs = loadEffectiveGSDPreferences()?.preferences;
+          const perUnitCapUsd =
+            typeof prefs?.per_unit_cost_cap_usd === "number" && Number.isFinite(prefs.per_unit_cost_cap_usd) && prefs.per_unit_cost_cap_usd > 0
+              ? prefs.per_unit_cost_cap_usd
+              : DEFAULT_PER_UNIT_COST_CAP_USD;
+          const { unitCostUsd, rollingAvgUsd } = getCurrentUnitCostStats(s.currentUnit.id);
+          if (unitCostUsd >= perUnitCapUsd) {
+            s.pendingVerificationRetry = null;
+            s.verificationRetryCount.delete(retryKey);
+            s.verificationRetryFailureHashes.delete(retryKey);
+            ctx.ui.notify(
+              `Unit ${s.currentUnit.id} hit per-unit cap $${perUnitCapUsd.toFixed(2)} — pausing auto-mode.`,
+              "error",
+            );
+            await pauseAuto(ctx, pi);
+            return "dispatched";
+          }
+          if (getUnitCostSpikeAction(unitCostUsd, rollingAvgUsd, 3.0) === "pause") {
+            s.pendingVerificationRetry = null;
+            s.verificationRetryCount.delete(retryKey);
+            s.verificationRetryFailureHashes.delete(retryKey);
+            ctx.ui.notify(
+              `Unit ${s.currentUnit.id} cost spike detected (${unitCostUsd.toFixed(2)} vs avg ${rollingAvgUsd.toFixed(2)}) — pausing auto-mode.`,
+              "error",
+            );
+            await pauseAuto(ctx, pi);
+            return "dispatched";
+          }
           const attempt = (s.verificationRetryCount.get(retryKey) ?? 0) + 1;
           const failureDetails = describeArtifactVerificationFailure(
             s.currentUnit.type,

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -47,6 +47,8 @@ import { decideVerificationVerdict } from "./verification-verdict.js";
 import { createRepositoryRegistryFromPreferences } from "./repository-registry.js";
 import type { SliceRow } from "./db-task-slice-rows.js";
 import { getSlice } from "./gsd-db.js";
+import { getLedger } from "./metrics.js";
+import { getUnitCostSpikeAction } from "./auto-budget.js";
 
 export interface VerificationContext {
   s: AutoSession;
@@ -55,6 +57,27 @@ export interface VerificationContext {
 }
 
 export type VerificationResult = "continue" | "retry" | "pause";
+
+function getCurrentUnitCostStats(unitId: string): { unitCostUsd: number; rollingAvgUsd: number } {
+  const ledger = getLedger();
+  if (!ledger || !Array.isArray(ledger.units) || ledger.units.length === 0) {
+    return { unitCostUsd: 0, rollingAvgUsd: 0 };
+  }
+  let unitCostUsd = 0;
+  let totalCost = 0;
+  let totalUnits = 0;
+  for (const unit of ledger.units) {
+    const cost = typeof unit?.cost === "number" ? unit.cost : 0;
+    if (!Number.isFinite(cost) || cost < 0) continue;
+    totalCost += cost;
+    totalUnits++;
+    if (unit?.id === unitId) unitCostUsd += cost;
+  }
+  return {
+    unitCostUsd,
+    rollingAvgUsd: totalUnits > 0 ? totalCost / totalUnits : 0,
+  };
+}
 
 function resolveVerificationTargets(
   basePath: string,
@@ -663,6 +686,33 @@ export async function runPostUnitVerification(
       await pauseAuto(ctx, pi);
       return "pause";
     } else if (autoFixEnabled && attempt + 1 <= maxRetries) {
+      const { unitCostUsd, rollingAvgUsd } = getCurrentUnitCostStats(s.currentUnit.id);
+      const perUnitCapUsd =
+        typeof prefs?.per_unit_cost_cap_usd === "number" && Number.isFinite(prefs.per_unit_cost_cap_usd) && prefs.per_unit_cost_cap_usd > 0
+          ? prefs.per_unit_cost_cap_usd
+          : 5.0;
+      if (unitCostUsd >= perUnitCapUsd) {
+        s.verificationRetryCount.delete(retryKey);
+        s.verificationRetryFailureHashes.delete(retryKey);
+        s.pendingVerificationRetry = null;
+        ctx.ui.notify(
+          `Unit ${s.currentUnit.id} hit per-unit cap $${perUnitCapUsd.toFixed(2)} — pausing auto-mode.`,
+          "error",
+        );
+        await pauseAuto(ctx, pi);
+        return "pause";
+      }
+      if (getUnitCostSpikeAction(unitCostUsd, rollingAvgUsd, 3.0) === "pause") {
+        s.verificationRetryCount.delete(retryKey);
+        s.verificationRetryFailureHashes.delete(retryKey);
+        s.pendingVerificationRetry = null;
+        ctx.ui.notify(
+          `Unit ${s.currentUnit.id} cost spike detected (${unitCostUsd.toFixed(2)} vs avg ${rollingAvgUsd.toFixed(2)}) — pausing auto-mode.`,
+          "error",
+        );
+        await pauseAuto(ctx, pi);
+        return "pause";
+      }
       const nextAttempt = attempt + 1;
       s.verificationRetryCount.set(retryKey, nextAttempt);
       s.pendingVerificationRetry = {

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -254,6 +254,8 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
 
 - `verification_max_retries`: number — maximum number of fix-and-retry cycles for verification failures. Default: `0` (no retries).
 
+- `per_unit_cost_cap_usd`: number — per-unit retry cost ceiling in USD for verification retries. Must be a positive finite number when set; invalid values are rejected during preference validation. Default: `5.0`. During auto-verification and artifact-retry flows, auto-mode pauses when the current unit reaches this cap or when current unit cost spikes to at least `3.0x` the rolling average.
+
 - `uat_dispatch`: boolean — when `true`, enables UAT (User Acceptance Testing) dispatch mode. Default: `false`.
 
 - `post_unit_hooks`: array — hooks that fire after a unit completes. Each entry has:

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -410,6 +410,7 @@ export interface GSDPreferences {
   verification_commands?: string[];
   verification_auto_fix?: boolean;
   verification_max_retries?: number;
+  per_unit_cost_cap_usd?: number;
   /** Search provider preference. "brave"/"tavily"/"ollama" force that backend and disable native Anthropic search. "native" forces native only. "auto" = current default behavior. */
   search_provider?: "brave" | "tavily" | "ollama" | "native" | "auto";
   /** Context selection mode for file inlining. "full" inlines entire files, "smart" uses semantic chunking. Default derived from token profile. */

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -124,6 +124,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "verification_commands",
   "verification_auto_fix",
   "verification_max_retries",
+  "per_unit_cost_cap_usd",
   "search_provider",
   "context_selection",
   "widget_mode",

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -926,6 +926,15 @@ export function validatePreferences(preferences: GSDPreferences): {
     }
   }
 
+  if (preferences.per_unit_cost_cap_usd !== undefined) {
+    const raw = preferences.per_unit_cost_cap_usd;
+    if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+      validated.per_unit_cost_cap_usd = raw;
+    } else {
+      errors.push("per_unit_cost_cap_usd must be a positive number");
+    }
+  }
+
   // ─── Git Preferences ───────────────────────────────────────────────────
   if (preferences.git && typeof preferences.git === "object") {
     const git: Record<string, unknown> = {};

--- a/src/resources/extensions/gsd/templates/PREFERENCES.md
+++ b/src/resources/extensions/gsd/templates/PREFERENCES.md
@@ -69,6 +69,7 @@ parallel:
 verification_commands: []
 verification_auto_fix:
 verification_max_retries:
+per_unit_cost_cap_usd:
 notifications:
   enabled:
   on_complete:

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -58,6 +58,7 @@ const PREF_SAMPLE_VALUES: Record<string, unknown> = {
   verification_commands: ["npm test"],
   verification_auto_fix: true,
   verification_max_retries: 1,
+  per_unit_cost_cap_usd: 5,
   search_provider: "web",
   context_selection: "auto",
   widget_mode: "small",

--- a/src/tests/auto-budget.test.ts
+++ b/src/tests/auto-budget.test.ts
@@ -88,5 +88,19 @@ describe("auto-budget", () => {
       assert.equal(getUnitCostSpikeAction(10, 0), "none");
       assert.equal(getUnitCostSpikeAction(10, Number.NaN), "none");
     });
+
+    it("returns none for invalid unit costs", () => {
+      assert.equal(getUnitCostSpikeAction(-1, 1), "none");
+      assert.equal(getUnitCostSpikeAction(Number.NEGATIVE_INFINITY, 1), "none");
+      assert.equal(getUnitCostSpikeAction(Number.POSITIVE_INFINITY, 1), "none");
+      assert.equal(getUnitCostSpikeAction(Number.NaN, 1), "none");
+    });
+
+    it("returns none for invalid multipliers", () => {
+      assert.equal(getUnitCostSpikeAction(10, 1, 0), "none");
+      assert.equal(getUnitCostSpikeAction(10, 1, -1), "none");
+      assert.equal(getUnitCostSpikeAction(10, 1, Number.NEGATIVE_INFINITY), "none");
+      assert.equal(getUnitCostSpikeAction(10, 1, Number.NaN), "none");
+    });
   });
 });

--- a/src/tests/auto-budget.test.ts
+++ b/src/tests/auto-budget.test.ts
@@ -1,6 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { getBudgetAlertLevel, getNewBudgetAlertLevel, getBudgetEnforcementAction } from "../resources/extensions/gsd/auto-budget.js";
+import {
+  getBudgetAlertLevel,
+  getNewBudgetAlertLevel,
+  getBudgetEnforcementAction,
+  getUnitCostSpikeAction,
+} from "../resources/extensions/gsd/auto-budget.js";
 
 describe("auto-budget", () => {
   describe("getBudgetAlertLevel", () => {
@@ -66,6 +71,22 @@ describe("auto-budget", () => {
 
     it("returns warn when at ceiling with warn enforcement", () => {
       assert.equal(getBudgetEnforcementAction("warn", 1.0), "warn");
+    });
+  });
+
+  describe("getUnitCostSpikeAction", () => {
+    it("returns none when below spike threshold", () => {
+      assert.equal(getUnitCostSpikeAction(2.9, 1.0), "none");
+    });
+
+    it("returns pause when at or above threshold", () => {
+      assert.equal(getUnitCostSpikeAction(3.0, 1.0), "pause");
+      assert.equal(getUnitCostSpikeAction(6.5, 2.0), "pause");
+    });
+
+    it("returns none for invalid averages", () => {
+      assert.equal(getUnitCostSpikeAction(10, 0), "none");
+      assert.equal(getUnitCostSpikeAction(10, Number.NaN), "none");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Added per-unit cost-cap and 3x rolling-average spike guards before verification/artifact retries, with focused passing tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5668
- [#5668 verification retry budget is count-only — no per-unit cost cap allows 6× cost spikes](https://github.com/gsd-build/gsd-2/issues/5668)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5668-verification-retry-budget-is-count-only--1778942700`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-unit cost cap preference to control spending in auto-mode.
  * Auto-mode now pauses when a unit reaches the per-unit cost cap or when a unit cost spikes relative to the rolling average.

* **Documentation**
  * Updated preferences schema and reference to include the new per-unit cost cap, validation rules, and default value.

* **Tests**
  * Added tests covering cost-spike detection and validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->