### PR TITLE
fix(issue): Clear stale paused-session replay after completed planning unit

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -499,6 +499,9 @@ function handlePausedSessionResumeRecovery(
 
   if (completedPausedUnit) {
     state.pausedSessionFile = null;
+    state.pausedUnitType = null;
+    state.pausedUnitId = null;
+    state.pendingCrashRecovery = null;
     return { skippedReplay: true };
   }
 
@@ -513,6 +516,8 @@ function handlePausedSessionResumeRecovery(
     notify(`Recovered ${recovery.trace.toolCallCount} tool calls from paused session. Resuming with context.`);
   }
   state.pausedSessionFile = null;
+  state.pausedUnitType = null;
+  state.pausedUnitId = null;
   return { skippedReplay: false };
 }
 
@@ -2683,8 +2688,8 @@ export async function startAuto(
         "resuming",
         s.currentMilestoneId ?? "unknown",
       );
-      clearPausedSession("paused-session DB cleanup failed (resume activation)");
     }
+    clearPausedSession("paused-session DB cleanup failed (resume activation)");
     pi.events.emit(CMUX_CHANNELS.LOG, { preferences: loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, message: s.stepMode ? "Step-mode resumed." : "Auto-mode resumed.", level: "progress" });
 
     try {

--- a/src/resources/extensions/gsd/tests/interrupted-session-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/interrupted-session-auto.test.ts
@@ -209,10 +209,10 @@ test("direct /gsd auto skips paused-session replay when recovered unit already c
 
     const state = {
       pausedSessionFile: join(base, ".gsd", "activity", "paused-session.jsonl"),
-      currentUnit: { type: "plan-slice", id: "M001/S01" },
-      pausedUnitType: null,
-      pausedUnitId: null,
-      pendingCrashRecovery: null,
+      currentUnit: null,
+      pausedUnitType: "plan-slice",
+      pausedUnitId: "M001/S01",
+      pendingCrashRecovery: "stale-recovery-prompt",
     };
 
     const result = _handlePausedSessionResumeRecoveryForTest(base, state);

--- a/src/resources/extensions/gsd/tests/interrupted-session-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/interrupted-session-auto.test.ts
@@ -219,6 +219,8 @@ test("direct /gsd auto skips paused-session replay when recovered unit already c
     assert.equal(result.skippedReplay, true);
     assert.equal(state.pausedSessionFile, null);
     assert.equal(state.pendingCrashRecovery, null);
+    assert.equal(state.pausedUnitType, null);
+    assert.equal(state.pausedUnitId, null);
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## Summary
- Cleared stale paused-session resume metadata and added regression coverage so completed plan-slice resumes no longer replay stale recovery context.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6193
- [#6193 Clear stale paused-session replay after completed planning unit](https://github.com/gsd-build/gsd-2/issues/6193)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6193-clear-stale-paused-session-replay-after--1778960929`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced paused session recovery handling to ensure complete and reliable cleanup of all session tracking state during crash recovery scenarios. This improvement guarantees proper state clearing when resuming from interruptions, regardless of system configuration, preventing incomplete state issues that could negatively impact subsequent session operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->