### PR TITLE
fix(auto-mode): pause instead of stop on milestone merge failure

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -503,26 +503,35 @@ export async function _runMilestoneMergeWithStashRestore(
   // already saw the postflightPopStash notify above.
   if (mergeError) {
     if (mergeError instanceof MergeConflictError) {
-      ctx.ui.notify(
-        `Merge conflict: ${mergeError.conflictedFiles.join(", ")}. Resolve conflicts manually and run /gsd auto to resume.`,
-        "error",
-      );
-      await deps.stopAuto(ctx, pi, `Merge conflict on milestone ${milestoneId}`);
+      // A merge conflict is a recoverable human checkpoint, not an
+      // infrastructure failure — the user resolves the conflict and runs
+      // `/gsd auto` to resume. Pause (don't stop): stopAuto tears down the
+      // session and, because `milestoneMergedInPhases` stays false here,
+      // re-runs the already-failed worktree merge in its cleanup step
+      // (#2645), then drops the user out of the interactive TUI onto a
+      // "stopped" surface.
+      const conflictReason = `Merge conflict on milestone ${milestoneId}: ${mergeError.conflictedFiles.join(", ")}. Resolve conflicts manually and run /gsd auto to resume.`;
+      ctx.ui.notify(conflictReason, "error");
+      await deps.pauseAuto(ctx, pi, {
+        message: conflictReason,
+        category: "unknown",
+      });
       return { action: "break", reason: "merge-conflict" };
     }
     logError("engine", "Milestone merge failed with non-conflict error", {
       milestone: milestoneId,
       error: String(mergeError),
     });
-    ctx.ui.notify(
-      `Merge failed: ${mergeError instanceof Error ? mergeError.message : String(mergeError)}. Resolve and run /gsd auto to resume.`,
-      "error",
-    );
-    await deps.stopAuto(
-      ctx,
-      pi,
-      `Merge error on milestone ${milestoneId}: ${String(mergeError)}`,
-    );
+    // Like a merge conflict, a non-conflict merge failure (index lock,
+    // network, permissions) is recoverable — the user fixes the cause and
+    // runs `/gsd auto` to resume. Pause (don't stop) so the session stays
+    // resumable and stopAuto's teardown does not re-run the failed merge.
+    const mergeFailReason = `Merge error on milestone ${milestoneId}: ${mergeError instanceof Error ? mergeError.message : String(mergeError)}. Resolve and run /gsd auto to resume.`;
+    ctx.ui.notify(mergeFailReason, "error");
+    await deps.pauseAuto(ctx, pi, {
+      message: mergeFailReason,
+      category: "unknown",
+    });
     return { action: "break", reason: "merge-failed" };
   }
 

--- a/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-merge-stash-restore.test.ts
@@ -17,6 +17,7 @@ interface CallLog {
   mergeCalls: number;
   postflightCalls: number;
   stopAutoCalls: Array<string | undefined>;
+  pauseAutoCalls: Array<string | undefined>;
   notifyCalls: Array<{ message: string; level: string }>;
   milestoneMergedInPhases: boolean;
 }
@@ -31,6 +32,7 @@ function buildIc(opts: {
     mergeCalls: 0,
     postflightCalls: 0,
     stopAutoCalls: [],
+    pauseAutoCalls: [],
     notifyCalls: [],
     milestoneMergedInPhases: false,
   };
@@ -98,6 +100,13 @@ function buildIc(opts: {
     },
     stopAuto: async (_c?: unknown, _p?: unknown, reason?: string) => {
       log.stopAutoCalls.push(reason);
+    },
+    pauseAuto: async (
+      _c?: unknown,
+      _p?: unknown,
+      errorContext?: { message: string },
+    ) => {
+      log.pauseAutoCalls.push(errorContext?.message);
     },
   };
 
@@ -190,8 +199,11 @@ test("regression #5538-followup: postflight pop runs even when mergeAndExit thro
     1,
     "postflight pop must run even on merge failure (was the bug)",
   );
-  assert.equal(log.stopAutoCalls.length, 1);
-  assert.match(log.stopAutoCalls[0] ?? "", /Merge error on milestone M002/);
+  // A non-conflict merge failure is recoverable — pause (resumable), do not
+  // hard-stop and re-run the failed merge in stopAuto's teardown.
+  assert.equal(log.stopAutoCalls.length, 0, "merge failure must not hard-stop");
+  assert.equal(log.pauseAutoCalls.length, 1);
+  assert.match(log.pauseAutoCalls[0] ?? "", /Merge error on milestone M002/);
   assert.equal(
     log.milestoneMergedInPhases,
     false,
@@ -222,8 +234,14 @@ test("regression #5538-followup: postflight pop runs even when mergeAndExit thro
     1,
     "postflight pop must run on merge conflict (was the bug)",
   );
-  assert.equal(log.stopAutoCalls.length, 1);
-  assert.match(log.stopAutoCalls[0] ?? "", /Merge conflict on milestone M002/);
+  // A merge conflict is a recoverable human checkpoint: auto-mode must PAUSE
+  // (resumable, stays in the TUI), not STOP (full session teardown + a
+  // duplicate worktree re-merge in stopAuto's cleanup step, then drops the
+  // user onto a "stopped" surface).
+  assert.equal(log.stopAutoCalls.length, 0, "merge conflict must not hard-stop");
+  assert.equal(log.pauseAutoCalls.length, 1);
+  assert.match(log.pauseAutoCalls[0] ?? "", /Merge conflict on milestone M002/);
+  assert.match(log.pauseAutoCalls[0] ?? "", /lib\/models\.ts/);
 });
 
 test("clean tree: no stash to pop, merge succeeds, no pop attempted", async () => {
@@ -318,10 +336,11 @@ test("merge error is reported even when stash pop also failed (merge-error takes
 
   assert.deepEqual(result, { action: "break", reason: "merge-failed" });
   assert.equal(log.postflightCalls, 1, "postflight pop still attempted");
-  assert.equal(log.stopAutoCalls.length, 1, "stopAuto called once, not twice");
+  assert.equal(log.stopAutoCalls.length, 0, "merge failure must not hard-stop");
+  assert.equal(log.pauseAutoCalls.length, 1, "pauseAuto called once, not twice");
   assert.match(
-    log.stopAutoCalls[0] ?? "",
+    log.pauseAutoCalls[0] ?? "",
     /Merge error/,
-    "stopAuto message reflects merge error, not stash failure",
+    "pause message reflects merge error, not stash failure",
   );
 });

--- a/src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts
+++ b/src/resources/extensions/gsd/tests/phases-merge-error-stops-auto.test.ts
@@ -2,9 +2,11 @@
  * phases-merge-error-stops-auto.test.ts — Regression test for #2766.
  *
  * When mergeAndExit throws a non-MergeConflictError, the auto loop must
- * stop instead of continuing with unmerged work. This test verifies that
- * all catch blocks in auto/phases.ts that handle mergeAndExit errors
- * call stopAuto and return { action: "break" } for non-conflict errors.
+ * halt instead of continuing with unmerged work. A merge failure is a
+ * recoverable human checkpoint, so the loop pauses (resumable via
+ * `/gsd auto`) rather than hard-stopping. This test verifies the catch
+ * block in auto/phases.ts calls pauseAuto and returns { action: "break" }
+ * for non-conflict errors.
  */
 
 import { createTestContext } from "./test-helpers.ts";
@@ -92,6 +94,13 @@ const ic = {
     async stopAuto(_ctx: unknown, _pi: unknown, reason?: string) {
       calls.push(`stop:${reason}`);
     },
+    async pauseAuto(
+      _ctx: unknown,
+      _pi: unknown,
+      errorContext?: { message: string },
+    ) {
+      calls.push(`pause:${errorContext?.message}`);
+    },
   },
 } as any;
 
@@ -106,12 +115,12 @@ if (result.action === "break") {
   assertTrue(result.reason === "merge-failed", "non-conflict merge error uses merge-failed reason");
 }
 assertTrue(
-  calls.join(" > ") === "invalidate > health > derive:/tmp/gsd-test > sync-sidebar > set-active:M001 > reconcile > preflight > merge > postflight > stop:Merge error on milestone M001: Error: remote rejected push",
-  `pre-dispatch stops immediately after non-conflict merge failure (${calls.join(" > ")})`,
+  calls.join(" > ") === "invalidate > health > derive:/tmp/gsd-test > sync-sidebar > set-active:M001 > reconcile > preflight > merge > postflight > pause:Merge error on milestone M001: remote rejected push. Resolve and run /gsd auto to resume.",
+  `pre-dispatch pauses immediately after non-conflict merge failure (${calls.join(" > ")})`,
 );
 assertTrue(
-  notifications.some((n) => n.level === "error" && n.message.includes("Merge failed: remote rejected push")),
-  "user is notified with an error that merge failed",
+  notifications.some((n) => n.level === "error" && n.message.includes("Merge error on milestone M001: remote rejected push")),
+  "user is notified with an error that the merge failed",
 );
 
 report();


### PR DESCRIPTION
## TL;DR

**What:** A merge conflict/error during milestone completion now pauses auto-mode instead of hard-stopping it.
**Why:** `stopAuto` tore down the session, re-ran the already-failed worktree merge, and dropped the user out of the TUI onto a "stopped" surface.
**How:** Switch both merge-failure branches in `_runMilestoneMergeWithStashRestore` from `stopAuto` to `pauseAuto`.

## What

`src/resources/extensions/gsd/auto/phases.ts` — in `_runMilestoneMergeWithStashRestore`, both the `MergeConflictError` branch and the non-conflict merge-error branch now call `deps.pauseAuto(...)` instead of `deps.stopAuto(...)`. The notification message is folded into the pause `errorContext` so the paused surface shows the resolve/resume guidance.

Tests updated to match the new contract:
- `tests/milestone-merge-stash-restore.test.ts` — added a `pauseAuto` spy; the two merge-failure regression tests now assert pause-not-stop.
- `tests/phases-merge-error-stops-auto.test.ts` — added a `pauseAuto` stub; updated the call-chain and notification assertions.

## Why

When auto-mode hit a real code conflict squash-merging a milestone branch into `main`, the user saw the merge-conflict error, then auto-mode fully stopped and the interactive TUI was replaced by a "stopped" surface — forcing a fresh `/gsd auto` from scratch rather than a resume.

Root cause: the conflict handler called `stopAuto`, which runs the full session teardown. Because `milestoneMergedInPhases` stays `false` after a failed merge, `stopAuto`'s worktree-cleanup step re-runs the *same* merge that just failed — producing a duplicate "Worktree cleanup failed" notification — and then clears the live progress widget for the terminal "stopped" outcome.

A merge conflict or merge error is a recoverable human checkpoint: the user resolves it and resumes. The dispatch layer already treats warning-level stops this way (pause, not stop). This aligns the milestone-merge path with that behavior.

## How

`pauseAuto` keeps `s.paused = true`, persists paused-session metadata, leaves the worktree intact, and shows a resumable "paused" outcome — so the user stays in the TUI on the error message and `/gsd auto` resumes after they resolve the conflict. It also skips the destructive teardown entirely, so the duplicate worktree re-merge no longer fires.

Both merge-failure branches are treated the same way for consistency — the non-conflict branch's message already said "Resolve and run /gsd auto to resume," which is pause semantics.

Verified with `npm run verify:pr` (build -> typecheck -> unit): 9446 passed, 0 failed.

This PR is AI-assisted.

### Change type

- [x] `fix` — Bug fix
- [x] `test` — Updating tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-mode now pauses on merge failures (conflicts and other errors) instead of hard-stopping, so sessions can be resumed.
  * Error messages updated to instruct users to resolve issues and run the auto command to continue.

* **Tests**
  * Updated tests to expect pause behavior and verify resumable flow and user notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->