### PR TITLE
fix(issue): pre-execution-checks fail due to absolute/relative path mismatch in task plans

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -20,7 +20,7 @@
 import { existsSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 import type { TaskRow } from "./db-task-slice-rows.js";
 import type { PreExecutionCheckJSON } from "./verification-evidence.ts";
 import { validateVerificationCommand } from "./verification-gate.js";
@@ -489,6 +489,13 @@ export function checkFilePathConsistency(
 ): PreExecutionCheckJSON[] {
   const results: PreExecutionCheckJSON[] = [];
   const resolutionRoots = [basePath, ...(context?.additionalRoots ?? [])];
+  const normalizedBasePath = normalizeFilePath(basePath);
+  const toComparisonPath = (filePath: string): string => {
+    const normalized = normalizeFilePath(filePath);
+    if (!isAbsolute(normalized)) return normalized;
+    const rel = normalizeFilePath(relative(normalizedBasePath, normalized));
+    return rel && !rel.startsWith("..") && rel !== "." ? rel : normalized;
+  };
 
   // Build a set of all files created by any task at any position (normalized).
   // Used to suppress consistency errors for files that will be caught with a
@@ -496,14 +503,14 @@ export function checkFilePathConsistency(
   const allTaskOutputs = new Set<string>();
   for (const t of tasks) {
     for (const f of t.expected_output) {
-      allTaskOutputs.add(normalizeFilePath(f));
+      allTaskOutputs.add(toComparisonPath(f));
     }
   }
 
   for (let i = 0; i < tasks.length; i++) {
     const task = tasks[i];
-    const priorOutputs = getExpectedOutputsUpTo(tasks, i);
-    const ownOutputs = new Set<string>(task.expected_output.map(normalizeFilePath));
+    const priorOutputs = new Set<string>(Array.from(getExpectedOutputsUpTo(tasks, i), toComparisonPath));
+    const ownOutputs = new Set<string>(task.expected_output.map(toComparisonPath));
     const filesToCheck = [...task.inputs];
 
     for (const file of filesToCheck) {
@@ -512,7 +519,7 @@ export function checkFilePathConsistency(
       if (!shouldValidateInputAsPath(file)) continue;
 
       // Normalize path for consistent comparison
-      const normalizedFile = normalizeFilePath(file);
+      const normalizedFile = toComparisonPath(file);
       if (containsGlobPattern(normalizedFile)) continue;
 
       // Check if file exists on disk

--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -449,6 +449,14 @@ function containsGlobPattern(candidate: string): boolean {
   return ["*", "?", "[", "]", "{", "}"].some((char) => candidate.includes(char));
 }
 
+function toComparisonPath(filePath: string, basePath: string): string {
+  const normalized = normalizeFilePath(filePath);
+  if (!isAbsolute(normalized)) return normalized;
+  const normalizedBasePath = normalizeFilePath(basePath);
+  const rel = normalizeFilePath(relative(normalizedBasePath, normalized));
+  return rel && !rel.startsWith("..") && rel !== "." ? rel : normalized;
+}
+
 /**
  * Build a set of files that will be created by tasks up to (but not including) taskIndex.
  * Also includes outputs of completed tasks at any position — a completed task has already
@@ -489,13 +497,6 @@ export function checkFilePathConsistency(
 ): PreExecutionCheckJSON[] {
   const results: PreExecutionCheckJSON[] = [];
   const resolutionRoots = [basePath, ...(context?.additionalRoots ?? [])];
-  const normalizedBasePath = normalizeFilePath(basePath);
-  const toComparisonPath = (filePath: string): string => {
-    const normalized = normalizeFilePath(filePath);
-    if (!isAbsolute(normalized)) return normalized;
-    const rel = normalizeFilePath(relative(normalizedBasePath, normalized));
-    return rel && !rel.startsWith("..") && rel !== "." ? rel : normalized;
-  };
 
   // Build a set of all files created by any task at any position (normalized).
   // Used to suppress consistency errors for files that will be caught with a
@@ -503,14 +504,16 @@ export function checkFilePathConsistency(
   const allTaskOutputs = new Set<string>();
   for (const t of tasks) {
     for (const f of t.expected_output) {
-      allTaskOutputs.add(toComparisonPath(f));
+      allTaskOutputs.add(toComparisonPath(f, basePath));
     }
   }
 
   for (let i = 0; i < tasks.length; i++) {
     const task = tasks[i];
-    const priorOutputs = new Set<string>(Array.from(getExpectedOutputsUpTo(tasks, i), toComparisonPath));
-    const ownOutputs = new Set<string>(task.expected_output.map(toComparisonPath));
+    const priorOutputs = new Set<string>(
+      Array.from(getExpectedOutputsUpTo(tasks, i), (filePath) => toComparisonPath(filePath, basePath)),
+    );
+    const ownOutputs = new Set<string>(task.expected_output.map((filePath) => toComparisonPath(filePath, basePath)));
     const filesToCheck = [...task.inputs];
 
     for (const file of filesToCheck) {
@@ -519,7 +522,7 @@ export function checkFilePathConsistency(
       if (!shouldValidateInputAsPath(file)) continue;
 
       // Normalize path for consistent comparison
-      const normalizedFile = toComparisonPath(file);
+      const normalizedFile = toComparisonPath(file, basePath);
       if (containsGlobPattern(normalizedFile)) continue;
 
       // Check if file exists on disk
@@ -580,7 +583,7 @@ export function checkTaskOrdering(
   for (let i = 0; i < tasks.length; i++) {
     const task = tasks[i];
     for (const file of task.expected_output) {
-      const normalizedFile = normalizeFilePath(file);
+      const normalizedFile = toComparisonPath(file, basePath);
       const existing = fileCreators.get(normalizedFile);
       if (!existing || (!existing.completed && task.status === "completed")) {
         fileCreators.set(normalizedFile, {
@@ -604,7 +607,7 @@ export function checkTaskOrdering(
       if (isRuntimeOnlyInput(file)) continue;
       if (!shouldValidateInputAsPath(file)) continue;
 
-      const normalizedFile = normalizeFilePath(file);
+      const normalizedFile = toComparisonPath(file, basePath);
       if (containsGlobPattern(normalizedFile)) continue;
       // A directory reference like `artifacts/M009-S03/` is never a concrete
       // read-before-create dependency: the fileCreators map is keyed by leaf

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -423,6 +423,40 @@ describe("checkFilePathConsistency with path normalization", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  test("absolute input path matches relative expected_output within basePath (#5519)", () => {
+    tempDir = join(tmpdir(), `pre-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+
+    try {
+      const absGenerated = join(tempDir, "src/new-file.ts");
+      const tasks = [
+        createTask({
+          id: "T01",
+          sequence: 0,
+          files: [],
+          inputs: [],
+          expected_output: ["src/new-file.ts"],
+        }),
+        createTask({
+          id: "T02",
+          sequence: 1,
+          files: [],
+          inputs: [absGenerated],
+          expected_output: [],
+        }),
+      ];
+
+      const results = checkFilePathConsistency(tasks, tempDir);
+      assert.deepEqual(
+        results,
+        [],
+        "Should pass because absolute/relative paths under basePath must compare equal",
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("checkTaskOrdering with path normalization", () => {

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -528,6 +528,38 @@ describe("checkTaskOrdering with path normalization", () => {
     const results = checkTaskOrdering(tasks, "/tmp");
     assert.deepEqual(results, [], "Should pass - T02 reads file that T01 already created");
   });
+
+  test("absolute input matches later relative expected_output and triggers ordering violation (#5519)", () => {
+    const tempDir = join(tmpdir(), `pre-exec-ordering-abs-rel-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+
+    try {
+      const tasks = [
+        createTask({
+          id: "T01",
+          sequence: 0,
+          files: [],
+          inputs: [join(tempDir, "src/new-file.ts")],
+          expected_output: [],
+        }),
+        createTask({
+          id: "T02",
+          sequence: 1,
+          files: [],
+          inputs: [],
+          expected_output: ["src/new-file.ts"],
+        }),
+      ];
+
+      const results = checkTaskOrdering(tasks, tempDir);
+      assert.equal(results.length, 1, "Should detect violation for equivalent absolute/relative paths");
+      assert.ok(results[0].message.includes("sequence violation"));
+      assert.ok(results[0].message.includes("T01"));
+      assert.ok(results[0].message.includes("T02"));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─── Task Ordering Tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Normalized file-path comparison in pre-execution checks to treat basePath absolute and relative paths equivalently, and verified with a focused passing test suite including a new #5519 regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5519
- [#5519 pre-execution-checks fail due to absolute/relative path mismatch in task plans](https://github.com/gsd-build/gsd-2/issues/5519)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5519-pre-execution-checks-fail-due-to-absolut-1778951707`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-path normalization so absolute and relative paths are treated consistently and safely (rejecting paths outside the base), ensuring accurate detection of input/output conflicts and ordering issues.
  * Aligned ordering checks with the same normalization logic to avoid false positives/negatives.

* **Tests**
  * Added unit tests for path-equivalence edge cases covering normalization and read-before-create ordering detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->