### PR TITLE
fix(issue): plan-slice never clears is_sketch flag — causes infinite refining loop

### DIFF
--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -270,6 +270,27 @@ test('handlePlanSlice clears sketch flag so DB-derived state leaves refining', a
   }
 });
 
+test('handlePlanSlice preserves sketch flag when render fails before artifacts exist', async () => {
+  const base = makeTmpBase();
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  try {
+    insertMilestone({ id: 'M001', title: 'Milestone', status: 'active' });
+    insertSlice({ id: 'S02', milestoneId: 'M001', title: 'Planning slice', status: 'pending', demo: 'Rendered plans exist.', isSketch: true });
+
+    const sliceDir = join(base, '.gsd', 'milestones', 'M001', 'slices', 'S02');
+    rmSync(sliceDir, { recursive: true, force: true });
+    writeFileSync(sliceDir, 'not a directory', 'utf-8');
+
+    const result = await handlePlanSlice(validParams(), base);
+    assert.ok('error' in result);
+    assert.match(result.error, /render failed:/);
+    assert.equal(getSlice('M001', 'S02')?.is_sketch, 1, 'sketch flag must stay set when plan artifacts could not render');
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('handlePlanSlice leaves omitted enrichment fields empty instead of rendering placeholders', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -329,7 +329,6 @@ export async function handlePlanSlice(
       if (isDeferredStatus(parentSlice.status)) {
         updateSliceStatus(params.milestoneId, params.sliceId, "pending");
       }
-      setSliceSketchFlag(params.milestoneId, params.sliceId, false);
 
       upsertSlicePlanning(params.milestoneId, params.sliceId, {
         goal: params.goal,
@@ -398,6 +397,7 @@ export async function handlePlanSlice(
     }
 
     const renderResult = await renderPlanFromDb(basePath, params.milestoneId, params.sliceId);
+    setSliceSketchFlag(params.milestoneId, params.sliceId, false);
     invalidateStateCache();
     clearParseCache();
 


### PR DESCRIPTION
## Summary
- Updated plan-slice to clear `is_sketch` only after successful plan render and verified with focused plan-slice and progressive-planning tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5556
- [#5556 plan-slice never clears is_sketch flag — causes infinite refining loop](https://github.com/gsd-build/gsd-2/issues/5556)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5556-plan-slice-never-clears-is-sketch-flag-c-1778963087`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parent slice status is now set to pending reliably during planning.
  * Ensures a slice’s sketch flag is not cleared when rendering fails before artifacts exist.

* **Tests**
  * Added an integration test that verifies the sketch flag is preserved when render/artifact issues occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->