### PR TITLE
fix(pi-tui): prevent short repaint scrollback pollution

### DIFF
--- a/packages/pi-tui/src/components/__tests__/editor.test.ts
+++ b/packages/pi-tui/src/components/__tests__/editor.test.ts
@@ -1,3 +1,5 @@
+// GSD-2 + packages/pi-tui/src/components/__tests__/editor.test.ts - Editor component regression tests.
+
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
@@ -60,6 +62,41 @@ describe("Editor", () => {
 		const rendered = editor.render(40).join("\n");
 
 		assert.ok(rendered.includes(CURSOR_MARKER));
+	});
+
+	it("keeps autocomplete height stable while suggestions shrink", () => {
+		const editor = new Editor(new TUI(makeTerminal()), theme);
+		editor.focused = true;
+		editor.setText("/");
+
+		let autocompleteRows = [
+			"/gsd",
+			"/git",
+			"/grep",
+			"/go",
+			"/group",
+			"(1/6)",
+		];
+		(editor as any).autocompleteState = "regular";
+		(editor as any).autocompleteList = { render: () => autocompleteRows };
+
+		const openLength = editor.render(40).length;
+
+		autocompleteRows = ["/gsd"];
+		const filteredLength = editor.render(40).length;
+
+		assert.equal(
+			filteredLength,
+			openLength,
+			"autocomplete should reserve rows during a completion session so filtering does not resize the TUI",
+		);
+
+		(editor as any).cancelAutocomplete();
+		const closedLength = editor.render(40).length;
+		assert.ok(
+			closedLength < openLength,
+			"autocomplete row reservation should clear when the completion session closes",
+		);
 	});
 
 	it("maps kitty keypad digits to plain editor text", () => {

--- a/packages/pi-tui/src/components/editor.ts
+++ b/packages/pi-tui/src/components/editor.ts
@@ -1,3 +1,5 @@
+// GSD-2 + packages/pi-tui/src/components/editor.ts - Multi-line editor with autocomplete rendering.
+
 import type { AutocompleteProvider, CombinedAutocompleteProvider } from "../autocomplete.js";
 import { getEditorKeybindings } from "../keybindings.js";
 import { decodeKittyPrintable, matchesKey } from "../keys.js";
@@ -159,6 +161,7 @@ export class Editor implements Component, Focusable {
 	private autocompleteState: "regular" | "force" | null = null;
 	private autocompletePrefix: string = "";
 	private autocompleteMaxVisible: number = 5;
+	private autocompleteRenderedRows: number = 0;
 
 	// Debounce for @ file autocomplete to prevent blocking the event loop
 	// with synchronous fuzzyFind calls on every keystroke
@@ -230,6 +233,7 @@ export class Editor implements Component, Focusable {
 		const newMaxVisible = Number.isFinite(maxVisible) ? Math.max(3, Math.min(20, Math.floor(maxVisible))) : 5;
 		if (this.autocompleteMaxVisible !== newMaxVisible) {
 			this.autocompleteMaxVisible = newMaxVisible;
+			this.autocompleteRenderedRows = Math.min(this.autocompleteRenderedRows, this.autocompleteMaxVisible + 1);
 			this.tui.requestRender();
 		}
 	}
@@ -446,10 +450,15 @@ export class Editor implements Component, Focusable {
 		// Add autocomplete list if active
 		if (this.autocompleteState && this.autocompleteList) {
 			const autocompleteResult = this.autocompleteList.render(contentWidth);
+			this.autocompleteRenderedRows = Math.max(this.autocompleteRenderedRows, autocompleteResult.length);
+			const reservedRows = Math.min(this.autocompleteRenderedRows, this.autocompleteMaxVisible + 1);
 			for (const line of autocompleteResult) {
 				const lineWidth = visibleWidth(line);
 				const linePadding = " ".repeat(Math.max(0, contentWidth - lineWidth));
 				result.push(`${leftPadding}${line}${linePadding}${rightPadding}`);
+			}
+			for (let i = autocompleteResult.length; i < reservedRows; i++) {
+				result.push(`${leftPadding}${" ".repeat(contentWidth)}${rightPadding}`);
 			}
 		}
 
@@ -2096,6 +2105,7 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 		this.autocompleteState = null;
 		this.autocompleteList = undefined;
 		this.autocompletePrefix = "";
+		this.autocompleteRenderedRows = 0;
 		this.clearAutocompleteDebounce();
 	}
 

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -720,6 +720,31 @@ export class TUI extends Container {
 			fs.appendFileSync(logPath, msg);
 		};
 
+		const repaintBottomAnchoredShortBlock = (): void => {
+			const startRow = Math.max(1, height - Math.max(1, newLines.length) + 1);
+			let buffer = this.useSynchronizedOutput ? "\x1b[?2026h" : "";
+			buffer += `\x1b[${startRow};1H`;
+			for (let i = 0; i < newLines.length; i++) {
+				if (i > 0) buffer += "\r\n";
+				buffer += "\x1b[2K";
+				let line = newLines[i];
+				if (!isImageLine(line) && visibleWidth(line) > width) {
+					line = truncateToWidth(line, width);
+				}
+				buffer += line;
+			}
+			if (this.useSynchronizedOutput) buffer += "\x1b[?2026l";
+			this.terminal.write(buffer);
+			this.cursorRow = Math.max(0, newLines.length - 1);
+			this.hardwareCursorRow = this.cursorRow;
+			this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
+			this.previousViewportTop = getViewportTop(this.maxLinesRendered);
+			this.positionHardwareCursor(cursorPos, newLines.length);
+			this.previousLines = newLines;
+			this.previousWidth = width;
+			this.previousHeight = height;
+		};
+
 		// First render - just output everything without clearing (assumes clean screen)
 		if (this.previousLines.length === 0 && !widthChanged && !heightChanged) {
 			logRedraw("first render");
@@ -846,6 +871,11 @@ export class TUI extends Container {
 			this.positionHardwareCursor(cursorPos, newLines.length);
 			this.previousViewportTop = getViewportTop(this.maxLinesRendered);
 			this.previousHeight = height;
+			return;
+		}
+
+		if (appendedLines && this.previousLines.length <= height && newLines.length <= height) {
+			repaintBottomAnchoredShortBlock();
 			return;
 		}
 

--- a/src/tests/tui-pin-to-bottom-on-clear.test.ts
+++ b/src/tests/tui-pin-to-bottom-on-clear.test.ts
@@ -101,9 +101,18 @@ describe("TUI pin-to-bottom on clear", () => {
     (tui as any).doRender();
 
     const frame = terminal.writtenData.join("");
+    const frameWithoutSync = frame.replace(/\x1b\[\?2026[hl]/g, "");
     assert.ok(
       !frame.includes("\x1b[2J"),
       `expected append to avoid full-screen clear to reduce flicker, got ${JSON.stringify(frame)}`,
+    );
+    assert.ok(
+      frameWithoutSync.startsWith("\x1b[17;1H"),
+      `expected short append to repaint from bottom anchor row 17 instead of scrolling, got ${JSON.stringify(frame)}`,
+    );
+    assert.ok(
+      !frameWithoutSync.startsWith("\r\n"),
+      `short bottom-anchored appends must not start with a newline that scrolls terminal history, got ${JSON.stringify(frame)}`,
     );
     assert.ok(
       frame.includes("line 4"),


### PR DESCRIPTION
## TL;DR

**What:** Prevent short bottom-anchored TUI repaints and slash autocomplete filtering from polluting terminal scrollback.
**Why:** Typing `/gsd` could leave a full-screen frame per keypress in normal terminal history.
**How:** Repaint short appended frames from an absolute bottom anchor, reserve autocomplete rows while completion is open, and add regression tests for both paths.

## What

This updates the pi-tui renderer and editor autocomplete behavior:

- Short bottom-anchored frame growth now repaints from an absolute anchor row instead of advancing with a leading newline.
- Autocomplete keeps its rendered row count stable during an active completion session when suggestions shrink.
- Regression tests cover the scrollback-producing append path and autocomplete shrink behavior.

## Why

The terminal UI runs in the normal buffer. When a short bottom-anchored frame grew while the cursor was already on the bottom row, the differential renderer emitted a leading `\r\n`. That scrolled the terminal and left prior full-screen TUI frames in scrollback. Slash autocomplete made this easy to hit because typing `/`, `/g`, `/gs`, `/gsd` changes the rendered editor/autocomplete height.

## How

The renderer now detects short visible frame appends and repaints the whole bottom-anchored block in place using absolute cursor positioning and line clears. The editor also remembers the largest autocomplete height seen during the current completion session and pads shorter suggestion renders with blank rows until autocomplete closes.

## Validation

- Red check: applying only the new tests to `upstream/main` failed as expected with 2 failing tests.
- Targeted: `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-tui/src/__tests__/tui.test.ts packages/pi-tui/src/components/__tests__/editor.test.ts src/tests/tui-pin-to-bottom-on-clear.test.ts src/tests/tui-autocomplete-ghost-lines.test.ts src/tests/tui-content-cursor-desync.test.ts` — 26 passed.
- Full preflight: `npm run verify:pr` — 9464 passed, 0 failed, 9 skipped.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

## Contribution notes

Prepared with AI assistance as required by CONTRIBUTING.md. No tool is credited as author or co-author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Autocomplete dropdown now maintains consistent vertical size across renders while suggestions list adjusts dynamically.
  * Optimized terminal rendering to reduce unnecessary full-screen repaints when content fits within viewport.

* **Tests**
  * Added regression test verifying autocomplete row height stability and proper cleanup when autocomplete is closed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->