### PR TITLE
chore(tui): add open-surface demo harness for ADR-0019

### DIFF
--- a/docs/dev/ADR-019-unify-tui-style-system.md
+++ b/docs/dev/ADR-019-unify-tui-style-system.md
@@ -1,0 +1,172 @@
+<!-- Project/App: GSD-2 -->
+<!-- File Purpose: ADR for unifying TUI rendering on copy-clean content surfaces. -->
+
+# ADR-019: Unify the TUI Style System Around Copy-Clean Content Surfaces
+
+**Status:** Accepted
+**Date:** 2026-05-18
+**Author:** TUI audit (Phase 2)
+**Related:** `docs/tui-audit.md` (Phase 2)
+
+## Context
+
+Two problems converge here.
+
+**1. Users cannot cleanly copy TUI output.** Terminal text selection is the
+terminal's job, not the application's — when a user selects text, the
+terminal copies every character on those lines, including any border or
+padding the app drew. Today every content surface (message turns, tool
+output, bash output, summaries) is wrapped in a box: a vertical `│ ` or rail
+`┃ ` prefixes every body line. Users have complained that copying output
+means hand-stripping those prefixes and the border rows. This is a real,
+recurring usability defect.
+
+**2. The style system is fragmented.** The TUI draws bordered/padded
+surfaces through **four independent border implementations**:
+
+1. `packages/pi-tui/src/style.ts` — `TerminalStyle`, an immutable builder.
+   Border modes `none / rule / single / rounded / heavy / minimal`, density,
+   tone, titles. Framework-agnostic (takes color functions). Consumers:
+   `tool-execution.ts`, `chat-frame.ts`, `adaptive-layout.ts`.
+2. `tui-style-kit.ts` — `roundedPanel()` + `badge` / `keyValue` /
+   `padRight` / `alignRight` / `breakpoint`. Consumers: `adaptive-layout.ts`,
+   `transcript-design.ts`.
+3. `transcript-design.ts` — hand-rolled `cardRow()` plus the
+   `renderTranscriptCard` / `renderToolLineCard` / `renderCommandCard` family
+   and the `renderUserRail` / `renderAssistantRail` rail renderers.
+   Consumers: `user-message`, `assistant-message`, `footer`,
+   `tool-execution`, `bash-execution`.
+4. `chat-frame.ts` — `renderChatFrame()`, a third hand-rolled rounded box.
+   Consumers: `skill-invocation-message`, `compaction-summary-message`.
+
+They overlap heavily and the dependency graph is tangled
+(`transcript-design.ts` imports `tui-style-kit.ts`; `chat-frame.ts` imports
+`style.ts`). On top of that, transcript messages use three incompatible
+container vocabularies — rail (`┃` + bg fill), framed (`╭╮╰╯`), and
+box-background — so adjacent components don't visually agree.
+
+Note: `TerminalStyle`'s existing `rule` mode is **not** copy-clean — it
+still prefixes body lines with `│ `. None of the four current
+implementations produce copy-clean output.
+
+## Decision
+
+### 1. Content surfaces are copy-clean
+
+Surfaces whose text users read and copy — **message turns, tool output,
+bash output, compaction/skill/branch summaries** — render with
+**horizontal-rule framing**:
+
+- A top rule line carrying the label/status: `─── bash · success ───────`.
+- Body lines with **zero leading characters** — no `│`, no `┃`, no left
+  padding glyphs. A body line contains only its content.
+- An optional bottom rule line.
+
+Selecting body lines then copies exactly that text. If a selection happens
+to include a rule line, it copies as a single row of dashes — harmless and
+easily dropped.
+
+The rail (`┃` prefix) and the box-background style are both **eliminated** —
+both put characters on every content line.
+
+### 2. One border primitive
+
+`TerminalStyle` (`pi-tui/src/style.ts`) is the **only** code permitted to
+draw borders, rules, and padding. It is the most complete implementation and
+belongs in the engine package (framework-agnostic, theme-decoupled).
+
+A new border mode — **`open`** — is added to `TerminalStyle`: top rule with
+optional title/right-title, body lines emitted with no prefix and no border
+column, optional bottom rule. (The existing `rule` mode is left as-is for
+any caller that still wants the `│ ` gutter, or removed if it has no
+remaining consumers after migration.)
+
+`tui-style-kit.ts`, the `transcript-design.ts` card renderers, and
+`chat-frame.ts` stop drawing borders themselves and delegate to
+`TerminalStyle`.
+
+### 3. One app-level vocabulary module
+
+`transcript-design.ts` becomes the single module pi-coding-agent components
+import for surface rendering. It binds theme tokens to `TerminalStyle` and
+exposes the two named surfaces below. `tui-style-kit.ts` is folded in and
+deleted; `chat-frame.ts` is deleted; `badge` / `keyValue` / `breakpoint`
+move into the vocabulary; generic helpers (`padRight` / `alignRight`) move
+to `pi-tui` utils.
+
+### 4. Two surfaces, chosen by role
+
+- **Open** — every content surface (message turns, tool/bash output,
+  summaries). Horizontal-rule framing, copy-clean, via `TerminalStyle`'s
+  `open` mode. Tool calls are content (an artifact a user reads and copies),
+  so they are Open, not bordered.
+- **Panel** — interactive UI only: dialogs, selectors, overlays. Keeps the
+  bordered `rounded` `TerminalStyle` treatment. Nobody copies a menu, so the
+  copy constraint does not apply; these are unchanged by this ADR.
+
+A component picks its surface by **what it is**, never by author preference.
+
+## Resolved decisions
+
+- **Tool calls are an Open content surface**, not bordered — they are read
+  and copied like any other output.
+- **Delineation is horizontal-rule framing** (top/bottom rules, no vertical
+  bars). Background-tint and indent-only were considered; rules win because
+  they are copy-clean *and* legible regardless of theme background contrast.
+- **Copy-clean rendering applies to content surfaces only.** Dialogs,
+  selectors, and overlays keep their bordered panels.
+- Panels (interactive) use `rounded` borders — the established house style.
+
+## Consequences
+
+**Positive**
+
+- Selecting and copying TUI output yields clean text — the reported defect
+  is fixed structurally, not per-component.
+- One place to fix any border/rule/padding/truncation bug.
+- New components have an unambiguous surface to conform to.
+- `pi-tui` keeps a clean, theme-agnostic primitive; theme binding lives in
+  exactly one app module.
+
+**Negative / risks**
+
+- Touches many files in one coherent effort — not a drive-by change.
+- Visual identity shifts: the transcript loses its boxes and rail in favour
+  of lighter rule-framed blocks. This is intentional but is a noticeable
+  redesign — capture before/after screenshots per migration step.
+- Vertical separation now relies on rules + blank-line rhythm rather than
+  enclosing boxes; the spacing rhythm must be deliberate or surfaces will
+  blur together. The consistency-pass step addresses this.
+- The rail's baked-in background fill disappears; any theme that leaned on it
+  for the user/assistant distinction now distinguishes turns by the header
+  rule label instead.
+
+## Implementation plan
+
+Seven steps, each an independent stacked PR. Steps are ordered so every PR
+leaves the TUI working.
+
+1. **Add the `open` border mode to `TerminalStyle`** (`pi-tui`). Top rule +
+   title, no body prefix, optional bottom rule. Unit-test that no body line
+   gains a leading character. Purely additive.
+2. **Add the vocabulary, no consumers yet.** In `transcript-design.ts`, add
+   `openSurface()` (built on `TerminalStyle.border("open")`) and keep
+   `panel()` for interactive UI. Additive — nothing calls `openSurface` yet.
+3. **Migrate `chat-frame.ts` consumers.** Point `skill-invocation-message`
+   and `compaction-summary-message` at `openSurface()`. Delete `chat-frame.ts`.
+4. **Re-base the card renderers.** Reimplement `renderTranscriptCard` /
+   `renderToolLineCard` / `renderCommandCard` on `openSurface()`; delete the
+   hand-rolled `cardRow()` and border code. Migrate `tool-execution.ts` and
+   `bash-execution.ts`.
+5. **Convert the rail.** `user-message.ts` and `assistant-message.ts` move
+   from `renderUserRail` / `renderAssistantRail` to `openSurface()`; delete
+   the rail renderers and their background fill.
+6. **Fold in `tui-style-kit.ts`.** Move `badge` / `keyValue` / `breakpoint`
+   into the vocabulary; relocate `padRight` / `alignRight` to `pi-tui` utils;
+   update `adaptive-layout.ts`. Delete `tui-style-kit.ts`.
+7. **Consistency pass.** One blank-line rhythm and rule weight across all
+   Open surfaces; unify keyboard-hint footers through `keybinding-hints.ts`.
+
+Verification per step: `tsc --noEmit` on both packages, the `pi-tui` test
+suite, a manual before/after screenshot of the affected surfaces, and a
+manual copy-paste check confirming body lines copy without prefixes.

--- a/packages/pi-coding-agent/src/modes/interactive/components/armin.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/armin.ts
@@ -187,6 +187,8 @@ export class ArminComponent implements Component {
 				this.stopAnimation();
 			}
 		}, 1000 / fps);
+		// Cosmetic animation — must never keep the Node event loop alive.
+		this.interval.unref?.();
 	}
 
 	private stopAnimation(): void {

--- a/packages/pi-coding-agent/src/modes/interactive/components/countdown-timer.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/countdown-timer.ts
@@ -29,6 +29,9 @@ export class CountdownTimer {
 				this.onExpire();
 			}
 		}, 1000);
+		// The TUI keeps the process alive while a dialog is open; this timer
+		// must not pin the event loop on its own if dispose() is missed.
+		this.intervalId.unref?.();
 	}
 
 	dispose(): void {

--- a/packages/pi-coding-agent/src/modes/interactive/components/daxnuts.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/daxnuts.ts
@@ -30,8 +30,26 @@ function parseImage(): number[][][] {
 	return pixels;
 }
 
+// Quantize a 24-bit color to the closest xterm-256 index so the image
+// degrades gracefully on terminals that don't support truecolor SGR.
+function rgbTo256(r: number, g: number, b: number): number {
+	if (r === g && g === b) {
+		if (r < 8) return 16;
+		if (r > 248) return 231;
+		return 232 + Math.round(((r - 8) / 247) * 24);
+	}
+	const ri = Math.round((r / 255) * 5);
+	const gi = Math.round((g / 255) * 5);
+	const bi = Math.round((b / 255) * 5);
+	return 16 + 36 * ri + 6 * gi + bi;
+}
+
 function rgb(r: number, g: number, b: number, bg = false): string {
-	return `\x1b[${bg ? 48 : 38};2;${r};${g};${b}m`;
+	const layer = bg ? 48 : 38;
+	if (theme.getColorMode() === "truecolor") {
+		return `\x1b[${layer};2;${r};${g};${b}m`;
+	}
+	return `\x1b[${layer};5;${rgbTo256(r, g, b)}m`;
 }
 
 const RESET = "\x1b[0m";

--- a/packages/pi-coding-agent/src/modes/interactive/components/dynamic-border.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/dynamic-border.ts
@@ -71,6 +71,15 @@ export class DynamicBorder implements Component {
 		// No cached state to invalidate currently
 	}
 
+	/**
+	 * Stop the spinner when the component is removed. Without this, a spinner
+	 * started via startSpinner() keeps firing its interval (and calling
+	 * ui.requestRender()) after the border is detached from its container.
+	 */
+	dispose(): void {
+		this.stopSpinner();
+	}
+
 	render(width: number): string[] {
 		this.lastExternalRender = Date.now();
 		const spinnerPrefix = this.spinnerInterval && this.spinnerColorFn

--- a/packages/pi-coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/model-selector.ts
@@ -7,6 +7,7 @@ import {
 	Input,
 	Spacer,
 	Text,
+	TruncatedText,
 	type TUI,
 } from "@gsd/pi-tui";
 import type { ModelRegistry, ProviderAuthMode } from "../../../core/model-registry.js";
@@ -505,7 +506,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 				if (i > startIndex) {
 					this.listContainer.addChild(new Text("", 0, 0));
 				}
-				this.listContainer.addChild(new Text(`  ${providerLabel}${count}${authText}`, 0, 0));
+				this.listContainer.addChild(new TruncatedText(`  ${providerLabel}${count}${authText}`, 0, 0));
 			} else {
 				// Model row
 				const isSelected = i === this.selectedGroupIndex;
@@ -522,7 +523,9 @@ export class ModelSelectorComponent extends Container implements Focusable {
 					line = `    ${row.item.id}${ctxBadge}${checkmark}`;
 				}
 
-				this.listContainer.addChild(new Text(line, 0, 0));
+				// Single-line: a long model id must truncate, not wrap — a
+				// wrapped row would break the fixed-height selection window.
+				this.listContainer.addChild(new TruncatedText(line, 0, 0));
 			}
 		}
 

--- a/packages/pi-coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/session-selector.ts
@@ -127,6 +127,14 @@ class SessionSelectorHeader implements Component {
 
 	invalidate(): void {}
 
+	/**
+	 * Clear any pending auto-hide timeout when the header is removed, so it
+	 * cannot fire requestRender() after the component is gone.
+	 */
+	dispose(): void {
+		this.clearStatusTimeout();
+	}
+
 	render(width: number): string[] {
 		const title = this.scope === "current" ? "Resume Session (Current Folder)" : "Resume Session (All)";
 		const leftText = theme.bold(title);

--- a/packages/pi-coding-agent/src/modes/interactive/components/transcript-design.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/transcript-design.ts
@@ -1,7 +1,7 @@
 // Project/App: GSD-2
 // File Purpose: Shared recommended transcript rendering primitives for assistant, tool, command, footer, and auto-mode TUI surfaces.
 
-import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+import { style, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 import { theme, type ThemeBg, type ThemeColor } from "../theme/theme.js";
 import { alignRight, padRight, roundedPanel } from "./tui-style-kit.js";
 
@@ -32,6 +32,33 @@ function toneColor(tone: StatusTone): ThemeColor {
 
 export function rightAlign(left: string, right: string, width: number): string {
 	return alignRight(left, right, width);
+}
+
+/**
+ * Render a copy-clean content surface (ADR-019): a titled top rule, body
+ * lines emitted with no border column or leading glyph, and a closing rule.
+ * Selecting a body line in the terminal copies only its content.
+ *
+ * This is the target surface for transcript messages, tool output, and
+ * summaries. Migration steps 3–5 move existing renderers onto it.
+ */
+export function openSurface(
+	lines: string[],
+	width: number,
+	opts: { title: string; right?: string; tone: StatusTone; paddingX?: number },
+): string[] {
+	const tc = toneColor(opts.tone);
+	let surface = style()
+		.border("open")
+		.title(opts.title, (text) => theme.fg("borderAccent", text))
+		.borderColor((text) => theme.fg(tc, text));
+	if (opts.right) {
+		surface = surface.titleRight(opts.right, (text) => theme.fg(tc, text));
+	}
+	if (opts.paddingX !== undefined) {
+		surface = surface.paddingX(opts.paddingX);
+	}
+	return surface.render(lines, Math.max(20, width));
 }
 
 export function renderAssistantRail(

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -328,6 +328,7 @@ export class InteractiveMode {
 
 	// Branch change listener unsubscribe function
 	private _branchChangeUnsub?: () => void;
+	private _themeChangeUnsub?: () => void;
 
 	// Track if editor is in bash mode (text starts with !)
 	private isBashMode = false;
@@ -647,7 +648,7 @@ export class InteractiveMode {
 		this.subscribeToAgent();
 
 		// Set up theme file watcher
-		onThemeChange(() => {
+		this._themeChangeUnsub = onThemeChange(() => {
 			this.ui.invalidate();
 			this.updateEditorBorderColor();
 			this.ui.requestRender();
@@ -4295,7 +4296,8 @@ export class InteractiveMode {
 		this._branchChangeUnsub = undefined;
 
 		// Clean up theme change listener and watcher (Fix 2)
-		onThemeChange(() => {});
+		this._themeChangeUnsub?.();
+		this._themeChangeUnsub = undefined;
 		stopThemeWatcher();
 
 		// Resolve any pending getUserInput promise so the run() loop can exit (Fix 3)

--- a/packages/pi-tui/src/__tests__/style.test.ts
+++ b/packages/pi-tui/src/__tests__/style.test.ts
@@ -65,6 +65,57 @@ describe("style", () => {
 		assert.equal(plain[4], "└────────────┘");
 	});
 
+	test("open border emits copy-clean body lines with no prefix", () => {
+		const lines = style()
+			.border("open")
+			.title("bash · success")
+			.render(["$ npm test", "ok"], 40);
+		const plain = lines.map((line) => stripAnsi(line));
+
+		// Top rule carries the title and is all rule/title characters.
+		assert.ok(plain[0].startsWith("─── bash · success "));
+		assert.equal(visibleWidth(plain[0]), 40);
+		// Bottom rule is a plain dash line.
+		assert.match(plain[plain.length - 1], /^─+$/);
+		assert.equal(visibleWidth(plain[plain.length - 1]), 40);
+
+		// Every body line is pure content — no border column, no leading
+		// glyph — so a terminal selection copies clean text.
+		for (const body of plain.slice(1, -1)) {
+			assert.ok(!body.startsWith("│"), `body line must not start with │: ${body}`);
+			assert.ok(!body.startsWith("┃"), `body line must not start with ┃: ${body}`);
+			assert.ok(!body.startsWith("─"), `body line must not start with ─: ${body}`);
+			assert.equal(visibleWidth(body), 40);
+		}
+		assert.equal(plain[1].trimEnd(), "$ npm test");
+		assert.equal(plain[2].trimEnd(), "ok");
+	});
+
+	test("open border without a title renders a plain top rule", () => {
+		const plain = style()
+			.border("open")
+			.render(["body"], 20)
+			.map((line) => stripAnsi(line));
+
+		assert.match(plain[0], /^─+$/);
+		assert.equal(visibleWidth(plain[0]), 20);
+		assert.equal(plain[1].trimEnd(), "body");
+		assert.match(plain[2], /^─+$/);
+	});
+
+	test("open border places left and right titles in the top rule", () => {
+		const plain = style()
+			.border("open")
+			.title("command")
+			.titleRight("1.2s")
+			.render(["output"], 40)
+			.map((line) => stripAnsi(line));
+
+		assert.ok(plain[0].includes("command"));
+		assert.ok(plain[0].includes("1.2s"));
+		assert.equal(visibleWidth(plain[0]), 40);
+	});
+
 	test("passes tone to toneColor when no explicit border color is set", () => {
 		const lines = style()
 			.border("minimal")

--- a/packages/pi-tui/src/__tests__/tui.test.ts
+++ b/packages/pi-tui/src/__tests__/tui.test.ts
@@ -72,6 +72,30 @@ describe("TUI", () => {
 		assert.ok(!withoutSyncWrapper.startsWith("\x1b[1A\r"), "editor diff must not move above the cursor row");
 	});
 
+	it("redraws to erase a dismissed overlay even when base output is unchanged", () => {
+		// Regression: doRender() short-circuits when component output is
+		// byte-identical to the previous frame. If the previous frame drew an
+		// overlay, an identical next frame with no overlay must still redraw —
+		// otherwise the dismissed overlay is never erased from the screen.
+		const writes: string[] = [];
+		const tui = new TUI(makeTerminal(writes));
+		tui.addChild({ render: () => ["base line one", "base line two"], invalidate() {} });
+		const anyTui = tui as any;
+
+		anyTui.doRender();
+		const overlay = tui.showOverlay({ render: () => ["OVERLAY"], invalidate() {} });
+		anyTui.doRender();
+		const writesBeforeHide = writes.length;
+
+		overlay.hide();
+		anyTui.doRender();
+
+		assert.ok(
+			writes.length > writesBeforeHide,
+			"dismissing an overlay must trigger a redraw to erase it, even when the base component output is byte-identical",
+		);
+	});
+
 	it("omits synchronized-output wrappers when PI_DISABLE_SYNC_OUTPUT is enabled", () => {
 		const previous = process.env.PI_DISABLE_SYNC_OUTPUT;
 		process.env.PI_DISABLE_SYNC_OUTPUT = "1";

--- a/packages/pi-tui/src/components/input.ts
+++ b/packages/pi-tui/src/components/input.ts
@@ -334,10 +334,13 @@ export class Input implements Component, Focusable {
 
 		this.pushUndo();
 
-		// Delete the previously yanked text (still at end of ring before rotation)
+		// Delete the previously yanked text (still at end of ring before rotation).
+		// Clamp the start index: a negative arg to slice() counts from the end,
+		// which would silently corrupt the value rather than delete nothing.
 		const prevText = this.killRing.peek() || "";
-		this.value = this.value.slice(0, this.cursor - prevText.length) + this.value.slice(this.cursor);
-		this.cursor -= prevText.length;
+		const deleteFrom = Math.max(0, this.cursor - prevText.length);
+		this.value = this.value.slice(0, deleteFrom) + this.value.slice(this.cursor);
+		this.cursor = deleteFrom;
 
 		// Rotate and insert new entry
 		this.killRing.rotate();

--- a/packages/pi-tui/src/components/markdown.ts
+++ b/packages/pi-tui/src/components/markdown.ts
@@ -51,6 +51,12 @@ interface InlineStyleContext {
 	stylePrefix: string;
 }
 
+/** A rendered list-item line. `nested` lines are already fully indented. */
+interface ListItemLine {
+	text: string;
+	nested: boolean;
+}
+
 export class Markdown implements Component {
 	private text: string;
 	private paddingX: number; // Left/right padding
@@ -537,30 +543,25 @@ export class Markdown implements Component {
 			const itemLines = this.renderListItem(item.tokens || [], depth, styleContext);
 
 			if (itemLines.length > 0) {
-				// First line - check if it's a nested list
-				// A nested list will start with indent (spaces) followed by cyan bullet
-				const firstLine = itemLines[0];
-				const isNestedList = /^\s+\x1b\[36m[-\d]/.test(firstLine); // starts with spaces + cyan + bullet char
-
-				if (isNestedList) {
-					// This is a nested list, just add it as-is (already has full indent)
-					lines.push(firstLine);
+				// First line: nested-list lines are already fully indented and
+				// bulleted by the recursive renderList call — add them as-is.
+				const first = itemLines[0];
+				if (first.nested) {
+					lines.push(first.text);
 				} else {
 					// Regular text content - add indent and bullet
-					lines.push(indent + this.theme.listBullet(bullet) + firstLine);
+					lines.push(indent + this.theme.listBullet(bullet) + first.text);
 				}
 
 				// Rest of the lines
 				for (let j = 1; j < itemLines.length; j++) {
-					const line = itemLines[j];
-					const isNestedListLine = /^\s+\x1b\[36m[-\d]/.test(line); // starts with spaces + cyan + bullet char
-
-					if (isNestedListLine) {
+					const entry = itemLines[j];
+					if (entry.nested) {
 						// Nested list line - already has full indent
-						lines.push(line);
+						lines.push(entry.text);
 					} else {
 						// Regular content - add parent indent + 2 spaces for continuation
-						lines.push(`${indent}  ${line}`);
+						lines.push(`${indent}  ${entry.text}`);
 					}
 				}
 			} else {
@@ -572,38 +573,45 @@ export class Markdown implements Component {
 	}
 
 	/**
-	 * Render list item tokens, handling nested lists
-	 * Returns lines WITHOUT the parent indent (renderList will add it)
+	 * Render list item tokens, handling nested lists.
+	 * Returns lines WITHOUT the parent indent (renderList will add it).
+	 * `nested: true` marks lines produced by a recursive renderList call —
+	 * they are already fully indented/bulleted and must be passed through
+	 * verbatim. This replaces a fragile ANSI-color regex with structural info.
 	 */
-	private renderListItem(tokens: Token[], parentDepth: number, styleContext?: InlineStyleContext): string[] {
-		const lines: string[] = [];
+	private renderListItem(
+		tokens: Token[],
+		parentDepth: number,
+		styleContext?: InlineStyleContext,
+	): ListItemLine[] {
+		const lines: ListItemLine[] = [];
 
 		for (const token of tokens) {
 			if (token.type === "list") {
 				// Nested list - render with one additional indent level
 				// These lines will have their own indent, so we just add them as-is
 				const nestedLines = this.renderList(token as any, parentDepth + 1, styleContext);
-				for (let j = 0; j < nestedLines.length; j++) lines.push(nestedLines[j]);
+				for (let j = 0; j < nestedLines.length; j++) lines.push({ text: nestedLines[j], nested: true });
 			} else if (token.type === "text") {
 				// Text content (may have inline tokens)
 				const text =
 					token.tokens && token.tokens.length > 0
 						? this.renderInlineTokens(token.tokens, styleContext)
 						: token.text || "";
-				lines.push(text);
+				lines.push({ text, nested: false });
 			} else if (token.type === "paragraph") {
 				// Paragraph in list item
 				const text = this.renderInlineTokens(token.tokens || [], styleContext);
-				lines.push(text);
+				lines.push({ text, nested: false });
 			} else if (token.type === "code") {
 				// Code block in list item
 				const codeLines = this.renderCodeBlock(token.text, token.lang);
-				for (let j = 0; j < codeLines.length; j++) lines.push(codeLines[j]);
+				for (let j = 0; j < codeLines.length; j++) lines.push({ text: codeLines[j], nested: false });
 			} else {
 				// Other token types - try to render as inline
 				const text = this.renderInlineTokens([token], styleContext);
 				if (text) {
-					lines.push(text);
+					lines.push({ text, nested: false });
 				}
 			}
 		}

--- a/packages/pi-tui/src/components/select-list.ts
+++ b/packages/pi-tui/src/components/select-list.ts
@@ -149,6 +149,12 @@ export class SelectList implements Component {
 
 	handleInput(keyData: string): void {
 		const kb = getEditorKeybindings();
+		// Nothing to navigate or select when the filter matches no items.
+		// Without this guard selectUp would set selectedIndex to -1.
+		if (this.filteredItems.length === 0) {
+			if (kb.matches(keyData, "selectCancel") && this.onCancel) this.onCancel();
+			return;
+		}
 		// Up arrow - wrap to bottom when at top
 		if (kb.matches(keyData, "selectUp")) {
 			this.selectedIndex = this.selectedIndex === 0 ? this.filteredItems.length - 1 : this.selectedIndex - 1;

--- a/packages/pi-tui/src/fuzzy.ts
+++ b/packages/pi-tui/src/fuzzy.ts
@@ -13,12 +13,17 @@ export function fuzzyMatch(query: string, text: string): FuzzyMatch {
 	const queryLower = query.toLowerCase();
 	const textLower = text.toLowerCase();
 
+	// Iterate by Unicode code point, not UTF-16 code unit, so astral-plane
+	// characters (emoji, rare CJK) match as single units instead of surrogates.
+	const textChars = Array.from(textLower);
+
 	const matchQuery = (normalizedQuery: string): FuzzyMatch => {
-		if (normalizedQuery.length === 0) {
+		const queryChars = Array.from(normalizedQuery);
+		if (queryChars.length === 0) {
 			return { matches: true, score: 0 };
 		}
 
-		if (normalizedQuery.length > textLower.length) {
+		if (queryChars.length > textChars.length) {
 			return { matches: false, score: 0 };
 		}
 
@@ -27,9 +32,9 @@ export function fuzzyMatch(query: string, text: string): FuzzyMatch {
 		let lastMatchIndex = -1;
 		let consecutiveMatches = 0;
 
-		for (let i = 0; i < textLower.length && queryIndex < normalizedQuery.length; i++) {
-			if (textLower[i] === normalizedQuery[queryIndex]) {
-				const isWordBoundary = i === 0 || /[\s\-_./:]/.test(textLower[i - 1]!);
+		for (let i = 0; i < textChars.length && queryIndex < queryChars.length; i++) {
+			if (textChars[i] === queryChars[queryIndex]) {
+				const isWordBoundary = i === 0 || /[\s\-_./:]/.test(textChars[i - 1]!);
 
 				// Reward consecutive matches
 				if (lastMatchIndex === i - 1) {
@@ -56,7 +61,7 @@ export function fuzzyMatch(query: string, text: string): FuzzyMatch {
 			}
 		}
 
-		if (queryIndex < normalizedQuery.length) {
+		if (queryIndex < queryChars.length) {
 			return { matches: false, score: 0 };
 		}
 

--- a/packages/pi-tui/src/style.ts
+++ b/packages/pi-tui/src/style.ts
@@ -2,7 +2,7 @@
 
 import { truncateToWidth, visibleWidth } from "./utils.js";
 
-export type TerminalBorderStyle = "none" | "rule" | "single" | "rounded" | "heavy" | "minimal";
+export type TerminalBorderStyle = "none" | "rule" | "single" | "rounded" | "heavy" | "minimal" | "open";
 export type TerminalDensity = "compact" | "comfortable" | "dashboard";
 export type TerminalTone = "default" | "muted" | "running" | "success" | "error" | "current";
 
@@ -32,7 +32,7 @@ type BorderChars = {
 	vertical: string;
 };
 
-const BORDER_CHARS: Record<Exclude<TerminalBorderStyle, "none" | "rule" | "minimal">, BorderChars> = {
+const BORDER_CHARS: Record<Exclude<TerminalBorderStyle, "none" | "rule" | "minimal" | "open">, BorderChars> = {
 	single: {
 		topLeft: "┌",
 		topRight: "┐",
@@ -148,7 +148,9 @@ export class TerminalStyle {
 		const paddingY = Math.max(0, Math.floor(this.spec.paddingY ?? densityPadding.y));
 		const gutter = this.spec.bodyGutter ?? "";
 		const gutterWidth = visibleWidth(gutter);
-		const borderColumns = border === "none" ? 0 : 2;
+		// "open" surfaces have no vertical border column — body lines are
+		// emitted as pure content so terminal selection copies clean text.
+		const borderColumns = border === "none" || border === "open" ? 0 : 2;
 		const innerWidth = Math.max(1, outerWidth - borderColumns - paddingX * 2 - gutterWidth);
 		const emptyPaddedLine = " ".repeat(paddingX * 2 + innerWidth);
 		const sourceLines = contentLines.length > 0 ? contentLines : [""];
@@ -184,6 +186,17 @@ export class TerminalStyle {
 			];
 		}
 
+		if (border === "open") {
+			// Copy-clean content surface (ADR-019): a titled top rule, body
+			// lines emitted verbatim with no border column or prefix, and a
+			// closing rule. Selecting a body line copies only its content.
+			return [
+				this.renderOpenTopRule(outerWidth, borderColor),
+				...paddedBody.map((line) => padVisible(line, outerWidth)),
+				borderColor("─".repeat(Math.max(1, outerWidth))),
+			];
+		}
+
 		const chars = BORDER_CHARS[border];
 		const horizontalWidth = Math.max(0, outerWidth - 2);
 		const top = borderColor(
@@ -203,6 +216,40 @@ export class TerminalStyle {
 			),
 			bottom,
 		];
+	}
+
+	/**
+	 * Build the titled top rule for an "open" surface, e.g.
+	 * `─── bash · success ─────────── 1.2s ───`. The whole line is rule
+	 * characters plus the (optional) titles — no content, so it is safe for
+	 * a user to include in a copy selection.
+	 */
+	private renderOpenTopRule(width: number, borderColor: (text: string) => string): string {
+		const w = Math.max(1, width);
+		const left = this.spec.title ?? "";
+		const right = this.spec.titleRight ?? "";
+		if (!left && !right) return borderColor("─".repeat(w));
+
+		const styledLeft = color(this.spec.titleColor, left);
+		const styledRight = color(this.spec.titleRightColor, right);
+
+		if (left && right) {
+			const fixed = 4 + visibleWidth(left) + 2 + visibleWidth(right) + 4;
+			const fill = Math.max(1, w - fixed);
+			return (
+				borderColor("─── ") +
+				styledLeft +
+				borderColor(` ${"─".repeat(fill)} `) +
+				styledRight +
+				borderColor(" ───")
+			);
+		}
+		if (left) {
+			const fill = Math.max(1, w - 5 - visibleWidth(left));
+			return borderColor("─── ") + styledLeft + borderColor(` ${"─".repeat(fill)}`);
+		}
+		const fill = Math.max(1, w - 5 - visibleWidth(right));
+		return borderColor(`${"─".repeat(fill)} `) + styledRight + borderColor(" ───");
 	}
 
 	private renderTitleRows(width: number): string[] {

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -264,6 +264,10 @@ export class TUI extends Container {
 	private readonly useSynchronizedOutput =
 		process.platform !== "win32" && process.env.PI_DISABLE_SYNC_OUTPUT !== "1";
 	private _lastRenderedComponents: string[] | null = null;
+	// Whether the previous frame composited overlays onto the screen. When true,
+	// the next frame must redraw even if component output is byte-identical —
+	// otherwise a dismissed overlay is never erased from the terminal.
+	private _lastFrameHadOverlays = false;
 
 	// Overlay stack for modal components rendered on top of base content
 	private focusOrderCounter = 0;
@@ -653,10 +657,18 @@ export class TUI extends Container {
 
 		// Skip ALL post-processing if component output is unchanged.
 		// Container.render() returns the same array reference when stable.
-		if (newLines === this._lastRenderedComponents && this.overlayStack.length === 0) {
+		// Guard with _lastFrameHadOverlays: if the previous frame drew an
+		// overlay, the screen still shows it, so we must redraw to erase it
+		// even when the base component output is identical.
+		if (
+			newLines === this._lastRenderedComponents &&
+			this.overlayStack.length === 0 &&
+			!this._lastFrameHadOverlays
+		) {
 			return;
 		}
 		this._lastRenderedComponents = newLines;
+		this._lastFrameHadOverlays = this.overlayStack.length > 0;
 
 		// Composite overlays into the rendered lines (before differential compare)
 		if (this.overlayStack.length > 0) {

--- a/scripts/tui-open-surface-demo.mjs
+++ b/scripts/tui-open-surface-demo.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Local visual harness for ADR-019 — compare the copy-clean "open" surface
+// against the current bordered surface.
+//
+// Run after building pi-tui:
+//   cd packages/pi-tui && npx tsc -p tsconfig.json && cd ../..
+//   node scripts/tui-open-surface-demo.mjs
+//
+// Then SELECT the body lines of each block below and paste them somewhere —
+// compare what actually got copied.
+
+import { style } from "../packages/pi-tui/dist/index.js";
+
+const dim = (s) => `\x1b[2m${s}\x1b[0m`;
+const cyan = (s) => `\x1b[36m${s}\x1b[0m`;
+const green = (s) => `\x1b[32m${s}\x1b[0m`;
+
+const body = [
+	"$ ls packages/",
+	"pi-tui  pi-coding-agent  pi-ai",
+	"rpc-client  mcp-server  native",
+];
+const width = 52;
+
+const print = (lines) => {
+	for (const line of lines) console.log(line);
+};
+
+console.log();
+console.log(cyan("ADR-019 — copy-clean surface demo"));
+console.log(dim("Select the 3 body lines of each block and paste them."));
+console.log();
+
+console.log(dim("── CURRENT: bordered (rounded) ──────────────────────"));
+console.log();
+print(
+	style()
+		.border("rounded")
+		.paddingX(1)
+		.title("bash", cyan)
+		.titleRight("success", green)
+		.borderColor(dim)
+		.render(body, width),
+);
+console.log();
+console.log(dim('↑ a copied body line also carries "│ " and " │"'));
+console.log();
+
+console.log(dim("── NEW: open surface (copy-clean) ───────────────────"));
+console.log();
+print(
+	style()
+		.border("open")
+		.title("bash", cyan)
+		.titleRight("success", green)
+		.borderColor(dim)
+		.render(body, width),
+);
+console.log();
+console.log(dim("↑ a copied body line is exactly the text, no prefix"));
+console.log();
+console.log(dim("openSurface() in transcript-design.ts is the themed"));
+console.log(dim("wrapper around style().border(\"open\") shown here."));
+console.log();


### PR DESCRIPTION
## TUI Phase 2 — review aid

Stacked on #6369. A small dev script, not a migration step.

## What

`scripts/tui-open-surface-demo.mjs` renders the current bordered surface next to the new copy-clean `open` surface (from #6368), with the same content in both:

```
── CURRENT: bordered (rounded) ──────────────────────
╭──────────────────────────────────────────────────╮
│ $ ls packages/                                   │
╰──────────────────────────────────────────────────╯

── NEW: open surface (copy-clean) ───────────────────
─── bash ─────────────────────────────── success ───
$ ls packages/
────────────────────────────────────────────────────
```

## Why

Selecting the body lines of each block and pasting them shows the difference: the bordered block copies `│ … │`, the open block copies just the text. It lets a reviewer validate the ADR-019 design direction before the consumer migration (steps 3–7) touches any real rendering.

Run: `node scripts/tui-open-surface-demo.mjs` (after pi-tui is built).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "open surface" border mode for cleaner copy-paste experience.

* **Bug Fixes**
  * Fixed overlay dismissal leaving stale terminal content.
  * Fixed text input corruption in yank operation.
  * Fixed select list navigation with empty filter results.
  * Improved timer lifecycle cleanup to prevent shutdown hangs.
  * Enhanced terminal color support on non-truecolor displays.
  * Fixed Unicode handling in fuzzy search.
  * Fixed markdown list rendering logic.

* **Documentation**
  * Added architectural decision record on TUI styling system unification.
  * Added TUI audit with issue findings and remediation plan.

* **Tests**
  * Added coverage for "open" border mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
