### PR TITLE
fix(issue): Infinite loop: autoHealSketchFlags defined but never called — plan-slice loops when progressive_planning is off

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -325,7 +325,7 @@ export async function deriveState(
   // from ROADMAP.md, PLAN.md, SUMMARY.md, REQUIREMENTS.md, or flag files.
   if (isDbAvailable()) {
     const stopDbTimer = debugTime("derive-state-db");
-    result = await deriveStateFromDb(basePath);
+    result = await deriveStateFromDb(basePath, opts?.projectRootForReads ?? basePath);
     stopDbTimer({ phase: result.phase, milestone: result.activeMilestone?.id });
     _telemetry.dbDeriveCount++;
   } else if (process.env.GSD_ALLOW_MARKDOWN_DERIVE_FALLBACK === "1") {
@@ -659,7 +659,10 @@ function checkReplanTrigger(basePath: string, milestoneId: string, sliceId: stri
   return !!sliceRow?.replan_triggered_at;
 }
 
-export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
+export async function deriveStateFromDb(
+  basePath: string,
+  artifactReadRoot: string = basePath,
+): Promise<GSDState> {
   const requirements = getRequirementCounts();
 
   const allMilestones = getAllMilestones();
@@ -744,7 +747,7 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   // This recovers if PLAN.md exists but is_sketch was never flipped to 0.
   if (activeMilestone?.id) {
     autoHealSketchFlags(activeMilestone.id, (sid) => {
-      const planPath = resolveSliceFile(basePath, activeMilestone.id, sid, "PLAN");
+      const planPath = resolveSliceFile(artifactReadRoot, activeMilestone.id, sid, "PLAN");
       return planPath !== null && existsSync(planPath);
     });
     activeSliceRow = getSlice(activeMilestone.id, activeSlice.id);

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -40,6 +40,7 @@ import { findMilestoneIds } from './milestone-ids.js';
 import { loadQueueOrder, sortByQueueOrder } from './queue-order.js';
 import { isClosedStatus, isDeferredStatus } from './status-guards.js';
 import { nativeBatchParseGsdFiles, type BatchParsedFile } from './native-parser-bridge.js';
+import { autoHealSketchFlags } from './state-reconciliation/drift/sketch-flag.js';
 
 import { join, resolve } from 'path';
 import { existsSync, readdirSync } from 'node:fs';
@@ -736,7 +737,18 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
       progress: { milestones: milestoneProgress, slices: sliceProgress },
     };
   }
-  const { activeSlice, activeSliceRow } = activeSliceContext;
+  const { activeSlice } = activeSliceContext;
+  let activeSliceRow = activeSliceContext.activeSliceRow;
+
+  // Heal stale sketch flags before honoring the DB-authoritative sketch gate.
+  // This recovers if PLAN.md exists but is_sketch was never flipped to 0.
+  if (activeMilestone?.id) {
+    autoHealSketchFlags(activeMilestone.id, (sid) => {
+      const planPath = resolveSliceFile(basePath, activeMilestone.id, sid, "PLAN");
+      return planPath !== null && existsSync(planPath);
+    });
+    activeSliceRow = getSlice(activeMilestone.id, activeSlice.id);
+  }
 
   // ADR-011: DB slice metadata is authoritative for sketch refinement.
   // PLAN.md and preference flags are projections/configuration and are

--- a/src/resources/extensions/gsd/tests/progressive-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/progressive-planning.test.ts
@@ -198,6 +198,26 @@ test("ADR-011: autoHealSketchFlags flips is_sketch=0 when PLAN file exists", asy
   assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "post-heal: flag cleared");
 });
 
+test("ADR-011: deriveStateFromDb auto-heals stale sketch flag when PLAN exists", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  writePreferences(base, "phases:\n  skip_research: false");
+  // Simulate plan-slice completion where PLAN exists but is_sketch was not flipped.
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
+    "# S02 Plan\n",
+  );
+  process.chdir(base);
+
+  const state = await deriveStateFromDb(base);
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "derive should clear stale is_sketch");
+  assert.equal(state.phase, "planning", "state should advance past refining once stale flag is healed");
+});
+
 test("ADR-011: schema v16 is idempotent — re-opening DB preserves is_sketch and sketch_scope columns", async (t) => {
   const originalCwd = process.cwd();
   const base = mkdtempSync(join(tmpdir(), "gsd-adr011-schema-"));

--- a/src/resources/extensions/gsd/tests/progressive-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/progressive-planning.test.ts
@@ -17,7 +17,7 @@ import {
   getSlice,
 } from "../gsd-db.ts";
 import { autoHealSketchFlags } from "../state-reconciliation/drift/sketch-flag.ts";
-import { deriveStateFromDb } from "../state.ts";
+import { deriveState, deriveStateFromDb } from "../state.ts";
 import { resolveDispatch } from "../auto-dispatch.ts";
 import type { DispatchContext } from "../auto-dispatch.ts";
 
@@ -216,6 +216,27 @@ test("ADR-011: deriveStateFromDb auto-heals stale sketch flag when PLAN exists",
   const state = await deriveStateFromDb(base);
   assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "derive should clear stale is_sketch");
   assert.equal(state.phase, "planning", "state should advance past refining once stale flag is healed");
+});
+
+test("ADR-011: deriveState uses canonical artifact root for sketch-flag healing", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  writePreferences(base, "phases:\n  skip_research: false");
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
+    "# S02 Plan\n",
+  );
+  const worktreePath = join(base, "worker");
+  mkdirSync(worktreePath, { recursive: true });
+  process.chdir(worktreePath);
+
+  const state = await deriveState(worktreePath, { projectRootForReads: base });
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "deriveState should heal from canonical artifact root");
+  assert.equal(state.phase, "planning", "state should advance past refining when PLAN exists at canonical root");
 });
 
 test("ADR-011: schema v16 is idempotent — re-opening DB preserves is_sketch and sketch_scope columns", async (t) => {


### PR DESCRIPTION
## Summary
- Wired `autoHealSketchFlags` into DB state derivation and added a regression test proving stale `is_sketch` flags are cleared so refining no longer loops.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5514
- [#5514 Infinite loop: autoHealSketchFlags defined but never called — plan-slice loops when progressive_planning is off](https://github.com/gsd-build/gsd-2/issues/5514)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5514-infinite-loop-autohealsketchflags-define-1778951100`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically reconciles and repairs stale sketch flags to ensure accurate state progression in planning workflows

* **Tests**
  * Added test coverage for automatic sketch flag reconciliation logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->