### PR TITLE
fix(issue): Blocked needs-remediation warning tells users to use internal tool instead of real recovery command

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -171,6 +171,16 @@ function formatWorktreeSafetyStopReason(result: Extract<WorktreeSafetyResult, { 
   return `Worktree Safety failed (${result.kind}).`;
 }
 
+function formatBlockedResumeMessage(blockers: string[]): string {
+  const hasNeedsRemediationDeadEnd = blockers.some((blocker) =>
+    blocker.includes("needs-remediation") && blocker.includes("all slices are complete")
+  );
+  if (hasNeedsRemediationDeadEnd) {
+    return "Blocked: milestone validation requires remediation but all slices are complete. Run /gsd dispatch reassess to add remediation slices, then /gsd auto to continue.";
+  }
+  return `Blocked: ${blockers.join(", ")}. Fix and run /gsd auto to resume.`;
+}
+
 function resolveEmptyWorktreeWithProjectContent(
   unitRoot: string,
   projectRoot: string,
@@ -1133,14 +1143,14 @@ export async function runPreDispatch(
         `No milestones found — check basePath resolution`,
       );
     } else if (state.phase === "blocked") {
-      const blockerMsg = `Blocked: ${state.blockers.join(", ")}`;
+      const blockedResumeMessage = formatBlockedResumeMessage(state.blockers);
       // Pause instead of hard-stop so the session is resumable with `/gsd auto`.
       // Hard-stop here was causing premature termination when slice dependencies
       // were temporarily unresolvable (e.g. after reassessment added new slices).
       await deps.pauseAuto(ctx, pi);
-      ctx.ui.notify(`${blockerMsg}. Fix and run /gsd auto to resume.`, "warning");
-      deps.sendDesktopNotification("GSD", blockerMsg, "warning", "attention", basename(s.originalBasePath || s.basePath));
-      deps.logCmuxEvent(prefs, blockerMsg, "warning");
+      ctx.ui.notify(blockedResumeMessage, "warning");
+      deps.sendDesktopNotification("GSD", blockedResumeMessage, "warning", "attention", basename(s.originalBasePath || s.basePath));
+      deps.logCmuxEvent(prefs, blockedResumeMessage, "warning");
     } else {
       const ids = incomplete.map((m: { id: string }) => m.id).join(", ");
       const diag = `basePath=${s.basePath}, milestones=[${state.registry.map((m: { id: string; status: string }) => `${m.id}:${m.status}`).join(", ")}], phase=${state.phase}`;
@@ -1238,7 +1248,7 @@ export async function runPreDispatch(
 
   // Terminal: blocked — pause instead of hard-stop so the session is resumable.
   if (state.phase === "blocked") {
-    const blockerMsg = `Blocked: ${state.blockers.join(", ")}`;
+    const blockedResumeMessage = formatBlockedResumeMessage(state.blockers);
     if (s.currentUnit) {
       await deps.closeoutUnit(
         ctx,
@@ -1250,9 +1260,9 @@ export async function runPreDispatch(
       );
     }
     await deps.pauseAuto(ctx, pi);
-    ctx.ui.notify(`${blockerMsg}. Fix and run /gsd auto to resume.`, "warning");
-    deps.sendDesktopNotification("GSD", blockerMsg, "warning", "attention", basename(s.originalBasePath || s.basePath));
-    deps.logCmuxEvent(prefs, blockerMsg, "warning");
+    ctx.ui.notify(blockedResumeMessage, "warning");
+    deps.sendDesktopNotification("GSD", blockedResumeMessage, "warning", "attention", basename(s.originalBasePath || s.basePath));
+    deps.logCmuxEvent(prefs, blockedResumeMessage, "warning");
     debugLog("autoLoop", { phase: "exit", reason: "blocked" });
     deps.emitJournalEvent({ ts: new Date().toISOString(), flowId: ic.flowId, seq: ic.nextSeq(), eventType: "terminal", data: { reason: "blocked", blockers: state.blockers } });
     return { action: "break", reason: "blocked" };

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -171,14 +171,36 @@ function formatWorktreeSafetyStopReason(result: Extract<WorktreeSafetyResult, { 
   return `Worktree Safety failed (${result.kind}).`;
 }
 
+type BlockerKind = "needs-remediation-dead-end" | "other";
+
+function classifyBlocker(blocker: string): BlockerKind {
+  const normalized = blocker.toLowerCase();
+  if (normalized.includes("needs-remediation") && normalized.includes("all slices are complete")) {
+    return "needs-remediation-dead-end";
+  }
+  return "other";
+}
+
+function sanitizeBlockerForUser(blocker: string): string {
+  return blocker.replaceAll("gsd_reassess_roadmap", "/gsd dispatch reassess");
+}
+
+/**
+ * Formats blocked resume guidance for users, ensuring internal tool names are
+ * never surfaced in notification text.
+ */
 function formatBlockedResumeMessage(blockers: string[]): string {
-  const hasNeedsRemediationDeadEnd = blockers.some((blocker) =>
-    blocker.includes("needs-remediation") && blocker.includes("all slices are complete")
+  const classifiedBlockers = blockers.map((blocker) => ({
+    blocker: sanitizeBlockerForUser(blocker),
+    kind: classifyBlocker(blocker),
+  }));
+  const hasNeedsRemediationDeadEnd = classifiedBlockers.some(
+    (classifiedBlocker) => classifiedBlocker.kind === "needs-remediation-dead-end"
   );
   if (hasNeedsRemediationDeadEnd) {
     return "Blocked: milestone validation requires remediation but all slices are complete. Run /gsd dispatch reassess to add remediation slices, then /gsd auto to continue.";
   }
-  return `Blocked: ${blockers.join(", ")}. Fix and run /gsd auto to resume.`;
+  return `Blocked: ${classifiedBlockers.map((classifiedBlocker) => classifiedBlocker.blocker).join(", ")}. Fix and run /gsd auto to resume.`;
 }
 
 function resolveEmptyWorktreeWithProjectContent(

--- a/src/resources/extensions/gsd/tests/auto-blocked-remediation-message.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-blocked-remediation-message.test.ts
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runPreDispatch } from "../auto/phases.ts";
+
+test("blocked remediation warning uses /gsd dispatch reassess and hides internal tool name", async () => {
+  const notifications: Array<{ message: string; level?: string }> = [];
+  const desktopMessages: string[] = [];
+
+  const ic = {
+    ctx: {
+      ui: {
+        notify(message: string, level?: string) {
+          notifications.push({ message, level });
+        },
+      },
+    },
+    pi: {},
+    s: {
+      basePath: "/tmp/gsd-test",
+      originalBasePath: "/tmp/gsd-test",
+      canonicalProjectRoot: "/tmp/gsd-test",
+      resourceVersionOnStart: "test",
+      currentMilestoneId: null,
+      currentUnit: null,
+      milestoneMergedInPhases: false,
+    },
+    prefs: undefined,
+    iteration: 1,
+    flowId: "flow-1",
+    nextSeq: () => 1,
+    deps: {
+      checkResourcesStale() {
+        return null;
+      },
+      invalidateAllCaches() {},
+      async preDispatchHealthGate() {
+        return { proceed: true, fixesApplied: [] };
+      },
+      async deriveState() {
+        return {
+          phase: "blocked",
+          activeMilestone: { id: "M005", title: "Milestone five" },
+          activeSlice: null,
+          activeTask: null,
+          recentDecisions: [],
+          blockers: [
+            "Milestone M005 validation verdict is needs-remediation but all slices are complete. Add remediation slices via gsd_reassess_roadmap, or run `/gsd verdict pass --rationale \"...\"` to override.",
+          ],
+          nextAction: "Resolve M005 remediation before proceeding.",
+          registry: [{ id: "M005", status: "active" }],
+        };
+      },
+      syncCmuxSidebar() {},
+      setActiveMilestoneId() {},
+      getIsolationMode() {
+        return "none";
+      },
+      captureIntegrationBranch() {},
+      pruneQueueOrder() {},
+      async rebuildState() {},
+      reconcileMergeState() {
+        return "clean";
+      },
+      async pauseAuto() {},
+      sendDesktopNotification(_title: string, message: string) {
+        desktopMessages.push(message);
+      },
+      logCmuxEvent() {},
+      emitJournalEvent() {},
+    },
+  } as any;
+
+  const result = await runPreDispatch(ic, {
+    recentUnits: [],
+    stuckRecoveryAttempts: 0,
+    consecutiveFinalizeTimeouts: 0,
+  });
+
+  assert.deepEqual(result, { action: "break", reason: "blocked" });
+
+  const warning = notifications.find((n) => n.level === "warning")?.message ?? "";
+  assert.match(warning, /\/gsd dispatch reassess/);
+  assert.doesNotMatch(warning, /gsd_reassess_roadmap/);
+
+  const desktop = desktopMessages[0] ?? "";
+  assert.match(desktop, /\/gsd dispatch reassess/);
+  assert.doesNotMatch(desktop, /gsd_reassess_roadmap/);
+});


### PR DESCRIPTION
## Summary
- Updated blocked remediation warnings to point users to `/gsd dispatch reassess` (not `gsd_reassess_roadmap`) and verified with a focused regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5562
- [#5562 Blocked needs-remediation warning tells users to use internal tool instead of real recovery command](https://github.com/gsd-build/gsd-2/issues/5562)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5562-blocked-needs-remediation-warning-tells--1778965501`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized and standardized the “blocked resume” messaging when dispatch is paused for remediation.
  * Notifications now consistently include guidance to run reassess and avoid leaking internal tool names.
  * In-app and desktop notifications show the same user-facing wording.

* **Tests**
  * Added coverage for blocked remediation warnings and notification content/consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->