### PR TITLE
fix(issue): auto-mode misses dead milestone lease holder before heartbeat TTL expires

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -102,6 +102,12 @@ import {
 import { handleCustomEngineReconcile } from "./workflow-custom-engine-reconcile.js";
 import { handleCustomEngineReconcileOutcome } from "./workflow-custom-engine-reconcile-outcome.js";
 
+/**
+ * Returns true if workerId is an active worker in this project whose OS
+ * process no longer exists. Used to detect dead lease holders before
+ * the heartbeat TTL expires. EPERM means the process is alive (we lack
+ * permission to signal it); any other kill(pid,0) error means dead.
+ */
 function isDeadLocalLeaseHolder(workerId: string, projectRoot: string): boolean {
   const worker = getAutoWorker(workerId);
   if (!worker) return false;

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -40,9 +40,10 @@ import {
   markFailed as markDispatchFailed,
   getRecentForUnit as getRecentDispatchesForUnit,
   getRecentUnitKeysForProjectRoot,
+  markLatestActiveForWorkerCanceled,
 } from "../db/unit-dispatches.js";
-import { claimMilestoneLease, refreshMilestoneLease } from "../db/milestone-leases.js";
-import { heartbeatAutoWorker } from "../db/auto-workers.js";
+import { claimMilestoneLease, refreshMilestoneLease, forceReleaseLeasesForWorker } from "../db/milestone-leases.js";
+import { heartbeatAutoWorker, getAutoWorker, markWorkerCrashed } from "../db/auto-workers.js";
 import { getRuntimeKv, setRuntimeKv } from "../db/runtime-kv.js";
 import { resolveUokFlags } from "../uok/flags.js";
 import { scheduleSidecarQueue } from "../uok/execution-graph.js";
@@ -100,6 +101,21 @@ import {
 } from "./workflow-custom-engine-verify-outcome.js";
 import { handleCustomEngineReconcile } from "./workflow-custom-engine-reconcile.js";
 import { handleCustomEngineReconcileOutcome } from "./workflow-custom-engine-reconcile-outcome.js";
+
+function isDeadLocalLeaseHolder(workerId: string, projectRoot: string): boolean {
+  const worker = getAutoWorker(workerId);
+  if (!worker) return false;
+  if (worker.status !== "active") return false;
+  if (worker.project_root_realpath !== projectRoot) return false;
+  if (!Number.isInteger(worker.pid) || worker.pid <= 0) return true;
+  if (worker.pid === process.pid) return false;
+  try {
+    process.kill(worker.pid, 0);
+    return false;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code !== "EPERM";
+  }
+}
 
 // ── Stuck detection persistence (#3704) ──────────────────────────────────
 // Phase C migration: stuck-state.json deleted in favor of DB-backed
@@ -856,11 +872,33 @@ export async function autoLoop(
       // process has a worker identity, make the milestone lease explicit before
       // claiming so a step-mode handoff cannot leave us running with a stale
       // in-memory token and no backing lease row.
-      const leaseBeforeClaim = ensureDispatchLease(s, iterData.mid, {
+      let leaseBeforeClaim = ensureDispatchLease(s, iterData.mid, {
         claimMilestoneLease,
         logLeaseRecovered: logDispatchLeaseRecovered,
         logLeaseRecoveryFailed: logDispatchLeaseRecoveryFailed,
       });
+      if (leaseBeforeClaim.kind === "blocked" && leaseBeforeClaim.holderWorkerId) {
+        const holderWorkerId = leaseBeforeClaim.holderWorkerId;
+        if (isDeadLocalLeaseHolder(holderWorkerId, s.canonicalProjectRoot)) {
+          markLatestActiveForWorkerCanceled(holderWorkerId, "crash-recovered");
+          markWorkerCrashed(holderWorkerId);
+          forceReleaseLeasesForWorker(holderWorkerId);
+          const retryLease = ensureDispatchLease(s, iterData.mid, {
+            claimMilestoneLease,
+            logLeaseRecovered: logDispatchLeaseRecovered,
+            logLeaseRecoveryFailed: logDispatchLeaseRecoveryFailed,
+          }, { forceReclaim: true });
+          if (retryLease.kind === "ready") {
+            leaseBeforeClaim = retryLease;
+          } else {
+            const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} before dispatching ${iterData.unitType} ${iterData.unitId}: ${retryLease.reason}`;
+            ctx.ui.notify(msg, "error");
+            finishTurn("stopped", "execution", msg);
+            await deps.stopAuto(ctx, pi, msg);
+            break;
+          }
+        }
+      }
       if (leaseBeforeClaim.kind === "blocked" || leaseBeforeClaim.kind === "failed") {
         const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} before dispatching ${iterData.unitType} ${iterData.unitId}: ${leaseBeforeClaim.reason}`;
         ctx.ui.notify(msg, "error");

--- a/src/resources/extensions/gsd/auto/workflow-dispatch-claim.ts
+++ b/src/resources/extensions/gsd/auto/workflow-dispatch-claim.ts
@@ -69,6 +69,16 @@ export interface EnsureDispatchLeaseDeps {
   }) => void;
 }
 
+/**
+ * Claim or reconfirm the milestone lease for the current session.
+ *
+ * Returns "ready" when the lease is held, "blocked" (with holderWorkerId)
+ * when another worker holds it, "degraded" when session state is
+ * incomplete, and "failed" on unexpected errors.
+ *
+ * Pass forceReclaim: true after force-releasing a dead holder's lease to
+ * bypass the in-memory token cache and re-acquire from the DB.
+ */
 export function ensureDispatchLease(
   s: AutoSession,
   milestoneId: string | undefined,
@@ -106,6 +116,13 @@ export function ensureDispatchLease(
   }
 }
 
+/**
+ * Record a new unit dispatch claim in the DB for this iteration.
+ *
+ * Returns "opened" with the new dispatch ID on success, "skip" when the
+ * unit is already active or the lease is stale, and "degraded" when
+ * required session state (workerId, milestoneLeaseToken) is absent.
+ */
 export function openDispatchClaim(
   s: AutoSession,
   flowId: string,

--- a/src/resources/extensions/gsd/auto/workflow-dispatch-claim.ts
+++ b/src/resources/extensions/gsd/auto/workflow-dispatch-claim.ts
@@ -12,7 +12,7 @@ export type DispatchClaimOutcome =
 export type DispatchLeaseOutcome =
   | { kind: "ready"; token: number; recovered: boolean }
   | { kind: "degraded"; reason: "missing-worker" | "missing-milestone" }
-  | { kind: "blocked"; reason: string }
+  | { kind: "blocked"; reason: string; holderWorkerId?: string }
   | { kind: "failed"; reason: string };
 
 type ClaimMilestoneLeaseResult =
@@ -87,7 +87,7 @@ export function ensureDispatchLease(
     if (!claim.ok) {
       const reason = `Milestone ${milestoneId} is held by worker ${claim.byWorker} until ${claim.expiresAt}.`;
       deps.logLeaseRecoveryFailed({ milestoneId, workerId: s.workerId, reason });
-      return { kind: "blocked", reason };
+      return { kind: "blocked", reason, holderWorkerId: claim.byWorker };
     }
 
     s.currentMilestoneId = milestoneId;

--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -344,6 +344,14 @@ export function emitCrashRecoveredUnitEnd(basePath: string, lock: LockData): voi
   emitOpenUnitEndForUnit(basePath, lock.unitType, lock.unitId, "crash-recovered");
 }
 
+/**
+ * Emit a synthetic unit-end journal event for a unit whose unit-start has
+ * no matching unit-end. Returns true if an event was emitted, false if the
+ * unit was already closed or no open start was found.
+ *
+ * Used by emitCrashRecoveredUnitEnd and the dispatch loop crash closeout
+ * path. Never throws — journal failure must not block recovery.
+ */
 export function emitOpenUnitEndForUnit(
   basePath: string,
   unitType: string,

--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -265,6 +265,7 @@ export function clearStaleWorkerLock(basePath: string): void {
     if (!worker) return;
     markLatestActiveForWorkerCanceled(worker.worker_id, "crash-recovered");
     markWorkerCrashed(worker.worker_id);
+    forceReleaseLeasesForWorker(worker.worker_id);
     deleteRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY);
   } catch {
     // Best-effort.

--- a/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
@@ -298,6 +298,10 @@ test("clearStaleWorkerLock crashes stale worker and cancels latest active dispat
   assert.ok(dispatch);
   assert.equal(dispatch!.status, "canceled");
   assert.equal(dispatch!.exit_reason, "crash-recovered");
+  const leaseRow = _getAdapter()!.prepare(
+    `SELECT status FROM milestone_leases WHERE milestone_id = :m`,
+  ).get({ ":m": "M001" }) as { status: string } | undefined;
+  assert.equal(leaseRow?.status, "released");
   assert.equal(getRuntimeKv("worker", workerId, "session_file"), null);
   assert.equal(readCrashLock(base), null);
 });

--- a/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
@@ -299,8 +299,8 @@ test("clearStaleWorkerLock crashes stale worker and cancels latest active dispat
   assert.equal(dispatch!.status, "canceled");
   assert.equal(dispatch!.exit_reason, "crash-recovered");
   const leaseRow = _getAdapter()!.prepare(
-    `SELECT status FROM milestone_leases WHERE milestone_id = :m`,
-  ).get({ ":m": "M001" }) as { status: string } | undefined;
+    `SELECT status FROM milestone_leases WHERE fencing_token = :ft`,
+  ).get({ ":ft": lease.token }) as { status: string } | undefined;
   assert.equal(leaseRow?.status, "released");
   assert.equal(getRuntimeKv("worker", workerId, "session_file"), null);
   assert.equal(readCrashLock(base), null);
@@ -325,7 +325,7 @@ test("clearLock marks stale worker crashed and releases held milestone lease", (
 
   assert.equal(getAutoWorker(workerId)?.status, "crashed");
   const leaseRow = _getAdapter()!.prepare(
-    `SELECT status FROM milestone_leases WHERE milestone_id = :m`,
-  ).get({ ":m": "M001" }) as { status: string } | undefined;
+    `SELECT status FROM milestone_leases WHERE fencing_token = :ft`,
+  ).get({ ":ft": lease.token }) as { status: string } | undefined;
   assert.equal(leaseRow?.status, "released");
 });

--- a/src/resources/extensions/gsd/tests/workflow-dispatch-claim.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-dispatch-claim.test.ts
@@ -271,6 +271,7 @@ test("ensureDispatchLease blocks when another worker holds the lease", () => {
   assert.deepEqual(outcome, {
     kind: "blocked",
     reason: "Milestone M001 is held by worker worker-2 until 2030-01-01T00:00:00.000Z.",
+    holderWorkerId: "worker-2",
   });
   assert.equal(session.milestoneLeaseToken, null);
   assert.deepEqual(failures, [{


### PR DESCRIPTION
## Summary
- Added dead-local-lease-holder recovery with one retry before stop and verified via focused dispatch/worker/crash-recovery tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6282
- [#6282 auto-mode misses dead milestone lease holder before heartbeat TTL expires](https://github.com/gsd-build/gsd-2/issues/6282)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6282-auto-mode-misses-dead-milestone-lease-ho-1778971501`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects dead local lease-holders, marks them canceled/crashed, and force-releases their milestone leases; retries reclaim and, if still blocked, notifies the UI and stops automatic dispatch to avoid hangs
  * Blocked lease results now include the holder worker ID to improve diagnostics and recovery

* **Tests**
  * Updated tests to verify milestone lease release and cleanup during crash-recovery scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->