### PR TITLE
fix(issue): auto startup never invokes stale_crash_lock auto-fix despite fixable:true marker

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -28,7 +28,7 @@ import { migrateToExternalState, recoverFailedMigration } from "./migrate-extern
 import { collectSecretsFromManifest } from "../get-secrets-from-user.js";
 import { gsdRoot, resolveMilestoneFile } from "./paths.js";
 import { invalidateAllCaches } from "./cache.js";
-import { writeLock, clearLock } from "./crash-recovery.js";
+import { writeLock, clearLock, readCrashLock, isLockProcessAlive } from "./crash-recovery.js";
 import {
   acquireSessionLock,
   releaseSessionLock,
@@ -618,6 +618,12 @@ export async function bootstrapAutoSession(
   if (dirCheck.severity === "blocked") {
     ctx.ui.notify(dirCheck.reason!, "error");
     return false;
+  }
+
+  const startupLock = readCrashLock(base);
+  if (startupLock && !isLockProcessAlive(startupLock)) {
+    clearLock(base);
+    ctx.ui.notify("Cleared stale auto-mode worker state.", "info");
   }
 
   const lockResult = acquireSessionLock(base);

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -302,7 +302,6 @@ import { createWorkspace, scopeMilestone } from "./workspace.js";
 import {
   registerAutoWorker,
   markWorkerStopping,
-  markWorkerStoppingByPid,
 } from "./db/auto-workers.js";
 import { releaseMilestoneLease } from "./db/milestone-leases.js";
 import { normalizeRealPath } from "./paths.js";
@@ -923,7 +922,7 @@ export function checkRemoteAutoSession(projectRoot: string): {
 
   if (!isLockProcessAlive(lock)) {
     // Stale lock from a dead process — not a live remote session
-    markWorkerStoppingByPid(normalizeRealPath(projectRoot), lock.pid);
+    clearLock(projectRoot);
     return { running: false };
   }
 

--- a/src/resources/extensions/gsd/tests/auto-remote-session-lock-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-remote-session-lock-cleanup.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { checkRemoteAutoSession } from "../auto.ts";
+import { openDatabase, closeDatabase, _getAdapter } from "../gsd-db.ts";
+import { registerAutoWorker } from "../db/auto-workers.ts";
+import { normalizeRealPath } from "../paths.ts";
+import { readCrashLock } from "../crash-recovery.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-remote-lock-cleanup-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch {}
+  try { rmSync(base, { recursive: true, force: true }); } catch {}
+}
+
+function expireWorker(workerId: string): void {
+  const db = _getAdapter()!;
+  db.prepare(
+    `UPDATE workers SET last_heartbeat_at = '1970-01-01T00:00:00.000Z' WHERE worker_id = :worker_id`,
+  ).run({ ":worker_id": workerId });
+}
+
+function setWorkerPid(workerId: string, pid: number): void {
+  const db = _getAdapter()!;
+  db.prepare(
+    `UPDATE workers SET pid = :pid WHERE worker_id = :worker_id`,
+  ).run({ ":pid": pid, ":worker_id": workerId });
+}
+
+test("checkRemoteAutoSession clears stale lock state when lock PID is dead", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  const workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(base) });
+  setWorkerPid(workerId, 99999);
+  expireWorker(workerId);
+
+  assert.ok(readCrashLock(base), "precondition: stale lock exists before remote session check");
+
+  const remote = checkRemoteAutoSession(base);
+  assert.deepEqual(remote, { running: false });
+  assert.equal(readCrashLock(base), null, "stale lock should be cleared by remote session check");
+});

--- a/src/resources/extensions/gsd/tests/auto-remote-session-lock-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-remote-session-lock-cleanup.test.ts
@@ -35,13 +35,25 @@ function setWorkerPid(workerId: string, pid: number): void {
   ).run({ ":pid": pid, ":worker_id": workerId });
 }
 
+function findDeadPidCandidate(): number {
+  const candidates = [99_999, 199_999, 299_999, 399_999];
+  for (const pid of candidates) {
+    try {
+      process.kill(pid, 0);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ESRCH") return pid;
+    }
+  }
+  throw new Error("Could not find a dead PID candidate for stale-lock test");
+}
+
 test("checkRemoteAutoSession clears stale lock state when lock PID is dead", (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
 
   openDatabase(join(base, ".gsd", "gsd.db"));
   const workerId = registerAutoWorker({ projectRootRealpath: normalizeRealPath(base) });
-  setWorkerPid(workerId, 99999);
+  setWorkerPid(workerId, findDeadPidCandidate());
   expireWorker(workerId);
 
   assert.ok(readCrashLock(base), "precondition: stale lock exists before remote session check");

--- a/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
+++ b/src/resources/extensions/gsd/tests/start-auto-detached.test.ts
@@ -105,6 +105,8 @@ test("auto bootstrap validates blocked directories before touching .gsd migratio
   const bootstrapIdx = autoStartSrc.indexOf("export async function bootstrapAutoSession(");
   const bootstrapBody = autoStartSrc.slice(bootstrapIdx);
   const bootstrapValidationIdx = bootstrapBody.indexOf("validateDirectory(base)");
+  const staleCrashReadIdx = bootstrapBody.indexOf("const startupLock = readCrashLock(base)");
+  const staleCrashClearIdx = bootstrapBody.indexOf("clearLock(base);");
   const lockIdx = bootstrapBody.indexOf("acquireSessionLock(base)");
   const bootstrapMigrationIdx = bootstrapBody.indexOf("migrateToExternalState(base)");
 
@@ -112,9 +114,15 @@ test("auto bootstrap validates blocked directories before touching .gsd migratio
   assert.ok(bootstrapValidationIdx > -1, "bootstrapAutoSession should validate the base directory");
   assert.ok(lockIdx > -1, "bootstrapAutoSession should acquire a session lock for safe projects");
   assert.ok(bootstrapMigrationIdx > -1, "bootstrapAutoSession should still migrate safe projects");
+  assert.ok(staleCrashReadIdx > -1, "bootstrapAutoSession should probe stale crash lock state before lock acquisition");
+  assert.ok(staleCrashClearIdx > -1, "bootstrapAutoSession should clear stale crash lock state when detected");
   assert.ok(
     bootstrapValidationIdx < lockIdx && bootstrapValidationIdx < bootstrapMigrationIdx,
     "fresh bootstrap must reject blocked directories before locking or migrating .gsd state",
+  );
+  assert.ok(
+    staleCrashReadIdx < lockIdx && staleCrashClearIdx < lockIdx,
+    "fresh bootstrap must auto-clear stale crash lock state before session lock acquisition",
   );
 });
 


### PR DESCRIPTION
## Summary
- Fixed stale crash-lock auto-healing at auto bootstrap and aligned remote dead-PID lock handling with stale-lock cleanup, with focused regression tests passing.

## Bugs Addressed
- [x] **Auto startup does not auto-fix stale crash lock**
- [x] **Remote session check leaves stale dead-PID lock in place**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5666
- [#5666 auto startup never invokes stale_crash_lock auto-fix despite fixable:true marker](https://github.com/gsd-build/gsd-2/issues/5666)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5666-auto-startup-never-invokes-stale-crash-l-1778944509`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash recovery: automatically detects and clears stale session/startup locks when the associated process is no longer running, and notifies the user when a stale lock is removed.

* **Tests**
  * Added and expanded tests to verify stale session-lock cleanup and that lock-clearing occurs before acquiring a new session.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->