### PR TITLE
fix(gsd): stabilize auto closeout reliability

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,6 +65,8 @@ Dispatch remains responsible for selecting the next Unit from reconciled state. 
 
   See `docs/dev/ADR-017-state-reconciliation-drift-driven.md`.
 
+- Foreground `/gsd next` and `/gsd auto` runs follow **Closeout Boundary Stop**: after the first durable task, slice, or milestone closeout boundary, the foreground terminal preserves the closeout transcript as the final visible surface instead of replacing it with a terminal roll-up widget. Headless runs may still emit durable terminal completion notifications/widgets for automation.
+
 ## Current implementation snapshot (phase 1)
 
 - `auto.ts` now wires a concrete Auto Orchestration module through `createWiredAutoOrchestrationModule(...)`.

--- a/src/resources/extensions/gsd/auto-budget.ts
+++ b/src/resources/extensions/gsd/auto-budget.ts
@@ -1,3 +1,5 @@
+// Project/App: GSD-2
+// File Purpose: Pure budget and context guard decisions for GSD auto-mode.
 /**
  * Budget alert level tracking and enforcement for auto-mode.
  * Pure functions — no module state or side effects.
@@ -44,11 +46,12 @@ export function getUnitCostSpikeAction(
 
 export function getContextPauseAction(
   contextPercent: number | null | undefined,
-  thresholdPercent: number | null | undefined,
+  thresholdPercent: number,
 ): "none" | "pause" {
-  if (!Number.isFinite(contextPercent ?? NaN)) return "none";
-  if (!Number.isFinite(thresholdPercent ?? NaN)) return "none";
-  const threshold = thresholdPercent as number;
-  if (threshold <= 0) return "none";
-  return (contextPercent as number) >= threshold ? "pause" : "none";
+  if (!Number.isFinite(contextPercent) || !Number.isFinite(thresholdPercent)) return "none";
+  if (contextPercent === null || contextPercent === undefined || thresholdPercent <= 0) return "none";
+
+  const usage = contextPercent <= 1 ? contextPercent * 100 : contextPercent;
+  const threshold = thresholdPercent <= 1 ? thresholdPercent * 100 : thresholdPercent;
+  return usage >= threshold ? "pause" : "none";
 }

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -966,7 +966,7 @@ export function updateProgressWidget(
         lines.push("");
         // Step-mode guidance — shown above keyboard hints when auto is paused
         if (accessors.isStepMode()) {
-          lines.push(`${pad}${theme.fg("accent", "→")} ${theme.fg("dim", "Ctrl+N to advance to next step  ·  /gsd status for overview")}`);
+          lines.push(`${pad}${theme.fg("accent", "→")} ${theme.fg("dim", "/gsd next to advance one step  ·  /gsd status for overview")}`);
         }
 
         // Hints line
@@ -1000,9 +1000,8 @@ export function setCompletionProgressWidget(
   snapshot: CompletionDashboardSnapshot,
 ): void {
   if (!ctx.hasUI) return;
-  const widgetKey = snapshot.allMilestonesComplete ? "gsd-outcome" : "gsd-progress";
-  const clearedWidgetKey = snapshot.allMilestonesComplete ? "gsd-progress" : "gsd-outcome";
-  ctx.ui.setWidget(clearedWidgetKey, undefined);
+  const widgetKey = "gsd-progress";
+  ctx.ui.setWidget("gsd-outcome", undefined);
 
   if (typeof ctx.ui?.setHeader === "function") {
     ctx.ui.setHeader(() => ({

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -619,13 +619,18 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (!needsRunUat) return null;
       const { sliceId, uatType } = needsRunUat;
 
-      // Cap run-uat dispatch attempts to prevent infinite replay (#3624)
-      const attempts = incrementUatCount(basePath, mid, sliceId);
-      if (attempts > MAX_UAT_ATTEMPTS) {
+      // Cap run-uat dispatch attempts to prevent infinite replay (#3624).
+      // Check before incrementing so an exhausted counter cannot create a
+      // no-progress skip loop that starves later dispatch rules.
+      const attempts = getUatCount(basePath, mid, sliceId);
+      if (attempts >= MAX_UAT_ATTEMPTS) {
         return {
-          action: "skip" as const,
+          action: "stop" as const,
+          reason: `Cannot dispatch run-uat for ${mid}/${sliceId}: retry limit reached after ${attempts} attempt(s) without a PASS assessment. Fix the underlying UAT/tool issue, reset the retry counter with /gsd doctor --fix, then rerun /gsd auto.`,
+          level: "warning" as const,
         };
       }
+      incrementUatCount(basePath, mid, sliceId);
       const uatFile = resolveSliceFile(basePath, mid, sliceId, "UAT")!;
       const uatContent = await loadFile(uatFile);
       return {

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -90,6 +90,7 @@ import { insertMilestoneValidationGates } from "./milestone-validation-gates.js"
 import { nativeHasChanges, nativeIsRepo, _resetHasChangesCache } from "./native-git-bridge.js";
 import { debugLog, isDebugEnabled } from "./debug-logger.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
+import { resolveWorktreeProjectRoot } from "./worktree-root.js";
 import { listUnmergedGitPaths } from "./git-conflict-state.js";
 import { runTurnGitAction } from "./git-service.js";
 import { parseUnitId } from "./unit-id.js";
@@ -1449,7 +1450,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "validating-milestone → validate-milestone",
-    match: async ({ state, mid, midTitle, basePath, prefs }) => {
+    match: async ({ state, mid, midTitle, basePath, prefs, session }) => {
       if (state.phase !== "validating-milestone") return null;
 
       // Safety guard (#1368): verify all roadmap slices have SUMMARY files before
@@ -1476,70 +1477,78 @@ export const DISPATCH_RULES: DispatchRule[] = [
 
       // Skip preference OR trivial scope: write a minimal pass-through VALIDATION file.
       if (prefs?.phases?.skip_milestone_validation || trivialVariant) {
-        const mDir = resolveMilestonePath(basePath, mid);
-        if (mDir) {
-          if (!existsSync(mDir)) mkdirSync(mDir, { recursive: true });
-          const validationPath = join(
-            mDir,
-            buildMilestoneFileName(mid, "VALIDATION"),
-          );
-          const skipSource = trivialVariant
-            ? "trivial-scope pipeline variant"
-            : "`skip_milestone_validation` preference";
-          const skipValidationReason = trivialVariant ? "trivial-scope" : "preference";
-          const content = [
-            "---",
-            "verdict: pass",
-            "skip_validation: true",
-            `skip_validation_reason: ${skipValidationReason}`,
-            "remediation_round: 0",
-            "---",
-            "",
-            "# Milestone Validation (skipped)",
-            "",
-            `Milestone validation was skipped via ${skipSource}.`,
-          ].join("\n");
-          writeFileSync(validationPath, content, "utf-8");
-          try {
-            // DB-backed state derivation keys off assessments, not only the file
-            // projection. Persist the skipped validation there too so the next
-            // loop iteration advances to completing-milestone instead of
-            // re-entering validating-milestone.
-            if (isDbAvailable()) {
-              transaction(() => {
-                insertAssessment({
-                  path: validationPath,
-                  milestoneId: mid,
-                  sliceId: null,
-                  taskId: null,
-                  status: "pass",
-                  scope: "milestone-validation",
-                  fullContent: content,
-                });
-                const gateSliceId = getMilestoneSlices(mid)[0]?.id;
-                if (gateSliceId) {
-                  insertMilestoneValidationGates(
-                    mid,
-                    gateSliceId,
-                    "pass",
-                    new Date().toISOString(),
-                  );
-                }
-              });
-            }
-          } catch (err) {
-            try {
-              unlinkSync(validationPath);
-            } catch (unlinkErr) {
-              logWarning(
-                "dispatch",
-                `failed to remove skipped validation file after DB write failure for ${mid}: ${unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr)}`,
-              );
-            }
-            throw err;
-          }
-          invalidateAllCaches();
+        const artifactBasePath = resolveArtifactBasePath(basePath, mid, session);
+        const projectRoot = resolveWorktreeProjectRoot(basePath, session?.originalBasePath);
+        const mDir = resolveMilestonePath(artifactBasePath, mid) ??
+          (projectRoot !== artifactBasePath ? resolveMilestonePath(projectRoot, mid) : null);
+        if (!mDir) {
+          return {
+            action: "stop",
+            reason: `Cannot skip milestone validation for ${mid}: milestone artifacts are missing under ${artifactBasePath}. Run /gsd doctor before resuming auto-mode.`,
+            level: "warning",
+          };
         }
+        if (!existsSync(mDir)) mkdirSync(mDir, { recursive: true });
+        const validationPath = join(
+          mDir,
+          buildMilestoneFileName(mid, "VALIDATION"),
+        );
+        const skipSource = trivialVariant
+          ? "trivial-scope pipeline variant"
+          : "`skip_milestone_validation` preference";
+        const skipValidationReason = trivialVariant ? "trivial-scope" : "preference";
+        const content = [
+          "---",
+          "verdict: pass",
+          "skip_validation: true",
+          `skip_validation_reason: ${skipValidationReason}`,
+          "remediation_round: 0",
+          "---",
+          "",
+          "# Milestone Validation (skipped)",
+          "",
+          `Milestone validation was skipped via ${skipSource}.`,
+        ].join("\n");
+        writeFileSync(validationPath, content, "utf-8");
+        try {
+          // DB-backed state derivation keys off assessments, not only the file
+          // projection. Persist the skipped validation there too so the next
+          // loop iteration advances to completing-milestone instead of
+          // re-entering validating-milestone.
+          if (isDbAvailable()) {
+            transaction(() => {
+              insertAssessment({
+                path: validationPath,
+                milestoneId: mid,
+                sliceId: null,
+                taskId: null,
+                status: "pass",
+                scope: "milestone-validation",
+                fullContent: content,
+              });
+              const gateSliceId = getMilestoneSlices(mid)[0]?.id;
+              if (gateSliceId) {
+                insertMilestoneValidationGates(
+                  mid,
+                  gateSliceId,
+                  "pass",
+                  new Date().toISOString(),
+                );
+              }
+            });
+          }
+        } catch (err) {
+          try {
+            unlinkSync(validationPath);
+          } catch (unlinkErr) {
+            logWarning(
+              "dispatch",
+              `failed to remove skipped validation file after DB write failure for ${mid}: ${unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr)}`,
+            );
+          }
+          throw err;
+        }
+        invalidateAllCaches();
         return { action: "skip" };
       }
       return {

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -78,6 +78,7 @@ import { writeTurnGitTransaction } from "./uok/gitops.js";
 import { isClosedStatus } from "./status-guards.js";
 import { detectAbandonMilestone } from "./abandon-detect.js";
 import { isDeterministicPolicyError } from "./auto-tool-tracking.js";
+import { formatConnectedStepStack, formatPostUnitStatusCard } from "./auto-status-message.js";
 import {
   clearProjectResearchInflightMarker,
   finalizeProjectResearchTimeout,
@@ -423,6 +424,8 @@ import {
   updateSliceProgressCache,
   unitVerb,
   describeNextUnit,
+  setAutoOutcomeWidget,
+  type AutoOutcomeSurfaceSnapshot,
 } from "./auto-dashboard.js";
 import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync } from "node:fs";
 import { join, relative } from "node:path";
@@ -553,16 +556,83 @@ export function detectRogueFileWrites(
  */
 export const MAX_ARTIFACT_VERIFICATION_RETRIES = 3;
 
-export const STEP_COMPLETE_FALLBACK_MESSAGE =
-  "Step complete. Run /gsd next to continue one step, or /gsd auto to run continuously.";
+function buildStepCompleteCallout(
+  currentUnit?: NonNullable<AutoSession["currentUnit"]> | null,
+): string {
+  const isTask = currentUnit?.type === "execute-task";
+  const completedLabel = currentUnit ? `${unitVerb(currentUnit.type)} ${currentUnit.id}` : "Step complete";
+  return formatConnectedStepStack(`✓ GSD ${isTask ? "Task" : "Step"} Complete`, completedLabel);
+}
+
+export const STEP_COMPLETE_FALLBACK_MESSAGE = buildStepCompleteCallout();
 
 export function buildStepCompleteMessage(nextState: import("./types.js").GSDState): string | null {
   if (nextState.phase === "complete") {
     return null;
   }
+  return buildStepCompleteCallout();
+}
+
+function buildStepCompleteMessageForUnit(
+  nextState: import("./types.js").GSDState,
+  currentUnit?: NonNullable<AutoSession["currentUnit"]> | null,
+): string | null {
+  if (nextState.phase === "complete") {
+    return null;
+  }
+  return buildStepCompleteCallout(currentUnit);
+}
+
+export function buildStepCompleteOutcome(
+  nextState: import("./types.js").GSDState,
+  currentUnit?: NonNullable<AutoSession["currentUnit"]> | null,
+): AutoOutcomeSurfaceSnapshot | null {
+  if (nextState.phase === "complete") {
+    return null;
+  }
   const next = describeNextUnit(nextState);
-  return `Step complete. Next: ${next.label}\n`
-    + `Run /gsd next to continue one step, or /gsd auto to run continuously.`;
+  return {
+    status: "step",
+    title: "Step complete",
+    detail: `Next: ${next.label}.`,
+    unitLabel: currentUnit ? `${unitVerb(currentUnit.type)} ${currentUnit.id}` : null,
+    nextAction: "Advance one step, or resume automatic mode.",
+    commands: ["/gsd next", "/gsd auto", "/gsd status for overview"],
+  };
+}
+
+export function setStepCompleteSurface(
+  ctx: ExtensionContext,
+  nextState: import("./types.js").GSDState,
+  currentUnit?: NonNullable<AutoSession["currentUnit"]> | null,
+): string | null {
+  const outcome = buildStepCompleteOutcome(nextState, currentUnit);
+  if (!outcome) {
+    return null;
+  }
+  if (ctx.hasUI && typeof ctx.ui?.setWidget === "function") {
+    ctx.ui.setWidget("gsd-progress", undefined);
+  }
+  setAutoOutcomeWidget(ctx, outcome);
+  return buildStepCompleteMessageForUnit(nextState, currentUnit);
+}
+
+export function setStepCompleteFallbackSurface(
+  ctx: ExtensionContext,
+  currentUnit?: NonNullable<AutoSession["currentUnit"]> | null,
+): string {
+  if (ctx.hasUI && typeof ctx.ui?.setWidget === "function") {
+    ctx.ui.setWidget("gsd-progress", undefined);
+  }
+  setAutoOutcomeWidget(ctx, {
+    status: "step",
+    title: "Step complete",
+    detail: "State refresh failed after the unit completed.",
+    unitLabel: currentUnit ? `${unitVerb(currentUnit.type)} ${currentUnit.id}` : null,
+    nextAction: "Inspect state, then advance one step or resume automatic mode.",
+    commands: ["/gsd status for overview", "/gsd next", "/gsd auto"],
+  });
+  return buildStepCompleteCallout(currentUnit);
 }
 
 /**
@@ -665,7 +735,7 @@ export async function autoCommitUnit(
 
     const commitMsg = autoCommitCurrentBranch(basePath, unitType, unitId, taskContext);
     if (commitMsg) {
-      ctx?.ui.notify(`Committed: ${commitMsg.split("\n")[0]}`, "info");
+      ctx?.ui.notify(formatPostUnitStatusCard("✓ Commit", commitMsg.split("\n")[0]), "info");
     }
     return commitMsg;
   } catch (e) {
@@ -819,9 +889,9 @@ async function runCloseoutGitAction(
       s.lastGitActionStatus = "ok";
 
       if (turnAction === "commit" && gitResult.commitMessage) {
-        ctx.ui.notify(`Committed: ${gitResult.commitMessage.split("\n")[0]}`, "info");
+        ctx.ui.notify(formatPostUnitStatusCard("✓ Commit", gitResult.commitMessage.split("\n")[0]), "info");
       } else if (turnAction === "snapshot" && gitResult.snapshotLabel) {
-        ctx.ui.notify(`Snapshot recorded: ${gitResult.snapshotLabel}`, "info");
+        ctx.ui.notify(formatPostUnitStatusCard("✓ Snapshot", gitResult.snapshotLabel), "info");
       }
     }
   } catch (e) {
@@ -2077,11 +2147,11 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
     try {
       const nextState = await deriveState(s.canonicalProjectRoot);
       phaseAfterUnit = nextState.phase;
-      const message = buildStepCompleteMessage(nextState);
+      const message = setStepCompleteSurface(ctx, nextState, s.currentUnit);
       if (message) ctx.ui.notify(message, "info");
     } catch (e) {
       debugLog("postUnit", { phase: "step-wizard-notify", error: String(e) });
-      ctx.ui.notify(STEP_COMPLETE_FALLBACK_MESSAGE, "info");
+      ctx.ui.notify(setStepCompleteFallbackSurface(ctx, s.currentUnit), "info");
     }
     return shouldReturnStepWizardAfterUnit(s.currentUnit?.type, phaseAfterUnit)
       ? "step-wizard"

--- a/src/resources/extensions/gsd/auto-status-message.ts
+++ b/src/resources/extensions/gsd/auto-status-message.ts
@@ -1,0 +1,45 @@
+// Project/App: GSD-2
+// File Purpose: Compact connected status message formatting for GSD TUI notifications.
+
+const STATUS_INDENT = "    ";
+const STATUS_RULE = "────────────────────────────────────────";
+const ANSI_RESET = "\x1b[0m";
+const ANSI_DIM = "\x1b[2m";
+const ANSI_BOLD = "\x1b[1m";
+const ANSI_GREEN = "\x1b[32m";
+const ANSI_RED = "\x1b[31m";
+const ANSI_BLUE = "\x1b[34m";
+const ANSI_CYAN = "\x1b[36m";
+
+function color(text: string, code: string): string {
+  return `${code}${text}${ANSI_RESET}`;
+}
+
+function titleColor(title: string): string {
+  if (title.includes("✕") || title.toLowerCase().includes("failed")) return ANSI_RED;
+  if (title.includes("✓")) return ANSI_GREEN;
+  return ANSI_BLUE;
+}
+
+export function formatPostUnitStatusCard(title: string, detail?: string): string {
+  const cleanTitle = title.trim();
+  const cleanDetail = detail?.trim();
+  const lines = [`${STATUS_INDENT}${color("╭─", ANSI_BLUE)} ${color(cleanTitle, `${titleColor(cleanTitle)}${ANSI_BOLD}`)}`];
+  if (cleanDetail) {
+    lines.push(`${STATUS_INDENT}   ${color(cleanDetail, ANSI_CYAN)}`);
+  }
+  lines.push(`${STATUS_INDENT}${color(`╰${STATUS_RULE}`, ANSI_BLUE)}`);
+  return lines.join("\n");
+}
+
+export function formatConnectedStepStack(
+  statusTitle: string,
+  completedLabel: string,
+): string {
+  const statusColor = titleColor(statusTitle);
+  return [
+    `${STATUS_INDENT}${color("╭─", ANSI_BLUE)} ${color(statusTitle, `${statusColor}${ANSI_BOLD}`)}`,
+    `${STATUS_INDENT}   ${color("Completed:", ANSI_DIM)} ${color(completedLabel, ANSI_CYAN)}`,
+    `${STATUS_INDENT}${color(`╰${STATUS_RULE}`, ANSI_BLUE)}`,
+  ].join("\n");
+}

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -39,6 +39,7 @@ import { writeVerificationJSON, type PostExecutionCheckJSON, type EvidenceJSON }
 import { logWarning } from "./workflow-logger.js";
 import { runPostExecutionChecks, type PostExecutionResult } from "./post-execution-checks.js";
 import type { AutoSession } from "./auto/session.js";
+import type { ErrorContext } from "./auto/types.js";
 import type { VerificationResult as VerificationGateResult } from "./types.js";
 import { join } from "node:path";
 import { resolveUokFlags } from "./uok/flags.js";
@@ -50,6 +51,7 @@ import type { SliceRow } from "./db-task-slice-rows.js";
 import { getSlice } from "./gsd-db.js";
 import { getLedger } from "./metrics.js";
 import { getUnitCostSpikeAction } from "./auto-budget.js";
+import { formatPostUnitStatusCard } from "./auto-status-message.js";
 
 export interface VerificationContext {
   s: AutoSession;
@@ -58,6 +60,7 @@ export interface VerificationContext {
 }
 
 export type VerificationResult = "continue" | "retry" | "pause";
+type PauseAutoFn = (ctx?: ExtensionContext, pi?: ExtensionAPI, errorContext?: ErrorContext) => Promise<void>;
 
 function getCurrentUnitCostStats(unitId: string): { unitCostUsd: number; rollingAvgUsd: number } {
   const ledger = getLedger();
@@ -194,7 +197,7 @@ function hasReassessmentEvidence(s: AutoSession, milestoneId: string): boolean {
  */
 async function runValidateMilestonePostCheck(
   vctx: VerificationContext,
-  pauseAuto: (ctx?: ExtensionContext, pi?: ExtensionAPI) => Promise<void>,
+  pauseAuto: PauseAutoFn,
 ): Promise<VerificationResult> {
   const { s, ctx, pi } = vctx;
   const prefs = loadEffectiveGSDPreferences()?.preferences;
@@ -310,7 +313,10 @@ async function runValidateMilestonePostCheck(
       `Milestone ${mid} validation returned needs-attention`,
       mid,
     );
-    await pauseAuto(ctx, pi);
+    await pauseAuto(ctx, pi, {
+      message: `Milestone ${mid} validation needs attention.`,
+      category: "unknown",
+    });
     return "pause";
   }
 
@@ -356,7 +362,10 @@ async function runValidateMilestonePostCheck(
     `No incomplete slices found for ${mid} while verdict=needs-remediation`,
     mid,
   );
-  await pauseAuto(ctx, pi);
+  await pauseAuto(ctx, pi, {
+    message: `Milestone ${mid} validation needs remediation but no remediation slices were added.`,
+    category: "unknown",
+  });
   return "pause";
 }
 
@@ -399,7 +408,7 @@ async function countIncompleteSlices(basePath: string, milestoneId: string): Pro
  */
 export async function runPostUnitVerification(
   vctx: VerificationContext,
-  pauseAuto: (ctx?: ExtensionContext, pi?: ExtensionAPI) => Promise<void>,
+  pauseAuto: PauseAutoFn,
 ): Promise<VerificationResult> {
   const { s, ctx, pi } = vctx;
 
@@ -438,7 +447,10 @@ export async function runPostUnitVerification(
     const explicitVerificationTargetsRequested = hasExplicitVerificationTargets(taskRow, sliceRow);
     if (explicitVerificationTargetsRequested && verificationTargets.length === 0) {
       logWarning("engine", "verification: explicit target_repositories requested but no repositories resolved");
-      await pauseAuto(ctx, pi);
+      await pauseAuto(ctx, pi, {
+        message: "Verification failed: no runnable host-owned verification checks were discovered.",
+        category: "unknown",
+      });
       return "pause";
     }
     const result = verificationTargets.length <= 1
@@ -523,11 +535,11 @@ export async function runPostUnitVerification(
       const passCount = result.checks.filter((c) => c.exitCode === 0).length;
       const total = result.checks.length;
       if (result.passed) {
-        ctx.ui.notify(`Verification gate: ${passCount}/${total} checks passed`);
+        ctx.ui.notify(formatPostUnitStatusCard("✓ Verification Gate", `${passCount}/${total} checks passed`));
       } else {
         const failures = result.checks.filter((c) => c.exitCode !== 0);
         const failNames = failures.map((f) => f.command).join(", ");
-        ctx.ui.notify(`Verification gate: FAILED — ${failNames}`);
+        ctx.ui.notify(formatPostUnitStatusCard("✕ Verification Gate", `FAILED — ${failNames}`));
         process.stderr.write(
           `verification-gate: ${total - passCount}/${total} checks failed\n`,
         );
@@ -786,7 +798,10 @@ export async function runPostUnitVerification(
         "error",
       );
       process.stderr.write(`verification-gate: ${verdict.failureContext}\n`);
-      await pauseAuto(ctx, pi);
+      await pauseAuto(ctx, pi, {
+        message: "Verification failed: no runnable host-owned verification checks were discovered.",
+        category: "unknown",
+      });
       return "pause";
     } else if (postExecBlockingFailure) {
       // Post-execution failures are cross-task consistency issues — retrying the same task won't fix them.
@@ -798,7 +813,10 @@ export async function runPostUnitVerification(
         `Post-execution checks failed — cross-task consistency issue detected, pausing for human review`,
         "error",
       );
-      await pauseAuto(ctx, pi);
+      await pauseAuto(ctx, pi, {
+        message: "Post-execution checks failed: cross-task consistency issue detected.",
+        category: "unknown",
+      });
       return "pause";
     } else if (autoFixEnabled && attempt + 1 <= maxRetries) {
       const { unitCostUsd, rollingAvgUsd } = getCurrentUnitCostStats(s.currentUnit.id);
@@ -814,19 +832,17 @@ export async function runPostUnitVerification(
           `Unit ${s.currentUnit.id} hit per-unit cap $${perUnitCapUsd.toFixed(2)} — pausing auto-mode.`,
           "error",
         );
-        await pauseAuto(ctx, pi);
+        await pauseAuto(ctx, pi, {
+          message: `Verification failed and unit ${s.currentUnit.id} hit per-unit cap $${perUnitCapUsd.toFixed(2)}.`,
+          category: "unknown",
+        });
         return "pause";
       }
       if (getUnitCostSpikeAction(unitCostUsd, rollingAvgUsd, 3.0) === "pause") {
-        s.verificationRetryCount.delete(retryKey);
-        s.verificationRetryFailureHashes.delete(retryKey);
-        s.pendingVerificationRetry = null;
         ctx.ui.notify(
-          `Unit ${s.currentUnit.id} cost spike detected (${unitCostUsd.toFixed(2)} vs avg ${rollingAvgUsd.toFixed(2)}) — pausing auto-mode.`,
-          "error",
+          `Unit ${s.currentUnit.id} cost spike detected (${unitCostUsd.toFixed(2)} vs avg ${rollingAvgUsd.toFixed(2)}) during verification retry; keeping verification failure as the authoritative blocker.`,
+          "warning",
         );
-        await pauseAuto(ctx, pi);
-        return "pause";
       }
       const nextAttempt = attempt + 1;
       s.verificationRetryCount.set(retryKey, nextAttempt);
@@ -862,7 +878,10 @@ export async function runPostUnitVerification(
         `Verification gate FAILED after ${attempt} ${attempt === 1 ? "retry" : "retries"} (${exhaustedSummary}) — pausing for human review`,
         "error",
       );
-      await pauseAuto(ctx, pi);
+      await pauseAuto(ctx, pi, {
+        message: `Verification gate failed after ${attempt} ${attempt === 1 ? "retry" : "retries"} (${exhaustedSummary}).`,
+        category: "unknown",
+      });
       return "pause";
     }
   } catch (err) {
@@ -871,7 +890,10 @@ export async function runPostUnitVerification(
       `Verification gate errored before producing an authoritative verdict: ${(err as Error).message}`,
       "error",
     );
-    await pauseAuto(ctx, pi);
+    await pauseAuto(ctx, pi, {
+      message: `Verification gate errored before producing an authoritative verdict: ${(err as Error).message}`,
+      category: "unknown",
+    });
     return "pause";
   }
 }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1270,7 +1270,9 @@ export async function stopAuto(
   const loadedPreferences = loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences;
   const stopNotificationPrefix = formatAutoStopNotificationPrefix(reason);
   const displayReason = formatAutoStopDisplayReason(reason);
-  const preserveCompletionSurface = Boolean(options.completionWidget);
+  const completionStopRequested = Boolean(options.completionWidget);
+  const renderCompletionWidget = completionStopRequested && process.env.GSD_HEADLESS === "1";
+  const preserveCompletionSurface = completionStopRequested;
   s.completionStopInProgress = preserveCompletionSurface;
 
   // #4764 — telemetry: record the exit reason, isolation mode, whether an auto
@@ -1529,7 +1531,7 @@ export async function stopAuto(
       debugLog("stop-cleanup-ledger", { error: e instanceof Error ? e.message : String(e) });
     }
 
-    if (preserveCompletionSurface && ctx && options.completionWidget) {
+    if (renderCompletionWidget && ctx && options.completionWidget) {
       const ledger = getLedger();
       const units = ledger?.units ?? [];
       const totals = units.length > 0 ? getProjectTotals(units) : null;
@@ -1676,7 +1678,12 @@ export async function stopAuto(
 
     // UI cleanup
     ctx?.ui.setStatus("gsd-auto", undefined);
-    if (!preserveCompletionSurface) {
+    if (renderCompletionWidget) {
+      // Headless callers keep the durable completion widget/notification path.
+    } else if (preserveCompletionSurface) {
+      ctx?.ui.setWidget("gsd-progress", undefined);
+      ctx?.ui.setWidget("gsd-outcome", undefined);
+    } else {
       ctx?.ui.setWidget("gsd-progress", undefined);
       const status = isBlockedStopReason(reason) ? "blocked" : reason?.toLowerCase().includes("fail") ? "failed" : "stopped";
       setLifecycleOutcome(ctx, {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -337,6 +337,20 @@ export function formatAutoStopNotification(prefix: string, totals: { cost: numbe
   ].join("\n");
 }
 
+function isBlockedStopReason(reason?: string | null): boolean {
+  return /^Blocked:\s*/i.test(reason ?? "");
+}
+
+function formatAutoStopDisplayReason(reason?: string | null): string {
+  return (reason ?? "").replace(/^Blocked:\s*/i, "").trim();
+}
+
+export function formatAutoStopNotificationPrefix(reason?: string | null): string {
+  const displayReason = formatAutoStopDisplayReason(reason);
+  const prefix = isBlockedStopReason(reason) ? "Auto-mode blocked" : "Auto-mode stopped";
+  return displayReason ? `${prefix} — ${displayReason}` : prefix;
+}
+
 /**
  * Phase B — register this auto-mode process in the workers table so other
  * workers and janitors can detect liveness via heartbeat. Best-effort: if
@@ -1254,7 +1268,8 @@ export async function stopAuto(
 ): Promise<void> {
   if (!s.active && !s.paused) return;
   const loadedPreferences = loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences;
-  const reasonSuffix = reason ? ` — ${reason}` : "";
+  const stopNotificationPrefix = formatAutoStopNotificationPrefix(reason);
+  const displayReason = formatAutoStopDisplayReason(reason);
   const preserveCompletionSurface = Boolean(options.completionWidget);
   s.completionStopInProgress = preserveCompletionSurface;
 
@@ -1499,7 +1514,7 @@ export async function stopAuto(
           ? "All milestones complete"
           : isMilestoneComplete
             ? `${reason}. Auto-mode finished this milestone`
-            : `Auto-mode stopped${reasonSuffix}`;
+            : stopNotificationPrefix;
         if (ledger && ledger.units.length > 0) {
           const totals = getProjectTotals(ledger.units);
           ctx?.ui.notify(
@@ -1567,7 +1582,7 @@ export async function stopAuto(
         basePath: s.originalBasePath || s.basePath || null,
       });
       if (process.env.GSD_HEADLESS === "1") {
-        ctx.ui.notify(`Auto-mode stopped${reasonSuffix}.`, "info");
+        ctx.ui.notify(`${stopNotificationPrefix}.`, "info");
       }
     }
 
@@ -1576,8 +1591,8 @@ export async function stopAuto(
       pi?.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "clear" as const, preferences: loadedPreferences });
       pi?.events.emit(CMUX_CHANNELS.LOG, {
         preferences: loadedPreferences,
-        message: `Auto-mode stopped${reasonSuffix || ""}.`,
-        level: reason?.startsWith("Blocked:") ? "warning" : "info",
+        message: `${stopNotificationPrefix}.`,
+        level: isBlockedStopReason(reason) ? "warning" : "info",
       });
     } catch (e) {
       debugLog("stop-cleanup-cmux", { error: e instanceof Error ? e.message : String(e) });
@@ -1663,11 +1678,11 @@ export async function stopAuto(
     ctx?.ui.setStatus("gsd-auto", undefined);
     if (!preserveCompletionSurface) {
       ctx?.ui.setWidget("gsd-progress", undefined);
-      const status = reason?.startsWith("Blocked:") ? "blocked" : reason?.toLowerCase().includes("fail") ? "failed" : "stopped";
+      const status = isBlockedStopReason(reason) ? "blocked" : reason?.toLowerCase().includes("fail") ? "failed" : "stopped";
       setLifecycleOutcome(ctx, {
         status,
         title: status === "blocked" ? "Auto-mode blocked" : status === "failed" ? "Auto-mode stopped with an issue" : "Auto-mode stopped",
-        detail: reason ?? "Auto-mode stopped.",
+        detail: displayReason || "Auto-mode stopped.",
         nextAction: status === "blocked"
           ? "Fix the blocker, then run /gsd auto to resume."
           : "Run /gsd status for the current project state, or /gsd auto to continue.",

--- a/src/resources/extensions/gsd/auto/lease-conflict-notice.ts
+++ b/src/resources/extensions/gsd/auto/lease-conflict-notice.ts
@@ -1,0 +1,62 @@
+// Project/App: GSD-2
+// File Purpose: Formats user-facing auto-mode milestone lease conflict notices.
+
+const LEASE_HELD_RE = /^Milestone\s+(\S+)\s+is held by worker\s+(.+?)\s+until\s+(.+?)\.?$/;
+
+export interface LeaseConflictNoticeInput {
+  milestoneId?: string | null;
+  unitType: string;
+  unitId: string;
+  reason: string;
+  now?: Date;
+}
+
+function formatRelativeDuration(ms: number): string {
+  const seconds = Math.max(1, Math.ceil(Math.abs(ms) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.ceil(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.ceil(minutes / 60);
+  return `${hours}h`;
+}
+
+function formatRetryWindow(expiresAt: string, now: Date): string {
+  const expiry = new Date(expiresAt);
+  if (Number.isNaN(expiry.getTime())) {
+    return `until ${expiresAt}`;
+  }
+
+  const clock = expiry.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "short",
+  });
+  const deltaMs = expiry.getTime() - now.getTime();
+  if (deltaMs <= 0) {
+    return `after ${clock} (the lease should be expired now)`;
+  }
+  return `after ${clock} (about ${formatRelativeDuration(deltaMs)})`;
+}
+
+export function formatLeaseConflictNotice(input: LeaseConflictNoticeInput): string {
+  const milestoneId = input.milestoneId || "the milestone";
+  const unitLabel = `${input.unitType} ${input.unitId}`;
+  const match = input.reason.match(LEASE_HELD_RE);
+
+  if (!match) {
+    return [
+      `Blocked: ${milestoneId} is already active in another GSD worker. Try /gsd status to inspect it, then rerun /gsd auto when it finishes.`,
+      `Waiting unit: ${unitLabel}.`,
+      `Details: ${input.reason}`,
+    ].join("\n");
+  }
+
+  const [, parsedMilestoneId, workerId, expiresAt] = match;
+  const retryWindow = formatRetryWindow(expiresAt, input.now ?? new Date());
+  return [
+    `Blocked: ${parsedMilestoneId} is already active in another GSD worker. Retry with /gsd auto ${retryWindow}.`,
+    `Waiting unit: ${unitLabel}.`,
+    `Details: held by ${workerId}.`,
+  ].join("\n");
+}

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -105,6 +105,7 @@ import {
 } from "./workflow-custom-engine-verify-outcome.js";
 import { handleCustomEngineReconcile } from "./workflow-custom-engine-reconcile.js";
 import { handleCustomEngineReconcileOutcome } from "./workflow-custom-engine-reconcile-outcome.js";
+import { formatLeaseConflictNotice } from "./lease-conflict-notice.js";
 
 /**
  * Returns true if workerId is an active worker in this project whose OS
@@ -240,6 +241,18 @@ function logCustomVerifyRetryLoadFailure(err: unknown): void {
   debugLog("autoLoop", {
     phase: "load-custom-verify-retries-failed",
     error: err instanceof Error ? err.message : String(err),
+  });
+}
+
+function leaseConflictNotice(
+  iterData: IterationData,
+  reason: string,
+): string {
+  return formatLeaseConflictNotice({
+    milestoneId: iterData.mid,
+    unitType: iterData.unitType,
+    unitId: iterData.unitId,
+    reason,
   });
 }
 
@@ -977,7 +990,7 @@ export async function autoLoop(
           if (retryLease.kind === "ready") {
             leaseBeforeClaim = retryLease;
           } else {
-            const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} before dispatching ${iterData.unitType} ${iterData.unitId}: ${retryLease.reason}`;
+            const msg = leaseConflictNotice(iterData, retryLease.reason);
             ctx.ui.notify(msg, "error");
             finishTurn("stopped", "execution", msg);
             await deps.stopAuto(ctx, pi, msg);
@@ -986,7 +999,7 @@ export async function autoLoop(
         }
       }
       if (leaseBeforeClaim.kind === "blocked" || leaseBeforeClaim.kind === "failed") {
-        const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} before dispatching ${iterData.unitType} ${iterData.unitId}: ${leaseBeforeClaim.reason}`;
+        const msg = leaseConflictNotice(iterData, leaseBeforeClaim.reason);
         ctx.ui.notify(msg, "error");
         finishTurn("stopped", "execution", msg);
         await deps.stopAuto(ctx, pi, msg);
@@ -1029,7 +1042,7 @@ export async function autoLoop(
                 : { kind: "degraded" },
           );
         } else {
-          const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} while claiming ${iterData.unitType} ${iterData.unitId}: ${leaseRecovery.reason}`;
+          const msg = leaseConflictNotice(iterData, leaseRecovery.reason);
           ctx.ui.notify(msg, "error");
           finishTurn("stopped", "execution", msg);
           await deps.stopAuto(ctx, pi, msg);
@@ -1038,7 +1051,7 @@ export async function autoLoop(
       }
       if (dispatchDecision.action === "skip") {
         if (dispatchDecision.reason === "stale-lease") {
-          const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} while claiming ${iterData.unitType} ${iterData.unitId}; dispatch claim still failed after recovery.`;
+          const msg = leaseConflictNotice(iterData, "dispatch claim still failed after stale-lease recovery");
           ctx.ui.notify(msg, "error");
           finishTurn("stopped", "execution", msg);
           await deps.stopAuto(ctx, pi, msg);

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1450,6 +1450,9 @@ export async function runDispatch(
   const alreadyClosedReason = getAlreadyClosedDispatchReason(unitType, unitId);
   if (alreadyClosedReason) {
     s.pendingVerificationRetry = null;
+    loopState.recentUnits = [];
+    loopState.stuckRecoveryAttempts = Math.max(loopState.stuckRecoveryAttempts, 1);
+    deps.invalidateAllCaches();
     debugLog("autoLoop", {
       phase: "dispatch-skip-already-closed",
       unitType,

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -57,7 +57,8 @@ import { writeUnitRuntimeRecord } from "../unit-runtime.js";
 import { withTimeout, FINALIZE_PRE_TIMEOUT_MS, FINALIZE_POST_TIMEOUT_MS } from "./finalize-timeout.js";
 import { getEligibleSlices } from "../slice-parallel-eligibility.js";
 import { isSliceParallelActive, startSliceParallel } from "../slice-parallel-orchestrator.js";
-import { isDbAvailable, getMilestoneSlices } from "../gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, getSlice, getTask, refreshOpenDatabaseFromDisk } from "../gsd-db.js";
+import { isClosedStatus } from "../status-guards.js";
 import { reconcileBeforeSpawn } from "../state-reconciliation.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
 import type { PostflightResult, PreflightResult } from "../clean-root-preflight.js";
@@ -68,6 +69,7 @@ import { resetEvidence, loadEvidenceFromDisk } from "../safety/evidence-collecto
 import { parseUnitId } from "../unit-id.js";
 import { createCheckpoint, cleanupCheckpoint, rollbackToCheckpoint } from "../safety/git-checkpoint.js";
 import { resolveSafetyHarnessConfig } from "../safety/safety-harness.js";
+import { getContextPauseAction } from "../auto-budget.js";
 import {
   getWorkflowTransportSupportError,
   getRequiredWorkflowToolsForAutoUnit,
@@ -164,6 +166,25 @@ function rememberRetryDispatch(
     mid: iterData.mid,
     midTitle: iterData.midTitle,
   };
+}
+
+function getAlreadyClosedDispatchReason(unitType: string, unitId: string): string | null {
+  if (!isDbAvailable()) return null;
+  refreshOpenDatabaseFromDisk();
+  const { milestone, slice, task } = parseUnitId(unitId);
+  if (unitType === "execute-task" && milestone && slice && task) {
+    const row = getTask(milestone, slice, task);
+    return row && isClosedStatus(row.status)
+      ? `execute-task ${unitId} is already ${row.status}`
+      : null;
+  }
+  if (unitType === "complete-slice" && milestone && slice) {
+    const row = getSlice(milestone, slice);
+    return row && isClosedStatus(row.status)
+      ? `complete-slice ${unitId} is already ${row.status}`
+      : null;
+  }
+  return null;
 }
 
 export function shouldDegradeEmptyWorktreeToProjectRoot(
@@ -1426,6 +1447,27 @@ export async function runDispatch(
     });
   }
 
+  const alreadyClosedReason = getAlreadyClosedDispatchReason(unitType, unitId);
+  if (alreadyClosedReason) {
+    s.pendingVerificationRetry = null;
+    debugLog("autoLoop", {
+      phase: "dispatch-skip-already-closed",
+      unitType,
+      unitId,
+      reason: alreadyClosedReason,
+    });
+    deps.emitJournalEvent({
+      ts: new Date().toISOString(),
+      flowId: ic.flowId,
+      seq: ic.nextSeq(),
+      eventType: "guard-block",
+      data: { unitType, unitId, reason: alreadyClosedReason },
+    });
+    ctx.ui.notify(`Skipping ${unitType} ${unitId}: ${alreadyClosedReason}.`, "info");
+    await new Promise((r) => setImmediate(r));
+    return { action: "continue" };
+  }
+
   deps.emitJournalEvent({
     ts: new Date().toISOString(),
     flowId: ic.flowId,
@@ -1829,19 +1871,16 @@ export async function runGuards(
   const contextThreshold = prefs?.context_pause_threshold ?? 0;
   if (contextThreshold > 0 && s.cmdCtx) {
     const contextUsage = s.cmdCtx.getContextUsage();
-    if (
-      contextUsage &&
-      contextUsage.percent !== null &&
-      contextUsage.percent >= contextThreshold
-    ) {
-      const msg = `Context window at ${contextUsage.percent}% (threshold: ${contextThreshold}%). Pausing to prevent truncated output.`;
+    if (getContextPauseAction(contextUsage?.percent, contextThreshold) === "pause") {
+      const contextPercent = contextUsage!.percent as number;
+      const msg = `Context window at ${contextPercent}% (threshold: ${contextThreshold}%). Pausing to prevent truncated output.`;
       ctx.ui.notify(
         `${msg} Run /gsd auto to continue (will start fresh session).`,
         "warning",
       );
       deps.sendDesktopNotification(
         "GSD",
-        `Context ${contextUsage.percent}% — paused`,
+        `Context ${contextPercent}% — paused`,
         "warning",
         "attention",
         basename(s.originalBasePath || s.basePath),

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -226,6 +226,34 @@ export function isTerminalDeletedWorktreeProviderError(
   return /[/\\]\.gsd[/\\](?:projects[/\\][^/\\]+[/\\])?worktrees[/\\][^/\\\s"']+/i.test(message);
 }
 
+type MessageEndLike = {
+  message: unknown;
+};
+
+export function suppressTerminalDeletedWorktreeMessageEnd(event: MessageEndLike): boolean {
+  const message = event.message as {
+    role?: unknown;
+    stopReason?: unknown;
+    errorMessage?: unknown;
+    content?: unknown;
+  };
+  if (!isAutoCompletionStopInProgress()) return false;
+  if (message?.role !== "assistant" || message.stopReason !== "error") return false;
+
+  const rawErrorMsg = message.errorMessage ? String(message.errorMessage) : "";
+  const displayMsg = resolveAgentEndErrorDisplay(rawErrorMsg, message.content);
+  if (!isTerminalDeletedWorktreeProviderError(`${rawErrorMsg}\n${displayMsg}`)) return false;
+
+  message.stopReason = "completed";
+  message.errorMessage = undefined;
+  message.content = [];
+  logWarning(
+    "bootstrap",
+    `Suppressing stale deleted-worktree provider error during terminal completion reroot: ${displayMsg || rawErrorMsg}`,
+  );
+  return true;
+}
+
 async function pauseTransientWithBackoff(
   cls: ErrorClass,
   pi: ExtensionAPI,

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -632,6 +632,11 @@ export function registerHooks(
     }
   });
 
+  pi.on("message_end", async (event) => {
+    const { suppressTerminalDeletedWorktreeMessageEnd } = await import("./agent-end-recovery.js");
+    suppressTerminalDeletedWorktreeMessageEnd(event);
+  });
+
   // Squash-merge quick-task branch back to the original branch after the
   // agent turn completes (#2668). cleanupQuickBranch is a no-op when no
   // quick-return state is pending, so this is safe to call on every turn.

--- a/src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts
@@ -57,4 +57,6 @@ test("getContextPauseAction pauses at or above a percentage threshold", () => {
   assert.equal(getContextPauseAction(90, 90), "pause");
   assert.equal(getContextPauseAction(95, 90), "pause");
   assert.equal(getContextPauseAction(95, 0), "none");
+  assert.equal(getContextPauseAction(0.75, 75), "pause");
+  assert.equal(getContextPauseAction(0.8, 0.75), "pause");
 });

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -283,7 +283,7 @@ test("setAutoOutcomeWidget renders a durable next-action handoff", () => {
   assert.match(output, /\/gsd auto/);
 });
 
-test("setCompletionProgressWidget uses the outcome slot for terminal all-complete handoff", () => {
+test("setCompletionProgressWidget keeps terminal all-complete handoff in progress slot", () => {
   const calls: Array<[string, unknown]> = [];
   setCompletionProgressWidget(
     {
@@ -313,13 +313,13 @@ test("setCompletionProgressWidget uses the outcome slot for terminal all-complet
   );
 
   assert.ok(
-    calls.some(([key, value]) => key === "gsd-progress" && value === undefined),
-    "terminal completion must clear the active progress widget",
+    calls.some(([key, value]) => key === "gsd-outcome" && value === undefined),
+    "terminal completion should clear stale outcome widgets before rendering progress roll-up",
   );
-  const outcome = calls.filter(([key]) => key === "gsd-outcome").at(-1);
-  assert.equal(typeof outcome?.[1], "function", "terminal completion must install the final handoff in the outcome slot");
+  const progress = calls.filter(([key]) => key === "gsd-progress").at(-1);
+  assert.equal(typeof progress?.[1], "function", "terminal completion must install the final handoff in the progress slot");
 
-  const component = (outcome?.[1] as any)(
+  const component = (progress?.[1] as any)(
     { requestRender() {} },
     { fg: (_color: string, text: string) => text, bold: (text: string) => text },
   );

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1172,6 +1172,67 @@ test("autoLoop persists stuck counter reset when dispatch recovery continues", a
   }
 });
 
+test("autoLoop skips provider dispatch when execute-task is already complete in DB", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.ui.setWidget = () => {};
+  const pi = makeMockPi();
+  const basePath = realpathSync(mkdtempSync(join(tmpdir(), "gsd-already-complete-dispatch-")));
+  mkdirSync(join(basePath, ".gsd"), { recursive: true });
+
+  try {
+    openDatabase(join(basePath, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Test Slice", status: "pending" });
+    insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "Task One", status: "complete" });
+
+    const s = makeLoopSession({
+      basePath,
+      originalBasePath: basePath,
+      canonicalProjectRoot: basePath,
+    });
+    let deriveCount = 0;
+    const notifications: string[] = [];
+    ctx.ui.notify = (msg: string) => notifications.push(msg);
+
+    const deps = makeMockDeps({
+      isDbAvailable: () => true,
+      deriveState: async () => {
+        deriveCount++;
+        if (deriveCount > 1) s.active = false;
+        return {
+          phase: "executing",
+          activeMilestone: { id: "M001", title: "Test", status: "active" },
+          activeSlice: { id: "S01", title: "Slice 1" },
+          activeTask: { id: "T01" },
+          registry: [{ id: "M001", status: "active" }],
+          blockers: [],
+        } as any;
+      },
+      resolveDispatch: async () => {
+        deps.callLog.push("resolveDispatch");
+        return {
+          action: "dispatch" as const,
+          unitType: "execute-task",
+          unitId: "M001/S01/T01",
+          prompt: "do the already-complete task",
+        };
+      },
+    });
+
+    await autoLoop(ctx, pi, s, deps);
+
+    assert.equal(pi.calls.length, 0, "completed task must not be sent to provider again");
+    assert.ok(!deps.callLog.includes("postUnitPreVerification"));
+    assert.ok(notifications.some((m) => m.includes("already complete")));
+  } finally {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(basePath, { recursive: true, force: true });
+  }
+});
+
 test("autoLoop stops before success notification when postflight stash restore needs recovery", async () => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -135,7 +135,7 @@ test("cleanupAfterLoopExit clears status and progress widget without replacing o
   }
 });
 
-test("cleanupAfterLoopExit preserves completion roll-up after stopAuto reset", async () => {
+test("cleanupAfterLoopExit preserves completion closeout surface after stopAuto reset", async () => {
   const statusCalls: unknown[] = [];
   const widgetCalls: unknown[] = [];
 
@@ -160,12 +160,12 @@ test("cleanupAfterLoopExit preserves completion roll-up after stopAuto reset", a
     assert.equal(
       widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-progress" && args[1] === undefined),
       false,
-      "post-loop completion cleanup must leave the final roll-up widget visible",
+      "post-loop completion cleanup must not clear the foreground closeout surface",
     );
     assert.equal(
       widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-outcome"),
       false,
-      "completion cleanup must not replace the roll-up with a generic outcome card",
+      "completion cleanup must not replace the closeout surface with a generic outcome card",
     );
     assert.equal(autoSession.completionStopInProgress, false);
   } finally {
@@ -434,7 +434,7 @@ test("rerootCommandSession refreshes command workspace to project root", async (
   assert.deepEqual(calls, ["/project/root"]);
 });
 
-test("stopAuto completion closeout reroots session, restores cwd, and preserves final widget", async (t) => {
+test("stopAuto foreground completion closeout reroots session and preserves the transcript surface", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-completion-stop-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
@@ -552,30 +552,12 @@ test("stopAuto completion closeout reroots session, restores cwd, and preserves 
     assert.deepEqual(newSessionWorkspaces, [base], "completion stop must reroot command session to original project root");
     assert.equal(restoreCalls, 1, "completion stop must restore project root through lifecycle");
     assert.equal(realpathSync(process.cwd()), realpathSync(base), "completion stop must chdir back to project root");
-    assert.ok(
-      widgetCalls.some(([key, value]) => key === "gsd-progress" && typeof value === "function"),
-      "completion stop must install a final progress widget",
-    );
     const lastProgressWidget = widgetCalls.filter(([key]) => key === "gsd-progress").at(-1);
-    assert.equal(typeof lastProgressWidget?.[1], "function", "completion stop must leave the final progress widget installed after reroot");
-    const factory = lastProgressWidget?.[1] as any;
-    const component = factory(
-      { requestRender() {} },
-      { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+    assert.equal(
+      lastProgressWidget?.[1],
+      undefined,
+      "foreground completion stop must clear stale progress widgets so the closeout transcript remains visible",
     );
-    const output = component.render(140).join("\n");
-    assert.match(output, /Milestone M003 roll-up/);
-    assert.match(output, /Outcome/);
-    assert.match(output, /Added budget warning output/);
-    assert.match(output, /Verification/);
-    assert.match(output, /Files: src\/resources\/extensions\/gsd\/auto-dashboard\.ts/);
-    assert.match(output, /Lessons: Milestone endings need report output/);
-    assert.match(output, /2\/3 slices/);
-    assert.match(output, /Next/);
-    assert.match(output, /Review the roll-up/);
-    assert.match(output, /\/gsd auto for next milestone/);
-    assert.doesNotMatch(output, /COMPLETE-MILESTONE/);
-    assert.doesNotMatch(output, /\/gsd auto to resume/);
     assert.ok(
       notifications.every(message => !message.includes("/gsd auto to resume")),
       "completion stop notification must not tell users to resume a finished auto run",
@@ -586,7 +568,7 @@ test("stopAuto completion closeout reroots session, restores cwd, and preserves 
     );
     assert.ok(
       widgetCalls.every(([key, value]) => key !== "gsd-outcome" || value === undefined),
-      "completion stop should use the roll-up as the single final surface",
+      "foreground completion stop must not replace the transcript with a generic outcome card",
     );
 
     const widgetCallCountBeforePostLoopCleanup = widgetCalls.length;
@@ -595,7 +577,12 @@ test("stopAuto completion closeout reroots session, restores cwd, and preserves 
     assert.equal(
       postLoopWidgetCalls.some(([key, value]) => key === "gsd-progress" && value === undefined),
       false,
-      "outer auto-loop cleanup must not clear the final completion roll-up after stopAuto returns",
+      "outer auto-loop cleanup must not touch the closeout surface after stopAuto returns",
+    );
+    assert.equal(
+      postLoopWidgetCalls.some(([key]) => key === "gsd-outcome"),
+      false,
+      "outer auto-loop cleanup must not add a replacement outcome after stopAuto returns",
     );
   } finally {
     try { closeDatabase(); } catch { /* noop */ }
@@ -693,7 +680,7 @@ test("stopAuto completion closeout emits a headless terminal notification withou
   }
 });
 
-test("stopAuto all-complete closeout clears active progress and leaves final outcome", async () => {
+test("stopAuto foreground all-complete closeout leaves the transcript as the final surface", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-all-complete-closeout-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
@@ -741,14 +728,15 @@ test("stopAuto all-complete closeout clears active progress and leaves final out
       },
     );
 
-    assert.ok(
-      widgetCalls.some(([key, value]) => key === "gsd-progress" && value === undefined),
-      "all-complete closeout must clear the stale active progress widget",
+    assert.equal(
+      widgetCalls.some(([key, value]) => key === "gsd-progress" && typeof value === "function"),
+      false,
+      "foreground all-complete closeout must not install a roll-up widget that pushes the transcript away",
     );
     const finalProgress = widgetCalls.filter(([key]) => key === "gsd-progress").at(-1);
-    assert.equal(finalProgress?.[1], undefined, "all-complete closeout must not reinstall active progress");
+    assert.equal(finalProgress?.[1], undefined, "foreground all-complete closeout clears stale progress widgets");
     const finalOutcome = widgetCalls.filter(([key]) => key === "gsd-outcome").at(-1);
-    assert.equal(typeof finalOutcome?.[1], "function", "all-complete closeout must install the final outcome widget");
+    assert.equal(finalOutcome?.[1], undefined, "foreground all-complete closeout must not add an outcome replacement");
   } finally {
     try { closeDatabase(); } catch { /* noop */ }
     autoSession.reset();

--- a/src/resources/extensions/gsd/tests/auto-post-unit-step-message.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-post-unit-step-message.test.ts
@@ -3,9 +3,13 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
 
 import {
+  buildStepCompleteOutcome,
   buildStepCompleteMessage,
+  setStepCompleteFallbackSurface,
+  setStepCompleteSurface,
   shouldReturnStepWizardAfterUnit,
   STEP_COMPLETE_FALLBACK_MESSAGE,
 } from "../auto-post-unit.ts";
@@ -25,12 +29,16 @@ function makeState(overrides: Partial<GSDState>): GSDState {
   };
 }
 
+function plain(message: string): string {
+  return stripVTControlCharacters(message);
+}
+
 test("buildStepCompleteMessage: terminal milestone completion leaves the roll-up as the only closeout message", () => {
   const msg = buildStepCompleteMessage(makeState({ phase: "complete" }));
   assert.equal(msg, null);
 });
 
-test("buildStepCompleteMessage: mid-flight step includes next unit label and /gsd next hint", () => {
+test("buildStepCompleteMessage: mid-flight step renders only the completion receipt", () => {
   const state = makeState({
     phase: "executing",
     activeSlice: { id: "S01", title: "Core" },
@@ -38,23 +46,168 @@ test("buildStepCompleteMessage: mid-flight step includes next unit label and /gs
   });
   const msg = buildStepCompleteMessage(state);
   assert.ok(msg);
-  assert.match(msg, /Next: Execute T03: Wire notify/);
-  assert.doesNotMatch(msg, /\/clear/);
-  assert.match(msg, /\/gsd next to continue one step/);
+  assert.match(msg, /\x1b\[/);
+  const text = plain(msg);
+  assert.match(text, /╭─ ✓ GSD Step Complete/);
+  assert.match(text, /Completed: Step complete/);
+  assert.match(text, /^    ╭─/m);
+  assert.doesNotMatch(text, /^          ╭─/m);
+  assert.doesNotMatch(text, /╭─ Next step/);
+  assert.doesNotMatch(text, /Next: Execute T03: Wire notify/);
+  assert.doesNotMatch(text, /\/clear/);
+  assert.doesNotMatch(text, /Continue: \/gsd next/);
+  assert.doesNotMatch(text, /Auto-run: \/gsd auto/);
+  assert.doesNotMatch(text, /\/gsd next/);
+  assert.doesNotMatch(text, /\/gsd auto/);
+  assert.doesNotMatch(text, /\n│\n/);
+  assert.doesNotMatch(text, /Ctrl\+N/);
 });
 
-test("buildStepCompleteMessage: unknown phase falls back to generic continue label", () => {
+test("buildStepCompleteMessage: unknown phase still renders only the completion receipt", () => {
   // Cast to bypass Phase union so we exercise the default branch of describeNextUnit.
   const state = makeState({ phase: "totally-unknown" as unknown as GSDState["phase"] });
   const msg = buildStepCompleteMessage(state);
   assert.ok(msg);
-  assert.match(msg, /Next: Continue/);
-  assert.doesNotMatch(msg, /\/clear/);
+  const text = plain(msg);
+  assert.match(text, /╭─ ✓ GSD Step Complete/);
+  assert.doesNotMatch(text, /╭─ Next step/);
+  assert.doesNotMatch(text, /Next: Continue/);
+  assert.doesNotMatch(text, /\/clear/);
 });
 
-test("STEP_COMPLETE_FALLBACK_MESSAGE: used when deriveState throws, points users at /gsd next without /clear", () => {
-  assert.doesNotMatch(STEP_COMPLETE_FALLBACK_MESSAGE, /\/clear/);
-  assert.match(STEP_COMPLETE_FALLBACK_MESSAGE, /\/gsd next/);
+test("STEP_COMPLETE_FALLBACK_MESSAGE: used when deriveState throws, stays a receipt without command hints", () => {
+  const text = plain(STEP_COMPLETE_FALLBACK_MESSAGE);
+  assert.match(text, /╭─ ✓ GSD Step Complete/);
+  assert.doesNotMatch(text, /╭─ Next step/);
+  assert.doesNotMatch(text, /\/clear/);
+  assert.doesNotMatch(text, /\/gsd next/);
+  assert.doesNotMatch(text, /\/gsd auto/);
+  assert.doesNotMatch(text, /Next: Continue/);
+  assert.doesNotMatch(text, /Ctrl\+N/);
+});
+
+test("buildStepCompleteOutcome: durable handoff includes next commands", () => {
+  const state = makeState({
+    phase: "executing",
+    activeSlice: { id: "S01", title: "Core" },
+    activeTask: { id: "T03", title: "Wire notify" },
+  });
+
+  const outcome = buildStepCompleteOutcome(state, {
+    type: "complete-slice",
+    id: "M011/S01",
+    startedAt: 123,
+  });
+
+  assert.ok(outcome);
+  assert.equal(outcome.status, "step");
+  assert.equal(outcome.title, "Step complete");
+  assert.match(outcome.detail ?? "", /Execute T03: Wire notify/);
+  assert.equal(outcome.unitLabel, "completing M011/S01");
+  assert.equal(outcome.nextAction, "Advance one step, or resume automatic mode.");
+  assert.doesNotMatch(outcome.nextAction, /\/gsd/);
+  assert.deepEqual(outcome.commands, ["/gsd next", "/gsd auto", "/gsd status for overview"]);
+});
+
+test("setStepCompleteSurface: clears stale progress and installs durable outcome panel", () => {
+  const calls: Array<[string, unknown]> = [];
+  const state = makeState({
+    phase: "executing",
+    activeSlice: { id: "S01", title: "Core" },
+    activeTask: { id: "T03", title: "Wire notify" },
+  });
+
+  const message = setStepCompleteSurface(
+    {
+      hasUI: true,
+      ui: {
+        setWidget(key: string, value: unknown) {
+          calls.push([key, value]);
+        },
+      },
+    } as any,
+    state,
+    { type: "complete-slice", id: "M011/S01", startedAt: 123 },
+  );
+
+  assert.ok(message);
+  assert.match(plain(message), /╭─ ✓ GSD Step Complete/);
+  assert.ok(
+    calls.some(([key, value]) => key === "gsd-progress" && value === undefined),
+    "step completion must clear the live progress widget so stale provider-idle state is not preserved",
+  );
+  const outcome = calls.find(([key, value]) => key === "gsd-outcome" && typeof value === "function");
+  assert.ok(outcome, "step completion must install the durable outcome widget");
+
+  const component = (outcome[1] as any)(
+    { requestRender() {} },
+    { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+  );
+  const output = component.render(120).join("\n");
+  assert.match(output, /Step complete/);
+  assert.match(output, /completing M011\/S01/);
+  assert.match(output, /Advance one step, or resume automatic mode/);
+  assert.match(output, /\/gsd next/);
+  assert.match(output, /\/gsd auto/);
+});
+
+test("setStepCompleteSurface: execute-task renders only the task completion receipt", () => {
+  const calls: Array<[string, unknown]> = [];
+  const state = makeState({
+    phase: "planning",
+    activeSlice: { id: "S02", title: "Follow-up" },
+  });
+
+  const message = setStepCompleteSurface(
+    {
+      hasUI: true,
+      ui: {
+        setWidget(key: string, value: unknown) {
+          calls.push([key, value]);
+        },
+      },
+    } as any,
+    state,
+    { type: "execute-task", id: "M011/S01/T02", startedAt: 123 },
+  );
+
+  assert.ok(message);
+  const text = plain(message);
+  assert.match(text, /╭─ ✓ GSD Task Complete/);
+  assert.match(text, /Completed: executing M011\/S01\/T02/);
+  assert.match(text, /^    ╭─/m);
+  assert.doesNotMatch(text, /^          ╭─/m);
+  assert.doesNotMatch(text, /╭─ Next step/);
+  assert.doesNotMatch(text, /Next: Plan S02: Follow-up/);
+  assert.doesNotMatch(text, /│/);
+});
+
+test("setStepCompleteFallbackSurface: fallback also clears progress and points to status", () => {
+  const calls: Array<[string, unknown]> = [];
+  const message = setStepCompleteFallbackSurface(
+    {
+      hasUI: true,
+      ui: {
+        setWidget(key: string, value: unknown) {
+          calls.push([key, value]);
+        },
+      },
+    } as any,
+    { type: "complete-slice", id: "M011/S01", startedAt: 123 },
+  );
+
+  assert.match(plain(message), /╭─ ✓ GSD Step Complete/);
+  assert.ok(calls.some(([key, value]) => key === "gsd-progress" && value === undefined));
+  const outcome = calls.find(([key, value]) => key === "gsd-outcome" && typeof value === "function");
+  assert.ok(outcome);
+  const component = (outcome[1] as any)(
+    { requestRender() {} },
+    { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+  );
+  const output = component.render(120).join("\n");
+  assert.match(output, /\/gsd status/);
+  assert.match(output, /\/gsd next/);
+  assert.match(output, /\/gsd auto/);
 });
 
 test("shouldReturnStepWizardAfterUnit: terminal milestone completion continues to merge-back path", () => {

--- a/src/resources/extensions/gsd/tests/auto-status-message.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-status-message.test.ts
@@ -1,0 +1,46 @@
+// Project/App: GSD-2
+// File Purpose: Visual contract tests for compact GSD status notification cards.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+
+import {
+  formatConnectedStepStack,
+  formatPostUnitStatusCard,
+} from "../auto-status-message.ts";
+
+test("formatPostUnitStatusCard wraps verification metadata in a compact card", () => {
+  const message = formatPostUnitStatusCard("✓ Verification Gate", "2/2 checks passed");
+  const plain = stripVTControlCharacters(message);
+
+  assert.match(message, /\x1b\[/);
+  assert.match(plain, /^    ╭─ ✓ Verification Gate/m);
+  assert.match(plain, /^       2\/2 checks passed/m);
+  assert.match(plain, /^    ╰/m);
+  assert.doesNotMatch(plain, /^          ╭─/m);
+  assert.doesNotMatch(plain, /│/);
+});
+
+test("formatConnectedStepStack renders task completion as a compact receipt", () => {
+  const message = formatConnectedStepStack(
+    "✓ GSD Task Complete",
+    "executing M011/S03/T01",
+  );
+  const plain = stripVTControlCharacters(message);
+
+  assert.match(message, /\x1b\[/);
+  assert.doesNotMatch(plain.split("\n")[0] ?? "", /╰────╮/);
+  assert.match(plain, /^    ╭─ ✓ GSD Task Complete/m);
+  assert.match(plain, /^       Completed: executing M011\/S03\/T01/m);
+  assert.match(plain, /^    ╰/m);
+  assert.doesNotMatch(plain, /^    ╰────╮/m);
+  assert.doesNotMatch(plain, /^    ╭─ Next step/m);
+  assert.doesNotMatch(plain, /Next: Execute T02: Build tag filter nav/);
+  assert.doesNotMatch(plain, /Continue: \/gsd next/);
+  assert.doesNotMatch(plain, /Auto-run: \/gsd auto/);
+  assert.doesNotMatch(plain, /\/gsd next/);
+  assert.doesNotMatch(plain, /\/gsd auto/);
+  assert.doesNotMatch(plain, /^          ╭─/m);
+  assert.doesNotMatch(plain, /│/);
+});

--- a/src/resources/extensions/gsd/tests/auto-stop-notification.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-stop-notification.test.ts
@@ -4,7 +4,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { formatAutoStopNotification } from "../auto.ts";
+import { formatAutoStopNotification, formatAutoStopNotificationPrefix } from "../auto.ts";
 
 test("auto stop notification keeps session totals on a separate line", () => {
   const message = formatAutoStopNotification(
@@ -16,5 +16,16 @@ test("auto stop notification keeps session totals on a separate line", () => {
   assert.equal(
     message,
     "Auto-mode stopped.\nSession: $0.652 · 87.0k tokens · 2 units",
+  );
+});
+
+test("blocked stop notification uses blocked headline without repeating the marker", () => {
+  const prefix = formatAutoStopNotificationPrefix(
+    "Blocked: M012 is already active in another GSD worker. Retry with /gsd auto after 1:58:59 PM.",
+  );
+
+  assert.equal(
+    prefix,
+    "Auto-mode blocked — M012 is already active in another GSD worker. Retry with /gsd auto after 1:58:59 PM.",
   );
 });

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -357,11 +357,11 @@ console.log('\n=== complete-slice: handler idempotency ===');
   const dbPath = tempDbPath();
   openDatabase(dbPath);
 
-  const { basePath, roadmapPath } = createTempProject();
+  const { basePath } = createTempProject();
 
   // Set up DB state
   insertMilestone({ id: 'M001' });
-  insertSlice({ id: 'S01', milestoneId: 'M001' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice', risk: 'medium', depends: [], demo: 'basic functionality works', sequence: 1 });
   insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', status: 'complete', title: 'Task 1' });
 
   const params = makeValidSliceParams();
@@ -370,17 +370,78 @@ console.log('\n=== complete-slice: handler idempotency ===');
   const r1 = await handleCompleteSlice(params, basePath);
   assertTrue(!('error' in r1), 'first call should succeed');
 
-  // Second call — state machine guard rejects (slice is already complete)
-  const r2 = await handleCompleteSlice(params, basePath);
-  assertTrue('error' in r2, 'second call should return error (slice already complete)');
-  if ('error' in r2) {
-    assertMatch(r2.error, /already complete/, 'error should mention already complete');
+  if ('error' in r1) {
+    cleanupDir(basePath);
+    cleanup(dbPath);
+    throw new Error('first completion unexpectedly failed');
+  }
+  const summaryBefore = fs.readFileSync(r1.summaryPath, 'utf-8');
+
+  // Second call — healthy duplicates unwind as non-mutating success.
+  const r2 = await handleCompleteSlice(
+    { ...params, oneLiner: 'This duplicate payload should not rewrite completed history' },
+    basePath,
+  );
+  assertTrue(!('error' in r2), 'second call should return duplicate success');
+  if (!('error' in r2)) {
+    assertEq(r2.duplicate, true, 'second call should be marked duplicate');
+    assertEq(
+      fs.readFileSync(r2.summaryPath, 'utf-8'),
+      summaryBefore,
+      'healthy duplicate should not rewrite the existing summary',
+    );
   }
 
   // Verify only 1 slice row (not duplicated)
   const adapter = _getAdapter()!;
   const sliceRows = adapter.prepare("SELECT * FROM slices WHERE milestone_id = 'M001' AND id = 'S01'").all();
   assertEq(sliceRows.length, 1, 'should have exactly 1 slice row after calls');
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-slice: Handler repairs already-complete slice with stale roadmap
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-slice: handler repairs stale duplicate roadmap ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+
+  const { basePath, roadmapPath } = createTempProject();
+
+  insertMilestone({ id: 'M001' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice', risk: 'medium', depends: [], demo: 'basic functionality works', sequence: 1 });
+  insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', status: 'complete', title: 'Task 1' });
+
+  const params = makeValidSliceParams();
+  const r1 = await handleCompleteSlice(params, basePath);
+  assertTrue(!('error' in r1), 'first completion should succeed');
+  if ('error' in r1) {
+    cleanupDir(basePath);
+    cleanup(dbPath);
+    throw new Error('first completion unexpectedly failed');
+  }
+
+  fs.writeFileSync(
+    roadmapPath,
+    fs.readFileSync(roadmapPath, 'utf-8').replace('- [x] **S01:', '- [ ] **S01:'),
+    'utf-8',
+  );
+  const staleRoadmap = parseRoadmap(fs.readFileSync(roadmapPath, 'utf-8'));
+  assertEq(staleRoadmap.slices.find(s => s.id === 'S01')?.done, false, 'fixture roadmap should be stale before repair');
+
+  const r2 = await handleCompleteSlice(params, basePath);
+  assertTrue(!('error' in r2), 'duplicate completion should repair stale artifacts instead of erroring');
+  if (!('error' in r2)) {
+    assertEq(r2.duplicate, true, 'repair result should be marked duplicate');
+    const repairedRoadmap = fs.readFileSync(roadmapPath, 'utf-8');
+    assertMatch(repairedRoadmap, /- \[x\] \*\*S01:/, 'duplicate completion should re-render roadmap as checked');
+    assertTrue(fs.existsSync(r2.summaryPath), 'summary should still exist after repair');
+    assertTrue(fs.existsSync(r2.uatPath), 'UAT should still exist after repair');
+  }
 
   cleanupDir(basePath);
   cleanup(dbPath);

--- a/src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/state-machine-live-validation.test.ts
@@ -524,7 +524,7 @@ describe("state-machine-live-validation", () => {
       assert.match((result as any).error, /incomplete tasks/);
     });
 
-    test("double slice completion returns error", async () => {
+    test("double slice completion repairs missing artifacts", async () => {
       base = createFullFixture();
       openDatabase(join(base, ".gsd", "gsd.db"));
       insertMilestone({ id: "M001", title: "Active", status: "active" });
@@ -532,8 +532,10 @@ describe("state-machine-live-validation", () => {
       insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", status: "complete" });
 
       const result = await handleCompleteSlice(makeSliceParams("S01", "M001") as any, base);
-      assert.ok("error" in result);
-      assert.match((result as any).error, /already complete/);
+      assert.ok(!("error" in result));
+      assert.equal(result.duplicate, true);
+      assert.equal(existsSync(result.summaryPath), true);
+      assert.equal(existsSync(result.uatPath), true);
     });
 
     test("cannot complete milestone with zero slices", async () => {

--- a/src/resources/extensions/gsd/tests/lease-conflict-notice.test.ts
+++ b/src/resources/extensions/gsd/tests/lease-conflict-notice.test.ts
@@ -1,0 +1,38 @@
+// Project/App: GSD-2
+// File Purpose: Regression tests for user-facing milestone lease conflict notices.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { formatLeaseConflictNotice } from "../auto/lease-conflict-notice.ts";
+
+test("lease conflict notice explains the retry action before worker details", () => {
+  const message = formatLeaseConflictNotice({
+    milestoneId: "M012",
+    unitType: "run-uat",
+    unitId: "M012/S01",
+    reason: "Milestone M012 is held by worker auto-Jeremys-MacBook-Pro-9.local-34036-ee4ef385 until 2026-05-20T18:58:59.275Z.",
+    now: new Date("2026-05-20T18:58:14.275Z"),
+  });
+
+  const lines = message.split("\n");
+  assert.match(lines[0] ?? "", /^Blocked: M012 is already active in another GSD worker\./);
+  assert.match(lines[0] ?? "", /Retry with \/gsd auto/);
+  assert.match(lines[0] ?? "", /about 45s/);
+  assert.equal(lines[1], "Waiting unit: run-uat M012/S01.");
+  assert.equal(lines[2], "Details: held by auto-Jeremys-MacBook-Pro-9.local-34036-ee4ef385.");
+  assert.doesNotMatch(lines[0] ?? "", /auto-Jeremys/);
+});
+
+test("lease conflict notice keeps unknown reasons as details", () => {
+  const message = formatLeaseConflictNotice({
+    milestoneId: "M012",
+    unitType: "run-uat",
+    unitId: "M012/S01",
+    reason: "stale_lease",
+  });
+
+  assert.match(message, /^Blocked: M012 is already active in another GSD worker\./);
+  assert.match(message, /Try \/gsd status/);
+  assert.match(message, /Details: stale_lease/);
+});

--- a/src/resources/extensions/gsd/tests/pipeline-variant-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/pipeline-variant-dispatch.test.ts
@@ -247,6 +247,50 @@ test("#4781 phase 2: validate-milestone rule writes pass-through VALIDATION for 
   assert.doesNotMatch(content, /#[0-9]{3,}/, "validation output must not include tracker-style refs");
 });
 
+test("validate-milestone skip writes to project root when active worktree lacks milestone projections", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+
+  seedMilestone(base, "M001", TRIVIAL_INPUT);
+  const adapter = _getAdapter();
+  assert.ok(adapter, "test database should be open");
+  adapter.prepare("UPDATE slices SET status = 'complete' WHERE milestone_id = 'M001'").run();
+
+  const { writeFileSync, readFileSync } = await import("node:fs");
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    [
+      "# M001",
+      "## Slices",
+      "- [x] **S01: First** `risk:low` `depends:[]`",
+      "- [x] **S02: Second** `risk:low` `depends:[]`",
+    ].join("\n"),
+  );
+
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  mkdirSync(join(worktree, ".gsd", "runtime"), { recursive: true });
+
+  const ctx = {
+    ...makeCtx({ base: worktree, mid: "M001", phase: "validating-milestone" }),
+    session: {
+      basePath: worktree,
+      originalBasePath: base,
+      currentMilestoneId: "M001",
+    } as DispatchContext["session"],
+  };
+  const result = await findRule(VALIDATE_RULE).match(ctx);
+
+  assert.ok(result, "rule must return a result, not null");
+  assert.strictEqual(result!.action, "skip", "trivial variant must still skip validation");
+
+  const validationPath = join(base, ".gsd", "milestones", "M001", "M001-VALIDATION.md");
+  assert.ok(existsSync(validationPath), "pass-through VALIDATION.md must be written to the project root");
+  assert.match(readFileSync(validationPath, "utf-8"), /skip_validation: true/);
+
+  const worktreeValidationPath = join(worktree, ".gsd", "milestones", "M001", "M001-VALIDATION.md");
+  assert.equal(existsSync(worktreeValidationPath), false, "missing worktree milestone projection must not receive a phantom validation");
+});
+
 test("#4781 phase 2: validate-milestone skip path does not persist gates without a real slice", async (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -19,6 +19,7 @@ import { AutoSession } from "../auto/session.ts";
 import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask, _getAdapter } from "../gsd-db.ts";
 import { invalidateAllCaches } from "../cache.ts";
 import { _clearGsdRootCache } from "../paths.ts";
+import { initMetrics, resetMetrics } from "../metrics.ts";
 
 // ─── Test Fixtures ───────────────────────────────────────────────────────────
 
@@ -91,6 +92,7 @@ function cleanupTestEnvironment(): void {
   } catch {
     // Ignore
   }
+  resetMetrics();
   try {
     rmSync(tempDir, { recursive: true, force: true });
   } catch {
@@ -163,6 +165,34 @@ function createTaskWithoutVerify(): void {
       estimate: "1h",
       files: [],
       verify: "",
+      inputs: [],
+      expectedOutput: [],
+      observabilityImpact: "",
+    },
+    sequence: 0,
+  });
+}
+
+function createFailingVerifyTask(): void {
+  insertMilestone({ id: "M001" });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Test Slice",
+    risk: "low",
+  });
+
+  insertTask({
+    id: "T01",
+    sliceId: "S01",
+    milestoneId: "M001",
+    title: "Task with failing verification",
+    status: "pending",
+    planning: {
+      description: "Task with deterministic failing verification",
+      estimate: "1h",
+      files: [],
+      verify: "node -e \"process.exit(1)\"",
       inputs: [],
       expectedOutput: [],
       observabilityImpact: "",
@@ -289,6 +319,44 @@ describe("Post-execution blocking failure retry bypass", () => {
     // On success, retry count should be cleared
     assert.equal(result, "continue");
     assert.equal(s.verificationRetryCount.has("execute-task:M001/S01/T01"), false);
+  });
+
+  test("cost spike during verification retry is warning telemetry, not the pause reason", async () => {
+    createFailingVerifyTask();
+    writePreferences({
+      enhanced_verification: true,
+      enhanced_verification_post: false,
+      verification_auto_fix: true,
+      verification_max_retries: 2,
+      per_unit_cost_cap_usd: 10,
+    });
+    writeFileSync(
+      join(tempDir, ".gsd", "metrics.json"),
+      JSON.stringify({
+        version: 1,
+        projectStartedAt: Date.now(),
+        units: [
+          { type: "execute-task", id: "M001/S01/T01", startedAt: 1, tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 1.48, toolCalls: 1, assistantMessages: 1 },
+          ...Array.from({ length: 9 }, (_, i) => ({ type: "execute-task", id: `M000/S00/T0${i}`, startedAt: 10 + i, tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0.01, toolCalls: 1, assistantMessages: 1 })),
+        ],
+      }),
+      "utf-8",
+    );
+    initMetrics(tempDir);
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
+
+    const result = await runPostUnitVerification({ s, ctx, pi }, pauseAutoMock);
+
+    assert.equal(result, "retry");
+    assert.equal(pauseAutoMock.mock.callCount(), 0);
+    assert.equal(s.pendingVerificationRetry?.unitId, "M001/S01/T01");
+    const messages = ctx.ui.notify.mock.calls.map((c: { arguments: unknown[] }) => String(c.arguments[0]));
+    assert.ok(messages.some((m: string) => m.includes("cost spike detected") && m.includes("authoritative blocker")));
+    assert.ok(messages.some((m: string) => m.includes("Verification failed") && m.includes("auto-fix attempt 1/2")));
   });
 
   test("post-exec failure notification mentions cross-task consistency", async () => {

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -15,8 +15,10 @@ import {
   isTerminalDeletedWorktreeProviderError,
   resetTransientRetryState,
   shouldDeferTransientErrorToCoreRetry,
+  suppressTerminalDeletedWorktreeMessageEnd,
 } from "../bootstrap/agent-end-recovery.ts";
 import { _buildCancelledUnitStopReason } from "../auto/phases.ts";
+import { autoSession } from "../auto-runtime-state.ts";
 import { getNextFallbackModel } from "../preferences.ts";
 // Zero-import module — imported by path rather than through the package
 // barrel to avoid pulling the full AgentSession / @gsd/pi-ai dep graph into
@@ -427,6 +429,45 @@ test("isTerminalDeletedWorktreeProviderError matches removed auto-worktree paths
     isTerminalDeletedWorktreeProviderError('Path "/Users/dev/.gsd/projects/abc123/worktrees/M005" failed with EACCES'),
     false,
   );
+});
+
+test("suppresses terminal completion deleted-worktree message before it renders", () => {
+  autoSession.reset();
+  autoSession.completionStopInProgress = true;
+  try {
+    const event = {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: 'Path "/Users/dev/.gsd/projects/abc123/worktrees/M005" does not exist',
+        content: [],
+      },
+    } as any;
+
+    assert.equal(suppressTerminalDeletedWorktreeMessageEnd(event), true);
+    assert.equal(event.message.stopReason, "completed");
+    assert.equal(event.message.errorMessage, undefined);
+    assert.deepEqual(event.message.content, []);
+  } finally {
+    autoSession.reset();
+  }
+});
+
+test("does not suppress deleted-worktree provider errors outside terminal completion", () => {
+  autoSession.reset();
+  const event = {
+    type: "message_end",
+    message: {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: 'Path "/Users/dev/.gsd/projects/abc123/worktrees/M005" does not exist',
+      content: [],
+    },
+  } as any;
+
+  assert.equal(suppressTerminalDeletedWorktreeMessageEnd(event), false);
+  assert.equal(event.message.stopReason, "error");
 });
 
 // ── resumeAutoAfterProviderDelay ────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/run-uat-replay-cap.test.ts
+++ b/src/resources/extensions/gsd/tests/run-uat-replay-cap.test.ts
@@ -36,7 +36,7 @@ function makeUatProject(): string {
   return base;
 }
 
-test("run-uat dispatch skips after three attempts without a verdict", async () => {
+test("run-uat dispatch stops after three attempts without a verdict", async () => {
   const basePath = makeUatProject();
   const rule = DISPATCH_RULES.find((r) => r.name === "run-uat (post-completion)");
   assert.ok(rule, "run-uat dispatch rule is registered");
@@ -58,8 +58,13 @@ test("run-uat dispatch skips after three attempts without a verdict", async () =
     }
 
     const capped = await rule.match(ctx as any);
-    assert.equal(capped?.action, "skip");
-    assert.equal(getUatCount(basePath, "M001", "S01"), 4);
+    assert.equal(capped?.action, "stop");
+    assert.match(capped?.reason ?? "", /retry limit reached/);
+    assert.equal(getUatCount(basePath, "M001", "S01"), 3);
+
+    const stillCapped = await rule.match(ctx as any);
+    assert.equal(stillCapped?.action, "stop");
+    assert.equal(getUatCount(basePath, "M001", "S01"), 3);
   } finally {
     rmSync(basePath, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
@@ -143,7 +143,7 @@ test("updateProgressWidget gracefully no-ops when ctx.ui lacks setHeader/setStat
 
 // ── NEXT-mode footer guidance ───────────────────────────────────────────
 
-test("auto-dashboard widget render output includes Ctrl+N guidance when isStepMode is true", (t) => {
+test("auto-dashboard widget render output includes /gsd next guidance when isStepMode is true", (t) => {
   const dir = makeTempDir("step-hint");
   mkdirSync(join(dir, ".gsd"), { recursive: true });
   t.after(() => cleanup(dir));
@@ -175,13 +175,13 @@ test("auto-dashboard widget render output includes Ctrl+N guidance when isStepMo
   const component = widgetFactory!(fakeTui, fakeTheme);
   const lines = component.render(120);
 
-  const hasStepHint = lines.some((line: string) => line.includes("Ctrl+N to advance"));
+  const hasStepHint = lines.some((line: string) => line.includes("/gsd next to advance one step"));
   assert.ok(hasStepHint, `expected step-mode hint in render output; got:\n${lines.join("\n")}`);
 
   if (component.dispose) component.dispose();
 });
 
-test("auto-dashboard widget render output omits Ctrl+N guidance when isStepMode is false", (t) => {
+test("auto-dashboard widget render output omits /gsd next guidance when isStepMode is false", (t) => {
   const dir = makeTempDir("no-step-hint");
   mkdirSync(join(dir, ".gsd"), { recursive: true });
   t.after(() => cleanup(dir));
@@ -213,7 +213,7 @@ test("auto-dashboard widget render output omits Ctrl+N guidance when isStepMode 
   const component = widgetFactory!(fakeTui, fakeTheme);
   const lines = component.render(120);
 
-  const hasStepHint = lines.some((line: string) => line.includes("Ctrl+N to advance"));
+  const hasStepHint = lines.some((line: string) => line.includes("/gsd next to advance one step"));
   assert.equal(hasStepHint, false, "step-mode hint must NOT appear when isStepMode is false");
 
   if (component.dispose) component.dispose();

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -11,6 +11,7 @@
  * projection diagnostics and do not roll back committed DB state.
  */
 
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { CompleteSliceParams } from "../types.js";
@@ -28,7 +29,7 @@ import {
   getPendingGatesForTurn,
 } from "../gsd-db.js";
 import { getGatesForTurn } from "../gate-registry.js";
-import { gsdProjectionRoot, clearPathCache } from "../paths.js";
+import { gsdProjectionRoot, clearPathCache, resolveMilestoneFile } from "../paths.js";
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { checkOwnership, sliceUnitKey } from "../unit-ownership.js";
 import { saveFile, clearParseCache } from "../files.js";
@@ -47,10 +48,9 @@ export interface CompleteSliceResult {
   summaryPath: string;
   uatPath: string;
   /**
-   * True when this call re-completed an already-closed slice from a turn
-   * superseded by timeout recovery or cancellation. Response is shaped like
-   * success so the orphaned LLM tool call unwinds cleanly without mutating
-   * state.
+   * True when this call reached an already-closed slice. Healthy duplicates
+   * and superseded stale turns return without mutation; current unhealthy
+   * duplicates repair missing/stale projections before returning.
    */
   duplicate?: boolean;
   stale?: boolean;
@@ -82,6 +82,27 @@ function sliceSummaryPath(basePath: string, milestoneId: string, sliceId: string
     sliceId,
     `${sliceId}-SUMMARY.md`,
   );
+}
+
+function hasCompleteSliceArtifactContract(basePath: string, milestoneId: string, sliceId: string): boolean {
+  clearPathCache();
+  clearParseCache();
+
+  const summaryPath = sliceSummaryPath(basePath, milestoneId, sliceId);
+  if (!existsSync(summaryPath)) return false;
+  const uatPath = summaryPath.replace(/-SUMMARY\.md$/, "-UAT.md");
+  if (!existsSync(uatPath)) return false;
+
+  const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP") ??
+    join(gsdProjectionRoot(basePath), "milestones", milestoneId, `${milestoneId}-ROADMAP.md`);
+  if (!existsSync(roadmapPath)) return false;
+
+  try {
+    const roadmap = parseRoadmap(readFileSync(roadmapPath, "utf-8"));
+    return roadmap.slices.some((slice) => slice.id === sliceId && slice.done);
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -323,6 +344,7 @@ export async function handleCompleteSlice(
   const completedAt = new Date().toISOString();
   let guardError: string | null = null;
   let existingSummaryMd = "";
+  let duplicateComplete = false;
 
   transaction(() => {
     // State machine preconditions (inside txn for atomicity).
@@ -337,11 +359,7 @@ export async function handleCompleteSlice(
     const slice = getSlice(params.milestoneId, params.sliceId);
     existingSummaryMd = slice?.full_summary_md?.trim() ?? "";
     if (slice && isClosedStatus(slice.status)) {
-      if (isStaleWrite("complete-slice")) {
-        guardError = "__stale_duplicate__";
-        return;
-      }
-      guardError = `slice ${params.sliceId} is already complete — use gsd_slice_reopen first if you need to redo it`;
+      duplicateComplete = true;
       return;
     }
 
@@ -368,22 +386,26 @@ export async function handleCompleteSlice(
     updateSliceStatus(params.milestoneId, params.sliceId, "complete", completedAt);
   });
 
-  if (guardError === "__stale_duplicate__") {
-    // Stale duplicate from a turn superseded by timeout recovery. Return a
-    // non-mutating success so the orphaned LLM tool call unwinds quietly.
+  if (duplicateComplete) {
     const staleSummaryPath = sliceSummaryPath(
       artifactBasePath,
       params.milestoneId,
       params.sliceId,
     );
-    return {
-      sliceId: params.sliceId,
-      milestoneId: params.milestoneId,
-      summaryPath: staleSummaryPath,
-      uatPath: staleSummaryPath.replace(/-SUMMARY\.md$/, "-UAT.md"),
-      duplicate: true,
-      stale: true,
-    };
+    const duplicateIsStale = isStaleWrite("complete-slice");
+    if (
+      duplicateIsStale ||
+      hasCompleteSliceArtifactContract(artifactBasePath, params.milestoneId, params.sliceId)
+    ) {
+      return {
+        sliceId: params.sliceId,
+        milestoneId: params.milestoneId,
+        summaryPath: staleSummaryPath,
+        uatPath: staleSummaryPath.replace(/-SUMMARY\.md$/, "-UAT.md"),
+        duplicate: true,
+        ...(duplicateIsStale ? { stale: true } : {}),
+      };
+    }
   }
 
   if (guardError) {
@@ -429,6 +451,7 @@ export async function handleCompleteSlice(
     await saveFile(uatPath, uatMd);
 
     const roadmap = await renderRoadmapFromDb(artifactBasePath, params.milestoneId);
+    clearParseCache();
     const roadmapSlice = parseRoadmap(roadmap.content).slices.find((slice) => slice.id === params.sliceId);
     if (!roadmapSlice?.done) {
       throw new Error(`roadmap render did not mark ${params.milestoneId}/${params.sliceId} complete`);
@@ -539,6 +562,7 @@ export async function handleCompleteSlice(
     milestoneId: params.milestoneId,
     summaryPath,
     uatPath,
+    ...(duplicateComplete ? { duplicate: true } : {}),
     ...(projectionStale ? { stale: true } : {}),
   };
 }

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -8,6 +8,7 @@ import {
   type ExecSandboxRequest,
   type ExecSandboxResult,
 } from "../exec-sandbox.js";
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import { isContextModeEnabled, type ContextModeConfig } from "../preferences-types.js";
 import { contextModeDisabledResult, type ToolExecutionResult } from "./context-mode-tool-result.js";
@@ -103,6 +104,27 @@ function pathInside(parent: string, target: string): boolean {
   return target === parent || target.startsWith(parentWithSep);
 }
 
+function comparablePathVariants(value: string): string[] {
+  const variants = new Set<string>();
+  const normalized = normalizeScanPath(path.resolve(value));
+  variants.add(normalized);
+  try {
+    variants.add(normalizeScanPath(realpathSync(normalized)));
+  } catch {
+    // Nonexistent paths are still compared lexically.
+  }
+  if (normalized.startsWith("/private/var/")) {
+    variants.add(normalized.replace(/^\/private\/var\//, "/var/"));
+  } else if (normalized.startsWith("/var/")) {
+    variants.add(`/private${normalized}`);
+  }
+  return [...variants];
+}
+
+function pathInsideAny(parents: readonly string[], targets: readonly string[]): boolean {
+  return targets.some((target) => parents.some((parent) => pathInside(parent, target)));
+}
+
 function stripWrappingQuotes(value: string): string {
   const trimmed = value.trim();
   if (trimmed.length < 2) return trimmed;
@@ -147,9 +169,11 @@ function resolvesToOriginalRootOutsideWorktree(script: string, baseDir: string):
 
   const normalizedWorktree = normalizeScanPath(path.resolve(parsed.worktreeRoot));
   const normalizedOriginalRoot = normalizeScanPath(path.resolve(parsed.originalRoot));
+  const worktreeRoots = comparablePathVariants(normalizedWorktree);
+  const originalRoots = comparablePathVariants(normalizedOriginalRoot);
   for (const value of extractPathLikeValues(script)) {
-    const resolved = normalizeScanPath(path.resolve(normalizedWorktree, value));
-    if (pathInside(normalizedOriginalRoot, resolved) && !pathInside(normalizedWorktree, resolved)) {
+    const resolved = comparablePathVariants(path.resolve(normalizedWorktree, value));
+    if (pathInsideAny(originalRoots, resolved) && !pathInsideAny(worktreeRoots, resolved)) {
       return true;
     }
   }
@@ -160,10 +184,12 @@ function scriptReferencesOriginalRootFromWorktree(script: string, baseDir: strin
   const parsed = parseWorktreeBase(baseDir);
   if (!parsed) return false;
   const normalizedScript = script.replace(/\\/g, "/");
-  const originalRootPattern = new RegExp(
-    `${escapeRegExp(parsed.originalRoot)}(?=$|[\\s'"\\\`;)&|<>]|/(?!\\.gsd/worktrees(?:/|$)))`,
-  );
-  return originalRootPattern.test(normalizedScript);
+  return comparablePathVariants(parsed.originalRoot).some((originalRoot) => {
+    const originalRootPattern = new RegExp(
+      `${escapeRegExp(originalRoot)}(?=$|[\\s'"\\\`;)&|<>]|/(?!\\.gsd/worktrees(?:/|$)))`,
+    );
+    return originalRootPattern.test(normalizedScript);
+  });
 }
 
 export async function executeGsdExec(


### PR DESCRIPTION
## TL;DR

**What:** Stabilizes GSD auto-mode closeout, retry blockers, completion display, and stale worktree error handling.
**Why:** Auto runs could loop or end on confusing stale errors after milestones merged or verification failed.
**How:** Adds explicit closeout guards, better pause reasons, retry cap behavior, stale deleted-worktree suppression during terminal completion, and keeps completion output visible.

## What

- Prevents validation skip loops and exhausted run-uat retry loops.
- Improves lease conflict and pause notices.
- Deduplicates step completion prompts.
- Preserves closeout transcript and keeps completion dashboard visible.
- Treats verification failures as the authoritative blocker when cost spikes happen during retry.
- Suppresses stale deleted-worktree message-end errors during terminal completion.
- Adds worktree/root path safety handling for `/private/var` vs `/var` path aliases.

## Why

Auto-mode should stop on the useful milestone summary and give actionable blockers, not continue into stale provider errors or retry loops.

## How

The closeout path now records clearer pause contexts, skips already-closed work, and suppresses terminal deleted-worktree errors only during completion stop cleanup.

## Verification

- Combined stack: `npm run typecheck:extensions`
- Combined stack: `npm run build:pi-coding-agent`
- Combined stack: focused GSD auto/closeout tests included in committed changes

## Change type checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
