### PR TITLE
fix(issue): triage-captures cannot update canonical CAPTURES.md from worktree isolation

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -732,9 +732,16 @@ const PLANNING_SAFE_TOOLS = new Set([
 ]);
 
 function isPathUnderGsd(absPath: string, basePath: string): boolean {
-  const gsdRoot = resolve(basePath, ".gsd");
-  const rel = relative(gsdRoot, absPath);
-  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  const localGsdRoot = resolve(basePath, ".gsd");
+  const localRel = relative(localGsdRoot, absPath);
+  if (localRel === "" || (!localRel.startsWith("..") && !isAbsolute(localRel))) return true;
+
+  const projectRoot = resolveWorktreeProjectRoot(basePath);
+  if (projectRoot === basePath) return false;
+
+  const canonicalGsdRoot = resolve(projectRoot, ".gsd");
+  const canonicalRel = relative(canonicalGsdRoot, absPath);
+  return canonicalRel === "" || (!canonicalRel.startsWith("..") && !isAbsolute(canonicalRel));
 }
 
 function matchesAllowedGlob(absPath: string, basePath: string, globs: readonly string[]): boolean {

--- a/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate-planning-unit.test.ts
@@ -82,6 +82,13 @@ test('planning-unit: allows edit to .gsd/ via relative path', () => {
   assert.strictEqual(r.block, false);
 });
 
+test('planning-unit: allows canonical project .gsd writes from worktree-isolated base path', () => {
+  const worktreeBase = join(BASE, '.gsd', 'worktrees', 'M001');
+  const canonicalCaptures = join(BASE, '.gsd', 'CAPTURES.md');
+  const r = shouldBlockPlanningUnit('edit', canonicalCaptures, worktreeBase, 'triage-captures', PLANNING);
+  assert.strictEqual(r.block, false);
+});
+
 test('planning-unit: rejects sibling directory that prefixes ".gsd"', () => {
   // <BASE>/.gsd-snapshot/x.md must NOT slip through a naive startsWith check.
   const r = shouldBlockPlanningUnit(


### PR DESCRIPTION
## Summary
- Planning write-gate now allows canonical project `.gsd` writes from worktree-isolated units, verified by targeted planning-unit tests passing.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #6306
- [#6306 triage-captures cannot update canonical CAPTURES.md from worktree isolation](https://github.com/gsd-build/gsd-2/issues/6306)

## User
- @lammersbjorn

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/6306-triage-captures-cannot-update-canonical--1778986387`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path validation for write operations to correctly handle worktree-based project configurations, preventing false blocking of authorized file operations.

* **Tests**
  * Added test coverage for worktree write operation validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->