### PR TITLE
fix(gsd): handle missing model prefs in setup wizard

### DIFF
--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -17,6 +17,7 @@ import {
   loadGlobalGSDPreferences,
   loadProjectGSDPreferences,
   loadEffectiveGSDPreferences,
+  normalizePreferencesShape,
   resolveAllSkillReferences,
 } from "./preferences.js";
 import { loadFile, saveFile, splitFrontmatter, parseFrontmatterMap } from "./files.js";
@@ -1571,8 +1572,12 @@ export async function handlePrefsWizard(
   // Order: existing-on-disk values, overlaid with prefill (caller's seeded answers).
   // Callers like /gsd init pass freshly-collected init answers as prefill so the
   // wizard menu shows them populated and writeable in one place.
+  // `normalizePreferencesShape` tolerates a missing preferences file, a malformed
+  // wrapper (`{ preferences: undefined }`), or a bare prefs object so the wizard
+  // never reaches the category menu with a half-formed root. See issue: /gsd setup
+  // prefs crashed with "Cannot read properties of undefined (reading 'models')".
   const prefs: Record<string, unknown> = {
-    ...(existing?.preferences ?? {}),
+    ...normalizePreferencesShape(existing),
     ...(prefill ?? {}),
   };
 

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -46,8 +46,9 @@ export function resolveModelForUnit(unitType: string): string | undefined {
  */
 export function resolveModelWithFallbacksForUnit(unitType: string): ResolvedModelConfig | undefined {
   const prefs = loadEffectiveGSDPreferences(undefined, { availableModelIds: [] });
-  if (!prefs?.preferences.models) return undefined;
-  const m = prefs.preferences.models as GSDModelConfigV2;
+  const models = prefs?.preferences?.models;
+  if (!models) return undefined;
+  const m = models as GSDModelConfigV2;
 
   let phaseConfig: string | GSDPhaseModelConfig | undefined;
   switch (unitType) {
@@ -151,9 +152,10 @@ export function resolveDefaultSessionModel(
   sessionProvider?: string,
 ): { provider: string; id: string } | undefined {
   const prefs = loadEffectiveGSDPreferences(undefined, { availableModelIds: [] });
-  if (!prefs?.preferences.models) return undefined;
+  const models = prefs?.preferences?.models;
+  if (!models) return undefined;
 
-  const m = prefs.preferences.models as GSDModelConfigV2;
+  const m = models as GSDModelConfigV2;
 
   // Priority: execution → planning → first configured value
   const candidates: Array<string | GSDPhaseModelConfig | undefined> = [

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -138,6 +138,36 @@ export function getProjectGSDPreferencesPath(basePath?: string): string {
   return projectPreferencesPath(basePath);
 }
 
+
+/**
+ * Normalize a value loaded from disk (or passed from another component) into
+ * a plain, mutable bare preferences object.
+ *
+ * Accepts:
+ *   - a `LoadedGSDPreferences` wrapper (`{ path, scope, preferences, ... }`)
+ *   - a bare `GSDPreferences` object
+ *   - `null` / `undefined` / any malformed value
+ *
+ * Returns a fresh `Record<string, unknown>` so callers may spread additional
+ * values without mutating the input. This is the single boundary the
+ * preferences wizard funnels existing-on-disk data through, so missing or
+ * partially-formed preference shapes can no longer reach code that assumes
+ * a fully-populated wrapper.
+ */
+export function normalizePreferencesShape(
+  loaded: unknown,
+): Record<string, unknown> {
+  if (!loaded || typeof loaded !== "object") return {};
+  const obj = loaded as Record<string, unknown>;
+  // Wrapper shape (`LoadedGSDPreferences`) carries the nested preferences
+  // under a `.preferences` key. Bare `GSDPreferences` never declares one
+  // (see preferences-types.ts), so the presence of that key is a reliable
+  // discriminator. Tolerate `preferences: undefined` by falling through to
+  // the empty-object return below.
+  const candidate = "preferences" in obj ? obj.preferences : obj;
+  if (!candidate || typeof candidate !== "object") return {};
+  return { ...(candidate as Record<string, unknown>) };
+}
 // ─── Loading ────────────────────────────────────────────────────────────────
 
 export function loadGlobalGSDPreferences(): LoadedGSDPreferences | null {

--- a/src/resources/extensions/gsd/tests/prefs-missing-models-crash.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-missing-models-crash.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression coverage for the `/gsd setup prefs` crash:
+ *   "Cannot read properties of undefined (reading 'models')"
+ *
+ * Originally caused by unsafe `prefs?.preferences.models` access (optional-
+ * chained on `prefs` only, not on `preferences`) plus a wizard entrypoint
+ * that did not normalize partially-formed preference shapes. These tests
+ * pin the new behavior so future refactors cannot silently re-introduce the
+ * crash.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { normalizePreferencesShape } from "../preferences.ts";
+import {
+  resolveDefaultSessionModel,
+  resolveModelWithFallbacksForUnit,
+} from "../preferences-models.ts";
+import { buildCategorySummaries, handlePrefsWizard } from "../commands-prefs-wizard.ts";
+import { readModelFromPreferences } from "../watch/header-renderer.ts";
+
+// ─── normalizePreferencesShape ─────────────────────────────────────────────
+
+test("normalizePreferencesShape: null/undefined/non-object → empty object", () => {
+  assert.deepEqual(normalizePreferencesShape(null), {});
+  assert.deepEqual(normalizePreferencesShape(undefined), {});
+  assert.deepEqual(normalizePreferencesShape("nope"), {});
+  assert.deepEqual(normalizePreferencesShape(42), {});
+});
+
+test("normalizePreferencesShape: wrapper with preferences=undefined → empty object", () => {
+  assert.deepEqual(
+    normalizePreferencesShape({ path: "/x", scope: "global", preferences: undefined }),
+    {},
+  );
+});
+
+test("normalizePreferencesShape: full wrapper unwraps to a fresh bare prefs object", () => {
+  const wrapper = {
+    path: "/x",
+    scope: "global" as const,
+    preferences: { mode: "team" as string, models: { execution: "p/m" } },
+  };
+  const out = normalizePreferencesShape(wrapper);
+  assert.deepEqual(out, { mode: "team", models: { execution: "p/m" } });
+  // Mutating the result must not bleed into the wrapper.
+  out.mode = "solo";
+  assert.equal(wrapper.preferences.mode, "team");
+});
+
+test("normalizePreferencesShape: bare prefs object pass-through (no `preferences` key)", () => {
+  const bare = { mode: "solo" as string, models: { planning: "p/m" } };
+  const out = normalizePreferencesShape(bare);
+  assert.deepEqual(out, bare);
+  out.mode = "team";
+  assert.equal(bare.mode, "solo");
+});
+
+// ─── buildCategorySummaries on missing models ──────────────────────────────
+
+test("buildCategorySummaries({}) reports models as not configured without throwing", () => {
+  const summaries = buildCategorySummaries({});
+  assert.equal(summaries.models, "(not configured)");
+});
+
+// ─── Model resolvers tolerate missing/partial preference shapes ────────────
+
+function withGsdHome(content: string | null, fn: () => void): void {
+  const oldHome = process.env.GSD_HOME;
+  const home = mkdtempSync(join(tmpdir(), "gsd-prefs-missing-"));
+  try {
+    process.env.GSD_HOME = home;
+    if (content !== null) {
+      writeFileSync(join(home, "PREFERENCES.md"), content);
+    }
+    fn();
+  } finally {
+    if (oldHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = oldHome;
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+test("resolveModelWithFallbacksForUnit returns undefined when no preferences file exists", () => {
+  withGsdHome(null, () => {
+    assert.equal(resolveModelWithFallbacksForUnit("execute-task"), undefined);
+  });
+});
+
+test("resolveModelWithFallbacksForUnit returns undefined when preferences omit models", () => {
+  withGsdHome("---\nmode: solo\n---\n", () => {
+    assert.equal(resolveModelWithFallbacksForUnit("execute-task"), undefined);
+  });
+});
+
+test("resolveDefaultSessionModel returns undefined when no preferences file exists", () => {
+  withGsdHome(null, () => {
+    assert.equal(resolveDefaultSessionModel("anthropic"), undefined);
+  });
+});
+
+test("resolveDefaultSessionModel returns undefined when preferences omit models", () => {
+  withGsdHome("---\nmode: solo\n---\n", () => {
+    assert.equal(resolveDefaultSessionModel("anthropic"), undefined);
+  });
+});
+
+test("readModelFromPreferences returns 'default' when preferences omit models", () => {
+  withGsdHome("---\nmode: solo\n---\n", () => {
+    assert.equal(readModelFromPreferences(), "default");
+  });
+});
+
+// ─── End-to-end wizard: no existing prefs + immediate Save & Exit ──────────
+
+test("handlePrefsWizard works with no existing preferences and Save & Exit", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-prefs-wizard-empty-"));
+  const prefsPath = join(dir, "PREFERENCES.md");
+  try {
+    let saveExitReturned = false;
+    const ctx = {
+      ui: {
+        notify() {},
+        select: async () => {
+          saveExitReturned = true;
+          return "── Save & Exit ──";
+        },
+      },
+      waitForIdle: async () => {},
+      reload: async () => {},
+    } as any;
+
+    await handlePrefsWizard(ctx, "project", undefined, { pathOverride: prefsPath });
+    assert.ok(saveExitReturned, "wizard should have prompted for category selection");
+
+    const saved = readFileSync(prefsPath, "utf-8");
+    assert.match(saved, /^---\n/, "saved file must start with frontmatter");
+    assert.match(saved, /version:\s*1/, "saved file must default version to 1");
+    // No bogus empty models block when no models were configured.
+    assert.doesNotMatch(saved, /^models:\s*$/m, "must not write empty models block");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/watch/header-renderer.ts
+++ b/src/resources/extensions/gsd/watch/header-renderer.ts
@@ -79,8 +79,9 @@ function frameLine(content: string, width: number): string {
 export function readModelFromPreferences(): string {
   try {
     const prefs = loadEffectiveGSDPreferences();
-    if (!prefs?.preferences.models) return "default";
-    const m = prefs.preferences.models as Record<string, unknown>;
+    const models = prefs?.preferences?.models;
+    if (!models) return "default";
+    const m = models as Record<string, unknown>;
     // Try common phases in priority order
     for (const phase of ["execution", "planning", "research", "discuss", "subagent"]) {
       const val = m[phase];


### PR DESCRIPTION
## TL;DR

**What:** Fix the `/gsd setup prefs` crash `Cannot read properties of undefined (reading 'models')` when model preferences are missing or partially loaded.
**Why:** Several model-preference readers used `prefs?.preferences.models` (optional-chained only on `prefs`, not on `preferences`), so they threw whenever the loaded wrapper carried `preferences: undefined`. The wizard also funneled existing-on-disk values through an inline `existing?.preferences ?? {}` that did not tolerate a malformed wrapper or a bare preference object.
**How:** Add a `normalizePreferencesShape(loaded)` boundary in `preferences.ts`, route the wizard entry through it, and replace the unsafe optional-chaining with safe `prefs?.preferences?.models`.

Closes #6340.

> AI-assisted PR. Author understands the change and is responsible for it.

## What

- `src/resources/extensions/gsd/preferences.ts` — new `normalizePreferencesShape(loaded: unknown): Record<string, unknown>` helper. Accepts the `LoadedGSDPreferences` wrapper, a bare `GSDPreferences` object, or `null`/`undefined`/malformed input and always returns a fresh, mutable plain object so callers can safely spread additional values without mutating the input.
- `src/resources/extensions/gsd/commands-prefs-wizard.ts` — `handlePrefsWizard` now spreads `normalizePreferencesShape(existing)` instead of `existing?.preferences ?? {}`.
- `src/resources/extensions/gsd/preferences-models.ts` — `resolveModelWithFallbacksForUnit` and `resolveDefaultSessionModel` now read through a locally-bound `const models = prefs?.preferences?.models` instead of `prefs?.preferences.models`.
- `src/resources/extensions/gsd/watch/header-renderer.ts` — `readModelFromPreferences` applies the same safe-chaining fix.
- `src/resources/extensions/gsd/tests/prefs-missing-models-crash.test.ts` — new regression test file (11 cases).

## Why

The root cause is a textual difference between two access patterns:

- ✅ `prefs?.preferences?.models` — safe when `prefs` is null **or** when `prefs.preferences` is undefined.
- ❌ `prefs?.preferences.models` — only safe when `prefs` is null. Throws when `prefs` exists but `prefs.preferences` is undefined.

The latter form leaked into `preferences-models.ts` and `watch/header-renderer.ts`. Combined with a wizard entry that did not normalize partially-formed wrappers, `/gsd setup prefs` could crash on real-world user states (no global PREFERENCES.md, malformed wrapper, etc.).

Fixing only the optional-chaining would address the symptom; adding a normalization boundary prevents similar drift in the future by centralizing the "wrapper vs bare" shape decision at the wizard entrypoint.

## How

1. **Boundary helper.** `normalizePreferencesShape` is a few lines and intentionally narrow: it distinguishes wrapper from bare by the presence of a `preferences` key (which `LoadedGSDPreferences` declares and `GSDPreferences` does not — see `preferences-types.ts`), tolerates `preferences: undefined`, and returns a shallow copy so callers can spread without mutating the source.
2. **Wizard adoption.** Only `handlePrefsWizard` adopts the helper here — that is the entrypoint of the crashing flow and was already the single place that built the root `prefs` object.
3. **Safe optional-chaining.** All three model readers now bind `const models = prefs?.preferences?.models` once, early-return on `!models`, and use the local. This both fixes the crash and removes the duplicated cast on the line below.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/prefs-missing-models-crash.test.ts` — 11/11 pass.
- Focused preferences-area run (`preferences.test.ts`, `prefs-wizard-coverage.test.ts`, `model-unittype-mapping.test.ts`, `token-profile.test.ts`, `preferences-formatting.test.ts`) — 109/109 pass.
- `npm run build:core` — clean.
- `npm run typecheck:extensions` — clean.
- `npm run test:unit` — surfaces 23 pre-existing failures in `stream-adapter`, `bashCommandMatchesSavedRules`, `enterMilestone`, and `bootstrapAutoSession`. Verified these fail on a clean `main` checkout (`git stash` + re-run) and are unrelated to this fix; preferences-area tests are green.

## Notes for reviewer

- No serialization changes. `writePreferencesFile` and `serializePreferencesToFrontmatter` are untouched, so existing valid prefs files round-trip unchanged.
- The unsafe pattern audit (`rg "preferences\\.models|preferences\\?\\.models"` under `src/resources/extensions/gsd`) shows that every other reader already uses safe chaining (`?.preferences?.X`). Only the three sites above needed correction.
- The regression test exercises real code paths, not source-grep (per `CONTRIBUTING.md` "No source-grep tests").

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Regression test added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes in the preferences setup flow when preference files are missing, malformed, or contain unexpected data structures.

* **Tests**
  * Added comprehensive regression test suite covering preferences handling during setup when files are missing or contain incomplete configuration data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->