### PR TITLE
fix(issue): fix(gsd): survivor finalization cannot recover self-referential milestone integration metadata

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -52,7 +52,7 @@ import {
   normalizeWorktreePathForCompare,
   resolveWorktreeProjectRoot,
 } from "./worktree-root.js";
-import { MergeConflictError, createDraftPR, readIntegrationBranch, RUNTIME_EXCLUSION_PATHS } from "./git-service.js";
+import { MergeConflictError, createDraftPR, readIntegrationBranch, resolveMilestoneIntegrationBranch, RUNTIME_EXCLUSION_PATHS } from "./git-service.js";
 import { buildPrEvidence } from "./pr-evidence.js";
 import { debugLog } from "./debug-logger.js";
 import { logWarning, logError } from "./workflow-logger.js";
@@ -1721,22 +1721,11 @@ export function mergeMilestoneToMain(
   const previousCwd = process.cwd();
   process.chdir(originalBasePath_);
 
-  // 4. Resolve integration branch — prefer milestone metadata, then preferences,
-  //    then auto-detect (origin/HEAD → main → master → current). Never hardcode
-  //    "main": repos using "master" or a custom default branch would fail at
-  //    checkout and leave the user with a broken merge state (#1668).
+  // 4. Resolve integration branch via shared resolver so stale/invalid
+  //    milestone metadata can recover to configured/detected fallbacks.
   const prefs = loadEffectiveGSDPreferences()?.preferences?.git ?? {};
-  const integrationBranch = readIntegrationBranch(
-    originalBasePath_,
-    milestoneId,
-  );
-  // Validate prefs.main_branch exists before using it — a stale preference
-  // (e.g. "master" when repo uses "main") causes merge failure (#3589).
-  const validatedPrefBranch = prefs.main_branch && nativeBranchExists(originalBasePath_, prefs.main_branch)
-    ? prefs.main_branch
-    : undefined;
-  const mainBranch =
-    integrationBranch ?? validatedPrefBranch ?? nativeDetectMainBranch(originalBasePath_);
+  const branchResolution = resolveMilestoneIntegrationBranch(originalBasePath_, milestoneId, prefs);
+  const mainBranch = branchResolution.effectiveBranch ?? nativeDetectMainBranch(originalBasePath_);
 
   // Fail closed when the resolved integration branch is the milestone branch
   // itself (#5024). Stale or corrupt metadata (e.g. integrationBranch recorded
@@ -1750,9 +1739,8 @@ export function mergeMilestoneToMain(
     throw new GSDError(
       GSD_GIT_ERROR,
       `Resolved integration branch "${mainBranch}" is the same ref as milestone branch ` +
-      `"${milestoneBranch}" — refusing to self-merge. Integration branch metadata is invalid; ` +
-      `set a distinct main_branch in GSD preferences or repair the milestone integration record ` +
-      `before retrying milestone completion.`,
+      `"${milestoneBranch}" — refusing to self-merge. ${branchResolution.reason}. ` +
+      `Repair milestone integration metadata before retrying milestone completion.`,
     );
   }
 

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -457,6 +457,10 @@ export interface IntegrationBranchResolution {
   reason: string;
 }
 
+function normalizeLocalBranchRef(branch: string): string {
+  return branch.replace(/^refs\/heads\//, "");
+}
+
 /**
  * Resolve a milestone's recorded integration branch into an actionable status.
  *
@@ -480,7 +484,14 @@ export function resolveMilestoneIntegrationBranch(
     };
   }
 
-  if (nativeBranchExists(basePath, recordedBranch)) {
+  const normalizedRecordedBranch = normalizeLocalBranchRef(recordedBranch);
+  const isRecordedMilestoneBranch = normalizedRecordedBranch.startsWith("milestone/");
+  const recordedBranchUsable = !isRecordedMilestoneBranch;
+  const recordedBranchStateMessage = isRecordedMilestoneBranch
+    ? `Recorded integration branch "${recordedBranch}" for milestone ${milestoneId} is invalid (milestone branches cannot be merge targets)`
+    : `Recorded integration branch "${recordedBranch}" for milestone ${milestoneId} no longer exists`;
+
+  if (recordedBranchUsable && nativeBranchExists(basePath, recordedBranch)) {
     return {
       recordedBranch,
       effectiveBranch: recordedBranch,
@@ -499,7 +510,7 @@ export function resolveMilestoneIntegrationBranch(
         recordedBranch,
         effectiveBranch: configuredBranch,
         status: "fallback",
-        reason: `Recorded integration branch "${recordedBranch}" for milestone ${milestoneId} no longer exists; using configured git.main_branch "${configuredBranch}" instead.`,
+        reason: `${recordedBranchStateMessage}; using configured git.main_branch "${configuredBranch}" instead.`,
       };
     }
 
@@ -507,7 +518,7 @@ export function resolveMilestoneIntegrationBranch(
       recordedBranch,
       effectiveBranch: null,
       status: "missing",
-      reason: `Recorded integration branch "${recordedBranch}" for milestone ${milestoneId} no longer exists, and configured git.main_branch "${configuredBranch}" is unavailable.`,
+      reason: `${recordedBranchStateMessage}, and configured git.main_branch "${configuredBranch}" is unavailable.`,
     };
   }
 
@@ -518,7 +529,7 @@ export function resolveMilestoneIntegrationBranch(
         recordedBranch,
         effectiveBranch: detectedBranch,
         status: "fallback",
-        reason: `Recorded integration branch "${recordedBranch}" for milestone ${milestoneId} no longer exists; using detected fallback branch "${detectedBranch}" instead.`,
+        reason: `${recordedBranchStateMessage}; using detected fallback branch "${detectedBranch}" instead.`,
       };
     }
   } catch {
@@ -529,7 +540,7 @@ export function resolveMilestoneIntegrationBranch(
     recordedBranch,
     effectiveBranch: null,
     status: "missing",
-    reason: `Recorded integration branch "${recordedBranch}" for milestone ${milestoneId} no longer exists, and no safe fallback branch could be determined.`,
+    reason: `${recordedBranchStateMessage}, and no safe fallback branch could be determined.`,
   };
 }
 

--- a/src/resources/extensions/gsd/tests/merge-self-branch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/merge-self-branch-guard.test.ts
@@ -1,12 +1,9 @@
-// gsd-2 / merge-self-branch-guard.test.ts — regression for #5024
+// gsd-2 / merge-self-branch-guard.test.ts — regressions for #5024 and #6250
 //
-// mergeMilestoneToMain() must fail closed when the resolved integration
-// branch is the same ref as the milestone branch. Stale or corrupt
-// integration metadata (e.g. integrationBranch recorded as "milestone/<MID>")
-// would otherwise let the squash merge resolve to a self-merge: the post-
-// merge no-op safety check (#1792) compares main vs milestone and finds an
-// empty diff (because they're the same ref), so the helper returns success
-// for work that never landed on a distinct integration branch.
+// mergeMilestoneToMain() must recover from stale/corrupt integration metadata
+// that points at milestone branches (integrationBranch recorded as
+// "milestone/<MID>"). #6250 requires this to fall back to a safe integration
+// target (configured/detected main branch) instead of failing forever.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -42,7 +39,7 @@ function createTempRepo(): string {
   return dir;
 }
 
-function assertSelfMergeRefIsRejected(recordedIntegrationBranch: string): void {
+function assertSelfMergeRefRecoversToMain(recordedIntegrationBranch: string): void {
   const savedCwd = process.cwd();
   let tempDir = "";
 
@@ -70,39 +67,23 @@ function assertSelfMergeRefIsRejected(recordedIntegrationBranch: string): void {
     git(["add", "."], tempDir);
     git(["commit", "-m", "chore: plant corrupt M001 meta"], tempDir);
 
-    // Create the milestone branch ref so any pre-guard branch operations
-    // wouldn't fail for unrelated reasons.
-    git(["branch", "milestone/M001"], tempDir);
+    // Create milestone branch with a unique commit so successful merge-back
+    // to main can be observed.
+    git(["checkout", "-b", "milestone/M001"], tempDir);
+    writeFileSync(join(tempDir, "feature.txt"), "feature work\n");
+    git(["add", "feature.txt"], tempDir);
+    git(["commit", "-m", "feat: milestone work"], tempDir);
+    git(["checkout", "main"], tempDir);
 
     const mainHeadBefore = git(["rev-parse", "main"], tempDir);
-    const milestoneHeadBefore = git(["rev-parse", "milestone/M001"], tempDir);
-
     process.chdir(tempDir);
 
-    assert.throws(
-      () => mergeMilestoneToMain(tempDir, "M001", ""),
-      (err: unknown) => {
-        assert.ok(err instanceof Error, "expected an Error to be thrown");
-        assert.match(
-          err.message,
-          /self-merge|same ref/i,
-          "error message should explain the self-merge refusal",
-        );
-        return true;
-      },
-    );
+    mergeMilestoneToMain(tempDir, "M001", "");
 
-    // Postcondition: neither branch should have been advanced by a merge
-    // commit. The guard fires before checkout/merge, so both refs must be
-    // unchanged from their pre-call state.
+    // Postcondition: merge-back lands on main.
     const mainHeadAfter = git(["rev-parse", "main"], tempDir);
-    const milestoneHeadAfter = git(["rev-parse", "milestone/M001"], tempDir);
-    assert.equal(mainHeadAfter, mainHeadBefore, "main must not have advanced");
-    assert.equal(
-      milestoneHeadAfter,
-      milestoneHeadBefore,
-      "milestone branch must not have advanced",
-    );
+    assert.notEqual(mainHeadAfter, mainHeadBefore, "main must advance via merge-back");
+    assert.equal(git(["rev-parse", "HEAD"], tempDir), mainHeadAfter, "repo remains on main after merge-back");
   } finally {
     process.chdir(savedCwd);
     process.env.HOME = originalHome;
@@ -115,10 +96,10 @@ function assertSelfMergeRefIsRejected(recordedIntegrationBranch: string): void {
   }
 }
 
-test("mergeMilestoneToMain refuses exact milestone branch self-merge metadata (#5024)", () => {
-  assertSelfMergeRefIsRejected("milestone/M001");
+test("mergeMilestoneToMain recovers from exact milestone self-ref integration metadata (#6250)", () => {
+  assertSelfMergeRefRecoversToMain("milestone/M001");
 });
 
-test("mergeMilestoneToMain refuses refs/heads milestone branch self-merge metadata (#5024)", () => {
-  assertSelfMergeRefIsRejected("refs/heads/milestone/M001");
+test("mergeMilestoneToMain recovers from refs/heads milestone self-ref integration metadata (#6250)", () => {
+  assertSelfMergeRefRecoversToMain("refs/heads/milestone/M001");
 });


### PR DESCRIPTION
## Summary
- Finalization now rejects self-referential milestone integration metadata via the shared resolver and successfully falls back to a valid integration branch, verified by targeted git-service and merge guard tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6250
- [#6250 fix(gsd): survivor finalization cannot recover self-referential milestone integration metadata](https://github.com/gsd-build/gsd-2/issues/6250)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6250-fix-gsd-survivor-finalization-cannot-rec-1778949901`