### PR TITLE
docs(gsd): clarify closeout boundary stop

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,6 +5,7 @@
 - **Auto Orchestration**: runtime coordination of GSD auto-mode units from start to completion, including dispatch and stop/resume behavior; unit-execution failure recovery is classified by the Recovery Classification module.
 - **Unit**: the smallest executable workflow step (e.g., plan slice, execute task, complete slice).
 - **Unit progression**: movement from one Unit to the next under orchestration rules.
+- **Closeout Boundary Stop**: the rule that a foreground run stops after the first task, slice, or milestone closeout boundary and leaves a durable final closeout surface visible in the live terminal, not merely scrollback or a cleared progress area.
 - **Dispatch decision**: selection of the next Unit plus rationale and preconditions.
 - **Recovery decision**: retry/escalate/abort choice after runtime failure.
 - **Runtime persistence**: lock state, transition journal, and any persisted execution state required for safe resume.


### PR DESCRIPTION
## TL;DR

**What:** Defines Closeout Boundary Stop as a durable live-terminal closeout surface.
**Why:** The domain contract should match foreground completion behavior so users are not left with cleared progress or scrollback-only evidence.
**How:** Adds the missing glossary entry; runtime behavior and regression tests already exist on main.

## What

Adds a `Closeout Boundary Stop` glossary entry to `CONTEXT.md`.

## Why

Foreground completion closeout needs a clear domain term for the behavior covered by the existing GSD TUI tests: completion leaves durable visible output instead of a blank terminal.

## How

Docs-only update. No runtime behavior change.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Tests

- `npm exec -- tsx --test src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts`
- `npm exec -- tsx --test src/resources/extensions/gsd/tests/auto-dashboard.test.ts`

## Assistance

AI-assisted; no AI author or co-author credit.