### PR TITLE
fix(issue): doctor --fix does not remove .gsd.migrating orphan after successful migration

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -446,6 +446,18 @@ export async function checkRuntimeHealth(
         if (shouldFix("failed_migration")) {
           if (recoverFailedMigration(basePath)) {
             fixesApplied.push("recovered failed migration (.gsd.migrating → .gsd)");
+          } else {
+            // If both directories exist, keep `.gsd` as source of truth and
+            // only remove the orphan backup when the active state looks intact.
+            const statePath = resolveGsdRootFile(basePath, "STATE");
+            if (existsSync(localGsd) && existsSync(statePath)) {
+              try {
+                rmSync(migratingPath, { recursive: true, force: true });
+                fixesApplied.push("removed stale failed-migration orphan (.gsd.migrating)");
+              } catch {
+                // Non-fatal — keep issue visible if cleanup fails.
+              }
+            }
           }
         }
       }

--- a/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
@@ -334,6 +334,30 @@ node_modules/
     } else {
     }
 
+    // ─── Test 8c: failed migration orphan cleanup when .gsd is intact ──
+    test('failed_migration orphan cleanup when .gsd and .gsd.migrating both exist', async () => {
+      const dir = createMinimalProject();
+      cleanups.push(dir);
+
+      // Mark the active .gsd as intact enough for doctor fix.
+      writeFileSync(join(dir, ".gsd", "STATE.md"), "# GSD State\n");
+      writeFileSync(join(dir, ".gsd", "PREFERENCES.md"), "---\nversion: 1\n---\n");
+      mkdirSync(join(dir, ".gsd.migrating"), { recursive: true });
+      writeFileSync(join(dir, ".gsd.migrating", "STATE.md"), "# stale\n");
+
+      const detect = await runGSDDoctor(dir);
+      const migrationIssues = detect.issues.filter(i => i.code === "failed_migration");
+      assert.ok(migrationIssues.length > 0, "detects failed migration orphan");
+
+      const fixed = await runGSDDoctor(dir, { fix: true });
+      assert.ok(
+        fixed.fixesApplied.some(f => f.includes("failed-migration orphan")),
+        `fix removes failed migration orphan (got: ${fixed.fixesApplied.join(", ")})`,
+      );
+      assert.ok(!existsSync(join(dir, ".gsd.migrating")), ".gsd.migrating removed after fix");
+      assert.ok(existsSync(join(dir, ".gsd")), ".gsd remains intact after fix");
+    });
+
     // ─── Test 9: Orphaned completed-units detection & fix ─────────────
     test('orphaned_completed_units', async () => {
       const dir = createMinimalProject();


### PR DESCRIPTION
## Summary
- doctor fix now removes stale .gsd.migrating when .gsd is intact, verified by targeted doctor-runtime integration tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5603
- [#5603 doctor --fix does not remove .gsd.migrating orphan after successful migration](https://github.com/gsd-build/gsd-2/issues/5603)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5603-doctor-fix-does-not-remove-gsd-migrating-1778980387`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced recovery process for failed migrations by automatically removing orphaned migration artifacts when the primary migration directory exists and is valid, preventing stale data from persisting after recovery attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->