### PR TITLE
fix(gsd): repair stale slice roadmap projection

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -48,7 +48,8 @@ import { WorktreeStateProjection } from "./worktree-state-projection.js";
 import { createWorkspace, scopeMilestone } from "./workspace.js";
 import { normalizeWorktreePathForCompare } from "./worktree-root.js";
 import { isDbAvailable, getDbPath, refreshOpenDatabaseFromDisk, getTask, getSlice, getMilestone, getMilestoneSlices, updateTaskStatus, _getAdapter, getVerificationEvidence } from "./gsd-db.js";
-import { renderPlanCheckboxes } from "./markdown-renderer.js";
+import { renderPlanCheckboxes, renderRoadmapFromDb } from "./markdown-renderer.js";
+import { parseRoadmap as parseLegacyRoadmap } from "./parsers-legacy.js";
 import { consumeSignal } from "./session-status-io.js";
 import {
   checkPostUnitHooks,
@@ -86,6 +87,7 @@ import { validateArtifact } from "./schemas/validate.js";
 import { verificationRetryKey } from "./auto/verification-retry-policy.js";
 import { getLedger } from "./metrics.js";
 import { getUnitCostSpikeAction } from "./auto-budget.js";
+import { resolveCanonicalMilestoneRoot } from "./worktree-manager.js";
 
 // ─── Path Comparison Helper ───────────────────────────────────────────────
 /** Compare two paths for physical identity, tolerating trailing slashes and symlinks. */
@@ -642,6 +644,45 @@ function describeArtifactVerificationFailure(unitType: string, unitId: string, b
 
   const expected = diagnoseExpectedArtifact(unitType, unitId, basePath);
   return `Artifact verification failed: ${relPath} exists but did not satisfy the ${unitType} completion contract${expected ? ` (${expected})` : ""}.`;
+}
+
+async function repairCompleteSliceRoadmapProjection(
+  unitType: string,
+  unitId: string,
+  basePath: string,
+): Promise<boolean> {
+  if (unitType !== "complete-slice") return false;
+
+  const { milestone: mid, slice: sid } = parseUnitId(unitId);
+  if (!mid || !sid) return false;
+
+  const slice = getSlice(mid, sid);
+  if (!slice || !isClosedStatus(slice.status)) return false;
+
+  const artifactBase = resolveCanonicalMilestoneRoot(basePath, mid);
+  const summaryPath = resolveExpectedArtifactPath(unitType, unitId, artifactBase);
+  const uatPath = resolveSliceFile(artifactBase, mid, sid, "UAT");
+  if (!summaryPath || !existsSync(summaryPath) || !uatPath || !existsSync(uatPath)) {
+    return false;
+  }
+
+  const roadmapPath = resolveMilestoneFile(artifactBase, mid, "ROADMAP");
+  if (roadmapPath && existsSync(roadmapPath)) {
+    try {
+      const roadmap = parseLegacyRoadmap(readFileSync(roadmapPath, "utf-8"));
+      if (roadmap.slices.find((roadmapSlice) => roadmapSlice.id === sid)?.done) {
+        return false;
+      }
+    } catch (err) {
+      logWarning(
+        "projection",
+        `complete-slice roadmap parse failed before repair for ${mid}/${sid}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  await renderRoadmapFromDb(artifactBase, mid);
+  return true;
 }
 
 export async function autoCommitUnit(
@@ -1263,6 +1304,27 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         }
       } catch (e) {
         debugLog("postUnit", { phase: "artifact-verify", error: String(e) });
+      }
+
+      try {
+        const repairedRoadmapProjection = await repairCompleteSliceRoadmapProjection(
+          s.currentUnit.type,
+          s.currentUnit.id,
+          s.basePath,
+        );
+        if (repairedRoadmapProjection) {
+          triggerArtifactVerified = verifyExpectedArtifact(s.currentUnit.type, s.currentUnit.id, s.basePath);
+          if (triggerArtifactVerified) {
+            invalidateAllCaches();
+          }
+          debugLog("postUnit", {
+            phase: "complete-slice-roadmap-projection-repaired",
+            unitType: s.currentUnit.type,
+            unitId: s.currentUnit.id,
+          });
+        }
+      } catch (e) {
+        debugLog("postUnit", { phase: "complete-slice-roadmap-projection-repair", error: String(e) });
       }
 
       // If verification failed, attempt to regenerate missing projection files

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -407,6 +407,47 @@ test("verifyExpectedArtifact detects roadmap [x] change despite parse cache", ()
   }
 });
 
+test("verifyExpectedArtifact accepts DB-complete slice when roadmap projection is stale", () => {
+  const base = makeTmpBase();
+  try {
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+    insertSlice({
+      milestoneId: "M001",
+      id: "S01",
+      title: "Test Slice",
+      status: "complete",
+      risk: "low",
+      depends: [],
+    });
+
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+      "# M001: Test Milestone\n\n## Slices\n\n- [ ] **S01: Test Slice** `risk:low` `depends:[]`\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
+      "# S01 Summary\n\nDone.\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-UAT.md"),
+      "# S01 UAT\n\nPassed.\n",
+      "utf-8",
+    );
+
+    assert.equal(
+      verifyExpectedArtifact("complete-slice", "M001/S01", base),
+      true,
+      "DB completion plus SUMMARY/UAT should prevent a retry even when ROADMAP is a stale projection",
+    );
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
 // ─── verifyExpectedArtifact: plan-slice empty scaffold regression (#699) ──
 
 test("verifyExpectedArtifact rejects plan-slice with empty scaffold", () => {

--- a/src/resources/extensions/gsd/tests/post-unit-state-rebuild.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-state-rebuild.test.ts
@@ -286,6 +286,41 @@ test("postUnitPreVerification continues closeout when artifact cost spike is obs
   }
 });
 
+test("postUnitPreVerification repairs stale complete-slice roadmap projection without retry", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-post-unit-slice-roadmap-"));
+  const notifications: string[] = [];
+  const pauseCalls = { count: 0 };
+  try {
+    writeProjectPreferences(base);
+    writeSliceFixture(base, { sliceDone: false });
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-UAT.md"),
+      "# S01 UAT\n\nPassed.\n",
+      "utf-8",
+    );
+    openPostUnitDb(base, { sliceStatus: "complete" });
+
+    const s = makeCompleteSliceSession(base);
+    const result = await postUnitPreVerification(
+      makePostUnitContext(s, notifications, pauseCalls),
+      { skipSettleDelay: true, skipWorktreeSync: true },
+    );
+
+    assert.equal(result, "continue");
+    assert.equal(pauseCalls.count, 0);
+    assert.equal(s.pendingVerificationRetry, null);
+    assert.match(
+      readFileSync(join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "utf-8"),
+      /- \[x\] \*\*S01:/,
+      "complete-slice closeout should repair ROADMAP from DB instead of retrying the closer",
+    );
+  } finally {
+    invalidateStateCache();
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("postUnitPreVerification accepts validation invalidated by same-turn reassessment", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-post-unit-validation-reassess-"));
   const notifications: string[] = [];


### PR DESCRIPTION
## TL;DR

**What:** Repairs stale complete-slice ROADMAP projections from DB state during post-unit verification.
**Why:** A slice can be complete in the DB with SUMMARY/UAT artifacts present while ROADMAP still shows `[ ]`, causing unnecessary closeout retries and leaving users at the wrong end-state.
**How:** When complete-slice verification sees a DB-complete slice with required artifacts, it re-renders the milestone roadmap from DB before deciding to retry.

## What

Adds a targeted post-unit repair path for complete-slice units and regression coverage for both artifact verification and post-unit pre-verification.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-recovery.test.ts src/resources/extensions/gsd/tests/post-unit-state-rebuild.test.ts`
- `npm run typecheck:extensions`
- `git diff --check`