### PR TITLE
Harden GSD migration import

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,10 +379,14 @@ The migration tool:
 
 - Parses your old `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, phase directories, plans, summaries, and research
 - Maps phases → slices, plans → tasks, milestones → milestones
+- Treats an explicit path as the target project root, so `/gsd migrate ~/projects/my-old-project` writes to `~/projects/my-old-project/.gsd`
+- Blocks zero-slice migrations and refuses to run while active, paused, or worktree session state exists
+- Backs up any existing `.gsd/` to `.gsd-backups/migrate-YYYYMMDD-HHMMSS/`, deletes the old `.gsd/`, and restores the backup if migration fails
+- Writes imported hierarchy into the GSD database, renders/verifies markdown projections from DB state, and records a migration audit under `.gsd/migration/`
 - Preserves completion state (`[x]` phases stay done, summaries carry over)
-- Consolidates research files into the new structure
+- Consolidates research files into the new structure and archives the full legacy `.planning` source under `.gsd/migration/legacy/`
 - Shows a preview before writing anything
-- Optionally runs an agent-driven review of the output for quality assurance
+- Optionally runs a read-only review of the output for quality assurance
 
 Supports format variations including milestone-sectioned roadmaps with `<details>` blocks, bold phase entries, bullet-format requirements, decimal phase numbering, and duplicate phase numbers across milestones.
 

--- a/docs/user-docs/migration.md
+++ b/docs/user-docs/migration.md
@@ -18,11 +18,15 @@ The migration tool:
 
 - Parses your old `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, phase directories, plans, summaries, and research
 - Maps phases → slices, plans → tasks, milestones → milestones
+- Treats an explicit path as the target project root, so `/gsd migrate ~/projects/my-old-project` writes to `~/projects/my-old-project/.gsd`
+- Blocks zero-slice migrations and refuses to run while active, paused, or worktree session state exists
+- Backs up any existing `.gsd/` to `.gsd-backups/migrate-YYYYMMDD-HHMMSS/`, deletes the old `.gsd/`, and restores the backup if migration fails
 - Writes the imported hierarchy into the GSD database, then renders markdown projections from that database
 - Preserves completion state (`[x]` phases stay done, summaries carry over)
-- Consolidates research files into the new structure
+- Consolidates research files into the new structure and archives the full legacy `.planning` source under `.gsd/migration/legacy/`
+- Records `.gsd/migration/MIGRATION.md` and `.gsd/migration/manifest.json` audit artifacts
 - Shows a preview before writing anything
-- Optionally runs an agent-driven review of the output for quality assurance
+- Optionally runs a read-only review of the output for quality assurance
 
 ## Supported Formats
 

--- a/gitbook/reference/commands.md
+++ b/gitbook/reference/commands.md
@@ -52,7 +52,7 @@
 | `/gsd setup` | Global setup status |
 | `/gsd skill-health` | Skill lifecycle dashboard |
 | `/gsd hooks` | Show configured hooks |
-| `/gsd migrate` | Migrate v1 `.planning` to `.gsd` format |
+| `/gsd migrate` | Migrate v1 `.planning` to DB-backed `.gsd` with backup and audit |
 | `/gsd recover` | Explicitly reconstruct database hierarchy state from rendered markdown after database loss or corruption |
 
 ## Milestone Management

--- a/gitbook/reference/migration.md
+++ b/gitbook/reference/migration.md
@@ -18,11 +18,15 @@ The migration tool:
 
 - Parses your old `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, phase directories, plans, summaries, and research
 - Maps phases → slices, plans → tasks, milestones → milestones
+- Treats an explicit path as the target project root, so `/gsd migrate ~/projects/my-old-project` writes to `~/projects/my-old-project/.gsd`
+- Blocks zero-slice migrations and refuses to run while active, paused, or worktree session state exists
+- Backs up any existing `.gsd/` to `.gsd-backups/migrate-YYYYMMDD-HHMMSS/`, deletes the old `.gsd/`, and restores the backup if migration fails
 - Writes the imported hierarchy into the GSD database, then renders markdown projections from that database
 - Preserves completion state (`[x]` phases stay done, summaries carry over)
-- Consolidates research files into the new structure
+- Consolidates research files into the new structure and archives the full legacy `.planning` source under `.gsd/migration/legacy/`
+- Records `.gsd/migration/MIGRATION.md` and `.gsd/migration/manifest.json` audit artifacts
 - Shows a preview before writing anything
-- Optionally runs an AI-driven review for quality assurance
+- Optionally runs a read-only review for quality assurance
 
 ## Supported Formats
 

--- a/mintlify-docs/guides/migration.mdx
+++ b/mintlify-docs/guides/migration.mdx
@@ -21,10 +21,15 @@ The migration tool:
 
 - Parses `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, phase directories, plans, summaries, and research
 - Maps phases → slices, plans → tasks, milestones → milestones
+- Treats an explicit path as the target project root, so `/gsd migrate ~/projects/my-old-project` writes to `~/projects/my-old-project/.gsd`
+- Blocks zero-slice migrations and refuses to run while active, paused, or worktree session state exists
+- Backs up any existing `.gsd/` to `.gsd-backups/migrate-YYYYMMDD-HHMMSS/`, deletes the old `.gsd/`, and restores the backup if migration fails
+- Writes imported hierarchy into the GSD database, then renders and verifies markdown projections from that database
 - Preserves completion state (`[x]` phases stay done, summaries carry over)
-- Consolidates research files
+- Consolidates research files and archives the full legacy `.planning` source under `.gsd/migration/legacy/`
+- Records `.gsd/migration/MIGRATION.md` and `.gsd/migration/manifest.json` audit artifacts
 - Shows a preview before writing anything
-- Optionally runs an agent-driven review of the output
+- Optionally runs a read-only review of the output
 
 ## Supported formats
 

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -59,7 +59,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "init", desc: "Project init wizard — detect, configure, bootstrap .gsd/" },
   { cmd: "setup", desc: "Configuration hub: status + sub-routes (llm, model, search, remote, keys, prefs, onboarding)" },
   { cmd: "onboarding", desc: "Re-run the setup wizard  [--resume|--reset|--step <name>]" },
-  { cmd: "migrate", desc: "Migrate a v1 .planning directory to .gsd format" },
+  { cmd: "migrate", desc: "Migrate a v1 .planning directory to DB-backed .gsd with backup + audit" },
   { cmd: "remote", desc: "Control remote auto-mode" },
   { cmd: "steer", desc: "Hard-steer plan documents during execution" },
   { cmd: "inspect", desc: "Show SQLite DB diagnostics" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -141,7 +141,7 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd cleanup        Remove merged branches or snapshots  [branches|snapshots]",
     "  /gsd closeout       Recover failed git closeout actions  [status|retry|resolve] [unit-id]",
     "  /gsd worktree       Manage worktrees from the TUI  [list|merge|clean|remove]",
-    "  /gsd migrate        Migrate .planning/ (v1) to .gsd/ (v2) format",
+    "  /gsd migrate        Migrate .planning/ (v1) to DB-backed .gsd/ with backup + audit",
     "  /gsd remote         Control remote auto-mode  [slack|discord|status|disconnect]",
     "  /gsd inspect        Show SQLite DB diagnostics (schema, row counts, recent entries)",
     "  /gsd update         Update GSD to the latest version via npm",

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -936,6 +936,16 @@ export function clearArtifacts(): void {
   try { currentDb.exec("DELETE FROM artifacts"); } catch (e) { logWarning("db", `clearArtifacts failed: ${(e as Error).message}`); }
 }
 
+export function clearDecisions(): void {
+  if (!currentDb) return;
+  try { currentDb.exec("DELETE FROM decisions"); } catch (e) { logWarning("db", `clearDecisions failed: ${(e as Error).message}`); }
+}
+
+export function clearRequirements(): void {
+  if (!currentDb) return;
+  try { currentDb.exec("DELETE FROM requirements"); } catch (e) { logWarning("db", `clearRequirements failed: ${(e as Error).message}`); }
+}
+
 export function insertArtifact(a: {
   path: string;
   artifact_type: string;

--- a/src/resources/extensions/gsd/migrate/audit.ts
+++ b/src/resources/extensions/gsd/migrate/audit.ts
@@ -1,0 +1,219 @@
+// GSD-2 - /gsd migrate audit helpers.
+// File Purpose: Legacy archive, migration manifest, and projection verification support.
+
+import { cpSync, existsSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import { saveFile } from "../files.js";
+import { insertArtifact } from "../gsd-db.js";
+import { renderAllFromDb } from "../markdown-renderer.js";
+import { gsdRoot } from "../paths.js";
+import { countDbHierarchy, countMarkdownHierarchy, type HierarchyCounts } from "../migration-auto-check.js";
+import type { MigrationPreview, WrittenFiles } from "./writer.js";
+
+interface ImportedMigrationCounts {
+  decisions: number;
+  requirements: number;
+  artifacts: number;
+  hierarchy: HierarchyCounts;
+}
+
+export interface LegacyArchiveResult {
+  archived: boolean;
+  archivePath: string;
+  manifestPath: string;
+  strategy: "full-source-copy";
+}
+
+export interface MigrationProjectionVerification {
+  markdown: HierarchyCounts;
+  db: HierarchyCounts;
+  rendered: number;
+  skipped: number;
+  errors: string[];
+}
+
+export interface MigrationAuditResult {
+  migrationPath: string;
+  manifestPath: string;
+  importedArtifacts: number;
+}
+
+export interface MigrationAuditInput {
+  sourcePath: string;
+  targetRoot: string;
+  backupPath: string | null;
+  preview: MigrationPreview;
+  written: WrittenFiles;
+  imported: ImportedMigrationCounts;
+  legacyArchive: LegacyArchiveResult;
+  verification: MigrationProjectionVerification;
+  startedAt: string;
+  completedAt: string;
+}
+
+function relToGsd(targetRoot: string, path: string): string {
+  return relative(gsdRoot(targetRoot), path).replaceAll("\\", "/");
+}
+
+function sameCounts(a: HierarchyCounts, b: HierarchyCounts): boolean {
+  return a.milestones === b.milestones && a.slices === b.slices && a.tasks === b.tasks;
+}
+
+function previewHierarchy(preview: MigrationPreview): HierarchyCounts {
+  return {
+    milestones: preview.milestoneCount,
+    slices: preview.totalSlices,
+    tasks: preview.totalTasks,
+  };
+}
+
+export async function archiveLegacyPlanningDirectory(
+  sourcePath: string,
+  targetRoot: string,
+): Promise<LegacyArchiveResult> {
+  const archiveRoot = join(gsdRoot(targetRoot), "migration", "legacy");
+  const archivePath = join(archiveRoot, "planning");
+  const manifestPath = join(archiveRoot, "manifest.json");
+
+  if (existsSync(sourcePath)) {
+    cpSync(sourcePath, archivePath, { recursive: true });
+  }
+
+  const manifest = {
+    sourcePath,
+    archivePath: relToGsd(targetRoot, archivePath),
+    strategy: "full-source-copy",
+    note: "Full .planning source copied so legacy content without a GSD-2 field is not lost.",
+  };
+
+  await saveFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  return {
+    archived: existsSync(archivePath),
+    archivePath,
+    manifestPath,
+    strategy: "full-source-copy",
+  };
+}
+
+export async function verifyMigrationProjection(
+  targetRoot: string,
+  preview: MigrationPreview,
+): Promise<MigrationProjectionVerification> {
+  const render = await renderAllFromDb(targetRoot);
+  const markdown = countMarkdownHierarchy(targetRoot);
+  const db = countDbHierarchy();
+  const expected = previewHierarchy(preview);
+  const errors = [...render.errors];
+
+  if (!sameCounts(db, expected)) {
+    errors.push(
+      `DB hierarchy ${db.milestones}M/${db.slices}S/${db.tasks}T did not match preview ${expected.milestones}M/${expected.slices}S/${expected.tasks}T`,
+    );
+  }
+  if (!sameCounts(markdown, db)) {
+    errors.push(
+      `Markdown projection ${markdown.milestones}M/${markdown.slices}S/${markdown.tasks}T did not match DB ${db.milestones}M/${db.slices}S/${db.tasks}T`,
+    );
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`migration projection verification failed: ${errors.join("; ")}`);
+  }
+
+  return {
+    markdown,
+    db,
+    rendered: render.rendered,
+    skipped: render.skipped,
+    errors,
+  };
+}
+
+function formatMigrationMarkdown(input: MigrationAuditInput): string {
+  const backup = input.backupPath ? input.backupPath : "none";
+  return [
+    "# Migration Audit",
+    "",
+    `- Started: ${input.startedAt}`,
+    `- Completed: ${input.completedAt}`,
+    `- Source: ${input.sourcePath}`,
+    `- Target: ${input.targetRoot}`,
+    `- Backup: ${backup}`,
+    `- Legacy archive: ${relToGsd(input.targetRoot, input.legacyArchive.archivePath)}`,
+    "",
+    "## Imported Counts",
+    "",
+    `- Decisions: ${input.imported.decisions}/${input.preview.decisions.total}`,
+    `- Requirements: ${input.imported.requirements}/${input.preview.requirements.total}`,
+    `- Milestones: ${input.imported.hierarchy.milestones}/${input.preview.milestoneCount}`,
+    `- Slices: ${input.imported.hierarchy.slices}/${input.preview.totalSlices}`,
+    `- Tasks: ${input.imported.hierarchy.tasks}/${input.preview.totalTasks}`,
+    `- Artifacts: ${input.imported.artifacts}`,
+    "",
+    "## Projection Verification",
+    "",
+    `- DB: ${input.verification.db.milestones}M/${input.verification.db.slices}S/${input.verification.db.tasks}T`,
+    `- Markdown: ${input.verification.markdown.milestones}M/${input.verification.markdown.slices}S/${input.verification.markdown.tasks}T`,
+    `- Rendered: ${input.verification.rendered}`,
+    `- Skipped: ${input.verification.skipped}`,
+    "",
+  ].join("\n");
+}
+
+export async function writeMigrationAudit(input: MigrationAuditInput): Promise<MigrationAuditResult> {
+  const migrationDir = join(gsdRoot(input.targetRoot), "migration");
+  const migrationPath = join(migrationDir, "MIGRATION.md");
+  const manifestPath = join(migrationDir, "manifest.json");
+
+  const manifest = {
+    sourcePath: input.sourcePath,
+    targetRoot: input.targetRoot,
+    backupPath: input.backupPath,
+    startedAt: input.startedAt,
+    completedAt: input.completedAt,
+    preview: input.preview,
+    written: input.written.counts,
+    imported: input.imported,
+    legacyArchive: {
+      archived: input.legacyArchive.archived,
+      path: relToGsd(input.targetRoot, input.legacyArchive.archivePath),
+      manifestPath: relToGsd(input.targetRoot, input.legacyArchive.manifestPath),
+      strategy: input.legacyArchive.strategy,
+    },
+    verification: input.verification,
+  };
+
+  await saveFile(migrationPath, formatMigrationMarkdown(input));
+  await saveFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  return {
+    migrationPath,
+    manifestPath,
+    importedArtifacts: importMigrationAuditArtifacts(input.targetRoot),
+  };
+}
+
+export function importMigrationAuditArtifacts(targetRoot: string): number {
+  const candidates = [
+    { path: join(gsdRoot(targetRoot), "migration", "MIGRATION.md"), type: "MIGRATION_AUDIT" },
+    { path: join(gsdRoot(targetRoot), "migration", "manifest.json"), type: "MIGRATION_MANIFEST" },
+    { path: join(gsdRoot(targetRoot), "migration", "legacy", "manifest.json"), type: "MIGRATION_LEGACY_MANIFEST" },
+  ];
+
+  let imported = 0;
+  for (const candidate of candidates) {
+    if (!existsSync(candidate.path)) continue;
+    insertArtifact({
+      path: relToGsd(targetRoot, candidate.path),
+      artifact_type: candidate.type,
+      milestone_id: null,
+      slice_id: null,
+      task_id: null,
+      full_content: readFileSync(candidate.path, "utf-8"),
+    });
+    imported++;
+  }
+  return imported;
+}

--- a/src/resources/extensions/gsd/migrate/command.ts
+++ b/src/resources/extensions/gsd/migrate/command.ts
@@ -5,13 +5,13 @@
  * preview → write pipeline, and shows confirmation UI via showNextAction.
  * All business logic lives in the pipeline modules (S01–S03).
  *
- * After a successful write, offers an agent-driven review that audits the
- * output for GSD-2 standards compliance.
+ * After a successful write, offers a read-only review that audits the output
+ * for GSD-2 standards compliance.
  */
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import { existsSync, readFileSync } from "node:fs";
-import { resolve, join, dirname } from "node:path";
+import { join, dirname } from "node:path";
 import { gsdRoot } from "../paths.js";
 import { fileURLToPath } from "node:url";
 import { showNextAction } from "../../shared/tui.js";
@@ -23,14 +23,38 @@ import {
   writeGSDDirectory,
 } from "./index.js";
 
-import type { MigrationPreview } from "./writer.js";
-import { homedir } from "node:os";
+import type { MigrationPreview, WrittenFiles } from "./writer.js";
 import { ensureDbOpen } from "../bootstrap/dynamic-tools.js";
-import { clearEngineHierarchy, transaction } from "../gsd-db.js";
+import { clearArtifacts, clearEngineHierarchy, transaction, _getAdapter } from "../gsd-db.js";
 import { migrateFromMarkdown } from "../md-importer.js";
 import { invalidateStateCache } from "../state.js";
+import {
+  archiveLegacyPlanningDirectory,
+  verifyMigrationProjection,
+  writeMigrationAudit,
+  type LegacyArchiveResult,
+  type MigrationAuditResult,
+  type MigrationProjectionVerification,
+} from "./audit.js";
+import {
+  assertMigrationHasSlices,
+  assertMigrationTargetAvailable,
+  prepareMigrationTarget,
+  resolveMigrationPaths,
+  restoreMigrationTarget,
+  type MigrationBackup,
+} from "./safety.js";
 
 export type MigrationImportCounts = ReturnType<typeof migrateFromMarkdown>;
+
+export interface MigrationExecutionResult {
+  backup: MigrationBackup;
+  written: WrittenFiles;
+  imported: MigrationImportCounts;
+  legacyArchive: LegacyArchiveResult;
+  verification: MigrationProjectionVerification;
+  audit: MigrationAuditResult;
+}
 
 function assertMigrationImportMatchesPreview(imported: MigrationImportCounts, preview: MigrationPreview): void {
   const mismatches: string[] = [];
@@ -64,13 +88,54 @@ export async function importWrittenMigrationToDb(
   }
 
   const counts = transaction(() => {
+    const adapter = _getAdapter();
+    if (!adapter) {
+      throw new Error("failed to access the GSD database adapter for migration import");
+    }
     clearEngineHierarchy();
+    clearArtifacts();
+    adapter.exec("DELETE FROM decisions");
+    adapter.exec("DELETE FROM requirements");
     const imported = migrateFromMarkdown(basePath);
     if (preview) assertMigrationImportMatchesPreview(imported, preview);
     return imported;
   });
   invalidateStateCache();
   return counts;
+}
+
+export async function executeMigrationWrite(
+  sourcePath: string,
+  targetRoot: string,
+  project: ReturnType<typeof transformToGSD>,
+  preview: MigrationPreview,
+  startedAt: string = new Date().toISOString(),
+): Promise<MigrationExecutionResult> {
+  const backup = prepareMigrationTarget(targetRoot);
+
+  try {
+    const written = await writeGSDDirectory(project, targetRoot);
+    const legacyArchive = await archiveLegacyPlanningDirectory(sourcePath, targetRoot);
+    const imported = await importWrittenMigrationToDb(targetRoot, preview);
+    const verification = await verifyMigrationProjection(targetRoot, preview);
+    const audit = await writeMigrationAudit({
+      sourcePath,
+      targetRoot,
+      backupPath: backup.backupPath,
+      preview,
+      written,
+      imported,
+      legacyArchive,
+      verification,
+      startedAt,
+      completedAt: new Date().toISOString(),
+    });
+
+    return { backup, written, imported, legacyArchive, verification, audit };
+  } catch (err) {
+    restoreMigrationTarget(backup);
+    throw err;
+  }
 }
 
 /** Format preview stats for embedding in the review prompt. */
@@ -131,18 +196,7 @@ export async function handleMigrate(
   pi: ExtensionAPI,
 ): Promise<void> {
   // ── Resolve source path ────────────────────────────────────────────────────
-  // Default to cwd when no args given; expand ~ to HOME
-  let rawPath = args.trim() || ".";
-  if (rawPath.startsWith("~/")) {
-    rawPath = join(homedir(), rawPath.slice(2));
-  } else if (rawPath === "~") {
-    rawPath = homedir();
-  }
-
-  let sourcePath = resolve(process.cwd(), rawPath);
-  if (!sourcePath.endsWith(".planning")) {
-    sourcePath = join(sourcePath, ".planning");
-  }
+  const { sourcePath, targetRoot } = resolveMigrationPaths(args);
 
   if (!existsSync(sourcePath)) {
     ctx.ui.notify(
@@ -180,6 +234,13 @@ export async function handleMigrate(
   const parsed = await parsePlanningDirectory(sourcePath);
   const project = transformToGSD(parsed);
   const preview = generatePreview(project);
+  try {
+    assertMigrationHasSlices(preview);
+    await assertMigrationTargetAvailable(targetRoot);
+  } catch (err) {
+    ctx.ui.notify((err as Error).message, "error");
+    return;
+  }
 
   // ── Build preview text ─────────────────────────────────────────────────────
   const lines: string[] = [
@@ -195,10 +256,11 @@ export async function handleMigrate(
     );
   }
 
-  const targetGsdExists = existsSync(gsdRoot(process.cwd()));
+  const targetGsdExists = existsSync(gsdRoot(targetRoot));
   if (targetGsdExists) {
     lines.push("");
-    lines.push("⚠ A .gsd directory already exists in the current working directory — it will be overwritten.");
+    lines.push(`⚠ A .gsd directory already exists at ${gsdRoot(targetRoot)}.`);
+    lines.push("It will be backed up, deleted, and rewritten fresh before DB import.");
   }
 
   // ── Confirmation via showNextAction ────────────────────────────────────────
@@ -209,7 +271,7 @@ export async function handleMigrate(
       {
         id: "confirm",
         label: "Write .gsd directory",
-        description: `Migrate ${preview.milestoneCount} milestone(s) to ${process.cwd()}/.gsd`,
+        description: `Migrate ${preview.milestoneCount} milestone(s) to ${gsdRoot(targetRoot)}`,
         recommended: true,
       },
       {
@@ -227,14 +289,24 @@ export async function handleMigrate(
   }
 
   // ── Write ──────────────────────────────────────────────────────────────────
-  ctx.ui.notify("Writing .gsd directory…", "info");
+  ctx.ui.notify("Writing .gsd directory and importing DB state…", "info");
 
-  const result = await writeGSDDirectory(project, process.cwd());
-  const gsdPath = gsdRoot(process.cwd());
-  const imported = await importWrittenMigrationToDb(process.cwd(), preview);
+  let execution: MigrationExecutionResult;
+  try {
+    execution = await executeMigrationWrite(sourcePath, targetRoot, project, preview);
+  } catch (err) {
+    ctx.ui.notify(
+      `Migration failed and the previous .gsd state was restored: ${(err as Error).message}`,
+      "error",
+    );
+    return;
+  }
+
+  const gsdPath = gsdRoot(targetRoot);
+  const { written, imported } = execution;
 
   ctx.ui.notify(
-    `✓ Migration complete — ${result.paths.length} file(s) written to .gsd/ and ${imported.hierarchy.milestones}M/${imported.hierarchy.slices}S/${imported.hierarchy.tasks}T imported to the database`,
+    `✓ Migration complete — ${written.paths.length} file(s) written to .gsd/, ${imported.hierarchy.milestones}M/${imported.hierarchy.slices}S/${imported.hierarchy.tasks}T imported to the database, and ${execution.audit.importedArtifacts} audit artifact(s) recorded`,
     "info",
   );
 
@@ -242,12 +314,14 @@ export async function handleMigrate(
   const reviewChoice = await showNextAction(ctx, {
     title: "Migration written",
     summary: [
-      `${result.paths.length} files written to .gsd/`,
+      `${written.paths.length} files written to .gsd/`,
       `${imported.hierarchy.milestones} milestone(s), ${imported.hierarchy.slices} slice(s), and ${imported.hierarchy.tasks} task(s) imported to gsd.db`,
+      `Legacy source archived at ${execution.legacyArchive.archivePath}`,
+      `Migration audit written at ${execution.audit.migrationPath}`,
       "",
       "The agent can now review the migrated output against GSD-2 standards —",
       "checking structure, content quality, deriveState() round-trip, and",
-      "requirement statuses. It will fix minor issues in-place.",
+      "requirement statuses. The review is read-only by default.",
     ],
     actions: [
       {

--- a/src/resources/extensions/gsd/migrate/command.ts
+++ b/src/resources/extensions/gsd/migrate/command.ts
@@ -25,7 +25,7 @@ import {
 
 import type { MigrationPreview, WrittenFiles } from "./writer.js";
 import { ensureDbOpen } from "../bootstrap/dynamic-tools.js";
-import { clearArtifacts, clearEngineHierarchy, transaction, _getAdapter } from "../gsd-db.js";
+import { clearArtifacts, clearDecisions, clearRequirements, clearEngineHierarchy, transaction } from "../gsd-db.js";
 import { migrateFromMarkdown } from "../md-importer.js";
 import { invalidateStateCache } from "../state.js";
 import {
@@ -88,14 +88,10 @@ export async function importWrittenMigrationToDb(
   }
 
   const counts = transaction(() => {
-    const adapter = _getAdapter();
-    if (!adapter) {
-      throw new Error("failed to access the GSD database adapter for migration import");
-    }
     clearEngineHierarchy();
     clearArtifacts();
-    adapter.exec("DELETE FROM decisions");
-    adapter.exec("DELETE FROM requirements");
+    clearDecisions();
+    clearRequirements();
     const imported = migrateFromMarkdown(basePath);
     if (preview) assertMigrationImportMatchesPreview(imported, preview);
     return imported;

--- a/src/resources/extensions/gsd/migrate/index.ts
+++ b/src/resources/extensions/gsd/migrate/index.ts
@@ -5,6 +5,8 @@ export { parsePlanningDirectory } from './parser.js';
 export { validatePlanningDirectory } from './validator.js';
 export { transformToGSD } from './transformer.js';
 export { writeGSDDirectory } from './writer.js';
+export { resolveMigrationPaths, assertMigrationHasSlices } from './safety.js';
+export { archiveLegacyPlanningDirectory, verifyMigrationProjection } from './audit.js';
 export type { WrittenFiles, MigrationPreview } from './writer.js';
 export { generatePreview } from './preview.js';
 export type {

--- a/src/resources/extensions/gsd/migrate/parser.ts
+++ b/src/resources/extensions/gsd/migrate/parser.ts
@@ -71,11 +71,11 @@ function parseQuickDir(dirName: string): { number: number; slug: string } | null
 
 // ─── Phase Scanner ─────────────────────────────────────────────────────────
 
-/** Plan file pattern: NN-NN-PLAN.md (e.g. 29-01-PLAN.md) */
-const PLAN_RE = /^(\d+(?:\.\d+)?)-(\d+)-PLAN\.md$/i;
+/** Plan file pattern: NN-NN-PLAN.md (e.g. 29-01-PLAN.md) or NN-NNb-PLAN.md. */
+const PLAN_RE = /^(\d+(?:\.\d+)?)-(\d+[a-z]?)-PLAN\.md$/i;
 
-/** Summary file pattern: NN-NN-SUMMARY.md (e.g. 29-01-SUMMARY.md) */
-const SUMMARY_RE = /^(\d+(?:\.\d+)?)-(\d+)-SUMMARY\.md$/i;
+/** Summary file pattern: NN-NN-SUMMARY.md (e.g. 29-01-SUMMARY.md) or NN-NNb-SUMMARY.md. */
+const SUMMARY_RE = /^(\d+(?:\.\d+)?)-(\d+[a-z]?)-SUMMARY\.md$/i;
 
 /** Research file pattern: contains RESEARCH (case-insensitive) */
 const RESEARCH_RE = /research/i;

--- a/src/resources/extensions/gsd/migrate/safety.ts
+++ b/src/resources/extensions/gsd/migrate/safety.ts
@@ -1,0 +1,149 @@
+// GSD-2 - /gsd migrate safety helpers.
+// File Purpose: Path resolution, target guards, backup, and restore support for v1 migration.
+
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+import { ensureDbOpen } from "../bootstrap/dynamic-tools.js";
+import { readCrashLock, isLockProcessAlive } from "../crash-recovery.js";
+import { closeDatabase } from "../gsd-db.js";
+import { readPausedSessionMetadata } from "../interrupted-session.js";
+import { gsdRoot } from "../paths.js";
+import type { MigrationPreview } from "./writer.js";
+
+export interface MigrationPaths {
+  sourcePath: string;
+  targetRoot: string;
+}
+
+export interface MigrationBackup {
+  hadExistingGsd: boolean;
+  backupPath: string | null;
+  targetGsdPath: string;
+}
+
+export class MigrationBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MigrationBlockedError";
+  }
+}
+
+function expandHome(pathArg: string): string {
+  if (pathArg === "~") return homedir();
+  if (pathArg.startsWith("~/")) return join(homedir(), pathArg.slice(2));
+  return pathArg;
+}
+
+export function resolveMigrationPaths(args: string, cwd: string = process.cwd()): MigrationPaths {
+  const rawPath = expandHome(args.trim() || ".");
+  const resolved = resolve(cwd, rawPath);
+
+  if (basename(resolved) === ".planning") {
+    return {
+      sourcePath: resolved,
+      targetRoot: dirname(resolved),
+    };
+  }
+
+  return {
+    sourcePath: join(resolved, ".planning"),
+    targetRoot: resolved,
+  };
+}
+
+function formatBackupTimestamp(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+  return `${year}${month}${day}-${hours}${minutes}${seconds}`;
+}
+
+function nextBackupPath(targetRoot: string, now: Date): string {
+  const backupRoot = join(targetRoot, ".gsd-backups");
+  const baseName = `migrate-${formatBackupTimestamp(now)}`;
+  let candidate = join(backupRoot, baseName);
+  let suffix = 2;
+
+  while (existsSync(candidate)) {
+    candidate = join(backupRoot, `${baseName}-${suffix}`);
+    suffix++;
+  }
+
+  return candidate;
+}
+
+export function prepareMigrationTarget(targetRoot: string, now: Date = new Date()): MigrationBackup {
+  const targetGsdPath = gsdRoot(targetRoot);
+  if (!existsSync(targetGsdPath)) {
+    return { hadExistingGsd: false, backupPath: null, targetGsdPath };
+  }
+
+  const backupPath = nextBackupPath(targetRoot, now);
+  mkdirSync(dirname(backupPath), { recursive: true });
+  cpSync(targetGsdPath, backupPath, { recursive: true });
+  rmSync(targetGsdPath, { recursive: true, force: true });
+
+  return { hadExistingGsd: true, backupPath, targetGsdPath };
+}
+
+export function restoreMigrationTarget(backup: MigrationBackup): void {
+  rmSync(backup.targetGsdPath, { recursive: true, force: true });
+  if (backup.backupPath && existsSync(backup.backupPath)) {
+    cpSync(backup.backupPath, backup.targetGsdPath, { recursive: true });
+  }
+}
+
+export function assertMigrationHasSlices(preview: MigrationPreview): void {
+  if (preview.totalSlices > 0) return;
+  throw new MigrationBlockedError(
+    "Migration blocked - the legacy project would produce zero slices. Add a ROADMAP.md or phases/ content before migrating.",
+  );
+}
+
+function hasWorktreeState(targetRoot: string): boolean {
+  const worktreesDir = join(gsdRoot(targetRoot), "worktrees");
+  if (!existsSync(worktreesDir)) return false;
+  try {
+    return readdirSync(worktreesDir, { withFileTypes: true })
+      .some((entry) => entry.isDirectory() || entry.isFile());
+  } catch {
+    return true;
+  }
+}
+
+export async function assertMigrationTargetAvailable(targetRoot: string): Promise<void> {
+  const targetGsdPath = gsdRoot(targetRoot);
+  if (!existsSync(targetGsdPath)) return;
+
+  if (hasWorktreeState(targetRoot)) {
+    throw new MigrationBlockedError(
+      "Migration blocked - existing GSD worktree state is present. Resolve or clean worktrees before migrating.",
+    );
+  }
+
+  const opened = await ensureDbOpen(targetRoot);
+  if (!opened) return;
+
+  try {
+    const lock = readCrashLock(targetRoot);
+    if (lock && lock.pid !== process.pid && isLockProcessAlive(lock)) {
+      throw new MigrationBlockedError(
+        `Migration blocked - auto-mode appears to be running for this project (PID ${lock.pid}). Stop it before migrating.`,
+      );
+    }
+
+    const paused = readPausedSessionMetadata(targetRoot);
+    if (paused) {
+      throw new MigrationBlockedError(
+        "Migration blocked - a paused auto-mode session exists for this project. Resume or stop it before migrating.",
+      );
+    }
+  } finally {
+    closeDatabase();
+  }
+}

--- a/src/resources/extensions/gsd/migrate/transformer.ts
+++ b/src/resources/extensions/gsd/migrate/transformer.ts
@@ -43,6 +43,17 @@ function firstSentence(text: string): string {
   return match ? match[0].trim() : trimmed;
 }
 
+function comparePlanNumbers(a: string, b: string): number {
+  const left = a.match(/^(\d+)([a-z]*)$/i);
+  const right = b.match(/^(\d+)([a-z]*)$/i);
+  if (left && right) {
+    const numeric = Number(left[1]) - Number(right[1]);
+    if (numeric !== 0) return numeric;
+    return left[2].localeCompare(right[2], undefined, { sensitivity: 'base' });
+  }
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
+}
+
 /** Preferred research ordering for consolidation. */
 const RESEARCH_ORDER = ['SUMMARY.md', 'ARCHITECTURE.md', 'STACK.md', 'FEATURES.md', 'PITFALLS.md'];
 
@@ -137,7 +148,7 @@ function buildSliceSummary(phase: PlanningPhase): GSDSliceSummaryData | null {
 
 function deriveDemo(phase: PlanningPhase, slug: string): string {
   // First plan's objective, first sentence
-  const planNumbers = Object.keys(phase.plans).sort((a, b) => Number(a) - Number(b));
+  const planNumbers = Object.keys(phase.plans).sort(comparePlanNumbers);
   if (planNumbers.length > 0) {
     const firstPlan = phase.plans[planNumbers[0]];
     if (firstPlan?.objective) {
@@ -159,7 +170,7 @@ function mapSlice(
 
   let tasks: GSDTask[] = [];
   if (phase) {
-    const planNumbers = Object.keys(phase.plans).sort((a, b) => Number(a) - Number(b));
+    const planNumbers = Object.keys(phase.plans).sort(comparePlanNumbers);
     tasks = planNumbers.map((pn, i) => mapTask(phase.plans[pn], i, phase.summaries));
   }
 
@@ -337,7 +348,7 @@ function deriveDecisions(parsed: PlanningProject): string {
   decisions.forEach((decision, index) => {
     const id = padId('D', index + 1, 3);
     const escaped = decision.replace(/\|/g, '\\|');
-    lines.push(`| ${id} | migration | migrated-summary | ${escaped} | ${escaped} | Migrated from legacy summary key-decisions | Yes | agent |`);
+    lines.push(`| ${id} | migration | legacy-import | ${escaped} | ${escaped} | Migrated from legacy summary key-decisions | Yes | human |`);
   });
 
   return lines.join('\n') + '\n';

--- a/src/resources/extensions/gsd/prompts/review-migration.md
+++ b/src/resources/extensions/gsd/prompts/review-migration.md
@@ -1,6 +1,6 @@
 ## Review Migrated .gsd Directory
 
-A `/gsd migrate` command just wrote a `.gsd/` directory from an old `.planning` source. Your job is to audit the output and verify it meets GSD-2 standards before the user starts working with it.
+A `/gsd migrate` command just wrote a `.gsd/` directory from an old `.planning` source. Your job is to audit the output and verify it meets GSD-2 standards before the user starts working with it. This review is read-only: report issues and recommended fixes, but do not edit files in place.
 
 ### Source
 - Old `.planning` directory: `{{sourcePath}}`
@@ -11,7 +11,7 @@ A `/gsd migrate` command just wrote a `.gsd/` directory from an old `.planning` 
 
 ### Review Checklist
 
-Work through each check. Report PASS/FAIL with specifics. Fix anything fixable in-place.
+Work through each check. Report PASS/FAIL with specifics. Do not fix files in place; migration repairs must go through DB-backed migration repair paths.
 
 #### 1. Structure Validation
 - Run `deriveState()` on the `.gsd` directory (import from `state.ts`, pass the **project root** as basePath)
@@ -60,7 +60,7 @@ Decisions:     PASS/FAIL/SKIP — <details>
 
 Overall: PASS / PASS WITH NOTES / FAIL
 Issues: <list any problems found>
-Fixes applied: <list any in-place fixes made>
+Recommended fixes: <list any fixes needed>
 ```
 
 If the overall result is FAIL, explain what needs manual attention. If PASS WITH NOTES, explain what's imperfect but acceptable. If PASS, confirm the `.gsd` directory is ready for GSD-2 auto-mode.

--- a/src/resources/extensions/gsd/skills/gsd-headless/references/commands.md
+++ b/src/resources/extensions/gsd/skills/gsd-headless/references/commands.md
@@ -45,7 +45,7 @@ All commands can be run via `gsd headless [command]`.
 | `knowledge <rule\|pattern\|lesson>` | Add persistent project knowledge |
 | `cleanup` | Remove merged branches or snapshots |
 | `export` | Export results (--json, --markdown) |
-| `migrate` | Migrate v1 .planning directory to .gsd format |
+| `migrate` | Migrate v1 .planning directory to DB-backed .gsd with backup and audit |
 | `remote` | Control remote auto-mode (slack, discord, status, disconnect) |
 | `inspect` | Show SQLite DB diagnostics (schema, row counts) |
 | `forensics` | Post-mortem investigation of auto-mode failures |

--- a/src/resources/extensions/gsd/tests/migrate-parser.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-parser.test.ts
@@ -490,6 +490,41 @@ test('Plan file with XML-in-markdown', async () => {
     }
 });
 
+test('Plan and summary files with letter-suffixed plan numbers', async () => {
+    const base = createFixtureBase();
+    try {
+      const planning = createPlanningDir(base);
+      writeFileSync(join(planning, 'ROADMAP.md'), SAMPLE_ROADMAP);
+
+      const phaseDir = join(planning, 'phases', '03-type-safety');
+      mkdirSync(phaseDir, { recursive: true });
+      writeFileSync(join(phaseDir, '03-03b-PLAN.md'), `---
+phase: "03-type-safety"
+plan: "03b"
+---
+
+<objective>Type the telehealth controller.</objective>
+`);
+      writeFileSync(join(phaseDir, '03-03b-SUMMARY.md'), `---
+phase: "03-type-safety"
+plan: "03b"
+subsystem: "api"
+---
+
+# 03-03b Summary
+`);
+
+      const project = await parsePlanningDirectory(planning);
+      const phase = project.phases['03-type-safety'];
+
+      assert.ok(phase?.plans?.['03b'] !== undefined, 'letter plan: plan exists');
+      assert.ok(phase?.summaries?.['03b'] !== undefined, 'letter plan: summary exists');
+      assert.deepStrictEqual(phase?.plans?.['03b']?.frontmatter.plan, '03b', 'letter plan: frontmatter plan preserved');
+    } finally {
+      cleanup(base);
+    }
+});
+
   // ─── Test 6: Summary file with YAML frontmatter ───────────────────────
 
 test('Summary file with YAML frontmatter', async () => {
@@ -745,4 +780,3 @@ test('Validation: missing PROJECT.md → warning', async () => {
       cleanup(base);
     }
 });
-

--- a/src/resources/extensions/gsd/tests/migrate-safety-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-safety-audit.test.ts
@@ -1,0 +1,242 @@
+// GSD-2 - /gsd migrate safety and audit regression tests.
+// File Purpose: Verifies migration hardening contracts for backup, target selection, archive, and DB projections.
+
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import test from "node:test";
+
+import { generatePreview } from "../migrate/preview.ts";
+import {
+  assertMigrationHasSlices,
+  assertMigrationTargetAvailable,
+  prepareMigrationTarget,
+  resolveMigrationPaths,
+  restoreMigrationTarget,
+} from "../migrate/safety.ts";
+import {
+  archiveLegacyPlanningDirectory,
+  verifyMigrationProjection,
+} from "../migrate/audit.ts";
+import { executeMigrationWrite, importWrittenMigrationToDb } from "../migrate/command.ts";
+import { writeGSDDirectory } from "../migrate/writer.ts";
+import { closeDatabase, getArtifact } from "../gsd-db.ts";
+import type { GSDProject } from "../migrate/types.ts";
+
+function makeBase(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function cleanup(base: string): void {
+  closeDatabase();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function write(path: string, content: string): void {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function createPlanningSource(base: string): string {
+  const planning = join(base, ".planning");
+  mkdirSync(planning, { recursive: true });
+  write(join(planning, "config.json"), `${JSON.stringify({ projectName: "legacy" })}\n`);
+  write(join(planning, "quick", "001-fix", "001-PLAN.md"), "# Quick task\n");
+  write(join(planning, "STATE.md"), "# State\n\n**Status:** in-progress\n");
+  return planning;
+}
+
+function projectFixture(): GSDProject {
+  return {
+    projectContent: "# Migrated Project\n\nA legacy project.\n",
+    decisionsContent: "",
+    requirements: [],
+    milestones: [
+      {
+        id: "M001",
+        title: "Migration",
+        vision: "Carry the legacy work forward.",
+        successCriteria: [],
+        research: null,
+        boundaryMap: [],
+        slices: [
+          {
+            id: "S01",
+            title: "First Slice",
+            risk: "medium",
+            depends: [],
+            done: false,
+            demo: "First slice works.",
+            goal: "First slice works.",
+            research: null,
+            summary: null,
+            tasks: [
+              {
+                id: "T01",
+                title: "First Task",
+                description: "Implement the first task.",
+                done: false,
+                estimate: "",
+                files: [],
+                mustHaves: [],
+                summary: null,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test("resolveMigrationPaths treats explicit source as target project root", () => {
+  const cwd = "/tmp/current";
+
+  assert.deepEqual(
+    resolveMigrationPaths("/tmp/legacy-project", cwd),
+    {
+      sourcePath: "/tmp/legacy-project/.planning",
+      targetRoot: "/tmp/legacy-project",
+    },
+  );
+
+  assert.deepEqual(
+    resolveMigrationPaths("/tmp/legacy-project/.planning", cwd),
+    {
+      sourcePath: "/tmp/legacy-project/.planning",
+      targetRoot: "/tmp/legacy-project",
+    },
+  );
+});
+
+test("prepareMigrationTarget backs up and prunes stale .gsd before restore", () => {
+  const base = makeBase("gsd-migrate-safety-");
+  try {
+    write(join(base, ".gsd", "STALE.md"), "old state\n");
+
+    const backup = prepareMigrationTarget(base, new Date(2026, 4, 20, 12, 34, 56));
+    assert.equal(backup.hadExistingGsd, true);
+    assert.equal(basename(backup.backupPath!), "migrate-20260520-123456");
+    assert.equal(existsSync(join(backup.backupPath!, "STALE.md")), true);
+    assert.equal(existsSync(join(base, ".gsd")), false, "old .gsd is removed before fresh write");
+
+    write(join(base, ".gsd", "NEW.md"), "failed migration output\n");
+    restoreMigrationTarget(backup);
+
+    assert.equal(existsSync(join(base, ".gsd", "STALE.md")), true, "backup restored");
+    assert.equal(existsSync(join(base, ".gsd", "NEW.md")), false, "failed output pruned");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("assertMigrationHasSlices blocks zero-slice migrations", () => {
+  assert.throws(
+    () => assertMigrationHasSlices({
+      decisions: { total: 0 },
+      milestoneCount: 1,
+      totalSlices: 0,
+      totalTasks: 0,
+      doneSlices: 0,
+      doneTasks: 0,
+      sliceCompletionPct: 0,
+      taskCompletionPct: 0,
+      requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, total: 0 },
+    }),
+    /zero slices/,
+  );
+});
+
+test("assertMigrationTargetAvailable blocks existing worktree state", async () => {
+  const base = makeBase("gsd-migrate-worktree-block-");
+  try {
+    write(join(base, ".gsd", "worktrees", "M001", "marker"), "active worktree\n");
+    await assert.rejects(
+      () => assertMigrationTargetAvailable(base),
+      /worktree state/,
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("archiveLegacyPlanningDirectory preserves unmodeled legacy content with manifest", async () => {
+  const base = makeBase("gsd-migrate-archive-");
+  try {
+    const planning = createPlanningSource(base);
+    const archive = await archiveLegacyPlanningDirectory(planning, base);
+
+    assert.equal(archive.archived, true);
+    assert.equal(existsSync(join(base, ".gsd", "migration", "legacy", "planning", "quick", "001-fix", "001-PLAN.md")), true);
+    assert.equal(existsSync(join(base, ".gsd", "migration", "legacy", "planning", "config.json")), true);
+
+    const manifest = JSON.parse(readFileSync(archive.manifestPath, "utf-8"));
+    assert.equal(manifest.strategy, "full-source-copy");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("executeMigrationWrite restores backup when DB import verification fails", async () => {
+  const base = makeBase("gsd-migrate-restore-");
+  try {
+    const planning = createPlanningSource(base);
+    write(join(base, ".gsd", "OLD.md"), "known-good state\n");
+
+    const project = projectFixture();
+    const preview = generatePreview(project);
+
+    await assert.rejects(
+      () => executeMigrationWrite(planning, base, project, { ...preview, totalTasks: preview.totalTasks + 1 }),
+      /migration DB import verification failed/,
+    );
+
+    assert.equal(existsSync(join(base, ".gsd", "OLD.md")), true, "original .gsd restored");
+    assert.equal(existsSync(join(base, ".gsd", "migration", "MIGRATION.md")), false, "failed audit output removed");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("executeMigrationWrite records audit artifacts and verifies DB-backed projection", async () => {
+  const base = makeBase("gsd-migrate-success-");
+  try {
+    const planning = createPlanningSource(base);
+    write(join(base, ".gsd", "STALE.md"), "old state\n");
+
+    const project = projectFixture();
+    const preview = generatePreview(project);
+    const result = await executeMigrationWrite(planning, base, project, preview);
+
+    assert.equal(existsSync(join(base, ".gsd", "STALE.md")), false, "fresh migration prunes stale files");
+    assert.equal(existsSync(join(result.backup.backupPath!, "STALE.md")), true, "old .gsd was backed up");
+    assert.equal(existsSync(join(base, ".gsd", "migration", "MIGRATION.md")), true);
+    assert.equal(existsSync(join(base, ".gsd", "migration", "manifest.json")), true);
+    assert.equal(existsSync(join(base, ".gsd", "migration", "legacy", "planning", "STATE.md")), true);
+
+    assert.ok(getArtifact("migration/MIGRATION.md"), "migration audit imported as DB artifact");
+    assert.ok(getArtifact("migration/manifest.json"), "migration manifest imported as DB artifact");
+    assert.deepEqual(result.verification.db, { milestones: 1, slices: 1, tasks: 1 });
+    assert.deepEqual(result.verification.markdown, { milestones: 1, slices: 1, tasks: 1 });
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("verifyMigrationProjection fails when DB hierarchy diverges from preview", async () => {
+  const base = makeBase("gsd-migrate-projection-");
+  try {
+    const project = projectFixture();
+    const preview = generatePreview(project);
+    await writeGSDDirectory(project, base);
+    await importWrittenMigrationToDb(base, preview);
+
+    await assert.rejects(
+      () => verifyMigrationProjection(base, { ...preview, totalTasks: preview.totalTasks + 1 }),
+      /DB hierarchy/,
+    );
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/migrate-transformer.test.ts
+++ b/src/resources/extensions/gsd/tests/migrate-transformer.test.ts
@@ -174,6 +174,34 @@ test('Scenario 1: Flat single-milestone', () => {
   assert.deepStrictEqual(result.milestones[0]?.boundaryMap, [], 'flat: boundaryMap defaults to empty');
 });
 
+test('Scenario 1b: Letter-suffixed plan numbers stay ordered and mapped', () => {
+  const project = emptyProject({
+    roadmap: flatRoadmap([
+      roadmapEntry(3, 'type-safety'),
+    ]),
+    phases: {
+      '3-type-safety': makePhase('3-type-safety', 3, 'type-safety', {
+        plans: {
+          '03': makePlan('03'),
+          '03b': makePlan('03b'),
+          '04': makePlan('04'),
+        },
+        summaries: {
+          '03b': makeSummary('03b'),
+        },
+      }),
+    },
+  });
+
+  const result = transformToGSD(project);
+  const tasks = result.milestones[0]?.slices[0]?.tasks ?? [];
+
+  assert.deepStrictEqual(tasks.length, 3, 'letter plan: all plans become tasks');
+  assert.deepStrictEqual(tasks.map((task) => task.id), ['T01', 'T02', 'T03'], 'letter plan: task IDs remain sequential');
+  assert.deepStrictEqual(tasks[1]?.title, '00 03b', 'letter plan: 03b sorts between 03 and 04');
+  assert.deepStrictEqual(tasks[1]?.done, true, 'letter plan: matching 03b summary marks task done');
+});
+
 // ─── Scenario 2: Multi-Milestone (2 milestones with independent numbering) ──
 
 test('Scenario 2: Multi-milestone', () => {


### PR DESCRIPTION
## Summary

- Harden `/gsd migrate` with target-root resolution, backup/restore behavior, target state guards, DB-backed projection verification, and migration audit artifacts.
- Preserve the full legacy `.planning` tree under `.gsd/migration/legacy/` while importing modeled hierarchy, decisions, requirements, and artifacts into `.gsd`.
- Support letter-suffixed legacy plan numbers like `03b`, which surfaced during a Clearpath migration dry run.
- Update migration docs/help text to match the safer write path and read-only review behavior.

## Validation

- Clearpath dry run from `/Users/jeremymcspadden/Github/clearpath-clinic/.planning` using a temp copy only:
  - 136 source files archived, archiveMissingCount 0
  - 48 plan files parsed into 48 migrated tasks
  - 48 summaries parsed
  - DB/markdown verification matched 1M / 9S / 48T
  - Imported 109 decisions, 39 requirements, 122 artifacts
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/migrate-parser.test.ts src/resources/extensions/gsd/tests/migrate-transformer.test.ts src/resources/extensions/gsd/tests/migrate-safety-audit.test.ts` passed: 38/38
- `npm run typecheck:extensions` passed
- `git diff --check` passed
