### PR TITLE
fix(gsd): keep completion rollup visible

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,6 +5,7 @@
 - **Auto Orchestration**: runtime coordination of GSD auto-mode units from start to completion, including dispatch and stop/resume behavior; unit-execution failure recovery is classified by the Recovery Classification module.
 - **Unit**: the smallest executable workflow step (e.g., plan slice, execute task, complete slice).
 - **Unit progression**: movement from one Unit to the next under orchestration rules.
+- **Closeout Boundary Stop**: the rule that a foreground run stops after the first task, slice, or milestone closeout boundary and leaves that closeout evidence as the visible terminal surface.
 - **Dispatch decision**: selection of the next Unit plus rationale and preconditions.
 - **Recovery decision**: retry/escalate/abort choice after runtime failure.
 - **Runtime persistence**: lock state, transition journal, and any persisted execution state required for safe resume.
@@ -63,6 +64,8 @@ Dispatch remains responsible for selecting the next Unit from reconciled state. 
 - State Reconciliation should be drift-driven. The Module surfaces terminal `blockers: string[]` and machine-actionable `DriftRecord[]`. Each pre-dispatch and pre-spawn site calls `reconcileBeforeDispatch` (strict closure). Drift catalog includes sketch-flag, merge-state, stale-render, stale-worker, unregistered-milestone, roadmap-divergence, missing-completion-timestamp. Repairs are idempotent. Re-derive is capped at 2 passes (loops only on cascading-drift success path). Persistent or repair-failed drift throws `ReconciliationFailedError` to Recovery Classification (kind `reconciliation-drift`).
 
   See `docs/dev/ADR-017-state-reconciliation-drift-driven.md`.
+
+- Foreground `/gsd next` and `/gsd auto` runs follow **Closeout Boundary Stop**: after the first durable task, slice, or milestone closeout boundary, the foreground terminal preserves the closeout transcript as the final visible surface instead of replacing it with a terminal roll-up widget. Headless runs may still emit durable terminal completion notifications/widgets for automation.
 
 ## Current implementation snapshot (phase 1)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,7 +5,7 @@
 - **Auto Orchestration**: runtime coordination of GSD auto-mode units from start to completion, including dispatch and stop/resume behavior; unit-execution failure recovery is classified by the Recovery Classification module.
 - **Unit**: the smallest executable workflow step (e.g., plan slice, execute task, complete slice).
 - **Unit progression**: movement from one Unit to the next under orchestration rules.
-- **Closeout Boundary Stop**: the rule that a foreground run stops after the first task, slice, or milestone closeout boundary and leaves that closeout evidence as the visible terminal surface.
+- **Closeout Boundary Stop**: the rule that a foreground run stops after the first task, slice, or milestone closeout boundary and leaves a durable final closeout surface visible in the live terminal, not merely scrollback or a cleared progress area.
 - **Dispatch decision**: selection of the next Unit plus rationale and preconditions.
 - **Recovery decision**: retry/escalate/abort choice after runtime failure.
 - **Runtime persistence**: lock state, transition journal, and any persisted execution state required for safe resume.

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -7,11 +7,28 @@ import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
 
 import { symlinkSync, realpathSync } from "node:fs";
 
-import { _getAdapter, closeDatabase, getSliceTasks } from "../../../src/resources/extensions/gsd/gsd-db.ts";
-import { _buildImportCandidates, registerWorkflowTools, WORKFLOW_TOOL_NAMES, validateProjectDir } from "./workflow-tools.ts";
+import {
+  _getAdapter,
+  closeDatabase,
+  getSliceTasks,
+  insertMilestone,
+  insertSlice,
+  openDatabase,
+  upsertMilestonePlanning,
+} from "../../../src/resources/extensions/gsd/gsd-db.ts";
+import { buildReassessRoadmapPrompt } from "../../../src/resources/extensions/gsd/auto-prompts.ts";
+import { invalidateAllCaches } from "../../../src/resources/extensions/gsd/cache.ts";
+import {
+  _buildBridgeImportCandidates,
+  _buildImportCandidates,
+  registerWorkflowTools,
+  WORKFLOW_TOOL_NAMES,
+  validateProjectDir,
+} from "./workflow-tools.ts";
 
 function makeTmpBase(): string {
   const base = join(tmpdir(), `gsd-mcp-workflow-${randomUUID()}`);
@@ -25,11 +42,58 @@ function cleanup(base: string): void {
   } catch {
     // swallow
   }
+  invalidateAllCaches();
   try {
     rmSync(base, { recursive: true, force: true });
   } catch {
     // swallow
   }
+}
+
+function seedContextModeFixture(base: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Context Mode", status: "active", depends_on: [] });
+  upsertMilestonePlanning("M001", {
+    title: "Context Mode",
+    status: "active",
+    vision: "Verify the bundled context-mode contract",
+    successCriteria: ["Prompt, tool, and persisted evidence surfaces agree"],
+    keyRisks: [],
+    proofStrategy: [],
+    verificationContract: "",
+    verificationIntegration: "",
+    verificationOperational: "",
+    verificationUat: "",
+    definitionOfDone: [],
+    requirementCoverage: "",
+    boundaryMapMarkdown: "",
+  });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Contract",
+    status: "complete",
+    risk: "low",
+    depends: [],
+    demo: "",
+    sequence: 1,
+  });
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    "# M001\n\n## Slices\n\n- [x] **S01: Contract** `risk:low` `depends:[]`\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
+    "# S01 Summary\n\n**Context mode contract is ready for reassessment.**\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(base, ".gsd", "last-snapshot.md"),
+    "# GSD context snapshot\n\nContext mode resume evidence.\n",
+    "utf-8",
+  );
 }
 
 function writeWriteGateSnapshot(
@@ -90,6 +154,16 @@ function cacheBustedWorkflowToolsImport(tag: string): string {
   return `./workflow-tools.${extension}?${tag}=${randomUUID()}`;
 }
 
+const workflowBridgeExtension = import.meta.url.includes("/dist-test/") ? "js" : "ts";
+process.env.GSD_WORKFLOW_EXECUTORS_MODULE ??= fileURLToPath(new URL(
+  `../../../src/resources/extensions/gsd/tools/workflow-tool-executors.${workflowBridgeExtension}`,
+  import.meta.url,
+));
+process.env.GSD_WORKFLOW_WRITE_GATE_MODULE ??= fileURLToPath(new URL(
+  `../../../src/resources/extensions/gsd/bootstrap/write-gate.${workflowBridgeExtension}`,
+  import.meta.url,
+));
+
 describe("workflow MCP tools", () => {
   it("registers the full headless-safe workflow tool surface", () => {
     const server = makeMockServer();
@@ -115,7 +189,7 @@ describe("workflow MCP tools", () => {
     assert.ok("reason" in taskReopen.params);
   });
 
-  it("prefers source TypeScript before compiled dist fallbacks", () => {
+  it("prefers source TypeScript for generic local module imports", () => {
     assert.deepEqual(
       _buildImportCandidates("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js"),
       [
@@ -123,6 +197,18 @@ describe("workflow MCP tools", () => {
         "../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js",
         "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.ts",
         "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.js",
+      ],
+    );
+  });
+
+  it("prefers compiled runtime bridge modules before source fallbacks", () => {
+    assert.deepEqual(
+      _buildBridgeImportCandidates("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js"),
+      [
+        "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.js",
+        "../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.ts",
+        "../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js",
+        "../../../src/resources/extensions/gsd/tools/workflow-tool-executors.ts",
       ],
     );
   });
@@ -333,6 +419,94 @@ describe("workflow MCP tools", () => {
 
       assertToolError(result, /context_mode\.enabled: false/);
       assert.equal((result as any).structuredContent.error, "context_mode_disabled");
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("Context Mode contract is wired through prompts, MCP tools, persisted evidence, and disabled-mode blocking", async () => {
+    const base = makeTmpBase();
+    try {
+      seedContextModeFixture(base);
+      invalidateAllCaches();
+
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const execTool = server.tools.find((t) => t.name === "gsd_exec");
+      const searchTool = server.tools.find((t) => t.name === "gsd_exec_search");
+      const resumeTool = server.tools.find((t) => t.name === "gsd_resume");
+      assert.ok(execTool, "exec tool should be registered");
+      assert.ok(searchTool, "exec search tool should be registered");
+      assert.ok(resumeTool, "resume tool should be registered");
+
+      const prompt = await buildReassessRoadmapPrompt("M001", "Context Mode", "S01", base);
+      assert.match(prompt, /## Context Mode/);
+      assert.match(prompt, /Lane: \*\*planning lane\*\*/);
+      assert.match(prompt, /## Context Snapshot/);
+      assert.match(prompt, /Context mode resume evidence/);
+      assert.ok(
+        prompt.indexOf("## Context Mode") < prompt.indexOf("## Context Snapshot"),
+        "prompt should explain Context Mode before injecting the snapshot",
+      );
+
+      const execResult = await execTool!.handler({
+        projectDir: base,
+        runtime: "node",
+        script: "console.log('context-contract-e2e');",
+        purpose: "context-contract-e2e",
+      });
+      assert.equal((execResult as any).isError, false);
+      assert.equal((execResult as any).structuredContent.operation, "gsd_exec");
+      assert.ok(existsSync((execResult as any).structuredContent.stdout_path), "stdout should be persisted");
+
+      const searchResult = await searchTool!.handler({
+        projectDir: base,
+        query: "context-contract-e2e",
+      });
+      assert.equal((searchResult as any).structuredContent.operation, "gsd_exec_search");
+      assert.equal((searchResult as any).structuredContent.matches, 1);
+      assert.equal(
+        (searchResult as any).structuredContent.results[0].stdout_path,
+        (execResult as any).structuredContent.stdout_path,
+        "search should rediscover the persisted exec evidence instead of rerunning it",
+      );
+
+      const resumeResult = await resumeTool!.handler({ projectDir: base });
+      assert.deepEqual((resumeResult as any).structuredContent, {
+        operation: "gsd_resume",
+        found: true,
+        bytes: Buffer.byteLength("# GSD context snapshot\n\nContext mode resume evidence.\n", "utf-8"),
+      });
+      assert.match((resumeResult as any).content[0].text as string, /Context mode resume evidence/);
+
+      const worktree = join(base, ".gsd", "worktrees", "M001");
+      mkdirSync(worktree, { recursive: true });
+      const rootSafetyResult = await execTool!.handler({
+        projectDir: worktree,
+        runtime: "node",
+        script: `console.log(${JSON.stringify(base)});`,
+      });
+      assertToolError(rootSafetyResult, /original project root/);
+
+      writeFileSync(
+        join(base, ".gsd", "PREFERENCES.md"),
+        "---\ncontext_mode:\n  enabled: false\n---\n",
+        "utf-8",
+      );
+      invalidateAllCaches();
+
+      const disabledPrompt = await buildReassessRoadmapPrompt("M001", "Context Mode", "S01", base);
+      assert.doesNotMatch(disabledPrompt, /## Context Mode|## Context Snapshot|Context mode resume evidence/);
+
+      for (const [tool, args] of [
+        [execTool, { projectDir: base, runtime: "node", script: "console.log('blocked');" }],
+        [searchTool, { projectDir: base, query: "context-contract-e2e" }],
+        [resumeTool, { projectDir: base }],
+      ] as const) {
+        const result = await tool!.handler(args);
+        assertToolError(result, /context_mode\.enabled: false/);
+        assert.equal((result as any).structuredContent.error, "context_mode_disabled");
+      }
     } finally {
       cleanup(base);
     }

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -547,6 +547,29 @@ function buildImportCandidates(relativePath: string): string[] {
   return [...new Set(candidates)];
 }
 
+function buildBridgeImportCandidates(relativePath: string): string[] {
+  const candidates: string[] = [];
+  const pushCompiledThenSource = (path: string | null) => {
+    if (!path) return;
+    candidates.push(path);
+    if (path.endsWith(".js")) candidates.push(path.replace(/\.js$/, ".ts"));
+  };
+
+  const sourcePath = relativePath.includes("/dist/")
+    ? relativePath.replace("/dist/", "/src/")
+    : relativePath;
+  const distPath = relativePath.includes("/src/")
+    ? relativePath.replace("/src/", "/dist/")
+    : relativePath.includes("/dist/")
+      ? relativePath
+      : null;
+
+  pushCompiledThenSource(distPath);
+  pushCompiledThenSource(sourcePath);
+
+  return [...new Set(candidates)];
+}
+
 function getWriteGateModuleCandidates(): string[] {
   const candidates: string[] = [];
   const explicitModule = process.env.GSD_WORKFLOW_WRITE_GATE_MODULE?.trim();
@@ -559,7 +582,7 @@ function getWriteGateModuleCandidates(): string[] {
   }
 
   candidates.push(
-    ...buildImportCandidates("../../../src/resources/extensions/gsd/bootstrap/write-gate.js")
+    ...buildBridgeImportCandidates("../../../src/resources/extensions/gsd/bootstrap/write-gate.js")
       .map((p) => new URL(p, import.meta.url).href),
   );
 
@@ -594,6 +617,11 @@ export function _buildImportCandidates(relativePath: string): string[] {
   // variant, before falling back to compiled dist. In source/dev execution a
   // stale dist/resources tree must not silently override edited source files.
   return buildImportCandidates(relativePath);
+}
+
+/** @internal — exported for testing only */
+export function _buildBridgeImportCandidates(relativePath: string): string[] {
+  return buildBridgeImportCandidates(relativePath);
 }
 
 async function importLocalModule<T>(relativePath: string): Promise<T> {
@@ -637,7 +665,7 @@ function getWorkflowExecutorModuleCandidates(env: NodeJS.ProcessEnv = process.en
   }
 
   candidates.push(
-    ...buildImportCandidates("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js")
+    ...buildBridgeImportCandidates("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js")
       .map((p) => new URL(p, import.meta.url).href),
   );
 

--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/assistant-message-design.test.ts
@@ -9,6 +9,7 @@ import type { AssistantMessage } from "@gsd/pi-ai";
 import { initTheme } from "../../theme/theme.js";
 import { AssistantMessageComponent } from "../assistant-message.js";
 import { formatTimestamp } from "../timestamp.js";
+import { renderAssistantRail } from "../transcript-design.js";
 
 initTheme("dark", false);
 
@@ -30,9 +31,11 @@ describe("AssistantMessageComponent open surface", () => {
 		assert.match(joined, /GSD/);
 		assert.match(joined, /gpt-test/);
 		assert.match(joined, /update the renderer/);
-		// Open surface — no rail glyph, no boxed bubble corners.
-		assert.doesNotMatch(joined, /[│┃╭╮╰╯]/, "assistant surface must use no rail or box glyphs");
-		// A titled top rule carries the GSD label.
+		assert.doesNotMatch(joined, /╰──────╮/);
+		assert.match(joined, /╭─ GSD/);
+		assert.match(joined, /╰─/);
+		assert.doesNotMatch(joined, /[│┃]/, "assistant content lines must not use side rail glyphs");
+		// A rounded titled top rule carries the GSD label.
 		assert.ok(
 			plain.some((line) => line.includes("GSD") && line.includes("─")),
 			`expected a titled top rule:\n${joined}`,
@@ -41,6 +44,27 @@ describe("AssistantMessageComponent open surface", () => {
 		const contentIndex = plain.findIndex((line) => line.includes("update the renderer"));
 		assert.ok(contentIndex > topRuleIndex + 1, `expected a breathing row before content:\n${joined}`);
 		assert.equal(plain[contentIndex + 1]?.trim(), "", `expected a breathing row after content:\n${joined}`);
+		assert.ok(plain[contentIndex].startsWith("   "), `assistant content should keep inner padding:\n${joined}`);
+		assert.doesNotMatch(
+			plain[contentIndex],
+			/^ {10,}/,
+			`assistant content should not preserve the old outer rail indent:\n${joined}`,
+		);
+		assert.equal(plain[contentIndex].length, 80, `assistant content row should fill the bubble background:\n${joined}`);
+		assert.equal(plain[contentIndex + 1]?.length, 80, `assistant breathing row should fill the bubble background:\n${joined}`);
+		assert.doesNotMatch(plain[contentIndex], /[│┃╭╮╰╯]/, `content line must stay copy-clean:\n${joined}`);
+	});
+
+	test("can render a connector only when explicitly requested", () => {
+		const standalone = renderAssistantRail(["Standalone"], 80, { label: "GSD" })
+			.map((line) => stripAnsi(line))
+			.join("\n");
+		const connected = renderAssistantRail(["Connected"], 80, { label: "GSD", connected: true })
+			.map((line) => stripAnsi(line))
+			.join("\n");
+
+		assert.doesNotMatch(standalone, /╰──────╮/);
+		assert.match(connected, /╰──────╮/);
 	});
 
 	test("renders metadata for a zero timestamp", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/user-message-design.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/user-message-design.test.ts
@@ -55,9 +55,10 @@ describe("UserMessageComponent open surface", () => {
 
 		assert.match(joined, /You/);
 		assert.match(joined, /feel like chat/);
-		// Open surface — no rail glyph, no boxed bubble corners.
-		assert.doesNotMatch(joined, /[│┃╭╮╰╯]/, "user surface must use no rail or box glyphs");
-		// A titled top rule carries the You label.
+		assert.match(joined, /╭─ You/);
+		assert.match(joined, /╰─/);
+		assert.doesNotMatch(joined, /[│┃]/, "user content lines must not use side rail glyphs");
+		// A rounded titled top rule carries the You label.
 		assert.ok(
 			joined.split("\n").some((line) => line.includes("You") && line.includes("─")),
 			`expected a titled top rule carrying the You label:\n${joined}`,
@@ -67,6 +68,9 @@ describe("UserMessageComponent open surface", () => {
 		const contentIndex = plain.findIndex((line) => line.includes("feel like chat"));
 		assert.ok(contentIndex > topRuleIndex + 1, `expected a breathing row before content:\n${joined}`);
 		assert.equal(plain[contentIndex + 1]?.trim(), "", `expected a breathing row after content:\n${joined}`);
+		assert.equal(plain[contentIndex].length, 100, `user content row should fill the bubble background:\n${joined}`);
+		assert.equal(plain[contentIndex + 1]?.length, 100, `user breathing row should fill the bubble background:\n${joined}`);
+		assert.doesNotMatch(plain[contentIndex], /[│┃╭╮╰╯]/, `content line must stay copy-clean:\n${joined}`);
 	});
 
 	test("does not inject OSC 133 zones for unsupported terminals", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-card-cleanup-and-success-runtime.test.ts
@@ -58,6 +58,35 @@ describe("Extension warning notifications", () => {
 			);
 		}
 	});
+
+	it("preserves explicit ANSI styling in info notifications", () => {
+		const chat = new Container();
+		const styled = "\x1b[32mStyled external notice\x1b[0m";
+		const result = renderExtensionNotifyInChat(chat, styled, "info");
+		const rendered = chat.render(80).join("\n");
+
+		assert.equal(result.rendered, true);
+		assert.match(rendered, /\x1b\[32mStyled external notice\x1b\[0m/);
+		assert.equal(stripAnsi(rendered).includes("Styled external notice"), true);
+	});
+
+	it("colors GSD status-card notifications with the interactive theme", () => {
+		const chat = new Container();
+		const card = [
+			"    ╭─ ✓ Verification Gate",
+			"       2/2 checks passed",
+			"    ╰────────────────────────────────────────",
+			"       Continue: /gsd next",
+		].join("\n");
+		const result = renderExtensionNotifyInChat(chat, card, "info");
+		const rendered = chat.render(100).join("\n");
+
+		assert.equal(result.rendered, true);
+		assert.ok(rendered.includes(theme.fg("success", theme.bold("✓ Verification Gate"))));
+		assert.ok(rendered.includes(theme.fg("borderAccent", "╭─")));
+		assert.ok(rendered.includes(theme.fg("success", "/gsd next")));
+		assert.match(stripAnsi(rendered), /2\/2 checks passed/);
+	});
 });
 
 describe("Blocking error banner", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/transcript-design.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/transcript-design.ts
@@ -24,6 +24,51 @@ function trimOuterBlankLines(lines: string[]): string[] {
 	return lines.slice(start, end);
 }
 
+function copyCleanRoundedSurface(
+	lines: string[],
+	width: number,
+	opts: {
+		title: string;
+		right?: string;
+		borderColor: ThemeColor;
+		bodyColor: ThemeColor;
+		paddingX?: number;
+		paddingY?: number;
+	},
+): string[] {
+	const outerWidth = Math.max(20, width);
+	const paddingX = Math.max(0, opts.paddingX ?? 3);
+	const paddingY = Math.max(0, opts.paddingY ?? 1);
+	const title = opts.title;
+	const right = opts.right ?? "";
+	const border = (text: string) => theme.fg(opts.borderColor, text);
+	const contentWidth = Math.max(1, outerWidth - paddingX);
+
+	const titleBudget = right ? Math.max(0, outerWidth - visibleWidth(right) - 9) : Math.max(0, outerWidth - 6);
+	const clippedTitle = truncateToWidth(title, titleBudget, "");
+	const clippedRight = right ? truncateToWidth(right, Math.max(0, outerWidth - visibleWidth(clippedTitle) - 9), "") : "";
+	const fixedWidth = 3 + visibleWidth(clippedTitle) + (clippedRight ? 3 + visibleWidth(clippedRight) : 0) + 1;
+	const fill = Math.max(1, outerWidth - fixedWidth);
+	const top = clippedRight
+		? border("╭─ ") + clippedTitle + border(` ${"─".repeat(fill)} `) + theme.fg("dim", clippedRight) + border("╮")
+		: border("╭─ ") + clippedTitle + border(` ${"─".repeat(fill)}╮`);
+	const bottom = border("╰" + "─".repeat(Math.max(1, outerWidth - 2)) + "╯");
+
+	const source = trimOuterBlankLines(lines);
+	const bodySource = source.length > 0 ? source : [""];
+	const blank = "";
+	const body = [
+		...Array.from({ length: paddingY }, () => blank),
+		...bodySource.map((line) =>
+			" ".repeat(paddingX) +
+			truncateToWidth(theme.fg(opts.bodyColor, line.trimEnd()), contentWidth, ""),
+		),
+		...Array.from({ length: paddingY }, () => blank),
+	];
+
+	return [top, ...body, bottom].map((line) => padRight(truncateToWidth(line, outerWidth, ""), outerWidth));
+}
+
 function toneColor(tone: StatusTone): ThemeColor {
 	switch (tone) {
 		case "running": return "toolRunning";
@@ -168,30 +213,22 @@ export function renderChatFrame(
 export function renderAssistantRail(
 	lines: string[],
 	width: number,
-	opts: { label: string; meta?: string; railColor?: ThemeColor } = { label: "GSD" },
+	opts: { label: string; meta?: string; railColor?: ThemeColor; connected?: boolean } = { label: "GSD" },
 ): string[] {
 	const railColor = opts.railColor ?? "borderAccent";
 	const source = trimOuterBlankLines(lines);
-	// Conversation turns omit the closing rule — the next turn's top rule
-	// separates them, which keeps a long transcript from filling with lines.
-	let surface = style()
-		.border("open")
-		.bottomRule(false)
-		.paddingY(1)
-		.borderColor((text) => theme.fg(railColor, text))
-		.title(theme.fg(railColor, theme.bold(opts.label)));
-	if (opts.meta) {
-		surface = surface.titleRight(theme.fg("dim", opts.meta));
-	}
-	// Inset the assistant block by two columns, as the rail did before the
-	// migration. The indent sits outside the tint; the tinted block fills
-	// the remaining width. Background colour is an SGR code, not a glyph, so
-	// it never lands in a copy selection — body lines stay copy-clean.
-	const indent = "  ";
+	const indent = "";
 	const innerWidth = Math.max(20, width - indent.length);
-	return surface
-		.render(source.length > 0 ? source : [""], innerWidth)
-		.map((line) => indent + theme.bg("customMessageBg", line));
+	const title = theme.fg(railColor, theme.bold(opts.label));
+	const surface = copyCleanRoundedSurface(source.length > 0 ? source : [""], innerWidth, {
+		title,
+		right: opts.meta,
+		borderColor: railColor,
+		bodyColor: "assistantMessageText",
+	});
+	const renderedSurface = surface.map((line) => indent + theme.bg("customMessageBg", line));
+	if (!opts.connected) return renderedSurface;
+	return [`${indent}${theme.fg(railColor, "      ╰──────╮")}`, ...renderedSurface];
 }
 
 export function renderUserRail(
@@ -200,21 +237,13 @@ export function renderUserRail(
 	opts: { label: string; meta?: string },
 ): string[] {
 	const source = trimOuterBlankLines(lines);
-	const body = (source.length > 0 ? source : [""]).map((line) =>
-		theme.fg("userMessageText", line.trimEnd()),
-	);
-	let surface = style()
-		.border("open")
-		.bottomRule(false)
-		.paddingY(1)
-		.borderColor((text) => theme.fg("border", text))
-		.title(theme.fg("border", theme.bold(opts.label)));
-	if (opts.meta) {
-		surface = surface.titleRight(theme.fg("dim", opts.meta));
-	}
-	return surface
-		.render(body, Math.max(20, width))
-		.map((line) => theme.bg("userMessageBg", line));
+	const surface = copyCleanRoundedSurface(source.length > 0 ? source : [""], Math.max(20, width), {
+		title: theme.fg("border", theme.bold(opts.label)),
+		right: opts.meta,
+		borderColor: "border",
+		bodyColor: "userMessageText",
+	});
+	return surface.map((line) => theme.bg("userMessageBg", line));
 }
 
 /**

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -199,6 +199,48 @@ export function shouldRenderExtensionNotifyInChat(type: ExtensionNotifyType): bo
 	return type !== "warning";
 }
 
+function hasAnsiStyling(message: string): boolean {
+	return /\x1b\[[0-9;]*m/.test(message);
+}
+
+function stripAnsiStyling(message: string): string {
+	return message.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function styleGsdStatusCardMessage(message: string): string | null {
+	const plain = stripAnsiStyling(message);
+	if (!/(Verification Gate|Commit|Snapshot|GSD .*Complete|Next step)/.test(plain)) return null;
+
+	const styled = plain.split("\n").map((line) => {
+		if (line.includes("╭─ ✓") || line.includes("✓ Verification Gate") || line.includes("✓ Commit") || line.includes("✓ Snapshot")) {
+			return line.replace(/(╭─)\s+(.*)/, (_match, border, title) =>
+				`${theme.fg("borderAccent", border)} ${theme.fg("success", theme.bold(title))}`);
+		}
+		if (line.includes("╭─ ✕") || line.includes("✕ Verification Gate")) {
+			return line.replace(/(╭─)\s+(.*)/, (_match, border, title) =>
+				`${theme.fg("borderAccent", border)} ${theme.fg("error", theme.bold(title))}`);
+		}
+		if (line.includes("╭─ Next step")) {
+			return line.replace(/(╭─)\s+(.*)/, (_match, border, title) =>
+				`${theme.fg("borderAccent", border)} ${theme.fg("accent", theme.bold(title))}`);
+		}
+		if (/^\s*╰/.test(line)) {
+			return theme.fg("borderAccent", line);
+		}
+		const contentMatch = /^(\s*)(.*)$/u.exec(line);
+		const indent = contentMatch?.[1] ?? "";
+		const text = contentMatch?.[2] ?? line;
+		if (/(Completed:|Next:|Continue:|Auto-run:)/.test(text)) {
+			const styled = text
+				.replace(/(Completed:|Next:|Continue:|Auto-run:)/g, (label) => theme.fg("dim", label))
+				.replace(/(\/gsd\s+(?:next|auto|status))/g, (command) => theme.fg("success", command));
+			return `${indent}${styled}`;
+		}
+		return text ? `${indent}${theme.fg("text", text)}` : line;
+	});
+	return styled.join("\n");
+}
+
 export interface ExtensionNotifyRenderResult {
 	rendered: boolean;
 	statusSpacer?: Spacer;
@@ -229,7 +271,12 @@ export function renderExtensionNotifyInChat(
 		return { rendered: true };
 	}
 
-	const statusText = new Text(theme.fg("dim", message), 1, 0);
+	const styledStatusCard = styleGsdStatusCardMessage(message);
+	const statusText = new Text(
+		styledStatusCard ?? (hasAnsiStyling(message) ? message : theme.fg("dim", message)),
+		1,
+		0,
+	);
 	chatContainer.addChild(statusText);
 	return { rendered: true, statusSpacer: spacer, statusText };
 }

--- a/scripts/__tests__/summarize-prompt-context.test.cjs
+++ b/scripts/__tests__/summarize-prompt-context.test.cjs
@@ -1,0 +1,92 @@
+// Project/App: GSD-2
+// File Purpose: Regression tests for the prompt-context debug log summarizer.
+
+const assert = require("node:assert/strict");
+const { mkdtempSync, writeFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  collectLogFiles,
+  formatSummary,
+  parsePromptContextEvents,
+  summarizeEvents,
+} = require("../summarize-prompt-context.cjs");
+
+test("parsePromptContextEvents reads only prompt-context JSONL events", () => {
+  const text = [
+    JSON.stringify({ event: "autoLoop", phase: "enter" }),
+    JSON.stringify({
+      event: "prompt-context",
+      unitType: "execute-task",
+      finalChars: 1200,
+      loaded: [{ key: "task-plan", mode: "inline", chars: 500 }],
+      skipped: [{ key: "knowledge", reason: "missing" }],
+    }),
+    "not json prompt-context",
+  ].join("\n");
+
+  const events = parsePromptContextEvents(text, "debug.log");
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].unitType, "execute-task");
+  assert.equal(events[0].source, "debug.log");
+  assert.equal(events[0].line, 2);
+});
+
+test("summarizeEvents aggregates prompt sizes and loaded block costs", () => {
+  const units = summarizeEvents([
+    {
+      event: "prompt-context",
+      unitType: "plan-slice",
+      finalChars: 1000,
+      loaded: [
+        { key: "templates", mode: "inline", chars: 700 },
+        { key: "decisions", mode: "on-demand", chars: 100 },
+      ],
+      skipped: [{ key: "knowledge", reason: "missing" }],
+    },
+    {
+      event: "prompt-context",
+      unitType: "plan-slice",
+      finalChars: 2000,
+      loaded: [{ key: "templates", mode: "inline", chars: 800 }],
+      skipped: [{ key: "knowledge", reason: "missing" }],
+    },
+  ]);
+
+  assert.equal(units.length, 1);
+  assert.equal(units[0].count, 2);
+  assert.equal(units[0].avgFinalChars, 1500);
+  assert.equal(units[0].maxFinalChars, 2000);
+  assert.equal(units[0].loaded[0].key, "templates");
+  assert.equal(units[0].loaded[0].totalChars, 1500);
+  assert.equal(units[0].skipped[0].key, "knowledge");
+  assert.equal(units[0].skipped[0].count, 2);
+});
+
+test("formatSummary renders a compact operator report", () => {
+  const output = formatSummary(summarizeEvents([
+    {
+      event: "prompt-context",
+      unitType: "complete-milestone",
+      finalChars: 16000,
+      loaded: [{ key: "project", mode: "inline", chars: 2500 }],
+      skipped: [],
+    },
+  ]));
+
+  assert.match(output, /Prompt Context Summary/);
+  assert.match(output, /complete-milestone/);
+  assert.match(output, /project \[inline\] total 2\.5K/);
+});
+
+test("collectLogFiles accepts a debug directory", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "gsd-prompt-context-"));
+  const logPath = path.join(dir, "debug-example.log");
+  writeFileSync(logPath, "");
+  writeFileSync(path.join(dir, "notes.txt"), "");
+
+  assert.deepEqual(collectLogFiles([dir]), [logPath]);
+});

--- a/scripts/summarize-prompt-context.cjs
+++ b/scripts/summarize-prompt-context.cjs
@@ -1,0 +1,182 @@
+// Project/App: GSD-2
+// File Purpose: Summarize prompt-context debug events from GSD debug logs.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function formatChars(value) {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(Math.round(value));
+}
+
+function parsePromptContextEvents(text, source = "<memory>") {
+  const events = [];
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.includes('"event":"prompt-context"') && !line.includes("prompt-context")) continue;
+    try {
+      const event = JSON.parse(line);
+      if (event && event.event === "prompt-context") {
+        events.push({ ...event, source, line: i + 1 });
+      }
+    } catch {
+      // Ignore non-JSON diagnostic lines that happen to mention prompt-context.
+    }
+  }
+  return events;
+}
+
+function addBlock(map, block) {
+  const key = `${block.key || "unknown"}:${block.mode || "unknown"}`;
+  const current = map.get(key) || {
+    key: block.key || "unknown",
+    mode: block.mode || "unknown",
+    count: 0,
+    totalChars: 0,
+    maxChars: 0,
+    reasons: new Map(),
+  };
+  const chars = Number(block.chars) || 0;
+  current.count += 1;
+  current.totalChars += chars;
+  current.maxChars = Math.max(current.maxChars, chars);
+  if (block.reason) {
+    current.reasons.set(block.reason, (current.reasons.get(block.reason) || 0) + 1);
+  }
+  map.set(key, current);
+}
+
+function addSkipped(map, skipped) {
+  const key = skipped.key || "unknown";
+  const current = map.get(key) || { key, count: 0, reasons: new Map() };
+  current.count += 1;
+  if (skipped.reason) {
+    current.reasons.set(skipped.reason, (current.reasons.get(skipped.reason) || 0) + 1);
+  }
+  map.set(key, current);
+}
+
+function summarizeEvents(events) {
+  const units = new Map();
+  for (const event of events) {
+    const unitType = event.unitType || "unknown";
+    const unit = units.get(unitType) || {
+      unitType,
+      count: 0,
+      totalFinalChars: 0,
+      maxFinalChars: 0,
+      loaded: new Map(),
+      skipped: new Map(),
+    };
+    const finalChars = Number(event.finalChars) || 0;
+    unit.count += 1;
+    unit.totalFinalChars += finalChars;
+    unit.maxFinalChars = Math.max(unit.maxFinalChars, finalChars);
+    for (const block of Array.isArray(event.loaded) ? event.loaded : []) addBlock(unit.loaded, block);
+    for (const skipped of Array.isArray(event.skipped) ? event.skipped : []) addSkipped(unit.skipped, skipped);
+    units.set(unitType, unit);
+  }
+
+  return [...units.values()]
+    .map(unit => ({
+      ...unit,
+      avgFinalChars: unit.count > 0 ? unit.totalFinalChars / unit.count : 0,
+      loaded: [...unit.loaded.values()].sort((a, b) => b.totalChars - a.totalChars),
+      skipped: [...unit.skipped.values()].sort((a, b) => b.count - a.count),
+    }))
+    .sort((a, b) => b.maxFinalChars - a.maxFinalChars);
+}
+
+function formatReasons(reasons) {
+  const items = [...reasons.entries()].sort((a, b) => b[1] - a[1]);
+  if (items.length === 0) return "";
+  return ` (${items.map(([reason, count]) => `${reason} x${count}`).join(", ")})`;
+}
+
+function formatSummary(units, options = {}) {
+  const maxBlocks = options.maxBlocks || 8;
+  const lines = ["Prompt Context Summary"];
+  if (units.length === 0) {
+    lines.push("No prompt-context events found.");
+    return lines.join("\n");
+  }
+
+  const eventCount = units.reduce((sum, unit) => sum + unit.count, 0);
+  lines.push(`Events: ${eventCount}`);
+  lines.push("");
+  lines.push("Unit type                 Events  Avg prompt  Max prompt");
+  lines.push("------------------------  ------  ----------  ----------");
+  for (const unit of units) {
+    lines.push(
+      `${unit.unitType.padEnd(24)}  ${String(unit.count).padStart(6)}  ${formatChars(unit.avgFinalChars).padStart(10)}  ${formatChars(unit.maxFinalChars).padStart(10)}`,
+    );
+  }
+
+  for (const unit of units) {
+    lines.push("");
+    lines.push(`${unit.unitType}`);
+    for (const block of unit.loaded.slice(0, maxBlocks)) {
+      lines.push(
+        `  ${block.key} [${block.mode}] total ${formatChars(block.totalChars)}, max ${formatChars(block.maxChars)}, count ${block.count}${formatReasons(block.reasons)}`,
+      );
+    }
+    if (unit.skipped.length > 0) {
+      lines.push(`  skipped: ${unit.skipped.map(item => `${item.key} x${item.count}${formatReasons(item.reasons)}`).join("; ")}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function collectLogFiles(inputs) {
+  const files = [];
+  for (const input of inputs) {
+    if (!fs.existsSync(input)) continue;
+    const stat = fs.statSync(input);
+    if (stat.isDirectory()) {
+      for (const file of fs.readdirSync(input)) {
+        if (file.startsWith("debug-") && file.endsWith(".log")) files.push(path.join(input, file));
+      }
+    } else if (stat.isFile()) {
+      files.push(input);
+    }
+  }
+  return [...new Set(files)].sort();
+}
+
+function summarizeFiles(files) {
+  const events = [];
+  for (const file of files) {
+    events.push(...parsePromptContextEvents(fs.readFileSync(file, "utf8"), file));
+  }
+  return summarizeEvents(events);
+}
+
+function main(argv) {
+  const inputs = argv.slice(2);
+  if (inputs.length === 0) {
+    console.error("Usage: node scripts/summarize-prompt-context.cjs <debug.log|debug-dir> [...]");
+    process.exitCode = 1;
+    return;
+  }
+  const files = collectLogFiles(inputs);
+  if (files.length === 0) {
+    console.error("No debug log files found.");
+    process.exitCode = 1;
+    return;
+  }
+  console.log(formatSummary(summarizeFiles(files)));
+}
+
+if (require.main === module) main(process.argv);
+
+module.exports = {
+  collectLogFiles,
+  formatSummary,
+  parsePromptContextEvents,
+  summarizeEvents,
+  summarizeFiles,
+};

--- a/src/resources/extensions/gsd/auto-budget.ts
+++ b/src/resources/extensions/gsd/auto-budget.ts
@@ -41,3 +41,14 @@ export function getUnitCostSpikeAction(
   if (!Number.isFinite(multiplier) || multiplier <= 0) return "none";
   return unitCostUsd >= (rollingAvgUsd * multiplier) ? "pause" : "none";
 }
+
+export function getContextPauseAction(
+  contextPercent: number | null | undefined,
+  thresholdPercent: number | null | undefined,
+): "none" | "pause" {
+  if (!Number.isFinite(contextPercent ?? NaN)) return "none";
+  if (!Number.isFinite(thresholdPercent ?? NaN)) return "none";
+  const threshold = thresholdPercent as number;
+  if (threshold <= 0) return "none";
+  return (contextPercent as number) >= threshold ? "pause" : "none";
+}

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -966,7 +966,7 @@ export function updateProgressWidget(
         lines.push("");
         // Step-mode guidance — shown above keyboard hints when auto is paused
         if (accessors.isStepMode()) {
-          lines.push(`${pad}${theme.fg("accent", "→")} ${theme.fg("dim", "Ctrl+N to advance to next step  ·  /gsd status for overview")}`);
+          lines.push(`${pad}${theme.fg("accent", "→")} ${theme.fg("dim", "/gsd next to advance one step  ·  /gsd status for overview")}`);
         }
 
         // Hints line
@@ -1000,9 +1000,8 @@ export function setCompletionProgressWidget(
   snapshot: CompletionDashboardSnapshot,
 ): void {
   if (!ctx.hasUI) return;
-  const widgetKey = snapshot.allMilestonesComplete ? "gsd-outcome" : "gsd-progress";
-  const clearedWidgetKey = snapshot.allMilestonesComplete ? "gsd-progress" : "gsd-outcome";
-  ctx.ui.setWidget(clearedWidgetKey, undefined);
+  const widgetKey = "gsd-progress";
+  ctx.ui.setWidget("gsd-outcome", undefined);
 
   if (typeof ctx.ui?.setHeader === "function") {
     ctx.ui.setHeader(() => ({

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -619,13 +619,18 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (!needsRunUat) return null;
       const { sliceId, uatType } = needsRunUat;
 
-      // Cap run-uat dispatch attempts to prevent infinite replay (#3624)
-      const attempts = incrementUatCount(basePath, mid, sliceId);
-      if (attempts > MAX_UAT_ATTEMPTS) {
+      // Cap run-uat dispatch attempts to prevent infinite replay (#3624).
+      // Check before incrementing so an exhausted counter cannot create a
+      // no-progress skip loop that starves later dispatch rules.
+      const attempts = getUatCount(basePath, mid, sliceId);
+      if (attempts >= MAX_UAT_ATTEMPTS) {
         return {
-          action: "skip" as const,
+          action: "stop" as const,
+          reason: `Cannot dispatch run-uat for ${mid}/${sliceId}: retry limit reached after ${attempts} attempt(s) without a PASS assessment. Fix the underlying UAT/tool issue, reset the retry counter with /gsd doctor --fix, then rerun /gsd auto.`,
+          level: "warning" as const,
         };
       }
+      incrementUatCount(basePath, mid, sliceId);
       const uatFile = resolveSliceFile(basePath, mid, sliceId, "UAT")!;
       const uatContent = await loadFile(uatFile);
       return {

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -90,6 +90,7 @@ import { insertMilestoneValidationGates } from "./milestone-validation-gates.js"
 import { nativeHasChanges, nativeIsRepo, _resetHasChangesCache } from "./native-git-bridge.js";
 import { debugLog, isDebugEnabled } from "./debug-logger.js";
 import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
+import { resolveWorktreeProjectRoot } from "./worktree-root.js";
 import { listUnmergedGitPaths } from "./git-conflict-state.js";
 import { runTurnGitAction } from "./git-service.js";
 import { parseUnitId } from "./unit-id.js";
@@ -1449,7 +1450,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "validating-milestone → validate-milestone",
-    match: async ({ state, mid, midTitle, basePath, prefs }) => {
+    match: async ({ state, mid, midTitle, basePath, prefs, session }) => {
       if (state.phase !== "validating-milestone") return null;
 
       // Safety guard (#1368): verify all roadmap slices have SUMMARY files before
@@ -1476,70 +1477,78 @@ export const DISPATCH_RULES: DispatchRule[] = [
 
       // Skip preference OR trivial scope: write a minimal pass-through VALIDATION file.
       if (prefs?.phases?.skip_milestone_validation || trivialVariant) {
-        const mDir = resolveMilestonePath(basePath, mid);
-        if (mDir) {
-          if (!existsSync(mDir)) mkdirSync(mDir, { recursive: true });
-          const validationPath = join(
-            mDir,
-            buildMilestoneFileName(mid, "VALIDATION"),
-          );
-          const skipSource = trivialVariant
-            ? "trivial-scope pipeline variant"
-            : "`skip_milestone_validation` preference";
-          const skipValidationReason = trivialVariant ? "trivial-scope" : "preference";
-          const content = [
-            "---",
-            "verdict: pass",
-            "skip_validation: true",
-            `skip_validation_reason: ${skipValidationReason}`,
-            "remediation_round: 0",
-            "---",
-            "",
-            "# Milestone Validation (skipped)",
-            "",
-            `Milestone validation was skipped via ${skipSource}.`,
-          ].join("\n");
-          writeFileSync(validationPath, content, "utf-8");
-          try {
-            // DB-backed state derivation keys off assessments, not only the file
-            // projection. Persist the skipped validation there too so the next
-            // loop iteration advances to completing-milestone instead of
-            // re-entering validating-milestone.
-            if (isDbAvailable()) {
-              transaction(() => {
-                insertAssessment({
-                  path: validationPath,
-                  milestoneId: mid,
-                  sliceId: null,
-                  taskId: null,
-                  status: "pass",
-                  scope: "milestone-validation",
-                  fullContent: content,
-                });
-                const gateSliceId = getMilestoneSlices(mid)[0]?.id;
-                if (gateSliceId) {
-                  insertMilestoneValidationGates(
-                    mid,
-                    gateSliceId,
-                    "pass",
-                    new Date().toISOString(),
-                  );
-                }
-              });
-            }
-          } catch (err) {
-            try {
-              unlinkSync(validationPath);
-            } catch (unlinkErr) {
-              logWarning(
-                "dispatch",
-                `failed to remove skipped validation file after DB write failure for ${mid}: ${unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr)}`,
-              );
-            }
-            throw err;
-          }
-          invalidateAllCaches();
+        const artifactBasePath = resolveArtifactBasePath(basePath, mid, session);
+        const projectRoot = resolveWorktreeProjectRoot(basePath, session?.originalBasePath);
+        const mDir = resolveMilestonePath(artifactBasePath, mid) ??
+          (projectRoot !== artifactBasePath ? resolveMilestonePath(projectRoot, mid) : null);
+        if (!mDir) {
+          return {
+            action: "stop",
+            reason: `Cannot skip milestone validation for ${mid}: milestone artifacts are missing under ${artifactBasePath}. Run /gsd doctor before resuming auto-mode.`,
+            level: "warning",
+          };
         }
+        if (!existsSync(mDir)) mkdirSync(mDir, { recursive: true });
+        const validationPath = join(
+          mDir,
+          buildMilestoneFileName(mid, "VALIDATION"),
+        );
+        const skipSource = trivialVariant
+          ? "trivial-scope pipeline variant"
+          : "`skip_milestone_validation` preference";
+        const skipValidationReason = trivialVariant ? "trivial-scope" : "preference";
+        const content = [
+          "---",
+          "verdict: pass",
+          "skip_validation: true",
+          `skip_validation_reason: ${skipValidationReason}`,
+          "remediation_round: 0",
+          "---",
+          "",
+          "# Milestone Validation (skipped)",
+          "",
+          `Milestone validation was skipped via ${skipSource}.`,
+        ].join("\n");
+        writeFileSync(validationPath, content, "utf-8");
+        try {
+          // DB-backed state derivation keys off assessments, not only the file
+          // projection. Persist the skipped validation there too so the next
+          // loop iteration advances to completing-milestone instead of
+          // re-entering validating-milestone.
+          if (isDbAvailable()) {
+            transaction(() => {
+              insertAssessment({
+                path: validationPath,
+                milestoneId: mid,
+                sliceId: null,
+                taskId: null,
+                status: "pass",
+                scope: "milestone-validation",
+                fullContent: content,
+              });
+              const gateSliceId = getMilestoneSlices(mid)[0]?.id;
+              if (gateSliceId) {
+                insertMilestoneValidationGates(
+                  mid,
+                  gateSliceId,
+                  "pass",
+                  new Date().toISOString(),
+                );
+              }
+            });
+          }
+        } catch (err) {
+          try {
+            unlinkSync(validationPath);
+          } catch (unlinkErr) {
+            logWarning(
+              "dispatch",
+              `failed to remove skipped validation file after DB write failure for ${mid}: ${unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr)}`,
+            );
+          }
+          throw err;
+        }
+        invalidateAllCaches();
         return { action: "skip" };
       }
       return {

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -78,6 +78,7 @@ import { writeTurnGitTransaction } from "./uok/gitops.js";
 import { isClosedStatus } from "./status-guards.js";
 import { detectAbandonMilestone } from "./abandon-detect.js";
 import { isDeterministicPolicyError } from "./auto-tool-tracking.js";
+import { formatConnectedStepStack, formatPostUnitStatusCard } from "./auto-status-message.js";
 import {
   clearProjectResearchInflightMarker,
   finalizeProjectResearchTimeout,
@@ -423,6 +424,8 @@ import {
   updateSliceProgressCache,
   unitVerb,
   describeNextUnit,
+  setAutoOutcomeWidget,
+  type AutoOutcomeSurfaceSnapshot,
 } from "./auto-dashboard.js";
 import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync } from "node:fs";
 import { join, relative } from "node:path";
@@ -553,16 +556,83 @@ export function detectRogueFileWrites(
  */
 export const MAX_ARTIFACT_VERIFICATION_RETRIES = 3;
 
-export const STEP_COMPLETE_FALLBACK_MESSAGE =
-  "Step complete. Run /gsd next to continue one step, or /gsd auto to run continuously.";
+function buildStepCompleteCallout(
+  currentUnit?: NonNullable<AutoSession["currentUnit"]> | null,
+): string {
+  const isTask = currentUnit?.type === "execute-task";
+  const completedLabel = currentUnit ? `${unitVerb(currentUnit.type)} ${currentUnit.id}` : "Step complete";
+  return formatConnectedStepStack(`✓ GSD ${isTask ? "Task" : "Step"} Complete`, completedLabel);
+}
+
+export const STEP_COMPLETE_FALLBACK_MESSAGE = buildStepCompleteCallout();
 
 export function buildStepCompleteMessage(nextState: import("./types.js").GSDState): string | null {
   if (nextState.phase === "complete") {
     return null;
   }
+  return buildStepCompleteCallout();
+}
+
+function buildStepCompleteMessageForUnit(
+  nextState: import("./types.js").GSDState,
+  currentUnit?: NonNullable<AutoSession["currentUnit"]> | null,
+): string | null {
+  if (nextState.phase === "complete") {
+    return null;
+  }
+  return buildStepCompleteCallout(currentUnit);
+}
+
+export function buildStepCompleteOutcome(
+  nextState: import("./types.js").GSDState,
+  currentUnit?: NonNullable<AutoSession["currentUnit"]> | null,
+): AutoOutcomeSurfaceSnapshot | null {
+  if (nextState.phase === "complete") {
+    return null;
+  }
   const next = describeNextUnit(nextState);
-  return `Step complete. Next: ${next.label}\n`
-    + `Run /gsd next to continue one step, or /gsd auto to run continuously.`;
+  return {
+    status: "step",
+    title: "Step complete",
+    detail: `Next: ${next.label}.`,
+    unitLabel: currentUnit ? `${unitVerb(currentUnit.type)} ${currentUnit.id}` : null,
+    nextAction: "Advance one step, or resume automatic mode.",
+    commands: ["/gsd next", "/gsd auto", "/gsd status for overview"],
+  };
+}
+
+export function setStepCompleteSurface(
+  ctx: ExtensionContext,
+  nextState: import("./types.js").GSDState,
+  currentUnit?: NonNullable<AutoSession["currentUnit"]> | null,
+): string | null {
+  const outcome = buildStepCompleteOutcome(nextState, currentUnit);
+  if (!outcome) {
+    return null;
+  }
+  if (ctx.hasUI && typeof ctx.ui?.setWidget === "function") {
+    ctx.ui.setWidget("gsd-progress", undefined);
+  }
+  setAutoOutcomeWidget(ctx, outcome);
+  return buildStepCompleteMessageForUnit(nextState, currentUnit);
+}
+
+export function setStepCompleteFallbackSurface(
+  ctx: ExtensionContext,
+  currentUnit?: NonNullable<AutoSession["currentUnit"]> | null,
+): string {
+  if (ctx.hasUI && typeof ctx.ui?.setWidget === "function") {
+    ctx.ui.setWidget("gsd-progress", undefined);
+  }
+  setAutoOutcomeWidget(ctx, {
+    status: "step",
+    title: "Step complete",
+    detail: "State refresh failed after the unit completed.",
+    unitLabel: currentUnit ? `${unitVerb(currentUnit.type)} ${currentUnit.id}` : null,
+    nextAction: "Inspect state, then advance one step or resume automatic mode.",
+    commands: ["/gsd status for overview", "/gsd next", "/gsd auto"],
+  });
+  return buildStepCompleteCallout(currentUnit);
 }
 
 /**
@@ -665,7 +735,7 @@ export async function autoCommitUnit(
 
     const commitMsg = autoCommitCurrentBranch(basePath, unitType, unitId, taskContext);
     if (commitMsg) {
-      ctx?.ui.notify(`Committed: ${commitMsg.split("\n")[0]}`, "info");
+      ctx?.ui.notify(formatPostUnitStatusCard("✓ Commit", commitMsg.split("\n")[0]), "info");
     }
     return commitMsg;
   } catch (e) {
@@ -819,9 +889,9 @@ async function runCloseoutGitAction(
       s.lastGitActionStatus = "ok";
 
       if (turnAction === "commit" && gitResult.commitMessage) {
-        ctx.ui.notify(`Committed: ${gitResult.commitMessage.split("\n")[0]}`, "info");
+        ctx.ui.notify(formatPostUnitStatusCard("✓ Commit", gitResult.commitMessage.split("\n")[0]), "info");
       } else if (turnAction === "snapshot" && gitResult.snapshotLabel) {
-        ctx.ui.notify(`Snapshot recorded: ${gitResult.snapshotLabel}`, "info");
+        ctx.ui.notify(formatPostUnitStatusCard("✓ Snapshot", gitResult.snapshotLabel), "info");
       }
     }
   } catch (e) {
@@ -2077,11 +2147,11 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
     try {
       const nextState = await deriveState(s.canonicalProjectRoot);
       phaseAfterUnit = nextState.phase;
-      const message = buildStepCompleteMessage(nextState);
+      const message = setStepCompleteSurface(ctx, nextState, s.currentUnit);
       if (message) ctx.ui.notify(message, "info");
     } catch (e) {
       debugLog("postUnit", { phase: "step-wizard-notify", error: String(e) });
-      ctx.ui.notify(STEP_COMPLETE_FALLBACK_MESSAGE, "info");
+      ctx.ui.notify(setStepCompleteFallbackSurface(ctx, s.currentUnit), "info");
     }
     return shouldReturnStepWizardAfterUnit(s.currentUnit?.type, phaseAfterUnit)
       ? "step-wizard"

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -37,7 +37,7 @@ import {
 } from "./gate-registry.js";
 import { formatDecisionsCompact, formatRequirementsCompact } from "./structured-data-formatter.js";
 import { readPhaseAnchor, formatAnchorForPrompt } from "./phase-anchor.js";
-import { composeContextModeInstructions, composeInlinedContext, type ArtifactResolver, type ContextModeRenderMode } from "./unit-context-composer.js";
+import { composeContextModeInstructions, composeInlinedContext, composeUnitContext, type ArtifactResolver, type ContextModeRenderMode, type ExcerptResolver } from "./unit-context-composer.js";
 import { readCompactionSnapshot } from "./compaction-snapshot.js";
 import { logWarning } from "./workflow-logger.js";
 import { inlineGraphSubgraph } from "./graph-context.js";
@@ -45,6 +45,7 @@ import { buildExtractionStepsBlock } from "./commands-extract-learnings.js";
 import { resolveSkillManifest, warnIfManifestHasMissingSkills } from "./skill-manifest.js";
 import { classifyProject, type ProjectClassification } from "./detection.js";
 import { hasBrowserRequiredText } from "./browser-evidence.js";
+import { debugLog } from "./debug-logger.js";
 
 // ─── Preamble Cap ─────────────────────────────────────────────────────────────
 
@@ -196,6 +197,51 @@ function capPreamble(preamble: string): string {
   const budget = Math.min(MAX_PREAMBLE_CHARS, resolvePromptBudgets().inlineContextBudgetChars);
   if (preamble.length <= budget) return preamble;
   return truncateAtSectionBoundary(preamble, budget).content;
+}
+
+type PromptContextMode = "inline" | "excerpt" | "on-demand" | "skipped";
+
+interface PromptContextTelemetryEntry {
+  readonly key: string;
+  readonly mode: PromptContextMode;
+  readonly chars: number;
+  readonly reason?: string;
+}
+
+function trackPromptContext(
+  entries: PromptContextTelemetryEntry[],
+  key: string,
+  mode: PromptContextMode,
+  body: string | null | undefined,
+  reason?: string,
+): void {
+  entries.push({
+    key,
+    mode,
+    chars: body?.length ?? 0,
+    ...(reason ? { reason } : {}),
+  });
+}
+
+function emitPromptContextTelemetry(
+  unitType: string,
+  entries: readonly PromptContextTelemetryEntry[],
+  finalBody: string,
+): void {
+  debugLog("prompt-context", {
+    unitType,
+    finalChars: finalBody.length,
+    loaded: entries.filter((entry) => entry.mode !== "skipped").map((entry) => ({
+      key: entry.key,
+      mode: entry.mode,
+      chars: entry.chars,
+      ...(entry.reason ? { reason: entry.reason } : {}),
+    })),
+    skipped: entries.filter((entry) => entry.mode === "skipped").map((entry) => ({
+      key: entry.key,
+      reason: entry.reason ?? "not applicable",
+    })),
+  });
 }
 
 function renderContextModeForPrompt(
@@ -657,6 +703,34 @@ export async function buildSliceSummaryExcerpt(
   }
 }
 
+export async function buildSliceAssessmentExcerpt(
+  absPath: string | null, relPath: string, sid: string,
+): Promise<string | null> {
+  const content = absPath ? await loadFile(absPath) : null;
+  if (!content) return null;
+
+  const verdict = extractVerdict(content);
+  const edgeCases = extractMarkdownSection(content, "Edge Cases");
+  const checksMatch = content.match(/\b(\d+\s*\/\s*\d+)\s+checks?\s+passed\b/i);
+  const lines = [
+    `### ${sid} Assessment (excerpt)`,
+    `Source: \`${relPath}\``,
+    "",
+  ];
+  if (verdict) lines.push(`**Verdict:** \`${verdict.toUpperCase()}\``);
+  if (checksMatch) lines.push(`**Checks:** ${checksMatch[1]} passed`);
+  if (edgeCases?.trim()) {
+    const trimmed = edgeCases.trim();
+    lines.push(
+      "",
+      "#### Edge cases",
+      trimmed.length > 600 ? `${trimmed.slice(0, 600)}\n… (truncated — see full \`${relPath}\`)` : trimmed,
+    );
+  }
+  lines.push("", `> **On-demand:** read \`${relPath}\` only if validation needs full UAT assessment detail.`);
+  return lines.join("\n");
+}
+
 export async function buildTaskSummaryExcerpt(
   absPath: string | null, relPath: string, tid: string, options?: { blocker?: boolean },
 ): Promise<string> {
@@ -905,6 +979,30 @@ export async function inlineProjectFromDb(
     logWarning("prompt", `inlineProjectFromDb failed: ${err instanceof Error ? err.message : String(err)}`);
   }
   return inlineGsdRootFile(base, "project.md", "Project");
+}
+
+function onDemandProjectBlock(reason: string): string {
+  return [
+    "### On-demand Project Context",
+    "",
+    `Project context is available at \`${relGsdRootFile("PROJECT")}\`. Read it only if ${reason}.`,
+  ].join("\n");
+}
+
+function onDemandDecisionsBlock(reason: string): string {
+  return [
+    "### On-demand Decisions",
+    "",
+    `Decision records are available at \`${relGsdRootFile("DECISIONS")}\`. Read them only if ${reason}.`,
+  ].join("\n");
+}
+
+function onDemandMilestoneContextBlock(contextRel: string, reason: string): string {
+  return [
+    "### On-demand Milestone Context",
+    "",
+    `Milestone context is available at \`${contextRel}\`. Read it only if ${reason}.`,
+  ].join("\n");
 }
 
 // ─── Stopwords for keyword extraction ─────────────────────────────────────
@@ -1801,61 +1899,92 @@ export async function buildDiscussRequirementsPrompt(
 }
 
 export async function buildResearchMilestonePrompt(mid: string, midTitle: string, base: string): Promise<string> {
-  // #4782 phase 3: research-milestone migrated through the composer.
-  // Declared inline order: milestone-context, project, requirements,
-  // decisions, templates. Knowledge stays outside the composer
-  // (budget-driven, scoped by keyword extraction — future phase folds
-  // policy-driven blocks in).
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
+
+  // Keep research milestone prompts focused on the milestone brief and
+  // research template. Project-wide docs stay on-demand instead of being
+  // loaded at the start of every milestone.
   const resolveArtifact: ArtifactResolver = async (key) => {
     switch (key) {
       case "milestone-context": {
         const p = resolveMilestoneFile(base, mid, "CONTEXT");
         const r = relMilestoneFile(base, mid, "CONTEXT");
-        return await inlineFile(p, r, "Milestone Context");
+        const body = await inlineFile(p, r, "Milestone Context");
+        trackPromptContext(contextTelemetry, "milestone-context", "inline", body);
+        return body;
       }
       case "project":
-        return await inlineProjectFromDb(base);
       case "requirements":
-        return await inlineRequirementsFromDb(base, mid);
       case "decisions":
-        return await inlineDecisionsFromDb(base, mid);
-      case "templates":
-        return inlineTemplate("research", "Research");
+        trackPromptContext(contextTelemetry, key, "skipped", null, "handled as on-demand path");
+        return null;
+      case "templates": {
+        const body = inlineTemplate("research", "Research");
+        trackPromptContext(contextTelemetry, "templates", "inline", body);
+        return body;
+      }
       default:
         return null;
     }
   };
 
-  const composed = await composeInlinedContext("research-milestone", resolveArtifact);
+  const composed = await composeUnitContext("research-milestone", {
+    base: { unitType: "research-milestone", basePath: base, milestoneId: mid },
+    resolveArtifact,
+  });
 
   // Knowledge block stays outside the composer — budgeted, scoped via
-  // keyword extraction (#4719). Inserted between decisions and the
-  // templates block to match the pre-migration output order. We split
-  // the composer output around the templates section to preserve that
-  // ordering.
+  // keyword extraction (#4719). Inserted before the template so research
+  // instructions remain the final contract in the preloaded block.
   const knowledgeInlineRM = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
   const parts: string[] = [];
-  if (knowledgeInlineRM && composed) {
-    // Insert knowledge before the template block so the overall order is:
-    //   milestone-context → project → requirements → decisions → KNOWLEDGE → research template
-    const idx = composed.lastIndexOf("### Output Template:");
+  if (composed.prepend) parts.push(composed.prepend);
+  if (knowledgeInlineRM && composed.inline) {
+    const idx = composed.inline.lastIndexOf("### Output Template:");
     if (idx > 0) {
-      const before = composed.slice(0, idx).replace(/\n\n---\n\n$/, "");
-      const after = composed.slice(idx);
+      const before = composed.inline.slice(0, idx).replace(/\n\n---\n\n$/, "");
+      const after = composed.inline.slice(idx);
       parts.push(before, knowledgeInlineRM, after);
     } else {
-      parts.push(composed, knowledgeInlineRM);
+      parts.push(composed.inline, knowledgeInlineRM);
     }
-  } else if (composed) {
-    parts.push(composed);
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInlineRM);
+  } else if (composed.inline) {
+    parts.push(composed.inline);
     if (knowledgeInlineRM) parts.push(knowledgeInlineRM);
+    trackPromptContext(contextTelemetry, "knowledge", knowledgeInlineRM ? "inline" : "skipped", knowledgeInlineRM, knowledgeInlineRM ? undefined : "missing");
+  } else {
+    trackPromptContext(contextTelemetry, "knowledge", knowledgeInlineRM ? "inline" : "skipped", knowledgeInlineRM, knowledgeInlineRM ? undefined : "missing");
   }
+
+  const onDemandDocs = [
+    "### On-demand Planning Context",
+    "",
+    "Broader project context is available if the research needs it. Read only the specific source that answers the question:",
+    "",
+    `- \`${relGsdRootFile("PROJECT")}\` — product/project narrative`,
+    `- \`${relGsdRootFile("REQUIREMENTS")}\` — requirement status and acceptance criteria`,
+    `- \`${relGsdRootFile("DECISIONS")}\` — active architecture/product decisions`,
+  ].join("\n");
+  parts.push(onDemandDocs);
+  trackPromptContext(contextTelemetry, "project,requirements,decisions", "on-demand", onDemandDocs);
+
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
 
   const inlinedContext = prependContextModeToBlock(
     "research-milestone",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("research-milestone", contextTelemetry, inlinedContext);
 
   const outputRelPath = relMilestoneFile(base, mid, "RESEARCH");
   return loadPrompt("research-milestone", {
@@ -1884,26 +2013,80 @@ export async function buildPlanMilestonePrompt(mid: string, midTitle: string, ba
   const researchRel = relMilestoneFile(base, mid, "RESEARCH");
 
   const inlined: string[] = [];
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
+  const pushTracked = (key: string, body: string, reason?: string): void => {
+    inlined.push(body);
+    trackPromptContext(contextTelemetry, key, "inline", body, reason);
+  };
 
   // Inject phase handoff anchor from research phase (if available)
   const researchAnchor = readPhaseAnchor(base, mid, "research-milestone");
-  if (researchAnchor) inlined.push(formatAnchorForPrompt(researchAnchor));
+  if (researchAnchor) {
+    pushTracked("research-anchor", formatAnchorForPrompt(researchAnchor));
+  } else {
+    trackPromptContext(contextTelemetry, "research-anchor", "skipped", null, "missing");
+  }
 
-  inlined.push(formatProjectClassificationForPlanning(classifyProject(base)));
+  pushTracked("project-classification", formatProjectClassificationForPlanning(classifyProject(base)));
 
-  inlined.push(await inlineFile(contextPath, contextRel, "Milestone Context"));
+  pushTracked("milestone-context", await inlineFile(contextPath, contextRel, "Milestone Context"));
   const researchInline = await inlineFileOptional(researchPath, researchRel, "Milestone Research");
-  if (researchInline) inlined.push(researchInline);
+  if (researchInline) {
+    pushTracked("milestone-research", researchInline);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-research", "skipped", null, "missing");
+  }
   const { inlinePriorMilestoneSummary } = await import("./files.js");
   const priorSummaryInline = await inlinePriorMilestoneSummary(mid, base);
-  if (priorSummaryInline) inlined.push(priorSummaryInline);
-  if (inlineLevel !== "minimal") {
+  if (priorSummaryInline) {
+    pushTracked("prior-milestone-summary", priorSummaryInline);
+  } else {
+    trackPromptContext(contextTelemetry, "prior-milestone-summary", "skipped", null, "missing");
+  }
+  if (inlineLevel === "full") {
     const projectInline = await inlineProjectFromDb(base);
-    if (projectInline) inlined.push(projectInline);
+    if (projectInline) {
+      pushTracked("project", projectInline, inlineLevel);
+    } else {
+      trackPromptContext(contextTelemetry, "project", "skipped", null, "missing");
+    }
     const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
-    if (requirementsInline) inlined.push(requirementsInline);
+    if (requirementsInline) {
+      pushTracked("requirements", requirementsInline, inlineLevel);
+    } else {
+      trackPromptContext(contextTelemetry, "requirements", "skipped", null, "missing");
+    }
     const decisionsInline = await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
-    if (decisionsInline) inlined.push(decisionsInline);
+    if (decisionsInline) {
+      pushTracked("decisions", decisionsInline, inlineLevel);
+    } else {
+      trackPromptContext(contextTelemetry, "decisions", "skipped", null, "missing");
+    }
+  } else if (inlineLevel === "standard") {
+    trackPromptContext(contextTelemetry, "project", "skipped", null, "handled as on-demand path");
+    const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
+    if (requirementsInline) {
+      pushTracked("requirements", requirementsInline, inlineLevel);
+    } else {
+      trackPromptContext(contextTelemetry, "requirements", "skipped", null, "missing");
+    }
+    trackPromptContext(contextTelemetry, "decisions", "skipped", null, "handled as on-demand path");
+  } else {
+    trackPromptContext(contextTelemetry, "project", "skipped", null, "handled as on-demand path");
+    trackPromptContext(contextTelemetry, "requirements", "skipped", null, "minimal inline level");
+    trackPromptContext(contextTelemetry, "decisions", "skipped", null, "handled as on-demand path");
+  }
+  if (inlineLevel !== "full") {
+    const onDemandDocs = [
+      "### On-demand Planning Context",
+      "",
+      "Broader project context is available if roadmap planning needs it. Read only the source that answers the planning question:",
+      "",
+      `- \`${relGsdRootFile("PROJECT")}\` - product/project narrative`,
+      `- \`${relGsdRootFile("DECISIONS")}\` - active architecture/product decisions`,
+    ].join("\n");
+    inlined.push(onDemandDocs);
+    trackPromptContext(contextTelemetry, "project,decisions", "on-demand", onDemandDocs);
   }
   const queuePath = resolveGsdRootFile(base, "QUEUE");
   if (existsSync(queuePath)) {
@@ -1913,28 +2096,44 @@ export async function buildPlanMilestonePrompt(mid: string, midTitle: string, ba
       "Project Queue",
       `${mid} ${midTitle}`,
     );
-    inlined.push(queueInline);
+    pushTracked("project-queue", queueInline);
+  } else {
+    trackPromptContext(contextTelemetry, "project-queue", "skipped", null, "missing");
   }
   // Scoped + budgeted — see issue #4719
   const knowledgeInlinePM = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
-  if (knowledgeInlinePM) inlined.push(knowledgeInlinePM);
-  inlined.push(inlineTemplate("roadmap", "Roadmap"));
+  if (knowledgeInlinePM) {
+    pushTracked("knowledge", knowledgeInlinePM);
+  } else {
+    trackPromptContext(contextTelemetry, "knowledge", "skipped", null, "missing");
+  }
+  pushTracked("templates", inlineTemplate("roadmap", "Roadmap"));
   if (inlineLevel === "full") {
-    inlined.push(inlineTemplate("decisions", "Decisions"));
-    inlined.push(inlineTemplate("plan", "Slice Plan"));
-    inlined.push(inlineTemplate("task-plan", "Task Plan"));
-    inlined.push(inlineTemplate("secrets-manifest", "Secrets Manifest"));
+    pushTracked("templates", inlineTemplate("decisions", "Decisions"));
+    pushTracked("templates", inlineTemplate("plan", "Slice Plan"));
+    pushTracked("templates", inlineTemplate("task-plan", "Task Plan"));
+    pushTracked("templates", inlineTemplate("secrets-manifest", "Secrets Manifest"));
   } else if (inlineLevel === "standard") {
-    inlined.push(inlineTemplate("decisions", "Decisions"));
-    inlined.push(inlineTemplate("plan", "Slice Plan"));
-    inlined.push(inlineTemplate("task-plan", "Task Plan"));
+    pushTracked("templates", inlineTemplate("decisions", "Decisions"));
+    pushTracked("templates", inlineTemplate("plan", "Slice Plan"));
+    pushTracked("templates", inlineTemplate("task-plan", "Task Plan"));
   }
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "plan-milestone",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("plan-milestone", contextTelemetry, inlinedContext);
 
   const outputRelPath = relMilestoneFile(base, mid, "ROADMAP");
   const researchOutputPath = join(base, relMilestoneFile(base, mid, "RESEARCH"));
@@ -1976,52 +2175,119 @@ export async function buildResearchSlicePrompt(
   const sliceContextRel = relSliceFile(base, mid, sid, "CONTEXT");
 
   const inlined: string[] = [];
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
 
   // Use roadmap excerpt instead of full roadmap for context reduction
   const roadmapExcerptRS = await inlineRoadmapExcerpt(base, mid, sid);
   if (roadmapExcerptRS) {
     inlined.push(roadmapExcerptRS);
+    trackPromptContext(contextTelemetry, "roadmap", "excerpt", roadmapExcerptRS);
   } else {
     // Fall back to full roadmap if excerpt fails
-    inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
+    const roadmapInline = await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap");
+    inlined.push(roadmapInline);
+    trackPromptContext(contextTelemetry, "roadmap", "inline", roadmapInline, "excerpt unavailable");
   }
 
   const contextInline = await inlineFileOptional(contextPath, contextRel, "Milestone Context");
-  if (contextInline) inlined.push(contextInline);
+  if (contextInline) {
+    inlined.push(contextInline);
+    trackPromptContext(contextTelemetry, "milestone-context", "inline", contextInline);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-context", "skipped", null, "missing");
+  }
   const sliceCtxInline = await inlineFileOptional(sliceContextPath, sliceContextRel, "Slice Context (from discussion)");
-  if (sliceCtxInline) inlined.push(sliceCtxInline);
+  if (sliceCtxInline) {
+    inlined.push(sliceCtxInline);
+    trackPromptContext(contextTelemetry, "slice-context", "inline", sliceCtxInline);
+  } else {
+    trackPromptContext(contextTelemetry, "slice-context", "skipped", null, "missing");
+  }
   const researchInline = await inlineFileOptional(milestoneResearchPath, milestoneResearchRel, "Milestone Research");
-  if (researchInline) inlined.push(researchInline);
+  if (researchInline) {
+    inlined.push(researchInline);
+    trackPromptContext(contextTelemetry, "milestone-research", "inline", researchInline);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-research", "skipped", null, "missing");
+  }
 
   // Derive scope from slice title for decision filtering (R005)
   const derivedScope = deriveSliceScope(sTitle);
-  const decisionsInline = await inlineDecisionsFromDb(base, mid, derivedScope);
-  if (decisionsInline) inlined.push(decisionsInline);
+  if (derivedScope) {
+    const decisionsInline = await inlineDecisionsFromDb(base, mid, derivedScope);
+    if (decisionsInline) {
+      inlined.push(decisionsInline);
+      trackPromptContext(contextTelemetry, "decisions", "inline", decisionsInline, `scope:${derivedScope}`);
+    } else {
+      trackPromptContext(contextTelemetry, "decisions", "skipped", null, `no scoped decisions for ${derivedScope}`);
+    }
+  } else {
+    const onDemandDecisions = [
+      "### On-demand Decisions",
+      "",
+      `No specific decision scope was derived from "${sTitle}". Read \`${relGsdRootFile("DECISIONS")}\` only if research needs prior architecture/product decisions.`,
+    ].join("\n");
+    inlined.push(onDemandDecisions);
+    trackPromptContext(contextTelemetry, "decisions", "on-demand", onDemandDecisions, "no derived scope");
+  }
   const requirementsInline = await inlineRequirementsFromDb(base, mid, sid);
-  if (requirementsInline) inlined.push(requirementsInline);
+  if (requirementsInline) {
+    inlined.push(requirementsInline);
+    trackPromptContext(contextTelemetry, "requirements", "inline", requirementsInline);
+  } else {
+    trackPromptContext(contextTelemetry, "requirements", "skipped", null, "missing");
+  }
 
   // Use scoped knowledge based on slice title keywords
   const keywords = extractKeywords(sTitle);
   const knowledgeInlineRS = await inlineKnowledgeScoped(base, keywords);
-  if (knowledgeInlineRS) inlined.push(knowledgeInlineRS);
+  if (knowledgeInlineRS) {
+    inlined.push(knowledgeInlineRS);
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInlineRS);
+  } else {
+    trackPromptContext(contextTelemetry, "knowledge", "skipped", null, "missing");
+  }
 
   // Knowledge graph: subgraph for this slice (graceful — skipped if no graph.json)
   const graphBlockRS = await inlineGraphSubgraph(base, `${sid} ${sTitle}`, { budget: 3000 });
-  if (graphBlockRS) inlined.push(graphBlockRS);
+  if (graphBlockRS) {
+    inlined.push(graphBlockRS);
+    trackPromptContext(contextTelemetry, "graph-subgraph", "inline", graphBlockRS);
+  } else {
+    trackPromptContext(contextTelemetry, "graph-subgraph", "skipped", null, "missing");
+  }
 
-  inlined.push(inlineTemplate("research", "Research"));
+  const templateInline = inlineTemplate("research", "Research");
+  inlined.push(templateInline);
+  trackPromptContext(contextTelemetry, "templates", "inline", templateInline);
 
   const depContent = await inlineDependencySummaries(mid, sid, base, resolveSummaryBudgetChars());
+  trackPromptContext(contextTelemetry, "dependency-summaries", depContent.trim() ? "inline" : "skipped", depContent, depContent.trim() ? undefined : "none");
   const activeOverrides = await loadActiveOverrides(base);
   const overridesInline = formatOverridesSection(activeOverrides);
-  if (overridesInline) inlined.unshift(overridesInline);
+  if (overridesInline) {
+    inlined.unshift(overridesInline);
+    trackPromptContext(contextTelemetry, "overrides", "inline", overridesInline);
+  } else {
+    trackPromptContext(contextTelemetry, "overrides", "skipped", null, "none active");
+  }
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "research-slice",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
     options?.contextModeRenderMode,
   );
+  emitPromptContextTelemetry("research-slice", contextTelemetry, inlinedContext);
 
   const outputRelPath = relSliceFile(base, mid, sid, "RESEARCH");
   return loadPrompt("research-slice", {
@@ -2083,53 +2349,128 @@ async function renderSlicePrompt(options: {
   const sliceContextRel = relSliceFile(base, mid, sid, "CONTEXT");
 
   const inlined: string[] = [...prependBlocks];
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
+  for (const block of prependBlocks) {
+    trackPromptContext(contextTelemetry, "prepend", "inline", block);
+  }
 
   // Phase handoff anchor from research phase (if available)
   const researchSliceAnchor = readPhaseAnchor(base, mid, "research-slice");
-  if (researchSliceAnchor) inlined.push(formatAnchorForPrompt(researchSliceAnchor));
+  if (researchSliceAnchor) {
+    const body = formatAnchorForPrompt(researchSliceAnchor);
+    inlined.push(body);
+    trackPromptContext(contextTelemetry, "research-anchor", "inline", body);
+  } else {
+    trackPromptContext(contextTelemetry, "research-anchor", "skipped", null, "missing");
+  }
 
   // Roadmap excerpt with full-roadmap fallback
   const roadmapExcerpt = await inlineRoadmapExcerpt(base, mid, sid);
   if (roadmapExcerpt) {
     inlined.push(roadmapExcerpt);
+    trackPromptContext(contextTelemetry, "roadmap", "excerpt", roadmapExcerpt);
   } else {
-    inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
+    const body = await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap");
+    inlined.push(body);
+    trackPromptContext(contextTelemetry, "roadmap", "inline", body, "excerpt unavailable");
   }
 
   const sliceCtxInline = await inlineFileOptional(sliceContextPath, sliceContextRel, "Slice Context (from discussion)");
-  if (sliceCtxInline) inlined.push(sliceCtxInline);
+  if (sliceCtxInline) {
+    inlined.push(sliceCtxInline);
+    trackPromptContext(contextTelemetry, "slice-context", "inline", sliceCtxInline);
+  } else {
+    trackPromptContext(contextTelemetry, "slice-context", "skipped", null, "missing");
+  }
   const researchInline = await inlineFileOptional(researchPath, researchRel, "Slice Research");
-  if (researchInline) inlined.push(researchInline);
+  if (researchInline) {
+    inlined.push(researchInline);
+    trackPromptContext(contextTelemetry, "slice-research", "inline", researchInline);
+  } else {
+    trackPromptContext(contextTelemetry, "slice-research", "skipped", null, "missing");
+  }
 
   if (level !== "minimal") {
     const derivedScope = deriveSliceScope(sTitle);
-    const decisionsInline = await inlineDecisionsFromDb(base, mid, derivedScope, level);
-    if (decisionsInline) inlined.push(decisionsInline);
+    if (derivedScope) {
+      const decisionsInline = await inlineDecisionsFromDb(base, mid, derivedScope, level);
+      if (decisionsInline) {
+        inlined.push(decisionsInline);
+        trackPromptContext(contextTelemetry, "decisions", "inline", decisionsInline, `scope:${derivedScope}`);
+      } else {
+        trackPromptContext(contextTelemetry, "decisions", "skipped", null, `no scoped decisions for ${derivedScope}`);
+      }
+    } else {
+      const onDemandDecisions = [
+        "### On-demand Decisions",
+        "",
+        `No specific decision scope was derived from "${sTitle}". Read \`${relGsdRootFile("DECISIONS")}\` only if planning needs prior architecture/product decisions.`,
+      ].join("\n");
+      inlined.push(onDemandDecisions);
+      trackPromptContext(contextTelemetry, "decisions", "on-demand", onDemandDecisions, "no derived scope");
+    }
     const requirementsInline = await inlineRequirementsFromDb(base, mid, sid, level);
-    if (requirementsInline) inlined.push(requirementsInline);
+    if (requirementsInline) {
+      inlined.push(requirementsInline);
+      trackPromptContext(contextTelemetry, "requirements", "inline", requirementsInline);
+    } else {
+      trackPromptContext(contextTelemetry, "requirements", "skipped", null, "missing");
+    }
+  } else {
+    trackPromptContext(contextTelemetry, "decisions", "skipped", null, "minimal inline level");
+    trackPromptContext(contextTelemetry, "requirements", "skipped", null, "minimal inline level");
   }
 
   const knowledgeInline = await inlineKnowledgeScoped(base, extractKeywords(sTitle));
-  if (knowledgeInline) inlined.push(knowledgeInline);
+  if (knowledgeInline) {
+    inlined.push(knowledgeInline);
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInline);
+  } else {
+    trackPromptContext(contextTelemetry, "knowledge", "skipped", null, "missing");
+  }
 
   const graphBlock = await inlineGraphSubgraph(base, `${sid} ${sTitle}`, { budget: 3000 });
-  if (graphBlock) inlined.push(graphBlock);
+  if (graphBlock) {
+    inlined.push(graphBlock);
+    trackPromptContext(contextTelemetry, "graph-subgraph", "inline", graphBlock);
+  } else {
+    trackPromptContext(contextTelemetry, "graph-subgraph", "skipped", null, "missing");
+  }
 
-  inlined.push(level === "minimal" ? inlineCompactTemplate("plan", "Slice Plan") : inlineTemplate("plan", "Slice Plan"));
+  const planTemplateInline = level === "minimal" ? inlineCompactTemplate("plan", "Slice Plan") : inlineTemplate("plan", "Slice Plan");
+  inlined.push(planTemplateInline);
+  trackPromptContext(contextTelemetry, "templates", "inline", planTemplateInline);
   if (level === "full") {
-    inlined.push(inlineTemplate("task-plan", "Task Plan"));
+    const taskPlanTemplateInline = inlineTemplate("task-plan", "Task Plan");
+    inlined.push(taskPlanTemplateInline);
+    trackPromptContext(contextTelemetry, "templates", "inline", taskPlanTemplateInline);
   }
 
   const depContent = await inlineDependencySummaries(mid, sid, base, resolveSummaryBudgetChars());
   const overridesInline = formatOverridesSection(await loadActiveOverrides(base));
-  if (overridesInline) inlined.unshift(overridesInline);
+  if (overridesInline) {
+    inlined.unshift(overridesInline);
+    trackPromptContext(contextTelemetry, "overrides", "inline", overridesInline);
+  } else {
+    trackPromptContext(contextTelemetry, "overrides", "skipped", null, "none active");
+  }
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     promptTemplate,
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
     options.contextModeRenderMode,
   );
+  emitPromptContextTelemetry(promptTemplate, contextTelemetry, inlinedContext);
   const executorContextConstraints = formatExecutorConstraints(sessionContextWindow, modelRegistry, sessionProvider);
   const outputRelPath = relSliceFile(base, mid, sid, "PLAN");
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
@@ -2287,6 +2628,7 @@ export async function buildExecuteTaskPrompt(
     ? level
     : { level: level as InlineLevel | undefined };
   const inlineLevel = opts.level ?? resolveInlineLevel();
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
 
   // Inject phase handoff anchor from planning phase (if available)
   const planAnchor = readPhaseAnchor(base, mid, "plan-slice");
@@ -2310,10 +2652,12 @@ export async function buildExecuteTaskPrompt(
       "## Inlined Task Plan (authoritative local execution contract)",
       `Task plan not found at dispatch time. Read \`${taskPlanRelPath}\` before executing.`,
     ].join("\n");
+  trackPromptContext(contextTelemetry, "task-plan", taskPlanContent ? "inline" : "on-demand", taskPlanInline, taskPlanContent ? undefined : "missing at dispatch");
 
   const slicePlanPath = resolveSliceFile(base, mid, sid, "PLAN");
   const slicePlanContent = slicePlanPath ? await loadFile(slicePlanPath) : null;
   const slicePlanExcerpt = extractSliceExecutionExcerpt(slicePlanContent, relSliceFile(base, mid, sid, "PLAN"));
+  trackPromptContext(contextTelemetry, "slice-plan", slicePlanExcerpt ? "excerpt" : "skipped", slicePlanExcerpt, slicePlanExcerpt ? undefined : "missing");
 
   // Check for continue file (new naming or legacy)
   const continueFile = resolveSliceFile(base, mid, sid, "CONTINUE");
@@ -2328,6 +2672,7 @@ export async function buildExecuteTaskPrompt(
     continueRelPath,
     legacyContinuePath ? `${relSlicePath(base, mid, sid)}/continue.md` : null,
   );
+  trackPromptContext(contextTelemetry, "resume-section", resumeSection.trim() ? "inline" : "skipped", resumeSection, resumeSection.trim() ? undefined : "missing");
 
   // For minimal inline level, only carry forward the most recent prior summary
   const effectivePriorSummaries = inlineLevel === "minimal" && priorSummaries.length > 1
@@ -2350,12 +2695,17 @@ export async function buildExecuteTaskPrompt(
 
   // Knowledge graph: tight subgraph for this task (graceful — skipped if no graph.json)
   const graphBlockET = await inlineGraphSubgraph(base, `${tid} ${tTitle}`, { budget: 2000 });
+  const decisionsOnDemandET = [
+    "### On-demand Decisions Template",
+    "",
+    "If this task records a durable architecture or product decision, read `templates/decisions.md` before calling `capture_thought` or `gsd_decision_save`.",
+  ].join("\n");
 
   const inlinedTemplates = inlineLevel === "minimal"
     ? inlineCompactTemplate("task-summary", "Task Summary")
     : [
         inlineTemplate("task-summary", "Task Summary"),
-        inlineTemplate("decisions", "Decisions"),
+        decisionsOnDemandET,
         ...(knowledgeContent ? [knowledgeContent] : []),
         ...(graphBlockET ? [graphBlockET] : []),
       ].join("\n\n---\n\n");
@@ -2377,6 +2727,13 @@ export async function buildExecuteTaskPrompt(
   if (carryForwardSection.length > carryForwardBudget) {
     finalCarryForward = truncateAtSectionBoundary(carryForwardSection, carryForwardBudget).content;
   }
+  trackPromptContext(
+    contextTelemetry,
+    "prior-task-summaries",
+    finalCarryForward.trim() ? "excerpt" : "skipped",
+    finalCarryForward,
+    finalCarryForward.length < carryForwardSection.length ? `truncated from ${carryForwardSection.length} chars` : undefined,
+  );
 
   // Inline RUNTIME.md if present
   const runtimePath = resolveRuntimeFile(base);
@@ -2384,8 +2741,10 @@ export async function buildExecuteTaskPrompt(
   const runtimeContext = runtimeContent
     ? `### Runtime Context\nSource: \`.gsd/RUNTIME.md\`\n\n${runtimeContent.trim()}`
     : "";
+  trackPromptContext(contextTelemetry, "runtime", runtimeContext ? "inline" : "skipped", runtimeContext, runtimeContext ? undefined : "missing");
 
   let phaseAnchorSection = planAnchor ? formatAnchorForPrompt(planAnchor) : "";
+  trackPromptContext(contextTelemetry, "plan-anchor", phaseAnchorSection ? "inline" : "skipped", phaseAnchorSection, phaseAnchorSection ? undefined : "missing");
 
   // ADR-011 Phase 2: inject any resolved-but-unapplied escalation override
   // into this task's prompt. Claim is atomic via DB UPDATE WHERE IS NULL, so
@@ -2419,8 +2778,17 @@ export async function buildExecuteTaskPrompt(
     { pending: new Set(etPending.map((g) => g.gate_id)), allowOmit: true },
   );
   phaseAnchorSection = prependContextModeToBlock("execute-task", base, phaseAnchorSection, opts.contextModeRenderMode);
+  trackPromptContext(contextTelemetry, "context-mode", phaseAnchorSection ? "inline" : "skipped", phaseAnchorSection, phaseAnchorSection ? undefined : "disabled or empty");
+  trackPromptContext(contextTelemetry, "overrides", overridesSection ? "inline" : "skipped", overridesSection, overridesSection ? undefined : "none active");
+  trackPromptContext(contextTelemetry, "gates", gatesToClose ? "inline" : "skipped", gatesToClose, gatesToClose ? undefined : "none pending");
+  trackPromptContext(contextTelemetry, "knowledge", knowledgeContent ? "inline" : "skipped", knowledgeContent, knowledgeContent ? undefined : "missing");
+  trackPromptContext(contextTelemetry, "graph-subgraph", graphBlockET ? "inline" : "skipped", graphBlockET, graphBlockET ? undefined : "missing");
+  if (inlineLevel !== "minimal") {
+    trackPromptContext(contextTelemetry, "decisions-template", "on-demand", decisionsOnDemandET);
+  }
+  trackPromptContext(contextTelemetry, "templates", "inline", inlinedTemplates, inlineLevel);
 
-  return loadPrompt("execute-task", {
+  const prompt = loadPrompt("execute-task", {
     overridesSection,
     runtimeContext,
     phaseAnchorSection,
@@ -2450,12 +2818,15 @@ export async function buildExecuteTaskPrompt(
       unitType: "execute-task",
     }),
   });
+  emitPromptContextTelemetry("execute-task", contextTelemetry, prompt);
+  return prompt;
 }
 
 export async function buildCompleteSlicePrompt(
   mid: string, midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
 ): Promise<string> {
   const inlineLevel = level ?? resolveInlineLevel();
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
 
   // #4782 phase 3: complete-slice migrated through composer. Manifest
   // declares [roadmap, slice-context, slice-plan, requirements,
@@ -2467,24 +2838,40 @@ export async function buildCompleteSlicePrompt(
       case "roadmap": {
         const p = resolveMilestoneFile(base, mid, "ROADMAP");
         const r = relMilestoneFile(base, mid, "ROADMAP");
-        return await inlineFile(p, r, "Milestone Roadmap");
+        const body = await inlineFile(p, r, "Milestone Roadmap");
+        trackPromptContext(contextTelemetry, "roadmap", "inline", body);
+        return body;
       }
       case "slice-context": {
         const p = resolveSliceFile(base, mid, sid, "CONTEXT");
         const r = relSliceFile(base, mid, sid, "CONTEXT");
-        return await inlineFileOptional(p, r, "Slice Context (from discussion)");
+        const body = await inlineFileOptional(p, r, "Slice Context (from discussion)");
+        trackPromptContext(contextTelemetry, "slice-context", body ? "inline" : "skipped", body, body ? undefined : "missing");
+        return body;
       }
       case "slice-plan": {
         const p = resolveSliceFile(base, mid, sid, "PLAN");
         const r = relSliceFile(base, mid, sid, "PLAN");
-        return await inlineFile(p, r, "Slice Plan");
+        const body = await inlineFile(p, r, "Slice Plan");
+        trackPromptContext(contextTelemetry, "slice-plan", "inline", body);
+        return body;
       }
       case "requirements":
-        if (inlineLevel === "minimal") return null;
-        return await inlineRequirementsFromDb(base, mid, sid, inlineLevel);
+        if (inlineLevel === "minimal") {
+          trackPromptContext(contextTelemetry, "requirements", "skipped", null, "minimal inline level");
+          return null;
+        }
+        {
+          const body = await inlineRequirementsFromDb(base, mid, sid, inlineLevel);
+          trackPromptContext(contextTelemetry, "requirements", body ? "inline" : "skipped", body, body ? undefined : "missing");
+          return body;
+        }
       case "prior-task-summaries": {
         const tDir = resolveTasksDir(base, mid, sid);
-        if (!tDir) return null;
+        if (!tDir) {
+          trackPromptContext(contextTelemetry, "prior-task-summaries", "skipped", null, "missing tasks dir");
+          return null;
+        }
         const summaryFiles = resolveTaskFiles(tDir, "SUMMARY").sort();
         const sRel = relSlicePath(base, mid, sid);
         const blocks: string[] = [];
@@ -2494,7 +2881,9 @@ export async function buildCompleteSlicePrompt(
           const taskId = file.replace(/-SUMMARY\.md$/i, "");
           blocks.push(await buildTaskSummaryExcerpt(absPath, relPath, taskId));
         }
-        return blocks.length > 0 ? blocks.join("\n\n---\n\n") : null;
+        const body = blocks.length > 0 ? blocks.join("\n\n---\n\n") : null;
+        trackPromptContext(contextTelemetry, "prior-task-summaries", body ? "excerpt" : "skipped", body, body ? undefined : "missing");
+        return body;
       }
       case "templates": {
         const parts = [inlineLevel === "minimal"
@@ -2503,7 +2892,9 @@ export async function buildCompleteSlicePrompt(
         if (inlineLevel !== "minimal") {
           parts.push(inlineTemplate("uat", "UAT"));
         }
-        return parts.join("\n\n---\n\n");
+        const body = parts.join("\n\n---\n\n");
+        trackPromptContext(contextTelemetry, "templates", "inline", body);
+        return body;
       }
       default:
         return null;
@@ -2519,6 +2910,11 @@ export async function buildCompleteSlicePrompt(
     base,
     [...extractKeywords(midTitle), ...extractKeywords(sTitle)],
   );
+  if (knowledgeInlineCS) {
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInlineCS);
+  } else {
+    trackPromptContext(contextTelemetry, "knowledge", "skipped", null, "missing");
+  }
 
   let body = composed;
   if (knowledgeInlineCS && body) {
@@ -2543,15 +2939,30 @@ export async function buildCompleteSlicePrompt(
   // the prepend contract).
   const completeActiveOverrides = await loadActiveOverrides(base);
   const completeOverridesInline = formatOverridesSection(completeActiveOverrides);
+  if (completeOverridesInline) {
+    trackPromptContext(contextTelemetry, "overrides", "inline", completeOverridesInline);
+  } else {
+    trackPromptContext(contextTelemetry, "overrides", "skipped", null, "none active");
+  }
   const finalBody = completeOverridesInline
     ? `${completeOverridesInline}\n\n---\n\n${body}`
     : body;
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${finalBody}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "complete-slice",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${finalBody}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("complete-slice", contextTelemetry, inlinedContext);
   const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
 
   const sliceRel = relSlicePath(base, mid, sid);
@@ -2594,7 +3005,10 @@ export async function buildCompleteMilestonePrompt(
   const validationContent = validationPath ? await loadFile(validationPath) : null;
 
   const inlined: string[] = [];
-  inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
+  const roadmapInline = await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap");
+  inlined.push(roadmapInline);
+  trackPromptContext(contextTelemetry, "roadmap", "inline", roadmapInline);
 
   // Inline all slice summaries (deduplicated by slice ID)
   let sliceIds: string[] = [];
@@ -2625,46 +3039,108 @@ export async function buildCompleteMilestonePrompt(
     summaryRelPaths.push(summaryRel);
     // Compact excerpt instead of full inline (#4780). Closer Reads the
     // full file on-demand when synthesizing LEARNINGS narrative.
-    inlined.push(await buildSliceSummaryExcerpt(summaryPath, summaryRel, sid));
+    const summaryExcerpt = await buildSliceSummaryExcerpt(summaryPath, summaryRel, sid);
+    inlined.push(summaryExcerpt);
+    trackPromptContext(contextTelemetry, "slice-summary", "excerpt", summaryExcerpt);
   }
   if (summaryRelPaths.length > 0) {
     const pathList = summaryRelPaths.map(p => `- \`${p}\``).join("\n");
-    inlined.push(
-      `### On-demand Slice Summaries\n\nExcerpted above. Read the full file for any slice when the excerpt's section heads don't carry enough narrative for the milestone summary you're drafting:\n\n${pathList}`,
-    );
+    const onDemandSummaries = `### On-demand Slice Summaries\n\nExcerpted above. Read the full file for any slice when the excerpt's section heads don't carry enough narrative for the milestone summary you're drafting:\n\n${pathList}`;
+    inlined.push(onDemandSummaries);
+    trackPromptContext(contextTelemetry, "slice-summary", "on-demand", onDemandSummaries);
   }
   const validationContext = [
     formatCloseoutReviewInstructions(validationContent, validationRel, [validationRel, roadmapRel, ...summaryRelPaths]),
   ];
+  trackPromptContext(contextTelemetry, "validation-review-instructions", "inline", validationContext[0]);
   if (validationContent) {
-    validationContext.push(`### Milestone Validation\nSource: \`${validationRel}\`\n\n${validationContent.trim()}`);
+    const validationInline = `### Milestone Validation\nSource: \`${validationRel}\`\n\n${validationContent.trim()}`;
+    validationContext.push(validationInline);
+    trackPromptContext(contextTelemetry, "milestone-validation", "inline", validationInline);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-validation", "skipped", null, "missing");
   }
   inlined.unshift(...validationContext);
 
-  // Inline root GSD files (skip for minimal — completion can read these if needed)
-  if (inlineLevel !== "minimal") {
+  // Inline compact requirement facts for standard closeout. Broader narrative
+  // docs stay on-demand unless the caller explicitly asks for full context.
+  if (inlineLevel === "full") {
     const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
-    if (requirementsInline) inlined.push(requirementsInline);
+    if (requirementsInline) {
+      inlined.push(requirementsInline);
+      trackPromptContext(contextTelemetry, "requirements", "inline", requirementsInline);
+    }
     const decisionsInline = await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
-    if (decisionsInline) inlined.push(decisionsInline);
+    if (decisionsInline) {
+      inlined.push(decisionsInline);
+      trackPromptContext(contextTelemetry, "decisions", "inline", decisionsInline);
+    }
     const projectInline = await inlineProjectFromDb(base);
-    if (projectInline) inlined.push(projectInline);
+    if (projectInline) {
+      inlined.push(projectInline);
+      trackPromptContext(contextTelemetry, "project", "inline", projectInline);
+    }
+  } else if (inlineLevel === "standard") {
+    const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
+    if (requirementsInline) {
+      inlined.push(requirementsInline);
+      trackPromptContext(contextTelemetry, "requirements", "inline", requirementsInline);
+    }
+    const decisionsOnDemand = onDemandDecisionsBlock("the slice summaries or validation artifact reference a decision that must be re-evaluated before closeout");
+    inlined.push(decisionsOnDemand);
+    trackPromptContext(contextTelemetry, "decisions", "on-demand", decisionsOnDemand);
+    const projectOnDemand = onDemandProjectBlock("the milestone summary needs product/domain wording that is not present in the roadmap, validation artifact, or slice summaries");
+    inlined.push(projectOnDemand);
+    trackPromptContext(contextTelemetry, "project", "on-demand", projectOnDemand);
+  } else {
+    trackPromptContext(contextTelemetry, "requirements", "skipped", null, "minimal inline level");
+    const decisionsOnDemand = onDemandDecisionsBlock("the closeout cannot be completed from the roadmap and slice summaries alone");
+    inlined.push(decisionsOnDemand);
+    trackPromptContext(contextTelemetry, "decisions", "on-demand", decisionsOnDemand);
+    const projectOnDemand = onDemandProjectBlock("the closeout cannot be completed from the roadmap and slice summaries alone");
+    inlined.push(projectOnDemand);
+    trackPromptContext(contextTelemetry, "project", "on-demand", projectOnDemand);
   }
   // Scoped + budgeted — see issue #4719
   const knowledgeInlineCM = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
-  if (knowledgeInlineCM) inlined.push(knowledgeInlineCM);
-  // Inline milestone context file (milestone-level, not GSD root)
+  if (knowledgeInlineCM) {
+    inlined.push(knowledgeInlineCM);
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInlineCM);
+  }
   const contextPath = resolveMilestoneFile(base, mid, "CONTEXT");
   const contextRel = relMilestoneFile(base, mid, "CONTEXT");
-  const contextInline = await inlineFileOptional(contextPath, contextRel, "Milestone Context");
-  if (contextInline) inlined.push(contextInline);
-  inlined.push(inlineTemplate("milestone-summary", "Milestone Summary"));
+  const contextInline = inlineLevel === "full"
+    ? await inlineFileOptional(contextPath, contextRel, "Milestone Context")
+    : null;
+  if (contextInline) {
+    inlined.push(contextInline);
+    trackPromptContext(contextTelemetry, "milestone-context", "inline", contextInline);
+  } else if (contextPath) {
+    const contextOnDemand = onDemandMilestoneContextBlock(contextRel, "the roadmap, validation artifact, and slice summaries do not explain the milestone's intent clearly enough");
+    inlined.push(contextOnDemand);
+    trackPromptContext(contextTelemetry, "milestone-context", "on-demand", contextOnDemand);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-context", "skipped", null, "missing");
+  }
+  const templateInline = inlineTemplate("milestone-summary", "Milestone Summary");
+  inlined.push(templateInline);
+  trackPromptContext(contextTelemetry, "templates", "inline", templateInline);
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "complete-milestone",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("complete-milestone", contextTelemetry, inlinedContext);
 
   const milestoneSummaryPath = join(base, `${relMilestonePath(base, mid)}/${mid}-SUMMARY.md`);
 
@@ -2702,7 +3178,10 @@ export async function buildValidateMilestonePrompt(
   const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
 
   const inlined: string[] = [];
-  inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
+  const roadmapInline = await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap");
+  inlined.push(roadmapInline);
+  trackPromptContext(contextTelemetry, "roadmap", "inline", roadmapInline);
 
   // Inline verification classes from planning (if available in DB)
   try {
@@ -2716,7 +3195,9 @@ export async function buildValidateMilestonePrompt(
         if (milestone.verification_operational) classes.push(`- **Operational:** ${milestone.verification_operational}`);
         if (milestone.verification_uat) classes.push(`- **UAT:** ${milestone.verification_uat}`);
         if (classes.length > 0) {
-          inlined.push(`### Verification Classes (from planning)\n\nThese verification tiers were defined during milestone planning. Each non-empty class must be checked for evidence during validation.\n\n${classes.join("\n")}`);
+          const verificationClasses = `### Verification Classes (from planning)\n\nThese verification tiers were defined during milestone planning. Each non-empty class must be checked for evidence during validation.\n\n${classes.join("\n")}`;
+          inlined.push(verificationClasses);
+          trackPromptContext(contextTelemetry, "verification-classes", "inline", verificationClasses);
         }
       }
     }
@@ -2724,7 +3205,9 @@ export async function buildValidateMilestonePrompt(
     logWarning("prompt", `buildValidateMilestonePrompt verification classes lookup failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 
-  // Inline all slice summaries and assessment results
+  // Validate from compact slice evidence first. Full slice summaries and
+  // assessments stay on-demand so milestone validation does not rehydrate the
+  // whole milestone on every closeout pass.
   let valSliceIds: string[] = [];
   try {
     const { isDbAvailable, getMilestoneSlices } = await import("./gsd-db.js");
@@ -2744,17 +3227,39 @@ export async function buildValidateMilestonePrompt(
     }
   }
   const seenValSlices = new Set<string>();
+  const onDemandValidationPaths: string[] = [];
   for (const sid of valSliceIds) {
     if (seenValSlices.has(sid)) continue;
     seenValSlices.add(sid);
     const summaryPath = resolveSliceFile(base, mid, sid, "SUMMARY");
     const summaryRel = relSliceFile(base, mid, sid, "SUMMARY");
-    inlined.push(await inlineFile(summaryPath, summaryRel, `${sid} Summary`));
+    const summaryExcerpt = await buildSliceSummaryExcerpt(summaryPath, summaryRel, sid);
+    inlined.push(summaryExcerpt);
+    onDemandValidationPaths.push(summaryRel);
+    trackPromptContext(contextTelemetry, "slice-summary", "excerpt", summaryExcerpt);
 
     const assessmentPath = resolveSliceFile(base, mid, sid, "ASSESSMENT");
     const assessmentRel = relSliceFile(base, mid, sid, "ASSESSMENT");
-    const assessmentInline = await inlineFileOptional(assessmentPath, assessmentRel, `${sid} Assessment`);
-    if (assessmentInline) inlined.push(assessmentInline);
+    const assessmentExcerpt = await buildSliceAssessmentExcerpt(assessmentPath, assessmentRel, sid);
+    if (assessmentExcerpt) {
+      inlined.push(assessmentExcerpt);
+      trackPromptContext(contextTelemetry, "slice-assessment", "excerpt", assessmentExcerpt);
+    } else {
+      trackPromptContext(contextTelemetry, "slice-assessment", "skipped", null, "missing");
+    }
+    onDemandValidationPaths.push(assessmentRel);
+  }
+  if (onDemandValidationPaths.length > 0) {
+    const pathList = onDemandValidationPaths.map(p => `- \`${p}\``).join("\n");
+    const onDemandBlock = [
+      "### On-demand Validation Artifacts",
+      "",
+      "Slice summaries and assessments are excerpted above. Read full files only when an excerpt is missing, truncated, or internally inconsistent with validation evidence:",
+      "",
+      pathList,
+    ].join("\n");
+    inlined.push(onDemandBlock);
+    trackPromptContext(contextTelemetry, "slice-summary,slice-assessment", "on-demand", onDemandBlock);
   }
 
   // Aggregate unresolved follow-ups and known limitations across slices
@@ -2769,7 +3274,9 @@ export async function buildValidateMilestonePrompt(
     if (summary.knownLimitations) outstandingItems.push(`- **${sid} Known Limitations:** ${summary.knownLimitations.trim()}`);
   }
   if (outstandingItems.length > 0) {
-    inlined.push(`### Outstanding Items (aggregated from slice summaries)\n\nThese follow-ups and known limitations were documented during slice completion but have not been resolved.\n\n${outstandingItems.join('\n')}`);
+    const outstandingBlock = `### Outstanding Items (aggregated from slice summaries)\n\nThese follow-ups and known limitations were documented during slice completion but have not been resolved.\n\n${outstandingItems.join('\n')}`;
+    inlined.push(outstandingBlock);
+    trackPromptContext(contextTelemetry, "outstanding-items", "inline", outstandingBlock);
   }
 
   // Inline existing VALIDATION file if this is a re-validation round
@@ -2780,32 +3287,89 @@ export async function buildValidateMilestonePrompt(
   if (validationContent) {
     const roundMatch = validationContent.match(/remediation_round:\s*(\d+)/);
     remediationRound = roundMatch ? parseInt(roundMatch[1], 10) + 1 : 1;
-    inlined.push(`### Previous Validation (re-validation round ${remediationRound})\nSource: \`${validationRel}\`\n\n${validationContent.trim()}`);
+    const previousValidation = `### Previous Validation (re-validation round ${remediationRound})\nSource: \`${validationRel}\`\n\n${validationContent.trim()}`;
+    inlined.push(previousValidation);
+    trackPromptContext(contextTelemetry, "milestone-validation", "inline", previousValidation);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-validation", "skipped", null, "missing");
   }
 
-  // Inline root GSD files
-  if (inlineLevel !== "minimal") {
+  // Validation keeps compact requirements inline, but broad narrative docs are
+  // on-demand in standard mode to avoid rehydrating full project context.
+  if (inlineLevel === "full") {
     const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
-    if (requirementsInline) inlined.push(requirementsInline);
+    if (requirementsInline) {
+      inlined.push(requirementsInline);
+      trackPromptContext(contextTelemetry, "requirements", "inline", requirementsInline);
+    }
     const decisionsInline = await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
-    if (decisionsInline) inlined.push(decisionsInline);
+    if (decisionsInline) {
+      inlined.push(decisionsInline);
+      trackPromptContext(contextTelemetry, "decisions", "inline", decisionsInline);
+    }
     const projectInline = await inlineProjectFromDb(base);
-    if (projectInline) inlined.push(projectInline);
+    if (projectInline) {
+      inlined.push(projectInline);
+      trackPromptContext(contextTelemetry, "project", "inline", projectInline);
+    }
+  } else if (inlineLevel === "standard") {
+    const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
+    if (requirementsInline) {
+      inlined.push(requirementsInline);
+      trackPromptContext(contextTelemetry, "requirements", "inline", requirementsInline);
+    }
+    const decisionsOnDemand = onDemandDecisionsBlock("a validation finding conflicts with an existing architectural decision");
+    inlined.push(decisionsOnDemand);
+    trackPromptContext(contextTelemetry, "decisions", "on-demand", decisionsOnDemand);
+    const projectOnDemand = onDemandProjectBlock("validation evidence needs product/domain context that is not present in the roadmap or slice artifacts");
+    inlined.push(projectOnDemand);
+    trackPromptContext(contextTelemetry, "project", "on-demand", projectOnDemand);
+  } else {
+    trackPromptContext(contextTelemetry, "requirements", "skipped", null, "minimal inline level");
+    const decisionsOnDemand = onDemandDecisionsBlock("validation cannot determine the correct verdict from milestone artifacts alone");
+    inlined.push(decisionsOnDemand);
+    trackPromptContext(contextTelemetry, "decisions", "on-demand", decisionsOnDemand);
+    const projectOnDemand = onDemandProjectBlock("validation cannot determine the correct verdict from milestone artifacts alone");
+    inlined.push(projectOnDemand);
+    trackPromptContext(contextTelemetry, "project", "on-demand", projectOnDemand);
   }
   // Scoped + budgeted — see issue #4719
   const knowledgeInline = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
-  if (knowledgeInline) inlined.push(knowledgeInline);
-  // Inline milestone context file
+  if (knowledgeInline) {
+    inlined.push(knowledgeInline);
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInline);
+  }
   const contextPath = resolveMilestoneFile(base, mid, "CONTEXT");
   const contextRel = relMilestoneFile(base, mid, "CONTEXT");
-  const contextInline = await inlineFileOptional(contextPath, contextRel, "Milestone Context");
-  if (contextInline) inlined.push(contextInline);
+  const contextInline = inlineLevel === "full"
+    ? await inlineFileOptional(contextPath, contextRel, "Milestone Context")
+    : null;
+  if (contextInline) {
+    inlined.push(contextInline);
+    trackPromptContext(contextTelemetry, "milestone-context", "inline", contextInline);
+  } else if (contextPath) {
+    const contextOnDemand = onDemandMilestoneContextBlock(contextRel, "the roadmap and slice artifacts do not explain the intended outcome clearly enough");
+    inlined.push(contextOnDemand);
+    trackPromptContext(contextTelemetry, "milestone-context", "on-demand", contextOnDemand);
+  } else {
+    trackPromptContext(contextTelemetry, "milestone-context", "skipped", null, "missing");
+  }
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "validate-milestone",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("validate-milestone", contextTelemetry, inlinedContext);
 
   const validationOutputPath = join(base, `${relMilestonePath(base, mid)}/${mid}-VALIDATION.md`);
   const roadmapOutputPath = `${relMilestonePath(base, mid)}/${mid}-ROADMAP.md`;
@@ -2929,9 +3493,9 @@ export async function buildReplanSlicePrompt(
 export async function buildRunUatPrompt(
   mid: string, sliceId: string, uatPath: string, uatContent: string, base: string,
 ): Promise<string> {
-  // #4782 phase 3: run-uat migrated to compose its inlined context via
-  // the manifest. Behavior-equivalent — resolver dispatches to the same
-  // inline* helpers as the pre-migration builder.
+  // Run-UAT keeps only the UAT body inline. Prior slice/project context is
+  // compact or on-demand so validation does not pay for full closeout context.
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
   const resolveArtifact: ArtifactResolver = async (key) => {
     switch (key) {
       case "slice-uat": {
@@ -2941,29 +3505,75 @@ export async function buildRunUatPrompt(
         // uatContent below) if the file changes mid-dispatch.
         const trimmed = uatContent.trim();
         if (!trimmed) {
-          return `### ${sliceId} UAT\nSource: \`${uatPath}\`\n\n_(not found — file does not exist yet)_`;
+          const body = `### ${sliceId} UAT\nSource: \`${uatPath}\`\n\n_(not found — file does not exist yet)_`;
+          trackPromptContext(contextTelemetry, "slice-uat", "inline", body);
+          return body;
         }
-        return `### ${sliceId} UAT\nSource: \`${uatPath}\`\n\n${trimmed}`;
+        const body = `### ${sliceId} UAT\nSource: \`${uatPath}\`\n\n${trimmed}`;
+        trackPromptContext(contextTelemetry, "slice-uat", "inline", body);
+        return body;
       }
       case "slice-summary": {
-        const p = resolveSliceFile(base, mid, sliceId, "SUMMARY");
-        if (!p) return null;
-        const r = relSliceFile(base, mid, sliceId, "SUMMARY");
-        return await inlineFileOptional(p, r, `${sliceId} Summary`);
+        trackPromptContext(contextTelemetry, "slice-summary", "skipped", null, "handled by excerpt resolver");
+        return null;
       }
-      case "project":
-        return await inlineProjectFromDb(base);
+      case "project": {
+        trackPromptContext(contextTelemetry, "project", "skipped", null, "handled as on-demand path");
+        return null;
+      }
+      default:
+        return null;
+    }
+  };
+  const resolveExcerpt: ExcerptResolver = async (key) => {
+    switch (key) {
+      case "slice-summary": {
+        const p = resolveSliceFile(base, mid, sliceId, "SUMMARY");
+        const r = relSliceFile(base, mid, sliceId, "SUMMARY");
+        if (!p) {
+          trackPromptContext(contextTelemetry, "slice-summary", "skipped", null, "missing");
+          return null;
+        }
+        const body = await buildSliceSummaryExcerpt(p, r, sliceId);
+        trackPromptContext(contextTelemetry, "slice-summary", "excerpt", body);
+        return body;
+      }
       default:
         return null;
     }
   };
 
-  const composed = await composeInlinedContext("run-uat", resolveArtifact);
+  const composed = await composeUnitContext("run-uat", {
+    base: { unitType: "run-uat", basePath: base, milestoneId: mid, sliceId },
+    resolveArtifact,
+    resolveExcerpt,
+  });
+  const parts: string[] = [];
+  if (composed.prepend) parts.push(composed.prepend);
+  if (composed.inline) parts.push(composed.inline);
+  const projectOnDemand = [
+    "### On-demand Project Context",
+    "",
+    `Project context is available at \`${relGsdRootFile("PROJECT")}\`. Read it only if the UAT spec or slice summary lacks enough product/domain context to assess the scenario.`,
+  ].join("\n");
+  parts.push(projectOnDemand);
+  trackPromptContext(contextTelemetry, "project", "on-demand", projectOnDemand);
+  const composedBody = parts.join("\n\n---\n\n");
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${composedBody}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "run-uat",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${composed}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("run-uat", contextTelemetry, inlinedContext);
 
   const uatResultPath = join(base, relSliceFile(base, mid, sliceId, "ASSESSMENT"));
   const uatType = resolveEffectiveUatType(uatContent);
@@ -2989,59 +3599,98 @@ export async function buildRunUatPrompt(
 export async function buildReassessRoadmapPrompt(
   mid: string, midTitle: string, completedSliceId: string, base: string, level?: InlineLevel,
 ): Promise<string> {
-  const inlineLevel = level ?? resolveInlineLevel();
+  void level;
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
 
-  // #4782 phase 2 pilot: reassess-roadmap is the first unit type to
-  // compose its inlined context through the manifest-driven composer.
-  // The resolver below dispatches artifact keys to the existing inline*
-  // helpers, preserving identical output so the migration is
-  // observable-equivalent. Knowledge stays outside the composer (it's
-  // budget-driven, not manifest-driven) until a later phase formalizes
-  // knowledge/memory policies as composer inputs.
+  // Reassess-roadmap runs between slices, so keep only the roadmap and
+  // completed-slice evidence in prompt. Broader project docs stay on-demand.
   const resolveArtifact: ArtifactResolver = async (key) => {
     switch (key) {
       case "roadmap": {
         const p = resolveMilestoneFile(base, mid, "ROADMAP");
         const r = relMilestoneFile(base, mid, "ROADMAP");
-        return await inlineFile(p, r, "Current Roadmap");
+        const body = await inlineFile(p, r, "Current Roadmap");
+        trackPromptContext(contextTelemetry, "roadmap", "inline", body);
+        return body;
       }
       case "slice-context": {
         const p = resolveSliceFile(base, mid, completedSliceId, "CONTEXT");
         const r = relSliceFile(base, mid, completedSliceId, "CONTEXT");
-        return await inlineFileOptional(p, r, "Slice Context (from discussion)");
+        const body = await inlineFileOptional(p, r, "Slice Context (from discussion)");
+        trackPromptContext(contextTelemetry, "slice-context", body ? "inline" : "skipped", body, body ? undefined : "missing");
+        return body;
       }
+      case "slice-summary": {
+        trackPromptContext(contextTelemetry, "slice-summary", "skipped", null, "handled by excerpt resolver");
+        return null;
+      }
+      case "project":
+      case "requirements":
+      case "decisions":
+        trackPromptContext(contextTelemetry, key, "skipped", null, "handled as on-demand path");
+        return null;
+      default:
+        return null;
+    }
+  };
+  const resolveExcerpt: ExcerptResolver = async (key) => {
+    switch (key) {
       case "slice-summary": {
         const p = resolveSliceFile(base, mid, completedSliceId, "SUMMARY");
         const r = relSliceFile(base, mid, completedSliceId, "SUMMARY");
-        return await inlineFile(p, r, `${completedSliceId} Summary`);
+        const body = await buildSliceSummaryExcerpt(p, r, completedSliceId);
+        trackPromptContext(contextTelemetry, "slice-summary", "excerpt", body);
+        return body;
       }
-      case "project":
-        if (inlineLevel === "minimal") return null;
-        return await inlineProjectFromDb(base);
-      case "requirements":
-        if (inlineLevel === "minimal") return null;
-        return await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
-      case "decisions":
-        if (inlineLevel === "minimal") return null;
-        return await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
       default:
         return null;
     }
   };
 
-  const composed = await composeInlinedContext("reassess-roadmap", resolveArtifact);
+  const composed = await composeUnitContext("reassess-roadmap", {
+    base: { unitType: "reassess-roadmap", basePath: base, milestoneId: mid, sliceId: completedSliceId },
+    resolveArtifact,
+    resolveExcerpt,
+  });
   const parts: string[] = [];
-  if (composed) parts.push(composed);
+  if (composed.prepend) parts.push(composed.prepend);
+  if (composed.inline) parts.push(composed.inline);
+  const onDemandDocs = [
+    "### On-demand Planning Context",
+    "",
+    "Broader project context is available if the roadmap update needs it. Read only the specific source that answers the reassessment question:",
+    "",
+    `- \`${relGsdRootFile("PROJECT")}\` — product/project narrative`,
+    `- \`${relGsdRootFile("REQUIREMENTS")}\` — requirement status and acceptance criteria`,
+    `- \`${relGsdRootFile("DECISIONS")}\` — active architecture/product decisions`,
+  ].join("\n");
+  parts.push(onDemandDocs);
+  trackPromptContext(contextTelemetry, "project,requirements,decisions", "on-demand", onDemandDocs);
   // Knowledge block stays outside the composer — budgeted, scoped via
   // keyword extraction (#4719). Future phase folds it in.
   const knowledgeInlineRA = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
-  if (knowledgeInlineRA) parts.push(knowledgeInlineRA);
+  if (knowledgeInlineRA) {
+    parts.push(knowledgeInlineRA);
+    trackPromptContext(contextTelemetry, "knowledge", "inline", knowledgeInlineRA);
+  } else {
+    trackPromptContext(contextTelemetry, "knowledge", "skipped", null, "missing");
+  }
 
+  const rawInlinedContext = `## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`;
+  const cappedInlinedContext = capPreamble(rawInlinedContext);
+  trackPromptContext(
+    contextTelemetry,
+    "cap",
+    cappedInlinedContext.length < rawInlinedContext.length ? "skipped" : "inline",
+    null,
+    cappedInlinedContext.length < rawInlinedContext.length ? `dropped ${rawInlinedContext.length - cappedInlinedContext.length} chars` : "within budget",
+  );
   const inlinedContext = prependContextModeToBlock(
     "reassess-roadmap",
     base,
-    capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`),
+    cappedInlinedContext,
   );
+  emitPromptContextTelemetry("reassess-roadmap", contextTelemetry, inlinedContext);
 
   const assessmentPath = join(base, relSliceFile(base, mid, completedSliceId, "ASSESSMENT"));
 
@@ -3115,6 +3764,15 @@ export async function buildReactiveExecutePrompt(
   // Build individual subagent prompts for each ready task
   const subagentSections: string[] = [];
   const readyTaskListLines: string[] = [];
+  const prefs = loadEffectiveGSDPreferences();
+  const contextWindow = resolveExecutorContextWindow(opts?.modelRegistry, prefs?.preferences, opts?.sessionContextWindow, opts?.sessionProvider);
+  const budgets = computeBudgets(contextWindow);
+  const perSubagentCarryForwardBudget = Math.max(
+    1_000,
+    Math.floor((budgets.inlineContextBudgetChars * 0.4) / Math.max(1, readyTaskIds.length)),
+  );
+  const contextTelemetry: PromptContextTelemetryEntry[] = [];
+  trackPromptContext(contextTelemetry, "graph-context", "inline", graphContext);
 
   for (const tid of readyTaskIds) {
     const node = graph.find((n) => n.id === tid);
@@ -3141,6 +3799,16 @@ export async function buildReactiveExecutePrompt(
           `Task plan not found at dispatch time. Read \`${taskPlanRelPath}\` before executing.`,
         ].join("\n");
     const carryForwardSection = await buildCarryForwardSection(depPaths, base);
+    const finalCarryForwardSection = carryForwardSection.length > perSubagentCarryForwardBudget
+      ? truncateAtSectionBoundary(carryForwardSection, perSubagentCarryForwardBudget).content
+      : carryForwardSection;
+    trackPromptContext(
+      contextTelemetry,
+      "prior-task-summaries",
+      finalCarryForwardSection.trim() ? "excerpt" : "skipped",
+      finalCarryForwardSection,
+      finalCarryForwardSection.length < carryForwardSection.length ? `truncated from ${carryForwardSection.length} chars for ${tid}` : tid,
+    );
     const taskSummaryPath = `${relSlicePath(base, mid, sid)}/tasks/${tid}-SUMMARY.md`;
     const taskPrompt = [
       `## UNIT: Execute Task ${tid} ("${tTitle}")`,
@@ -3149,7 +3817,7 @@ export async function buildReactiveExecutePrompt(
       "Implement from the inlined task plan below. Verify changes, then call `gsd_task_complete`.",
       "Do not run git commands.",
       "",
-      carryForwardSection,
+      finalCarryForwardSection,
       "",
       taskPlanInline,
       "",
@@ -3174,8 +3842,9 @@ export async function buildReactiveExecutePrompt(
   }
 
   const inlinedTemplates = inlineTemplate("task-summary", "Task Summary");
+  trackPromptContext(contextTelemetry, "templates", "inline", inlinedTemplates);
 
-  return loadPrompt("reactive-execute", {
+  const prompt = loadPrompt("reactive-execute", {
     workingDirectory: base,
     milestoneId: mid,
     milestoneTitle: midTitle,
@@ -3187,6 +3856,8 @@ export async function buildReactiveExecutePrompt(
     subagentPrompts: subagentSections.join("\n\n---\n\n"),
     inlinedTemplates,
   });
+  emitPromptContextTelemetry("reactive-execute", contextTelemetry, prompt);
+  return prompt;
 }
 
 // ─── Gate Evaluation ──────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/auto-status-message.ts
+++ b/src/resources/extensions/gsd/auto-status-message.ts
@@ -1,0 +1,45 @@
+// Project/App: GSD-2
+// File Purpose: Compact connected status message formatting for GSD TUI notifications.
+
+const STATUS_INDENT = "    ";
+const STATUS_RULE = "────────────────────────────────────────";
+const ANSI_RESET = "\x1b[0m";
+const ANSI_DIM = "\x1b[2m";
+const ANSI_BOLD = "\x1b[1m";
+const ANSI_GREEN = "\x1b[32m";
+const ANSI_RED = "\x1b[31m";
+const ANSI_BLUE = "\x1b[34m";
+const ANSI_CYAN = "\x1b[36m";
+
+function color(text: string, code: string): string {
+  return `${code}${text}${ANSI_RESET}`;
+}
+
+function titleColor(title: string): string {
+  if (title.includes("✕") || title.toLowerCase().includes("failed")) return ANSI_RED;
+  if (title.includes("✓")) return ANSI_GREEN;
+  return ANSI_BLUE;
+}
+
+export function formatPostUnitStatusCard(title: string, detail?: string): string {
+  const cleanTitle = title.trim();
+  const cleanDetail = detail?.trim();
+  const lines = [`${STATUS_INDENT}${color("╭─", ANSI_BLUE)} ${color(cleanTitle, `${titleColor(cleanTitle)}${ANSI_BOLD}`)}`];
+  if (cleanDetail) {
+    lines.push(`${STATUS_INDENT}   ${color(cleanDetail, ANSI_CYAN)}`);
+  }
+  lines.push(`${STATUS_INDENT}${color(`╰${STATUS_RULE}`, ANSI_BLUE)}`);
+  return lines.join("\n");
+}
+
+export function formatConnectedStepStack(
+  statusTitle: string,
+  completedLabel: string,
+): string {
+  const statusColor = titleColor(statusTitle);
+  return [
+    `${STATUS_INDENT}${color("╭─", ANSI_BLUE)} ${color(statusTitle, `${statusColor}${ANSI_BOLD}`)}`,
+    `${STATUS_INDENT}   ${color("Completed:", ANSI_DIM)} ${color(completedLabel, ANSI_CYAN)}`,
+    `${STATUS_INDENT}${color(`╰${STATUS_RULE}`, ANSI_BLUE)}`,
+  ].join("\n");
+}

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -39,6 +39,7 @@ import { writeVerificationJSON, type PostExecutionCheckJSON, type EvidenceJSON }
 import { logWarning } from "./workflow-logger.js";
 import { runPostExecutionChecks, type PostExecutionResult } from "./post-execution-checks.js";
 import type { AutoSession } from "./auto/session.js";
+import type { ErrorContext } from "./auto/types.js";
 import type { VerificationResult as VerificationGateResult } from "./types.js";
 import { join } from "node:path";
 import { resolveUokFlags } from "./uok/flags.js";
@@ -50,6 +51,7 @@ import type { SliceRow } from "./db-task-slice-rows.js";
 import { getSlice } from "./gsd-db.js";
 import { getLedger } from "./metrics.js";
 import { getUnitCostSpikeAction } from "./auto-budget.js";
+import { formatPostUnitStatusCard } from "./auto-status-message.js";
 
 export interface VerificationContext {
   s: AutoSession;
@@ -58,6 +60,7 @@ export interface VerificationContext {
 }
 
 export type VerificationResult = "continue" | "retry" | "pause";
+type PauseAutoFn = (ctx?: ExtensionContext, pi?: ExtensionAPI, errorContext?: ErrorContext) => Promise<void>;
 
 function getCurrentUnitCostStats(unitId: string): { unitCostUsd: number; rollingAvgUsd: number } {
   const ledger = getLedger();
@@ -194,7 +197,7 @@ function hasReassessmentEvidence(s: AutoSession, milestoneId: string): boolean {
  */
 async function runValidateMilestonePostCheck(
   vctx: VerificationContext,
-  pauseAuto: (ctx?: ExtensionContext, pi?: ExtensionAPI) => Promise<void>,
+  pauseAuto: PauseAutoFn,
 ): Promise<VerificationResult> {
   const { s, ctx, pi } = vctx;
   const prefs = loadEffectiveGSDPreferences()?.preferences;
@@ -310,7 +313,10 @@ async function runValidateMilestonePostCheck(
       `Milestone ${mid} validation returned needs-attention`,
       mid,
     );
-    await pauseAuto(ctx, pi);
+    await pauseAuto(ctx, pi, {
+      message: `Milestone ${mid} validation needs attention.`,
+      category: "unknown",
+    });
     return "pause";
   }
 
@@ -356,7 +362,10 @@ async function runValidateMilestonePostCheck(
     `No incomplete slices found for ${mid} while verdict=needs-remediation`,
     mid,
   );
-  await pauseAuto(ctx, pi);
+  await pauseAuto(ctx, pi, {
+    message: `Milestone ${mid} validation needs remediation but no remediation slices were added.`,
+    category: "unknown",
+  });
   return "pause";
 }
 
@@ -399,7 +408,7 @@ async function countIncompleteSlices(basePath: string, milestoneId: string): Pro
  */
 export async function runPostUnitVerification(
   vctx: VerificationContext,
-  pauseAuto: (ctx?: ExtensionContext, pi?: ExtensionAPI) => Promise<void>,
+  pauseAuto: PauseAutoFn,
 ): Promise<VerificationResult> {
   const { s, ctx, pi } = vctx;
 
@@ -438,7 +447,10 @@ export async function runPostUnitVerification(
     const explicitVerificationTargetsRequested = hasExplicitVerificationTargets(taskRow, sliceRow);
     if (explicitVerificationTargetsRequested && verificationTargets.length === 0) {
       logWarning("engine", "verification: explicit target_repositories requested but no repositories resolved");
-      await pauseAuto(ctx, pi);
+      await pauseAuto(ctx, pi, {
+        message: "Verification failed: no runnable host-owned verification checks were discovered.",
+        category: "unknown",
+      });
       return "pause";
     }
     const result = verificationTargets.length <= 1
@@ -523,11 +535,11 @@ export async function runPostUnitVerification(
       const passCount = result.checks.filter((c) => c.exitCode === 0).length;
       const total = result.checks.length;
       if (result.passed) {
-        ctx.ui.notify(`Verification gate: ${passCount}/${total} checks passed`);
+        ctx.ui.notify(formatPostUnitStatusCard("✓ Verification Gate", `${passCount}/${total} checks passed`));
       } else {
         const failures = result.checks.filter((c) => c.exitCode !== 0);
         const failNames = failures.map((f) => f.command).join(", ");
-        ctx.ui.notify(`Verification gate: FAILED — ${failNames}`);
+        ctx.ui.notify(formatPostUnitStatusCard("✕ Verification Gate", `FAILED — ${failNames}`));
         process.stderr.write(
           `verification-gate: ${total - passCount}/${total} checks failed\n`,
         );
@@ -786,7 +798,10 @@ export async function runPostUnitVerification(
         "error",
       );
       process.stderr.write(`verification-gate: ${verdict.failureContext}\n`);
-      await pauseAuto(ctx, pi);
+      await pauseAuto(ctx, pi, {
+        message: "Verification failed: no runnable host-owned verification checks were discovered.",
+        category: "unknown",
+      });
       return "pause";
     } else if (postExecBlockingFailure) {
       // Post-execution failures are cross-task consistency issues — retrying the same task won't fix them.
@@ -798,7 +813,10 @@ export async function runPostUnitVerification(
         `Post-execution checks failed — cross-task consistency issue detected, pausing for human review`,
         "error",
       );
-      await pauseAuto(ctx, pi);
+      await pauseAuto(ctx, pi, {
+        message: "Post-execution checks failed: cross-task consistency issue detected.",
+        category: "unknown",
+      });
       return "pause";
     } else if (autoFixEnabled && attempt + 1 <= maxRetries) {
       const { unitCostUsd, rollingAvgUsd } = getCurrentUnitCostStats(s.currentUnit.id);
@@ -814,19 +832,17 @@ export async function runPostUnitVerification(
           `Unit ${s.currentUnit.id} hit per-unit cap $${perUnitCapUsd.toFixed(2)} — pausing auto-mode.`,
           "error",
         );
-        await pauseAuto(ctx, pi);
+        await pauseAuto(ctx, pi, {
+          message: `Verification failed and unit ${s.currentUnit.id} hit per-unit cap $${perUnitCapUsd.toFixed(2)}.`,
+          category: "unknown",
+        });
         return "pause";
       }
       if (getUnitCostSpikeAction(unitCostUsd, rollingAvgUsd, 3.0) === "pause") {
-        s.verificationRetryCount.delete(retryKey);
-        s.verificationRetryFailureHashes.delete(retryKey);
-        s.pendingVerificationRetry = null;
         ctx.ui.notify(
-          `Unit ${s.currentUnit.id} cost spike detected (${unitCostUsd.toFixed(2)} vs avg ${rollingAvgUsd.toFixed(2)}) — pausing auto-mode.`,
-          "error",
+          `Unit ${s.currentUnit.id} cost spike detected (${unitCostUsd.toFixed(2)} vs avg ${rollingAvgUsd.toFixed(2)}) during verification retry; keeping verification failure as the authoritative blocker.`,
+          "warning",
         );
-        await pauseAuto(ctx, pi);
-        return "pause";
       }
       const nextAttempt = attempt + 1;
       s.verificationRetryCount.set(retryKey, nextAttempt);
@@ -862,7 +878,10 @@ export async function runPostUnitVerification(
         `Verification gate FAILED after ${attempt} ${attempt === 1 ? "retry" : "retries"} (${exhaustedSummary}) — pausing for human review`,
         "error",
       );
-      await pauseAuto(ctx, pi);
+      await pauseAuto(ctx, pi, {
+        message: `Verification gate failed after ${attempt} ${attempt === 1 ? "retry" : "retries"} (${exhaustedSummary}).`,
+        category: "unknown",
+      });
       return "pause";
     }
   } catch (err) {
@@ -871,7 +890,10 @@ export async function runPostUnitVerification(
       `Verification gate errored before producing an authoritative verdict: ${(err as Error).message}`,
       "error",
     );
-    await pauseAuto(ctx, pi);
+    await pauseAuto(ctx, pi, {
+      message: `Verification gate errored before producing an authoritative verdict: ${(err as Error).message}`,
+      category: "unknown",
+    });
     return "pause";
   }
 }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1271,7 +1271,7 @@ export async function stopAuto(
   const stopNotificationPrefix = formatAutoStopNotificationPrefix(reason);
   const displayReason = formatAutoStopDisplayReason(reason);
   const completionStopRequested = Boolean(options.completionWidget);
-  const renderCompletionWidget = completionStopRequested && process.env.GSD_HEADLESS === "1";
+  const installCompletionWidget = completionStopRequested;
   const preserveCompletionSurface = completionStopRequested;
   s.completionStopInProgress = preserveCompletionSurface;
 
@@ -1531,7 +1531,7 @@ export async function stopAuto(
       debugLog("stop-cleanup-ledger", { error: e instanceof Error ? e.message : String(e) });
     }
 
-    if (renderCompletionWidget && ctx && options.completionWidget) {
+    if (installCompletionWidget && ctx && options.completionWidget) {
       const ledger = getLedger();
       const units = ledger?.units ?? [];
       const totals = units.length > 0 ? getProjectTotals(units) : null;
@@ -1678,8 +1678,8 @@ export async function stopAuto(
 
     // UI cleanup
     ctx?.ui.setStatus("gsd-auto", undefined);
-    if (renderCompletionWidget) {
-      // Headless callers keep the durable completion widget/notification path.
+    if (installCompletionWidget) {
+      // Completion stops keep the durable final closeout surface visible.
     } else if (preserveCompletionSurface) {
       ctx?.ui.setWidget("gsd-progress", undefined);
       ctx?.ui.setWidget("gsd-outcome", undefined);

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -84,6 +84,7 @@ import {
   getBudgetAlertLevel,
   getNewBudgetAlertLevel,
   getBudgetEnforcementAction,
+  getContextPauseAction,
 } from "./auto-budget.js";
 import {
   markToolStart as _markToolStart,
@@ -633,6 +634,7 @@ export {
   getBudgetAlertLevel,
   getNewBudgetAlertLevel,
   getBudgetEnforcementAction,
+  getContextPauseAction,
 } from "./auto-budget.js";
 
 function closeOutSignalInterruptedUnit(currentBasePath: string): void {
@@ -1873,8 +1875,11 @@ export async function pauseAuto(
     unitLabel: pausedUnitLabel,
   });
   if (ctx) initHealthWidget(ctx);
+  const pauseMessage = _errorContext?.message
+    ? `${s.stepMode ? "Step" : "Auto"}-mode paused: ${_errorContext.message}`
+    : `${s.stepMode ? "Step" : "Auto"}-mode paused (Escape). Type to interact, or ${resumeCmd} to resume.`;
   ctx?.ui.notify(
-    `${s.stepMode ? "Step" : "Auto"}-mode paused (Escape). Type to interact, or ${resumeCmd} to resume.`,
+    pauseMessage,
     "info",
   );
 }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1268,7 +1268,9 @@ export async function stopAuto(
   const loadedPreferences = loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences;
   const stopNotificationPrefix = formatAutoStopNotificationPrefix(reason);
   const displayReason = formatAutoStopDisplayReason(reason);
-  const preserveCompletionSurface = Boolean(options.completionWidget);
+  const completionStopRequested = Boolean(options.completionWidget);
+  const renderCompletionWidget = completionStopRequested && process.env.GSD_HEADLESS === "1";
+  const preserveCompletionSurface = completionStopRequested;
   s.completionStopInProgress = preserveCompletionSurface;
 
   // #4764 — telemetry: record the exit reason, isolation mode, whether an auto
@@ -1527,7 +1529,7 @@ export async function stopAuto(
       debugLog("stop-cleanup-ledger", { error: e instanceof Error ? e.message : String(e) });
     }
 
-    if (preserveCompletionSurface && ctx && options.completionWidget) {
+    if (renderCompletionWidget && ctx && options.completionWidget) {
       const ledger = getLedger();
       const units = ledger?.units ?? [];
       const totals = units.length > 0 ? getProjectTotals(units) : null;
@@ -1674,7 +1676,12 @@ export async function stopAuto(
 
     // UI cleanup
     ctx?.ui.setStatus("gsd-auto", undefined);
-    if (!preserveCompletionSurface) {
+    if (renderCompletionWidget) {
+      // Headless callers keep the durable completion widget/notification path.
+    } else if (preserveCompletionSurface) {
+      ctx?.ui.setWidget("gsd-progress", undefined);
+      ctx?.ui.setWidget("gsd-outcome", undefined);
+    } else {
       ctx?.ui.setWidget("gsd-progress", undefined);
       const status = isBlockedStopReason(reason) ? "blocked" : reason?.toLowerCase().includes("fail") ? "failed" : "stopped";
       setLifecycleOutcome(ctx, {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -336,6 +336,20 @@ export function formatAutoStopNotification(prefix: string, totals: { cost: numbe
   ].join("\n");
 }
 
+function isBlockedStopReason(reason?: string | null): boolean {
+  return /^Blocked:\s*/i.test(reason ?? "");
+}
+
+function formatAutoStopDisplayReason(reason?: string | null): string {
+  return (reason ?? "").replace(/^Blocked:\s*/i, "").trim();
+}
+
+export function formatAutoStopNotificationPrefix(reason?: string | null): string {
+  const displayReason = formatAutoStopDisplayReason(reason);
+  const prefix = isBlockedStopReason(reason) ? "Auto-mode blocked" : "Auto-mode stopped";
+  return displayReason ? `${prefix} — ${displayReason}` : prefix;
+}
+
 /**
  * Phase B — register this auto-mode process in the workers table so other
  * workers and janitors can detect liveness via heartbeat. Best-effort: if
@@ -1252,7 +1266,8 @@ export async function stopAuto(
 ): Promise<void> {
   if (!s.active && !s.paused) return;
   const loadedPreferences = loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences;
-  const reasonSuffix = reason ? ` — ${reason}` : "";
+  const stopNotificationPrefix = formatAutoStopNotificationPrefix(reason);
+  const displayReason = formatAutoStopDisplayReason(reason);
   const preserveCompletionSurface = Boolean(options.completionWidget);
   s.completionStopInProgress = preserveCompletionSurface;
 
@@ -1497,7 +1512,7 @@ export async function stopAuto(
           ? "All milestones complete"
           : isMilestoneComplete
             ? `${reason}. Auto-mode finished this milestone`
-            : `Auto-mode stopped${reasonSuffix}`;
+            : stopNotificationPrefix;
         if (ledger && ledger.units.length > 0) {
           const totals = getProjectTotals(ledger.units);
           ctx?.ui.notify(
@@ -1565,7 +1580,7 @@ export async function stopAuto(
         basePath: s.originalBasePath || s.basePath || null,
       });
       if (process.env.GSD_HEADLESS === "1") {
-        ctx.ui.notify(`Auto-mode stopped${reasonSuffix}.`, "info");
+        ctx.ui.notify(`${stopNotificationPrefix}.`, "info");
       }
     }
 
@@ -1574,8 +1589,8 @@ export async function stopAuto(
       pi?.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "clear" as const, preferences: loadedPreferences });
       pi?.events.emit(CMUX_CHANNELS.LOG, {
         preferences: loadedPreferences,
-        message: `Auto-mode stopped${reasonSuffix || ""}.`,
-        level: reason?.startsWith("Blocked:") ? "warning" : "info",
+        message: `${stopNotificationPrefix}.`,
+        level: isBlockedStopReason(reason) ? "warning" : "info",
       });
     } catch (e) {
       debugLog("stop-cleanup-cmux", { error: e instanceof Error ? e.message : String(e) });
@@ -1661,11 +1676,11 @@ export async function stopAuto(
     ctx?.ui.setStatus("gsd-auto", undefined);
     if (!preserveCompletionSurface) {
       ctx?.ui.setWidget("gsd-progress", undefined);
-      const status = reason?.startsWith("Blocked:") ? "blocked" : reason?.toLowerCase().includes("fail") ? "failed" : "stopped";
+      const status = isBlockedStopReason(reason) ? "blocked" : reason?.toLowerCase().includes("fail") ? "failed" : "stopped";
       setLifecycleOutcome(ctx, {
         status,
         title: status === "blocked" ? "Auto-mode blocked" : status === "failed" ? "Auto-mode stopped with an issue" : "Auto-mode stopped",
-        detail: reason ?? "Auto-mode stopped.",
+        detail: displayReason || "Auto-mode stopped.",
         nextAction: status === "blocked"
           ? "Fix the blocker, then run /gsd auto to resume."
           : "Run /gsd status for the current project state, or /gsd auto to continue.",

--- a/src/resources/extensions/gsd/auto/lease-conflict-notice.ts
+++ b/src/resources/extensions/gsd/auto/lease-conflict-notice.ts
@@ -1,0 +1,62 @@
+// Project/App: GSD-2
+// File Purpose: Formats user-facing auto-mode milestone lease conflict notices.
+
+const LEASE_HELD_RE = /^Milestone\s+(\S+)\s+is held by worker\s+(.+?)\s+until\s+(.+?)\.?$/;
+
+export interface LeaseConflictNoticeInput {
+  milestoneId?: string | null;
+  unitType: string;
+  unitId: string;
+  reason: string;
+  now?: Date;
+}
+
+function formatRelativeDuration(ms: number): string {
+  const seconds = Math.max(1, Math.ceil(Math.abs(ms) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.ceil(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.ceil(minutes / 60);
+  return `${hours}h`;
+}
+
+function formatRetryWindow(expiresAt: string, now: Date): string {
+  const expiry = new Date(expiresAt);
+  if (Number.isNaN(expiry.getTime())) {
+    return `until ${expiresAt}`;
+  }
+
+  const clock = expiry.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "short",
+  });
+  const deltaMs = expiry.getTime() - now.getTime();
+  if (deltaMs <= 0) {
+    return `after ${clock} (the lease should be expired now)`;
+  }
+  return `after ${clock} (about ${formatRelativeDuration(deltaMs)})`;
+}
+
+export function formatLeaseConflictNotice(input: LeaseConflictNoticeInput): string {
+  const milestoneId = input.milestoneId || "the milestone";
+  const unitLabel = `${input.unitType} ${input.unitId}`;
+  const match = input.reason.match(LEASE_HELD_RE);
+
+  if (!match) {
+    return [
+      `Blocked: ${milestoneId} is already active in another GSD worker. Try /gsd status to inspect it, then rerun /gsd auto when it finishes.`,
+      `Waiting unit: ${unitLabel}.`,
+      `Details: ${input.reason}`,
+    ].join("\n");
+  }
+
+  const [, parsedMilestoneId, workerId, expiresAt] = match;
+  const retryWindow = formatRetryWindow(expiresAt, input.now ?? new Date());
+  return [
+    `Blocked: ${parsedMilestoneId} is already active in another GSD worker. Retry with /gsd auto ${retryWindow}.`,
+    `Waiting unit: ${unitLabel}.`,
+    `Details: held by ${workerId}.`,
+  ].join("\n");
+}

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -105,6 +105,7 @@ import {
 } from "./workflow-custom-engine-verify-outcome.js";
 import { handleCustomEngineReconcile } from "./workflow-custom-engine-reconcile.js";
 import { handleCustomEngineReconcileOutcome } from "./workflow-custom-engine-reconcile-outcome.js";
+import { formatLeaseConflictNotice } from "./lease-conflict-notice.js";
 
 /**
  * Returns true if workerId is an active worker in this project whose OS
@@ -240,6 +241,18 @@ function logCustomVerifyRetryLoadFailure(err: unknown): void {
   debugLog("autoLoop", {
     phase: "load-custom-verify-retries-failed",
     error: err instanceof Error ? err.message : String(err),
+  });
+}
+
+function leaseConflictNotice(
+  iterData: IterationData,
+  reason: string,
+): string {
+  return formatLeaseConflictNotice({
+    milestoneId: iterData.mid,
+    unitType: iterData.unitType,
+    unitId: iterData.unitId,
+    reason,
   });
 }
 
@@ -977,7 +990,7 @@ export async function autoLoop(
           if (retryLease.kind === "ready") {
             leaseBeforeClaim = retryLease;
           } else {
-            const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} before dispatching ${iterData.unitType} ${iterData.unitId}: ${retryLease.reason}`;
+            const msg = leaseConflictNotice(iterData, retryLease.reason);
             ctx.ui.notify(msg, "error");
             finishTurn("stopped", "execution", msg);
             await deps.stopAuto(ctx, pi, msg);
@@ -986,7 +999,7 @@ export async function autoLoop(
         }
       }
       if (leaseBeforeClaim.kind === "blocked" || leaseBeforeClaim.kind === "failed") {
-        const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} before dispatching ${iterData.unitType} ${iterData.unitId}: ${leaseBeforeClaim.reason}`;
+        const msg = leaseConflictNotice(iterData, leaseBeforeClaim.reason);
         ctx.ui.notify(msg, "error");
         finishTurn("stopped", "execution", msg);
         await deps.stopAuto(ctx, pi, msg);
@@ -1029,7 +1042,7 @@ export async function autoLoop(
                 : { kind: "degraded" },
           );
         } else {
-          const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} while claiming ${iterData.unitType} ${iterData.unitId}: ${leaseRecovery.reason}`;
+          const msg = leaseConflictNotice(iterData, leaseRecovery.reason);
           ctx.ui.notify(msg, "error");
           finishTurn("stopped", "execution", msg);
           await deps.stopAuto(ctx, pi, msg);
@@ -1038,7 +1051,7 @@ export async function autoLoop(
       }
       if (dispatchDecision.action === "skip") {
         if (dispatchDecision.reason === "stale-lease") {
-          const msg = `Lost milestone lease for ${iterData.mid ?? "unknown"} while claiming ${iterData.unitType} ${iterData.unitId}; dispatch claim still failed after recovery.`;
+          const msg = leaseConflictNotice(iterData, "dispatch claim still failed after stale-lease recovery");
           ctx.ui.notify(msg, "error");
           finishTurn("stopped", "execution", msg);
           await deps.stopAuto(ctx, pi, msg);

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -57,7 +57,8 @@ import { writeUnitRuntimeRecord } from "../unit-runtime.js";
 import { withTimeout, FINALIZE_PRE_TIMEOUT_MS, FINALIZE_POST_TIMEOUT_MS } from "./finalize-timeout.js";
 import { getEligibleSlices } from "../slice-parallel-eligibility.js";
 import { isSliceParallelActive, startSliceParallel } from "../slice-parallel-orchestrator.js";
-import { isDbAvailable, getMilestoneSlices } from "../gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, getSlice, getTask, refreshOpenDatabaseFromDisk } from "../gsd-db.js";
+import { isClosedStatus } from "../status-guards.js";
 import { reconcileBeforeSpawn } from "../state-reconciliation.js";
 import type { MinimalModelRegistry } from "../context-budget.js";
 import type { PostflightResult, PreflightResult } from "../clean-root-preflight.js";
@@ -68,6 +69,7 @@ import { resetEvidence, loadEvidenceFromDisk } from "../safety/evidence-collecto
 import { parseUnitId } from "../unit-id.js";
 import { createCheckpoint, cleanupCheckpoint, rollbackToCheckpoint } from "../safety/git-checkpoint.js";
 import { resolveSafetyHarnessConfig } from "../safety/safety-harness.js";
+import { getContextPauseAction } from "../auto-budget.js";
 import {
   getWorkflowTransportSupportError,
   getRequiredWorkflowToolsForAutoUnit,
@@ -164,6 +166,25 @@ function rememberRetryDispatch(
     mid: iterData.mid,
     midTitle: iterData.midTitle,
   };
+}
+
+function getAlreadyClosedDispatchReason(unitType: string, unitId: string): string | null {
+  if (!isDbAvailable()) return null;
+  refreshOpenDatabaseFromDisk();
+  const { milestone, slice, task } = parseUnitId(unitId);
+  if (unitType === "execute-task" && milestone && slice && task) {
+    const row = getTask(milestone, slice, task);
+    return row && isClosedStatus(row.status)
+      ? `execute-task ${unitId} is already ${row.status}`
+      : null;
+  }
+  if (unitType === "complete-slice" && milestone && slice) {
+    const row = getSlice(milestone, slice);
+    return row && isClosedStatus(row.status)
+      ? `complete-slice ${unitId} is already ${row.status}`
+      : null;
+  }
+  return null;
 }
 
 export function shouldDegradeEmptyWorktreeToProjectRoot(
@@ -1426,6 +1447,27 @@ export async function runDispatch(
     });
   }
 
+  const alreadyClosedReason = getAlreadyClosedDispatchReason(unitType, unitId);
+  if (alreadyClosedReason) {
+    s.pendingVerificationRetry = null;
+    debugLog("autoLoop", {
+      phase: "dispatch-skip-already-closed",
+      unitType,
+      unitId,
+      reason: alreadyClosedReason,
+    });
+    deps.emitJournalEvent({
+      ts: new Date().toISOString(),
+      flowId: ic.flowId,
+      seq: ic.nextSeq(),
+      eventType: "guard-block",
+      data: { unitType, unitId, reason: alreadyClosedReason },
+    });
+    ctx.ui.notify(`Skipping ${unitType} ${unitId}: ${alreadyClosedReason}.`, "info");
+    await new Promise((r) => setImmediate(r));
+    return { action: "continue" };
+  }
+
   deps.emitJournalEvent({
     ts: new Date().toISOString(),
     flowId: ic.flowId,
@@ -1829,19 +1871,16 @@ export async function runGuards(
   const contextThreshold = prefs?.context_pause_threshold ?? 0;
   if (contextThreshold > 0 && s.cmdCtx) {
     const contextUsage = s.cmdCtx.getContextUsage();
-    if (
-      contextUsage &&
-      contextUsage.percent !== null &&
-      contextUsage.percent >= contextThreshold
-    ) {
-      const msg = `Context window at ${contextUsage.percent}% (threshold: ${contextThreshold}%). Pausing to prevent truncated output.`;
+    if (getContextPauseAction(contextUsage?.percent, contextThreshold) === "pause") {
+      const contextPercent = contextUsage!.percent as number;
+      const msg = `Context window at ${contextPercent}% (threshold: ${contextThreshold}%). Pausing to prevent truncated output.`;
       ctx.ui.notify(
         `${msg} Run /gsd auto to continue (will start fresh session).`,
         "warning",
       );
       deps.sendDesktopNotification(
         "GSD",
-        `Context ${contextUsage.percent}% — paused`,
+        `Context ${contextPercent}% — paused`,
         "warning",
         "attention",
         basename(s.originalBasePath || s.basePath),

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -226,6 +226,34 @@ export function isTerminalDeletedWorktreeProviderError(
   return /[/\\]\.gsd[/\\](?:projects[/\\][^/\\]+[/\\])?worktrees[/\\][^/\\\s"']+/i.test(message);
 }
 
+type MessageEndLike = {
+  message: unknown;
+};
+
+export function suppressTerminalDeletedWorktreeMessageEnd(event: MessageEndLike): boolean {
+  const message = event.message as {
+    role?: unknown;
+    stopReason?: unknown;
+    errorMessage?: unknown;
+    content?: unknown;
+  };
+  if (!isAutoCompletionStopInProgress()) return false;
+  if (message?.role !== "assistant" || message.stopReason !== "error") return false;
+
+  const rawErrorMsg = message.errorMessage ? String(message.errorMessage) : "";
+  const displayMsg = resolveAgentEndErrorDisplay(rawErrorMsg, message.content);
+  if (!isTerminalDeletedWorktreeProviderError(`${rawErrorMsg}\n${displayMsg}`)) return false;
+
+  message.stopReason = "completed";
+  message.errorMessage = undefined;
+  message.content = [];
+  logWarning(
+    "bootstrap",
+    `Suppressing stale deleted-worktree provider error during terminal completion reroot: ${displayMsg || rawErrorMsg}`,
+  );
+  return true;
+}
+
 async function pauseTransientWithBackoff(
   cls: ErrorClass,
   pi: ExtensionAPI,

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -632,6 +632,11 @@ export function registerHooks(
     }
   });
 
+  pi.on("message_end", async (event) => {
+    const { suppressTerminalDeletedWorktreeMessageEnd } = await import("./agent-end-recovery.js");
+    suppressTerminalDeletedWorktreeMessageEnd(event);
+  });
+
   // Squash-merge quick-task branch back to the original branch after the
   // agent turn completes (#2668). cleanupQuickBranch is a no-op when no
   // quick-return state is pending, so this is safe to call on every turn.

--- a/src/resources/extensions/gsd/commands-mcp-status.ts
+++ b/src/resources/extensions/gsd/commands-mcp-status.ts
@@ -7,25 +7,38 @@
  *   /gsd mcp             — Overview of all servers (alias: /gsd mcp status)
  *   /gsd mcp status      — Same as bare /gsd mcp
  *   /gsd mcp check <srv> — Detailed status for a specific server
+ *   /gsd mcp test <srv>  — Test handshake + tools/list for a server
+ *   /gsd mcp enable <srv> / disable <srv> — Toggle local server exposure
+ *   /gsd mcp import <srv> [as <name>] — Copy a discovered server into local config
  *   /gsd mcp init [dir]  — Write project-local GSD workflow MCP config
  */
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
-import { existsSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 
 import { ensureProjectWorkflowMcpConfig } from "./mcp-project-config.js";
-import { gsdHome } from "./gsd-home.js";
+import {
+  deleteProjectLocalMcpServer,
+  readMcpManagementStatus,
+  setProjectLocalMcpServerDisabled,
+  testMcpServerConnection,
+  upsertProjectLocalMcpServer,
+  type ManagedMcpConnectionTestResult,
+  type ManagedMcpTransport,
+} from "../mcp-client/manager.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export interface McpServerStatus {
   name: string;
-  transport: "stdio" | "http" | "unknown";
+  transport: ManagedMcpTransport;
   connected: boolean;
   toolCount: number;
   error: string | undefined;
+  disabled?: boolean;
+  sourcePath?: string;
+  envWarnings?: string[];
 }
 
 export interface McpServerDetail extends McpServerStatus {
@@ -59,65 +72,6 @@ export function formatMcpInitResult(
   ].join("\n");
 }
 
-// ─── Config reader (standalone — does not import mcp-client internals) ──────
-
-interface McpServerRawConfig {
-  name: string;
-  transport: "stdio" | "http" | "unknown";
-  command?: string;
-  args?: string[];
-  url?: string;
-}
-
-function readMcpConfigs(): McpServerRawConfig[] {
-  const servers: McpServerRawConfig[] = [];
-  const seen = new Set<string>();
-  const configPaths = [
-    join(process.cwd(), ".mcp.json"),
-    join(process.cwd(), ".gsd", "mcp.json"),
-    join(gsdHome(), "mcp.json"),
-  ];
-
-  for (const configPath of configPaths) {
-    try {
-      if (!existsSync(configPath)) continue;
-      const raw = readFileSync(configPath, "utf-8");
-      const data = JSON.parse(raw) as Record<string, unknown>;
-      const mcpServers = (data.mcpServers ?? data.servers) as
-        | Record<string, Record<string, unknown>>
-        | undefined;
-      if (!mcpServers || typeof mcpServers !== "object") continue;
-
-      for (const [name, config] of Object.entries(mcpServers)) {
-        if (seen.has(name)) continue;
-        seen.add(name);
-
-        const hasCommand = typeof config.command === "string";
-        const hasUrl = typeof config.url === "string";
-        const transport: McpServerRawConfig["transport"] = hasCommand
-          ? "stdio"
-          : hasUrl
-            ? "http"
-            : "unknown";
-
-        servers.push({
-          name,
-          transport,
-          ...(hasCommand && {
-            command: config.command as string,
-            args: Array.isArray(config.args) ? (config.args as string[]) : undefined,
-          }),
-          ...(hasUrl && { url: config.url as string }),
-        });
-      }
-    } catch {
-      // Non-fatal — config file may not exist or be malformed
-    }
-  }
-
-  return servers;
-}
-
 // ─── Formatters (exported for testing) ──────────────────────────────────────
 
 export function formatMcpStatusReport(servers: McpServerStatus[]): string {
@@ -134,17 +88,21 @@ export function formatMcpStatusReport(servers: McpServerStatus[]): string {
   const lines: string[] = [`MCP Server Status — ${servers.length} server(s)\n`];
 
   for (const s of servers) {
-    const icon = s.error ? "✗" : s.connected ? "✓" : "○";
-    const status = s.error
+    const icon = s.disabled ? "⊘" : s.error ? "✗" : s.connected ? "✓" : "○";
+    const status = s.disabled
+      ? "disabled"
+      : s.error
       ? `error: ${s.error}`
       : s.connected
         ? `connected — ${s.toolCount} tools`
         : "disconnected";
-    lines.push(`  ${icon} ${s.name} (${s.transport}) — ${status}`);
+    const warningText = s.envWarnings?.length ? ` — ${s.envWarnings.length} warning(s)` : "";
+    lines.push(`  ${icon} ${s.name} (${s.transport}) — ${status}${warningText}`);
   }
 
   lines.push("");
   lines.push("Use /gsd mcp check <server> for details on a specific server.");
+  lines.push("Use /gsd mcp test <server> to verify handshake and tool discovery.");
   lines.push("Use mcp_discover to connect and list tools for a server.");
 
   return lines.join("\n");
@@ -154,8 +112,11 @@ export function formatMcpServerDetail(server: McpServerDetail): string {
   const lines: string[] = [`MCP Server: ${server.name}\n`];
 
   lines.push(`  Transport: ${server.transport}`);
+  if (server.sourcePath) lines.push(`  Source:    ${server.sourcePath}`);
 
-  if (server.error) {
+  if (server.disabled) {
+    lines.push(`  Status:    disabled`);
+  } else if (server.error) {
     lines.push(`  Status:    error`);
     lines.push(`  Error:     ${server.error}`);
   } else if (server.connected) {
@@ -174,7 +135,35 @@ export function formatMcpServerDetail(server: McpServerDetail): string {
     lines.push(`  Run mcp_discover("${server.name}") to connect and list tools.`);
   }
 
+  if (server.envWarnings?.length) {
+    lines.push("");
+    lines.push("  Warnings:");
+    for (const warning of server.envWarnings) {
+      lines.push(`    - ${warning}`);
+    }
+  }
+
   return lines.join("\n");
+}
+
+export function formatMcpConnectionTestResult(result: ManagedMcpConnectionTestResult): string {
+  if (result.ok) {
+    return [
+      `MCP test passed for ${result.server}.`,
+      "",
+      `Transport: ${result.transport}`,
+      `Tools:     ${result.toolCount}`,
+      ...(result.tools.length > 0 ? ["", "Available tools:", ...result.tools.map((tool) => `  - ${tool}`)] : []),
+    ].join("\n");
+  }
+
+  return [
+    `MCP test failed for ${result.server}.`,
+    "",
+    `Transport: ${result.transport}`,
+    `Error:     ${result.error ?? "Unknown error"}`,
+    ...(result.warnings.length > 0 ? ["", "Warnings:", ...result.warnings.map((warning) => `  - ${warning}`)] : []),
+  ].join("\n");
 }
 
 // ─── Command handler ────────────────────────────────────────────────────────
@@ -188,7 +177,8 @@ export async function handleMcpStatus(
 ): Promise<void> {
   const trimmed = args.trim();
   const lowered = trimmed.toLowerCase();
-  const configs = readMcpConfigs();
+  const management = readMcpManagementStatus({ includeDisabled: true });
+  const configs = management.servers;
   const systemPrompt = ctx.getSystemPrompt();
 
   // /gsd mcp init [dir]
@@ -205,6 +195,97 @@ export async function handleMcpStatus(
         `Failed to prepare MCP config for ${targetPath}: ${err instanceof Error ? err.message : String(err)}`,
         "error",
       );
+    }
+    return;
+  }
+
+  // /gsd mcp test <server>
+  if (lowered.startsWith("test ")) {
+    const serverName = trimmed.slice("test ".length).trim();
+    const result = await testMcpServerConnection(serverName);
+    ctx.ui.notify(formatMcpConnectionTestResult(result), result.ok ? "info" : "warning");
+    return;
+  }
+
+  // /gsd mcp disable <server>
+  if (lowered.startsWith("disable ")) {
+    const serverName = trimmed.slice("disable ".length).trim();
+    try {
+      const updated = setProjectLocalMcpServerDisabled(serverName, true);
+      ctx.ui.notify(`Disabled MCP server "${updated.name}" in ${updated.sourcePath}.`, "info");
+    } catch (err) {
+      ctx.ui.notify(err instanceof Error ? err.message : String(err), "warning");
+    }
+    return;
+  }
+
+  // /gsd mcp enable <server>
+  if (lowered.startsWith("enable ")) {
+    const serverName = trimmed.slice("enable ".length).trim();
+    try {
+      const updated = setProjectLocalMcpServerDisabled(serverName, false);
+      ctx.ui.notify(`Enabled MCP server "${updated.name}" in ${updated.sourcePath}.`, "info");
+    } catch (err) {
+      ctx.ui.notify(err instanceof Error ? err.message : String(err), "warning");
+    }
+    return;
+  }
+
+  // /gsd mcp delete <server> --confirm
+  if (lowered.startsWith("delete ")) {
+    const raw = trimmed.slice("delete ".length).trim();
+    const confirmed = /\s--confirm$/.test(raw) || raw === "--confirm";
+    const serverName = raw.replace(/\s--confirm$/, "").trim();
+    if (!confirmed || !serverName) {
+      ctx.ui.notify(`Usage: /gsd mcp delete <server> --confirm`, "warning");
+      return;
+    }
+    try {
+      deleteProjectLocalMcpServer(serverName);
+      ctx.ui.notify(`Deleted local MCP server "${serverName}".`, "info");
+    } catch (err) {
+      ctx.ui.notify(err instanceof Error ? err.message : String(err), "warning");
+    }
+    return;
+  }
+
+  // /gsd mcp import <server> [as <name>]
+  if (lowered.startsWith("import ")) {
+    const raw = trimmed.slice("import ".length).trim();
+    const match = raw.match(/^(.*?)\s+as\s+(.+)$/i);
+    const sourceName = (match?.[1] ?? raw).trim();
+    const nextName = (match?.[2] ?? sourceName).trim();
+    const source = configs.find((config) => config.name === sourceName);
+    if (!source) {
+      const available = configs.map((config) => config.name).join(", ") || "(none)";
+      ctx.ui.notify(`Unknown MCP server: "${sourceName}"\n\nAvailable: ${available}`, "warning");
+      return;
+    }
+    if (source.transport === "unsupported") {
+      ctx.ui.notify(`Cannot import "${sourceName}" because transport is unsupported.`, "warning");
+      return;
+    }
+    try {
+      const saved = upsertProjectLocalMcpServer({
+        name: nextName,
+        transport: source.transport,
+        command: source.command,
+        args: source.args,
+        env: source.env,
+        cwd: source.cwd,
+        url: source.url,
+        headers: source.headers,
+        oauth: source.oauth,
+        disabled: source.disabled,
+        importedFrom: {
+          name: source.name,
+          sourcePath: source.sourcePath,
+          sourceTool: source.sourceKind,
+        },
+      });
+      ctx.ui.notify(`Imported MCP server "${source.name}" as "${saved.name}" into ${saved.sourcePath}.`, "info");
+    } catch (err) {
+      ctx.ui.notify(err instanceof Error ? err.message : String(err), "warning");
     }
     return;
   }
@@ -249,6 +330,9 @@ export async function handleMcpStatus(
         toolCount: toolNames.length,
         tools: toolNames,
         error,
+        disabled: config.disabled,
+        sourcePath: config.sourcePath,
+        envWarnings: config.envWarnings,
       }),
       "info",
     );
@@ -285,18 +369,33 @@ export async function handleMcpStatus(
         connected,
         toolCount,
         error,
+        disabled: config.disabled,
+        sourcePath: config.sourcePath,
+        envWarnings: config.envWarnings,
       });
     }
 
-    ctx.ui.notify(formatMcpStatusReport(statuses), "info");
+    const warningLines = [
+      ...management.warnings,
+      ...management.duplicates.map((dup) => `Duplicate "${dup.name}" from ${dup.shadowedSourcePath} is shadowed by ${dup.keptSourcePath}.`),
+    ];
+    const report = warningLines.length > 0
+      ? `${formatMcpStatusReport(statuses)}\n\nConfig warnings:\n${warningLines.map((line) => `  - ${line}`).join("\n")}`
+      : formatMcpStatusReport(statuses);
+    ctx.ui.notify(report, "info");
     return;
   }
 
   // Unknown subcommand
   ctx.ui.notify(
-    "Usage: /gsd mcp [status|check <server>|init [dir]]\n\n" +
+    "Usage: /gsd mcp [status|check <server>|test <server>|enable <server>|disable <server>|delete <server> --confirm|import <server> [as <name>]|init [dir]]\n\n" +
     "  status           Show all MCP server statuses (default)\n" +
     "  check <server>   Detailed status for a specific server\n" +
+    "  test <server>    Verify MCP handshake and tools/list\n" +
+    "  enable <server>  Enable a local GSD-managed server\n" +
+    "  disable <server> Disable a local GSD-managed server\n" +
+    "  delete <server> --confirm  Delete a local GSD-managed server\n" +
+    "  import <server> [as <name>] Copy a discovered server to .gsd/mcp.json\n" +
     "  init [dir]       Write .mcp.json for the local GSD workflow MCP server",
     "warning",
   );

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -44,10 +44,10 @@ function tryParseNumber(val: string): number | null {
   return !isNaN(n) && isFinite(n) ? n : null;
 }
 
-/** Parse a string as a number in the 0–100 range, or return null on failure. */
+/** Parse a string as 0 or a whole percentage in the 1–100 range, or return null on failure. */
 function tryParsePercentage(val: string): number | null {
   const n = Number(val);
-  return !isNaN(n) && n >= 0 && n <= 100 ? n : null;
+  return !isNaN(n) && (n === 0 || (n >= 1 && n <= 100)) ? n : null;
 }
 
 // ─── Prompt helpers (reduce boilerplate across configure* functions) ─────────
@@ -1053,7 +1053,7 @@ async function configureBudget(ctx: ExtensionCommandContext, prefs: Record<strin
         prefs.context_pause_threshold = parsed;
       }
     } else if (val) {
-      ctx.ui.notify(`Invalid context pause threshold "${val}" — must be 0-100. Keeping previous value.`, "warning");
+      ctx.ui.notify(`Invalid context pause threshold "${val}" — use 0 to disable or 1-100 percent. Keeping previous value.`, "warning");
     }
   }
 }

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -132,7 +132,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd skill-health   Skill lifecycle dashboard",
     "  /gsd extensions     Manage extensions  [list|enable|disable|info]",
     "  /gsd fast           Toggle OpenAI service tier  [on|off|flex|status]",
-    "  /gsd mcp            MCP server status and connectivity  [status|check <server>|init [dir]]",
+    "  /gsd mcp            MCP server management  [status|check|test|enable|disable|import|delete|init]",
     "",
     "MAINTENANCE",
     "  /gsd doctor         Diagnose and repair .gsd/ state  [audit|fix|heal] [scope]",

--- a/src/resources/extensions/gsd/dashboard-overlay.ts
+++ b/src/resources/extensions/gsd/dashboard-overlay.ts
@@ -18,6 +18,7 @@ import type { AutoDashboardData } from "./auto-dashboard.js";
 import {
   getLedger, getProjectTotals, aggregateByPhase, aggregateBySlice,
   aggregateByModel, aggregateCacheHitRate, formatCost, formatTokenCount, formatCostProjection,
+  getPromptSizeStats,
   type UnitMetrics,
 } from "./metrics.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
@@ -48,6 +49,11 @@ export function unitLabel(type: string): string {
   }
 }
 
+function formatCharCount(chars: number): string {
+  if (chars >= 1_000_000) return `${(chars / 1_000_000).toFixed(2)}M chars`;
+  if (chars >= 1_000) return `${(chars / 1_000).toFixed(1)}k chars`;
+  return `${chars} chars`;
+}
 
 export class GSDDashboardOverlay {
   private tui: { requestRender: () => void };
@@ -497,6 +503,18 @@ export class GSDDashboardOverlay {
           budgetParts.push(th.fg("error", `${totals.continueHereFiredCount} continue-here fired`));
         }
         lines.push(row(budgetParts.join(`  ${th.fg("dim", "·")}  `)));
+      }
+
+      const promptStats = getPromptSizeStats(ledger.units);
+      if (promptStats) {
+        const promptParts = [
+          `${th.fg("dim", "avg prompt:")} ${th.fg("text", formatCharCount(promptStats.averagePromptChars))}`,
+          `${th.fg("dim", "max:")} ${th.fg("text", formatCharCount(promptStats.maxPromptChars))}`,
+        ];
+        if (promptStats.averageCompressionSavings != null) {
+          promptParts.push(`${th.fg("dim", "compression:")} ${th.fg("success", `${promptStats.averageCompressionSavings}%`)}`);
+        }
+        lines.push(row(promptParts.join(`  ${th.fg("dim", "·")}  `)));
       }
 
       const phases = aggregateByPhase(ledger.units);

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -163,7 +163,7 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
   - `halt` — stop auto-mode immediately.
   - Default: `"pause"`.
 
-- `context_pause_threshold`: number (0-100) — context window usage percentage at which auto-mode should pause to suggest checkpointing. Set to `0` to disable. Default: `0` (disabled).
+- `context_pause_threshold`: number (`0` or `1-100`) — live context window usage percentage at which auto-mode should pause to suggest checkpointing. Set to `0` to disable. Use whole percentages like `75`, not fractional ratios like `0.75`. Default: `0` (disabled).
 
 - `token_profile`: `"budget"`, `"balanced"`, `"quality"`, or `"burn-max"` — coordinates model selection, phase skipping, and context compression. `budget` skips research/reassessment and uses cheaper models; `balanced` (default) skips research/reassessment to reduce token burn; `quality` prefers higher-quality models; `burn-max` keeps full-context defaults, disables downgrade routing, and keeps phase skips off.
 

--- a/src/resources/extensions/gsd/git-constants.ts
+++ b/src/resources/extensions/gsd/git-constants.ts
@@ -22,13 +22,13 @@ const LEAKING_GIT_ENV_VARS = [
 ] as const;
 
 function buildSafeParentEnv(): NodeJS.ProcessEnv {
-  const safe: NodeJS.ProcessEnv = {};
+  const safe: Record<string, string | undefined> = {};
   for (const [k, v] of Object.entries(process.env)) {
     if (!LEAKING_GIT_ENV_VARS.includes(k as (typeof LEAKING_GIT_ENV_VARS)[number])) {
       safe[k] = v;
     }
   }
-  return safe;
+  return safe as NodeJS.ProcessEnv;
 }
 
 /** Env overlay that suppresses interactive git credential prompts and git-svn noise. */

--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -238,6 +238,16 @@ export function snapshotUnitMetrics(
     const totalInput = tokens.cacheRead + tokens.input;
     unit.cacheHitRate = totalInput > 0 ? Math.round((tokens.cacheRead / totalInput) * 100) : 0;
   }
+  if (
+    unit.promptCharCount != null &&
+    unit.baselineCharCount != null &&
+    unit.baselineCharCount > 0
+  ) {
+    unit.compressionSavings = Math.max(
+      0,
+      Math.round(((unit.baselineCharCount - unit.promptCharCount) / unit.baselineCharCount) * 100),
+    );
+  }
 
   // ── Idempotency guard ──────────────────────────────────────────────────
   // Prevent duplicate metrics entries when multiple callers snapshot the
@@ -426,6 +436,16 @@ export function snapshotUnitMetricsByScope(
     const totalInput = tokens.cacheRead + tokens.input;
     unit.cacheHitRate = totalInput > 0 ? Math.round((tokens.cacheRead / totalInput) * 100) : 0;
   }
+  if (
+    unit.promptCharCount != null &&
+    unit.baselineCharCount != null &&
+    unit.baselineCharCount > 0
+  ) {
+    unit.compressionSavings = Math.max(
+      0,
+      Math.round(((unit.baselineCharCount - unit.promptCharCount) / unit.baselineCharCount) * 100),
+    );
+  }
 
   // Idempotency guard: update in-place on duplicate, append otherwise.
   const dupeIdx = scopedLedger.units.findIndex(
@@ -499,6 +519,14 @@ export interface ProjectTotals {
   apiRequests: number;
   totalTruncationSections: number;
   continueHereFiredCount: number;
+}
+
+export interface PromptSizeStats {
+  units: number;
+  averagePromptChars: number;
+  maxPromptChars: number;
+  averageBaselineChars: number | null;
+  averageCompressionSavings: number | null;
 }
 
 function emptyTokens(): TokenCounts {
@@ -595,6 +623,52 @@ export function getProjectTotals(units: UnitMetrics[]): ProjectTotals {
     if (u.continueHereFired) totals.continueHereFiredCount++;
   }
   return totals;
+}
+
+export function getPromptSizeStats(units: UnitMetrics[]): PromptSizeStats | null {
+  const promptUnits = units.filter(
+    (u) => typeof u.promptCharCount === "number" && Number.isFinite(u.promptCharCount) && u.promptCharCount > 0,
+  );
+  if (promptUnits.length === 0) return null;
+
+  let promptTotal = 0;
+  let maxPromptChars = 0;
+  let baselineTotal = 0;
+  let baselineCount = 0;
+  let savingsTotal = 0;
+  let savingsCount = 0;
+
+  for (const unit of promptUnits) {
+    const promptChars = unit.promptCharCount!;
+    promptTotal += promptChars;
+    maxPromptChars = Math.max(maxPromptChars, promptChars);
+
+    if (
+      typeof unit.baselineCharCount === "number" &&
+      Number.isFinite(unit.baselineCharCount) &&
+      unit.baselineCharCount > 0
+    ) {
+      baselineTotal += unit.baselineCharCount;
+      baselineCount++;
+      const savings = Math.max(0, ((unit.baselineCharCount - promptChars) / unit.baselineCharCount) * 100);
+      savingsTotal += savings;
+      savingsCount++;
+    } else if (
+      typeof unit.compressionSavings === "number" &&
+      Number.isFinite(unit.compressionSavings)
+    ) {
+      savingsTotal += Math.max(0, unit.compressionSavings);
+      savingsCount++;
+    }
+  }
+
+  return {
+    units: promptUnits.length,
+    averagePromptChars: Math.round(promptTotal / promptUnits.length),
+    maxPromptChars,
+    averageBaselineChars: baselineCount > 0 ? Math.round(baselineTotal / baselineCount) : null,
+    averageCompressionSavings: savingsCount > 0 ? Math.round(savingsTotal / savingsCount) : null,
+  };
 }
 
 // ─── Tier Aggregation ────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -366,13 +366,16 @@ export function validatePreferences(preferences: GSDPreferences): {
 
   // ─── Context Pause Threshold ────────────────────────────────────────
   if (preferences.context_pause_threshold !== undefined) {
-    const raw = preferences.context_pause_threshold;
-    if (typeof raw === "number" && Number.isFinite(raw)) {
-      validated.context_pause_threshold = raw;
-    } else if (typeof raw === "string" && Number.isFinite(Number(raw))) {
-      validated.context_pause_threshold = Number(raw);
+    const raw = (preferences as Record<string, unknown>).context_pause_threshold;
+    const value = typeof raw === "string" && raw.trim() !== "" ? Number(raw) : raw;
+    if (
+      typeof value === "number" &&
+      Number.isFinite(value) &&
+      (value === 0 || (value >= 1 && value <= 100))
+    ) {
+      validated.context_pause_threshold = value;
     } else {
-      errors.push("context_pause_threshold must be a finite number");
+      errors.push("context_pause_threshold must be 0 to disable or a percentage between 1 and 100");
     }
   }
 

--- a/src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   getBudgetAlertLevel,
   getBudgetEnforcementAction,
+  getContextPauseAction,
   getNewBudgetAlertLevel,
 } from "../auto.js";
 
@@ -47,4 +48,13 @@ test("getBudgetEnforcementAction maps the configured ceiling behavior", () => {
   assert.equal(getBudgetEnforcementAction("warn", 1.0), "warn");
   assert.equal(getBudgetEnforcementAction("pause", 1.0), "pause");
   assert.equal(getBudgetEnforcementAction("halt", 1.0), "halt");
+});
+
+test("getContextPauseAction pauses at or above a percentage threshold", () => {
+  assert.equal(getContextPauseAction(undefined, 90), "none");
+  assert.equal(getContextPauseAction(null, 90), "none");
+  assert.equal(getContextPauseAction(89.9, 90), "none");
+  assert.equal(getContextPauseAction(90, 90), "pause");
+  assert.equal(getContextPauseAction(95, 90), "pause");
+  assert.equal(getContextPauseAction(95, 0), "none");
 });

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -283,7 +283,7 @@ test("setAutoOutcomeWidget renders a durable next-action handoff", () => {
   assert.match(output, /\/gsd auto/);
 });
 
-test("setCompletionProgressWidget uses the outcome slot for terminal all-complete handoff", () => {
+test("setCompletionProgressWidget uses the progress slot for terminal all-complete handoff", () => {
   const calls: Array<[string, unknown]> = [];
   setCompletionProgressWidget(
     {
@@ -313,13 +313,13 @@ test("setCompletionProgressWidget uses the outcome slot for terminal all-complet
   );
 
   assert.ok(
-    calls.some(([key, value]) => key === "gsd-progress" && value === undefined),
-    "terminal completion must clear the active progress widget",
+    calls.some(([key, value]) => key === "gsd-outcome" && value === undefined),
+    "terminal completion must clear stale outcome widgets",
   );
-  const outcome = calls.filter(([key]) => key === "gsd-outcome").at(-1);
-  assert.equal(typeof outcome?.[1], "function", "terminal completion must install the final handoff in the outcome slot");
+  const progress = calls.filter(([key]) => key === "gsd-progress").at(-1);
+  assert.equal(typeof progress?.[1], "function", "terminal completion must install the final handoff in the progress slot");
 
-  const component = (outcome?.[1] as any)(
+  const component = (progress?.[1] as any)(
     { requestRender() {} },
     { fg: (_color: string, text: string) => text, bold: (text: string) => text },
   );

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1172,6 +1172,67 @@ test("autoLoop persists stuck counter reset when dispatch recovery continues", a
   }
 });
 
+test("autoLoop skips provider dispatch when execute-task is already complete in DB", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.ui.setWidget = () => {};
+  const pi = makeMockPi();
+  const basePath = realpathSync(mkdtempSync(join(tmpdir(), "gsd-already-complete-dispatch-")));
+  mkdirSync(join(basePath, ".gsd"), { recursive: true });
+
+  try {
+    openDatabase(join(basePath, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Test Slice", status: "pending" });
+    insertTask({ id: "T01", milestoneId: "M001", sliceId: "S01", title: "Task One", status: "complete" });
+
+    const s = makeLoopSession({
+      basePath,
+      originalBasePath: basePath,
+      canonicalProjectRoot: basePath,
+    });
+    let deriveCount = 0;
+    const notifications: string[] = [];
+    ctx.ui.notify = (msg: string) => notifications.push(msg);
+
+    const deps = makeMockDeps({
+      isDbAvailable: () => true,
+      deriveState: async () => {
+        deriveCount++;
+        if (deriveCount > 1) s.active = false;
+        return {
+          phase: "executing",
+          activeMilestone: { id: "M001", title: "Test", status: "active" },
+          activeSlice: { id: "S01", title: "Slice 1" },
+          activeTask: { id: "T01" },
+          registry: [{ id: "M001", status: "active" }],
+          blockers: [],
+        } as any;
+      },
+      resolveDispatch: async () => {
+        deps.callLog.push("resolveDispatch");
+        return {
+          action: "dispatch" as const,
+          unitType: "execute-task",
+          unitId: "M001/S01/T01",
+          prompt: "do the already-complete task",
+        };
+      },
+    });
+
+    await autoLoop(ctx, pi, s, deps);
+
+    assert.equal(pi.calls.length, 0, "completed task must not be sent to provider again");
+    assert.ok(!deps.callLog.includes("postUnitPreVerification"));
+    assert.ok(notifications.some((m) => m.includes("already complete")));
+  } finally {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(basePath, { recursive: true, force: true });
+  }
+});
+
 test("autoLoop stops before success notification when postflight stash restore needs recovery", async () => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -434,7 +434,7 @@ test("rerootCommandSession refreshes command workspace to project root", async (
   assert.deepEqual(calls, ["/project/root"]);
 });
 
-test("stopAuto foreground completion closeout reroots session and preserves the transcript surface", async (t) => {
+test("stopAuto foreground completion closeout reroots session and installs the durable roll-up surface", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-completion-stop-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
@@ -554,10 +554,17 @@ test("stopAuto foreground completion closeout reroots session and preserves the 
     assert.equal(realpathSync(process.cwd()), realpathSync(base), "completion stop must chdir back to project root");
     const lastProgressWidget = widgetCalls.filter(([key]) => key === "gsd-progress").at(-1);
     assert.equal(
-      lastProgressWidget?.[1],
-      undefined,
-      "foreground completion stop must clear stale progress widgets so the closeout transcript remains visible",
+      typeof lastProgressWidget?.[1],
+      "function",
+      "foreground completion stop must leave the durable roll-up widget visible",
     );
+    const rollup = (lastProgressWidget?.[1] as any)(
+      { requestRender() {} },
+      { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+    ).render(140).join("\n");
+    assert.match(rollup, /Milestone M003 roll-up/);
+    assert.match(rollup, /Budget tracking/);
+    assert.match(rollup, /Users can see what shipped without opening a fresh session/);
     assert.ok(
       notifications.every(message => !message.includes("/gsd auto to resume")),
       "completion stop notification must not tell users to resume a finished auto run",
@@ -680,7 +687,7 @@ test("stopAuto completion closeout emits a headless terminal notification withou
   }
 });
 
-test("stopAuto foreground all-complete closeout leaves the transcript as the final surface", async () => {
+test("stopAuto foreground all-complete closeout leaves a durable roll-up as the final surface", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-all-complete-closeout-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
@@ -730,11 +737,17 @@ test("stopAuto foreground all-complete closeout leaves the transcript as the fin
 
     assert.equal(
       widgetCalls.some(([key, value]) => key === "gsd-progress" && typeof value === "function"),
-      false,
-      "foreground all-complete closeout must not install a roll-up widget that pushes the transcript away",
+      true,
+      "foreground all-complete closeout must install a durable roll-up widget",
     );
     const finalProgress = widgetCalls.filter(([key]) => key === "gsd-progress").at(-1);
-    assert.equal(finalProgress?.[1], undefined, "foreground all-complete closeout clears stale progress widgets");
+    assert.equal(typeof finalProgress?.[1], "function", "foreground all-complete closeout keeps the roll-up visible");
+    const rollup = (finalProgress?.[1] as any)(
+      { requestRender() {} },
+      { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+    ).render(140).join("\n");
+    assert.match(rollup, /All milestones complete/);
+    assert.match(rollup, /Review the roll-up/);
     const finalOutcome = widgetCalls.filter(([key]) => key === "gsd-outcome").at(-1);
     assert.equal(finalOutcome?.[1], undefined, "foreground all-complete closeout must not add an outcome replacement");
   } finally {

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -135,7 +135,7 @@ test("cleanupAfterLoopExit clears status and progress widget without replacing o
   }
 });
 
-test("cleanupAfterLoopExit preserves completion roll-up after stopAuto reset", async () => {
+test("cleanupAfterLoopExit preserves completion closeout surface after stopAuto reset", async () => {
   const statusCalls: unknown[] = [];
   const widgetCalls: unknown[] = [];
 
@@ -160,12 +160,12 @@ test("cleanupAfterLoopExit preserves completion roll-up after stopAuto reset", a
     assert.equal(
       widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-progress" && args[1] === undefined),
       false,
-      "post-loop completion cleanup must leave the final roll-up widget visible",
+      "post-loop completion cleanup must not clear the foreground closeout surface",
     );
     assert.equal(
       widgetCalls.some((args) => Array.isArray(args) && args[0] === "gsd-outcome"),
       false,
-      "completion cleanup must not replace the roll-up with a generic outcome card",
+      "completion cleanup must not replace the closeout surface with a generic outcome card",
     );
     assert.equal(autoSession.completionStopInProgress, false);
   } finally {
@@ -434,7 +434,7 @@ test("rerootCommandSession refreshes command workspace to project root", async (
   assert.deepEqual(calls, ["/project/root"]);
 });
 
-test("stopAuto completion closeout reroots session, restores cwd, and preserves final widget", async (t) => {
+test("stopAuto foreground completion closeout reroots session and preserves the transcript surface", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-completion-stop-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
@@ -552,30 +552,12 @@ test("stopAuto completion closeout reroots session, restores cwd, and preserves 
     assert.deepEqual(newSessionWorkspaces, [base], "completion stop must reroot command session to original project root");
     assert.equal(restoreCalls, 1, "completion stop must restore project root through lifecycle");
     assert.equal(realpathSync(process.cwd()), realpathSync(base), "completion stop must chdir back to project root");
-    assert.ok(
-      widgetCalls.some(([key, value]) => key === "gsd-progress" && typeof value === "function"),
-      "completion stop must install a final progress widget",
-    );
     const lastProgressWidget = widgetCalls.filter(([key]) => key === "gsd-progress").at(-1);
-    assert.equal(typeof lastProgressWidget?.[1], "function", "completion stop must leave the final progress widget installed after reroot");
-    const factory = lastProgressWidget?.[1] as any;
-    const component = factory(
-      { requestRender() {} },
-      { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+    assert.equal(
+      lastProgressWidget?.[1],
+      undefined,
+      "foreground completion stop must clear stale progress widgets so the closeout transcript remains visible",
     );
-    const output = component.render(140).join("\n");
-    assert.match(output, /Milestone M003 roll-up/);
-    assert.match(output, /Outcome/);
-    assert.match(output, /Added budget warning output/);
-    assert.match(output, /Verification/);
-    assert.match(output, /Files: src\/resources\/extensions\/gsd\/auto-dashboard\.ts/);
-    assert.match(output, /Lessons: Milestone endings need report output/);
-    assert.match(output, /2\/3 slices/);
-    assert.match(output, /Next/);
-    assert.match(output, /Review the roll-up/);
-    assert.match(output, /\/gsd auto for next milestone/);
-    assert.doesNotMatch(output, /COMPLETE-MILESTONE/);
-    assert.doesNotMatch(output, /\/gsd auto to resume/);
     assert.ok(
       notifications.every(message => !message.includes("/gsd auto to resume")),
       "completion stop notification must not tell users to resume a finished auto run",
@@ -586,7 +568,7 @@ test("stopAuto completion closeout reroots session, restores cwd, and preserves 
     );
     assert.ok(
       widgetCalls.every(([key, value]) => key !== "gsd-outcome" || value === undefined),
-      "completion stop should use the roll-up as the single final surface",
+      "foreground completion stop must not replace the transcript with a generic outcome card",
     );
 
     const widgetCallCountBeforePostLoopCleanup = widgetCalls.length;
@@ -595,7 +577,12 @@ test("stopAuto completion closeout reroots session, restores cwd, and preserves 
     assert.equal(
       postLoopWidgetCalls.some(([key, value]) => key === "gsd-progress" && value === undefined),
       false,
-      "outer auto-loop cleanup must not clear the final completion roll-up after stopAuto returns",
+      "outer auto-loop cleanup must not touch the closeout surface after stopAuto returns",
+    );
+    assert.equal(
+      postLoopWidgetCalls.some(([key]) => key === "gsd-outcome"),
+      false,
+      "outer auto-loop cleanup must not add a replacement outcome after stopAuto returns",
     );
   } finally {
     try { closeDatabase(); } catch { /* noop */ }
@@ -693,7 +680,7 @@ test("stopAuto completion closeout emits a headless terminal notification withou
   }
 });
 
-test("stopAuto all-complete closeout clears active progress and leaves final outcome", async () => {
+test("stopAuto foreground all-complete closeout leaves the transcript as the final surface", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-all-complete-closeout-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
@@ -741,14 +728,15 @@ test("stopAuto all-complete closeout clears active progress and leaves final out
       },
     );
 
-    assert.ok(
-      widgetCalls.some(([key, value]) => key === "gsd-progress" && value === undefined),
-      "all-complete closeout must clear the stale active progress widget",
+    assert.equal(
+      widgetCalls.some(([key, value]) => key === "gsd-progress" && typeof value === "function"),
+      false,
+      "foreground all-complete closeout must not install a roll-up widget that pushes the transcript away",
     );
     const finalProgress = widgetCalls.filter(([key]) => key === "gsd-progress").at(-1);
-    assert.equal(finalProgress?.[1], undefined, "all-complete closeout must not reinstall active progress");
+    assert.equal(finalProgress?.[1], undefined, "foreground all-complete closeout clears stale progress widgets");
     const finalOutcome = widgetCalls.filter(([key]) => key === "gsd-outcome").at(-1);
-    assert.equal(typeof finalOutcome?.[1], "function", "all-complete closeout must install the final outcome widget");
+    assert.equal(finalOutcome?.[1], undefined, "foreground all-complete closeout must not add an outcome replacement");
   } finally {
     try { closeDatabase(); } catch { /* noop */ }
     autoSession.reset();

--- a/src/resources/extensions/gsd/tests/auto-post-unit-step-message.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-post-unit-step-message.test.ts
@@ -3,9 +3,13 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
 
 import {
+  buildStepCompleteOutcome,
   buildStepCompleteMessage,
+  setStepCompleteFallbackSurface,
+  setStepCompleteSurface,
   shouldReturnStepWizardAfterUnit,
   STEP_COMPLETE_FALLBACK_MESSAGE,
 } from "../auto-post-unit.ts";
@@ -25,12 +29,16 @@ function makeState(overrides: Partial<GSDState>): GSDState {
   };
 }
 
+function plain(message: string): string {
+  return stripVTControlCharacters(message);
+}
+
 test("buildStepCompleteMessage: terminal milestone completion leaves the roll-up as the only closeout message", () => {
   const msg = buildStepCompleteMessage(makeState({ phase: "complete" }));
   assert.equal(msg, null);
 });
 
-test("buildStepCompleteMessage: mid-flight step includes next unit label and /gsd next hint", () => {
+test("buildStepCompleteMessage: mid-flight step renders only the completion receipt", () => {
   const state = makeState({
     phase: "executing",
     activeSlice: { id: "S01", title: "Core" },
@@ -38,23 +46,168 @@ test("buildStepCompleteMessage: mid-flight step includes next unit label and /gs
   });
   const msg = buildStepCompleteMessage(state);
   assert.ok(msg);
-  assert.match(msg, /Next: Execute T03: Wire notify/);
-  assert.doesNotMatch(msg, /\/clear/);
-  assert.match(msg, /\/gsd next to continue one step/);
+  assert.match(msg, /\x1b\[/);
+  const text = plain(msg);
+  assert.match(text, /╭─ ✓ GSD Step Complete/);
+  assert.match(text, /Completed: Step complete/);
+  assert.match(text, /^    ╭─/m);
+  assert.doesNotMatch(text, /^          ╭─/m);
+  assert.doesNotMatch(text, /╭─ Next step/);
+  assert.doesNotMatch(text, /Next: Execute T03: Wire notify/);
+  assert.doesNotMatch(text, /\/clear/);
+  assert.doesNotMatch(text, /Continue: \/gsd next/);
+  assert.doesNotMatch(text, /Auto-run: \/gsd auto/);
+  assert.doesNotMatch(text, /\/gsd next/);
+  assert.doesNotMatch(text, /\/gsd auto/);
+  assert.doesNotMatch(text, /\n│\n/);
+  assert.doesNotMatch(text, /Ctrl\+N/);
 });
 
-test("buildStepCompleteMessage: unknown phase falls back to generic continue label", () => {
+test("buildStepCompleteMessage: unknown phase still renders only the completion receipt", () => {
   // Cast to bypass Phase union so we exercise the default branch of describeNextUnit.
   const state = makeState({ phase: "totally-unknown" as unknown as GSDState["phase"] });
   const msg = buildStepCompleteMessage(state);
   assert.ok(msg);
-  assert.match(msg, /Next: Continue/);
-  assert.doesNotMatch(msg, /\/clear/);
+  const text = plain(msg);
+  assert.match(text, /╭─ ✓ GSD Step Complete/);
+  assert.doesNotMatch(text, /╭─ Next step/);
+  assert.doesNotMatch(text, /Next: Continue/);
+  assert.doesNotMatch(text, /\/clear/);
 });
 
-test("STEP_COMPLETE_FALLBACK_MESSAGE: used when deriveState throws, points users at /gsd next without /clear", () => {
-  assert.doesNotMatch(STEP_COMPLETE_FALLBACK_MESSAGE, /\/clear/);
-  assert.match(STEP_COMPLETE_FALLBACK_MESSAGE, /\/gsd next/);
+test("STEP_COMPLETE_FALLBACK_MESSAGE: used when deriveState throws, stays a receipt without command hints", () => {
+  const text = plain(STEP_COMPLETE_FALLBACK_MESSAGE);
+  assert.match(text, /╭─ ✓ GSD Step Complete/);
+  assert.doesNotMatch(text, /╭─ Next step/);
+  assert.doesNotMatch(text, /\/clear/);
+  assert.doesNotMatch(text, /\/gsd next/);
+  assert.doesNotMatch(text, /\/gsd auto/);
+  assert.doesNotMatch(text, /Next: Continue/);
+  assert.doesNotMatch(text, /Ctrl\+N/);
+});
+
+test("buildStepCompleteOutcome: durable handoff includes next commands", () => {
+  const state = makeState({
+    phase: "executing",
+    activeSlice: { id: "S01", title: "Core" },
+    activeTask: { id: "T03", title: "Wire notify" },
+  });
+
+  const outcome = buildStepCompleteOutcome(state, {
+    type: "complete-slice",
+    id: "M011/S01",
+    startedAt: 123,
+  });
+
+  assert.ok(outcome);
+  assert.equal(outcome.status, "step");
+  assert.equal(outcome.title, "Step complete");
+  assert.match(outcome.detail ?? "", /Execute T03: Wire notify/);
+  assert.equal(outcome.unitLabel, "completing M011/S01");
+  assert.equal(outcome.nextAction, "Advance one step, or resume automatic mode.");
+  assert.doesNotMatch(outcome.nextAction, /\/gsd/);
+  assert.deepEqual(outcome.commands, ["/gsd next", "/gsd auto", "/gsd status for overview"]);
+});
+
+test("setStepCompleteSurface: clears stale progress and installs durable outcome panel", () => {
+  const calls: Array<[string, unknown]> = [];
+  const state = makeState({
+    phase: "executing",
+    activeSlice: { id: "S01", title: "Core" },
+    activeTask: { id: "T03", title: "Wire notify" },
+  });
+
+  const message = setStepCompleteSurface(
+    {
+      hasUI: true,
+      ui: {
+        setWidget(key: string, value: unknown) {
+          calls.push([key, value]);
+        },
+      },
+    } as any,
+    state,
+    { type: "complete-slice", id: "M011/S01", startedAt: 123 },
+  );
+
+  assert.ok(message);
+  assert.match(plain(message), /╭─ ✓ GSD Step Complete/);
+  assert.ok(
+    calls.some(([key, value]) => key === "gsd-progress" && value === undefined),
+    "step completion must clear the live progress widget so stale provider-idle state is not preserved",
+  );
+  const outcome = calls.find(([key, value]) => key === "gsd-outcome" && typeof value === "function");
+  assert.ok(outcome, "step completion must install the durable outcome widget");
+
+  const component = (outcome[1] as any)(
+    { requestRender() {} },
+    { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+  );
+  const output = component.render(120).join("\n");
+  assert.match(output, /Step complete/);
+  assert.match(output, /completing M011\/S01/);
+  assert.match(output, /Advance one step, or resume automatic mode/);
+  assert.match(output, /\/gsd next/);
+  assert.match(output, /\/gsd auto/);
+});
+
+test("setStepCompleteSurface: execute-task renders only the task completion receipt", () => {
+  const calls: Array<[string, unknown]> = [];
+  const state = makeState({
+    phase: "planning",
+    activeSlice: { id: "S02", title: "Follow-up" },
+  });
+
+  const message = setStepCompleteSurface(
+    {
+      hasUI: true,
+      ui: {
+        setWidget(key: string, value: unknown) {
+          calls.push([key, value]);
+        },
+      },
+    } as any,
+    state,
+    { type: "execute-task", id: "M011/S01/T02", startedAt: 123 },
+  );
+
+  assert.ok(message);
+  const text = plain(message);
+  assert.match(text, /╭─ ✓ GSD Task Complete/);
+  assert.match(text, /Completed: executing M011\/S01\/T02/);
+  assert.match(text, /^    ╭─/m);
+  assert.doesNotMatch(text, /^          ╭─/m);
+  assert.doesNotMatch(text, /╭─ Next step/);
+  assert.doesNotMatch(text, /Next: Plan S02: Follow-up/);
+  assert.doesNotMatch(text, /│/);
+});
+
+test("setStepCompleteFallbackSurface: fallback also clears progress and points to status", () => {
+  const calls: Array<[string, unknown]> = [];
+  const message = setStepCompleteFallbackSurface(
+    {
+      hasUI: true,
+      ui: {
+        setWidget(key: string, value: unknown) {
+          calls.push([key, value]);
+        },
+      },
+    } as any,
+    { type: "complete-slice", id: "M011/S01", startedAt: 123 },
+  );
+
+  assert.match(plain(message), /╭─ ✓ GSD Step Complete/);
+  assert.ok(calls.some(([key, value]) => key === "gsd-progress" && value === undefined));
+  const outcome = calls.find(([key, value]) => key === "gsd-outcome" && typeof value === "function");
+  assert.ok(outcome);
+  const component = (outcome[1] as any)(
+    { requestRender() {} },
+    { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+  );
+  const output = component.render(120).join("\n");
+  assert.match(output, /\/gsd status/);
+  assert.match(output, /\/gsd next/);
+  assert.match(output, /\/gsd auto/);
 });
 
 test("shouldReturnStepWizardAfterUnit: terminal milestone completion continues to merge-back path", () => {

--- a/src/resources/extensions/gsd/tests/auto-status-message.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-status-message.test.ts
@@ -1,0 +1,46 @@
+// Project/App: GSD-2
+// File Purpose: Visual contract tests for compact GSD status notification cards.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+
+import {
+  formatConnectedStepStack,
+  formatPostUnitStatusCard,
+} from "../auto-status-message.ts";
+
+test("formatPostUnitStatusCard wraps verification metadata in a compact card", () => {
+  const message = formatPostUnitStatusCard("✓ Verification Gate", "2/2 checks passed");
+  const plain = stripVTControlCharacters(message);
+
+  assert.match(message, /\x1b\[/);
+  assert.match(plain, /^    ╭─ ✓ Verification Gate/m);
+  assert.match(plain, /^       2\/2 checks passed/m);
+  assert.match(plain, /^    ╰/m);
+  assert.doesNotMatch(plain, /^          ╭─/m);
+  assert.doesNotMatch(plain, /│/);
+});
+
+test("formatConnectedStepStack renders task completion as a compact receipt", () => {
+  const message = formatConnectedStepStack(
+    "✓ GSD Task Complete",
+    "executing M011/S03/T01",
+  );
+  const plain = stripVTControlCharacters(message);
+
+  assert.match(message, /\x1b\[/);
+  assert.doesNotMatch(plain.split("\n")[0] ?? "", /╰────╮/);
+  assert.match(plain, /^    ╭─ ✓ GSD Task Complete/m);
+  assert.match(plain, /^       Completed: executing M011\/S03\/T01/m);
+  assert.match(plain, /^    ╰/m);
+  assert.doesNotMatch(plain, /^    ╰────╮/m);
+  assert.doesNotMatch(plain, /^    ╭─ Next step/m);
+  assert.doesNotMatch(plain, /Next: Execute T02: Build tag filter nav/);
+  assert.doesNotMatch(plain, /Continue: \/gsd next/);
+  assert.doesNotMatch(plain, /Auto-run: \/gsd auto/);
+  assert.doesNotMatch(plain, /\/gsd next/);
+  assert.doesNotMatch(plain, /\/gsd auto/);
+  assert.doesNotMatch(plain, /^          ╭─/m);
+  assert.doesNotMatch(plain, /│/);
+});

--- a/src/resources/extensions/gsd/tests/auto-stop-notification.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-stop-notification.test.ts
@@ -4,7 +4,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { formatAutoStopNotification } from "../auto.ts";
+import { formatAutoStopNotification, formatAutoStopNotificationPrefix } from "../auto.ts";
 
 test("auto stop notification keeps session totals on a separate line", () => {
   const message = formatAutoStopNotification(
@@ -16,5 +16,16 @@ test("auto stop notification keeps session totals on a separate line", () => {
   assert.equal(
     message,
     "Auto-mode stopped.\nSession: $0.652 · 87.0k tokens · 2 units",
+  );
+});
+
+test("blocked stop notification uses blocked headline without repeating the marker", () => {
+  const prefix = formatAutoStopNotificationPrefix(
+    "Blocked: M012 is already active in another GSD worker. Retry with /gsd auto after 1:58:59 PM.",
+  );
+
+  assert.equal(
+    prefix,
+    "Auto-mode blocked — M012 is already active in another GSD worker. Retry with /gsd auto after 1:58:59 PM.",
   );
 });

--- a/src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts
@@ -10,7 +10,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { buildSliceSummaryExcerpt, buildCompleteMilestonePrompt } from "../auto-prompts.ts";
+import { buildSliceSummaryExcerpt, buildCompleteMilestonePrompt, buildValidateMilestonePrompt } from "../auto-prompts.ts";
 import { invalidateAllCaches } from "../cache.ts";
 
 // ─── Fixture helpers ──────────────────────────────────────────────────────
@@ -33,6 +33,13 @@ function writeRoadmap(base: string, content: string): void {
 function writeSummary(base: string, sid: string, content: string): void {
   writeFileSync(
     join(base, ".gsd", "milestones", "M001", "slices", sid, `${sid}-SUMMARY.md`),
+    content,
+  );
+}
+
+function writeAssessment(base: string, sid: string, content: string): void {
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", sid, `${sid}-ASSESSMENT.md`),
     content,
   );
 }
@@ -231,6 +238,8 @@ test("#4780 closer prompt: uses excerpts + lists on-demand slice SUMMARY paths",
   writeRoadmap(base, makeRoadmap());
   writeSummary(base, "S01", makeFatSummary("S01"));
   writeSummary(base, "S02", makeFatSummary("S02"));
+  writeFileSync(join(base, ".gsd", "PROJECT.md"), "# Project\n\nBroad product context should stay on-demand.");
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# Context\n\nMilestone context should stay on-demand.");
 
   const prompt = await buildCompleteMilestonePrompt("M001", "Test Milestone", base);
 
@@ -242,6 +251,16 @@ test("#4780 closer prompt: uses excerpts + lists on-demand slice SUMMARY paths",
   assert.match(prompt, /### On-demand Slice Summaries/);
   assert.match(prompt, /S01-SUMMARY\.md/);
   assert.match(prompt, /S02-SUMMARY\.md/);
+  assert.match(prompt, /### On-demand Project Context/);
+  assert.match(prompt, /### On-demand Milestone Context/);
+  assert.ok(
+    !prompt.includes("Broad product context should stay on-demand."),
+    "standard complete-milestone prompt should not inline project narrative",
+  );
+  assert.ok(
+    !prompt.includes("Milestone context should stay on-demand."),
+    "standard complete-milestone prompt should not inline milestone context narrative",
+  );
 
   // Fat narrative (the 20x-repeated paragraph) is NOT inlined
   assert.ok(
@@ -290,5 +309,58 @@ test("complete-milestone prompt caps repeated inlined context around 20k chars",
     inlinedContext.length <= 21_000,
     `inlined context ${inlinedContext.length} chars should stay near the 20k cap`,
   );
-  assert.match(inlinedContext, /\[\.\.\.truncated \d+ sections\]/);
+});
+
+test("validate-milestone prompt uses slice excerpts and on-demand paths instead of full prior artifacts", async (t) => {
+  const base = createBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  writeRoadmap(base, makeRoadmap());
+  writeSummary(base, "S01", makeFatSummary("S01"));
+  writeSummary(base, "S02", makeFatSummary("S02"));
+  writeFileSync(join(base, ".gsd", "PROJECT.md"), "# Project\n\nBroad validation product context should stay on-demand.");
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# Context\n\nValidation milestone context should stay on-demand.");
+  writeAssessment(
+    base,
+    "S01",
+    [
+      "# Assessment",
+      "",
+      "Verdict: PASS — 15 checks passed across runtime simulation.",
+      "",
+      "## Edge Cases",
+      "Empty query, no matches, and priority sort all pass.",
+      "",
+      "## Full Runtime Trace",
+      "This very noisy assessment trace should stay out of the prompt. ".repeat(80),
+    ].join("\n"),
+  );
+
+  const prompt = await buildValidateMilestonePrompt("M001", "Test Milestone", base);
+
+  assert.match(prompt, /### S01 Summary \(excerpt\)/);
+  assert.match(prompt, /### S02 Summary \(excerpt\)/);
+  assert.match(prompt, /### S01 Assessment \(excerpt\)/);
+  assert.match(prompt, /### On-demand Validation Artifacts/);
+  assert.match(prompt, /### On-demand Project Context/);
+  assert.match(prompt, /### On-demand Milestone Context/);
+  assert.match(prompt, /S01-SUMMARY\.md/);
+  assert.match(prompt, /S01-ASSESSMENT\.md/);
+  assert.ok(
+    !prompt.includes("Broad validation product context should stay on-demand."),
+    "standard validate-milestone prompt should not inline project narrative",
+  );
+  assert.ok(
+    !prompt.includes("Validation milestone context should stay on-demand."),
+    "standard validate-milestone prompt should not inline milestone context narrative",
+  );
+  assert.ok(
+    !prompt.includes("threads the cache key through every call site."),
+    "validate prompt must not inline full slice summary narrative",
+  );
+  assert.ok(
+    !prompt.includes("This very noisy assessment trace should stay out of the prompt."),
+    "validate prompt must not inline full assessment traces",
+  );
 });

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -357,11 +357,11 @@ console.log('\n=== complete-slice: handler idempotency ===');
   const dbPath = tempDbPath();
   openDatabase(dbPath);
 
-  const { basePath, roadmapPath } = createTempProject();
+  const { basePath } = createTempProject();
 
   // Set up DB state
   insertMilestone({ id: 'M001' });
-  insertSlice({ id: 'S01', milestoneId: 'M001' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice', risk: 'medium', depends: [], demo: 'basic functionality works', sequence: 1 });
   insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', status: 'complete', title: 'Task 1' });
 
   const params = makeValidSliceParams();
@@ -370,17 +370,78 @@ console.log('\n=== complete-slice: handler idempotency ===');
   const r1 = await handleCompleteSlice(params, basePath);
   assertTrue(!('error' in r1), 'first call should succeed');
 
-  // Second call — state machine guard rejects (slice is already complete)
-  const r2 = await handleCompleteSlice(params, basePath);
-  assertTrue('error' in r2, 'second call should return error (slice already complete)');
-  if ('error' in r2) {
-    assertMatch(r2.error, /already complete/, 'error should mention already complete');
+  if ('error' in r1) {
+    cleanupDir(basePath);
+    cleanup(dbPath);
+    throw new Error('first completion unexpectedly failed');
+  }
+  const summaryBefore = fs.readFileSync(r1.summaryPath, 'utf-8');
+
+  // Second call — healthy duplicates unwind as non-mutating success.
+  const r2 = await handleCompleteSlice(
+    { ...params, oneLiner: 'This duplicate payload should not rewrite completed history' },
+    basePath,
+  );
+  assertTrue(!('error' in r2), 'second call should return duplicate success');
+  if (!('error' in r2)) {
+    assertEq(r2.duplicate, true, 'second call should be marked duplicate');
+    assertEq(
+      fs.readFileSync(r2.summaryPath, 'utf-8'),
+      summaryBefore,
+      'healthy duplicate should not rewrite the existing summary',
+    );
   }
 
   // Verify only 1 slice row (not duplicated)
   const adapter = _getAdapter()!;
   const sliceRows = adapter.prepare("SELECT * FROM slices WHERE milestone_id = 'M001' AND id = 'S01'").all();
   assertEq(sliceRows.length, 1, 'should have exactly 1 slice row after calls');
+
+  cleanupDir(basePath);
+  cleanup(dbPath);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// complete-slice: Handler repairs already-complete slice with stale roadmap
+// ═══════════════════════════════════════════════════════════════════════════
+
+console.log('\n=== complete-slice: handler repairs stale duplicate roadmap ===');
+{
+  const dbPath = tempDbPath();
+  openDatabase(dbPath);
+
+  const { basePath, roadmapPath } = createTempProject();
+
+  insertMilestone({ id: 'M001' });
+  insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Test Slice', risk: 'medium', depends: [], demo: 'basic functionality works', sequence: 1 });
+  insertTask({ id: 'T01', sliceId: 'S01', milestoneId: 'M001', status: 'complete', title: 'Task 1' });
+
+  const params = makeValidSliceParams();
+  const r1 = await handleCompleteSlice(params, basePath);
+  assertTrue(!('error' in r1), 'first completion should succeed');
+  if ('error' in r1) {
+    cleanupDir(basePath);
+    cleanup(dbPath);
+    throw new Error('first completion unexpectedly failed');
+  }
+
+  fs.writeFileSync(
+    roadmapPath,
+    fs.readFileSync(roadmapPath, 'utf-8').replace('- [x] **S01:', '- [ ] **S01:'),
+    'utf-8',
+  );
+  const staleRoadmap = parseRoadmap(fs.readFileSync(roadmapPath, 'utf-8'));
+  assertEq(staleRoadmap.slices.find(s => s.id === 'S01')?.done, false, 'fixture roadmap should be stale before repair');
+
+  const r2 = await handleCompleteSlice(params, basePath);
+  assertTrue(!('error' in r2), 'duplicate completion should repair stale artifacts instead of erroring');
+  if (!('error' in r2)) {
+    assertEq(r2.duplicate, true, 'repair result should be marked duplicate');
+    const repairedRoadmap = fs.readFileSync(roadmapPath, 'utf-8');
+    assertMatch(repairedRoadmap, /- \[x\] \*\*S01:/, 'duplicate completion should re-render roadmap as checked');
+    assertTrue(fs.existsSync(r2.summaryPath), 'summary should still exist after repair');
+    assertTrue(fs.existsSync(r2.uatPath), 'UAT should still exist after repair');
+  }
 
   cleanupDir(basePath);
   cleanup(dbPath);

--- a/src/resources/extensions/gsd/tests/dashboard-budget.test.ts
+++ b/src/resources/extensions/gsd/tests/dashboard-budget.test.ts
@@ -15,9 +15,9 @@ import assert from 'node:assert/strict';
 
 import {
   type UnitMetrics,
-  type MetricsLedger,
   aggregateByModel,
   getProjectTotals,
+  getPromptSizeStats,
   formatTokenCount,
 } from "../metrics.js";
 // ─── Test helpers ─────────────────────────────────────────────────────────────
@@ -82,6 +82,25 @@ function renderCostBudgetLine(units: UnitMetrics[]): string | null {
     return parts.join(" · ");
   }
   return null;
+}
+
+function formatCharCount(chars: number): string {
+  if (chars >= 1_000_000) return `${(chars / 1_000_000).toFixed(2)}M chars`;
+  if (chars >= 1_000) return `${(chars / 1_000).toFixed(1)}k chars`;
+  return `${chars} chars`;
+}
+
+function renderPromptSizeLine(units: UnitMetrics[]): string | null {
+  const stats = getPromptSizeStats(units);
+  if (!stats) return null;
+  const parts = [
+    `avg prompt: ${formatCharCount(stats.averagePromptChars)}`,
+    `max: ${formatCharCount(stats.maxPromptChars)}`,
+  ];
+  if (stats.averageCompressionSavings != null) {
+    parts.push(`compression: ${stats.averageCompressionSavings}%`);
+  }
+  return parts.join(" · ");
 }
 
 /**
@@ -262,6 +281,18 @@ describe('dashboard-budget', () => {
     assert.doesNotMatch(line!, /truncated/, "cost budget continue-only: no truncation text");
     assert.match(line!, /1 continue-here fired/, "cost budget continue-only: shows count");
   }
+
+  test('Cost & Usage: prompt-size summary line', () => {
+    const units = [
+      makeUnit({ promptCharCount: 40_000, baselineCharCount: 80_000 }),
+      makeUnit({ promptCharCount: 20_000, baselineCharCount: 40_000 }),
+    ];
+    const line = renderPromptSizeLine(units);
+    assert.ok(line !== null, "prompt-size line rendered when prompt data exists");
+    assert.match(line!, /avg prompt: 30\.0k chars/, "prompt-size line shows average prompt size");
+    assert.match(line!, /max: 40\.0k chars/, "prompt-size line shows max prompt size");
+    assert.match(line!, /compression: 50%/, "prompt-size line shows average compression savings");
+  });
 
   // ─── Backward compat: no budget fields ────────────────────────────────────────
 

--- a/src/resources/extensions/gsd/tests/lease-conflict-notice.test.ts
+++ b/src/resources/extensions/gsd/tests/lease-conflict-notice.test.ts
@@ -1,0 +1,38 @@
+// Project/App: GSD-2
+// File Purpose: Regression tests for user-facing milestone lease conflict notices.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { formatLeaseConflictNotice } from "../auto/lease-conflict-notice.ts";
+
+test("lease conflict notice explains the retry action before worker details", () => {
+  const message = formatLeaseConflictNotice({
+    milestoneId: "M012",
+    unitType: "run-uat",
+    unitId: "M012/S01",
+    reason: "Milestone M012 is held by worker auto-Jeremys-MacBook-Pro-9.local-34036-ee4ef385 until 2026-05-20T18:58:59.275Z.",
+    now: new Date("2026-05-20T18:58:14.275Z"),
+  });
+
+  const lines = message.split("\n");
+  assert.match(lines[0] ?? "", /^Blocked: M012 is already active in another GSD worker\./);
+  assert.match(lines[0] ?? "", /Retry with \/gsd auto/);
+  assert.match(lines[0] ?? "", /about 45s/);
+  assert.equal(lines[1], "Waiting unit: run-uat M012/S01.");
+  assert.equal(lines[2], "Details: held by auto-Jeremys-MacBook-Pro-9.local-34036-ee4ef385.");
+  assert.doesNotMatch(lines[0] ?? "", /auto-Jeremys/);
+});
+
+test("lease conflict notice keeps unknown reasons as details", () => {
+  const message = formatLeaseConflictNotice({
+    milestoneId: "M012",
+    unitType: "run-uat",
+    unitId: "M012/S01",
+    reason: "stale_lease",
+  });
+
+  assert.match(message, /^Blocked: M012 is already active in another GSD worker\./);
+  assert.match(message, /Try \/gsd status/);
+  assert.match(message, /Details: stale_lease/);
+});

--- a/src/resources/extensions/gsd/tests/mcp-status.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-status.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   formatMcpInitResult,
+  formatMcpConnectionTestResult,
   formatMcpStatusReport,
   formatMcpServerDetail,
   hasHostMcpTool,
@@ -37,6 +38,15 @@ describe("formatMcpStatusReport", () => {
     const result = formatMcpStatusReport(servers);
     assert.match(result, /error/i);
     assert.match(result, /Connection refused/);
+  });
+
+  test("shows disabled state separately from disconnected", () => {
+    const servers: McpServerStatus[] = [
+      { name: "disabled-server", transport: "stdio", connected: false, toolCount: 0, error: undefined, disabled: true },
+    ];
+    const result = formatMcpStatusReport(servers);
+    assert.match(result, /disabled-server/);
+    assert.match(result, /disabled/i);
   });
 
   test("includes server count in header", () => {
@@ -101,6 +111,50 @@ describe("formatMcpServerDetail", () => {
       error: undefined,
     });
     assert.match(result, /disconnected/i);
+  });
+
+  test("shows env warnings for server detail", () => {
+    const result = formatMcpServerDetail({
+      name: "warned",
+      transport: "http",
+      connected: false,
+      toolCount: 0,
+      tools: [],
+      error: undefined,
+      envWarnings: ["headers.Authorization references unset environment variable TOKEN."],
+    });
+    assert.match(result, /Warnings/);
+    assert.match(result, /TOKEN/);
+  });
+});
+
+describe("formatMcpConnectionTestResult", () => {
+  test("summarizes successful tools/list", () => {
+    const result = formatMcpConnectionTestResult({
+      ok: true,
+      server: "demo",
+      transport: "stdio",
+      toolCount: 1,
+      tools: ["ping"],
+      warnings: [],
+    });
+    assert.match(result, /passed/i);
+    assert.match(result, /ping/);
+  });
+
+  test("summarizes failed connection with warnings", () => {
+    const result = formatMcpConnectionTestResult({
+      ok: false,
+      server: "demo",
+      transport: "http",
+      toolCount: 0,
+      tools: [],
+      warnings: ["url references unset environment variable TOKEN."],
+      error: "bad config",
+    });
+    assert.match(result, /failed/i);
+    assert.match(result, /bad config/);
+    assert.match(result, /TOKEN/);
   });
 });
 

--- a/src/resources/extensions/gsd/tests/metrics.test.ts
+++ b/src/resources/extensions/gsd/tests/metrics.test.ts
@@ -17,6 +17,7 @@ import {
   aggregateBySlice,
   aggregateByModel,
   getProjectTotals,
+  getPromptSizeStats,
   formatCost,
   formatTokenCount,
   initMetrics,
@@ -104,6 +105,25 @@ test("getProjectTotals defaults budget fields to 0 for old units", () => {
   const totals = getProjectTotals([makeUnit(), makeUnit()]);
   assert.equal(totals.totalTruncationSections, 0);
   assert.equal(totals.continueHereFiredCount, 0);
+});
+
+test("getPromptSizeStats summarizes prompt bloat and compression", () => {
+  const stats = getPromptSizeStats([
+    makeUnit({ promptCharCount: 40_000, baselineCharCount: 80_000 }),
+    makeUnit({ promptCharCount: 20_000, baselineCharCount: 40_000 }),
+    makeUnit(),
+  ]);
+
+  assert.ok(stats, "prompt-size stats should exist when units have promptCharCount");
+  assert.equal(stats.units, 2);
+  assert.equal(stats.averagePromptChars, 30_000);
+  assert.equal(stats.maxPromptChars, 40_000);
+  assert.equal(stats.averageBaselineChars, 60_000);
+  assert.equal(stats.averageCompressionSavings, 50);
+});
+
+test("getPromptSizeStats returns null for old units without prompt data", () => {
+  assert.equal(getPromptSizeStats([makeUnit(), makeUnit()]), null);
 });
 
 // ── aggregateByPhase ─────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/pipeline-variant-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/pipeline-variant-dispatch.test.ts
@@ -247,6 +247,50 @@ test("#4781 phase 2: validate-milestone rule writes pass-through VALIDATION for 
   assert.doesNotMatch(content, /#[0-9]{3,}/, "validation output must not include tracker-style refs");
 });
 
+test("validate-milestone skip writes to project root when active worktree lacks milestone projections", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+
+  seedMilestone(base, "M001", TRIVIAL_INPUT);
+  const adapter = _getAdapter();
+  assert.ok(adapter, "test database should be open");
+  adapter.prepare("UPDATE slices SET status = 'complete' WHERE milestone_id = 'M001'").run();
+
+  const { writeFileSync, readFileSync } = await import("node:fs");
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    [
+      "# M001",
+      "## Slices",
+      "- [x] **S01: First** `risk:low` `depends:[]`",
+      "- [x] **S02: Second** `risk:low` `depends:[]`",
+    ].join("\n"),
+  );
+
+  const worktree = join(base, ".gsd", "worktrees", "M001");
+  mkdirSync(join(worktree, ".gsd", "runtime"), { recursive: true });
+
+  const ctx = {
+    ...makeCtx({ base: worktree, mid: "M001", phase: "validating-milestone" }),
+    session: {
+      basePath: worktree,
+      originalBasePath: base,
+      currentMilestoneId: "M001",
+    } as DispatchContext["session"],
+  };
+  const result = await findRule(VALIDATE_RULE).match(ctx);
+
+  assert.ok(result, "rule must return a result, not null");
+  assert.strictEqual(result!.action, "skip", "trivial variant must still skip validation");
+
+  const validationPath = join(base, ".gsd", "milestones", "M001", "M001-VALIDATION.md");
+  assert.ok(existsSync(validationPath), "pass-through VALIDATION.md must be written to the project root");
+  assert.match(readFileSync(validationPath, "utf-8"), /skip_validation: true/);
+
+  const worktreeValidationPath = join(worktree, ".gsd", "milestones", "M001", "M001-VALIDATION.md");
+  assert.equal(existsSync(worktreeValidationPath), false, "missing worktree milestone projection must not receive a phantom validation");
+});
+
 test("#4781 phase 2: validate-milestone skip path does not persist gates without a real slice", async (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));

--- a/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/post-exec-retry-bypass.test.ts
@@ -19,6 +19,7 @@ import { AutoSession } from "../auto/session.ts";
 import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask, _getAdapter } from "../gsd-db.ts";
 import { invalidateAllCaches } from "../cache.ts";
 import { _clearGsdRootCache } from "../paths.ts";
+import { initMetrics, resetMetrics } from "../metrics.ts";
 
 // ─── Test Fixtures ───────────────────────────────────────────────────────────
 
@@ -91,6 +92,7 @@ function cleanupTestEnvironment(): void {
   } catch {
     // Ignore
   }
+  resetMetrics();
   try {
     rmSync(tempDir, { recursive: true, force: true });
   } catch {
@@ -163,6 +165,34 @@ function createTaskWithoutVerify(): void {
       estimate: "1h",
       files: [],
       verify: "",
+      inputs: [],
+      expectedOutput: [],
+      observabilityImpact: "",
+    },
+    sequence: 0,
+  });
+}
+
+function createFailingVerifyTask(): void {
+  insertMilestone({ id: "M001" });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Test Slice",
+    risk: "low",
+  });
+
+  insertTask({
+    id: "T01",
+    sliceId: "S01",
+    milestoneId: "M001",
+    title: "Task with failing verification",
+    status: "pending",
+    planning: {
+      description: "Task with deterministic failing verification",
+      estimate: "1h",
+      files: [],
+      verify: "node -e \"process.exit(1)\"",
       inputs: [],
       expectedOutput: [],
       observabilityImpact: "",
@@ -289,6 +319,44 @@ describe("Post-execution blocking failure retry bypass", () => {
     // On success, retry count should be cleared
     assert.equal(result, "continue");
     assert.equal(s.verificationRetryCount.has("execute-task:M001/S01/T01"), false);
+  });
+
+  test("cost spike during verification retry is warning telemetry, not the pause reason", async () => {
+    createFailingVerifyTask();
+    writePreferences({
+      enhanced_verification: true,
+      enhanced_verification_post: false,
+      verification_auto_fix: true,
+      verification_max_retries: 2,
+      per_unit_cost_cap_usd: 10,
+    });
+    writeFileSync(
+      join(tempDir, ".gsd", "metrics.json"),
+      JSON.stringify({
+        version: 1,
+        projectStartedAt: Date.now(),
+        units: [
+          { type: "execute-task", id: "M001/S01/T01", startedAt: 1, tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 1.48, toolCalls: 1, assistantMessages: 1 },
+          ...Array.from({ length: 9 }, (_, i) => ({ type: "execute-task", id: `M000/S00/T0${i}`, startedAt: 10 + i, tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }, cost: 0.01, toolCalls: 1, assistantMessages: 1 })),
+        ],
+      }),
+      "utf-8",
+    );
+    initMetrics(tempDir);
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const pauseAutoMock = mock.fn(async () => {});
+    const s = makeMockSession(tempDir, { type: "execute-task", id: "M001/S01/T01" });
+
+    const result = await runPostUnitVerification({ s, ctx, pi }, pauseAutoMock);
+
+    assert.equal(result, "retry");
+    assert.equal(pauseAutoMock.mock.callCount(), 0);
+    assert.equal(s.pendingVerificationRetry?.unitId, "M001/S01/T01");
+    const messages = ctx.ui.notify.mock.calls.map((c: { arguments: unknown[] }) => String(c.arguments[0]));
+    assert.ok(messages.some((m: string) => m.includes("cost spike detected") && m.includes("authoritative blocker")));
+    assert.ok(messages.some((m: string) => m.includes("Verification failed") && m.includes("auto-fix attempt 1/2")));
   });
 
   test("post-exec failure notification mentions cross-task consistency", async () => {

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -319,11 +319,20 @@ test("valid values pass through correctly", () => {
   const { preferences: p1 } = validatePreferences({ budget_enforcement: "halt" });
   assert.equal(p1.budget_enforcement, "halt");
 
-  const { preferences: p2 } = validatePreferences({ context_pause_threshold: 0.75 });
-  assert.equal(p2.context_pause_threshold, 0.75);
+  const { preferences: p2 } = validatePreferences({ context_pause_threshold: 75 });
+  assert.equal(p2.context_pause_threshold, 75);
 
   const { preferences: p3 } = validatePreferences({ auto_supervisor: { model: "claude-opus-4-6" } });
   assert.equal(p3.auto_supervisor?.model, "claude-opus-4-6");
+});
+
+test("context_pause_threshold rejects fractional ratio values", () => {
+  const { preferences, errors } = validatePreferences({ context_pause_threshold: 0.75 });
+  assert.equal(preferences.context_pause_threshold, undefined);
+  assert.ok(
+    errors.some((e) => e.includes("context_pause_threshold")),
+    "fractional ratio values should fail instead of pausing at less than one percent",
+  );
 });
 
 test("min_request_interval_ms floors decimals and rejects timer overflow values", () => {

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -25,7 +25,7 @@ const PREF_SAMPLE_VALUES: Record<string, unknown> = {
   unique_milestone_ids: true,
   budget_ceiling: 12.5,
   budget_enforcement: "warn",
-  context_pause_threshold: 0.8,
+  context_pause_threshold: 80,
   notifications: {
     enabled: true,
     on_complete: true,

--- a/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
@@ -12,7 +12,7 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
-import { buildExecuteTaskPrompt, buildPlanSlicePrompt, inlineDependencySummaries } from "../auto-prompts.js";
+import { buildExecuteTaskPrompt, buildPlanSlicePrompt, buildReactiveExecutePrompt, buildResearchSlicePrompt, inlineDependencySummaries } from "../auto-prompts.js";
 import { computeBudgets, truncateAtSectionBoundary } from "../context-budget.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -204,6 +204,46 @@ describe("prompt-budget: plan-slice template", () => {
       cleanup(base);
     }
   });
+
+  it("does not inline milestone-wide decisions when slice title has no specific scope", async () => {
+    const base = createFixtureBase();
+    try {
+      setupDependencyFixture(base, "M001", "S01", ["S00"], { S00: "### Results\n\nDone." });
+      writeFileSync(
+        join(base, ".gsd", "DECISIONS.md"),
+        "# Decisions\n\n- This broad decision body should stay out of generic slice planning prompts.\n",
+      );
+
+      const prompt = await buildPlanSlicePrompt("M001", "Milestone", "S01", "Setup implementation testing", base, "standard");
+
+      assert.match(prompt, /### On-demand Decisions/);
+      assert.match(prompt, /\.gsd\/DECISIONS\.md/);
+      assert.doesNotMatch(prompt, /broad decision body should stay out/);
+    } finally {
+      cleanup(base);
+    }
+  });
+});
+
+describe("prompt-budget: research-slice context", () => {
+  it("does not inline milestone-wide decisions when slice title has no specific scope", async () => {
+    const base = createFixtureBase();
+    try {
+      setupDependencyFixture(base, "M001", "S01", ["S00"], { S00: "### Results\n\nDone." });
+      writeFileSync(
+        join(base, ".gsd", "DECISIONS.md"),
+        "# Decisions\n\n- This broad research decision body should stay out of generic slice research prompts.\n",
+      );
+
+      const prompt = await buildResearchSlicePrompt("M001", "Milestone", "S01", "Setup implementation testing", base);
+
+      assert.match(prompt, /### On-demand Decisions/);
+      assert.match(prompt, /\.gsd\/DECISIONS\.md/);
+      assert.doesNotMatch(prompt, /broad research decision body should stay out/);
+    } finally {
+      cleanup(base);
+    }
+  });
 });
 
 // ─── Executor constraints formatting ──────────────────────────────────────────
@@ -344,6 +384,29 @@ describe("prompt-budget: execute-task template", () => {
       });
       assert.match(prompt, /verification/i);
       assert.match(prompt, /~51K chars/);
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("standard execute-task prompt keeps decisions template on demand", async () => {
+    const base = createFixtureBase();
+    try {
+      const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+      const taskDir = join(sliceDir, "tasks");
+      mkdirSync(taskDir, { recursive: true });
+      writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# Roadmap\n");
+      writeFileSync(join(sliceDir, "S01-PLAN.md"), "# Slice Plan\n");
+      writeFileSync(join(taskDir, "T01-PLAN.md"), "# Task Plan\n");
+
+      const prompt = await buildExecuteTaskPrompt("M001", "S01", "Slice", "T01", "Task", base, {
+        level: "standard",
+        sessionContextWindow: 128_000,
+      });
+
+      assert.match(prompt, /### On-demand Decisions Template/);
+      assert.match(prompt, /templates\/decisions\.md/);
+      assert.doesNotMatch(prompt, /### Output Template: Decisions/);
     } finally {
       cleanup(base);
     }
@@ -498,6 +561,67 @@ describe("prompt-budget: execute-task builder truncation pattern", () => {
     if (assembled.length > budget128K.inlineContextBudgetChars) {
       assert.ok(result.content.includes("[...truncated"), "should truncate when content exceeds 128K budget");
       assert.ok(result.droppedSections > 0, "should report dropped sections");
+    }
+  });
+});
+
+describe("prompt-budget: reactive-execute builder", () => {
+  it("caps dependency carry-forward per ready subagent", async () => {
+    const base = createFixtureBase();
+    try {
+      const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+      const taskDir = join(sliceDir, "tasks");
+      mkdirSync(taskDir, { recursive: true });
+      writeFileSync(
+        join(sliceDir, "S01-PLAN.md"),
+        [
+          "# S01: Slice",
+          "",
+          "## Tasks",
+          "",
+          "- [x] **T01: First dep** `est:15m`",
+          "- [x] **T02: Second dep** `est:15m`",
+          "- [ ] **T03: Ready task** `est:15m`",
+        ].join("\n"),
+      );
+      writeFileSync(join(taskDir, "T01-PLAN.md"), "## Expected Output\n\n- `src/a.ts` - A\n");
+      writeFileSync(join(taskDir, "T02-PLAN.md"), "## Expected Output\n\n- `src/b.ts` - B\n");
+      writeFileSync(
+        join(taskDir, "T03-PLAN.md"),
+        [
+          "## Inputs",
+          "",
+          "- `src/a.ts`",
+          "- `src/b.ts`",
+          "",
+          "## Expected Output",
+          "",
+          "- `src/c.ts`",
+        ].join("\n"),
+      );
+      const hugeSummary = [
+        "---",
+        "provides: []",
+        "key_decisions: []",
+        "patterns_established: []",
+        "key_files: []",
+        "---",
+        "# Summary",
+        "",
+        "## Diagnostics",
+        "Large diagnostic ".repeat(3000),
+      ].join("\n");
+      writeFileSync(join(taskDir, "T01-SUMMARY.md"), hugeSummary);
+      writeFileSync(join(taskDir, "T02-SUMMARY.md"), hugeSummary);
+
+      const prompt = await buildReactiveExecutePrompt("M001", "Milestone", "S01", "Slice", ["T03"], base, undefined, {
+        sessionContextWindow: 32_000,
+      });
+
+      assert.match(prompt, /\[\.\.\.truncated/);
+      assert.ok(prompt.length < hugeSummary.length * 2, "reactive prompt should not include full dependency summaries");
+    } finally {
+      cleanup(base);
     }
   });
 });

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -15,8 +15,10 @@ import {
   isTerminalDeletedWorktreeProviderError,
   resetTransientRetryState,
   shouldDeferTransientErrorToCoreRetry,
+  suppressTerminalDeletedWorktreeMessageEnd,
 } from "../bootstrap/agent-end-recovery.ts";
 import { _buildCancelledUnitStopReason } from "../auto/phases.ts";
+import { autoSession } from "../auto-runtime-state.ts";
 import { getNextFallbackModel } from "../preferences.ts";
 // Zero-import module — imported by path rather than through the package
 // barrel to avoid pulling the full AgentSession / @gsd/pi-ai dep graph into
@@ -427,6 +429,45 @@ test("isTerminalDeletedWorktreeProviderError matches removed auto-worktree paths
     isTerminalDeletedWorktreeProviderError('Path "/Users/dev/.gsd/projects/abc123/worktrees/M005" failed with EACCES'),
     false,
   );
+});
+
+test("suppresses terminal completion deleted-worktree message before it renders", () => {
+  autoSession.reset();
+  autoSession.completionStopInProgress = true;
+  try {
+    const event = {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: 'Path "/Users/dev/.gsd/projects/abc123/worktrees/M005" does not exist',
+        content: [],
+      },
+    } as any;
+
+    assert.equal(suppressTerminalDeletedWorktreeMessageEnd(event), true);
+    assert.equal(event.message.stopReason, "completed");
+    assert.equal(event.message.errorMessage, undefined);
+    assert.deepEqual(event.message.content, []);
+  } finally {
+    autoSession.reset();
+  }
+});
+
+test("does not suppress deleted-worktree provider errors outside terminal completion", () => {
+  autoSession.reset();
+  const event = {
+    type: "message_end",
+    message: {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: 'Path "/Users/dev/.gsd/projects/abc123/worktrees/M005" does not exist',
+      content: [],
+    },
+  } as any;
+
+  assert.equal(suppressTerminalDeletedWorktreeMessageEnd(event), false);
+  assert.equal(event.message.stopReason, "error");
 });
 
 // ── resumeAutoAfterProviderDelay ────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/research-milestone-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/research-milestone-composer.test.ts
@@ -79,16 +79,13 @@ test("#4782 phase 3: buildResearchMilestonePrompt emits milestone-context then r
     `milestone-context (${contextIdx}) must precede research template (${researchIdx})`);
 });
 
-test("#4782 phase 3: buildResearchMilestonePrompt preserves manifest order across optional artifacts (#4925 review)", async (t) => {
+test("buildResearchMilestonePrompt keeps broad project docs on-demand", async (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   invalidateAllCaches();
 
   seed(base, "M001");
   writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# M001 Context\n");
-  // Seed PROJECT.md into the artifacts table so inlineProjectFromDb resolves
-  // to a non-null body. Lets us verify the project block sits between
-  // milestone-context and the templates block per manifest order.
   insertArtifact({
     path: "PROJECT.md",
     artifact_type: "project",
@@ -97,18 +94,39 @@ test("#4782 phase 3: buildResearchMilestonePrompt preserves manifest order acros
     task_id: null,
     full_content: "# Project\n\nResearch composer fixture project.\n",
   });
+  insertArtifact({
+    path: "REQUIREMENTS.md",
+    artifact_type: "requirements",
+    milestone_id: null,
+    slice_id: null,
+    task_id: null,
+    full_content: "# Requirements\n\nResearch composer fixture requirements.\n",
+  });
+  insertArtifact({
+    path: "DECISIONS.md",
+    artifact_type: "decisions",
+    milestone_id: null,
+    slice_id: null,
+    task_id: null,
+    full_content: "# Decisions\n\nResearch composer fixture decisions.\n",
+  });
 
   const prompt = await buildResearchMilestonePrompt("M001", "Research Test", base);
 
-  // Manifest-declared order: milestone-context, project, requirements, decisions, templates.
   const contextIdx = prompt.indexOf("### Milestone Context");
-  const projectIdx = prompt.indexOf("### Project");
   const researchIdx = prompt.indexOf("### Output Template: Research");
+  const onDemandIdx = prompt.indexOf("### On-demand Planning Context");
   assert.ok(contextIdx > -1, "milestone-context block missing");
-  assert.ok(projectIdx > -1, "project block missing — seed should have populated it");
   assert.ok(researchIdx > -1, "research template block missing");
+  assert.ok(onDemandIdx > -1, "on-demand planning context missing");
   assert.ok(
-    contextIdx < projectIdx && projectIdx < researchIdx,
-    `manifest order violated: milestone-context (${contextIdx}) < project (${projectIdx}) < research-template (${researchIdx})`,
+    contextIdx < researchIdx && researchIdx < onDemandIdx,
+    `manifest order violated: milestone-context (${contextIdx}) < research-template (${researchIdx}) < on-demand (${onDemandIdx})`,
   );
+  assert.doesNotMatch(prompt, /Research composer fixture project/);
+  assert.doesNotMatch(prompt, /Research composer fixture requirements/);
+  assert.doesNotMatch(prompt, /Research composer fixture decisions/);
+  assert.match(prompt, /`\.gsd\/PROJECT\.md`/);
+  assert.match(prompt, /`\.gsd\/REQUIREMENTS\.md`/);
+  assert.match(prompt, /`\.gsd\/DECISIONS\.md`/);
 });

--- a/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
+++ b/src/resources/extensions/gsd/tests/right-sized-workflow-prompts.test.ts
@@ -93,6 +93,27 @@ test("plan-milestone prompt keeps normal guidance for typed projects", async () 
   }
 });
 
+test("plan-milestone standard prompt keeps project and decisions on-demand", async () => {
+  const base = makeRepo({
+    "package.json": "{\"scripts\":{\"test\":\"node --test\"}}\n",
+    "src/index.js": "console.log('ok');\n",
+    ".gsd/PROJECT.md": "# Project\n\nPlan broad project body.\n",
+    ".gsd/REQUIREMENTS.md": "# Requirements\n\nPlan requirement body.\n",
+    ".gsd/DECISIONS.md": "# Decisions\n\nPlan decision body.\n",
+  });
+  try {
+    const prompt = await buildPlanMilestonePrompt("M001", "Update app", base, "standard");
+    assert.match(prompt, /### On-demand Planning Context/);
+    assert.match(prompt, /`\.gsd\/PROJECT\.md`/);
+    assert.match(prompt, /`\.gsd\/DECISIONS\.md`/);
+    assert.match(prompt, /Plan requirement body/);
+    assert.doesNotMatch(prompt, /Plan broad project body/);
+    assert.doesNotMatch(prompt, /Plan decision body/);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("workflow docs no longer contain blanket 4-10 slice guidance", () => {
   const docs = readFileSync(join(process.cwd(), "src", "resources", "GSD-WORKFLOW.md"), "utf-8");
   assert.doesNotMatch(docs, /4-10 slices/);

--- a/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
@@ -59,8 +59,8 @@ function seed(base: string, mid: string): void {
     demo: "",
     sequence: 1,
   });
-  // Seed PROJECT.md so inlineProjectFromDb resolves — the run-uat manifest
-  // declares "project" as the third inline artifact (#4925 review).
+  // Seed PROJECT.md so the run-uat prompt can advertise the on-demand path
+  // without inlining the full project body.
   insertArtifact({
     path: "PROJECT.md",
     artifact_type: "project",
@@ -71,7 +71,7 @@ function seed(base: string, mid: string): void {
   });
 }
 
-test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project via composer", async (t) => {
+test("#4782 phase 3: buildRunUatPrompt inlines UAT and keeps summary/project context compact", async (t) => {
   const base = makeBase();
   t.after(() => cleanup(base));
   invalidateAllCaches();
@@ -98,14 +98,14 @@ test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project
   assert.match(prompt, /## Context Mode/);
   assert.match(prompt, /verification lane/);
 
-  // Artifacts from the manifest inline list, in declared order:
-  // slice-uat → slice-summary → project (#4925 review).
+  // Context appears in dependency order: UAT body, compact slice-summary
+  // excerpt, then on-demand project context.
   const uatIdx = prompt.indexOf("### S01 UAT");
-  const summaryIdx = prompt.indexOf("### S01 Summary");
-  const projectIdx = prompt.indexOf("### Project");
+  const summaryIdx = prompt.indexOf("### S01 Summary (excerpt)");
+  const projectIdx = prompt.indexOf("### On-demand Project Context");
   assert.ok(uatIdx > -1, "slice UAT block missing");
-  assert.ok(summaryIdx > -1, "slice summary block missing");
-  assert.ok(projectIdx > -1, "project block missing — manifest declares project as 3rd inline");
+  assert.ok(summaryIdx > -1, "slice summary excerpt missing");
+  assert.ok(projectIdx > -1, "project on-demand block missing");
   assert.ok(
     uatIdx < summaryIdx && summaryIdx < projectIdx,
     `manifest order violated: uat (${uatIdx}) < summary (${summaryIdx}) < project (${projectIdx})`,
@@ -116,11 +116,13 @@ test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project
   assert.match(prompt, /fresh in-memory snapshot/);
   assert.ok(!prompt.includes("stale on-disk body"), "resolver re-read disk instead of using uatContent snapshot");
 
-  // Summary body content inlined
-  assert.match(prompt, /What Happened[\s\S]*Ship/);
+  // Summary excerpt is present, but full body narrative is not.
+  assert.match(prompt, /One-liner/);
+  assert.ok(!prompt.includes("## What Happened\nShip."), "run-uat should not inline full slice summary body");
 
-  // Project body content inlined
-  assert.match(prompt, /Run-UAT composer fixture project/);
+  // Project path is advertised on-demand; full project body is not inlined.
+  assert.match(prompt, /\.gsd\/PROJECT\.md/);
+  assert.ok(!prompt.includes("Run-UAT composer fixture project"), "run-uat should not inline full project context");
 });
 
 test("#4782 phase 3: buildRunUatPrompt omits optional slice summary when file is missing", async (t) => {
@@ -140,10 +142,9 @@ test("#4782 phase 3: buildRunUatPrompt omits optional slice summary when file is
   assert.match(prompt, /### S01 UAT/);
   // No empty "S01 Summary" section — section body would be blank without a file
   assert.ok(!prompt.includes("### S01 Summary"));
-  // Project still present (third inline artifact, not optional) and follows
-  // UAT directly with the skipped summary collapsed (#4925 review).
+  // Project on-demand context still follows UAT with the skipped summary collapsed.
   const uatIdx = prompt.indexOf("### S01 UAT");
-  const projectIdx = prompt.indexOf("### Project");
+  const projectIdx = prompt.indexOf("### On-demand Project Context");
   assert.ok(projectIdx > uatIdx, `project must follow UAT when summary is omitted (uat=${uatIdx}, project=${projectIdx})`);
   // No double separator from a skipped block
   assert.ok(!prompt.includes("---\n\n---"));

--- a/src/resources/extensions/gsd/tests/run-uat-replay-cap.test.ts
+++ b/src/resources/extensions/gsd/tests/run-uat-replay-cap.test.ts
@@ -36,7 +36,7 @@ function makeUatProject(): string {
   return base;
 }
 
-test("run-uat dispatch skips after three attempts without a verdict", async () => {
+test("run-uat dispatch stops after three attempts without a verdict", async () => {
   const basePath = makeUatProject();
   const rule = DISPATCH_RULES.find((r) => r.name === "run-uat (post-completion)");
   assert.ok(rule, "run-uat dispatch rule is registered");
@@ -58,8 +58,13 @@ test("run-uat dispatch skips after three attempts without a verdict", async () =
     }
 
     const capped = await rule.match(ctx as any);
-    assert.equal(capped?.action, "skip");
-    assert.equal(getUatCount(basePath, "M001", "S01"), 4);
+    assert.equal(capped?.action, "stop");
+    assert.match(capped?.reason ?? "", /retry limit reached/);
+    assert.equal(getUatCount(basePath, "M001", "S01"), 3);
+
+    const stillCapped = await rule.match(ctx as any);
+    assert.equal(stillCapped?.action, "stop");
+    assert.equal(getUatCount(basePath, "M001", "S01"), 3);
   } finally {
     rmSync(basePath, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts
@@ -143,7 +143,7 @@ test("updateProgressWidget gracefully no-ops when ctx.ui lacks setHeader/setStat
 
 // ── NEXT-mode footer guidance ───────────────────────────────────────────
 
-test("auto-dashboard widget render output includes Ctrl+N guidance when isStepMode is true", (t) => {
+test("auto-dashboard widget render output includes /gsd next guidance when isStepMode is true", (t) => {
   const dir = makeTempDir("step-hint");
   mkdirSync(join(dir, ".gsd"), { recursive: true });
   t.after(() => cleanup(dir));
@@ -175,13 +175,13 @@ test("auto-dashboard widget render output includes Ctrl+N guidance when isStepMo
   const component = widgetFactory!(fakeTui, fakeTheme);
   const lines = component.render(120);
 
-  const hasStepHint = lines.some((line: string) => line.includes("Ctrl+N to advance"));
+  const hasStepHint = lines.some((line: string) => line.includes("/gsd next to advance one step"));
   assert.ok(hasStepHint, `expected step-mode hint in render output; got:\n${lines.join("\n")}`);
 
   if (component.dispose) component.dispose();
 });
 
-test("auto-dashboard widget render output omits Ctrl+N guidance when isStepMode is false", (t) => {
+test("auto-dashboard widget render output omits /gsd next guidance when isStepMode is false", (t) => {
   const dir = makeTempDir("no-step-hint");
   mkdirSync(join(dir, ".gsd"), { recursive: true });
   t.after(() => cleanup(dir));
@@ -213,7 +213,7 @@ test("auto-dashboard widget render output omits Ctrl+N guidance when isStepMode 
   const component = widgetFactory!(fakeTui, fakeTheme);
   const lines = component.render(120);
 
-  const hasStepHint = lines.some((line: string) => line.includes("Ctrl+N to advance"));
+  const hasStepHint = lines.some((line: string) => line.includes("/gsd next to advance one step"));
   assert.equal(hasStepHint, false, "step-mode hint must NOT appear when isStepMode is false");
 
   if (component.dispose) component.dispose();

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -46,7 +46,7 @@ test("#4782 composer: returns empty string for unknown unit type", async () => {
 });
 
 test("#4782 composer: walks the manifest's inline list in declared order", async () => {
-  // reassess-roadmap manifest: [roadmap, slice-context, slice-summary, project, requirements, decisions]
+  // reassess-roadmap manifest keeps broad project docs out of inline context.
   const calls: ArtifactKey[] = [];
   const resolver: ArtifactResolver = async (key) => {
     calls.push(key);
@@ -56,10 +56,6 @@ test("#4782 composer: walks the manifest's inline list in declared order", async
   assert.deepEqual(calls, [
     "roadmap",
     "slice-context",
-    "slice-summary",
-    "project",
-    "requirements",
-    "decisions",
   ]);
   // Output joins blocks with the "---" separator.
   assert.match(out, /BODY:roadmap\n\n---\n\nBODY:slice-context/);
@@ -75,7 +71,7 @@ test("#4782 composer: null-returning resolvers are silently omitted", async () =
   assert.ok(!out.includes("BODY:slice-context"));
   assert.ok(!out.includes("BODY:project"));
   // Remaining keys still emitted in declared order
-  assert.match(out, /BODY:roadmap\n\n---\n\nBODY:slice-summary\n\n---\n\nBODY:requirements\n\n---\n\nBODY:decisions/);
+  assert.strictEqual(out, "BODY:roadmap");
 });
 
 test("#4782 composer: empty-string resolvers are omitted (treated as no-op)", async () => {
@@ -257,8 +253,15 @@ test("#4782 phase 2: buildReassessRoadmapPrompt emits composer-shaped context wi
   assert.match(prompt, /S01: First/);
 
   // Slice summary present
-  assert.match(prompt, /### S01 Summary/);
+  assert.match(prompt, /### S01 Summary \(excerpt\)/);
   assert.match(prompt, /One-liner/);
+  assert.ok(!prompt.includes("## What Happened\nDone."), "reassess prompt should not inline full completed-slice narrative");
+
+  // Broad project docs are advertised on demand instead of fully inlined.
+  assert.match(prompt, /### On-demand Planning Context/);
+  assert.match(prompt, /\.gsd\/PROJECT\.md/);
+  assert.match(prompt, /\.gsd\/REQUIREMENTS\.md/);
+  assert.match(prompt, /\.gsd\/DECISIONS\.md/);
 
   // Slice context is optional and not present in this fixture — must not
   // leave a stray empty section
@@ -374,20 +377,20 @@ test("#4924 v2 composer: omitting resolveArtifact skips inline keys without erro
 });
 
 test("#4924 v2 composer: walks inline + excerpt + computed sections in declared order", async () => {
-  // Reuse the run-uat manifest shape (small inline, no excerpt/computed) and
-  // synthesise a manifest-shape override via a temporary registration would
-  // require touching production data. Instead, drive the composer through
-  // the existing manifest plus mock resolvers and verify ordering against
-  // the declared sequence.
+  // Run-uat now keeps the UAT body inline and moves slice summary to excerpt
+  // context, so verify both resolver lanes preserve manifest order.
   const calls: string[] = [];
   const resolveArtifact: ArtifactResolver = async (key) => {
     calls.push(`art:${key}`);
     return `BODY:${key}`;
   };
-  const out = await composeUnitContext("run-uat", { base: { ...fakeBase, unitType: "run-uat" }, resolveArtifact });
-  // run-uat manifest inline order: slice-uat, slice-summary, project
-  assert.deepEqual(calls, ["art:slice-uat", "art:slice-summary", "art:project"]);
-  assert.match(out.inline, /BODY:slice-uat\n\n---\n\nBODY:slice-summary\n\n---\n\nBODY:project/);
+  const resolveExcerpt: ExcerptResolver = async (key) => {
+    calls.push(`excerpt:${key}`);
+    return `EXCERPT:${key}`;
+  };
+  const out = await composeUnitContext("run-uat", { base: { ...fakeBase, unitType: "run-uat" }, resolveArtifact, resolveExcerpt });
+  assert.deepEqual(calls, ["art:slice-uat", "excerpt:slice-summary"]);
+  assert.match(out.inline, /BODY:slice-uat\n\n---\n\nEXCERPT:slice-summary/);
 });
 
 test("#4924 v2 composer: excerpt section calls resolveExcerpt for declared keys", async () => {
@@ -487,7 +490,7 @@ test("#4924 v2 composer: computed builder returning null omits the section (no e
 
 test("#4924 v2 composer: backward-compat — composeInlinedContext still works for v1 callers", async () => {
   const out = await composeInlinedContext("run-uat", async (key) => `BODY:${key}`);
-  assert.match(out, /BODY:slice-uat\n\n---\n\nBODY:slice-summary\n\n---\n\nBODY:project/);
+  assert.strictEqual(out, "BODY:slice-uat");
 });
 
 test("#4926 review: computed builders see normalized base.unitType matching the resolved manifest", async () => {

--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -177,6 +177,28 @@ test("#4782 phase 1: complete-milestone manifest declares slice-summary as excer
   );
 });
 
+test("closeout manifests keep broad narrative docs on-demand in standard mode", () => {
+  for (const unitType of ["validate-milestone", "complete-milestone"] as const) {
+    const m = UNIT_MANIFESTS[unitType];
+    assert.ok(
+      m.artifacts.onDemand.includes("project"),
+      `${unitType} should keep project narrative on-demand`,
+    );
+    assert.ok(
+      m.artifacts.onDemand.includes("milestone-context"),
+      `${unitType} should keep milestone context on-demand`,
+    );
+    assert.ok(
+      !m.artifacts.inline.includes("project"),
+      `${unitType} should not inline project narrative by default`,
+    );
+    assert.ok(
+      !m.artifacts.inline.includes("milestone-context"),
+      `${unitType} should not inline milestone context by default`,
+    );
+  }
+});
+
 // ─── v2 contract invariants (#4924) ──────────────────────────────────────
 
 test("#4924: computed + prepend ids (when declared) are non-empty strings", () => {

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -11,6 +11,7 @@
  * projection diagnostics and do not roll back committed DB state.
  */
 
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { CompleteSliceParams } from "../types.js";
@@ -28,7 +29,7 @@ import {
   getPendingGatesForTurn,
 } from "../gsd-db.js";
 import { getGatesForTurn } from "../gate-registry.js";
-import { gsdProjectionRoot, clearPathCache } from "../paths.js";
+import { gsdProjectionRoot, clearPathCache, resolveMilestoneFile } from "../paths.js";
 import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { checkOwnership, sliceUnitKey } from "../unit-ownership.js";
 import { saveFile, clearParseCache } from "../files.js";
@@ -47,10 +48,9 @@ export interface CompleteSliceResult {
   summaryPath: string;
   uatPath: string;
   /**
-   * True when this call re-completed an already-closed slice from a turn
-   * superseded by timeout recovery or cancellation. Response is shaped like
-   * success so the orphaned LLM tool call unwinds cleanly without mutating
-   * state.
+   * True when this call reached an already-closed slice. Healthy duplicates
+   * and superseded stale turns return without mutation; current unhealthy
+   * duplicates repair missing/stale projections before returning.
    */
   duplicate?: boolean;
   stale?: boolean;
@@ -82,6 +82,27 @@ function sliceSummaryPath(basePath: string, milestoneId: string, sliceId: string
     sliceId,
     `${sliceId}-SUMMARY.md`,
   );
+}
+
+function hasCompleteSliceArtifactContract(basePath: string, milestoneId: string, sliceId: string): boolean {
+  clearPathCache();
+  clearParseCache();
+
+  const summaryPath = sliceSummaryPath(basePath, milestoneId, sliceId);
+  if (!existsSync(summaryPath)) return false;
+  const uatPath = summaryPath.replace(/-SUMMARY\.md$/, "-UAT.md");
+  if (!existsSync(uatPath)) return false;
+
+  const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP") ??
+    join(gsdProjectionRoot(basePath), "milestones", milestoneId, `${milestoneId}-ROADMAP.md`);
+  if (!existsSync(roadmapPath)) return false;
+
+  try {
+    const roadmap = parseRoadmap(readFileSync(roadmapPath, "utf-8"));
+    return roadmap.slices.some((slice) => slice.id === sliceId && slice.done);
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -323,6 +344,7 @@ export async function handleCompleteSlice(
   const completedAt = new Date().toISOString();
   let guardError: string | null = null;
   let existingSummaryMd = "";
+  let duplicateComplete = false;
 
   transaction(() => {
     // State machine preconditions (inside txn for atomicity).
@@ -337,11 +359,7 @@ export async function handleCompleteSlice(
     const slice = getSlice(params.milestoneId, params.sliceId);
     existingSummaryMd = slice?.full_summary_md?.trim() ?? "";
     if (slice && isClosedStatus(slice.status)) {
-      if (isStaleWrite("complete-slice")) {
-        guardError = "__stale_duplicate__";
-        return;
-      }
-      guardError = `slice ${params.sliceId} is already complete — use gsd_slice_reopen first if you need to redo it`;
+      duplicateComplete = true;
       return;
     }
 
@@ -368,22 +386,26 @@ export async function handleCompleteSlice(
     updateSliceStatus(params.milestoneId, params.sliceId, "complete", completedAt);
   });
 
-  if (guardError === "__stale_duplicate__") {
-    // Stale duplicate from a turn superseded by timeout recovery. Return a
-    // non-mutating success so the orphaned LLM tool call unwinds quietly.
+  if (duplicateComplete) {
     const staleSummaryPath = sliceSummaryPath(
       artifactBasePath,
       params.milestoneId,
       params.sliceId,
     );
-    return {
-      sliceId: params.sliceId,
-      milestoneId: params.milestoneId,
-      summaryPath: staleSummaryPath,
-      uatPath: staleSummaryPath.replace(/-SUMMARY\.md$/, "-UAT.md"),
-      duplicate: true,
-      stale: true,
-    };
+    const duplicateIsStale = isStaleWrite("complete-slice");
+    if (
+      duplicateIsStale ||
+      hasCompleteSliceArtifactContract(artifactBasePath, params.milestoneId, params.sliceId)
+    ) {
+      return {
+        sliceId: params.sliceId,
+        milestoneId: params.milestoneId,
+        summaryPath: staleSummaryPath,
+        uatPath: staleSummaryPath.replace(/-SUMMARY\.md$/, "-UAT.md"),
+        duplicate: true,
+        ...(duplicateIsStale ? { stale: true } : {}),
+      };
+    }
   }
 
   if (guardError) {
@@ -429,6 +451,7 @@ export async function handleCompleteSlice(
     await saveFile(uatPath, uatMd);
 
     const roadmap = await renderRoadmapFromDb(artifactBasePath, params.milestoneId);
+    clearParseCache();
     const roadmapSlice = parseRoadmap(roadmap.content).slices.find((slice) => slice.id === params.sliceId);
     if (!roadmapSlice?.done) {
       throw new Error(`roadmap render did not mark ${params.milestoneId}/${params.sliceId} complete`);
@@ -539,6 +562,7 @@ export async function handleCompleteSlice(
     milestoneId: params.milestoneId,
     summaryPath,
     uatPath,
+    ...(duplicateComplete ? { duplicate: true } : {}),
     ...(projectionStale ? { stale: true } : {}),
   };
 }

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -8,6 +8,7 @@ import {
   type ExecSandboxRequest,
   type ExecSandboxResult,
 } from "../exec-sandbox.js";
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import { isContextModeEnabled, type ContextModeConfig } from "../preferences-types.js";
 import { contextModeDisabledResult, type ToolExecutionResult } from "./context-mode-tool-result.js";
@@ -103,6 +104,27 @@ function pathInside(parent: string, target: string): boolean {
   return target === parent || target.startsWith(parentWithSep);
 }
 
+function comparablePathVariants(value: string): string[] {
+  const variants = new Set<string>();
+  const normalized = normalizeScanPath(path.resolve(value));
+  variants.add(normalized);
+  try {
+    variants.add(normalizeScanPath(realpathSync(normalized)));
+  } catch {
+    // Nonexistent paths are still compared lexically.
+  }
+  if (normalized.startsWith("/private/var/")) {
+    variants.add(normalized.replace(/^\/private\/var\//, "/var/"));
+  } else if (normalized.startsWith("/var/")) {
+    variants.add(`/private${normalized}`);
+  }
+  return [...variants];
+}
+
+function pathInsideAny(parents: readonly string[], targets: readonly string[]): boolean {
+  return targets.some((target) => parents.some((parent) => pathInside(parent, target)));
+}
+
 function stripWrappingQuotes(value: string): string {
   const trimmed = value.trim();
   if (trimmed.length < 2) return trimmed;
@@ -147,9 +169,11 @@ function resolvesToOriginalRootOutsideWorktree(script: string, baseDir: string):
 
   const normalizedWorktree = normalizeScanPath(path.resolve(parsed.worktreeRoot));
   const normalizedOriginalRoot = normalizeScanPath(path.resolve(parsed.originalRoot));
+  const worktreeRoots = comparablePathVariants(normalizedWorktree);
+  const originalRoots = comparablePathVariants(normalizedOriginalRoot);
   for (const value of extractPathLikeValues(script)) {
-    const resolved = normalizeScanPath(path.resolve(normalizedWorktree, value));
-    if (pathInside(normalizedOriginalRoot, resolved) && !pathInside(normalizedWorktree, resolved)) {
+    const resolved = comparablePathVariants(path.resolve(normalizedWorktree, value));
+    if (pathInsideAny(originalRoots, resolved) && !pathInsideAny(worktreeRoots, resolved)) {
       return true;
     }
   }
@@ -160,10 +184,12 @@ function scriptReferencesOriginalRootFromWorktree(script: string, baseDir: strin
   const parsed = parseWorktreeBase(baseDir);
   if (!parsed) return false;
   const normalizedScript = script.replace(/\\/g, "/");
-  const originalRootPattern = new RegExp(
-    `${escapeRegExp(parsed.originalRoot)}(?=$|[\\s'"\\\`;)&|<>]|/(?!\\.gsd/worktrees(?:/|$)))`,
-  );
-  return originalRootPattern.test(normalizedScript);
+  return comparablePathVariants(parsed.originalRoot).some((originalRoot) => {
+    const originalRootPattern = new RegExp(
+      `${escapeRegExp(originalRoot)}(?=$|[\\s'"\\\`;)&|<>]|/(?!\\.gsd/worktrees(?:/|$)))`,
+    );
+    return originalRootPattern.test(normalizedScript);
+  });
 }
 
 export async function executeGsdExec(

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -368,11 +368,11 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     contextMode: "research",
     tools: TOOLS_PLANNING,
     artifacts: {
-      // Phase 3 migration (#4782): matches today's actual
-      // buildResearchMilestonePrompt inlining order.
-      inline: ["milestone-context", "project", "requirements", "decisions", "templates"],
+      // Keep the milestone-specific prompt compact. Broader project docs
+      // stay addressable without being loaded into every research turn.
+      inline: ["milestone-context", "templates"],
       excerpt: [],
-      onDemand: [],
+      onDemand: ["project", "requirements", "decisions"],
     },
     maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
   },
@@ -385,9 +385,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     contextMode: "planning",
     tools: TOOLS_PLANNING,
     artifacts: {
-      inline: ["project", "requirements", "decisions", "milestone-research", "templates"],
+      inline: ["milestone-context", "requirements", "milestone-research", "templates"],
       excerpt: [],
-      onDemand: [],
+      onDemand: ["project", "decisions"],
     },
     maxSystemPromptChars: COMMON_BUDGET_LARGE,
   },
@@ -417,9 +417,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     // fixes before milestone closeout can proceed.
     tools: TOOLS_ALL,
     artifacts: {
-      inline: ["roadmap", "slice-summary", "slice-uat", "requirements", "decisions", "templates"],
-      excerpt: [],
-      onDemand: [],
+      inline: ["roadmap", "requirements", "templates"],
+      excerpt: ["slice-summary", "slice-assessment"],
+      onDemand: ["slice-summary", "slice-assessment", "decisions", "project", "milestone-context"],
     },
     maxSystemPromptChars: COMMON_BUDGET_LARGE,
   },
@@ -437,9 +437,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
       // #4780 landed slice-summary as excerpt for this unit; phase 2 of
       // the architecture will read this manifest as the source of truth
       // and retire the special-case wiring in auto-prompts.ts.
-      inline: ["roadmap", "milestone-context", "requirements", "decisions", "project", "templates"],
+      inline: ["roadmap", "requirements", "templates"],
       excerpt: ["slice-summary"],
-      onDemand: ["slice-summary"],
+      onDemand: ["slice-summary", "decisions", "project", "milestone-context"],
     },
     maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
   },
@@ -458,7 +458,7 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     artifacts: {
       inline: ["roadmap", "milestone-research", "dependency-summaries", "templates"],
       excerpt: [],
-      onDemand: [],
+      onDemand: ["decisions"],
     },
     maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
   },
@@ -543,12 +543,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     contextMode: "planning",
     tools: TOOLS_PLANNING,
     artifacts: {
-      // Phase 2 pilot (#4782): manifest now matches today's actual
-      // buildReassessRoadmapPrompt behavior for equivalence. Phase 3
-      // will tighten this list once the composer reports real telemetry.
-      inline: ["roadmap", "slice-context", "slice-summary", "project", "requirements", "decisions"],
-      excerpt: [],
-      onDemand: [],
+      inline: ["roadmap", "slice-context"],
+      excerpt: ["slice-summary"],
+      onDemand: ["project", "requirements", "decisions"],
     },
     maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
   },
@@ -595,13 +592,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     contextMode: "verification",
     tools: TOOLS_VERIFICATION,
     artifacts: {
-      // Phase 3 migration (#4782): manifest matches today's actual
-      // buildRunUatPrompt inlining. Prior phase-1 entry listed
-      // `slice-plan` aspirationally — the real builder inlines the UAT
-      // file, the slice SUMMARY (optional), and the project row.
-      inline: ["slice-uat", "slice-summary", "project"],
-      excerpt: [],
-      onDemand: [],
+      inline: ["slice-uat"],
+      excerpt: ["slice-summary"],
+      onDemand: ["slice-summary", "project"],
     },
     maxSystemPromptChars: COMMON_BUDGET_SMALL,
   },

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -135,8 +135,8 @@ function getBundledWorkflowMcpCliPath(env: NodeJS.ProcessEnv): string | null {
 function getBundledWorkflowExecutorModulePath(): string | null {
   const candidates = [
     resolve(fileURLToPath(new URL("./tools/workflow-tool-executors.js", import.meta.url))),
-    resolve(fileURLToPath(new URL("./tools/workflow-tool-executors.ts", import.meta.url))),
     resolve(fileURLToPath(new URL("../../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.js", import.meta.url))),
+    resolve(fileURLToPath(new URL("./tools/workflow-tool-executors.ts", import.meta.url))),
   ];
 
   for (const candidate of candidates) {
@@ -149,8 +149,8 @@ function getBundledWorkflowExecutorModulePath(): string | null {
 function getBundledWorkflowWriteGateModulePath(): string | null {
   const candidates = [
     resolve(fileURLToPath(new URL("./bootstrap/write-gate.js", import.meta.url))),
-    resolve(fileURLToPath(new URL("./bootstrap/write-gate.ts", import.meta.url))),
     resolve(fileURLToPath(new URL("../../../../dist/resources/extensions/gsd/bootstrap/write-gate.js", import.meta.url))),
+    resolve(fileURLToPath(new URL("./bootstrap/write-gate.ts", import.meta.url))),
   ];
 
   for (const candidate of candidates) {

--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -24,28 +24,19 @@ import { Type } from "@sinclair/typebox";
 import { Client } from "@modelcontextprotocol/sdk/client";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
 import { buildHttpTransportOpts } from "./auth.js";
-import type { McpHttpAuthConfig } from "./auth.js";
-import { gsdHome } from "../gsd/gsd-home.js";
+import {
+	buildMcpChildEnv,
+	clearMcpConfigCache,
+	getMcpServerConfig,
+	readMcpServerConfigs,
+	resolveMcpEnv,
+	type ManagedMcpServerConfig,
+} from "./manager.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface McpServerConfig {
-	name: string;
-	transport: "stdio" | "http" | "unknown";
-	sourcePath: string;
-	command?: string;
-	args?: string[];
-	env?: Record<string, string>;
-	url?: string;
-	cwd?: string;
-	/** Static headers for HTTP transport (supports ${VAR} env resolution). */
-	headers?: Record<string, string>;
-	/** OAuth config for HTTP transport. */
-	oauth?: McpHttpAuthConfig["oauth"];
-}
+type McpServerConfig = ManagedMcpServerConfig;
 
 interface McpToolSchema {
 	name: string;
@@ -62,28 +53,8 @@ interface ManagedConnection {
 
 const connections = new Map<string, ManagedConnection>();
 const pendingConnections = new Map<string, Promise<Client>>();
-let configCache: McpServerConfig[] | null = null;
 const toolCache = new Map<string, McpToolSchema[]>();
 const trustedStdioServers = new Set<string>();
-
-const CHILD_ENV_ALLOWLIST = new Set([
-	"PATH",
-	"Path",
-	"HOME",
-	"USER",
-	"USERNAME",
-	"USERPROFILE",
-	"SHELL",
-	"TMPDIR",
-	"TEMP",
-	"TMP",
-	"SystemRoot",
-	"WINDIR",
-	"APPDATA",
-	"LOCALAPPDATA",
-	"XDG_CONFIG_HOME",
-	"XDG_CACHE_HOME",
-]);
 
 function stdioTrustKey(config: McpServerConfig): string {
 	return JSON.stringify({
@@ -97,77 +68,11 @@ function stdioTrustKey(config: McpServerConfig): string {
 }
 
 function readConfigs(): McpServerConfig[] {
-	if (configCache) return configCache;
-
-	const servers: McpServerConfig[] = [];
-	const seen = new Set<string>();
-	const configPaths = [
-		join(process.cwd(), ".mcp.json"),
-		join(process.cwd(), ".gsd", "mcp.json"),
-		join(gsdHome(), "mcp.json"),
-	];
-
-	for (const configPath of configPaths) {
-		try {
-			if (!existsSync(configPath)) continue;
-			const raw = readFileSync(configPath, "utf-8");
-			const data = JSON.parse(raw) as Record<string, unknown>;
-			const mcpServers = (data.mcpServers ?? data.servers) as
-				| Record<string, Record<string, unknown>>
-				| undefined;
-			if (!mcpServers || typeof mcpServers !== "object") continue;
-
-			for (const [name, config] of Object.entries(mcpServers)) {
-				if (seen.has(name)) continue;
-				seen.add(name);
-
-				const hasCommand = typeof config.command === "string";
-				const hasUrl = typeof config.url === "string";
-				const transport: McpServerConfig["transport"] = hasCommand
-					? "stdio"
-					: hasUrl
-						? "http"
-						: "unknown";
-
-				const hasHeaders = hasUrl && config.headers && typeof config.headers === "object";
-				const hasOAuth = hasUrl && config.oauth && typeof config.oauth === "object";
-
-				servers.push({
-					name,
-					transport,
-					sourcePath: configPath,
-					...(hasCommand && {
-						command: config.command as string,
-						args: Array.isArray(config.args) ? (config.args as string[]) : undefined,
-						env: config.env && typeof config.env === "object"
-							? (config.env as Record<string, string>)
-							: undefined,
-						cwd: typeof config.cwd === "string" ? config.cwd : undefined,
-					}),
-					...(hasUrl && { url: config.url as string }),
-					headers: hasHeaders ? config.headers as Record<string, string> : undefined,
-					oauth: hasOAuth ? config.oauth as McpHttpAuthConfig["oauth"] : undefined,
-				});
-			}
-		} catch {
-			// Non-fatal — config file may not exist or be malformed
-		}
-	}
-
-	configCache = servers;
-	return servers;
+	return readMcpServerConfigs();
 }
 
 export function _buildMcpChildEnvForTest(configEnv: Record<string, string> | undefined): Record<string, string> {
-	const childEnv: Record<string, string> = {};
-	for (const key of CHILD_ENV_ALLOWLIST) {
-		const value = process.env[key];
-		if (typeof value === "string") childEnv[key] = value;
-	}
-	return {
-		...childEnv,
-		...(configEnv ? resolveEnv(configEnv) : {}),
-	};
+	return buildMcpChildEnv(configEnv);
 }
 
 export function _buildMcpTrustConfirmOptionsForTest(signal?: AbortSignal): { timeout: number; signal?: AbortSignal } {
@@ -209,27 +114,12 @@ async function assertTrustedStdioServer(
 // Exported for tests (see tests/server-name-spaces.test.ts).
 // Production call sites treat this as module-private.
 export function getServerConfig(name: string): McpServerConfig | undefined {
-	const trimmed = name.trim();
-	return readConfigs().find((s) =>
-		s.name === trimmed ||
-		s.name.toLowerCase() === trimmed.toLowerCase(),
-	);
+	return getMcpServerConfig(name);
 }
 
 /** Resolve ${VAR} references in env values against process.env. */
 function resolveEnv(env: Record<string, string>): Record<string, string> {
-	const resolved: Record<string, string> = {};
-	for (const [key, value] of Object.entries(env)) {
-		if (typeof value === "string") {
-			resolved[key] = value.replace(
-				/\$\{([^}]+)\}/g,
-				(_match, varName) => process.env[varName] ?? "",
-			);
-		} else {
-			resolved[key] = value;
-		}
-	}
-	return resolved;
+	return resolveMcpEnv(env);
 }
 
 async function getOrConnect(name: string, signal?: AbortSignal, ctx?: ExtensionContext): Promise<Client> {
@@ -403,14 +293,12 @@ export default function (pi: ExtensionAPI) {
 		}),
 
 		async execute(_id, params) {
-			if (params.refresh) configCache = null;
-
-			const servers = readConfigs();
+			const servers = readMcpServerConfigs({ refresh: !!params.refresh });
 			return {
 				content: [{ type: "text", text: formatServerList(servers) }],
 				details: {
 					serverCount: servers.length,
-					cached: !params.refresh && configCache !== null,
+					cached: !params.refresh,
 				},
 			};
 		},
@@ -633,6 +521,6 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_switch", async () => {
 		await closeAll();
-		configCache = null;
+		clearMcpConfigCache();
 	});
 }

--- a/src/resources/extensions/mcp-client/manager.ts
+++ b/src/resources/extensions/mcp-client/manager.ts
@@ -1,0 +1,516 @@
+/**
+ * GSD-2 — Shared MCP connection management.
+ *
+ * File Purpose: Reads, writes, and tests user-configured MCP server entries
+ * for runtime tools, TUI commands, and app settings surfaces.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { buildHttpTransportOpts, type McpHttpAuthConfig } from "./auth.js";
+import { gsdHome } from "../gsd/gsd-home.js";
+
+export type ManagedMcpTransport = "stdio" | "http" | "unsupported";
+export type ManagedMcpSourceKind = "project-shared" | "project-local" | "global";
+
+export interface ManagedMcpConfigSource {
+	path: string;
+	kind: ManagedMcpSourceKind;
+	label: string;
+}
+
+export interface ManagedMcpServerConfig {
+	name: string;
+	transport: ManagedMcpTransport;
+	sourcePath: string;
+	sourceKind: ManagedMcpSourceKind;
+	disabled: boolean;
+	command?: string;
+	args?: string[];
+	env?: Record<string, string>;
+	url?: string;
+	cwd?: string;
+	headers?: Record<string, string>;
+	oauth?: McpHttpAuthConfig["oauth"];
+	envWarnings: string[];
+}
+
+export interface ManagedMcpServerInput {
+	name: string;
+	transport: Exclude<ManagedMcpTransport, "unsupported">;
+	command?: string;
+	args?: string[];
+	env?: Record<string, string>;
+	url?: string;
+	cwd?: string;
+	headers?: Record<string, string>;
+	oauth?: McpHttpAuthConfig["oauth"];
+	disabled?: boolean;
+	importedFrom?: {
+		name?: string;
+		sourcePath?: string;
+		sourceTool?: string;
+	};
+}
+
+export interface ManagedMcpStatus {
+	servers: ManagedMcpServerConfig[];
+	duplicates: Array<{
+		name: string;
+		keptSourcePath: string;
+		shadowedSourcePath: string;
+	}>;
+	warnings: string[];
+	localConfigPath: string;
+}
+
+export interface ManagedMcpConnectionTestResult {
+	ok: boolean;
+	server: string;
+	transport: ManagedMcpTransport;
+	toolCount: number;
+	tools: string[];
+	warnings: string[];
+	error?: string;
+}
+
+interface RawMcpConfigFile {
+	mcpServers?: Record<string, Record<string, unknown>>;
+	servers?: Record<string, Record<string, unknown>>;
+	[key: string]: unknown;
+}
+
+const CHILD_ENV_ALLOWLIST = new Set([
+	"PATH",
+	"Path",
+	"HOME",
+	"USER",
+	"USERNAME",
+	"USERPROFILE",
+	"SHELL",
+	"TMPDIR",
+	"TEMP",
+	"TMP",
+	"SystemRoot",
+	"WINDIR",
+	"APPDATA",
+	"LOCALAPPDATA",
+	"XDG_CONFIG_HOME",
+	"XDG_CACHE_HOME",
+]);
+
+let cachedStatus: ManagedMcpStatus | null = null;
+let cachedStatusKey = "";
+
+export function clearMcpConfigCache(): void {
+	cachedStatus = null;
+	cachedStatusKey = "";
+}
+
+export function getProjectLocalMcpConfigPath(projectDir = process.cwd()): string {
+	return join(projectDir, ".gsd", "mcp.json");
+}
+
+export function getMcpConfigSources(
+	projectDir = process.cwd(),
+	gsdHomeDir = gsdHome(),
+): ManagedMcpConfigSource[] {
+	return [
+		{ path: join(projectDir, ".mcp.json"), kind: "project-shared", label: "Project shared" },
+		{ path: getProjectLocalMcpConfigPath(projectDir), kind: "project-local", label: "Project local" },
+		{ path: join(gsdHomeDir, "mcp.json"), kind: "global", label: "Global" },
+	];
+}
+
+export function readMcpManagementStatus(options: {
+	projectDir?: string;
+	gsdHomeDir?: string;
+	refresh?: boolean;
+	includeDisabled?: boolean;
+} = {}): ManagedMcpStatus {
+	const projectDir = options.projectDir ?? process.cwd();
+	const gsdHomeDir = options.gsdHomeDir ?? gsdHome();
+	const cacheKey = JSON.stringify({ projectDir, gsdHomeDir, includeDisabled: !!options.includeDisabled });
+	if (!options.refresh && cachedStatus && cachedStatusKey === cacheKey) {
+		return cachedStatus;
+	}
+
+	const seen = new Map<string, ManagedMcpServerConfig>();
+	const servers: ManagedMcpServerConfig[] = [];
+	const duplicates: ManagedMcpStatus["duplicates"] = [];
+	const warnings: string[] = [];
+
+	for (const source of getMcpConfigSources(projectDir, gsdHomeDir)) {
+		const loaded = readRawConfigFile(source.path);
+		if (!loaded.exists) continue;
+		if (loaded.error) {
+			warnings.push(`${source.path}: ${loaded.error}`);
+			continue;
+		}
+		const mcpServers = loaded.data?.mcpServers ?? loaded.data?.servers;
+		if (!mcpServers || typeof mcpServers !== "object") continue;
+
+		for (const [name, rawConfig] of Object.entries(mcpServers)) {
+			if (!rawConfig || typeof rawConfig !== "object") continue;
+			const normalized = normalizeRawServerConfig(name, rawConfig, source);
+			const existing = seen.get(name);
+			if (existing) {
+				duplicates.push({
+					name,
+					keptSourcePath: existing.sourcePath,
+					shadowedSourcePath: source.path,
+				});
+				continue;
+			}
+			seen.set(name, normalized);
+			if (!normalized.disabled || options.includeDisabled) {
+				servers.push(normalized);
+			}
+		}
+	}
+
+	const status = {
+		servers,
+		duplicates,
+		warnings,
+		localConfigPath: getProjectLocalMcpConfigPath(projectDir),
+	};
+	cachedStatus = status;
+	cachedStatusKey = cacheKey;
+	return status;
+}
+
+export function readMcpServerConfigs(options: {
+	projectDir?: string;
+	gsdHomeDir?: string;
+	refresh?: boolean;
+	includeDisabled?: boolean;
+} = {}): ManagedMcpServerConfig[] {
+	return readMcpManagementStatus(options).servers;
+}
+
+export function getMcpServerConfig(
+	name: string,
+	options: { projectDir?: string; gsdHomeDir?: string; includeDisabled?: boolean } = {},
+): ManagedMcpServerConfig | undefined {
+	const trimmed = name.trim();
+	return readMcpServerConfigs(options).find((server) =>
+		server.name === trimmed ||
+		server.name.toLowerCase() === trimmed.toLowerCase(),
+	);
+}
+
+export function buildMcpChildEnv(configEnv: Record<string, string> | undefined): Record<string, string> {
+	const childEnv: Record<string, string> = {};
+	for (const key of CHILD_ENV_ALLOWLIST) {
+		const value = process.env[key];
+		if (typeof value === "string") childEnv[key] = value;
+	}
+	return {
+		...childEnv,
+		...(configEnv ? resolveMcpEnv(configEnv) : {}),
+	};
+}
+
+export function resolveMcpEnv(env: Record<string, string>): Record<string, string> {
+	const resolved: Record<string, string> = {};
+	for (const [key, value] of Object.entries(env)) {
+		resolved[key] = typeof value === "string" ? resolveMcpString(value) : value;
+	}
+	return resolved;
+}
+
+export function resolveMcpString(value: string): string {
+	return value.replace(
+		/\$\{([^}]+)\}/g,
+		(_match, varName) => process.env[varName] ?? "",
+	);
+}
+
+export function upsertProjectLocalMcpServer(
+	input: ManagedMcpServerInput,
+	options: { projectDir?: string; previousName?: string } = {},
+): ManagedMcpServerConfig {
+	const projectDir = options.projectDir ?? process.cwd();
+	const nextName = input.name.trim();
+	if (!nextName) throw new Error("MCP server name is required.");
+
+	const previousName = options.previousName?.trim();
+	const existing = getMcpServerConfig(nextName, { projectDir, includeDisabled: true });
+	if (existing && previousName !== nextName) {
+		throw new Error(`MCP server "${nextName}" already exists in ${existing.sourcePath}. Rename the server before saving.`);
+	}
+
+	const configPath = getProjectLocalMcpConfigPath(projectDir);
+	const file = readEditableConfigFile(configPath);
+	if (previousName && previousName !== nextName) {
+		delete file.mcpServers[previousName];
+	}
+	file.mcpServers[nextName] = serializeServerInput({ ...input, name: nextName });
+	writeEditableConfigFile(configPath, file);
+	clearMcpConfigCache();
+
+	const saved = getMcpServerConfig(nextName, { projectDir, includeDisabled: true });
+	if (!saved) throw new Error(`MCP server "${nextName}" was saved but could not be reloaded.`);
+	return saved;
+}
+
+export function setProjectLocalMcpServerDisabled(
+	name: string,
+	disabled: boolean,
+	options: { projectDir?: string } = {},
+): ManagedMcpServerConfig {
+	const projectDir = options.projectDir ?? process.cwd();
+	const configPath = getProjectLocalMcpConfigPath(projectDir);
+	const file = readEditableConfigFile(configPath);
+	const current = file.mcpServers[name];
+	if (!current) throw new Error(`MCP server "${name}" is not managed in ${configPath}. Import it before editing local state.`);
+	current.disabled = disabled;
+	writeEditableConfigFile(configPath, file);
+	clearMcpConfigCache();
+	const saved = getMcpServerConfig(name, { projectDir, includeDisabled: true });
+	if (!saved) throw new Error(`MCP server "${name}" was updated but could not be reloaded.`);
+	return saved;
+}
+
+export function deleteProjectLocalMcpServer(
+	name: string,
+	options: { projectDir?: string } = {},
+): void {
+	const projectDir = options.projectDir ?? process.cwd();
+	const configPath = getProjectLocalMcpConfigPath(projectDir);
+	const file = readEditableConfigFile(configPath);
+	if (!file.mcpServers[name]) throw new Error(`MCP server "${name}" is not managed in ${configPath}.`);
+	delete file.mcpServers[name];
+	writeEditableConfigFile(configPath, file);
+	clearMcpConfigCache();
+}
+
+export async function testMcpServerConnection(
+	nameOrConfig: string | ManagedMcpServerConfig,
+	options: {
+		projectDir?: string;
+		signal?: AbortSignal;
+		timeoutMs?: number;
+	} = {},
+): Promise<ManagedMcpConnectionTestResult> {
+	const config = typeof nameOrConfig === "string"
+		? getMcpServerConfig(nameOrConfig, { projectDir: options.projectDir, includeDisabled: true })
+		: nameOrConfig;
+	if (!config) {
+		return {
+			ok: false,
+			server: typeof nameOrConfig === "string" ? nameOrConfig : "",
+			transport: "unsupported",
+			toolCount: 0,
+			tools: [],
+			warnings: [],
+			error: "Unknown MCP server.",
+		};
+	}
+	if (config.disabled) {
+		return {
+			ok: false,
+			server: config.name,
+			transport: config.transport,
+			toolCount: 0,
+			tools: [],
+			warnings: config.envWarnings,
+			error: "MCP server is disabled.",
+		};
+	}
+	if (config.transport === "unsupported") {
+		return {
+			ok: false,
+			server: config.name,
+			transport: config.transport,
+			toolCount: 0,
+			tools: [],
+			warnings: config.envWarnings,
+			error: "MCP server transport is unsupported.",
+		};
+	}
+	if (config.envWarnings.length > 0) {
+		return {
+			ok: false,
+			server: config.name,
+			transport: config.transport,
+			toolCount: 0,
+			tools: [],
+			warnings: config.envWarnings,
+			error: "MCP server config references unset environment variables.",
+		};
+	}
+
+	const client = new Client({ name: "gsd", version: "1.0.0" });
+	let transport: StdioClientTransport | StreamableHTTPClientTransport | undefined;
+	const timeout = options.timeoutMs ?? 30_000;
+	try {
+		if (config.transport === "stdio") {
+			transport = new StdioClientTransport({
+				command: config.command ?? "",
+				args: config.args,
+				env: buildMcpChildEnv(config.env),
+				cwd: config.cwd,
+				stderr: "pipe",
+			});
+		} else {
+			const resolvedUrl = resolveMcpString(config.url ?? "");
+			transport = new StreamableHTTPClientTransport(
+				new URL(resolvedUrl),
+				buildHttpTransportOpts({ headers: config.headers, oauth: config.oauth }),
+			);
+		}
+
+		await client.connect(transport, { signal: options.signal, timeout });
+		const result = await client.listTools(undefined, { signal: options.signal, timeout });
+		const tools = (result.tools ?? []).map((tool) => tool.name);
+		return {
+			ok: true,
+			server: config.name,
+			transport: config.transport,
+			toolCount: tools.length,
+			tools,
+			warnings: [],
+		};
+	} catch (error) {
+		return {
+			ok: false,
+			server: config.name,
+			transport: config.transport,
+			toolCount: 0,
+			tools: [],
+			warnings: config.envWarnings,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	} finally {
+		if (transport) {
+			try {
+				await transport.close();
+			} catch {
+				// Best-effort cleanup after test connection.
+			}
+		}
+		try {
+			await client.close();
+		} catch {
+			// Best-effort cleanup after test connection.
+		}
+	}
+}
+
+function readRawConfigFile(path: string): {
+	exists: boolean;
+	data?: RawMcpConfigFile;
+	error?: string;
+} {
+	if (!existsSync(path)) return { exists: false };
+	try {
+		return { exists: true, data: JSON.parse(readFileSync(path, "utf-8")) as RawMcpConfigFile };
+	} catch (error) {
+		return { exists: true, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+function readEditableConfigFile(path: string): RawMcpConfigFile & { mcpServers: Record<string, Record<string, unknown>> } {
+	const loaded = readRawConfigFile(path);
+	if (loaded.error) throw new Error(`Unable to read MCP config ${path}: ${loaded.error}`);
+	const data = loaded.data ?? {};
+	const mcpServers = data.mcpServers && typeof data.mcpServers === "object" ? data.mcpServers : {};
+	return { ...data, mcpServers };
+}
+
+function writeEditableConfigFile(path: string, data: RawMcpConfigFile): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+}
+
+function normalizeRawServerConfig(
+	name: string,
+	config: Record<string, unknown>,
+	source: ManagedMcpConfigSource,
+): ManagedMcpServerConfig {
+	const transport = detectTransport(config);
+	const env = isRecordOfStrings(config.env) ? config.env : undefined;
+	const headers = isRecordOfStrings(config.headers) ? config.headers : undefined;
+	const url = typeof config.url === "string" ? config.url : undefined;
+	const command = typeof config.command === "string" ? config.command : undefined;
+	return {
+		name,
+		transport,
+		sourcePath: source.path,
+		sourceKind: source.kind,
+		disabled: config.disabled === true,
+		...(command ? { command } : {}),
+		args: Array.isArray(config.args) ? config.args.filter((arg): arg is string => typeof arg === "string") : undefined,
+		env,
+		...(url ? { url } : {}),
+		cwd: typeof config.cwd === "string" ? config.cwd : undefined,
+		headers,
+		oauth: config.oauth && typeof config.oauth === "object" ? config.oauth as McpHttpAuthConfig["oauth"] : undefined,
+		envWarnings: collectEnvWarnings([
+			["url", url],
+			...Object.entries(env ?? {}).map(([key, value]) => [`env.${key}`, value] as [string, string | undefined]),
+			...Object.entries(headers ?? {}).map(([key, value]) => [`headers.${key}`, value] as [string, string | undefined]),
+		]),
+	};
+}
+
+function detectTransport(config: Record<string, unknown>): ManagedMcpTransport {
+	const type = typeof config.type === "string" ? config.type.toLowerCase() : undefined;
+	if (type && type !== "stdio" && type !== "http") return "unsupported";
+	if (typeof config.command === "string") return "stdio";
+	if (typeof config.url === "string" && type !== "stdio") return "http";
+	return "unsupported";
+}
+
+function serializeServerInput(input: ManagedMcpServerInput): Record<string, unknown> {
+	if (input.transport === "stdio") {
+		if (!input.command?.trim()) throw new Error("Stdio MCP servers require a command.");
+		return stripUndefined({
+			type: "stdio",
+			command: input.command.trim(),
+			args: input.args,
+			env: input.env,
+			cwd: input.cwd,
+			disabled: input.disabled === true ? true : undefined,
+			_gsdImportedFrom: input.importedFrom,
+		});
+	}
+	if (!input.url?.trim()) throw new Error("HTTP MCP servers require a URL.");
+	return stripUndefined({
+		type: "http",
+		url: input.url.trim(),
+		headers: input.headers,
+		oauth: input.oauth,
+		disabled: input.disabled === true ? true : undefined,
+		_gsdImportedFrom: input.importedFrom,
+	});
+}
+
+function collectEnvWarnings(values: Array<[string, string | undefined]>): string[] {
+	const warnings: string[] = [];
+	for (const [label, value] of values) {
+		if (!value) continue;
+		for (const match of value.matchAll(/\$\{([^}]+)\}/g)) {
+			const varName = match[1];
+			if (varName && process.env[varName] === undefined) {
+				warnings.push(`${label} references unset environment variable ${varName}.`);
+			}
+		}
+	}
+	return warnings;
+}
+
+function isRecordOfStrings(value: unknown): value is Record<string, string> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	return Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function stripUndefined(value: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}

--- a/src/resources/extensions/mcp-client/tests/manager.test.ts
+++ b/src/resources/extensions/mcp-client/tests/manager.test.ts
@@ -1,0 +1,165 @@
+/**
+ * GSD-2 — MCP manager tests.
+ *
+ * File Purpose: Behaviour coverage for shared MCP config management and
+ * side-effect-free connection testing.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+	clearMcpConfigCache,
+	deleteProjectLocalMcpServer,
+	readMcpManagementStatus,
+	readMcpServerConfigs,
+	setProjectLocalMcpServerDisabled,
+	testMcpServerConnection,
+	upsertProjectLocalMcpServer,
+	type ManagedMcpServerConfig,
+} from "../manager.js";
+
+function makeProject(): { projectDir: string; gsdHomeDir: string; cleanup: () => void } {
+	const projectDir = mkdtempSync(join(tmpdir(), "gsd-mcp-manager-project-"));
+	const gsdHomeDir = mkdtempSync(join(tmpdir(), "gsd-mcp-manager-home-"));
+	mkdirSync(join(projectDir, ".gsd"), { recursive: true });
+	return {
+		projectDir,
+		gsdHomeDir,
+		cleanup: () => {
+			rmSync(projectDir, { recursive: true, force: true });
+			rmSync(gsdHomeDir, { recursive: true, force: true });
+			clearMcpConfigCache();
+		},
+	};
+}
+
+test("MCP manager reads sources with precedence, disabled state, duplicates, and env warnings", () => {
+	const previousToken = process.env.MISSING_MANAGER_TOKEN;
+	delete process.env.MISSING_MANAGER_TOKEN;
+	const { projectDir, gsdHomeDir, cleanup } = makeProject();
+	try {
+		writeFileSync(
+			join(projectDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					shared: { command: "node", args: ["shared.js"] },
+					warned: { url: "https://example.test/${MISSING_MANAGER_TOKEN}" },
+				},
+			}),
+			"utf-8",
+		);
+		writeFileSync(
+			join(projectDir, ".gsd", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					local: { command: "node", disabled: true },
+				},
+			}),
+			"utf-8",
+		);
+		writeFileSync(
+			join(gsdHomeDir, "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					shared: { command: "node", args: ["global.js"] },
+				},
+			}),
+			"utf-8",
+		);
+
+		const status = readMcpManagementStatus({ projectDir, gsdHomeDir, includeDisabled: true, refresh: true });
+		assert.deepEqual(status.servers.map((server) => server.name), ["shared", "warned", "local"]);
+		assert.equal(status.servers.find((server) => server.name === "local")?.disabled, true);
+		assert.equal(status.duplicates[0]?.name, "shared");
+		assert.match(status.servers.find((server) => server.name === "warned")?.envWarnings[0] ?? "", /MISSING_MANAGER_TOKEN/);
+
+		const runtimeServers = readMcpServerConfigs({ projectDir, gsdHomeDir, refresh: true });
+		assert.deepEqual(runtimeServers.map((server) => server.name), ["shared", "warned"]);
+	} finally {
+		if (previousToken === undefined) delete process.env.MISSING_MANAGER_TOKEN;
+		else process.env.MISSING_MANAGER_TOKEN = previousToken;
+		cleanup();
+	}
+});
+
+test("MCP manager writes local config and blocks duplicate names unless renamed", () => {
+	const { projectDir, cleanup } = makeProject();
+	try {
+		writeFileSync(
+			join(projectDir, ".mcp.json"),
+			JSON.stringify({ mcpServers: { existing: { command: "node" } } }),
+			"utf-8",
+		);
+
+		assert.throws(
+			() => upsertProjectLocalMcpServer({ name: "existing", transport: "stdio", command: "node" }, { projectDir }),
+			/already exists/,
+		);
+
+		const saved = upsertProjectLocalMcpServer(
+			{ name: "local-server", transport: "stdio", command: "node", args: ["server.js"], disabled: true },
+			{ projectDir },
+		);
+		assert.equal(saved.sourceKind, "project-local");
+		assert.equal(saved.disabled, true);
+
+		const enabled = setProjectLocalMcpServerDisabled("local-server", false, { projectDir });
+		assert.equal(enabled.disabled, false);
+
+		deleteProjectLocalMcpServer("local-server", { projectDir });
+		const raw = JSON.parse(readFileSync(join(projectDir, ".gsd", "mcp.json"), "utf-8")) as { mcpServers: Record<string, unknown> };
+		assert.equal(raw.mcpServers["local-server"], undefined);
+	} finally {
+		cleanup();
+	}
+});
+
+test("MCP connection test performs handshake and tools/list without invoking tools", async () => {
+	const { projectDir, cleanup } = makeProject();
+	try {
+		const require = createRequire(import.meta.url);
+		const mcpModuleUrl = pathToFileURL(require.resolve("@modelcontextprotocol/sdk/server/mcp.js")).href;
+		const stdioModuleUrl = pathToFileURL(require.resolve("@modelcontextprotocol/sdk/server/stdio.js")).href;
+		const calledPath = join(projectDir, "called-tool.txt");
+		const serverPath = join(projectDir, "fake-mcp-server.mjs");
+		writeFileSync(
+			serverPath,
+			[
+				`const { McpServer } = await import(${JSON.stringify(mcpModuleUrl)});`,
+				`const { StdioServerTransport } = await import(${JSON.stringify(stdioModuleUrl)});`,
+				'import { writeFileSync } from "node:fs";',
+				`const calledPath = ${JSON.stringify(calledPath)};`,
+				'const server = new McpServer({ name: "fake", version: "1.0.0" }, { capabilities: { tools: {} } });',
+				'server.tool("fake_tool", "Should not be invoked by test connection", {}, async () => {',
+				'  writeFileSync(calledPath, "called", "utf-8");',
+				'  return { content: [{ type: "text", text: "called" }] };',
+				'});',
+				'await server.connect(new StdioServerTransport());',
+			].join("\n"),
+			"utf-8",
+		);
+
+		const result = await testMcpServerConnection({
+			name: "fake",
+			transport: "stdio",
+			sourcePath: join(projectDir, ".gsd", "mcp.json"),
+			sourceKind: "project-local",
+			disabled: false,
+			command: process.execPath,
+			args: [serverPath],
+			envWarnings: [],
+		} satisfies ManagedMcpServerConfig, { projectDir, timeoutMs: 10_000 });
+
+		assert.equal(result.ok, true, result.error);
+		assert.deepEqual(result.tools, ["fake_tool"]);
+		assert.equal(existsSync(calledPath), false, "connection test must not invoke MCP tools");
+	} finally {
+		cleanup();
+	}
+});

--- a/src/tests/integration/web-mcp-management-contract.test.ts
+++ b/src/tests/integration/web-mcp-management-contract.test.ts
@@ -1,0 +1,57 @@
+// GSD-2 — Web MCP management contract tests.
+// File Purpose: Verifies the app-facing MCP service uses the shared manager.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  collectMcpManagementData,
+  mutateMcpManagement,
+} from "../../web/mcp-management-service.ts";
+
+test("web MCP management service lists, saves, disables, and deletes local servers", async () => {
+  const projectDir = mkdtempSync(join(tmpdir(), "web-mcp-project-"));
+  const gsdHomeDir = mkdtempSync(join(tmpdir(), "web-mcp-home-"));
+  const previousGsdHome = process.env.GSD_HOME;
+  try {
+    process.env.GSD_HOME = gsdHomeDir;
+    mkdirSync(join(projectDir, ".gsd"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".mcp.json"),
+      JSON.stringify({ mcpServers: { shared: { command: "node", args: ["shared.js"] } } }),
+      "utf-8",
+    );
+
+    const listed = await collectMcpManagementData(projectDir);
+    assert.ok(listed.servers.some((server) => server.name === "shared"));
+
+    const saved = await mutateMcpManagement({
+      action: "save",
+      server: { name: "local", transport: "stdio", command: "node", args: ["local.js"] },
+    }, projectDir);
+    assert.equal(saved.status, "ok");
+    if (saved.status === "ok") {
+      assert.ok(saved.data.servers.some((server) => server.name === "local" && server.sourceKind === "project-local"));
+    }
+
+    const disabled = await mutateMcpManagement({ action: "disable", name: "local" }, projectDir);
+    assert.equal(disabled.status, "ok");
+    if (disabled.status === "ok") {
+      assert.equal(disabled.data.servers.find((server) => server.name === "local")?.disabled, true);
+    }
+
+    const deleted = await mutateMcpManagement({ action: "delete", name: "local" }, projectDir);
+    assert.equal(deleted.status, "ok");
+    if (deleted.status === "ok") {
+      assert.equal(deleted.data.servers.some((server) => server.name === "local"), false);
+    }
+  } finally {
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(gsdHomeDir, { recursive: true, force: true });
+  }
+});

--- a/src/web/mcp-management-service.ts
+++ b/src/web/mcp-management-service.ts
@@ -1,0 +1,174 @@
+// GSD-2 — Web MCP management service.
+// File Purpose: Bridges app API routes to the shared MCP management module.
+
+import { execFile } from "node:child_process"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
+import { buildSubprocessPrefixArgs, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
+import type {
+  WebMcpManagementPayload,
+  WebMcpMutationRequest,
+  WebMcpMutationResponse,
+} from "../../web/lib/mcp-management-types.ts"
+
+const MCP_MANAGEMENT_MAX_BUFFER = 4 * 1024 * 1024
+
+function resolveTsLoaderPath(packageRoot: string): string {
+  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
+}
+
+export async function collectMcpManagementData(projectCwdOverride?: string): Promise<WebMcpManagementPayload> {
+  const result = await runMcpManagementSubprocess({ action: "list" }, projectCwdOverride)
+  if ("status" in result && result.status === "error") {
+    throw new Error(result.error)
+  }
+  return result as WebMcpManagementPayload
+}
+
+export async function mutateMcpManagement(
+  request: WebMcpMutationRequest,
+  projectCwdOverride?: string,
+): Promise<WebMcpMutationResponse> {
+  return runMcpManagementSubprocess(request, projectCwdOverride) as Promise<WebMcpMutationResponse>
+}
+
+async function runMcpManagementSubprocess(
+  action: WebMcpMutationRequest | { action: "list" },
+  projectCwdOverride?: string,
+): Promise<WebMcpManagementPayload | WebMcpMutationResponse> {
+  const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
+  const { packageRoot, projectCwd } = config
+  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
+  const managerResolution = resolveSubprocessModule(packageRoot, "resources/extensions/mcp-client/manager.ts")
+  const discoveryResolution = resolveSubprocessModule(packageRoot, "resources/extensions/universal-config/discovery.ts")
+
+  const requiredPaths = managerResolution.useCompiledJs
+    ? [managerResolution.modulePath, discoveryResolution.modulePath]
+    : [resolveTsLoader, managerResolution.modulePath, discoveryResolution.modulePath]
+  for (const requiredPath of requiredPaths) {
+    if (!existsSync(requiredPath)) {
+      throw new Error(`MCP management provider not found; missing=${requiredPath}`)
+    }
+  }
+
+  const script = [
+    'const { pathToFileURL } = await import("node:url");',
+    'const manager = await import(pathToFileURL(process.env.GSD_MCP_MANAGER_MODULE).href);',
+    'const discovery = await import(pathToFileURL(process.env.GSD_MCP_DISCOVERY_MODULE).href);',
+    'const projectDir = process.env.GSD_MCP_PROJECT_CWD;',
+    'const action = JSON.parse(process.env.GSD_MCP_ACTION);',
+    'function toWebServer(server) {',
+    '  return {',
+    '    name: server.name, transport: server.transport, sourcePath: server.sourcePath, sourceKind: server.sourceKind,',
+    '    disabled: server.disabled, command: server.command, args: server.args, env: server.env, url: server.url, cwd: server.cwd, headers: server.headers,',
+    '    envWarnings: server.envWarnings ?? [], connected: false, toolCount: 0, tools: [],',
+    '  };',
+    '}',
+    'function importableTransport(item) {',
+    '  if (typeof item.command === "string") return "stdio";',
+    '  if (typeof item.url === "string" && item.transport !== "sse") return "http";',
+    '  return "unsupported";',
+    '}',
+    'async function buildPayload() {',
+    '  const status = manager.readMcpManagementStatus({ projectDir, includeDisabled: true, refresh: true });',
+    '  const existingNames = new Set(status.servers.map((server) => server.name));',
+    '  const discovered = await discovery.discoverAllConfigs(projectDir);',
+    '  const importableServers = discovered.allItems',
+    '    .filter((item) => item.type === "mcp-server")',
+    '    .map((item) => {',
+    '      const transport = importableTransport(item);',
+    '      return {',
+    '        name: item.name, transport, sourcePath: item.source.path, sourceTool: item.source.toolName,',
+    '        command: item.command, args: item.args, env: item.env, url: item.url, headers: item.headers,',
+    '        unsupportedReason: transport === "unsupported" ? "Unsupported transport" : undefined,',
+    '        conflicts: existingNames.has(item.name),',
+    '      };',
+    '    });',
+    '  return {',
+    '    servers: status.servers.map(toWebServer),',
+    '    importableServers,',
+    '    duplicates: status.duplicates,',
+    '    warnings: status.warnings,',
+    '    localConfigPath: status.localConfigPath,',
+    '  };',
+    '}',
+    'async function run() {',
+    '  if (action.action === "list") return buildPayload();',
+    '  if (action.action === "save") {',
+    '    manager.upsertProjectLocalMcpServer(action.server, { projectDir, previousName: action.previousName });',
+    '    return { status: "ok", data: await buildPayload() };',
+    '  }',
+    '  if (action.action === "enable" || action.action === "disable") {',
+    '    manager.setProjectLocalMcpServerDisabled(action.name, action.action === "disable", { projectDir });',
+    '    return { status: "ok", data: await buildPayload() };',
+    '  }',
+    '  if (action.action === "delete") {',
+    '    manager.deleteProjectLocalMcpServer(action.name, { projectDir });',
+    '    return { status: "ok", data: await buildPayload() };',
+    '  }',
+    '  if (action.action === "test") {',
+    '    const result = await manager.testMcpServerConnection(action.name, { projectDir });',
+    '    return { status: "ok", data: await buildPayload(), result };',
+    '  }',
+    '  if (action.action === "import") {',
+    '    if (action.server.transport === "unsupported") throw new Error(`Cannot import unsupported MCP transport for ${action.server.name}.`);',
+    '    manager.upsertProjectLocalMcpServer({',
+    '      name: action.name || action.server.name, transport: action.server.transport,',
+    '      command: action.server.command, args: action.server.args, env: action.server.env, url: action.server.url, headers: action.server.headers,',
+    '      importedFrom: { name: action.server.name, sourcePath: action.server.sourcePath, sourceTool: action.server.sourceTool },',
+    '    }, { projectDir });',
+    '    return { status: "ok", data: await buildPayload() };',
+    '  }',
+    '  throw new Error(`Unknown MCP management action: ${action.action}`);',
+    '}',
+    'try { process.stdout.write(JSON.stringify(await run())); }',
+    'catch (error) { process.stdout.write(JSON.stringify({ status: "error", error: error instanceof Error ? error.message : String(error) })); }',
+  ].join(" ")
+
+  const prefixArgs = buildSubprocessPrefixArgs(
+    packageRoot,
+    managerResolution,
+    pathToFileURL(resolveTsLoader).href,
+  )
+
+  return await new Promise<WebMcpManagementPayload | WebMcpMutationResponse>((resolveResult, reject) => {
+    execFile(
+      process.execPath,
+      [
+        ...prefixArgs,
+        "--eval",
+        script,
+      ],
+      {
+        cwd: packageRoot,
+        env: {
+          ...process.env,
+          GSD_MCP_MANAGER_MODULE: managerResolution.modulePath,
+          GSD_MCP_DISCOVERY_MODULE: discoveryResolution.modulePath,
+          GSD_MCP_PROJECT_CWD: projectCwd,
+          GSD_MCP_ACTION: JSON.stringify(action),
+        },
+        maxBuffer: MCP_MANAGEMENT_MAX_BUFFER,
+        windowsHide: true,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`MCP management subprocess failed: ${stderr || error.message}`))
+          return
+        }
+        try {
+          resolveResult(JSON.parse(stdout) as WebMcpManagementPayload | WebMcpMutationResponse)
+        } catch (parseError) {
+          reject(
+            new Error(
+              `MCP management subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+            ),
+          )
+        }
+      },
+    )
+  })
+}

--- a/web/app/api/mcp-connections/route.ts
+++ b/web/app/api/mcp-connections/route.ts
@@ -1,0 +1,57 @@
+// GSD-2 — MCP connections API route.
+// File Purpose: Exposes app-side MCP connection management actions.
+
+import {
+  collectMcpManagementData,
+  mutateMcpManagement,
+} from "../../../../src/web/mcp-management-service.ts"
+import { requireProjectCwd } from "../../../../src/web/bridge-service.ts"
+import type { WebMcpMutationRequest } from "@/lib/mcp-management-types"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function GET(request: Request): Promise<Response> {
+  try {
+    const projectCwd = requireProjectCwd(request)
+    const payload = await collectMcpManagementData(projectCwd)
+    return Response.json(payload, {
+      headers: { "Cache-Control": "no-store" },
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return Response.json(
+      { error: message },
+      {
+        status: 500,
+        headers: { "Cache-Control": "no-store" },
+      },
+    )
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  try {
+    const projectCwd = requireProjectCwd(request)
+    const body = await request.json() as WebMcpMutationRequest
+    const payload = await mutateMcpManagement(body, projectCwd)
+    if (payload.status === "error") {
+      return Response.json(payload, {
+        status: 400,
+        headers: { "Cache-Control": "no-store" },
+      })
+    }
+    return Response.json(payload, {
+      headers: { "Cache-Control": "no-store" },
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return Response.json(
+      { status: "error", error: message },
+      {
+        status: 500,
+        headers: { "Cache-Control": "no-store" },
+      },
+    )
+  }
+}

--- a/web/components/gsd/command-surface.tsx
+++ b/web/components/gsd/command-surface.tsx
@@ -57,7 +57,7 @@ import {
 } from "@/lib/dev-overrides"
 import { DoctorPanel, ForensicsPanel, SkillHealthPanel } from "./diagnostics-panels"
 import { KnowledgeCapturesPanel } from "./knowledge-captures-panel"
-import { PrefsPanel, ModelRoutingPanel, BudgetPanel, RemoteQuestionsPanel, GeneralPanel, ExperimentalPanel } from "./settings-panels"
+import { PrefsPanel, ModelRoutingPanel, BudgetPanel, RemoteQuestionsPanel, McpConnectionsPanel, GeneralPanel, ExperimentalPanel } from "./settings-panels"
 import { DevRootSettingsSection } from "./projects-view"
 import {
   QuickPanel,
@@ -2129,7 +2129,12 @@ export function CommandSurface() {
       case "session": return renderSessionSection()
       case "compact": return renderCompactSection()
       case "workspace": return <DevRootSettingsSection />
-      case "integrations": return <RemoteQuestionsPanel />
+      case "integrations": return (
+        <div className="space-y-6">
+          <RemoteQuestionsPanel />
+          <McpConnectionsPanel />
+        </div>
+      )
       case "gsd-forensics": return <ForensicsPanel />
       case "gsd-doctor": return <DoctorPanel />
       case "gsd-skill-health": return <SkillHealthPanel />
@@ -2143,6 +2148,7 @@ export function CommandSurface() {
           <ModelRoutingPanel />
           <BudgetPanel />
           <RemoteQuestionsPanel />
+          <McpConnectionsPanel />
           <GeneralPanel />
           <ExperimentalPanel />
         </div>

--- a/web/components/gsd/settings-panels.tsx
+++ b/web/components/gsd/settings-panels.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react"
 
 import {
   AlertTriangle,
+  Cable,
   CheckCircle2,
   CircleDashed,
   Cpu,
@@ -13,13 +14,17 @@ import {
   FlaskConical,
   KeyRound,
   LoaderCircle,
+  Plus,
+  Power,
+  PowerOff,
   Radio,
   RefreshCw,
   RotateCcw,
   Settings,
   SkipForward,
   SlidersHorizontal,
-  Type,
+  Server,
+  Trash2,
   Wand2,
 } from "lucide-react"
 import { useDevOverrides } from "@/lib/dev-overrides"
@@ -31,6 +36,15 @@ import type {
   SettingsPatternHistory,
   SettingsRoutingHistory,
 } from "@/lib/settings-types"
+import type {
+  WebMcpConnectionTestResult,
+  WebMcpImportableServer,
+  WebMcpManagementPayload,
+  WebMcpMutationRequest,
+  WebMcpMutationResponse,
+  WebMcpServer,
+  WebMcpTransport,
+} from "@/lib/mcp-management-types"
 import { cn } from "@/lib/utils"
 import {
   formatCost,
@@ -616,7 +630,6 @@ export function RemoteQuestionsPanel() {
   const { data, busy, refresh } = useSettingsData()
   const existingConfig = data?.preferences?.remoteQuestions ?? null
 
-  const [envVarSet, setEnvVarSet] = useState(false)
   const [envVarName, setEnvVarName] = useState<string | null>(null)
   const [apiLoading, setApiLoading] = useState(true)
   const [tokenSet, setTokenSet] = useState(false)
@@ -647,7 +660,6 @@ export function RemoteQuestionsPanel() {
         return
       }
       const json: RemoteQuestionsApiResponse = await res.json()
-      setEnvVarSet(json.envVarSet)
       setEnvVarName(json.envVarName)
       setTokenSet(json.tokenSet)
       setIsConfigured(json.status === "configured" && json.config !== null)
@@ -664,15 +676,21 @@ export function RemoteQuestionsPanel() {
     }
   }, [])
 
-  useEffect(() => { void fetchApiStatus() }, [fetchApiStatus])
+  useEffect(() => {
+    const timer = window.setTimeout(() => { void fetchApiStatus() }, 0)
+    return () => window.clearTimeout(timer)
+  }, [fetchApiStatus])
 
   useEffect(() => {
-    if (existingConfig?.channel) {
-      setChannel(existingConfig.channel)
+    if (!existingConfig?.channel) return
+    const nextChannel = existingConfig.channel
+    const timer = window.setTimeout(() => {
+      setChannel(nextChannel)
       setChannelId(existingConfig.channelId ?? "")
       setTimeoutMinutes(existingConfig.timeoutMinutes ?? 5)
       setPollIntervalSeconds(existingConfig.pollIntervalSeconds ?? 5)
-    }
+    }, 0)
+    return () => window.clearTimeout(timer)
   }, [existingConfig])
 
   const channelIdValid = channelId.trim().length > 0 && CHANNEL_ID_PATTERNS[channel].test(channelId.trim())
@@ -887,7 +905,7 @@ export function RemoteQuestionsPanel() {
         />
         {channelId.trim().length > 0 && !CHANNEL_ID_PATTERNS[channel].test(channelId.trim()) && (
           <p className="text-[11px] text-destructive/70">
-            Doesn't match the expected format for {selectedChannelOption.label}
+            Does not match the expected format for {selectedChannelOption.label}
           </p>
         )}
       </div>
@@ -1019,6 +1037,347 @@ export function RemoteQuestionsPanel() {
           </Button>
         </div>
       </div>
+    </div>
+  )
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// MCP CONNECTIONS PANEL
+// ═══════════════════════════════════════════════════════════════════════
+
+function formatRecordLines(record: Record<string, string> | undefined): string {
+  if (!record) return ""
+  return Object.entries(record).map(([key, value]) => `${key}=${value}`).join("\n")
+}
+
+function parseRecordLines(text: string): Record<string, string> | undefined {
+  const entries = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const equals = line.indexOf("=")
+      if (equals <= 0) throw new Error(`Invalid key=value line: ${line}`)
+      return [line.slice(0, equals).trim(), line.slice(equals + 1)] as const
+    })
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined
+}
+
+function formatArgs(args: string[] | undefined): string {
+  return args?.join("\n") ?? ""
+}
+
+function parseArgs(text: string): string[] | undefined {
+  const args = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+  return args.length > 0 ? args : undefined
+}
+
+function serverTone(server: WebMcpServer): "default" | "warning" | "success" | "info" {
+  if (server.disabled || server.transport === "unsupported") return "warning"
+  if (server.connected || server.toolCount > 0) return "success"
+  return "info"
+}
+
+export function McpConnectionsPanel() {
+  const [payload, setPayload] = useState<WebMcpManagementPayload | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [testing, setTesting] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [testResult, setTestResult] = useState<WebMcpConnectionTestResult | null>(null)
+  const [editingName, setEditingName] = useState<string | null>(null)
+  const [name, setName] = useState("")
+  const [transport, setTransport] = useState<Exclude<WebMcpTransport, "unsupported">>("stdio")
+  const [command, setCommand] = useState("")
+  const [argsText, setArgsText] = useState("")
+  const [cwd, setCwd] = useState("")
+  const [url, setUrl] = useState("")
+  const [envText, setEnvText] = useState("")
+  const [headersText, setHeadersText] = useState("")
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await authFetch("/api/mcp-connections", { cache: "no-store" })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error ?? `MCP request failed (${res.status})`)
+      setPayload(json as WebMcpManagementPayload)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => { void load() }, 0)
+    return () => window.clearTimeout(timer)
+  }, [load])
+
+  useEffect(() => {
+    if (!success) return
+    const timer = setTimeout(() => setSuccess(null), 3000)
+    return () => clearTimeout(timer)
+  }, [success])
+
+  function resetForm() {
+    setEditingName(null)
+    setName("")
+    setTransport("stdio")
+    setCommand("")
+    setArgsText("")
+    setCwd("")
+    setUrl("")
+    setEnvText("")
+    setHeadersText("")
+  }
+
+  function editServer(server: WebMcpServer) {
+    if (server.transport === "unsupported") return
+    setEditingName(server.name)
+    setName(server.name)
+    setTransport(server.transport)
+    setCommand(server.command ?? "")
+    setArgsText(formatArgs(server.args))
+    setCwd(server.cwd ?? "")
+    setUrl(server.url ?? "")
+    setEnvText(formatRecordLines(server.env))
+    setHeadersText(formatRecordLines(server.headers))
+  }
+
+  async function mutate(request: WebMcpMutationRequest) {
+    const res = await authFetch("/api/mcp-connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    })
+    const json = await res.json() as WebMcpMutationResponse
+    if (json.status === "error") throw new Error(json.error)
+    if (!res.ok) throw new Error(`MCP request failed (${res.status})`)
+    setPayload(json.data)
+    return json
+  }
+
+  async function saveServer() {
+    setSaving(true)
+    setError(null)
+    setSuccess(null)
+    try {
+      const server = transport === "stdio"
+        ? {
+          name: name.trim(),
+          transport,
+          command: command.trim(),
+          args: parseArgs(argsText),
+          env: parseRecordLines(envText),
+          cwd: cwd.trim() || undefined,
+        }
+        : {
+          name: name.trim(),
+          transport,
+          url: url.trim(),
+          headers: parseRecordLines(headersText),
+        }
+      await mutate({ action: "save", previousName: editingName ?? undefined, server })
+      setSuccess(editingName ? "MCP server updated" : "MCP server saved")
+      resetForm()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function toggleServer(server: WebMcpServer) {
+    setError(null)
+    try {
+      await mutate({ action: server.disabled ? "enable" : "disable", name: server.name })
+      setSuccess(server.disabled ? "MCP server enabled" : "MCP server disabled")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  async function deleteServer(server: WebMcpServer) {
+    if (!window.confirm(`Delete local MCP server "${server.name}"?`)) return
+    setError(null)
+    try {
+      await mutate({ action: "delete", name: server.name })
+      setSuccess("MCP server deleted")
+      if (editingName === server.name) resetForm()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  async function testServer(server: WebMcpServer) {
+    setTesting(server.name)
+    setError(null)
+    setTestResult(null)
+    try {
+      const json = await mutate({ action: "test", name: server.name })
+      setTestResult(json.result ?? null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setTesting(null)
+    }
+  }
+
+  async function importServer(server: WebMcpImportableServer) {
+    const nextName = server.conflicts
+      ? window.prompt(`Rename imported MCP server "${server.name}"`, `${server.name}-local`)
+      : server.name
+    if (!nextName) return
+    setError(null)
+    try {
+      await mutate({ action: "import", server, name: nextName })
+      setSuccess("MCP server imported")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const canSave = name.trim().length > 0 && (
+    transport === "stdio" ? command.trim().length > 0 : url.trim().length > 0
+  )
+
+  return (
+    <div className="space-y-5" data-testid="settings-mcp-connections">
+      <SettingsHeader
+        title="MCP Connections"
+        icon={<Cable className="h-3.5 w-3.5" />}
+        subtitle={payload ? `${payload.servers.length} configured` : null}
+        onRefresh={() => void load()}
+        refreshing={loading}
+      />
+
+      {error && <SettingsError message={error} />}
+      {success && (
+        <div className="flex items-center gap-2 rounded-lg border border-success/15 bg-success/[0.04] px-3 py-2 text-xs text-muted-foreground">
+          <CheckCircle2 className="h-3.5 w-3.5 text-success" />
+          {success}
+        </div>
+      )}
+      {loading && !payload && <SettingsLoading label="Loading MCP connections…" />}
+
+      {payload && (
+        <>
+          <div className="flex flex-wrap gap-2">
+            <Pill label="Local config" value={payload.localConfigPath} />
+            <Pill label="Importable" value={payload.importableServers.length} variant="info" />
+            {payload.duplicates.length > 0 && <Pill label="Duplicates" value={payload.duplicates.length} variant="warning" />}
+          </div>
+
+          {payload.warnings.length > 0 && (
+            <div className="space-y-1 rounded-lg border border-warning/20 bg-warning/5 px-3 py-2 text-[11px] text-warning">
+              {payload.warnings.map((warning) => <div key={warning}>{warning}</div>)}
+            </div>
+          )}
+
+          <div className="grid gap-2">
+            {payload.servers.length === 0 && <SettingsEmpty message="No MCP servers configured" />}
+            {payload.servers.map((server) => (
+              <div key={`${server.sourcePath}:${server.name}`} className="rounded-lg border border-border/50 bg-card/50 px-3 py-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Server className="h-3.5 w-3.5 text-muted-foreground" />
+                      <span className="font-mono text-xs text-foreground">{server.name}</span>
+                      <Pill label={server.transport} value={server.disabled ? "disabled" : "enabled"} variant={serverTone(server)} />
+                    </div>
+                    <div className="truncate font-mono text-[10px] text-muted-foreground">{server.sourcePath}</div>
+                    {server.envWarnings.length > 0 && (
+                      <div className="text-[11px] text-warning">{server.envWarnings[0]}</div>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 flex-wrap justify-end gap-1">
+                    <Button type="button" size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => void testServer(server)} disabled={testing === server.name || server.disabled || server.transport === "unsupported"}>
+                      {testing === server.name ? <LoaderCircle className="h-3.5 w-3.5 animate-spin" /> : <FlaskConical className="h-3.5 w-3.5" />}
+                      Test
+                    </Button>
+                    <Button type="button" size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => void toggleServer(server)}>
+                      {server.disabled ? <Power className="h-3.5 w-3.5" /> : <PowerOff className="h-3.5 w-3.5" />}
+                      {server.disabled ? "Enable" : "Disable"}
+                    </Button>
+                    <Button type="button" size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => editServer(server)} disabled={server.transport === "unsupported"}>
+                      Edit
+                    </Button>
+                    <Button type="button" size="sm" variant="ghost" className="h-7 px-2 text-xs text-destructive/80" onClick={() => void deleteServer(server)} disabled={server.sourceKind !== "project-local"}>
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {testResult && (
+            <div className={cn(
+              "rounded-lg border px-3 py-2 text-xs",
+              testResult.ok ? "border-success/20 bg-success/5 text-success" : "border-warning/20 bg-warning/5 text-warning",
+            )}>
+              {testResult.ok
+                ? `${testResult.server} responded with ${testResult.toolCount} tools`
+                : `${testResult.server} failed: ${testResult.error ?? "unknown error"}`}
+            </div>
+          )}
+
+          <div className="space-y-3 rounded-lg border border-border/50 bg-card/50 px-3 py-3">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-xs font-medium text-muted-foreground">{editingName ? "Edit local server" : "Add local server"}</div>
+              {editingName && (
+                <Button type="button" size="sm" variant="ghost" className="h-7 text-xs" onClick={resetForm}>Cancel</Button>
+              )}
+            </div>
+            <div className="grid gap-2 md:grid-cols-2">
+              <input value={name} onChange={(event) => setName(event.target.value)} placeholder="server-name" className="rounded-lg border border-border/50 bg-background px-3 py-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+              <select value={transport} onChange={(event) => setTransport(event.target.value as Exclude<WebMcpTransport, "unsupported">)} className="rounded-lg border border-border/50 bg-background px-3 py-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring">
+                <option value="stdio">stdio</option>
+                <option value="http">http</option>
+              </select>
+              {transport === "stdio" ? (
+                <>
+                  <input value={command} onChange={(event) => setCommand(event.target.value)} placeholder="/absolute/path/to/server" className="rounded-lg border border-border/50 bg-background px-3 py-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+                  <input value={cwd} onChange={(event) => setCwd(event.target.value)} placeholder="cwd (optional)" className="rounded-lg border border-border/50 bg-background px-3 py-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+                  <textarea value={argsText} onChange={(event) => setArgsText(event.target.value)} placeholder="args, one per line" rows={3} className="rounded-lg border border-border/50 bg-background px-3 py-2 font-mono text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+                  <textarea value={envText} onChange={(event) => setEnvText(event.target.value)} placeholder="ENV_KEY=value" rows={3} className="rounded-lg border border-border/50 bg-background px-3 py-2 font-mono text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+                </>
+              ) : (
+                <>
+                  <input value={url} onChange={(event) => setUrl(event.target.value)} placeholder="https://server.example/mcp" className="md:col-span-2 rounded-lg border border-border/50 bg-background px-3 py-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+                  <textarea value={headersText} onChange={(event) => setHeadersText(event.target.value)} placeholder="Authorization=Bearer ${TOKEN}" rows={3} className="md:col-span-2 rounded-lg border border-border/50 bg-background px-3 py-2 font-mono text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring" />
+                </>
+              )}
+            </div>
+            <Button type="button" size="sm" onClick={() => void saveServer()} disabled={!canSave || saving} className="gap-1.5">
+              {saving ? <LoaderCircle className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}
+              {editingName ? "Update server" : "Save server"}
+            </Button>
+          </div>
+
+          {payload.importableServers.length > 0 && (
+            <div className="space-y-2">
+              <div className="text-xs font-medium text-muted-foreground">Discovered imports</div>
+              <div className="grid gap-2">
+                {payload.importableServers.slice(0, 6).map((server) => (
+                  <div key={`${server.sourcePath}:${server.name}`} className="flex items-center justify-between gap-3 rounded-lg border border-border/50 bg-card/50 px-3 py-2">
+                    <div className="min-w-0">
+                      <div className="font-mono text-xs text-foreground">{server.name}</div>
+                      <div className="truncate text-[10px] text-muted-foreground">{server.sourceTool} · {server.sourcePath}</div>
+                    </div>
+                    <Button type="button" size="sm" variant="ghost" className="h-7 text-xs" disabled={server.transport === "unsupported"} onClick={() => void importServer(server)}>
+                      Import
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
     </div>
   )
 }
@@ -1300,7 +1659,10 @@ export function ExperimentalPanel() {
   // Sync local state from loaded prefs
   useEffect(() => {
     if (!prefs) return
-    setFlags({ rtk: prefs.experimental?.rtk === true })
+    const timer = window.setTimeout(() => {
+      setFlags({ rtk: prefs.experimental?.rtk === true })
+    }, 0)
+    return () => window.clearTimeout(timer)
   }, [prefs])
 
   async function toggle(flagKey: string, next: boolean) {

--- a/web/lib/mcp-management-types.ts
+++ b/web/lib/mcp-management-types.ts
@@ -1,0 +1,91 @@
+// GSD-2 — Browser-safe MCP management contracts.
+// File Purpose: Shared TypeScript interfaces for app MCP connection management.
+
+export type WebMcpTransport = "stdio" | "http" | "unsupported"
+export type WebMcpSourceKind = "project-shared" | "project-local" | "global" | "discovered"
+
+export interface WebMcpServer {
+  name: string
+  transport: WebMcpTransport
+  sourcePath: string
+  sourceKind: WebMcpSourceKind
+  disabled: boolean
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  cwd?: string
+  headers?: Record<string, string>
+  envWarnings: string[]
+  connected: boolean
+  toolCount: number
+  tools: string[]
+}
+
+export interface WebMcpImportableServer {
+  name: string
+  transport: WebMcpTransport
+  sourcePath: string
+  sourceTool: string
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  headers?: Record<string, string>
+  unsupportedReason?: string
+  conflicts: boolean
+}
+
+export interface WebMcpDuplicate {
+  name: string
+  keptSourcePath: string
+  shadowedSourcePath: string
+}
+
+export interface WebMcpManagementPayload {
+  servers: WebMcpServer[]
+  importableServers: WebMcpImportableServer[]
+  duplicates: WebMcpDuplicate[]
+  warnings: string[]
+  localConfigPath: string
+}
+
+export interface WebMcpConnectionTestResult {
+  ok: boolean
+  server: string
+  transport: WebMcpTransport
+  toolCount: number
+  tools: string[]
+  warnings: string[]
+  error?: string
+}
+
+export type WebMcpMutationRequest =
+  | {
+      action: "save"
+      previousName?: string
+      server: {
+        name: string
+        transport: Exclude<WebMcpTransport, "unsupported">
+        command?: string
+        args?: string[]
+        env?: Record<string, string>
+        url?: string
+        cwd?: string
+        headers?: Record<string, string>
+        disabled?: boolean
+      }
+    }
+  | { action: "enable"; name: string }
+  | { action: "disable"; name: string }
+  | { action: "delete"; name: string }
+  | { action: "test"; name: string }
+  | {
+      action: "import"
+      server: WebMcpImportableServer
+      name?: string
+    }
+
+export type WebMcpMutationResponse =
+  | { status: "ok"; data: WebMcpManagementPayload; result?: WebMcpConnectionTestResult }
+  | { status: "error"; error: string }


### PR DESCRIPTION
## TL;DR

**What:** Keep the final GSD completion roll-up visible for foreground milestone and all-complete stops.
**Why:** Users were left on an empty-looking live terminal and had to scroll back to understand what happened.
**How:** Install the existing completion roll-up whenever `completionWidget` is provided, and update the foreground regression tests plus context wording.

## What

- Updated `stopAuto` so completion stops keep the durable roll-up surface in foreground runs, not only headless runs.
- Kept the existing headless notification behavior for automation callers.
- Clarified the `Closeout Boundary Stop` domain term in `CONTEXT.md`.
- Updated tests to assert foreground completion leaves the roll-up visible.

## Why

The closeout contract says the user should see completion evidence in the live terminal. The prior foreground path cleared `gsd-progress` and relied on scrollback, which made completed runs appear blank or ambiguous.

## How

The change reuses the existing `setCompletionProgressWidget` renderer and narrows the behavior to `stopAuto(..., { completionWidget })` paths. Non-completion stops still clear progress and render the normal lifecycle outcome.

## Validation

- `npm exec -- tsx --test src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts`
- `npm exec -- tsx --test src/resources/extensions/gsd/tests/auto-dashboard.test.ts`
- `npm exec -- tsx --test src/resources/extensions/gsd/tests/tui-header-lifecycle.test.ts`
- `npm run typecheck:extensions`
- `git diff --check -- CONTEXT.md src/resources/extensions/gsd/auto.ts src/resources/extensions/gsd/tests/auto-dashboard.test.ts src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts`

## Notes

AI assistance disclosed per CONTRIBUTING; no tool is credited as author or co-author.
