### PR TITLE
fix(issue): doctor --fix does not remove .gsd.migrating orphan after successful migration

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -446,6 +446,12 @@ export async function checkRuntimeHealth(
         if (shouldFix("failed_migration")) {
           if (recoverFailedMigration(basePath)) {
             fixesApplied.push("recovered failed migration (.gsd.migrating → .gsd)");
+          } else {
+            const stateFile = join(localGsd, "STATE.md");
+            if (existsSync(localGsd) && existsSync(stateFile)) {
+              rmSync(migratingPath, { recursive: true, force: true });
+              fixesApplied.push("removed orphaned .gsd.migrating after verifying active .gsd state");
+            }
           }
         }
       }

--- a/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
@@ -359,6 +359,26 @@ node_modules/
       assert.deepStrictEqual(content.length, 0, "all orphaned keys removed");
     });
 
+    test('failed_migration fix removes orphaned .gsd.migrating when .gsd is intact', async () => {
+      const dir = createMinimalProject();
+      cleanups.push(dir);
+
+      writeFileSync(join(dir, ".gsd", "STATE.md"), "# GSD State\n");
+      mkdirSync(join(dir, ".gsd.migrating"), { recursive: true });
+      writeFileSync(join(dir, ".gsd.migrating", "stale.txt"), "stale\n");
+
+      const detect = await runGSDDoctor(dir);
+      const migrationIssues = detect.issues.filter(i => i.code === "failed_migration");
+      assert.ok(migrationIssues.length > 0, "detects failed migration orphan");
+
+      const fixed = await runGSDDoctor(dir, { fix: true });
+      assert.ok(
+        fixed.fixesApplied.some(f => f.includes("removed orphaned .gsd.migrating")),
+        "fix removes orphaned .gsd.migrating when .gsd is intact",
+      );
+      assert.ok(!existsSync(join(dir, ".gsd.migrating")), ".gsd.migrating removed after fix");
+    });
+
     // ─── Test: hook/ compound keys are NOT flagged as orphaned (#2826) ─
     test('orphaned_completed_units — hook/ compound keys not flagged', async () => {
       const dir = createMinimalProject();


### PR DESCRIPTION
## Summary
- doctor --fix now removes orphaned `.gsd.migrating` when `.gsd` is intact (gated by `.gsd/STATE.md`), verified by focused doctor runtime integration tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5603
- [#5603 doctor --fix does not remove .gsd.migrating orphan after successful migration](https://github.com/gsd-build/gsd-2/issues/5603)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5603-doctor-fix-does-not-remove-gsd-migrating-1778980538`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime health diagnostics to automatically detect and recover from failed migration states with enhanced verification checks.

* **Tests**
  * Added integration test for failed migration detection and recovery workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->