### PR TITLE
fix(issue): plan-slice / refine-slice never clears is_sketch=1, causing infinite refine-slice dispatch loop

### DIFF
--- a/src/resources/extensions/gsd/prompts/refine-slice.md
+++ b/src/resources/extensions/gsd/prompts/refine-slice.md
@@ -39,7 +39,7 @@ The Sketch Scope inlined above is a **hard constraint**. Plan within it. If code
 Before decomposing:
 
 1. Read inlined prior slice SUMMARY files. Note interface shifts, file-layout changes, and constraints.
-2. Use `rg`, `find`, and targeted reads to confirm current code for files the sketch references. If a module/type/API moved or changed, reflect that.
+2. Use `read`, `grep`, `glob`, `ls`, and targeted reads to confirm current code for files the sketch references. If you need richer search, use read-only `bash` commands. If a module/type/API moved or changed, reflect that.
 3. If prior slices flagged fragility or known issues relevant to this slice, fold them into task verification.
 
 ### Source Files


### PR DESCRIPTION
## Summary
- Updated refine-slice prompt tooling guidance to match planning-dispatch policy and verified progressive-planning/refine-loop coverage tests pass.

## Bugs Addressed
- [ ] **Sketch flag never cleared after successful refine-slice** _(skipped: already fixed in this branch (`setSliceSketchFlag(..., false)` in plan/refine transaction path and `autoHealSketchFlags` call in state derivation).)_
- [x] **Refine-slice prompt conflicts with planning-dispatch tool policy**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5531
- [#5531 plan-slice / refine-slice never clears is_sketch=1, causing infinite refine-slice dispatch loop](https://github.com/gsd-build/gsd-2/issues/5531)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5531-plan-slice-refine-slice-never-clears-is--1778956508`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions for verifying referenced source code with improved command recommendations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->