### PR TITLE
fix(issue): Auto-mode stuck in completing-milestone loop when agent aborted mid-completion

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -97,6 +97,7 @@ export type ArtifactRecoveryDbRefreshResult =
 export function refreshRecoveryDbForArtifact(
   unitType: string,
   unitId: string,
+  basePath: string,
 ): ArtifactRecoveryDbRefreshResult {
   if (unitType !== "plan-slice" && unitType !== "execute-task" && unitType !== "complete-milestone") return { ok: true };
   if (!isDbAvailable()) return { ok: true };
@@ -170,6 +171,15 @@ export function refreshRecoveryDbForArtifact(
           message: `Stuck recovery found complete-milestone ${unitId} artifacts, but task ${slice.id}/${openTask.id} is still "${openTask.status}" in the DB.`,
         };
       }
+    }
+
+    if (hasImplementationArtifacts(basePath, mid) !== "present") {
+      return {
+        ok: false,
+        fatal: true,
+        reason: "complete-milestone-implementation-missing",
+        message: `Stuck recovery found complete-milestone ${unitId} artifacts, but implementation evidence is not present.`,
+      };
     }
 
     updateMilestoneStatus(mid, "complete", new Date().toISOString());

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -15,7 +15,7 @@ import { appendEvent } from "./workflow-events.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { clearParseCache } from "./files.js";
 import { parseRoadmap as parseLegacyRoadmap, parsePlan as parseLegacyPlan } from "./parsers-legacy.js";
-import { isDbAvailable, getTask, getSlice, getSliceTasks, getPendingGates, updateTaskStatus, updateSliceStatus, insertSlice, getMilestone, refreshOpenDatabaseFromDisk, getCompletedMilestoneTaskFileHints, getMilestoneCommitAttributionShas, recordMilestoneCommitAttribution } from "./gsd-db.js";
+import { isDbAvailable, getTask, getSlice, getSliceTasks, getPendingGates, updateTaskStatus, updateSliceStatus, insertSlice, getMilestone, getMilestoneSlices, getLatestAssessmentByScope, updateMilestoneStatus, refreshOpenDatabaseFromDisk, getCompletedMilestoneTaskFileHints, getMilestoneCommitAttributionShas, recordMilestoneCommitAttribution } from "./gsd-db.js";
 import { isValidationTerminal } from "./state.js";
 import { getErrorMessage } from "./error-utils.js";
 import { logWarning, logError } from "./workflow-logger.js";
@@ -98,16 +98,82 @@ export function refreshRecoveryDbForArtifact(
   unitType: string,
   unitId: string,
 ): ArtifactRecoveryDbRefreshResult {
-  if (unitType !== "plan-slice" && unitType !== "execute-task") return { ok: true };
+  if (unitType !== "plan-slice" && unitType !== "execute-task" && unitType !== "complete-milestone") return { ok: true };
   if (!isDbAvailable()) return { ok: true };
 
   if (!refreshOpenDatabaseFromDisk()) {
     return {
       ok: false,
-      fatal: unitType === "execute-task",
+      fatal: unitType === "execute-task" || unitType === "complete-milestone",
       reason: `${unitType}-db-refresh-failed`,
       message: `Stuck recovery found ${unitType} ${unitId} artifacts, but the DB refresh failed.`,
     };
+  }
+
+  if (unitType === "complete-milestone") {
+    const { milestone: mid } = parseUnitId(unitId);
+    if (!mid) {
+      return {
+        ok: false,
+        fatal: true,
+        reason: "complete-milestone-invalid-unit-id",
+        message: `Stuck recovery found complete-milestone ${unitId} artifacts, but the unit id could not be parsed for DB reconciliation.`,
+      };
+    }
+
+    const milestone = getMilestone(mid);
+    if (!milestone) {
+      return {
+        ok: false,
+        fatal: true,
+        reason: "complete-milestone-artifact-db-missing",
+        message: `Stuck recovery found complete-milestone ${unitId} artifacts, but no matching DB milestone row exists after refresh.`,
+      };
+    }
+    if (isClosedStatus(milestone.status)) return { ok: true };
+
+    const validation = getLatestAssessmentByScope(mid, "milestone-validation");
+    if (validation?.status !== "pass") {
+      return {
+        ok: false,
+        fatal: true,
+        reason: "complete-milestone-validation-not-pass",
+        message: `Stuck recovery found complete-milestone ${unitId} artifacts, but milestone-validation is "${validation?.status ?? "absent"}" in the DB.`,
+      };
+    }
+
+    const slices = getMilestoneSlices(mid);
+    if (slices.length === 0) {
+      return {
+        ok: false,
+        fatal: true,
+        reason: "complete-milestone-slices-missing",
+        message: `Stuck recovery found complete-milestone ${unitId} artifacts, but no slices exist in the DB.`,
+      };
+    }
+    const openSlice = slices.find((slice) => !isClosedStatus(slice.status));
+    if (openSlice) {
+      return {
+        ok: false,
+        fatal: true,
+        reason: "complete-milestone-slice-open",
+        message: `Stuck recovery found complete-milestone ${unitId} artifacts, but slice ${openSlice.id} is still "${openSlice.status}" in the DB.`,
+      };
+    }
+    for (const slice of slices) {
+      const openTask = getSliceTasks(mid, slice.id).find((task) => !isClosedStatus(task.status));
+      if (openTask) {
+        return {
+          ok: false,
+          fatal: true,
+          reason: "complete-milestone-task-open",
+          message: `Stuck recovery found complete-milestone ${unitId} artifacts, but task ${slice.id}/${openTask.id} is still "${openTask.status}" in the DB.`,
+        };
+      }
+    }
+
+    updateMilestoneStatus(mid, "complete", new Date().toISOString());
+    return { ok: true };
   }
 
   if (unitType !== "execute-task") return { ok: true };

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1445,7 +1445,7 @@ export async function runDispatch(
             level: 1,
             action: "artifact-found",
           });
-          const recoveryDb = refreshRecoveryDbForArtifact(unitType, unitId);
+          const recoveryDb = refreshRecoveryDbForArtifact(unitType, unitId, s.basePath);
           if (!recoveryDb.ok) {
             ctx.ui.notify(
               recoveryDb.fatal
@@ -1486,7 +1486,7 @@ export async function runDispatch(
             level: 2,
             action: "artifact-found",
           });
-          const recoveryDb = refreshRecoveryDbForArtifact(unitType, unitId);
+          const recoveryDb = refreshRecoveryDbForArtifact(unitType, unitId, s.basePath);
           if (recoveryDb.ok) {
             ctx.ui.notify(
               `Stuck recovery: artifact for ${unitType} ${unitId} found on disk after cache invalidation. Continuing.`,

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1440,17 +1440,6 @@ export async function runDispatch(
           s.basePath,
         );
         if (artifactExists) {
-          if (unitType === "complete-milestone") {
-            const stuckDiag = diagnoseExpectedArtifact(unitType, unitId, s.basePath);
-            const stuckParts = [
-              `Detected ${unitType} ${unitId} output on disk, but the same unit is still being derived.`,
-              "This usually means the milestone summary exists while the DB row still does not mark the milestone complete.",
-            ];
-            if (stuckDiag) stuckParts.push(`Expected: ${stuckDiag}`);
-            ctx.ui.notify(stuckParts.join(" "), "warning");
-            await deps.pauseAuto(ctx, pi);
-            return { action: "break", reason: "complete-milestone-artifact-db-mismatch" };
-          }
           debugLog("autoLoop", {
             phase: "stuck-recovery",
             level: 1,
@@ -1491,7 +1480,7 @@ export async function runDispatch(
           unitId,
           s.basePath,
         );
-        if (artifactExists && unitType !== "complete-milestone") {
+        if (artifactExists) {
           debugLog("autoLoop", {
             phase: "stuck-recovery",
             level: 2,

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -47,6 +47,10 @@ function makeTmpProject(): string {
   return dir;
 }
 
+function runGit(base: string, args: string[]): void {
+  execFileSync("git", args, { cwd: base, stdio: ["ignore", "pipe", "pipe"] });
+}
+
 afterEach(() => {
   closeDatabase();
   for (const dir of tmpDirs) {
@@ -274,7 +278,7 @@ test("resolveExpectedArtifactPath returns correct path for all slice-level types
 test("refreshRecoveryDbForArtifact treats missing execute-task DB rows as fatal mismatches", () => {
   makeTmpProject();
 
-  const result = refreshRecoveryDbForArtifact("execute-task", "M001/S01/T01");
+  const result = refreshRecoveryDbForArtifact("execute-task", "M001/S01/T01", process.cwd());
 
   assert.deepEqual(result, {
     ok: false,
@@ -327,11 +331,72 @@ test("refreshRecoveryDbForArtifact closes complete-milestone DB row when artifac
     scope: "milestone-validation",
     fullContent: "---\nverdict: pass\n---\n",
   });
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(join(milestoneDir, "M001-SUMMARY.md"), "# Milestone Summary\n");
+  writeFileSync(join(milestoneDir, "M001-VALIDATION.md"), "---\nverdict: pass\n---\n");
+  runGit(base, ["init", "-b", "main"]);
+  runGit(base, ["config", "user.email", "test@example.com"]);
+  runGit(base, ["config", "user.name", "Test User"]);
+  runGit(base, ["checkout", "-b", "milestone/M001"]);
+  writeFileSync(join(base, "feature.ts"), "export const shipped = true;\n");
+  runGit(base, ["add", "feature.ts"]);
+  runGit(base, ["commit", "-m", "feat: implementation evidence"]);
+  writeFileSync(join(base, ".gsd", "integration-branch"), "main\n");
 
-  const result = refreshRecoveryDbForArtifact("complete-milestone", "M001");
+  const result = refreshRecoveryDbForArtifact("complete-milestone", "M001", base);
 
   assert.deepEqual(result, { ok: true });
   assert.equal(getMilestone("M001")?.status, "complete");
+});
+
+test("refreshRecoveryDbForArtifact fails closed for complete-milestone without implementation evidence", () => {
+  const base = mkdtempSync(join(tmpdir(), "auto-recovery-complete-ms-no-impl-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  tmpDirs.push(base);
+  insertMilestone({ id: "M001", title: "Stale completion", status: "active" });
+  insertSlice({
+    milestoneId: "M001",
+    id: "S01",
+    title: "Done Slice",
+    status: "complete",
+    risk: "low",
+    depends: [],
+  });
+  insertTask({
+    milestoneId: "M001",
+    sliceId: "S01",
+    id: "T01",
+    title: "Done Task",
+    status: "complete",
+  });
+  insertAssessment({
+    path: ".gsd/milestones/M001/M001-VALIDATION.md",
+    milestoneId: "M001",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "---\nverdict: pass\n---\n",
+  });
+  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(join(milestoneDir, "M001-SUMMARY.md"), "# Milestone Summary\n");
+  writeFileSync(join(milestoneDir, "M001-VALIDATION.md"), "---\nverdict: pass\n---\n");
+  runGit(base, ["init", "-b", "main"]);
+  runGit(base, ["config", "user.email", "test@example.com"]);
+  runGit(base, ["config", "user.name", "Test User"]);
+  runGit(base, ["add", ".gsd"]);
+  runGit(base, ["commit", "-m", "chore: gsd artifacts only"]);
+
+  const result = refreshRecoveryDbForArtifact("complete-milestone", "M001", base);
+
+  assert.deepEqual(result, {
+    ok: false,
+    fatal: true,
+    reason: "complete-milestone-implementation-missing",
+    message: "Stuck recovery found complete-milestone M001 artifacts, but implementation evidence is not present.",
+  });
+  assert.equal(getMilestone("M001")?.status, "active");
 });
 
 // ─── diagnoseExpectedArtifact ─────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -9,7 +9,7 @@ import { randomUUID } from "node:crypto";
 
 import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArtifactPath, diagnoseExpectedArtifact, diagnoseWorktreeIntegrityFailure, buildLoopRemediationSteps, writeBlockerPlaceholder, refreshRecoveryDbForArtifact } from "../auto-recovery.ts";
 import { resolveMilestoneFile } from "../paths.ts";
-import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask, getMilestoneCommitAttributionShas } from "../gsd-db.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow, insertTask, insertAssessment, getMilestone, getMilestoneCommitAttributionShas } from "../gsd-db.ts";
 import { clearParseCache } from "../files.ts";
 import { parseRoadmap } from "../parsers-legacy.ts";
 import { invalidateAllCaches } from "../cache.ts";
@@ -282,6 +282,56 @@ test("refreshRecoveryDbForArtifact treats missing execute-task DB rows as fatal 
     reason: "execute-task-artifact-db-missing",
     message: "Stuck recovery found execute-task M001/S01/T01 artifacts, but no matching DB task row exists after refresh.",
   });
+});
+
+test("refreshRecoveryDbForArtifact closes complete-milestone DB row when artifacts exist but DB is stale (#5568)", () => {
+  const base = mkdtempSync(join(tmpdir(), "auto-recovery-complete-ms-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  tmpDirs.push(base);
+  insertMilestone({ id: "M001", title: "Stale completion", status: "active" });
+  insertSlice({
+    milestoneId: "M001",
+    id: "S01",
+    title: "Done Slice",
+    status: "complete",
+    risk: "low",
+    depends: [],
+  });
+  insertSlice({
+    milestoneId: "M001",
+    id: "S02",
+    title: "Done Slice",
+    status: "complete",
+    risk: "low",
+    depends: [],
+  });
+  insertTask({
+    milestoneId: "M001",
+    sliceId: "S01",
+    id: "T01",
+    title: "Done Task",
+    status: "complete",
+  });
+  insertTask({
+    milestoneId: "M001",
+    sliceId: "S02",
+    id: "T02",
+    title: "Done Task 2",
+    status: "complete",
+  });
+  insertAssessment({
+    path: ".gsd/milestones/M001/M001-VALIDATION.md",
+    milestoneId: "M001",
+    status: "pass",
+    scope: "milestone-validation",
+    fullContent: "---\nverdict: pass\n---\n",
+  });
+
+  const result = refreshRecoveryDbForArtifact("complete-milestone", "M001");
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(getMilestone("M001")?.status, "complete");
 });
 
 // ─── diagnoseExpectedArtifact ─────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -336,7 +336,7 @@ test("runDispatch checks prior-slice completion against the project root in work
   ]);
 });
 
-test("runDispatch pauses when complete-milestone summary exists on disk but the unit is still stuck (#4289)", async (t) => {
+test("runDispatch retries when complete-milestone summary exists on disk and stuck recovery can proceed (#4289)", async (t) => {
   const capture = createEventCapture();
   let pauseCalls = 0;
   let stopCalls = 0;
@@ -399,10 +399,9 @@ test("runDispatch pauses when complete-milestone summary exists on disk but the 
     consecutiveFinalizeTimeouts: 0,
   });
 
-  assert.equal(result.action, "break");
-  assert.equal((result as any).reason, "complete-milestone-artifact-db-mismatch");
-  assert.equal(pauseCalls, 1, "complete-milestone disk/db mismatch should pause auto-mode");
-  assert.equal(stopCalls, 0, "mismatch pause should not hard-stop the loop");
+  assert.equal(result.action, "continue");
+  assert.equal(pauseCalls, 0, "artifact-based recovery should retry before pausing");
+  assert.equal(stopCalls, 0, "artifact-based recovery should not hard-stop the loop");
 });
 
 test("runDispatch pauses when execute-task artifacts exist but DB status is still open", async (t) => {


### PR DESCRIPTION
## Summary
- Added complete-milestone DB reconciliation in stuck recovery and verified with focused auto-recovery and auto-phases tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5568
- [#5568 Auto-mode stuck in completing-milestone loop when agent aborted mid-completion](https://github.com/gsd-build/gsd-2/issues/5568)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5568-auto-mode-stuck-in-completing-milestone--1778970305`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved milestone completion recovery: milestones are now DB-verified like tasks, refresh failures for these unit types are treated as fatal, and milestone completion is reconciled when validation and implementation evidence are present.
  * Unified stuck-recovery behavior so milestone artifact handling follows the same continue/pause flow as other units.

* **Tests**
  * Added regression and integration tests for successful milestone reconciliation and fatal failure when implementation evidence is missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->