### PR TITLE
fix(issue): Resolve task-plan artifact checks against active milestone worktree

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -245,7 +245,6 @@ function resolveArtifactBasePath(
   if (
     session?.basePath &&
     session.currentMilestoneId === mid &&
-    session.basePath !== session.originalBasePath &&
     existsSync(session.basePath)
   ) {
     return session.basePath;

--- a/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-missing-task-plans.test.ts
@@ -192,6 +192,33 @@ test("dispatch: active session worktree task plan wins over missing original-roo
     `unitId should be M004/S02/T01, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`);
 });
 
+test("dispatch: artifact checks trust active session basePath even when originalBasePath matches", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-worktree-session-basepath-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  scaffoldMilestoneContext(tmp, "M004");
+  scaffoldSlicePlan(tmp, "M004", "S02");
+
+  const activeMilestoneRoot = join(tmp, ".gsd", "runtime-active", "M004");
+  mkdirSync(activeMilestoneRoot, { recursive: true });
+  scaffoldMilestoneContext(activeMilestoneRoot, "M004");
+  scaffoldSlicePlan(activeMilestoneRoot, "M004", "S02");
+  scaffoldTaskPlan(activeMilestoneRoot, "M004", "S02", "T01");
+
+  const ctx = makeContextFor(tmp, "M004", "S02", "T01", {
+    basePath: activeMilestoneRoot,
+    originalBasePath: activeMilestoneRoot,
+    currentMilestoneId: "M004",
+  });
+  const result = await resolveDispatch(ctx);
+
+  assert.equal(result.action, "dispatch");
+  assert.ok(result.action === "dispatch" && result.unitType === "execute-task",
+    `unitType should be execute-task, got: ${result.action === "dispatch" ? result.unitType : "(stop)"}`);
+  assert.ok(result.action === "dispatch" && result.unitId === "M004/S02/T01",
+    `unitId should be M004/S02/T01, got: ${result.action === "dispatch" ? result.unitId : "(stop)"}`);
+});
+
 test("dispatch: plan-slice recovery loop — second call after plan-slice still recovers cleanly", async (t) => {
   // Simulate: plan-slice ran but T01-PLAN.md is still missing (e.g. agent crashed mid-write).
   // Dispatch should still re-dispatch plan-slice, not hard-stop.


### PR DESCRIPTION
## Summary
- Fixed executing-phase task-plan recovery to honor active milestone session worktree paths and added regression coverage, with targeted dispatch/worktree tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6192
- [#6192 Resolve task-plan artifact checks against active milestone worktree](https://github.com/gsd-build/gsd-2/issues/6192)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6192-resolve-task-plan-artifact-checks-agains-1778960960`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session path resolution to correctly handle cases where alternate paths exist, ensuring proper dispatch operations in runtime-active scenarios.

* **Tests**
  * Added regression test for dispatch resolution with matching active and original session paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->