### PR TITLE
fix(issue): v1→v2 migration parser: add Strategy 2 for milestone-summary + subsection format

### DIFF
--- a/src/resources/extensions/gsd/migrate/parsers.ts
+++ b/src/resources/extensions/gsd/migrate/parsers.ts
@@ -67,6 +67,7 @@ function parsePhaseEntry(line: string): PlanningRoadmapEntry | null {
     let title = fmtPhaseColon[3].trim();
     // Strip trailing parentheticals, plan counts, and completion notes
     title = title.replace(/\s*\(\d+\/\d+\s+plans?\)/, '')
+                 .replace(/\s*[—–]\s+.*$/, '') // strip em/en-dash description suffix
                  .replace(/\s*--\s+.*$/, '')
                  .replace(/\s*-\s+.*$/, '')  // strip "- description" suffix
                  .replace(/\s*\(completed.*\)$/i, '')
@@ -158,7 +159,14 @@ export function parseOldRoadmap(content: string): PlanningRoadmap {
     return result;
   }
 
-  // ─── Strategy 2: Detect ## heading-sectioned milestones ───
+  // ─── Strategy 2: Detect ## Milestones summary + ### vN.N subsections ───
+  const summaryMilestones = parseMilestoneSummaryFormat(lines);
+  if (summaryMilestones.length > 0) {
+    result.milestones = summaryMilestones;
+    return result;
+  }
+
+  // ─── Strategy 3: Detect ## heading-sectioned milestones ───
   const milestoneHeadingRegex = /^##\s+(.+)$/;
   const milestoneHeadings: { index: number; id: string; title: string }[] = [];
 
@@ -207,7 +215,7 @@ export function parseOldRoadmap(content: string): PlanningRoadmap {
       result.milestones.push(milestone);
     }
   } else {
-    // ─── Strategy 3: Flat format — just extract all phase checkbox lines ───
+    // ─── Strategy 4: Flat format — just extract all phase checkbox lines ───
     for (const line of lines) {
       const entry = parsePhaseEntry(line.trim());
       if (entry) {
@@ -265,6 +273,124 @@ function parseDetailsBlockMilestones(lines: string[]): PlanningRoadmapMilestone[
         currentMilestone.phases.push(entry);
       }
     }
+  }
+
+  return milestones;
+}
+
+/**
+ * Parse a `## Milestones` summary section paired with `### vN.N ... (Phases N-M)` subsections.
+ * Returns empty array if not detected.
+ */
+function parseMilestoneSummaryFormat(lines: string[]): PlanningRoadmapMilestone[] {
+  let milestoneSectionStart = -1;
+  let milestoneSectionEnd = lines.length;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (/^##\s+Milestones?\s*$/i.test(lines[i].trim())) {
+      milestoneSectionStart = i + 1;
+      for (let j = i + 1; j < lines.length; j++) {
+        if (/^##\s+/.test(lines[j])) {
+          milestoneSectionEnd = j;
+          break;
+        }
+      }
+      break;
+    }
+  }
+
+  if (milestoneSectionStart === -1) return [];
+
+  type MilestoneSummaryEntry = {
+    id: string;
+    title: string;
+    done: boolean;
+    phaseStart: number;
+    phaseEnd: number;
+  };
+
+  const summaryEntries: MilestoneSummaryEntry[] = [];
+  for (let i = milestoneSectionStart; i < milestoneSectionEnd; i++) {
+    const line = lines[i].trim();
+    if (!line.startsWith('-')) continue;
+    const stripped = line.replace(/\*\*/g, '');
+    const match = stripped.match(
+      /^-\s+\[([ xX])\]\s+(?:Phase\s+)?\d+(?:\.\d+)?\s*:\s*(v[\d.]+)\s+(.+?)(?:\s*[—–]\s*Phases?\s+(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?))?(?:\s*\(.*\))?\s*$/
+    );
+    if (!match) continue;
+
+    const id = match[2];
+    const titleSuffix = match[3]
+      .replace(/\s*[—–]\s*Phases?\s+\d+(?:\.\d+)?\s*-\s*\d+(?:\.\d+)?.*$/, '')
+      .replace(/\s*\(.*\)\s*$/, '')
+      .trim();
+
+    summaryEntries.push({
+      id,
+      title: `${id} ${titleSuffix}`.trim(),
+      done: match[1].toLowerCase() === 'x',
+      phaseStart: match[4] ? parseFloat(match[4]) : 0,
+      phaseEnd: match[5] ? parseFloat(match[5]) : 0,
+    });
+  }
+
+  if (summaryEntries.length === 0) return [];
+
+  const subsectionPhases = new Map<string, PlanningRoadmapEntry[]>();
+  for (let i = 0; i < lines.length; i++) {
+    const headingMatch = lines[i].trim().match(/^###\s+(v[\d.]+)\s+(.+?)(?:\s*\(Phases?\s+[\d.]+\s*-\s*[\d.]+\))?\s*$/i);
+    if (!headingMatch) continue;
+
+    const id = headingMatch[1];
+    const phases: PlanningRoadmapEntry[] = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      const sectionLine = lines[j].trim();
+      if (/^##\s+/.test(sectionLine) || /^###\s+/.test(sectionLine)) break;
+      const entry = parsePhaseEntry(sectionLine);
+      if (entry) phases.push(entry);
+    }
+
+    if (phases.length > 0) subsectionPhases.set(id, phases);
+  }
+
+  const milestones: PlanningRoadmapMilestone[] = [];
+  for (const entry of summaryEntries) {
+    const phases = subsectionPhases.get(entry.id);
+    if (phases && phases.length > 0) {
+      milestones.push({
+        id: entry.id,
+        title: entry.title,
+        collapsed: false,
+        phases,
+      });
+      continue;
+    }
+
+    if (entry.done && entry.phaseStart > 0 && entry.phaseEnd >= entry.phaseStart) {
+      const synthetic: PlanningRoadmapEntry[] = [];
+      for (let n = entry.phaseStart; n <= entry.phaseEnd; n += 1) {
+        synthetic.push({
+          number: n,
+          title: `Phase ${n}`,
+          done: true,
+          raw: `synthetic:${entry.id}:${n}`,
+        });
+      }
+      milestones.push({
+        id: entry.id,
+        title: entry.title,
+        collapsed: false,
+        phases: synthetic,
+      });
+      continue;
+    }
+
+    milestones.push({
+      id: entry.id,
+      title: entry.title,
+      collapsed: false,
+      phases: [],
+    });
   }
 
   return milestones;

--- a/src/resources/extensions/gsd/tests/migrate-validator-parsers.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-validator-parsers.test.ts
@@ -74,6 +74,17 @@ const SAMPLE_MILESTONE_SECTIONED_ROADMAP = `# Project Roadmap
 - [ ] 31 — Notifications
 `;
 
+const SAMPLE_MILESTONE_SUMMARY_SUBSECTION_ROADMAP = `# Project Roadmap
+
+## Milestones
+- [x] **Phase 1: v1.0 MVP** — Phases 1-6 (shipped 2026-02-24)
+- [ ] **Phase 45: v1.8 Production Readiness** — Phases 45-54 (in progress)
+
+### v1.8 Production Readiness (Phases 45-54)
+- [ ] **Phase 45: Feature X** — long description...
+- [ ] **Phase 46: Feature Y** — long description...
+`;
+
 const SAMPLE_PLAN_XML = `---
 phase: "29-auth-system"
 plan: "01"
@@ -289,6 +300,30 @@ test('parseOldRoadmap: milestone-sectioned with <details>', () => {
     assert.deepStrictEqual(p29?.done, true, 'ms roadmap: phase 29 done');
     const p30 = v25?.phases.find(p => p.number === 30);
     assert.deepStrictEqual(p30?.done, false, 'ms roadmap: phase 30 not done');
+});
+
+test('parseOldRoadmap: milestones summary + vN.N subsections', () => {
+    const roadmap = parseOldRoadmap(SAMPLE_MILESTONE_SUMMARY_SUBSECTION_ROADMAP);
+    assert.deepStrictEqual(roadmap.phases.length, 0, 'summary+subsections: no flat phases');
+    assert.deepStrictEqual(roadmap.milestones.length, 2, 'summary+subsections: two milestones');
+
+    const v10 = roadmap.milestones.find(m => m.id === 'v1.0');
+    assert.ok(v10 !== undefined, 'summary+subsections: v1.0 found');
+    assert.deepStrictEqual(v10?.phases.length, 6, 'summary+subsections: v1.0 uses synthetic completed range');
+    assert.ok(v10?.phases.every(p => p.done) ?? false, 'summary+subsections: v1.0 synthetic phases marked done');
+
+    const v18 = roadmap.milestones.find(m => m.id === 'v1.8');
+    assert.ok(v18 !== undefined, 'summary+subsections: v1.8 found');
+    assert.deepStrictEqual(v18?.phases.length, 2, 'summary+subsections: v1.8 phases parsed from subsection');
+    assert.deepStrictEqual(v18?.phases[0]?.number, 45, 'summary+subsections: first subsection phase number');
+    assert.deepStrictEqual(v18?.phases[0]?.title, 'Feature X', 'summary+subsections: em-dash description stripped');
+    assert.deepStrictEqual(v18?.phases[1]?.number, 46, 'summary+subsections: second subsection phase number');
+});
+
+test('parseOldRoadmap: phase title strips em-dash suffix description', () => {
+    const roadmap = parseOldRoadmap('- [ ] Phase 45: Feature X — long description...');
+    assert.deepStrictEqual(roadmap.phases.length, 1, 'em-dash strip: one parsed phase');
+    assert.deepStrictEqual(roadmap.phases[0]?.title, 'Feature X', 'em-dash strip: title excludes suffix description');
 });
 
   // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Added Strategy 2 milestone-summary/subsection roadmap parsing and em-dash suffix stripping, then verified with the migrate validator/parser test suite.

## Bugs Addressed
- [x] **Parser misses Milestones summary plus vN.N subsection format**
- [x] **Phase titles retain em-dash description suffix**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5536
- [#5536 v1→v2 migration parser: add Strategy 2 for milestone-summary + subsection format](https://github.com/gsd-build/gsd-2/issues/5536)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5536-v1-v2-migration-parser-add-strategy-2-fo-1778957102`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Phase titles now normalize properly by removing trailing dash-formatted descriptions.
  * Roadmap parsing now supports milestone summaries paired with version-specific subsections for improved structure handling.

* **Tests**
  * Added test coverage for the new roadmap format and phase title sanitization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->