### PR TITLE
fix(issue): slice-parallel: wrong PLAN.md paths in conflict detector + no resume after stopAuto

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -56,7 +56,7 @@ import { verifyExpectedArtifact, diagnoseExpectedArtifact, buildLoopRemediationS
 import { writeUnitRuntimeRecord } from "../unit-runtime.js";
 import { withTimeout, FINALIZE_PRE_TIMEOUT_MS, FINALIZE_POST_TIMEOUT_MS } from "./finalize-timeout.js";
 import { getEligibleSlices } from "../slice-parallel-eligibility.js";
-import { startSliceParallel } from "../slice-parallel-orchestrator.js";
+import { isSliceParallelActive, startSliceParallel } from "../slice-parallel-orchestrator.js";
 import { isDbAvailable, getMilestoneSlices } from "../gsd-db.js";
 import { reconcileBeforeSpawn } from "../state-reconciliation.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
@@ -884,6 +884,12 @@ export async function runPreDispatch(
     isDbAvailable()
   ) {
     try {
+      const projectRoot = _resolveDispatchGuardBasePath(s);
+      if (isSliceParallelActive(projectRoot)) {
+        ctx.ui.notify("Slice-parallel: workers are still running; waiting for completion before next dispatch.", "info");
+        await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+        return { action: "continue" };
+      }
       const dbSlices = getMilestoneSlices(mid);
       if (dbSlices.length > 0) {
         const doneIds = new Set(dbSlices.filter(sl => sl.status === "complete" || sl.status === "done").map(sl => sl.id));
@@ -928,8 +934,7 @@ export async function runPreDispatch(
               `Slice-parallel: started ${result.started.length} worker(s): ${result.started.join(", ")}.`,
               "info",
             );
-            await deps.stopAuto(ctx, pi, `Slice-parallel dispatched for ${mid}`);
-            return { action: "break", reason: "slice-parallel-dispatched" };
+            return { action: "continue" };
           }
           // Fall through to sequential if no workers started
         }

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -912,7 +912,7 @@ export async function runPreDispatch(
           );
           // ADR-017 #5707: reconcile before spawning so each worker doesn't
           // independently race on the same drift. Failure aborts the spawn.
-          const spawnGate = await reconcileBeforeSpawn(s.basePath);
+          const spawnGate = await reconcileBeforeSpawn(projectRoot);
           if (!spawnGate.ok) {
             ctx.ui.notify(
               `Slice-parallel: aborting spawn — ${spawnGate.reason}`,
@@ -921,7 +921,7 @@ export async function runPreDispatch(
             return { action: "break", reason: `slice-parallel-reconciliation-failed: ${spawnGate.reason}` };
           }
           const result = await startSliceParallel(
-            s.basePath,
+            projectRoot,
             mid,
             eligible,
             {

--- a/src/resources/extensions/gsd/slice-parallel-conflict.ts
+++ b/src/resources/extensions/gsd/slice-parallel-conflict.ts
@@ -55,8 +55,8 @@ export function hasFileConflict(
   sliceA: string,
   sliceB: string,
 ): boolean {
-  const planPathA = join(basePath, ".gsd", "milestones", mid, sliceA, "PLAN.md");
-  const planPathB = join(basePath, ".gsd", "milestones", mid, sliceB, "PLAN.md");
+  const planPathA = join(basePath, ".gsd", "milestones", mid, "slices", sliceA, `${sliceA}-PLAN.md`);
+  const planPathB = join(basePath, ".gsd", "milestones", mid, "slices", sliceB, `${sliceB}-PLAN.md`);
 
   // Conservative: missing PLAN = block
   if (!existsSync(planPathA) || !existsSync(planPathB)) {

--- a/src/resources/extensions/gsd/slice-parallel-orchestrator.ts
+++ b/src/resources/extensions/gsd/slice-parallel-orchestrator.ts
@@ -367,7 +367,24 @@ export function restoreSliceState(basePath: string): PersistedSliceState | null 
  * crash followed by a fresh process is detectable. (Issue #4980 HIGH-8)
  */
 export function isSliceParallelActive(basePath?: string): boolean {
-  if (sliceState?.active === true) return true;
+  const hasRunningWorkers = (): boolean => {
+    if (!sliceState) return false;
+    for (const worker of sliceState.workers.values()) {
+      if (worker.state === "running") {
+        if (worker.process) return true;
+        if (isRecoveredSliceWorkerAlive(worker)) return true;
+      }
+    }
+    return false;
+  };
+
+  if (sliceState?.active === true) {
+    if (hasRunningWorkers()) return true;
+    sliceState.active = false;
+    removeSliceStateFile(sliceState.basePath);
+    return false;
+  }
+
   if (!basePath) return false;
   const restored = restoreSliceState(basePath);
   if (!restored || restored.workers.length === 0) return false;
@@ -398,7 +415,11 @@ export function isSliceParallelActive(basePath?: string): boolean {
       cost: w.cost,
     });
   }
-  return true;
+
+  if (hasRunningWorkers()) return true;
+  sliceState.active = false;
+  removeSliceStateFile(sliceState.basePath);
+  return false;
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/slice-parallel-conflict.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-parallel-conflict.test.ts
@@ -21,9 +21,9 @@ function makeTmpBase(): string {
 }
 
 function writeSlicePlan(base: string, mid: string, sid: string, content: string): void {
-  const dir = join(base, ".gsd", "milestones", mid, sid);
+  const dir = join(base, ".gsd", "milestones", mid, "slices", sid);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, "PLAN.md"), content, "utf-8");
+  writeFileSync(join(dir, `${sid}-PLAN.md`), content, "utf-8");
 }
 
 describe("hasFileConflict", () => {

--- a/src/resources/extensions/gsd/tests/slice-parallel-orchestrator.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-parallel-orchestrator.test.ts
@@ -13,6 +13,7 @@ import {
   _buildSliceWorkerEnvForTest,
   _resolveSliceParallelMaxWorkersForTest,
   getSliceOrchestratorState,
+  isSliceParallelActive,
   restoreSliceState,
   resetSliceOrchestrator,
   SLICE_WORKER_AUTO_ARGS,
@@ -233,6 +234,45 @@ describe("slice-parallel-orchestrator recovery identity", () => {
       assert.equal(restored.workers[0].pid, child.pid);
     } finally {
       child.kill("SIGTERM");
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  it("treats persisted non-running workers as inactive and clears stale state file", () => {
+    const basePath = makeTempProject();
+    try {
+      writeFileSync(
+        join(basePath, ".gsd", "slice-orchestrator.json"),
+        JSON.stringify({
+          active: true,
+          workers: [{
+            milestoneId: "M900",
+            sliceId: "S01",
+            pid: 0,
+            workerToken: "done-worker",
+            processStartFingerprint: null,
+            worktreePath: join(basePath, ".gsd", "worktrees", "M900-S01"),
+            startedAt: Date.now(),
+            state: "stopped",
+            completedUnits: 1,
+            cost: 0,
+          }],
+          totalCost: 0,
+          maxWorkers: 1,
+          startedAt: Date.now(),
+          basePath,
+        }),
+        "utf-8",
+      );
+
+      assert.equal(isSliceParallelActive(basePath), false);
+      assert.equal(
+        existsSync(join(basePath, ".gsd", "slice-orchestrator.json")),
+        false,
+        "stale non-running persisted state should be removed",
+      );
+    } finally {
+      resetSliceOrchestrator();
       rmSync(basePath, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary
- Fixed slice-parallel PLAN path matching and kept auto-mode running with active-worker gating so parallel dispatch can recover and resume.

## Bugs Addressed
- [x] **Wrong PLAN.md paths in conflict detection**
- [x] **stopAuto with no recovery**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5511
- [#5511 slice-parallel: wrong PLAN.md paths in conflict detector + no resume after stopAuto](https://github.com/gsd-build/gsd-2/issues/5511)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5511-slice-parallel-wrong-plan-md-paths-in-co-1778949295`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slice-parallel reliability by verifying workers are actually running before acting and cleaning up stale persisted state.
  * Auto-dispatch now skips redundant parallel dispatch when active workers exist and resumes flow appropriately.
  * Conflict detection adapted to a revised per-slice PLAN file layout to correctly detect blocking conflicts.

* **Tests**
  * Added/updated tests covering recovery from stale orchestrator state and the new per-slice PLAN layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->