### PR TITLE
fix(issue): git stash push --include-untracked fails on Windows when untracked file has reserved device name (nul, con, prn, aux)

### DIFF
--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -387,10 +387,6 @@ export function preflightCleanRoot(
     };
   }
 
-  // Warn the user before stashing
-  const warnMsg = `Working tree has uncommitted changes before milestone ${milestoneId} merge. Auto-stashing to allow clean merge (stash will be restored after merge).`;
-  notify(warnMsg, "warning");
-
   if (process.platform === "win32") {
     const reservedUntracked = listUntrackedPaths(basePath).filter(hasWindowsReservedBasename);
     if (reservedUntracked.length > 0) {
@@ -401,6 +397,10 @@ export function preflightCleanRoot(
       return { stashPushed: false, summary: `stash-skipped-reserved-device-names: ${reservedList}` };
     }
   }
+
+  // Warn the user before stashing
+  const warnMsg = `Working tree has uncommitted changes before milestone ${milestoneId} merge. Auto-stashing to allow clean merge (stash will be restored after merge).`;
+  notify(warnMsg, "warning");
 
   // Push the stash
   try {

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -21,6 +21,31 @@ import { logWarning } from "./workflow-logger.js";
 import { nativeHasChanges } from "./native-git-bridge.js";
 import { listUnmergedGitPaths } from "./git-conflict-state.js";
 
+const WINDOWS_RESERVED_BASENAMES = new Set([
+  "con",
+  "prn",
+  "aux",
+  "nul",
+  "com1",
+  "com2",
+  "com3",
+  "com4",
+  "com5",
+  "com6",
+  "com7",
+  "com8",
+  "com9",
+  "lpt1",
+  "lpt2",
+  "lpt3",
+  "lpt4",
+  "lpt5",
+  "lpt6",
+  "lpt7",
+  "lpt8",
+  "lpt9",
+]);
+
 export interface PreflightResult {
   /** true when a stash was pushed and postflightPopStash should be called */
   stashPushed: boolean;
@@ -133,6 +158,27 @@ function findOverlappingDirtyMilestonePaths(basePath: string, milestoneId: strin
   return dirtyPaths
     .filter((path) => !path.startsWith(".gsd/") && changedPathSet.has(path))
     .sort();
+}
+
+function listUntrackedPaths(basePath: string): string[] {
+  try {
+    const output = gitText(basePath, ["status", "--porcelain", "-z", "--untracked-files=all"]);
+    const entries = output.split("\0").filter(Boolean);
+    const untracked: string[] = [];
+    for (const entry of entries) {
+      if (entry.startsWith("?? ")) untracked.push(entry.slice(3));
+    }
+    return untracked;
+  } catch {
+    return [];
+  }
+}
+
+function hasWindowsReservedBasename(path: string): boolean {
+  const normalized = path.replace(/\\/g, "/");
+  const base = normalized.split("/").pop() ?? normalized;
+  const [name] = base.split(".", 1);
+  return WINDOWS_RESERVED_BASENAMES.has(name.toLowerCase());
 }
 
 function listStashUntrackedPaths(basePath: string, stashRef: string): string[] | null {
@@ -344,6 +390,17 @@ export function preflightCleanRoot(
   // Warn the user before stashing
   const warnMsg = `Working tree has uncommitted changes before milestone ${milestoneId} merge. Auto-stashing to allow clean merge (stash will be restored after merge).`;
   notify(warnMsg, "warning");
+
+  if (process.platform === "win32") {
+    const reservedUntracked = listUntrackedPaths(basePath).filter(hasWindowsReservedBasename);
+    if (reservedUntracked.length > 0) {
+      const reservedList = reservedUntracked.join(", ");
+      const msg = `Auto-stash blocked before milestone ${milestoneId} merge: untracked Windows reserved device name(s): ${reservedList}`;
+      logWarning("preflight", msg);
+      notify(`Auto-stash skipped before milestone ${milestoneId} merge — reserved Windows device name(s) detected: ${reservedList}`, "warning");
+      return { stashPushed: false, summary: `stash-skipped-reserved-device-names: ${reservedList}` };
+    }
+  }
 
   // Push the stash
   try {

--- a/src/resources/extensions/gsd/exec-sandbox.ts
+++ b/src/resources/extensions/gsd/exec-sandbox.ts
@@ -118,6 +118,12 @@ function resolveCommand(runtime: ExecSandboxRequest["runtime"]): { cmd: string; 
   }
 }
 
+function sanitizeBashScriptForWindows(script: string): string {
+  if (process.platform !== "win32") return script;
+  // Git Bash can materialize literal `nul` files for NUL redirects.
+  return script.replace(/(\d*>>?) *\bNUL\b(?=\s|;|\||&|\)|$)/gi, "$1 /dev/null");
+}
+
 function tail(buf: Buffer, chars: number): string {
   if (chars <= 0) return "";
   const text = buf.toString("utf-8");
@@ -148,13 +154,14 @@ export function runExecSandbox(
 
     const timeoutMs = clampTimeout(request, opts);
     const { cmd, args } = resolveCommand(request.runtime);
+    const script = request.runtime === "bash" ? sanitizeBashScriptForWindows(request.script) : request.script;
     const env = buildChildEnv(opts);
     const useProcessGroup = process.platform !== "win32";
 
     const started = Date.now();
     let child;
     try {
-      child = spawn(cmd, [...args, request.script], {
+      child = spawn(cmd, [...args, script], {
         cwd: opts.baseDir,
         env,
         stdio: ["ignore", "pipe", "pipe"],

--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -55,6 +55,13 @@ const BASELINE_PATTERNS = [
   // ── OS junk ──
   ".DS_Store",
   "Thumbs.db",
+  // Windows reserved device names (prevents undeletable untracked entries)
+  "nul",
+  "con",
+  "prn",
+  "aux",
+  "com[1-9]",
+  "lpt[1-9]",
 
   // ── Editor / IDE ──
   "*.swp",

--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -57,11 +57,17 @@ const BASELINE_PATTERNS = [
   "Thumbs.db",
   // Windows reserved device names (prevents undeletable untracked entries)
   "nul",
+  "nul.*",
   "con",
+  "con.*",
   "prn",
+  "prn.*",
   "aux",
+  "aux.*",
   "com[1-9]",
+  "com[1-9].*",
   "lpt[1-9]",
+  "lpt[1-9].*",
 
   // ── Editor / IDE ──
   "*.swp",

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -175,6 +175,33 @@ test("preflightCleanRoot blocks unresolved stash-apply conflicts before stashing
   }
 });
 
+test("preflightCleanRoot — skips stash on Windows reserved untracked name", () => {
+  const originalPlatform = process.platform;
+  const repo = createTempRepo();
+  try {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    writeFileSync(join(repo, "nul"), "");
+
+    const notifications: Array<{ msg: string; level: string }> = [];
+    const result = preflightCleanRoot(repo, "M003W", (msg, level) => {
+      notifications.push({ msg, level });
+    });
+
+    assert.equal(result.stashPushed, false, "stash must be skipped for reserved Windows names");
+    assert.match(result.summary, /stash-skipped-reserved-device-names/);
+    assert.ok(
+      notifications.some((n) => n.level === "warning" && n.msg.includes("reserved Windows device name")),
+      "warning notification must mention reserved Windows device names",
+    );
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    const stashList = run("git stash list", repo);
+    assert.equal(stashList, "", "no stash entry should be created");
+  } finally {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});
+
 // ── postflightPopStash: restores stashed changes ──────────────────────────
 
 test("postflightPopStash — restores stashed changes and emits info notification", () => {

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -180,7 +180,11 @@ test("preflightCleanRoot — skips stash on Windows reserved untracked name", ()
   const repo = createTempRepo();
   try {
     Object.defineProperty(process, "platform", { value: "win32" });
-    writeFileSync(join(repo, "nul"), "");
+    if (originalPlatform !== "win32") {
+      writeFileSync(join(repo, "nul"), "");
+    } else {
+      writeFileSync(join(repo, "reserved-name-sentinel.txt"), "");
+    }
 
     const notifications: Array<{ msg: string; level: string }> = [];
     const result = preflightCleanRoot(repo, "M003W", (msg, level) => {

--- a/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
@@ -3,7 +3,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -114,6 +114,23 @@ test('runExecSandbox: node runtime executes JS', async () => {
     assert.equal(result.exit_code, 0);
     assert.ok(result.digest.includes('node-ok:3'));
   } finally {
+    cleanup(base);
+  }
+});
+
+test('runExecSandbox: rewrites NUL redirects for bash on Windows', async () => {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, 'platform', { value: 'win32' });
+  const base = freshBase();
+  try {
+    const result = await runExecSandbox(
+      { runtime: 'bash', script: 'echo should-not-create-file > NUL' },
+      baseOpts(base),
+    );
+    assert.equal(result.exit_code, 0);
+    assert.equal(existsSync(join(base, 'NUL')), false, 'must not materialize a literal NUL file');
+  } finally {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
     cleanup(base);
   }
 });

--- a/src/resources/extensions/gsd/tests/gitignore-bg-shell-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/gitignore-bg-shell-runtime.test.ts
@@ -67,7 +67,7 @@ describe('ensureGitignore writes .bg-shell/ baseline (#4902)', () => {
       ensureGitignore(dir);
       const ignore = fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8');
       const lines = new Set(ignore.split('\n').map((l) => l.trim()).filter(Boolean));
-      for (const pattern of ['nul', 'con', 'prn', 'aux', 'com[1-9]', 'lpt[1-9]']) {
+      for (const pattern of ['nul', 'nul.*', 'con', 'con.*', 'prn', 'prn.*', 'aux', 'aux.*', 'com[1-9]', 'com[1-9].*', 'lpt[1-9]', 'lpt[1-9].*']) {
         assert.ok(lines.has(pattern), `missing Windows reserved pattern: ${pattern}`);
       }
     } finally {

--- a/src/resources/extensions/gsd/tests/gitignore-bg-shell-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/gitignore-bg-shell-runtime.test.ts
@@ -60,4 +60,18 @@ describe('ensureGitignore writes .bg-shell/ baseline (#4902)', () => {
       cleanup(dir);
     }
   });
+
+  test('adds Windows reserved device-name patterns', () => {
+    const dir = makeTmpRepo();
+    try {
+      ensureGitignore(dir);
+      const ignore = fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8');
+      const lines = new Set(ignore.split('\n').map((l) => l.trim()).filter(Boolean));
+      for (const pattern of ['nul', 'con', 'prn', 'aux', 'com[1-9]', 'lpt[1-9]']) {
+        assert.ok(lines.has(pattern), `missing Windows reserved pattern: ${pattern}`);
+      }
+    } finally {
+      cleanup(dir);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Added Windows reserved-name protections in exec/preflight plus baseline gitignore entries, with focused tests all passing.

## Bugs Addressed
- [x] **Windows shell redirection creates literal `nul` file**
- [x] **Preflight stash fails on Windows reserved device names**

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5582
- [#5582 git stash push --include-untracked fails on Windows when untracked file has reserved device name (nul, con, prn, aux)](https://github.com/gsd-build/gsd-2/issues/5582)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5582-git-stash-push-include-untracked-fails-o-1778972711`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stash now skips safely on Windows when untracked paths include reserved device names (e.g., nul, con, prn, aux, com1–com9, lpt1–lpt9), avoiding problematic stashing and notifying the user.
  * Bash sandbox on Windows rewrites NUL redirects to /dev/null to prevent literal NUL file creation.
  * .gitignore baseline now includes patterns to ignore Windows reserved device names.

* **Tests**
  * Added regression tests covering the Windows reserved-name stash skip, Bash NUL rewrite, and gitignore patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->