### PR TITLE
fix(issue): [Bug]: [Windows] Worktree fails to merge back to main after slice execution — source code stranded in .gsd/worktrees/M001/

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -188,6 +188,7 @@ import { recoverFailedMigration } from "./migrate-external.js";
 import { initRegistry, convertDispatchRules } from "./rule-registry.js";
 import { emitJournalEvent as _emitJournalEvent, type JournalEntry } from "./journal.js";
 import { isClosedStatus } from "./status-guards.js";
+import { MILESTONE_ID_RE } from "./milestone-ids.js";
 import {
   type AutoDashboardData,
   updateProgressWidget as _updateProgressWidget,
@@ -1321,7 +1322,11 @@ export async function stopAuto(
     // Skip if phases.ts already merged this milestone — avoids the double
     // mergeAndExit that fails because the branch was already deleted (#2645).
     try {
-      if (s.currentMilestoneId && !s.milestoneMergedInPhases) {
+      const stopMilestoneId = _resolveStopAutoMilestoneId(
+        s.currentMilestoneId,
+        s.basePath,
+      );
+      if (stopMilestoneId && !s.milestoneMergedInPhases) {
         const notifyCtx = ctx
           ? { notify: ctx.ui.notify.bind(ctx.ui) }
           : { notify: () => {} };
@@ -1338,19 +1343,19 @@ export async function stopAuto(
         let milestoneComplete = false;
         try {
           if (isDbAvailable()) {
-            const dbRow = getMilestone(s.currentMilestoneId);
+            const dbRow = getMilestone(stopMilestoneId);
             milestoneComplete = dbRow?.status === "complete";
           } else {
             const summaryPath = resolveMilestoneFile(
               s.originalBasePath || s.basePath,
-              s.currentMilestoneId,
+              stopMilestoneId,
               "SUMMARY",
             );
             if (!summaryPath) {
               // Also check in the worktree path (SUMMARY may not be synced yet)
               const wtSummaryPath = resolveMilestoneFile(
                 s.basePath,
-                s.currentMilestoneId,
+                stopMilestoneId,
                 "SUMMARY",
               );
               milestoneComplete = wtSummaryPath !== null;
@@ -1364,7 +1369,7 @@ export async function stopAuto(
         }
 
         const exitAction = _selectStopAutoWorktreeExit({
-          currentMilestoneId: s.currentMilestoneId,
+          currentMilestoneId: stopMilestoneId,
           milestoneComplete,
           milestoneMergedInPhases: s.milestoneMergedInPhases,
         });
@@ -1372,7 +1377,7 @@ export async function stopAuto(
         if (exitAction === "merge") {
           // Milestone is complete — merge worktree branch back to main
           const r = lifecycle.exitMilestone(
-            s.currentMilestoneId,
+            stopMilestoneId,
             { merge: true },
             notifyCtx,
           );
@@ -1380,7 +1385,7 @@ export async function stopAuto(
         } else if (exitAction === "preserve") {
           // Milestone still in progress — preserve branch for later resumption
           const r = lifecycle.exitMilestone(
-            s.currentMilestoneId,
+            stopMilestoneId,
             { merge: false, preserveBranch: true },
             notifyCtx,
           );
@@ -1663,6 +1668,15 @@ export async function stopAuto(
 }
 
 export type StopAutoWorktreeExitAction = "none" | "merge" | "preserve";
+
+export function _resolveStopAutoMilestoneId(
+  currentMilestoneId: string | null,
+  basePath: string,
+): string | null {
+  if (currentMilestoneId) return currentMilestoneId;
+  const detected = detectWorktreeName(basePath);
+  return detected && MILESTONE_ID_RE.test(detected) ? detected : null;
+}
 
 export function _selectStopAutoWorktreeExit(args: {
   currentMilestoneId: string | null;

--- a/src/resources/extensions/gsd/tests/stop-auto-merge-back.test.ts
+++ b/src/resources/extensions/gsd/tests/stop-auto-merge-back.test.ts
@@ -11,7 +11,7 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { _selectStopAutoWorktreeExit } from "../auto.ts";
+import { _resolveStopAutoMilestoneId, _selectStopAutoWorktreeExit } from "../auto.ts";
 
 test("#5576: stopAuto should check milestone completion status before choosing exit strategy", () => {
   assert.equal(
@@ -65,5 +65,19 @@ test("#5576: stopAuto returns none when phases are already merged even if milest
       milestoneMergedInPhases: true,
     }),
     "none",
+  );
+});
+
+test("#6273: stopAuto infers milestone id from milestone worktree path when session milestone id is missing", () => {
+  assert.equal(
+    _resolveStopAutoMilestoneId(null, "/repo/.gsd/worktrees/M001"),
+    "M001",
+  );
+});
+
+test("#6273: stopAuto does not infer non-milestone worktree names", () => {
+  assert.equal(
+    _resolveStopAutoMilestoneId(null, "/repo/.gsd/worktrees/feature-x"),
+    null,
   );
 });


### PR DESCRIPTION
## Summary
- stopAuto now infers milestone ID from `.gsd/worktrees/M###` when missing and correctly runs merge/preserve exit, verified by targeted regression tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6273
- [#6273 [Bug]: [Windows] Worktree fails to merge back to main after slice execution — source code stranded in .gsd/worktrees/M001/](https://github.com/gsd-build/gsd-2/issues/6273)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6273-bug-windows-worktree-fails-to-merge-back-1778966092`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree exit handling to reliably determine the correct milestone ID from worktree paths when the current session milestone ID is unavailable, ensuring consistent behavior across different worktree scenarios.

* **Tests**
  * Added regression tests verifying that milestone IDs are correctly inferred from milestone worktree names and that non-milestone worktrees are properly handled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->