### PR TITLE
fix(issue): [Bug]: TTY EIO during streaming leaves agent in stuck state — only /compact recovers

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -361,6 +361,7 @@ export class InteractiveMode {
 	private extensionInput: ExtensionInputComponent | undefined = undefined;
 	private extensionEditor: ExtensionEditorComponent | undefined = undefined;
 	private extensionTerminalInputUnsubscribers = new Set<() => void>();
+	private stdinErrorHandler: ((err: Error) => void) | undefined = undefined;
 
 	// Extension widgets (components rendered above/below the editor)
 	private extensionWidgetsAbove = new Map<string, Component & { dispose?(): void }>();
@@ -534,6 +535,22 @@ export class InteractiveMode {
 		}
 	}
 
+	private installStdinErrorRecovery(): void {
+		if (this.stdinErrorHandler) return;
+		this.stdinErrorHandler = (err: Error) => {
+			const errno = err as NodeJS.ErrnoException;
+			const isReadEio = errno.code === "EIO" || /read EIO/i.test(err.message);
+			if (!isReadEio) return;
+
+			process.stderr.write(`[pi] stdin EIO detected, aborting active stream\n`);
+			if (this.session.isStreaming) {
+				this.agent.abort("unknown");
+				this.showWarning("Terminal input was interrupted (EIO). Aborted the active response; send your message again.");
+			}
+		};
+		process.stdin.on("error", this.stdinErrorHandler);
+	}
+
 	async init(): Promise<void> {
 		if (this.isInitialized) return;
 
@@ -639,6 +656,7 @@ export class InteractiveMode {
 
 		// Start the UI
 		this.ui.start();
+		this.installStdinErrorRecovery();
 		this.isInitialized = true;
 
 		// Set terminal title
@@ -4322,6 +4340,10 @@ export class InteractiveMode {
 		this.footerDataProvider.dispose();
 		if (this.unsubscribe) {
 			this.unsubscribe();
+		}
+		if (this.stdinErrorHandler) {
+			process.stdin.removeListener("error", this.stdinErrorHandler);
+			this.stdinErrorHandler = undefined;
 		}
 		if (this.isInitialized) {
 			this.ui.stop();

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -29,6 +29,10 @@ export function handleRecoverableExtensionProcessError(err: Error): boolean {
   if ((err as NodeJS.ErrnoException).code === "EPIPE") {
     process.exit(0);
   }
+  if ((err as NodeJS.ErrnoException).code === "EIO") {
+    process.stderr.write(`[gsd] EIO: ${err.message}\n`);
+    return true;
+  }
   if ((err as NodeJS.ErrnoException).code === "ENOENT") {
     const syscall = (err as NodeJS.ErrnoException).syscall;
     if (syscall?.startsWith("spawn")) {

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -30,8 +30,11 @@ export function handleRecoverableExtensionProcessError(err: Error): boolean {
     process.exit(0);
   }
   if ((err as NodeJS.ErrnoException).code === "EIO") {
-    process.stderr.write(`[gsd] EIO: ${err.message}\n`);
-    return true;
+    const syscall = (err as NodeJS.ErrnoException).syscall;
+    if (syscall === "read") {
+      process.stderr.write(`[gsd] EIO: ${err.message}\n`);
+      return true;
+    }
   }
   if ((err as NodeJS.ErrnoException).code === "ENOENT") {
     const syscall = (err as NodeJS.ErrnoException).syscall;

--- a/src/resources/extensions/gsd/tests/register-extension-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/register-extension-guard.test.ts
@@ -48,7 +48,7 @@ test("handleRecoverableExtensionProcessError swallows uv_cwd ENOENT", () => {
   }
 });
 
-test("handleRecoverableExtensionProcessError swallows EIO", () => {
+test("handleRecoverableExtensionProcessError swallows read EIO", () => {
 	let stderr = "";
 	const originalWrite = process.stderr.write.bind(process.stderr);
 	process.stderr.write = ((chunk: string | Uint8Array) => {
@@ -68,6 +68,16 @@ test("handleRecoverableExtensionProcessError swallows EIO", () => {
 	} finally {
 		process.stderr.write = originalWrite;
 	}
+});
+
+test("handleRecoverableExtensionProcessError leaves non-read EIO unhandled", () => {
+  const handled = handleRecoverableExtensionProcessError(
+    Object.assign(new Error("open EIO"), {
+      code: "EIO",
+      syscall: "open",
+    }),
+  );
+  assert.equal(handled, false);
 });
 
 test("handleRecoverableExtensionProcessError leaves unrelated errors unhandled", () => {

--- a/src/resources/extensions/gsd/tests/register-extension-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/register-extension-guard.test.ts
@@ -48,6 +48,28 @@ test("handleRecoverableExtensionProcessError swallows uv_cwd ENOENT", () => {
   }
 });
 
+test("handleRecoverableExtensionProcessError swallows EIO", () => {
+	let stderr = "";
+	const originalWrite = process.stderr.write.bind(process.stderr);
+	process.stderr.write = ((chunk: string | Uint8Array) => {
+		stderr += String(chunk);
+		return true;
+	}) as typeof process.stderr.write;
+
+	try {
+		const handled = handleRecoverableExtensionProcessError(
+			Object.assign(new Error("read EIO"), {
+				code: "EIO",
+				syscall: "read",
+			}),
+		);
+		assert.equal(handled, true);
+		assert.match(stderr, /\[gsd\] EIO: read EIO/);
+	} finally {
+		process.stderr.write = originalWrite;
+	}
+});
+
 test("handleRecoverableExtensionProcessError leaves unrelated errors unhandled", () => {
   const handled = handleRecoverableExtensionProcessError(
     Object.assign(new Error("permission denied"), {


### PR DESCRIPTION
## Summary
- Added recoverable EIO handling and stdin-EIO stream-abort recovery, verified with targeted guard tests.

## Bugs Addressed
- [x] **TTY read EIO is not handled as recoverable terminal error**
- [x] **Agent remains stuck after stream interruption from TTY EIO**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5558
- [#5558 [Bug]: TTY EIO during streaming leaves agent in stuck state — only /compact recovers](https://github.com/gsd-build/gsd-2/issues/5558)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5558-bug-tty-eio-during-streaming-leaves-agen-1778964306`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive mode now recovers from stdin read failures: streaming responses are aborted gracefully and a warning is shown instead of crashing.

* **Bug Fixes**
  * Extension process error handling treats specific read-related EIO errors as recoverable, avoiding forced termination and crash logs.

* **Tests**
  * Added tests covering recoverable EIO/read error handling and non-recoverable cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->