### PR TITLE
fix(issue): [Bug]: survivor-branch finalization runs before adoptSessionRoot, causing git branch --show-current ENOENT on /gsd auto resume

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -958,12 +958,14 @@ export async function bootstrapAutoSession(
     // hasSurvivorBranch after a successful promotion.
     if (decideSurvivorAction(hasSurvivorBranch, state.phase) === "finalize") {
       const mid = survivorMilestoneId!;
+      const lifecycle = buildLifecycle();
+      lifecycle.adoptSessionRoot(base);
       // Commit 68ef58a3c made `_mergeBranchMode` throw on wrong-branch
       // instead of returning false silently. Wrap the call so the throw is
       // converted into an error notify + clean bootstrap abort, not an
       // unhandled exception propagating to the slash-command caller (#5549
       // post-merge audit, R2).
-      const finalize = _finalizeSurvivorBranch(buildLifecycle(), mid, ctx.ui);
+      const finalize = _finalizeSurvivorBranch(lifecycle, mid, ctx.ui);
       if (!finalize.merged) {
         return releaseLockAndReturn();
       }

--- a/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-lifecycle.test.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 import {
   WorktreeLifecycle,
+  mergeMilestoneStandalone,
   resolvePausedResumeBasePath,
   type WorktreeLifecycleDeps,
   type WorktreeLifecycleTestOverrides,
@@ -648,6 +649,21 @@ test("adoptSessionRoot does not chdir, rebuild git service, or invalidate caches
 
   assert.equal(deps.calls.filter((c) => c.fn === "gitServiceFactory").length, 0);
   assert.equal(deps.calls.filter((c) => c.fn === "invalidateAllCaches").length, 0);
+});
+
+test("mergeMilestoneStandalone fails loud when both base paths are empty", () => {
+  const deps = makeDeps();
+  assert.throws(
+    () =>
+      mergeMilestoneStandalone(deps, {
+        originalBasePath: "",
+        worktreeBasePath: "",
+        milestoneId: "M001",
+        isolationDegraded: false,
+        notify: () => {},
+      }),
+    /requires originalBasePath or worktreeBasePath/,
+  );
 });
 
 // ─── resumeFromPausedSession (ADR-016 phase 2 / B3, issue #5621) ──────────────

--- a/src/resources/extensions/gsd/worktree-lifecycle.ts
+++ b/src/resources/extensions/gsd/worktree-lifecycle.ts
@@ -1236,6 +1236,11 @@ export function mergeMilestoneStandalone(
 ): MergeStandaloneResult {
   const { originalBasePath, worktreeBasePath, milestoneId, notify } = mctx;
   validateMilestoneId(milestoneId);
+  if (!originalBasePath && !worktreeBasePath) {
+    throw new Error(
+      `Internal error: mergeMilestoneStandalone(${milestoneId}) requires originalBasePath or worktreeBasePath.`,
+    );
+  }
 
   if (mctx.isolationDegraded) {
     if (originalBasePath) {


### PR DESCRIPTION
## Summary
- Adopted session root before survivor finalization and added an empty-base-path merge guard, verified by focused gsd tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6247
- [#6247 [Bug]: survivor-branch finalization runs before adoptSessionRoot, causing git branch --show-current ENOENT on /gsd auto resume](https://github.com/gsd-build/gsd-2/issues/6247)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6247-bug-survivor-branch-finalization-runs-be-1778948691`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session lifecycle initialization to ensure proper root adoption during finalization operations.
  * Added validation to prevent invalid state conditions when merging sessions.

* **Tests**
  * Expanded test coverage for session merge and lifecycle validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->