### PR TITLE
feat(subagent): propagate named-agent thinking policy

### DIFF
--- a/src/resources/extensions/subagent/agents.ts
+++ b/src/resources/extensions/subagent/agents.ts
@@ -10,11 +10,25 @@ const PROJECT_AGENT_DIR_CANDIDATES = [".gsd", ".pi"] as const;
 
 export type AgentScope = "user" | "project" | "both";
 
+/** CLI thinking levels accepted by the embedded OpenCode-compatible runtime. */
+export type AgentThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+const AGENT_THINKING_LEVELS = new Set<AgentThinkingLevel>([
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+]);
+
 export interface AgentConfig {
 	name: string;
 	description: string;
 	tools?: string[];
 	model?: string;
+	/** Normalized from either the OpenCode `variant` or native `thinking` frontmatter. */
+	thinking?: AgentThinkingLevel;
 	conflictsWith?: string[];
 	systemPrompt: string;
 	source: "user" | "project";
@@ -31,6 +45,10 @@ interface AgentFrontmatter extends Record<string, unknown> {
 	description?: string;
 	tools?: string | string[];
 	model?: string;
+	/** OpenCode-compatible name for the requested thinking/reasoning level. */
+	variant?: string;
+	/** Native CLI name for the requested thinking/reasoning level. */
+	thinking?: string;
 	conflicts_with?: string;
 }
 
@@ -58,6 +76,15 @@ function parseAgentTools(value: string | string[] | undefined): string[] | undef
 	}
 
 	return undefined;
+}
+
+function parseAgentThinkingLevel(variant: unknown, thinking: unknown): AgentThinkingLevel | undefined {
+	// `thinking` is the native spelling. `variant` is accepted for materialized
+	// OpenCode agent definitions, so either form produces the same child CLI flag.
+	const candidate = typeof thinking === "string" ? thinking : typeof variant === "string" ? variant : undefined;
+	return candidate && AGENT_THINKING_LEVELS.has(candidate as AgentThinkingLevel)
+		? candidate as AgentThinkingLevel
+		: undefined;
 }
 
 function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig[] {
@@ -94,12 +121,14 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
 
 		const tools = parseAgentTools(frontmatter.tools);
 		const conflictsWith = parseConflictsWith(frontmatter.conflicts_with);
+		const thinking = parseAgentThinkingLevel(frontmatter.variant, frontmatter.thinking);
 
 		agents.push({
 			name: frontmatter.name,
 			description: frontmatter.description,
 			tools: tools && tools.length > 0 ? tools : undefined,
 			model: frontmatter.model,
+			thinking,
 			conflictsWith,
 			systemPrompt: body,
 			source,

--- a/src/resources/extensions/subagent/launch.ts
+++ b/src/resources/extensions/subagent/launch.ts
@@ -7,6 +7,15 @@ import type { AgentConfig } from "./agents.js";
 
 export const SUBAGENT_CHILD_ENV_VAR = "GSD_SUBAGENT_CHILD";
 export const SUBAGENT_CHILD_ENV_VALUE = "1";
+export const SUBAGENT_CURRENT_AGENT_ENV_VAR = "GSD_SUBAGENT_CURRENT_AGENT";
+export const SUBAGENT_PARENT_AGENT_ENV_VAR = "GSD_SUBAGENT_PARENT_AGENT";
+export const SUBAGENT_DELEGATION_DEPTH_ENV_VAR = "GSD_SUBAGENT_DELEGATION_DEPTH";
+
+// These are intentionally string constants rather than an extension import: GSD
+// remains usable without WXCode, while a governed child still receives the
+// identity/depth that the execution-routing extension validates.
+const WXCODE_CURRENT_AGENT_ENV_VAR = "WXCODE_EXECUTION_ROUTING_CURRENT_AGENT";
+const WXCODE_DELEGATION_DEPTH_ENV_VAR = "WXCODE_EXECUTION_ROUTING_DEPTH";
 
 export type SubagentContextMode = "fresh" | "fork";
 
@@ -43,16 +52,48 @@ export function isSubagentChildProcess(env: NodeJS.ProcessEnv = process.env): bo
 	return env[SUBAGENT_CHILD_ENV_VAR] === SUBAGENT_CHILD_ENV_VALUE;
 }
 
-export function buildSubagentProcessEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
-	return {
+function parseDelegationDepth(value: string | undefined): number {
+	if (!value || !/^(0|[1-9]\d*)$/.test(value)) return 0;
+	const depth = Number(value);
+	return Number.isSafeInteger(depth) ? depth : 0;
+}
+
+export function buildSubagentProcessEnv(
+	env: NodeJS.ProcessEnv = process.env,
+	childAgentName?: string,
+): NodeJS.ProcessEnv {
+	const childEnv: NodeJS.ProcessEnv = {
 		...env,
 		[SUBAGENT_CHILD_ENV_VAR]: SUBAGENT_CHILD_ENV_VALUE,
 	};
+	if (!childAgentName) return childEnv;
+
+	const parentAgent = env[SUBAGENT_CURRENT_AGENT_ENV_VAR] ?? env[WXCODE_CURRENT_AGENT_ENV_VAR];
+	const parentDepth = parseDelegationDepth(
+		env[SUBAGENT_DELEGATION_DEPTH_ENV_VAR] ?? env[WXCODE_DELEGATION_DEPTH_ENV_VAR],
+	);
+	const childDepth = String(parentDepth + 1);
+	childEnv[SUBAGENT_CURRENT_AGENT_ENV_VAR] = childAgentName;
+	childEnv[SUBAGENT_DELEGATION_DEPTH_ENV_VAR] = childDepth;
+	if (parentAgent) childEnv[SUBAGENT_PARENT_AGENT_ENV_VAR] = parentAgent;
+
+	if (env[WXCODE_CURRENT_AGENT_ENV_VAR] !== undefined || env[WXCODE_DELEGATION_DEPTH_ENV_VAR] !== undefined) {
+		childEnv[WXCODE_CURRENT_AGENT_ENV_VAR] = childAgentName;
+		childEnv[WXCODE_DELEGATION_DEPTH_ENV_VAR] = childDepth;
+	}
+	return childEnv;
 }
 
 export function buildShellEnvAssignments(env: NodeJS.ProcessEnv = process.env): string[] {
-	const value = env[SUBAGENT_CHILD_ENV_VAR];
-	return value ? [`${SUBAGENT_CHILD_ENV_VAR}=${JSON.stringify(value)}`] : [];
+	const names = [
+		SUBAGENT_CHILD_ENV_VAR,
+		SUBAGENT_CURRENT_AGENT_ENV_VAR,
+		SUBAGENT_PARENT_AGENT_ENV_VAR,
+		SUBAGENT_DELEGATION_DEPTH_ENV_VAR,
+		WXCODE_CURRENT_AGENT_ENV_VAR,
+		WXCODE_DELEGATION_DEPTH_ENV_VAR,
+	];
+	return names.flatMap((name) => env[name] === undefined ? [] : [`${name}=${JSON.stringify(env[name])}`]);
 }
 
 export function buildSubagentProcessArgs(
@@ -71,6 +112,9 @@ export function buildSubagentProcessArgs(
 	}
 	const effectiveModel = modelOverride ?? agent.model;
 	if (effectiveModel) args.push("--model", effectiveModel);
+	// Thinking is part of the named agent contract; a caller-supplied model
+	// override must never erase the snapshot materialized reasoning policy.
+	if (agent.thinking) args.push("--thinking", agent.thinking);
 	if (agent.tools && agent.tools.length > 0) args.push("--tools", agent.tools.join(","));
 	if (tmpPromptPath) args.push("--append-system-prompt", tmpPromptPath);
 	args.push(`Task: ${task}`);
@@ -124,7 +168,7 @@ export function createSubagentLaunchPlan(input: SubagentLaunchInput): SubagentLa
 			input.modelOverride,
 			session,
 		),
-		env: buildSubagentProcessEnv(),
+		env: buildSubagentProcessEnv(process.env, input.agent.name),
 		cwd: input.cwd ?? input.defaultCwd,
 		session,
 	};

--- a/src/resources/extensions/subagent/tests/agents-thinking.test.ts
+++ b/src/resources/extensions/subagent/tests/agents-thinking.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { discoverAgents } from "../agents.js";
+
+describe("agent thinking frontmatter", () => {
+	let dir: string | undefined;
+
+	afterEach(() => {
+		if (dir) rmSync(dir, { recursive: true, force: true });
+		dir = undefined;
+	});
+
+	it("loads OpenCode-compatible variant as the named agent thinking policy", () => {
+		dir = mkdtempSync(join(tmpdir(), "gsd-agent-thinking-"));
+		const agentsDir = join(dir, ".gsd", "agents");
+		mkdirSync(agentsDir, { recursive: true });
+		writeFileSync(join(agentsDir, "research.md"), [
+			"---",
+			"name: research",
+			"description: Research agent",
+			"model: openai/gpt-5.6-terra",
+			"variant: high",
+			"---",
+			"Research carefully.",
+		].join("\n"));
+
+		const result = discoverAgents(dir, "project");
+		assert.equal(result.agents.length, 1);
+		assert.equal(result.agents[0]?.thinking, "high");
+	});
+
+	it("prefers explicit native thinking when both spellings are present", () => {
+		dir = mkdtempSync(join(tmpdir(), "gsd-agent-thinking-"));
+		const agentsDir = join(dir, ".gsd", "agents");
+		mkdirSync(agentsDir, { recursive: true });
+		writeFileSync(join(agentsDir, "analysis.md"), [
+			"---",
+			"name: analysis",
+			"description: Analysis agent",
+			"variant: low",
+			"thinking: xhigh",
+			"---",
+			"Analyze carefully.",
+		].join("\n"));
+
+		assert.equal(discoverAgents(dir, "project").agents[0]?.thinking, "xhigh");
+	});
+});

--- a/src/resources/extensions/subagent/tests/launch.test.ts
+++ b/src/resources/extensions/subagent/tests/launch.test.ts
@@ -12,6 +12,7 @@ import type { AgentConfig } from "../agents.js";
 import {
 	SUBAGENT_CHILD_ENV_VAR,
 	SUBAGENT_CHILD_ENV_VALUE,
+	buildShellEnvAssignments,
 	buildSubagentProcessEnv,
 	createSubagentLaunchPlan,
 	isSubagentChildProcess,
@@ -111,5 +112,25 @@ describe("subagent launch module", () => {
 		}
 
 		assert.deepEqual(calls, []);
+	});
+
+	it("propagates the named child identity and increments governed delegation depth", () => {
+		const env = buildSubagentProcessEnv({
+			WXCODE_EXECUTION_ROUTING_CURRENT_AGENT: "projects-orchestrator",
+			WXCODE_EXECUTION_ROUTING_DEPTH: "0",
+		}, "research-agent");
+		assert.equal(env.GSD_SUBAGENT_PARENT_AGENT, "projects-orchestrator");
+		assert.equal(env.GSD_SUBAGENT_CURRENT_AGENT, "research-agent");
+		assert.equal(env.GSD_SUBAGENT_DELEGATION_DEPTH, "1");
+		assert.equal(env.WXCODE_EXECUTION_ROUTING_CURRENT_AGENT, "research-agent");
+		assert.equal(env.WXCODE_EXECUTION_ROUTING_DEPTH, "1");
+		assert.deepEqual(buildShellEnvAssignments(env), [
+			"GSD_SUBAGENT_CHILD=\"1\"",
+			"GSD_SUBAGENT_CURRENT_AGENT=\"research-agent\"",
+			"GSD_SUBAGENT_PARENT_AGENT=\"projects-orchestrator\"",
+			"GSD_SUBAGENT_DELEGATION_DEPTH=\"1\"",
+			"WXCODE_EXECUTION_ROUTING_CURRENT_AGENT=\"research-agent\"",
+			"WXCODE_EXECUTION_ROUTING_DEPTH=\"1\"",
+		]);
 	});
 });

--- a/src/resources/extensions/subagent/tests/model-override.test.ts
+++ b/src/resources/extensions/subagent/tests/model-override.test.ts
@@ -52,4 +52,12 @@ describe("buildSubagentProcessArgs model override", () => {
 		assert.notEqual(modelIndex, -1);
 		assert.equal(args[modelIndex + 1], "model-override");
 	});
+
+	it("keeps the named agent's thinking policy when a model override is supplied", () => {
+		const agent = makeAgent({ model: "model-a", thinking: "high" });
+		const args = buildSubagentProcessArgs(agent, "task", null, "model-b");
+		const thinkingIndex = args.indexOf("--thinking");
+		assert.notEqual(thinkingIndex, -1, "named agent thinking must reach the child CLI");
+		assert.equal(args[thinkingIndex + 1], "high");
+	});
 });


### PR DESCRIPTION
## Summary
- accept OpenCode variant and native thinking in named-agent frontmatter
- pass the named agent thinking level to child CLI launches
- propagate parent/current agent identity and delegation depth to nested children
- keep the behavior provider-agnostic and optional for existing agents

## Verification
- npm run build:core
- npm run typecheck:extensions
- 13 focused subagent tests
- git diff --check