### PR TITLE
Keep completion rollup visible

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1271,7 +1271,7 @@ export async function stopAuto(
   const stopNotificationPrefix = formatAutoStopNotificationPrefix(reason);
   const displayReason = formatAutoStopDisplayReason(reason);
   const completionStopRequested = Boolean(options.completionWidget);
-  const renderCompletionWidget = completionStopRequested && process.env.GSD_HEADLESS === "1";
+  const installCompletionWidget = completionStopRequested;
   const preserveCompletionSurface = completionStopRequested;
   s.completionStopInProgress = preserveCompletionSurface;
 
@@ -1531,7 +1531,7 @@ export async function stopAuto(
       debugLog("stop-cleanup-ledger", { error: e instanceof Error ? e.message : String(e) });
     }
 
-    if (renderCompletionWidget && ctx && options.completionWidget) {
+    if (installCompletionWidget && ctx && options.completionWidget) {
       const ledger = getLedger();
       const units = ledger?.units ?? [];
       const totals = units.length > 0 ? getProjectTotals(units) : null;
@@ -1678,8 +1678,8 @@ export async function stopAuto(
 
     // UI cleanup
     ctx?.ui.setStatus("gsd-auto", undefined);
-    if (renderCompletionWidget) {
-      // Headless callers keep the durable completion widget/notification path.
+    if (installCompletionWidget) {
+      // Completion stops keep the durable final closeout surface visible.
     } else if (preserveCompletionSurface) {
       ctx?.ui.setWidget("gsd-progress", undefined);
       ctx?.ui.setWidget("gsd-outcome", undefined);

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -434,7 +434,7 @@ test("rerootCommandSession refreshes command workspace to project root", async (
   assert.deepEqual(calls, ["/project/root"]);
 });
 
-test("stopAuto foreground completion closeout reroots session and preserves the transcript surface", async (t) => {
+test("stopAuto foreground completion closeout reroots session and installs the durable roll-up surface", async (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-completion-stop-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
@@ -554,10 +554,17 @@ test("stopAuto foreground completion closeout reroots session and preserves the 
     assert.equal(realpathSync(process.cwd()), realpathSync(base), "completion stop must chdir back to project root");
     const lastProgressWidget = widgetCalls.filter(([key]) => key === "gsd-progress").at(-1);
     assert.equal(
-      lastProgressWidget?.[1],
-      undefined,
-      "foreground completion stop must clear stale progress widgets so the closeout transcript remains visible",
+      typeof lastProgressWidget?.[1],
+      "function",
+      "foreground completion stop must leave the durable roll-up widget visible",
     );
+    const rollup = (lastProgressWidget?.[1] as any)(
+      { requestRender() {} },
+      { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+    ).render(140).join("\n");
+    assert.match(rollup, /Milestone M003 roll-up/);
+    assert.match(rollup, /Budget tracking/);
+    assert.match(rollup, /Users can see what shipped without opening a fresh session/);
     assert.ok(
       notifications.every(message => !message.includes("/gsd auto to resume")),
       "completion stop notification must not tell users to resume a finished auto run",
@@ -680,7 +687,7 @@ test("stopAuto completion closeout emits a headless terminal notification withou
   }
 });
 
-test("stopAuto foreground all-complete closeout leaves the transcript as the final surface", async () => {
+test("stopAuto foreground all-complete closeout leaves a durable roll-up as the final surface", async () => {
   const base = mkdtempSync(join(tmpdir(), "gsd-all-complete-closeout-"));
   const previousCwd = process.cwd();
   const widgetCalls: Array<[string, unknown]> = [];
@@ -730,11 +737,17 @@ test("stopAuto foreground all-complete closeout leaves the transcript as the fin
 
     assert.equal(
       widgetCalls.some(([key, value]) => key === "gsd-progress" && typeof value === "function"),
-      false,
-      "foreground all-complete closeout must not install a roll-up widget that pushes the transcript away",
+      true,
+      "foreground all-complete closeout must install a durable roll-up widget",
     );
     const finalProgress = widgetCalls.filter(([key]) => key === "gsd-progress").at(-1);
-    assert.equal(finalProgress?.[1], undefined, "foreground all-complete closeout clears stale progress widgets");
+    assert.equal(typeof finalProgress?.[1], "function", "foreground all-complete closeout keeps the roll-up visible");
+    const rollup = (finalProgress?.[1] as any)(
+      { requestRender() {} },
+      { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+    ).render(140).join("\n");
+    assert.match(rollup, /All milestones complete/);
+    assert.match(rollup, /Review the roll-up/);
     const finalOutcome = widgetCalls.filter(([key]) => key === "gsd-outcome").at(-1);
     assert.equal(finalOutcome?.[1], undefined, "foreground all-complete closeout must not add an outcome replacement");
   } finally {


### PR DESCRIPTION
## Summary

- Extract the remaining closeout-rollup fix from the stale mixed MCP branch onto a clean branch from current `main`.
- Keep the durable milestone completion roll-up visible for foreground completion stops instead of clearing it after the final stop cleanup.
- Preserve the already-merged MCP connection manager work by deleting the stale mixed branch separately.

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-dashboard.test.ts src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts` passed: 56/56
