### PR TITLE
fix(gsd-db): deleteSlice misses quality_gates FK cascade and leaves orphan rows

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -2150,7 +2150,25 @@ export function deleteTask(milestoneId: string, sliceId: string, taskId: string)
 export function deleteSlice(milestoneId: string, sliceId: string): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   transaction(() => {
-    // Cascade-style manual deletion: evidence → tasks → dependencies → slice
+    // Cascade-style manual deletion: gates → orphan rows → evidence → tasks → dependencies → slice.
+    // quality_gates carries a true FK → slices and must be cleared before the slice row goes;
+    // gate_runs / replan_history / assessments / artifacts reference the slice without an FK
+    // and are cleaned here to avoid orphans, matching the deleteMilestone pattern.
+    currentDb!.prepare(
+      `DELETE FROM quality_gates WHERE milestone_id = :mid AND slice_id = :sid`,
+    ).run({ ":mid": milestoneId, ":sid": sliceId });
+    currentDb!.prepare(
+      `DELETE FROM gate_runs WHERE milestone_id = :mid AND slice_id = :sid`,
+    ).run({ ":mid": milestoneId, ":sid": sliceId });
+    currentDb!.prepare(
+      `DELETE FROM replan_history WHERE milestone_id = :mid AND slice_id = :sid`,
+    ).run({ ":mid": milestoneId, ":sid": sliceId });
+    currentDb!.prepare(
+      `DELETE FROM assessments WHERE milestone_id = :mid AND slice_id = :sid`,
+    ).run({ ":mid": milestoneId, ":sid": sliceId });
+    currentDb!.prepare(
+      `DELETE FROM artifacts WHERE milestone_id = :mid AND slice_id = :sid`,
+    ).run({ ":mid": milestoneId, ":sid": sliceId });
     currentDb!.prepare(
       `DELETE FROM verification_evidence WHERE milestone_id = :mid AND slice_id = :sid`,
     ).run({ ":mid": milestoneId, ":sid": sliceId });

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -32,6 +32,7 @@ import {
   getSliceTasks,
   getActiveMilestoneFromDb,
   deleteMilestone,
+  deleteSlice,
   clearEngineHierarchy,
   recordMilestoneCommitAttribution,
   getMilestoneCommitAttributionShas,
@@ -1115,6 +1116,64 @@ describe('gsd-db', () => {
       assert.deepEqual(getMilestoneCommitAttributionShas('M001'), ['fedcba9876543210fedcba9876543210fedcba98']);
       clearEngineHierarchy();
       assert.deepEqual(getMilestoneCommitAttributionShas('M001'), []);
+      closeDatabase();
+    });
+  });
+
+  // ─── deleteSlice cascade (#6484) ─────────────────────────────────────────
+
+  describe('deleteSlice cascade', () => {
+    test('deleteSlice clears quality_gates FK rows and orphan gate_runs/replan_history/assessments/artifacts', () => {
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'Milestone', status: 'active' });
+      insertSlice({ milestoneId: 'M001', id: 'S01', status: 'active' });
+      insertTask({
+        milestoneId: 'M001',
+        sliceId: 'S01',
+        id: 'T01',
+        title: 'Task under the slice',
+        planning: {
+          description: 'desc',
+          estimate: 'small',
+          files: ['src/a.ts'],
+          verify: 'npm test',
+          inputs: ['docs/in.md'],
+          expectedOutput: ['dist/out.md'],
+          observabilityImpact: '',
+        },
+      });
+
+      const adapter = _getAdapter()!;
+      adapter.prepare(
+        `INSERT INTO quality_gates (milestone_id, slice_id, gate_id) VALUES ('M001', 'S01', 'G1')`,
+      ).run();
+      adapter.prepare(
+        `INSERT INTO gate_runs (trace_id, turn_id, gate_id, milestone_id, slice_id) VALUES ('tr1', 'tu1', 'G1', 'M001', 'S01')`,
+      ).run();
+      adapter.prepare(
+        `INSERT INTO replan_history (milestone_id, slice_id) VALUES ('M001', 'S01')`,
+      ).run();
+      adapter.prepare(
+        `INSERT INTO assessments (path, milestone_id, slice_id) VALUES ('assessments/S01.md', 'M001', 'S01')`,
+      ).run();
+      adapter.prepare(
+        `INSERT INTO artifacts (path, milestone_id, slice_id) VALUES ('artifacts/S01.md', 'M001', 'S01')`,
+      ).run();
+
+      // Pre-fix this threw FOREIGN KEY constraint failed (quality_gates FK → slices)
+      // or left orphan rows in the four non-FK tables.
+      deleteSlice('M001', 'S01');
+
+      for (const table of ['quality_gates', 'gate_runs', 'replan_history', 'assessments', 'artifacts', 'tasks']) {
+        const row = adapter.prepare(
+          `SELECT count(*) as cnt FROM ${table} WHERE milestone_id = 'M001' AND slice_id = 'S01'`,
+        ).get() as { cnt: number };
+        assert.equal(row.cnt, 0, `${table} rows should be removed by deleteSlice`);
+      }
+      const slices = adapter.prepare(
+        `SELECT count(*) as cnt FROM slices WHERE milestone_id = 'M001' AND id = 'S01'`,
+      ).get() as { cnt: number };
+      assert.equal(slices.cnt, 0, 'slice row should be removed by deleteSlice');
       closeDatabase();
     });
   });


### PR DESCRIPTION
Fixes #6484

### What

`deleteSlice()` manually cascades `verification_evidence` → `tasks` → `slice_dependencies` (both directions) → `slices`, but misses `quality_gates` — the one sibling table with a true FK → slices:

```sql
-- db-base-schema.ts
FOREIGN KEY (milestone_id, slice_id) REFERENCES slices(milestone_id, id)
```

Deleting any slice that has gate rows fails with `FOREIGN KEY constraint failed` (or silently orphans them with FKs off). Four more tables reference the slice by `(milestone_id, slice_id)` without an FK — `gate_runs`, `replan_history`, `assessments`, `artifacts` — and are left as orphan rows, inconsistent with the `deleteMilestone` cleanup pattern.

### How

Five additional `DELETE`s ahead of the existing cascade, matching the function's manual-DELETE style (no schema migration): `quality_gates` first (the FK fix), then the four orphan cleanups. Full schema audit of why exactly these five tables is in #6484.

### Testing

- New regression test inserts rows into all five tables, calls `deleteSlice`, and asserts every table is clear. **Without the fix the test fails with `FOREIGN KEY constraint failed`** (verified by reverting the fix).
- `npm run verify:pr` run locally on Windows: 9669 passed — no new failures vs a clean-main baseline on the same machine (main itself has ~100 pre-existing Windows-only path-separator failures on this box; Linux CI should be authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
