### PR TITLE
fix(auto): rule-registry no-match fallback uses level "warning" (#6423)

### DIFF
--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -137,7 +137,11 @@ export class RuleRegistry {
     return {
       action: "stop",
       reason: `Unhandled phase "${ctx.state.phase}" — run /gsd doctor to diagnose.`,
-      level: "info",
+      // Must match the inline fallback at auto-dispatch.ts so the wired
+      // adapter maps "stop" → "pause" (recoverable) instead of a terminal
+      // stop. The two no-match fallbacks share the same reason string; their
+      // levels must agree. See issue #6423 for the symptom this caused.
+      level: "warning",
       matchedRule: "<no-match>",
     };
   }

--- a/src/resources/extensions/gsd/tests/rule-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/rule-registry.test.ts
@@ -408,4 +408,24 @@ describe("RuleRegistry", () => {
     assert.deepStrictEqual(result.action, "stop", "result is a stop action");
     assert.deepStrictEqual(result.matchedRule, "<no-match>", "matchedRule is '<no-match>' on fallback");
   });
+
+  // Regression for #6423: the registry's no-match fallback must use
+  // level: "warning" so the wired adapter maps it to a recoverable "pause".
+  // The inline fallback at auto-dispatch.ts already uses "warning"; these
+  // two paths share the same reason string and must agree on level.
+  test("evaluateDispatch no-match fallback uses level: 'warning' (#6423)", async () => {
+    const rules: UnifiedRule[] = [
+      mockDispatchRule("only-planning", "planning"),
+    ];
+    const registry = new RuleRegistry(rules);
+    const ctx = makeContext("some-unknown-phase");
+    const result = await registry.evaluateDispatch(ctx);
+
+    assert.deepStrictEqual(result.action, "stop");
+    assert.deepStrictEqual(
+      (result as { level: string }).level,
+      "warning",
+      "no-match fallback must be 'warning' (not 'info') to remain recoverable in the wired adapter",
+    );
+  });
 });


### PR DESCRIPTION
> 🤖 **AI-generated patch.** Authored by an autonomous agent (Claude Code) from a forensic analysis of a real auto-mode session. A human reviewed the diagnosis and fix before this PR was opened.

## Summary

`RuleRegistry.evaluateDispatch` returns `level: "info"` on its no-match fallback. The wired adapter in `auto.ts` only maps `action: "stop"` to a recoverable `pause` when `level === "warning"`; any other level becomes a terminal stop. The inline no-match fallback at `auto-dispatch.ts:1818` already uses `level: "warning"`, so the two code paths produced different lifecycle outcomes for the same condition.

This PR aligns the registry fallback with the inline one — single-line literal change plus a regression test.

Fixes #6423.

## Why

Forensic evidence from a real session (`/Users/private/code/aia/.gsd/journal/2026-05-18.jsonl`):

```json
{"ts":"2026-05-18T10:48:17.150Z","flowId":"auto-orchestrator-1779101296745","seq":2,"eventType":"guard-block","data":{"source":"auto-orchestrator","name":"advance-blocked","reason":"Unhandled phase \"planning\" — run /gsd doctor to diagnose."}}
{"ts":"2026-05-18T11:48:02.560Z","flowId":"auto-orchestrator-1779104882150","seq":2,"eventType":"guard-block","data":{"source":"auto-orchestrator","name":"advance-blocked","reason":"Unhandled phase \"executing\" — run /gsd doctor to diagnose."}}
```

14 of 15 guard-blocks on auto-orchestrator flows in this session were the registry `Unhandled phase` fallback (phases: `executing` ×8, `summarizing` ×4, `planning` ×2). User-visible surface: repeated false "auto-mode paused" notifications. Tasks did still progress (62/63 complete) because some `start()` calls happened to land on phases the orchestrator's `decideNextUnit` could resolve — masking the underlying bug.

## Change

```diff
     return {
       action: "stop",
       reason: `Unhandled phase "${ctx.state.phase}" — run /gsd doctor to diagnose.`,
-      level: "info",
+      // Must match the inline fallback at auto-dispatch.ts so the wired
+      // adapter maps "stop" → "pause" (recoverable) instead of a terminal
+      // stop. The two no-match fallbacks share the same reason string; their
+      // levels must agree. See issue #6423 for the symptom this caused.
+      level: "warning",
       matchedRule: "<no-match>",
     };
```

Plus a regression test in `tests/rule-registry.test.ts` asserting the fallback level explicitly.

## Test plan

- [ ] `npm test -- tests/rule-registry.test.ts` passes (existing test + new regression test)
- [ ] Existing `tests/integration/state-machine-edge-cases.test.ts` "dispatch: complete phase → stop with info level" still passes — that test exercises the `complete → stop` rule (`auto-dispatch.ts:1737-1740`), which intentionally uses `level: "info"` for terminal milestone completion. Unrelated to the no-match fallback.

## Cross-reference

- Issue: #6423
- Sibling fix (already merged): #6218 — start/resume double-advance. PR #6218 removed the ghost dispatch that was one of two paths into this fallback; the other path (base-path drift) still hits the fallback but should now `pause` cleanly with this change.

---

*PR opened by Claude Code (Anthropic) on behalf of @botinate.*
