### PR TITLE
fix(issue): [Bug]: auto-mode stuck-stop: worktree isolation breaks plan-slice artifact verifier (path mismatch)

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -30,6 +30,9 @@ import {
   resolveMilestoneFile,
   clearPathCache,
   resolveGsdRootFile,
+  gsdProjectionRoot,
+  resolveDir,
+  resolveFile,
 } from "./paths.js";
 import {
   existsSync,
@@ -48,6 +51,7 @@ import { hasVerdict } from "./verdict-parser.js";
 import { validateArtifact } from "./schemas/validate.js";
 import { getProjectResearchStatus } from "./project-research-policy.js";
 import { isGsdWorktreePath } from "./worktree-root.js";
+import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 
 // Re-export so existing consumers of auto-recovery.ts keep working.
 export { resolveExpectedArtifactPath, diagnoseExpectedArtifact };
@@ -804,7 +808,24 @@ export function verifyExpectedArtifact(
     }
   }
 
-  const absPath = resolveExpectedArtifactPath(unitType, unitId, base);
+  let absPath = resolveExpectedArtifactPath(unitType, unitId, base);
+  if (unitType === "plan-slice") {
+    const { milestone: mid, slice: sid } = parseUnitId(unitId);
+    if (mid && sid) {
+      const canonicalBase = resolveCanonicalMilestoneRoot(base, mid);
+      const projectionRoot = gsdProjectionRoot(canonicalBase);
+      const mDir = resolveDir(join(projectionRoot, "milestones"), mid);
+      const sDir = mDir
+        ? resolveDir(join(projectionRoot, "milestones", mDir, "slices"), sid)
+        : null;
+      const pFile = sDir
+        ? resolveFile(join(projectionRoot, "milestones", mDir!, "slices", sDir), sid, "PLAN")
+        : null;
+      if (mDir && sDir && pFile) {
+        absPath = join(projectionRoot, "milestones", mDir, "slices", sDir, pFile);
+      }
+    }
+  }
   // For unit types with no verifiable artifact (null path), the parent directory
   // is missing on disk — treat as stale completion state so the key gets evicted (#313).
   if (!absPath) {
@@ -881,9 +902,9 @@ export function verifyExpectedArtifact(
         }
 
         if (taskIds && taskIds.length > 0) {
-          const tasksDir = resolveTasksDir(base, mid, sid);
-          if (!tasksDir) {
-            logWarning("recovery", `verify-fail ${unitType} ${unitId}: resolveTasksDir returned null for ${mid}/${sid}`);
+          const tasksDir = join(dirname(absPath), "tasks");
+          if (!existsSync(tasksDir)) {
+            logWarning("recovery", `verify-fail ${unitType} ${unitId}: tasks dir missing ${tasksDir}`);
             return false;
           }
           for (const tid of taskIds) {

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -524,6 +524,50 @@ test("verifyExpectedArtifact plan-slice passes when all task plan files exist", 
   }
 });
 
+test("verifyExpectedArtifact plan-slice prefers active worktree projection artifacts when project root is stale (#6295)", () => {
+  const base = makeTmpBase();
+  try {
+    const rootSliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    const rootTasksDir = join(rootSliceDir, "tasks");
+    mkdirSync(rootTasksDir, { recursive: true });
+    writeFileSync(
+      join(rootSliceDir, "S01-PLAN.md"),
+      [
+        "# S01: stale root projection",
+        "",
+        "## Tasks",
+        "",
+        "- [ ] **T01: Task one** `est:1h`",
+      ].join("\n"),
+    );
+    // Intentionally do not create root T01-PLAN.md.
+
+    const worktreeBase = join(base, ".gsd", "worktrees", "M001");
+    mkdirSync(worktreeBase, { recursive: true });
+    writeFileSync(join(worktreeBase, ".git"), `gitdir: ${join(base, ".git", "worktrees", "M001")}\n`);
+
+    const wtSliceDir = join(worktreeBase, ".gsd", "milestones", "M001", "slices", "S01");
+    const wtTasksDir = join(wtSliceDir, "tasks");
+    mkdirSync(wtTasksDir, { recursive: true });
+    writeFileSync(
+      join(wtSliceDir, "S01-PLAN.md"),
+      [
+        "# S01: live worktree projection",
+        "",
+        "## Tasks",
+        "",
+        "- [ ] **T01: Task one** `est:1h`",
+      ].join("\n"),
+    );
+    writeFileSync(join(wtTasksDir, "T01-PLAN.md"), "# T01 Plan\n\nLive worktree task plan.");
+
+    const result = verifyExpectedArtifact("plan-slice", "M001/S01", base);
+    assert.equal(result, true, "verification should read active worktree projection artifacts");
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("verifyExpectedArtifact plan-slice fails when a task plan file is missing (#739)", () => {
   const base = makeTmpBase();
   try {


### PR DESCRIPTION
## Summary
- Fixed plan-slice verifier path resolution to read active worktree projection artifacts and validated with the focused auto-recovery test suite.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6295
- [#6295 [Bug]: auto-mode stuck-stop: worktree isolation breaks plan-slice artifact verifier (path mismatch)](https://github.com/gsd-build/gsd-2/issues/6295)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6295-bug-auto-mode-stuck-stop-worktree-isolat-1778983295`