### PR TITLE
fix(issue): gsd_skip_slice does not cascade task statuses to skipped

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -10,7 +10,7 @@ import { randomUUID } from "node:crypto";
 
 import { symlinkSync, realpathSync } from "node:fs";
 
-import { _getAdapter, closeDatabase } from "../../../src/resources/extensions/gsd/gsd-db.ts";
+import { _getAdapter, closeDatabase, getSliceTasks } from "../../../src/resources/extensions/gsd/gsd-db.ts";
 import { _buildImportCandidates, registerWorkflowTools, WORKFLOW_TOOL_NAMES, validateProjectDir } from "./workflow-tools.ts";
 
 function makeTmpBase(): string {
@@ -625,6 +625,116 @@ describe("workflow MCP tools", () => {
       assert.equal(parsed.milestoneId, "M001");
       assert.equal(parsed.sliceCount, 1);
       assert.equal(parsed.slices[0].id, "S01");
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("gsd_skip_slice cascades pending/active tasks to skipped", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const milestoneTool = server.tools.find((t) => t.name === "gsd_plan_milestone");
+      const sliceTool = server.tools.find((t) => t.name === "gsd_plan_slice");
+      const planTaskTool = server.tools.find((t) => t.name === "gsd_plan_task");
+      const skipTool = server.tools.find((t) => t.name === "gsd_skip_slice");
+      assert.ok(milestoneTool, "milestone planning tool should be registered");
+      assert.ok(sliceTool, "slice planning tool should be registered");
+      assert.ok(planTaskTool, "task planning tool should be registered");
+      assert.ok(skipTool, "skip slice tool should be registered");
+
+      await milestoneTool!.handler({
+        projectDir: base,
+        milestoneId: "M001",
+        title: "Skip slice cascade",
+        vision: "Ensure skip cascades task statuses.",
+        slices: [
+          {
+            sliceId: "S01",
+            title: "Slice to skip",
+            risk: "low",
+            depends: [],
+            demo: "Tasks are skipped when slice is skipped.",
+            goal: "Create pending tasks and skip the slice.",
+            successCriteria: "Tasks become skipped after gsd_skip_slice.",
+            proofLevel: "integration",
+            integrationClosure: "MCP skip tool updates slice and tasks together.",
+            observabilityImpact: "Regression test guards pending-task dead-end.",
+          },
+        ],
+      });
+
+      await sliceTool!.handler({
+        projectDir: base,
+        milestoneId: "M001",
+        sliceId: "S01",
+        goal: "Create tasks that should be cascaded.",
+        tasks: [
+          {
+            taskId: "T01",
+            title: "Pending one",
+            description: "Will be skipped via cascade.",
+            estimate: "5m",
+            files: ["src/a.ts"],
+            verify: "node --test",
+            inputs: ["M001-ROADMAP.md"],
+            expectedOutput: ["T01-PLAN.md"],
+          },
+          {
+            taskId: "T02",
+            title: "Pending two",
+            description: "Will be skipped via cascade.",
+            estimate: "5m",
+            files: ["src/b.ts"],
+            verify: "node --test",
+            inputs: ["M001-ROADMAP.md"],
+            expectedOutput: ["T02-PLAN.md"],
+          },
+        ],
+      });
+
+      await planTaskTool!.handler({
+        projectDir: base,
+        milestoneId: "M001",
+        sliceId: "S01",
+        taskId: "T01",
+        title: "Pending one",
+        description: "Will be skipped via cascade.",
+        estimate: "5m",
+        files: ["src/a.ts"],
+        verify: "node --test",
+        inputs: ["M001-ROADMAP.md"],
+        expectedOutput: ["T01-PLAN.md"],
+      });
+
+      await planTaskTool!.handler({
+        projectDir: base,
+        milestoneId: "M001",
+        sliceId: "S01",
+        taskId: "T02",
+        title: "Pending two",
+        description: "Will be skipped via cascade.",
+        estimate: "5m",
+        files: ["src/b.ts"],
+        verify: "node --test",
+        inputs: ["M001-ROADMAP.md"],
+        expectedOutput: ["T02-PLAN.md"],
+      });
+
+      const skipResult = await skipTool!.handler({
+        projectDir: base,
+        milestoneId: "M001",
+        sliceId: "S01",
+        reason: "descoped",
+      });
+      assert.match((skipResult as any).content[0].text as string, /Skipped slice S01/);
+
+      const tasks = getSliceTasks("M001", "S01");
+      assert.equal(tasks.length, 2, "expected planned tasks to exist");
+      for (const task of tasks) {
+        assert.equal(task.status, "skipped", `task ${task.id} should be skipped by cascade`);
+      }
     } finally {
       cleanup(base);
     }

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -722,6 +722,10 @@ describe("workflow MCP tools", () => {
         expectedOutput: ["T02-PLAN.md"],
       });
 
+      _getAdapter()!
+        .prepare("UPDATE tasks SET status = 'active' WHERE milestone_id = ? AND slice_id = ? AND id = ?")
+        .run("M001", "S01", "T02");
+
       const skipResult = await skipTool!.handler({
         projectDir: base,
         milestoneId: "M001",

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -1809,21 +1809,16 @@ export function registerWorkflowTools(realServer: McpToolServer): void {
       const { projectDir, milestoneId, sliceId, reason } = parseWorkflowArgs(skipSliceSchema, args);
       await enforceWorkflowWriteGate("gsd_skip_slice", projectDir, milestoneId);
       await runSerializedWorkflowDbOperation(projectDir, async () => {
-        const { getSlice, updateSliceStatus } = await importLocalModule<any>("../../../src/resources/extensions/gsd/gsd-db.js");
+        const { handleSkipSlice } = await importLocalModule<any>("../../../src/resources/extensions/gsd/tools/skip-slice.js");
         const { invalidateStateCache } = await importLocalModule<any>("../../../src/resources/extensions/gsd/state.js");
         const { rebuildState } = await importLocalModule<any>("../../../src/resources/extensions/gsd/doctor.js");
-        const slice = getSlice(milestoneId, sliceId);
-        if (!slice) {
-          throw new Error(`Slice ${sliceId} not found in milestone ${milestoneId}`);
+        const result = handleSkipSlice({ milestoneId, sliceId, reason });
+        if (result.error) {
+          throw new Error(result.error);
         }
-        if (slice.status === "complete" || slice.status === "done") {
-          throw new Error(`Slice ${sliceId} is already complete and cannot be skipped`);
-        }
-        if (slice.status !== "skipped") {
-          updateSliceStatus(milestoneId, sliceId, "skipped");
-          invalidateStateCache();
-          await rebuildState(projectDir);
-        }
+
+        invalidateStateCache();
+        await rebuildState(projectDir);
       });
       return {
         content: [{ type: "text" as const, text: `Skipped slice ${sliceId} (${milestoneId}). Reason: ${reason ?? "User-directed skip"}.` }],


### PR DESCRIPTION
## Summary
- Updated MCP `gsd_skip_slice` to cascade task statuses via the shared handler and added/passed a regression test proving skipped-slice task cascade.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5569
- [#5569 gsd_skip_slice does not cascade task statuses to skipped](https://github.com/gsd-build/gsd-2/issues/5569)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5569-gsd-skip-slice-does-not-cascade-task-sta-1778969104`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test that verifies skipping a slice marks all tasks in that slice as skipped.

* **Improvements**
  * Updated the slice-skip tool to centralize skip logic, rebuild state and invalidate caches for more reliable behavior and clearer error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->