### PR TITLE
fix(issue): doctor --fix does not remove .gsd.migrating orphan after successful migration

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -22,7 +22,10 @@ function isCurrentGsdStateIntactForMigratingCleanup(basePath: string): boolean {
   try {
     const stateFile = resolveGsdRootFile(basePath, "STATE");
     const milestonesPath = milestonesDir(basePath);
-    return existsSync(stateFile) && existsSync(milestonesPath);
+    const dbPath = join(gsdRoot(basePath), "gsd.db");
+    const hasDbFile = existsSync(dbPath);
+    const hasNonEmptyDb = hasDbFile && statSync(dbPath).size > 0;
+    return existsSync(stateFile) && existsSync(milestonesPath) && hasNonEmptyDb;
   } catch {
     return false;
   }
@@ -460,8 +463,8 @@ export async function checkRuntimeHealth(
             try {
               rmSync(migratingPath, { recursive: true, force: true });
               fixesApplied.push("removed stale .gsd.migrating orphan after validating current .gsd state");
-            } catch {
-              // Keep issue visible if cleanup fails
+            } catch (err) {
+              fixesApplied.push(`failed to remove stale .gsd.migrating orphan at ${migratingPath}: ${err instanceof Error ? err.message : String(err)}`);
             }
           }
         }

--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -18,6 +18,16 @@ import { findMilestoneIds } from "./milestone-ids.js";
 
 const MAX_UAT_ATTEMPTS = 3;
 
+function isCurrentGsdStateIntactForMigratingCleanup(basePath: string): boolean {
+  try {
+    const stateFile = resolveGsdRootFile(basePath, "STATE");
+    const milestonesPath = milestonesDir(basePath);
+    return existsSync(stateFile) && existsSync(milestonesPath);
+  } catch {
+    return false;
+  }
+}
+
 function hasAssessmentVerdict(basePath: string, mid: string, sid: string): boolean {
   const assessmentPath = join(gsdRoot(basePath), "milestones", mid, "slices", sid, `${sid}-ASSESSMENT.md`);
   if (!existsSync(assessmentPath)) return false;
@@ -446,6 +456,13 @@ export async function checkRuntimeHealth(
         if (shouldFix("failed_migration")) {
           if (recoverFailedMigration(basePath)) {
             fixesApplied.push("recovered failed migration (.gsd.migrating → .gsd)");
+          } else if (isCurrentGsdStateIntactForMigratingCleanup(basePath)) {
+            try {
+              rmSync(migratingPath, { recursive: true, force: true });
+              fixesApplied.push("removed stale .gsd.migrating orphan after validating current .gsd state");
+            } catch {
+              // Keep issue visible if cleanup fails
+            }
           }
         }
       }

--- a/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
@@ -341,6 +341,7 @@ node_modules/
 
       // Intact current state marker required by cleanup gate.
       writeFileSync(join(dir, ".gsd", "STATE.md"), "# GSD State\n");
+      writeFileSync(join(dir, ".gsd", "gsd.db"), "db");
       mkdirSync(join(dir, ".gsd.migrating"), { recursive: true });
       writeFileSync(join(dir, ".gsd.migrating", "stale.txt"), "stale snapshot");
 
@@ -352,6 +353,19 @@ node_modules/
       await runGSDDoctor(dir, { fix: true });
       assert.ok(!existsSync(join(dir, ".gsd.migrating")), "orphan .gsd.migrating removed");
       assert.ok(existsSync(join(dir, ".gsd")), "current .gsd preserved");
+    });
+
+    test('failed_migration orphan NOT removed when .gsd is incomplete', async () => {
+      const dir = createMinimalProject();
+      cleanups.push(dir);
+
+      rmSync(join(dir, ".gsd", "STATE.md"), { force: true });
+      mkdirSync(join(dir, ".gsd.migrating"), { recursive: true });
+      writeFileSync(join(dir, ".gsd.migrating", "STATE.md"), "# Migrating state\n");
+
+      await runGSDDoctor(dir, { fix: true });
+      assert.ok(existsSync(join(dir, ".gsd.migrating")), ".gsd.migrating preserved when current .gsd is incomplete");
+      assert.ok(existsSync(join(dir, ".gsd", "milestones", "M001")), "current .gsd milestones preserved");
     });
 
     test('orphaned_completed_units', async () => {

--- a/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
@@ -335,6 +335,25 @@ node_modules/
     }
 
     // ─── Test 9: Orphaned completed-units detection & fix ─────────────
+    test('failed_migration orphan cleanup when .gsd is intact', async () => {
+      const dir = createMinimalProject();
+      cleanups.push(dir);
+
+      // Intact current state marker required by cleanup gate.
+      writeFileSync(join(dir, ".gsd", "STATE.md"), "# GSD State\n");
+      mkdirSync(join(dir, ".gsd.migrating"), { recursive: true });
+      writeFileSync(join(dir, ".gsd.migrating", "stale.txt"), "stale snapshot");
+
+      const detect = await runGSDDoctor(dir);
+      const migrationIssues = detect.issues.filter(i => i.code === "failed_migration");
+      assert.ok(migrationIssues.length > 0, "detects failed migration orphan");
+      assert.ok(migrationIssues[0]?.fixable === true, "failed migration is fixable");
+
+      await runGSDDoctor(dir, { fix: true });
+      assert.ok(!existsSync(join(dir, ".gsd.migrating")), "orphan .gsd.migrating removed");
+      assert.ok(existsSync(join(dir, ".gsd")), "current .gsd preserved");
+    });
+
     test('orphaned_completed_units', async () => {
       const dir = createMinimalProject();
       cleanups.push(dir);


### PR DESCRIPTION
## Summary
- Added a doctor runtime fix path to safely delete orphan `.gsd.migrating` when `.gsd` is intact and verified it with the focused doctor runtime integration tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5603
- [#5603 doctor --fix does not remove .gsd.migrating orphan after successful migration](https://github.com/gsd-build/gsd-2/issues/5603)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5603-doctor-fix-does-not-remove-gsd-migrating-1778980869`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed external-state migrations: when the current state appears intact, stale migration artifacts are now detected and safely removed; cleanup failures are recorded without hiding the original issue, and valid project data is preserved.

* **Tests**
  * Added integration tests validating orphaned migration cleanup behavior for intact and incomplete state scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->