### PR TITLE
fix(issue): pre-execution-checks: plan-slice template wraps annotations inside backticks, causing false file-not-found blocking (regression of #4623)

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -362,7 +362,12 @@ function extractPathFromAnnotation(raw: string): string {
 
   const backtickMatch = trimmed.match(/^(`+)([^`]+)\1(?:(?:\s+[—–-]\s+.+)|(?:\s+\([^()]+\)))?$/);
   if (backtickMatch) {
-    return backtickMatch[2].trim();
+    const inner = backtickMatch[2].trim();
+    const innerParenMatch = inner.match(/^(.+?)\s+\([^()]+\)$/);
+    if (innerParenMatch) return innerParenMatch[1].trim();
+    const innerAnnotatedMatch = inner.match(/^(.+?)\s+[—–-]\s+.+$/);
+    if (innerAnnotatedMatch) return innerAnnotatedMatch[1].trim();
+    return inner;
   }
 
   // Strip leading/trailing double or single quotes wrapping the whole value.

--- a/src/resources/extensions/gsd/tests/pre-exec-backtick-strip.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-exec-backtick-strip.test.ts
@@ -32,6 +32,13 @@ describe('normalizeFilePath backtick stripping (#3649)', () => {
     )
   })
 
+  it('strips dash-style annotation text inside a single backtick pair (#5566)', () => {
+    assert.equal(
+      normalizeFilePath('`src/foo.ts — current state`'),
+      'src/foo.ts',
+    )
+  })
+
   it('strips stray backticks from dash-annotated bare paths (#4550)', () => {
     assert.equal(
       normalizeFilePath('.gsd/KNOWLEDGE.md` — append-only S05 lessons section'),

--- a/src/resources/extensions/gsd/tests/pre-exec-backtick-strip.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-exec-backtick-strip.test.ts
@@ -25,6 +25,13 @@ describe('normalizeFilePath backtick stripping (#3649)', () => {
     assert.equal(normalizeFilePath('``src/foo.ts`` (current state)'), 'src/foo.ts')
   })
 
+  it('strips annotation text inside a single backtick pair (#5566)', () => {
+    assert.equal(
+      normalizeFilePath('`monitoring/services/url_validator.py (new file — no prior inputs)`'),
+      'monitoring/services/url_validator.py',
+    )
+  })
+
   it('strips stray backticks from dash-annotated bare paths (#4550)', () => {
     assert.equal(
       normalizeFilePath('.gsd/KNOWLEDGE.md` — append-only S05 lessons section'),


### PR DESCRIPTION
## Summary
- Fixed pre-execution path parsing for annotation text inside single backticks and verified with a focused regression test suite.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5566
- [#5566 pre-execution-checks: plan-slice template wraps annotations inside backticks, causing false file-not-found blocking (regression of #4623)](https://github.com/gsd-build/gsd-2/issues/5566)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5566-pre-execution-checks-plan-slice-template-1778968499`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-path normalization: when paths are enclosed in single backticks, trailing parenthetical segments and trailing dash-style annotations are removed, yielding cleaner, consistent paths for validation.

* **Tests**
  * Added regression tests verifying backtick-wrapped paths strip trailing parenthetical and dash annotations, preventing false mismatches in path checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->