### PR TITLE
fix(issue): Bug: TTY guard exempts non-TTY invocations with any positional arg — InteractiveMode hangs on unknown subcommands (partial regression of #107)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -320,7 +320,12 @@ exitIfManagedResourcesAreNewer(agentDir)
 
 // Early TTY check — must come before heavy initialization to avoid dangling
 // handles that prevent process.exit() from completing promptly.
-const knownNonInteractiveSubcommands = new Set([
+// Subcommands exempt from the early non-TTY guard.
+// They are allowed past this gate and must enforce any command-specific TTY
+// requirements themselves (for example, `sessions` can be interactive).
+// Keep this list in sync with implemented CLI subcommands: if a legitimate
+// command is missing here, non-TTY invocation will fail early with a TTY error.
+const subcommandsExemptFromEarlyTtyCheck = new Set([
   'auto',
   'config',
   'graph',
@@ -334,8 +339,8 @@ const knownNonInteractiveSubcommands = new Set([
   'worktree',
   'wt',
 ])
-const isKnownSubcommand = knownNonInteractiveSubcommands.has(cliFlags.messages[0] ?? '')
-if (!process.stdin.isTTY && !isPrintMode && !isKnownSubcommand && !cliFlags.listModels && !cliFlags.web) {
+const isSubcommandExemptFromEarlyTtyCheck = subcommandsExemptFromEarlyTtyCheck.has(cliFlags.messages[0] ?? '')
+if (!process.stdin.isTTY && !isPrintMode && !isSubcommandExemptFromEarlyTtyCheck && !cliFlags.listModels && !cliFlags.web) {
   printNonTtyErrorAndExit(undefined, false)
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -320,8 +320,22 @@ exitIfManagedResourcesAreNewer(agentDir)
 
 // Early TTY check — must come before heavy initialization to avoid dangling
 // handles that prevent process.exit() from completing promptly.
-const hasSubcommand = cliFlags.messages.length > 0
-if (!process.stdin.isTTY && !isPrintMode && !hasSubcommand && !cliFlags.listModels && !cliFlags.web) {
+const knownNonInteractiveSubcommands = new Set([
+  'auto',
+  'config',
+  'graph',
+  'headless',
+  'install',
+  'list',
+  'remove',
+  'sessions',
+  'update',
+  'web',
+  'worktree',
+  'wt',
+])
+const isKnownSubcommand = knownNonInteractiveSubcommands.has(cliFlags.messages[0] ?? '')
+if (!process.stdin.isTTY && !isPrintMode && !isKnownSubcommand && !cliFlags.listModels && !cliFlags.web) {
   printNonTtyErrorAndExit(undefined, false)
 }
 

--- a/src/tests/integration/e2e-smoke.test.ts
+++ b/src/tests/integration/e2e-smoke.test.ts
@@ -347,6 +347,21 @@ test("gsd with no TTY exits 1 with clean terminal-required error", async () => {
   assertNoCrashMarkers(combined);
 });
 
+test("gsd with unknown subcommand and no TTY exits 1 without hanging", async () => {
+  const result = await runGsd(["nonsense"], 15_000);
+
+  assert.ok(!result.timedOut, "process should not hang");
+  assert.strictEqual(result.code, 1, `expected exit 1, got ${result.code}`);
+
+  const combined = stripAnsi(result.stdout + result.stderr);
+  assert.ok(
+    combined.includes("TTY") || combined.includes("terminal") || combined.includes("Interactive"),
+    `expected TTY/terminal error message, got:\n${combined.slice(0, 500)}`,
+  );
+
+  assertNoCrashMarkers(combined);
+});
+
 // ---------------------------------------------------------------------------
 // 10. gsd with unknown flags does not crash
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Tightened the early non-TTY guard to only allow known subcommands and added a regression test proving unknown subcommands now fail fast instead of hanging.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5524
- [#5524 Bug: TTY guard exempts non-TTY invocations with any positional arg — InteractiveMode hangs on unknown subcommands (partial regression of #107)](https://github.com/gsd-build/gsd-2/issues/5524)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5524-bug-tty-guard-exempts-non-tty-invocation-1778953499`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved CLI handling for known subcommands in non-TTY environments, allowing them to execute without requiring a terminal.
* Enhanced error handling and messaging for unknown subcommands in non-interactive mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->