### PR TITLE
fix(issue): Add auto-mode diagnostic for root/worktree artifact mismatch

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1207,16 +1207,18 @@ export const DISPATCH_RULES: DispatchRule[] = [
           const expectedTaskPlanPath = join(artifactBasePath, relTaskFile(artifactBasePath, mid, sid, tid, "PLAN"));
           const originalProjectRoot = session?.originalBasePath || basePath;
           const activeMilestoneWorktreePath = session?.basePath || basePath;
-          const artifactExists = taskPlanPath ? existsSync(taskPlanPath) : false;
+          const expectedTaskPlanExists = existsSync(expectedTaskPlanPath);
           debugLog("dispatch-missing-task-plan-recovery", {
             selectedDispatchRule: "executing → execute-task (recover missing task plan → plan-slice)",
             basePathUsedForArtifactChecks: artifactBasePath,
             milestoneRoot: artifactBasePath,
             originalProjectRoot,
             activeMilestoneWorktreePath,
+            hasRootWorktreeMismatch: originalProjectRoot !== activeMilestoneWorktreePath,
             expectedTaskPlanPath,
             projectionTaskPlanPath,
-            artifactExists,
+            expectedTaskPlanExists,
+            artifactExists: expectedTaskPlanExists,
             projectionArtifactExists: existsSync(projectionTaskPlanPath),
           });
         }

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1218,6 +1218,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
             expectedTaskPlanPath,
             projectionTaskPlanPath,
             expectedTaskPlanExists,
+            // Retained for compatibility with existing diagnostic parsers.
             artifactExists: expectedTaskPlanExists,
             projectionArtifactExists: existsSync(projectionTaskPlanPath),
           });

--- a/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
@@ -244,7 +244,9 @@ test("dispatch: missing task plan recovery logs root/worktree diagnostic when de
   assert.ok(entry, "diagnostic event should be logged when recovery fires in debug mode");
   assert.equal(entry!.basePathUsedForArtifactChecks, tmp);
   assert.equal(entry!.artifactExists, false, "task plan is genuinely absent");
+  assert.equal(entry!.expectedTaskPlanExists, false, "expected task plan is genuinely absent");
   assert.equal(entry!.projectionArtifactExists, false, "projection task plan is genuinely absent");
+  assert.equal(entry!.hasRootWorktreeMismatch, false, "root/worktree mismatch should be false in single-root scenario");
   assert.equal(typeof entry!.expectedTaskPlanPath, "string");
   assert.equal(typeof entry!.projectionTaskPlanPath, "string");
 });


### PR DESCRIPTION
## Summary
- Added precise debug logging for plan-slice missing-task-plan recovery path context (root/worktree, expected path, existence) and verified with focused dispatch recovery tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6194
- [#6194 Add auto-mode diagnostic for root/worktree artifact mismatch](https://github.com/gsd-build/gsd-2/issues/6194)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6194-add-auto-mode-diagnostic-for-root-worktr-1778960908`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging for missing-task-plan recovery to report root/worktree mismatch and task-plan existence more accurately.

* **Tests**
  * Added assertions to ensure recovery diagnostics include the correct root/worktree mismatch flag in single-root scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->