### PR TITLE
ci(release): use npm trusted publishing

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:
@@ -101,7 +102,8 @@ jobs:
   publish:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.publish == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # npm trusted publishing requires GitHub-hosted runners for OIDC.
+    runs-on: ubuntu-latest
     name: Publish platform packages
 
     steps:
@@ -111,7 +113,12 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          cache: "npm"
+          package-manager-cache: false
+
+      - name: Verify trusted publishing toolchain
+        run: |
+          node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) { throw new Error('Trusted publishing requires Node >= 22.14.0'); }"
+          node -e "const v=require('child_process').execSync('npm --version',{encoding:'utf8'}).trim().split('.').map(Number); if (v[0] < 11 || (v[0] === 11 && v[1] < 5) || (v[0] === 11 && v[1] === 5 && v[2] < 1)) { throw new Error('Trusted publishing requires npm >= 11.5.1'); }"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -144,20 +151,20 @@ jobs:
           fi
 
       - name: Publish platform packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           for platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc; do
             echo "Publishing @gsd-build/engine-${platform}..."
             cd "native/npm/${platform}"
-            OUTPUT=$(npm publish --access public ${{ steps.version-check.outputs.tag_flag }} 2>&1) && echo "$OUTPUT" || {
+            if OUTPUT=$(npm publish --access public ${{ steps.version-check.outputs.tag_flag }} 2>&1); then
+              echo "$OUTPUT"
+            else
               if echo "$OUTPUT" | grep -q "cannot publish over the previously published"; then
                 echo "Already published, skipping"
               else
                 echo "::error::Failed to publish ${platform}: $OUTPUT"
                 exit 1
               fi
-            }
+            fi
             cd "$GITHUB_WORKSPACE"
           done
 
@@ -213,18 +220,18 @@ jobs:
         run: npm run validate-pack
 
       - name: Publish main package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           # --ignore-scripts: skip prepublishOnly since we built explicitly above
-          OUTPUT=$(npm publish --ignore-scripts ${{ steps.version-check.outputs.tag_flag }} 2>&1) && echo "$OUTPUT" || {
+          if OUTPUT=$(npm publish --ignore-scripts ${{ steps.version-check.outputs.tag_flag }} 2>&1); then
+            echo "$OUTPUT"
+          else
             if echo "$OUTPUT" | grep -q "cannot publish over the previously published\|You cannot publish over"; then
               echo "Already published, skipping"
             else
               echo "$OUTPUT"
               exit 1
             fi
-          }
+          fi
 
       - name: Post-publish smoke test
         run: |

--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -19,12 +19,14 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
   packages: write
 
 jobs:
   dev-publish:
     name: Dev Publish
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # npm trusted publishing requires GitHub-hosted runners for OIDC.
+    runs-on: ubuntu-latest
     environment: dev
     container:
       image: ghcr.io/gsd-build/gsd-ci-builder:latest
@@ -49,10 +51,15 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-          cache: 'npm'
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Verify trusted publishing toolchain
+        run: |
+          node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) { throw new Error('Trusted publishing requires Node >= 22.14.0'); }"
+          node -e "const v=require('child_process').execSync('npm --version',{encoding:'utf8'}).trim().split('.').map(Number); if (v[0] < 11 || (v[0] === 11 && v[1] < 5) || (v[0] === 11 && v[1] === 5 && v[2] < 1)) { throw new Error('Trusted publishing requires npm >= 11.5.1'); }"
 
       - name: Install web host dependencies
         run: npm --prefix web ci
@@ -84,17 +91,17 @@ jobs:
       - name: Smoke test
         run: |
           chmod +x dist/loader.js
-          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          export GSD_SMOKE_BINARY
           npm run test:smoke
 
       - name: Publish @dev
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION=$(node -e 'process.stdout.write(require("./package.json").version)')
           if npm view "gsd-pi@${VERSION}" version 2>/dev/null; then
-            echo "Version ${VERSION} already published — moving @dev tag"
-            npm dist-tag add "gsd-pi@${VERSION}" dev
+            echo "::error::Version ${VERSION} already exists. Trusted publishing only authenticates npm publish, not dist-tag mutation."
+            echo "::error::Move the tag manually if intended: npm dist-tag add gsd-pi@${VERSION} dev"
+            exit 1
           else
             npm publish --tag dev
           fi
@@ -137,7 +144,8 @@ jobs:
 
       - name: Run smoke tests (against installed binary)
         run: |
-          export GSD_SMOKE_BINARY=$(which gsd)
+          GSD_SMOKE_BINARY=$(which gsd)
+          export GSD_SMOKE_BINARY
           npm run test:smoke
 
       - name: Install repo dependencies (for regression harness)
@@ -145,7 +153,8 @@ jobs:
 
       - name: Run live regression tests (against installed binary)
         run: |
-          export GSD_SMOKE_BINARY=$(which gsd)
+          GSD_SMOKE_BINARY=$(which gsd)
+          export GSD_SMOKE_BINARY
           npm run test:live-regression
 
       - name: Warn on verify failure

--- a/.github/workflows/next-publish.yml
+++ b/.github/workflows/next-publish.yml
@@ -18,12 +18,14 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
   packages: write
 
 jobs:
   next-publish:
     name: Next Publish
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # npm trusted publishing requires GitHub-hosted runners for OIDC.
+    runs-on: ubuntu-latest
     environment: next
     container:
       image: ghcr.io/gsd-build/gsd-ci-builder:latest
@@ -48,10 +50,15 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-          cache: 'npm'
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Verify trusted publishing toolchain
+        run: |
+          node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) { throw new Error('Trusted publishing requires Node >= 22.14.0'); }"
+          node -e "const v=require('child_process').execSync('npm --version',{encoding:'utf8'}).trim().split('.').map(Number); if (v[0] < 11 || (v[0] === 11 && v[1] < 5) || (v[0] === 11 && v[1] === 5 && v[2] < 1)) { throw new Error('Trusted publishing requires npm >= 11.5.1'); }"
 
       - name: Install web host dependencies
         run: npm --prefix web ci
@@ -83,17 +90,17 @@ jobs:
       - name: Smoke test
         run: |
           chmod +x dist/loader.js
-          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          export GSD_SMOKE_BINARY
           npm run test:smoke
 
       - name: Publish @next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION=$(node -e 'process.stdout.write(require("./package.json").version)')
           if npm view "gsd-pi@${VERSION}" version 2>/dev/null; then
-            echo "Version ${VERSION} already published — moving @next tag"
-            npm dist-tag add "gsd-pi@${VERSION}" next
+            echo "::error::Version ${VERSION} already exists. Trusted publishing only authenticates npm publish, not dist-tag mutation."
+            echo "::error::Move the tag manually if intended: npm dist-tag add gsd-pi@${VERSION} next"
+            exit 1
           else
             npm publish --tag next
           fi
@@ -126,10 +133,9 @@ jobs:
           exit 1
 
       - name: Run smoke tests (against installed binary)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          export GSD_SMOKE_BINARY=$(which gsd)
+          GSD_SMOKE_BINARY=$(which gsd)
+          export GSD_SMOKE_BINARY
           npm run test:smoke
 
       - name: Install repo dependencies (for regression harness)
@@ -137,7 +143,8 @@ jobs:
 
       - name: Run live regression tests (against installed binary)
         run: |
-          export GSD_SMOKE_BINARY=$(which gsd)
+          GSD_SMOKE_BINARY=$(which gsd)
+          export GSD_SMOKE_BINARY
           npm run test:live-regression
 
       - name: Warn on verify failure

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -13,13 +13,15 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
   packages: write
   pull-requests: write
 
 jobs:
   prod-release:
     name: Production Release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # npm trusted publishing requires GitHub-hosted runners for OIDC.
+    runs-on: ubuntu-latest
     environment: prod
     steps:
       - uses: actions/checkout@v6
@@ -32,10 +34,15 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-          cache: 'npm'
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Verify trusted publishing toolchain
+        run: |
+          node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) { throw new Error('Trusted publishing requires Node >= 22.14.0'); }"
+          node -e "const v=require('child_process').execSync('npm --version',{encoding:'utf8'}).trim().split('.').map(Number); if (v[0] < 11 || (v[0] === 11 && v[1] < 5) || (v[0] === 11 && v[1] === 5 && v[2] < 1)) { throw new Error('Trusted publishing requires npm >= 11.5.1'); }"
 
       - name: Cache Next.js build
         uses: useblacksmith/cache@v5
@@ -95,23 +102,26 @@ jobs:
       - name: Run live regression tests (against release build)
         run: |
           chmod +x dist/loader.js
-          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          export GSD_SMOKE_BINARY
           npm run test:live-regression
 
       - name: Publish release to npm @latest
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
-          OUTPUT=$(npm publish 2>&1) && echo "$OUTPUT" || {
+          if OUTPUT=$(npm publish 2>&1); then
+            echo "$OUTPUT"
+          else
             if echo "$OUTPUT" | grep -q "cannot publish over the previously published"; then
-              echo "Version already published — promoting to latest"
-              npm dist-tag add "gsd-pi@${RELEASE_VERSION}" latest
+              echo "::error::Version ${RELEASE_VERSION} already exists. Trusted publishing only authenticates npm publish, not dist-tag mutation."
+              echo "::error::Promote manually if intended: npm dist-tag add gsd-pi@${RELEASE_VERSION} latest"
+              exit 1
             else
               echo "$OUTPUT"
               exit 1
             fi
-          }
+          fi
 
       - name: Push release commit and tag
         env:


### PR DESCRIPTION
## TL;DR

**What:** Moves npm release publishing workflows to npm trusted publishing.
**Why:** Release workflows should not rely on long-lived npm publish tokens when OIDC can authenticate `npm publish`.
**How:** Adds GitHub OIDC permissions, uses GitHub-hosted runners for publish jobs, removes `NPM_TOKEN` from publish steps, and adds explicit Node/npm toolchain checks.

## What

- Adds `id-token: write` to npm publish workflows.
- Removes `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN` from publish steps.
- Runs npm publish jobs on `ubuntu-latest`, since npm trusted publishing requires GitHub-hosted runners.
- Adds Node/npm version checks for trusted publishing support.
- Replaces automated `npm dist-tag add` fallbacks with fail-loud manual instructions because npm OIDC does not authenticate dist-tag mutation.

## Why

This reduces release secret surface area and aligns npm publishing with npm trusted publisher OIDC requirements.

## How

The workflows still use `actions/setup-node` with the npm registry URL, but no publish token is injected. `npm publish` obtains the OIDC token through GitHub Actions. Existing already-published-version paths now fail with the exact manual dist-tag command instead of assuming token auth.

## Tests

- `actionlint -ignore 'SC1001|SC1012' .github/workflows/dev-publish.yml .github/workflows/next-publish.yml .github/workflows/prod-release.yml .github/workflows/build-native.yml`
- `git diff --check`

## Follow-up

Configure npm trusted publisher entries on npmjs.com for each published package and matching workflow filename before the next publish run.
