### PR TITLE
fix(gsd): block on needs-attention verdict (#6137) — alternative to closed #6148

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -464,13 +464,11 @@ async function buildRegistryAndFindActive(
       }
 
       if (allSlicesDone) {
-        const validation = getLatestAssessmentByScope(m.id, "milestone-validation");
-        const verdict = typeof validation?.status === "string" ? validation.status : undefined;
-        if (verdict === "needs-attention") {
-          registry.push({ id: m.id, title, status: "parked", ...(deps.length > 0 ? { dependsOn: deps } : {}) });
-          continue;
-        }
-
+        // needs-attention must NOT be silently parked here. Doing so produces a
+        // phantom pre-planning phase when this is the only candidate, hiding the
+        // actionable blocker from the operator (#6137 supersedes the #6136 fix).
+        // Fall through to the active-milestone path so handleAllSlicesDone returns
+        // phase: 'blocked' with the validation-findings remediation guidance.
         activeMilestone = { id: m.id, title };
         activeMilestoneSlices = slices;
         activeMilestoneFound = true;
@@ -589,19 +587,24 @@ async function handleAllSlicesDone(
     };
   }
 
-  // All roadmap slices are done (enforced by caller) and verdict is
-  // needs-remediation — remediation cannot progress without new slices.
-  // Return blocked instead of re-dispatching validate-milestone (#4506).
-  if (verdict === 'needs-remediation') {
+  // All roadmap slices are done (enforced by caller) and verdict is terminal-blocking.
+  // - needs-remediation: cannot progress without new slices (#4506).
+  // - needs-attention: cannot progress without operator review of validation findings (#6137).
+  // Both must return blocked to avoid the dispatch guard rejecting completing-milestone
+  // on every tick, which produces a phantom completing-milestone phase that stops auto-mode.
+  if (verdict === 'needs-remediation' || verdict === 'needs-attention') {
+    const remediation = verdict === 'needs-remediation'
+      ? `Add remediation slices via gsd_reassess_roadmap, or run \`/gsd verdict pass --rationale "..."\` to override.`
+      : `Address the validation findings and re-run validation, or run \`/gsd verdict pass --rationale "..."\` to override.`;
+    const nextActionSuffix = verdict === 'needs-remediation' ? 'remediation' : 'validation findings';
     return {
       activeMilestone, activeSlice: null, activeTask: null,
       phase: 'blocked',
       recentDecisions: [],
       blockers: [
-        `Milestone ${activeMilestone.id} validation verdict is needs-remediation but all slices are complete. ` +
-          `Add remediation slices via gsd_reassess_roadmap, or run \`/gsd verdict pass --rationale "..."\` to override.`,
+        `Milestone ${activeMilestone.id} validation verdict is ${verdict} but all slices are complete. ${remediation}`,
       ],
-      nextAction: `Resolve ${activeMilestone.id} remediation before proceeding.`,
+      nextAction: `Resolve ${activeMilestone.id} ${nextActionSuffix} before proceeding.`,
       registry, requirements,
       progress: { milestones: milestoneProgress, slices: sliceProgress },
     };
@@ -1096,10 +1099,9 @@ export async function _deriveStateImpl(
       const validationContent = validationFile ? await cachedLoadFile(validationFile) : null;
       const validationTerminal = validationContent ? isValidationTerminal(validationContent) : false;
       const verdict = validationContent ? extractVerdict(validationContent) : undefined;
-      if (verdict === "needs-attention") {
-        registry.push({ id: mid, title, status: "parked" });
-        continue;
-      }
+      // needs-attention must NOT be silently parked here either (#6137 supersedes #6136).
+      // Fall through to the active-milestone path so the downstream guard returns
+      // phase: 'blocked' with actionable resolution text.
       // needs-remediation is terminal but requires re-validation (#3596)
       const needsRevalidation = !validationTerminal || verdict === 'needs-remediation';
 
@@ -1331,7 +1333,14 @@ export async function _deriveStateImpl(
       };
     }
 
-    if (verdict === 'needs-remediation') {
+    // needs-remediation and needs-attention both block completion (#4506, #6137).
+    // Without this guard auto-mode falls through to completing-milestone, then the
+    // dispatch guard rejects it on every tick — a phantom phase that stops auto-mode.
+    if (verdict === 'needs-remediation' || verdict === 'needs-attention') {
+      const remediation = verdict === 'needs-remediation'
+        ? `Add remediation slices via gsd_reassess_roadmap, or run \`/gsd verdict pass --rationale "..."\` to override.`
+        : `Address the validation findings and re-run validation, or run \`/gsd verdict pass --rationale "..."\` to override.`;
+      const nextActionSuffix = verdict === 'needs-remediation' ? 'remediation' : 'validation findings';
       return {
         activeMilestone,
         activeSlice: null,
@@ -1339,10 +1348,9 @@ export async function _deriveStateImpl(
         phase: 'blocked',
         recentDecisions: [],
         blockers: [
-          `Milestone ${activeMilestone.id} validation verdict is needs-remediation but all slices are complete. ` +
-            `Add remediation slices via gsd_reassess_roadmap, or run \`/gsd verdict pass --rationale "..."\` to override.`,
+          `Milestone ${activeMilestone.id} validation verdict is ${verdict} but all slices are complete. ${remediation}`,
         ],
-        nextAction: `Resolve ${activeMilestone.id} remediation before proceeding.`,
+        nextAction: `Resolve ${activeMilestone.id} ${nextActionSuffix} before proceeding.`,
         registry,
         requirements,
         progress: {

--- a/src/resources/extensions/gsd/tests/needs-attention-blocked.test.ts
+++ b/src/resources/extensions/gsd/tests/needs-attention-blocked.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression test for #6137 — needs-attention verdict must produce phase:'blocked'
+ *
+ * The dispatch guard in auto-dispatch.ts rejects complete-milestone when verdict
+ * !== 'pass'. Before this fix, state.ts derived phase:'completing-milestone' for
+ * both 'pass' and 'needs-attention' verdicts. Auto-mode then entered the
+ * completing-milestone rule on every tick and stopped immediately — a phantom
+ * phase that produced no progress (#6137).
+ *
+ * This test verifies that needs-attention now derives phase:'blocked', mirroring
+ * the existing needs-remediation guard in #3670.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  closeDatabase,
+  insertAssessment,
+  insertMilestone,
+  insertSlice,
+  openDatabase,
+} from '../gsd-db.ts';
+import { deriveStateFromDb } from '../state.ts';
+
+describe('needs-attention dead-end guard (#6137)', () => {
+  test('needs-attention assessment blocks completion when every slice is done', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-needs-attention-'));
+    try {
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'Needs attention', status: 'active' });
+      insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Done slice', status: 'complete' });
+      insertAssessment({
+        path: join(base, '.gsd', 'milestones', 'M001', 'M001-VALIDATION.md'),
+        milestoneId: 'M001',
+        status: 'needs-attention',
+        scope: 'milestone-validation',
+        fullContent: 'Verdict: needs-attention',
+      });
+
+      const state = await deriveStateFromDb(base);
+
+      assert.equal(state.phase, 'blocked', 'needs-attention must produce phase:blocked, not completing-milestone');
+      assert.match(state.nextAction, /validation findings/i, 'nextAction names the actionable resolution path');
+      assert.ok(
+        state.blockers.some((blocker) => blocker.includes('needs-attention')),
+        'blocker text identifies the verdict',
+      );
+      assert.ok(
+        state.blockers.some((blocker) => /verdict pass --rationale/.test(blocker)),
+        'blocker offers the operator override path',
+      );
+    } finally {
+      closeDatabase();
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test('needs-remediation still blocks completion (regression guard for #3670)', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-needs-remediation-still-blocks-'));
+    try {
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M002', title: 'Needs remediation', status: 'active' });
+      insertSlice({ id: 'S01', milestoneId: 'M002', title: 'Done slice', status: 'complete' });
+      insertAssessment({
+        path: join(base, '.gsd', 'milestones', 'M002', 'M002-VALIDATION.md'),
+        milestoneId: 'M002',
+        status: 'needs-remediation',
+        scope: 'milestone-validation',
+        fullContent: 'Verdict: needs-remediation',
+      });
+
+      const state = await deriveStateFromDb(base);
+
+      assert.equal(state.phase, 'blocked');
+      assert.match(state.nextAction, /remediation/i);
+      assert.ok(
+        state.blockers.some((blocker) => blocker.includes('needs-remediation')),
+        'needs-remediation guard remains intact',
+      );
+    } finally {
+      closeDatabase();
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test('pass verdict still routes to completing-milestone (negative control)', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-pass-routes-completion-'));
+    try {
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M003', title: 'Passing', status: 'active' });
+      insertSlice({ id: 'S01', milestoneId: 'M003', title: 'Done slice', status: 'complete' });
+      insertAssessment({
+        path: join(base, '.gsd', 'milestones', 'M003', 'M003-VALIDATION.md'),
+        milestoneId: 'M003',
+        status: 'pass',
+        scope: 'milestone-validation',
+        fullContent: 'Verdict: pass',
+      });
+
+      const state = await deriveStateFromDb(base);
+
+      assert.equal(state.phase, 'completing-milestone', 'pass verdict must NOT be blocked by the new guard');
+    } finally {
+      closeDatabase();
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/resources/extensions/gsd/tests/validate-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone.test.ts
@@ -205,23 +205,29 @@ test("deriveState returns blocked when needs-remediation has no incomplete slice
   }
 });
 
-test("deriveState parks milestone when validation verdict is needs-attention and no summary (#6136)", async () => {
+test("deriveState blocks milestone when validation verdict is needs-attention and no summary (#6137 supersedes #6136)", async () => {
+  // #6136 originally parked needs-attention milestones, producing a phantom
+  // pre-planning phase that hid the blocker. #6137 supersedes: needs-attention
+  // must derive phase:'blocked' so the operator sees the actionable resolution.
   const base = makeTmpBase();
   try {
     writeRoadmap(base, "M001", ALL_DONE_ROADMAP);
     writeValidation(base, "M001", "---\nverdict: needs-attention\nremediation_round: 0\n---\n\n# Validation\nNeeds attention.");
 
     const state = await deriveState(base);
-    assert.equal(state.phase, "pre-planning");
-    assert.equal(state.activeMilestone, null);
-    assert.equal(state.registry.find(entry => entry.id === "M001")?.status, "parked");
-    assert.ok(state.nextAction.includes("parked"));
+    assert.equal(state.phase, "blocked");
+    assert.equal(state.activeMilestone?.id, "M001");
+    assert.match(state.nextAction, /validation findings/i);
+    assert.ok(
+      state.blockers.some(b => b.includes("needs-attention") && b.includes("M001")),
+      "blocker text identifies the milestone and verdict",
+    );
   } finally {
     cleanup(base);
   }
 });
 
-test("deriveState parks DB-backed milestone when validation verdict is needs-attention (#6136)", async () => {
+test("deriveState blocks DB-backed milestone when validation verdict is needs-attention (#6137 supersedes #6136)", async () => {
   const base = makeTmpBase();
   try {
     openTestDb(base);
@@ -237,10 +243,13 @@ test("deriveState parks DB-backed milestone when validation verdict is needs-att
     });
 
     const state = await deriveState(base);
-    assert.equal(state.phase, "pre-planning");
-    assert.equal(state.activeMilestone, null);
-    assert.equal(state.registry.find(entry => entry.id === "M001")?.status, "parked");
-    assert.ok(state.nextAction.includes("parked"));
+    assert.equal(state.phase, "blocked");
+    assert.equal(state.activeMilestone?.id, "M001");
+    assert.match(state.nextAction, /validation findings/i);
+    assert.ok(
+      state.blockers.some(b => b.includes("needs-attention") && b.includes("M001")),
+      "blocker text identifies the milestone and verdict",
+    );
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
Closes #6137.

## Context

This PR proposes an alternative approach to #6137 after the prior attempt #6148 was closed without merge.

The original #6136 fix parked `needs-attention` milestones in the registry, producing a phantom `phase: 'pre-planning'` with `nextAction` "All remaining milestones are parked (M00X)" when the parked milestone was the only candidate. The operator saw a deceptive idle state instead of the actionable validation blocker. In multi-milestone projects the parking also silently advanced to the next milestone, hiding the unresolved review request.

#6137 specified that needs-attention should derive `phase: 'blocked'` (same shape as the needs-remediation guard from #4506/#3670). This PR implements exactly that.

## Approach

1. Extend the existing `verdict === 'needs-remediation'` guards in both `handleAllSlicesDone` (DB path) and the markdown-fallback path at `state.ts:1319` to also match `'needs-attention'`. Both verdicts now return `phase: 'blocked'` with verdict-specific resolution text:
   - **needs-remediation:** "Add remediation slices via `gsd_reassess_roadmap`, or run `/gsd verdict pass --rationale "..."` to override."
   - **needs-attention:** "Address the validation findings and re-run validation, or run `/gsd verdict pass --rationale "..."` to override."
2. Remove the two `needs-attention` → parking-skip branches in the registry-building loops (`state.ts:468` and `state.ts:1087`). The active-milestone path now reaches the verdict guard cleanly.

## Test changes

- Two existing tests in `validate-milestone.test.ts` asserted the old #6136 parked-then-pre-planning behavior. Updated to assert the new spec — `phase: 'blocked'` + `activeMilestone` set + blocker text identifies the verdict. Comment trails note that #6137 supersedes #6136 for the parking decision.
- New regression test `needs-attention-blocked.test.ts` covers all three verdicts through `deriveStateFromDb`:
  - `needs-attention` → blocked + validation-findings remediation text
  - `needs-remediation` → blocked + remediation-slices text (#3670 guard intact)
  - `pass` → completing-milestone (negative control)

## Verification

Local test sweep on rebased branch:
- `needs-attention-blocked.test.ts`: 3/3 pass
- `validate-milestone.test.ts`: 22/22 pass (2 updated, rest untouched)
- `needs-remediation-revalidation.test.ts`: 1/1 pass (regression guard for #3670)
- Total: 36/36 across these suites

Broader sweep (288 tests across 56 suites in state + dispatch surface) also passed on the pre-rebase branch.

## Files

- `src/resources/extensions/gsd/state.ts`: 2 verdict guards extended, 2 parking-skip branches removed
- `src/resources/extensions/gsd/tests/needs-attention-blocked.test.ts`: new
- `src/resources/extensions/gsd/tests/validate-milestone.test.ts`: 2 tests updated per #6137

## Notes

- This PR's commit author is `Agency-Lead` (our agency identity for AI-assisted commits). The PR is opened under my personal GH account.
- If the maintainer would prefer a different approach (mirroring whatever direction caused #6148 to be closed), happy to revise.

---

Branch: `webanrigh/gsd-2:fix/6137-needs-attention-blocked-rebased`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Milestone completion now correctly blocks when validation findings are present, applying the same completion-blocking behavior as remediation issues. This prevents premature advancement when outstanding validation concerns must be addressed.
  * Enhanced user guidance to differentiate between validation findings and remediation blockers, providing clearer context on what must be resolved before milestone advancement is allowed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->