### PR TITLE
fix(issue): claude-code-cli extension never bridges tool lifecycle into pi extension event bus — write-gate verification is dead code under externalCli

### DIFF
--- a/packages/pi-coding-agent/src/core/sdk.ts
+++ b/packages/pi-coding-agent/src/core/sdk.ts
@@ -493,12 +493,46 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		getProviderOptions: async (currentModel) => {
 			if (currentModel.provider !== "claude-code") return undefined;
 			const runner = extensionRunnerRef.current;
-			if (!runner?.hasUI()) {
+			if (!runner) {
 				return { cwd: workspaceRootRef.current };
 			}
 			return {
 				cwd: workspaceRootRef.current,
-				extensionUIContext: runner.getUIContext(),
+				...(runner.hasUI() ? { extensionUIContext: runner.getUIContext() } : {}),
+				onExternalToolCall: async (toolCall: { id: string; name: string; arguments: Record<string, unknown> }) => {
+					if (!runner.hasHandlers("tool_call")) return;
+					await runner.emitToolCall({
+						type: "tool_call",
+						toolCallId: toolCall.id,
+						toolName: toolCall.name,
+						input: toolCall.arguments,
+					});
+				},
+				onExternalToolResult: async (event: {
+					toolCall: { id: string; name: string; arguments: Record<string, unknown> };
+					result: {
+						content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+						details?: Record<string, unknown>;
+						isError: boolean;
+					};
+				}) => {
+					if (!runner.hasHandlers("tool_result")) return;
+					const content = event.result.content.map((block) => {
+						if (block.type === "image" && typeof block.data === "string" && typeof block.mimeType === "string") {
+							return { type: "image" as const, data: block.data, mimeType: block.mimeType };
+						}
+						return { type: "text" as const, text: typeof block.text === "string" ? block.text : "" };
+					});
+					await runner.emitToolResult({
+						type: "tool_result",
+						toolCallId: event.toolCall.id,
+						toolName: event.toolCall.name,
+						input: event.toolCall.arguments,
+						content,
+						details: event.result.details,
+						isError: event.result.isError,
+					});
+				},
 			};
 		},
 		getApiKey: async (provider) => {

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -66,7 +66,7 @@ interface ClaudeCodeStreamOptions extends SimpleStreamOptions {
 	onExternalToolResult?: (event: { toolCall: ToolCall; result: ExternalToolResultPayload }) => Promise<void> | void;
 }
 
-function serverToolUseToToolCallLike(block: {
+export function serverToolUseToToolCallLike(block: {
 	id: string;
 	name: string;
 	input: unknown;

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -1815,19 +1815,22 @@ async function pumpSdkMessages(
 
 					if (!builder) break;
 
-					const assistantEvent = builder.handleEvent(event);
-					if (assistantEvent) {
-						stream.push(assistantEvent);
-						if (assistantEvent.type === "toolcall_start" && assistantEvent.toolCall) {
-							try {
-								await onExternalToolCall?.(assistantEvent.toolCall);
-							} catch (error) {
-								console.warn("[claude-code] onExternalToolCall callback failed:", error);
+						const assistantEvent = builder.handleEvent(event);
+						if (assistantEvent) {
+							stream.push(assistantEvent);
+							if (assistantEvent.type === "toolcall_start") {
+								const toolBlock = assistantEvent.partial.content[assistantEvent.contentIndex];
+								if (toolBlock?.type === "toolCall") {
+									try {
+										await onExternalToolCall?.(toolBlock);
+									} catch (error) {
+										console.warn("[claude-code] onExternalToolCall callback failed:", error);
+									}
+								}
 							}
 						}
+						break;
 					}
-					break;
-				}
 
 				// -- Complete assistant message (non-streaming fallback) --
 				case "assistant": {

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -66,6 +66,23 @@ interface ClaudeCodeStreamOptions extends SimpleStreamOptions {
 	onExternalToolResult?: (event: { toolCall: ToolCall; result: ExternalToolResultPayload }) => Promise<void> | void;
 }
 
+function serverToolUseToToolCallLike(block: {
+	id: string;
+	name: string;
+	input: unknown;
+}): ToolCall {
+	const argumentsValue =
+		block.input && typeof block.input === "object" && !Array.isArray(block.input)
+			? (block.input as Record<string, unknown>)
+			: { input: block.input };
+	return {
+		type: "toolCall",
+		id: block.id,
+		name: block.name,
+		arguments: argumentsValue,
+	};
+}
+
 /** Resolve the workspace root for local Claude Code process execution. */
 export function resolveClaudeCodeCwd(options?: SimpleStreamOptions): string {
 	return options?.cwd && options.cwd.trim().length > 0 ? options.cwd : process.cwd();
@@ -1802,7 +1819,11 @@ async function pumpSdkMessages(
 					if (assistantEvent) {
 						stream.push(assistantEvent);
 						if (assistantEvent.type === "toolcall_start" && assistantEvent.toolCall) {
-							void Promise.resolve(onExternalToolCall?.(assistantEvent.toolCall)).catch(() => {});
+							try {
+								await onExternalToolCall?.(assistantEvent.toolCall);
+							} catch (error) {
+								console.warn("[claude-code] onExternalToolCall callback failed:", error);
+							}
 						}
 					}
 					break;
@@ -1858,10 +1879,14 @@ async function pumpSdkMessages(
 							// Push synthetic completion events with result attached so the
 							// chat-controller can update pending ToolExecutionComponents.
 							if (block.type === "toolCall") {
-								void Promise.resolve(onExternalToolResult?.({
-									toolCall: block,
-									result: extResult,
-								})).catch(() => {});
+								try {
+									await onExternalToolResult?.({
+										toolCall: block,
+										result: extResult,
+									});
+								} catch (error) {
+									console.warn("[claude-code] onExternalToolResult callback failed:", error);
+								}
 								stream.push({
 									type: "toolcall_end",
 									contentIndex,
@@ -1869,6 +1894,14 @@ async function pumpSdkMessages(
 									partial: builder.message,
 								});
 							} else if (block.type === "serverToolUse") {
+								try {
+									await onExternalToolResult?.({
+										toolCall: serverToolUseToToolCallLike(block),
+										result: extResult,
+									});
+								} catch (error) {
+									console.warn("[claude-code] onExternalToolResult callback failed:", error);
+								}
 								stream.push({
 									type: "server_tool_use",
 									contentIndex,

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -62,6 +62,8 @@ type ToolCallWithExternalResult = ToolCall & {
 /** `SimpleStreamOptions` extended with an optional extension UI context for elicitation dialogs. */
 interface ClaudeCodeStreamOptions extends SimpleStreamOptions {
 	extensionUIContext?: ExtensionUIContext;
+	onExternalToolCall?: (toolCall: ToolCall) => Promise<void> | void;
+	onExternalToolResult?: (event: { toolCall: ToolCall; result: ExternalToolResultPayload }) => Promise<void> | void;
 }
 
 /** Resolve the workspace root for local Claude Code process execution. */
@@ -1714,6 +1716,8 @@ async function pumpSdkMessages(
 		const queryPrompt = buildSdkQueryPrompt(context, prompt);
 		const permissionMode = await resolveClaudePermissionMode();
 		const uiContext = (options as ClaudeCodeStreamOptions | undefined)?.extensionUIContext;
+		const onExternalToolCall = (options as ClaudeCodeStreamOptions | undefined)?.onExternalToolCall;
+		const onExternalToolResult = (options as ClaudeCodeStreamOptions | undefined)?.onExternalToolResult;
 		const cwd = resolveClaudeCodeCwd(options);
 		const canUseToolHandler = createClaudeCodeCanUseToolHandler(uiContext);
 		// When no UI is available (headless / auto-mode), auto-approve all
@@ -1797,6 +1801,9 @@ async function pumpSdkMessages(
 					const assistantEvent = builder.handleEvent(event);
 					if (assistantEvent) {
 						stream.push(assistantEvent);
+						if (assistantEvent.type === "toolcall_start" && assistantEvent.toolCall) {
+							void Promise.resolve(onExternalToolCall?.(assistantEvent.toolCall)).catch(() => {});
+						}
 					}
 					break;
 				}
@@ -1851,6 +1858,10 @@ async function pumpSdkMessages(
 							// Push synthetic completion events with result attached so the
 							// chat-controller can update pending ToolExecutionComponents.
 							if (block.type === "toolCall") {
+								void Promise.resolve(onExternalToolResult?.({
+									toolCall: block,
+									result: extResult,
+								})).catch(() => {});
 								stream.push({
 									type: "toolcall_end",
 									contentIndex,

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -24,6 +24,7 @@ import {
 	createClaudeCodeElicitationHandler,
 	extractImageBlocksFromContext,
 	extractToolResultsFromSdkUserMessage,
+	serverToolUseToToolCallLike,
 	getClaudeLookupCommand,
 	parseAskUserQuestionsElicitation,
 	parseTextInputElicitation,
@@ -409,6 +410,36 @@ describe("stream-adapter — no transcript fabrication (#4102)", () => {
 });
 
 describe("stream-adapter — Claude Code external tool results", () => {
+	test("serverToolUseToToolCallLike preserves object input for extension tool_result routing", () => {
+		const toolCall = serverToolUseToToolCallLike({
+			id: "srv-1",
+			name: "workflow_gate",
+			input: { gateId: "Q3", verdict: "pass" },
+		});
+
+		assert.deepEqual(toolCall, {
+			type: "toolCall",
+			id: "srv-1",
+			name: "workflow_gate",
+			arguments: { gateId: "Q3", verdict: "pass" },
+		});
+	});
+
+	test("serverToolUseToToolCallLike wraps non-object input under input key", () => {
+		const toolCall = serverToolUseToToolCallLike({
+			id: "srv-2",
+			name: "workflow_gate",
+			input: "raw-value",
+		});
+
+		assert.deepEqual(toolCall, {
+			type: "toolCall",
+			id: "srv-2",
+			name: "workflow_gate",
+			arguments: { input: "raw-value" },
+		});
+	});
+
 	test("extractToolResultsFromSdkUserMessage maps tool_result content to tool payloads", () => {
 		const message: SDKUserMessage = {
 			type: "user",


### PR DESCRIPTION
## Summary
- Added a minimal claude-code externalCli bridge that emits `tool_call`/`tool_result` into pi extension hooks and verified with stream-adapter plus depth-verification gate tests.

## Verification
- Completed in the repository worktree before push.

## Related Issue
- Closes #5630
- [#5630 claude-code-cli extension never bridges tool lifecycle into pi extension event bus — write-gate verification is dead code under externalCli](https://github.com/gsd-build/gsd-2/issues/5630)

## User
- @comfan12

## Repo
- `gsd-build/gsd-2`

## Branch
- `issue/5630-claude-code-cli-extension-never-bridges--1778987542`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved external tool integration: richer event forwarding and result handling between the agent and external tool runners, preserving images and converting other outputs into readable content for downstream processing. Callbacks for tool start/result are invoked safely and failures are logged; start/end signaling is clearer.
* **Tests**
  * Added regression tests to ensure external tool result wrapping and argument preservation behave correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->