### PR TITLE
fix(issue): doctor --fix does not remove .gsd.migrating orphan after successful migration

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -446,6 +446,19 @@ export async function checkRuntimeHealth(
         if (shouldFix("failed_migration")) {
           if (recoverFailedMigration(basePath)) {
             fixesApplied.push("recovered failed migration (.gsd.migrating → .gsd)");
+          } else if (existsSync(localGsd)) {
+            const stateFilePath = resolveGsdRootFile(basePath, "STATE");
+            if (existsSync(stateFilePath)) {
+              try {
+                // Safety gate: only prune orphaned .gsd.migrating when the
+                // current .gsd state can be derived successfully.
+                await deriveState(basePath);
+                rmSync(migratingPath, { recursive: true, force: true });
+                fixesApplied.push("removed orphaned .gsd.migrating after verifying .gsd state");
+              } catch {
+                // Keep orphan in place when state validation fails.
+              }
+            }
           }
         }
       }

--- a/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
@@ -15,6 +15,8 @@ import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 
 import { runGSDDoctor } from "../../doctor.ts";
+import { checkRuntimeHealth } from "../../doctor-runtime-checks.ts";
+import { invalidateStateCache } from "../../state.ts";
 function run(cmd: string, cwd: string): string {
   return execSync(cmd, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
 }
@@ -276,6 +278,40 @@ None
         "fix removes orphaned .gsd.migrating when .gsd validates",
       );
       assert.ok(!existsSync(join(dir, ".gsd.migrating")), ".gsd.migrating removed after fix");
+    });
+
+    test('failed_migration orphan is preserved when .gsd is invalid', async () => {
+      const dir = createMinimalProject();
+      cleanups.push(dir);
+
+      // Simulate crash window where both directories exist.
+      mkdirSync(join(dir, ".gsd.migrating"), { recursive: true });
+      writeFileSync(join(dir, ".gsd", "STATE.md"), "# GSD State\n");
+
+      const detectIssues: Array<{ code: string }> = [];
+      await checkRuntimeHealth(dir, detectIssues as any, [], () => false);
+      const migrationIssues = detectIssues.filter(i => i.code === "failed_migration");
+      assert.ok(migrationIssues.length > 0, "detects failed migration orphan");
+
+      // Force deriveState() to throw in the doctor fallback safety gate by
+      // dropping a required table from the currently open DB connection.
+      const { openDatabase, _getAdapter, closeDatabase } = await import("../../gsd-db.ts");
+      openDatabase(join(dir, ".gsd", "gsd.db"));
+      try {
+        _getAdapter()!.exec("DROP TABLE milestones");
+        invalidateStateCache();
+
+        const fixIssues: Array<{ code: string }> = [];
+        const fixesApplied: string[] = [];
+        await checkRuntimeHealth(dir, fixIssues as any, fixesApplied, (code) => code === "failed_migration");
+        assert.ok(existsSync(join(dir, ".gsd.migrating")), ".gsd.migrating preserved when .gsd validation fails");
+        assert.ok(
+          !fixesApplied.some(f => f.includes("removed orphaned .gsd.migrating")),
+          "fix does not remove orphaned .gsd.migrating when .gsd is invalid",
+        );
+      } finally {
+        closeDatabase();
+      }
     });
 
     // ─── Test 7: Gitignore missing patterns detection & fix ───────────

--- a/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
@@ -256,6 +256,28 @@ None
       assert.ok(content.includes("M001"), "rebuilt STATE.md references milestone");
     });
 
+    // ─── Test 6b: failed migration orphan cleanup when .gsd is intact ──
+    test('failed_migration orphan is removed when .gsd is valid', async () => {
+      const dir = createMinimalProject();
+      cleanups.push(dir);
+
+      // Simulate crash window where both directories exist.
+      mkdirSync(join(dir, ".gsd.migrating"), { recursive: true });
+      writeFileSync(join(dir, ".gsd", "STATE.md"), "# GSD State\n");
+
+      const detect = await runGSDDoctor(dir);
+      const migrationIssues = detect.issues.filter(i => i.code === "failed_migration");
+      assert.ok(migrationIssues.length > 0, "detects failed migration orphan");
+      assert.ok(migrationIssues[0]?.fixable === true, "failed migration orphan is fixable");
+
+      const fixed = await runGSDDoctor(dir, { fix: true });
+      assert.ok(
+        fixed.fixesApplied.some(f => f.includes("removed orphaned .gsd.migrating")),
+        "fix removes orphaned .gsd.migrating when .gsd validates",
+      );
+      assert.ok(!existsSync(join(dir, ".gsd.migrating")), ".gsd.migrating removed after fix");
+    });
+
     // ─── Test 7: Gitignore missing patterns detection & fix ───────────
     if (process.platform !== "win32") {
     test('gitignore_missing_patterns', async () => {


### PR DESCRIPTION
## Summary
- Added a guarded `doctor --fix` fallback that deletes orphan `.gsd.migrating` when `.gsd` validates, with a passing integration regression test.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5603
- [#5603 doctor --fix does not remove .gsd.migrating orphan after successful migration](https://github.com/gsd-build/gsd-2/issues/5603)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5603-doctor-fix-does-not-remove-gsd-migrating-1778980083`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for failed migrations: when automatic recovery initially fails, the system now attempts a safer fallback to determine current migration state before removing orphaned migration markers, reducing risk of accidental data loss.

* **Tests**
  * Added integration tests covering successful orphan cleanup and a safety gate that prevents cleanup when validation of existing migration state fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->