### PR TITLE
fix(issue): pre-execution-checks: bare-string annotation path extractor misses parenthetical suffixes, blocks dispatch

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -375,7 +375,7 @@ function extractPathFromAnnotation(raw: string): string {
     return quoteMatch[2].trim();
   }
 
-  const annotatedMatch = trimmed.match(/^(.+?)\s+[—–-]\s+.+$/);
+  const annotatedMatch = trimmed.match(/^(.+?)(?:\s+[—–-]\s+.+|\s+\([^()]+\))$/);
   if (annotatedMatch) {
     const prefix = annotatedMatch[1].trim();
     const prefixBacktickMatch = prefix.match(/`([^`]+)`/);

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -2052,6 +2052,28 @@ describe("checkFilePathConsistency quote-wrapped annotation (#3747)", () => {
     );
   });
 
+  test("bare path with parenthetical annotation strips suffix before path check", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-paren-${Date.now()}`);
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+    writeFileSync(join(tempDir, "src/paren.ts"), "// content");
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["src/paren.ts (note)"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(
+      results.length,
+      0,
+      "Parenthetical suffix should be stripped and resolved to the real file",
+    );
+  });
+
   test("prose value with spaces inside quotes is skipped (not a path)", () => {
     // "some description text" contains spaces — should not be checked as a path
     const tasks = [


### PR DESCRIPTION
## Summary
- Fixed bare-string annotation parsing to strip trailing parenthetical notes and validated it with a targeted pre-execution checks test run.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5505
- [#5505 pre-execution-checks: bare-string annotation path extractor misses parenthetical suffixes, blocks dispatch](https://github.com/gsd-build/gsd-2/issues/5505)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5505-pre-execution-checks-bare-string-annotat-1778947499`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of annotated file paths to support multiple annotation formats (dashed suffixes and parenthetical notations), enabling better recognition and normalization of various annotation styles.

* **Tests**
  * Added test coverage to verify proper handling and processing of file paths with parenthetical suffixes in annotations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->