### PR TITLE
fix(headless): exit on auto pause notifications

### DIFF
--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -25,6 +25,7 @@ export const EXIT_CANCELLED = 11
  *   error     → 1
  *   timeout   → 1
  *   blocked   → 10
+ *   paused    → 10
  *   cancelled → 11
  *
  * Unknown statuses default to EXIT_ERROR (1).
@@ -39,6 +40,7 @@ export function mapStatusToExitCode(status: string): number {
     case 'timeout':
       return EXIT_ERROR
     case 'blocked':
+    case 'paused':
       return EXIT_BLOCKED
     case 'cancelled':
       return EXIT_CANCELLED
@@ -54,9 +56,11 @@ export function mapStatusToExitCode(status: string): number {
 /**
  * Detect genuine auto-mode termination notifications.
  *
- * Only matches the actual stop signals emitted by stopAuto():
+ * Only matches the actual stop/pause signals emitted by stopAuto()/pauseAuto():
  *   "Auto-mode stopped..."
  *   "Step-mode stopped..."
+ *   "Auto-mode paused..."
+ *   "Step-mode paused..."
  *
  * Does NOT match progress notifications that happen to contain words like
  * "complete" or "stopped" (e.g., "Override resolved — rewrite-docs completed",
@@ -64,7 +68,8 @@ export function mapStatusToExitCode(status: string): number {
  *
  * Blocked detection is separate — checked via isBlockedNotification.
  */
-export const TERMINAL_PREFIXES = ['auto-mode stopped', 'step-mode stopped']
+export const PAUSED_PREFIXES = ['auto-mode paused', 'step-mode paused']
+export const TERMINAL_PREFIXES = ['auto-mode stopped', 'step-mode stopped', ...PAUSED_PREFIXES]
 export const IDLE_TIMEOUT_MS = 15_000
 // new-milestone is a long-running creative task where the LLM may pause
 // between tool calls (e.g. after mkdir, before writing files). Use a
@@ -81,8 +86,8 @@ export function isTerminalNotification(event: Record<string, unknown>): boolean 
 export function isBlockedNotification(event: Record<string, unknown>): boolean {
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
   const message = String(event.message ?? '').toLowerCase()
-  // Blocked notifications come through stopAuto as "Auto-mode stopped (Blocked: ...)"
-  return message.includes('blocked:')
+  // Recoverable pauses need operator intervention in headless mode.
+  return message.includes('blocked:') || PAUSED_PREFIXES.some((prefix) => message.startsWith(prefix))
 }
 
 export function isMilestoneReadyNotification(event: Record<string, unknown>): boolean {

--- a/src/tests/headless-detection.test.ts
+++ b/src/tests/headless-detection.test.ts
@@ -15,7 +15,8 @@ import assert from "node:assert/strict";
 
 // ─── Extracted detection logic (mirrors headless.ts) ────────────────────────
 
-const TERMINAL_PREFIXES = ['auto-mode stopped', 'step-mode stopped']
+const PAUSED_PREFIXES = ['auto-mode paused', 'step-mode paused']
+const TERMINAL_PREFIXES = ['auto-mode stopped', 'step-mode stopped', ...PAUSED_PREFIXES]
 
 function isTerminalNotification(event: Record<string, unknown>): boolean {
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
@@ -26,7 +27,7 @@ function isTerminalNotification(event: Record<string, unknown>): boolean {
 function isBlockedNotification(event: Record<string, unknown>): boolean {
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
   const message = String(event.message ?? '').toLowerCase()
-  return message.includes('blocked:')
+  return message.includes('blocked:') || PAUSED_PREFIXES.some((prefix) => message.startsWith(prefix))
 }
 
 const QUICK_COMMANDS = new Set([
@@ -69,6 +70,14 @@ test("detects 'Step-mode stopped.' as terminal", () => {
   assert.ok(isTerminalNotification(makeNotify("Step-mode stopped.")))
 })
 
+test("detects 'Auto-mode paused.' as terminal", () => {
+  assert.ok(isTerminalNotification(makeNotify("Auto-mode paused (Escape). Type to interact, or /gsd auto to resume.")))
+})
+
+test("detects 'Step-mode paused.' as terminal", () => {
+  assert.ok(isTerminalNotification(makeNotify("Step-mode paused (Escape). Type to interact, or /gsd next to resume.")))
+})
+
 // ─── False positives that previously triggered early exit (#879) ────────────
 
 test("does NOT match 'All slices are complete — nothing to discuss.'", () => {
@@ -108,6 +117,10 @@ test("detects blocked notification with 'Blocked:' prefix", () => {
 
 test("detects inline 'Blocked:' message", () => {
   assert.ok(isBlockedNotification(makeNotify("Blocked: no active milestone. Fix and run /gsd auto.")))
+})
+
+test("detects pause notifications as blocked in headless mode", () => {
+  assert.ok(isBlockedNotification(makeNotify("Auto-mode paused due to provider error: connection reset")))
 })
 
 test("does NOT match 'blocked' without colon (avoids false positives)", () => {

--- a/src/tests/headless-events.test.ts
+++ b/src/tests/headless-events.test.ts
@@ -156,9 +156,15 @@ import {
   EXIT_ERROR,
   EXIT_BLOCKED,
   EXIT_CANCELLED,
+  isBlockedNotification,
   isInteractiveHeadlessTool,
+  isTerminalNotification,
   shouldArmHeadlessIdleTimeout,
 } from '../headless-events.js'
+
+function makeNotify(message: string): Record<string, unknown> {
+  return { type: 'extension_ui_request', method: 'notify', message }
+}
 
 // ─── mapStatusToExitCode ─────────────────────────────────────────────────
 
@@ -186,12 +192,33 @@ test('mapStatusToExitCode: "blocked" returns EXIT_BLOCKED', () => {
   assert.equal(mapStatusToExitCode('blocked'), EXIT_BLOCKED)
 })
 
+test('mapStatusToExitCode: "paused" returns EXIT_BLOCKED', () => {
+  assert.equal(mapStatusToExitCode('paused'), EXIT_BLOCKED)
+})
+
 test('mapStatusToExitCode: "cancelled" returns EXIT_CANCELLED', () => {
   assert.equal(mapStatusToExitCode('cancelled'), EXIT_CANCELLED)
 })
 
 test('mapStatusToExitCode: unknown status returns EXIT_ERROR', () => {
   assert.equal(mapStatusToExitCode('unknown'), EXIT_ERROR)
+})
+
+test('isTerminalNotification: auto-mode pause notifications are terminal', () => {
+  assert.equal(isTerminalNotification(makeNotify('Auto-mode paused (Escape). Type to interact, or /gsd auto to resume.')), true)
+})
+
+test('isTerminalNotification: step-mode pause notifications are terminal', () => {
+  assert.equal(isTerminalNotification(makeNotify('Step-mode paused (Escape). Type to interact, or /gsd next to resume.')), true)
+})
+
+test('isBlockedNotification: pause notifications require intervention in headless mode', () => {
+  assert.equal(isBlockedNotification(makeNotify('Auto-mode paused (Escape). Type to interact, or /gsd auto to resume.')), true)
+  assert.equal(isBlockedNotification(makeNotify('Auto-mode paused due to provider error: connection reset')), true)
+})
+
+test('isBlockedNotification: avoids blocked text without blocked marker', () => {
+  assert.equal(isBlockedNotification(makeNotify('The request was blocked by the firewall')), false)
 })
 
 test('isInteractiveHeadlessTool: ask_user_questions is interactive', () => {


### PR DESCRIPTION
## TL;DR

**What:** Treat auto/step pause notifications as terminal headless events and exit as blocked.
**Why:** Recoverable milestone/workflow pauses should surface required intervention instead of waiting for idle timeout.
**How:** Share paused notification prefixes in the event classifier, map `paused` status to blocked exit code, and add regression tests without source-grep patterns.

## What

Updates `src/headless-events.ts` so `Auto-mode paused...` and `Step-mode paused...` notifications complete headless runs. Paused notifications now classify as blocked/intervention exits, matching the fact that headless cannot resume through an interactive prompt.

Adds regression coverage in the headless event tests and keeps the older detection mirror test aligned with the shared classifier behavior.

## Why

Recent workflow/milestone merge failure handling pauses auto-mode instead of hard-stopping. In headless mode, pause notifications were not terminal, so recoverable failures could look like hangs and eventually time out instead of exiting with a useful blocked signal.

## How

The classifier now defines paused prefixes once, includes them in terminal notification detection, and treats them as blocked notifications. `mapStatusToExitCode('paused')` also returns `EXIT_BLOCKED` for callers that receive lifecycle status directly.

## Tests

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/headless-events.test.ts src/tests/headless-detection.test.ts`
- `bash scripts/check-source-grep-tests.sh`
- `npm run test:compile`
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test dist-test/src/tests/headless-events.test.js dist-test/src/tests/headless-detection.test.js`
- `npm run verify:pr`

## Checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Paused application status now returns the same exit code as blocked status in headless mode.
  * Paused notifications are now properly recognized as blocked notifications in headless mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/gsd-2/pull/6386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->