### PR TITLE
fix(auto): wire ScheduleWakeup continuation

### DIFF
--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -26,9 +26,12 @@ import { debugLog } from "../debug-logger.js";
 import { logWarning, logError } from "../workflow-logger.js";
 import { resolveAutoSupervisorConfig } from "../preferences.js";
 import { readUnitRuntimeRecord, type AutoUnitRuntimeRecord } from "../unit-runtime.js";
+import { consumeAutoWakeup } from "./schedule-wakeup.js";
 
 const UNIT_FAILSAFE_BUFFER_MS = 30_000;
 const UNIT_FAILSAFE_RECHECK_MS = 30_000;
+const WAKEUP_SLEEP_CHUNK_MS = 1_000;
+const MAX_WAKEUPS_PER_UNIT = 100;
 
 export function shouldDeferUnitFailsafeTimeout(
   runtime: AutoUnitRuntimeRecord | null,
@@ -49,6 +52,17 @@ export function shouldDeferUnitFailsafeTimeout(
   if (runtime.lastProgressKind.includes("recovery")) return true;
   if (runtime.recoveryAttempts && runtime.recoveryAttempts > 0) return true;
   return progressAgeMs >= 0 && progressAgeMs <= opts.freshProgressMs;
+}
+
+async function sleepForScheduledWakeup(s: AutoSession, delayMs: number): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, delayMs);
+  while (Date.now() < deadline) {
+    if (!s.active || s.paused) return false;
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, Math.min(WAKEUP_SLEEP_CHUNK_MS, deadline - Date.now())),
+    );
+  }
+  return s.active && !s.paused;
 }
 
 // Tracks the latest session-switch attempt so a late timeout settlement from an
@@ -226,56 +240,114 @@ export async function runUnit(
   let unitTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
   let result: UnitResult;
   try {
+    const awaitAgentEndWithTimeout = (agentEndPromise: Promise<UnitResult>): Promise<UnitResult> => {
+      const timeoutResult = new Promise<UnitResult>((resolve) => {
+        const settleOrDefer = () => {
+          let runtime: AutoUnitRuntimeRecord | null;
+          try {
+            runtime = readUnitRuntimeRecord(s.basePath, unitType, unitId);
+          } catch (error) {
+            debugLog("runUnit", {
+              phase: "unit-failsafe-runtime-read-failed",
+              unitType,
+              unitId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            resolve({
+              status: "cancelled",
+              errorContext: {
+                message: "Unit hard timeout — supervision may have failed; runtime progress could not be read",
+                category: "timeout",
+                isTransient: true,
+              },
+            });
+            return;
+          }
+          if (shouldDeferUnitFailsafeTimeout(runtime, {
+            nowMs: Date.now(),
+            currentUnitStartedAt: s.currentUnit?.startedAt,
+            freshProgressMs,
+          })) {
+            debugLog("runUnit", {
+              phase: "unit-failsafe-deferred",
+              unitType,
+              unitId,
+              runtimePhase: runtime?.phase,
+              lastProgressKind: runtime?.lastProgressKind,
+            });
+            unitTimeoutHandle = setTimeout(settleOrDefer, UNIT_FAILSAFE_RECHECK_MS);
+            return;
+          }
+          resolve({ status: "cancelled", errorContext: { message: "Unit hard timeout — supervision may have failed", category: "timeout", isTransient: true } });
+        };
+        unitTimeoutHandle = setTimeout(settleOrDefer, UNIT_HARD_TIMEOUT_MS);
+      });
+      return runWithTurnGeneration(capturedTurnGen, () =>
+        Promise.race([agentEndPromise, timeoutResult]),
+      );
+    };
+
     pi.sendMessage(
       { customType: "gsd-auto", content: prompt, display: s.verbose },
       { triggerTurn: true },
     );
 
     debugLog("runUnit", { phase: "awaiting-agent-end", unitType, unitId });
-    const timeoutResult = new Promise<UnitResult>((resolve) => {
-      const settleOrDefer = () => {
-        let runtime: AutoUnitRuntimeRecord | null;
-        try {
-          runtime = readUnitRuntimeRecord(s.basePath, unitType, unitId);
-        } catch (error) {
-          debugLog("runUnit", {
-            phase: "unit-failsafe-runtime-read-failed",
-            unitType,
-            unitId,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          resolve({
-            status: "cancelled",
-            errorContext: {
-              message: "Unit hard timeout — supervision may have failed; runtime progress could not be read",
-              category: "timeout",
-              isTransient: true,
-            },
-          });
-          return;
-        }
-        if (shouldDeferUnitFailsafeTimeout(runtime, {
-          nowMs: Date.now(),
-          currentUnitStartedAt: s.currentUnit?.startedAt,
-          freshProgressMs,
-        })) {
-          debugLog("runUnit", {
-            phase: "unit-failsafe-deferred",
-            unitType,
-            unitId,
-            runtimePhase: runtime?.phase,
-            lastProgressKind: runtime?.lastProgressKind,
-          });
-          unitTimeoutHandle = setTimeout(settleOrDefer, UNIT_FAILSAFE_RECHECK_MS);
-          return;
-        }
-        resolve({ status: "cancelled", errorContext: { message: "Unit hard timeout — supervision may have failed", category: "timeout", isTransient: true } });
-      };
-      unitTimeoutHandle = setTimeout(settleOrDefer, UNIT_HARD_TIMEOUT_MS);
-    });
-    result = await runWithTurnGeneration(capturedTurnGen, () =>
-      Promise.race([unitPromise, timeoutResult]),
-    );
+    result = await awaitAgentEndWithTimeout(unitPromise);
+    if (unitTimeoutHandle) {
+      clearTimeout(unitTimeoutHandle);
+      unitTimeoutHandle = undefined;
+    }
+
+    let wakeupCount = 0;
+    while (result.status === "completed" && s.active && !s.paused) {
+      const wakeup = consumeAutoWakeup(s.basePath, unitType, unitId);
+      if (!wakeup) break;
+      wakeupCount += 1;
+      if (wakeupCount > MAX_WAKEUPS_PER_UNIT) {
+        result = {
+          status: "cancelled",
+          errorContext: {
+            message: `ScheduleWakeup limit exceeded for ${unitType} ${unitId}`,
+            category: "timeout",
+            isTransient: false,
+          },
+        };
+        break;
+      }
+      debugLog("runUnit", {
+        phase: "schedule-wakeup-wait",
+        unitType,
+        unitId,
+        delayMs: wakeup.delayMs,
+        reason: wakeup.reason,
+      });
+      const slept = await sleepForScheduledWakeup(s, wakeup.delayMs);
+      if (!slept) {
+        result = {
+          status: "cancelled",
+          errorContext: {
+            message: `ScheduleWakeup interrupted for ${unitType} ${unitId}`,
+            category: "aborted",
+            isTransient: true,
+          },
+        };
+        break;
+      }
+      const continuationPromise = new Promise<UnitResult>((resolve) => {
+        _setCurrentResolve(resolve);
+      });
+      pi.sendMessage(
+        { customType: "gsd-auto", content: wakeup.prompt, display: s.verbose },
+        { triggerTurn: true },
+      );
+      debugLog("runUnit", { phase: "schedule-wakeup-awaiting-agent-end", unitType, unitId });
+      result = await awaitAgentEndWithTimeout(continuationPromise);
+      if (unitTimeoutHandle) {
+        clearTimeout(unitTimeoutHandle);
+        unitTimeoutHandle = undefined;
+      }
+    }
   } finally {
     if (unitTimeoutHandle) clearTimeout(unitTimeoutHandle);
     ctx.ui.setWorkingMessage?.(undefined);

--- a/src/resources/extensions/gsd/auto/schedule-wakeup.ts
+++ b/src/resources/extensions/gsd/auto/schedule-wakeup.ts
@@ -1,0 +1,40 @@
+// Project/App: GSD-2
+// File Purpose: Auto-mode ScheduleWakeup state shared between the tool and runUnit.
+
+export interface ScheduledWakeup {
+  basePath: string;
+  unitType: string;
+  unitId: string;
+  delayMs: number;
+  prompt: string;
+  reason: string;
+  createdAt: number;
+}
+
+function wakeupKey(basePath: string, unitType: string, unitId: string): string {
+  return `${basePath}\0${unitType}\0${unitId}`;
+}
+
+const pendingWakeups = new Map<string, ScheduledWakeup>();
+
+export function scheduleAutoWakeup(wakeup: ScheduledWakeup): void {
+  pendingWakeups.set(
+    wakeupKey(wakeup.basePath, wakeup.unitType, wakeup.unitId),
+    wakeup,
+  );
+}
+
+export function consumeAutoWakeup(
+  basePath: string,
+  unitType: string,
+  unitId: string,
+): ScheduledWakeup | null {
+  const key = wakeupKey(basePath, unitType, unitId);
+  const wakeup = pendingWakeups.get(key) ?? null;
+  pendingWakeups.delete(key);
+  return wakeup;
+}
+
+export function _resetAutoWakeupsForTest(): void {
+  pendingWakeups.clear();
+}

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -11,6 +11,7 @@ import { registerExecTools } from "./exec-tools.js";
 import { registerJournalTools } from "./journal-tools.js";
 import { registerMemoryTools } from "./memory-tools.js";
 import { registerQueryTools } from "./query-tools.js";
+import { registerScheduleWakeupTool } from "./schedule-wakeup-tool.js";
 import { registerHooks } from "./register-hooks.js";
 import { registerShortcuts } from "./register-shortcuts.js";
 import { writeCrashLog } from "./crash-log.js";
@@ -123,6 +124,7 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
     ["query-tools", () => registerQueryTools(pi)],
     ["memory-tools", () => registerMemoryTools(pi)],
     ["exec-tools", () => registerExecTools(pi)],
+    ["schedule-wakeup-tool", () => registerScheduleWakeupTool(pi)],
     ["shortcuts", () => registerShortcuts(pi)],
     // cmux is a library (no pi), so gsd sets up the event listeners on its
     // behalf using the shared event channel contract. Registration is

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -845,21 +845,8 @@ export function registerHooks(
     // turn used the host Edit tool to modify user source files.
     const dash = getAutoRuntimeSnapshot();
 
-    // ── Block ScheduleWakeup during auto-mode (#6328) ────────────────────
-    // Auto-mode intercepts agent_end and drives session lifecycle itself.
-    // ScheduleWakeup timers fire into a stale host context and never resume
-    // the auto loop, making the call a silent no-op. Block it with a clear
-    // message so the agent doesn't end a unit expecting a callback.
-    if (dash.active && toolName === "ScheduleWakeup") {
-      return {
-        block: true,
-        reason: [
-          "ScheduleWakeup is not compatible with auto-mode.",
-          "Auto-mode manages session lifecycle: wakeup timers have no effect inside an active auto-mode unit.",
-          "To wait for an external process, complete the current task and implement polling in a subsequent unit.",
-        ].join(" "),
-      };
-    }
+    // ScheduleWakeup is registered by the GSD extension so auto-mode can
+    // continue the same unit session after long external waits.
     const guidedUnit = getGuidedUnitContext(discussionBasePath);
     const activeUnitType = dash.currentUnit?.type ?? guidedUnit?.unitType;
     if (activeUnitType) {

--- a/src/resources/extensions/gsd/bootstrap/schedule-wakeup-tool.ts
+++ b/src/resources/extensions/gsd/bootstrap/schedule-wakeup-tool.ts
@@ -1,0 +1,81 @@
+// Project/App: GSD-2
+// File Purpose: Registers the auto-mode ScheduleWakeup continuation tool.
+
+import { Type } from "@sinclair/typebox";
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+
+import { getAutoRuntimeSnapshot } from "../auto-runtime-state.js";
+import { scheduleAutoWakeup } from "../auto/schedule-wakeup.js";
+import { resolveCtxCwd } from "./dynamic-tools.js";
+
+const MAX_WAKEUP_DELAY_SECONDS = 24 * 60 * 60;
+
+export function registerScheduleWakeupTool(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "ScheduleWakeup",
+    label: "Schedule Wakeup",
+    description:
+      "In GSD auto-mode, pause the current unit and continue the same session after a delay. " +
+      "Use this for long external processes that need polling without ending the unit as no-artifact.",
+    promptSnippet: "Schedule a same-session auto-mode wakeup after a delay.",
+    promptGuidelines: [
+      "Use ScheduleWakeup at the end of an execute-task turn when waiting for a long external process.",
+      "Include a prompt that says exactly what external state to check next and what artifact to write when done.",
+      "Re-arm ScheduleWakeup on each polling turn if the external process is still running.",
+    ],
+    parameters: Type.Object({
+      delaySeconds: Type.Number({
+        minimum: 1,
+        maximum: MAX_WAKEUP_DELAY_SECONDS,
+        description: "How many seconds to wait before continuing the same auto-mode session.",
+      }),
+      prompt: Type.String({
+        minLength: 1,
+        description: "Prompt to send when the session wakes up.",
+      }),
+      reason: Type.Optional(Type.String({
+        description: "Why this delay is appropriate.",
+      })),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const dash = getAutoRuntimeSnapshot();
+      const currentUnit = dash.currentUnit;
+      const basePath = dash.basePath || resolveCtxCwd(ctx);
+
+      if (!dash.active || !currentUnit) {
+        return {
+          content: [{ type: "text", text: "ScheduleWakeup is only available during an active GSD auto-mode unit." }],
+          details: { operation: "schedule_wakeup", error: "auto_mode_inactive" },
+          isError: true,
+        };
+      }
+
+      const delaySeconds = Math.max(
+        1,
+        Math.min(MAX_WAKEUP_DELAY_SECONDS, Math.floor(params.delaySeconds)),
+      );
+      scheduleAutoWakeup({
+        basePath,
+        unitType: currentUnit.type,
+        unitId: currentUnit.id,
+        delayMs: delaySeconds * 1000,
+        prompt: params.prompt,
+        reason: params.reason ?? "",
+        createdAt: Date.now(),
+      });
+
+      return {
+        content: [{
+          type: "text",
+          text: `Wakeup scheduled for ${delaySeconds}s. Auto-mode will continue ${currentUnit.type} ${currentUnit.id} in the same session.`,
+        }],
+        details: {
+          operation: "schedule_wakeup",
+          delaySeconds,
+          unitType: currentUnit.type,
+          unitId: currentUnit.id,
+        },
+      };
+    },
+  });
+}

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -21,6 +21,7 @@ import {
   isSessionSwitchAbortGraceActive,
 } from "../auto/resolve.js";
 import { runUnit, shouldDeferUnitFailsafeTimeout } from "../auto/run-unit.js";
+import { scheduleAutoWakeup, _resetAutoWakeupsForTest } from "../auto/schedule-wakeup.js";
 import { writeUnitRuntimeRecord, readUnitRuntimeRecord } from "../unit-runtime.js";
 import { autoLoop } from "../auto/loop.js";
 import { runDispatch, runUnitPhase } from "../auto/phases.js";
@@ -185,6 +186,61 @@ test("resolveAgentEnd resolves a pending runUnit promise", async () => {
   const result = await resultPromise;
   assert.equal(result.status, "completed");
   assert.deepEqual(result.event, event);
+});
+
+test("runUnit honors ScheduleWakeup by continuing the same unit session", async () => {
+  _resetPendingResolve();
+  _resetAutoWakeupsForTest();
+
+  const ctx = {
+    ...makeMockCtx(),
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setWorkingMessage: () => {},
+    },
+    sessionManager: {
+      getEntries: () => [],
+    },
+    modelRegistry: {
+      getProviderAuthMode: () => undefined,
+      isProviderRequestReady: () => true,
+    },
+  } as any;
+  const pi = makeMockPi();
+  const s = makeMockSession();
+  const firstEvent = makeEvent([{ role: "assistant", content: "submitted job" }]);
+  const secondEvent = makeEvent([{ role: "assistant", content: "job finished" }]);
+
+  const resultPromise = runUnit(
+    ctx,
+    pi,
+    s,
+    "execute-task",
+    "M001/S01/T01",
+    "submit external job",
+  );
+
+  await waitForMicrotasks(() => pi.calls.length === 1, "initial unit dispatch");
+  scheduleAutoWakeup({
+    basePath: s.basePath,
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    delayMs: 0,
+    prompt: "check external job and write the task summary if complete",
+    reason: "poll external job",
+    createdAt: Date.now(),
+  });
+  resolveAgentEnd(firstEvent);
+
+  await waitForMicrotasks(() => pi.calls.length === 2, "scheduled wakeup dispatch");
+  assert.equal((pi.calls[1] as any[])[0].content, "check external job and write the task summary if complete");
+  resolveAgentEnd(secondEvent);
+
+  const result = await resultPromise;
+  assert.equal(result.status, "completed");
+  assert.deepEqual(result.event, secondEvent);
+  assert.equal(pi.calls.length, 2);
 });
 
 test("runUnit suppresses the global working-message loader for auto dashboard runs", async () => {


### PR DESCRIPTION
## Linked issue

Closes #6328
Refs #4340

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Wires `ScheduleWakeup` as a GSD-owned auto-mode continuation tool.
**Why:** Long external processes need a same-session polling path instead of silently no-oping or finalizing the unit as `no-artifact`.
**How:** Registers a `ScheduleWakeup` tool, stores pending wakeups for the active unit, and teaches `runUnit` to sleep and send the wake prompt back into the same session.

## What

This change adds an auto-mode `ScheduleWakeup` implementation for long-running external work:

- Registers `ScheduleWakeup` from the GSD extension.
- Records pending wakeups by base path and active unit.
- Lets `runUnit` consume a wakeup after `agent_end`, sleep in interruptible chunks, and continue the same unit session with the supplied prompt.
- Removes the previous auto-mode block that treated `ScheduleWakeup` as incompatible.
- Adds a regression test proving a scheduled wakeup continues the same unit and returns the final agent result.

## Why

The previous #6328 containment made `ScheduleWakeup` fail loud, which was safer than a silent no-op but still left long external processes without the expected same-session polling path. This keeps the fail-loud fix for stale idempotency from #6328 while restoring a working wakeup path for external jobs.

## How

`ScheduleWakeup` now stores a pending wakeup for the current auto-mode unit. When the unit turn ends, `runUnit` checks for that wakeup before finalizing. If one exists, it waits for the requested delay, sends the wake prompt into the same session, and awaits the next `agent_end`. The tool is one-shot by design, so agents re-arm it on each polling turn when the external process is still running.

A per-unit cap prevents unbounded wake loops, and pause/stop state interrupts the sleep.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Verified locally:

- `npm run typecheck:extensions`
- `npm run test:compile`
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test dist-test/src/resources/extensions/gsd/tests/auto-loop.test.js` — 102 passed

## AI disclosure

- [ ] This PR includes AI-assisted code
