### PR TITLE
fix(issue): findStaleWorkerForProject masks dead PIDs behind 60s heartbeat gate (db/auto-workers.js:200)

### DIFF
--- a/src/resources/extensions/gsd/db/auto-workers.ts
+++ b/src/resources/extensions/gsd/db/auto-workers.ts
@@ -267,6 +267,18 @@ export function findStaleWorkerForProject(
   const db = _getAdapter()!;
   const cutoffMs = Date.now() - HEARTBEAT_TTL_SECONDS * 1000;
   const cutoffIso = new Date(cutoffMs).toISOString();
+
+  const latestActiveRow = db.prepare(
+    `SELECT worker_id, host, pid, started_at, version,
+            last_heartbeat_at, status, project_root_realpath
+     FROM workers
+     WHERE project_root_realpath = :project_root
+       AND status = 'active'
+     ORDER BY started_at DESC
+     LIMIT 1`,
+  ).get({ ":project_root": projectRootRealpath }) as AutoWorkerRow | undefined;
+  if (latestActiveRow && !isWorkerProcessAlive(latestActiveRow)) return latestActiveRow;
+
   const row = db.prepare(
     `SELECT worker_id, host, pid, started_at, version,
             last_heartbeat_at, status, project_root_realpath

--- a/src/resources/extensions/gsd/tests/auto-workers.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-workers.test.ts
@@ -16,6 +16,7 @@ import {
   markWorkerStoppingByPid,
   getActiveAutoWorkers,
   getAutoWorker,
+  findStaleWorkerForProject,
 } from "../db/auto-workers.ts";
 
 function makeBase(): string {
@@ -115,4 +116,19 @@ test("getActiveAutoWorkers filters by status and TTL", (t) => {
   const after = getActiveAutoWorkers();
   assert.equal(after.length, 1);
   assert.equal(after[0].worker_id, b);
+});
+
+test("findStaleWorkerForProject returns dead PID immediately even before heartbeat TTL", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const id = registerAutoWorker({ projectRootRealpath: base });
+  _getAdapter()!.prepare(
+    `UPDATE workers SET pid = -1 WHERE worker_id = :worker_id`,
+  ).run({ ":worker_id": id });
+
+  const stale = findStaleWorkerForProject(base);
+  assert.ok(stale, "dead pid should be detected as stale immediately");
+  assert.equal(stale!.worker_id, id);
 });


### PR DESCRIPTION
## Summary
- findStaleWorkerForProject now checks active worker PID liveness before heartbeat TTL gating, validated by a new focused regression test and passing auto-workers test run.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5665
- [#5665 findStaleWorkerForProject masks dead PIDs behind 60s heartbeat gate (db/auto-workers.js:200)](https://github.com/gsd-build/gsd-2/issues/5665)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5665-findstaleworkerforproject-masks-dead-pid-1778944018`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of stale worker processes by checking if a worker's system process is still alive, allowing faster identification and replacement of non-responsive workers.

* **Tests**
  * Added test coverage for edge cases in worker staleness detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->