### PR TITLE
refactor(tui): borderless rule-header panels for copy/paste-safe output

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -29,7 +29,7 @@ import { execFileSync } from "node:child_process";
 import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 import { makeUI } from "../shared/tui.js";
 import { GLYPH, INDENT } from "../shared/mod.js";
-import { padRightVisible, renderFrame, renderProgressBar, rightAlign, wrapVisibleText } from "./tui/render-kit.js";
+import { padRightVisible, renderPanel, renderProgressBar, rightAlign, wrapVisibleText } from "./tui/render-kit.js";
 import { computeProgressScore } from "./progress-score.js";
 import {
   getGlobalGSDPreferencesPath,
@@ -1118,12 +1118,14 @@ export function setAutoOutcomeWidget(
           : snapshot.status === "blocked" ? "!"
             : snapshot.status === "paused" ? "||"
               : "●";
-      const innerWidth = Math.max(8, width - 4);
+      // renderPanel indents body lines by 2; mirror that for wrap width.
+      const innerWidth = Math.max(8, width - 2);
       const maxLines = 7;
       const lines: string[] = [];
       const elapsed = snapshot.startedAt ? formatAutoElapsed(snapshot.startedAt) : "";
       const heading = `${theme.fg(color, icon)} ${theme.fg("accent", theme.bold("GSD"))} ${theme.fg("text", snapshot.title)}`;
-      lines.push(rightAlign(heading, elapsed ? theme.fg("dim", elapsed) : "", innerWidth));
+      // Elapsed rides inline after the title on the header rule.
+      const title = elapsed ? `${heading}  ${theme.fg("dim", elapsed)}` : heading;
       const commands = snapshot.commands?.filter(Boolean) ?? [];
       const commandLine = commands.length > 0 ? theme.fg("dim", commands.join("  ·  ")) : null;
 
@@ -1149,7 +1151,7 @@ export function setAutoOutcomeWidget(
         lines.push(commandLine);
       }
 
-      return renderFrame(theme, lines, width, { borderColor: color, paddingX: 1 });
+      return renderPanel(theme, title, lines, width, { ruleColor: color });
     },
     invalidate(): void {},
     dispose(): void {},

--- a/src/resources/extensions/gsd/tests/tui-render-kit.test.ts
+++ b/src/resources/extensions/gsd/tests/tui-render-kit.test.ts
@@ -9,6 +9,7 @@ import {
   padRightVisible,
   renderFrame,
   renderKeyHints,
+  renderPanel,
   renderProgressBar,
   rightAlign,
   safeLine,
@@ -57,6 +58,27 @@ describe("tui render kit", () => {
     for (const width of [3, 40, 80]) {
       assertWidth(renderFrame(theme, ["row", "long ".repeat(40)], width), width);
     }
+  });
+
+  test("renderPanel stays within width and draws no vertical borders", () => {
+    for (const width of [3, 40, 80]) {
+      const lines = renderPanel(theme, "Title", ["row", "long ".repeat(40)], width);
+      assertWidth(lines, width);
+      // The whole point of renderPanel: no `│` side bars on any line, so
+      // terminal text selection copies clean content.
+      for (const line of lines) {
+        assert.ok(!line.includes("│"), `renderPanel line must not contain a vertical bar: "${line}"`);
+      }
+    }
+  });
+
+  test("renderPanel indents body lines so chrome never sits on copyable text", () => {
+    const lines = renderPanel(theme, "Title", ["body"], 40);
+    // [header, blank, body, footer rule]
+    const body = lines[2];
+    assert.ok(body.startsWith("  body"), `body should be indented: "${body}"`);
+    assert.match(lines[0], /^── Title ─+$/, "header is an inline-titled rule");
+    assert.match(lines[lines.length - 1], /^─+$/, "panel closes with a plain rule");
   });
 
   test("renderKeyHints and renderProgressBar fit caller budgets", () => {

--- a/src/resources/extensions/gsd/tui/render-kit.ts
+++ b/src/resources/extensions/gsd/tui/render-kit.ts
@@ -80,6 +80,50 @@ export function statusGlyph(
   }
 }
 
+/**
+ * Render a titled panel without vertical borders.
+ *
+ * Unlike {@link renderFrame}, this draws no `│` side bars — only a header rule
+ * with an inline title and a closing rule. Body lines are indented. Because no
+ * box-drawing character ever sits on a content line, terminal text selection
+ * copies clean text. Use this for inline output users may copy; keep
+ * {@link renderFrame} for transient overlays that benefit from a full box.
+ *
+ *   ── Title ────────────────────────────────
+ *
+ *     body line
+ *     body line
+ *   ──────────────────────────────────────────
+ */
+export function renderPanel(
+  theme: ThemeLike,
+  title: string,
+  inner: string[],
+  width: number,
+  options: { ruleColor?: string; indent?: number } = {},
+): string[] {
+  if (width < 4) {
+    return [safeLine(title, width), ...inner.map((line) => safeLine(line, width))];
+  }
+
+  const ruleColor = options.ruleColor ?? "borderAccent";
+  const indent = Math.max(0, options.indent ?? 2);
+  const rule = (text: string) => theme.fg(ruleColor, text);
+
+  // Header rule: "── <title> ───────"
+  const lead = "── ";
+  const headerUsed = visibleWidth(lead) + visibleWidth(title) + 1;
+  const headerFill = Math.max(0, width - headerUsed);
+  const header = safeLine(rule(lead) + title + " " + rule("─".repeat(headerFill)), width, "");
+
+  // Body lines, indented so no chrome sits on copyable text.
+  const pad = " ".repeat(indent);
+  const contentWidth = Math.max(0, width - indent);
+  const body = inner.map((line) => safeLine(pad + safeLine(line, contentWidth), width, ""));
+
+  return [header, "", ...body, rule("─".repeat(width))];
+}
+
 export function renderFrame(
   theme: ThemeLike,
   inner: string[],

--- a/src/resources/extensions/gsd/watch/header-renderer.ts
+++ b/src/resources/extensions/gsd/watch/header-renderer.ts
@@ -63,10 +63,16 @@ function rightAlign(left: string, right: string, width: number): string {
   return truncateToWidth(left + " ".repeat(gap) + right, width, "");
 }
 
-function frameLine(content: string, width: number): string {
-  if (width < 3) return truncateToWidth(content, Math.max(0, width), "");
-  const innerWidth = Math.max(0, width - 2);
-  return `${color("│", colors.border)}${padVisible(content, innerWidth)}${color("│", colors.border)}`;
+/** Left indent for borderless panel content. */
+const PANEL_INDENT = "  ";
+
+/**
+ * Indent a content line for the borderless header. No side bars are drawn, so
+ * terminal text selection copies clean content instead of `│` chars.
+ */
+function panelLine(content: string, width: number): string {
+  const innerWidth = Math.max(0, width - PANEL_INDENT.length);
+  return PANEL_INDENT + truncateToWidth(content, innerWidth, "");
 }
 
 // ─── Data Readers ─────────────────────────────────────────────────────────────
@@ -236,11 +242,13 @@ export function formatMcpRow(servers: string[], width: number): string {
 export function renderHeaderLines(data: HeaderData, width: number): string[] {
   if (width < 40) return renderStackedHeader(data, width);
   const outerWidth = width;
-  const innerWidth = Math.max(0, outerWidth - 2);
+  const innerWidth = Math.max(0, outerWidth - PANEL_INDENT.length);
   const logoLines = GSD_LOGO;
   const logoWidth = Math.max(...logoLines.map((line) => visibleWidth(line)));
-  const gap = ` ${color("│", colors.dim)} `;
-  const panelWidth = innerWidth - logoWidth - visibleWidth(gap);
+  // Plain spaces, not a `│` divider — a vertical bar here would be dragged
+  // into every copied logo row.
+  const gap = "   ";
+  const panelWidth = innerWidth - logoWidth - gap.length;
 
   if (panelWidth < 44) {
     return renderStackedHeader(data, width);
@@ -280,14 +288,14 @@ export function renderHeaderLines(data: HeaderData, width: number): string[] {
     ),
   ];
 
-  const lines = [
-    color("╭" + "─".repeat(Math.max(0, outerWidth - 2)) + "╮", colors.border),
-  ];
+  const lines: string[] = [];
   for (let i = 0; i < logoLines.length; i++) {
     const logo = padVisible(color(logoLines[i], colors.border), logoWidth);
-    lines.push(frameLine(`${logo}${gap}${panelLines[i] ?? ""}`, outerWidth));
+    lines.push(panelLine(`${logo}${gap}${panelLines[i] ?? ""}`, outerWidth));
   }
-  lines.push(color("╰" + "─".repeat(Math.max(0, outerWidth - 2)) + "╯", colors.border));
+  // Closing rule only — it sits on its own line, so selecting header content
+  // never picks it up.
+  lines.push(color("─".repeat(Math.max(0, outerWidth)), colors.border));
   return lines;
 }
 
@@ -299,22 +307,24 @@ function renderStackedHeader(data: HeaderData, width: number): string[] {
   if (outerWidth < 3) {
     return [color(truncateToWidth("GSD", outerWidth, ""), colors.accent)];
   }
-  const lines: string[] = [color("╭" + "─".repeat(Math.max(0, outerWidth - 2)) + "╮", colors.border)];
+  const innerWidth = Math.max(0, outerWidth - PANEL_INDENT.length);
+  const lines: string[] = [];
 
   // Title
-  lines.push(frameLine(`${color("GSD", colors.accent)} ${bold(color("Project Console", colors.text))}`, outerWidth));
+  lines.push(panelLine(`${color("GSD", colors.accent)} ${bold(color("Project Console", colors.text))}`, outerWidth));
 
   // Info
-  lines.push(frameLine(formatInfoLine("Project", data.directory, outerWidth - 2), outerWidth));
-  lines.push(frameLine(formatInfoLine("Command", "/gsd start", outerWidth - 2), outerWidth));
-  lines.push(frameLine(formatInfoLine("Branch", data.branch, outerWidth - 2), outerWidth));
-  lines.push(frameLine(formatInfoLine("Model", data.model, outerWidth - 2), outerWidth));
+  lines.push(panelLine(formatInfoLine("Project", data.directory, innerWidth), outerWidth));
+  lines.push(panelLine(formatInfoLine("Command", "/gsd start", innerWidth), outerWidth));
+  lines.push(panelLine(formatInfoLine("Branch", data.branch, innerWidth), outerWidth));
+  lines.push(panelLine(formatInfoLine("Model", data.model, innerWidth), outerWidth));
 
   // MCP
-  const mcpRow = formatMcpRow(data.mcpServers, Math.max(1, outerWidth - 7));
-  if (mcpRow) lines.push(frameLine(`${color("MCP", colors.muted)} ${mcpRow}`, outerWidth));
-  lines.push(frameLine(`${color("/gsd to begin", colors.accent)}  ${color("/gsd help", colors.muted)}`, outerWidth));
-  lines.push(color("╰" + "─".repeat(Math.max(0, outerWidth - 2)) + "╯", colors.border));
+  const mcpRow = formatMcpRow(data.mcpServers, Math.max(1, innerWidth - 5));
+  if (mcpRow) lines.push(panelLine(`${color("MCP", colors.muted)} ${mcpRow}`, outerWidth));
+  lines.push(panelLine(`${color("/gsd to begin", colors.accent)}  ${color("/gsd help", colors.muted)}`, outerWidth));
+  // Closing rule on its own line keeps header content copy-clean.
+  lines.push(color("─".repeat(outerWidth), colors.border));
 
   return lines;
 }

--- a/src/tests/welcome-screen.test.ts
+++ b/src/tests/welcome-screen.test.ts
@@ -155,17 +155,19 @@ test('Project row does not truncate short milestone text', (t) => {
   assert.ok(!projectLine!.includes('…'), 'short title should not be truncated')
 })
 
-test('rounded command-center borders extend to full terminal width on wide terminals', (t) => {
+test('command-center renders a borderless panel with a full-width closing rule', (t) => {
   const origColumns = process.stderr.columns
   ;(process.stderr as any).columns = 250
   t.after(() => { ;(process.stderr as any).columns = origColumns })
 
   const out = strip(capture({ version: '1.0.0' }))
   const lines = out.split('\n')
-  // Top and bottom rounded borders should be 249 chars (columns - 1)
-  const borderLines = lines.filter(l => /^[╭╰]─+[╮╯]$/.test(l.trim()))
-  assert.equal(borderLines.length, 2, 'expected top and bottom rounded border lines')
-  for (const border of borderLines) {
-    assert.equal(border.trim().length, 249, `border should be 249 chars wide, got ${border.trim().length}`)
+  // No box corners — content lines must stay copy/paste-safe (no side bars).
+  for (const corner of ['╭', '╮', '╰', '╯']) {
+    assert.ok(!out.includes(corner), `welcome screen must not draw box border char ${corner}`)
   }
+  // Exactly one closing rule, spanning the terminal width (columns - 1 = 249).
+  const ruleLines = lines.filter(l => /^─+$/.test(l.trim()))
+  assert.equal(ruleLines.length, 1, 'expected exactly one closing rule line')
+  assert.equal(ruleLines[0].trim().length, 249, `rule should be 249 chars wide, got ${ruleLines[0].trim().length}`)
 })

--- a/src/welcome-screen.ts
+++ b/src/welcome-screen.ts
@@ -98,11 +98,6 @@ function rightAlign(left: string, right: string, width: number): string {
   return clampVisible(left + ' '.repeat(gap) + right, width)
 }
 
-function frameLine(content: string, width: number): string {
-  const inner = Math.max(1, width - 2)
-  return chalk.hex('#a7ba78')('│') + rpad(content, inner) + chalk.hex('#a7ba78')('│')
-}
-
 /** Clamp rendered terminal output by visible columns. Falls back to plain text only when truncating. */
 function clampVisible(s: string, w: number): string {
   if (w <= 0) return ''
@@ -131,7 +126,9 @@ export function buildWelcomeScreenLines(opts: WelcomeScreenOptions): string[] {
 
   const innerWidth = Math.max(1, termWidth - 2)
   const logoWidth = Math.max(...GSD_LOGO.map((line) => visLen(line)))
-  const divider = ` ${chalk.dim('│')} `
+  // Plain spaces, not a `│` divider — a vertical bar would be dragged into
+  // every copied logo row.
+  const divider = '   '
   const panelWidth = innerWidth - logoWidth - visLen(divider)
   if (panelWidth < 44) {
     return ['', `  Get Shit Done v${version}`, `  ${shortCwd}`, '']
@@ -172,13 +169,14 @@ export function buildWelcomeScreenLines(opts: WelcomeScreenOptions): string[] {
   ]
 
   // ── Render ──────────────────────────────────────────────────────────────────
+  // No box: logo + panel are indented, with a single closing rule. Every
+  // content line is plain text, so terminal selection copies cleanly.
   const out: string[] = ['']
-  out.push(chalk.hex('#a7ba78')('╭' + '─'.repeat(termWidth - 2) + '╮'))
   for (let i = 0; i < GSD_LOGO.length; i++) {
     const logo = rpad(chalk.hex('#a7ba78')(GSD_LOGO[i]), logoWidth)
-    out.push(frameLine(`${logo}${divider}${panelRows[i] ?? ''}`, termWidth))
+    out.push('  ' + clampVisible(`${logo}${divider}${panelRows[i] ?? ''}`, termWidth - 2))
   }
-  out.push(chalk.hex('#a7ba78')('╰' + '─'.repeat(termWidth - 2) + '╯'))
+  out.push(chalk.hex('#a7ba78')('─'.repeat(Math.max(0, termWidth))))
   out.push('')
 
   return out.map((line) => clampVisible(line, termWidth))


### PR DESCRIPTION
## Problem

Users couldn't copy/paste CLI output cleanly — box borders draw a `│` on **every content line**, and column dividers were vertical bars too. Any terminal text selection dragged border chars into the copied text.

## Change

Replaces the boxed look for **inline output** with a **borderless panel**: an inline-titled header rule, indented body, and a closing rule. No box-drawing char ever sits on a content line, so selection copies clean text. Horizontal rules stay — they live on their own lines and are never caught in a body selection.

| Surface | Before | After |
|---------|--------|-------|
| `render-kit` | `renderFrame()` only | adds `renderPanel()` |
| auto-mode completion snapshot | `╭─╮ │ … │ ╰─╯` | `── title ──` + indented body + rule |
| watch header / welcome screen | boxed logo + `│` column divider | borderless, spaces for the divider, single closing rule |

Transient overlays (notification, parallel-monitor) **keep** `renderFrame` — they pop over the screen and are rarely copied; a box helps them stand out.

```
── ✓ GSD Milestone 3 complete  2m14s ────────────────────────

  Reason  merge conflict on milestones.md
  Next    resolve and rerun /gsd auto
─────────────────────────────────────────────────────────────
```

## Verification

- `tui-render-kit` — passes, +2 tests asserting `renderPanel` draws no `│` and indents the body
- `header-renderer`, `welcome-screen` — pass; welcome-screen border test rewritten to assert no box corners + one closing rule
- `auto-dashboard` suite — 49/49 pass
- Extensions typecheck + `build:core` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added borderless panel rendering for terminal UI elements.

* **Improvements**
  * Redesigned welcome screen and header layouts from bordered frames to cleaner borderless panels.
  * Enhanced terminal text selection for clean copying without embedded border characters.

* **Tests**
  * Added test coverage for panel rendering functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->