### PR TITLE
feat(mcp): add app connection management

### DIFF
--- a/packages/mcp-server/src/workflow-tools-parity.test.ts
+++ b/packages/mcp-server/src/workflow-tools-parity.test.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Parity tests for GSD workflow task completion over native and MCP transports.
 // ADR-008 validation criterion #3 — behavior-parity lock-in for gsd_task_complete.
 //
 // ADR-008 §1 ("One handler layer, multiple transports") is shipped: both
@@ -19,6 +21,7 @@ import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
 
 import {
   closeDatabase,
@@ -166,6 +169,16 @@ const COMPLETION_ARGS = {
   keyFiles: ["src/demo.ts"],
   keyDecisions: ["Used Option A from the plan."],
 };
+
+const workflowBridgeExtension = import.meta.url.includes("/dist-test/") ? "js" : "ts";
+process.env.GSD_WORKFLOW_EXECUTORS_MODULE ??= fileURLToPath(new URL(
+  `../../../src/resources/extensions/gsd/tools/workflow-tool-executors.${workflowBridgeExtension}`,
+  import.meta.url,
+));
+process.env.GSD_WORKFLOW_WRITE_GATE_MODULE ??= fileURLToPath(new URL(
+  `../../../src/resources/extensions/gsd/bootstrap/write-gate.${workflowBridgeExtension}`,
+  import.meta.url,
+));
 
 describe("ADR-008 parity: gsd_task_complete native vs MCP", () => {
   it("native and MCP produce equivalent DB row, summary, and journal event", async () => {

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -7,11 +7,28 @@ import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
 
 import { symlinkSync, realpathSync } from "node:fs";
 
-import { _getAdapter, closeDatabase, getSliceTasks } from "../../../src/resources/extensions/gsd/gsd-db.ts";
-import { _buildImportCandidates, registerWorkflowTools, WORKFLOW_TOOL_NAMES, validateProjectDir } from "./workflow-tools.ts";
+import {
+  _getAdapter,
+  closeDatabase,
+  getSliceTasks,
+  insertMilestone,
+  insertSlice,
+  openDatabase,
+  upsertMilestonePlanning,
+} from "../../../src/resources/extensions/gsd/gsd-db.ts";
+import { buildReassessRoadmapPrompt } from "../../../src/resources/extensions/gsd/auto-prompts.ts";
+import { invalidateAllCaches } from "../../../src/resources/extensions/gsd/cache.ts";
+import {
+  _buildBridgeImportCandidates,
+  _buildImportCandidates,
+  registerWorkflowTools,
+  WORKFLOW_TOOL_NAMES,
+  validateProjectDir,
+} from "./workflow-tools.ts";
 
 function makeTmpBase(): string {
   const base = join(tmpdir(), `gsd-mcp-workflow-${randomUUID()}`);
@@ -25,11 +42,58 @@ function cleanup(base: string): void {
   } catch {
     // swallow
   }
+  invalidateAllCaches();
   try {
     rmSync(base, { recursive: true, force: true });
   } catch {
     // swallow
   }
+}
+
+function seedContextModeFixture(base: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Context Mode", status: "active", depends_on: [] });
+  upsertMilestonePlanning("M001", {
+    title: "Context Mode",
+    status: "active",
+    vision: "Verify the bundled context-mode contract",
+    successCriteria: ["Prompt, tool, and persisted evidence surfaces agree"],
+    keyRisks: [],
+    proofStrategy: [],
+    verificationContract: "",
+    verificationIntegration: "",
+    verificationOperational: "",
+    verificationUat: "",
+    definitionOfDone: [],
+    requirementCoverage: "",
+    boundaryMapMarkdown: "",
+  });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Contract",
+    status: "complete",
+    risk: "low",
+    depends: [],
+    demo: "",
+    sequence: 1,
+  });
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    "# M001\n\n## Slices\n\n- [x] **S01: Contract** `risk:low` `depends:[]`\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
+    "# S01 Summary\n\n**Context mode contract is ready for reassessment.**\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(base, ".gsd", "last-snapshot.md"),
+    "# GSD context snapshot\n\nContext mode resume evidence.\n",
+    "utf-8",
+  );
 }
 
 function writeWriteGateSnapshot(
@@ -90,6 +154,16 @@ function cacheBustedWorkflowToolsImport(tag: string): string {
   return `./workflow-tools.${extension}?${tag}=${randomUUID()}`;
 }
 
+const workflowBridgeExtension = import.meta.url.includes("/dist-test/") ? "js" : "ts";
+process.env.GSD_WORKFLOW_EXECUTORS_MODULE ??= fileURLToPath(new URL(
+  `../../../src/resources/extensions/gsd/tools/workflow-tool-executors.${workflowBridgeExtension}`,
+  import.meta.url,
+));
+process.env.GSD_WORKFLOW_WRITE_GATE_MODULE ??= fileURLToPath(new URL(
+  `../../../src/resources/extensions/gsd/bootstrap/write-gate.${workflowBridgeExtension}`,
+  import.meta.url,
+));
+
 describe("workflow MCP tools", () => {
   it("registers the full headless-safe workflow tool surface", () => {
     const server = makeMockServer();
@@ -115,7 +189,7 @@ describe("workflow MCP tools", () => {
     assert.ok("reason" in taskReopen.params);
   });
 
-  it("prefers source TypeScript before compiled dist fallbacks", () => {
+  it("prefers source TypeScript for generic local module imports", () => {
     assert.deepEqual(
       _buildImportCandidates("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js"),
       [
@@ -123,6 +197,18 @@ describe("workflow MCP tools", () => {
         "../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js",
         "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.ts",
         "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.js",
+      ],
+    );
+  });
+
+  it("prefers compiled runtime bridge modules before source fallbacks", () => {
+    assert.deepEqual(
+      _buildBridgeImportCandidates("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js"),
+      [
+        "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.js",
+        "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.ts",
+        "../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js",
+        "../../../src/resources/extensions/gsd/tools/workflow-tool-executors.ts",
       ],
     );
   });
@@ -333,6 +419,94 @@ describe("workflow MCP tools", () => {
 
       assertToolError(result, /context_mode\.enabled: false/);
       assert.equal((result as any).structuredContent.error, "context_mode_disabled");
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("Context Mode contract is wired through prompts, MCP tools, persisted evidence, and disabled-mode blocking", async () => {
+    const base = makeTmpBase();
+    try {
+      seedContextModeFixture(base);
+      invalidateAllCaches();
+
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const execTool = server.tools.find((t) => t.name === "gsd_exec");
+      const searchTool = server.tools.find((t) => t.name === "gsd_exec_search");
+      const resumeTool = server.tools.find((t) => t.name === "gsd_resume");
+      assert.ok(execTool, "exec tool should be registered");
+      assert.ok(searchTool, "exec search tool should be registered");
+      assert.ok(resumeTool, "resume tool should be registered");
+
+      const prompt = await buildReassessRoadmapPrompt("M001", "Context Mode", "S01", base);
+      assert.match(prompt, /## Context Mode/);
+      assert.match(prompt, /Lane: \*\*planning lane\*\*/);
+      assert.match(prompt, /## Context Snapshot/);
+      assert.match(prompt, /Context mode resume evidence/);
+      assert.ok(
+        prompt.indexOf("## Context Mode") < prompt.indexOf("## Context Snapshot"),
+        "prompt should explain Context Mode before injecting the snapshot",
+      );
+
+      const execResult = await execTool!.handler({
+        projectDir: base,
+        runtime: "node",
+        script: "console.log('context-contract-e2e');",
+        purpose: "context-contract-e2e",
+      });
+      assert.equal((execResult as any).isError, false);
+      assert.equal((execResult as any).structuredContent.operation, "gsd_exec");
+      assert.ok(existsSync((execResult as any).structuredContent.stdout_path), "stdout should be persisted");
+
+      const searchResult = await searchTool!.handler({
+        projectDir: base,
+        query: "context-contract-e2e",
+      });
+      assert.equal((searchResult as any).structuredContent.operation, "gsd_exec_search");
+      assert.equal((searchResult as any).structuredContent.matches, 1);
+      assert.equal(
+        (searchResult as any).structuredContent.results[0].stdout_path,
+        (execResult as any).structuredContent.stdout_path,
+        "search should rediscover the persisted exec evidence instead of rerunning it",
+      );
+
+      const resumeResult = await resumeTool!.handler({ projectDir: base });
+      assert.deepEqual((resumeResult as any).structuredContent, {
+        operation: "gsd_resume",
+        found: true,
+        bytes: Buffer.byteLength("# GSD context snapshot\n\nContext mode resume evidence.\n", "utf-8"),
+      });
+      assert.match((resumeResult as any).content[0].text as string, /Context mode resume evidence/);
+
+      const worktree = join(base, ".gsd", "worktrees", "M001");
+      mkdirSync(worktree, { recursive: true });
+      const rootSafetyResult = await execTool!.handler({
+        projectDir: worktree,
+        runtime: "node",
+        script: `console.log(${JSON.stringify(base)});`,
+      });
+      assertToolError(rootSafetyResult, /original project root/);
+
+      writeFileSync(
+        join(base, ".gsd", "PREFERENCES.md"),
+        "---\ncontext_mode:\n  enabled: false\n---\n",
+        "utf-8",
+      );
+      invalidateAllCaches();
+
+      const disabledPrompt = await buildReassessRoadmapPrompt("M001", "Context Mode", "S01", base);
+      assert.doesNotMatch(disabledPrompt, /## Context Mode|## Context Snapshot|Context mode resume evidence/);
+
+      for (const [tool, args] of [
+        [execTool, { projectDir: base, runtime: "node", script: "console.log('blocked');" }],
+        [searchTool, { projectDir: base, query: "context-contract-e2e" }],
+        [resumeTool, { projectDir: base }],
+      ] as const) {
+        const result = await tool!.handler(args);
+        assertToolError(result, /context_mode\.enabled: false/);
+        assert.equal((result as any).structuredContent.error, "context_mode_disabled");
+      }
     } finally {
       cleanup(base);
     }

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -547,6 +547,29 @@ function buildImportCandidates(relativePath: string): string[] {
   return [...new Set(candidates)];
 }
 
+function buildBridgeImportCandidates(relativePath: string): string[] {
+  const candidates: string[] = [];
+  const pushCompiledThenSource = (path: string | null) => {
+    if (!path) return;
+    candidates.push(path);
+    if (path.endsWith(".js")) candidates.push(path.replace(/\.js$/, ".ts"));
+  };
+
+  const sourcePath = relativePath.includes("/dist/")
+    ? relativePath.replace("/dist/", "/src/")
+    : relativePath;
+  const distPath = relativePath.includes("/src/")
+    ? relativePath.replace("/src/", "/dist/")
+    : relativePath.includes("/dist/")
+      ? relativePath
+      : null;
+
+  pushCompiledThenSource(distPath);
+  pushCompiledThenSource(sourcePath);
+
+  return [...new Set(candidates)];
+}
+
 function getWriteGateModuleCandidates(): string[] {
   const candidates: string[] = [];
   const explicitModule = process.env.GSD_WORKFLOW_WRITE_GATE_MODULE?.trim();
@@ -559,7 +582,7 @@ function getWriteGateModuleCandidates(): string[] {
   }
 
   candidates.push(
-    ...buildImportCandidates("../../../src/resources/extensions/gsd/bootstrap/write-gate.js")
+    ...buildBridgeImportCandidates("../../../src/resources/extensions/gsd/bootstrap/write-gate.js")
       .map((p) => new URL(p, import.meta.url).href),
   );
 
@@ -594,6 +617,11 @@ export function _buildImportCandidates(relativePath: string): string[] {
   // variant, before falling back to compiled dist. In source/dev execution a
   // stale dist/resources tree must not silently override edited source files.
   return buildImportCandidates(relativePath);
+}
+
+/** @internal — exported for testing only */
+export function _buildBridgeImportCandidates(relativePath: string): string[] {
+  return buildBridgeImportCandidates(relativePath);
 }
 
 async function importLocalModule<T>(relativePath: string): Promise<T> {
@@ -637,7 +665,7 @@ function getWorkflowExecutorModuleCandidates(env: NodeJS.ProcessEnv = process.en
   }
 
   candidates.push(
-    ...buildImportCandidates("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js")
+    ...buildBridgeImportCandidates("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js")
       .map((p) => new URL(p, import.meta.url).href),
   );
 

--- a/src/resources/extensions/gsd/commands-mcp-status.ts
+++ b/src/resources/extensions/gsd/commands-mcp-status.ts
@@ -7,25 +7,38 @@
  *   /gsd mcp             — Overview of all servers (alias: /gsd mcp status)
  *   /gsd mcp status      — Same as bare /gsd mcp
  *   /gsd mcp check <srv> — Detailed status for a specific server
+ *   /gsd mcp test <srv>  — Test handshake + tools/list for a server
+ *   /gsd mcp enable <srv> / disable <srv> — Toggle local server exposure
+ *   /gsd mcp import <srv> [as <name>] — Copy a discovered server into local config
  *   /gsd mcp init [dir]  — Write project-local GSD workflow MCP config
  */
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
-import { existsSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 
 import { ensureProjectWorkflowMcpConfig } from "./mcp-project-config.js";
-import { gsdHome } from "./gsd-home.js";
+import {
+  deleteProjectLocalMcpServer,
+  readMcpManagementStatus,
+  setProjectLocalMcpServerDisabled,
+  testMcpServerConnection,
+  upsertProjectLocalMcpServer,
+  type ManagedMcpConnectionTestResult,
+  type ManagedMcpTransport,
+} from "../mcp-client/manager.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export interface McpServerStatus {
   name: string;
-  transport: "stdio" | "http" | "unknown";
+  transport: ManagedMcpTransport;
   connected: boolean;
   toolCount: number;
   error: string | undefined;
+  disabled?: boolean;
+  sourcePath?: string;
+  envWarnings?: string[];
 }
 
 export interface McpServerDetail extends McpServerStatus {
@@ -59,65 +72,6 @@ export function formatMcpInitResult(
   ].join("\n");
 }
 
-// ─── Config reader (standalone — does not import mcp-client internals) ──────
-
-interface McpServerRawConfig {
-  name: string;
-  transport: "stdio" | "http" | "unknown";
-  command?: string;
-  args?: string[];
-  url?: string;
-}
-
-function readMcpConfigs(): McpServerRawConfig[] {
-  const servers: McpServerRawConfig[] = [];
-  const seen = new Set<string>();
-  const configPaths = [
-    join(process.cwd(), ".mcp.json"),
-    join(process.cwd(), ".gsd", "mcp.json"),
-    join(gsdHome(), "mcp.json"),
-  ];
-
-  for (const configPath of configPaths) {
-    try {
-      if (!existsSync(configPath)) continue;
-      const raw = readFileSync(configPath, "utf-8");
-      const data = JSON.parse(raw) as Record<string, unknown>;
-      const mcpServers = (data.mcpServers ?? data.servers) as
-        | Record<string, Record<string, unknown>>
-        | undefined;
-      if (!mcpServers || typeof mcpServers !== "object") continue;
-
-      for (const [name, config] of Object.entries(mcpServers)) {
-        if (seen.has(name)) continue;
-        seen.add(name);
-
-        const hasCommand = typeof config.command === "string";
-        const hasUrl = typeof config.url === "string";
-        const transport: McpServerRawConfig["transport"] = hasCommand
-          ? "stdio"
-          : hasUrl
-            ? "http"
-            : "unknown";
-
-        servers.push({
-          name,
-          transport,
-          ...(hasCommand && {
-            command: config.command as string,
-            args: Array.isArray(config.args) ? (config.args as string[]) : undefined,
-          }),
-          ...(hasUrl && { url: config.url as string }),
-        });
-      }
-    } catch {
-      // Non-fatal — config file may not exist or be malformed
-    }
-  }
-
-  return servers;
-}
-
 // ─── Formatters (exported for testing) ──────────────────────────────────────
 
 export function formatMcpStatusReport(servers: McpServerStatus[]): string {
@@ -134,17 +88,21 @@ export function formatMcpStatusReport(servers: McpServerStatus[]): string {
   const lines: string[] = [`MCP Server Status — ${servers.length} server(s)\n`];
 
   for (const s of servers) {
-    const icon = s.error ? "✗" : s.connected ? "✓" : "○";
-    const status = s.error
+    const icon = s.disabled ? "⊘" : s.error ? "✗" : s.connected ? "✓" : "○";
+    const status = s.disabled
+      ? "disabled"
+      : s.error
       ? `error: ${s.error}`
       : s.connected
         ? `connected — ${s.toolCount} tools`
         : "disconnected";
-    lines.push(`  ${icon} ${s.name} (${s.transport}) — ${status}`);
+    const warningText = s.envWarnings?.length ? ` — ${s.envWarnings.length} warning(s)` : "";
+    lines.push(`  ${icon} ${s.name} (${s.transport}) — ${status}${warningText}`);
   }
 
   lines.push("");
   lines.push("Use /gsd mcp check <server> for details on a specific server.");
+  lines.push("Use /gsd mcp test <server> to verify handshake and tool discovery.");
   lines.push("Use mcp_discover to connect and list tools for a server.");
 
   return lines.join("\n");
@@ -154,8 +112,11 @@ export function formatMcpServerDetail(server: McpServerDetail): string {
   const lines: string[] = [`MCP Server: ${server.name}\n`];
 
   lines.push(`  Transport: ${server.transport}`);
+  if (server.sourcePath) lines.push(`  Source:    ${server.sourcePath}`);
 
-  if (server.error) {
+  if (server.disabled) {
+    lines.push(`  Status:    disabled`);
+  } else if (server.error) {
     lines.push(`  Status:    error`);
     lines.push(`  Error:     ${server.error}`);
   } else if (server.connected) {
@@ -174,7 +135,35 @@ export function formatMcpServerDetail(server: McpServerDetail): string {
     lines.push(`  Run mcp_discover("${server.name}") to connect and list tools.`);
   }
 
+  if (server.envWarnings?.length) {
+    lines.push("");
+    lines.push("  Warnings:");
+    for (const warning of server.envWarnings) {
+      lines.push(`    - ${warning}`);
+    }
+  }
+
   return lines.join("\n");
+}
+
+export function formatMcpConnectionTestResult(result: ManagedMcpConnectionTestResult): string {
+  if (result.ok) {
+    return [
+      `MCP test passed for ${result.server}.`,
+      "",
+      `Transport: ${result.transport}`,
+      `Tools:     ${result.toolCount}`,
+      ...(result.tools.length > 0 ? ["", "Available tools:", ...result.tools.map((tool) => `  - ${tool}`)] : []),
+    ].join("\n");
+  }
+
+  return [
+    `MCP test failed for ${result.server}.`,
+    "",
+    `Transport: ${result.transport}`,
+    `Error:     ${result.error ?? "Unknown error"}`,
+    ...(result.warnings.length > 0 ? ["", "Warnings:", ...result.warnings.map((warning) => `  - ${warning}`)] : []),
+  ].join("\n");
 }
 
 // ─── Command handler ────────────────────────────────────────────────────────
@@ -188,7 +177,8 @@ export async function handleMcpStatus(
 ): Promise<void> {
   const trimmed = args.trim();
   const lowered = trimmed.toLowerCase();
-  const configs = readMcpConfigs();
+  const management = readMcpManagementStatus({ includeDisabled: true });
+  const configs = management.servers;
   const systemPrompt = ctx.getSystemPrompt();
 
   // /gsd mcp init [dir]
@@ -205,6 +195,97 @@ export async function handleMcpStatus(
         `Failed to prepare MCP config for ${targetPath}: ${err instanceof Error ? err.message : String(err)}`,
         "error",
       );
+    }
+    return;
+  }
+
+  // /gsd mcp test <server>
+  if (lowered.startsWith("test ")) {
+    const serverName = trimmed.slice("test ".length).trim();
+    const result = await testMcpServerConnection(serverName);
+    ctx.ui.notify(formatMcpConnectionTestResult(result), result.ok ? "info" : "warning");
+    return;
+  }
+
+  // /gsd mcp disable <server>
+  if (lowered.startsWith("disable ")) {
+    const serverName = trimmed.slice("disable ".length).trim();
+    try {
+      const updated = setProjectLocalMcpServerDisabled(serverName, true);
+      ctx.ui.notify(`Disabled MCP server "${updated.name}" in ${updated.sourcePath}.`, "info");
+    } catch (err) {
+      ctx.ui.notify(err instanceof Error ? err.message : String(err), "warning");
+    }
+    return;
+  }
+
+  // /gsd mcp enable <server>
+  if (lowered.startsWith("enable ")) {
+    const serverName = trimmed.slice("enable ".length).trim();
+    try {
+      const updated = setProjectLocalMcpServerDisabled(serverName, false);
+      ctx.ui.notify(`Enabled MCP server "${updated.name}" in ${updated.sourcePath}.`, "info");
+    } catch (err) {
+      ctx.ui.notify(err instanceof Error ? err.message : String(err), "warning");
+    }
+    return;
+  }
+
+  // /gsd mcp delete <server> --confirm
+  if (lowered.startsWith("delete ")) {
+    const raw = trimmed.slice("delete ".length).trim();
+    const confirmed = /\s--confirm$/.test(raw) || raw === "--confirm";
+    const serverName = raw.replace(/\s--confirm$/, "").trim();
+    if (!confirmed || !serverName) {
+      ctx.ui.notify(`Usage: /gsd mcp delete <server> --confirm`, "warning");
+      return;
+    }
+    try {
+      deleteProjectLocalMcpServer(serverName);
+      ctx.ui.notify(`Deleted local MCP server "${serverName}".`, "info");
+    } catch (err) {
+      ctx.ui.notify(err instanceof Error ? err.message : String(err), "warning");
+    }
+    return;
+  }
+
+  // /gsd mcp import <server> [as <name>]
+  if (lowered.startsWith("import ")) {
+    const raw = trimmed.slice("import ".length).trim();
+    const match = raw.match(/^(.*?)\s+as\s+(.+)$/i);
+    const sourceName = (match?.[1] ?? raw).trim();
+    const nextName = (match?.[2] ?? sourceName).trim();
+    const source = configs.find((config) => config.name === sourceName);
+    if (!source) {
+      const available = configs.map((config) => config.name).join(", ") || "(none)";
+      ctx.ui.notify(`Unknown MCP server: "${sourceName}"\n\nAvailable: ${available}`, "warning");
+      return;
+    }
+    if (source.transport === "unsupported") {
+      ctx.ui.notify(`Cannot import "${sourceName}" because transport is unsupported.`, "warning");
+      return;
+    }
+    try {
+      const saved = upsertProjectLocalMcpServer({
+        name: nextName,
+        transport: source.transport,
+        command: source.command,
+        args: source.args,
+        env: source.env,
+        cwd: source.cwd,
+        url: source.url,
+        headers: source.headers,
+        oauth: source.oauth,
+        disabled: source.disabled,
+        importedFrom: {
+          name: source.name,
+          sourcePath: source.sourcePath,
+          sourceTool: source.sourceKind,
+        },
+      });
+      ctx.ui.notify(`Imported MCP server "${source.name}" as "${saved.name}" into ${saved.sourcePath}.`, "info");
+    } catch (err) {
+      ctx.ui.notify(err instanceof Error ? err.message : String(err), "warning");
     }
     return;
   }
@@ -249,6 +330,9 @@ export async function handleMcpStatus(
         toolCount: toolNames.length,
         tools: toolNames,
         error,
+        disabled: config.disabled,
+        sourcePath: config.sourcePath,
+        envWarnings: config.envWarnings,
       }),
       "info",
     );
@@ -285,18 +369,33 @@ export async function handleMcpStatus(
         connected,
         toolCount,
         error,
+        disabled: config.disabled,
+        sourcePath: config.sourcePath,
+        envWarnings: config.envWarnings,
       });
     }
 
-    ctx.ui.notify(formatMcpStatusReport(statuses), "info");
+    const warningLines = [
+      ...management.warnings,
+      ...management.duplicates.map((dup) => `Duplicate "${dup.name}" from ${dup.shadowedSourcePath} is shadowed by ${dup.keptSourcePath}.`),
+    ];
+    const report = warningLines.length > 0
+      ? `${formatMcpStatusReport(statuses)}\n\nConfig warnings:\n${warningLines.map((line) => `  - ${line}`).join("\n")}`
+      : formatMcpStatusReport(statuses);
+    ctx.ui.notify(report, "info");
     return;
   }
 
   // Unknown subcommand
   ctx.ui.notify(
-    "Usage: /gsd mcp [status|check <server>|init [dir]]\n\n" +
+    "Usage: /gsd mcp [status|check <server>|test <server>|enable <server>|disable <server>|delete <server> --confirm|import <server> [as <name>]|init [dir]]\n\n" +
     "  status           Show all MCP server statuses (default)\n" +
     "  check <server>   Detailed status for a specific server\n" +
+    "  test <server>    Verify MCP handshake and tools/list\n" +
+    "  enable <server>  Enable a local GSD-managed server\n" +
+    "  disable <server> Disable a local GSD-managed server\n" +
+    "  delete <server> --confirm  Delete a local GSD-managed server\n" +
+    "  import <server> [as <name>] Copy a discovered server to .gsd/mcp.json\n" +
     "  init [dir]       Write .mcp.json for the local GSD workflow MCP server",
     "warning",
   );

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -132,7 +132,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd skill-health   Skill lifecycle dashboard",
     "  /gsd extensions     Manage extensions  [list|enable|disable|info]",
     "  /gsd fast           Toggle OpenAI service tier  [on|off|flex|status]",
-    "  /gsd mcp            MCP server status and connectivity  [status|check <server>|init [dir]]",
+    "  /gsd mcp            MCP server management  [status|check|test|enable|disable|import|delete|init]",
     "",
     "MAINTENANCE",
     "  /gsd doctor         Diagnose and repair .gsd/ state  [audit|fix|heal] [scope]",

--- a/src/resources/extensions/gsd/git-constants.ts
+++ b/src/resources/extensions/gsd/git-constants.ts
@@ -22,13 +22,13 @@ const LEAKING_GIT_ENV_VARS = [
 ] as const;
 
 function buildSafeParentEnv(): NodeJS.ProcessEnv {
-  const safe: NodeJS.ProcessEnv = {};
+  const safe: Record<string, string | undefined> = {};
   for (const [k, v] of Object.entries(process.env)) {
     if (!LEAKING_GIT_ENV_VARS.includes(k as (typeof LEAKING_GIT_ENV_VARS)[number])) {
       safe[k] = v;
     }
   }
-  return safe;
+  return safe as NodeJS.ProcessEnv;
 }
 
 /** Env overlay that suppresses interactive git credential prompts and git-svn noise. */

--- a/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
@@ -261,6 +261,23 @@ test('executeGsdExec: rejects original-root scripts from milestone worktrees', a
   }
 });
 
+test('executeGsdExec: rejects macOS /var alias of original root from milestone worktrees', async () => {
+  const originalRoot = '/var/folders/example/project';
+  const realpathedWorktree = '/private/var/folders/example/project/.gsd/worktrees/M004';
+
+  const result = await executeGsdExec(
+    { runtime: 'bash', script: `cd ${originalRoot} && node todo.js --help` },
+    { baseDir: realpathedWorktree, preferences: { context_mode: { enabled: true } } },
+  );
+
+  assert.equal(result.isError, true);
+  assert.equal((result.details as { error?: string }).error, 'invalid_params');
+  assert.match(
+    (result.details as { detail?: string }).detail ?? '',
+    /original project root/,
+  );
+});
+
 test('executeGsdExec: rejects original-root traversal after shell boolean operators', async () => {
   const base = freshBase();
   try {

--- a/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
@@ -90,15 +90,15 @@ test('runExecSandbox: forwards only allowlisted env vars', async () => {
   const base = freshBase();
   try {
     const result = await runExecSandbox(
-      { runtime: 'bash', script: 'echo PATH=$PATH SECRET=$GSD_TEST_SECRET' },
+      { runtime: 'bash', script: 'echo PATH=$PATH BLOCKED=$GSD_TEST_BLOCKED_VALUE' },
       baseOpts(base, {
         env_allowlist: [],
-        env: { PATH: '/usr/bin:/bin', HOME: '/tmp', GSD_TEST_SECRET: 'should-be-blocked' },
+        env: { PATH: '/usr/bin:/bin', HOME: '/tmp', GSD_TEST_BLOCKED_VALUE: 'blocked-value' },
       }),
     );
     const stdout = readFileSync(result.stdout_path, 'utf-8');
     assert.ok(stdout.includes('PATH=/usr/bin:/bin'), 'PATH forwarded');
-    assert.ok(!stdout.includes('should-be-blocked'), 'non-allowlisted var blocked');
+    assert.ok(!stdout.includes('blocked-value'), 'non-allowlisted var blocked');
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/mcp-status.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-status.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   formatMcpInitResult,
+  formatMcpConnectionTestResult,
   formatMcpStatusReport,
   formatMcpServerDetail,
   hasHostMcpTool,
@@ -37,6 +38,15 @@ describe("formatMcpStatusReport", () => {
     const result = formatMcpStatusReport(servers);
     assert.match(result, /error/i);
     assert.match(result, /Connection refused/);
+  });
+
+  test("shows disabled state separately from disconnected", () => {
+    const servers: McpServerStatus[] = [
+      { name: "disabled-server", transport: "stdio", connected: false, toolCount: 0, error: undefined, disabled: true },
+    ];
+    const result = formatMcpStatusReport(servers);
+    assert.match(result, /disabled-server/);
+    assert.match(result, /disabled/i);
   });
 
   test("includes server count in header", () => {
@@ -101,6 +111,50 @@ describe("formatMcpServerDetail", () => {
       error: undefined,
     });
     assert.match(result, /disconnected/i);
+  });
+
+  test("shows env warnings for server detail", () => {
+    const result = formatMcpServerDetail({
+      name: "warned",
+      transport: "http",
+      connected: false,
+      toolCount: 0,
+      tools: [],
+      error: undefined,
+      envWarnings: ["headers.Authorization references unset environment variable TOKEN."],
+    });
+    assert.match(result, /Warnings/);
+    assert.match(result, /TOKEN/);
+  });
+});
+
+describe("formatMcpConnectionTestResult", () => {
+  test("summarizes successful tools/list", () => {
+    const result = formatMcpConnectionTestResult({
+      ok: true,
+      server: "demo",
+      transport: "stdio",
+      toolCount: 1,
+      tools: ["ping"],
+      warnings: [],
+    });
+    assert.match(result, /passed/i);
+    assert.match(result, /ping/);
+  });
+
+  test("summarizes failed connection with warnings", () => {
+    const result = formatMcpConnectionTestResult({
+      ok: false,
+      server: "demo",
+      transport: "http",
+      toolCount: 0,
+      tools: [],
+      warnings: ["url references unset environment variable TOKEN."],
+      error: "bad config",
+    });
+    assert.match(result, /failed/i);
+    assert.match(result, /bad config/);
+    assert.match(result, /TOKEN/);
   });
 });
 

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -84,7 +84,10 @@ function escapeRegExp(value: string): string {
 }
 
 function normalizeScanPath(value: string): string {
-  return value.replace(/\\/g, "/").replace(/\/+$/, "");
+  const normalized = value.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized.startsWith("/private/var/")
+    ? normalized.slice("/private".length)
+    : normalized;
 }
 
 function parseWorktreeBase(baseDir: string): { originalRoot: string; worktreeRoot: string } | null {

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -135,8 +135,8 @@ function getBundledWorkflowMcpCliPath(env: NodeJS.ProcessEnv): string | null {
 function getBundledWorkflowExecutorModulePath(): string | null {
   const candidates = [
     resolve(fileURLToPath(new URL("./tools/workflow-tool-executors.js", import.meta.url))),
-    resolve(fileURLToPath(new URL("./tools/workflow-tool-executors.ts", import.meta.url))),
     resolve(fileURLToPath(new URL("../../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.js", import.meta.url))),
+    resolve(fileURLToPath(new URL("./tools/workflow-tool-executors.ts", import.meta.url))),
   ];
 
   for (const candidate of candidates) {
@@ -149,8 +149,8 @@ function getBundledWorkflowExecutorModulePath(): string | null {
 function getBundledWorkflowWriteGateModulePath(): string | null {
   const candidates = [
     resolve(fileURLToPath(new URL("./bootstrap/write-gate.js", import.meta.url))),
-    resolve(fileURLToPath(new URL("./bootstrap/write-gate.ts", import.meta.url))),
     resolve(fileURLToPath(new URL("../../../../dist/resources/extensions/gsd/bootstrap/write-gate.js", import.meta.url))),
+    resolve(fileURLToPath(new URL("./bootstrap/write-gate.ts", import.meta.url))),
   ];
 
   for (const candidate of candidates) {

--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -24,28 +24,19 @@ import { Type } from "@sinclair/typebox";
 import { Client } from "@modelcontextprotocol/sdk/client";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
 import { buildHttpTransportOpts } from "./auth.js";
-import type { McpHttpAuthConfig } from "./auth.js";
-import { gsdHome } from "../gsd/gsd-home.js";
+import {
+	buildMcpChildEnv,
+	clearMcpConfigCache,
+	getMcpServerConfig,
+	readMcpServerConfigs,
+	resolveMcpEnv,
+	type ManagedMcpServerConfig,
+} from "./manager.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface McpServerConfig {
-	name: string;
-	transport: "stdio" | "http" | "unknown";
-	sourcePath: string;
-	command?: string;
-	args?: string[];
-	env?: Record<string, string>;
-	url?: string;
-	cwd?: string;
-	/** Static headers for HTTP transport (supports ${VAR} env resolution). */
-	headers?: Record<string, string>;
-	/** OAuth config for HTTP transport. */
-	oauth?: McpHttpAuthConfig["oauth"];
-}
+type McpServerConfig = ManagedMcpServerConfig;
 
 interface McpToolSchema {
 	name: string;
@@ -62,28 +53,8 @@ interface ManagedConnection {
 
 const connections = new Map<string, ManagedConnection>();
 const pendingConnections = new Map<string, Promise<Client>>();
-let configCache: McpServerConfig[] | null = null;
 const toolCache = new Map<string, McpToolSchema[]>();
 const trustedStdioServers = new Set<string>();
-
-const CHILD_ENV_ALLOWLIST = new Set([
-	"PATH",
-	"Path",
-	"HOME",
-	"USER",
-	"USERNAME",
-	"USERPROFILE",
-	"SHELL",
-	"TMPDIR",
-	"TEMP",
-	"TMP",
-	"SystemRoot",
-	"WINDIR",
-	"APPDATA",
-	"LOCALAPPDATA",
-	"XDG_CONFIG_HOME",
-	"XDG_CACHE_HOME",
-]);
 
 function stdioTrustKey(config: McpServerConfig): string {
 	return JSON.stringify({
@@ -97,77 +68,11 @@ function stdioTrustKey(config: McpServerConfig): string {
 }
 
 function readConfigs(): McpServerConfig[] {
-	if (configCache) return configCache;
-
-	const servers: McpServerConfig[] = [];
-	const seen = new Set<string>();
-	const configPaths = [
-		join(process.cwd(), ".mcp.json"),
-		join(process.cwd(), ".gsd", "mcp.json"),
-		join(gsdHome(), "mcp.json"),
-	];
-
-	for (const configPath of configPaths) {
-		try {
-			if (!existsSync(configPath)) continue;
-			const raw = readFileSync(configPath, "utf-8");
-			const data = JSON.parse(raw) as Record<string, unknown>;
-			const mcpServers = (data.mcpServers ?? data.servers) as
-				| Record<string, Record<string, unknown>>
-				| undefined;
-			if (!mcpServers || typeof mcpServers !== "object") continue;
-
-			for (const [name, config] of Object.entries(mcpServers)) {
-				if (seen.has(name)) continue;
-				seen.add(name);
-
-				const hasCommand = typeof config.command === "string";
-				const hasUrl = typeof config.url === "string";
-				const transport: McpServerConfig["transport"] = hasCommand
-					? "stdio"
-					: hasUrl
-						? "http"
-						: "unknown";
-
-				const hasHeaders = hasUrl && config.headers && typeof config.headers === "object";
-				const hasOAuth = hasUrl && config.oauth && typeof config.oauth === "object";
-
-				servers.push({
-					name,
-					transport,
-					sourcePath: configPath,
-					...(hasCommand && {
-						command: config.command as string,
-						args: Array.isArray(config.args) ? (config.args as string[]) : undefined,
-						env: config.env && typeof config.env === "object"
-							? (config.env as Record<string, string>)
-							: undefined,
-						cwd: typeof config.cwd === "string" ? config.cwd : undefined,
-					}),
-					...(hasUrl && { url: config.url as string }),
-					headers: hasHeaders ? config.headers as Record<string, string> : undefined,
-					oauth: hasOAuth ? config.oauth as McpHttpAuthConfig["oauth"] : undefined,
-				});
-			}
-		} catch {
-			// Non-fatal — config file may not exist or be malformed
-		}
-	}
-
-	configCache = servers;
-	return servers;
+	return readMcpServerConfigs();
 }
 
 export function _buildMcpChildEnvForTest(configEnv: Record<string, string> | undefined): Record<string, string> {
-	const childEnv: Record<string, string> = {};
-	for (const key of CHILD_ENV_ALLOWLIST) {
-		const value = process.env[key];
-		if (typeof value === "string") childEnv[key] = value;
-	}
-	return {
-		...childEnv,
-		...(configEnv ? resolveEnv(configEnv) : {}),
-	};
+	return buildMcpChildEnv(configEnv);
 }
 
 export function _buildMcpTrustConfirmOptionsForTest(signal?: AbortSignal): { timeout: number; signal?: AbortSignal } {
@@ -209,27 +114,12 @@ async function assertTrustedStdioServer(
 // Exported for tests (see tests/server-name-spaces.test.ts).
 // Production call sites treat this as module-private.
 export function getServerConfig(name: string): McpServerConfig | undefined {
-	const trimmed = name.trim();
-	return readConfigs().find((s) =>
-		s.name === trimmed ||
-		s.name.toLowerCase() === trimmed.toLowerCase(),
-	);
+	return getMcpServerConfig(name);
 }
 
 /** Resolve ${VAR} references in env values against process.env. */
 function resolveEnv(env: Record<string, string>): Record<string, string> {
-	const resolved: Record<string, string> = {};
-	for (const [key, value] of Object.entries(env)) {
-		if (typeof value === "string") {
-			resolved[key] = value.replace(
-				/\$\{([^}]+)\}/g,
-				(_match, varName) => process.env[varName] ?? "",
-			);
-		} else {
-			resolved[key] = value;
-		}
-	}
-	return resolved;
+	return resolveMcpEnv(env);
 }
 
 async function getOrConnect(name: string, signal?: AbortSignal, ctx?: ExtensionContext): Promise<Client> {
@@ -403,14 +293,12 @@ export default function (pi: ExtensionAPI) {
 		}),
 
 		async execute(_id, params) {
-			if (params.refresh) configCache = null;
-
-			const servers = readConfigs();
+			const servers = readMcpServerConfigs({ refresh: !!params.refresh });
 			return {
 				content: [{ type: "text", text: formatServerList(servers) }],
 				details: {
 					serverCount: servers.length,
-					cached: !params.refresh && configCache !== null,
+					cached: !params.refresh,
 				},
 			};
 		},
@@ -633,6 +521,6 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_switch", async () => {
 		await closeAll();
-		configCache = null;
+		clearMcpConfigCache();
 	});
 }

--- a/src/resources/extensions/mcp-client/manager.ts
+++ b/src/resources/extensions/mcp-client/manager.ts
@@ -1,0 +1,516 @@
+/**
+ * GSD-2 — Shared MCP connection management.
+ *
+ * File Purpose: Reads, writes, and tests user-configured MCP server entries
+ * for runtime tools, TUI commands, and app settings surfaces.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { buildHttpTransportOpts, type McpHttpAuthConfig } from "./auth.js";
+import { gsdHome } from "../gsd/gsd-home.js";
+
+export type ManagedMcpTransport = "stdio" | "http" | "unsupported";
+export type ManagedMcpSourceKind = "project-shared" | "project-local" | "global";
+
+export interface ManagedMcpConfigSource {
+	path: string;
+	kind: ManagedMcpSourceKind;
+	label: string;
+}
+
+export interface ManagedMcpServerConfig {
+	name: string;
+	transport: ManagedMcpTransport;
+	sourcePath: string;
+	sourceKind: ManagedMcpSourceKind;
+	disabled: boolean;
+	command?: string;
+	args?: string[];
+	env?: Record<string, string>;
+	url?: string;
+	cwd?: string;
+	headers?: Record<string, string>;
+	oauth?: McpHttpAuthConfig["oauth"];
+	envWarnings: string[];
+}
+
+export interface ManagedMcpServerInput {
+	name: string;
+	transport: Exclude<ManagedMcpTransport, "unsupported">;
+	command?: string;
+	args?: string[];
+	env?: Record<string, string>;
+	url?: string;
+	cwd?: string;
+	headers?: Record<string, string>;
+	oauth?: McpHttpAuthConfig["oauth"];
+	disabled?: boolean;
+	importedFrom?: {
+		name?: string;
+		sourcePath?: string;
+		sourceTool?: string;
+	};
+}
+
+export interface ManagedMcpStatus {
+	servers: ManagedMcpServerConfig[];
+	duplicates: Array<{
+		name: string;
+		keptSourcePath: string;
+		shadowedSourcePath: string;
+	}>;
+	warnings: string[];
+	localConfigPath: string;
+}
+
+export interface ManagedMcpConnectionTestResult {
+	ok: boolean;
+	server: string;
+	transport: ManagedMcpTransport;
+	toolCount: number;
+	tools: string[];
+	warnings: string[];
+	error?: string;
+}
+
+interface RawMcpConfigFile {
+	mcpServers?: Record<string, Record<string, unknown>>;
+	servers?: Record<string, Record<string, unknown>>;
+	[key: string]: unknown;
+}
+
+const CHILD_ENV_ALLOWLIST = new Set([
+	"PATH",
+	"Path",
+	"HOME",
+	"USER",
+	"USERNAME",
+	"USERPROFILE",
+	"SHELL",
+	"TMPDIR",
+	"TEMP",
+	"TMP",
+	"SystemRoot",
+	"WINDIR",
+	"APPDATA",
+	"LOCALAPPDATA",
+	"XDG_CONFIG_HOME",
+	"XDG_CACHE_HOME",
+]);
+
+let cachedStatus: ManagedMcpStatus | null = null;
+let cachedStatusKey = "";
+
+export function clearMcpConfigCache(): void {
+	cachedStatus = null;
+	cachedStatusKey = "";
+}
+
+export function getProjectLocalMcpConfigPath(projectDir = process.cwd()): string {
+	return join(projectDir, ".gsd", "mcp.json");
+}
+
+export function getMcpConfigSources(
+	projectDir = process.cwd(),
+	gsdHomeDir = gsdHome(),
+): ManagedMcpConfigSource[] {
+	return [
+		{ path: join(projectDir, ".mcp.json"), kind: "project-shared", label: "Project shared" },
+		{ path: getProjectLocalMcpConfigPath(projectDir), kind: "project-local", label: "Project local" },
+		{ path: join(gsdHomeDir, "mcp.json"), kind: "global", label: "Global" },
+	];
+}
+
+export function readMcpManagementStatus(options: {
+	projectDir?: string;
+	gsdHomeDir?: string;
+	refresh?: boolean;
+	includeDisabled?: boolean;
+} = {}): ManagedMcpStatus {
+	const projectDir = options.projectDir ?? process.cwd();
+	const gsdHomeDir = options.gsdHomeDir ?? gsdHome();
+	const cacheKey = JSON.stringify({ projectDir, gsdHomeDir, includeDisabled: !!options.includeDisabled });
+	if (!options.refresh && cachedStatus && cachedStatusKey === cacheKey) {
+		return cachedStatus;
+	}
+
+	const seen = new Map<string, ManagedMcpServerConfig>();
+	const servers: ManagedMcpServerConfig[] = [];
+	const duplicates: ManagedMcpStatus["duplicates"] = [];
+	const warnings: string[] = [];
+
+	for (const source of getMcpConfigSources(projectDir, gsdHomeDir)) {
+		const loaded = readRawConfigFile(source.path);
+		if (!loaded.exists) continue;
+		if (loaded.error) {
+			warnings.push(`${source.path}: ${loaded.error}`);
+			continue;
+		}
+		const mcpServers = loaded.data?.mcpServers ?? loaded.data?.servers;
+		if (!mcpServers || typeof mcpServers !== "object") continue;
+
+		for (const [name, rawConfig] of Object.entries(mcpServers)) {
+			if (!rawConfig || typeof rawConfig !== "object") continue;
+			const normalized = normalizeRawServerConfig(name, rawConfig, source);
+			const existing = seen.get(name);
+			if (existing) {
+				duplicates.push({
+					name,
+					keptSourcePath: existing.sourcePath,
+					shadowedSourcePath: source.path,
+				});
+				continue;
+			}
+			seen.set(name, normalized);
+			if (!normalized.disabled || options.includeDisabled) {
+				servers.push(normalized);
+			}
+		}
+	}
+
+	const status = {
+		servers,
+		duplicates,
+		warnings,
+		localConfigPath: getProjectLocalMcpConfigPath(projectDir),
+	};
+	cachedStatus = status;
+	cachedStatusKey = cacheKey;
+	return status;
+}
+
+export function readMcpServerConfigs(options: {
+	projectDir?: string;
+	gsdHomeDir?: string;
+	refresh?: boolean;
+	includeDisabled?: boolean;
+} = {}): ManagedMcpServerConfig[] {
+	return readMcpManagementStatus(options).servers;
+}
+
+export function getMcpServerConfig(
+	name: string,
+	options: { projectDir?: string; gsdHomeDir?: string; includeDisabled?: boolean } = {},
+): ManagedMcpServerConfig | undefined {
+	const trimmed = name.trim();
+	return readMcpServerConfigs(options).find((server) =>
+		server.name === trimmed ||
+		server.name.toLowerCase() === trimmed.toLowerCase(),
+	);
+}
+
+export function buildMcpChildEnv(configEnv: Record<string, string> | undefined): Record<string, string> {
+	const childEnv: Record<string, string> = {};
+	for (const key of CHILD_ENV_ALLOWLIST) {
+		const value = process.env[key];
+		if (typeof value === "string") childEnv[key] = value;
+	}
+	return {
+		...childEnv,
+		...(configEnv ? resolveMcpEnv(configEnv) : {}),
+	};
+}
+
+export function resolveMcpEnv(env: Record<string, string>): Record<string, string> {
+	const resolved: Record<string, string> = {};
+	for (const [key, value] of Object.entries(env)) {
+		resolved[key] = typeof value === "string" ? resolveMcpString(value) : value;
+	}
+	return resolved;
+}
+
+export function resolveMcpString(value: string): string {
+	return value.replace(
+		/\$\{([^}]+)\}/g,
+		(_match, varName) => process.env[varName] ?? "",
+	);
+}
+
+export function upsertProjectLocalMcpServer(
+	input: ManagedMcpServerInput,
+	options: { projectDir?: string; previousName?: string } = {},
+): ManagedMcpServerConfig {
+	const projectDir = options.projectDir ?? process.cwd();
+	const nextName = input.name.trim();
+	if (!nextName) throw new Error("MCP server name is required.");
+
+	const previousName = options.previousName?.trim();
+	const existing = getMcpServerConfig(nextName, { projectDir, includeDisabled: true });
+	if (existing && previousName !== nextName) {
+		throw new Error(`MCP server "${nextName}" already exists in ${existing.sourcePath}. Rename the server before saving.`);
+	}
+
+	const configPath = getProjectLocalMcpConfigPath(projectDir);
+	const file = readEditableConfigFile(configPath);
+	if (previousName && previousName !== nextName) {
+		delete file.mcpServers[previousName];
+	}
+	file.mcpServers[nextName] = serializeServerInput({ ...input, name: nextName });
+	writeEditableConfigFile(configPath, file);
+	clearMcpConfigCache();
+
+	const saved = getMcpServerConfig(nextName, { projectDir, includeDisabled: true });
+	if (!saved) throw new Error(`MCP server "${nextName}" was saved but could not be reloaded.`);
+	return saved;
+}
+
+export function setProjectLocalMcpServerDisabled(
+	name: string,
+	disabled: boolean,
+	options: { projectDir?: string } = {},
+): ManagedMcpServerConfig {
+	const projectDir = options.projectDir ?? process.cwd();
+	const configPath = getProjectLocalMcpConfigPath(projectDir);
+	const file = readEditableConfigFile(configPath);
+	const current = file.mcpServers[name];
+	if (!current) throw new Error(`MCP server "${name}" is not managed in ${configPath}. Import it before editing local state.`);
+	current.disabled = disabled;
+	writeEditableConfigFile(configPath, file);
+	clearMcpConfigCache();
+	const saved = getMcpServerConfig(name, { projectDir, includeDisabled: true });
+	if (!saved) throw new Error(`MCP server "${name}" was updated but could not be reloaded.`);
+	return saved;
+}
+
+export function deleteProjectLocalMcpServer(
+	name: string,
+	options: { projectDir?: string } = {},
+): void {
+	const projectDir = options.projectDir ?? process.cwd();
+	const configPath = getProjectLocalMcpConfigPath(projectDir);
+	const file = readEditableConfigFile(configPath);
+	if (!file.mcpServers[name]) throw new Error(`MCP server "${name}" is not managed in ${configPath}.`);
+	delete file.mcpServers[name];
+	writeEditableConfigFile(configPath, file);
+	clearMcpConfigCache();
+}
+
+export async function testMcpServerConnection(
+	nameOrConfig: string | ManagedMcpServerConfig,
+	options: {
+		projectDir?: string;
+		signal?: AbortSignal;
+		timeoutMs?: number;
+	} = {},
+): Promise<ManagedMcpConnectionTestResult> {
+	const config = typeof nameOrConfig === "string"
+		? getMcpServerConfig(nameOrConfig, { projectDir: options.projectDir, includeDisabled: true })
+		: nameOrConfig;
+	if (!config) {
+		return {
+			ok: false,
+			server: typeof nameOrConfig === "string" ? nameOrConfig : "",
+			transport: "unsupported",
+			toolCount: 0,
+			tools: [],
+			warnings: [],
+			error: "Unknown MCP server.",
+		};
+	}
+	if (config.disabled) {
+		return {
+			ok: false,
+			server: config.name,
+			transport: config.transport,
+			toolCount: 0,
+			tools: [],
+			warnings: config.envWarnings,
+			error: "MCP server is disabled.",
+		};
+	}
+	if (config.transport === "unsupported") {
+		return {
+			ok: false,
+			server: config.name,
+			transport: config.transport,
+			toolCount: 0,
+			tools: [],
+			warnings: config.envWarnings,
+			error: "MCP server transport is unsupported.",
+		};
+	}
+	if (config.envWarnings.length > 0) {
+		return {
+			ok: false,
+			server: config.name,
+			transport: config.transport,
+			toolCount: 0,
+			tools: [],
+			warnings: config.envWarnings,
+			error: "MCP server config references unset environment variables.",
+		};
+	}
+
+	const client = new Client({ name: "gsd", version: "1.0.0" });
+	let transport: StdioClientTransport | StreamableHTTPClientTransport | undefined;
+	const timeout = options.timeoutMs ?? 30_000;
+	try {
+		if (config.transport === "stdio") {
+			transport = new StdioClientTransport({
+				command: config.command ?? "",
+				args: config.args,
+				env: buildMcpChildEnv(config.env),
+				cwd: config.cwd,
+				stderr: "pipe",
+			});
+		} else {
+			const resolvedUrl = resolveMcpString(config.url ?? "");
+			transport = new StreamableHTTPClientTransport(
+				new URL(resolvedUrl),
+				buildHttpTransportOpts({ headers: config.headers, oauth: config.oauth }),
+			);
+		}
+
+		await client.connect(transport, { signal: options.signal, timeout });
+		const result = await client.listTools(undefined, { signal: options.signal, timeout });
+		const tools = (result.tools ?? []).map((tool) => tool.name);
+		return {
+			ok: true,
+			server: config.name,
+			transport: config.transport,
+			toolCount: tools.length,
+			tools,
+			warnings: [],
+		};
+	} catch (error) {
+		return {
+			ok: false,
+			server: config.name,
+			transport: config.transport,
+			toolCount: 0,
+			tools: [],
+			warnings: config.envWarnings,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	} finally {
+		if (transport) {
+			try {
+				await transport.close();
+			} catch {
+				// Best-effort cleanup after test connection.
+			}
+		}
+		try {
+			await client.close();
+		} catch {
+			// Best-effort cleanup after test connection.
+		}
+	}
+}
+
+function readRawConfigFile(path: string): {
+	exists: boolean;
+	data?: RawMcpConfigFile;
+	error?: string;
+} {
+	if (!existsSync(path)) return { exists: false };
+	try {
+		return { exists: true, data: JSON.parse(readFileSync(path, "utf-8")) as RawMcpConfigFile };
+	} catch (error) {
+		return { exists: true, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+function readEditableConfigFile(path: string): RawMcpConfigFile & { mcpServers: Record<string, Record<string, unknown>> } {
+	const loaded = readRawConfigFile(path);
+	if (loaded.error) throw new Error(`Unable to read MCP config ${path}: ${loaded.error}`);
+	const data = loaded.data ?? {};
+	const mcpServers = data.mcpServers && typeof data.mcpServers === "object" ? data.mcpServers : {};
+	return { ...data, mcpServers };
+}
+
+function writeEditableConfigFile(path: string, data: RawMcpConfigFile): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+}
+
+function normalizeRawServerConfig(
+	name: string,
+	config: Record<string, unknown>,
+	source: ManagedMcpConfigSource,
+): ManagedMcpServerConfig {
+	const transport = detectTransport(config);
+	const env = isRecordOfStrings(config.env) ? config.env : undefined;
+	const headers = isRecordOfStrings(config.headers) ? config.headers : undefined;
+	const url = typeof config.url === "string" ? config.url : undefined;
+	const command = typeof config.command === "string" ? config.command : undefined;
+	return {
+		name,
+		transport,
+		sourcePath: source.path,
+		sourceKind: source.kind,
+		disabled: config.disabled === true,
+		...(command ? { command } : {}),
+		args: Array.isArray(config.args) ? config.args.filter((arg): arg is string => typeof arg === "string") : undefined,
+		env,
+		...(url ? { url } : {}),
+		cwd: typeof config.cwd === "string" ? config.cwd : undefined,
+		headers,
+		oauth: config.oauth && typeof config.oauth === "object" ? config.oauth as McpHttpAuthConfig["oauth"] : undefined,
+		envWarnings: collectEnvWarnings([
+			["url", url],
+			...Object.entries(env ?? {}).map(([key, value]) => [`env.${key}`, value] as [string, string | undefined]),
+			...Object.entries(headers ?? {}).map(([key, value]) => [`headers.${key}`, value] as [string, string | undefined]),
+		]),
+	};
+}
+
+function detectTransport(config: Record<string, unknown>): ManagedMcpTransport {
+	const type = typeof config.type === "string" ? config.type.toLowerCase() : undefined;
+	if (type && type !== "stdio" && type !== "http") return "unsupported";
+	if (typeof config.command === "string") return "stdio";
+	if (typeof config.url === "string" && type !== "stdio") return "http";
+	return "unsupported";
+}
+
+function serializeServerInput(input: ManagedMcpServerInput): Record<string, unknown> {
+	if (input.transport === "stdio") {
+		if (!input.command?.trim()) throw new Error("Stdio MCP servers require a command.");
+		return stripUndefined({
+			type: "stdio",
+			command: input.command.trim(),
+			args: input.args,
+			env: input.env,
+			cwd: input.cwd,
+			disabled: input.disabled === true ? true : undefined,
+			_gsdImportedFrom: input.importedFrom,
+		});
+	}
+	if (!input.url?.trim()) throw new Error("HTTP MCP servers require a URL.");
+	return stripUndefined({
+		type: "http",
+		url: input.url.trim(),
+		headers: input.headers,
+		oauth: input.oauth,
+		disabled: input.disabled === true ? true : undefined,
+		_gsdImportedFrom: input.importedFrom,
+	});
+}
+
+function collectEnvWarnings(values: Array<[string, string | undefined]>): string[] {
+	const warnings: string[] = [];
+	for (const [label, value] of values) {
+		if (!value) continue;
+		for (const match of value.matchAll(/\$\{([^}]+)\}/g)) {
+			const varName = match[1];
+			if (varName && process.env[varName] === undefined) {
+				warnings.push(`${label} references unset environment variable ${varName}.`);
+			}
+		}
+	}
+	return warnings;
+}
+
+function isRecordOfStrings(value: unknown): value is Record<string, string> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	return Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function stripUndefined(value: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}

--- a/src/resources/extensions/mcp-client/tests/manager.test.ts
+++ b/src/resources/extensions/mcp-client/tests/manager.test.ts
@@ -1,0 +1,165 @@
+/**
+ * GSD-2 — MCP manager tests.
+ *
+ * File Purpose: Behaviour coverage for shared MCP config management and
+ * side-effect-free connection testing.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+	clearMcpConfigCache,
+	deleteProjectLocalMcpServer,
+	readMcpManagementStatus,
+	readMcpServerConfigs,
+	setProjectLocalMcpServerDisabled,
+	testMcpServerConnection,
+	upsertProjectLocalMcpServer,
+	type ManagedMcpServerConfig,
+} from "../manager.js";
+
+function makeProject(): { projectDir: string; gsdHomeDir: string; cleanup: () => void } {
+	const projectDir = mkdtempSync(join(tmpdir(), "gsd-mcp-manager-project-"));
+	const gsdHomeDir = mkdtempSync(join(tmpdir(), "gsd-mcp-manager-home-"));
+	mkdirSync(join(projectDir, ".gsd"), { recursive: true });
+	return {
+		projectDir,
+		gsdHomeDir,
+		cleanup: () => {
+			rmSync(projectDir, { recursive: true, force: true });
+			rmSync(gsdHomeDir, { recursive: true, force: true });
+			clearMcpConfigCache();
+		},
+	};
+}
+
+test("MCP manager reads sources with precedence, disabled state, duplicates, and env warnings", () => {
+	const previousToken = process.env.MISSING_MANAGER_TOKEN;
+	delete process.env.MISSING_MANAGER_TOKEN;
+	const { projectDir, gsdHomeDir, cleanup } = makeProject();
+	try {
+		writeFileSync(
+			join(projectDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					shared: { command: "node", args: ["shared.js"] },
+					warned: { url: "https://example.test/${MISSING_MANAGER_TOKEN}" },
+				},
+			}),
+			"utf-8",
+		);
+		writeFileSync(
+			join(projectDir, ".gsd", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					local: { command: "node", disabled: true },
+				},
+			}),
+			"utf-8",
+		);
+		writeFileSync(
+			join(gsdHomeDir, "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					shared: { command: "node", args: ["global.js"] },
+				},
+			}),
+			"utf-8",
+		);
+
+		const status = readMcpManagementStatus({ projectDir, gsdHomeDir, includeDisabled: true, refresh: true });
+		assert.deepEqual(status.servers.map((server) => server.name), ["shared", "warned", "local"]);
+		assert.equal(status.servers.find((server) => server.name === "local")?.disabled, true);
+		assert.equal(status.duplicates[0]?.name, "shared");
+		assert.match(status.servers.find((server) => server.name === "warned")?.envWarnings[0] ?? "", /MISSING_MANAGER_TOKEN/);
+
+		const runtimeServers = readMcpServerConfigs({ projectDir, gsdHomeDir, refresh: true });
+		assert.deepEqual(runtimeServers.map((server) => server.name), ["shared", "warned"]);
+	} finally {
+		if (previousToken === undefined) delete process.env.MISSING_MANAGER_TOKEN;
+		else process.env.MISSING_MANAGER_TOKEN = previousToken;
+		cleanup();
+	}
+});
+
+test("MCP manager writes local config and blocks duplicate names unless renamed", () => {
+	const { projectDir, cleanup } = makeProject();
+	try {
+		writeFileSync(
+			join(projectDir, ".mcp.json"),
+			JSON.stringify({ mcpServers: { existing: { command: "node" } } }),
+			"utf-8",
+		);
+
+		assert.throws(
+			() => upsertProjectLocalMcpServer({ name: "existing", transport: "stdio", command: "node" }, { projectDir }),
+			/already exists/,
+		);
+
+		const saved = upsertProjectLocalMcpServer(
+			{ name: "local-server", transport: "stdio", command: "node", args: ["server.js"], disabled: true },
+			{ projectDir },
+		);
+		assert.equal(saved.sourceKind, "project-local");
+		assert.equal(saved.disabled, true);
+
+		const enabled = setProjectLocalMcpServerDisabled("local-server", false, { projectDir });
+		assert.equal(enabled.disabled, false);
+
+		deleteProjectLocalMcpServer("local-server", { projectDir });
+		const raw = JSON.parse(readFileSync(join(projectDir, ".gsd", "mcp.json"), "utf-8")) as { mcpServers: Record<string, unknown> };
+		assert.equal(raw.mcpServers["local-server"], undefined);
+	} finally {
+		cleanup();
+	}
+});
+
+test("MCP connection test performs handshake and tools/list without invoking tools", async () => {
+	const { projectDir, cleanup } = makeProject();
+	try {
+		const require = createRequire(import.meta.url);
+		const mcpModuleUrl = pathToFileURL(require.resolve("@modelcontextprotocol/sdk/server/mcp.js")).href;
+		const stdioModuleUrl = pathToFileURL(require.resolve("@modelcontextprotocol/sdk/server/stdio.js")).href;
+		const calledPath = join(projectDir, "called-tool.txt");
+		const serverPath = join(projectDir, "fake-mcp-server.mjs");
+		writeFileSync(
+			serverPath,
+			[
+				`const { McpServer } = await import(${JSON.stringify(mcpModuleUrl)});`,
+				`const { StdioServerTransport } = await import(${JSON.stringify(stdioModuleUrl)});`,
+				'import { writeFileSync } from "node:fs";',
+				`const calledPath = ${JSON.stringify(calledPath)};`,
+				'const server = new McpServer({ name: "fake", version: "1.0.0" }, { capabilities: { tools: {} } });',
+				'server.tool("fake_tool", "Should not be invoked by test connection", {}, async () => {',
+				'  writeFileSync(calledPath, "called", "utf-8");',
+				'  return { content: [{ type: "text", text: "called" }] };',
+				'});',
+				'await server.connect(new StdioServerTransport());',
+			].join("\n"),
+			"utf-8",
+		);
+
+		const result = await testMcpServerConnection({
+			name: "fake",
+			transport: "stdio",
+			sourcePath: join(projectDir, ".gsd", "mcp.json"),
+			sourceKind: "project-local",
+			disabled: false,
+			command: process.execPath,
+			args: [serverPath],
+			envWarnings: [],
+		} satisfies ManagedMcpServerConfig, { projectDir, timeoutMs: 10_000 });
+
+		assert.equal(result.ok, true, result.error);
+		assert.deepEqual(result.tools, ["fake_tool"]);
+		assert.equal(existsSync(calledPath), false, "connection test must not invoke MCP tools");
+	} finally {
+		cleanup();
+	}
+});

--- a/src/tests/integration/web-mcp-management-contract.test.ts
+++ b/src/tests/integration/web-mcp-management-contract.test.ts
@@ -1,0 +1,57 @@
+// GSD-2 — Web MCP management contract tests.
+// File Purpose: Verifies the app-facing MCP service uses the shared manager.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  collectMcpManagementData,
+  mutateMcpManagement,
+} from "../../web/mcp-management-service.ts";
+
+test("web MCP management service lists, saves, disables, and deletes local servers", async () => {
+  const projectDir = mkdtempSync(join(tmpdir(), "web-mcp-project-"));
+  const gsdHomeDir = mkdtempSync(join(tmpdir(), "web-mcp-home-"));
+  const previousGsdHome = process.env.GSD_HOME;
+  try {
+    process.env.GSD_HOME = gsdHomeDir;
+    mkdirSync(join(projectDir, ".gsd"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".mcp.json"),
+      JSON.stringify({ mcpServers: { shared: { command: "node", args: ["shared.js"] } } }),
+      "utf-8",
+    );
+
+    const listed = await collectMcpManagementData(projectDir);
+    assert.ok(listed.servers.some((server) => server.name === "shared"));
+
+    const saved = await mutateMcpManagement({
+      action: "save",
+      server: { name: "local", transport: "stdio", command: "node", args: ["local.js"] },
+    }, projectDir);
+    assert.equal(saved.status, "ok");
+    if (saved.status === "ok") {
+      assert.ok(saved.data.servers.some((server) => server.name === "local" && server.sourceKind === "project-local"));
+    }
+
+    const disabled = await mutateMcpManagement({ action: "disable", name: "local" }, projectDir);
+    assert.equal(disabled.status, "ok");
+    if (disabled.status === "ok") {
+      assert.equal(disabled.data.servers.find((server) => server.name === "local")?.disabled, true);
+    }
+
+    const deleted = await mutateMcpManagement({ action: "delete", name: "local" }, projectDir);
+    assert.equal(deleted.status, "ok");
+    if (deleted.status === "ok") {
+      assert.equal(deleted.data.servers.some((server) => server.name === "local"), false);
+    }
+  } finally {
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(gsdHomeDir, { recursive: true, force: true });
+  }
+});

--- a/src/web/mcp-management-service.ts
+++ b/src/web/mcp-management-service.ts
@@ -1,0 +1,174 @@
+// GSD-2 — Web MCP management service.
+// File Purpose: Bridges app API routes to the shared MCP management module.
+
+import { execFile } from "node:child_process"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
+import { buildSubprocessPrefixArgs, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
+import type {
+  WebMcpManagementPayload,
+  WebMcpMutationRequest,
+  WebMcpMutationResponse,
+} from "../../web/lib/mcp-management-types.ts"
+
+const MCP_MANAGEMENT_MAX_BUFFER = 4 * 1024 * 1024
+
+function resolveTsLoaderPath(packageRoot: string): string {
+  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
+}
+
+export async function collectMcpManagementData(projectCwdOverride?: string): Promise<WebMcpManagementPayload> {
+  const result = await runMcpManagementSubprocess({ action: "list" }, projectCwdOverride)
+  if ("status" in result && result.status === "error") {
+    throw new Error(result.error)
+  }
+  return result as WebMcpManagementPayload
+}
+
+export async function mutateMcpManagement(
+  request: WebMcpMutationRequest,
+  projectCwdOverride?: string,
+): Promise<WebMcpMutationResponse> {
+  return runMcpManagementSubprocess(request, projectCwdOverride) as Promise<WebMcpMutationResponse>
+}
+
+async function runMcpManagementSubprocess(
+  action: WebMcpMutationRequest | { action: "list" },
+  projectCwdOverride?: string,
+): Promise<WebMcpManagementPayload | WebMcpMutationResponse> {
+  const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
+  const { packageRoot, projectCwd } = config
+  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
+  const managerResolution = resolveSubprocessModule(packageRoot, "resources/extensions/mcp-client/manager.ts")
+  const discoveryResolution = resolveSubprocessModule(packageRoot, "resources/extensions/universal-config/discovery.ts")
+
+  const requiredPaths = managerResolution.useCompiledJs
+    ? [managerResolution.modulePath, discoveryResolution.modulePath]
+    : [resolveTsLoader, managerResolution.modulePath, discoveryResolution.modulePath]
+  for (const requiredPath of requiredPaths) {
+    if (!existsSync(requiredPath)) {
+      throw new Error(`MCP management provider not found; missing=${requiredPath}`)
+    }
+  }
+
+  const script = [
+    'const { pathToFileURL } = await import("node:url");',
+    'const manager = await import(pathToFileURL(process.env.GSD_MCP_MANAGER_MODULE).href);',
+    'const discovery = await import(pathToFileURL(process.env.GSD_MCP_DISCOVERY_MODULE).href);',
+    'const projectDir = process.env.GSD_MCP_PROJECT_CWD;',
+    'const action = JSON.parse(process.env.GSD_MCP_ACTION);',
+    'function toWebServer(server) {',
+    '  return {',
+    '    name: server.name, transport: server.transport, sourcePath: server.sourcePath, sourceKind: server.sourceKind,',
+    '    disabled: server.disabled, command: server.command, args: server.args, env: server.env, url: server.url, cwd: server.cwd, headers: server.headers,',
+    '    envWarnings: server.envWarnings ?? [], connected: false, toolCount: 0, tools: [],',
+    '  };',
+    '}',
+    'function importableTransport(item) {',
+    '  if (typeof item.command === "string") return "stdio";',
+    '  if (typeof item.url === "string" && item.transport !== "sse") return "http";',
+    '  return "unsupported";',
+    '}',
+    'async function buildPayload() {',
+    '  const status = manager.readMcpManagementStatus({ projectDir, includeDisabled: true, refresh: true });',
+    '  const existingNames = new Set(status.servers.map((server) => server.name));',
+    '  const discovered = await discovery.discoverAllConfigs(projectDir);',
+    '  const importableServers = discovered.allItems',
+    '    .filter((item) => item.type === "mcp-server")',
+    '    .map((item) => {',
+    '      const transport = importableTransport(item);',
+    '      return {',
+    '        name: item.name, transport, sourcePath: item.source.path, sourceTool: item.source.toolName,',
+    '        command: item.command, args: item.args, env: item.env, url: item.url, headers: item.headers,',
+    '        unsupportedReason: transport === "unsupported" ? "Unsupported transport" : undefined,',
+    '        conflicts: existingNames.has(item.name),',
+    '      };',
+    '    });',
+    '  return {',
+    '    servers: status.servers.map(toWebServer),',
+    '    importableServers,',
+    '    duplicates: status.duplicates,',
+    '    warnings: status.warnings,',
+    '    localConfigPath: status.localConfigPath,',
+    '  };',
+    '}',
+    'async function run() {',
+    '  if (action.action === "list") return buildPayload();',
+    '  if (action.action === "save") {',
+    '    manager.upsertProjectLocalMcpServer(action.server, { projectDir, previousName: action.previousName });',
+    '    return { status: "ok", data: await buildPayload() };',
+    '  }',
+    '  if (action.action === "enable" || action.action === "disable") {',
+    '    manager.setProjectLocalMcpServerDisabled(action.name, action.action === "disable", { projectDir });',
+    '    return { status: "ok", data: await buildPayload() };',
+    '  }',
+    '  if (action.action === "delete") {',
+    '    manager.deleteProjectLocalMcpServer(action.name, { projectDir });',
+    '    return { status: "ok", data: await buildPayload() };',
+    '  }',
+    '  if (action.action === "test") {',
+    '    const result = await manager.testMcpServerConnection(action.name, { projectDir });',
+    '    return { status: "ok", data: await buildPayload(), result };',
+    '  }',
+    '  if (action.action === "import") {',
+    '    if (action.server.transport === "unsupported") throw new Error(`Cannot import unsupported MCP transport for ${action.server.name}.`);',
+    '    manager.upsertProjectLocalMcpServer({',
+    '      name: action.name || action.server.name, transport: action.server.transport,',
+    '      command: action.server.command, args: action.server.args, env: action.server.env, url: action.server.url, headers: action.server.headers,',
+    '      importedFrom: { name: action.server.name, sourcePath: action.server.sourcePath, sourceTool: action.server.sourceTool },',
+    '    }, { projectDir });',
+    '    return { status: "ok", data: await buildPayload() };',
+    '  }',
+    '  throw new Error(`Unknown MCP management action: ${action.action}`);',
+    '}',
+    'try { process.stdout.write(JSON.stringify(await run())); }',
+    'catch (error) { process.stdout.write(JSON.stringify({ status: "error", error: error instanceof Error ? error.message : String(error) })); }',
+  ].join(" ")
+
+  const prefixArgs = buildSubprocessPrefixArgs(
+    packageRoot,
+    managerResolution,
+    pathToFileURL(resolveTsLoader).href,
+  )
+
+  return await new Promise<WebMcpManagementPayload | WebMcpMutationResponse>((resolveResult, reject) => {
+    execFile(
+      process.execPath,
+      [
+        ...prefixArgs,
+        "--eval",
+        script,
+      ],
+      {
+        cwd: packageRoot,
+        env: {
+          ...process.env,
+          GSD_MCP_MANAGER_MODULE: managerResolution.modulePath,
+          GSD_MCP_DISCOVERY_MODULE: discoveryResolution.modulePath,
+          GSD_MCP_PROJECT_CWD: projectCwd,
+          GSD_MCP_ACTION: JSON.stringify(action),
+        },
+        maxBuffer: MCP_MANAGEMENT_MAX_BUFFER,
+        windowsHide: true,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`MCP management subprocess failed: ${stderr || error.message}`))
+          return
+        }
+        try {
+          resolveResult(JSON.parse(stdout) as WebMcpManagementPayload | WebMcpMutationResponse)
+        } catch (parseError) {
+          reject(
+            new Error(
+              `MCP management subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+            ),
+          )
+        }
+      },
+    )
+  })
+}

--- a/web/app/api/mcp-connections/route.ts
+++ b/web/app/api/mcp-connections/route.ts
@@ -1,0 +1,57 @@
+// GSD-2 — MCP connections API route.
+// File Purpose: Exposes app-side MCP connection management actions.
+
+import {
+  collectMcpManagementData,
+  mutateMcpManagement,
+} from "../../../../src/web/mcp-management-service.ts"
+import { requireProjectCwd } from "../../../../src/web/bridge-service.ts"
+import type { WebMcpMutationRequest } from "@/lib/mcp-management-types"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function GET(request: Request): Promise<Response> {
+  try {
+    const projectCwd = requireProjectCwd(request)
+    const payload = await collectMcpManagementData(projectCwd)
+    return Response.json(payload, {
+      headers: { "Cache-Control": "no-store" },
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return Response.json(
+      { error: message },
+      {
+        status: 500,
+        headers: { "Cache-Control": "no-store" },
+      },
+    )
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  try {
+    const projectCwd = requireProjectCwd(request)
+    const body = await request.json() as WebMcpMutationRequest
+    const payload = await mutateMcpManagement(body, projectCwd)
+    if (payload.status === "error") {
+      return Response.json(payload, {
+        status: 400,
+        headers: { "Cache-Control": "no-store" },
+      })
+    }
+    return Response.json(payload, {
+      headers: { "Cache-Control": "no-store" },
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return Response.json(
+      { status: "error", error: message },
+      {
+        status: 500,
+        headers: { "Cache-Control": "no-store" },
+      },
+    )
+  }
+}

--- a/web/components/gsd/command-surface.tsx
+++ b/web/components/gsd/command-surface.tsx
@@ -57,7 +57,7 @@ import {
 } from "@/lib/dev-overrides"
 import { DoctorPanel, ForensicsPanel, SkillHealthPanel } from "./diagnostics-panels"
 import { KnowledgeCapturesPanel } from "./knowledge-captures-panel"
-import { PrefsPanel, ModelRoutingPanel, BudgetPanel, RemoteQuestionsPanel, GeneralPanel, ExperimentalPanel } from "./settings-panels"
+import { PrefsPanel, ModelRoutingPanel, BudgetPanel, RemoteQuestionsPanel, McpConnectionsPanel, GeneralPanel, ExperimentalPanel } from "./settings-panels"
 import { DevRootSettingsSection } from "./projects-view"
 import {
   QuickPanel,
@@ -2129,7 +2129,12 @@ export function CommandSurface() {
       case "session": return renderSessionSection()
       case "compact": return renderCompactSection()
       case "workspace": return <DevRootSettingsSection />
-      case "integrations": return <RemoteQuestionsPanel />
+      case "integrations": return (
+        <div className="space-y-6">
+          <RemoteQuestionsPanel />
+          <McpConnectionsPanel />
+        </div>
+      )
       case "gsd-forensics": return <ForensicsPanel />
       case "gsd-doctor": return <DoctorPanel />
       case "gsd-skill-health": return <SkillHealthPanel />
@@ -2143,6 +2148,7 @@ export function CommandSurface() {
           <ModelRoutingPanel />
           <BudgetPanel />
           <RemoteQuestionsPanel />
+          <McpConnectionsPanel />
           <GeneralPanel />
           <ExperimentalPanel />
         </div>

--- a/web/components/gsd/settings-panels.tsx
+++ b/web/components/gsd/settings-panels.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react"
 
 import {
   AlertTriangle,
+  Cable,
   CheckCircle2,
   CircleDashed,
   Cpu,
@@ -13,13 +14,17 @@ import {
   FlaskConical,
   KeyRound,
   LoaderCircle,
+  Plus,
+  Power,
+  PowerOff,
   Radio,
   RefreshCw,
   RotateCcw,
   Settings,
   SkipForward,
   SlidersHorizontal,
-  Type,
+  Server,
+  Trash2,
   Wand2,
 } from "lucide-react"
 import { useDevOverrides } from "@/lib/dev-overrides"
@@ -31,6 +36,15 @@ import type {
   SettingsPatternHistory,
   SettingsRoutingHistory,
 } from "@/lib/settings-types"
+import type {
+  WebMcpConnectionTestResult,
+  WebMcpImportableServer,
+  WebMcpManagementPayload,
+  WebMcpMutationRequest,
+  WebMcpMutationResponse,
+  WebMcpServer,
+  WebMcpTransport,
+} from "@/lib/mcp-management-types"
 import { cn } from "@/lib/utils"
 import {
   formatCost,
@@ -616,7 +630,6 @@ export function RemoteQuestionsPanel() {
   const { data, busy, refresh } = useSettingsData()
   const existingConfig = data?.preferences?.remoteQuestions ?? null
 
-  const [envVarSet, setEnvVarSet] = useState(false)
   const [envVarName, setEnvVarName] = useState<string | null>(null)
   const [apiLoading, setApiLoading] = useState(true)
   const [tokenSet, setTokenSet] = useState(false)
@@ -647,7 +660,6 @@ export function RemoteQuestionsPanel() {
         return
       }
       const json: RemoteQuestionsApiResponse = await res.json()
-      setEnvVarSet(json.envVarSet)
       setEnvVarName(json.envVarName)
       setTokenSet(json.tokenSet)
       setIsConfigured(json.status === "configured" && json.config !== null)
@@ -664,15 +676,21 @@ export function RemoteQuestionsPanel() {
     }
   }, [])
 
-  useEffect(() => { void fetchApiStatus() }, [fetchApiStatus])
+  useEffect(() => {
+    const timer = window.setTimeout(() => { void fetchApiStatus() }, 0)
+    return () => window.clearTimeout(timer)
+  }, [fetchApiStatus])
 
   useEffect(() => {
-    if (existingConfig?.channel) {
-      setChannel(existingConfig.channel)
+    if (!existingConfig?.channel) return
+    const nextChannel = existingConfig.channel
+    const timer = window.setTimeout(() => {
+      setChannel(nextChannel)
       setChannelId(existingConfig.channelId ?? "")
       setTimeoutMinutes(existingConfig.timeoutMinutes ?? 5)
       setPollIntervalSeconds(existingConfig.pollIntervalSeconds ?? 5)
-    }
+    }, 0)
+    return () => window.clearTimeout(timer)
   }, [existingConfig])
 
   const channelIdValid = channelId.trim().length > 0 && CHANNEL_ID_PATTERNS[channel].test(channelId.trim())
@@ -887,7 +905,7 @@ export function RemoteQuestionsPanel() {
         />
         {channelId.trim().length > 0 && !CHANNEL_ID_PATTERNS[channel].test(channelId.trim()) && (
           <p className="text-[11px] text-destructive/70">
-            Doesn't match the expected format for {selectedChannelOption.label}
+            Does not match the expected format for {selectedChannelOption.label}
           </p>
         )}
       </div>
@@ -1019,6 +1037,347 @@ export function RemoteQuestionsPanel() {
           </Button>
         </div>
       </div>
+    </div>
+  )
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// MCP CONNECTIONS PANEL
+// ═══════════════════════════════════════════════════════════════════════
+
+function formatRecordLines(record: Record<string, string> | undefined): string {
+  if (!record) return ""
+  return Object.entries(record).map(([key, value]) => `${key}=${value}`).join("\n")
+}
+
+function parseRecordLines(text: string): Record<string, string> | undefined {
+  const entries = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const equals = line.indexOf("=")
+      if (equals <= 0) throw new Error(`Invalid key=value line: ${line}`)
+      return [line.slice(0, equals).trim(), line.slice(equals + 1)] as const
+    })
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined
+}
+
+function formatArgs(args: string[] | undefined): string {
+  return args?.join("\n") ?? ""
+}
+
+function parseArgs(text: string): string[] | undefined {
+  const args = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+  return args.length > 0 ? args : undefined
+}
+
+function serverTone(server: WebMcpServer): "default" | "warning" | "success" | "info" {
+  if (server.disabled || server.transport === "unsupported") return "warning"
+  if (server.connected || server.toolCount > 0) return "success"
+  return "info"
+}
+
+export function McpConnectionsPanel() {
+  const [payload, setPayload] = useState<WebMcpManagementPayload | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [testing, setTesting] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [testResult, setTestResult] = useState<WebMcpConnectionTestResult | null>(null)
+  const [editingName, setEditingName] = useState<string | null>(null)
+  const [name, setName] = useState("")
+  const [transport, setTransport] = useState<Exclude<WebMcpTransport, "unsupported">>("stdio")
+  const [command, setCommand] = useState("")
+  const [argsText, setArgsText] = useState("")
+  const [cwd, setCwd] = useState("")
+  const [url, setUrl] = useState("")
+  const [envText, setEnvText] = useState("")
+  const [headersText, setHeadersText] = useState("")
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await authFetch("/api/mcp-connections", { cache: "no-store" })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error ?? `MCP request failed (${res.status})`)
+      setPayload(json as WebMcpManagementPayload)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => { void load() }, 0)
+    return () => window.clearTimeout(timer)
+  }, [load])
+
+  useEffect(() => {
+    if (!success) return
+    const timer = setTimeout(() => setSuccess(null), 3000)
+    return () => clearTimeout(timer)
+  }, [success])
+
+  function resetForm() {
+    setEditingName(null)
+    setName("")
+    setTransport("stdio")
+    setCommand("")
+    setArgsText("")
+    setCwd("")
+    setUrl("")
+    setEnvText("")
+    setHeadersText("")
+  }
+
+  function editServer(server: WebMcpServer) {
+    if (server.transport === "unsupported") return
+    setEditingName(server.name)
+    setName(server.name)
+    setTransport(server.transport)
+    setCommand(server.command ?? "")
+    setArgsText(formatArgs(server.args))
+    setCwd(server.cwd ?? "")
+    setUrl(server.url ?? "")
+    setEnvText(formatRecordLines(server.env))
+    setHeadersText(formatRecordLines(server.headers))
+  }
+
+  async function mutate(request: WebMcpMutationRequest) {
+    const res = await authFetch("/api/mcp-connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    })
+    const json = await res.json() as WebMcpMutationResponse
+    if (json.status === "error") throw new Error(json.error)
+    if (!res.ok) throw new Error(`MCP request failed (${res.status})`)
+    setPayload(json.data)
+    return json
+  }
+
+  async function saveServer() {
+    setSaving(true)
+    setError(null)
+    setSuccess(null)
+    try {
+      const server = transport === "stdio"
+        ? {
+          name: name.trim(),
+          transport,
+          command: command.trim(),
+          args: parseArgs(argsText),
+          env: parseRecordLines(envText),
+          cwd: cwd.trim() || undefined,
+        }
+        : {
+          name: name.trim(),
+          transport,
+          url: url.trim(),
+          headers: parseRecordLines(headersText),
+        }
+      await mutate({ action: "save", previousName: editingName ?? undefined, server })
+      setSuccess(editingName ? "MCP server updated" : "MCP server saved")
+      resetForm()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function toggleServer(server: WebMcpServer) {
+    setError(null)
+    try {
+      await mutate({ action: server.disabled ? "enable" : "disable", name: server.name })
+      setSuccess(server.disabled ? "MCP server enabled" : "MCP server disabled")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  async function deleteServer(server: WebMcpServer) {
+    if (!window.confirm(`Delete local MCP server "${server.name}"?`)) return
+    setError(null)
+    try {
+      await mutate({ action: "delete", name: server.name })
+      setSuccess("MCP server deleted")
+      if (editingName === server.name) resetForm()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  async function testServer(server: WebMcpServer) {
+    setTesting(server.name)
+    setError(null)
+    setTestResult(null)
+    try {
+      const json = await mutate({ action: "test", name: server.name })
+      setTestResult(json.result ?? null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setTesting(null)
+    }
+  }
+
+  async function importServer(server: WebMcpImportableServer) {
+    const nextName = server.conflicts
+      ? window.prompt(`Rename imported MCP server "${server.name}"`, `${server.name}-local`)
+      : server.name
+    if (!nextName) return
+    setError(null)
+    try {
+      await mutate({ action: "import", server, name: nextName })
+      setSuccess("MCP server imported")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const canSave = name.trim().length > 0 && (
+    transport === "stdio" ? command.trim().length > 0 : url.trim().length > 0
+  )
+
+  return (
+    <div className="space-y-5" data-testid="settings-mcp-connections">
+      <SettingsHeader
+        title="MCP Connections"
+        icon={<Cable className="h-3.5 w-3.5" />}
+        subtitle={payload ? `${payload.servers.length} configured` : null}
+        onRefresh={() => void load()}
+        refreshing={loading}
+      />
+
+      {error && <SettingsError message={error} />}
+      {success && (
+        <div className="flex items-center gap-2 rounded-lg border border-success/15 bg-success/[0.04] px-3 py-2 text-xs text-muted-foreground">
+          <CheckCircle2 className="h-3.5 w-3.5 text-success" />
+          {success}
+        </div>
+      )}
+      {loading && !payload && <SettingsLoading label="Loading MCP connections…" />}
+
+      {payload && (
+        <>
+          <div className="flex flex-wrap gap-2">
+            <Pill label="Local config" value={payload.localConfigPath} />
+            <Pill label="Importable" value={payload.importableServers.length} variant="info" />
+            {payload.duplicates.length > 0 && <Pill label="Duplicates" value={payload.duplicates.length} variant="warning" />}
+          </div>
+
+          {payload.warnings.length > 0 && (
+            <div className="space-y-1 rounded-lg border border-warning/20 bg-warning/5 px-3 py-2 text-[11px] text-warning">
+              {payload.warnings.map((warning) => <div key={warning}>{warning}</div>)}
+            </div>
+          )}
+
+          <div className="grid gap-2">
+            {payload.servers.length === 0 && <SettingsEmpty message="No MCP servers configured" />}
+            {payload.servers.map((server) => (
+              <div key={`${server.sourcePath}:${server.name}`} className="rounded-lg border border-border/50 bg-card/50 px-3 py-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Server className="h-3.5 w-3.5 text-muted-foreground" />
+                      <span className="font-mono text-xs text-foreground">{server.name}</span>
+                      <Pill label={server.transport} value={server.disabled ? "disabled" : "enabled"} variant={serverTone(server)} />
+                    </div>
+                    <div className="truncate font-mono text-[10px] text-muted-foreground">{server.sourcePath}</div>
+                    {server.envWarnings.length > 0 && (
+                      <div className="text-[11px] text-warning">{server.envWarnings[0]}</div>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 flex-wrap justify-end gap-1">
+                    <Button type="button" size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => void testServer(server)} disabled={testing === server.name || server.disabled || server.transport === "unsupported"}>
+                      {testing === server.name ? <LoaderCircle className="h-3.5 w-3.5 animate-spin" /> : <FlaskConical className="h-3.5 w-3.5" />}
+                      Test
+                    </Button>
+                    <Button type="button" size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => void toggleServer(server)}>
+                      {server.disabled ? <Power className="h-3.5 w-3.5" /> : <PowerOff className="h-3.5 w-3.5" />}
+                      {server.disabled ? "Enable" : "Disable"}
+                    </Button>
+                    <Button type="button" size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => editServer(server)} disabled={server.transport === "unsupported"}>
+                      Edit
+                    </Button>
+                    <Button type="button" size="sm" variant="ghost" className="h-7 px-2 text-xs text-destructive/80" onClick={() => void deleteServer(server)} disabled={server.sourceKind !== "project-local"}>
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {testResult && (
+            <div className={cn(
+              "rounded-lg border px-3 py-2 text-xs",
+              testResult.ok ? "border-success/20 bg-success/5 text-success" : "border-warning/20 bg-warning/5 text-warning",
+            )}>
+              {testResult.ok
+                ? `${testResult.server} responded with ${testResult.toolCount} tools`
+                : `${testResult.server} failed: ${testResult.error ?? "unknown error"}`}
+            </div>
+          )}
+
+          <div className="space-y-3 rounded-lg border border-border/50 bg-card/50 px-3 py-3">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-xs font-medium text-muted-foreground">{editingName ? "Edit local server" : "Add local server"}</div>
+              {editingName && (
+                <Button type="button" size="sm" variant="ghost" className="h-7 text-xs" onClick={resetForm}>Cancel</Button>
+              )}
+            </div>
+            <div className="grid gap-2 md:grid-cols-2">
+              <input value={name} onChange={(event) => setName(event.target.value)} placeholder="server-name" className="rounded-lg border border-border/50 bg-background px-3 py-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+              <select value={transport} onChange={(event) => setTransport(event.target.value as Exclude<WebMcpTransport, "unsupported">)} className="rounded-lg border border-border/50 bg-background px-3 py-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring">
+                <option value="stdio">stdio</option>
+                <option value="http">http</option>
+              </select>
+              {transport === "stdio" ? (
+                <>
+                  <input value={command} onChange={(event) => setCommand(event.target.value)} placeholder="/absolute/path/to/server" className="rounded-lg border border-border/50 bg-background px-3 py-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+                  <input value={cwd} onChange={(event) => setCwd(event.target.value)} placeholder="cwd (optional)" className="rounded-lg border border-border/50 bg-background px-3 py-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+                  <textarea value={argsText} onChange={(event) => setArgsText(event.target.value)} placeholder="args, one per line" rows={3} className="rounded-lg border border-border/50 bg-background px-3 py-2 font-mono text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+                  <textarea value={envText} onChange={(event) => setEnvText(event.target.value)} placeholder="ENV_KEY=value" rows={3} className="rounded-lg border border-border/50 bg-background px-3 py-2 font-mono text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+                </>
+              ) : (
+                <>
+                  <input value={url} onChange={(event) => setUrl(event.target.value)} placeholder="https://server.example/mcp" className="md:col-span-2 rounded-lg border border-border/50 bg-background px-3 py-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+                  <textarea value={headersText} onChange={(event) => setHeadersText(event.target.value)} placeholder="Authorization=Bearer ${TOKEN}" rows={3} className="md:col-span-2 rounded-lg border border-border/50 bg-background px-3 py-2 font-mono text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+                </>
+              )}
+            </div>
+            <Button type="button" size="sm" onClick={() => void saveServer()} disabled={!canSave || saving} className="gap-1.5">
+              {saving ? <LoaderCircle className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}
+              {editingName ? "Update server" : "Save server"}
+            </Button>
+          </div>
+
+          {payload.importableServers.length > 0 && (
+            <div className="space-y-2">
+              <div className="text-xs font-medium text-muted-foreground">Discovered imports</div>
+              <div className="grid gap-2">
+                {payload.importableServers.slice(0, 6).map((server) => (
+                  <div key={`${server.sourcePath}:${server.name}`} className="flex items-center justify-between gap-3 rounded-lg border border-border/50 bg-card/50 px-3 py-2">
+                    <div className="min-w-0">
+                      <div className="font-mono text-xs text-foreground">{server.name}</div>
+                      <div className="truncate text-[10px] text-muted-foreground">{server.sourceTool} · {server.sourcePath}</div>
+                    </div>
+                    <Button type="button" size="sm" variant="ghost" className="h-7 text-xs" disabled={server.transport === "unsupported"} onClick={() => void importServer(server)}>
+                      Import
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
     </div>
   )
 }
@@ -1300,7 +1659,10 @@ export function ExperimentalPanel() {
   // Sync local state from loaded prefs
   useEffect(() => {
     if (!prefs) return
-    setFlags({ rtk: prefs.experimental?.rtk === true })
+    const timer = window.setTimeout(() => {
+      setFlags({ rtk: prefs.experimental?.rtk === true })
+    }, 0)
+    return () => window.clearTimeout(timer)
   }, [prefs])
 
   async function toggle(flagKey: string, next: boolean) {

--- a/web/lib/mcp-management-types.ts
+++ b/web/lib/mcp-management-types.ts
@@ -1,0 +1,91 @@
+// GSD-2 — Browser-safe MCP management contracts.
+// File Purpose: Shared TypeScript interfaces for app MCP connection management.
+
+export type WebMcpTransport = "stdio" | "http" | "unsupported"
+export type WebMcpSourceKind = "project-shared" | "project-local" | "global" | "discovered"
+
+export interface WebMcpServer {
+  name: string
+  transport: WebMcpTransport
+  sourcePath: string
+  sourceKind: WebMcpSourceKind
+  disabled: boolean
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  cwd?: string
+  headers?: Record<string, string>
+  envWarnings: string[]
+  connected: boolean
+  toolCount: number
+  tools: string[]
+}
+
+export interface WebMcpImportableServer {
+  name: string
+  transport: WebMcpTransport
+  sourcePath: string
+  sourceTool: string
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  headers?: Record<string, string>
+  unsupportedReason?: string
+  conflicts: boolean
+}
+
+export interface WebMcpDuplicate {
+  name: string
+  keptSourcePath: string
+  shadowedSourcePath: string
+}
+
+export interface WebMcpManagementPayload {
+  servers: WebMcpServer[]
+  importableServers: WebMcpImportableServer[]
+  duplicates: WebMcpDuplicate[]
+  warnings: string[]
+  localConfigPath: string
+}
+
+export interface WebMcpConnectionTestResult {
+  ok: boolean
+  server: string
+  transport: WebMcpTransport
+  toolCount: number
+  tools: string[]
+  warnings: string[]
+  error?: string
+}
+
+export type WebMcpMutationRequest =
+  | {
+      action: "save"
+      previousName?: string
+      server: {
+        name: string
+        transport: Exclude<WebMcpTransport, "unsupported">
+        command?: string
+        args?: string[]
+        env?: Record<string, string>
+        url?: string
+        cwd?: string
+        headers?: Record<string, string>
+        disabled?: boolean
+      }
+    }
+  | { action: "enable"; name: string }
+  | { action: "disable"; name: string }
+  | { action: "delete"; name: string }
+  | { action: "test"; name: string }
+  | {
+      action: "import"
+      server: WebMcpImportableServer
+      name?: string
+    }
+
+export type WebMcpMutationResponse =
+  | { status: "ok"; data: WebMcpManagementPayload; result?: WebMcpConnectionTestResult }
+  | { status: "error"; error: string }


### PR DESCRIPTION
## TL;DR

**What:** Adds MCP app connection management and fixes workflow MCP bridge module resolution.
**Why:** Local and packaged MCP workflow paths need to resolve reliably across source and compiled environments.
**How:** Adds the connection manager/API surface and prefers compiled workflow bridge modules before source fallbacks for runtime bridge imports.

## What

- Adds MCP connection management service/types/API route and web settings surface.
- Adds bundled MCP client manager support and tests.
- Updates workflow MCP module resolution for bridge executors/write-gate modules.
- Adds context-mode contract coverage through workflow MCP tools.

## Why

The workflow MCP bridge needs to use compiled runtime modules when running from packaged/dist contexts, while keeping source fallbacks for local development.

## How

Runtime bridge imports now use a compiled-first candidate list. Generic local imports keep the existing source-first behavior.

## Verification

- Combined stack: `npm run typecheck:extensions`
- Combined stack: `npm run build:pi-coding-agent`
- Combined stack: focused GSD prompt/manifest/budget tests

## Change type checklist

- [x] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
