### PR TITLE
fix(issue): [Bug]: git add fails on (none) placeholder in task summary

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -176,7 +176,7 @@ async function buildTaskCommitContextForUnit(
     sliceTitle: stripKnownIdPrefix(slice?.title, sid),
     oneLiner: summary?.oneLiner || task?.one_liner || undefined,
     keyFiles:
-      summary?.frontmatter.key_files?.filter(f => !f.includes("{{") && f.trim() !== "(none)") ??
+      summary?.frontmatter.key_files?.filter(f => !f.includes("{{") && !/^(?:\(none\)|none\.?|n\/a)$/i.test(f.trim())) ??
       task?.key_files ??
       undefined,
     issueNumber: ghIssueNumber,

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -176,7 +176,12 @@ async function buildTaskCommitContextForUnit(
     sliceTitle: stripKnownIdPrefix(slice?.title, sid),
     oneLiner: summary?.oneLiner || task?.one_liner || undefined,
     keyFiles:
-      summary?.frontmatter.key_files?.filter(f => !f.includes("{{") && !/^(?:\(none\)|none\.?|n\/a)$/i.test(f.trim())) ??
+      summary?.frontmatter.key_files?.filter((f) => {
+        const normalized = f.trim();
+        return normalized.length > 0 &&
+          !normalized.includes("{{") &&
+          !/^(?:\(none\)|none\.?|n\/a)$/i.test(normalized);
+      }) ??
       task?.key_files ??
       undefined,
     issueNumber: ghIssueNumber,

--- a/src/resources/extensions/gsd/tests/post-unit-git-failure.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-git-failure.test.ts
@@ -16,3 +16,10 @@ test("postUnitPreVerification blocks on git action failure", () => {
   assert.ok(failureBlock.includes('return "dispatched"'));
   assert.ok(!failureBlock.includes("git-action-failed-nonblocking"));
 });
+
+test("buildTaskCommitContextForUnit filters placeholder key_files entries", () => {
+  const keyFilesBlock = extractSourceRegion(source, "keyFiles:");
+  assert.ok(keyFilesBlock.includes("normalized.length > 0"));
+  assert.ok(keyFilesBlock.includes("!normalized.includes(\"{{\")"));
+  assert.ok(keyFilesBlock.includes("/^(?:\\(none\\)|none\\.?|n\\/a)$/i.test(normalized)"));
+});


### PR DESCRIPTION
## Summary
- Expanded `key_files` placeholder filtering in auto post-unit commit context and verified with focused git-service and post-unit tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5504
- [#5504 [Bug]: git add fails on (none) placeholder in task summary](https://github.com/gsd-build/gsd-2/issues/5504)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5504-bug-git-add-fails-on-none-placeholder-in-1778948102`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file absence indicators in task processing, now recognizing additional common "no files" variants (case-insensitive matches) for more consistent data processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->