### PR TITLE
fix(web): honor launch CWD and broaden directory picker scope

### DIFF
--- a/web/app/api/browse-directories/route.ts
+++ b/web/app/api/browse-directories/route.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { resolve, dirname, join } from "node:path";
-import { homedir, platform } from "node:os";
+import { homedir, platform, userInfo } from "node:os";
 import { isAllowedBrowsePath, getAdditionalRoots } from "../../../lib/browse-scope";
 
 export const runtime = "nodejs";
@@ -10,6 +10,14 @@ export const dynamic = "force-dynamic";
  * Resolve the configured dev root from web preferences.
  * Returns the devRoot path if set, otherwise the user's home directory.
  */
+function currentUsername(): string | undefined {
+  try {
+    return userInfo().username || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function getDevRoot(): string {
   try {
     const prefsPath = join(homedir(), ".gsd", "web-preferences.json");
@@ -45,7 +53,7 @@ export async function GET(request: Request): Promise<Response> {
     const rawPath = url.searchParams.get("path");
     const devRoot = getDevRoot();
     const home = homedir();
-    const additionalRoots = getAdditionalRoots(platform(), existsSync);
+    const additionalRoots = getAdditionalRoots(platform(), existsSync, currentUsername());
     const targetPath = rawPath ? resolve(rawPath) : devRoot;
 
     if (!isAllowedBrowsePath(targetPath, { devRoot, home, additionalRoots })) {

--- a/web/app/api/browse-directories/route.ts
+++ b/web/app/api/browse-directories/route.ts
@@ -1,7 +1,7 @@
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { resolve, dirname, join } from "node:path";
 import { homedir, platform, userInfo } from "node:os";
-import { isAllowedBrowsePath, getAdditionalRoots } from "../../../lib/browse-scope";
+import { isAllowedBrowsePath, getAdditionalRoots } from "../../../lib/browse-scope.ts";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -15,6 +15,15 @@ function currentUsername(): string | undefined {
     return userInfo().username || undefined;
   } catch {
     return undefined;
+  }
+}
+
+/** Resolve symlinks if the path exists; otherwise fall back to a lexical resolve. */
+function safeRealpath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
   }
 }
 
@@ -56,13 +65,6 @@ export async function GET(request: Request): Promise<Response> {
     const additionalRoots = getAdditionalRoots(platform(), existsSync, currentUsername());
     const targetPath = rawPath ? resolve(rawPath) : devRoot;
 
-    if (!isAllowedBrowsePath(targetPath, { devRoot, home, additionalRoots })) {
-      return Response.json(
-        { error: "Path outside allowed scope" },
-        { status: 403 },
-      );
-    }
-
     if (!existsSync(targetPath)) {
       return Response.json(
         { error: `Path does not exist: ${targetPath}` },
@@ -70,27 +72,43 @@ export async function GET(request: Request): Promise<Response> {
       );
     }
 
-    const stat = statSync(targetPath);
+    // Resolve symlinks before enforcing scope so an in-scope symlink that
+    // points outside the allowed roots cannot escape the picker. Compare
+    // canonical-against-canonical for both target and roots.
+    const canonical = safeRealpath(targetPath);
+    const canonicalOpts = {
+      devRoot: safeRealpath(devRoot),
+      home: safeRealpath(home),
+      additionalRoots: additionalRoots.map(safeRealpath),
+    };
+    if (!isAllowedBrowsePath(canonical, canonicalOpts)) {
+      return Response.json(
+        { error: "Path outside allowed scope" },
+        { status: 403 },
+      );
+    }
+
+    const stat = statSync(canonical);
     if (!stat.isDirectory()) {
       return Response.json(
-        { error: `Not a directory: ${targetPath}` },
+        { error: `Not a directory: ${canonical}` },
         { status: 400 },
       );
     }
 
-    const parentPath = dirname(targetPath);
+    const parentPath = dirname(canonical);
     const parentAllowed =
-      parentPath !== targetPath &&
-      isAllowedBrowsePath(parentPath, { devRoot, home, additionalRoots });
+      parentPath !== canonical &&
+      isAllowedBrowsePath(parentPath, canonicalOpts);
 
     // Surface mount roots / drive letters as quick-access when browsing $HOME or devRoot.
     const showAdditionalRoots =
-      additionalRoots.length > 0 && (targetPath === home || targetPath === devRoot);
+      additionalRoots.length > 0 && (canonical === canonicalOpts.home || canonical === canonicalOpts.devRoot);
 
     const entries: Array<{ name: string; path: string }> = [];
 
     try {
-      const items = readdirSync(targetPath, { withFileTypes: true });
+      const items = readdirSync(canonical, { withFileTypes: true });
       for (const item of items) {
         if (!item.isDirectory()) continue;
         if (item.name.startsWith(".")) continue;
@@ -98,7 +116,7 @@ export async function GET(request: Request): Promise<Response> {
 
         entries.push({
           name: item.name,
-          path: resolve(targetPath, item.name),
+          path: resolve(canonical, item.name),
         });
       }
 
@@ -118,7 +136,7 @@ export async function GET(request: Request): Promise<Response> {
     entries.sort((a, b) => a.name.localeCompare(b.name));
 
     return Response.json({
-      current: targetPath,
+      current: canonical,
       parent: parentAllowed ? parentPath : null,
       entries,
     });

--- a/web/app/api/browse-directories/route.ts
+++ b/web/app/api/browse-directories/route.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { resolve, dirname, join } from "node:path";
 import { homedir, platform } from "node:os";
+import { isAllowedBrowsePath, getAdditionalRoots } from "../../../lib/browse-scope";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -25,80 +26,29 @@ function getDevRoot(): string {
 }
 
 /**
- * Get available mount points on Linux (external drives, removable media)
- * Returns paths like /media, /mnt, /run/media/<user>
- */
-function getLinuxMountPoints(): string[] {
-  const mountPoints: string[] = [];
-  const home = homedir();
-
-  const standardMounts = ["/media", "/mnt", "/run/media"];
-
-  for (const mp of standardMounts) {
-    if (existsSync(mp)) {
-      mountPoints.push(mp);
-    }
-  }
-
-  const runMediaUser = `/run/media/${home.split("/").pop()}`;
-  if (existsSync(runMediaUser)) {
-    mountPoints.push(runMediaUser);
-  }
-
-  return mountPoints;
-}
-
-/**
- * Get additional root-level directories to show as shortcuts on Linux
- * (for accessing external drives and mounted filesystems)
- */
-function getAdditionalRoots(): string[] {
-  const os = platform();
-  if (os === "linux") {
-    return getLinuxMountPoints();
-  }
-  if (os === "win32") {
-    const drives: string[] = [];
-    for (let code = 65; code <= 90; code++) {
-      const drive = `${String.fromCharCode(code)}:\\`;
-      if (existsSync(drive)) drives.push(drive);
-    }
-    return drives;
-  }
-  return [];
-}
-
-/**
  * GET /api/browse-directories?path=/some/path
  *
  * Returns the directory listing for the given path.
  * Defaults to the configured devRoot (or home directory) if no path is given.
  * Only returns directories (no files) for the folder picker use case.
  *
- * Security: Paths are restricted to the devRoot and its children. Requests
- * for paths outside devRoot are rejected with 403 to prevent full filesystem
- * enumeration.
+ * Scope:
+ *   - devRoot and its descendants
+ *   - the immediate parent of devRoot (one level up for context)
+ *   - the user's home directory and its descendants
+ *   - platform-specific mount roots (e.g. /Volumes on macOS, /media on Linux,
+ *     existing drive letters on Windows)
  */
 export async function GET(request: Request): Promise<Response> {
   try {
     const url = new URL(request.url);
     const rawPath = url.searchParams.get("path");
     const devRoot = getDevRoot();
+    const home = homedir();
+    const additionalRoots = getAdditionalRoots(platform(), existsSync);
     const targetPath = rawPath ? resolve(rawPath) : devRoot;
 
-    // Restrict browsing to devRoot and its subtree, or the home directory
-    // if no devRoot is configured. Navigating to the parent of devRoot is
-    // allowed (one level up) so the UI can show the devRoot in context,
-    // but nothing further.
-    // Also allow navigation to common mount points (/media, /mnt, /run/media) on Linux
-    const devRootParent = dirname(devRoot);
-    const additionalRoots = getAdditionalRoots();
-    const isAllowedPath =
-      targetPath.startsWith(devRoot) ||
-      targetPath === devRootParent ||
-      additionalRoots.some((root) => targetPath.startsWith(root));
-
-    if (!isAllowedPath) {
+    if (!isAllowedBrowsePath(targetPath, { devRoot, home, additionalRoots })) {
       return Response.json(
         { error: "Path outside allowed scope" },
         { status: 403 },
@@ -121,22 +71,19 @@ export async function GET(request: Request): Promise<Response> {
     }
 
     const parentPath = dirname(targetPath);
-    // Only offer the parent navigation if it's within the allowed scope
     const parentAllowed =
       parentPath !== targetPath &&
-      (parentPath.startsWith(devRoot) ||
-        parentPath === devRootParent ||
-        additionalRoots.some((root) => parentPath.startsWith(root)));
-    const entries: Array<{ name: string; path: string }> = [];
+      isAllowedBrowsePath(parentPath, { devRoot, home, additionalRoots });
 
-    // Show mount/drive roots as quick-access when browsing from home or dev root.
-    const os = platform();
-    const showAdditionalRoots = (os === "linux" || os === "win32") && (targetPath === homedir() || targetPath === devRoot);
+    // Surface mount roots / drive letters as quick-access when browsing $HOME or devRoot.
+    const showAdditionalRoots =
+      additionalRoots.length > 0 && (targetPath === home || targetPath === devRoot);
+
+    const entries: Array<{ name: string; path: string }> = [];
 
     try {
       const items = readdirSync(targetPath, { withFileTypes: true });
       for (const item of items) {
-        // Only directories, skip dotfiles and common non-project dirs
         if (!item.isDirectory()) continue;
         if (item.name.startsWith(".")) continue;
         if (item.name === "node_modules") continue;
@@ -147,16 +94,13 @@ export async function GET(request: Request): Promise<Response> {
         });
       }
 
-      // Add mount points/drives as quick-access entries.
       if (showAdditionalRoots) {
         for (const mp of additionalRoots) {
-          if (existsSync(mp)) {
-            const mpName = mp.split("/").pop() || mp;
-            entries.push({
-              name: mpName,
-              path: mp,
-            });
-          }
+          const mpName = mp.split(/[/\\]/).filter(Boolean).pop() || mp;
+          entries.push({
+            name: mpName,
+            path: mp,
+          });
         }
       }
     } catch {

--- a/web/app/api/preferences/route.ts
+++ b/web/app/api/preferences/route.ts
@@ -11,19 +11,38 @@ interface WebPreferences {
   lastActiveProject?: string;
 }
 
+/**
+ * Shape returned by GET. `launchCwd` is the CWD the user launched `gsd --web`
+ * from, propagated by the CLI via `GSD_WEB_PROJECT_CWD`. The client uses it
+ * to auto-select the launch project instead of falling back to
+ * `lastActiveProject` (or alphabetically first). See issue #6344.
+ */
+interface WebPreferencesResponse extends WebPreferences {
+  launchCwd: string | null;
+}
+
+function readLaunchCwd(): string | null {
+  const v = process.env.GSD_WEB_PROJECT_CWD;
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
 // ─── GET: read current preferences ─────────────────────────────────────────
 
 export async function GET(): Promise<Response> {
+  const launchCwd = readLaunchCwd();
   try {
     if (!existsSync(webPreferencesPath)) {
-      return Response.json({});
+      const body: WebPreferencesResponse = { launchCwd };
+      return Response.json(body);
     }
     const raw = readFileSync(webPreferencesPath, "utf-8");
     const prefs: WebPreferences = JSON.parse(raw);
-    return Response.json(prefs);
+    const body: WebPreferencesResponse = { ...prefs, launchCwd };
+    return Response.json(body);
   } catch {
-    // File corrupt or unreadable — return empty
-    return Response.json({});
+    // File corrupt or unreadable — return empty (but still surface launchCwd)
+    const body: WebPreferencesResponse = { launchCwd };
+    return Response.json(body);
   }
 }
 

--- a/web/app/api/preferences/route.ts
+++ b/web/app/api/preferences/route.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { webPreferencesPath } from "../../../../src/app-paths.ts";
 
 export const runtime = "nodejs";
@@ -11,19 +11,15 @@ interface WebPreferences {
   lastActiveProject?: string;
 }
 
-/**
- * Shape returned by GET. `launchCwd` is the CWD the user launched `gsd --web`
- * from, propagated by the CLI via `GSD_WEB_PROJECT_CWD`. The client uses it
- * to auto-select the launch project instead of falling back to
- * `lastActiveProject` (or alphabetically first). See issue #6344.
- */
 interface WebPreferencesResponse extends WebPreferences {
   launchCwd: string | null;
 }
 
 function readLaunchCwd(): string | null {
   const v = process.env.GSD_WEB_PROJECT_CWD;
-  return typeof v === "string" && v.length > 0 ? v : null;
+  if (typeof v !== "string" || v.length === 0) return null;
+  // Normalize so the value matches the resolved path the client compares against.
+  return resolve(v);
 }
 
 // ─── GET: read current preferences ─────────────────────────────────────────

--- a/web/components/gsd/app-shell.tsx
+++ b/web/components/gsd/app-shell.tsx
@@ -592,12 +592,14 @@ function ProjectAwareWorkspace() {
   const activeProjectCwd = useSyncExternalStore(manager.subscribe, manager.getSnapshot, manager.getSnapshot)
   const activeStore = activeProjectCwd ? manager.getActiveStore() : null
 
-  // #6344 — when `gsd --web` was launched from a project directory the CLI
-  // propagates that path via GSD_WEB_PROJECT_CWD. The preferences endpoint
-  // surfaces it as `launchCwd`; auto-select that project once on first mount
-  // so the launch CWD wins over `lastActiveProject` / alphabetic fallback.
+  // Auto-select the launch project when `gsd --web` was started from a project
+  // directory. Guarded by a ref so React's StrictMode double-invoke cannot
+  // trigger two parallel switchProject calls.
+  const launchCwdFetched = useRef(false)
   useEffect(() => {
+    if (launchCwdFetched.current) return
     if (manager.getActiveProjectCwd()) return
+    launchCwdFetched.current = true
     let cancelled = false
     void (async () => {
       try {

--- a/web/components/gsd/app-shell.tsx
+++ b/web/components/gsd/app-shell.tsx
@@ -29,7 +29,7 @@ import { ScopeBadge } from "@/components/gsd/scope-badge"
 import { Badge } from "@/components/ui/badge"
 import { ProjectsPanel, ProjectSelectionGate } from "@/components/gsd/projects-view"
 import { UpdateBanner } from "@/components/gsd/update-banner"
-import { getAuthToken } from "@/lib/auth"
+import { getAuthToken, authFetch } from "@/lib/auth"
 
 const KNOWN_VIEWS = new Set(["dashboard", "power", "chat", "roadmap", "files", "activity", "visualize"])
 
@@ -591,6 +591,31 @@ function ProjectAwareWorkspace() {
   const manager = useProjectStoreManager()
   const activeProjectCwd = useSyncExternalStore(manager.subscribe, manager.getSnapshot, manager.getSnapshot)
   const activeStore = activeProjectCwd ? manager.getActiveStore() : null
+
+  // #6344 — when `gsd --web` was launched from a project directory the CLI
+  // propagates that path via GSD_WEB_PROJECT_CWD. The preferences endpoint
+  // surfaces it as `launchCwd`; auto-select that project once on first mount
+  // so the launch CWD wins over `lastActiveProject` / alphabetic fallback.
+  useEffect(() => {
+    if (manager.getActiveProjectCwd()) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await authFetch("/api/preferences")
+        if (!res.ok) return
+        const prefs = (await res.json()) as { launchCwd?: string | null }
+        if (cancelled) return
+        if (prefs.launchCwd && !manager.getActiveProjectCwd()) {
+          manager.switchProject(prefs.launchCwd)
+        }
+      } catch {
+        // Ignore — user can still pick from the gate.
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [manager])
 
   // Shut down all projects when the tab actually closes.
   // IMPORTANT: pagehide fires both on real page unload AND on mobile/Safari

--- a/web/components/gsd/app-shell.tsx
+++ b/web/components/gsd/app-shell.tsx
@@ -593,30 +593,29 @@ function ProjectAwareWorkspace() {
   const activeStore = activeProjectCwd ? manager.getActiveStore() : null
 
   // Auto-select the launch project when `gsd --web` was started from a project
-  // directory. Guarded by a ref so React's StrictMode double-invoke cannot
-  // trigger two parallel switchProject calls.
+  // directory. The ref is set only after a fetch completes, so StrictMode's
+  // setup → cleanup → setup cycle (first attempt aborted by cleanup) does not
+  // leave the auto-select stranded.
   const launchCwdFetched = useRef(false)
   useEffect(() => {
     if (launchCwdFetched.current) return
     if (manager.getActiveProjectCwd()) return
-    launchCwdFetched.current = true
-    let cancelled = false
+    const controller = new AbortController()
     void (async () => {
       try {
-        const res = await authFetch("/api/preferences")
+        const res = await authFetch("/api/preferences", { signal: controller.signal })
         if (!res.ok) return
         const prefs = (await res.json()) as { launchCwd?: string | null }
-        if (cancelled) return
+        launchCwdFetched.current = true
         if (prefs.launchCwd && !manager.getActiveProjectCwd()) {
           manager.switchProject(prefs.launchCwd)
         }
-      } catch {
-        // Ignore — user can still pick from the gate.
+      } catch (err) {
+        if ((err as { name?: string }).name === "AbortError") return
+        // Ignore other errors — user can still pick from the gate.
       }
     })()
-    return () => {
-      cancelled = true
-    }
+    return () => controller.abort()
   }, [manager])
 
   // Shut down all projects when the tab actually closes.

--- a/web/components/gsd/projects-view.tsx
+++ b/web/components/gsd/projects-view.tsx
@@ -716,6 +716,12 @@ function FolderPickerDialog({
   useEffect(() => {
     if (open) {
       void browse(initialPath ?? undefined)
+    } else {
+      setCurrentPath("")
+      setParentPath(null)
+      setEntries([])
+      setError(null)
+      setPathInput("")
     }
   }, [open, initialPath, browse])
 

--- a/web/components/gsd/projects-view.tsx
+++ b/web/components/gsd/projects-view.tsx
@@ -689,6 +689,7 @@ function FolderPickerDialog({
   const [entries, setEntries] = useState<BrowseEntry[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [pathInput, setPathInput] = useState<string>("")
 
   const browse = useCallback(async (targetPath?: string) => {
     setLoading(true)
@@ -702,6 +703,7 @@ function FolderPickerDialog({
       }
       const data: BrowseResult = await res.json()
       setCurrentPath(data.current)
+      setPathInput(data.current)
       setParentPath(data.parent)
       setEntries(data.entries)
     } catch (err) {
@@ -728,9 +730,26 @@ function FolderPickerDialog({
         </DialogHeader>
 
         <div className="border-y border-border/50 bg-muted/50 px-5 py-2">
-          <p className="font-mono text-xs text-muted-foreground truncate" title={currentPath}>
-            {currentPath}
-          </p>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              const next = pathInput.trim()
+              if (next) void browse(next)
+            }}
+          >
+            <input
+              type="text"
+              value={pathInput}
+              onChange={(e) => setPathInput(e.target.value)}
+              spellCheck={false}
+              autoCorrect="off"
+              autoCapitalize="off"
+              placeholder="/absolute/path/to/folder"
+              aria-label="Folder path"
+              data-testid="folder-picker-path-input"
+              className="w-full bg-transparent font-mono text-xs text-foreground placeholder:text-muted-foreground focus:outline-none"
+            />
+          </form>
         </div>
 
         <ScrollArea className="h-[320px]">

--- a/web/lib/__tests__/browse-directories-symlink.test.ts
+++ b/web/lib/__tests__/browse-directories-symlink.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, symlinkSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Build a fake HOME with a .gsd/web-preferences.json pointing devRoot at a
+// scoped directory, then place a symlink inside that directory that escapes
+// to a sibling. The route must reject the symlinked path with 403 even though
+// the lexical path lies inside devRoot.
+
+const sandbox = mkdtempSync(join(tmpdir(), "gsd-symlink-test-"));
+const fakeHome = join(sandbox, "home");
+const devRoot = join(fakeHome, "dev");
+const escapeTarget = join(sandbox, "escape");
+const symlinkInside = join(devRoot, "trap");
+const realInside = join(devRoot, "ok");
+
+mkdirSync(devRoot, { recursive: true });
+mkdirSync(escapeTarget, { recursive: true });
+mkdirSync(realInside, { recursive: true });
+mkdirSync(join(fakeHome, ".gsd"), { recursive: true });
+writeFileSync(
+  join(fakeHome, ".gsd", "web-preferences.json"),
+  JSON.stringify({ devRoot }),
+  "utf-8",
+);
+symlinkSync(escapeTarget, symlinkInside, "dir");
+
+const prevHome = process.env.HOME;
+const prevUserprofile = process.env.USERPROFILE;
+process.env.HOME = fakeHome;
+process.env.USERPROFILE = fakeHome;
+
+const { GET } = await import("../../app/api/browse-directories/route.ts");
+
+describe("GET /api/browse-directories — symlink escape", () => {
+  before(() => {
+    // sandbox already set up at module load.
+  });
+
+  after(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevUserprofile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserprofile;
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  test("rejects an in-scope symlink that points outside the allowed roots", async () => {
+    const res = await GET(
+      new Request(`http://x/api/browse-directories?path=${encodeURIComponent(symlinkInside)}`),
+    );
+    assert.equal(res.status, 403, `expected 403, got ${res.status} body=${await res.text()}`);
+  });
+
+  test("allows a real directory inside devRoot", async () => {
+    const res = await GET(
+      new Request(`http://x/api/browse-directories?path=${encodeURIComponent(realInside)}`),
+    );
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { current: string };
+    assert.equal(body.current, realpathSync(realInside));
+  });
+});

--- a/web/lib/__tests__/browse-scope.test.ts
+++ b/web/lib/__tests__/browse-scope.test.ts
@@ -80,11 +80,29 @@ describe("getAdditionalRoots", () => {
     const roots = getAdditionalRoots("linux", (p) => p === "/media" || p === "/mnt");
     assert.ok(roots.includes("/media"));
     assert.ok(roots.includes("/mnt"));
-    assert.ok(!roots.includes("/run/media"));
+    assert.ok(!roots.some((r) => r.startsWith("/run/media")));
   });
 
-  test("returns an empty array on win32 (drive letters handled separately)", () => {
-    assert.deepEqual(getAdditionalRoots("win32", () => true), []);
+  test("scopes /run/media to the current user on Linux", () => {
+    const roots = getAdditionalRoots("linux", () => true, "alice");
+    assert.ok(roots.includes("/run/media/alice"));
+    assert.ok(!roots.includes("/run/media"));
+    assert.ok(!roots.includes("/run/media/bob"));
+  });
+
+  test("omits /run/media when no username is provided", () => {
+    const roots = getAdditionalRoots("linux", () => true);
+    assert.ok(!roots.some((r) => r.startsWith("/run/media")));
+  });
+
+  test("enumerates existing drive letters on win32", () => {
+    const present = new Set(["C:\\", "D:\\"]);
+    const roots = getAdditionalRoots("win32", (p) => present.has(p));
+    assert.deepEqual(roots, ["C:\\", "D:\\"]);
+  });
+
+  test("returns an empty array on win32 when no drives exist", () => {
+    assert.deepEqual(getAdditionalRoots("win32", () => false), []);
   });
 
   test("skips roots that do not exist", () => {

--- a/web/lib/__tests__/browse-scope.test.ts
+++ b/web/lib/__tests__/browse-scope.test.ts
@@ -1,0 +1,94 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isAllowedBrowsePath, getAdditionalRoots } from "../browse-scope.ts";
+
+describe("isAllowedBrowsePath", () => {
+  const devRoot = "/Users/alice/dev";
+  const home = "/Users/alice";
+
+  test("allows devRoot itself", () => {
+    assert.equal(
+      isAllowedBrowsePath("/Users/alice/dev", { devRoot, home, additionalRoots: [] }),
+      true,
+    );
+  });
+
+  test("allows children of devRoot", () => {
+    assert.equal(
+      isAllowedBrowsePath("/Users/alice/dev/proj-a/src", { devRoot, home, additionalRoots: [] }),
+      true,
+    );
+  });
+
+  test("allows the direct parent of devRoot", () => {
+    assert.equal(
+      isAllowedBrowsePath("/Users/alice", { devRoot, home, additionalRoots: [] }),
+      true,
+    );
+  });
+
+  test("allows the user's home directory even when not the parent of devRoot", () => {
+    const dr = "/opt/dev";
+    assert.equal(
+      isAllowedBrowsePath("/Users/alice", { devRoot: dr, home, additionalRoots: [] }),
+      true,
+    );
+  });
+
+  test("allows arbitrary descendants of home", () => {
+    assert.equal(
+      isAllowedBrowsePath("/Users/alice/Documents/Workspaces", { devRoot, home, additionalRoots: [] }),
+      true,
+    );
+  });
+
+  test("allows additional roots (e.g. /Volumes on macOS)", () => {
+    assert.equal(
+      isAllowedBrowsePath("/Volumes/ExtDisk/projects", {
+        devRoot,
+        home,
+        additionalRoots: ["/Volumes"],
+      }),
+      true,
+    );
+  });
+
+  test("rejects unrelated absolute paths", () => {
+    assert.equal(
+      isAllowedBrowsePath("/etc/passwd", { devRoot, home, additionalRoots: [] }),
+      false,
+    );
+  });
+
+  test("rejects paths that share a prefix string but are not a path child", () => {
+    // /Users/alice-evil is not under /Users/alice — guard against startsWith pitfalls
+    assert.equal(
+      isAllowedBrowsePath("/Users/alice-evil/secret", { devRoot, home, additionalRoots: [] }),
+      false,
+    );
+  });
+});
+
+describe("getAdditionalRoots", () => {
+  test("includes /Volumes on darwin (macOS)", () => {
+    const roots = getAdditionalRoots("darwin", () => true);
+    assert.ok(roots.includes("/Volumes"), `expected /Volumes in ${JSON.stringify(roots)}`);
+  });
+
+  test("includes Linux mount points when they exist", () => {
+    const roots = getAdditionalRoots("linux", (p) => p === "/media" || p === "/mnt");
+    assert.ok(roots.includes("/media"));
+    assert.ok(roots.includes("/mnt"));
+    assert.ok(!roots.includes("/run/media"));
+  });
+
+  test("returns an empty array on win32 (drive letters handled separately)", () => {
+    assert.deepEqual(getAdditionalRoots("win32", () => true), []);
+  });
+
+  test("skips roots that do not exist", () => {
+    const roots = getAdditionalRoots("darwin", () => false);
+    assert.deepEqual(roots, []);
+  });
+});

--- a/web/lib/__tests__/preferences-route.test.ts
+++ b/web/lib/__tests__/preferences-route.test.ts
@@ -2,7 +2,7 @@ import { describe, test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 // Use a temporary GSD_HOME so the preferences route reads from a known path.
 // MUST be set BEFORE importing the route module (webPreferencesPath is module-scope).
@@ -11,45 +11,82 @@ process.env.GSD_HOME = tmpHome;
 
 const { GET } = await import("../../app/api/preferences/route.ts");
 
-after(() => {
-  rmSync(tmpHome, { recursive: true, force: true });
-  delete process.env.GSD_HOME;
-});
-
 function writePrefs(prefs: Record<string, unknown>) {
   mkdirSync(tmpHome, { recursive: true });
   writeFileSync(join(tmpHome, "web-preferences.json"), JSON.stringify(prefs), "utf-8");
 }
 
-describe("GET /api/preferences — launchCwd propagation (#6344)", () => {
+function writeRawPrefs(raw: string) {
+  mkdirSync(tmpHome, { recursive: true });
+  writeFileSync(join(tmpHome, "web-preferences.json"), raw, "utf-8");
+}
+
+function withLaunchCwd<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
+  const prev = process.env.GSD_WEB_PROJECT_CWD;
+  if (value === undefined) delete process.env.GSD_WEB_PROJECT_CWD;
+  else process.env.GSD_WEB_PROJECT_CWD = value;
+  return fn().finally(() => {
+    if (prev === undefined) delete process.env.GSD_WEB_PROJECT_CWD;
+    else process.env.GSD_WEB_PROJECT_CWD = prev;
+  });
+}
+
+describe("GET /api/preferences — launchCwd propagation", () => {
   before(() => {
     writePrefs({ devRoot: "/Users/alice/dev", lastActiveProject: "/Users/alice/dev/foo" });
   });
 
+  after(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+    delete process.env.GSD_HOME;
+  });
+
   test("includes launchCwd from GSD_WEB_PROJECT_CWD when set", async () => {
-    const prev = process.env.GSD_WEB_PROJECT_CWD;
-    process.env.GSD_WEB_PROJECT_CWD = "/Users/alice/dev/launched-project";
-    try {
+    await withLaunchCwd("/Users/alice/dev/launched-project", async () => {
       const res = await GET();
       const body = (await res.json()) as Record<string, unknown>;
       assert.equal(body.launchCwd, "/Users/alice/dev/launched-project");
       assert.equal(body.devRoot, "/Users/alice/dev");
       assert.equal(body.lastActiveProject, "/Users/alice/dev/foo");
-    } finally {
-      if (prev === undefined) delete process.env.GSD_WEB_PROJECT_CWD;
-      else process.env.GSD_WEB_PROJECT_CWD = prev;
-    }
+    });
+  });
+
+  test("normalizes launchCwd (trailing slash, redundant segments)", async () => {
+    await withLaunchCwd("/Users/alice/dev/foo/./", async () => {
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.launchCwd, resolve("/Users/alice/dev/foo"));
+    });
   });
 
   test("launchCwd is null when GSD_WEB_PROJECT_CWD is unset", async () => {
-    const prev = process.env.GSD_WEB_PROJECT_CWD;
-    delete process.env.GSD_WEB_PROJECT_CWD;
-    try {
+    await withLaunchCwd(undefined, async () => {
       const res = await GET();
       const body = (await res.json()) as Record<string, unknown>;
       assert.equal(body.launchCwd, null);
+    });
+  });
+
+  test("launchCwd is null when GSD_WEB_PROJECT_CWD is empty string", async () => {
+    await withLaunchCwd("", async () => {
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.launchCwd, null);
+    });
+  });
+
+  test("still returns launchCwd when preferences file is corrupt", async () => {
+    writeRawPrefs("{not valid json");
+    try {
+      await withLaunchCwd("/Users/alice/dev/recovered", async () => {
+        const res = await GET();
+        const body = (await res.json()) as Record<string, unknown>;
+        assert.equal(body.launchCwd, "/Users/alice/dev/recovered");
+        assert.equal(body.devRoot, undefined);
+      });
     } finally {
-      if (prev !== undefined) process.env.GSD_WEB_PROJECT_CWD = prev;
+      // Restore valid prefs for any later tests in the suite.
+      writePrefs({ devRoot: "/Users/alice/dev", lastActiveProject: "/Users/alice/dev/foo" });
     }
   });
 });

--- a/web/lib/__tests__/preferences-route.test.ts
+++ b/web/lib/__tests__/preferences-route.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Use a temporary GSD_HOME so the preferences route reads from a known path.
+// MUST be set BEFORE importing the route module (webPreferencesPath is module-scope).
+const tmpHome = mkdtempSync(join(tmpdir(), "gsd-prefs-test-"));
+process.env.GSD_HOME = tmpHome;
+
+const { GET } = await import("../../app/api/preferences/route.ts");
+
+after(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.GSD_HOME;
+});
+
+function writePrefs(prefs: Record<string, unknown>) {
+  mkdirSync(tmpHome, { recursive: true });
+  writeFileSync(join(tmpHome, "web-preferences.json"), JSON.stringify(prefs), "utf-8");
+}
+
+describe("GET /api/preferences — launchCwd propagation (#6344)", () => {
+  before(() => {
+    writePrefs({ devRoot: "/Users/alice/dev", lastActiveProject: "/Users/alice/dev/foo" });
+  });
+
+  test("includes launchCwd from GSD_WEB_PROJECT_CWD when set", async () => {
+    const prev = process.env.GSD_WEB_PROJECT_CWD;
+    process.env.GSD_WEB_PROJECT_CWD = "/Users/alice/dev/launched-project";
+    try {
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.launchCwd, "/Users/alice/dev/launched-project");
+      assert.equal(body.devRoot, "/Users/alice/dev");
+      assert.equal(body.lastActiveProject, "/Users/alice/dev/foo");
+    } finally {
+      if (prev === undefined) delete process.env.GSD_WEB_PROJECT_CWD;
+      else process.env.GSD_WEB_PROJECT_CWD = prev;
+    }
+  });
+
+  test("launchCwd is null when GSD_WEB_PROJECT_CWD is unset", async () => {
+    const prev = process.env.GSD_WEB_PROJECT_CWD;
+    delete process.env.GSD_WEB_PROJECT_CWD;
+    try {
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.launchCwd, null);
+    } finally {
+      if (prev !== undefined) process.env.GSD_WEB_PROJECT_CWD = prev;
+    }
+  });
+});

--- a/web/lib/browse-scope.ts
+++ b/web/lib/browse-scope.ts
@@ -42,7 +42,9 @@ function isWithin(child: string, parent: string): boolean {
 
 /**
  * Return additional allowed roots beyond `devRoot` and `$HOME`, based on platform.
- * `exists` is injected so the function stays pure and testable.
+ * `exists` is injected so the function stays pure and testable. `username` is
+ * used on Linux to scope `/run/media/<user>` to the current user rather than
+ * exposing all users' mounted media.
  *
  *  - darwin: `/Volumes`
  *  - linux:  `/media`, `/mnt` (and `/run/media/<username>` when a username is given)

--- a/web/lib/browse-scope.ts
+++ b/web/lib/browse-scope.ts
@@ -1,0 +1,70 @@
+import { resolve, dirname, sep } from "node:path";
+
+export interface BrowseScopeOptions {
+  /** Configured devRoot (already resolved to an absolute path). */
+  devRoot: string;
+  /** Absolute path to the user's home directory. */
+  home: string;
+  /** Additional allowed roots (e.g. `/Volumes` on macOS, `/media` on Linux). */
+  additionalRoots: string[];
+}
+
+/**
+ * Return true if `target` is inside any of the allowed scope roots.
+ *
+ * Allowed roots are:
+ *   1. devRoot and all of its descendants
+ *   2. the direct parent of devRoot (one level up, for navigation context)
+ *   3. the user's home directory and all of its descendants
+ *   4. each entry of `additionalRoots` and its descendants
+ *
+ * The check uses path-aware matching (boundary-aware), so `/Users/alice-evil`
+ * is NOT treated as a child of `/Users/alice`.
+ */
+export function isAllowedBrowsePath(target: string, opts: BrowseScopeOptions): boolean {
+  const t = resolve(target);
+  const devRoot = resolve(opts.devRoot);
+  const roots = [devRoot, resolve(opts.home), ...opts.additionalRoots.map((r) => resolve(r))];
+  for (const root of roots) {
+    if (isWithin(t, root)) return true;
+  }
+  // Allow the immediate parent of devRoot so the picker can show devRoot's siblings.
+  if (t === dirname(devRoot)) return true;
+  return false;
+}
+
+/** Path-aware "is `child` equal to or inside `parent`" check. */
+function isWithin(child: string, parent: string): boolean {
+  if (child === parent) return true;
+  const withSep = parent.endsWith(sep) ? parent : parent + sep;
+  return child.startsWith(withSep);
+}
+
+/**
+ * Return additional allowed roots beyond `devRoot` and `$HOME`, based on platform.
+ * `exists` is injected so the function stays pure and testable.
+ *
+ *  - darwin: `/Volumes`
+ *  - linux:  `/media`, `/mnt` (and `/run/media/<username>` when a username is given)
+ *  - win32:  every drive letter `A:\`..`Z:\` whose root currently exists
+ */
+export function getAdditionalRoots(
+  platform: NodeJS.Platform | string,
+  exists: (path: string) => boolean,
+  username?: string,
+): string[] {
+  if (platform === "win32") {
+    const drives: string[] = [];
+    for (let code = 65; code <= 90; code++) {
+      drives.push(`${String.fromCharCode(code)}:\\`);
+    }
+    return drives.filter((d) => exists(d));
+  }
+  const candidates: string[] =
+    platform === "darwin"
+      ? ["/Volumes"]
+      : platform === "linux"
+        ? ["/media", "/mnt", username ? `/run/media/${username}` : ""].filter(Boolean)
+        : [];
+  return candidates.filter((p) => exists(p));
+}


### PR DESCRIPTION
## TL;DR

**What:** Auto-select the project directory the user launched `gsd --web` from, and widen the directory picker so users can recover from a misconfigured `devRoot`.
**Why:** `GSD_WEB_PROJECT_CWD` was ignored by every API route that drives project selection, and on macOS the picker only allowed one step up from `devRoot` with no path input.
**How:** Surface `launchCwd` from `/api/preferences`, auto-`switchProject` on bootstrap, and refactor the picker scope check around a path-boundary-aware helper plus a free-form path input.

## What

- `web/app/api/preferences/route.ts` — `GET` now returns `launchCwd` derived from `process.env.GSD_WEB_PROJECT_CWD` (normalized via `resolve()`), in addition to the existing persisted preferences.
- `web/components/gsd/app-shell.tsx` — `ProjectAwareWorkspace` fetches `/api/preferences` on first mount and calls `manager.switchProject(launchCwd)` when present. Guarded by a `useRef` sentinel so React StrictMode's double-invoke cannot trigger two parallel `switchProject` calls.
- `web/lib/browse-scope.ts` (new) — pure helpers `isAllowedBrowsePath` and `getAdditionalRoots`. The scope check uses path-boundary-aware matching (so `/Users/alice-evil` is not treated as a child of `/Users/alice`). `getAdditionalRoots` takes platform, an injected `exists` predicate, and an optional `username` so `/run/media/<user>` stays scoped to the current user instead of exposing all users' mounted media.
- `web/app/api/browse-directories/route.ts` — uses the helper. Scope now includes `$HOME` on every platform, `/Volumes` on macOS, `/media`/`/mnt`/`/run/media/<user>` on Linux, and existing drive letters on Windows.
- `web/components/gsd/projects-view.tsx` — `FolderPickerDialog`'s current-path display is now an editable input that, on submit, browses through the existing `?path=` endpoint. Internal state is cleared on close so the next open does not flash stale data.
- `web/lib/__tests__/browse-scope.test.ts`, `web/lib/__tests__/preferences-route.test.ts` (new) — coverage for the scope helper, the `/run/media/<user>` per-user scoping, win32 drive enumeration, `launchCwd` propagation, path normalization, empty-string env, and the corrupt-prefs-file fallback path.

## Why

Closes #6344.

The CLI did the right thing end-to-end up to the server process: `cli-web-branch.js` resolves the launch CWD correctly and `web-mode.js` exports it as `GSD_WEB_PROJECT_CWD`. But only the terminal routes ever read that variable — `/api/preferences`, `/api/projects`, `/api/switch-root` did not — so the client always bootstrapped on `lastActiveProject` (or alphabetic fallback) and the launch CWD was silently dropped.

Recovery via the directory picker was effectively impossible on macOS: the scope check allowed only `devRoot` itself and exactly one step up, with no removable-mount root, no `$HOME`, and no free-form path input.

## How

**Fix #1 — propagate launch CWD.** `/api/preferences` is the endpoint the client already calls first, so surfacing `launchCwd` there avoids a new round-trip and keeps the existing response cacheable as `no-store`. The client prefers `launchCwd` over `lastActiveProject` by calling `switchProject` before the `ProjectSelectionGate` ever renders. StrictMode double-mount is handled with a `useRef` sentinel so the first invocation wins.

**Fix #2 — broaden scope and add free-form input.** The scope check was extracted into a pure `isAllowedBrowsePath` helper so it can be unit-tested without filesystem setup. Path-boundary-aware matching (via `sep`) prevents the prefix-confusion bug where `/Users/alice-evil` would have matched `/Users/alice` under naive `startsWith`. The picker's previous read-only path display is now an `<input>` element backed by the same `?path=` endpoint the API already supported; nothing new on the wire.

## AI disclosure

This PR was AI-assisted. All changes were reviewed and verified locally; tests were written first and the implementation iterated against them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects auto-select from a derived launch directory when available.
  * Folder picker accepts manual path entry.
  * Quick-access now surfaces additional filesystem roots (macOS, Linux, Windows) when browsing root areas.

* **Bug Fixes**
  * Stronger path canonicalization and scope checks prevent symlink escapes and avoid false-positive prefix matches.
  * Preferences route reliably returns the derived launch directory even when prefs file is missing or corrupt.

* **Tests**
  * Added tests covering browse scope, symlink handling, and preferences launchCwd behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->