### PR TITLE
fix(tui): unref loader and spinner intervals so they never block process exit

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/dynamic-border.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/dynamic-border.test.ts
@@ -65,6 +65,26 @@ describe("DynamicBorder spinner", () => {
 		}
 	});
 
+	it("unref's the spinner interval so it never blocks process exit", () => {
+		// The pinned-zone spinner is purely cosmetic. A ref'd interval keeps the
+		// Node event loop alive until stopSpinner() runs — which made test
+		// processes hang and CI time out.
+		const border = new DynamicBorder((s) => s);
+		const tui = makeTUI();
+		try {
+			border.startSpinner(tui as any, (s) => s);
+			const interval = (border as any).spinnerInterval as NodeJS.Timeout;
+			assert.ok(interval, "startSpinner should create the animation interval");
+			assert.equal(
+				interval.hasRef(),
+				false,
+				"spinner interval must be unref'd so it never blocks process exit",
+			);
+		} finally {
+			border.stopSpinner();
+		}
+	});
+
 	it("updates lastExternalRender on each render() call", () => {
 		const border = new DynamicBorder((s) => s);
 		const anyBorder = border as any;

--- a/packages/pi-coding-agent/src/modes/interactive/components/dynamic-border.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/dynamic-border.ts
@@ -46,6 +46,9 @@ export class DynamicBorder implements Component {
 				ui.requestRender();
 			}
 		}, 200);
+		// The spinner is purely cosmetic — it must never keep the Node event loop
+		// alive on its own (otherwise a process can hang waiting for it to stop).
+		this.spinnerInterval.unref?.();
 		ui.requestRender();
 	}
 

--- a/packages/pi-tui/src/__tests__/loader.test.ts
+++ b/packages/pi-tui/src/__tests__/loader.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { Loader } from "../components/loader.js";
+import type { TUI } from "../tui.js";
+
+const stubUI = { requestRender() {} } as unknown as TUI;
+const identity = (s: string) => s;
+
+describe("Loader — process exit safety", () => {
+	it("does not keep the Node event loop alive (animation interval is unref'd)", () => {
+		// The loader animation is purely cosmetic. If its 80ms interval is ref'd,
+		// every process that creates a Loader hangs on exit until stop() runs.
+		// That regression made `node --test` never terminate and silently burned
+		// CI's entire build-job timeout budget.
+		const loader = new Loader(stubUI, identity, identity);
+		try {
+			const interval = (loader as unknown as { intervalId: NodeJS.Timeout | null })
+				.intervalId;
+			assert.ok(interval, "loader should start its animation interval on construction");
+			assert.equal(
+				interval.hasRef(),
+				false,
+				"loader interval must be unref'd so it never blocks process exit",
+			);
+		} finally {
+			loader.dispose();
+		}
+	});
+});

--- a/packages/pi-tui/src/components/loader.ts
+++ b/packages/pi-tui/src/components/loader.ts
@@ -53,6 +53,9 @@ export class Loader extends Text {
 				this.ui.requestRender();
 			}
 		}, 80);
+		// The loader animation is purely cosmetic — it must never keep the Node
+		// event loop alive on its own (otherwise a process can hang on exit).
+		this.intervalId.unref?.();
 		// Trigger initial render
 		if (this.ui) {
 			this.ui.requestRender();


### PR DESCRIPTION
## Problem

The CI `build` job has been getting **cancelled** at its 25-minute `timeout-minutes` while running `npm run test:packages` — blocking PRs (surfaced on #6325, but not caused by it; `main` runs hit the same hang).

Root cause: `node --test` for `@gsd/pi-coding-agent` **never exits**. Two cosmetic animation timers are ref'd and keep the Node event loop alive:

- `pi-tui` `Loader` — 80ms `setInterval` (`loader.ts`)
- `DynamicBorder` pinned-zone spinner — 200ms `setInterval` (`dynamic-border.ts`)

When a process creates a `Loader` (via `chat-controller`) and tries to exit before `stop()`/`stopSpinner()` runs, it hangs forever. All tests *pass* — the process just won't terminate.

## Fix

`.unref()` both intervals. A purely cosmetic animation must never hold the process open; `unref()` keeps it running while it matters and lets the loop drain on exit.

## Verification

- `chat-controller-ordering.test.js` — was hanging → now exits cleanly, 22/22 pass
- Full `@gsd/pi-coding-agent` suite — **821 tests, 820 pass, 1 skipped, 0 fail, 0 cancelled**, process exits clean
- Both packages typecheck clean
- Adds regression tests asserting both intervals are `unref`'d (they fail if a ref'd timer is reintroduced)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spinner and loader animations to not block application shutdown in interactive mode and TUI components.

* **Tests**
  * Added test cases verifying that cosmetic animation intervals properly exit with the application without blocking process shutdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->