### PR TITLE
fix(issue): doctor --fix does not remove .gsd.migrating orphan after successful migration

### DIFF
--- a/src/resources/extensions/gsd/migrate-external.ts
+++ b/src/resources/extensions/gsd/migrate-external.ts
@@ -199,7 +199,18 @@ export function recoverFailedMigration(basePath: string): boolean {
   const migratingPath = join(basePath, ".gsd.migrating");
 
   if (!existsSync(migratingPath)) return false;
-  if (existsSync(localGsd)) return false; // both exist -- ambiguous, don't touch
+  if (existsSync(localGsd)) {
+    // Safe orphan cleanup path: local state is present and migration snapshot remains.
+    const hasStateMd = existsSync(join(localGsd, "STATE.md"));
+    const hasDb = existsSync(join(localGsd, "gsd.db"));
+    if (!hasStateMd || !hasDb) return false; // ambiguous, don't touch
+    try {
+      rmSync(migratingPath, { recursive: true, force: true });
+      return true;
+    } catch {
+      return false;
+    }
+  }
 
   try {
     renameSync(migratingPath, localGsd);

--- a/src/resources/extensions/gsd/tests/auto-migrating-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-migrating-recovery.test.ts
@@ -48,6 +48,22 @@ test("recoverFailedMigration returns false when both .gsd and .gsd.migrating exi
   assert.ok(existsSync(join(base, ".gsd.migrating")), ".gsd.migrating must still exist");
 });
 
+test("recoverFailedMigration removes .gsd.migrating orphan when .gsd is intact", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-migrating-orphan-cleanup-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdPath = join(base, ".gsd");
+  mkdirSync(gsdPath, { recursive: true });
+  writeFileSync(join(gsdPath, "STATE.md"), "# GSD State\n");
+  writeFileSync(join(gsdPath, "gsd.db"), "");
+  mkdirSync(join(base, ".gsd.migrating"), { recursive: true });
+
+  const recovered = recoverFailedMigration(base);
+  assert.equal(recovered, true, "should remove orphan migration directory");
+  assert.ok(existsSync(gsdPath), ".gsd must still exist");
+  assert.ok(!existsSync(join(base, ".gsd.migrating")), ".gsd.migrating should be removed");
+});
+
 test("recoverFailedMigration preserves contents of .gsd.migrating", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-migrating-contents-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary
- Added a guarded orphan-cleanup path in failed migration recovery and verified it with targeted recovery tests (5 passing).

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5603
- [#5603 doctor --fix does not remove .gsd.migrating orphan after successful migration](https://github.com/gsd-build/gsd-2/issues/5603)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5603-doctor-fix-does-not-remove-gsd-migrating-1778980943`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migration recovery now intelligently handles cases where both a current state and incomplete migration data coexist. When the current state is valid, cleanup occurs; in ambiguous situations, artifacts are preserved for safety.

* **Tests**
  * Added regression test verifying proper cleanup of incomplete migration artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->