### PR TITLE
fix(tui): clamp Input.yankPop deletion index

### DIFF
--- a/packages/pi-tui/src/__tests__/tui.test.ts
+++ b/packages/pi-tui/src/__tests__/tui.test.ts
@@ -72,6 +72,30 @@ describe("TUI", () => {
 		assert.ok(!withoutSyncWrapper.startsWith("\x1b[1A\r"), "editor diff must not move above the cursor row");
 	});
 
+	it("redraws to erase a dismissed overlay even when base output is unchanged", () => {
+		// Regression: doRender() short-circuits when component output is
+		// byte-identical to the previous frame. If the previous frame drew an
+		// overlay, an identical next frame with no overlay must still redraw —
+		// otherwise the dismissed overlay is never erased from the screen.
+		const writes: string[] = [];
+		const tui = new TUI(makeTerminal(writes));
+		tui.addChild({ render: () => ["base line one", "base line two"], invalidate() {} });
+		const anyTui = tui as any;
+
+		anyTui.doRender();
+		const overlay = tui.showOverlay({ render: () => ["OVERLAY"], invalidate() {} });
+		anyTui.doRender();
+		const writesBeforeHide = writes.length;
+
+		overlay.hide();
+		anyTui.doRender();
+
+		assert.ok(
+			writes.length > writesBeforeHide,
+			"dismissing an overlay must trigger a redraw to erase it, even when the base component output is byte-identical",
+		);
+	});
+
 	it("omits synchronized-output wrappers when PI_DISABLE_SYNC_OUTPUT is enabled", () => {
 		const previous = process.env.PI_DISABLE_SYNC_OUTPUT;
 		process.env.PI_DISABLE_SYNC_OUTPUT = "1";

--- a/packages/pi-tui/src/components/input.ts
+++ b/packages/pi-tui/src/components/input.ts
@@ -334,10 +334,13 @@ export class Input implements Component, Focusable {
 
 		this.pushUndo();
 
-		// Delete the previously yanked text (still at end of ring before rotation)
+		// Delete the previously yanked text (still at end of ring before rotation).
+		// Clamp the start index: a negative arg to slice() counts from the end,
+		// which would silently corrupt the value rather than delete nothing.
 		const prevText = this.killRing.peek() || "";
-		this.value = this.value.slice(0, this.cursor - prevText.length) + this.value.slice(this.cursor);
-		this.cursor -= prevText.length;
+		const deleteFrom = Math.max(0, this.cursor - prevText.length);
+		this.value = this.value.slice(0, deleteFrom) + this.value.slice(this.cursor);
+		this.cursor = deleteFrom;
 
 		// Rotate and insert new entry
 		this.killRing.rotate();

--- a/packages/pi-tui/src/components/markdown.ts
+++ b/packages/pi-tui/src/components/markdown.ts
@@ -51,6 +51,12 @@ interface InlineStyleContext {
 	stylePrefix: string;
 }
 
+/** A rendered list-item line. `nested` lines are already fully indented. */
+interface ListItemLine {
+	text: string;
+	nested: boolean;
+}
+
 export class Markdown implements Component {
 	private text: string;
 	private paddingX: number; // Left/right padding
@@ -537,30 +543,25 @@ export class Markdown implements Component {
 			const itemLines = this.renderListItem(item.tokens || [], depth, styleContext);
 
 			if (itemLines.length > 0) {
-				// First line - check if it's a nested list
-				// A nested list will start with indent (spaces) followed by cyan bullet
-				const firstLine = itemLines[0];
-				const isNestedList = /^\s+\x1b\[36m[-\d]/.test(firstLine); // starts with spaces + cyan + bullet char
-
-				if (isNestedList) {
-					// This is a nested list, just add it as-is (already has full indent)
-					lines.push(firstLine);
+				// First line: nested-list lines are already fully indented and
+				// bulleted by the recursive renderList call — add them as-is.
+				const first = itemLines[0];
+				if (first.nested) {
+					lines.push(first.text);
 				} else {
 					// Regular text content - add indent and bullet
-					lines.push(indent + this.theme.listBullet(bullet) + firstLine);
+					lines.push(indent + this.theme.listBullet(bullet) + first.text);
 				}
 
 				// Rest of the lines
 				for (let j = 1; j < itemLines.length; j++) {
-					const line = itemLines[j];
-					const isNestedListLine = /^\s+\x1b\[36m[-\d]/.test(line); // starts with spaces + cyan + bullet char
-
-					if (isNestedListLine) {
+					const entry = itemLines[j];
+					if (entry.nested) {
 						// Nested list line - already has full indent
-						lines.push(line);
+						lines.push(entry.text);
 					} else {
 						// Regular content - add parent indent + 2 spaces for continuation
-						lines.push(`${indent}  ${line}`);
+						lines.push(`${indent}  ${entry.text}`);
 					}
 				}
 			} else {
@@ -572,38 +573,45 @@ export class Markdown implements Component {
 	}
 
 	/**
-	 * Render list item tokens, handling nested lists
-	 * Returns lines WITHOUT the parent indent (renderList will add it)
+	 * Render list item tokens, handling nested lists.
+	 * Returns lines WITHOUT the parent indent (renderList will add it).
+	 * `nested: true` marks lines produced by a recursive renderList call —
+	 * they are already fully indented/bulleted and must be passed through
+	 * verbatim. This replaces a fragile ANSI-color regex with structural info.
 	 */
-	private renderListItem(tokens: Token[], parentDepth: number, styleContext?: InlineStyleContext): string[] {
-		const lines: string[] = [];
+	private renderListItem(
+		tokens: Token[],
+		parentDepth: number,
+		styleContext?: InlineStyleContext,
+	): ListItemLine[] {
+		const lines: ListItemLine[] = [];
 
 		for (const token of tokens) {
 			if (token.type === "list") {
 				// Nested list - render with one additional indent level
 				// These lines will have their own indent, so we just add them as-is
 				const nestedLines = this.renderList(token as any, parentDepth + 1, styleContext);
-				for (let j = 0; j < nestedLines.length; j++) lines.push(nestedLines[j]);
+				for (let j = 0; j < nestedLines.length; j++) lines.push({ text: nestedLines[j], nested: true });
 			} else if (token.type === "text") {
 				// Text content (may have inline tokens)
 				const text =
 					token.tokens && token.tokens.length > 0
 						? this.renderInlineTokens(token.tokens, styleContext)
 						: token.text || "";
-				lines.push(text);
+				lines.push({ text, nested: false });
 			} else if (token.type === "paragraph") {
 				// Paragraph in list item
 				const text = this.renderInlineTokens(token.tokens || [], styleContext);
-				lines.push(text);
+				lines.push({ text, nested: false });
 			} else if (token.type === "code") {
 				// Code block in list item
 				const codeLines = this.renderCodeBlock(token.text, token.lang);
-				for (let j = 0; j < codeLines.length; j++) lines.push(codeLines[j]);
+				for (let j = 0; j < codeLines.length; j++) lines.push({ text: codeLines[j], nested: false });
 			} else {
 				// Other token types - try to render as inline
 				const text = this.renderInlineTokens([token], styleContext);
 				if (text) {
-					lines.push(text);
+					lines.push({ text, nested: false });
 				}
 			}
 		}

--- a/packages/pi-tui/src/components/select-list.ts
+++ b/packages/pi-tui/src/components/select-list.ts
@@ -149,6 +149,12 @@ export class SelectList implements Component {
 
 	handleInput(keyData: string): void {
 		const kb = getEditorKeybindings();
+		// Nothing to navigate or select when the filter matches no items.
+		// Without this guard selectUp would set selectedIndex to -1.
+		if (this.filteredItems.length === 0) {
+			if (kb.matches(keyData, "selectCancel") && this.onCancel) this.onCancel();
+			return;
+		}
 		// Up arrow - wrap to bottom when at top
 		if (kb.matches(keyData, "selectUp")) {
 			this.selectedIndex = this.selectedIndex === 0 ? this.filteredItems.length - 1 : this.selectedIndex - 1;

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -264,6 +264,10 @@ export class TUI extends Container {
 	private readonly useSynchronizedOutput =
 		process.platform !== "win32" && process.env.PI_DISABLE_SYNC_OUTPUT !== "1";
 	private _lastRenderedComponents: string[] | null = null;
+	// Whether the previous frame composited overlays onto the screen. When true,
+	// the next frame must redraw even if component output is byte-identical —
+	// otherwise a dismissed overlay is never erased from the terminal.
+	private _lastFrameHadOverlays = false;
 
 	// Overlay stack for modal components rendered on top of base content
 	private focusOrderCounter = 0;
@@ -653,10 +657,18 @@ export class TUI extends Container {
 
 		// Skip ALL post-processing if component output is unchanged.
 		// Container.render() returns the same array reference when stable.
-		if (newLines === this._lastRenderedComponents && this.overlayStack.length === 0) {
+		// Guard with _lastFrameHadOverlays: if the previous frame drew an
+		// overlay, the screen still shows it, so we must redraw to erase it
+		// even when the base component output is identical.
+		if (
+			newLines === this._lastRenderedComponents &&
+			this.overlayStack.length === 0 &&
+			!this._lastFrameHadOverlays
+		) {
 			return;
 		}
 		this._lastRenderedComponents = newLines;
+		this._lastFrameHadOverlays = this.overlayStack.length > 0;
 
 		// Composite overlays into the rendered lines (before differential compare)
 		if (this.overlayStack.length > 0) {


### PR DESCRIPTION
## Stack — TUI Phase 0 (5/8)

Builds on #6359. Stacked branch — diff also includes commits below it until they merge.

## Problem

`yankPop()` computed the deletion start as `cursor - prevText.length` with no floor. A negative index passed to `String.slice()` counts from the end of the string, so an underflow would silently corrupt the input value rather than delete nothing.

## Fix

Clamp the deletion start index to 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cursor position errors when using text yank operations in input fields.
  * Improved nested list rendering reliability in markdown content.
  * Fixed select list behavior when search filters return no results.
  * Fixed dismissed overlays persisting on screen.

* **Documentation**
  * Added comprehensive audit documentation detailing identified issues and remediation plan.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->