### PR TITLE
fix(issue): completing-milestone guard false-positive: proseMatch does not recognize DEFERRED verdict

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1566,7 +1566,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
                 // or prose evidence patterns the validation agent may emit.
                 const structuredMatch =
                   validationContent.includes("Operational") &&
-                  (validationContent.includes("MET") || validationContent.includes("N/A") || validationContent.includes("SATISFIED"));
+                  (validationContent.includes("MET") || validationContent.includes("N/A") || validationContent.includes("SATISFIED") || validationContent.includes("DEFERRED"));
                 const proseMatch =
                   /[Oo]perational[\s\S]{0,500}?(?:✅|pass|verified|confirmed|met|complete|true|yes|addressed|covered|satisfied|partially|deferred|n\/a|not[\s-]+applicable)/i.test(validationContent);
                 const hasOperationalCheck =

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -1568,7 +1568,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
                   validationContent.includes("Operational") &&
                   (validationContent.includes("MET") || validationContent.includes("N/A") || validationContent.includes("SATISFIED"));
                 const proseMatch =
-                  /[Oo]perational[\s\S]{0,500}?(?:✅|pass|verified|confirmed|met|complete|true|yes|addressed|covered|satisfied|partially|n\/a|not[\s-]+applicable)/i.test(validationContent);
+                  /[Oo]perational[\s\S]{0,500}?(?:✅|pass|verified|confirmed|met|complete|true|yes|addressed|covered|satisfied|partially|deferred|n\/a|not[\s-]+applicable)/i.test(validationContent);
                 const hasOperationalCheck =
                   skippedByMarker ||
                   skippedByPreference ||

--- a/src/resources/extensions/gsd/tests/validation-gate-patterns.test.ts
+++ b/src/resources/extensions/gsd/tests/validation-gate-patterns.test.ts
@@ -25,7 +25,7 @@ function hasOperationalEvidence(validationContent: string): boolean {
     validationContent.includes("Operational") &&
     (validationContent.includes("MET") || validationContent.includes("N/A") || validationContent.includes("SATISFIED"));
   const proseMatch =
-    /[Oo]perational[\s\S]{0,500}?(?:✅|pass|verified|confirmed|met|complete|true|yes|addressed|covered|satisfied|partially|n\/a|not[\s-]+applicable)/i.test(
+    /[Oo]perational[\s\S]{0,500}?(?:✅|pass|verified|confirmed|met|complete|true|yes|addressed|covered|satisfied|partially|deferred|n\/a|not[\s-]+applicable)/i.test(
       validationContent,
     );
   return structuredMatch || proseMatch;
@@ -101,6 +101,11 @@ test('prose: "Operational: n/a" passes', () => {
 
 test('prose: "Operational: complete" passes', () => {
   const content = `Operational: complete — all health checks green.`;
+  assert.ok(hasOperationalEvidence(content));
+});
+
+test('prose: "Operational: DEFERRED" passes', () => {
+  const content = `| **Operational** | daemon stop → port released → daemon start 成功 | Deferred pending follow-up evidence. | ⚠️ DEFERRED |`;
   assert.ok(hasOperationalEvidence(content));
 });
 

--- a/src/resources/extensions/gsd/tests/validation-gate-patterns.test.ts
+++ b/src/resources/extensions/gsd/tests/validation-gate-patterns.test.ts
@@ -23,7 +23,7 @@ import assert from "node:assert/strict";
 function hasOperationalEvidence(validationContent: string): boolean {
   const structuredMatch =
     validationContent.includes("Operational") &&
-    (validationContent.includes("MET") || validationContent.includes("N/A") || validationContent.includes("SATISFIED"));
+    (validationContent.includes("MET") || validationContent.includes("N/A") || validationContent.includes("SATISFIED") || validationContent.includes("DEFERRED"));
   const proseMatch =
     /[Oo]perational[\s\S]{0,500}?(?:✅|pass|verified|confirmed|met|complete|true|yes|addressed|covered|satisfied|partially|deferred|n\/a|not[\s-]+applicable)/i.test(
       validationContent,
@@ -104,8 +104,15 @@ test('prose: "Operational: complete" passes', () => {
   assert.ok(hasOperationalEvidence(content));
 });
 
-test('prose: "Operational: DEFERRED" passes', () => {
+test('mixed/table: "Operational: DEFERRED" passes', () => {
   const content = `| **Operational** | daemon stop → port released → daemon start 成功 | Deferred pending follow-up evidence. | ⚠️ DEFERRED |`;
+  assert.ok(hasOperationalEvidence(content));
+});
+
+test("structured: Operational + DEFERRED passes", () => {
+  const content = `| Criteria       | Status   |
+| Operational    | DEFERRED |
+| Functional     | MET      |`;
   assert.ok(hasOperationalEvidence(content));
 });
 


### PR DESCRIPTION
## Summary
- Added `deferred` to completing-milestone operational prose matching and verified with a targeted regression test that now passes.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5631
- [#5631 completing-milestone guard false-positive: proseMatch does not recognize DEFERRED verdict](https://github.com/gsd-build/gsd-2/issues/5631)

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5631-completing-milestone-guard-false-positiv-1778985098`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened validation to accept "DEFERRED" as an acceptable operational verification status during milestone completion.
  * Improved prose-based detection to recognize "deferred" wording (case-insensitive) alongside existing "not applicable" phrasing, and added tests covering these cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->