### PR TITLE
fix(issue): auto-mode: stuck-detection Level 1 recovery reset enables infinite re-dispatch loop (43+ dispatches)

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -50,7 +50,7 @@ import {
   formatForNotification,
   hasAnyIssues,
 } from "../workflow-logger.js";
-import { gsdRoot } from "../paths.js";
+import { gsdRoot, normalizeRealPath } from "../paths.js";
 import { atomicWriteSync } from "../atomic-write.js";
 import { verifyExpectedArtifact, diagnoseExpectedArtifact, buildLoopRemediationSteps, refreshRecoveryDbForArtifact } from "../auto-recovery.js";
 import { writeUnitRuntimeRecord } from "../unit-runtime.js";
@@ -59,6 +59,8 @@ import { getEligibleSlices } from "../slice-parallel-eligibility.js";
 import { isSliceParallelActive, startSliceParallel } from "../slice-parallel-orchestrator.js";
 import { isDbAvailable, getMilestoneSlices, getSlice, getTask, refreshOpenDatabaseFromDisk } from "../gsd-db.js";
 import { isClosedStatus } from "../status-guards.js";
+import { setRuntimeKv } from "../db/runtime-kv.js";
+import { getLatestForUnit } from "../db/unit-dispatches.js";
 import { reconcileBeforeSpawn } from "../state-reconciliation.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
 import type { PostflightResult, PreflightResult } from "../clean-root-preflight.js";
@@ -88,6 +90,7 @@ import {
 } from "../root-write-leak-guard.js";
 
 export const STUCK_WINDOW_SIZE = 6;
+const STUCK_RECOVERY_ATTEMPTS_KEY = "stuck_recovery_attempts";
 
 // ─── Path Comparison Helper ───────────────────────────────────────────────
 /** Compare two paths for physical identity, tolerating trailing slashes and symlinks. */
@@ -99,6 +102,21 @@ function isIsolatedWorktreeSession(s: AutoSession): boolean {
   return Boolean(s.originalBasePath)
     && Boolean(s.basePath)
     && !isSamePathLocal(s.originalBasePath, s.basePath);
+}
+
+function persistStuckRecoveryAttempts(s: AutoSession, loopState: LoopState): void {
+  const scopeId = normalizeRealPath(
+    s.scope?.workspace.projectRoot ?? (s.originalBasePath || s.basePath),
+  );
+  if (!scopeId) return;
+  try {
+    setRuntimeKv("global", scopeId, STUCK_RECOVERY_ATTEMPTS_KEY, loopState.stuckRecoveryAttempts);
+  } catch (err) {
+    debugLog("autoLoop", {
+      phase: "save-stuck-state-failed",
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 async function applyVerificationRetryPolicy(
@@ -1556,7 +1574,9 @@ export async function runDispatch(
   // Always record this dispatch in the sliding window and run detection so
   // Rules 1/3/4 can catch retry loops with repeated failure content (#5719).
   // Rules 2/2b suppress legitimate retry backoff through the dispatch ledger.
-  loopState.recentUnits.push({ key: derivedKey });
+  const latestDispatch = getLatestForUnit(derivedKey);
+  const recentError = latestDispatch?.error_summary ?? undefined;
+  loopState.recentUnits.push({ key: derivedKey, error: recentError });
   while (loopState.recentUnits.length > STUCK_WINDOW_SIZE) {
     loopState.recentUnits.shift();
   }
@@ -1577,6 +1597,7 @@ export async function runDispatch(
       if (loopState.stuckRecoveryAttempts === 0) {
         // Level 1: try verifying the artifact, then cache invalidation + retry
         loopState.stuckRecoveryAttempts++;
+        persistStuckRecoveryAttempts(s, loopState);
         const artifactExists = verifyExpectedArtifact(
           unitType,
           unitId,
@@ -1647,7 +1668,6 @@ export async function runDispatch(
               "info",
             );
             loopState.recentUnits.length = 0;
-            loopState.stuckRecoveryAttempts = 0;
             return { action: "continue" };
           }
           ctx.ui.notify(

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1112,6 +1112,7 @@ export async function runPreDispatch(
     s.unitLifetimeDispatches.clear();
     loopState.recentUnits.length = 0;
     loopState.stuckRecoveryAttempts = 0;
+    persistStuckRecoveryAttempts(s, loopState);
 
     // Worktree lifecycle on milestone transition — merge current, enter next.
     // #2909 / #5538-followup: preflight stash + always-on postflight pop.
@@ -1709,6 +1710,7 @@ export async function runDispatch(
         to: derivedKey,
       });
       loopState.stuckRecoveryAttempts = 0;
+      persistStuckRecoveryAttempts(s, loopState);
     }
   }
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1099,7 +1099,7 @@ test("autoLoop exits on terminal complete state", async (t) => {
   );
 });
 
-test("autoLoop persists stuck counter reset when dispatch recovery continues", async () => {
+test("autoLoop preserves stuck recovery counter when dispatch recovery continues", async () => {
   _resetPendingResolve();
 
   const ctx = makeMockCtx();
@@ -1163,8 +1163,8 @@ test("autoLoop persists stuck counter reset when dispatch recovery continues", a
 
     assert.equal(
       getRuntimeKv<number>("global", basePath, "stuck_recovery_attempts"),
-      0,
-      "dispatch-level artifact recovery exits through continue, so the reset counter must still persist",
+      1,
+      "dispatch-level artifact recovery exits through continue and must preserve escalation state",
     );
   } finally {
     try { closeDatabase(); } catch { /* noop */ }

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -770,7 +770,7 @@ test("runDispatch escapes Level 2 stuck stop when artifact verifies after cache 
   assert.equal(invalidateCalls, 1, "Level 2 escape should invalidate caches before rechecking artifacts");
   assert.equal(stopCalls, 0, "verified artifacts should escape Level 2 hard stop");
   assert.deepEqual(loopState.recentUnits, [], "Level 2 artifact escape should clear the stuck window");
-  assert.equal(loopState.stuckRecoveryAttempts, 0, "Level 2 artifact escape should reset the recovery counter");
+  assert.equal(loopState.stuckRecoveryAttempts, 1, "Level 2 artifact escape should preserve the recovery counter");
 });
 
 test("runUnitPhase emits unit-start and unit-end with causedBy reference", async () => {


### PR DESCRIPTION
## Summary
- Fixed stuck recovery counter handling and error-populated stuck windows, then validated with focused auto-loop and stuck-detection tests passing.

## Bugs Addressed
- [x] **Level 1 recovery counter resets, causing infinite redispatch loops**
- [x] **Stuck recovery attempts are not persisted on Level 1 fallthrough**
- [x] **Stuck detection rules for repeated errors are unreachable**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5564
- [#5564 auto-mode: stuck-detection Level 1 recovery reset enables infinite re-dispatch loop (43+ dispatches)](https://github.com/gsd-build/gsd-2/issues/5564)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5564-auto-mode-stuck-detection-level-1-recove-1778967310`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-loop recovery now persists and preserves stuck-recovery counters across recovery phases, ensuring correct escalation and continuity.
  * Recovery tracking now captures dispatch error summaries alongside unit history for better diagnostics.

* **Tests**
  * Updated tests to assert that stuck-recovery attempts are preserved when dispatch recovery continues and during specific recovery scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->