### PR TITLE
fix(issue): Auto-mode discuss-milestone pauses permanently: message_update approval gate blocks CONTEXT write

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -37,7 +37,7 @@ import {
 } from "./paths.js";
 import { parseRoadmap } from "./parsers-legacy.js";
 import { validateArtifact } from "./schemas/validate.js";
-import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, readdirSync } from "node:fs";
 import { logWarning, logError } from "./workflow-logger.js";
 import { join } from "node:path";
 import { hasImplementationArtifacts } from "./auto-recovery.js";
@@ -268,6 +268,26 @@ function isRegistryMilestoneComplete(state: GSDState, mid: string): boolean {
   );
 }
 
+function hasMilestonePassedDiscuss(basePath: string, mid: string): boolean {
+  const slices = getMilestoneSlices(mid);
+  for (const slice of slices) {
+    const planPath = resolveSliceFile(basePath, mid, slice.id, "PLAN");
+    if (planPath && existsSync(planPath)) return true;
+  }
+  const milestonePath = resolveMilestonePath(basePath, mid);
+  if (milestonePath) {
+    const slicesDir = join(milestonePath, "slices");
+    if (existsSync(slicesDir)) {
+      for (const sliceEntry of readdirSync(slicesDir, { withFileTypes: true })) {
+        if (!sliceEntry.isDirectory()) continue;
+        const planPath = join(slicesDir, sliceEntry.name, `${sliceEntry.name}-PLAN.md`);
+        if (existsSync(planPath)) return true;
+      }
+    }
+  }
+  return hasImplementationArtifacts(basePath, mid) === "present";
+}
+
 /**
  * Check for milestone slices missing SUMMARY files.
  * Returns array of missing slice IDs, or empty array if all present or DB unavailable.
@@ -425,6 +445,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (!EXECUTION_ENTRY_PHASES.has(state.phase)) return null;
       if (!MILESTONE_ID_RE.test(mid)) return null;
       if (isRegistryMilestoneComplete(state, mid)) return null;
+      if (hasMilestonePassedDiscuss(basePath, mid)) return null;
       // Align with the plan-v2 gate's lookup semantics: whitespace-only counts
       // as missing, and an auto worktree may fall back to GSD_PROJECT_ROOT.
       if (hasFinalizedMilestoneContext(basePath, mid)) return null;

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -269,10 +269,16 @@ function isRegistryMilestoneComplete(state: GSDState, mid: string): boolean {
 }
 
 function hasMilestonePassedDiscuss(basePath: string, mid: string): boolean {
-  const slices = getMilestoneSlices(mid);
-  for (const slice of slices) {
-    const planPath = resolveSliceFile(basePath, mid, slice.id, "PLAN");
-    if (planPath && existsSync(planPath)) return true;
+  if (isDbAvailable()) {
+    try {
+      const slices = getMilestoneSlices(mid);
+      for (const slice of slices) {
+        const planPath = resolveSliceFile(basePath, mid, slice.id, "PLAN");
+        if (planPath && existsSync(planPath)) return true;
+      }
+    } catch {
+      // Fall through to filesystem checks when DB access is degraded.
+    }
   }
   const milestonePath = resolveMilestonePath(basePath, mid);
   if (milestonePath) {

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -276,8 +276,12 @@ function hasMilestonePassedDiscuss(basePath: string, mid: string): boolean {
         const planPath = resolveSliceFile(basePath, mid, slice.id, "PLAN");
         if (planPath && existsSync(planPath)) return true;
       }
-    } catch {
+    } catch (err) {
       // Fall through to filesystem checks when DB access is degraded.
+      logWarning(
+        "dispatch",
+        `discuss-progress DB check failed for ${mid}, falling back to filesystem: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
   const milestonePath = resolveMilestonePath(basePath, mid);

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -508,6 +508,13 @@ export function registerHooks(
       const milestoneId = extractDepthVerificationMilestoneId(pendingApprovalGate);
       if (milestoneId) markDepthVerified(milestoneId, beforeAgentBasePath);
       clearPendingGate(beforeAgentBasePath);
+      if (isAutoPaused() && !isAutoActive()) {
+        const { resumeAutoAfterProviderDelay } = await import("./provider-error-resume.js");
+        void resumeAutoAfterProviderDelay(pi, ctx).catch((err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          ctx.ui.notify(`Failed to resume auto-mode after approval: ${message}`, "warning");
+        });
+      }
     }
     clearDeferredApprovalGate(beforeAgentBasePath);
 
@@ -641,6 +648,7 @@ export function registerHooks(
     if (approvalQuestionAbortInFlight) return;
 
     const dash = getAutoRuntimeSnapshot();
+    if (dash.active) return;
     let unitType = dash.currentUnit?.type;
     let unitId = dash.currentUnit?.id;
 

--- a/src/resources/extensions/gsd/tests/execution-entry-missing-context-4671.test.ts
+++ b/src/resources/extensions/gsd/tests/execution-entry-missing-context-4671.test.ts
@@ -45,7 +45,7 @@ function buildState(phase: Phase): GSDState {
 
 function makeBasePath(prefix: string): string {
   const dir = mkdtempSync(join(tmpdir(), `gsd-4671-${prefix}-`));
-  mkdirSync(join(dir, ".gsd", "milestones", "M001"), { recursive: true });
+  mkdirSync(join(dir, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
   return dir;
 }
 
@@ -94,6 +94,20 @@ describe("#4671 execution-entry phase missing-context recovery", () => {
       );
       const action = await findRule().match(buildCtx(basePath, buildState("executing")));
       assert.strictEqual(action, null, "rule must fall through when CONTEXT.md exists");
+    } finally {
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  test("phase=executing with slice PLAN.md present → falls through (milestone already passed discuss)", async () => {
+    const basePath = makeBasePath("has-plan");
+    try {
+      writeFileSync(
+        join(basePath, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+        "# S01 Plan\n\n- [ ] **T01**: work\n",
+      );
+      const action = await findRule().match(buildCtx(basePath, buildState("executing")));
+      assert.strictEqual(action, null, "rule must fall through when planning artifacts already exist");
     } finally {
       rmSync(basePath, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Fixed auto-mode approval-gate deadlock/resume behavior and added a stale-dispatch guard, verified with targeted extension tests passing.

## Bugs Addressed
- [x] **Approval gate runs during auto-mode and blocks CONTEXT write**
- [x] **Verified approval gate does not restart paused auto loop**
- [x] **Dispatch rule can re-enter discuss phase after later stages complete**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6251
- [#6251 Auto-mode discuss-milestone pauses permanently: message_update approval gate blocks CONTEXT write](https://github.com/gsd-build/gsd-2/issues/6251)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6251-auto-mode-discuss-milestone-pauses-perma-1778949066`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant recovery redirect during milestone execution when the milestone has already completed the discuss step.

* **Improvements**
  * Enhanced approval gate flow to resume auto-mode after approval-triggered pauses.
  * Skipped approval-abort logic while auto-mode is active to avoid unnecessary interruptions.

* **Tests**
  * Added regression test covering execution-entry cases where slice-level artifacts indicate discuss already ran.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->