### PR TITLE
perf(gsd): reduce prompt context loaded during auto runs

### DIFF
--- a/scripts/__tests__/summarize-prompt-context.test.cjs
+++ b/scripts/__tests__/summarize-prompt-context.test.cjs
@@ -1,0 +1,92 @@
+// Project/App: GSD-2
+// File Purpose: Regression tests for the prompt-context debug log summarizer.
+
+const assert = require("node:assert/strict");
+const { mkdtempSync, writeFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  collectLogFiles,
+  formatSummary,
+  parsePromptContextEvents,
+  summarizeEvents,
+} = require("../summarize-prompt-context.cjs");
+
+test("parsePromptContextEvents reads only prompt-context JSONL events", () => {
+  const text = [
+    JSON.stringify({ event: "autoLoop", phase: "enter" }),
+    JSON.stringify({
+      event: "prompt-context",
+      unitType: "execute-task",
+      finalChars: 1200,
+      loaded: [{ key: "task-plan", mode: "inline", chars: 500 }],
+      skipped: [{ key: "knowledge", reason: "missing" }],
+    }),
+    "not json prompt-context",
+  ].join("\n");
+
+  const events = parsePromptContextEvents(text, "debug.log");
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].unitType, "execute-task");
+  assert.equal(events[0].source, "debug.log");
+  assert.equal(events[0].line, 2);
+});
+
+test("summarizeEvents aggregates prompt sizes and loaded block costs", () => {
+  const units = summarizeEvents([
+    {
+      event: "prompt-context",
+      unitType: "plan-slice",
+      finalChars: 1000,
+      loaded: [
+        { key: "templates", mode: "inline", chars: 700 },
+        { key: "decisions", mode: "on-demand", chars: 100 },
+      ],
+      skipped: [{ key: "knowledge", reason: "missing" }],
+    },
+    {
+      event: "prompt-context",
+      unitType: "plan-slice",
+      finalChars: 2000,
+      loaded: [{ key: "templates", mode: "inline", chars: 800 }],
+      skipped: [{ key: "knowledge", reason: "missing" }],
+    },
+  ]);
+
+  assert.equal(units.length, 1);
+  assert.equal(units[0].count, 2);
+  assert.equal(units[0].avgFinalChars, 1500);
+  assert.equal(units[0].maxFinalChars, 2000);
+  assert.equal(units[0].loaded[0].key, "templates");
+  assert.equal(units[0].loaded[0].totalChars, 1500);
+  assert.equal(units[0].skipped[0].key, "knowledge");
+  assert.equal(units[0].skipped[0].count, 2);
+});
+
+test("formatSummary renders a compact operator report", () => {
+  const output = formatSummary(summarizeEvents([
+    {
+      event: "prompt-context",
+      unitType: "complete-milestone",
+      finalChars: 16000,
+      loaded: [{ key: "project", mode: "inline", chars: 2500 }],
+      skipped: [],
+    },
+  ]));
+
+  assert.match(output, /Prompt Context Summary/);
+  assert.match(output, /complete-milestone/);
+  assert.match(output, /project \[inline\] total 2\.5K/);
+});
+
+test("collectLogFiles accepts a debug directory", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "gsd-prompt-context-"));
+  const logPath = path.join(dir, "debug-example.log");
+  writeFileSync(logPath, "");
+  writeFileSync(path.join(dir, "notes.txt"), "");
+
+  assert.deepEqual(collectLogFiles([dir]), [logPath]);
+});

--- a/scripts/summarize-prompt-context.cjs
+++ b/scripts/summarize-prompt-context.cjs
@@ -1,0 +1,182 @@
+// Project/App: GSD-2
+// File Purpose: Summarize prompt-context debug events from GSD debug logs.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function formatChars(value) {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(Math.round(value));
+}
+
+function parsePromptContextEvents(text, source = "<memory>") {
+  const events = [];
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.includes('"event":"prompt-context"') && !line.includes("prompt-context")) continue;
+    try {
+      const event = JSON.parse(line);
+      if (event && event.event === "prompt-context") {
+        events.push({ ...event, source, line: i + 1 });
+      }
+    } catch {
+      // Ignore non-JSON diagnostic lines that happen to mention prompt-context.
+    }
+  }
+  return events;
+}
+
+function addBlock(map, block) {
+  const key = `${block.key || "unknown"}:${block.mode || "unknown"}`;
+  const current = map.get(key) || {
+    key: block.key || "unknown",
+    mode: block.mode || "unknown",
+    count: 0,
+    totalChars: 0,
+    maxChars: 0,
+    reasons: new Map(),
+  };
+  const chars = Number(block.chars) || 0;
+  current.count += 1;
+  current.totalChars += chars;
+  current.maxChars = Math.max(current.maxChars, chars);
+  if (block.reason) {
+    current.reasons.set(block.reason, (current.reasons.get(block.reason) || 0) + 1);
+  }
+  map.set(key, current);
+}
+
+function addSkipped(map, skipped) {
+  const key = skipped.key || "unknown";
+  const current = map.get(key) || { key, count: 0, reasons: new Map() };
+  current.count += 1;
+  if (skipped.reason) {
+    current.reasons.set(skipped.reason, (current.reasons.get(skipped.reason) || 0) + 1);
+  }
+  map.set(key, current);
+}
+
+function summarizeEvents(events) {
+  const units = new Map();
+  for (const event of events) {
+    const unitType = event.unitType || "unknown";
+    const unit = units.get(unitType) || {
+      unitType,
+      count: 0,
+      totalFinalChars: 0,
+      maxFinalChars: 0,
+      loaded: new Map(),
+      skipped: new Map(),
+    };
+    const finalChars = Number(event.finalChars) || 0;
+    unit.count += 1;
+    unit.totalFinalChars += finalChars;
+    unit.maxFinalChars = Math.max(unit.maxFinalChars, finalChars);
+    for (const block of Array.isArray(event.loaded) ? event.loaded : []) addBlock(unit.loaded, block);
+    for (const skipped of Array.isArray(event.skipped) ? event.skipped : []) addSkipped(unit.skipped, skipped);
+    units.set(unitType, unit);
+  }
+
+  return [...units.values()]
+    .map(unit => ({
+      ...unit,
+      avgFinalChars: unit.count > 0 ? unit.totalFinalChars / unit.count : 0,
+      loaded: [...unit.loaded.values()].sort((a, b) => b.totalChars - a.totalChars),
+      skipped: [...unit.skipped.values()].sort((a, b) => b.count - a.count),
+    }))
+    .sort((a, b) => b.maxFinalChars - a.maxFinalChars);
+}
+
+function formatReasons(reasons) {
+  const items = [...reasons.entries()].sort((a, b) => b[1] - a[1]);
+  if (items.length === 0) return "";
+  return ` (${items.map(([reason, count]) => `${reason} x${count}`).join(", ")})`;
+}
+
+function formatSummary(units, options = {}) {
+  const maxBlocks = options.maxBlocks || 8;
+  const lines = ["Prompt Context Summary"];
+  if (units.length === 0) {
+    lines.push("No prompt-context events found.");
+    return lines.join("\n");
+  }
+
+  const eventCount = units.reduce((sum, unit) => sum + unit.count, 0);
+  lines.push(`Events: ${eventCount}`);
+  lines.push("");
+  lines.push("Unit type                 Events  Avg prompt  Max prompt");
+  lines.push("------------------------  ------  ----------  ----------");
+  for (const unit of units) {
+    lines.push(
+      `${unit.unitType.padEnd(24)}  ${String(unit.count).padStart(6)}  ${formatChars(unit.avgFinalChars).padStart(10)}  ${formatChars(unit.maxFinalChars).padStart(10)}`,
+    );
+  }
+
+  for (const unit of units) {
+    lines.push("");
+    lines.push(`${unit.unitType}`);
+    for (const block of unit.loaded.slice(0, maxBlocks)) {
+      lines.push(
+        `  ${block.key} [${block.mode}] total ${formatChars(block.totalChars)}, max ${formatChars(block.maxChars)}, count ${block.count}${formatReasons(block.reasons)}`,
+      );
+    }
+    if (unit.skipped.length > 0) {
+      lines.push(`  skipped: ${unit.skipped.map(item => `${item.key} x${item.count}${formatReasons(item.reasons)}`).join("; ")}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function collectLogFiles(inputs) {
+  const files = [];
+  for (const input of inputs) {
+    if (!fs.existsSync(input)) continue;
+    const stat = fs.statSync(input);
+    if (stat.isDirectory()) {
+      for (const file of fs.readdirSync(input)) {
+        if (file.startsWith("debug-") && file.endsWith(".log")) files.push(path.join(input, file));
+      }
+    } else if (stat.isFile()) {
+      files.push(input);
+    }
+  }
+  return [...new Set(files)].sort();
+}
+
+function summarizeFiles(files) {
+  const events = [];
+  for (const file of files) {
+    events.push(...parsePromptContextEvents(fs.readFileSync(file, "utf8"), file));
+  }
+  return summarizeEvents(events);
+}
+
+function main(argv) {
+  const inputs = argv.slice(2);
+  if (inputs.length === 0) {
+    console.error("Usage: node scripts/summarize-prompt-context.cjs <debug.log|debug-dir> [...]");
+    process.exitCode = 1;
+    return;
+  }
+  const files = collectLogFiles(inputs);
+  if (files.length === 0) {
+    console.error("No debug log files found.");
+    process.exitCode = 1;
+    return;
+  }
+  console.log(formatSummary(summarizeFiles(files)));
+}
+
+if (require.main === module) main(process.argv);
+
+module.exports = {
+  collectLogFiles,
+  formatSummary,
+  parsePromptContextEvents,
+  summarizeEvents,
+  summarizeFiles,
+};

--- a/src/resources/extensions/gsd/auto-budget.ts
+++ b/src/resources/extensions/gsd/auto-budget.ts
@@ -41,3 +41,14 @@ export function getUnitCostSpikeAction(
   if (!Number.isFinite(multiplier) || multiplier <= 0) return "none";
   return unitCostUsd >= (rollingAvgUsd * multiplier) ? "pause" : "none";
 }
+
+export function getContextPauseAction(
+  contextPercent: number | null | undefined,
+  thresholdPercent: number | null | undefined,
+): "none" | "pause" {
+  if (!Number.isFinite(contextPercent ?? NaN)) return "none";
+  if (!Number.isFinite(thresholdPercent ?? NaN)) return "none";
+  const threshold = thresholdPercent as number;
+  if (threshold <= 0) return "none";
+  return (contextPercent as number) >= threshold ? "pause" : "none";
+}

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -37,7 +37,7 @@ import {
 } from "./gate-registry.js";
 import { formatDecisionsCompact, formatRequirementsCompact } from "./structured-data-formatter.js";
 import { readPhaseAnchor, formatAnchorForPrompt } from "./phase-anchor.js";
-import { composeContextModeInstructions, composeInlinedContext, type ArtifactResolver, type ContextModeRenderMode } from "./unit-context-composer.js";
+import { composeContextModeInstructions, composeInlinedContext, composeUnitContext, type ArtifactResolver, type ContextModeRenderMode, type ExcerptResolver } from "./unit-context-composer.js";
 import { readCompactionSnapshot } from "./compaction-snapshot.js";
 import { logWarning } from "./workflow-logger.js";
 import { inlineGraphSubgraph } from "./graph-context.js";
@@ -45,6 +45,7 @@ import { buildExtractionStepsBlock } from "./commands-extract-learnings.js";
 import { resolveSkillManifest, warnIfManifestHasMissingSkills } from "./skill-manifest.js";
 import { classifyProject, type ProjectClassification } from "./detection.js";
 import { hasBrowserRequiredText } from "./browser-evidence.js";
+import { debugLog } from "./debug-logger.js";
 
 // ─── Preamble Cap ─────────────────────────────────────────────────────────────
 
@@ -196,6 +197,51 @@ function capPreamble(preamble: string): string {
   const budget = Math.min(MAX_PREAMBLE_CHARS, resolvePromptBudgets().inlineContextBudgetChars);
   if (preamble.length <= budget) return preamble;
   return truncateAtSectionBoundary(preamble, budget).content;
+}
+
+type PromptContextMode = "inline" | "excerpt" | "on-demand" | "skipped";
+
+interface PromptContextTelemetryEntry {
+  readonly key: string;
+  readonly mode: PromptContextMode;
+  readonly chars: number;
+  readonly reason?: string;
+}
+
+function trackPromptContext(
+  entries: PromptContextTelemetryEntry[],
+  key: string,
+  mode: PromptContextMode,
+  body: string | null | undefined,
+  reason?: string,
+): void {
+  entries.push({
+    key,
+    mode,
+    chars: body?.length ?? 0,
+    ...(reason ? { reason } : {}),
+  });
+}
+
+function emitPromptContextTelemetry(
+  unitType: string,
+  entries: readonly PromptContextTelemetryEntry[],
+  finalBody: string,
+): void {
+  debugLog("prompt-context", {
+    unitType,
+    finalChars: finalBody.length,
+    loaded: entries.filter((entry) => entry.mode !== "skipped").map((entry) => ({
+      key: entry.key,
+      mode: entry.mode,
+      chars: entry.chars,
+      ...(entry.reason ? { reason: entry.reason } : {}),
+    })),
+    skipped: entries.filter((entry) => entry.mode === "skipped").map((entry) => ({
+      key: entry.key,
+      reason: entry.reason ?? "not applicable",
+    })),
+  });
 }
 
 function renderContextModeForPrompt(
@@ -657,6 +703,34 @@ export async function buildSliceSummaryExcerpt(
   }
 }
 
+export async function buildSliceAssessmentExcerpt(
+  absPath: string | null, relPath: string, sid: string,
+): Promise<string | null> {
+  const content = absPath ? await loadFile(absPath) : null;
+  if (!content) return null;
+
+  const verdict = extractVerdict(content);
+  const edgeCases = extractMarkdownSection(content, "Edge Cases");
+  const checksMatch = content.match(/\b(\d+\s*\/\s*\d+)\s+checks?\s+passed\b/i);
+  const lines = [
+    `### ${sid} Assessment (excerpt)`,
+    `Source: \`${relPath}\``,
+    "",
+  ];
+  if (verdict) lines.push(`**Verdict:** \`${verdict.toUpperCase()}\``);
+  if (checksMatch) lines.push(`**Checks:** ${checksMatch[1]} passed`);
+  if (edgeCases?.trim()) {
+    const trimmed = edgeCases.trim();
+    lines.push(
+      "",
+      "#### Edge cases",
+      trimmed.length > 600 ? `${trimmed.slice(0, 600)}\n… (truncated — see full \`${relPath}\`)` : trimmed,
+    );
+  }
+  lines.push("", `> **On-demand:** read \`${relPath}\` only if validation needs full UAT assessment detail.`);
+  return lines.join("\n");
+}
+
 export async function buildTaskSummaryExcerpt(
   absPath: string | null, relPath: string, tid: string, options?: { blocker?: boolean },
 ): Promise<string> {
@@ -905,6 +979,30 @@ export async function inlineProjectFromDb(
     logWarning("prompt", `inlineProjectFromDb failed: ${err instanceof Error ? err.message : String(err)}`);
   }
   return inlineGsdRootFile(base, "project.md", "Project");
+}
+
+function onDemandProjectBlock(reason: string): string {
+  return [
+    "### On-demand Project Context",
+    "",
+    `Project context is available at \`${relGsdRootFile("PROJECT")}\`. Read it only if ${reason}.`,
+  ].join("\n");
+}
+
+function onDemandDecisionsBlock(reason: string): string {
+  return [
+    "### On-demand Decisions",
+    "",
+    `Decision records are available at \`${relGsdRootFile("DECISIONS")}\`. Read them only if ${reason}.`,
+  ].join("\n");
+}
+
+function onDemandMilestoneContextBlock(contextRel: string, reason: string): string {
+  return [
+    "### On-demand Milestone Context",
+    "",
+    `Milestone context is available at \`${contextRel}\`. Read it only if ${reason}.`,
+  ].join("\n");
 }
 
 // ─── Stopwords for keyword extraction ─────────────────────────────────────
@@ -1801,61 +1899,92 @@ export async function buildDiscussRequirementsPrompt(
 }
 
 export async function buildResearchMilestonePrompt(mid: string, midTitle: string, base: string): Promise<string> {
-  // #4782 phase 3: research-milestone migrated through the composer.
-  // Declared inline order: milestone-context, project, requirements,
-  // decisions, templates. Knowledge stays outside the composer
-  // (budget-driven, scoped by keyword extraction — future phase folds
-  // policy-driven blocks in).
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
+
+  // Keep research milestone prompts focused on the milestone brief and
+  // research template. Project-wide docs stay on-demand instead of being
+  // loaded at the start of every milestone.
   const resolveArtifact: ArtifactResolver = async (key) => {
     switch (key) {
       case "milestone-context": {
         const p = resolveMilestoneFile(base, mid, "CONTEXT");
         const r = relMilestoneFile(base, mid, "CONTEXT");
-        return await inlineFile(p, r, "Milestone Context");
+        const body = await inlineFile(p, r, "Milestone Context");
+        trackPromptContext(contextTelemetry, "milestone-context", "inline", body);
+        return body;
       }
       case "project":
-        return await inlineProjectFromDb(base);
       case "requirements":
-        return await inlineRequirementsFromDb(base, mid);
       case "decisions":
-        return await inlineDecisionsFromDb(base, mid);
-      case "templates":
-        return inlineTemplate("research", "Research");
+        trackPromptContext(contextTelemetry, key, "skipped", null, "handled as on-demand path");
+        return null;
+      case "templates": {
+        const body = inlineTemplate("research", "Research");
+        trackPromptContext(contextTelemetry, "templates", "inline", body);
+        return body;
+      }
       default:
         return null;
     }
   };
 
-  const composed = await composeInlinedContext("research-milestone", resolveArtifact);
+  const composed = await composeUnitContext("research-milestone", {
+    base: { unitType: "research-milestone", basePath: base, milestoneId: mid },
+    resolveArtifact,
+  });
 
   // Knowledge block stays outside the composer — budgeted, scoped via
-  // keyword extraction (#4719). Inserted between decisions and the
-  // templates block to match the pre-migration output order. We split
-  // the composer output around the templates section to preserve that
-  // ordering.
+  // keyword extraction (#4719). Inserted before the template so research
+  // instructions remain the final contract in the preloaded block.
   const knowledgeInlineRM = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
   const parts: string[] = [];
-  if (knowledgeInlineRM && composed) {
-    // Insert knowledge before the template block so the overall order is:
-    //   milestone-context → project → requirements → decisions → KNOWLEDGE → research template
-    const idx = composed.lastIndexOf("### Output Template:");
+  if (composed.prepend) parts.push(composed.prepend);
+  if (knowledgeInlineRM && composed.inline) {
+    const idx = composed.inline.lastIndexOf("### Output Template:");
     if (idx > 0) {
-      const before = composed.slice(0, idx).replace(/\n\n---\n\n$/, "");
-      const after = composed.slice(idx);
+      const before = composed.inline.slice(0, idx).replace(/\n\n---\n\n$/, "");
+      const after = composed.inline.slice(idx);
       parts.push(before, knowledgeInlineRM, after);
     } else {
-      parts.push(composed, knowledgeInlineRM);
+      parts.push(composed.inline, knowledgeInlineRM);
     }
-  } else if (composed) {
-    parts.push(composed);
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInlineRM);
+  } else if (composed.inline) {
+    parts.push(composed.inline);
     if (knowledgeInlineRM) parts.push(knowledgeInlineRM);
+    trackPromptContext(contextTelemetry, "knowledge", knowledgeInlineRM ? "inline" : "skipped", knowledgeInlineRM, knowledgeInlineRM ? undefined : "missing");
+  } else {
+    trackPromptContext(contextTelemetry, "knowledge", knowledgeInlineRM ? "inline" : "skipped", knowledgeInlineRM, knowledgeInlineRM ? undefined : "missing");
   }
+
+  const onDemandDocs = [
+    "### On-demand Planning Context",
+    "",
+    "Broader project context is available if the research needs it. Read only the specific source that answers the question:",
+    "",
+    `- \`${relGsdRootFile("PROJECT")}\` — product/project narrative`,
+    `- \`${relGsdRootFile("REQUIREMENTS")}\` — requirement status and acceptance criteria`,
+    `- \`${relGsdRootFile("DECISIONS")}\` — active architecture/product decisions`,
+  ].join("\n");
+  parts.push(onDemandDocs);
+  trackPromptContext(contextTelemetry, "project,requirements,decisions", "on-demand", onDemandDocs);
+
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
 
   const inlinedContext = prependContextModeToBlock(
     "research-milestone",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("research-milestone", contextTelemetry, inlinedContext);
 
   const outputRelPath = relMilestoneFile(base, mid, "RESEARCH");
   return loadPrompt("research-milestone", {
@@ -1884,26 +2013,80 @@ export async function buildPlanMilestonePrompt(mid: string, midTitle: string, ba
   const researchRel = relMilestoneFile(base, mid, "RESEARCH");
 
   const inlined: string[] = [];
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
+  const pushTracked = (key: string, body: string, reason?: string): void => {
+    inlined.push(body);
+    trackPromptContext(contextTelemetry, key, "inline", body, reason);
+  };
 
   // Inject phase handoff anchor from research phase (if available)
   const researchAnchor = readPhaseAnchor(base, mid, "research-milestone");
-  if (researchAnchor) inlined.push(formatAnchorForPrompt(researchAnchor));
+  if (researchAnchor) {
+    pushTracked("research-anchor", formatAnchorForPrompt(researchAnchor));
+  } else {
+    trackPromptContext(contextTelemetry, "research-anchor", "skipped", null, "missing");
+  }
 
-  inlined.push(formatProjectClassificationForPlanning(classifyProject(base)));
+  pushTracked("project-classification", formatProjectClassificationForPlanning(classifyProject(base)));
 
-  inlined.push(await inlineFile(contextPath, contextRel, "Milestone Context"));
+  pushTracked("milestone-context", await inlineFile(contextPath, contextRel, "Milestone Context"));
   const researchInline = await inlineFileOptional(researchPath, researchRel, "Milestone Research");
-  if (researchInline) inlined.push(researchInline);
+  if (researchInline) {
+    pushTracked("milestone-research", researchInline);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-research", "skipped", null, "missing");
+  }
   const { inlinePriorMilestoneSummary } = await import("./files.js");
   const priorSummaryInline = await inlinePriorMilestoneSummary(mid, base);
-  if (priorSummaryInline) inlined.push(priorSummaryInline);
-  if (inlineLevel !== "minimal") {
+  if (priorSummaryInline) {
+    pushTracked("prior-milestone-summary", priorSummaryInline);
+  } else {
+    trackPromptContext(contextTelemetry, "prior-milestone-summary", "skipped", null, "missing");
+  }
+  if (inlineLevel === "full") {
     const projectInline = await inlineProjectFromDb(base);
-    if (projectInline) inlined.push(projectInline);
+    if (projectInline) {
+      pushTracked("project", projectInline, inlineLevel);
+    } else {
+      trackPromptContext(contextTelemetry, "project", "skipped", null, "missing");
+    }
     const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
-    if (requirementsInline) inlined.push(requirementsInline);
+    if (requirementsInline) {
+      pushTracked("requirements", requirementsInline, inlineLevel);
+    } else {
+      trackPromptContext(contextTelemetry, "requirements", "skipped", null, "missing");
+    }
     const decisionsInline = await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
-    if (decisionsInline) inlined.push(decisionsInline);
+    if (decisionsInline) {
+      pushTracked("decisions", decisionsInline, inlineLevel);
+    } else {
+      trackPromptContext(contextTelemetry, "decisions", "skipped", null, "missing");
+    }
+  } else if (inlineLevel === "standard") {
+    trackPromptContext(contextTelemetry, "project", "skipped", null, "handled as on-demand path");
+    const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
+    if (requirementsInline) {
+      pushTracked("requirements", requirementsInline, inlineLevel);
+    } else {
+      trackPromptContext(contextTelemetry, "requirements", "skipped", null, "missing");
+    }
+    trackPromptContext(contextTelemetry, "decisions", "skipped", null, "handled as on-demand path");
+  } else {
+    trackPromptContext(contextTelemetry, "project", "skipped", null, "handled as on-demand path");
+    trackPromptContext(contextTelemetry, "requirements", "skipped", null, "minimal inline level");
+    trackPromptContext(contextTelemetry, "decisions", "skipped", null, "handled as on-demand path");
+  }
+  if (inlineLevel !== "full") {
+    const onDemandDocs = [
+      "### On-demand Planning Context",
+      "",
+      "Broader project context is available if roadmap planning needs it. Read only the source that answers the planning question:",
+      "",
+      `- \`${relGsdRootFile("PROJECT")}\` - product/project narrative`,
+      `- \`${relGsdRootFile("DECISIONS")}\` - active architecture/product decisions`,
+    ].join("\n");
+    inlined.push(onDemandDocs);
+    trackPromptContext(contextTelemetry, "project,decisions", "on-demand", onDemandDocs);
   }
   const queuePath = resolveGsdRootFile(base, "QUEUE");
   if (existsSync(queuePath)) {
@@ -1913,28 +2096,44 @@ export async function buildPlanMilestonePrompt(mid: string, midTitle: string, ba
       "Project Queue",
       `${mid} ${midTitle}`,
     );
-    inlined.push(queueInline);
+    pushTracked("project-queue", queueInline);
+  } else {
+    trackPromptContext(contextTelemetry, "project-queue", "skipped", null, "missing");
   }
   // Scoped + budgeted — see issue #4719
   const knowledgeInlinePM = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
-  if (knowledgeInlinePM) inlined.push(knowledgeInlinePM);
-  inlined.push(inlineTemplate("roadmap", "Roadmap"));
+  if (knowledgeInlinePM) {
+    pushTracked("knowledge", knowledgeInlinePM);
+  } else {
+    trackPromptContext(contextTelemetry, "knowledge", "skipped", null, "missing");
+  }
+  pushTracked("templates", inlineTemplate("roadmap", "Roadmap"));
   if (inlineLevel === "full") {
-    inlined.push(inlineTemplate("decisions", "Decisions"));
-    inlined.push(inlineTemplate("plan", "Slice Plan"));
-    inlined.push(inlineTemplate("task-plan", "Task Plan"));
-    inlined.push(inlineTemplate("secrets-manifest", "Secrets Manifest"));
+    pushTracked("templates", inlineTemplate("decisions", "Decisions"));
+    pushTracked("templates", inlineTemplate("plan", "Slice Plan"));
+    pushTracked("templates", inlineTemplate("task-plan", "Task Plan"));
+    pushTracked("templates", inlineTemplate("secrets-manifest", "Secrets Manifest"));
   } else if (inlineLevel === "standard") {
-    inlined.push(inlineTemplate("decisions", "Decisions"));
-    inlined.push(inlineTemplate("plan", "Slice Plan"));
-    inlined.push(inlineTemplate("task-plan", "Task Plan"));
+    pushTracked("templates", inlineTemplate("decisions", "Decisions"));
+    pushTracked("templates", inlineTemplate("plan", "Slice Plan"));
+    pushTracked("templates", inlineTemplate("task-plan", "Task Plan"));
   }
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "plan-milestone",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("plan-milestone", contextTelemetry, inlinedContext);
 
   const outputRelPath = relMilestoneFile(base, mid, "ROADMAP");
   const researchOutputPath = join(base, relMilestoneFile(base, mid, "RESEARCH"));
@@ -1976,52 +2175,119 @@ export async function buildResearchSlicePrompt(
   const sliceContextRel = relSliceFile(base, mid, sid, "CONTEXT");
 
   const inlined: string[] = [];
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
 
   // Use roadmap excerpt instead of full roadmap for context reduction
   const roadmapExcerptRS = await inlineRoadmapExcerpt(base, mid, sid);
   if (roadmapExcerptRS) {
     inlined.push(roadmapExcerptRS);
+    trackPromptContext(contextTelemetry, "roadmap", "excerpt", roadmapExcerptRS);
   } else {
     // Fall back to full roadmap if excerpt fails
-    inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
+    const roadmapInline = await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap");
+    inlined.push(roadmapInline);
+    trackPromptContext(contextTelemetry, "roadmap", "inline", roadmapInline, "excerpt unavailable");
   }
 
   const contextInline = await inlineFileOptional(contextPath, contextRel, "Milestone Context");
-  if (contextInline) inlined.push(contextInline);
+  if (contextInline) {
+    inlined.push(contextInline);
+    trackPromptContext(contextTelemetry, "milestone-context", "inline", contextInline);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-context", "skipped", null, "missing");
+  }
   const sliceCtxInline = await inlineFileOptional(sliceContextPath, sliceContextRel, "Slice Context (from discussion)");
-  if (sliceCtxInline) inlined.push(sliceCtxInline);
+  if (sliceCtxInline) {
+    inlined.push(sliceCtxInline);
+    trackPromptContext(contextTelemetry, "slice-context", "inline", sliceCtxInline);
+  } else {
+    trackPromptContext(contextTelemetry, "slice-context", "skipped", null, "missing");
+  }
   const researchInline = await inlineFileOptional(milestoneResearchPath, milestoneResearchRel, "Milestone Research");
-  if (researchInline) inlined.push(researchInline);
+  if (researchInline) {
+    inlined.push(researchInline);
+    trackPromptContext(contextTelemetry, "milestone-research", "inline", researchInline);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-research", "skipped", null, "missing");
+  }
 
   // Derive scope from slice title for decision filtering (R005)
   const derivedScope = deriveSliceScope(sTitle);
-  const decisionsInline = await inlineDecisionsFromDb(base, mid, derivedScope);
-  if (decisionsInline) inlined.push(decisionsInline);
+  if (derivedScope) {
+    const decisionsInline = await inlineDecisionsFromDb(base, mid, derivedScope);
+    if (decisionsInline) {
+      inlined.push(decisionsInline);
+      trackPromptContext(contextTelemetry, "decisions", "inline", decisionsInline, `scope:${derivedScope}`);
+    } else {
+      trackPromptContext(contextTelemetry, "decisions", "skipped", null, `no scoped decisions for ${derivedScope}`);
+    }
+  } else {
+    const onDemandDecisions = [
+      "### On-demand Decisions",
+      "",
+      `No specific decision scope was derived from "${sTitle}". Read \`${relGsdRootFile("DECISIONS")}\` only if research needs prior architecture/product decisions.`,
+    ].join("\n");
+    inlined.push(onDemandDecisions);
+    trackPromptContext(contextTelemetry, "decisions", "on-demand", onDemandDecisions, "no derived scope");
+  }
   const requirementsInline = await inlineRequirementsFromDb(base, mid, sid);
-  if (requirementsInline) inlined.push(requirementsInline);
+  if (requirementsInline) {
+    inlined.push(requirementsInline);
+    trackPromptContext(contextTelemetry, "requirements", "inline", requirementsInline);
+  } else {
+    trackPromptContext(contextTelemetry, "requirements", "skipped", null, "missing");
+  }
 
   // Use scoped knowledge based on slice title keywords
   const keywords = extractKeywords(sTitle);
   const knowledgeInlineRS = await inlineKnowledgeScoped(base, keywords);
-  if (knowledgeInlineRS) inlined.push(knowledgeInlineRS);
+  if (knowledgeInlineRS) {
+    inlined.push(knowledgeInlineRS);
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInlineRS);
+  } else {
+    trackPromptContext(contextTelemetry, "knowledge", "skipped", null, "missing");
+  }
 
   // Knowledge graph: subgraph for this slice (graceful — skipped if no graph.json)
   const graphBlockRS = await inlineGraphSubgraph(base, `${sid} ${sTitle}`, { budget: 3000 });
-  if (graphBlockRS) inlined.push(graphBlockRS);
+  if (graphBlockRS) {
+    inlined.push(graphBlockRS);
+    trackPromptContext(contextTelemetry, "graph-subgraph", "inline", graphBlockRS);
+  } else {
+    trackPromptContext(contextTelemetry, "graph-subgraph", "skipped", null, "missing");
+  }
 
-  inlined.push(inlineTemplate("research", "Research"));
+  const templateInline = inlineTemplate("research", "Research");
+  inlined.push(templateInline);
+  trackPromptContext(contextTelemetry, "templates", "inline", templateInline);
 
   const depContent = await inlineDependencySummaries(mid, sid, base, resolveSummaryBudgetChars());
+  trackPromptContext(contextTelemetry, "dependency-summaries", depContent.trim() ? "inline" : "skipped", depContent, depContent.trim() ? undefined : "none");
   const activeOverrides = await loadActiveOverrides(base);
   const overridesInline = formatOverridesSection(activeOverrides);
-  if (overridesInline) inlined.unshift(overridesInline);
+  if (overridesInline) {
+    inlined.unshift(overridesInline);
+    trackPromptContext(contextTelemetry, "overrides", "inline", overridesInline);
+  } else {
+    trackPromptContext(contextTelemetry, "overrides", "skipped", null, "none active");
+  }
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "research-slice",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
     options?.contextModeRenderMode,
   );
+  emitPromptContextTelemetry("research-slice", contextTelemetry, inlinedContext);
 
   const outputRelPath = relSliceFile(base, mid, sid, "RESEARCH");
   return loadPrompt("research-slice", {
@@ -2083,53 +2349,128 @@ async function renderSlicePrompt(options: {
   const sliceContextRel = relSliceFile(base, mid, sid, "CONTEXT");
 
   const inlined: string[] = [...prependBlocks];
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
+  for (const block of prependBlocks) {
+    trackPromptContext(contextTelemetry, "prepend", "inline", block);
+  }
 
   // Phase handoff anchor from research phase (if available)
   const researchSliceAnchor = readPhaseAnchor(base, mid, "research-slice");
-  if (researchSliceAnchor) inlined.push(formatAnchorForPrompt(researchSliceAnchor));
+  if (researchSliceAnchor) {
+    const body = formatAnchorForPrompt(researchSliceAnchor);
+    inlined.push(body);
+    trackPromptContext(contextTelemetry, "research-anchor", "inline", body);
+  } else {
+    trackPromptContext(contextTelemetry, "research-anchor", "skipped", null, "missing");
+  }
 
   // Roadmap excerpt with full-roadmap fallback
   const roadmapExcerpt = await inlineRoadmapExcerpt(base, mid, sid);
   if (roadmapExcerpt) {
     inlined.push(roadmapExcerpt);
+    trackPromptContext(contextTelemetry, "roadmap", "excerpt", roadmapExcerpt);
   } else {
-    inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
+    const body = await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap");
+    inlined.push(body);
+    trackPromptContext(contextTelemetry, "roadmap", "inline", body, "excerpt unavailable");
   }
 
   const sliceCtxInline = await inlineFileOptional(sliceContextPath, sliceContextRel, "Slice Context (from discussion)");
-  if (sliceCtxInline) inlined.push(sliceCtxInline);
+  if (sliceCtxInline) {
+    inlined.push(sliceCtxInline);
+    trackPromptContext(contextTelemetry, "slice-context", "inline", sliceCtxInline);
+  } else {
+    trackPromptContext(contextTelemetry, "slice-context", "skipped", null, "missing");
+  }
   const researchInline = await inlineFileOptional(researchPath, researchRel, "Slice Research");
-  if (researchInline) inlined.push(researchInline);
+  if (researchInline) {
+    inlined.push(researchInline);
+    trackPromptContext(contextTelemetry, "slice-research", "inline", researchInline);
+  } else {
+    trackPromptContext(contextTelemetry, "slice-research", "skipped", null, "missing");
+  }
 
   if (level !== "minimal") {
     const derivedScope = deriveSliceScope(sTitle);
-    const decisionsInline = await inlineDecisionsFromDb(base, mid, derivedScope, level);
-    if (decisionsInline) inlined.push(decisionsInline);
+    if (derivedScope) {
+      const decisionsInline = await inlineDecisionsFromDb(base, mid, derivedScope, level);
+      if (decisionsInline) {
+        inlined.push(decisionsInline);
+        trackPromptContext(contextTelemetry, "decisions", "inline", decisionsInline, `scope:${derivedScope}`);
+      } else {
+        trackPromptContext(contextTelemetry, "decisions", "skipped", null, `no scoped decisions for ${derivedScope}`);
+      }
+    } else {
+      const onDemandDecisions = [
+        "### On-demand Decisions",
+        "",
+        `No specific decision scope was derived from "${sTitle}". Read \`${relGsdRootFile("DECISIONS")}\` only if planning needs prior architecture/product decisions.`,
+      ].join("\n");
+      inlined.push(onDemandDecisions);
+      trackPromptContext(contextTelemetry, "decisions", "on-demand", onDemandDecisions, "no derived scope");
+    }
     const requirementsInline = await inlineRequirementsFromDb(base, mid, sid, level);
-    if (requirementsInline) inlined.push(requirementsInline);
+    if (requirementsInline) {
+      inlined.push(requirementsInline);
+      trackPromptContext(contextTelemetry, "requirements", "inline", requirementsInline);
+    } else {
+      trackPromptContext(contextTelemetry, "requirements", "skipped", null, "missing");
+    }
+  } else {
+    trackPromptContext(contextTelemetry, "decisions", "skipped", null, "minimal inline level");
+    trackPromptContext(contextTelemetry, "requirements", "skipped", null, "minimal inline level");
   }
 
   const knowledgeInline = await inlineKnowledgeScoped(base, extractKeywords(sTitle));
-  if (knowledgeInline) inlined.push(knowledgeInline);
+  if (knowledgeInline) {
+    inlined.push(knowledgeInline);
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInline);
+  } else {
+    trackPromptContext(contextTelemetry, "knowledge", "skipped", null, "missing");
+  }
 
   const graphBlock = await inlineGraphSubgraph(base, `${sid} ${sTitle}`, { budget: 3000 });
-  if (graphBlock) inlined.push(graphBlock);
+  if (graphBlock) {
+    inlined.push(graphBlock);
+    trackPromptContext(contextTelemetry, "graph-subgraph", "inline", graphBlock);
+  } else {
+    trackPromptContext(contextTelemetry, "graph-subgraph", "skipped", null, "missing");
+  }
 
-  inlined.push(level === "minimal" ? inlineCompactTemplate("plan", "Slice Plan") : inlineTemplate("plan", "Slice Plan"));
+  const planTemplateInline = level === "minimal" ? inlineCompactTemplate("plan", "Slice Plan") : inlineTemplate("plan", "Slice Plan");
+  inlined.push(planTemplateInline);
+  trackPromptContext(contextTelemetry, "templates", "inline", planTemplateInline);
   if (level === "full") {
-    inlined.push(inlineTemplate("task-plan", "Task Plan"));
+    const taskPlanTemplateInline = inlineTemplate("task-plan", "Task Plan");
+    inlined.push(taskPlanTemplateInline);
+    trackPromptContext(contextTelemetry, "templates", "inline", taskPlanTemplateInline);
   }
 
   const depContent = await inlineDependencySummaries(mid, sid, base, resolveSummaryBudgetChars());
   const overridesInline = formatOverridesSection(await loadActiveOverrides(base));
-  if (overridesInline) inlined.unshift(overridesInline);
+  if (overridesInline) {
+    inlined.unshift(overridesInline);
+    trackPromptContext(contextTelemetry, "overrides", "inline", overridesInline);
+  } else {
+    trackPromptContext(contextTelemetry, "overrides", "skipped", null, "none active");
+  }
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     promptTemplate,
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
     options.contextModeRenderMode,
   );
+  emitPromptContextTelemetry(promptTemplate, contextTelemetry, inlinedContext);
   const executorContextConstraints = formatExecutorConstraints(sessionContextWindow, modelRegistry, sessionProvider);
   const outputRelPath = relSliceFile(base, mid, sid, "PLAN");
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
@@ -2287,6 +2628,7 @@ export async function buildExecuteTaskPrompt(
     ? level
     : { level: level as InlineLevel | undefined };
   const inlineLevel = opts.level ?? resolveInlineLevel();
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
 
   // Inject phase handoff anchor from planning phase (if available)
   const planAnchor = readPhaseAnchor(base, mid, "plan-slice");
@@ -2310,10 +2652,12 @@ export async function buildExecuteTaskPrompt(
       "## Inlined Task Plan (authoritative local execution contract)",
       `Task plan not found at dispatch time. Read \`${taskPlanRelPath}\` before executing.`,
     ].join("\n");
+  trackPromptContext(contextTelemetry, "task-plan", taskPlanContent ? "inline" : "on-demand", taskPlanInline, taskPlanContent ? undefined : "missing at dispatch");
 
   const slicePlanPath = resolveSliceFile(base, mid, sid, "PLAN");
   const slicePlanContent = slicePlanPath ? await loadFile(slicePlanPath) : null;
   const slicePlanExcerpt = extractSliceExecutionExcerpt(slicePlanContent, relSliceFile(base, mid, sid, "PLAN"));
+  trackPromptContext(contextTelemetry, "slice-plan", slicePlanExcerpt ? "excerpt" : "skipped", slicePlanExcerpt, slicePlanExcerpt ? undefined : "missing");
 
   // Check for continue file (new naming or legacy)
   const continueFile = resolveSliceFile(base, mid, sid, "CONTINUE");
@@ -2328,6 +2672,7 @@ export async function buildExecuteTaskPrompt(
     continueRelPath,
     legacyContinuePath ? `${relSlicePath(base, mid, sid)}/continue.md` : null,
   );
+  trackPromptContext(contextTelemetry, "resume-section", resumeSection.trim() ? "inline" : "skipped", resumeSection, resumeSection.trim() ? undefined : "missing");
 
   // For minimal inline level, only carry forward the most recent prior summary
   const effectivePriorSummaries = inlineLevel === "minimal" && priorSummaries.length > 1
@@ -2350,12 +2695,17 @@ export async function buildExecuteTaskPrompt(
 
   // Knowledge graph: tight subgraph for this task (graceful — skipped if no graph.json)
   const graphBlockET = await inlineGraphSubgraph(base, `${tid} ${tTitle}`, { budget: 2000 });
+  const decisionsOnDemandET = [
+    "### On-demand Decisions Template",
+    "",
+    "If this task records a durable architecture or product decision, read `templates/decisions.md` before calling `capture_thought` or `gsd_decision_save`.",
+  ].join("\n");
 
   const inlinedTemplates = inlineLevel === "minimal"
     ? inlineCompactTemplate("task-summary", "Task Summary")
     : [
         inlineTemplate("task-summary", "Task Summary"),
-        inlineTemplate("decisions", "Decisions"),
+        decisionsOnDemandET,
         ...(knowledgeContent ? [knowledgeContent] : []),
         ...(graphBlockET ? [graphBlockET] : []),
       ].join("\n\n---\n\n");
@@ -2377,6 +2727,13 @@ export async function buildExecuteTaskPrompt(
   if (carryForwardSection.length > carryForwardBudget) {
     finalCarryForward = truncateAtSectionBoundary(carryForwardSection, carryForwardBudget).content;
   }
+  trackPromptContext(
+    contextTelemetry,
+    "prior-task-summaries",
+    finalCarryForward.trim() ? "excerpt" : "skipped",
+    finalCarryForward,
+    finalCarryForward.length < carryForwardSection.length ? `truncated from ${carryForwardSection.length} chars` : undefined,
+  );
 
   // Inline RUNTIME.md if present
   const runtimePath = resolveRuntimeFile(base);
@@ -2384,8 +2741,10 @@ export async function buildExecuteTaskPrompt(
   const runtimeContext = runtimeContent
     ? `### Runtime Context\nSource: \`.gsd/RUNTIME.md\`\n\n${runtimeContent.trim()}`
     : "";
+  trackPromptContext(contextTelemetry, "runtime", runtimeContext ? "inline" : "skipped", runtimeContext, runtimeContext ? undefined : "missing");
 
   let phaseAnchorSection = planAnchor ? formatAnchorForPrompt(planAnchor) : "";
+  trackPromptContext(contextTelemetry, "plan-anchor", phaseAnchorSection ? "inline" : "skipped", phaseAnchorSection, phaseAnchorSection ? undefined : "missing");
 
   // ADR-011 Phase 2: inject any resolved-but-unapplied escalation override
   // into this task's prompt. Claim is atomic via DB UPDATE WHERE IS NULL, so
@@ -2419,8 +2778,17 @@ export async function buildExecuteTaskPrompt(
     { pending: new Set(etPending.map((g) => g.gate_id)), allowOmit: true },
   );
   phaseAnchorSection = prependContextModeToBlock("execute-task", base, phaseAnchorSection, opts.contextModeRenderMode);
+  trackPromptContext(contextTelemetry, "context-mode", phaseAnchorSection ? "inline" : "skipped", phaseAnchorSection, phaseAnchorSection ? undefined : "disabled or empty");
+  trackPromptContext(contextTelemetry, "overrides", overridesSection ? "inline" : "skipped", overridesSection, overridesSection ? undefined : "none active");
+  trackPromptContext(contextTelemetry, "gates", gatesToClose ? "inline" : "skipped", gatesToClose, gatesToClose ? undefined : "none pending");
+  trackPromptContext(contextTelemetry, "knowledge", knowledgeContent ? "inline" : "skipped", knowledgeContent, knowledgeContent ? undefined : "missing");
+  trackPromptContext(contextTelemetry, "graph-subgraph", graphBlockET ? "inline" : "skipped", graphBlockET, graphBlockET ? undefined : "missing");
+  if (inlineLevel !== "minimal") {
+    trackPromptContext(contextTelemetry, "decisions-template", "on-demand", decisionsOnDemandET);
+  }
+  trackPromptContext(contextTelemetry, "templates", "inline", inlinedTemplates, inlineLevel);
 
-  return loadPrompt("execute-task", {
+  const prompt = loadPrompt("execute-task", {
     overridesSection,
     runtimeContext,
     phaseAnchorSection,
@@ -2450,12 +2818,15 @@ export async function buildExecuteTaskPrompt(
       unitType: "execute-task",
     }),
   });
+  emitPromptContextTelemetry("execute-task", contextTelemetry, prompt);
+  return prompt;
 }
 
 export async function buildCompleteSlicePrompt(
   mid: string, midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
 ): Promise<string> {
   const inlineLevel = level ?? resolveInlineLevel();
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
 
   // #4782 phase 3: complete-slice migrated through composer. Manifest
   // declares [roadmap, slice-context, slice-plan, requirements,
@@ -2467,24 +2838,40 @@ export async function buildCompleteSlicePrompt(
       case "roadmap": {
         const p = resolveMilestoneFile(base, mid, "ROADMAP");
         const r = relMilestoneFile(base, mid, "ROADMAP");
-        return await inlineFile(p, r, "Milestone Roadmap");
+        const body = await inlineFile(p, r, "Milestone Roadmap");
+        trackPromptContext(contextTelemetry, "roadmap", "inline", body);
+        return body;
       }
       case "slice-context": {
         const p = resolveSliceFile(base, mid, sid, "CONTEXT");
         const r = relSliceFile(base, mid, sid, "CONTEXT");
-        return await inlineFileOptional(p, r, "Slice Context (from discussion)");
+        const body = await inlineFileOptional(p, r, "Slice Context (from discussion)");
+        trackPromptContext(contextTelemetry, "slice-context", body ? "inline" : "skipped", body, body ? undefined : "missing");
+        return body;
       }
       case "slice-plan": {
         const p = resolveSliceFile(base, mid, sid, "PLAN");
         const r = relSliceFile(base, mid, sid, "PLAN");
-        return await inlineFile(p, r, "Slice Plan");
+        const body = await inlineFile(p, r, "Slice Plan");
+        trackPromptContext(contextTelemetry, "slice-plan", "inline", body);
+        return body;
       }
       case "requirements":
-        if (inlineLevel === "minimal") return null;
-        return await inlineRequirementsFromDb(base, mid, sid, inlineLevel);
+        if (inlineLevel === "minimal") {
+          trackPromptContext(contextTelemetry, "requirements", "skipped", null, "minimal inline level");
+          return null;
+        }
+        {
+          const body = await inlineRequirementsFromDb(base, mid, sid, inlineLevel);
+          trackPromptContext(contextTelemetry, "requirements", body ? "inline" : "skipped", body, body ? undefined : "missing");
+          return body;
+        }
       case "prior-task-summaries": {
         const tDir = resolveTasksDir(base, mid, sid);
-        if (!tDir) return null;
+        if (!tDir) {
+          trackPromptContext(contextTelemetry, "prior-task-summaries", "skipped", null, "missing tasks dir");
+          return null;
+        }
         const summaryFiles = resolveTaskFiles(tDir, "SUMMARY").sort();
         const sRel = relSlicePath(base, mid, sid);
         const blocks: string[] = [];
@@ -2494,7 +2881,9 @@ export async function buildCompleteSlicePrompt(
           const taskId = file.replace(/-SUMMARY\.md$/i, "");
           blocks.push(await buildTaskSummaryExcerpt(absPath, relPath, taskId));
         }
-        return blocks.length > 0 ? blocks.join("\n\n---\n\n") : null;
+        const body = blocks.length > 0 ? blocks.join("\n\n---\n\n") : null;
+        trackPromptContext(contextTelemetry, "prior-task-summaries", body ? "excerpt" : "skipped", body, body ? undefined : "missing");
+        return body;
       }
       case "templates": {
         const parts = [inlineLevel === "minimal"
@@ -2503,7 +2892,9 @@ export async function buildCompleteSlicePrompt(
         if (inlineLevel !== "minimal") {
           parts.push(inlineTemplate("uat", "UAT"));
         }
-        return parts.join("\n\n---\n\n");
+        const body = parts.join("\n\n---\n\n");
+        trackPromptContext(contextTelemetry, "templates", "inline", body);
+        return body;
       }
       default:
         return null;
@@ -2519,6 +2910,11 @@ export async function buildCompleteSlicePrompt(
     base,
     [...extractKeywords(midTitle), ...extractKeywords(sTitle)],
   );
+  if (knowledgeInlineCS) {
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInlineCS);
+  } else {
+    trackPromptContext(contextTelemetry, "knowledge", "skipped", null, "missing");
+  }
 
   let body = composed;
   if (knowledgeInlineCS && body) {
@@ -2543,15 +2939,30 @@ export async function buildCompleteSlicePrompt(
   // the prepend contract).
   const completeActiveOverrides = await loadActiveOverrides(base);
   const completeOverridesInline = formatOverridesSection(completeActiveOverrides);
+  if (completeOverridesInline) {
+    trackPromptContext(contextTelemetry, "overrides", "inline", completeOverridesInline);
+  } else {
+    trackPromptContext(contextTelemetry, "overrides", "skipped", null, "none active");
+  }
   const finalBody = completeOverridesInline
     ? `${completeOverridesInline}\n\n---\n\n${body}`
     : body;
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${finalBody}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "complete-slice",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${finalBody}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("complete-slice", contextTelemetry, inlinedContext);
   const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
 
   const sliceRel = relSlicePath(base, mid, sid);
@@ -2594,7 +3005,10 @@ export async function buildCompleteMilestonePrompt(
   const validationContent = validationPath ? await loadFile(validationPath) : null;
 
   const inlined: string[] = [];
-  inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
+  const roadmapInline = await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap");
+  inlined.push(roadmapInline);
+  trackPromptContext(contextTelemetry, "roadmap", "inline", roadmapInline);
 
   // Inline all slice summaries (deduplicated by slice ID)
   let sliceIds: string[] = [];
@@ -2625,46 +3039,108 @@ export async function buildCompleteMilestonePrompt(
     summaryRelPaths.push(summaryRel);
     // Compact excerpt instead of full inline (#4780). Closer Reads the
     // full file on-demand when synthesizing LEARNINGS narrative.
-    inlined.push(await buildSliceSummaryExcerpt(summaryPath, summaryRel, sid));
+    const summaryExcerpt = await buildSliceSummaryExcerpt(summaryPath, summaryRel, sid);
+    inlined.push(summaryExcerpt);
+    trackPromptContext(contextTelemetry, "slice-summary", "excerpt", summaryExcerpt);
   }
   if (summaryRelPaths.length > 0) {
     const pathList = summaryRelPaths.map(p => `- \`${p}\``).join("\n");
-    inlined.push(
-      `### On-demand Slice Summaries\n\nExcerpted above. Read the full file for any slice when the excerpt's section heads don't carry enough narrative for the milestone summary you're drafting:\n\n${pathList}`,
-    );
+    const onDemandSummaries = `### On-demand Slice Summaries\n\nExcerpted above. Read the full file for any slice when the excerpt's section heads don't carry enough narrative for the milestone summary you're drafting:\n\n${pathList}`;
+    inlined.push(onDemandSummaries);
+    trackPromptContext(contextTelemetry, "slice-summary", "on-demand", onDemandSummaries);
   }
   const validationContext = [
     formatCloseoutReviewInstructions(validationContent, validationRel, [validationRel, roadmapRel, ...summaryRelPaths]),
   ];
+  trackPromptContext(contextTelemetry, "validation-review-instructions", "inline", validationContext[0]);
   if (validationContent) {
-    validationContext.push(`### Milestone Validation\nSource: \`${validationRel}\`\n\n${validationContent.trim()}`);
+    const validationInline = `### Milestone Validation\nSource: \`${validationRel}\`\n\n${validationContent.trim()}`;
+    validationContext.push(validationInline);
+    trackPromptContext(contextTelemetry, "milestone-validation", "inline", validationInline);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-validation", "skipped", null, "missing");
   }
   inlined.unshift(...validationContext);
 
-  // Inline root GSD files (skip for minimal — completion can read these if needed)
-  if (inlineLevel !== "minimal") {
+  // Inline compact requirement facts for standard closeout. Broader narrative
+  // docs stay on-demand unless the caller explicitly asks for full context.
+  if (inlineLevel === "full") {
     const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
-    if (requirementsInline) inlined.push(requirementsInline);
+    if (requirementsInline) {
+      inlined.push(requirementsInline);
+      trackPromptContext(contextTelemetry, "requirements", "inline", requirementsInline);
+    }
     const decisionsInline = await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
-    if (decisionsInline) inlined.push(decisionsInline);
+    if (decisionsInline) {
+      inlined.push(decisionsInline);
+      trackPromptContext(contextTelemetry, "decisions", "inline", decisionsInline);
+    }
     const projectInline = await inlineProjectFromDb(base);
-    if (projectInline) inlined.push(projectInline);
+    if (projectInline) {
+      inlined.push(projectInline);
+      trackPromptContext(contextTelemetry, "project", "inline", projectInline);
+    }
+  } else if (inlineLevel === "standard") {
+    const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
+    if (requirementsInline) {
+      inlined.push(requirementsInline);
+      trackPromptContext(contextTelemetry, "requirements", "inline", requirementsInline);
+    }
+    const decisionsOnDemand = onDemandDecisionsBlock("the slice summaries or validation artifact reference a decision that must be re-evaluated before closeout");
+    inlined.push(decisionsOnDemand);
+    trackPromptContext(contextTelemetry, "decisions", "on-demand", decisionsOnDemand);
+    const projectOnDemand = onDemandProjectBlock("the milestone summary needs product/domain wording that is not present in the roadmap, validation artifact, or slice summaries");
+    inlined.push(projectOnDemand);
+    trackPromptContext(contextTelemetry, "project", "on-demand", projectOnDemand);
+  } else {
+    trackPromptContext(contextTelemetry, "requirements", "skipped", null, "minimal inline level");
+    const decisionsOnDemand = onDemandDecisionsBlock("the closeout cannot be completed from the roadmap and slice summaries alone");
+    inlined.push(decisionsOnDemand);
+    trackPromptContext(contextTelemetry, "decisions", "on-demand", decisionsOnDemand);
+    const projectOnDemand = onDemandProjectBlock("the closeout cannot be completed from the roadmap and slice summaries alone");
+    inlined.push(projectOnDemand);
+    trackPromptContext(contextTelemetry, "project", "on-demand", projectOnDemand);
   }
   // Scoped + budgeted — see issue #4719
   const knowledgeInlineCM = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
-  if (knowledgeInlineCM) inlined.push(knowledgeInlineCM);
-  // Inline milestone context file (milestone-level, not GSD root)
+  if (knowledgeInlineCM) {
+    inlined.push(knowledgeInlineCM);
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInlineCM);
+  }
   const contextPath = resolveMilestoneFile(base, mid, "CONTEXT");
   const contextRel = relMilestoneFile(base, mid, "CONTEXT");
-  const contextInline = await inlineFileOptional(contextPath, contextRel, "Milestone Context");
-  if (contextInline) inlined.push(contextInline);
-  inlined.push(inlineTemplate("milestone-summary", "Milestone Summary"));
+  const contextInline = inlineLevel === "full"
+    ? await inlineFileOptional(contextPath, contextRel, "Milestone Context")
+    : null;
+  if (contextInline) {
+    inlined.push(contextInline);
+    trackPromptContext(contextTelemetry, "milestone-context", "inline", contextInline);
+  } else if (contextPath) {
+    const contextOnDemand = onDemandMilestoneContextBlock(contextRel, "the roadmap, validation artifact, and slice summaries do not explain the milestone's intent clearly enough");
+    inlined.push(contextOnDemand);
+    trackPromptContext(contextTelemetry, "milestone-context", "on-demand", contextOnDemand);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-context", "skipped", null, "missing");
+  }
+  const templateInline = inlineTemplate("milestone-summary", "Milestone Summary");
+  inlined.push(templateInline);
+  trackPromptContext(contextTelemetry, "templates", "inline", templateInline);
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "complete-milestone",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("complete-milestone", contextTelemetry, inlinedContext);
 
   const milestoneSummaryPath = join(base, `${relMilestonePath(base, mid)}/${mid}-SUMMARY.md`);
 
@@ -2702,7 +3178,10 @@ export async function buildValidateMilestonePrompt(
   const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
 
   const inlined: string[] = [];
-  inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
+  const roadmapInline = await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap");
+  inlined.push(roadmapInline);
+  trackPromptContext(contextTelemetry, "roadmap", "inline", roadmapInline);
 
   // Inline verification classes from planning (if available in DB)
   try {
@@ -2716,7 +3195,9 @@ export async function buildValidateMilestonePrompt(
         if (milestone.verification_operational) classes.push(`- **Operational:** ${milestone.verification_operational}`);
         if (milestone.verification_uat) classes.push(`- **UAT:** ${milestone.verification_uat}`);
         if (classes.length > 0) {
-          inlined.push(`### Verification Classes (from planning)\n\nThese verification tiers were defined during milestone planning. Each non-empty class must be checked for evidence during validation.\n\n${classes.join("\n")}`);
+          const verificationClasses = `### Verification Classes (from planning)\n\nThese verification tiers were defined during milestone planning. Each non-empty class must be checked for evidence during validation.\n\n${classes.join("\n")}`;
+          inlined.push(verificationClasses);
+          trackPromptContext(contextTelemetry, "verification-classes", "inline", verificationClasses);
         }
       }
     }
@@ -2724,7 +3205,9 @@ export async function buildValidateMilestonePrompt(
     logWarning("prompt", `buildValidateMilestonePrompt verification classes lookup failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 
-  // Inline all slice summaries and assessment results
+  // Validate from compact slice evidence first. Full slice summaries and
+  // assessments stay on-demand so milestone validation does not rehydrate the
+  // whole milestone on every closeout pass.
   let valSliceIds: string[] = [];
   try {
     const { isDbAvailable, getMilestoneSlices } = await import("./gsd-db.js");
@@ -2744,17 +3227,39 @@ export async function buildValidateMilestonePrompt(
     }
   }
   const seenValSlices = new Set<string>();
+  const onDemandValidationPaths: string[] = [];
   for (const sid of valSliceIds) {
     if (seenValSlices.has(sid)) continue;
     seenValSlices.add(sid);
     const summaryPath = resolveSliceFile(base, mid, sid, "SUMMARY");
     const summaryRel = relSliceFile(base, mid, sid, "SUMMARY");
-    inlined.push(await inlineFile(summaryPath, summaryRel, `${sid} Summary`));
+    const summaryExcerpt = await buildSliceSummaryExcerpt(summaryPath, summaryRel, sid);
+    inlined.push(summaryExcerpt);
+    onDemandValidationPaths.push(summaryRel);
+    trackPromptContext(contextTelemetry, "slice-summary", "excerpt", summaryExcerpt);
 
     const assessmentPath = resolveSliceFile(base, mid, sid, "ASSESSMENT");
     const assessmentRel = relSliceFile(base, mid, sid, "ASSESSMENT");
-    const assessmentInline = await inlineFileOptional(assessmentPath, assessmentRel, `${sid} Assessment`);
-    if (assessmentInline) inlined.push(assessmentInline);
+    const assessmentExcerpt = await buildSliceAssessmentExcerpt(assessmentPath, assessmentRel, sid);
+    if (assessmentExcerpt) {
+      inlined.push(assessmentExcerpt);
+      trackPromptContext(contextTelemetry, "slice-assessment", "excerpt", assessmentExcerpt);
+    } else {
+      trackPromptContext(contextTelemetry, "slice-assessment", "skipped", null, "missing");
+    }
+    onDemandValidationPaths.push(assessmentRel);
+  }
+  if (onDemandValidationPaths.length > 0) {
+    const pathList = onDemandValidationPaths.map(p => `- \`${p}\``).join("\n");
+    const onDemandBlock = [
+      "### On-demand Validation Artifacts",
+      "",
+      "Slice summaries and assessments are excerpted above. Read full files only when an excerpt is missing, truncated, or internally inconsistent with validation evidence:",
+      "",
+      pathList,
+    ].join("\n");
+    inlined.push(onDemandBlock);
+    trackPromptContext(contextTelemetry, "slice-summary,slice-assessment", "on-demand", onDemandBlock);
   }
 
   // Aggregate unresolved follow-ups and known limitations across slices
@@ -2769,7 +3274,9 @@ export async function buildValidateMilestonePrompt(
     if (summary.knownLimitations) outstandingItems.push(`- **${sid} Known Limitations:** ${summary.knownLimitations.trim()}`);
   }
   if (outstandingItems.length > 0) {
-    inlined.push(`### Outstanding Items (aggregated from slice summaries)\n\nThese follow-ups and known limitations were documented during slice completion but have not been resolved.\n\n${outstandingItems.join('\n')}`);
+    const outstandingBlock = `### Outstanding Items (aggregated from slice summaries)\n\nThese follow-ups and known limitations were documented during slice completion but have not been resolved.\n\n${outstandingItems.join('\n')}`;
+    inlined.push(outstandingBlock);
+    trackPromptContext(contextTelemetry, "outstanding-items", "inline", outstandingBlock);
   }
 
   // Inline existing VALIDATION file if this is a re-validation round
@@ -2780,32 +3287,89 @@ export async function buildValidateMilestonePrompt(
   if (validationContent) {
     const roundMatch = validationContent.match(/remediation_round:\s*(\d+)/);
     remediationRound = roundMatch ? parseInt(roundMatch[1], 10) + 1 : 1;
-    inlined.push(`### Previous Validation (re-validation round ${remediationRound})\nSource: \`${validationRel}\`\n\n${validationContent.trim()}`);
+    const previousValidation = `### Previous Validation (re-validation round ${remediationRound})\nSource: \`${validationRel}\`\n\n${validationContent.trim()}`;
+    inlined.push(previousValidation);
+    trackPromptContext(contextTelemetry, "milestone-validation", "inline", previousValidation);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-validation", "skipped", null, "missing");
   }
 
-  // Inline root GSD files
-  if (inlineLevel !== "minimal") {
+  // Validation keeps compact requirements inline, but broad narrative docs are
+  // on-demand in standard mode to avoid rehydrating full project context.
+  if (inlineLevel === "full") {
     const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
-    if (requirementsInline) inlined.push(requirementsInline);
+    if (requirementsInline) {
+      inlined.push(requirementsInline);
+      trackPromptContext(contextTelemetry, "requirements", "inline", requirementsInline);
+    }
     const decisionsInline = await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
-    if (decisionsInline) inlined.push(decisionsInline);
+    if (decisionsInline) {
+      inlined.push(decisionsInline);
+      trackPromptContext(contextTelemetry, "decisions", "inline", decisionsInline);
+    }
     const projectInline = await inlineProjectFromDb(base);
-    if (projectInline) inlined.push(projectInline);
+    if (projectInline) {
+      inlined.push(projectInline);
+      trackPromptContext(contextTelemetry, "project", "inline", projectInline);
+    }
+  } else if (inlineLevel === "standard") {
+    const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
+    if (requirementsInline) {
+      inlined.push(requirementsInline);
+      trackPromptContext(contextTelemetry, "requirements", "inline", requirementsInline);
+    }
+    const decisionsOnDemand = onDemandDecisionsBlock("a validation finding conflicts with an existing architectural decision");
+    inlined.push(decisionsOnDemand);
+    trackPromptContext(contextTelemetry, "decisions", "on-demand", decisionsOnDemand);
+    const projectOnDemand = onDemandProjectBlock("validation evidence needs product/domain context that is not present in the roadmap or slice artifacts");
+    inlined.push(projectOnDemand);
+    trackPromptContext(contextTelemetry, "project", "on-demand", projectOnDemand);
+  } else {
+    trackPromptContext(contextTelemetry, "requirements", "skipped", null, "minimal inline level");
+    const decisionsOnDemand = onDemandDecisionsBlock("validation cannot determine the correct verdict from milestone artifacts alone");
+    inlined.push(decisionsOnDemand);
+    trackPromptContext(contextTelemetry, "decisions", "on-demand", decisionsOnDemand);
+    const projectOnDemand = onDemandProjectBlock("validation cannot determine the correct verdict from milestone artifacts alone");
+    inlined.push(projectOnDemand);
+    trackPromptContext(contextTelemetry, "project", "on-demand", projectOnDemand);
   }
   // Scoped + budgeted — see issue #4719
   const knowledgeInline = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
-  if (knowledgeInline) inlined.push(knowledgeInline);
-  // Inline milestone context file
+  if (knowledgeInline) {
+    inlined.push(knowledgeInline);
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInline);
+  }
   const contextPath = resolveMilestoneFile(base, mid, "CONTEXT");
   const contextRel = relMilestoneFile(base, mid, "CONTEXT");
-  const contextInline = await inlineFileOptional(contextPath, contextRel, "Milestone Context");
-  if (contextInline) inlined.push(contextInline);
+  const contextInline = inlineLevel === "full"
+    ? await inlineFileOptional(contextPath, contextRel, "Milestone Context")
+    : null;
+  if (contextInline) {
+    inlined.push(contextInline);
+    trackPromptContext(contextTelemetry, "milestone-context", "inline", contextInline);
+  } else if (contextPath) {
+    const contextOnDemand = onDemandMilestoneContextBlock(contextRel, "the roadmap and slice artifacts do not explain the intended outcome clearly enough");
+    inlined.push(contextOnDemand);
+    trackPromptContext(contextTelemetry, "milestone-context", "on-demand", contextOnDemand);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-context", "skipped", null, "missing");
+  }
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "validate-milestone",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("validate-milestone", contextTelemetry, inlinedContext);
 
   const validationOutputPath = join(base, `${relMilestonePath(base, mid)}/${mid}-VALIDATION.md`);
   const roadmapOutputPath = `${relMilestonePath(base, mid)}/${mid}-ROADMAP.md`;
@@ -2929,9 +3493,9 @@ export async function buildReplanSlicePrompt(
 export async function buildRunUatPrompt(
   mid: string, sliceId: string, uatPath: string, uatContent: string, base: string,
 ): Promise<string> {
-  // #4782 phase 3: run-uat migrated to compose its inlined context via
-  // the manifest. Behavior-equivalent — resolver dispatches to the same
-  // inline* helpers as the pre-migration builder.
+  // Run-UAT keeps only the UAT body inline. Prior slice/project context is
+  // compact or on-demand so validation does not pay for full closeout context.
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
   const resolveArtifact: ArtifactResolver = async (key) => {
     switch (key) {
       case "slice-uat": {
@@ -2941,29 +3505,75 @@ export async function buildRunUatPrompt(
         // uatContent below) if the file changes mid-dispatch.
         const trimmed = uatContent.trim();
         if (!trimmed) {
-          return `### ${sliceId} UAT\nSource: \`${uatPath}\`\n\n_(not found — file does not exist yet)_`;
+          const body = `### ${sliceId} UAT\nSource: \`${uatPath}\`\n\n_(not found — file does not exist yet)_`;
+          trackPromptContext(contextTelemetry, "slice-uat", "inline", body);
+          return body;
         }
-        return `### ${sliceId} UAT\nSource: \`${uatPath}\`\n\n${trimmed}`;
+        const body = `### ${sliceId} UAT\nSource: \`${uatPath}\`\n\n${trimmed}`;
+        trackPromptContext(contextTelemetry, "slice-uat", "inline", body);
+        return body;
       }
       case "slice-summary": {
-        const p = resolveSliceFile(base, mid, sliceId, "SUMMARY");
-        if (!p) return null;
-        const r = relSliceFile(base, mid, sliceId, "SUMMARY");
-        return await inlineFileOptional(p, r, `${sliceId} Summary`);
+        trackPromptContext(contextTelemetry, "slice-summary", "skipped", null, "handled by excerpt resolver");
+        return null;
       }
-      case "project":
-        return await inlineProjectFromDb(base);
+      case "project": {
+        trackPromptContext(contextTelemetry, "project", "skipped", null, "handled as on-demand path");
+        return null;
+      }
+      default:
+        return null;
+    }
+  };
+  const resolveExcerpt: ExcerptResolver = async (key) => {
+    switch (key) {
+      case "slice-summary": {
+        const p = resolveSliceFile(base, mid, sliceId, "SUMMARY");
+        const r = relSliceFile(base, mid, sliceId, "SUMMARY");
+        if (!p) {
+          trackPromptContext(contextTelemetry, "slice-summary", "skipped", null, "missing");
+          return null;
+        }
+        const body = await buildSliceSummaryExcerpt(p, r, sliceId);
+        trackPromptContext(contextTelemetry, "slice-summary", "excerpt", body);
+        return body;
+      }
       default:
         return null;
     }
   };
 
-  const composed = await composeInlinedContext("run-uat", resolveArtifact);
+  const composed = await composeUnitContext("run-uat", {
+    base: { unitType: "run-uat", basePath: base, milestoneId: mid, sliceId },
+    resolveArtifact,
+    resolveExcerpt,
+  });
+  const parts: string[] = [];
+  if (composed.prepend) parts.push(composed.prepend);
+  if (composed.inline) parts.push(composed.inline);
+  const projectOnDemand = [
+    "### On-demand Project Context",
+    "",
+    `Project context is available at \`${relGsdRootFile("PROJECT")}\`. Read it only if the UAT spec or slice summary lacks enough product/domain context to assess the scenario.`,
+  ].join("\n");
+  parts.push(projectOnDemand);
+  trackPromptContext(contextTelemetry, "project", "on-demand", projectOnDemand);
+  const composedBody = parts.join("\n\n---\n\n");
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${composedBody}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "run-uat",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${composed}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("run-uat", contextTelemetry, inlinedContext);
 
   const uatResultPath = join(base, relSliceFile(base, mid, sliceId, "ASSESSMENT"));
   const uatType = resolveEffectiveUatType(uatContent);
@@ -2989,59 +3599,98 @@ export async function buildRunUatPrompt(
 export async function buildReassessRoadmapPrompt(
   mid: string, midTitle: string, completedSliceId: string, base: string, level?: InlineLevel,
 ): Promise<string> {
-  const inlineLevel = level ?? resolveInlineLevel();
+  void level;
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
 
-  // #4782 phase 2 pilot: reassess-roadmap is the first unit type to
-  // compose its inlined context through the manifest-driven composer.
-  // The resolver below dispatches artifact keys to the existing inline*
-  // helpers, preserving identical output so the migration is
-  // observable-equivalent. Knowledge stays outside the composer (it's
-  // budget-driven, not manifest-driven) until a later phase formalizes
-  // knowledge/memory policies as composer inputs.
+  // Reassess-roadmap runs between slices, so keep only the roadmap and
+  // completed-slice evidence in prompt. Broader project docs stay on-demand.
   const resolveArtifact: ArtifactResolver = async (key) => {
     switch (key) {
       case "roadmap": {
         const p = resolveMilestoneFile(base, mid, "ROADMAP");
         const r = relMilestoneFile(base, mid, "ROADMAP");
-        return await inlineFile(p, r, "Current Roadmap");
+        const body = await inlineFile(p, r, "Current Roadmap");
+        trackPromptContext(contextTelemetry, "roadmap", "inline", body);
+        return body;
       }
       case "slice-context": {
         const p = resolveSliceFile(base, mid, completedSliceId, "CONTEXT");
         const r = relSliceFile(base, mid, completedSliceId, "CONTEXT");
-        return await inlineFileOptional(p, r, "Slice Context (from discussion)");
+        const body = await inlineFileOptional(p, r, "Slice Context (from discussion)");
+        trackPromptContext(contextTelemetry, "slice-context", body ? "inline" : "skipped", body, body ? undefined : "missing");
+        return body;
       }
+      case "slice-summary": {
+        trackPromptContext(contextTelemetry, "slice-summary", "skipped", null, "handled by excerpt resolver");
+        return null;
+      }
+      case "project":
+      case "requirements":
+      case "decisions":
+        trackPromptContext(contextTelemetry, key, "skipped", null, "handled as on-demand path");
+        return null;
+      default:
+        return null;
+    }
+  };
+  const resolveExcerpt: ExcerptResolver = async (key) => {
+    switch (key) {
       case "slice-summary": {
         const p = resolveSliceFile(base, mid, completedSliceId, "SUMMARY");
         const r = relSliceFile(base, mid, completedSliceId, "SUMMARY");
-        return await inlineFile(p, r, `${completedSliceId} Summary`);
+        const body = await buildSliceSummaryExcerpt(p, r, completedSliceId);
+        trackPromptContext(contextTelemetry, "slice-summary", "excerpt", body);
+        return body;
       }
-      case "project":
-        if (inlineLevel === "minimal") return null;
-        return await inlineProjectFromDb(base);
-      case "requirements":
-        if (inlineLevel === "minimal") return null;
-        return await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
-      case "decisions":
-        if (inlineLevel === "minimal") return null;
-        return await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
       default:
         return null;
     }
   };
 
-  const composed = await composeInlinedContext("reassess-roadmap", resolveArtifact);
+  const composed = await composeUnitContext("reassess-roadmap", {
+    base: { unitType: "reassess-roadmap", basePath: base, milestoneId: mid, sliceId: completedSliceId },
+    resolveArtifact,
+    resolveExcerpt,
+  });
   const parts: string[] = [];
-  if (composed) parts.push(composed);
+  if (composed.prepend) parts.push(composed.prepend);
+  if (composed.inline) parts.push(composed.inline);
+  const onDemandDocs = [
+    "### On-demand Planning Context",
+    "",
+    "Broader project context is available if the roadmap update needs it. Read only the specific source that answers the reassessment question:",
+    "",
+    `- \`${relGsdRootFile("PROJECT")}\` — product/project narrative`,
+    `- \`${relGsdRootFile("REQUIREMENTS")}\` — requirement status and acceptance criteria`,
+    `- \`${relGsdRootFile("DECISIONS")}\` — active architecture/product decisions`,
+  ].join("\n");
+  parts.push(onDemandDocs);
+  trackPromptContext(contextTelemetry, "project,requirements,decisions", "on-demand", onDemandDocs);
   // Knowledge block stays outside the composer — budgeted, scoped via
   // keyword extraction (#4719). Future phase folds it in.
   const knowledgeInlineRA = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
-  if (knowledgeInlineRA) parts.push(knowledgeInlineRA);
+  if (knowledgeInlineRA) {
+    parts.push(knowledgeInlineRA);
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInlineRA);
+  } else {
+    trackPromptContext(contextTelemetry, "knowledge", "skipped", null, "missing");
+  }
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "reassess-roadmap",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("reassess-roadmap", contextTelemetry, inlinedContext);
 
   const assessmentPath = join(base, relSliceFile(base, mid, completedSliceId, "ASSESSMENT"));
 
@@ -3115,6 +3764,15 @@ export async function buildReactiveExecutePrompt(
   // Build individual subagent prompts for each ready task
   const subagentSections: string[] = [];
   const readyTaskListLines: string[] = [];
+  const prefs = loadEffectiveGSDPreferences();
+  const contextWindow = resolveExecutorContextWindow(opts?.modelRegistry, prefs?.preferences, opts?.sessionContextWindow, opts?.sessionProvider);
+  const budgets = computeBudgets(contextWindow);
+  const perSubagentCarryForwardBudget = Math.max(
+    1_000,
+    Math.floor((budgets.inlineContextBudgetChars * 0.4) / Math.max(1, readyTaskIds.length)),
+  );
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
+  trackPromptContext(contextTelemetry, "graph-context", "inline", graphContext);
 
   for (const tid of readyTaskIds) {
     const node = graph.find((n) => n.id === tid);
@@ -3141,6 +3799,16 @@ export async function buildReactiveExecutePrompt(
           `Task plan not found at dispatch time. Read \`${taskPlanRelPath}\` before executing.`,
         ].join("\n");
     const carryForwardSection = await buildCarryForwardSection(depPaths, base);
+    const finalCarryForwardSection = carryForwardSection.length > perSubagentCarryForwardBudget
+      ? truncateAtSectionBoundary(carryForwardSection, perSubagentCarryForwardBudget).content
+      : carryForwardSection;
+    trackPromptContext(
+      contextTelemetry,
+      "prior-task-summaries",
+      finalCarryForwardSection.trim() ? "excerpt" : "skipped",
+      finalCarryForwardSection,
+      finalCarryForwardSection.length < carryForwardSection.length ? `truncated from ${carryForwardSection.length} chars for ${tid}` : tid,
+    );
     const taskSummaryPath = `${relSlicePath(base, mid, sid)}/tasks/${tid}-SUMMARY.md`;
     const taskPrompt = [
       `## UNIT: Execute Task ${tid} ("${tTitle}")`,
@@ -3149,7 +3817,7 @@ export async function buildReactiveExecutePrompt(
       "Implement from the inlined task plan below. Verify changes, then call `gsd_task_complete`.",
       "Do not run git commands.",
       "",
-      carryForwardSection,
+      finalCarryForwardSection,
       "",
       taskPlanInline,
       "",
@@ -3174,8 +3842,9 @@ export async function buildReactiveExecutePrompt(
   }
 
   const inlinedTemplates = inlineTemplate("task-summary", "Task Summary");
+  trackPromptContext(contextTelemetry, "templates", "inline", inlinedTemplates);
 
-  return loadPrompt("reactive-execute", {
+  const prompt = loadPrompt("reactive-execute", {
     workingDirectory: base,
     milestoneId: mid,
     milestoneTitle: midTitle,
@@ -3187,6 +3856,8 @@ export async function buildReactiveExecutePrompt(
     subagentPrompts: subagentSections.join("\n\n---\n\n"),
     inlinedTemplates,
   });
+  emitPromptContextTelemetry("reactive-execute", contextTelemetry, prompt);
+  return prompt;
 }
 
 // ─── Gate Evaluation ──────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -84,6 +84,7 @@ import {
   getBudgetAlertLevel,
   getNewBudgetAlertLevel,
   getBudgetEnforcementAction,
+  getContextPauseAction,
 } from "./auto-budget.js";
 import {
   markToolStart as _markToolStart,
@@ -619,6 +620,7 @@ export {
   getBudgetAlertLevel,
   getNewBudgetAlertLevel,
   getBudgetEnforcementAction,
+  getContextPauseAction,
 } from "./auto-budget.js";
 
 function closeOutSignalInterruptedUnit(currentBasePath: string): void {
@@ -1851,8 +1853,11 @@ export async function pauseAuto(
     unitLabel: pausedUnitLabel,
   });
   if (ctx) initHealthWidget(ctx);
+  const pauseMessage = _errorContext?.message
+    ? `${s.stepMode ? "Step" : "Auto"}-mode paused: ${_errorContext.message}`
+    : `${s.stepMode ? "Step" : "Auto"}-mode paused (Escape). Type to interact, or ${resumeCmd} to resume.`;
   ctx?.ui.notify(
-    `${s.stepMode ? "Step" : "Auto"}-mode paused (Escape). Type to interact, or ${resumeCmd} to resume.`,
+    pauseMessage,
     "info",
   );
 }

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -44,10 +44,10 @@ function tryParseNumber(val: string): number | null {
   return !isNaN(n) && isFinite(n) ? n : null;
 }
 
-/** Parse a string as a number in the 0–100 range, or return null on failure. */
+/** Parse a string as 0 or a whole percentage in the 1–100 range, or return null on failure. */
 function tryParsePercentage(val: string): number | null {
   const n = Number(val);
-  return !isNaN(n) && n >= 0 && n <= 100 ? n : null;
+  return !isNaN(n) && (n === 0 || (n >= 1 && n <= 100)) ? n : null;
 }
 
 // ─── Prompt helpers (reduce boilerplate across configure* functions) ─────────
@@ -1053,7 +1053,7 @@ async function configureBudget(ctx: ExtensionCommandContext, prefs: Record<strin
         prefs.context_pause_threshold = parsed;
       }
     } else if (val) {
-      ctx.ui.notify(`Invalid context pause threshold "${val}" — must be 0-100. Keeping previous value.`, "warning");
+      ctx.ui.notify(`Invalid context pause threshold "${val}" — use 0 to disable or 1-100 percent. Keeping previous value.`, "warning");
     }
   }
 }

--- a/src/resources/extensions/gsd/dashboard-overlay.ts
+++ b/src/resources/extensions/gsd/dashboard-overlay.ts
@@ -18,6 +18,7 @@ import type { AutoDashboardData } from "./auto-dashboard.js";
 import {
   getLedger, getProjectTotals, aggregateByPhase, aggregateBySlice,
   aggregateByModel, aggregateCacheHitRate, formatCost, formatTokenCount, formatCostProjection,
+  getPromptSizeStats,
   type UnitMetrics,
 } from "./metrics.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
@@ -48,6 +49,11 @@ export function unitLabel(type: string): string {
   }
 }
 
+function formatCharCount(chars: number): string {
+  if (chars >= 1_000_000) return `${(chars / 1_000_000).toFixed(2)}M chars`;
+  if (chars >= 1_000) return `${(chars / 1_000).toFixed(1)}k chars`;
+  return `${chars} chars`;
+}
 
 export class GSDDashboardOverlay {
   private tui: { requestRender: () => void };
@@ -497,6 +503,18 @@ export class GSDDashboardOverlay {
           budgetParts.push(th.fg("error", `${totals.continueHereFiredCount} continue-here fired`));
         }
         lines.push(row(budgetParts.join(`  ${th.fg("dim", "·")}  `)));
+      }
+
+      const promptStats = getPromptSizeStats(ledger.units);
+      if (promptStats) {
+        const promptParts = [
+          `${th.fg("dim", "avg prompt:")} ${th.fg("text", formatCharCount(promptStats.averagePromptChars))}`,
+          `${th.fg("dim", "max:")} ${th.fg("text", formatCharCount(promptStats.maxPromptChars))}`,
+        ];
+        if (promptStats.averageCompressionSavings != null) {
+          promptParts.push(`${th.fg("dim", "compression:")} ${th.fg("success", `${promptStats.averageCompressionSavings}%`)}`);
+        }
+        lines.push(row(promptParts.join(`  ${th.fg("dim", "·")}  `)));
       }
 
       const phases = aggregateByPhase(ledger.units);

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -163,7 +163,7 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
   - `halt` — stop auto-mode immediately.
   - Default: `"pause"`.
 
-- `context_pause_threshold`: number (0-100) — context window usage percentage at which auto-mode should pause to suggest checkpointing. Set to `0` to disable. Default: `0` (disabled).
+- `context_pause_threshold`: number (`0` or `1-100`) — live context window usage percentage at which auto-mode should pause to suggest checkpointing. Set to `0` to disable. Use whole percentages like `75`, not fractional ratios like `0.75`. Default: `0` (disabled).
 
 - `token_profile`: `"budget"`, `"balanced"`, `"quality"`, or `"burn-max"` — coordinates model selection, phase skipping, and context compression. `budget` skips research/reassessment and uses cheaper models; `balanced` (default) skips research/reassessment to reduce token burn; `quality` prefers higher-quality models; `burn-max` keeps full-context defaults, disables downgrade routing, and keeps phase skips off.
 

--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -238,6 +238,16 @@ export function snapshotUnitMetrics(
     const totalInput = tokens.cacheRead + tokens.input;
     unit.cacheHitRate = totalInput > 0 ? Math.round((tokens.cacheRead / totalInput) * 100) : 0;
   }
+  if (
+    unit.promptCharCount != null &&
+    unit.baselineCharCount != null &&
+    unit.baselineCharCount > 0
+  ) {
+    unit.compressionSavings = Math.max(
+      0,
+      Math.round(((unit.baselineCharCount - unit.promptCharCount) / unit.baselineCharCount) * 100),
+    );
+  }
 
   // ── Idempotency guard ──────────────────────────────────────────────────
   // Prevent duplicate metrics entries when multiple callers snapshot the
@@ -426,6 +436,16 @@ export function snapshotUnitMetricsByScope(
     const totalInput = tokens.cacheRead + tokens.input;
     unit.cacheHitRate = totalInput > 0 ? Math.round((tokens.cacheRead / totalInput) * 100) : 0;
   }
+  if (
+    unit.promptCharCount != null &&
+    unit.baselineCharCount != null &&
+    unit.baselineCharCount > 0
+  ) {
+    unit.compressionSavings = Math.max(
+      0,
+      Math.round(((unit.baselineCharCount - unit.promptCharCount) / unit.baselineCharCount) * 100),
+    );
+  }
 
   // Idempotency guard: update in-place on duplicate, append otherwise.
   const dupeIdx = scopedLedger.units.findIndex(
@@ -499,6 +519,14 @@ export interface ProjectTotals {
   apiRequests: number;
   totalTruncationSections: number;
   continueHereFiredCount: number;
+}
+
+export interface PromptSizeStats {
+  units: number;
+  averagePromptChars: number;
+  maxPromptChars: number;
+  averageBaselineChars: number | null;
+  averageCompressionSavings: number | null;
 }
 
 function emptyTokens(): TokenCounts {
@@ -595,6 +623,52 @@ export function getProjectTotals(units: UnitMetrics[]): ProjectTotals {
     if (u.continueHereFired) totals.continueHereFiredCount++;
   }
   return totals;
+}
+
+export function getPromptSizeStats(units: UnitMetrics[]): PromptSizeStats | null {
+  const promptUnits = units.filter(
+    (u) => typeof u.promptCharCount === "number" && Number.isFinite(u.promptCharCount) && u.promptCharCount > 0,
+  );
+  if (promptUnits.length === 0) return null;
+
+  let promptTotal = 0;
+  let maxPromptChars = 0;
+  let baselineTotal = 0;
+  let baselineCount = 0;
+  let savingsTotal = 0;
+  let savingsCount = 0;
+
+  for (const unit of promptUnits) {
+    const promptChars = unit.promptCharCount!;
+    promptTotal += promptChars;
+    maxPromptChars = Math.max(maxPromptChars, promptChars);
+
+    if (
+      typeof unit.baselineCharCount === "number" &&
+      Number.isFinite(unit.baselineCharCount) &&
+      unit.baselineCharCount > 0
+    ) {
+      baselineTotal += unit.baselineCharCount;
+      baselineCount++;
+      const savings = Math.max(0, ((unit.baselineCharCount - promptChars) / unit.baselineCharCount) * 100);
+      savingsTotal += savings;
+      savingsCount++;
+    } else if (
+      typeof unit.compressionSavings === "number" &&
+      Number.isFinite(unit.compressionSavings)
+    ) {
+      savingsTotal += Math.max(0, unit.compressionSavings);
+      savingsCount++;
+    }
+  }
+
+  return {
+    units: promptUnits.length,
+    averagePromptChars: Math.round(promptTotal / promptUnits.length),
+    maxPromptChars,
+    averageBaselineChars: baselineCount > 0 ? Math.round(baselineTotal / baselineCount) : null,
+    averageCompressionSavings: savingsCount > 0 ? Math.round(savingsTotal / savingsCount) : null,
+  };
 }
 
 // ─── Tier Aggregation ────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -366,13 +366,16 @@ export function validatePreferences(preferences: GSDPreferences): {
 
   // ─── Context Pause Threshold ────────────────────────────────────────
   if (preferences.context_pause_threshold !== undefined) {
-    const raw = preferences.context_pause_threshold;
-    if (typeof raw === "number" && Number.isFinite(raw)) {
-      validated.context_pause_threshold = raw;
-    } else if (typeof raw === "string" && Number.isFinite(Number(raw))) {
-      validated.context_pause_threshold = Number(raw);
+    const raw = (preferences as Record<string, unknown>).context_pause_threshold;
+    const value = typeof raw === "string" && raw.trim() !== "" ? Number(raw) : raw;
+    if (
+      typeof value === "number" &&
+      Number.isFinite(value) &&
+      (value === 0 || (value >= 1 && value <= 100))
+    ) {
+      validated.context_pause_threshold = value;
     } else {
-      errors.push("context_pause_threshold must be a finite number");
+      errors.push("context_pause_threshold must be 0 to disable or a percentage between 1 and 100");
     }
   }
 

--- a/src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   getBudgetAlertLevel,
   getBudgetEnforcementAction,
+  getContextPauseAction,
   getNewBudgetAlertLevel,
 } from "../auto.js";
 
@@ -47,4 +48,13 @@ test("getBudgetEnforcementAction maps the configured ceiling behavior", () => {
   assert.equal(getBudgetEnforcementAction("warn", 1.0), "warn");
   assert.equal(getBudgetEnforcementAction("pause", 1.0), "pause");
   assert.equal(getBudgetEnforcementAction("halt", 1.0), "halt");
+});
+
+test("getContextPauseAction pauses at or above a percentage threshold", () => {
+  assert.equal(getContextPauseAction(undefined, 90), "none");
+  assert.equal(getContextPauseAction(null, 90), "none");
+  assert.equal(getContextPauseAction(89.9, 90), "none");
+  assert.equal(getContextPauseAction(90, 90), "pause");
+  assert.equal(getContextPauseAction(95, 90), "pause");
+  assert.equal(getContextPauseAction(95, 0), "none");
 });

--- a/src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts
@@ -10,7 +10,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { buildSliceSummaryExcerpt, buildCompleteMilestonePrompt } from "../auto-prompts.ts";
+import { buildSliceSummaryExcerpt, buildCompleteMilestonePrompt, buildValidateMilestonePrompt } from "../auto-prompts.ts";
 import { invalidateAllCaches } from "../cache.ts";
 
 // ─── Fixture helpers ──────────────────────────────────────────────────────
@@ -33,6 +33,13 @@ function writeRoadmap(base: string, content: string): void {
 function writeSummary(base: string, sid: string, content: string): void {
   writeFileSync(
     join(base, ".gsd", "milestones", "M001", "slices", sid, `${sid}-SUMMARY.md`),
+    content,
+  );
+}
+
+function writeAssessment(base: string, sid: string, content: string): void {
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", sid, `${sid}-ASSESSMENT.md`),
     content,
   );
 }
@@ -231,6 +238,8 @@ test("#4780 closer prompt: uses excerpts + lists on-demand slice SUMMARY paths",
   writeRoadmap(base, makeRoadmap());
   writeSummary(base, "S01", makeFatSummary("S01"));
   writeSummary(base, "S02", makeFatSummary("S02"));
+  writeFileSync(join(base, ".gsd", "PROJECT.md"), "# Project\n\nBroad product context should stay on-demand.");
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# Context\n\nMilestone context should stay on-demand.");
 
   const prompt = await buildCompleteMilestonePrompt("M001", "Test Milestone", base);
 
@@ -242,6 +251,16 @@ test("#4780 closer prompt: uses excerpts + lists on-demand slice SUMMARY paths",
   assert.match(prompt, /### On-demand Slice Summaries/);
   assert.match(prompt, /S01-SUMMARY\.md/);
   assert.match(prompt, /S02-SUMMARY\.md/);
+  assert.match(prompt, /### On-demand Project Context/);
+  assert.match(prompt, /### On-demand Milestone Context/);
+  assert.ok(
+    !prompt.includes("Broad product context should stay on-demand."),
+    "standard complete-milestone prompt should not inline project narrative",
+  );
+  assert.ok(
+    !prompt.includes("Milestone context should stay on-demand."),
+    "standard complete-milestone prompt should not inline milestone context narrative",
+  );
 
   // Fat narrative (the 20x-repeated paragraph) is NOT inlined
   assert.ok(
@@ -290,5 +309,58 @@ test("complete-milestone prompt caps repeated inlined context around 20k chars",
     inlinedContext.length <= 21_000,
     `inlined context ${inlinedContext.length} chars should stay near the 20k cap`,
   );
-  assert.match(inlinedContext, /\[\.\.\.truncated \d+ sections\]/);
+});
+
+test("validate-milestone prompt uses slice excerpts and on-demand paths instead of full prior artifacts", async (t) => {
+  const base = createBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  writeRoadmap(base, makeRoadmap());
+  writeSummary(base, "S01", makeFatSummary("S01"));
+  writeSummary(base, "S02", makeFatSummary("S02"));
+  writeFileSync(join(base, ".gsd", "PROJECT.md"), "# Project\n\nBroad validation product context should stay on-demand.");
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# Context\n\nValidation milestone context should stay on-demand.");
+  writeAssessment(
+    base,
+    "S01",
+    [
+      "# Assessment",
+      "",
+      "Verdict: PASS — 15 checks passed across runtime simulation.",
+      "",
+      "## Edge Cases",
+      "Empty query, no matches, and priority sort all pass.",
+      "",
+      "## Full Runtime Trace",
+      "This very noisy assessment trace should stay out of the prompt. ".repeat(80),
+    ].join("\n"),
+  );
+
+  const prompt = await buildValidateMilestonePrompt("M001", "Test Milestone", base);
+
+  assert.match(prompt, /### S01 Summary \(excerpt\)/);
+  assert.match(prompt, /### S02 Summary \(excerpt\)/);
+  assert.match(prompt, /### S01 Assessment \(excerpt\)/);
+  assert.match(prompt, /### On-demand Validation Artifacts/);
+  assert.match(prompt, /### On-demand Project Context/);
+  assert.match(prompt, /### On-demand Milestone Context/);
+  assert.match(prompt, /S01-SUMMARY\.md/);
+  assert.match(prompt, /S01-ASSESSMENT\.md/);
+  assert.ok(
+    !prompt.includes("Broad validation product context should stay on-demand."),
+    "standard validate-milestone prompt should not inline project narrative",
+  );
+  assert.ok(
+    !prompt.includes("Validation milestone context should stay on-demand."),
+    "standard validate-milestone prompt should not inline milestone context narrative",
+  );
+  assert.ok(
+    !prompt.includes("threads the cache key through every call site."),
+    "validate prompt must not inline full slice summary narrative",
+  );
+  assert.ok(
+    !prompt.includes("This very noisy assessment trace should stay out of the prompt."),
+    "validate prompt must not inline full assessment traces",
+  );
 });

--- a/src/resources/extensions/gsd/tests/dashboard-budget.test.ts
+++ b/src/resources/extensions/gsd/tests/dashboard-budget.test.ts
@@ -15,9 +15,9 @@ import assert from 'node:assert/strict';
 
 import {
   type UnitMetrics,
-  type MetricsLedger,
   aggregateByModel,
   getProjectTotals,
+  getPromptSizeStats,
   formatTokenCount,
 } from "../metrics.js";
 // ─── Test helpers ─────────────────────────────────────────────────────────────
@@ -82,6 +82,25 @@ function renderCostBudgetLine(units: UnitMetrics[]): string | null {
     return parts.join(" · ");
   }
   return null;
+}
+
+function formatCharCount(chars: number): string {
+  if (chars >= 1_000_000) return `${(chars / 1_000_000).toFixed(2)}M chars`;
+  if (chars >= 1_000) return `${(chars / 1_000).toFixed(1)}k chars`;
+  return `${chars} chars`;
+}
+
+function renderPromptSizeLine(units: UnitMetrics[]): string | null {
+  const stats = getPromptSizeStats(units);
+  if (!stats) return null;
+  const parts = [
+    `avg prompt: ${formatCharCount(stats.averagePromptChars)}`,
+    `max: ${formatCharCount(stats.maxPromptChars)}`,
+  ];
+  if (stats.averageCompressionSavings != null) {
+    parts.push(`compression: ${stats.averageCompressionSavings}%`);
+  }
+  return parts.join(" · ");
 }
 
 /**
@@ -262,6 +281,18 @@ describe('dashboard-budget', () => {
     assert.doesNotMatch(line!, /truncated/, "cost budget continue-only: no truncation text");
     assert.match(line!, /1 continue-here fired/, "cost budget continue-only: shows count");
   }
+
+  test('Cost & Usage: prompt-size summary line', () => {
+    const units = [
+      makeUnit({ promptCharCount: 40_000, baselineCharCount: 80_000 }),
+      makeUnit({ promptCharCount: 20_000, baselineCharCount: 40_000 }),
+    ];
+    const line = renderPromptSizeLine(units);
+    assert.ok(line !== null, "prompt-size line rendered when prompt data exists");
+    assert.match(line!, /avg prompt: 30\.0k chars/, "prompt-size line shows average prompt size");
+    assert.match(line!, /max: 40\.0k chars/, "prompt-size line shows max prompt size");
+    assert.match(line!, /compression: 50%/, "prompt-size line shows average compression savings");
+  });
 
   // ─── Backward compat: no budget fields ────────────────────────────────────────
 

--- a/src/resources/extensions/gsd/tests/metrics.test.ts
+++ b/src/resources/extensions/gsd/tests/metrics.test.ts
@@ -17,6 +17,7 @@ import {
   aggregateBySlice,
   aggregateByModel,
   getProjectTotals,
+  getPromptSizeStats,
   formatCost,
   formatTokenCount,
   initMetrics,
@@ -104,6 +105,25 @@ test("getProjectTotals defaults budget fields to 0 for old units", () => {
   const totals = getProjectTotals([makeUnit(), makeUnit()]);
   assert.equal(totals.totalTruncationSections, 0);
   assert.equal(totals.continueHereFiredCount, 0);
+});
+
+test("getPromptSizeStats summarizes prompt bloat and compression", () => {
+  const stats = getPromptSizeStats([
+    makeUnit({ promptCharCount: 40_000, baselineCharCount: 80_000 }),
+    makeUnit({ promptCharCount: 20_000, baselineCharCount: 40_000 }),
+    makeUnit(),
+  ]);
+
+  assert.ok(stats, "prompt-size stats should exist when units have promptCharCount");
+  assert.equal(stats.units, 2);
+  assert.equal(stats.averagePromptChars, 30_000);
+  assert.equal(stats.maxPromptChars, 40_000);
+  assert.equal(stats.averageBaselineChars, 60_000);
+  assert.equal(stats.averageCompressionSavings, 50);
+});
+
+test("getPromptSizeStats returns null for old units without prompt data", () => {
+  assert.equal(getPromptSizeStats([makeUnit(), makeUnit()]), null);
 });
 
 // ── aggregateByPhase ─────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -319,11 +319,20 @@ test("valid values pass through correctly", () => {
   const { preferences: p1 } = validatePreferences({ budget_enforcement: "halt" });
   assert.equal(p1.budget_enforcement, "halt");
 
-  const { preferences: p2 } = validatePreferences({ context_pause_threshold: 0.75 });
-  assert.equal(p2.context_pause_threshold, 0.75);
+  const { preferences: p2 } = validatePreferences({ context_pause_threshold: 75 });
+  assert.equal(p2.context_pause_threshold, 75);
 
   const { preferences: p3 } = validatePreferences({ auto_supervisor: { model: "claude-opus-4-6" } });
   assert.equal(p3.auto_supervisor?.model, "claude-opus-4-6");
+});
+
+test("context_pause_threshold rejects fractional ratio values", () => {
+  const { preferences, errors } = validatePreferences({ context_pause_threshold: 0.75 });
+  assert.equal(preferences.context_pause_threshold, undefined);
+  assert.ok(
+    errors.some((e) => e.includes("context_pause_threshold")),
+    "fractional ratio values should fail instead of pausing at less than one percent",
+  );
 });
 
 test("min_request_interval_ms floors decimals and rejects timer overflow values", () => {

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -25,7 +25,7 @@ const PREF_SAMPLE_VALUES: Record<string, unknown> = {
   unique_milestone_ids: true,
   budget_ceiling: 12.5,
   budget_enforcement: "warn",
-  context_pause_threshold: 0.8,
+  context_pause_threshold: 80,
   notifications: {
     enabled: true,
     on_complete: true,

--- a/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
@@ -12,7 +12,7 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
-import { buildExecuteTaskPrompt, buildPlanSlicePrompt, inlineDependencySummaries } from "../auto-prompts.js";
+import { buildExecuteTaskPrompt, buildPlanSlicePrompt, buildReactiveExecutePrompt, buildResearchSlicePrompt, inlineDependencySummaries } from "../auto-prompts.js";
 import { computeBudgets, truncateAtSectionBoundary } from "../context-budget.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -204,6 +204,46 @@ describe("prompt-budget: plan-slice template", () => {
       cleanup(base);
     }
   });
+
+  it("does not inline milestone-wide decisions when slice title has no specific scope", async () => {
+    const base = createFixtureBase();
+    try {
+      setupDependencyFixture(base, "M001", "S01", ["S00"], { S00: "### Results\n\nDone." });
+      writeFileSync(
+        join(base, ".gsd", "DECISIONS.md"),
+        "# Decisions\n\n- This broad decision body should stay out of generic slice planning prompts.\n",
+      );
+
+      const prompt = await buildPlanSlicePrompt("M001", "Milestone", "S01", "Setup implementation testing", base, "standard");
+
+      assert.match(prompt, /### On-demand Decisions/);
+      assert.match(prompt, /\.gsd\/DECISIONS\.md/);
+      assert.doesNotMatch(prompt, /broad decision body should stay out/);
+    } finally {
+      cleanup(base);
+    }
+  });
+});
+
+describe("prompt-budget: research-slice context", () => {
+  it("does not inline milestone-wide decisions when slice title has no specific scope", async () => {
+    const base = createFixtureBase();
+    try {
+      setupDependencyFixture(base, "M001", "S01", ["S00"], { S00: "### Results\n\nDone." });
+      writeFileSync(
+        join(base, ".gsd", "DECISIONS.md"),
+        "# Decisions\n\n- This broad research decision body should stay out of generic slice research prompts.\n",
+      );
+
+      const prompt = await buildResearchSlicePrompt("M001", "Milestone", "S01", "Setup implementation testing", base);
+
+      assert.match(prompt, /### On-demand Decisions/);
+      assert.match(prompt, /\.gsd\/DECISIONS\.md/);
+      assert.doesNotMatch(prompt, /broad research decision body should stay out/);
+    } finally {
+      cleanup(base);
+    }
+  });
 });
 
 // ─── Executor constraints formatting ──────────────────────────────────────────
@@ -344,6 +384,29 @@ describe("prompt-budget: execute-task template", () => {
       });
       assert.match(prompt, /verification/i);
       assert.match(prompt, /~51K chars/);
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("standard execute-task prompt keeps decisions template on demand", async () => {
+    const base = createFixtureBase();
+    try {
+      const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+      const taskDir = join(sliceDir, "tasks");
+      mkdirSync(taskDir, { recursive: true });
+      writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# Roadmap\n");
+      writeFileSync(join(sliceDir, "S01-PLAN.md"), "# Slice Plan\n");
+      writeFileSync(join(taskDir, "T01-PLAN.md"), "# Task Plan\n");
+
+      const prompt = await buildExecuteTaskPrompt("M001", "S01", "Slice", "T01", "Task", base, {
+        level: "standard",
+        sessionContextWindow: 128_000,
+      });
+
+      assert.match(prompt, /### On-demand Decisions Template/);
+      assert.match(prompt, /templates\/decisions\.md/);
+      assert.doesNotMatch(prompt, /### Output Template: Decisions/);
     } finally {
       cleanup(base);
     }
@@ -498,6 +561,67 @@ describe("prompt-budget: execute-task builder truncation pattern", () => {
     if (assembled.length > budget128K.inlineContextBudgetChars) {
       assert.ok(result.content.includes("[...truncated"), "should truncate when content exceeds 128K budget");
       assert.ok(result.droppedSections > 0, "should report dropped sections");
+    }
+  });
+});
+
+describe("prompt-budget: reactive-execute builder", () => {
+  it("caps dependency carry-forward per ready subagent", async () => {
+    const base = createFixtureBase();
+    try {
+      const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+      const taskDir = join(sliceDir, "tasks");
+      mkdirSync(taskDir, { recursive: true });
+      writeFileSync(
+        join(sliceDir, "S01-PLAN.md"),
+        [
+          "# S01: Slice",
+          "",
+          "## Tasks",
+          "",
+          "- [x] **T01: First dep** `est:15m`",
+          "- [x] **T02: Second dep** `est:15m`",
+          "- [ ] **T03: Ready task** `est:15m`",
+        ].join("\n"),
+      );
+      writeFileSync(join(taskDir, "T01-PLAN.md"), "## Expected Output\n\n- `src/a.ts` - A\n");
+      writeFileSync(join(taskDir, "T02-PLAN.md"), "## Expected Output\n\n- `src/b.ts` - B\n");
+      writeFileSync(
+        join(taskDir, "T03-PLAN.md"),
+        [
+          "## Inputs",
+          "",
+          "- `src/a.ts`",
+          "- `src/b.ts`",
+          "",
+          "## Expected Output",
+          "",
+          "- `src/c.ts`",
+        ].join("\n"),
+      );
+      const hugeSummary = [
+        "---",
+        "provides: []",
+        "key_decisions: []",
+        "patterns_established: []",
+        "key_files: []",
+        "---",
+        "# Summary",
+        "",
+        "## Diagnostics",
+        "Large diagnostic ".repeat(3000),
+      ].join("\n");
+      writeFileSync(join(taskDir, "T01-SUMMARY.md"), hugeSummary);
+      writeFileSync(join(taskDir, "T02-SUMMARY.md"), hugeSummary);
+
+      const prompt = await buildReactiveExecutePrompt("M001", "Milestone", "S01", "Slice", ["T03"], base, undefined, {
+        sessionContextWindow: 32_000,
+      });
+
+      assert.match(prompt, /\[\.\.\.truncated/);
+      assert.ok(prompt.length < hugeSummary.length * 2, "reactive prompt should not include full dependency summaries");
+    } finally {
+      cleanup(base);
     }
   });
 });

--- a/src/resources/extensions/gsd/tests/research-milestone-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/research-milestone-composer.test.ts
@@ -79,16 +79,13 @@ test("#4782 phase 3: buildResearchMilestonePrompt emits milestone-context then r
     `milestone-context (${contextIdx}) must precede research template (${researchIdx})`);
 });
 
-test("#4782 phase 3: buildResearchMilestonePrompt preserves manifest order across optional artifacts (#4925 review)", async (t) => {
+test("buildResearchMilestonePrompt keeps broad project docs on-demand", async (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   invalidateAllCaches();
 
   seed(base, "M001");
   writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# M001 Context\n");
-  // Seed PROJECT.md into the artifacts table so inlineProjectFromDb resolves
-  // to a non-null body. Lets us verify the project block sits between
-  // milestone-context and the templates block per manifest order.
   insertArtifact({
     path: "PROJECT.md",
     artifact_type: "project",
@@ -97,18 +94,39 @@ test("#4782 phase 3: buildResearchMilestonePrompt preserves manifest order acros
     task_id: null,
     full_content: "# Project\n\nResearch composer fixture project.\n",
   });
+  insertArtifact({
+    path: "REQUIREMENTS.md",
+    artifact_type: "requirements",
+    milestone_id: null,
+    slice_id: null,
+    task_id: null,
+    full_content: "# Requirements\n\nResearch composer fixture requirements.\n",
+  });
+  insertArtifact({
+    path: "DECISIONS.md",
+    artifact_type: "decisions",
+    milestone_id: null,
+    slice_id: null,
+    task_id: null,
+    full_content: "# Decisions\n\nResearch composer fixture decisions.\n",
+  });
 
   const prompt = await buildResearchMilestonePrompt("M001", "Research Test", base);
 
-  // Manifest-declared order: milestone-context, project, requirements, decisions, templates.
   const contextIdx = prompt.indexOf("### Milestone Context");
-  const projectIdx = prompt.indexOf("### Project");
   const researchIdx = prompt.indexOf("### Output Template: Research");
+  const onDemandIdx = prompt.indexOf("### On-demand Planning Context");
   assert.ok(contextIdx > -1, "milestone-context block missing");
-  assert.ok(projectIdx > -1, "project block missing — seed should have populated it");
   assert.ok(researchIdx > -1, "research template block missing");
+  assert.ok(onDemandIdx > -1, "on-demand planning context missing");
   assert.ok(
-    contextIdx < projectIdx && projectIdx < researchIdx,
-    `manifest order violated: milestone-context (${contextIdx}) < project (${projectIdx}) < research-template (${researchIdx})`,
+    contextIdx < researchIdx && researchIdx < onDemandIdx,
+    `manifest order violated: milestone-context (${contextIdx}) < research-template (${researchIdx}) < on-demand (${onDemandIdx})`,
   );
+  assert.doesNotMatch(prompt, /Research composer fixture project/);
+  assert.doesNotMatch(prompt, /Research composer fixture requirements/);
+  assert.doesNotMatch(prompt, /Research composer fixture decisions/);
+  assert.match(prompt, /`\.gsd\/PROJECT\.md`/);
+  assert.match(prompt, /`\.gsd\/REQUIREMENTS\.md`/);
+  assert.match(prompt, /`\.gsd\/DECISIONS\.md`/);
 });

--- a/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
+++ b/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
@@ -93,6 +93,27 @@ test("plan-milestone prompt keeps normal guidance for typed projects", async () 
   }
 });
 
+test("plan-milestone standard prompt keeps project and decisions on-demand", async () => {
+  const base = makeRepo({
+    "package.json": "{\"scripts\":{\"test\":\"node --test\"}}\n",
+    "src/index.js": "console.log('ok');\n",
+    ".gsd/PROJECT.md": "# Project\n\nPlan broad project body.\n",
+    ".gsd/REQUIREMENTS.md": "# Requirements\n\nPlan requirement body.\n",
+    ".gsd/DECISIONS.md": "# Decisions\n\nPlan decision body.\n",
+  });
+  try {
+    const prompt = await buildPlanMilestonePrompt("M001", "Update app", base, "standard");
+    assert.match(prompt, /### On-demand Planning Context/);
+    assert.match(prompt, /`\.gsd\/PROJECT\.md`/);
+    assert.match(prompt, /`\.gsd\/DECISIONS\.md`/);
+    assert.match(prompt, /Plan requirement body/);
+    assert.doesNotMatch(prompt, /Plan broad project body/);
+    assert.doesNotMatch(prompt, /Plan decision body/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("workflow docs no longer contain blanket 4-10 slice guidance", () => {
   const docs = readFileSync(join(process.cwd(), "src", "resources", "GSD-WORKFLOW.md"), "utf-8");
   assert.doesNotMatch(docs, /4-10 slices/);

--- a/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
@@ -59,8 +59,8 @@ function seed(base: string, mid: string): void {
     demo: "",
     sequence: 1,
   });
-  // Seed PROJECT.md so inlineProjectFromDb resolves — the run-uat manifest
-  // declares "project" as the third inline artifact (#4925 review).
+  // Seed PROJECT.md so the run-uat prompt can advertise the on-demand path
+  // without inlining the full project body.
   insertArtifact({
     path: "PROJECT.md",
     artifact_type: "project",
@@ -71,7 +71,7 @@ function seed(base: string, mid: string): void {
   });
 }
 
-test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project via composer", async (t) => {
+test("#4782 phase 3: buildRunUatPrompt inlines UAT and keeps summary/project context compact", async (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   invalidateAllCaches();
@@ -98,14 +98,14 @@ test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project
   assert.match(prompt, /## Context Mode/);
   assert.match(prompt, /verification lane/);
 
-  // Artifacts from the manifest inline list, in declared order:
-  // slice-uat → slice-summary → project (#4925 review).
+  // Context appears in dependency order: UAT body, compact slice-summary
+  // excerpt, then on-demand project context.
   const uatIdx = prompt.indexOf("### S01 UAT");
-  const summaryIdx = prompt.indexOf("### S01 Summary");
-  const projectIdx = prompt.indexOf("### Project");
+  const summaryIdx = prompt.indexOf("### S01 Summary (excerpt)");
+  const projectIdx = prompt.indexOf("### On-demand Project Context");
   assert.ok(uatIdx > -1, "slice UAT block missing");
-  assert.ok(summaryIdx > -1, "slice summary block missing");
-  assert.ok(projectIdx > -1, "project block missing — manifest declares project as 3rd inline");
+  assert.ok(summaryIdx > -1, "slice summary excerpt missing");
+  assert.ok(projectIdx > -1, "project on-demand block missing");
   assert.ok(
     uatIdx < summaryIdx && summaryIdx < projectIdx,
     `manifest order violated: uat (${uatIdx}) < summary (${summaryIdx}) < project (${projectIdx})`,
@@ -116,11 +116,13 @@ test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project
   assert.match(prompt, /fresh in-memory snapshot/);
   assert.ok(!prompt.includes("stale on-disk body"), "resolver re-read disk instead of using uatContent snapshot");
 
-  // Summary body content inlined
-  assert.match(prompt, /What Happened[\s\S]*Ship/);
+  // Summary excerpt is present, but full body narrative is not.
+  assert.match(prompt, /One-liner/);
+  assert.ok(!prompt.includes("## What Happened\nShip."), "run-uat should not inline full slice summary body");
 
-  // Project body content inlined
-  assert.match(prompt, /Run-UAT composer fixture project/);
+  // Project path is advertised on-demand; full project body is not inlined.
+  assert.match(prompt, /\.gsd\/PROJECT\.md/);
+  assert.ok(!prompt.includes("Run-UAT composer fixture project"), "run-uat should not inline full project context");
 });
 
 test("#4782 phase 3: buildRunUatPrompt omits optional slice summary when file is missing", async (t) => {
@@ -140,10 +142,9 @@ test("#4782 phase 3: buildRunUatPrompt omits optional slice summary when file is
   assert.match(prompt, /### S01 UAT/);
   // No empty "S01 Summary" section — section body would be blank without a file
   assert.ok(!prompt.includes("### S01 Summary"));
-  // Project still present (third inline artifact, not optional) and follows
-  // UAT directly with the skipped summary collapsed (#4925 review).
+  // Project on-demand context still follows UAT with the skipped summary collapsed.
   const uatIdx = prompt.indexOf("### S01 UAT");
-  const projectIdx = prompt.indexOf("### Project");
+  const projectIdx = prompt.indexOf("### On-demand Project Context");
   assert.ok(projectIdx > uatIdx, `project must follow UAT when summary is omitted (uat=${uatIdx}, project=${projectIdx})`);
   // No double separator from a skipped block
   assert.ok(!prompt.includes("---\n\n---"));

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -46,7 +46,7 @@ test("#4782 composer: returns empty string for unknown unit type", async () => {
 });
 
 test("#4782 composer: walks the manifest's inline list in declared order", async () => {
-  // reassess-roadmap manifest: [roadmap, slice-context, slice-summary, project, requirements, decisions]
+  // reassess-roadmap manifest keeps broad project docs out of inline context.
   const calls: ArtifactKey[] = [];
   const resolver: ArtifactResolver = async (key) => {
     calls.push(key);
@@ -56,10 +56,6 @@ test("#4782 composer: walks the manifest's inline list in declared order", async
   assert.deepEqual(calls, [
     "roadmap",
     "slice-context",
-    "slice-summary",
-    "project",
-    "requirements",
-    "decisions",
   ]);
   // Output joins blocks with the "---" separator.
   assert.match(out, /BODY:roadmap\n\n---\n\nBODY:slice-context/);
@@ -75,7 +71,7 @@ test("#4782 composer: null-returning resolvers are silently omitted", async () =
   assert.ok(!out.includes("BODY:slice-context"));
   assert.ok(!out.includes("BODY:project"));
   // Remaining keys still emitted in declared order
-  assert.match(out, /BODY:roadmap\n\n---\n\nBODY:slice-summary\n\n---\n\nBODY:requirements\n\n---\n\nBODY:decisions/);
+  assert.strictEqual(out, "BODY:roadmap");
 });
 
 test("#4782 composer: empty-string resolvers are omitted (treated as no-op)", async () => {
@@ -257,8 +253,15 @@ test("#4782 phase 2: buildReassessRoadmapPrompt emits composer-shaped context wi
   assert.match(prompt, /S01: First/);
 
   // Slice summary present
-  assert.match(prompt, /### S01 Summary/);
+  assert.match(prompt, /### S01 Summary \(excerpt\)/);
   assert.match(prompt, /One-liner/);
+  assert.ok(!prompt.includes("## What Happened\nDone."), "reassess prompt should not inline full completed-slice narrative");
+
+  // Broad project docs are advertised on demand instead of fully inlined.
+  assert.match(prompt, /### On-demand Planning Context/);
+  assert.match(prompt, /\.gsd\/PROJECT\.md/);
+  assert.match(prompt, /\.gsd\/REQUIREMENTS\.md/);
+  assert.match(prompt, /\.gsd\/DECISIONS\.md/);
 
   // Slice context is optional and not present in this fixture — must not
   // leave a stray empty section
@@ -374,20 +377,20 @@ test("#4924 v2 composer: omitting resolveArtifact skips inline keys without erro
 });
 
 test("#4924 v2 composer: walks inline + excerpt + computed sections in declared order", async () => {
-  // Reuse the run-uat manifest shape (small inline, no excerpt/computed) and
-  // synthesise a manifest-shape override via a temporary registration would
-  // require touching production data. Instead, drive the composer through
-  // the existing manifest plus mock resolvers and verify ordering against
-  // the declared sequence.
+  // Run-uat now keeps the UAT body inline and moves slice summary to excerpt
+  // context, so verify both resolver lanes preserve manifest order.
   const calls: string[] = [];
   const resolveArtifact: ArtifactResolver = async (key) => {
     calls.push(`art:${key}`);
     return `BODY:${key}`;
   };
-  const out = await composeUnitContext("run-uat", { base: { ...fakeBase, unitType: "run-uat" }, resolveArtifact });
-  // run-uat manifest inline order: slice-uat, slice-summary, project
-  assert.deepEqual(calls, ["art:slice-uat", "art:slice-summary", "art:project"]);
-  assert.match(out.inline, /BODY:slice-uat\n\n---\n\nBODY:slice-summary\n\n---\n\nBODY:project/);
+  const resolveExcerpt: ExcerptResolver = async (key) => {
+    calls.push(`excerpt:${key}`);
+    return `EXCERPT:${key}`;
+  };
+  const out = await composeUnitContext("run-uat", { base: { ...fakeBase, unitType: "run-uat" }, resolveArtifact, resolveExcerpt });
+  assert.deepEqual(calls, ["art:slice-uat", "excerpt:slice-summary"]);
+  assert.match(out.inline, /BODY:slice-uat\n\n---\n\nEXCERPT:slice-summary/);
 });
 
 test("#4924 v2 composer: excerpt section calls resolveExcerpt for declared keys", async () => {
@@ -487,7 +490,7 @@ test("#4924 v2 composer: computed builder returning null omits the section (no e
 
 test("#4924 v2 composer: backward-compat — composeInlinedContext still works for v1 callers", async () => {
   const out = await composeInlinedContext("run-uat", async (key) => `BODY:${key}`);
-  assert.match(out, /BODY:slice-uat\n\n---\n\nBODY:slice-summary\n\n---\n\nBODY:project/);
+  assert.strictEqual(out, "BODY:slice-uat");
 });
 
 test("#4926 review: computed builders see normalized base.unitType matching the resolved manifest", async () => {

--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -177,6 +177,28 @@ test("#4782 phase 1: complete-milestone manifest declares slice-summary as excer
   );
 });
 
+test("closeout manifests keep broad narrative docs on-demand in standard mode", () => {
+  for (const unitType of ["validate-milestone", "complete-milestone"] as const) {
+    const m = UNIT_MANIFESTS[unitType];
+    assert.ok(
+      m.artifacts.onDemand.includes("project"),
+      `${unitType} should keep project narrative on-demand`,
+    );
+    assert.ok(
+      m.artifacts.onDemand.includes("milestone-context"),
+      `${unitType} should keep milestone context on-demand`,
+    );
+    assert.ok(
+      !m.artifacts.inline.includes("project"),
+      `${unitType} should not inline project narrative by default`,
+    );
+    assert.ok(
+      !m.artifacts.inline.includes("milestone-context"),
+      `${unitType} should not inline milestone context by default`,
+    );
+  }
+});
+
 // ─── v2 contract invariants (#4924) ──────────────────────────────────────
 
 test("#4924: computed + prepend ids (when declared) are non-empty strings", () => {

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -368,11 +368,11 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     contextMode: "research",
     tools: TOOLS_PLANNING,
     artifacts: {
-      // Phase 3 migration (#4782): matches today's actual
-      // buildResearchMilestonePrompt inlining order.
-      inline: ["milestone-context", "project", "requirements", "decisions", "templates"],
+      // Keep the milestone-specific prompt compact. Broader project docs
+      // stay addressable without being loaded into every research turn.
+      inline: ["milestone-context", "templates"],
       excerpt: [],
-      onDemand: [],
+      onDemand: ["project", "requirements", "decisions"],
     },
     maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
   },
@@ -385,9 +385,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     contextMode: "planning",
     tools: TOOLS_PLANNING,
     artifacts: {
-      inline: ["project", "requirements", "decisions", "milestone-research", "templates"],
+      inline: ["milestone-context", "requirements", "milestone-research", "templates"],
       excerpt: [],
-      onDemand: [],
+      onDemand: ["project", "decisions"],
     },
     maxSystemPromptChars: COMMON_BUDGET_LARGE,
   },
@@ -417,9 +417,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     // fixes before milestone closeout can proceed.
     tools: TOOLS_ALL,
     artifacts: {
-      inline: ["roadmap", "slice-summary", "slice-uat", "requirements", "decisions", "templates"],
-      excerpt: [],
-      onDemand: [],
+      inline: ["roadmap", "requirements", "templates"],
+      excerpt: ["slice-summary", "slice-assessment"],
+      onDemand: ["slice-summary", "slice-assessment", "decisions", "project", "milestone-context"],
     },
     maxSystemPromptChars: COMMON_BUDGET_LARGE,
   },
@@ -437,9 +437,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
       // #4780 landed slice-summary as excerpt for this unit; phase 2 of
       // the architecture will read this manifest as the source of truth
       // and retire the special-case wiring in auto-prompts.ts.
-      inline: ["roadmap", "milestone-context", "requirements", "decisions", "project", "templates"],
+      inline: ["roadmap", "requirements", "templates"],
       excerpt: ["slice-summary"],
-      onDemand: ["slice-summary"],
+      onDemand: ["slice-summary", "decisions", "project", "milestone-context"],
     },
     maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
   },
@@ -458,7 +458,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     artifacts: {
       inline: ["roadmap", "milestone-research", "dependency-summaries", "templates"],
       excerpt: [],
-      onDemand: [],
+      onDemand: ["decisions"],
     },
     maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
   },
@@ -543,12 +543,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     contextMode: "planning",
     tools: TOOLS_PLANNING,
     artifacts: {
-      // Phase 2 pilot (#4782): manifest now matches today's actual
-      // buildReassessRoadmapPrompt behavior for equivalence. Phase 3
-      // will tighten this list once the composer reports real telemetry.
-      inline: ["roadmap", "slice-context", "slice-summary", "project", "requirements", "decisions"],
-      excerpt: [],
-      onDemand: [],
+      inline: ["roadmap", "slice-context"],
+      excerpt: ["slice-summary"],
+      onDemand: ["project", "requirements", "decisions"],
     },
     maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
   },
@@ -595,13 +592,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     contextMode: "verification",
     tools: TOOLS_VERIFICATION,
     artifacts: {
-      // Phase 3 migration (#4782): manifest matches today's actual
-      // buildRunUatPrompt inlining. Prior phase-1 entry listed
-      // `slice-plan` aspirationally — the real builder inlines the UAT
-      // file, the slice SUMMARY (optional), and the project row.
-      inline: ["slice-uat", "slice-summary", "project"],
-      excerpt: [],
-      onDemand: [],
+      inline: ["slice-uat"],
+      excerpt: ["slice-summary"],
+      onDemand: ["slice-summary", "project"],
     },
     maxSystemPromptChars: COMMON_BUDGET_SMALL,
   },


### PR DESCRIPTION
## TL;DR

**What:** Reduces prompt context loaded during GSD auto runs and adds prompt-context telemetry tooling.
**Why:** Auto-mode token usage was too high because broad project/milestone context was loaded when on-demand references were enough.
**How:** Moves broad closeout/project context to on-demand paths in standard mode, adds prompt-context debug events, and adds a summarizer for debug logs.

## What

- Adds prompt-context telemetry for prompt builders.
- Keeps broad closeout docs on-demand by default for validation/completion prompts.
- Adds compact excerpts for closeout evidence paths.
- Adds budget/context dashboard telemetry for prompt size and compression savings.
- Adds `scripts/summarize-prompt-context.cjs` with tests.

## Why

Recent auto runs showed high context and token burn. The closeout prompts were still inlining broad project and milestone narrative even when slice summaries and validation artifacts were sufficient.

## How

Standard mode now preloads compact evidence and gives explicit read-on-demand paths for broader docs. Full mode remains available when a caller intentionally wants expanded context.

## Verification

- `node --test scripts/__tests__/summarize-prompt-context.test.cjs`
- Combined stack: focused prompt-budget, prompt composer, closeout, and manifest tests
- Combined stack: `npm run typecheck:extensions`
- Combined stack: `npm run build:pi-coding-agent`
- Combined stack: `git diff --check`

## Change type checklist

- [x] `perf` — Performance/cost improvement
- [x] `feat` — New telemetry/tooling capability
- [x] `test` — Adding or updating tests
