### PR TITLE
fix(tui): render copy-clean rounded message surfaces

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
@@ -9,6 +9,7 @@ import type { AssistantMessage } from "@gsd/pi-ai";
 import { initTheme } from "../../theme/theme.js";
 import { AssistantMessageComponent } from "../assistant-message.js";
 import { formatTimestamp } from "../timestamp.js";
+import { renderAssistantRail } from "../transcript-design.js";
 
 initTheme("dark", false);
 
@@ -30,9 +31,11 @@ describe("AssistantMessageComponent open surface", () => {
 		assert.match(joined, /GSD/);
 		assert.match(joined, /gpt-test/);
 		assert.match(joined, /update the renderer/);
-		// Open surface — no rail glyph, no boxed bubble corners.
-		assert.doesNotMatch(joined, /[│┃╭╮╰╯]/, "assistant surface must use no rail or box glyphs");
-		// A titled top rule carries the GSD label.
+		assert.doesNotMatch(joined, /╰──────╮/);
+		assert.match(joined, /╭─ GSD/);
+		assert.match(joined, /╰─/);
+		assert.doesNotMatch(joined, /[│┃]/, "assistant content lines must not use side rail glyphs");
+		// A rounded titled top rule carries the GSD label.
 		assert.ok(
 			plain.some((line) => line.includes("GSD") && line.includes("─")),
 			`expected a titled top rule:\n${joined}`,
@@ -41,6 +44,27 @@ describe("AssistantMessageComponent open surface", () => {
 		const contentIndex = plain.findIndex((line) => line.includes("update the renderer"));
 		assert.ok(contentIndex > topRuleIndex + 1, `expected a breathing row before content:\n${joined}`);
 		assert.equal(plain[contentIndex + 1]?.trim(), "", `expected a breathing row after content:\n${joined}`);
+		assert.ok(plain[contentIndex].startsWith("   "), `assistant content should keep inner padding:\n${joined}`);
+		assert.doesNotMatch(
+			plain[contentIndex],
+			/^ {10,}/,
+			`assistant content should not preserve the old outer rail indent:\n${joined}`,
+		);
+		assert.equal(plain[contentIndex].length, 80, `assistant content row should fill the bubble background:\n${joined}`);
+		assert.equal(plain[contentIndex + 1]?.length, 80, `assistant breathing row should fill the bubble background:\n${joined}`);
+		assert.doesNotMatch(plain[contentIndex], /[│┃╭╮╰╯]/, `content line must stay copy-clean:\n${joined}`);
+	});
+
+	test("can render a connector only when explicitly requested", () => {
+		const standalone = renderAssistantRail(["Standalone"], 80, { label: "GSD" })
+			.map((line) => stripAnsi(line))
+			.join("\n");
+		const connected = renderAssistantRail(["Connected"], 80, { label: "GSD", connected: true })
+			.map((line) => stripAnsi(line))
+			.join("\n");
+
+		assert.doesNotMatch(standalone, /╰──────╮/);
+		assert.match(connected, /╰──────╮/);
 	});
 
 	test("renders metadata for a zero timestamp", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/user-message-design.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/user-message-design.test.ts
@@ -55,9 +55,10 @@ describe("UserMessageComponent open surface", () => {
 
 		assert.match(joined, /You/);
 		assert.match(joined, /feel like chat/);
-		// Open surface — no rail glyph, no boxed bubble corners.
-		assert.doesNotMatch(joined, /[│┃╭╮╰╯]/, "user surface must use no rail or box glyphs");
-		// A titled top rule carries the You label.
+		assert.match(joined, /╭─ You/);
+		assert.match(joined, /╰─/);
+		assert.doesNotMatch(joined, /[│┃]/, "user content lines must not use side rail glyphs");
+		// A rounded titled top rule carries the You label.
 		assert.ok(
 			joined.split("\n").some((line) => line.includes("You") && line.includes("─")),
 			`expected a titled top rule carrying the You label:\n${joined}`,
@@ -67,6 +68,9 @@ describe("UserMessageComponent open surface", () => {
 		const contentIndex = plain.findIndex((line) => line.includes("feel like chat"));
 		assert.ok(contentIndex > topRuleIndex + 1, `expected a breathing row before content:\n${joined}`);
 		assert.equal(plain[contentIndex + 1]?.trim(), "", `expected a breathing row after content:\n${joined}`);
+		assert.equal(plain[contentIndex].length, 100, `user content row should fill the bubble background:\n${joined}`);
+		assert.equal(plain[contentIndex + 1]?.length, 100, `user breathing row should fill the bubble background:\n${joined}`);
+		assert.doesNotMatch(plain[contentIndex], /[│┃╭╮╰╯]/, `content line must stay copy-clean:\n${joined}`);
 	});
 
 	test("does not inject OSC 133 zones for unsupported terminals", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
@@ -58,6 +58,35 @@ describe("Extension warning notifications", () => {
 			);
 		}
 	});
+
+	it("preserves explicit ANSI styling in info notifications", () => {
+		const chat = new Container();
+		const styled = "\x1b[32mStyled external notice\x1b[0m";
+		const result = renderExtensionNotifyInChat(chat, styled, "info");
+		const rendered = chat.render(80).join("\n");
+
+		assert.equal(result.rendered, true);
+		assert.match(rendered, /\x1b\[32mStyled external notice\x1b\[0m/);
+		assert.equal(stripAnsi(rendered).includes("Styled external notice"), true);
+	});
+
+	it("colors GSD status-card notifications with the interactive theme", () => {
+		const chat = new Container();
+		const card = [
+			"    ╭─ ✓ Verification Gate",
+			"       2/2 checks passed",
+			"    ╰────────────────────────────────────────",
+			"       Continue: /gsd next",
+		].join("\n");
+		const result = renderExtensionNotifyInChat(chat, card, "info");
+		const rendered = chat.render(100).join("\n");
+
+		assert.equal(result.rendered, true);
+		assert.ok(rendered.includes(theme.fg("success", theme.bold("✓ Verification Gate"))));
+		assert.ok(rendered.includes(theme.fg("borderAccent", "╭─")));
+		assert.ok(rendered.includes(theme.fg("success", "/gsd next")));
+		assert.match(stripAnsi(rendered), /2\/2 checks passed/);
+	});
 });
 
 describe("Blocking error banner", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/transcript-design.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/transcript-design.ts
@@ -24,6 +24,51 @@ function trimOuterBlankLines(lines: string[]): string[] {
 	return lines.slice(start, end);
 }
 
+function copyCleanRoundedSurface(
+	lines: string[],
+	width: number,
+	opts: {
+		title: string;
+		right?: string;
+		borderColor: ThemeColor;
+		bodyColor: ThemeColor;
+		paddingX?: number;
+		paddingY?: number;
+	},
+): string[] {
+	const outerWidth = Math.max(20, width);
+	const paddingX = Math.max(0, opts.paddingX ?? 3);
+	const paddingY = Math.max(0, opts.paddingY ?? 1);
+	const title = opts.title;
+	const right = opts.right ?? "";
+	const border = (text: string) => theme.fg(opts.borderColor, text);
+	const contentWidth = Math.max(1, outerWidth - paddingX);
+
+	const titleBudget = right ? Math.max(0, outerWidth - visibleWidth(right) - 9) : Math.max(0, outerWidth - 6);
+	const clippedTitle = truncateToWidth(title, titleBudget, "");
+	const clippedRight = right ? truncateToWidth(right, Math.max(0, outerWidth - visibleWidth(clippedTitle) - 9), "") : "";
+	const fixedWidth = 3 + visibleWidth(clippedTitle) + (clippedRight ? 3 + visibleWidth(clippedRight) : 0) + 1;
+	const fill = Math.max(1, outerWidth - fixedWidth);
+	const top = clippedRight
+		? border("╭─ ") + clippedTitle + border(` ${"─".repeat(fill)} `) + theme.fg("dim", clippedRight) + border("╮")
+		: border("╭─ ") + clippedTitle + border(` ${"─".repeat(fill)}╮`);
+	const bottom = border("╰" + "─".repeat(Math.max(1, outerWidth - 2)) + "╯");
+
+	const source = trimOuterBlankLines(lines);
+	const bodySource = source.length > 0 ? source : [""];
+	const blank = "";
+	const body = [
+		...Array.from({ length: paddingY }, () => blank),
+		...bodySource.map((line) =>
+			" ".repeat(paddingX) +
+			truncateToWidth(theme.fg(opts.bodyColor, line.trimEnd()), contentWidth, ""),
+		),
+		...Array.from({ length: paddingY }, () => blank),
+	];
+
+	return [top, ...body, bottom].map((line) => padRight(truncateToWidth(line, outerWidth, ""), outerWidth));
+}
+
 function toneColor(tone: StatusTone): ThemeColor {
 	switch (tone) {
 		case "running": return "toolRunning";
@@ -168,30 +213,22 @@ export function renderChatFrame(
 export function renderAssistantRail(
 	lines: string[],
 	width: number,
-	opts: { label: string; meta?: string; railColor?: ThemeColor } = { label: "GSD" },
+	opts: { label: string; meta?: string; railColor?: ThemeColor; connected?: boolean } = { label: "GSD" },
 ): string[] {
 	const railColor = opts.railColor ?? "borderAccent";
 	const source = trimOuterBlankLines(lines);
-	// Conversation turns omit the closing rule — the next turn's top rule
-	// separates them, which keeps a long transcript from filling with lines.
-	let surface = style()
-		.border("open")
-		.bottomRule(false)
-		.paddingY(1)
-		.borderColor((text) => theme.fg(railColor, text))
-		.title(theme.fg(railColor, theme.bold(opts.label)));
-	if (opts.meta) {
-		surface = surface.titleRight(theme.fg("dim", opts.meta));
-	}
-	// Inset the assistant block by two columns, as the rail did before the
-	// migration. The indent sits outside the tint; the tinted block fills
-	// the remaining width. Background colour is an SGR code, not a glyph, so
-	// it never lands in a copy selection — body lines stay copy-clean.
-	const indent = "  ";
+	const indent = "";
 	const innerWidth = Math.max(20, width - indent.length);
-	return surface
-		.render(source.length > 0 ? source : [""], innerWidth)
-		.map((line) => indent + theme.bg("customMessageBg", line));
+	const title = theme.fg(railColor, theme.bold(opts.label));
+	const surface = copyCleanRoundedSurface(source.length > 0 ? source : [""], innerWidth, {
+		title,
+		right: opts.meta,
+		borderColor: railColor,
+		bodyColor: "assistantMessageText",
+	});
+	const renderedSurface = surface.map((line) => indent + theme.bg("customMessageBg", line));
+	if (!opts.connected) return renderedSurface;
+	return [`${indent}${theme.fg(railColor, "      ╰──────╮")}`, ...renderedSurface];
 }
 
 export function renderUserRail(
@@ -200,21 +237,13 @@ export function renderUserRail(
 	opts: { label: string; meta?: string },
 ): string[] {
 	const source = trimOuterBlankLines(lines);
-	const body = (source.length > 0 ? source : [""]).map((line) =>
-		theme.fg("userMessageText", line.trimEnd()),
-	);
-	let surface = style()
-		.border("open")
-		.bottomRule(false)
-		.paddingY(1)
-		.borderColor((text) => theme.fg("border", text))
-		.title(theme.fg("border", theme.bold(opts.label)));
-	if (opts.meta) {
-		surface = surface.titleRight(theme.fg("dim", opts.meta));
-	}
-	return surface
-		.render(body, Math.max(20, width))
-		.map((line) => theme.bg("userMessageBg", line));
+	const surface = copyCleanRoundedSurface(source.length > 0 ? source : [""], Math.max(20, width), {
+		title: theme.fg("border", theme.bold(opts.label)),
+		right: opts.meta,
+		borderColor: "border",
+		bodyColor: "userMessageText",
+	});
+	return surface.map((line) => theme.bg("userMessageBg", line));
 }
 
 /**

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -199,6 +199,48 @@ export function shouldRenderExtensionNotifyInChat(type: ExtensionNotifyType): bo
 	return type !== "warning";
 }
 
+function hasAnsiStyling(message: string): boolean {
+	return /\x1b\[[0-9;]*m/.test(message);
+}
+
+function stripAnsiStyling(message: string): string {
+	return message.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function styleGsdStatusCardMessage(message: string): string | null {
+	const plain = stripAnsiStyling(message);
+	if (!/(Verification Gate|Commit|Snapshot|GSD .*Complete|Next step)/.test(plain)) return null;
+
+	const styled = plain.split("\n").map((line) => {
+		if (line.includes("╭─ ✓") || line.includes("✓ Verification Gate") || line.includes("✓ Commit") || line.includes("✓ Snapshot")) {
+			return line.replace(/(╭─)\s+(.*)/, (_match, border, title) =>
+				`${theme.fg("borderAccent", border)} ${theme.fg("success", theme.bold(title))}`);
+		}
+		if (line.includes("╭─ ✕") || line.includes("✕ Verification Gate")) {
+			return line.replace(/(╭─)\s+(.*)/, (_match, border, title) =>
+				`${theme.fg("borderAccent", border)} ${theme.fg("error", theme.bold(title))}`);
+		}
+		if (line.includes("╭─ Next step")) {
+			return line.replace(/(╭─)\s+(.*)/, (_match, border, title) =>
+				`${theme.fg("borderAccent", border)} ${theme.fg("accent", theme.bold(title))}`);
+		}
+		if (/^\s*╰/.test(line)) {
+			return theme.fg("borderAccent", line);
+		}
+		const contentMatch = /^(\s*)(.*)$/u.exec(line);
+		const indent = contentMatch?.[1] ?? "";
+		const text = contentMatch?.[2] ?? line;
+		if (/(Completed:|Next:|Continue:|Auto-run:)/.test(text)) {
+			const styled = text
+				.replace(/(Completed:|Next:|Continue:|Auto-run:)/g, (label) => theme.fg("dim", label))
+				.replace(/(\/gsd\s+(?:next|auto|status))/g, (command) => theme.fg("success", command));
+			return `${indent}${styled}`;
+		}
+		return text ? `${indent}${theme.fg("text", text)}` : line;
+	});
+	return styled.join("\n");
+}
+
 export interface ExtensionNotifyRenderResult {
 	rendered: boolean;
 	statusSpacer?: Spacer;
@@ -229,7 +271,12 @@ export function renderExtensionNotifyInChat(
 		return { rendered: true };
 	}
 
-	const statusText = new Text(theme.fg("dim", message), 1, 0);
+	const styledStatusCard = styleGsdStatusCardMessage(message);
+	const statusText = new Text(
+		styledStatusCard ?? (hasAnsiStyling(message) ? message : theme.fg("dim", message)),
+		1,
+		0,
+	);
 	chatContainer.addChild(statusText);
 	return { rendered: true, statusSpacer: spacer, statusText };
 }


### PR DESCRIPTION
## TL;DR

**What:** Renders assistant/user messages as rounded, copy-clean surfaces and styles GSD status-card notifications.
**Why:** Prior message framing made copy/paste noisy and left GSD status notices visually underpowered.
**How:** Centralizes rounded transcript rendering without side rails in content lines, and preserves/stylizes explicit status-card ANSI output.

## What

- Updates assistant and user transcript surfaces to use rounded frames with copy-clean body lines.
- Adds an explicit connected assistant rail option only when requested.
- Styles GSD verification/commit/next-step status cards in chat notifications.
- Adds tests for copy-clean body rows, full-width background rows, connector opt-in, and styled notification rendering.

## Why

The TUI needed clearer visual hierarchy without adding glyphs that pollute copied message content.

## How

A shared rounded surface renderer handles title, metadata, padding, and background fill while keeping content rows free of side rails.

## Verification

- Combined stack: `npm run build:pi-coding-agent`
- Combined stack: focused TUI component tests were included in the committed changes

## Change type checklist

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
