### PR TITLE
fix(auto-mode): block stash restore conflict states

### DIFF
--- a/docs/user-docs/auto-mode.md
+++ b/docs/user-docs/auto-mode.md
@@ -104,6 +104,8 @@ Common block reasons and operator actions:
 | `missing-closeout-tool` | A closeout unit such as task, slice, milestone, UAT, or gate completion has no required workflow tool available. | Restore the missing `gsd_*` workflow tool registration or update the unit manifest/tool contract so the unit can durably save its result. |
 | `root-missing` / `root-not-directory` | A source-writing unit would run from a missing or invalid unit root. | Recreate or repair the milestone worktree/root, or clear an incorrect `GSD_UNIT_ROOT`, before launching another source-writing unit. |
 | `git-metadata-missing` | A source-writing unit root exists but is not a git worktree or repository root. | Run the unit from the project root or milestone worktree with valid `.git` metadata; recreate the worktree if it was deleted or partially copied. |
+| `preflight-unmerged-conflicts` | Milestone merge preflight found unresolved Git conflict stages in the working tree. | Resolve conflicts manually (`git status`, fix files, stage resolutions), then run `/gsd auto` to resume. |
+| `preflight-dirty-overlap` | Milestone merge preflight found local dirty files that overlap files changed by the milestone branch. | Commit or stash your local edits manually, or move them out of the way, then rerun `/gsd auto`. |
 
 Recovery classification now treats deterministic policy, tool-schema, stale-worker, and invalid-worktree failures as non-transient stops. Provider failures still use provider-specific transient classification and may retry automatically, while verification drift and unknown runtime failures escalate for inspection because repeating the same dispatch can preserve the drift.
 

--- a/docs/user-docs/troubleshooting.md
+++ b/docs/user-docs/troubleshooting.md
@@ -159,6 +159,21 @@ If recovery still fails, repair runtime state instead of manually deleting indiv
 
 **Fix:** GSD auto-resolves conflicts on `.gsd/` runtime files. For content conflicts in code files, the LLM is given an opportunity to resolve them via a fix-merge session. If that fails, manual resolution is needed.
 
+### Auto mode stops before merge with preflight conflict/overlap errors
+
+**Symptoms:** Auto mode stops with a pre-merge reason like unresolved Git conflicts or dirty working tree overlap.
+
+**What it means:** Milestone merge preflight now fail-closes before merge when either:
+- the repo already has unresolved conflict stages (`git diff --name-only --diff-filter=U` is non-empty), or
+- local dirty files overlap files modified by the milestone branch.
+
+In these states GSD does not auto-stash and does not auto-fix; it stops so you can resolve safely.
+
+**Fix:**
+- Resolve conflict markers and stage the resolved files.
+- Commit, stash, or discard overlapping local edits outside GSD.
+- Re-run `/gsd auto` after `git status` is clean (or at least free of overlapping/conflicted paths).
+
 ### Pre-dispatch says the milestone integration branch no longer exists
 
 **Symptoms:** Auto mode or `/gsd doctor` reports that a milestone recorded an integration branch that no longer exists in git.

--- a/packages/pi-coding-agent/src/modes/interactive/components/dynamic-border.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/dynamic-border.ts
@@ -46,6 +46,7 @@ export class DynamicBorder implements Component {
 				ui.requestRender();
 			}
 		}, 200);
+		this.spinnerInterval.unref?.();
 		ui.requestRender();
 	}
 

--- a/packages/pi-tui/src/components/loader.ts
+++ b/packages/pi-tui/src/components/loader.ts
@@ -53,6 +53,7 @@ export class Loader extends Text {
 				this.ui.requestRender();
 			}
 		}, 80);
+		this.intervalId.unref?.();
 		// Trigger initial render
 		if (this.ui) {
 			this.ui.requestRender();

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -86,9 +86,11 @@ import {
 import { annotateBackgroundable } from "./delegation-policy.js";
 import { invalidateAllCaches } from "./cache.js";
 import { insertMilestoneValidationGates } from "./milestone-validation-gates.js";
-import { nativeHasChanges } from "./native-git-bridge.js";
+import { nativeHasChanges, _resetHasChangesCache } from "./native-git-bridge.js";
 import { debugLog, isDebugEnabled } from "./debug-logger.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
+import { listUnmergedGitPaths } from "./git-conflict-state.js";
+import { runTurnGitAction } from "./git-service.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -158,6 +160,45 @@ export interface DispatchRule {
   name: string;
   /** Return a DispatchAction if this rule matches, null to fall through */
   match: (ctx: DispatchContext) => Promise<DispatchAction | null>;
+}
+
+function commitPendingMilestoneCloseoutChanges(basePath: string, mid: string): DispatchAction | null {
+  const conflictedPaths = listUnmergedGitPaths(basePath);
+  if (conflictedPaths.length > 0) {
+    return {
+      action: "stop",
+      reason: `Cannot complete milestone ${mid}: unresolved Git conflicts detected in ${conflictedPaths.join(", ")}. Resolve conflicts before closing.`,
+      level: "error",
+    };
+  }
+
+  _resetHasChangesCache();
+  if (!nativeHasChanges(basePath)) return null;
+
+  const gitResult = runTurnGitAction({
+    basePath,
+    action: "commit",
+    unitType: "complete-milestone-preflight",
+    unitId: mid,
+  });
+  if (gitResult.status !== "ok") {
+    return {
+      action: "stop",
+      reason: `Cannot complete milestone ${mid}: failed to commit pending changes before closing: ${gitResult.error ?? "unknown git error"}.`,
+      level: "warning",
+    };
+  }
+
+  _resetHasChangesCache();
+  if (nativeHasChanges(basePath)) {
+    return {
+      action: "stop",
+      reason: `Cannot complete milestone ${mid}: uncommitted changes remain after the pre-completion commit. Commit or stash before closing.`,
+      level: "warning",
+    };
+  }
+
+  return null;
 }
 
 export type DeepProjectStage =
@@ -1410,14 +1451,8 @@ export const DISPATCH_RULES: DispatchRule[] = [
         }
       }
 
-      // Safety guard (#6132): refuse closure with uncommitted git changes.
-      if (nativeHasChanges(basePath)) {
-        return {
-          action: "stop",
-          reason: "Cannot complete milestone: uncommitted changes detected. Commit or stash before closing.",
-          level: "warning",
-        };
-      }
+      const closeoutGitStop = commitPendingMilestoneCloseoutChanges(basePath, mid);
+      if (closeoutGitStop) return closeoutGitStop;
 
       // Safety guard (#6132): when UAT dispatch is enabled, enforce a PASS
       // verdict for each closed slice before milestone closure.

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -86,7 +86,7 @@ import {
 import { annotateBackgroundable } from "./delegation-policy.js";
 import { invalidateAllCaches } from "./cache.js";
 import { insertMilestoneValidationGates } from "./milestone-validation-gates.js";
-import { nativeHasChanges, _resetHasChangesCache } from "./native-git-bridge.js";
+import { nativeHasChanges, nativeIsRepo, _resetHasChangesCache } from "./native-git-bridge.js";
 import { debugLog, isDebugEnabled } from "./debug-logger.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 import { listUnmergedGitPaths } from "./git-conflict-state.js";
@@ -163,6 +163,8 @@ export interface DispatchRule {
 }
 
 function commitPendingMilestoneCloseoutChanges(basePath: string, mid: string): DispatchAction | null {
+  if (!nativeIsRepo(basePath)) return null;
+
   const conflictedPaths = listUnmergedGitPaths(basePath);
   if (conflictedPaths === null) {
     return {

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -164,6 +164,13 @@ export interface DispatchRule {
 
 function commitPendingMilestoneCloseoutChanges(basePath: string, mid: string): DispatchAction | null {
   const conflictedPaths = listUnmergedGitPaths(basePath);
+  if (conflictedPaths === null) {
+    return {
+      action: "stop",
+      reason: `Cannot complete milestone ${mid}: failed to evaluate unresolved Git conflicts. Resolve Git/worktree state manually before closing.`,
+      level: "error",
+    };
+  }
   if (conflictedPaths.length > 0) {
     return {
       action: "stop",

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -460,6 +460,18 @@ export async function _runMilestoneMergeWithStashRestore(
     milestoneId,
     ctx.ui.notify.bind(ctx.ui),
   );
+  if (preflight.blocked) {
+    const reason = preflight.blockedReason === "unmerged-conflicts"
+      ? `Pre-merge unresolved Git conflicts block milestone ${milestoneId}`
+      : `Pre-merge dirty working tree overlaps milestone ${milestoneId}`;
+    await deps.stopAuto(ctx, pi, reason);
+    return {
+      action: "break",
+      reason: preflight.blockedReason === "unmerged-conflicts"
+        ? "preflight-unmerged-conflicts"
+        : "preflight-dirty-overlap",
+    };
+  }
 
   let mergeError: unknown = null;
   const exitResult = deps.lifecycle.exitMilestone(

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -19,12 +19,21 @@ import { join } from "node:path";
 import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { logWarning } from "./workflow-logger.js";
 import { nativeHasChanges } from "./native-git-bridge.js";
+import { listUnmergedGitPaths } from "./git-conflict-state.js";
 
 export interface PreflightResult {
   /** true when a stash was pushed and postflightPopStash should be called */
   stashPushed: boolean;
+  /** true when the merge must not start because dirty files need user action */
+  blocked?: boolean;
+  /** Machine-readable reason for blocked preflight. */
+  blockedReason?: "dirty-overlap" | "unmerged-conflicts";
   /** Unique marker embedded in the stash message for targeted restoration */
   stashMarker?: string;
+  /** Dirty paths that overlap the milestone branch diff and would conflict after merge */
+  overlappingPaths?: string[];
+  /** Paths with unresolved Git conflict stages. */
+  conflictedPaths?: string[];
   /** human-readable summary of what happened (empty string for clean trees) */
   summary: string;
 }
@@ -79,6 +88,47 @@ function parseAlreadyExistsNoCheckoutPaths(text: string): string[] {
 
 function readZeroDelimitedPaths(output: string): string[] {
   return output.split("\0").filter(Boolean);
+}
+
+function listDirtyPaths(basePath: string): string[] | null {
+  try {
+    const paths = new Set<string>();
+    for (const args of [
+      ["diff", "--name-only", "-z"],
+      ["diff", "--cached", "--name-only", "-z"],
+      ["ls-files", "--others", "--exclude-standard", "-z"],
+    ]) {
+      for (const path of readZeroDelimitedPaths(gitText(basePath, args))) {
+        paths.add(path);
+      }
+    }
+    return [...paths];
+  } catch {
+    return null;
+  }
+}
+
+function listMilestoneChangedPaths(basePath: string, milestoneId: string): string[] | null {
+  const milestoneBranch = `milestone/${milestoneId}`;
+  try {
+    gitText(basePath, ["rev-parse", "--verify", "--quiet", `refs/heads/${milestoneBranch}`]);
+    const mergeBase = gitText(basePath, ["merge-base", "HEAD", milestoneBranch]).trim();
+    if (!mergeBase) return null;
+    return readZeroDelimitedPaths(gitText(basePath, ["diff", "--name-only", "-z", mergeBase, milestoneBranch]));
+  } catch {
+    return null;
+  }
+}
+
+function findOverlappingDirtyMilestonePaths(basePath: string, milestoneId: string): string[] | null {
+  const dirtyPaths = listDirtyPaths(basePath);
+  const changedPaths = listMilestoneChangedPaths(basePath, milestoneId);
+  if (!dirtyPaths || !changedPaths) return null;
+
+  const changedPathSet = new Set(changedPaths.filter((path) => !path.startsWith(".gsd/")));
+  return dirtyPaths
+    .filter((path) => !path.startsWith(".gsd/") && changedPathSet.has(path))
+    .sort();
 }
 
 function listStashUntrackedPaths(basePath: string, stashRef: string): string[] | null {
@@ -229,6 +279,36 @@ export function preflightCleanRoot(
 
   if (!isDirty) {
     return { stashPushed: false, summary: "" };
+  }
+
+  const conflictedPaths = listUnmergedGitPaths(basePath);
+  if (conflictedPaths.length > 0) {
+    const msg =
+      `Working tree has unresolved Git conflicts before milestone ${milestoneId} merge: ` +
+      `${conflictedPaths.join(", ")}. Resolve these files manually before resuming auto-mode.`;
+    notify(msg, "error");
+    return {
+      stashPushed: false,
+      blocked: true,
+      blockedReason: "unmerged-conflicts",
+      conflictedPaths,
+      summary: msg,
+    };
+  }
+
+  const overlappingPaths = findOverlappingDirtyMilestonePaths(basePath, milestoneId);
+  if (overlappingPaths && overlappingPaths.length > 0) {
+    const msg =
+      `Working tree has uncommitted files that overlap milestone ${milestoneId} changes: ` +
+      `${overlappingPaths.join(", ")}. Commit, stash, or discard those files before resuming auto-mode.`;
+    notify(msg, "error");
+    return {
+      stashPushed: false,
+      blocked: true,
+      blockedReason: "dirty-overlap",
+      overlappingPaths,
+      summary: msg,
+    };
   }
 
   // Warn the user before stashing

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -27,13 +27,13 @@ export interface PreflightResult {
   /** true when the merge must not start because dirty files need user action */
   blocked?: boolean;
   /** Machine-readable reason for blocked preflight. */
-  blockedReason?: "dirty-overlap" | "unmerged-conflicts";
+  blockedReason?: "dirty-overlap" | "dirty-overlap-eval-failed" | "unmerged-conflicts" | "unmerged-conflicts-eval-failed";
   /** Unique marker embedded in the stash message for targeted restoration */
   stashMarker?: string;
   /** Dirty paths that overlap the milestone branch diff and would conflict after merge */
-  overlappingPaths?: string[];
+  overlappingPaths?: string[] | null;
   /** Paths with unresolved Git conflict stages. */
-  conflictedPaths?: string[];
+  conflictedPaths?: string[] | null;
   /** human-readable summary of what happened (empty string for clean trees) */
   summary: string;
 }
@@ -112,6 +112,10 @@ function listMilestoneChangedPaths(basePath: string, milestoneId: string): strin
   const milestoneBranch = `milestone/${milestoneId}`;
   try {
     gitText(basePath, ["rev-parse", "--verify", "--quiet", `refs/heads/${milestoneBranch}`]);
+  } catch {
+    return [];
+  }
+  try {
     const mergeBase = gitText(basePath, ["merge-base", "HEAD", milestoneBranch]).trim();
     if (!mergeBase) return null;
     return readZeroDelimitedPaths(gitText(basePath, ["diff", "--name-only", "-z", mergeBase, milestoneBranch]));
@@ -282,6 +286,19 @@ export function preflightCleanRoot(
   }
 
   const conflictedPaths = listUnmergedGitPaths(basePath);
+  if (conflictedPaths === null) {
+    const msg =
+      `Unable to verify unresolved Git conflicts before milestone ${milestoneId} merge. ` +
+      `Resolve Git/worktree state manually before resuming auto-mode.`;
+    notify(msg, "error");
+    return {
+      stashPushed: false,
+      blocked: true,
+      blockedReason: "unmerged-conflicts-eval-failed",
+      conflictedPaths: null,
+      summary: msg,
+    };
+  }
   if (conflictedPaths.length > 0) {
     const msg =
       `Working tree has unresolved Git conflicts before milestone ${milestoneId} merge: ` +
@@ -297,6 +314,19 @@ export function preflightCleanRoot(
   }
 
   const overlappingPaths = findOverlappingDirtyMilestonePaths(basePath, milestoneId);
+  if (overlappingPaths === null) {
+    const msg =
+      `Unable to verify dirty-path overlap for milestone ${milestoneId}. ` +
+      `Resolve Git/worktree state manually before resuming auto-mode.`;
+    notify(msg, "error");
+    return {
+      stashPushed: false,
+      blocked: true,
+      blockedReason: "dirty-overlap-eval-failed",
+      overlappingPaths: null,
+      summary: msg,
+    };
+  }
   if (overlappingPaths && overlappingPaths.length > 0) {
     const msg =
       `Working tree has uncommitted files that overlap milestone ${milestoneId} changes: ` +

--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -15,6 +15,7 @@ import { RUNTIME_EXCLUSION_PATHS, resolveMilestoneIntegrationBranch, writeIntegr
 import { nativeIsRepo, nativeWorktreeList, nativeWorktreeRemove, nativeBranchList, nativeBranchDelete, nativeLsFiles, nativeRmCached, nativeHasChanges, nativeLastCommitEpoch, nativeGetCurrentBranch, nativeAddTracked, nativeCommit } from "./native-git-bridge.js";
 import { getAllWorktreeHealth } from "./worktree-health.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { listUnmergedGitPaths } from "./git-conflict-state.js";
 
 /**
  * Returns true if the directory contains only doctor artifacts
@@ -116,6 +117,7 @@ export async function checkGitHealth(
   }
 
   const gitDir = resolveGitDir(basePath);
+  const unmergedPaths = listUnmergedGitPaths(basePath);
 
   // ── Orphaned auto-worktrees & Stale milestone branches ────────────────
   // These checks only apply in worktree/branch modes — skip in none mode
@@ -264,6 +266,17 @@ export async function checkGitHealth(
       if (existsSync(join(gitDir, d))) found.push(d);
     }
 
+    if (unmergedPaths.length > 0) {
+      issues.push({
+        severity: "error",
+        code: "unresolved_git_conflicts",
+        scope: "project",
+        unitId: "project",
+        message: `Unresolved Git conflicts detected: ${unmergedPaths.join(", ")}. Resolve these files manually before auto-mode can proceed.`,
+        fixable: false,
+      });
+    }
+
     if (found.length > 0) {
       issues.push({
         severity: "error",
@@ -271,12 +284,14 @@ export async function checkGitHealth(
         scope: "project",
         unitId: "project",
         message: `Corrupt merge/rebase state detected: ${found.join(", ")}`,
-        fixable: true,
+        fixable: unmergedPaths.length === 0,
       });
 
-      if (shouldFix("corrupt_merge_state")) {
+      if (shouldFix("corrupt_merge_state") && unmergedPaths.length === 0) {
         const result = abortAndReset(basePath);
         fixesApplied.push(`cleaned merge state: ${result.cleaned.join(", ")}`);
+      } else if (shouldFix("corrupt_merge_state")) {
+        fixesApplied.push("skipped merge-state reset because unresolved conflicts require manual resolution");
       }
     }
   } catch {

--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -122,7 +122,8 @@ export async function checkGitHealth(
     issues.push({
       severity: "error",
       code: "corrupt_merge_state",
-      scope: "repo",
+      scope: "project",
+      unitId: "project",
       message: "Failed to evaluate unresolved Git conflicts. Resolve Git/worktree state manually before resuming auto-mode.",
       fixable: false,
     });

--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -118,6 +118,16 @@ export async function checkGitHealth(
 
   const gitDir = resolveGitDir(basePath);
   const unmergedPaths = listUnmergedGitPaths(basePath);
+  if (unmergedPaths === null) {
+    issues.push({
+      severity: "error",
+      code: "corrupt_merge_state",
+      scope: "repo",
+      message: "Failed to evaluate unresolved Git conflicts. Resolve Git/worktree state manually before resuming auto-mode.",
+      fixable: false,
+    });
+    return;
+  }
 
   // ── Orphaned auto-worktrees & Stale milestone branches ────────────────
   // These checks only apply in worktree/branch modes — skip in none mode

--- a/src/resources/extensions/gsd/doctor-proactive.ts
+++ b/src/resources/extensions/gsd/doctor-proactive.ts
@@ -26,6 +26,7 @@ import { nativeIsRepo, nativeHasChanges, nativeLastCommitEpoch, nativeGetCurrent
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { runEnvironmentChecks } from "./doctor-environment.js";
 import { ensureDbOpen } from "./bootstrap/dynamic-tools.js";
+import { listUnmergedGitPaths } from "./git-conflict-state.js";
 
 // ── Health Score Tracking ──────────────────────────────────────────────────
 
@@ -215,6 +216,13 @@ export interface PreDispatchHealthResult {
 export async function preDispatchHealthGate(basePath: string): Promise<PreDispatchHealthResult> {
   const issues: string[] = [];
   const fixesApplied: string[] = [];
+  const unmergedPaths = nativeIsRepo(basePath) ? listUnmergedGitPaths(basePath) : [];
+
+  if (unmergedPaths.length > 0) {
+    issues.push(
+      `Unresolved Git conflicts: ${unmergedPaths.join(", ")}. Resolve these files manually before resuming auto-mode.`,
+    );
+  }
 
   // ── Stale crash lock blocks dispatch ──
   // If a stale lock exists, the crash recovery path should handle it,
@@ -241,7 +249,11 @@ export async function preDispatchHealthGate(basePath: string): Promise<PreDispat
       const blockers = ["MERGE_HEAD", "rebase-apply", "rebase-merge"].filter(
         f => existsSync(join(gitDir, f)),
       );
-      if (blockers.length > 0) {
+      if (blockers.length > 0 && unmergedPaths.length > 0) {
+        issues.push(
+          `Corrupt git state: ${blockers.join(", ")} with unresolved conflicts. Resolve conflicts manually before running /gsd doctor fix.`,
+        );
+      } else if (blockers.length > 0) {
         // Try to auto-heal
         try {
           const result = abortAndReset(basePath);
@@ -310,7 +322,7 @@ export async function preDispatchHealthGate(basePath: string): Promise<PreDispat
       const snapshotsEnabled = prefs.git?.snapshots !== false;
       const thresholdMinutes = prefs.stale_commit_threshold_minutes ?? 30;
 
-      if (snapshotsEnabled && thresholdMinutes > 0 && nativeHasChanges(basePath)) {
+      if (snapshotsEnabled && thresholdMinutes > 0 && unmergedPaths.length === 0 && nativeHasChanges(basePath)) {
         const branch = nativeGetCurrentBranch(basePath);
         const lastEpoch = nativeLastCommitEpoch(basePath, branch || "HEAD");
         const nowEpoch = Math.floor(Date.now() / 1000);

--- a/src/resources/extensions/gsd/doctor-proactive.ts
+++ b/src/resources/extensions/gsd/doctor-proactive.ts
@@ -217,6 +217,10 @@ export async function preDispatchHealthGate(basePath: string): Promise<PreDispat
   const issues: string[] = [];
   const fixesApplied: string[] = [];
   const unmergedPaths = nativeIsRepo(basePath) ? listUnmergedGitPaths(basePath) : [];
+  if (unmergedPaths === null) {
+    issues.push("Failed to evaluate unresolved Git conflicts. Resolve Git/worktree state manually before resuming auto-mode.");
+    return { proceed: false, reason: issues[0], issues, fixesApplied };
+  }
 
   if (unmergedPaths.length > 0) {
     issues.push(

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -14,6 +14,7 @@ export type DoctorIssueCode =
   | "orphaned_auto_worktree"
   | "stale_milestone_branch"
   | "corrupt_merge_state"
+  | "unresolved_git_conflicts"
   | "tracked_runtime_files"
   | "legacy_slice_branches"
   | "stale_crash_lock"

--- a/src/resources/extensions/gsd/git-conflict-state.ts
+++ b/src/resources/extensions/gsd/git-conflict-state.ts
@@ -1,0 +1,23 @@
+// Project/App: GSD-2
+// File Purpose: Detect unresolved Git conflict state before automation runs.
+
+import { execFileSync } from "node:child_process";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
+
+function splitZeroDelimited(output: string): string[] {
+  return output.split("\0").filter(Boolean);
+}
+
+export function listUnmergedGitPaths(basePath: string): string[] {
+  try {
+    const output = execFileSync("git", ["diff", "--name-only", "--diff-filter=U", "-z"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      env: GIT_NO_PROMPT_ENV,
+    });
+    return [...new Set(splitZeroDelimited(output))].sort();
+  } catch {
+    return [];
+  }
+}

--- a/src/resources/extensions/gsd/git-conflict-state.ts
+++ b/src/resources/extensions/gsd/git-conflict-state.ts
@@ -8,7 +8,7 @@ function splitZeroDelimited(output: string): string[] {
   return output.split("\0").filter(Boolean);
 }
 
-export function listUnmergedGitPaths(basePath: string): string[] {
+export function listUnmergedGitPaths(basePath: string): string[] | null {
   try {
     const output = execFileSync("git", ["diff", "--name-only", "--diff-filter=U", "-z"], {
       cwd: basePath,
@@ -18,6 +18,6 @@ export function listUnmergedGitPaths(basePath: string): string[] {
     });
     return [...new Set(splitZeroDelimited(output))].sort();
   } catch {
-    return [];
+    return null;
   }
 }

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -111,6 +111,67 @@ test("preflightCleanRoot — untracked file triggers stash with --include-untrac
   }
 });
 
+test("preflightCleanRoot blocks dirty files that overlap milestone changes before stashing", () => {
+  const repo = createTempRepo();
+  try {
+    run("git checkout -b milestone/M003B", repo);
+    writeFileSync(join(repo, "README.md"), "# milestone change\n");
+    run("git add README.md", repo);
+    run('git commit -m "feat: change readme"', repo);
+    run("git checkout main", repo);
+
+    writeFileSync(join(repo, "README.md"), "# local work\n");
+
+    const notifications: Array<{ msg: string; level: string }> = [];
+    const result = preflightCleanRoot(repo, "M003B", (msg, level) => {
+      notifications.push({ msg, level });
+    });
+
+    assert.equal(result.blocked, true, "overlapping dirty paths must block before merge");
+    assert.equal(result.stashPushed, false, "blocked preflight must not stash");
+    assert.deepEqual(result.overlappingPaths, ["README.md"]);
+    assert.ok(
+      notifications.some((n) => n.level === "error" && n.msg.includes("README.md")),
+      "blocking notification must name the overlapping file",
+    );
+    assert.equal(run("git stash list", repo), "", "blocked preflight must not create a stash");
+    assert.match(run("git status --porcelain", repo), /M README\.md/, "local work must stay in the working tree");
+  } finally {
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});
+
+test("preflightCleanRoot blocks unresolved stash-apply conflicts before stashing", () => {
+  const repo = createTempRepo();
+  try {
+    writeFileSync(join(repo, "README.md"), "# local stashed work\n");
+    run('git stash push -m "local work"', repo);
+    writeFileSync(join(repo, "README.md"), "# merged milestone work\n");
+    run("git add README.md", repo);
+    run('git commit -m "feat: merged readme"', repo);
+    execSync("git stash apply 'stash@{0}' || true", { cwd: repo, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" });
+
+    assert.match(run("git diff --name-only --diff-filter=U", repo), /README\.md/, "fixture must have unresolved conflict");
+
+    const notifications: Array<{ msg: string; level: string }> = [];
+    const result = preflightCleanRoot(repo, "M003C", (msg, level) => {
+      notifications.push({ msg, level });
+    });
+
+    assert.equal(result.blocked, true, "unresolved conflicts must block before merge");
+    assert.equal(result.blockedReason, "unmerged-conflicts");
+    assert.equal(result.stashPushed, false, "blocked preflight must not create another stash");
+    assert.deepEqual(result.conflictedPaths, ["README.md"]);
+    assert.ok(
+      notifications.some((n) => n.level === "error" && n.msg.includes("unresolved Git conflicts")),
+      "blocking notification must explain unresolved conflicts",
+    );
+  } finally {
+    run("git reset --hard HEAD 2>/dev/null || true", repo);
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});
+
 // ── postflightPopStash: restores stashed changes ──────────────────────────
 
 test("postflightPopStash — restores stashed changes and emits info notification", () => {

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -11,7 +11,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 
 import { preflightCleanRoot, postflightPopStash } from "../clean-root-preflight.ts";
 
@@ -149,7 +149,8 @@ test("preflightCleanRoot blocks unresolved stash-apply conflicts before stashing
     writeFileSync(join(repo, "README.md"), "# merged milestone work\n");
     run("git add README.md", repo);
     run('git commit -m "feat: merged readme"', repo);
-    execSync("git stash apply 'stash@{0}' || true", { cwd: repo, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" });
+    const apply = spawnSync("git", ["stash", "apply", "stash@{0}"], { cwd: repo, encoding: "utf-8" });
+    if (apply.error) throw apply.error;
 
     assert.match(run("git diff --name-only --diff-filter=U", repo), /README\.md/, "fixture must have unresolved conflict");
 

--- a/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
@@ -32,6 +32,10 @@ function initGitRepo(base: string): void {
   execFileSync("git", ["commit", "-m", "initial"], { cwd: base, stdio: "ignore" });
 }
 
+function gitOutput(base: string, args: string[]): string {
+  return execFileSync("git", args, { cwd: base, encoding: "utf-8" });
+}
+
 function buildDispatchCtx(basePath: string): DispatchContext {
   return {
     basePath,
@@ -101,15 +105,39 @@ describe("completing-milestone dispatch guard (#4324)", () => {
     assert.equal(result?.unitId, "M001");
   });
 
-  test("blocks complete-milestone dispatch when the working tree is dirty (#6132)", async () => {
+  test("commits pending closeout changes before complete-milestone dispatch (#6132)", async () => {
     base = makeBase();
     initGitRepo(base);
     writeFileSync(join(base, "implementation.txt"), "dirty\n");
 
     const result = await rule.match(buildDispatchCtx(base));
 
+    assert.equal(result?.action, "dispatch");
+    assert.equal(result?.unitType, "complete-milestone");
+    assert.equal(gitOutput(base, ["status", "--porcelain"]), "");
+    assert.match(gitOutput(base, ["log", "-1", "--pretty=%B"]), /auto-commit after complete-milestone-preflight/);
+  });
+
+  test("blocks complete-milestone dispatch when unresolved Git conflicts remain (#6132)", async () => {
+    base = makeBase();
+    initGitRepo(base);
+    writeFileSync(join(base, "implementation.txt"), "stashed change\n");
+    execFileSync("git", ["stash", "push", "-m", "conflicting closeout"], { cwd: base, stdio: "ignore" });
+    writeFileSync(join(base, "implementation.txt"), "committed change\n");
+    execFileSync("git", ["add", "implementation.txt"], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "change implementation"], { cwd: base, stdio: "ignore" });
+    try {
+      execFileSync("git", ["stash", "apply", "stash@{0}"], { cwd: base, stdio: "ignore" });
+    } catch {
+      // Expected conflict state.
+    }
+
+    const result = await rule.match(buildDispatchCtx(base));
+
     assert.equal(result?.action, "stop");
-    assert.match(result?.reason ?? "", /uncommitted changes detected/i);
+    assert.equal(result?.level, "error");
+    assert.match(result?.reason ?? "", /unresolved Git conflicts detected/i);
+    assert.match(gitOutput(base, ["status", "--porcelain"]), /^UU implementation\.txt/m);
   });
 
   test("blocks complete-milestone dispatch when UAT verdict is non-PASS and uat_dispatch is enabled (#6132)", async () => {

--- a/src/resources/extensions/gsd/tests/integration/doctor-git.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-git.test.ts
@@ -77,6 +77,21 @@ Completed.
   return dir;
 }
 
+function createStashApplyConflict(): string {
+  const dir = createRepoWithCompletedMilestone();
+  writeFileSync(join(dir, "README.md"), "# local stashed work\n");
+  run('git stash push -m "local work"', dir);
+  writeFileSync(join(dir, "README.md"), "# merged milestone work\n");
+  run("git add README.md", dir);
+  run('git commit -m "feat: merged readme"', dir);
+  execSync("git stash apply 'stash@{0}' || true", {
+    cwd: dir,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  });
+  return dir;
+}
+
 /** Create a repo whose slices are done but milestone closeout is still pending. */
 function createRepoWithSlicesDoneButNoMilestoneSummary(): string {
   const dir = realpathSync(mkdtempSync(join(tmpdir(), "doc-git-test-")));
@@ -293,6 +308,26 @@ describe('doctor-git', async () => {
 
       // Verify MERGE_HEAD is gone
       assert.ok(!existsSync(join(dir, ".git", "MERGE_HEAD")), "MERGE_HEAD removed after fix");
+    });
+
+    test('unresolved_git_conflicts is manual-only and preserves conflict state', async () => {
+      const dir = createStashApplyConflict();
+      cleanups.push(dir);
+      assert.equal(existsSync(join(dir, ".git", "MERGE_HEAD")), false, "stash apply conflict should not require MERGE_HEAD");
+
+      const detect = await runGSDDoctor(dir);
+      const conflictIssues = detect.issues.filter(i => i.code === "unresolved_git_conflicts");
+      assert.equal(conflictIssues.length, 1, "detects unresolved Git conflict index");
+      assert.equal(conflictIssues[0]?.severity, "error");
+      assert.equal(conflictIssues[0]?.fixable, false);
+      assert.match(conflictIssues[0]?.message ?? "", /README\.md/);
+
+      const fixed = await runGSDDoctor(dir, { fix: true });
+      assert.ok(
+        !fixed.fixesApplied.some((fix) => fix.includes("cleaned merge state")),
+        "doctor fix must not reset conflict files",
+      );
+      assert.match(run("git diff --name-only --diff-filter=U", dir), /README\.md/, "conflict remains for manual resolution");
     });
 
     // ─── Test 4: Tracked runtime files detection & fix ─────────────────

--- a/src/resources/extensions/gsd/tests/integration/doctor-git.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-git.test.ts
@@ -14,7 +14,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, realpathSync, readFileSync, symlinkSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 
 import { runGSDDoctor } from "../../doctor.ts";
 import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../../gsd-db.ts";
@@ -84,11 +84,11 @@ function createStashApplyConflict(): string {
   writeFileSync(join(dir, "README.md"), "# merged milestone work\n");
   run("git add README.md", dir);
   run('git commit -m "feat: merged readme"', dir);
-  execSync("git stash apply 'stash@{0}' || true", {
+  const apply = spawnSync("git", ["stash", "apply", "stash@{0}"], {
     cwd: dir,
-    stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf-8",
   });
+  if (apply.error) throw apply.error;
   return dir;
 }
 

--- a/src/resources/extensions/gsd/tests/integration/doctor-proactive.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-proactive.test.ts
@@ -68,6 +68,21 @@ _None_
   return dir;
 }
 
+function createStashApplyConflict(): string {
+  const dir = createGitRepo();
+  writeFileSync(join(dir, "README.md"), "# local stashed work\n");
+  run('git stash push -m "local work"', dir);
+  writeFileSync(join(dir, "README.md"), "# merged milestone work\n");
+  run("git add README.md", dir);
+  run('git commit -m "feat: merged readme"', dir);
+  execSync("git stash apply 'stash@{0}' || true", {
+    cwd: dir,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  });
+  return dir;
+}
+
 describe('doctor-proactive', async () => {
   const cleanups: string[] = [];
 
@@ -285,6 +300,23 @@ describe('doctor-proactive', async () => {
     } else {
       console.log("  (skipped on Windows)");
     }
+    });
+
+    test('health gate: unresolved stash-apply conflicts block without reset', async () => {
+      const dir = createStashApplyConflict();
+      cleanups.push(dir);
+      assert.equal(existsSync(join(dir, ".git", "MERGE_HEAD")), false, "stash apply conflict should not require MERGE_HEAD");
+
+      const result = await preDispatchHealthGate(dir);
+
+      assert.equal(result.proceed, false, "gate blocks unresolved conflict state");
+      assert.match(result.reason ?? "", /Unresolved Git conflicts/);
+      assert.match(result.reason ?? "", /README\.md/);
+      assert.ok(
+        !result.fixesApplied.some((fix) => fix.includes("cleaned merge state")),
+        "must not reset or auto-heal user conflict files",
+      );
+      assert.match(run("git diff --name-only --diff-filter=U", dir), /README\.md/, "conflict remains for manual resolution");
     });
 
     test('health gate: STATE.md missing — auto-healed', async () => {

--- a/src/resources/extensions/gsd/tests/integration/doctor-proactive.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-proactive.test.ts
@@ -12,7 +12,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 
 import {
   preDispatchHealthGate,
@@ -75,11 +75,11 @@ function createStashApplyConflict(): string {
   writeFileSync(join(dir, "README.md"), "# merged milestone work\n");
   run("git add README.md", dir);
   run('git commit -m "feat: merged readme"', dir);
-  execSync("git stash apply 'stash@{0}' || true", {
+  const apply = spawnSync("git", ["stash", "apply", "stash@{0}"], {
     cwd: dir,
-    stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf-8",
   });
+  if (apply.error) throw apply.error;
   return dir;
 }
 

--- a/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
@@ -122,6 +122,22 @@ const STASH_NOT_PUSHED: PreflightResult = {
   summary: "",
 };
 
+const PREFLIGHT_BLOCKED: PreflightResult = {
+  stashPushed: false,
+  blocked: true,
+  blockedReason: "dirty-overlap",
+  overlappingPaths: ["todo.js", "test-todo-cli.js"],
+  summary: "Working tree has uncommitted files that overlap milestone M002 changes.",
+};
+
+const PREFLIGHT_UNMERGED: PreflightResult = {
+  stashPushed: false,
+  blocked: true,
+  blockedReason: "unmerged-conflicts",
+  conflictedPaths: ["todo.js", "test-todo-cli.js"],
+  summary: "Working tree has unresolved Git conflicts before milestone M002 merge.",
+};
+
 const POP_OK: PostflightResult = {
   restored: true,
   needsManualRecovery: false,
@@ -222,6 +238,50 @@ test("clean tree: no stash to pop, merge succeeds, no pop attempted", async () =
   assert.equal(result, null);
   assert.equal(log.postflightCalls, 0, "no pop when nothing was stashed");
   assert.equal(log.milestoneMergedInPhases, true);
+});
+
+test("dirty overlap: preflight stops before merge and postflight restore", async () => {
+  const { ic, log } = buildIc({
+    preflightResult: PREFLIGHT_BLOCKED,
+    mergeBehavior: "succeed",
+    postflightResult: POP_OK,
+  });
+
+  const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+  assert.deepEqual(result, {
+    action: "break",
+    reason: "preflight-dirty-overlap",
+  });
+  assert.equal(log.mergeCalls, 0, "blocked preflight must not start milestone merge");
+  assert.equal(log.postflightCalls, 0, "blocked preflight must not attempt stash restore");
+  assert.equal(log.stopAutoCalls.length, 1);
+  assert.match(
+    log.stopAutoCalls[0] ?? "",
+    /Pre-merge dirty working tree overlaps milestone M002/,
+  );
+});
+
+test("unmerged conflicts: preflight stops before merge and postflight restore", async () => {
+  const { ic, log } = buildIc({
+    preflightResult: PREFLIGHT_UNMERGED,
+    mergeBehavior: "succeed",
+    postflightResult: POP_OK,
+  });
+
+  const result = await _runMilestoneMergeWithStashRestore(ic, "M002");
+
+  assert.deepEqual(result, {
+    action: "break",
+    reason: "preflight-unmerged-conflicts",
+  });
+  assert.equal(log.mergeCalls, 0, "unmerged conflict preflight must not start milestone merge");
+  assert.equal(log.postflightCalls, 0, "unmerged conflict preflight must not attempt stash restore");
+  assert.equal(log.stopAutoCalls.length, 1);
+  assert.match(
+    log.stopAutoCalls[0] ?? "",
+    /Pre-merge unresolved Git conflicts block milestone M002/,
+  );
 });
 
 test("merge succeeds but stash pop needs manual recovery -> postflight-stash-restore-failed break", async () => {


### PR DESCRIPTION
## TL;DR

**What:** Blocks unsafe milestone merge/restore states and commits pending closeout changes before milestone completion starts.
**Why:** Auto-mode could either leave a repo conflicted after post-merge stash restore or pause after validation because generated closeout artifacts were still uncommitted.
**How:** Adds pre-merge conflict/overlap checks, manual-only conflict handling, and a complete-milestone preflight commit for pending closeout changes.

## What

- Added a shared unresolved Git conflict detector for `git diff --diff-filter=U` paths.
- Updated clean-root preflight to block before merging when dirty files overlap `milestone/<id>` changes.
- Updated clean-root preflight to block before stashing/merging when unresolved Git conflicts already exist.
- Updated auto-mode merge phases to stop with distinct preflight reasons before merge/postflight restore.
- Updated pre-dispatch health and doctor checks to report unresolved Git conflicts as manual-only instead of auto-resetting.
- Updated `complete-milestone` dispatch to commit pending closeout changes before closure, while still stopping on unresolved conflicts or dirty state that remains after the commit attempt.

## Why

When project-root dirty files overlap milestone output, the old flow stashed local work, merged the milestone, then attempted `git stash apply`. If the same files changed on both sides, Git could leave the repo with unresolved `UU` entries after the merge had already completed.

A second closeout path could also pause after validation with `Cannot complete milestone: uncommitted changes detected` because lifecycle-only units such as `validate-milestone` can produce generated artifacts that are not committed before the next `complete-milestone` dispatch guard runs.

## How

The merge fix moves the collision check before the milestone merge. If dirty paths overlap the milestone branch diff, auto-mode stops and names the files before it stashes or merges. If unresolved Git conflict paths already exist, auto-mode and doctor both surface them as manual recovery work and preserve the conflict state.

The closeout fix changes the completion guard from a hard dirty-tree stop to a pre-completion git closeout: it refuses unresolved conflicts first, commits pending closeout changes through the existing turn git action path, then re-checks the tree before dispatching `complete-milestone`.

## Validation

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts`
- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts src/resources/extensions/gsd/tests/clean-root-preflight.test.ts src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts src/resources/extensions/gsd/tests/integration/doctor-proactive.test.ts src/resources/extensions/gsd/tests/integration/doctor-git.test.ts`
- [x] `npm run typecheck:extensions`
- [x] `git diff --check`

## Change Type

- [x] `fix` — Bug fix
- [x] `test` — Regression coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto mode now attempts to save pending milestone closeout changes before finishing and stops with clear, actionable reasons if unresolved Git conflicts or overlapping local edits block a merge.

* **Bug Fixes**
  * Health checks and pre-dispatch gates now block dispatch when unresolved Git conflicts exist and correctly report them as manual-only, preventing automatic fixes.

* **Documentation**
  * User docs and troubleshooting updated with causes, manual resolution steps, and how to resume auto mode after resolving conflicts/overlaps.

* **Tests**
  * Added regression and integration tests covering blocked preflight cases for unresolved conflicts and dirty-overlap scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->