### PR TITLE
fix(issue): findStaleWorkerForProject masks dead PIDs behind 60s heartbeat gate (db/auto-workers.js:200)

### DIFF
--- a/src/resources/extensions/gsd/db/auto-workers.ts
+++ b/src/resources/extensions/gsd/db/auto-workers.ts
@@ -251,13 +251,11 @@ function isWorkerProcessAlive(candidate: Pick<AutoWorkerRow, "host" | "pid">): b
 
 /**
  * Phase C pt 2 — find the most-recent active worker for a project root and
- * return it when stale.
+ * return it when its PID is stale.
  *
  * Used by crash-recovery.ts:readCrashLock to detect when a prior auto-mode
- * session ended without cleanup. Staleness is evaluated in two independent
- * ways: (1) the worker PID is not alive via isWorkerProcessAlive(), or
- * (2) the heartbeat has expired by HEARTBEAT_TTL_SECONDS
- * (Date.parse(last_heartbeat_at) < cutoffMs).
+ * session ended without cleanup. A dead PID is enough to mark the worker
+ * stale immediately; the heartbeat TTL must not hide a crashed process.
  *
  * Returns null when DB is unavailable or when no stale worker exists for this
  * project root.
@@ -267,7 +265,6 @@ export function findStaleWorkerForProject(
 ): AutoWorkerRow | null {
   if (!isDbAvailable()) return null;
   const db = _getAdapter()!;
-  const cutoffMs = Date.now() - HEARTBEAT_TTL_SECONDS * 1000;
   const row = db.prepare(
     `SELECT worker_id, host, pid, started_at, version,
             last_heartbeat_at, status, project_root_realpath
@@ -278,7 +275,6 @@ export function findStaleWorkerForProject(
      LIMIT 1`,
   ).get({ ":project_root": projectRootRealpath }) as AutoWorkerRow | undefined;
   if (row && !isWorkerProcessAlive(row)) return row;
-  if (row && Date.parse(row.last_heartbeat_at) < cutoffMs) return row;
 
   // Older rows and external fixtures may have captured a non-realpath spelling
   // of the same project root, e.g. /var/... vs /private/var/... on macOS.
@@ -293,9 +289,6 @@ export function findStaleWorkerForProject(
   return activeRows.find(
     (candidate) =>
       normalizeRealPath(candidate.project_root_realpath) === canonicalProjectRoot
-      && (
-        !isWorkerProcessAlive(candidate)
-        || Date.parse(candidate.last_heartbeat_at) < cutoffMs
-      ),
+      && !isWorkerProcessAlive(candidate),
   ) ?? null;
 }

--- a/src/resources/extensions/gsd/db/auto-workers.ts
+++ b/src/resources/extensions/gsd/db/auto-workers.ts
@@ -268,7 +268,6 @@ export function findStaleWorkerForProject(
   if (!isDbAvailable()) return null;
   const db = _getAdapter()!;
   const cutoffMs = Date.now() - HEARTBEAT_TTL_SECONDS * 1000;
-  const cutoffIso = new Date(cutoffMs).toISOString();
   const row = db.prepare(
     `SELECT worker_id, host, pid, started_at, version,
             last_heartbeat_at, status, project_root_realpath

--- a/src/resources/extensions/gsd/db/auto-workers.ts
+++ b/src/resources/extensions/gsd/db/auto-workers.ts
@@ -250,15 +250,17 @@ function isWorkerProcessAlive(candidate: Pick<AutoWorkerRow, "host" | "pid">): b
 }
 
 /**
- * Phase C pt 2 — find the most recently active worker for a project root
- * whose heartbeat has lapsed (the "previous crashed session" indicator).
+ * Phase C pt 2 — find the most-recent active worker for a project root and
+ * return it when stale.
  *
  * Used by crash-recovery.ts:readCrashLock to detect when a prior auto-mode
- * session ended without cleanup. Workers are only treated as stale after
- * their heartbeat has lapsed and the OS PID liveness check says the process
- * is no longer alive.
+ * session ended without cleanup. Staleness is evaluated in two independent
+ * ways: (1) the worker PID is not alive via isWorkerProcessAlive(), or
+ * (2) the heartbeat has expired by HEARTBEAT_TTL_SECONDS
+ * (Date.parse(last_heartbeat_at) < cutoffMs).
  *
- * Returns null if no stale worker exists for this project root.
+ * Returns null when DB is unavailable or when no stale worker exists for this
+ * project root.
  */
 export function findStaleWorkerForProject(
   projectRootRealpath: string,

--- a/src/resources/extensions/gsd/db/auto-workers.ts
+++ b/src/resources/extensions/gsd/db/auto-workers.ts
@@ -273,26 +273,28 @@ export function findStaleWorkerForProject(
      FROM workers
      WHERE project_root_realpath = :project_root
        AND status = 'active'
-       AND last_heartbeat_at < :cutoff
      ORDER BY started_at DESC
      LIMIT 1`,
-  ).get({ ":project_root": projectRootRealpath, ":cutoff": cutoffIso }) as AutoWorkerRow | undefined;
+  ).get({ ":project_root": projectRootRealpath }) as AutoWorkerRow | undefined;
   if (row && !isWorkerProcessAlive(row)) return row;
+  if (row && Date.parse(row.last_heartbeat_at) < cutoffMs) return row;
 
   // Older rows and external fixtures may have captured a non-realpath spelling
   // of the same project root, e.g. /var/... vs /private/var/... on macOS.
   const canonicalProjectRoot = normalizeRealPath(projectRootRealpath);
-  const staleRows = db.prepare(
+  const activeRows = db.prepare(
     `SELECT worker_id, host, pid, started_at, version,
             last_heartbeat_at, status, project_root_realpath
      FROM workers
      WHERE status = 'active'
-       AND last_heartbeat_at < :cutoff
      ORDER BY started_at DESC`,
-  ).all({ ":cutoff": cutoffIso }) as unknown as AutoWorkerRow[];
-  return staleRows.find(
+  ).all() as unknown as AutoWorkerRow[];
+  return activeRows.find(
     (candidate) =>
       normalizeRealPath(candidate.project_root_realpath) === canonicalProjectRoot
-      && !isWorkerProcessAlive(candidate),
+      && (
+        !isWorkerProcessAlive(candidate)
+        || Date.parse(candidate.last_heartbeat_at) < cutoffMs
+      ),
   ) ?? null;
 }

--- a/src/resources/extensions/gsd/tests/auto-workers.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-workers.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { hostname, tmpdir } from "node:os";
 
 import { openDatabase, closeDatabase } from "../gsd-db.ts";
 import { _getAdapter } from "../gsd-db.ts";
@@ -16,6 +16,7 @@ import {
   markWorkerStoppingByPid,
   getActiveAutoWorkers,
   getAutoWorker,
+  findStaleWorkerForProject,
 } from "../db/auto-workers.ts";
 
 function makeBase(): string {
@@ -115,4 +116,34 @@ test("getActiveAutoWorkers filters by status and TTL", (t) => {
   const after = getActiveAutoWorkers();
   assert.equal(after.length, 1);
   assert.equal(after[0].worker_id, b);
+});
+
+test("findStaleWorkerForProject returns dead PID even with fresh heartbeat", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const workerId = "auto-dead-pid-fresh-heartbeat";
+  const now = new Date().toISOString();
+  _getAdapter()!.prepare(
+    `INSERT INTO workers (
+      worker_id, host, pid, started_at, version,
+      last_heartbeat_at, status, project_root_realpath
+    ) VALUES (
+      :worker_id, :host, :pid, :started_at, :version,
+      :last_heartbeat_at, 'active', :project_root_realpath
+    )`,
+  ).run({
+    ":worker_id": workerId,
+    ":host": hostname(),
+    ":pid": 9_999_999,
+    ":started_at": now,
+    ":version": "1",
+    ":last_heartbeat_at": now,
+    ":project_root_realpath": base,
+  });
+
+  const stale = findStaleWorkerForProject(base);
+  assert.ok(stale, "dead PID should be surfaced immediately");
+  assert.equal(stale!.worker_id, workerId);
 });


### PR DESCRIPTION
## Summary
- Removed the heartbeat-age gate before PID liveness in stale worker detection and added a passing regression test for dead PID with fresh heartbeat.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5665
- [#5665 findStaleWorkerForProject masks dead PIDs behind 60s heartbeat gate (db/auto-workers.js:200)](https://github.com/gsd-build/gsd-2/issues/5665)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5665-findstaleworkerforproject-masks-dead-pid-1778943901`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated auto-mode session staleness detection to rely on process liveness (PID) rather than heartbeat age; selects the most recently started active session when evaluating staleness.

* **Tests**
  * Added test confirming a worker with a dead process is considered stale even if its heartbeat timestamp is recent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->