### PR TITLE
fix(issue): gsd_validate_milestone accepts verificationClasses that omit planned Operational class

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -993,6 +993,8 @@ export function registerDbTools(pi: ExtensionAPI): void {
     promptGuidelines: [
       "Use gsd_validate_milestone when all slices are done and the milestone needs validation before completion.",
       "Parameters: milestoneId, verdict, remediationRound, successCriteriaChecklist, sliceDeliveryAudit, crossSliceIntegration, requirementCoverage, verificationClasses (optional), verdictRationale, remediationPlan (optional).",
+      "If verification classes were planned, verificationClasses must include canonical class rows using the exact class names Contract, Integration, Operational, and UAT when present in planning.",
+      "Planned verification text marked as none/not required/not applicable/N/A (including suffixed variants such as 'not required - backend-only') is treated as not applicable and does not require a class row.",
       "If verdict is 'needs-remediation', also provide remediationPlan and use gsd_reassess_roadmap to add remediation slices to the roadmap.",
       "On success, returns validationPath where VALIDATION.md was written.",
     ],
@@ -1004,7 +1006,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       sliceDeliveryAudit: Type.String({ description: "Markdown table auditing each slice's claimed vs delivered output" }),
       crossSliceIntegration: Type.String({ description: "Markdown describing any cross-slice boundary mismatches" }),
       requirementCoverage: Type.String({ description: "Markdown describing any unaddressed requirements" }),
-      verificationClasses: Type.Optional(Type.String({ description: "Markdown describing verification class compliance and gaps" })),
+      verificationClasses: Type.Optional(Type.String({ description: "Markdown describing verification class compliance and gaps using canonical class names (Contract, Integration, Operational, UAT) for each applicable planned class" })),
       verdictRationale: Type.String({ description: "Why this verdict was chosen" }),
       remediationPlan: Type.Optional(Type.String({ description: "Remediation plan (required if verdict is needs-remediation)" })),
     }),

--- a/src/resources/extensions/gsd/tests/validate-milestone-write-order.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-write-order.test.ts
@@ -199,4 +199,23 @@ describe("handleValidateMilestone write ordering (#2725)", () => {
     );
     assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
   });
+
+  it("treats 'not required - ...' verification values as not applicable", async () => {
+    base = makeTmpBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({
+      id: "M001",
+      planning: {
+        verificationOperational: "not required - backend-only",
+      },
+    });
+    insertSlice({ id: "S01", milestoneId: "M001" });
+
+    const result = await handleValidateMilestone(
+      { ...VALID_PARAMS, verificationClasses: "| Check | Result |\n| --- | --- |\n| Generic verification | PASS |" },
+      base,
+    );
+    assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
+  });
 });

--- a/src/resources/extensions/gsd/tests/validate-milestone-write-order.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-write-order.test.ts
@@ -150,4 +150,53 @@ describe("handleValidateMilestone write ordering (#2725)", () => {
     assert.equal(row?.trace_id, "trace-val-1");
     assert.equal(row?.turn_id, "turn-val-1");
   });
+
+  it("rejects verificationClasses that omit planned Operational class", async () => {
+    base = makeTmpBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({
+      id: "M001",
+      planning: {
+        verificationOperational: "Camoufox subprocess lifecycle/cleanup proof",
+      },
+    });
+    insertSlice({ id: "S01", milestoneId: "M001" });
+
+    const result = await handleValidateMilestone(
+      { ...VALID_PARAMS, verificationClasses: "| Check | Result |\n| --- | --- |\n| Generic verification | PASS |" },
+      base,
+    );
+    assert.ok("error" in result, "expected validation to fail");
+    assert.match(result.error, /must include canonical row "Operational"/);
+
+    const adapter = _getAdapter()!;
+    const row = adapter.prepare(
+      `SELECT status FROM assessments WHERE milestone_id = 'M001' AND scope = 'milestone-validation'`,
+    ).get() as { status: string } | undefined;
+    assert.equal(row, undefined, "assessment row should not be written when verification classes are invalid");
+  });
+
+  it("accepts verificationClasses when planned Operational class is present", async () => {
+    base = makeTmpBase();
+    const dbPath = join(base, ".gsd", "gsd.db");
+    openDatabase(dbPath);
+    insertMilestone({
+      id: "M001",
+      planning: {
+        verificationOperational: "Camoufox subprocess lifecycle/cleanup proof",
+      },
+    });
+    insertSlice({ id: "S01", milestoneId: "M001" });
+
+    const result = await handleValidateMilestone(
+      {
+        ...VALID_PARAMS,
+        verificationClasses:
+          "| Class | Planned Check | Evidence | Verdict |\n| --- | --- | --- | --- |\n| Operational | Camoufox subprocess lifecycle/cleanup proof | S01 + process-death evidence | NEEDS-ATTENTION |",
+      },
+      base,
+    );
+    assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
+  });
 });

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -473,6 +473,38 @@ test("executeValidateMilestone persists validation artifact and gate records", a
   }
 });
 
+test("executeValidateMilestone rejects verificationClasses that omit planned Operational class", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    seedMilestone("M002", "Milestone Two");
+    const db = _getAdapter();
+    db!.prepare("UPDATE milestones SET verification_operational = ? WHERE id = ?").run(
+      "Camoufox subprocess lifecycle/cleanup proof",
+      "M002",
+    );
+    seedSlice("M002", "S02", "complete");
+
+    const result = await inProjectDir(base, () => executeValidateMilestone({
+      milestoneId: "M002",
+      verdict: "pass",
+      remediationRound: 0,
+      successCriteriaChecklist: "- [x] Works",
+      sliceDeliveryAudit: "| Slice | Result |\n| --- | --- |\n| S02 | pass |",
+      crossSliceIntegration: "No cross-slice issues.",
+      requirementCoverage: "All requirements covered.",
+      verificationClasses: "| Check | Result |\n| --- | --- |\n| Generic verification | PASS |",
+      verdictRationale: "Everything passed.",
+    }, base));
+
+    assert.equal(result.isError, true);
+    assert.match(String(result.details.error), /must include canonical row "Operational"/);
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 test("executeCompleteMilestone sanitizes raw params and writes milestone summary", async () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tools/validate-milestone.ts
+++ b/src/resources/extensions/gsd/tools/validate-milestone.ts
@@ -15,6 +15,7 @@ import {
   transaction,
   insertAssessment,
   getMilestoneSlices,
+  getMilestone,
 } from "../gsd-db.js";
 import { resolveMilestonePath, clearPathCache } from "../paths.js";
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
@@ -51,6 +52,24 @@ export interface ValidateMilestoneOptions {
   uokGatesEnabled?: boolean;
   traceId?: string;
   turnId?: string;
+}
+
+function isVerificationNotApplicable(value: string): boolean {
+  const v = (value ?? "").toLowerCase().trim().replace(/[.\s]+$/, "");
+  if (!v || v === "none") return true;
+  return /^(?:none(?:[\s._\u2014-]+[\s\S]*)?|n\/?a|not[\s._-]+(?:applicable|required|needed|provided)|no[\s._-]+operational[\s\S]*)$/i.test(v);
+}
+
+function getRequiredVerificationClasses(milestoneId: string): string[] {
+  const milestone = getMilestone(milestoneId);
+  if (!milestone) return [];
+
+  const required: string[] = [];
+  if (!isVerificationNotApplicable(milestone.verification_contract)) required.push("Contract");
+  if (!isVerificationNotApplicable(milestone.verification_integration)) required.push("Integration");
+  if (!isVerificationNotApplicable(milestone.verification_operational)) required.push("Operational");
+  if (!isVerificationNotApplicable(milestone.verification_uat)) required.push("UAT");
+  return required;
 }
 
 function renderValidationMarkdown(params: ValidateMilestoneParams): string {
@@ -98,6 +117,18 @@ export async function handleValidateMilestone(
   }
   if (!isValidMilestoneVerdict(params.verdict)) {
     return { error: `verdict must be one of: ${VALIDATION_VERDICTS.join(", ")}` };
+  }
+  const requiredClasses = getRequiredVerificationClasses(params.milestoneId);
+  if (requiredClasses.length > 0) {
+    const verificationClasses = params.verificationClasses ?? "";
+    const missingClass = requiredClasses.find(
+      (className) => !new RegExp(`\\b${className}\\b`, "i").test(verificationClasses),
+    );
+    if (missingClass) {
+      return {
+        error: `verificationClasses must include canonical row "${missingClass}" because this milestone planned ${missingClass.toLowerCase()} verification`,
+      };
+    }
   }
 
   // ── Resolve paths and render markdown ────────────────────────────────

--- a/src/resources/extensions/gsd/tools/validate-milestone.ts
+++ b/src/resources/extensions/gsd/tools/validate-milestone.ts
@@ -57,7 +57,7 @@ export interface ValidateMilestoneOptions {
 function isVerificationNotApplicable(value: string): boolean {
   const v = (value ?? "").toLowerCase().trim().replace(/[.\s]+$/, "");
   if (!v || v === "none") return true;
-  return /^(?:none(?:[\s._\u2014-]+[\s\S]*)?|n\/?a|not[\s._-]+(?:applicable|required|needed|provided)|no[\s._-]+operational[\s\S]*)$/i.test(v);
+  return /^(?:none(?:[\s._\u2014-]+[\s\S]*)?|n\/?a(?:[\s._\u2014-]+[\s\S]*)?|not[\s._-]+(?:applicable|required|needed|provided)(?:[\s._\u2014-]+[\s\S]*)?|no[\s._-]+operational[\s\S]*)$/i.test(v);
 }
 
 function getRequiredVerificationClasses(milestoneId: string): string[] {


### PR DESCRIPTION
## Summary
- Added canonical verification-class enforcement to milestone validation and verified it with focused handler/executor regression tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5500
- [#5500 gsd_validate_milestone accepts verificationClasses that omit planned Operational class](https://github.com/gsd-build/gsd-2/issues/5500)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5500-gsd-validate-milestone-accepts-verificat-1778946300`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Milestone validation now enforces required verification classes for Operational, Contract, Integration, and UAT when planned, and treats values beginning with "not required - ..." as not applicable.
* **Tests**
  * Added unit tests covering validation success/failure cases and ensuring no records are written when validation fails.
* **Documentation**
  * Clarified guidance on how verification classes should be provided and interpreted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->