### PR TITLE
fix(issue): stale_crash_lock fix not durable: clearLock() skips workers table UPDATE

### DIFF
--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -30,7 +30,6 @@ import { join } from "node:path";
 import {
   findStaleWorkerForProject,
   getAllAutoWorkers,
-  markWorkerCrashed,
   markWorkerStopping,
   markWorkerStoppingByPid,
   type AutoWorkerRow,
@@ -230,7 +229,7 @@ export function clearLock(basePath: string): void {
     const projectRoot = normalizeRealPath(basePath);
     const staleWorker = findStaleWorkerForProject(projectRoot);
     if (staleWorker) {
-      markWorkerCrashed(staleWorker.worker_id);
+      markWorkerStopping(staleWorker.worker_id);
       forceReleaseLeasesForWorker(staleWorker.worker_id);
       deleteRuntimeKv("worker", staleWorker.worker_id, SESSION_FILE_KV_KEY);
       return;
@@ -264,7 +263,7 @@ export function clearStaleWorkerLock(basePath: string): void {
     const worker = findStaleWorkerForProject(projectRoot);
     if (!worker) return;
     markLatestActiveForWorkerCanceled(worker.worker_id, "crash-recovered");
-    markWorkerCrashed(worker.worker_id);
+    markWorkerStopping(worker.worker_id);
     forceReleaseLeasesForWorker(worker.worker_id);
     deleteRuntimeKv("worker", worker.worker_id, SESSION_FILE_KV_KEY);
   } catch {

--- a/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
+++ b/src/resources/extensions/gsd/tests/crash-recovery-via-db.test.ts
@@ -243,7 +243,7 @@ test("clearLock removes the session_file row for the active worker", (t) => {
     "session_file row deleted by clearLock");
 });
 
-test("clearLock marks stale worker crashed when no current-process worker matches", (t) => {
+test("clearLock marks stale worker stopping when no current-process worker matches", (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   openDatabase(join(base, ".gsd", "gsd.db"));
@@ -257,12 +257,12 @@ test("clearLock marks stale worker crashed when no current-process worker matche
 
   clearLock(base);
 
-  assert.equal(getAutoWorker(workerId)?.status, "crashed");
+  assert.equal(getAutoWorker(workerId)?.status, "stopping");
   assert.equal(getRuntimeKv("worker", workerId, "session_file"), null);
   assert.equal(readCrashLock(base), null);
 });
 
-test("clearStaleWorkerLock crashes stale worker and cancels latest active dispatch", (t) => {
+test("clearStaleWorkerLock marks stale worker stopping and cancels latest active dispatch", (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   openDatabase(join(base, ".gsd", "gsd.db"));
@@ -293,7 +293,7 @@ test("clearStaleWorkerLock crashes stale worker and cancels latest active dispat
 
   clearStaleWorkerLock(base);
 
-  assert.equal(getAutoWorker(workerId)?.status, "crashed");
+  assert.equal(getAutoWorker(workerId)?.status, "stopping");
   const dispatch = getLatestForUnit("M001/S01/T02");
   assert.ok(dispatch);
   assert.equal(dispatch!.status, "canceled");
@@ -306,7 +306,7 @@ test("clearStaleWorkerLock crashes stale worker and cancels latest active dispat
   assert.equal(readCrashLock(base), null);
 });
 
-test("clearLock marks stale worker crashed and releases held milestone lease", (t) => {
+test("clearLock marks stale worker stopping and releases held milestone lease", (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   openDatabase(join(base, ".gsd", "gsd.db"));
@@ -323,7 +323,7 @@ test("clearLock marks stale worker crashed and releases held milestone lease", (
 
   clearLock(base);
 
-  assert.equal(getAutoWorker(workerId)?.status, "crashed");
+  assert.equal(getAutoWorker(workerId)?.status, "stopping");
   const leaseRow = _getAdapter()!.prepare(
     `SELECT status FROM milestone_leases WHERE fencing_token = :ft`,
   ).get({ ":ft": lease.token }) as { status: string } | undefined;


### PR DESCRIPTION
## Summary
- Made stale crash-lock cleanup durable by updating stale workers to non-active `stopping` status and verified with focused crash-recovery DB tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5604
- [#5604 stale_crash_lock fix not durable: clearLock() skips workers table UPDATE](https://github.com/gsd-build/gsd-2/issues/5604)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5604-stale-crash-lock-fix-not-durable-clearlo-1778982698`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved crash recovery handling by refining how the system manages stale worker state transitions during recovery operations, enhancing system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->